### PR TITLE
fix: display the current language directly at the top and do not disp…

### DIFF
--- a/web/src/layouts/components/right-toolbar/index.less
+++ b/web/src/layouts/components/right-toolbar/index.less
@@ -15,3 +15,7 @@
   vertical-align: middle;
   cursor: pointer;
 }
+
+.language {
+  cursor: pointer;
+}

--- a/web/src/layouts/components/right-toolbar/index.tsx
+++ b/web/src/layouts/components/right-toolbar/index.tsx
@@ -1,6 +1,5 @@
-import { ReactComponent as TranslationIcon } from '@/assets/svg/translation.svg';
 import { useTranslate } from '@/hooks/commonHooks';
-import { GithubOutlined } from '@ant-design/icons';
+import { DownOutlined, GithubOutlined } from '@ant-design/icons';
 import { Dropdown, MenuProps, Space } from 'antd';
 import camelCase from 'lodash/camelCase';
 import React from 'react';
@@ -8,6 +7,7 @@ import User from '../user';
 
 import { LanguageList } from '@/constants/common';
 import { useChangeLanguage } from '@/hooks/logicHooks';
+import { useSelector } from 'umi';
 import styled from './index.less';
 
 const Circle = ({ children, ...restProps }: React.PropsWithChildren) => {
@@ -25,6 +25,7 @@ const handleGithubCLick = () => {
 const RightToolBar = () => {
   const { t } = useTranslate('common');
   const changeLanguage = useChangeLanguage();
+  const { language = '' } = useSelector((state) => state.settingModel.userInfo);
 
   const handleItemClick: MenuProps['onClick'] = ({ key }) => {
     changeLanguage(key);
@@ -40,14 +41,15 @@ const RightToolBar = () => {
   return (
     <div className={styled.toolbarWrapper}>
       <Space wrap size={16}>
+        <Dropdown menu={{ items, onClick: handleItemClick }} placement="bottom">
+          <Space className={styled.language}>
+            <b>{t(camelCase(language))}</b>
+            <DownOutlined />
+          </Space>
+        </Dropdown>
         <Circle>
           <GithubOutlined onClick={handleGithubCLick} />
         </Circle>
-        <Dropdown menu={{ items, onClick: handleItemClick }} placement="bottom">
-          <Circle>
-            <TranslationIcon />
-          </Circle>
-        </Dropdown>
         {/* <Circle>
           <MonIcon />
         </Circle> */}

--- a/web/src/pages/chat/shared-hooks.ts
+++ b/web/src/pages/chat/shared-hooks.ts
@@ -129,6 +129,7 @@ export const useSendSharedMessage = (
     async (message: string, id?: string) => {
       const retcode = await completeConversation({
         conversation_id: id ?? conversationId,
+        quote: false,
         messages: [
           ...(conversation?.message ?? []).map((x: IMessage) => omit(x, 'id')),
           {


### PR DESCRIPTION
…lay reference symbols for documents in external chat boxes  #566 #577

### What problem does this PR solve?

fix: display the current language directly at the top and do not display reference symbols for documents in external chat boxes  #566 #577

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

