### PR TITLE
Fix: setuptools package definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ full = [
 ]
 
 [tool.setuptools]
-packages = ['rag', 'api', 'sdk', 'helm','agent', 'deepdoc', 'graphrag', 'flask_session', 'intergrations', 'agentic_reasoning']
+packages = ['agent', 'agentic_reasoning', 'api', 'deepdoc', 'graphrag', 'intergrations', 'rag', 'sdk.python.ragflow_sdk']
 
 [[tool.uv.index]]
 url = "https://mirrors.aliyun.com/pypi/simple"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ full = [
 ]
 
 [tool.setuptools]
-packages = ['agent', 'agentic_reasoning', 'api', 'deepdoc', 'graphrag', 'intergrations', 'rag', 'sdk.python.ragflow_sdk']
+packages = ['agent', 'agentic_reasoning', 'api', 'deepdoc', 'graphrag', 'intergrations.chatgpt-on-wechat.plugins', 'mcp.server', 'rag', 'sdk.python.ragflow_sdk']
 
 [[tool.uv.index]]
 url = "https://mirrors.aliyun.com/pypi/simple"


### PR DESCRIPTION
### What problem does this PR solve?
For `uv package`/`uv pip install ".[full]"`, bug introduced in #6370:

* Removes erroneous (non-package) directories (`helm`, `flask_session`)
* Adds `mcp.server` package
* Resolves "warning: package would be ignored" ambiguity by changing `sdk` to `sdk.python.ragflow_sdk`
* Resolves "error: package directory 'intergrations' does not exist" by including `intergrations.chatgpt-on-wechat.plugins` explicitly
* Also rearranges packages in alphabetical order, for DX.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
