### PR TITLE
Test: Added test cases for List Sessions With Chat Assistant HTTP API

### DIFF
--- a/sdk/python/test/libs/utils/__init__.py
+++ b/sdk/python/test/libs/utils/__init__.py
@@ -56,3 +56,8 @@ def wait_for(timeout=10, interval=1, error_msg="Timeout"):
         return wrapper
 
     return decorator
+
+
+def is_sorted(data, field, descending=True):
+    timestamps = [ds[field] for ds in data]
+    return all(a >= b for a, b in zip(timestamps, timestamps[1:])) if descending else all(a <= b for a, b in zip(timestamps, timestamps[1:]))

--- a/sdk/python/test/test_http_api/test_dataset_mangement/test_list_datasets.py
+++ b/sdk/python/test/test_http_api/test_dataset_mangement/test_list_datasets.py
@@ -18,11 +18,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from common import INVALID_API_TOKEN, list_datasets
 from libs.auth import RAGFlowHttpApiAuth
-
-
-def is_sorted(data, field, descending=True):
-    timestamps = [ds[field] for ds in data]
-    return all(a >= b for a, b in zip(timestamps, timestamps[1:])) if descending else all(a <= b for a, b in zip(timestamps, timestamps[1:]))
+from libs.utils import is_sorted
 
 
 class TestAuthorization:
