### PR TITLE
Remove use of eval() from operators.py

### DIFF
--- a/deepdoc/vision/operators.py
+++ b/deepdoc/vision/operators.py
@@ -108,7 +108,7 @@ class NormalizeImage(object):
 
     def __init__(self, scale=None, mean=None, std=None, order='chw', **kwargs):
         if isinstance(scale, str):
-            scale = eval(scale)
+            scale = np.float32(scale) if scale != 'None' else None
         self.scale = np.float32(scale if scale is not None else 1.0 / 255.0)
         mean = mean if mean is not None else [0.485, 0.456, 0.406]
         std = std if std is not None else [0.229, 0.224, 0.225]


### PR DESCRIPTION
Use `np.float32()` instead.

### What problem does this PR solve?

Using `eval()` can lead to code injections.

I think `eval()` is only used to parse a floating point number here. This change preserves the correct behavior if the string `"None"` is supplied. But if that behavior isn't intended then this part could be just deleted instead, since `np.float32()` is parsing strings anyway:

```Python
        if isinstance(scale, str):
            scale = eval(scale)
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
