### PR TITLE
fix: Fix return type annotation in truncate function

### DIFF
--- a/rag/utils/__init__.py
+++ b/rag/utils/__init__.py
@@ -85,6 +85,6 @@ def num_tokens_from_string(string: str) -> int:
     return 0
 
 
-def truncate(string: str, max_len: int) -> int:
+def truncate(string: str, max_len: int) -> str:
     """Returns truncated text if the length of text exceed max_len."""
     return encoder.decode(encoder.encode(string)[:max_len])


### PR DESCRIPTION
### What problem does this PR solve?

Fix return type annotation in truncate function

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
