### PR TITLE
fix python_api_reference.md update dataset bug

### DIFF
--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -313,7 +313,7 @@ A dictionary representing the attributes to update, with the following keys:
 from ragflow_sdk import RAGFlow
 
 rag_object = RAGFlow(api_key="<YOUR_API_KEY>", base_url="http://<YOUR_BASE_URL>:9380")
-dataset = rag_object.list_datasets(name="kb_name")
+dataset = rag_object.list_datasets(name="kb_name")[0]
 dataset.update({"embedding_model":"BAAI/bge-zh-v1.5", "chunk_method":"manual"})
 ```
 

--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -313,7 +313,8 @@ A dictionary representing the attributes to update, with the following keys:
 from ragflow_sdk import RAGFlow
 
 rag_object = RAGFlow(api_key="<YOUR_API_KEY>", base_url="http://<YOUR_BASE_URL>:9380")
-dataset = rag_object.list_datasets(name="kb_name")[0]
+dataset = rag_object.list_datasets(name="kb_name")
+dataset = dataset[0]
 dataset.update({"embedding_model":"BAAI/bge-zh-v1.5", "chunk_method":"manual"})
 ```
 


### PR DESCRIPTION
### What problem does this PR solve?

There is a small bug in the update dataset of this document. The return type of rag_oobject.list_datasets is a list type, and the first item should be taken as' ragflow_stdk.modules.dataset ' DataSet`， Adapt to the update.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
