### PR TITLE
feat: The same query conditions on the search page should not request the interface every time the mind map drawer is opened. #2759

### DIFF
--- a/web/src/pages/search/hooks.ts
+++ b/web/src/pages/search/hooks.ts
@@ -7,7 +7,7 @@ import {
 } from '@/hooks/logic-hooks';
 import { IAnswer } from '@/interfaces/database/chat';
 import api from '@/utils/api';
-import { get, isEmpty, trim } from 'lodash';
+import { get, isEmpty, isEqual, trim } from 'lodash';
 import {
   ChangeEventHandler,
   useCallback,
@@ -188,6 +188,7 @@ export const useTestRetrieval = (
 
 export const useShowMindMapDrawer = (kbIds: string[], question: string) => {
   const { visible, showModal, hideModal } = useSetModalState();
+  const ref = useRef<any>();
 
   const {
     fetchMindMap,
@@ -196,7 +197,14 @@ export const useShowMindMapDrawer = (kbIds: string[], question: string) => {
   } = useFetchMindMap();
 
   const handleShowModal = useCallback(() => {
-    fetchMindMap({ question: trim(question), kb_ids: kbIds });
+    const searchParams = { question: trim(question), kb_ids: kbIds };
+    if (
+      !isEmpty(searchParams.question) &&
+      !isEqual(searchParams, ref.current)
+    ) {
+      ref.current = searchParams;
+      fetchMindMap(searchParams);
+    }
     showModal();
   }, [fetchMindMap, showModal, question, kbIds]);
 


### PR DESCRIPTION


### What problem does this PR solve?

feat: The same query conditions on the search page should not request the interface every time the mind map drawer is opened. #2759

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
