### PR TITLE
Fix: Use self.dataStore.indexExist in all_tags method of Dealer

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -449,7 +449,7 @@ class Dealer:
         return res
 
     def all_tags(self, tenant_id: str, kb_ids: list[str], S=1000):
-        if not self.docStoreConn.indexExist(index_name(tenant_id), kb_ids[0]):
+        if not self.dataStore.indexExist(index_name(tenant_id), kb_ids[0]):
             return []
         res = self.dataStore.search([], [], {}, [], OrderByExpr(), 0, 0, index_name(tenant_id), kb_ids, ["tag_kwd"])
         return self.dataStore.getAggregation(res, "tag_kwd")


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes an AttributeError in the all_tags method of the Dealer class. Previously, the method incorrectly called self.docStoreConn.indexExist instead of self.dataStore.indexExist. Since self.docStoreConn was never set (and self.dataStore is already initialized in init), this resulted in an error when attempting to check if the index exists. This change ensures that the proper connector is used for the index existence check, thereby resolving the issue._

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
