### PR TITLE
Fix: Resolve inconsistency in APIToken dialog_id field definition

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -935,7 +935,7 @@ class Conversation(DataBaseModel):
 class APIToken(DataBaseModel):
     tenant_id = CharField(max_length=32, null=False, index=True)
     token = CharField(max_length=255, null=False, index=True)
-    dialog_id = CharField(max_length=32, null=False, index=True)
+    dialog_id = CharField(max_length=32, null=True, index=True)
     source = CharField(max_length=16, null=True, help_text="none|agent|dialog", index=True)
     beta = CharField(max_length=255, null=True, index=True)
 


### PR DESCRIPTION
The `dialog_id` field was inconsistently defined:
- In the `migrate_db()` function, it was set to `null=True`.
- In the model class, it was defined as `null=False`.

This inconsistency caused an issue during the initial deployment where the database table did not allow `dialog_id` to be null. As a result, calling `APITokenService.save(**obj)` in `system_app.py` raised the following error:

```
peewee.IntegrityError: null value in column "dialog_id" violates not-null constraint
```

### What problem does this PR solve?

Error: peewee.IntegrityError: null value in column "dialog_id" violates not-null constraint

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
