### PR TITLE
Fix: language selection display on the profile settings page

### DIFF
--- a/web/src/pages/user-setting/setting-profile/index.tsx
+++ b/web/src/pages/user-setting/setting-profile/index.tsx
@@ -1,3 +1,6 @@
+import { LanguageList, LanguageMap } from '@/constants/common';
+import { useTranslate } from '@/hooks/common-hooks';
+import { useChangeLanguage } from '@/hooks/logic-hooks';
 import { useFetchUserInfo, useSaveSetting } from '@/hooks/user-setting-hooks';
 import {
   getBase64FromUploadFileList,
@@ -16,15 +19,10 @@ import {
   Upload,
   UploadFile,
 } from 'antd';
-import camelCase from 'lodash/camelCase';
 import { useEffect } from 'react';
 import SettingTitle from '../components/setting-title';
 import { TimezoneList } from '../constants';
 import { useValidateSubmittable } from '../hooks';
-
-import { LanguageList } from '@/constants/common';
-import { useTranslate } from '@/hooks/common-hooks';
-import { useChangeLanguage } from '@/hooks/logic-hooks';
 import parentStyles from '../index.less';
 import styles from './index.less';
 
@@ -155,7 +153,7 @@ const UserSettingProfile = () => {
             >
               {LanguageList.map((x) => (
                 <Option value={x} key={x}>
-                  {t(camelCase(x), { keyPrefix: 'common' })}
+                  {LanguageMap[x as keyof typeof LanguageMap]}
                 </Option>
               ))}
             </Select>


### PR DESCRIPTION
### What problem does this PR solve?

Improve the language selection display on the profile settings page.

| before | after |
| --- | --- |
|![截屏2025-02-28 上午8 46 54](https://github.com/user-attachments/assets/0924275c-99d4-4ddd-8935-693286c0d07f)|![CleanShot 2025-02-28 at 09 58 21](https://github.com/user-attachments/assets/a96c9d73-8e16-40a8-aa80-d31fecc18edf)|

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
