### PR TITLE
Feat: The image displayed in the reply message can also be clicked to display the location of the source document where the slice is located #7623

### DIFF
--- a/web/src/components/image/index.tsx
+++ b/web/src/components/image/index.tsx
@@ -7,6 +7,7 @@ import styles from './index.less';
 interface IImage {
   id: string;
   className: string;
+  onClick?(): void;
 }
 
 const Image = ({ id, className, ...props }: IImage) => {

--- a/web/src/pages/chat/markdown-content/index.less
+++ b/web/src/pages/chat/markdown-content/index.less
@@ -17,10 +17,15 @@
 }
 
 .referenceChunkImage {
+  width: 10vw;
+  object-fit: contain;
+}
+
+.referenceInnerChunkImage {
   display: block;
   object-fit: contain;
   max-width: 100%;
-  max-height: 15vh;
+  max-height: 6vh;
 }
 
 .referenceImagePreview {


### PR DESCRIPTION
### What problem does this PR solve?

Feat: The image displayed in the reply message can also be clicked to display the location of the source document where the slice is located #7623

### Type of change


- [x] New Feature (non-breaking change which adds functionality)

