### PR TITLE
feat: deleting a node does not require a confirmation box to pop up #918

### DIFF
--- a/web/src/components/operate-dropdown/index.tsx
+++ b/web/src/components/operate-dropdown/index.tsx
@@ -11,6 +11,7 @@ interface IProps {
   iconFontSize?: number;
   items?: MenuProps['items'];
   height?: number;
+  needsDeletionValidation?: boolean;
 }
 
 const OperateDropdown = ({
@@ -19,12 +20,17 @@ const OperateDropdown = ({
   iconFontSize = 30,
   items: otherItems = [],
   height = 24,
+  needsDeletionValidation = true,
 }: React.PropsWithChildren<IProps>) => {
   const { t } = useTranslation();
   const showDeleteConfirm = useShowDeleteConfirm();
 
   const handleDelete = () => {
-    showDeleteConfirm({ onOk: deleteItem });
+    if (needsDeletionValidation) {
+      showDeleteConfirm({ onOk: deleteItem });
+    } else {
+      deleteItem();
+    }
   };
 
   const handleDropdownMenuClick: MenuProps['onClick'] = ({ domEvent, key }) => {

--- a/web/src/pages/flow/canvas/node/dropdown.tsx
+++ b/web/src/pages/flow/canvas/node/dropdown.tsx
@@ -41,6 +41,7 @@ const NodeDropdown = ({ id }: IProps) => {
       height={14}
       deleteItem={deleteNode}
       items={items}
+      needsDeletionValidation={false}
     ></OperateDropdown>
   );
 };


### PR DESCRIPTION
### What problem does this PR solve?

feat: deleting a node does not require a confirmation box to pop up #918

### Type of change


- [x] New Feature (non-breaking change which adds functionality)

