### PR TITLE
Fix: mcp server start

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -150,7 +150,7 @@ function start_mcp_server() {
         --port="${MCP_PORT}" \
         --base_url="${MCP_BASE_URL}" \
         --mode="${MCP_MODE}" \
-        --api_key="${MCP_HOST_API_KEY}" \ &
+        --api_key="${MCP_HOST_API_KEY}" &
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### What problem does this PR solve?

Fix the entrypoint file from the docker container to solve #7249 

Here is the important part from the logs:
```
docker logs -f ragflow-server
...
usage: server.py [-h] [--base_url BASE_URL] [--host HOST] [--port PORT]
[--mode MODE] [--api_key API_KEY]
server.py: error: unrecognized arguments:
...
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
