### PR TITLE
Fix non-null violation when inviting people to team

### DIFF
--- a/api/apps/tenant_app.py
+++ b/api/apps/tenant_app.py
@@ -57,6 +57,7 @@ def create(tenant_id):
         id=get_uuid(),
         user_id=user_id,
         tenant_id=tenant_id,
+        invited_by=current_user.id,
         role=UserTenantRole.INVITE,
         status=StatusEnum.VALID.value)
 


### PR DESCRIPTION

### What problem does this PR solve?

Not sure why MySQL is inserting empty string in this case, but when I use postgres I got `null value in column "invited_by" of relation "user_tenant" violates not-null constraint`

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
