### PR TITLE
Fix: PUT method does not work as expected with Invoke component

### DIFF
--- a/agent/component/invoke.py
+++ b/agent/component/invoke.py
@@ -95,7 +95,7 @@ class Invoke(ComponentBase, ABC):
 
         if method == 'put':
             response = requests.put(url=url,
-                                    data=args,
+                                    json=args,
                                     headers=headers,
                                     proxies=proxies,
                                     timeout=self._param.timeout)


### PR DESCRIPTION
### What problem does this PR solve?
Invoke component can be used to call third party services.
Tried GET/POST/PUT from web UI, and found PUT request failed like this:  (test api: api/v1/chats/<assistant_id>)
 ```
{"code":100,"data":null,"message":"AttributeError("'NoneType' object has no attribute 'get'")"}
```

Root cause: Invoke PUT with a 'data=args' parameter, which is a form-encoded data, however the default content type setting of request header is application/json. The test api could not deal with such case.

Fix: use the 'json' parameter of reqeusts.put(), same as Invoke POST. Do not use the 'data' parameter.
Another way is to use 'data=json.dumps(args)'.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
