### PR TITLE
Remove eval() from operators.py

### DIFF
--- a/deepdoc/vision/operators.py
+++ b/deepdoc/vision/operators.py
@@ -108,7 +108,7 @@ class NormalizeImage:
 
     def __init__(self, scale=None, mean=None, std=None, order='chw', **kwargs):
         if isinstance(scale, str):
-            scale = eval(scale)
+            scale = np.float32(scale) if scale != 'None' else None
         self.scale = np.float32(scale if scale is not None else 1.0 / 255.0)
         mean = mean if mean is not None else [0.485, 0.456, 0.406]
         std = std if std is not None else [0.229, 0.224, 0.225]


### PR DESCRIPTION
Use np.float32() instead for parsing numbers.

### What problem does this PR solve?

Using `eval()` can lead to code injections.

I think `eval()` is only used to parse a floating point number here. This change preserves the correct behavior if the string `"None"` is supplied. But if that behavior isn't intended then this part could be just deleted instead, since `np.float32()` is parsing strings anyway:

```Python
        if isinstance(scale, str):
            scale = eval(scale)
```

I've made this exact change before and submitted it to ragflow, it was accepted and listed in the changes to v0.17.0, but the `eval()` is actually back again in that same version. It only was briefly gone in git. See: https://github.com/infiniflow/ragflow/pull/4888

If this is just a copy-pasta from another project, where can I find that other project to submit a pull request to?

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)