### PR TITLE
Refa: drop useless fasttext

### DIFF
--- a/deepdoc/vision/operators.py
+++ b/deepdoc/vision/operators.py
@@ -145,18 +145,6 @@ class ToCHWImage(object):
         return data
 
 
-class Fasttext(object):
-    def __init__(self, path="None", **kwargs):
-        import fasttext
-        self.fast_model = fasttext.load_model(path)
-
-    def __call__(self, data):
-        label = data['label']
-        fast_label = self.fast_model[label]
-        data['fast_label'] = fast_label
-        return data
-
-
 class KeepKeys(object):
     def __init__(self, keep_keys, **kwargs):
         self.keep_keys = keep_keys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "elastic-transport==8.12.0",
     "elasticsearch==8.12.1",
     "elasticsearch-dsl==8.12.0",
-    "fasttext==0.9.3",
     "filelock==3.15.4",
     "flask==3.0.3",
     "flask-cors==5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1421,17 +1421,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fasttext"
-version = "0.9.3"
-source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pybind11" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/9f/3b/9a10b95eaf565358339162848863197c3f0a29b540ca22b2951df2d66a48/fasttext-0.9.3.tar.gz", hash = "sha256:eb03f2ef6340c6ac9e4398a30026f05471da99381b307aafe2f56e4cd26baaef" }
-
-[[package]]
 name = "feedparser"
 version = "6.0.11"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
@@ -4762,7 +4751,6 @@ dependencies = [
     { name = "elastic-transport" },
     { name = "elasticsearch" },
     { name = "elasticsearch-dsl" },
-    { name = "fasttext" },
     { name = "filelock" },
     { name = "flasgger" },
     { name = "flask" },
@@ -4894,7 +4882,6 @@ requires-dist = [
     { name = "elasticsearch-dsl", specifier = "==8.12.0" },
     { name = "fastembed", marker = "(platform_machine != 'x86_64' and extra == 'full') or (sys_platform == 'darwin' and extra == 'full')", specifier = ">=0.3.6,<0.4.0" },
     { name = "fastembed-gpu", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'full'", specifier = ">=0.3.6,<0.4.0" },
-    { name = "fasttext", specifier = "==0.9.3" },
     { name = "filelock", specifier = "==3.15.4" },
     { name = "flagembedding", marker = "extra == 'full'", specifier = "==1.2.10" },
     { name = "flasgger", specifier = ">=0.9.7.1,<0.10.0" },


### PR DESCRIPTION
### What problem does this PR solve?

This patch drop useless fastext which is seems useless in the code base 
and its very kind of hard install
should close #4498


### Type of change

- [x] Refactoring