### PR TITLE
Fix: intermittent heartbeat reporting issue.

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -99,10 +99,8 @@ CURRENT_TASKS = {}
 
 MAX_CONCURRENT_TASKS = int(os.environ.get('MAX_CONCURRENT_TASKS', "5"))
 MAX_CONCURRENT_CHUNK_BUILDERS = int(os.environ.get('MAX_CONCURRENT_CHUNK_BUILDERS', "1"))
-MAX_CONCURRENT_MINIO = int(os.environ.get('MAX_CONCURRENT_MINIO', '10'))
 task_limiter = trio.CapacityLimiter(MAX_CONCURRENT_TASKS)
 chunk_limiter = trio.CapacityLimiter(MAX_CONCURRENT_CHUNK_BUILDERS)
-minio_limiter = trio.CapacityLimiter(MAX_CONCURRENT_MINIO)
 WORKER_HEARTBEAT_TIMEOUT = int(os.environ.get('WORKER_HEARTBEAT_TIMEOUT', '120'))
 stop_event = threading.Event()
 


### PR DESCRIPTION
### What problem does this PR solve?

The task executor’s heartbeat-reporting job can sometimes be blocked for up to 4 minutes, causing it to miss its heartbeat and be removed from TASK_EXE.
![image](https://github.com/user-attachments/assets/2b1c3c38-e6a0-4f5b-9373-2caa977c88ce)


Change Highlights:

Detached report_status from Trio
Moved the heartbeat‐reporting job out of the Trio task group and into its own dedicated thread.

Removed redis_lock.release()
The Redis lock has a 60-second TTL to throttle how often the cleanup task can run. Calling release() allowed other task executors to grab the lock immediately—leading to excessively frequent cleanups when you have many workers.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
