### PR TITLE
Fix for #7516

### DIFF
--- a/web/src/hooks/auth-hooks.ts
+++ b/web/src/hooks/auth-hooks.ts
@@ -1,4 +1,5 @@
 import authorizationUtil from '@/utils/authorization-util';
+import { useQueryClient } from '@tanstack/react-query';
 import { message } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'umi';
@@ -11,6 +12,7 @@ export const useLoginWithGithub = () => {
     [currentQueryParameters],
   );
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   if (error) {
     message.error(error);
@@ -26,6 +28,7 @@ export const useLoginWithGithub = () => {
     authorizationUtil.setAuthorization(auth);
     newQueryParameters.delete('auth');
     setSearchParams(newQueryParameters);
+    queryClient.invalidateQueries({ queryKey: ['tenantInfo'] });
   }
   return auth;
 };


### PR DESCRIPTION
### What problem does this PR solve?

This makes it so GitHub OAuth users get their `user_default_llm` settings like the rest of the other ones do.

The SSO work @wengchaoxi is doing probably should take this into consideration, but it won't be a sufficient fix to cover all cases.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
