### PR TITLE
Fix: Prevent password boxes other than login passwords from displaying passwords saved in the browser's password manager by default. #6033

### DIFF
--- a/web/src/components/tavily-item.tsx
+++ b/web/src/components/tavily-item.tsx
@@ -14,7 +14,10 @@ export function TavilyItem({
     <Form.Item label={'Tavily API Key'} tooltip={t('tavilyApiKeyTip')}>
       <div className="flex flex-col gap-1">
         <Form.Item name={name} noStyle>
-          <Input.Password placeholder={t('tavilyApiKeyMessage')} />
+          <Input.Password
+            placeholder={t('tavilyApiKeyMessage')}
+            autoComplete="new-password"
+          />
         </Form.Item>
         <Typography.Link href="https://app.tavily.com/home" target={'_blank'}>
           {t('tavilyApiKeyHelp')}


### PR DESCRIPTION
### What problem does this PR solve?

Fix: Prevent password boxes other than login passwords from displaying passwords saved in the browser's password manager by default. #6033

### Type of change


- [x] New Feature (non-breaking change which adds functionality)

