### PR TITLE
Fix a bug in 'assistant-setting.tsx' that causes the upload button to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Cargo.lock
 docker/ragflow-logs/
 /flask_session
 /logs
+rag/res/deepdoc

--- a/web/src/pages/chat/chat-configuration-modal/assistant-setting.tsx
+++ b/web/src/pages/chat/chat-configuration-modal/assistant-setting.tsx
@@ -22,6 +22,15 @@ const AssistantSetting = ({ show }: ISegmentedContentProps) => {
     return e?.fileList;
   };
 
+  const uploadButtion = (
+    <button style={{ border: 0, background: 'none' }} type="button">
+            <PlusOutlined />
+            <div style={{ marginTop: 8 }}>
+              {t('upload', { keyPrefix: 'common' })}
+            </div>
+          </button>
+  )
+
   return (
     <section
       className={classNames({
@@ -46,12 +55,7 @@ const AssistantSetting = ({ show }: ISegmentedContentProps) => {
           maxCount={1}
           showUploadList={{ showPreviewIcon: false, showRemoveIcon: false }}
         >
-          <button style={{ border: 0, background: 'none' }} type="button">
-            <PlusOutlined />
-            <div style={{ marginTop: 8 }}>
-              {t('upload', { keyPrefix: 'common' })}
-            </div>
-          </button>
+          {show ? uploadButtion : null}
         </Upload>
       </Form.Item>
       <Form.Item


### PR DESCRIPTION
… incorrectly appear on the model settings page.

### What problem does this PR solve?

This is an issue with the Upload component on the assistant-setting page. I use the show variable to explicitly control the button component within it.

see:
![20240516000417](https://github.com/infiniflow/ragflow/assets/37476944/de88f911-6dbd-412d-a981-86cf60aa2257)


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):  Add the local models that DeepDoc depends on to the gitignore file in dev mode.
