### PR TITLE
Fix: The selected state of the TreeView node cannot be seen on Mac #7000

### DIFF
--- a/web/src/components/ui/tree-view.tsx
+++ b/web/src/components/ui/tree-view.tsx
@@ -11,7 +11,7 @@ const treeVariants = cva(
 );
 
 const selectedTreeVariants = cva(
-  'before:opacity-100 before:bg-accent/70 text-accent-foreground',
+  'before:opacity-100 before:bg-[#4E74Fd]/70 text-accent-foreground',
 );
 
 export interface TreeDataItem {


### PR DESCRIPTION
### What problem does this PR solve?

Fix: The selected state of the TreeView node cannot be seen on Mac #7000

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

