### PR TITLE
Fix: drop useless ABC method

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -15,7 +15,6 @@
 #
 import logging
 import json
-from abc import ABC
 from copy import deepcopy
 from functools import partial
 
@@ -25,7 +24,7 @@ from agent.component import component_class
 from agent.component.base import ComponentBase
 
 
-class Canvas(ABC):
+class Canvas:
     """
     dsl = {
         "components": {


### PR DESCRIPTION
### What problem does this PR solve?

seems  no need use ABC here, there's no `abstractmethod` here

### Type of change

- [x] Performance Improvement