### PR TITLE
[bug]import typing.cast for leiden.py

### DIFF
--- a/graphrag/leiden.py
+++ b/graphrag/leiden.py
@@ -7,7 +7,7 @@ Reference:
 
 import logging
 import html
-from typing import Any
+from typing import Any, cast
 from graspologic.partition import hierarchical_leiden
 from graspologic.utils import largest_connected_component
 


### PR DESCRIPTION
### What problem does this PR solve?

leiden alg throws exception for lack func cast definition

### Type of change

- Bug Fix (non-breaking change which fixes an issue)

