### PR TITLE
Create an .env variable for Server Listening port - to sync the setti…

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -4,6 +4,9 @@ STACK_VERSION=8.11.3
 # Set the cluster name
 CLUSTER_NAME=rag_flow
 
+# Port to expose for Server HTTP to the host
+LISTEN_SRV_PORT=3000
+
 # Port to expose Elasticsearch HTTP API to the host
 ES_PORT=1200
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     container_name: ragflow-server
     ports:
       - ${SVR_HTTP_PORT}:9380
-      - 80:80
+      - ${LISTEN_SRV_PORT}:80
       - 443:443
     volumes:
       - ./service_conf.yaml:/ragflow/conf/service_conf.yaml

--- a/docker/nginx/ragflow.conf
+++ b/docker/nginx/ragflow.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen ${LISTEN_SRV_PORT};
     server_name _;
     root /ragflow/web/dist;
 


### PR DESCRIPTION
…ng to nginx

### What problem does this PR solve?

If you manual change the listening port of Server to somthing like this:

services:
  ragflow:
    depends_on:
      mysql:
        condition: service_healthy
      es01:
        condition: service_healthy
    image: infiniflow/ragflow:v1.0
    container_name: ragflow-server
    ports:
      - ${SVR_HTTP_PORT}:9380
      - 3000:80
      - 443:443
      
nginx fails to server the server because the Listening port is hardcoded in 
ragflow.conf

Issue link:#[Link the issue here]

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)

