### PR TITLE
Fix: improve recover_pending_tasks timeout

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -700,12 +700,13 @@ def recover_pending_tasks():
                             f"time since delivered: {msg['time_since_delivered'] / 1000} s"
                         )
                         REDIS_CONN.requeue_msg(queue_name, SVR_CONSUMER_GROUP_NAME, msg['message_id'])
-
-            stop_event.wait(60)
         except Exception:
             logging.warning("recover_pending_tasks got exception")
         finally:
             redis_lock.release()
+            stop_event.wait(60)
+        
+
 
 
 async def main():


### PR DESCRIPTION
### What problem does this PR solve?

Fix the redis lock will always timeout (change the logic order release lock first)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

