### PR TITLE
Fix: Setuptools project.license as a TOML table deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,8 @@
 name = "ragflow"
 version = "0.18.0"
 description = "[RAGFlow](https://ragflow.io/) is an open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. It offers a streamlined RAG workflow for businesses of any scale, combining LLM (Large Language Models) to provide truthful question-answering capabilities, backed by well-founded citations from various complex formatted data."
-authors = [
-    { name = "Zhichang Yu", email = "yuzhichang@gmail.com" }
-]
-license = { file = "LICENSE" }
+authors = [{ name = "Zhichang Yu", email = "yuzhichang@gmail.com" }]
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [


### PR DESCRIPTION
TOML-table-based project.license is deprecated as per PEP 639, see: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

### What problem does this PR solve?

The following error when building project (e.g. `uv build`)

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
