### PR TITLE
Enhance email validation: Allow top-level domains with 5 letters

### DIFF
--- a/api/apps/user_app.py
+++ b/api/apps/user_app.py
@@ -354,7 +354,7 @@ def user_add():
     email_address = req["email"]
 
     # Validate the email address
-    if not re.match(r"^[\w\._-]+@([\w_-]+\.)+[\w-]{2,4}$", email_address):
+    if not re.match(r"^[\w\._-]+@([\w_-]+\.)+[\w-]{2,5}$", email_address):
         return get_json_result(data=False,
                                retmsg=f'Invalid email address: {email_address}!',
                                retcode=RetCode.OPERATING_ERROR)


### PR DESCRIPTION

### What problem does this PR solve?

Currently singing up to ragflow using a mail-adress with associated top-level domains that have more than 4 chars will fail due to a regex validation that enforces just this.

In our use case, we'd like to use e-mail addresses with `.swiss` top-level domains, which is a valid TLD associated with the country switzerland in the IANA root database.

This change makes the validation accept 5-letter TLDs.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): Making validation for lenient, accepting more valid input.
