### PR TITLE
Remove use of eval() from ocr.py

### DIFF
--- a/deepdoc/vision/ocr.py
+++ b/deepdoc/vision/ocr.py
@@ -19,6 +19,7 @@ from huggingface_hub import snapshot_download
 
 from api.utils.file_utils import get_project_base_directory
 from .operators import *  # noqa: F403
+from . import operators
 import math
 import numpy as np
 import cv2
@@ -55,7 +56,7 @@ def create_operators(op_param_list, global_config=None):
         param = {} if operator[op_name] is None else operator[op_name]
         if global_config is not None:
             param.update(global_config)
-        op = eval(op_name)(**param)
+        op = getattr(operators, op_name)(**param)
         ops.append(op)
     return ops
 


### PR DESCRIPTION
`eval(op_name)` -> `getattr(operators, op_name)`

### What problem does this PR solve?

Using `eval()` can lead to code injections and is entirely unnecessary here.

### Type of change

- [x] Other (please describe):

Best practice code improvement, preventing the possibility of code injection.