### PR TITLE
Fix: Preserve quotes while handling variable substitution withTemplate component.

### DIFF
--- a/agent/component/template.py
+++ b/agent/component/template.py
@@ -109,15 +109,13 @@ class Template(ComponentBase):
             pass
 
         for n, v in kwargs.items():
-            try:
-                v = json.dumps(v, ensure_ascii=False)
-            except Exception:
-                pass
+            if not isinstance(v, str):
+                try:
+                    v = json.dumps(v, ensure_ascii=False)
+                except Exception:
+                    pass
             content = re.sub(
                 r"\{%s\}" % re.escape(n), v, content
-            )
-            content = re.sub(
-                r"(\\\")", "", content
             )
             content = re.sub(
                 r"(#+)", r" \1 ", content


### PR DESCRIPTION
###Address Problem:
    The original implementation used re.sub(r"(\\\"|\")", "", content) which stripped all quotes from the processed content. While this worked for simple Jinja2-rendered templates, it caused formatting issues when :
-Quotes were required in the final output (e.g., JSON, Python Code strings) 

###Solution:
    1. Selective JSON Serialization.
    2. Removed Global Quote Removal

### What problem does this PR solve?

This PR addresses an issue in template processing where all quotation marks (" and \") were being removed from content, potentially corrupting string formatting in rendered outputs. **In fact, extra quotes is generated by json.dumps(v, ensure_ascii=False).**

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
