### PR TITLE
Fix: read flow blank template strings from i18n file

### DIFF
--- a/web/src/hooks/flow-hooks.ts
+++ b/web/src/hooks/flow-hooks.ts
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { message } from 'antd';
 import { set } from 'lodash';
 import get from 'lodash/get';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'umi';
 import { v4 as uuid } from 'uuid';
 
@@ -51,6 +52,8 @@ export const EmptyDsl = {
 };
 
 export const useFetchFlowTemplates = (): ResponseType<IFlowTemplate[]> => {
+  const { t } = useTranslation();
+
   const { data } = useQuery({
     queryKey: ['fetchFlowTemplates'],
     initialData: [],
@@ -59,8 +62,8 @@ export const useFetchFlowTemplates = (): ResponseType<IFlowTemplate[]> => {
       if (Array.isArray(data?.data)) {
         data.data.unshift({
           id: uuid(),
-          title: 'Blank',
-          description: 'Create your agent from scratch',
+          title: t('flow.blank'),
+          description: t('flow.createFromNothing'),
           dsl: EmptyDsl,
         });
       }


### PR DESCRIPTION
### What problem does this PR solve?

Blank and createFromNothing were not read from the i18n file when Agent was created
创建Agent的时候 Blank 和 createFromNothing  没从i18n文件中读取

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
