### PR TITLE
Support OpenAI gpt-4o and gpt-4o-mini for img2text

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -73,9 +73,15 @@
                     "model_type": "chat"
                 },
                 {
-                    "llm_name": "gpt-4-vision-preview",
+                    "llm_name": "gpt-4o-2024-08-06",
                     "tags": "LLM,CHAT,IMAGE2TEXT",
-                    "max_tokens": 765,
+                    "max_tokens": 128000,
+                    "model_type": "image2text"
+                },
+                 {
+                    "llm_name": "gpt-4o-mini-2024-07-18",
+                    "tags": "LLM,CHAT,IMAGE2TEXT",
+                    "max_tokens": 128000,
                     "model_type": "image2text"
                 },
                 {


### PR DESCRIPTION
### What problem does this PR solve?

OpenAI has deprecated the gpt-4-vision-preview model. This PR adds support for the newer gpt-4o and gpt-4o-mini models in the img2text feature.

![image](https://github.com/user-attachments/assets/6dddf2dc-1b9e-4e94-bf07-6bf77d39122b)

This PR add addtional 4o/4o-mini entry for img2text besides original ones. Utilized [alias](https://platform.openai.com/docs/models#gpt-4o) model names (e.g., gpt-4o-2024-08-06) because the database schema uses the model name as the primary key.



- [x] Other (please describe): model update
