### PR TITLE
fix: TypeError: only length-1 arrays can be converted to Python scalars

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -558,7 +558,7 @@ class CoHereEmbed(Base):
             input_type="search_query",
             embedding_types=["float"],
         )
-        return res.embeddings.float[0], int(
+        return np.array(res.embeddings.float[0]), int(
             res.meta.billed_units.input_tokens
         )
 

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -558,7 +558,7 @@ class CoHereEmbed(Base):
             input_type="search_query",
             embedding_types=["float"],
         )
-        return np.array([d for d in res.embeddings.float]), int(
+        return res.embeddings.float[0], int(
             res.meta.billed_units.input_tokens
         )
 


### PR DESCRIPTION
### What problem does this PR solve?
fix "TypeError: only length-1 arrays can be converted to Python scalars" while using cohere embedding model.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)

![image](https://github.com/user-attachments/assets/2c21a69f-cd76-4d25-b320-058964812db8)
