### PR TITLE
Set helm resource-policy to be keep

### DIFF
--- a/helm/templates/elasticsearch.yaml
+++ b/helm/templates/elasticsearch.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "ragflow.fullname" . }}-es-data
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "ragflow.labels" . | nindent 4 }}
     app.kubernetes.io/component: elasticsearch

--- a/helm/templates/infinity.yaml
+++ b/helm/templates/infinity.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "ragflow.fullname" . }}-infinity
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "ragflow.labels" . | nindent 4 }}
     app.kubernetes.io/component: infinity

--- a/helm/templates/minio.yaml
+++ b/helm/templates/minio.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "ragflow.fullname" . }}-minio
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "ragflow.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/helm/templates/mysql.yaml
+++ b/helm/templates/mysql.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "ragflow.fullname" . }}-mysql
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "ragflow.labels" . | nindent 4 }}
     app.kubernetes.io/component: mysql

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ragflow.fullname" . }}-redis
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "ragflow.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis


### PR DESCRIPTION
Modified the chart to retain persistent volumes by default when the chart is uninstalled, following established best practices in the Helm community (e.g., Bitnami charts)

### What problem does this PR solve?

Previously, deleting the helm chart would automatically remove all persistent data, which poses a risk of accidental data loss.

### Rationale

This change aligns with industry standards to safeguard data by requiring explicit action to remove persistence, rather than making deletion the default behavior.

### Impact: 

Users who intentionally want to remove persistent data will need to do so manually or by setting appropriate flags during chart uninstallation.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
