### PR TITLE
Fix: 'Chunk not found!' error in team-sharing knowledge base.

### DIFF
--- a/api/apps/chunk_app.py
+++ b/api/apps/chunk_app.py
@@ -93,12 +93,14 @@ def get():
         tenants = UserTenantService.query(user_id=current_user.id)
         if not tenants:
             return get_data_error_result(message="Tenant not found!")
-        tenant_id = tenants[0].tenant_id
-
-        kb_ids = KnowledgebaseService.get_kb_ids(tenant_id)
-        chunk = settings.docStoreConn.get(chunk_id, search.index_name(tenant_id), kb_ids)
+        for tenant in tenants:
+            kb_ids = KnowledgebaseService.get_kb_ids(tenant.tenant_id)
+            chunk = settings.docStoreConn.get(chunk_id, search.index_name(tenant.tenant_id), kb_ids)
+            if chunk:
+                break
         if chunk is None:
             return server_error_response(Exception("Chunk not found"))
+
         k = []
         for n in chunk.keys():
             if re.search(r"(_vec$|_sm_|_tks|_ltks)", n):


### PR DESCRIPTION
### What problem does this PR solve?

As issue #3268  mentioned, "Chun not found!" exception will occur, especially during the teamwork of knowledge bases.

### The reason of this bug

"tenants" are the people on current_user's team, including the team owner itself. The old one only checks the first "tenant", tenants[0], which will cause error when anyone editing the chunk that is not in tenants[0]'s knowledge base.

My modification won't introduce new errors while iterate all the tenant then retrieve knowledge bases of each.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
