### PR TITLE
Feat: Add OAuth `state` parameter for CSRF protection

### DIFF
--- a/api/apps/auth/oauth.py
+++ b/api/apps/auth/oauth.py
@@ -45,7 +45,7 @@ class OAuthClient:
         self.http_request_timeout = 7
 
 
-    def get_authorization_url(self):
+    def get_authorization_url(self, state=None):
         """
         Generate the authorization URL for user login.
         """
@@ -56,6 +56,8 @@ class OAuthClient:
         }
         if self.scope:
             params["scope"] = self.scope
+        if state:
+            params["state"] = state
         authorization_url = f"{self.authorization_url}?{urllib.parse.urlencode(params)}"
         return authorization_url
 


### PR DESCRIPTION
### What problem does this PR solve?

Add OAuth `state` parameter for CSRF protection:
- Updated `get_authorization_url()` to accept an optional state parameter
- Generated a unique state value during OAuth login and stored in session
- Verified state parameter in callback to ensure request legitimacy

This PR follows OAuth 2.0 security best practices by ensuring that the authorization request originates from the same user who initiated the flow.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
