### PR TITLE
Fix: tenant_id spelling error.

### DIFF
--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -322,9 +322,9 @@ def get_error_data_result(
     return jsonify(response)
 
 
-def generate_confirmation_token(tenent_id):
-    serializer = URLSafeTimedSerializer(tenent_id)
-    return "ragflow-" + serializer.dumps(get_uuid(), salt=tenent_id)[2:34]
+def generate_confirmation_token(tenant_id):
+    serializer = URLSafeTimedSerializer(tenant_id)
+    return "ragflow-" + serializer.dumps(get_uuid(), salt=tenant_id)[2:34]
 
 
 def valid(permission, valid_permission, chunk_method, valid_chunk_method):


### PR DESCRIPTION
### What problem does this PR solve?

In the generate_confirmation_token method, a spelling error was found with 'tenent_id'. The correct spelling should be 'tenant_id'.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
