### PR TITLE
Fix: don't modify S3 file name when not using prefix_path

### DIFF
--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -54,8 +54,6 @@ class RAGFlowS3:
             # used as the file prefix. This is especially useful when you're using the default bucket
             if self.prefix_path:
                 fnm = f"{self.prefix_path}/{bucket}/{fnm}"
-            else:
-                fnm = f"{bucket}/{fnm}"
             return method(self, bucket, fnm, *args, **kwargs)
         return wrapper
 


### PR DESCRIPTION
### What problem does this PR solve?

Hello, I encountered a problem when trying to use a S3 backend (seaweedfs) for storage in RAGFlow: when calling `STORAGE_IMPL.get("bucket", "key")`, the actual request sent to S3 is `bucket/bucket/key`, causing a `NoSuchKey` error.

I compared the code in `s3_conn.py` to `minio_conn.py` and `oss_conn.py`, then decided to remove the `else` branch in `use_prefix_path` method, and it works. I didn't configure `prefix_path` or `bucket` in `s3` section of the `service_conf.yaml`.

I think this is a bug, but not sure.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
