### PR TITLE
Fix: when remove document do not delete the file in storage if the source is not knowledge base

### DIFF
--- a/api/apps/document_app.py
+++ b/api/apps/document_app.py
@@ -331,10 +331,10 @@ def rm():
                     message="Database error (Document removal)!")
 
             f2d = File2DocumentService.get_by_document_id(doc_id)
-            FileService.filter_delete([File.source_type == FileSource.KNOWLEDGEBASE, File.id == f2d[0].file_id])
+            deleted_file_count = FileService.filter_delete([File.source_type == FileSource.KNOWLEDGEBASE, File.id == f2d[0].file_id])
             File2DocumentService.delete_by_document_id(doc_id)
-
-            STORAGE_IMPL.rm(b, n)
+            if deleted_file_count > 0:
+                STORAGE_IMPL.rm(b, n)
         except Exception as e:
             errors += str(e)
 


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/infiniflow/ragflow/issues/6905

When deleting a document will check before removing it from storage

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
