### PR TITLE
Add Multi-Language Descriptions for 'Switch' Component and Update Message Assistant Placeholder

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -329,7 +329,7 @@ The above is the content you need to summarize.`,
       chat: 'Chat',
       newChat: 'New chat',
       send: 'Send',
-      sendPlaceholder: 'Message Resume Assistant...',
+      sendPlaceholder: 'Message the Assistant...',
       chatConfiguration: 'Chat Configuration',
       chatConfigurationDescription:
         ' Here, dress up a dedicated assistant for your special knowledge bases! 💕',
@@ -659,6 +659,7 @@ The above is the content you need to summarize.`,
       messageDescription:
         "A component that sends out a static message. If multiple messages are supplied, it randomly selects one to send. Ensure its downstream is 'Answer', the interface component.",
       keywordDescription: `A component that retrieves top N search results from user's input. Ensure the TopN value is set properly before use.`,
+      switchDescription: `A component that evaluates conditions based on the output of previous components and directs the flow of execution accordingly. It allows for complex branching logic by defining cases and specifying actions for each case or default action if no conditions are met.`,
       wikipediaDescription: `This component is used to get search result from wikipedia.org. Typically, it performs as a supplement to knowledgebases. Top N specifies the number of search results you need to adapt.`,
       promptText: `Please summarize the following paragraphs. Be careful with the numbers, do not make things up. Paragraphs as following:
         {input}

--- a/web/src/locales/zh-traditional.ts
+++ b/web/src/locales/zh-traditional.ts
@@ -616,6 +616,7 @@ export default {
       messageDescription:
         '此元件用於向使用者發送靜態訊息。您可以準備幾條訊息，這些訊息將隨機選擇。',
       keywordDescription: `該組件用於從用戶的問題中提取關鍵字。 Top N指定需要提取的關鍵字數量。`,
+      switchDescription: `該組件用於根據前面組件的輸出評估條件，並相應地引導執行流程。通過定義各種情況並指定操作，或在不滿足條件時採取默認操作，實現複雜的分支邏輯。`,
       wikipediaDescription: `此元件用於從 https://www.wikipedia.org/ 取得搜尋結果。通常，它作為知識庫的補充。 Top N 指定您需要調整的搜尋結果數。`,
       promptText: `請總結以下段落。注意數字，不要胡編亂造。段落如下：
 {input}

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -634,6 +634,7 @@ export default {
       messageDescription:
         '此组件用于向用户发送静态信息。您可以准备几条消息，这些消息将被随机选择。',
       keywordDescription: `该组件用于从用户的问题中提取关键词。Top N指定需要提取的关键词数量。`,
+      switchDescription: `该组件用于根据前面组件的输出评估条件，并相应地引导执行流程。通过定义各种情况并指定操作，或在不满足条件时采取默认操作，实现复杂的分支逻辑。`,
       wikipediaDescription: `此组件用于从 https://www.wikipedia.org/ 获取搜索结果。通常，它作为知识库的补充。Top N 指定您需要调整的搜索结果数量。`,
       promptText: `请总结以下段落。注意数字，不要胡编乱造。段落如下：
 {input}


### PR DESCRIPTION
### What problem does this PR solve?

_This PR addresses the need to describe the "Switch" component across different languages and corrects a misleading description for a placeholder message not exclusively tied to a specific assistant type. By providing clearer and more accurate descriptions, this PR aims to improve user understanding and usability of the Switch component and the "Message Resume Assistant..." placeholder in a multilingual context._

### Explanation of Changes

1. **Added Descriptions for "Switch" Component**: 
   - Descriptions were added for the "Switch" component in three different locales:
     - **English (EN)**: Provides a concise description of what the "Switch" component does, focusing on its ability to evaluate conditions and direct the flow of execution.
     - **Simplified Chinese (ZH)**: Translated the English description into Simplified Chinese to cater to users who prefer this locale.
     - **Traditional Chinese (ZH-Traditional)**: Added a Traditional Chinese version of the description to support users in regions that use Traditional Chinese.
   
2. **Corrected "Message Resume Assistant..." to "Message the Assistant..."**:
   - Updated the description from "Message Resume Assistant..." to "Message the Assistant..." in the English locale. This correction makes the description more generic and accurate, reflecting the placeholder's broader functionality, which is not limited to Resume Assistants. It now clearly communicates that the placeholder can be used with various types of assistants, not just those related to resumes.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
