### PR TITLE
Reverted build slim image documentation

### DIFF
--- a/docs/guides/develop/build_docker_image.mdx
+++ b/docs/guides/develop/build_docker_image.mdx
@@ -41,7 +41,7 @@ While we also test RAGFlow on ARM64 platforms, we do not plan to maintain RAGFlo
 ```bash
 git clone https://github.com/infiniflow/ragflow.git
 cd ragflow/
-docker compose -f docker/docker-compose-macos.yml up -d
+docker build --build-arg LIGHTEN=1 -f Dockerfile -t infiniflow/ragflow:nightly-slim .
 ```
 
 


### PR DESCRIPTION
### Fixed documentation for building docker image

I'm assuming that this was a mistake (but I could be missing something) [here](https://github.com/infiniflow/ragflow/pull/4658/files#:~:text=docker%20build%20%2D%2Dbuild%2Darg%20LIGHTEN%3D1%20%2Df%20Dockerfile%20%2Dt%20infiniflow/ragflow%3Anightly%2Dslim%20.) when the docker building instructions for the slim image was just changed away from an actual `docker build` command to the mac os `docker compose up` command. This is just reverting the change.

### Type of change

- [X] Documentation Update

