### PR TITLE
fix: task executor not removed from redis after it down

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -661,7 +661,7 @@ async def report_status():
                     if expired == 0:
                         logging.info(f"{consumer_name} expired, removed")
                         REDIS_CONN.srem("TASKEXE", consumer_name)
-                redis_lock.release()
+                        REDIS_CONN.delete(consumer_name)
         except Exception:
             logging.exception("report_status got exception")
         await trio.sleep(30)

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -301,6 +301,16 @@ class RedisDB:
         """
         return bool(self.lua_delete_if_equal(keys=[key], args=[expected_value], client=self.REDIS))
 
+    def delete(self, key) -> bool:
+        try:
+            self.REDIS.delete(key)
+            return True
+        except Exception as e:
+            logging.warning("RedisDB.delete " + str(key) + " got exception: " + str(e))
+            self.__open__()
+        return False
+    
+    
 REDIS_CONN = RedisDB()
 
 


### PR DESCRIPTION
### What problem does this PR solve?

If you start ragflow using Kubernetes, the task_executor will have a different hostname each time, resulting in a different consumer ID on every startup. After the pod is stopped, the consumer stored in TASK_EXE is not removed.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
