### PR TITLE
Feat: Add deepseek to llm_factories

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -845,6 +845,12 @@
             "status": "1",
             "llm": [
                 {
+                    "llm_name": "deepseek.r1-v1:0",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat"
+                },
+                {
                     "llm_name": "ai21.j2-ultra-v1",
                     "tags": "LLM,CHAT,8k",
                     "max_tokens": 8191,


### PR DESCRIPTION
### What problem does this PR solve?

AWS Bedrock has made deepseek-r1 available on its serverless inference.

This adds the R1 serverless model for use via the bedrock model abilities.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
