### PR TITLE
when qwen rerank model not return ok, raise exception to notice user

### DIFF
--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -452,4 +452,5 @@ class QWenRerank(Base):
             for r in resp.output.results:
                 rank[r.index] = r.relevance_score
             return rank, resp.usage.total_tokens
-        return rank, 0
+        else:
+            raise ValueError(f"Error calling QWenRerank model {self.model_name}: {resp.status_code} - {resp.text}")


### PR DESCRIPTION
### What problem does this PR solve?

When calling the Qwen rerank model, if the model does not return correctly, an exception should be raised to notify the user, rather than simply returning a value of 0, as this would be confusing to the user.
### Type of change          

- [x] New Feature (non-breaking change which adds functionality)

