### PR TITLE
fix: inject config when use oss

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ./nginx/proxy.conf:/etc/nginx/proxy.conf
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ../history_data_agent:/ragflow/history_data_agent
+      - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
 
     env_file: .env
     environment:


### PR DESCRIPTION
### What problem does this PR solve?

When enabling OSS configuration, the configuration fails to load because the script's first character is #. This issue can be resolved by modifying the configuration file through volume injection/mounting.


### Type of change

- [✅ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
