### PR TITLE
Fix: missing 'redis' package in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -100,6 +100,7 @@ python-dotenv==1.0.1
 python-pptx==0.6.23
 pytz==2024.1
 PyYAML==6.0.1
+redis==5.0.3
 regex==2023.12.25
 requests==2.31.0
 ruamel.yaml==0.18.6


### PR DESCRIPTION
### What problem does this PR solve?

This commit resolves an issue where the 'redis' package was inadvertently omitted from the requirements.txt file. The package has now been added to ensure all dependencies are correctly installed for the project.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
