### PR TITLE
Fix: add support for non-stream response with session.ask_without_stream

### DIFF
--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -1485,8 +1485,8 @@ The parameters in `begin` component.
 from ragflow_sdk import RAGFlow, Agent
 
 rag_object = RAGFlow(api_key="<YOUR_API_KEY>", base_url="http://<YOUR_BASE_URL>:9380")
-AGENT_id = "AGENT_ID"
-agent = rag_object.list_agents(id = AGENT_id)[0]
+agent_id = "AGENT_ID"
+agent = rag_object.list_agents(id = agent_id)[0]
 session = agent.create_session()
 ```
 

--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -1485,7 +1485,7 @@ The parameters in `begin` component.
 from ragflow_sdk import RAGFlow, Agent
 
 rag_object = RAGFlow(api_key="<YOUR_API_KEY>", base_url="http://<YOUR_BASE_URL>:9380")
-AGENT_ID = "AGENT_ID"
+AGENT_id = "AGENT_ID"
 agent = rag_object.list_agents(id = AGENT_id)[0]
 session = agent.create_session()
 ```

--- a/sdk/python/ragflow_sdk/modules/session.py
+++ b/sdk/python/ragflow_sdk/modules/session.py
@@ -64,6 +64,31 @@ class Session(Base):
         if not stream:
             return message
     
+    def ask_without_stream(self, question="", stream=False, **kwargs):
+        if self.__session_type == "agent":
+            res = self._ask_agent(question, stream)
+        elif self.__session_type == "chat":
+            res = self._ask_chat(question, stream, **kwargs)
+
+        if stream:
+            raise Exception("Please use session.ask() function!")
+        else:
+            try:
+                json_data = json.loads(res.text)
+            except ValueError:
+                raise Exception(f"Invalid response {res}")
+            answer = json_data["data"]["answer"]
+            reference = json_data["data"].get("reference", {})
+            temp_dict = {
+                "content": answer,
+                "role": "assistant"
+            }
+            if reference and "chunks" in reference:
+                chunks = reference["chunks"]
+                temp_dict["reference"] = chunks
+            message = Message(self.rag, temp_dict)
+            return message
+
     def _ask_chat(self, question: str, stream: bool, **kwargs):
         json_data = {"question": question, "stream": stream, "session_id": self.id}
         json_data.update(kwargs)


### PR DESCRIPTION
Add support for non-stream response with session.ask_without_stream and fix a typo mistake in python API doc
There are requirements for non-stream response, especially for commands exection, e.g. text2SQL. The commands have to be completed before the agent is triggered.

### What problem does this PR solve?

It's to fix the [Issue: 6206](https://github.com/infiniflow/ragflow/issues/6206)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
