### PR TITLE
Fix Redis Consumption Bug When entrypoint.sh's WS>1

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -94,9 +94,9 @@ def set_progress(task_id, from_page=0, to_page=-1,
         sys.exit()
 
 
-def collect():
+def collect(thread_num):
     try:
-        payload = REDIS_CONN.queue_consumer(SVR_QUEUE_NAME, "rag_flow_svr_task_broker", "rag_flow_svr_task_consumer")
+        payload = REDIS_CONN.queue_consumer(SVR_QUEUE_NAME, "rag_flow_svr_task_broker", f"rag_flow_svr_task_consumer_{thread_num}")
         if not payload:
             time.sleep(1)
             return pd.DataFrame()
@@ -245,8 +245,8 @@ def embedding(docs, mdl, parser_config={}, callback=None):
     return tk_count
 
 
-def main():
-    rows = collect()
+def main(thread_num):
+    rows = collect(thread_num)
     if len(rows) == 0:
         return
 
@@ -318,4 +318,7 @@ if __name__ == "__main__":
     peewee_logger.setLevel(database_logger.level)
 
     while True:
-        main()
+        if len(sys.argv) == 3:
+            main(sys.argv[1])
+        else:
+            main('0')

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -94,9 +94,9 @@ def set_progress(task_id, from_page=0, to_page=-1,
         sys.exit()
 
 
-def collect(thread_num):
+def collect(worker_id):
     try:
-        payload = REDIS_CONN.queue_consumer(SVR_QUEUE_NAME, "rag_flow_svr_task_broker", f"rag_flow_svr_task_consumer_{thread_num}")
+        payload = REDIS_CONN.queue_consumer(SVR_QUEUE_NAME, "rag_flow_svr_task_broker", f"rag_flow_svr_task_consumer_{worker_id}")
         if not payload:
             time.sleep(1)
             return pd.DataFrame()
@@ -245,8 +245,8 @@ def embedding(docs, mdl, parser_config={}, callback=None):
     return tk_count
 
 
-def main(thread_num):
-    rows = collect(thread_num)
+def main(worker_id):
+    rows = collect(worker_id)
     if len(rows) == 0:
         return
 


### PR DESCRIPTION
### What problem does this PR solve?

**Description:**

#734 I encountered a bug related to Redis consumption under the condition where entrypoint.sh has WS>1.

**Cause:** 
The issue arises from utilizing the same consumer_name across multiple instances, leading to anomalies. For instance, my testing occasionally revealed that tasks successfully dispatched to Redis could fail to be consumed.

This behavior also precipitated additional complications.

**Resolution:** 
To address this, we've implemented a fix by assigning unique consumer_names to the queue_consumer of each thread, effectively mitigating the identified issues and ensuring reliable task consumption from Redis.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
