### PR TITLE
Fix: image file can't preview

### DIFF
--- a/web/src/pages/document-viewer/image/index.tsx
+++ b/web/src/pages/document-viewer/image/index.tsx
@@ -1,0 +1,43 @@
+import { Image as AntImage } from 'antd';
+import { useEffect, useState } from 'react';
+
+import { Authorization } from '@/constants/authorization';
+import { getAuthorization } from '@/utils/authorization-util';
+
+interface ImageProps {
+  src: string;
+  preview?: boolean;
+}
+
+const Image = ({ src, preview = false }: ImageProps) => {
+  const [imageSrc, setImageSrc] = useState<string>('');
+
+  useEffect(() => {
+    const loadImage = async () => {
+      try {
+        const response = await fetch(src, {
+          headers: {
+            [Authorization]: getAuthorization(),
+          },
+        });
+        const blob = await response.blob();
+        const objectUrl = URL.createObjectURL(blob);
+        setImageSrc(objectUrl);
+      } catch (error) {
+        console.error('Failed to load image:', error);
+      }
+    };
+
+    loadImage();
+
+    return () => {
+      if (imageSrc) {
+        URL.revokeObjectURL(imageSrc);
+      }
+    };
+  }, [src]);
+
+  return imageSrc ? <AntImage src={imageSrc} preview={preview} /> : null;
+};
+
+export default Image;

--- a/web/src/pages/document-viewer/index.tsx
+++ b/web/src/pages/document-viewer/index.tsx
@@ -1,9 +1,10 @@
 import { Images } from '@/constants/common';
 import { api_host } from '@/utils/api';
-import { Flex, Image } from 'antd';
+import { Flex } from 'antd';
 import { useParams, useSearchParams } from 'umi';
 import Docx from './docx';
 import Excel from './excel';
+import Image from './image';
 import Pdf from './pdf';
 
 import { previewHtmlFile } from '@/utils/file-util';


### PR DESCRIPTION
### What problem does this PR solve?

![CleanShot 2025-03-05 at 10 12 28](https://github.com/user-attachments/assets/412b1663-5d65-4dca-9137-63d0ec5eaadd)
the preview botton of image not work for me.

request url: `http://127.0.0.1:9222/document/af570920f80e11efb8e967fd67f0d8c7?ext=jpg&prefix=file`
response: `{"code":401,"data":null,"message":"<Unauthorized '401: Unauthorized'>"}`


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
