### PR TITLE
modify the encryption to first perform base64 encoding and then encrypt

### DIFF
--- a/api/utils/t_crypt.py
+++ b/api/utils/t_crypt.py
@@ -11,10 +11,11 @@ def crypt(line):
         file_utils.get_project_base_directory(),
         "conf",
         "public.pem")
-    rsa_key = RSA.importKey(open(file_path).read())
+    rsa_key = RSA.importKey(open(file_path).read(),"Welcome")
     cipher = Cipher_pkcs1_v1_5.new(rsa_key)
-    return base64.b64encode(cipher.encrypt(
-        line.encode('utf-8'))).decode("utf-8")
+    password_base64 = base64.b64encode(line.encode('utf-8')).decode("utf-8")
+    encrypted_password = cipher.encrypt(password_base64.encode())
+    return base64.b64encode(encrypted_password).decode('utf-8')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What problem does this PR solve?

The encryption should first perform base64 encoding and then encrypt, to maintain consistency with the frontend

#1620 

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
