### PR TITLE
feat: Add global exception handler

### DIFF
--- a/api/apps/__init__.py
+++ b/api/apps/__init__.py
@@ -34,12 +34,14 @@ from flask_login import LoginManager
 from api import settings
 from api.utils.api_utils import server_error_response
 from api.constants import API_VERSION
+from api.error import error_handler
 
 __all__ = ["app"]
 
 Request.json = property(lambda self: self.get_json(force=True, silent=True))
 
 app = Flask(__name__)
+error_handler.init_app(app)
 
 # Add this at the beginning of your file to configure Swagger UI
 swagger_config = {

--- a/api/error/error_handler.py
+++ b/api/error/error_handler.py
@@ -1,0 +1,12 @@
+from flask import Flask
+
+
+def init_app(app: Flask):
+
+    @app.errorhandler(ValueError)
+    def handle_value_error(error):
+        return {"message": str(error), "code": 400}, 400
+
+    @app.errorhandler(Exception)
+    def handle_value_error(error):
+        return {"message": str(error), "code": 500}, 500

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -50,6 +50,7 @@ type ResultCode =
 const errorHandler = (error: {
   response: Response;
   message: string;
+  data?: object;
 }): Response | any => {
   const { response } = error;
   if (error.message === FAILED_TO_FETCH) {
@@ -63,6 +64,7 @@ const errorHandler = (error: {
       description: error.message,
       duration: 3,
     });
+    error.data = { code: 1999, message: error.message };
   }
   return error ?? { data: { code: 1999 } };
 };

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -101,7 +101,7 @@ request.interceptors.response.use(async (response: Response, options) => {
     message.error(RetcodeMessage[response?.status as ResultCode]);
     return {
       ...response,
-      data: { data: { code: 1999 } }
+      data: { code: 1999 }
     };
   }
 

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -50,25 +50,21 @@ type ResultCode =
 const errorHandler = (error: {
   response: Response;
   message: string;
-}): Response => {
+}): Response | any => {
   const { response } = error;
   if (error.message === FAILED_TO_FETCH) {
     notification.error({
       description: i18n.t('message.networkAnomalyDescription'),
       message: i18n.t('message.networkAnomaly'),
     });
-  } else {
-    if (response && response.status) {
-      const errorText =
-        RetcodeMessage[response.status as ResultCode] || response.statusText;
-      const { status, url } = response;
-      notification.error({
-        message: `${i18n.t('message.requestError')} ${status}: ${url}`,
-        description: errorText,
-      });
-    }
+  } else if (!response && error.message) {
+    notification.error({
+      message: `${i18n.t('message.hint')}`,
+      description: error.message,
+      duration: 3,
+    });
   }
-  return response ?? { data: { code: 1999 } };
+  return error ?? { data: { code: 1999 } };
 };
 
 const request: RequestMethod = extend({

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -99,6 +99,10 @@ request.interceptors.request.use((url: string, options: any) => {
 request.interceptors.response.use(async (response: Response, options) => {
   if (response?.status === 413 || response?.status === 504) {
     message.error(RetcodeMessage[response?.status as ResultCode]);
+    return {
+      ...response,
+      data: { data: { code: 1999 } }
+    };
   }
 
   if (options.responseType === 'blob') {


### PR DESCRIPTION
### What problem does this PR solve?

Add Global Exception Hanlder.

In the request.ts file, for all responses except 413 and 504, the code attempts to parse the body as JSON. If an error occurs during this process, the response in the errorHandler will be null, and the frontend will not display any error messages.
![image](https://github.com/user-attachments/assets/657419d8-5bc2-45b7-aad6-5a8864322c49)


For responses where the body is JSON but the HTTP status code is ≥ 400, the umi-request library does not parse the body into the data property of the response. As a result, downstream code may encounter an undefined error when trying to access data.code. In such cases, the entire error object should be returned, as it contains the data property with the value of the response body.
![image](https://github.com/user-attachments/assets/7f3435f9-7c22-4da0-b80b-9af5aa76ce6b)


### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
