### PR TITLE
Add `.doc` file parser.

### DIFF
--- a/api/utils/file_utils.py
+++ b/api/utils/file_utils.py
@@ -147,7 +147,7 @@ def filename_type(filename):
         return FileType.PDF.value
 
     if re.match(
-            r".*\.(docx|ppt|pptx|yml|xml|htm|json|csv|txt|ini|xls|xlsx|wps|rtf|hlp|pages|numbers|key|md)$", filename):
+            r".*\.(doc|docx|ppt|pptx|yml|xml|htm|json|csv|txt|ini|xls|xlsx|wps|rtf|hlp|pages|numbers|key|md)$", filename):
         return FileType.DOC.value
 
     if re.match(

--- a/rag/app/book.py
+++ b/rag/app/book.py
@@ -110,6 +110,8 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
         doc_parsed = parser.from_buffer(binary)
         sections = doc_parsed['content'].split('\n')
         sections = [(l, "") for l in sections if l]
+        remove_contents_table(sections, eng=is_english(
+            random_choices([t for t, _ in sections], k=200)))
         callback(0.8, "Finish parsing.")
 
     else:

--- a/rag/app/book.py
+++ b/rag/app/book.py
@@ -11,6 +11,7 @@
 #  limitations under the License.
 #
 import copy
+from tika import parser
 import re
 from io import BytesIO
 
@@ -103,9 +104,17 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
             random_choices([t for t, _ in sections], k=200)))
         callback(0.8, "Finish parsing.")
 
+    elif re.search(r"\.doc$", filename, re.IGNORECASE):
+        callback(0.1, "Start to parse.")
+        binary = BytesIO(binary)
+        doc_parsed = parser.from_buffer(binary)
+        sections = doc_parsed['content'].split('\n')
+        sections = [(l, "") for l in sections if l]
+        callback(0.8, "Finish parsing.")
+
     else:
         raise NotImplementedError(
-            "file type not supported yet(docx, pdf, txt supported)")
+            "file type not supported yet(doc, docx, pdf, txt supported)")
 
     make_colon_as_title(sections)
     bull = bullets_category(

--- a/rag/app/laws.py
+++ b/rag/app/laws.py
@@ -11,6 +11,7 @@
 #  limitations under the License.
 #
 import copy
+from tika import parser
 import re
 from io import BytesIO
 from docx import Document
@@ -123,9 +124,18 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
         sections = txt.split("\n")
         sections = [l for l in sections if l]
         callback(0.8, "Finish parsing.")
+
+    elif re.search(r"\.doc$", filename, re.IGNORECASE):
+        callback(0.1, "Start to parse.")
+        binary = BytesIO(binary)
+        doc_parsed = parser.from_buffer(binary)
+        sections = doc_parsed['content'].split('\n')
+        sections = [(l, "") for l in sections if l]
+        callback(0.8, "Finish parsing.")
+
     else:
         raise NotImplementedError(
-            "file type not supported yet(docx, pdf, txt supported)")
+            "file type not supported yet(doc, docx, pdf, txt supported)")
 
     # is it English
     eng = lang.lower() == "english"  # is_english(sections)

--- a/rag/app/laws.py
+++ b/rag/app/laws.py
@@ -130,7 +130,7 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
         binary = BytesIO(binary)
         doc_parsed = parser.from_buffer(binary)
         sections = doc_parsed['content'].split('\n')
-        sections = [(l, "") for l in sections if l]
+        sections = [l for l in sections if l]
         callback(0.8, "Finish parsing.")
 
     else:

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -10,6 +10,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from tika import parser
 from io import BytesIO
 from docx import Document
 import re
@@ -154,9 +155,17 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
         sections = [(l, "") for l in sections if l]
         callback(0.8, "Finish parsing.")
 
