### PR TITLE
fix: Search page search results are cleared after output #2677

### DIFF
--- a/web/src/pages/search/hooks.ts
+++ b/web/src/pages/search/hooks.ts
@@ -94,9 +94,6 @@ export const useSendQuestion = (kbIds: string[]) => {
     if (!isEmpty(answer)) {
       setCurrentAnswer(answer);
     }
-    return () => {
-      setCurrentAnswer({} as IAnswer);
-    };
   }, [answer]);
 
   useEffect(() => {


### PR DESCRIPTION
### What problem does this PR solve?

fix: Search page search results are cleared after output #2677

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
