### PR TITLE
fix(rag): fix error in viewing document chunk and cannot start task_executor server

### DIFF
--- a/graphrag/graph_extractor.py
+++ b/graphrag/graph_extractor.py
@@ -9,7 +9,7 @@ import logging
 import numbers
 import re
 import traceback
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 from dataclasses import dataclass
 import tiktoken
 from graphrag.graph_prompt import GRAPH_EXTRACTION_PROMPT, CONTINUE_PROMPT, LOOP_PROMPT

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -61,7 +61,7 @@ class Dealer:
                 condition[key] = req[key]
         return condition
 
-    def search(self, req, idx_names: list[str], kb_ids: list[str], emb_mdl=None, highlight = False):
+    def search(self, req, idx_names: str | list[str], kb_ids: list[str], emb_mdl=None, highlight = False):
         filters = self.get_filters(req)
         orderBy = OrderByExpr()
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix error in viewing document chunk
￼
<img width="1677" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/acd84cde-f38c-4190-b135-5e5139ae2613">

Viewing document chunk details in a BeartypeCallHintParamViolation error.

Traceback (most recent call last):
  File "ragflow/.venv/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "ragflow/.venv/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ragflow/.venv/lib/python3.12/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ragflow/api/apps/chunk_app.py", line 311, in knowledge_graph
    sres = settings.retrievaler.search(req, search.index_name(tenant_id), kb_ids)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<@beartype(rag.nlp.search.Dealer.search) at 0x3381fd800>", line 39, in search
beartype.roar.BeartypeCallHintParamViolation: Method rag.nlp.search.Dealer.search() parameter idx_names='ragflow_0e1e67f431d711ef98fc00155d29195d' violates type hint list[str], as str 'ragflow_0e1e67f431d711ef98fc00155d29195d' not instance of list.
2024-11-19 11:30:29,817 ERROR    91013 Method rag.nlp.search.Dealer.search() parameter idx_names='ragflow_0e1e67f431d711ef98fc00155d29195d' violates type hint list[str], as str 'ragflow_0e1e67f431d711ef98fc00155d29195d' not instance of list.
Traceback (most recent call last):
  File "ragflow/api/apps/chunk_app.py", line 60, in list_chunk
    sres = settings.retrievaler.search(query, search.index_name(tenant_id), kb_ids, highlight=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<@beartype(rag.nlp.search.Dealer.search) at 0x3381fd800>", line 39, in search
beartype.roar.BeartypeCallHintParamViolation: Method rag.nlp.search.Dealer.search() parameter idx_names='ragflow_0e1e67f431d711ef98fc00155d29195d' violates type hint list[str], as str 'ragflow_0e1e67f431d711ef98fc00155d29195d' not instance of list.


because in nlp/search.py,the idx_names is only list
￼
<img width="1098" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/4998cb1e-94bc-470b-b2f4-41ecb5b08f8a">

but the DocStoreConnection.search method accept list or str
<img width="1175" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/ee918b4a-87a5-42c9-a6d2-d0db0884b875">

￼
and his implements also list and str
es_conn.py
￼
<img width="1121" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/3e6dc030-0a0d-416c-8fd4-0b4cfd576f8c">

infinity_conn.py
￼
<img width="1221" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/44edac2b-6b81-45b0-a3fc-cb1c63219015">

2. Fix cannot star task_executor server with Unresolved reference 'Mapping'
<img width="1283" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/421f17b8-d0a5-46d3-bc4d-d05dc9dfc934">

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