@@ -125,24 +121,9 @@ class TestDatasetsList:
     @pytest.mark.parametrize(
         "params, expected_code, assertions, expected_message",
         [
-            (
-                {"orderby": None},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", True)),
-                "",
-            ),
-            (
-                {"orderby": "create_time"},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", True)),
-                "",
-            ),
-            (
-                {"orderby": "update_time"},
-                0,
-                lambda r: (is_sorted(r["data"], "update_time", True)),
-                "",
-            ),
+            ({"orderby": None}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
+            ({"orderby": "create_time"}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
+            ({"orderby": "update_time"}, 0, lambda r: (is_sorted(r["data"], "update_time", True)), ""),
             pytest.param(
                 {"orderby": "name", "desc": "False"},
                 0,
@@ -178,54 +159,14 @@ class TestDatasetsList:
     @pytest.mark.parametrize(
         "params, expected_code, assertions, expected_message",
         [
-            (
-                {"desc": None},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", True)),
-                "",
-            ),
-            (
-                {"desc": "true"},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", True)),
-                "",
-            ),
-            (
-                {"desc": "True"},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", True)),
-                "",
-            ),
-            (
-                {"desc": True},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", True)),
-                "",
-            ),
-            (
-                {"desc": "false"},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", False)),
-                "",
-            ),
-            (
-                {"desc": "False"},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", False)),
-                "",
-            ),
-            (
-                {"desc": False},
-                0,
-                lambda r: (is_sorted(r["data"], "create_time", False)),
-                "",
-            ),
-            (
-                {"desc": "False", "orderby": "update_time"},
-                0,
-                lambda r: (is_sorted(r["data"], "update_time", False)),
-                "",
-            ),
+            ({"desc": None}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
+            ({"desc": "true"}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
+            ({"desc": "True"}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
+            ({"desc": True}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
+            ({"desc": "false"}, 0, lambda r: (is_sorted(r["data"], "create_time", False)), ""),
+            ({"desc": "False"}, 0, lambda r: (is_sorted(r["data"], "create_time", False)), ""),
+            ({"desc": False}, 0, lambda r: (is_sorted(r["data"], "create_time", False)), ""),
+            ({"desc": "False", "orderby": "update_time"}, 0, lambda r: (is_sorted(r["data"], "update_time", False)), ""),
             pytest.param(
                 {"desc": "unknown"},
                 102,

--- a/sdk/python/test/test_http_api/test_file_management_within_dataset/test_list_documents.py
+++ b/sdk/python/test/test_http_api/test_file_management_within_dataset/test_list_documents.py
@@ -18,11 +18,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from common import INVALID_API_TOKEN, list_documnets
 from libs.auth import RAGFlowHttpApiAuth
-
-
-def is_sorted(data, field, descending=True):
-    timestamps = [ds[field] for ds in data]
-    return all(a >= b for a, b in zip(timestamps, timestamps[1:])) if descending else all(a <= b for a, b in zip(timestamps, timestamps[1:]))
+from libs.utils import is_sorted
 
 
 class TestAuthorization:
@@ -153,38 +149,11 @@ class TestDocumentsList:
     @pytest.mark.parametrize(
         "params, expected_code, assertions, expected_message",
         [
-            (
-                {"orderby": None},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", True)),
-                "",
-            ),
-            (
-                {"orderby": "create_time"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", True)),
-                "",
-            ),
-            (
-                {"orderby": "update_time"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "update_time", True)),
-                "",
-            ),
-            pytest.param(
-                {"orderby": "name", "desc": "False"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "name", False)),
-                "",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
-            pytest.param(
-                {"orderby": "unknown"},
-                102,
-                0,
-                "orderby should be create_time or update_time",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
+            ({"orderby": None}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", True)), ""),
+            ({"orderby": "create_time"}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", True)), ""),
+            ({"orderby": "update_time"}, 0, lambda r: (is_sorted(r["data"]["docs"], "update_time", True)), ""),
+            pytest.param({"orderby": "name", "desc": "False"}, 0, lambda r: (is_sorted(r["data"]["docs"], "name", False)), "", marks=pytest.mark.skip(reason="issues/5851")),
+            pytest.param({"orderby": "unknown"}, 102, 0, "orderby should be create_time or update_time", marks=pytest.mark.skip(reason="issues/5851")),
         ],
     )
     def test_orderby(
@@ -208,62 +177,15 @@ class TestDocumentsList:
     @pytest.mark.parametrize(
         "params, expected_code, assertions, expected_message",
         [
-            (
-                {"desc": None},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", True)),
-                "",
-            ),
-            (
-                {"desc": "true"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", True)),
-                "",
-            ),
-            (
-                {"desc": "True"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", True)),
-                "",
-            ),
-            (
-                {"desc": True},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", True)),
-                "",
-            ),
-            pytest.param(
-                {"desc": "false"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", False)),
-                "",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
-            (
-                {"desc": "False"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", False)),
-                "",
-            ),
-            (
-                {"desc": False},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "create_time", False)),
-                "",
-            ),
-            (
-                {"desc": "False", "orderby": "update_time"},
-                0,
-                lambda r: (is_sorted(r["data"]["docs"], "update_time", False)),
-                "",
-            ),
-            pytest.param(
-                {"desc": "unknown"},
-                102,
-                0,
-                "desc should be true or false",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
+            ({"desc": None}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", True)), ""),
+            ({"desc": "true"}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", True)), ""),
+            ({"desc": "True"}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", True)), ""),
+            ({"desc": True}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", True)), ""),
+            pytest.param({"desc": "false"}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", False)), "", marks=pytest.mark.skip(reason="issues/5851")),
+            ({"desc": "False"}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", False)), ""),
+            ({"desc": False}, 0, lambda r: (is_sorted(r["data"]["docs"], "create_time", False)), ""),
+            ({"desc": "False", "orderby": "update_time"}, 0, lambda r: (is_sorted(r["data"]["docs"], "update_time", False)), ""),
+            pytest.param({"desc": "unknown"}, 102, 0, "desc should be true or false", marks=pytest.mark.skip(reason="issues/5851")),
         ],
     )
     def test_desc(

--- a/sdk/python/test/test_http_api/test_session_management/conftest.py
+++ b/sdk/python/test/test_http_api/test_session_management/conftest.py
@@ -1,0 +1,35 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import pytest
+from common import create_session_with_chat_assistant, delete_session_with_chat_assistants
+
+
+@pytest.fixture(scope="class")
+def add_sessions_with_chat_assistant(request, get_http_api_auth, add_chat_assistants):
+    _, _, chat_assistant_ids = add_chat_assistants
+
+    def cleanup():
+        for chat_assistant_id in chat_assistant_ids:
+            delete_session_with_chat_assistants(get_http_api_auth, chat_assistant_id)
+
+    request.addfinalizer(cleanup)
+
+    session_ids = []
+    for i in range(5):
+        res = create_session_with_chat_assistant(get_http_api_auth, chat_assistant_ids[0], {"name": f"session_with_chat_assistant_{i}"})
+        session_ids.append(res["data"]["id"])
+
+    return chat_assistant_ids[0], session_ids

--- a/sdk/python/test/test_http_api/test_session_management/test_list_sessions_with_chat_assistant.py
+++ b/sdk/python/test/test_http_api/test_session_management/test_list_sessions_with_chat_assistant.py
@@ -16,7 +16,7 @@
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-from common import INVALID_API_TOKEN, delete_datasets, list_chat_assistants
+from common import INVALID_API_TOKEN, delete_chat_assistants, list_session_with_chat_assistants
 from libs.auth import RAGFlowHttpApiAuth
 from libs.utils import is_sorted
 
@@ -34,44 +34,27 @@ class TestAuthorization:
         ],
     )
     def test_invalid_auth(self, auth, expected_code, expected_message):
-        res = list_chat_assistants(auth)
+        res = list_session_with_chat_assistants(auth, "chat_assistant_id")
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
 
-@pytest.mark.usefixtures("add_chat_assistants")
-class TestChatAssistantsList:
-    def test_default(self, get_http_api_auth):
-        res = list_chat_assistants(get_http_api_auth)
-        assert res["code"] == 0
-        assert len(res["data"]) == 5
-
+class TestSessionsWithChatAssistantList:
     @pytest.mark.parametrize(
         "params, expected_code, expected_page_size, expected_message",
         [
             ({"page": None, "page_size": 2}, 0, 2, ""),
-            ({"page": 0, "page_size": 2}, 0, 2, ""),
+            pytest.param({"page": 0, "page_size": 2}, 100, 0, "ValueError('Search does not support negative slicing.')", marks=pytest.mark.skip),
             ({"page": 2, "page_size": 2}, 0, 2, ""),
             ({"page": 3, "page_size": 2}, 0, 1, ""),
             ({"page": "3", "page_size": 2}, 0, 1, ""),
-            pytest.param(
-                {"page": -1, "page_size": 2},
-                100,
-                0,
-                "1064",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
-            pytest.param(
-                {"page": "a", "page_size": 2},
-                100,
-                0,
-                """ValueError("invalid literal for int() with base 10: \'a\'")""",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
+            pytest.param({"page": -1, "page_size": 2}, 100, 0, "ValueError('Search does not support negative slicing.')", marks=pytest.mark.skip),
+            pytest.param({"page": "a", "page_size": 2}, 100, 0, """ValueError("invalid literal for int() with base 10: \'a\'")""", marks=pytest.mark.skip),
         ],
     )
-    def test_page(self, get_http_api_auth, params, expected_code, expected_page_size, expected_message):
-        res = list_chat_assistants(get_http_api_auth, params=params)
+    def test_page(self, get_http_api_auth, add_sessions_with_chat_assistant, params, expected_code, expected_page_size, expected_message):
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_page_size
@@ -86,31 +69,13 @@ class TestChatAssistantsList:
             ({"page_size": 1}, 0, 1, ""),
             ({"page_size": 6}, 0, 5, ""),
             ({"page_size": "1"}, 0, 1, ""),
-            pytest.param(
-                {"page_size": -1},
-                100,
-                0,
-                "1064",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
-            pytest.param(
-                {"page_size": "a"},
-                100,
-                0,
-                """ValueError("invalid literal for int() with base 10: \'a\'")""",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
+            pytest.param({"page_size": -1}, 0, 5, "", marks=pytest.mark.skip),
+            pytest.param({"page_size": "a"}, 100, 0, """ValueError("invalid literal for int() with base 10: \'a\'")""", marks=pytest.mark.skip),
         ],
     )
-    def test_page_size(
-        self,
-        get_http_api_auth,
-        params,
-        expected_code,
-        expected_page_size,
-        expected_message,
-    ):
-        res = list_chat_assistants(get_http_api_auth, params=params)
+    def test_page_size(self, get_http_api_auth, add_sessions_with_chat_assistant, params, expected_code, expected_page_size, expected_message):
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_page_size
@@ -123,31 +88,21 @@ class TestChatAssistantsList:
             ({"orderby": None}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
             ({"orderby": "create_time"}, 0, lambda r: (is_sorted(r["data"], "create_time", True)), ""),
             ({"orderby": "update_time"}, 0, lambda r: (is_sorted(r["data"], "update_time", True)), ""),
-            pytest.param(
-                {"orderby": "name", "desc": "False"},
-                0,
-                lambda r: (is_sorted(r["data"], "name", False)),
-                "",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
-            pytest.param(
-                {"orderby": "unknown"},
-                102,
-                0,
-                "orderby should be create_time or update_time",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
+            ({"orderby": "name", "desc": "False"}, 0, lambda r: (is_sorted(r["data"], "name", False)), ""),
+            pytest.param({"orderby": "unknown"}, 102, 0, "orderby should be create_time or update_time", marks=pytest.mark.skip(reason="issues/")),
         ],
     )
     def test_orderby(
         self,
         get_http_api_auth,
+        add_sessions_with_chat_assistant,
         params,
         expected_code,
         assertions,
         expected_message,
     ):
-        res = list_chat_assistants(get_http_api_auth, params=params)
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -166,24 +121,20 @@ class TestChatAssistantsList:
             ({"desc": "False"}, 0, lambda r: (is_sorted(r["data"], "create_time", False)), ""),
             ({"desc": False}, 0, lambda r: (is_sorted(r["data"], "create_time", False)), ""),
             ({"desc": "False", "orderby": "update_time"}, 0, lambda r: (is_sorted(r["data"], "update_time", False)), ""),
-            pytest.param(
-                {"desc": "unknown"},
-                102,
-                0,
-                "desc should be true or false",
-                marks=pytest.mark.skip(reason="issues/5851"),
-            ),
+            pytest.param({"desc": "unknown"}, 102, 0, "desc should be true or false", marks=pytest.mark.skip(reason="issues/")),
         ],
     )
     def test_desc(
         self,
         get_http_api_auth,
+        add_sessions_with_chat_assistant,
         params,
         expected_code,
         assertions,
         expected_message,
     ):
-        res = list_chat_assistants(get_http_api_auth, params=params)
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -196,15 +147,16 @@ class TestChatAssistantsList:
         [
             ({"name": None}, 0, 5, ""),
             ({"name": ""}, 0, 5, ""),
-            ({"name": "test_chat_assistant_1"}, 0, 1, ""),
-            ({"name": "unknown"}, 102, 0, "The chat doesn't exist"),
+            ({"name": "session_with_chat_assistant_1"}, 0, 1, ""),
+            ({"name": "unknown"}, 0, 0, ""),
         ],
     )
-    def test_name(self, get_http_api_auth, params, expected_code, expected_num, expected_message):
-        res = list_chat_assistants(get_http_api_auth, params=params)
+    def test_name(self, get_http_api_auth, add_sessions_with_chat_assistant, params, expected_code, expected_num, expected_message):
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
-            if params["name"] in [None, ""]:
+            if params["name"] != "session_with_chat_assistant_1":
                 assert len(res["data"]) == expected_num
             else:
                 assert res["data"][0]["name"] == params["name"]
@@ -212,33 +164,25 @@ class TestChatAssistantsList:
             assert res["message"] == expected_message
 
     @pytest.mark.parametrize(
-        "chat_assistant_id, expected_code, expected_num, expected_message",
+        "session_id, expected_code, expected_num, expected_message",
         [
             (None, 0, 5, ""),
             ("", 0, 5, ""),
             (lambda r: r[0], 0, 1, ""),
-            ("unknown", 102, 0, "The chat doesn't exist"),
+            ("unknown", 0, 0, "The chat doesn't exist"),
         ],
     )
-    def test_id(
-        self,
-        get_http_api_auth,
-        add_chat_assistants,
-        chat_assistant_id,
-        expected_code,
-        expected_num,
-        expected_message,
-    ):
-        _, _, chat_assistant_ids = add_chat_assistants
-        if callable(chat_assistant_id):
-            params = {"id": chat_assistant_id(chat_assistant_ids)}
+    def test_id(self, get_http_api_auth, add_sessions_with_chat_assistant, session_id, expected_code, expected_num, expected_message):
+        chat_assistant_id, session_ids = add_sessions_with_chat_assistant
+        if callable(session_id):
+            params = {"id": session_id(session_ids)}
         else:
-            params = {"id": chat_assistant_id}
+            params = {"id": session_id}
 
-        res = list_chat_assistants(get_http_api_auth, params=params)
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
-            if params["id"] in [None, ""]:
+            if params["id"] != session_ids[0]:
                 assert len(res["data"]) == expected_num
             else:
                 assert res["data"][0]["id"] == params["id"]
@@ -246,31 +190,22 @@ class TestChatAssistantsList:
             assert res["message"] == expected_message
 
     @pytest.mark.parametrize(
-        "chat_assistant_id, name, expected_code, expected_num, expected_message",
+        "session_id, name, expected_code, expected_num, expected_message",
         [
-            (lambda r: r[0], "test_chat_assistant_0", 0, 1, ""),
-            (lambda r: r[0], "test_chat_assistant_1", 102, 0, "The chat doesn't exist"),
-            (lambda r: r[0], "unknown", 102, 0, "The chat doesn't exist"),
-            ("id", "chat_assistant_0", 102, 0, "The chat doesn't exist"),
+            (lambda r: r[0], "session_with_chat_assistant_0", 0, 1, ""),
+            (lambda r: r[0], "session_with_chat_assistant_100", 0, 0, ""),
+            (lambda r: r[0], "unknown", 0, 0, ""),
+            ("id", "session_with_chat_assistant_0", 0, 0, ""),
         ],
     )
-    def test_name_and_id(
-        self,
-        get_http_api_auth,
-        add_chat_assistants,
-        chat_assistant_id,
-        name,
-        expected_code,
-        expected_num,
-        expected_message,
-    ):
-        _, _, chat_assistant_ids = add_chat_assistants
-        if callable(chat_assistant_id):
-            params = {"id": chat_assistant_id(chat_assistant_ids), "name": name}
+    def test_name_and_id(self, get_http_api_auth, add_sessions_with_chat_assistant, session_id, name, expected_code, expected_num, expected_message):
+        chat_assistant_id, session_ids = add_sessions_with_chat_assistant
+        if callable(session_id):
+            params = {"id": session_id(session_ids), "name": name}
         else:
-            params = {"id": chat_assistant_id, "name": name}
+            params = {"id": session_id, "name": name}
 
-        res = list_chat_assistants(get_http_api_auth, params=params)
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_num
@@ -278,23 +213,25 @@ class TestChatAssistantsList:
             assert res["message"] == expected_message
 
     @pytest.mark.slow
-    def test_concurrent_list(self, get_http_api_auth):
+    def test_concurrent_list(self, get_http_api_auth, add_sessions_with_chat_assistant):
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(list_chat_assistants, get_http_api_auth) for i in range(100)]
+            futures = [executor.submit(list_session_with_chat_assistants, get_http_api_auth, chat_assistant_id) for i in range(100)]
         responses = [f.result() for f in futures]
         assert all(r["code"] == 0 for r in responses)
 
-    def test_invalid_params(self, get_http_api_auth):
+    def test_invalid_params(self, get_http_api_auth, add_sessions_with_chat_assistant):
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
         params = {"a": "b"}
-        res = list_chat_assistants(get_http_api_auth, params=params)
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id, params=params)
         assert res["code"] == 0
         assert len(res["data"]) == 5
 
-    def test_list_chats_after_deleting_associated_dataset(self, get_http_api_auth, add_chat_assistants):
-        dataset_id, _, _ = add_chat_assistants
-        res = delete_datasets(get_http_api_auth, {"ids": [dataset_id]})
+    def test_list_chats_after_deleting_associated_chat_assistant(self, get_http_api_auth, add_sessions_with_chat_assistant):
+        chat_assistant_id, _ = add_sessions_with_chat_assistant
+        res = delete_chat_assistants(get_http_api_auth, {"ids": [chat_assistant_id]})
         assert res["code"] == 0
 
-        res = list_chat_assistants(get_http_api_auth)
-        assert res["code"] == 0
-        assert len(res["data"]) == 5
+        res = list_session_with_chat_assistants(get_http_api_auth, chat_assistant_id)
+        assert res["code"] == 102
+        assert "You don't own the assistant" in res["message"]


### PR DESCRIPTION
### What problem does this PR solve?

cover [List chat assistant's sessions](https://ragflow.io/docs/dev/http_api_reference#list-chat-assistants-sessions) endpoints

### Type of change

- [x] Update test cases