### PR TITLE
Fix: optimize setting config initialization to resolve Minio initialization error

### DIFF
--- a/rag/settings.py
+++ b/rag/settings.py
@@ -21,7 +21,7 @@ from api.utils.file_utils import get_project_base_directory
 # Server
 RAG_CONF_PATH = os.path.join(get_project_base_directory(), "conf")
 
-# 从系统环境变量中获取存储类型和文档存擎
+# Get storage type and document engine from system environment variables
 STORAGE_IMPL_TYPE = os.getenv('STORAGE_IMPL', 'MINIO')
 DOC_ENGINE = os.getenv('DOC_ENGINE', 'elasticsearch')
 
@@ -32,7 +32,7 @@ S3 = {}
 MINIO = {}
 OSS = {}
 
-# 根据环境变量初始化对应选择的配置数据,解决因没有配置初始化报错问题
+# Initialize the selected configuration data based on environment variables to solve the problem of initialization errors due to lack of configuration
 if DOC_ENGINE == 'elasticsearch':
     ES = get_base_config("es", {})
 elif DOC_ENGINE == 'infinity':

--- a/rag/settings.py
+++ b/rag/settings.py
@@ -21,12 +21,32 @@ from api.utils.file_utils import get_project_base_directory
 # Server
 RAG_CONF_PATH = os.path.join(get_project_base_directory(), "conf")
 
-ES = get_base_config("es", {})
-INFINITY = get_base_config("infinity", {"uri": "infinity:23817"})
-AZURE = get_base_config("azure", {})
-S3 = get_base_config("s3", {})
-MINIO = decrypt_database_config(name="minio")
-OSS = get_base_config("oss", {})
+# 从系统环境变量中获取存储类型和文档存擎
+STORAGE_IMPL_TYPE = os.getenv('STORAGE_IMPL', 'MINIO')
+DOC_ENGINE = os.getenv('DOC_ENGINE', 'elasticsearch')
+
+ES = {}
+INFINITY = {}
+AZURE = {}
+S3 = {}
+MINIO = {}
+OSS = {}
+
+# 根据环境变量初始化对应选择的配置数据,解决因没有配置初始化报错问题
+if DOC_ENGINE == 'elasticsearch':
+    ES = get_base_config("es", {})
+elif DOC_ENGINE == 'infinity':
+    INFINITY = get_base_config("infinity", {"uri": "infinity:23817"})
+
+if STORAGE_IMPL_TYPE in ['AZURE_SPN', 'AZURE_SAS']:
+    AZURE = get_base_config("azure", {})
+elif STORAGE_IMPL_TYPE == 'AWS_S3':
+    S3 = get_base_config("s3", {})
+elif STORAGE_IMPL_TYPE == 'MINIO':
+    MINIO = decrypt_database_config(name="minio")
+elif STORAGE_IMPL_TYPE == 'OSS':
+    OSS = get_base_config("oss", {})
+
 try:
     REDIS = decrypt_database_config(name="redis")
 except Exception:


### PR DESCRIPTION
### What problem does this PR solve?

Optimize setting configuration initialization to resolve Minio initialization error caused by using a specific storage.

Reproduction Scenario:
Using Aliyun OSS as the backend storage with the STORAGE_IMPL environment variable set to OSS.
The service_conf.yaml.template configuration file contains OSS-related configurations, while other storage configurations are commented out.
When the service starts, it still attempts to initialize the Minio storage. Since there is no Minio configuration in service_conf.yaml.template, it results in an error due to the missing configuration file.

Optimization Measures:
Automatically determine the required initialization configuration based on the environment variable.
Do not initialize configurations for unused resources.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
