### PR TITLE
Remove eval() from search.py

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -15,6 +15,7 @@
 #
 import logging
 import re
+import json
 from dataclasses import dataclass
 
 from rag.settings import TAG_FLD, PAGERANK_FLD
@@ -258,7 +259,7 @@ class Dealer:
         q_denor = np.sqrt(np.sum([s*s for t,s in query_rfea.items() if t != PAGERANK_FLD]))
         for i in search_res.ids:
             nor, denor = 0, 0
-            for t, sc in eval(search_res.field[i].get(TAG_FLD, "{}")).items():
+            for t, sc in json.loads(search_res.field[i].get(TAG_FLD, "{}")).items():
                 if t in query_rfea:
                     nor += query_rfea[t] * sc
                 denor += sc * sc


### PR DESCRIPTION
### What problem does this PR solve?

Using `eval()` can lead to code injections. I think this loads a JSON field, right? If yes, why is this done via `eval()` and not `json.loads()`?

I've already made this change before and it is listed in the changelog of v0.17.0, but somehow it was reverted before the actual release of that version again! See: https://github.com/infiniflow/ragflow/pull/4887

If this is just a copy-pasta from another project, where can I find that other project to submit a pull request to?

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
