### PR TITLE
feat: add docker-compose setup for isolated Redis instance

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -18,6 +18,10 @@ MEM_LIMIT=8073741824
 MYSQL_PASSWORD=infini_rag_flow
 MYSQL_PORT=5455
 
+# Port to expose Redis to the host
+REDIS_PASSWORD=infini_rag_flow
+REDIS_PORT=5456
+
 # Port to expose minio to the host
 MINIO_CONSOLE_PORT=9001
 MINIO_PORT=9000

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -74,6 +74,25 @@ services:
       retries: 3
     restart: always
 
+  redis:
+    container_name: ragflow-redis
+    image: redis:7.2.4
+    ports:
+      - "${REDIS_PORT}:6379"
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      TZ: ${TIMEZONE}
+    volumes:
+      - redis_data:/data
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    healthcheck:
+      test: [ "CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping | grep PONG" ]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    networks:
+      - ragflow
+    restart: always
 
   minio:
     image: quay.io/minio/minio:RELEASE.2023-12-20T01-00-02Z
@@ -99,6 +118,8 @@ volumes:
 #  kibanadata:
 #    driver: local
   mysql_data:
+    driver: local
+  redis_data:
     driver: local
   minio_data:
     driver: local


### PR DESCRIPTION
Configure a dedicated Redis service in docker-compose with environment-controlled port and password settings, ensuring an isolated instance for the project.

### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
