### PR TITLE
Fix: Option ineffective in Chat API

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -159,8 +159,10 @@ def update(tenant_id, chat_id, session_id):
 @token_required
 def chat_completion(tenant_id, chat_id):
     req = request.json
-    if not req or not req.get("session_id"):
+    if not req:
         req = {"question": ""}
+    if not req.get("session_id"):
+        req["question"]=""
     if not DialogService.query(tenant_id=tenant_id, id=chat_id, status=StatusEnum.VALID.value):
         return get_error_data_result(f"You don't own the chat {chat_id}")
     if req.get("session_id"):


### PR DESCRIPTION
### What problem does this PR solve?

API options like `stream` was ignored when no session_id was provided.

This PR fixes the issue.

Test command and expected result:
```
curl  --request POST \
     --url http://:9222/api/v1/chats/2f2e1d30ee6111efafe211749b004925/completions \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer ragflow-xxx' \
     --data '{
   "question":"Who are you",
   "stream":false
}'
{"code":0,"data":"data:{\"code\": 0, \"message\": \"\", \"data\": {\"answer\": \"Hi! I'm your assistant, what can I do for you?\", \"reference\": {}, \"audio_binary\": null, \"id\": null, \"session_id\": \"82ceb0fcee7111efafe211749b004925\"}}\n\n"}

```



### Type of change

- [*] Bug Fix (non-breaking change which fixes an issue)
