### PR TITLE
Fix: multiple top-level packages error in Python project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,5 +136,8 @@ full = [
     "transformers>=4.35.0,<5.0.0"
 ]
 
+[tool.setuptools]
+packages = ['rag', 'api', 'sdk', 'helm','agent', 'deepdoc', 'graphrag', 'flask_session', 'intergrations', 'agentic_reasoning']
+
 [[tool.uv.index]]
 url = "https://mirrors.aliyun.com/pypi/simple"


### PR DESCRIPTION
### What problem does this PR solve?

This PR resolves the issue of multiple top-level packages being detected in the Python project, which caused errors when using uv pip install. The problem occurred because the project had multiple directories files at the root level, leading to a flat-layout error.
To fix this, the pyproject.toml file was updated to explicitly list the packages using the [tool.setuptools] section. This ensures that the correct packages are included during installation, avoiding the flat-layout error.
Type of change

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
