### PR TITLE
fix: empty or contains only empty strings.

### DIFF
--- a/agent/component/retrieval.py
+++ b/agent/component/retrieval.py
@@ -76,7 +76,8 @@ class Retrieval(ComponentBase, ABC):
 
         if not kbinfos["chunks"]:
             df = Retrieval.be_output("")
-            df["empty_response"] = self._param.empty_response
+            if self._param.empty_response and self._param.empty_response.strip():
+                df["empty_response"] = self._param.empty_response
             return df
 
         df = pd.DataFrame(kbinfos["chunks"])


### PR DESCRIPTION
### What problem does this PR solve?
the setting was kept empty for Empty_response. In expectation, this case should get a response from the LLM if can't find the references from the knowledgebase.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

![image](https://github.com/user-attachments/assets/9c382b1d-40f6-43b0-848c-fa6863f9a253)
![image](https://github.com/user-attachments/assets/032d2001-97a2-4faa-91bf-c9c57caf2070)
