### PR TITLE
API doc: Correct Base URL and Dataset URL.

### DIFF
--- a/docs/references/ragflow_api.md
+++ b/docs/references/ragflow_api.md
@@ -8,12 +8,12 @@ RAGFlow offers RESTful APIs for you to integrate its capabilities into third-par
 
 ## Base URL
 ```
-http://<host_address>/api/v1/
+http://<host_address>/v1/api/
 ```
 
 ## Dataset URL
 ```
-http://<host_address>/api/v1/dataset
+http://<host_address>/v1/api/dataset
 ```
 
 ## Authorization

--- a/docs/references/ragflow_api.md
+++ b/docs/references/ragflow_api.md
@@ -13,7 +13,7 @@ http://<host_address>/v1/api/
 
 ## Dataset URL
 ```
-http://<host_address>/v1/api/dataset
+http://<host_address>/api/v1/dataset
 ```
 
 ## Authorization


### PR DESCRIPTION
The correct URL is http://<host_address>/v1/api , not http://<host_address>/api/v1 .

### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
