### PR TITLE
Update Groq AI Model Config

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -930,12 +930,6 @@
             "status": "1",
             "llm": [
                 {
-                    "llm_name": "gemma-7b-it",
-                    "tags": "LLM,CHAT,15k",
-                    "max_tokens": 8192,
-                    "model_type": "chat"
-                },
-                {
                     "llm_name": "gemma2-9b-it",
                     "tags": "LLM,CHAT,15k",
                     "max_tokens": 8192,


### PR DESCRIPTION
With current config will get error "Fail to access model(gemma-7b-it) using this api key"
Since the model has been removed, according to Groq official document: https://console.groq.com/docs/models

### Type of change

- [ x] Bug Fix (non-breaking change which fixes an issue)