### PR TITLE
Fix: The right coordinates of Categorize and Switch operators are misplaced #3868

### DIFF
--- a/web/src/components/editable-cell.tsx
+++ b/web/src/components/editable-cell.tsx
@@ -90,11 +90,7 @@ export const EditableCell: React.FC<EditableCellProps> = ({
         <Input ref={inputRef} onPressEnter={save} onBlur={save} />
       </Form.Item>
     ) : (
-      <div
-        className="editable-cell-value-wrap"
-        // style={{ paddingRight: 24 }}
-        onClick={toggleEdit}
-      >
+      <div onClick={toggleEdit} className="truncate">
         <Text>{children}</Text>
       </div>
     );

--- a/web/src/pages/flow/canvas/node/hooks.ts
+++ b/web/src/pages/flow/canvas/node/hooks.ts
@@ -35,7 +35,7 @@ export const useBuildCategorizeHandlePositions = ({
         list.push({
           text: x,
           idx,
-          top: idx === 0 ? 98 : list[idx - 1].top + 8 + 26,
+          top: idx === 0 ? 98 + 20 : list[idx - 1].top + 8 + 26,
         });
       });
 
@@ -71,7 +71,7 @@ export const useBuildSwitchHandlePositions = ({
     }> = [];
 
     [...conditions, ''].forEach((x, idx) => {
-      let top = idx === 0 ? 58 : list[idx - 1].top + 32; // case number (Case 1) height + flex gap
+      let top = idx === 0 ? 58 + 20 : list[idx - 1].top + 32; // case number (Case 1) height + flex gap
       if (idx - 1 >= 0) {
         const previousItems = conditions[idx - 1]?.items ?? [];
         if (previousItems.length > 0) {

--- a/web/src/pages/flow/canvas/node/relevant-node.tsx
+++ b/web/src/pages/flow/canvas/node/relevant-node.tsx
@@ -33,7 +33,7 @@ export function RelevantNode({ id, data, selected }: NodeProps<NodeData>) {
         isConnectable
         className={styles.handle}
         id={'yes'}
-        style={{ ...RightHandleStyle, top: 59 }}
+        style={{ ...RightHandleStyle, top: 57 + 20 }}
       ></Handle>
       <Handle
         type="source"
@@ -41,7 +41,7 @@ export function RelevantNode({ id, data, selected }: NodeProps<NodeData>) {
         isConnectable
         className={styles.handle}
         id={'no'}
-        style={{ ...RightHandleStyle, top: 112 }}
+        style={{ ...RightHandleStyle, top: 115 + 20 }}
       ></Handle>
       <NodeHeader
         id={id}


### PR DESCRIPTION
### What problem does this PR solve?

Fix: The right coordinates of Categorize and Switch operators are misplaced #3868

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)


