### PR TITLE
fix: Fail to access model(xxxxx).'results'

### DIFF
--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -155,7 +155,7 @@ class YoudaoRerank(DefaultRerank):
 class XInferenceRerank(Base):
     def __init__(self, key="xxxxxxx", model_name="", base_url=""):
         if base_url.split("/")[-1] != "v1":
-            base_url = os.path.join(base_url, "v1")
+            base_url = os.path.join(base_url, "v1/rerank")
         self.model_name = model_name
         self.base_url = base_url
         self.headers = {


### PR DESCRIPTION
### What problem does this PR solve?

fix bug: Xinference rerank model base_url should be  'http://<XINFERENCE_HOST>:<XINFERENCE_PORT>/v1/rerank'

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
