### PR TITLE
Fix: Can not select GPT-4o / 4o mini as Chat Model #4421

### DIFF
--- a/web/src/pages/user-setting/setting-model/system-model-setting-modal/index.tsx
+++ b/web/src/pages/user-setting/setting-model/system-model-setting-modal/index.tsx
@@ -58,7 +58,13 @@ const SystemModelSettingModal = ({
           name="llm_id"
           tooltip={t('chatModelTip')}
         >
-          <Select options={allOptions[LlmModelType.Chat]} allowClear />
+          <Select
+            options={[
+              ...allOptions[LlmModelType.Chat],
+              ...allOptions[LlmModelType.Image2text],
+            ]}
+            allowClear
+          />
         </Form.Item>
         <Form.Item
           label={t('embeddingModel')}


### PR DESCRIPTION
### What problem does this PR solve?

Fix: Can not select GPT-4o / 4o mini as Chat Model #4421

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

