### PR TITLE
Fix: Correct parameter retrieval in thumbup api

### DIFF
--- a/api/apps/conversation_app.py
+++ b/api/apps/conversation_app.py
@@ -78,7 +78,7 @@ def set_conversation():
 def get():
     conv_id = request.args["conversation_id"]
     try:
-        
+
         e, conv = ConversationService.get_by_id(conv_id)
         if not e:
             return get_data_error_result(message="Conversation not found!")
@@ -118,7 +118,7 @@ def get():
 
 @manager.route('/getsse/<dialog_id>', methods=['GET'])  # type: ignore # noqa: F821
 def getsse(dialog_id):
-    
+
     token = request.headers.get('Authorization').split()
     if len(token) != 2:
         return get_data_error_result(message='Authorization is not valid!"')
@@ -324,7 +324,7 @@ def thumbup():
     e, conv = ConversationService.get_by_id(req["conversation_id"])
     if not e:
         return get_data_error_result(message="Conversation not found!")
-    up_down = req.get("set")
+    up_down = req.get("thumbup")
     feedback = req.get("feedback", "")
     conv = conv.to_dict()
     for i, msg in enumerate(conv["message"]):


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/infiniflow/ragflow/issues/5546

up_down was using req.get("set") to retrieve the parameter, but according to the frontend code, it should be req.get("thumbup"). 


![image](https://github.com/user-attachments/assets/7189c982-f80e-48c9-a0a3-40f8a5d9e47b)


https://github.com/infiniflow/ragflow/blob/1842ca03345e8f204b69c45d4d1b8c21dcc3cd0d/web/src/interfaces/request/chat.ts#L3

https://github.com/infiniflow/ragflow/blob/1842ca03345e8f204b69c45d4d1b8c21dcc3cd0d/api/apps/conversation_app.py#L327

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)



