### PR TITLE
Fix:After being idle for a while, new tasks need to be cancel and redo

### DIFF
--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -117,7 +117,7 @@ class RedisDB:
                 self.REDIS.xgroup_create(
                     queue_name,
                     group_name,
-                    id="$",
+                    id="0",
                     mkstream=True
                 )
             args = {


### PR DESCRIPTION
### What problem does this PR solve?

After being idle for a while (When Redis Queue exceeds the SVR_QUEUE_RETENTION(60*60) expiration time), new tasks need to be cancel and redo.

When use xgroup_create to create a consumer group, set the ID to "$", meaning that only messages added to the stream after the group is created will be visible to new consumers. If the application scenario requires processing messages that already exist in the queue, you might need to change this ID to "0", so that the new consumer group can read all messages from the beginning.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

