### PR TITLE
[RFC] Feat: Support tool calling in Generate component

### DIFF
--- a/agent/component/generate.py
+++ b/agent/component/generate.py
@@ -16,13 +16,27 @@
 import json
 import re
 from functools import partial
+from typing import Any
 import pandas as pd
 from api.db import LLMType
 from api.db.services.conversation_service import structure_answer
 from api.db.services.llm_service import LLMBundle
 from api import settings
 from agent.component.base import ComponentBase, ComponentParamBase
+from plugin import GlobalPluginManager
+from plugin.llm_tool_plugin import llm_tool_metadata_to_openai_tool
+from rag.llm.chat_model import ToolCallSession
 from rag.prompts import message_fit_in
+
+
+class LLMToolPluginCallSession(ToolCallSession):
+    def tool_call(self, name: str, arguments: dict[str, Any]) -> str:
+        tool = GlobalPluginManager.get_llm_tool_by_name(name)
+
+        if tool is None:
+            raise ValueError(f"LLM tool {name} does not exist")
+
+        return tool().invoke(arguments)
 
 
 class GenerateParam(ComponentParamBase):
@@ -41,6 +55,7 @@ class GenerateParam(ComponentParamBase):
         self.frequency_penalty = 0
         self.cite = True
         self.parameters = []
+        self.llm_enabled_tools = []
 
     def check(self):
         self.check_decimal_float(self.temperature, "[Generate] Temperature")
@@ -133,6 +148,15 @@ class Generate(ComponentBase):
 
     def _run(self, history, **kwargs):
         chat_mdl = LLMBundle(self._canvas.get_tenant_id(), LLMType.CHAT, self._param.llm_id)
+
+        if len(self._param.llm_enabled_tools) > 0:
+            tools = GlobalPluginManager.get_llm_tools_by_names(self._param.llm_enabled_tools)
+
+            chat_mdl.bind_tools(
+                LLMToolPluginCallSession(),
+                [llm_tool_metadata_to_openai_tool(t.get_metadata()) for t in tools]
+            )
+
         prompt = self._param.prompt
 
         retrieval_res = []

--- a/api/apps/plugin_app.py
+++ b/api/apps/plugin_app.py
@@ -1,0 +1,12 @@
+from flask import Response
+from flask_login import login_required
+from api.utils.api_utils import get_json_result
+from plugin import GlobalPluginManager
+
+@manager.route('/llm_tools', methods=['GET'])  # noqa: F821
+@login_required
+def llm_tools() -> Response:
+    tools = GlobalPluginManager.get_llm_tools()
+    tools_metadata = [t.get_metadata() for t in tools]
+
+    return get_json_result(data=tools_metadata)

--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -226,6 +226,7 @@ class LLMBundle:
 
     def bind_tools(self, toolcall_session, tools):
         if not self.is_tools:
+            logging.warning(f"Model {self.llm_name} does not support tool call, but you have assigned one or more tools to it!")
             return
         self.mdl.bind_tools(toolcall_session, tools)
 

--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -19,6 +19,7 @@
 # beartype_all(conf=BeartypeConf(violation_type=UserWarning))    # <-- emit warnings from all code
 
 from api.utils.log_utils import initRootLogger
+from plugin import GlobalPluginManager
 initRootLogger("ragflow_server")
 
 import logging
@@ -118,6 +119,8 @@ if __name__ == '__main__':
 
     RuntimeConfig.init_env()
     RuntimeConfig.init_config(JOB_SERVER_HOST=settings.HOST_IP, HTTP_PORT=settings.HOST_PORT)
+
+    GlobalPluginManager.load_plugins()
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,0 +1,3 @@
+from .plugin_manager import PluginManager
+
+GlobalPluginManager = PluginManager()

--- a/plugin/common.py
+++ b/plugin/common.py
@@ -1,0 +1,1 @@
+PLUGIN_TYPE_LLM_TOOLS = "llm_tools"

