### PR TITLE
Bug fix - email processing could be run now from API

### DIFF
--- a/api/apps/api_app.py
+++ b/api/apps/api_app.py
@@ -454,6 +454,8 @@ def upload():
             doc["parser_id"] = ParserType.AUDIO.value
         if re.search(r"\.(ppt|pptx|pages)$", filename):
             doc["parser_id"] = ParserType.PRESENTATION.value
+        if re.search(r"\.(eml)$", filename):
+            doc["parser_id"] = ParserType.EMAIL.value
 
         doc_result = DocumentService.insert(doc)
         FileService.add_file_from_kb(doc, kb_folder["id"], kb.tenant_id)


### PR DESCRIPTION
### What problem does this PR solve?

If .eml file is uploaded, there is always General method chosen for email processing, even if parsing_method is defined in the request. This change solves this issue.

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
