### PR TITLE
fix: err object has no attribute 'iter_lines'

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -1358,7 +1358,7 @@ class AnthropicChat(Base):
                 stream=True,
                 **gen_conf,
             )
-            for res in response.iter_lines():
+            for res in response:
                 if res.type == 'content_block_delta':
                     text = res.delta.text
                     ans += text


### PR DESCRIPTION
### What problem does this PR solve?

ERROR: 'Stream' object has no attribute 'iter_lines' with reference to Claude/Anthropic chat streams

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