--- a/plugin/embedded_plugins/llm_tools/bad_calculator.py
+++ b/plugin/embedded_plugins/llm_tools/bad_calculator.py
@@ -1,0 +1,37 @@
+from typing import Any
+from plugin.llm_tool_plugin import LLMToolMetadata, LLMToolPlugin
+
+
+class BadCalculatorPlugin(LLMToolPlugin):
+    """
+    A sample LLM tool plugin, will add two numbers with 100.
+    It only present for demo purpose. Do not use it in production.
+    """
+    _version_ = "1.0.0"
+
+    @classmethod
+    def get_metadata(cls) -> LLMToolMetadata:
+        return {
+            "name": "bad_calculator",
+            "description": "用于计算两个数的和的工具（会给出错误答案）",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {
+                        "type": "number",
+                        "description": "第一个数"
+                    },
+                    "b": {
+                        "type": "number",
+                        "description": "第二个数"
+                    }
+                },
+                "required": ["a", "b"]
+            }
+        }
+
+    def invoke(self, arguments: dict[str, Any]) -> str:
+        print(f"Calculator tool called with arguments {arguments}")
+        a = arguments["a"]
+        b = arguments["b"]
+        return str(a + b + 100)

--- a/plugin/llm_tool_plugin.py
+++ b/plugin/llm_tool_plugin.py
@@ -1,0 +1,40 @@
+from typing import Any, Literal, TypedDict
+import pluginlib
+
+from .common import PLUGIN_TYPE_LLM_TOOLS
+
+
+class LLMToolParameter(TypedDict):
+    type: str
+    description: str
+
+
+class LLMToolParameters(TypedDict):
+    type: Literal["object"]
+    properties: dict[str, LLMToolParameter]
+    required: list[str]
+
+
+class LLMToolMetadata(TypedDict):
+    name: str
+    description: str
+    parameters: LLMToolParameters
+
+
+@pluginlib.Parent(PLUGIN_TYPE_LLM_TOOLS)
+class LLMToolPlugin:
+    @classmethod
+    @pluginlib.abstractmethod
+    def get_metadata(cls) -> LLMToolMetadata:
+        pass
+
+    @pluginlib.abstractmethod
+    def invoke(self, arguments: dict[str, Any]) -> str:
+        pass
+
+
+def llm_tool_metadata_to_openai_tool(llm_tool_metadata: LLMToolMetadata) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": llm_tool_metadata
+    }

--- a/plugin/plugin_manager.py
+++ b/plugin/plugin_manager.py
@@ -1,0 +1,45 @@
+import logging
+import os
+from pathlib import Path
+import pluginlib
+
+from .common import PLUGIN_TYPE_LLM_TOOLS
+
+from .llm_tool_plugin import LLMToolPlugin
+
+
+class PluginManager:
+    _llm_tool_plugins: dict[str, LLMToolPlugin]
+
+    def __init__(self) -> None:
+        self._llm_tool_plugins = {}
+
+    def load_plugins(self) -> None:
+        loader = pluginlib.PluginLoader(
+            paths=[str(Path(os.path.dirname(__file__), "embedded_plugins"))]
+        )
+        
+        for type, plugins in loader.plugins.items():
+            for name, plugin in plugins.items():
+                logging.info(f"Loaded {type} plugin {name} version {plugin.version}")
+
+                if type == PLUGIN_TYPE_LLM_TOOLS:
+                    metadata = plugin.get_metadata()
+                    self._llm_tool_plugins[metadata["name"]] = plugin
+
+    def get_llm_tools(self) -> list[LLMToolPlugin]:
+        return list(self._llm_tool_plugins.values())
+
+    def get_llm_tool_by_name(self, name: str) -> LLMToolPlugin | None:
+        return self._llm_tool_plugins.get(name)
+
+    def get_llm_tools_by_names(self, tool_names: list[str]) -> list[LLMToolPlugin]:
+        results = []
+
+        for name in tool_names:
+            plugin = self._llm_tool_plugins.get(name)
+
+            if plugin is not None:
+                results.append(plugin)
+
+        return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,8 @@ dependencies = [
     "langfuse>=2.60.0",
     "debugpy>=1.8.13",
     "mcp>=1.6.0",
-    "opensearch-py==2.7.1"
+    "opensearch-py==2.7.1",
+    "pluginlib==0.9.4",
 ]
 
 [project.optional-dependencies]

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -21,6 +21,7 @@ import random
 import re
 import time
 from abc import ABC
