### PR TITLE
Agent Update: Fix Role Issue and Enhance KB Search

### DIFF
--- a/agent/component/generate.py
+++ b/agent/component/generate.py
@@ -216,6 +216,8 @@ class Generate(ComponentBase):
             return
 
         msg = self._canvas.get_history(self._param.message_history_window_size)
+        if msg and msg[0]['role'] == 'assistant':
+            msg.pop(0)
         if len(msg) < 1:
             msg.append({"role": "user", "content": "Output: "})
         _, msg = message_fit_in([{"role": "system", "content": prompt}, *msg], int(chat_mdl.max_length * 0.97))

--- a/agent/component/retrieval.py
+++ b/agent/component/retrieval.py
@@ -53,7 +53,9 @@ class Retrieval(ComponentBase, ABC):
     def _run(self, history, **kwargs):
         query = self.get_input()
         query = str(query["content"][0]) if "content" in query else ""
-
+        lines = query.split('\n')
+        user_queries = [line.split("USER:", 1)[1] for line in lines if line.startswith("USER:")]
+        query = user_queries[-1] if user_queries else ""
         kbs = KnowledgebaseService.get_by_ids(self._param.kb_ids)
         if not kbs:
             return Retrieval.be_output("")


### PR DESCRIPTION
### What problem does this PR solve?

**generate.py 更新：**
问题：部分模型提供商对输入对话内容的格式有严格校验，要求第一条内容的 role 不能为 assistant，否则会报错。
解决：删除了系统设置的 agent 开场白，确保传递给模型的对话内容中，第一条内容的 role 不为 assistant。

**retrieval.py 更新：**
问题：当前知识库检索使用全部对话内容作为输入，可能导致检索结果不准确。
解决：改为仅使用用户最后提出的一个问题进行知识库检索，提高检索的准确性。

**Update generate.py:**
Issue: Some model providers have strict validation rules for the format of input conversation content, requiring that the role of the first content must not be assistant. Otherwise, an error will occur.
Solution: Removed the system-set agent opening statement to ensure that the role of the first content in the conversation passed to the model is not assistant.

**Update retrieval.py:**
Issue: The current knowledge base retrieval uses the entire conversation content as input, which may lead to inaccurate retrieval results.
Solution: Changed the retrieval logic to use only the last question asked by the user for knowledge base retrieval, improving retrieval accuracy.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Performance Improvement

