### PR TITLE
feat: Recover pending tasks while pod restart.

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -661,7 +661,7 @@ async def report_status():
                     if expired == 0:
                         logging.info(f"{consumer_name} expired, removed")
                         REDIS_CONN.srem("TASKEXE", consumer_name)
-                redis_lock.release()
+                        REDIS_CONN.delete(consumer_name)
         except Exception:
             logging.exception("report_status got exception")
         await trio.sleep(30)

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -301,6 +301,16 @@ class RedisDB:
         """
         return bool(self.lua_delete_if_equal(keys=[key], args=[expected_value], client=self.REDIS))
 
+    def delete(self, key) -> bool:
+        try:
+            self.REDIS.delete(key)
+            return True
+        except Exception as e:
+            logging.warning("RedisDB.delete " + str(key) + " got exception: " + str(e))
+            self.__open__()
+        return False
+    
+    
 REDIS_CONN = RedisDB()
 
 

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -282,6 +282,28 @@ class RedisDB:
             )
             self.__open__()
 
+    def get_pending_msg(self, queue, group_name):
+        try:
+            messages = self.REDIS.xpending_range(queue, group_name, '-', '+', 10)
+            return messages
+        except Exception as e:
+            if 'No such key' not in (str(e) or ''):
+                logging.warning(
+                    "RedisDB.get_pending_msg " + str(queue) + " got exception: " + str(e)
+                )
+        return []
+
+    def requeue_msg(self, queue: str, group_name: str, msg_id: str):
+        try:
+            messages = self.REDIS.xrange(queue, msg_id, msg_id)
+            if messages:
+                self.REDIS.xadd(queue, messages[0][1])
+                self.REDIS.xack(queue, group_name, msg_id)
+        except Exception as e:
+            logging.warning(
+                "RedisDB.get_pending_msg " + str(queue) + " got exception: " + str(e)
+            )
+
     def queue_info(self, queue, group_name) -> dict | None:
         try:
             groups = self.REDIS.xinfo_groups(queue)


### PR DESCRIPTION
### What problem does this PR solve?

If you deploy Ragflow using Kubernetes, the hostname will change during a rolling update. This causes the consumer name of the task executor to change, making it impossible to schedule tasks that were previously in a pending state.
To address this, I introduced a recovery task that scans these pending messages and re-publishes them, allowing the tasks to continue being processed.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
