### PR TITLE
Fix: incorrect total chunks count in retrieval function after similarity filtering (#6741) 

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -383,6 +383,8 @@ class Dealer:
         if doc_ids:
             similarity_threshold = 0
             page_size = 30
+        filtered_count = sum(1 for s in sim if s >= similarity_threshold)
+        ranks["total"] = filtered_count
         for i in idx:
             if sim[i] < similarity_threshold:
                 break


### PR DESCRIPTION
### Related Issue: 
https://github.com/infiniflow/ragflow/issues/6741
### Environment:
Using nightly version
Commit version: [3bb1e01](https://github.com/infiniflow/ragflow/commit/3bb1e012e611dee83e92fc6d18fb1f35f2f945a7)

### Bug Description:
The retrieval function in rag/nlp/search.py returns the original total chunks number
even after chunks are filtered by similarity_threshold. This creates inconsistency
between the actual returned chunks and the reported total.
### Changes Made:
Added code to count how many search results actually meet or exceed the configured similarity threshold
Positioned the calculation after the doc_ids conditional logic to ensure special cases are handled correctly
Updated the ranks["total"] value to store this filtered count instead of using the raw search result count
