### PR TITLE
Don't split and strip input in retrieval component.

### DIFF
--- a/agent/component/retrieval.py
+++ b/agent/component/retrieval.py
@@ -56,8 +56,6 @@ class Retrieval(ComponentBase, ABC):
     def _run(self, history, **kwargs):
         query = self.get_input()
         query = str(query["content"][0]) if "content" in query else ""
-        lines = query.split('\n')
-        query = lines[-1] if lines else ""
         kbs = KnowledgebaseService.get_by_ids(self._param.kb_ids)
         if not kbs:
             return Retrieval.be_output("")


### PR DESCRIPTION
### What problem does this PR solve?

Actually fix #6241 

Hello, I ran into the same problem as #6241. When I'm testing my agent flow in the web ui using `Run` button with a file input, the retrieval component always gave an empty output.

In the code I found that:

`web/src/pages/flow/debug-content/index.tsx`:

```tsx
const onOk = useCallback(async () => {
    const values = await form.validateFields();
    const nextValues = Object.entries(values).map(([key, value]) => {
      const item = parameters[Number(key)];
      let nextValue = value;
      if (Array.isArray(value)) {
        nextValue = ``;

        value.forEach((x) => {
          nextValue +=
            x?.originFileObj instanceof File
              ? `${x.name}\n${x.response?.data}\n----\n`    // Here, the file content always ends in '\n'
              : `${x.url}\n${x.result}\n----\n`;
        });
      }
      return { ...item, value: nextValue };
    });

    ok(nextValues);
  }, [form, ok, parameters]);
```

while in the `agent/component/retrieval.py`:

```python
def _run(self, history, **kwargs):
        query = self.get_input()
        query = str(query["content"][0]) if "content" in query else ""
        lines = query.split('\n')                     # inputs are split to ['xxx','yyy','----','']
        query = lines[-1] if lines else ""      # Here we always get '', thus no result
        kbs = KnowledgebaseService.get_by_ids(self._param.kb_ids)
        if not kbs:
            return Retrieval.be_output("")
```

so the code will never got correct result.

I'm not sure why the input needs such a split here, so I just removed the splitting, and it works well on my side.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
