### PR TITLE
Disable SQL DB binlog in Helm chart

### DIFF
--- a/helm/templates/mysql.yaml
+++ b/helm/templates/mysql.yaml
@@ -55,6 +55,7 @@ spec:
           - --default-authentication-plugin=mysql_native_password
           - --tls_version=TLSv1.2,TLSv1.3
           - --init-file=/data/application/init.sql
+          - --disable-log-bin
         ports:
           - containerPort: 3306
             name: mysql


### PR DESCRIPTION
### What problem does this PR solve?

The initial Helm chart implementation added in #3815 suffers from an issue where the 5GB data volume for the SQL DB is filled up with [binlog](https://dev.mysql.com/doc/refman/8.4/en/binary-log.html) files after just a few days. Since the app uses a non-replicated SQL DB config I think it makes sense to disable the binlog in the SQL DB container. This is achieved by simply adding the required argument to the container startup command.

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
