### PR TITLE
Fix: Capture the problem that the knowledge graph interface returns null and causes page errors #4543

### DIFF
--- a/web/src/pages/add-knowledge/components/knowledge-sidebar/index.tsx
+++ b/web/src/pages/add-knowledge/components/knowledge-sidebar/index.tsx
@@ -79,7 +79,7 @@ const KnowledgeSidebar = () => {
       ),
     ];
 
-    if (!isEmpty(data.graph)) {
+    if (!isEmpty(data?.graph)) {
       list.push(
         getItem(
           KnowledgeRouteKey.KnowledgeGraph,


### PR DESCRIPTION


### What problem does this PR solve?

Fix: Capture the problem that the knowledge graph interface returns null and causes page errors #4543

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

