### PR TITLE
Add separate API service resource to Helm chart

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "ragflow.fullname" $ }}
+                name: {{ .Release.Name }}
                 port:
                   name: http
           {{- end }}

--- a/helm/templates/ragflow.yaml
+++ b/helm/templates/ragflow.yaml
@@ -31,6 +31,8 @@ spec:
         ports:
           - containerPort: 80
             name: http
+          - containerPort: 9380
+            name: http-api
         volumeMounts:
           - mountPath: /etc/nginx/conf.d/ragflow.conf
             subPath: ragflow.conf
@@ -70,3 +72,23 @@ spec:
       targetPort: http
       name: http
   type: {{ .Values.ragflow.service.type }}
+---
+{{- if .Values.ragflow.api.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    {{- include "ragflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ragflow
+spec:
+  selector:
+    {{- include "ragflow.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ragflow
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: http-api
+      name: http-api
+  type: {{ .Values.ragflow.api.service.type }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -69,6 +69,10 @@ ragflow:
   service:
     # Use LoadBalancer to expose the web interface externally
     type: ClusterIP
+  api:
+    service:
+      enabled: true
+      type: ClusterIP
 
 infinity:
   image:


### PR DESCRIPTION
### What problem does this PR solve?

Adds a new Kubernetes Service resource to the Helm chart which specifically targets the RAGFlow API. This feature useful for cases where you want to expose the RAGFlow HTTP API separately from the web interface, for example if RAGFlow is running behind an authenticating proxy it allows a route to bypass the proxy (e.g. by defining a separate ingress resource which forwards to the separate API-only k8s service added here) to provide RAGFlow API access. This is still secure since API access is already authenticated by API keys inside RAGFlow itself.

### Type of change

- [X] New Feature (non-breaking change which adds functionality)
