### PR TITLE
Fix mcp server startup failure

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,14 +9,14 @@ services:
         condition: service_healthy
     image: ${RAGFLOW_IMAGE}
     # example to setup MCP server
-    # command:
-    #   - --enable-mcpserver
-    #   - --mcp-host=0.0.0.0
-    #   - --mcp-port=9382
-    #   - --mcp-base-url=http://127.0.0.1:9380
-    #   - --mcp-script-path=/ragflow/mcp/server/server.py
-    #   - --mcp-mode=self-host
-    #   - --mcp-host-api-key="ragflow-xxxxxxx"
+    command:
+      - --enable-mcpserver
+      - --mcp-host=0.0.0.0
+      - --mcp-port=9382
+      - --mcp-base-url=http://127.0.0.1:9380
+      - --mcp-script-path=/ragflow/mcp/server/server.py
+      - --mcp-mode=self-host
+      - --mcp-host-api-key="ragflow-xxxxxxx"  #replace key as your api-key 
     container_name: ragflow-server
     ports:
       - ${SVR_HTTP_PORT}:9380

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -145,7 +145,7 @@ function task_exe() {
 
 function start_mcp_server() {
     echo "Starting MCP Server on ${MCP_HOST}:${MCP_PORT} with base URL ${MCP_BASE_URL}..."
-    "$PY" "${MCP_SCRIPT_PATH}" \
+    "$PY" /ragflow/mcp/server/wrapper.py "${MCP_SCRIPT_PATH}" \
         --host="${MCP_HOST}" \
         --port="${MCP_PORT}" \
         --base_url="${MCP_BASE_URL}" \

--- a/docs/develop/mcp.md
+++ b/docs/develop/mcp.md
@@ -83,8 +83,13 @@ services:
       - --mcp-mode=self-host # `self-host` or `host`
       - --mcp-host-api-key="ragflow-xxxxxxx" # only need to privide when mode is `self-host`
 ```
-
-Then launch it normally `docker compose -f docker-compose.yml`.
+cd ragflow-main/docker/
+chmod +x entrypoint.sh
+cd ragflow-main/mcp/server/
+chmod +x wrapper.py
+cd ragflow-main/docker/
+docker compose -f docker-compose.yml up -d
+docker logs ragflow-server
 
 ```bash
 ragflow-server  | Starting MCP Server on 0.0.0.0:9382 with base URL http://127.0.0.1:9380...

--- a/docs/develop/mcp.md
+++ b/docs/develop/mcp.md
@@ -59,7 +59,11 @@ For testing purposes, there is an [MCP client example](#example_mcp_client) prov
 
 Here are three augments required, the first two,`host` and `port`, are self-explained. The`base_url` is the address of the ready-to-serve RAGFlow server to actually perform the task.
 
-### Launching from Docker
+### only do this from old version code upgrade to version 0.18.0 (option) 
+1.download mcp directory to your local 
+2.download entrypoint.sh&docker-compose.yml to your local
+
+### Launching from Docker with both upgrade or new install 
 
 Building a standalone MCP server image is straightforward and easy, so we just proposed a way to launch it with RAGFlow server here.
 

--- a/mcp/server/wrapper.py
+++ b/mcp/server/wrapper.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import sys
+import os
+import subprocess
+
+# 记录所有参数
+with open('/tmp/server_args.log', 'w') as f:
+    f.write("Command arguments:\n")
+    for i, arg in enumerate(sys.argv):
+        f.write(f"Arg {i}: {arg}\n")
+    f.write("\nEnvironment variables:\n")
+    for key, value in os.environ.items():
+        f.write(f"{key}={value}\n")
+
+# 执行原始命令
+original_script = sys.argv[1]
+args = sys.argv[2:]
+print(f"Executing: {original_script} with args: {args}")
+subprocess.run([sys.executable, original_script] + args)


### PR DESCRIPTION
### What problem does this PR solve?

Close #7321

mcp server can not auto start success , it says:
"docker logs ragflow-server
Starting nginx...
Starting ragflow_server...
Starting MCP Server on 0.0.0.0:9382 with base URL http://127.0.0.1:9380/...
Starting 1 task executor(s) on host '21f4c54985b7'...
2025-04-25 19:19:57,082 INFO     16 ragflow_server log path: /ragflow/logs/ragflow_server.log, log levels: {'peewee': 'WARNING', 'pdfminer': 'WARNING', 'root': 'INFO'}
usage: server.py [-h] [--base_url BASE_URL] [--host HOST] [--port PORT]
                 [--mode MODE] [--api_key API_KEY]
server.py: error: unrecognized arguments:"

because ：An array with quotation marks cannot be passed directly to a parameter and a numerical value


steps:
1.add wrapper.py
2.edit entrypoint.sh tool call wrapper.py
3.edit docker-compose.yml  add volume mapping for two files step 1&2
4.fix mcp.md ,tell how to manual fix mcp auto start problem with upgrate from old versions with no data lost【option only with upgrade】


### Type of change

- [x] Bug Fix (mcp server can auto start success)

