### PR TITLE
Fix: Fix the error of Ollama embeddings interface returning  "500 Internal Server Error"

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -260,14 +260,16 @@ class OllamaEmbed(Base):
         tks_num = 0
         for txt in texts:
             res = self.client.embeddings(prompt=txt,
-                                         model=self.model_name)
+                                         model=self.model_name,
+                                         options={"use_mmap": True})
             arr.append(res["embedding"])
             tks_num += 128
         return np.array(arr), tks_num
 
     def encode_queries(self, text):
         res = self.client.embeddings(prompt=text,
-                                     model=self.model_name)
+                                     model=self.model_name,
+                                     options={"use_mmap": True})
         return np.array(res["embedding"]), 128
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix the error where the Ollama embeddings interface returns a “500 Internal Server Error” when using models such as xiaobu-embedding-v2 for embedding.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)