### PR TITLE
fix: add exception handling for get_by_id method

### DIFF
--- a/api/db/services/common_service.py
+++ b/api/db/services/common_service.py
@@ -225,9 +225,12 @@ class CommonService:
         #     pid: Record ID
         # Returns:
         #     Tuple of (success, record)
-        obj = cls.model.get_or_none(cls.model.id == pid)
-        if obj:
-            return True, obj
+        try:
+            obj = cls.model.get_or_none(cls.model.id == pid)
+            if obj:
+                return True, obj
+        except Exception:
+            pass
         return False, None
 
     @classmethod


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #6548 

Add exception handling to prevent exceptions from propagating back to the web, which may lead to failure in displaying conversation content.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
