### PR TITLE
When creating an assistant, no dataset is specified, a different default system promt is used

### DIFF
--- a/api/apps/dialog_app.py
+++ b/api/apps/dialog_app.py
@@ -43,7 +43,7 @@ def set_dialog():
     similarity_threshold = req.get("similarity_threshold", 0.1)
     vector_similarity_weight = req.get("vector_similarity_weight", 0.3)
     llm_setting = req.get("llm_setting", {})
-    default_prompt = {
+    default_prompt_with_dataset = {
         "system": """你是一个智能助手，请总结知识库的内容来回答问题，请列举知识库中的数据详细回答。当所有知识库内容都与问题无关时，你的回答必须包括“知识库中未找到您要的答案！”这句话。回答需要考虑聊天历史。
 以下是知识库：
 {knowledge}
@@ -54,6 +54,20 @@ def set_dialog():
         ],
         "empty_response": "Sorry! 知识库中未找到相关内容！"
     }
+    default_prompt_no_dataset = {
+        "system": """You are a helpful assistant.""",
+        "prologue": "您好，我是您的助手小樱，长得可爱又善良，can I help you?",
+        "parameters": [
+           
+        ],
+        "empty_response": ""
+    }
+    if req.get("kb_ids"):
+        default_prompt = default_prompt_with_dataset
+    else:
+        default_prompt = default_prompt_no_dataset
+
+
     prompt_config = req.get("prompt_config", default_prompt)
 
     if not prompt_config["system"]:

--- a/api/apps/dialog_app.py
+++ b/api/apps/dialog_app.py
@@ -62,16 +62,14 @@ def set_dialog():
         ],
         "empty_response": ""
     }
-    if req.get("kb_ids"):
-        default_prompt = default_prompt_with_dataset
-    else:
-        default_prompt = default_prompt_no_dataset
-
-
-    prompt_config = req.get("prompt_config", default_prompt)
+    prompt_config = req.get("prompt_config", default_prompt_with_dataset)
 
     if not prompt_config["system"]:
-        prompt_config["system"] = default_prompt["system"]
+        prompt_config["system"] = default_prompt_with_dataset["system"]
+    
+    if not req.get("kb_ids", []):
+        if prompt_config['system'] == default_prompt_with_dataset['system'] or "{knowledge}" in prompt_config['system']:
+            prompt_config = default_prompt_no_dataset
 
     for p in prompt_config["parameters"]:
         if p["optional"]:


### PR DESCRIPTION

### What problem does this PR solve?

- Updated the dialog settings function to add a default prompt configuration for no dataset.
- The prompt configuration will be determined based on the presence of `kb_ids` in the request.


### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (Non-breaking change, adding functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
