### PR TITLE
fix(api): ensure non-empty references in conversation chunks

### DIFF
--- a/api/apps/api_app.py
+++ b/api/apps/api_app.py
@@ -232,9 +232,10 @@ def completion():
                 API4ConversationService.append_message(conv.id, conv.to_dict())
                 break
 
-            for chunk_i in answer['reference'].get('chunks',[]):
-                chunk_i['doc_name'] = chunk_i['docnm_kwd']
-                chunk_i.pop('docnm_kwd')
+            if answer['reference'] is not None and (len(answer['reference']) > 0):
+                for chunk_i in answer['reference'].get('chunks', []):
+                    chunk_i['doc_name'] = chunk_i['docnm_kwd']
+                    chunk_i.pop('docnm_kwd')
 
             return get_json_result(data=answer)
 
@@ -252,6 +253,8 @@ def get(conversation_id):
 
         conv = conv.to_dict()
         for referenct_i in conv['reference']:
+            if referenct_i is None or len(referenct_i) == 0:
+                continue
             for chunk_i in referenct_i['chunks']:
                 if 'docnm_kwd' in chunk_i.keys():
                     chunk_i['doc_name'] = chunk_i['docnm_kwd']


### PR DESCRIPTION
Verify that 'reference' is not None and its length is greater than 0 before processing chunks in API4ConversationService. This prevents potential errors when 'reference' is missing or empty.

### What problem does this PR solve?

Verify that 'reference' is not None and its length is greater than 0 before processing chunks in API4ConversationService. This prevents potential errors when 'reference' is missing or empty.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
