### PR TITLE
Update table.py to convert clmns to string

### DIFF
--- a/rag/app/table.py
+++ b/rag/app/table.py
@@ -193,14 +193,14 @@ def chunk(filename, binary=None, from_page=0, to_page=10000000000,
             if n in df.columns:
                 del df[n]
         clmns = df.columns.values
-        txts = list(copy.deepcopy(clmns))
+        txts = [str(n) for n in clmns] #list(copy.deepcopy(clmns))
         py_clmns = [
             PY.get_pinyins(
                 re.sub(
                     r"(/.*|（[^（）]+?）|\([^()]+?\))",
                     "",
                     n),
-                '_')[0] for n in clmns]
+                '_')[0] for n in txts]
         clmn_tys = []
         for j in range(len(clmns)):
             cln, ty = column_data_type(df[clmns[j]])
@@ -208,7 +208,7 @@ def chunk(filename, binary=None, from_page=0, to_page=10000000000,
             df[clmns[j]] = cln
             if ty == "text":
                 txts.extend([str(c) for c in cln if c])
-        clmns_map = [(py_clmns[i].lower() + fieds_map[clmn_tys[i]], clmns[i].replace("_", " "))
+        clmns_map = [(py_clmns[i].lower() + fieds_map[clmn_tys[i]], txts[i].replace("_", " "))
                      for i in range(len(clmns))]
 
         eng = lang.lower() == "english"  # is_english(txts)

--- a/rag/app/table.py
+++ b/rag/app/table.py
@@ -193,14 +193,14 @@ def chunk(filename, binary=None, from_page=0, to_page=10000000000,
             if n in df.columns:
                 del df[n]
         clmns = df.columns.values
-        txts = [str(n) for n in clmns] #list(copy.deepcopy(clmns))
+        txts = list(copy.deepcopy(clmns))
         py_clmns = [
             PY.get_pinyins(
                 re.sub(
                     r"(/.*|（[^（）]+?）|\([^()]+?\))",
                     "",
-                    n),
-                '_')[0] for n in txts]
+                    str(n)),
+                '_')[0] for n in clmns]
         clmn_tys = []
         for j in range(len(clmns)):
             cln, ty = column_data_type(df[clmns[j]])
@@ -208,7 +208,7 @@ def chunk(filename, binary=None, from_page=0, to_page=10000000000,
             df[clmns[j]] = cln
             if ty == "text":
                 txts.extend([str(c) for c in cln if c])
-        clmns_map = [(py_clmns[i].lower() + fieds_map[clmn_tys[i]], txts[i].replace("_", " "))
+        clmns_map = [(py_clmns[i].lower() + fieds_map[clmn_tys[i]], str(clmns[i]).replace("_", " "))
                      for i in range(len(clmns))]
 
         eng = lang.lower() == "english"  # is_english(txts)


### PR DESCRIPTION
### What problem does this PR solve?

When handling some excel file, following error might occur, looks like some clmns item could be in type 'int':

[INFO] [2024-04-17 16:01:40,644] [_internal._log] [line:96]: 172.29.0.6 - - [17/Apr/2024 16:01:40] "GET /v1/document/list?kb_id=615d3698fc6711ee85920242ac140006&page=1&page_size=10 HTTP/1.1" 200 - Traceback (most recent call last):
  File "/ragflow/rag/svr/task_executor.py", line 130, in build
    cks = chunker.chunk(row["name"], binary=binary, from_page=row["from_page"],
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ragflow/rag/app/table.py", line 198, in chunk
    py_clmns = [
               ^
  File "/ragflow/rag/app/table.py", line 200, in <listcomp>
    re.sub(
  File "/root/miniconda3/envs/py11/lib/python3.11/re/__init__.py", line 185, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'int'

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

