### PR TITLE
fix: Unable to create a new chat assistant after closing the edit modal #1833

### DIFF
--- a/web/src/pages/chat/hooks.ts
+++ b/web/src/pages/chat/hooks.ts
@@ -244,15 +244,20 @@ export const useEditDialog = () => {
     showModal: showDialogEditModal,
   } = useSetModalState();
 
+  const hideModal = useCallback(() => {
+    setDialog({} as IDialog);
+    hideDialogEditModal();
+  }, [hideDialogEditModal]);
+
   const onDialogEditOk = useCallback(
     async (dialog: IDialog) => {
       const ret = await submitDialog(dialog);
 
       if (ret === 0) {
-        hideDialogEditModal();
+        hideModal();
       }
     },
-    [submitDialog, hideDialogEditModal],
+    [submitDialog, hideModal],
   );
 
   const handleShowDialogEditModal = useCallback(
@@ -277,7 +282,7 @@ export const useEditDialog = () => {
     initialDialog: dialog,
     onDialogEditOk,
     dialogEditVisible,
-    hideDialogEditModal,
+    hideDialogEditModal: hideModal,
     showDialogEditModal: handleShowDialogEditModal,
     clearDialog,
   };


### PR DESCRIPTION

### What problem does this PR solve?

fix: Unable to create a new chat assistant after closing the edit modal #1833

### Type of change


- [x] New Feature (non-breaking change which adds functionality)

