### PR TITLE
Update utils.py

### DIFF
--- a/graphrag/utils.py
+++ b/graphrag/utils.py
@@ -56,7 +56,7 @@ def perform_variable_replacements(
     def replace_all(input: str) -> str:
         result = input
         for k, v in variables.items():
-            result = result.replace(f"{{{k}}}", v)
+            result = result.replace(f"{{{k}}}", str(v))
         return result
 
     result = replace_all(result)


### PR DESCRIPTION
### What problem does this PR solve?

when there are multiple entities, the variable `v` may be a list, which will lead to this error:
```
| File "/mnt/d/wrf/ragflow/ragflow/graphrag/utils.py", line 59, in replace_all
| result = result.replace(f"{{{k}}}", v)
| TypeError: replace() argument 2 must be str, not list
```
this pr assign this `v` to be a str

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
