### PR TITLE
Fix: Prevent message sending when using IME composition

### DIFF
--- a/web/src/components/message-input/index.tsx
+++ b/web/src/components/message-input/index.tsx
@@ -156,8 +156,14 @@ const MessageInput = ({
     setFileList([]);
   }, [fileList, onPressEnter, isUploadingFile]);
 
+  const [isComposing, setIsComposing] = useState(false);
+
+  const handleCompositionStart = () => setIsComposing(true);
+  const handleCompositionEnd = () => setIsComposing(false);
+
   const handleInputKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === 'Enter' && !e.nativeEvent.shiftKey) {
+      if (isComposing) return;
       e.preventDefault();
       handlePressEnter();
     }
@@ -219,6 +225,8 @@ const MessageInput = ({
           className={classNames({ [styles.inputWrapper]: fileList.length === 0 })}
           onKeyDown={handleInputKeyDown}
           onChange={onInputChange}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
           autoSize={{ minRows: 1, maxRows: 6 }}
         />
         <Space>


### PR DESCRIPTION
### What problem does this PR solve?

This pull request addresses an issue where the "Enter" key would send the message prematurely while using Input Method Editor (IME) for text composition. This problem occurs when users are typing with a non-Latin input method, such as Chinese(Zhuyin), and press "Enter" to confirm their selection, which unintentionally triggers message submission.

Before:

https://github.com/user-attachments/assets/233f3ac9-4b4b-4424-b4ab-ea2e31bb0663

After:

https://github.com/user-attachments/assets/f1c01af6-d1d7-4a79-9e81-5bdf3c0b3529




### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
