### PR TITLE
fix:  Remove unnecessary minio initialization

### DIFF
--- a/rag/utils/minio_conn.py
+++ b/rag/utils/minio_conn.py
@@ -118,18 +118,3 @@ class RAGFlowMinio:
                 time.sleep(1)
         return
 
-
-MINIO = RAGFlowMinio()
-
-if __name__ == "__main__":
-    conn = RAGFlowMinio()
-    fnm = "/opt/home/kevinhu/docgpt/upload/13/11-408.jpg"
-    from PIL import Image
-
-    img = Image.open(fnm)
-    buff = BytesIO()
-    img.save(buff, format='JPEG')
-    print(conn.put("test", "11-408.jpg", buff.getvalue()))
-    bts = conn.get("test", "11-408.jpg")
-    img = Image.open(BytesIO(bts))
-    img.save("test.jpg")


### PR DESCRIPTION
### What problem does this PR solve?

Prevent applications from failing to start due to calling non-existent or incorrect Minio connection configurations when using file storage outside of Minio

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