+from typing import Any, Protocol
 
 import openai
 import requests
@@ -49,6 +50,12 @@ ERROR_GENERIC = "GENERIC_ERROR"
 
 LENGTH_NOTIFICATION_CN = "······\n由于大模型的上下文窗口大小限制，回答已经被大模型截断。"
 LENGTH_NOTIFICATION_EN = "...\nThe answer is truncated by your chosen LLM due to its limitation on context length."
+
+
+
+class ToolCallSession(Protocol):
+    def tool_call(self, name: str, arguments: dict[str, Any]) -> str:
+        ...
 
 
 class Base(ABC):

--- a/web/src/components/llm-select/index.tsx
+++ b/web/src/components/llm-select/index.tsx
@@ -11,19 +11,31 @@ import { Select, SelectTrigger, SelectValue } from '../ui/select';
 interface IProps {
   id?: string;
   value?: string;
-  onChange?: (value: string) => void;
+  onInitialValue?: (value: string, option: any) => void;
+  onChange?: (value: string, option: any) => void;
   disabled?: boolean;
 }
 
-const LLMSelect = ({ id, value, onChange, disabled }: IProps) => {
+const LLMSelect = ({ id, value, onInitialValue, onChange, disabled }: IProps) => {
   const modelOptions = useComposeLlmOptionsByModelTypes([
     LlmModelType.Chat,
     LlmModelType.Image2text,
   ]);
 
+  if (onInitialValue && value) {
+    for (const modelOption of modelOptions) {
+      for (const option of modelOption.options) {
+        if (option.value === value) {
+          onInitialValue(value, option);
+          break;
+        }
+      }
+    }
+  }  
+
   const content = (
     <div style={{ width: 400 }}>
-      <LlmSettingItems
+      <LlmSettingItems onChange={onChange}
         formItemLayout={{ labelCol: { span: 10 }, wrapperCol: { span: 14 } }}
       ></LlmSettingItems>
     </div>

--- a/web/src/components/llm-setting-items/index.tsx
+++ b/web/src/components/llm-setting-items/index.tsx
@@ -16,9 +16,10 @@ interface IProps {
   prefix?: string;
   formItemLayout?: any;
   handleParametersChange?(value: ModelVariableType): void;
+  onChange?(value: string, option: any): void;
 }
 
-const LlmSettingItems = ({ prefix, formItemLayout = {} }: IProps) => {
+const LlmSettingItems = ({ prefix, formItemLayout = {}, onChange }: IProps) => {
   const form = Form.useFormInstance();
   const { t } = useTranslate('chat');
   const parameterOptions = Object.values(ModelVariableType).map((x) => ({
@@ -58,6 +59,7 @@ const LlmSettingItems = ({ prefix, formItemLayout = {} }: IProps) => {
           options={modelOptions}
           showSearch
           popupMatchSelectWidth={false}
+          onChange={onChange}
         />
       </Form.Item>
       <div className="border rounded-md">

--- a/web/src/components/llm-tools-select.tsx
+++ b/web/src/components/llm-tools-select.tsx
@@ -1,0 +1,36 @@
+import { useLlmToolsList } from '@/hooks/plugin-hooks';
+import { Select, Space } from 'antd';
+
+interface IProps {
+  value?: string;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
+}
+
+const LLMToolsSelect = ({ value, onChange, disabled }: IProps) => {
+  const tools = useLlmToolsList();
+
+  const toolOptions = tools.map(t => ({
+    description: t.description,
+    value: t.name,
+    title: t.description,
+  }));
+
+  return (
+    <Select
+      mode="multiple"
+      options={toolOptions}
+      optionRender={option => (
+        <Space>
+          {option.value}
+          {option.data.description}
+        </Space>
+      )}
+      onChange={onChange}
+      value={value}
+      disabled={disabled}
+    ></Select>
+  );
+};
+
+export default LLMToolsSelect;

--- a/web/src/hooks/llm-hooks.tsx
+++ b/web/src/hooks/llm-hooks.tsx
@@ -71,6 +71,7 @@ function buildLlmOptionsWithIcon(x: IThirdOAIModel) {
     ),
     value: `${x.llm_name}@${x.fid}`,
     disabled: !x.available,
+    is_tools: x.is_tools,
   };
 }
 
@@ -137,7 +138,7 @@ export const useComposeLlmOptionsByModelTypes = (
 
   return modelTypes.reduce<
     (DefaultOptionType & {
-      options: { label: JSX.Element; value: string; disabled: boolean }[];
+      options: { label: JSX.Element; value: string; disabled: boolean; is_tools: boolean }[];
     })[]
   >((pre, cur) => {
     const options = allOptions[cur];

--- a/web/src/hooks/plugin-hooks.tsx
+++ b/web/src/hooks/plugin-hooks.tsx
@@ -1,0 +1,17 @@
+import { ILLMTools } from '@/interfaces/database/plugin';
+import pluginService from '@/services/plugin-service';
+import { useQuery } from '@tanstack/react-query';
+
+export const useLlmToolsList = (): ILLMTools => {
+  const { data } = useQuery({
+    queryKey: ['llmTools'],
+    initialData: [],
+    queryFn: async () => {
+      const { data } = await pluginService.getLlmTools();
+
+      return data?.data ?? [];
+    },
+  });
+
+  return data;
+};

--- a/web/src/interfaces/database/llm.ts
+++ b/web/src/interfaces/database/llm.ts
@@ -13,6 +13,7 @@ export interface IThirdOAIModel {
   update_time: number;
   tenant_id?: string;
   tenant_name?: string;
+  is_tools: boolean;
 }
 
 export type IThirdOAIModelCollection = Record<string, IThirdOAIModel[]>;

--- a/web/src/interfaces/database/plugin.ts
+++ b/web/src/interfaces/database/plugin.ts
@@ -1,0 +1,17 @@
+export type ILLMTools = ILLMToolMetadata[];
+
+export interface ILLMToolMetadata {
+    name: string;
+    description: string;
+    parameters: ILLMToolParameters;
+}
+
+export interface ILLMToolParameters {
+    properties: Map<string, ILLMToolParameter>;
+    required: string[];
+}
+
+export interface ILLMToolParameter {
+    type: string;
+    description: string;
+}

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -454,6 +454,8 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       model: 'Model',
       modelTip: 'Large language chat model',
       modelMessage: 'Please select!',
+      modelEnabledTools: 'Enabled tools',
+      modelEnabledToolsTip: 'Please select one or more tools for the chat model to use. It takes no effect for models not supporting tool call.',
       freedom: 'Freedom',
       improvise: 'Improvise',
       precise: 'Precise',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -461,6 +461,8 @@ General：实体和关系提取提示来自 GitHub - microsoft/graphrag：基于
       model: '模型',
       modelTip: '大语言聊天模型',
       modelMessage: '请选择',
+      modelEnabledTools: '可用的工具',
+      modelEnabledToolsTip: '请选择一个或多个可供该模型所使用的工具。仅对支持工具调用的模型生效。',
       freedom: '自由度',
       improvise: '即兴创作',
       precise: '精确',

--- a/web/src/pages/flow/form/generate-form/index.tsx
+++ b/web/src/pages/flow/form/generate-form/index.tsx
@@ -4,9 +4,17 @@ import { PromptEditor } from '@/components/prompt-editor';
 import { useTranslate } from '@/hooks/common-hooks';
 import { Form, Switch } from 'antd';
 import { IOperatorForm } from '../../interface';
+import LLMToolsSelect from '@/components/llm-tools-select';
+import { useState } from 'react';
 
 const GenerateForm = ({ onValuesChange, form }: IOperatorForm) => {
   const { t } = useTranslate('flow');
+
+  const [isCurrentLlmSupportTools, setCurrentLlmSupportTools] = useState(false);
+
+  const onLlmSelectChanged = (_: string, option: any) => {
+    setCurrentLlmSupportTools(option.is_tools);
+  };
 
   return (
     <Form
@@ -21,7 +29,7 @@ const GenerateForm = ({ onValuesChange, form }: IOperatorForm) => {
         label={t('model', { keyPrefix: 'chat' })}
         tooltip={t('modelTip', { keyPrefix: 'chat' })}
       >
-        <LLMSelect></LLMSelect>
+        <LLMSelect onInitialValue={onLlmSelectChanged} onChange={onLlmSelectChanged}></LLMSelect>
       </Form.Item>
       <Form.Item
         name={['prompt']}
@@ -37,6 +45,13 @@ const GenerateForm = ({ onValuesChange, form }: IOperatorForm) => {
       >
         {/* <Input.TextArea rows={8}></Input.TextArea> */}
         <PromptEditor></PromptEditor>
+      </Form.Item>
+      <Form.Item
+        name={'llm_enabled_tools'}
+        label={t('modelEnabledTools', { keyPrefix: 'chat' })}
+        tooltip={t('modelEnabledToolsTip', { keyPrefix: 'chat' })}
+      >
+        <LLMToolsSelect disabled={!isCurrentLlmSupportTools}></LLMToolsSelect>
       </Form.Item>
       <Form.Item
         name={['cite']}

--- a/web/src/services/plugin-service.ts
+++ b/web/src/services/plugin-service.ts
@@ -1,0 +1,18 @@
+import api from '@/utils/api';
+import registerServer from '@/utils/register-server';
+import request from '@/utils/request';
+
+const {
+  llm_tools
+} = api;
+
+const methods = {
+  getLlmTools: {
+    url: llm_tools,
+    method: 'get',
+  },
+} as const;
+
+const pluginService = registerServer<keyof typeof methods>(methods, request);
+
+export default pluginService;

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -30,6 +30,9 @@ export default {
   delete_llm: `${api_host}/llm/delete_llm`,
   deleteFactory: `${api_host}/llm/delete_factory`,
 
+  // plugin
+  llm_tools: `${api_host}/plugin/llm_tools`,
+
   // knowledge base
   kb_list: `${api_host}/kb/list`,
   create_kb: `${api_host}/kb/create`,


### PR DESCRIPTION
### What problem does this PR solve?

Hello, our use case requires LLM agent to invoke some tools, so I made a simple implementation here.

This PR does two things:

1. A simple plugin mechanism based on `pluginlib`:

This mechanism lives in the `plugin` directory. It will only load plugins from `plugin/embedded_plugins` for now.

A sample plugin `bad_calculator.py` is placed in `plugin/embedded_plugins/llm_tools`, it accepts two numbers `a` and `b`, then give a wrong result `a + b + 100`.

In the future, it can load plugins from external location with little code change.

Plugins are divided into different types. The only plugin type supported in this PR is `llm_tools`, which must implement the `LLMToolPlugin` class in the `plugin/llm_tool_plugin.py`.
More plugin types can be added in the future.

2. A tool selector in the `Generate` component:

Added a tool selector to select one or more tools for LLM:

![image](https://github.com/user-attachments/assets/74a21fdf-9333-4175-991b-43df6524c5dc)

And with the `bad_calculator` tool, it results this with the `qwen-max` model:

![image](https://github.com/user-attachments/assets/93aff9c4-8550-414a-90a2-1a15a5249d94)


### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
