### PR TITLE
fixbug for computing 'not concating feature'

### DIFF
--- a/deepdoc/parser/pdf_parser.py
+++ b/deepdoc/parser/pdf_parser.py
@@ -396,7 +396,7 @@ class RAGFlowPdfParser:
             ]
             # features for not concating
             feats = [
-                b.get("layoutno", 0) != b.get("layoutno", 0),
+                b.get("layoutno", 0) != b_.get("layoutno", 0),
                 b["text"].strip()[-1] in "。？！?",
                 self.is_english and b["text"].strip()[-1] in ".!?",
                 b["page_number"] == b_["page_number"] and b_["top"] -


### PR DESCRIPTION
### What problem does this PR solve?

When pdfparser call `_naive_vertical_merge` method，there is a "not concating feature " value  by computing difference between `b` and `b_`'s layoutno ,but actually is `b` and `b`. I think it's a bug, so fix it. Please check again.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
