### PR TITLE
Fix: knowledge graph resolution with infinity raise error tokenizing in specific situations

### DIFF
--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -68,6 +68,7 @@ def equivalent_condition_to_str(condition: dict, table_instance=None) -> str | N
             inCond = list()
             for item in v:
                 if isinstance(item, str):
+                    item = item.replace("'","''")
                     inCond.append(f"'{item}'")
                 else:
                     inCond.append(str(item))


### PR DESCRIPTION
### What problem does this PR solve?

When running graph resolution with infinity, if single quotation marks appeared in the entities name that to be delete, an error tokenizing of sqlglot might occur after calling infinity.

For example:
```
INFINITY delete table ragflow_xxx, filter knowledge_graph_kwd IN ('entity') AND entity_kwd IN ('86 IMAGES FROM PREVIOUS CONTESTS', 'ADAM OPTIMIZATION', 'BACKGROUND'ESTIMATION')
```
may raise error
```
Error tokenizing 'TS', 'ADAM OPTIMIZATION', 'BACKGROUND'ESTIMATION''
```
and make the document parsing failed。

Replace one single quotation mark with double single quotation marks can let sqlglot tokenize the entity name correctly.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
