### PR TITLE
Fix: Starting the source code on Windows, the 'HTTP API' returns 404

### DIFF
--- a/api/apps/__init__.py
+++ b/api/apps/__init__.py
@@ -119,8 +119,9 @@ def register_page(page_path):
     sys.modules[module_name] = page
     spec.loader.exec_module(page)
     page_name = getattr(page, "page_name", page_name)
+    sdk_path = "\\sdk\\" if sys.platform.startswith("win") else "/sdk/"
     url_prefix = (
-        f"/api/{API_VERSION}" if "/sdk/" in path else f"/{API_VERSION}/{page_name}"
+        f"/api/{API_VERSION}" if sdk_path in path else f"/{API_VERSION}/{page_name}"
     )
 
     app.register_blueprint(page.manager, url_prefix=url_prefix)


### PR DESCRIPTION
Fix: When starting the backend service from source code on Windows, the "HTTP API" no longer returns 404.