### PR TITLE
Use s3 configuration from settings module

### DIFF
--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -6,15 +6,17 @@ from botocore.client import Config
 import time
 from io import BytesIO
 from rag.utils import singleton
+from rag import settings
 
 @singleton
 class RAGFlowS3(object):
     def __init__(self):
         self.conn = None
-        self.endpoint = os.getenv('ENDPOINT', None)
-        self.access_key = os.getenv('ACCESS_KEY', None)
-        self.secret_key = os.getenv('SECRET_KEY', None)
-        self.region = os.getenv('REGION', None)
+        self.s3_config = settings.S3
+        self.endpoint = self.s3_config.get('endpoint', None)
+        self.access_key = self.s3_config.get('access_key', None)
+        self.secret_key = self.s3_config.get('secret_key', None)
+        self.region = self.s3_config.get('region', None)
         self.__open__()
 
     def __open__(self):


### PR DESCRIPTION
### What problem does this PR solve?

Fix the issue when retrieving AWS credentials from the S3 configuration from the settings module instead of getting from the environment variables.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
