### PR TITLE
Fix: whole knowledge graph lost after removing any document in the knowledge base

### DIFF
--- a/graphrag/general/index.py
+++ b/graphrag/general/index.py
@@ -204,7 +204,7 @@ async def merge_subgraph(
 ):
     start = trio.current_time()
     change = GraphChange()
-    old_graph = await get_graph(tenant_id, kb_id)
+    old_graph = await get_graph(tenant_id, kb_id, subgraph.graph["source_id"])
     if old_graph is not None:
         logging.info("Merge with an exiting graph...................")
         tidy_graph(old_graph, callback)

--- a/graphrag/utils.py
+++ b/graphrag/utils.py
@@ -406,10 +406,9 @@ async def get_graph_doc_ids(tenant_id, kb_id) -> list[str]:
     return doc_ids
 
 
-async def get_graph(tenant_id, kb_id):
+async def get_graph(tenant_id, kb_id, exclude_rebuild=None):
     conds = {
-        "fields": ["content_with_weight", "source_id"],
-        "removed_kwd": "N",
+        "fields": ["content_with_weight", "removed_kwd", "source_id"],
         "size": 1,
         "knowledge_graph_kwd": ["graph"]
     }
@@ -417,20 +416,23 @@ async def get_graph(tenant_id, kb_id):
     if not res.total == 0:
         for id in res.ids:
             try:
-                g = json_graph.node_link_graph(json.loads(res.field[id]["content_with_weight"]), edges="edges")
-                if "source_id" not in g.graph:
-                    g.graph["source_id"] = res.field[id]["source_id"]
+                if res.field[id]["removed_kwd"] == "N":
+                    g = json_graph.node_link_graph(json.loads(res.field[id]["content_with_weight"]), edges="edges")
+                    if "source_id" not in g.graph:
+                        g.graph["source_id"] = res.field[id]["source_id"]
+                else:
+                    g = await rebuild_graph(tenant_id, kb_id, exclude_rebuild)
                 return g
             except Exception:
                 continue
-    result = await rebuild_graph(tenant_id, kb_id)
+    result = None
     return result
 
 
 async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, change: GraphChange, callback):
     start = trio.current_time()
 
-    await trio.to_thread.run_sync(lambda: settings.docStoreConn.delete({"knowledge_graph_kwd": ["graph"]}, search.index_name(tenant_id), kb_id))
+    await trio.to_thread.run_sync(lambda: settings.docStoreConn.delete({"knowledge_graph_kwd": ["graph", "subgraph"]}, search.index_name(tenant_id), kb_id))
 
     if change.removed_nodes:
         await trio.to_thread.run_sync(lambda: settings.docStoreConn.delete({"knowledge_graph_kwd": ["entity"], "entity_kwd": sorted(change.removed_nodes)}, search.index_name(tenant_id), kb_id))
@@ -453,6 +455,23 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
         "available_int": 0,
         "removed_kwd": "N"
     }]
+    
+    # generate updated subgraphs
+    for source in graph.graph["source_id"]:
+        subgraph = graph.subgraph([n for n in graph.nodes if source in graph.nodes[n]["source_id"]]).copy()
+        subgraph.graph["source_id"] = [source]
+        for n in subgraph.nodes:
+            subgraph.nodes[n]["source_id"] = [source]
+        chunks.append({
+            "id": get_uuid(),
+            "content_with_weight": json.dumps(nx.node_link_data(subgraph, edges="edges"), ensure_ascii=False),
+            "knowledge_graph_kwd": "subgraph",
+            "kb_id": kb_id,
+            "source_id": [source],
+            "available_int": 0,
+            "removed_kwd": "N"
+        })
+    
     async with trio.open_nursery() as nursery:
         for node in change.added_updated_nodes:
             node_attrs = graph.nodes[node]
@@ -553,14 +572,13 @@ def flat_uniq_list(arr, key):
     return list(set(res))
 
 
-async def rebuild_graph(tenant_id, kb_id):
+async def rebuild_graph(tenant_id, kb_id, exclude_rebuild=None):
     graph = nx.Graph()
