### PR TITLE
Fix: Error in sending placeholder words in Chinese and Chinese-Traditional

### DIFF
--- a/web/src/locales/zh-traditional.ts
+++ b/web/src/locales/zh-traditional.ts
@@ -400,7 +400,7 @@ export default {
       chat: '聊天',
       newChat: '新建聊天',
       send: '發送',
-      sendPlaceholder: '消息概要助手...',
+      sendPlaceholder: '給助理髮送消息...',
       chatConfiguration: '聊天配置',
       chatConfigurationDescription: '為你的知識庫配置專屬聊天助手！💕',
       assistantName: '助理姓名',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -417,7 +417,7 @@ General：实体和关系提取提示来自 GitHub - microsoft/graphrag：基于
       chat: '聊天',
       newChat: '新建聊天',
       send: '发送',
-      sendPlaceholder: '消息概要助手...',
+      sendPlaceholder: '给助理发送消息...',
       chatConfiguration: '聊天配置',
       chatConfigurationDescription: '为你的知识库配置专属聊天助手！ 💕',
       assistantName: '助理姓名',


### PR DESCRIPTION
### What problem does this PR solve?

The assistant message placeholder is incorrect, I have finished modifying both Chinese and traditional Chinese characters

### Type of change


- [x] Bug Fix
