### PR TITLE
fix: Entity types are only displayed when the knowledge graph is selected #1594

### DIFF
--- a/web/src/pages/add-knowledge/components/knowledge-setting/configuration.tsx
+++ b/web/src/pages/add-knowledge/components/knowledge-setting/configuration.tsx
@@ -98,13 +98,16 @@ const ConfigurationForm = ({ form }: { form: FormInstance }) => {
           ))}
         </Select>
       </Form.Item>
-      <EntityTypesItem></EntityTypesItem>
+
       <Form.Item noStyle dependencies={['parser_id']}>
         {({ getFieldValue }) => {
           const parserId = getFieldValue('parser_id');
 
           return (
             <>
+              {parserId === 'knowledge_graph' && (
+                <EntityTypesItem></EntityTypesItem>
+              )}
               {parserId === 'naive' && (
                 <>
                   <MaxTokenNumber></MaxTokenNumber>


### PR DESCRIPTION


### What problem does this PR solve?

fix: Entity types are only displayed when the knowledge graph is selected #1594

### Type of change


- [x] New Feature (non-breaking change which adds functionality)

