### PR TITLE
fix: standardize property name from 'chat' to 'chat_id'

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -387,7 +387,7 @@ def list(chat_id,tenant_id):
         for info in infos:
             if "prompt" in info:
                 info.pop("prompt")
-        conv["chat"] = conv.pop("dialog_id")
+        conv["chat_id"] = conv.pop("dialog_id")
         if conv["reference"]:
             messages = conv["messages"]
             message_num = 0


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses the inconsistency in property naming within the codebase by renaming the 'chat' property to 'chat_id' in the session.py file. This change aims to align the naming convention with other parts of the application that refer to chat identifiers as 'chat_id', thereby improving code clarity and maintainability.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
