### PR TITLE
fix duplicate task consumption bug in multi-task executor runs

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -113,9 +113,8 @@ def set_progress(task_id, from_page=0, to_page=-1, prog=None, msg="Processing...
 def collect():
     global CONSUMER_NAME, PAYLOAD
     try:
-        PAYLOAD = REDIS_CONN.get_unacked_for(CONSUMER_NAME, SVR_QUEUE_NAME, "rag_flow_svr_task_broker")
-        if not PAYLOAD:
-            PAYLOAD = REDIS_CONN.queue_consumer(SVR_QUEUE_NAME, "rag_flow_svr_task_broker", CONSUMER_NAME)
+        PAYLOAD = REDIS_CONN.queue_consumer(SVR_QUEUE_NAME, "rag_flow_svr_task_broker", CONSUMER_NAME)
+        
         if not PAYLOAD:
             time.sleep(1)
             return pd.DataFrame()


### PR DESCRIPTION
### What problem does this PR solve?

REDIS_CONN.get_unacked_for causes duplicate task handling in multi-consumer mode. Use REDIS_CONN.queue_consumer to ensure mutually-exclusive task processing.

After change:
executor-task-0:
![image](https://github.com/user-attachments/assets/f3e9cf53-172e-4763-94e4-cf30ada3c0d0)

executor-task-1:
![image](https://github.com/user-attachments/assets/13bdb240-2455-4fc7-9801-013bc5730353)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
