### PR TITLE
fix: all documents in the knowledge base cannot be selected if they have not been parsed. #214

### DIFF
--- a/web/src/hooks/knowledgeHook.ts
+++ b/web/src/hooks/knowledgeHook.ts
@@ -135,7 +135,7 @@ export const useFetchKnowledgeList = (
   const { data = [] } = knowledgeModel;
   const list = useMemo(() => {
     return shouldFilterListWithoutDocument
-      ? data.filter((x: IKnowledge) => x.doc_num > 0)
+      ? data.filter((x: IKnowledge) => x.chunk_num > 0)
       : data;
   }, [data, shouldFilterListWithoutDocument]);
 


### PR DESCRIPTION
### What problem does this PR solve?

fix: all documents in the knowledge base cannot be selected if they have not been parsed. 

Issue link: #214

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

