### PR TITLE
Remove usage of eval() from postprocess.py

### DIFF
--- a/deepdoc/vision/postprocess.py
+++ b/deepdoc/vision/postprocess.py
@@ -23,7 +23,7 @@ import pyclipper
 
 
 def build_post_process(config, global_config=None):
-    support_dict = ['DBPostProcess', 'CTCLabelDecode']
+    support_dict = {'DBPostProcess': DBPostProcess, 'CTCLabelDecode': CTCLabelDecode}
 
     config = copy.deepcopy(config)
     module_name = config.pop('name')
@@ -31,10 +31,11 @@ def build_post_process(config, global_config=None):
         return
     if global_config is not None:
         config.update(global_config)
-    assert module_name in support_dict, Exception(
-        'post process only support {}'.format(support_dict))
-    module_class = eval(module_name)(**config)
-    return module_class
+    module_class = support_dict.get(module_name)
+    if module_class is None:
+        raise ValueError(
+            'post process only support {}'.format(list(support_dict)))
+    return module_class(**config)
 
 
 class DBPostProcess(object):


### PR DESCRIPTION
Remove usage of `eval()` from postprocess.py

### What problem does this PR solve?

The use of `eval()` is a potential security risk. While the use of `eval()` is guarded and thus not a security risk normally, `assert`s aren't run if `-O` or `-OO` is passed to the interpreter, and as such then the guard would not apply.  In any case there is no reason to use `eval()` here at all.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

Potential security fix if somehow the passed `modul_name` could be user controlled.