### PR TITLE
Fix: helm template redis

### DIFF
--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: 8Gi
+            storage: {{ .Values.redis.storage.capacity }}
   {{- end }}
 ---
 apiVersion: v1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -133,6 +133,8 @@ redis:
   storage:
     className:
     capacity: 5Gi
+  persistence:
+    enabled: true
   deployment:
     strategy:
     resources:


### PR DESCRIPTION
### What problem does this PR solve?

Fixes bug & regression introduced by [PR #7187 - refactor: Update Redis configuration to use StatefulSet instead of deployment with pvc](https://github.com/infiniflow/ragflow/pull/7187):

1. Fixes bug #7403  - `redis.persistence.enabled` missing from `helm/values.yaml` causes helm error:

        [ERROR] templates/: template: ragflow/templates/redis.yaml:55:24: executing "ragflow/templates/redis.yaml" at <.Values.redis.persistence.enabled>: nil pointer evaluating interface {}.enabled

2. Fixes regression: reverts hardcoded redis.storage.capacity value back to using variable `redis.storage.capacity` from `helm/values.yaml`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
