### PR TITLE
fix: Fix dead code in device selection logic for InferenceSession

### DIFF
--- a/deepdoc/vision/ocr.py
+++ b/deepdoc/vision/ocr.py
@@ -70,7 +70,7 @@ def load_model(model_dir, nm):
     options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
     options.intra_op_num_threads = 2
     options.inter_op_num_threads = 2
-    if False and ort.get_device() == "GPU":
+    if ort.get_device() == "GPU":
         sess = ort.InferenceSession(
             model_file_path,
             options=options,


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes a dead code issue in the device selection logic for `InferenceSession`. The current condition `if False and ort.get_device() == "GPU":` will always evaluate to `False`, resulting in the `CUDAExecutionProvider` never being used, regardless of the device type. This PR corrects the condition to ensure that the `CUDAExecutionProvider` is used when the device is GPU, as intended. This change ensures that the model leverages the appropriate hardware for inference, improving performance when a GPU is available.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)