### PR TITLE
Fix: failed to acquire lock exception with retry mechanism for postgres and mysql

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -330,12 +330,12 @@ class PostgresDatabaseLock:
             raise Exception(f"postgres lock {self.lock_name} does not exist")
 
     def __enter__(self):
-        if isinstance(self.db, PooledDatabase.POSTGRES):
+        if isinstance(self.db, PooledPostgresqlDatabase):
             self.lock()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(self.db, PooledDatabase.POSTGRES):
+        if isinstance(self.db, PooledPostgresqlDatabase):
             self.unlock()
 
     def __call__(self, func):
@@ -377,12 +377,12 @@ class MysqlDatabaseLock:
             raise Exception(f"mysql lock {self.lock_name} does not exist")
 
     def __enter__(self):
-        if isinstance(self.db, PooledDatabase.MYSQL):
+        if isinstance(self.db, PooledMySQLDatabase):
             self.lock()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(self.db, PooledDatabase.MYSQL):
+        if isinstance(self.db, PooledMySQLDatabase):
             self.unlock()
 
     def __call__(self, func):

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -303,7 +303,7 @@ def with_retry(max_retries=3, retry_delay=1.0):
 class PostgresDatabaseLock:
     def __init__(self, lock_name, timeout=10, db=None):
         self.lock_name = lock_name
-        self.lock_id = hashlib.md5(lock_name.encode()).hexdigest()
+        self.lock_id = int(hashlib.md5(lock_name.encode()).hexdigest(), 16) % (2**31-1)
         self.timeout = int(timeout)
         self.db = db if db else DB
 

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -309,7 +309,7 @@ class PostgresDatabaseLock:
 
     @with_retry(max_retries=3, retry_delay=1.0)
     def lock(self):
-        cursor = self.db.execute_sql("SELECT pg_try_advisory_lock(%s)", self.lock_id)
+        cursor = self.db.execute_sql("SELECT pg_try_advisory_lock(%s)", (self.lock_id,))
         ret = cursor.fetchone()
         if ret[0] == 0:
             raise Exception(f"acquire postgres lock {self.lock_name} timeout")
@@ -320,7 +320,7 @@ class PostgresDatabaseLock:
 
     @with_retry(max_retries=3, retry_delay=1.0)
     def unlock(self):
-        cursor = self.db.execute_sql("SELECT pg_advisory_unlock(%s)", self.lock_id)
+        cursor = self.db.execute_sql("SELECT pg_advisory_unlock(%s)", (self.lock_id,))
         ret = cursor.fetchone()
         if ret[0] == 0:
             raise Exception(f"postgres lock {self.lock_name} was not established by this thread")

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -19,6 +19,7 @@ import operator
 import os
 import sys
 import typing
+import time
 from enum import Enum
 from functools import wraps
 
@@ -260,39 +261,79 @@ class BaseDataBase:
         logging.info("init database on cluster mode successfully")
 
 
+def with_retry(max_retries=3, retry_delay=1.0):
+    """Decorator: Add retry mechanism to database operations
+    
+    Args:
+        max_retries (int): maximum number of retries
+        retry_delay (float): initial retry delay (seconds), will increase exponentially
+        
+    Returns:
+        decorated function
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exception = None
+            for retry in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    last_exception = e
+                    # get self and method name for logging
+                    self_obj = args[0] if args else None
+                    func_name = func.__name__
+                    lock_name = getattr(self_obj, 'lock_name', 'unknown') if self_obj else 'unknown'
+                    
+                    if retry < max_retries - 1:
+                        current_delay = retry_delay * (2 ** retry)
+                        logging.warning(f"{func_name} {lock_name} failed: {str(e)}, retrying ({retry+1}/{max_retries})")
+                        time.sleep(current_delay)
+                    else:
+                        logging.error(f"{func_name} {lock_name} failed after all attempts: {str(e)}")
+            
+            if last_exception:
+                raise last_exception
+            return False
+        return wrapper
+    return decorator
+
+
 class PostgresDatabaseLock:
     def __init__(self, lock_name, timeout=10, db=None):
         self.lock_name = lock_name
         self.timeout = int(timeout)
         self.db = db if db else DB
 
+    @with_retry(max_retries=3, retry_delay=1.0)
     def lock(self):
-        cursor = self.db.execute_sql("SELECT pg_try_advisory_lock(%s)", self.timeout)
+        cursor = self.db.execute_sql("SELECT pg_try_advisory_lock(%s)", (self.lock_name,))
         ret = cursor.fetchone()
-        if ret[0] == 0:
+        if ret[0] is False:
             raise Exception(f"acquire postgres lock {self.lock_name} timeout")
-        elif ret[0] == 1:
+        elif ret[0] is True:
             return True
         else:
             raise Exception(f"failed to acquire lock {self.lock_name}")
 
+    @with_retry(max_retries=3, retry_delay=1.0)
     def unlock(self):
-        cursor = self.db.execute_sql("SELECT pg_advisory_unlock(%s)", self.timeout)
+        cursor = self.db.execute_sql("SELECT pg_advisory_unlock(%s)", (self.lock_name,))
         ret = cursor.fetchone()
-        if ret[0] == 0:
+        if ret[0] is False:
             raise Exception(f"postgres lock {self.lock_name} was not established by this thread")
-        elif ret[0] == 1:
+        elif ret[0] is True:
             return True
         else:
             raise Exception(f"postgres lock {self.lock_name} does not exist")
 
     def __enter__(self):
-        if isinstance(self.db, PostgresDatabaseLock):
+        if isinstance(self.db, PooledPostgresqlDatabase):
             self.lock()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(self.db, PostgresDatabaseLock):
+        if isinstance(self.db, PooledPostgresqlDatabase):
             self.unlock()
 
     def __call__(self, func):
@@ -310,6 +351,7 @@ class MysqlDatabaseLock:
         self.timeout = int(timeout)
         self.db = db if db else DB
 
+    @with_retry(max_retries=3, retry_delay=1.0)
     def lock(self):
         # SQL parameters only support %s format placeholders
         cursor = self.db.execute_sql("SELECT GET_LOCK(%s, %s)", (self.lock_name, self.timeout))
@@ -321,6 +363,7 @@ class MysqlDatabaseLock:
         else:
             raise Exception(f"failed to acquire lock {self.lock_name}")
 
+    @with_retry(max_retries=3, retry_delay=1.0)
     def unlock(self):
         cursor = self.db.execute_sql("SELECT RELEASE_LOCK(%s)", (self.lock_name,))
         ret = cursor.fetchone()


### PR DESCRIPTION
Added the with_retry decorator in db_models.py to add a retry mechanism for database operations. Applied the retry mechanism to the lock and unlock methods of the PostgresDatabaseLock and MysqlDatabaseLock classes to enhance the reliability of lock operations.

### What problem does this PR solve?
resolve failed to acquire lock exception with retry mechanism

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)