### PR TITLE
fix Conversation roles must alternate user/assistant/user/assistant/... bug

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -240,8 +240,13 @@ def chat_completion_openai_like(tenant_id, chat_id):
     dia = dia[0]
 
     # Filter system and non-sense assistant messages
-    msg = None
-    msg = [m for m in messages if m["role"] != "system" and (m["role"] != "assistant" or msg)]
+    msg = []
+    for m in messages:
+        if m["role"] == "system":
+            continue
+        if m["role"] == "assistant" and not msg:
+            continue
+        msg.append(m)
 
     # tools = get_tools()
     # toolcall_session = SimpleFunctionCallServer()


### PR DESCRIPTION
### What problem does this PR solve?

The old logic filters out all assistant messages from messages, which, in multi-turn conversations, results in only user messages being retained. This leads to an error in locally deployed models: Conversation roles must alternate user/assistant/user/assistant/...

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