+    elif re.search(r"\.doc$", filename, re.IGNORECASE):
+        callback(0.1, "Start to parse.")
+        binary = BytesIO(binary)
+        doc_parsed = parser.from_buffer(binary)
+        sections = doc_parsed['content'].split('\n')
+        sections = [(l, "") for l in sections if l]
+        callback(0.8, "Finish parsing.")
+
     else:
         raise NotImplementedError(
-            "file type not supported yet(docx, pdf, txt supported)")
+            "file type not supported yet(doc, docx, pdf, txt supported)")
 
     chunks = naive_merge(
         sections, parser_config.get(

--- a/rag/app/one.py
+++ b/rag/app/one.py
@@ -102,7 +102,7 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
         binary = BytesIO(binary)
         doc_parsed = parser.from_buffer(binary)
         sections = doc_parsed['content'].split('\n')
-        sections = [(l, "") for l in sections if l]
+        sections = [l for l in sections if l]
         callback(0.8, "Finish parsing.")
 
     else:

--- a/rag/app/one.py
+++ b/rag/app/one.py
@@ -10,6 +10,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from tika import parser
+from io import BytesIO
 import re
 from rag.app import laws
 from rag.nlp import huqie, tokenize, find_codec
@@ -95,9 +97,17 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
         sections = [s for s in sections if s]
         callback(0.8, "Finish parsing.")
 
+    elif re.search(r"\.doc$", filename, re.IGNORECASE):
+        callback(0.1, "Start to parse.")
+        binary = BytesIO(binary)
+        doc_parsed = parser.from_buffer(binary)
+        sections = doc_parsed['content'].split('\n')
+        sections = [(l, "") for l in sections if l]
+        callback(0.8, "Finish parsing.")
+
     else:
         raise NotImplementedError(
-            "file type not supported yet(docx, pdf, txt supported)")
+            "file type not supported yet(doc, docx, pdf, txt supported)")
 
     doc = {
         "docnm_kwd": filename,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
 Aspose.Slides==24.2.0
+async-timeout==4.0.3
 attrs==23.2.0
+BCEmbedding==0.1.4
 blinker==1.7.0
 cachelib==0.12.0
 cachetools==5.3.3
@@ -19,6 +21,7 @@ cryptography==42.0.5
 dashscope==1.14.1
 datasets==2.17.1
 datrie==0.8.2
+demjson==2.2.4
 demjson3==3.0.6
 dill==0.3.8
 distro==1.9.0
@@ -26,8 +29,9 @@ elastic-transport==8.12.0
 elasticsearch==8.12.1
 elasticsearch-dsl==8.12.0
 et-xmlfile==1.1.0
-filelock==3.13.1
+exceptiongroup==1.2.0
 fastembed==0.2.6
+filelock==3.13.1
 FlagEmbedding==1.2.5
 Flask==3.0.2
 Flask-Cors==4.0.0
@@ -47,6 +51,7 @@ install==1.3.5
 itsdangerous==2.1.2
 Jinja2==3.1.3
 joblib==1.3.2
+loguru==0.7.2
 lxml==5.1.0
 MarkupSafe==2.1.5
 minio==7.2.4
@@ -69,6 +74,9 @@ nvidia-cusparse-cu12==12.1.0.106
 nvidia-nccl-cu12==2.19.3
 nvidia-nvjitlink-cu12==12.3.101
 nvidia-nvtx-cu12==12.1.105
+ollama==0.1.8
+onnx==1.16.0
+onnxruntime==1.17.3
 onnxruntime-gpu==1.17.1
 openai==1.12.0
 opencv-python==4.9.0.80
@@ -116,6 +124,7 @@ sniffio==1.3.1
 StrEnum==0.4.15
 sympy==1.12
 threadpoolctl==3.3.0
+tika==2.6.0
 tiktoken==0.6.0
 tokenizers==0.15.2
 torch==2.2.1
@@ -132,5 +141,3 @@ xpinyin==0.7.6
 xxhash==3.4.1
 yarl==1.9.4
 zhipuai==2.0.1
-BCEmbedding
-loguru==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,7 @@ anyio==4.3.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
 Aspose.Slides==24.2.0
-async-timeout==4.0.3
 attrs==23.2.0
-BCEmbedding==0.1.4
 blinker==1.7.0
 cachelib==0.12.0
 cachetools==5.3.3
@@ -21,7 +19,6 @@ cryptography==42.0.5
 dashscope==1.14.1
 datasets==2.17.1
 datrie==0.8.2
-demjson==2.2.4
 demjson3==3.0.6
 dill==0.3.8
 distro==1.9.0
@@ -29,9 +26,8 @@ elastic-transport==8.12.0
 elasticsearch==8.12.1
 elasticsearch-dsl==8.12.0
 et-xmlfile==1.1.0
-exceptiongroup==1.2.0
-fastembed==0.2.6
 filelock==3.13.1
+fastembed==0.2.6
 FlagEmbedding==1.2.5
 Flask==3.0.2
 Flask-Cors==4.0.0
@@ -51,7 +47,6 @@ install==1.3.5
 itsdangerous==2.1.2
 Jinja2==3.1.3
 joblib==1.3.2
-loguru==0.7.2
 lxml==5.1.0
 MarkupSafe==2.1.5
 minio==7.2.4
@@ -74,9 +69,6 @@ nvidia-cusparse-cu12==12.1.0.106
 nvidia-nccl-cu12==2.19.3
 nvidia-nvjitlink-cu12==12.3.101
 nvidia-nvtx-cu12==12.1.105
-ollama==0.1.8
-onnx==1.16.0
-onnxruntime==1.17.3
 onnxruntime-gpu==1.17.1
 openai==1.12.0
 opencv-python==4.9.0.80
@@ -141,3 +133,5 @@ xpinyin==0.7.6
 xxhash==3.4.1
 yarl==1.9.4
 zhipuai==2.0.1
+BCEmbedding
+loguru==0.7.2


### PR DESCRIPTION
### What problem does this PR solve?
Add `.doc` file parser, using tika.
```
pip install tika
```
```
from tika import parser
from io import BytesIO

def extract_text_from_doc_bytes(doc_bytes):
    file_like_object = BytesIO(doc_bytes)
    parsed = parser.from_buffer(file_like_object)
    return parsed["content"]
```
### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
