### PR TITLE
Fix email validation regex

### DIFF
--- a/api/apps/user_app.py
+++ b/api/apps/user_app.py
@@ -566,7 +566,7 @@ def user_add():
     email_address = req["email"]
 
     # Validate the email address
-    if not re.match(r"^[\w\._-]+@([\w_-]+\.)+[\w-]{2,5}$", email_address):
+    if not re.match(r"^[\w\._-]+@([\w_-]+\.)+[\w-]{2,}$", email_address):
         return get_json_result(
             data=False,
             message=f"Invalid email address: {email_address}!",


### PR DESCRIPTION
### What problem does this PR solve?

This pull request aims to fix a bug that prevents certain email addresses from signing up. The affected TLDs were returning 'invalid email address' errors:

.museum
.software
.photography
.technology
.marketing
.education
.international
.community
.construction
.government
.consulting
....

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
