### PR TITLE
Fix: binlog_expire_logs_seconds

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -81,6 +81,7 @@ services:
       --default-authentication-plugin=mysql_native_password
       --tls_version="TLSv1.2,TLSv1.3"
       --init-file /data/application/init.sql
+      --binlog_expire_logs_seconds=604800
     ports:
       - ${MYSQL_PORT}:3306
     volumes:


### PR DESCRIPTION
This PR updates the MySQL container configuration by setting the parameter --binlog_expire_logs_seconds to 604800 seconds (7 days). This change ensures that MySQL automatically purges binary logs older than 7 days, helping to conserve disk space and maintain precise log management.

### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
