### PR TITLE
Feat: Add the functionality to load environment variables from a .env file

### DIFF
--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -3,6 +3,27 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
+# Function to load environment variables from .env file
+load_env_file() {
+    # Get the directory of the current script
+    local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local env_file="$script_dir/.env"
+
+    # Check if .env file exists
+    if [ -f "$env_file" ]; then
+        echo "Loading environment variables from: $env_file"
+        # Source the .env file
+        set -a
+        source "$env_file" 
+        set +a
+    else
+        echo "Warning: .env file not found at: $env_file"
+    fi
+}
+
+# Load environment variables
+load_env_file
+
 # Unset HTTP proxies that might be set by Docker daemon
 export http_proxy=""; export https_proxy=""; export no_proxy=""; export HTTP_PROXY=""; export HTTPS_PROXY=""; export NO_PROXY=""
 export PYTHONPATH=$(pwd)


### PR DESCRIPTION
### Change Content

- A new function `load_env_file` has been added to load environment variables from a .env file in the current script directory.
- If the .env file exists, the variables within it will be loaded; if it does not exist, a warning message will be output.

I found this issue while testing this pr: https://github.com/infiniflow/ragflow/pull/6327. The locally started server did not read the REGISTER_ENABLED variables in the .env. The result has always been the default True
### What problem does this PR solve?

Follow the tutorial in the README.md to start from source code. base's container that is es、redis，etc will load .env. Therefore, `launch_backend_service.sh` should also load .env to be consistent with the configuration of the docker container when it was started

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
