### PR TITLE
chore: disable Kibana volume storage in Docker Compose

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -96,8 +96,8 @@ services:
 volumes:
   esdata01:
     driver: local
-  kibanadata:
-    driver: local
+#  kibanadata:
+#    driver: local
   mysql_data:
     driver: local
   minio_data:


### PR DESCRIPTION
Since Kibana service is not currently being used, the associated volume 'kibanadata' has been commented out in the Docker Compose file. This change helps to prevent the allocation of unnecessary resources and simplifies the configuration.

### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): Configuration adjustment to disable unused Kibana volume storage
