### PR TITLE
Docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,14 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
    export HF_ENDPOINT=https://hf-mirror.com
    ```
 
-5. Launch backend service:
+5. If your operating system does not have jemalloc, please install it as follows,
+   ```bash
+   # ubuntu
+   sudo apt-get install libjemalloc-dev
+   # centos
+   sudo yum install jemalloc
+   ```
+   Launch backend service:
 
    ```bash
    source .venv/bin/activate
@@ -335,12 +342,13 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
    bash docker/launch_backend_service.sh
    ```
 
-6. Install frontend dependencies:
+
+7. Install frontend dependencies:
    ```bash
    cd web
    npm install
    ```
-7. Launch frontend service:
+8. Launch frontend service:
 
    ```bash
    npm run dev

--- a/README.md
+++ b/README.md
@@ -334,7 +334,8 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
    # centos
    sudo yum install jemalloc
    ```
-   Launch backend service:
+   
+6. Launch backend service:
 
    ```bash
    source .venv/bin/activate


### PR DESCRIPTION
### What problem does this PR solve?

Add libjemalloc installation command. If the operating system does not have the libjemalloc library, the execution of entrypoint.sh and launch_backend_service.sh will be interrupted, and the rag/svr/task_executor.py script will not be started normally.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
