### PR TITLE
Remove thinking block from keyword node's result

### DIFF
--- a/agent/component/keyword.py
+++ b/agent/component/keyword.py
@@ -57,6 +57,7 @@ class KeywordExtract(Generate, ABC):
         ans = chat_mdl.chat(self._param.get_prompt(), [{"role": "user", "content": query}],
                             self._param.gen_conf())
 
+        ans = re.sub(r"<think>.*</think>", "", ans, flags=re.DOTALL)
         ans = re.sub(r".*keyword:", "", ans).strip()
         logging.debug(f"ans: {ans}")
         return KeywordExtract.be_output(ans)


### PR DESCRIPTION
### What problem does this PR solve?

For now, if you use thinking model (deepseek-r1:32b with ollama server in my case) in "Keyword" node, result contains all <think> block and so node return not only keywords 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
