### PR TITLE
fix: the length of the merged chunk can exceed chunk_token_num

### DIFF
--- a/rag/nlp/__init__.py
+++ b/rag/nlp/__init__.py
@@ -472,8 +472,7 @@ def naive_merge(sections, chunk_token_num=128, delimiter="\n。；！？"):
         if tnum < 8:
             pos = ""
         # Ensure that the length of the merged chunk does not exceed chunk_token_num  
-        if tk_nums[-1] > chunk_token_num:
-
+        if tk_nums[-1] + tnum > chunk_token_num:
             if t.find(pos) < 0:
                 t += pos
             cks.append(t)


### PR DESCRIPTION
### What problem does this PR solve?
Suppose：
    chunk1.tnum=3
    chunk2.tnum=3
    chunk_token_num=5
current result：because: chunk1.tnum<= chunk_token_num, so: chunk1 chunk2 was merged.
BUT actually chunk2 should not be merged to chunk1, becasue 3+3 > 5.
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
