### PR TITLE
Fix: Error message is incorrect when updating chat name #6850

### DIFF
--- a/api/apps/sdk/chat.py
+++ b/api/apps/sdk/chat.py
@@ -223,11 +223,11 @@ def update(tenant_id, chat_id):
             return get_error_data_result(f"`rerank_model` {req.get('rerank_id')} doesn't exist")
     if "name" in req:
         if not req.get("name"):
-            return get_error_data_result(message="`name` is not empty.")
+            return get_error_data_result(message="`name` cannot be empty.")
         if req["name"].lower() != res["name"].lower() \
                 and len(
             DialogService.query(name=req["name"], tenant_id=tenant_id, status=StatusEnum.VALID.value)) > 0:
-            return get_error_data_result(message="Duplicated chat name in updating dataset.")
+            return get_error_data_result(message="Duplicated chat name in updating chat.")
     if "prompt_config" in req:
         res["prompt_config"].update(req["prompt_config"])
         for p in res["prompt_config"]["parameters"]:

--- a/sdk/python/test/test_http_api/test_chat_assistant_management/test_update_chat_assistant.py
+++ b/sdk/python/test/test_http_api/test_chat_assistant_management/test_update_chat_assistant.py
@@ -46,9 +46,9 @@ class TestChatAssistantUpdate:
             ({"name": "valid_name"}, 0, ""),
             pytest.param({"name": "a" * (CHAT_ASSISTANT_LIMIT + 1)}, 102, "", marks=pytest.mark.skip(reason="issues/")),
             pytest.param({"name": 1}, 100, "", marks=pytest.mark.skip(reason="issues/")),
-            pytest.param({"name": ""}, 102, "`name` is empty.", marks=pytest.mark.skip(reason="issues/")),
-            pytest.param({"name": "test_chat_assistant_1"}, 102, "Duplicated chat name in updating chat.", marks=pytest.mark.skip(reason="issues/")),
-            pytest.param({"name": "TEST_CHAT_ASSISTANT_1"}, 102, "Duplicated chat name in updating chat.", marks=pytest.mark.skip(reason="issues/")),
+            ({"name": ""}, 102, "`name` cannot be empty."),
+            ({"name": "test_chat_assistant_1"}, 102, "Duplicated chat name in updating chat."),
+            ({"name": "TEST_CHAT_ASSISTANT_1"}, 102, "Duplicated chat name in updating chat."),
         ],
     )
     def test_name(self, get_http_api_auth, add_chat_assistants_func, payload, expected_code, expected_message):


### PR DESCRIPTION
### What problem does this PR solve?

#6850 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
