### PR TITLE
add nginx path for sdk handlers (#2899)

### DIFF
--- a/docker/nginx/ragflow.conf
+++ b/docker/nginx/ragflow.conf
@@ -10,7 +10,7 @@ server {
     gzip_vary on;
     gzip_disable "MSIE [1-6]\.";
 
-    location /v1 {
+    location ~ ^/(v1|api) {
         proxy_pass http://ragflow:9380;
         include proxy.conf;
     }


### PR DESCRIPTION
### What problem does this PR solve?

add the nginx path `/api` for sdk handlers 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
