### PR TITLE
Fix agent completion requiring calling twice with parameters in begin component

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -115,9 +115,10 @@ def create_agent_session(tenant_id, agent_id):
                     else:
                         if "value" in ele:
                             ele.pop("value")
-    else:
-        for ans in canvas.run(stream=False):
-            pass
+
+    for ans in canvas.run(stream=False):
+        pass
+    
     cvs.dsl = json.loads(str(canvas))
     conv = {"id": get_uuid(), "dialog_id": cvs.id, "user_id": user_id, "message": [{"role": "assistant", "content": canvas.get_prologue()}], "source": "agent", "dsl": cvs.dsl}
     API4ConversationService.save(**conv)


### PR DESCRIPTION
### What problem does this PR solve?

Fix #5418

Actually, the fix #4329 also works for agent flows with parameters, so this PR just relaxes the `else` branch of that. With this PR, it works fine on my side, may need more testing to make sure this does not break something.

I guess the real problem may be deeply hidden in the code which relates to conversation and canvas execution. After a few hours of debugging, I see the only difference between with and without parameters in `begin` component, is the `history` field of canvas data. When the `begin` component contains some parameters, the debug log shows:

```
025-03-29 19:50:38,521 DEBUG    356590 {
            "component_name": "Begin",
            "params": {"output_var_name": "output", "message_history_window_size": 22, "query": [{"type": "fileUrls", "key": "fileUrls", "name": "files", "optional": true, "value": "问题.txt\n今天天气怎么样"}], "inputs": [], "debug_inputs": [], "prologue": "你好！ 我是你的助理，有什么可以帮到你的吗？", "output": null},
            "output": null,
            "inputs": []
        }, history: [["user", "请回答我上传文件中的问题。"]], kwargs: {"stream": false}
2025-03-29 19:50:38,523 DEBUG    356590 {
            "component_name": "Answer",
            "params": {"output_var_name": "output", "message_history_window_size": 22, "query": [], "inputs": [], "debug_inputs": [], "post_answers": [], "output": null},
            "output": null,
            "inputs": []
        }, history: [["user", "请回答我上传文件中的问题。"]], kwargs: {"stream": false}
```

Then it does not go further along the flow.

When the `begin` component does not contain any parameter, the debug log shows:

```
2025-03-29 19:41:13,518 DEBUG    353596 {
            "component_name": "Begin",
            "params": {"output_var_name": "output", "message_history_window_size": 22, "query": [], "inputs": [], "debug_inputs": [], "prologue": "你好！ 我是你的助理，有什么可以帮到你的吗？", "output": null},
            "output": null,
            "inputs": []
        }, history: [], kwargs: {"stream": false}
2025-03-29 19:41:13,520 DEBUG    353596 {
            "component_name": "Answer",
            "params": {"output_var_name": "output", "message_history_window_size": 22, "query": [], "inputs": [], "debug_inputs": [], "post_answers": [], "output": null},
            "output": null,
            "inputs": []
        }, history: [], kwargs: {"stream": false}
2025-03-29 19:41:13,556 INFO     353596 127.0.0.1 - - [29/Mar/2025 19:41:13] "POST /api/v1/agents/fee6886a0c6f11f09b48eb8798e9aa9b/sessions?user_id=123 HTTP/1.1" 200 -
2025-03-29 19:41:21,115 DEBUG    353596 Canvas.prepare2run: Retrieval:LateGuestsNotice
2025-03-29 19:41:21,116 DEBUG    353596 {
            "component_name": "Retrieval",
            "params": {"output_var_name": "output", "message_history_window_size": 22, "query": [], "inputs": [], "debug_inputs": [], "similarity_threshold": 0.2, "keywords_similarity_weight": 0.3, "top_n": 8, "top_k": 1024, "kb_ids": ["9aca3c700c5911f0811caf35658b9385"], "rerank_id": "", "empty_response": "", "tavily_api_key": "", "use_kg": false, "output": null},
            "output": null,
            "inputs": []
        }, history: [["user", "请回答我上传文件中的问题。"]], kwargs: {"stream": false}
```

It correctly goes along the flow and generates correct answer.

You can see the difference: when the `begin` component has any parameter, the `history` field is filled from the beginning, while it is just `[]` if the `begin` component has no parameter.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