-    src_ids = set()
-    flds = ["entity_kwd", "from_entity_kwd", "to_entity_kwd", "knowledge_graph_kwd", "content_with_weight", "source_id"]
+    flds = ["knowledge_graph_kwd", "content_with_weight", "source_id"]
     bs = 256
     for i in range(0, 1024*bs, bs):
         es_res = await trio.to_thread.run_sync(lambda: settings.docStoreConn.search(flds, [],
-                                 {"kb_id": kb_id, "knowledge_graph_kwd": ["entity"]},
+                                 {"kb_id": kb_id, "knowledge_graph_kwd": ["subgraph"]},
                                  [],
                                  OrderByExpr(),
                                  i, bs, search.index_name(tenant_id), [kb_id]
@@ -572,36 +590,27 @@ async def rebuild_graph(tenant_id, kb_id):
             break
 
         for id, d in es_res.items():
-            assert d["knowledge_graph_kwd"] == "entity"
-            src_ids.update(d.get("source_id", []))
-            attrs = json.loads(d["content_with_weight"])
-            entity_kwd = d["entity_kwd"][0] if isinstance(d["entity_kwd"], list) else d["entity_kwd"]   # judge infinity or es output
-            graph.add_node(entity_kwd, **attrs)
-
-    for i in range(0, 1024*bs, bs):
-        es_res = await trio.to_thread.run_sync(lambda: settings.docStoreConn.search(flds, [],
-                                 {"kb_id": kb_id, "knowledge_graph_kwd": ["relation"]},
-                                 [],
-                                 OrderByExpr(),
-                                 i, bs, search.index_name(tenant_id), [kb_id]
-                                 ))
-        # tot = settings.docStoreConn.getTotal(es_res)
-        es_res = settings.docStoreConn.getFields(es_res, flds)
-
-        if len(es_res) == 0:
-            break
-
-        for id, d in es_res.items():
-            assert d["knowledge_graph_kwd"] == "relation"
-            src_ids.update(d.get("source_id", []))
-            from_entity_kwd = d["from_entity_kwd"][0] if isinstance(d["from_entity_kwd"], list) else d["from_entity_kwd"]
-            to_entity_kwd = d["to_entity_kwd"][0] if isinstance(d["to_entity_kwd"], list) else d["to_entity_kwd"]
-            if graph.has_node(from_entity_kwd) and graph.has_node(to_entity_kwd):
-                attrs = json.loads(d["content_with_weight"])
-                graph.add_edge(from_entity_kwd, to_entity_kwd, **attrs)
+            assert d["knowledge_graph_kwd"] == "subgraph"
+            if isinstance(exclude_rebuild, list):
+                if sum([n in d["source_id"] for n in exclude_rebuild]):
+                    continue
+            elif exclude_rebuild in d["source_id"]:
+                continue
+            
+            next_graph = json_graph.node_link_graph(json.loads(d["content_with_weight"]), edges="edges")
+            merged_graph = nx.compose(graph, next_graph)
+            merged_source = {
+                n: graph.nodes[n]["source_id"] + next_graph.nodes[n]["source_id"]
+                for n in graph.nodes & next_graph.nodes
+            }
+            nx.set_node_attributes(merged_graph, merged_source, "source_id")
+            if "source_id" in graph.graph:
+                merged_graph.graph["source_id"] = graph.graph["source_id"] + next_graph.graph["source_id"]
+            else:
+                merged_graph.graph["source_id"] = next_graph.graph["source_id"]
+            graph = merged_graph
 
     if len(graph.nodes) == 0:
         return None
-    src_ids = sorted(src_ids)
-    graph.graph["source_id"] = src_ids
+    graph.graph["source_id"] = sorted(graph.graph["source_id"])
     return graph

--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -573,6 +573,7 @@ class InfinityConnection(DocStoreConnection):
                 newValue[k] = "_".join(f"{num:08x}" for num in v)
             elif k == "remove":
                 if isinstance(v, str):
+                    assert v in clmns, f"'{v}' should be in '{clmns}'."
                     ty, de = clmns[v]
                     if ty.lower().find("cha"):
                         if not de:
@@ -596,7 +597,7 @@ class InfinityConnection(DocStoreConnection):
                         new_v = old_v[k].copy()
                         new_v.remove(remove_v)
                         kv_key = json.dumps([k, new_v])
-                        if not kv_key in remove_opt:
+                        if kv_key not in remove_opt:
                             remove_opt[kv_key] = [id]
                         else:
                             remove_opt[kv_key].append(id)

--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -136,7 +136,7 @@ class InfinityConnection(DocStoreConnection):
         logger.info(f"Use Infinity {infinity_uri} as the doc engine.")
         for _ in range(24):
             try:
-                connPool = ConnectionPool(infinity_uri)
+                connPool = ConnectionPool(infinity_uri, max_size=32)
                 inf_conn = connPool.get_conn()
                 res = inf_conn.show_current_node()
                 if res.error_code == ErrorCode.OK and res.server_status in ["started", "alive"]:
@@ -590,6 +590,7 @@ class InfinityConnection(DocStoreConnection):
         if removeValue:
             col_to_remove = list(removeValue.keys())
             row_to_opt = table_instance.output(col_to_remove + ['id']).filter(filter).to_df()
+            logger.debug(f"INFINITY search table {str(table_name)}, filter {filter}, result: {str(row_to_opt[0])}")
             row_to_opt = self.getFields(row_to_opt, col_to_remove)
             for id, old_v in row_to_opt.items():
                 for k, remove_v in removeValue.items():


### PR DESCRIPTION
### What problem does this PR solve?

When you removed any document in a knowledge base using knowledge graph, the graph's `removed_kwd` is set to "Y".  
However, in the function `graphrag.utils.get_gaph`, `rebuild_graph` method is passed and directly return `None` while `removed_kwd=Y`, making residual part of the graph abandoned (but old entity data still exist in db).

Besides, infinity instance actually pass deleting graph components' `source_id` when removing document. It may cause wrong graph after rebuild.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)