### PR TITLE
Fix: wrong “available” property when list chunk 

### DIFF
--- a/api/apps/sdk/doc.py
+++ b/api/apps/sdk/doc.py
@@ -961,7 +961,7 @@ def list_chunks(tenant_id, dataset_id, document_id):
                 "questions": sres.field[id].get("question_kwd", []),
                 "dataset_id": sres.field[id].get("kb_id", sres.field[id].get("dataset_id")),
                 "image_id": sres.field[id].get("img_id", ""),
-                "available": bool(sres.field[id].get("available_int", 1)),
+                "available": bool(int(sres.field[id].get("available_int", "1"))),
                 "positions": sres.field[id].get("position_int",[]),
             }
             res["chunks"].append(d)


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/infiniflow/ragflow/issues/7083

Internal due to when returning from ES, fields changed to str, so the bool conversion does not work as expected.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

