### PR TITLE
[Bug]: When use OpenAI chat model , raise ERROR: 'CompletionUsage' object has no attribute 'get' #2948

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -73,7 +73,7 @@ class Base(ABC):
                             + num_tokens_from_string(resp.choices[0].delta.content)
                     )
                     if not hasattr(resp, "usage") or not resp.usage
-                    else resp.usage.get("total_tokens", total_tokens)
+                    else dict(resp.usage).get('total_tokens', total_tokens)
                 )
                 if resp.choices[0].finish_reason == "length":
                     ans += "...\nFor the content length reason, it stopped, continue?" if is_english(


### PR DESCRIPTION
[Bug]: When use OpenAI chat model , raise ERROR: 'CompletionUsage' object has no attribute 'get' #2948

### What problem does this PR solve?

the detail of this PR is shown at https://github.com/infiniflow/ragflow/issues/2948

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)