### PR TITLE
Update the Dockerfile.cuda

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -15,6 +15,7 @@ ADD ./api ./api
 ADD ./conf ./conf
 ADD ./deepdoc ./deepdoc
 ADD ./rag ./rag
+ADD ./graph ./graph
 
 ENV PYTHONPATH=/ragflow/
 ENV HF_ENDPOINT=https://hf-mirror.com

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -4,8 +4,8 @@ USER  root
 WORKDIR /ragflow
 
 ## for cuda > 12.0
-RUN /root/miniconda3/envs/py11/bin/pip uninstall -y onnxruntime-gpu
-RUN /root/miniconda3/envs/py11/bin/pip install onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
+RUN pip uninstall -y onnxruntime-gpu
+RUN pip install onnxruntime-gpu --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
 
 
 ADD ./web ./web


### PR DESCRIPTION
Fix the `Dockerfile.cuda`, as the `/root/miniconda3/envs/py11/bin/pip` is not found in the base images.

### What problem does this PR solve?

`/root/miniconda3/envs/py11/bin/pip` is not found in the base images.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
