### PR TITLE
fix: hide the add button when the folder is a knowledge base

### DIFF
--- a/web/src/interfaces/database/file-manager.ts
+++ b/web/src/interfaces/database/file-manager.ts
@@ -28,4 +28,5 @@ export interface IFolder {
   type: string;
   update_date: string;
   update_time: number;
+  source_type: string;
 }

--- a/web/src/pages/file-manager/file-toolbar.tsx
+++ b/web/src/pages/file-manager/file-toolbar.tsx
@@ -26,6 +26,7 @@ import {
   useSelectBreadcrumbItems,
 } from './hooks';
 
+import { useSelectParentFolderList } from '@/hooks/fileManagerHooks';
 import styles from './index.less';
 
 interface IProps {
@@ -46,7 +47,9 @@ const FileToolbar = ({
   const { handleInputChange, searchString } = useHandleSearchChange();
   const breadcrumbItems = useSelectBreadcrumbItems();
   const { handleBreadcrumbClick } = useHandleBreadcrumbClick();
-  const isKnowledgeBase = breadcrumbItems.at(-1)?.title === '.knowledgebase';
+  const parentFolderList = useSelectParentFolderList();
+  const isKnowledgeBase =
+    parentFolderList.at(-1)?.source_type === 'knowledgebase';
 
   const itemRender: BreadcrumbProps['itemRender'] = (
     currentRoute,


### PR DESCRIPTION
### What problem does this PR solve?

#764 fix: hide the add button when the folder is a knowledge base

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

