### PR TITLE
Feat: Allow using only the latest one message in conversation for retrieval

### DIFF
--- a/agent/component/retrieval.py
+++ b/agent/component/retrieval.py
@@ -46,6 +46,7 @@ class RetrievalParam(ComponentParamBase):
         self.empty_response = ""
         self.tavily_api_key = ""
         self.use_kg = False
+        self.use_latest_msg_only = False
 
     def check(self):
         self.check_decimal_float(self.similarity_threshold, "[Retrieval] Similarity threshold")
@@ -57,7 +58,10 @@ class Retrieval(ComponentBase, ABC):
     component_name = "Retrieval"
 
     def _run(self, history, **kwargs):
-        query = self.get_input()
+        query = self.get_input(
+            latest_msg_only=self._param.use_latest_msg_only
+        )
+
         query = str(query["content"][0]) if "content" in query else ""
 
         kb_ids: list[str] = self._param.kb_ids or []

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1262,6 +1262,8 @@ This delimiter is used to split the input text into several text pieces echo of 
       knowledgeBasesTip:
         'Select the knowledge bases to associate with this chat assistant, or choose variables containing knowledge base IDs below.',
       knowledgeBaseVars: 'Knowledge base variables',
+      useLatestMessageOnly: 'Only use latest message in conversation',
+      useLatestMessageOnlyTip: 'If you are using output from the Answer component, enabling this will only use the latest one history message from it for retrieval.',
     },
   },
 };

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1217,6 +1217,8 @@ General：实体和关系提取提示来自 GitHub - microsoft/graphrag：基于
         '系统提示为大模型提供任务描述、规定回复方式，以及设置其他各种要求。系统提示通常与 key （变量）合用，通过变量设置大模型的输入数据。你可以通过斜杠或者 (x) 按钮显示可用的 key。',
       knowledgeBasesTip: '选择关联的知识库，或者在下方选择包含知识库ID的变量。',
       knowledgeBaseVars: '知识库变量',
+      useLatestMessageOnly: '仅使用对话中的最新消息',
+      useLatestMessageOnlyTip: '如果你使用了对话组件的输出，那么启用该选项将仅使用对话组件中的最新一条消息进行检索。',
     },
     footer: {
       profile: 'All rights reserved @ React',

--- a/web/src/pages/flow/form/retrieval-form/index.tsx
+++ b/web/src/pages/flow/form/retrieval-form/index.tsx
@@ -6,7 +6,7 @@ import TopNItem from '@/components/top-n-item';
 import { UseKnowledgeGraphItem } from '@/components/use-knowledge-graph-item';
 import { useTranslate } from '@/hooks/common-hooks';
 import type { FormProps } from 'antd';
-import { Form, Input } from 'antd';
+import { Form, Input, Switch } from 'antd';
 import { IOperatorForm } from '../../interface';
 import DynamicInputVariable from '../components/dynamic-input-variable';
 
@@ -42,6 +42,14 @@ const RetrievalForm = ({ onValuesChange, form, node }: IOperatorForm) => {
       <TopNItem></TopNItem>
       <Rerank></Rerank>
       <TavilyItem name={'tavily_api_key'}></TavilyItem>
+      <Form.Item
+        label={t('useLatestMessageOnly')}
+        tooltip={t('useLatestMessageOnlyTip')}
+        name="use_latest_msg_only"
+        initialValue={false}
+      >
+        <Switch></Switch>
+      </Form.Item>
       <UseKnowledgeGraphItem filedName={'use_kg'}></UseKnowledgeGraphItem>
       <KnowledgeBaseItem
         tooltipText={t('knowledgeBasesTip')}


### PR DESCRIPTION
### What problem does this PR solve?

Hello, we are facing a similar problem as #7491, where the `Retrieval` component is using the whole conversation in the `Answer` component, causing a non-precise retrieval result, while we only need the `Retrieval` component to search for the latest message only.

However, there may be some use cases needing the current behavior.

So, here, I propose an approach to resolve this: 

I added a switch to control the output fetching behavior for the `Retrieval` component:

![image](https://github.com/user-attachments/assets/af82b4bf-3ba5-4df8-9ac4-f21379ebf7d4)

When the switch is ON, it only fetches the latest one message from the `Answer` component for retrieval. Otherwise it keeps the original behavior.
The switch default is OFF to retain compatibility of old flows.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
