### PR TITLE
Fix session.ask return generator bug when stream=False on python sdk

### DIFF
--- a/sdk/python/ragflow_sdk/modules/session.py
+++ b/sdk/python/ragflow_sdk/modules/session.py
@@ -38,6 +38,7 @@ class Session(Base):
             res = self._ask_agent(question, stream)
         elif self.__session_type == "chat":
             res = self._ask_chat(question, stream, **kwargs)
+            
         for line in res.iter_lines():
             line = line.decode("utf-8")
             if line.startswith("{"):
@@ -58,8 +59,11 @@ class Session(Base):
                 chunks = reference["chunks"]
                 temp_dict["reference"] = chunks
             message = Message(self.rag, temp_dict)
-            yield message
-
+            if stream:
+                yield message
+        if not stream:
+            return message
+    
     def _ask_chat(self, question: str, stream: bool, **kwargs):
         json_data = {"question": question, "stream": True, "session_id": self.id}
         json_data.update(kwargs)


### PR DESCRIPTION
add non-stream mode support to session.ask function

### What problem does this PR solve?

same as title,  I do not know why the stream=False is not work on the server side also, when stream=False, the response in the session._ask_chat is a fully connnected SSE string.

This is a quick fix on the sdk side to make the response format align with API docs

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
