### PR TITLE
Update agent session API, to support uploading files while create a new session

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -2171,9 +2171,9 @@ Creates a session with an agent.
 #### Request
 
 - Method: POST
-- URL: `/api/v1/agents/{agent_id}/sessions`
+- URL: `/api/v1/agents/{agent_id}/sessions?user_id={user_id}`
 - Headers:
-  - `'content-Type: application/json'`
+  - `'content-Type: application/json' or 'multipart/form-data'`
   - `'Authorization: Bearer <YOUR_API_KEY>'`
 - Body:
   - the required parameters:`str`
@@ -2202,11 +2202,21 @@ curl --request POST \
             "file":"Who are you"
      }'
 ```
+If `begin` component in the agent has required file parameters:
+```bash
+curl --request POST \
+     --url http://{address}/api/v1/agents/{agent_id}/sessions?user_id={user_id} \
+     --header 'Content-Type: multipart/form-data' \
+     --header 'Authorization: Bearer <YOUR_API_KEY>' \
+     --form '<FILE_KEY>=@./test1.png'    
+```
 
 ##### Request parameters
 
 - `agent_id`: (*Path parameter*)  
   The ID of the associated agent.
+- `user_id`: (*Filter parameter*), string
+  The optional user-defined ID for parsing docs(especially images) when creating session while uploading files.
 
 #### Response
 

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -2177,9 +2177,8 @@ Creates a session with an agent.
   - `'Authorization: Bearer <YOUR_API_KEY>'`
 - Body:
   - the required parameters:`str`
-  - the optional parameters:`str`
-    - `"user_id"`: `string`  
-      The optional user-defined ID.
+  - other parameters:
+    The parameters in the begin component.
 
 ##### Request example
 If `begin` component in the agent doesn't have required parameters:


### PR DESCRIPTION
### What problem does this PR solve?
Update the agent session API "POST /api/v1/agents/{agent_id}/sessions", to support uploading files while create a new session:
    - currently, the API only supports requesting with a json body. If user wants to upload a doc or image when create session, like what is already supported on the web client, we need to update the API.
    - if upload an image, ragflow will call image2text, and a user_id is needed for the image2text model. So we need to send user_id in the API request. As form-data is needed to upload files, not json body, seems we need to put the user_id in the url as an optional parameter (currently user_id is an optional in json body).


### Type of change

- [x] Documentation Update
- [x] Other (please describe):
