### PR TITLE
Iframe should support input variables

### DIFF
--- a/web/src/pages/chat/shared-hooks.ts
+++ b/web/src/pages/chat/shared-hooks.ts
@@ -22,11 +22,19 @@ export const useSendButtonDisabled = (value: string) => {
 
 export const useGetSharedChatSearchParams = () => {
   const [searchParams] = useSearchParams();
-
+  const dataPrefix = "data_";
+  const data = {};
+  
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (key.startsWith(dataPrefix)) {
+        data[key.replace(dataPrefix, "")] = value;
+    }
+  }
   return {
     from: searchParams.get('from') as SharedFrom,
     sharedId: searchParams.get('shared_id'),
     locale: searchParams.get('locale'),
+    data: data,
     visibleAvatar: searchParams.get('visible_avatar')
       ? searchParams.get('visible_avatar') !== '1'
       : true,
@@ -34,7 +42,7 @@ export const useGetSharedChatSearchParams = () => {
 };
 
 export const useSendSharedMessage = () => {
-  const { from, sharedId: conversationId } = useGetSharedChatSearchParams();
+  const { from, sharedId: conversationId, data } = useGetSharedChatSearchParams();
   const { createSharedConversation: setConversation } =
     useCreateNextSharedConversation();
   const { handleInputChange, value, setValue } = useHandleMessageInputChange();
@@ -52,12 +60,13 @@ export const useSendSharedMessage = () => {
 
   const sendMessage = useCallback(
     async (message: Message, id?: string) => {
-      const res = await send({
+      const payload = {
         conversation_id: id ?? conversationId,
         quote: true,
         question: message.content,
         session_id: get(derivedMessages, '0.session_id'),
-      });
+      };
+      const res = await send({ ...payload, ...data });
 
       if (isCompletionError(res)) {
         // cancel loading

--- a/web/src/pages/flow/header/index.tsx
+++ b/web/src/pages/flow/header/index.tsx
@@ -8,8 +8,7 @@ import { Button, Flex, Space } from 'antd';
 import { useCallback } from 'react';
 import { Link, useParams } from 'umi';
 import {
-  useGetBeginNodeDataQuery,
-  useGetBeginNodeDataQueryIsEmpty,
+  useGetBeginNodeDataQuery
 } from '../hooks/use-get-begin-query';
 import {
   useSaveGraph,
@@ -35,8 +34,7 @@ const FlowHeader = ({ showChatDrawer, chatDrawerVisible }: IProps) => {
   const getBeginNodeDataQuery = useGetBeginNodeDataQuery();
   const { showEmbedModal, hideEmbedModal, embedVisible, beta } =
     useShowEmbedModal();
-  const isBeginNodeDataQueryEmpty = useGetBeginNodeDataQueryIsEmpty();
-
+  
   const handleShowEmbedModal = useCallback(() => {
     showEmbedModal();
   }, [showEmbedModal]);
@@ -79,7 +77,6 @@ const FlowHeader = ({ showChatDrawer, chatDrawerVisible }: IProps) => {
           <Button
             type="primary"
             onClick={handleShowEmbedModal}
-            disabled={!isBeginNodeDataQueryEmpty}
           >
             <b>{t('embedIntoSite', { keyPrefix: 'common' })}</b>
           </Button>

--- a/web/src/pages/flow/header/index.tsx
+++ b/web/src/pages/flow/header/index.tsx
@@ -39,7 +39,7 @@ const FlowHeader = ({ showChatDrawer, chatDrawerVisible }: IProps) => {
   const handleShowEmbedModal = useCallback(() => {
     showEmbedModal();
   }, [showEmbedModal]);
-  
+
   const handleRunAgent = useCallback(() => {
     const query: BeginQuery[] = getBeginNodeDataQuery();
     if (query.length > 0) {

--- a/web/src/pages/flow/header/index.tsx
+++ b/web/src/pages/flow/header/index.tsx
@@ -8,7 +8,8 @@ import { Button, Flex, Space } from 'antd';
 import { useCallback } from 'react';
 import { Link, useParams } from 'umi';
 import {
-  useGetBeginNodeDataQuery
+  useGetBeginNodeDataQuery,
+  useGetBeginNodeDataQueryIsSafe
 } from '../hooks/use-get-begin-query';
 import {
   useSaveGraph,
@@ -34,11 +35,11 @@ const FlowHeader = ({ showChatDrawer, chatDrawerVisible }: IProps) => {
   const getBeginNodeDataQuery = useGetBeginNodeDataQuery();
   const { showEmbedModal, hideEmbedModal, embedVisible, beta } =
     useShowEmbedModal();
-  
+  const isBeginNodeDataQuerySafe = useGetBeginNodeDataQueryIsSafe();
   const handleShowEmbedModal = useCallback(() => {
     showEmbedModal();
   }, [showEmbedModal]);
-
+  
   const handleRunAgent = useCallback(() => {
     const query: BeginQuery[] = getBeginNodeDataQuery();
     if (query.length > 0) {
@@ -77,6 +78,7 @@ const FlowHeader = ({ showChatDrawer, chatDrawerVisible }: IProps) => {
           <Button
             type="primary"
             onClick={handleShowEmbedModal}
+            disabled={!isBeginNodeDataQuerySafe}
           >
             <b>{t('embedIntoSite', { keyPrefix: 'common' })}</b>
           </Button>

--- a/web/src/pages/flow/hooks/use-get-begin-query.tsx
+++ b/web/src/pages/flow/hooks/use-get-begin-query.tsx
@@ -16,18 +16,21 @@ export const useGetBeginNodeDataQuery = () => {
   return getBeginNodeDataQuery;
 };
 
-export const useGetBeginNodeDataQueryIsEmpty = () => {
-  const [isBeginNodeDataQueryEmpty, setIsBeginNodeDataQueryEmpty] =
+export const useGetBeginNodeDataQueryIsSafe = () => {
+  const [isBeginNodeDataQuerySafe, setIsBeginNodeDataQuerySafe] =
     useState(false);
   const getBeginNodeDataQuery = useGetBeginNodeDataQuery();
   const nodes = useGraphStore((state) => state.nodes);
 
   useEffect(() => {
     const query: BeginQuery[] = getBeginNodeDataQuery();
-    setIsBeginNodeDataQueryEmpty(query.length === 0);
+    const isSafe = !(query.some(function (item, index) {
+        return !item.optional && ["file"].includes(item.type);
+    }));
+    setIsBeginNodeDataQuerySafe(query.length === 0);
   }, [getBeginNodeDataQuery, nodes]);
 
-  return isBeginNodeDataQueryEmpty;
+  return isBeginNodeDataQuerySafe;
 };
 
 // exclude nodes with branches

--- a/web/src/pages/flow/hooks/use-get-begin-query.tsx
+++ b/web/src/pages/flow/hooks/use-get-begin-query.tsx
@@ -27,7 +27,7 @@ export const useGetBeginNodeDataQueryIsSafe = () => {
     const isSafe = !(query.some(function (item, index) {
         return !item.optional && ["file"].includes(item.type);
     }));
-    setIsBeginNodeDataQuerySafe(query.length === 0);
+    setIsBeginNodeDataQuerySafe(isSafe);
   }, [getBeginNodeDataQuery, nodes]);
 
   return isBeginNodeDataQuerySafe;


### PR DESCRIPTION
Add the ability to append variable values in the share chat by utilising a data_{variable} query string value

### What problem does this PR solve?

Right now we cannot embed a chat in website when it has variables in the begin component.
This  PR tries to read the variables values from the query string via a data_ prefixed variable.

#5016 

### Type of change

- [x] New Feature (non-breaking change which adds functionality)