### PR TITLE
Fix: remove deprecated `permission` field

### DIFF
--- a/api/apps/kb_app.py
+++ b/api/apps/kb_app.py
@@ -73,7 +73,7 @@ def create():
 
 @manager.route('/update', methods=['post'])  # noqa: F821
 @login_required
-@validate_request("kb_id", "name", "description", "permission", "parser_id")
+@validate_request("kb_id", "name", "description", "parser_id")
 @not_allowed_parameters("id", "tenant_id", "created_by", "create_time", "update_time", "create_date", "update_date", "created_by")
 def update():
     req = request.json


### PR DESCRIPTION
### What problem does this PR solve?

Fix: remove deprecated KB updating `permission` field. #6911 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
