### PR TITLE
Fix: incorrect total chunks count in retrieval function after similarity filtering (#6741)

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -363,7 +363,6 @@ class Dealer:
 
         sres = self.search(req, [index_name(tid) for tid in tenant_ids],
                            kb_ids, embd_mdl, highlight, rank_feature=rank_feature)
-        ranks["total"] = sres.total
 
         if rerank_mdl and sres.total > 0:
             sim, tsim, vsim = self.rerank_by_model(rerank_mdl,
@@ -425,7 +424,7 @@ class Dealer:
                                                        v in sorted(ranks["doc_aggs"].items(),
                                                                    key=lambda x: x[1]["count"] * -1)]
         ranks["chunks"] = ranks["chunks"][:page_size]
-
+        ranks["total"] = len(ranks["chunks"])
         return ranks
 
     def sql_retrieval(self, sql, fetch_size=128, format="json"):


### PR DESCRIPTION
### Related Issue: #6741
### Environment:

Using nightly version
Commit version: [3bb1e01](https://github.com/infiniflow/ragflow/commit/3bb1e012e611dee83e92fc6d18fb1f35f2f945a7) 

### Bug Description:
The retrieval function in rag/nlp/search.py returns the original total chunks number 
even after chunks are filtered by similarity_threshold. This creates inconsistency 
between the actual returned chunks and the reported total.