### PR TITLE
Fix: Resolved a bug where sibling components in Canvas were not restricted to fetching data from the upstream when parallel components were present.

### DIFF
--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -463,6 +463,9 @@ class ComponentBase(ABC):
         if len(self._canvas.path) > 1:
             reversed_cpnts.extend(self._canvas.path[-2])
         reversed_cpnts.extend(self._canvas.path[-1])
+        #需要筛选出当前com的upstream的元素->获取upstream
+        up_cpns = self.get_upstream()
+        reversed_up_cpnts = [cpn for cpn in reversed_cpnts if cpn in up_cpns]
 
         if self._param.query:
             self._param.inputs = []
@@ -505,7 +508,7 @@ class ComponentBase(ABC):
 
         upstream_outs = []
 
-        for u in reversed_cpnts[::-1]:
+        for u in reversed_up_cpnts[::-1]:
             if self.get_component_name(u) in ["switch", "concentrator"]:
                 continue
             if self.component_name.lower() == "generate" and self.get_component_name(u) == "retrieval":
@@ -565,8 +568,10 @@ class ComponentBase(ABC):
         if len(self._canvas.path) > 1:
             reversed_cpnts.extend(self._canvas.path[-2])
         reversed_cpnts.extend(self._canvas.path[-1])
+        up_cpns = self.get_upstream()
+        reversed_up_cpnts = [cpn for cpn in reversed_cpnts if cpn in up_cpns]
 
-        for u in reversed_cpnts[::-1]:
+        for u in reversed_up_cpnts[::-1]:
             if self.get_component_name(u) in ["switch", "answer"]:
                 continue
             return self._canvas.get_component(u)["obj"].output()[1]
@@ -584,3 +589,7 @@ class ComponentBase(ABC):
     def get_parent(self):
         pid = self._canvas.get_component(self._id)["parent_id"]
         return self._canvas.get_component(pid)["obj"]
+
+    def get_upstream(self):
+        cpn_nms = self._canvas.get_component(self._id)['upstream']
+        return cpn_nms

--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -463,7 +463,6 @@ class ComponentBase(ABC):
         if len(self._canvas.path) > 1:
             reversed_cpnts.extend(self._canvas.path[-2])
         reversed_cpnts.extend(self._canvas.path[-1])
-        #需要筛选出当前com的upstream的元素->获取upstream
         up_cpns = self.get_upstream()
         reversed_up_cpnts = [cpn for cpn in reversed_cpnts if cpn in up_cpns]
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix: Resolved a bug where sibling components in Canvas were not restricted to fetching data from the upstream when parallel components were present.
Issue: When parallel components existed in Canvas, sibling components incorrectly fetched data without being limited to the upstream scope, causing data retrieval issues.
Solution: Adjusted the data fetching logic to ensure sibling components only retrieve data from the upstream scope.
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
