### PR TITLE
docs: Migrate README to Compose V2 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ To update the default HTTP serving port (80), go to [docker-compose.yml](./docke
 Updates to the above configurations require a reboot of all containers to take effect:
 
 > ```bash
-> $ docker-compose -f docker/docker-compose.yml up -d
+> $ docker compose -f docker/docker-compose.yml up -d
 > ```
 
 ## 🔧 Build a Docker image without embedding models

--- a/README_ja.md
+++ b/README_ja.md
@@ -192,7 +192,7 @@
 > すべてのシステム設定のアップデートを有効にするには、システムの再起動が必要です:
 >
 > ```bash
-> $ docker-compose up -d
+> $ docker compose -f docker/docker-compose.yml up -d
 > ```
 
 ## 🔧 ソースコードでDockerイメージを作成（埋め込みモデルなし）

--- a/README_ko.md
+++ b/README_ko.md
@@ -194,7 +194,7 @@
 > 모든 시스템 구성 업데이트는 적용되기 위해 시스템 재부팅이 필요합니다.
 >
 > ```bash
-> $ docker-compose up -d
+> $ docker compose -f docker/docker-compose.yml up -d
 > ```
 
 ## 🔧 소스 코드로 Docker 이미지를 컴파일합니다(임베딩 모델 포함하지 않음)


### PR DESCRIPTION
### What problem does this PR solve?

This PR updates README to reflect the migration from Compose V1 (`docker-compose`) to Compose V2 (`docker compose`):

### Type of change

- [x] Documentation Update

### Source

The migration details and differences between Compose V1 and Compose V2 are based on the official Docker documentation:  
[Docker Docs: Migrate to Compose V2](https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2)
