### PR TITLE
fix: stop rerank by model when search result is empty

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -313,7 +313,7 @@ class Dealer:
         ranks["total"] = sres.total
 
         if page <= RERANK_PAGE_LIMIT:
-            if rerank_mdl:
+            if rerank_mdl and sres.total > 0:
                 sim, tsim, vsim = self.rerank_by_model(rerank_mdl,
                     sres, question, 1 - vector_similarity_weight, vector_similarity_weight)
             else:


### PR DESCRIPTION
### What problem does this PR solve?


stop rerank by model when search result is empty, otherwise rerank may raise an error (qwen).

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
