### PR TITLE
allowing docker container to access service on host

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -46,7 +46,7 @@ services:
     ports:
       - ${MYSQL_PORT}:3306
     volumes:
-      - ./mysql_data:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
       - ./init.sql:/data/application/init.sql
     networks:
       - ragflow

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -46,7 +46,7 @@ services:
     ports:
       - ${MYSQL_PORT}:3306
     volumes:
-      - mysql_data:/var/lib/mysql
+      - ./mysql_data:/var/lib/mysql
       - ./init.sql:/data/application/init.sql
     networks:
       - ragflow

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,3 +29,5 @@ services:
     networks:
       - ragflow
     restart: always
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
### What problem does this PR solve?

1. The mysql_data path mapping in docker-compose-base.yml does not use local path,
making mysql container unable to start, 44a91525ac96a86ee02e95d1f5c383b3a94b9455 fixes it.
2. services running (e.g., ollama) running on the host could not be accessed from docker containers

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
