### PR TITLE
Fix: HTTP API Updates Read-Only Dataset Fields During Modification #5923 

### DIFF
--- a/api/apps/document_app.py
+++ b/api/apps/document_app.py
@@ -347,7 +347,7 @@ def rm():
 @manager.route('/run', methods=['POST'])  # noqa: F821
 @login_required
 @validate_request("doc_ids", "run")
-def run():
+def run(): 
     req = request.json
     for doc_id in req["doc_ids"]:
         if not DocumentService.accessible(doc_id, current_user.id):

--- a/api/apps/sdk/chat.py
+++ b/api/apps/sdk/chat.py
@@ -31,7 +31,7 @@ from api.utils.api_utils import get_result
 @token_required
 def create(tenant_id):
     req = request.json
-    ids = [i for i in req.get("dataset_ids", []) if i]
+    ids = [i for i in req.get("dataset_ids", []) if i] 
     for kb_id in ids:
         kbs = KnowledgebaseService.accessible(kb_id=kb_id, user_id=tenant_id)
         if not kbs:

--- a/api/apps/sdk/dataset.py
+++ b/api/apps/sdk/dataset.py
@@ -276,7 +276,7 @@ def delete(tenant_id):
     return get_result(code=settings.RetCode.SUCCESS)
 
 
-@manager.route("/datasets/<dataset_id>", methods=["PUT"])  # noqa: F821
+@manager.route("/datasets/<dataset_id>", methods=["PUT"])  # noqa: F821  
 @token_required
 def update(tenant_id, dataset_id):
     """
@@ -330,7 +330,7 @@ def update(tenant_id, dataset_id):
         return get_error_data_result(message="You don't own the dataset")
     req = request.json
     e, t = TenantService.get_by_id(tenant_id)
-    invalid_keys = {"id", "embd_id", "chunk_num", "doc_num", "parser_id"}
+    invalid_keys = {"id", "embd_id", "chunk_num", "doc_num", "parser_id", "create_date", "create_time", "created_by", "status","token_num","update_date","update_time"}
     if any(key in req for key in invalid_keys):
         return get_error_data_result(message="The input parameters are invalid.")
     permission = req.get("permission")

--- a/sdk/python/ragflow_sdk/ragflow.py
+++ b/sdk/python/ragflow_sdk/ragflow.py
@@ -129,7 +129,7 @@ class RAGFlow:
 
         temp_dict = {"name": name,
                      "avatar": avatar,
-                     "dataset_ids": dataset_list,
+                     "dataset_ids": dataset_list if dataset_list else [],
                      "llm": llm.to_json(),
                      "prompt": prompt.to_json()}
         res = self.post("/chats", temp_dict)

--- a/sdk/python/test/test_frontend_api/common.py
+++ b/sdk/python/test/test_frontend_api/common.py
@@ -68,7 +68,7 @@ def upload_file(auth, dataset_id, path):
 
 def list_document(auth, dataset_id):
     authorization = {"Authorization": auth}
-    url = f"{HOST_ADDRESS}/v1/document/list?kb_id={dataset_id}"
+    url = f"{HOST_ADDRESS}/v1/document/list?kb_id={dataset_id}" 
     res = requests.get(url=url, headers=authorization)
     return res.json()
 
@@ -85,7 +85,7 @@ def parse_docs(auth, doc_ids):
     authorization = {"Authorization": auth}
     json_req = {
         "doc_ids": doc_ids,
-        "run": 1
+        "run": 1 
     }
     url = f"{HOST_ADDRESS}/v1/document/run"
     res = requests.post(url=url, headers=authorization, json=json_req)

--- a/sdk/python/test/test_http_api/test_dataset_mangement/common.py
+++ b/sdk/python/test/test_http_api/test_dataset_mangement/common.py
@@ -39,7 +39,7 @@ def list_dataset(auth, params=None):
 
 def update_dataset(auth, dataset_id, payload):
     res = requests.put(
-        url=f"{API_URL}/{dataset_id}", headers=HEADERS, auth=auth, json=payload
+        url=f"{API_URL}/{dataset_id}", headers=HEADERS, auth=auth, json=payload 
     )
     return res.json()
 


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #5923 

Fixes the readonly variables from payload at
 /datasets/<dataset_id> 

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

Now if user tries to modify readonly values then it will show " The input parameters are invalid. "

invalid_keys = {"id", "embd_id", "chunk_num", "doc_num", "parser_id", "create_date", "create_time", "created_by", "status","token_num","update_date","update_time"}
    if any(key in req for key in invalid_keys):
        return get_error_data_result(message="The input parameters are invalid.")
i have include those readonly keys in invalid_keys

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
