### PR TITLE
remove version top-level element in the compose.yml file

### DIFF
--- a/docker/docker-compose-CN.yml
+++ b/docker/docker-compose-CN.yml
@@ -1,6 +1,3 @@
-version: '2.2'
-
-
 include:
   - path: ./docker-compose-base.yml
     env_file: ./.env

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -1,5 +1,3 @@
-version: '2.2'
-
 services:
   es01:
     container_name: ragflow-es-01

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.2'
-
 include:
   - path: ./docker-compose-base.yml
     env_file: ./.env


### PR DESCRIPTION
### What problem does this PR solve?
![image](https://github.com/infiniflow/ragflow/assets/106524776/56eec972-e92a-4cd2-92cc-4c20ba478a52)

- remove version top-level element in the compose.yml file
when use command `docker compose -f docker-compose-CN.yml up -d` ,it will waring,[maybe it appear after v25,5](https://github.com/mailcow/mailcow-dockerized/issues/5797#issuecomment-2011349228)
![image](https://github.com/infiniflow/ragflow/assets/106524776/e42ebfb7-d51e-4423-b6dd-3a7568a6be4f)

ref to https://docs.docker.com/compose/intro/history/#docker-compose-cli-versioning
> Version one of the Docker Compose command-line binary was first released in 2014. It was written in Python, and is invoked with docker-compose. Typically, Compose V1 projects include a top-level version element in the compose.yml file, with values ranging from 2.0 to 3.8, which refer to the specific [file formats](https://docs.docker.com/compose/intro/history/#compose-file-format-versioning).

> Version two of the Docker Compose command-line binary was announced in 2020, is written in Go, and is invoked with docker compose. Compose V2 ignores the version top-level element in the compose.yml file.
 
Also in `README.MD` show `Docker >= 24.0.0 & Docker Compose >= v2.26.1`. so i want to remove the version.

### Type of change

- [x] Other (please describe):
remove warning