### PR TITLE
Fix: File selection in Retrieval testing causes other options to disappear

### DIFF
--- a/web/src/pages/add-knowledge/components/knowledge-testing/testing-result/select-files.tsx
+++ b/web/src/pages/add-knowledge/components/knowledge-testing/testing-result/select-files.tsx
@@ -50,7 +50,7 @@ const SelectFiles = ({ setSelectedDocumentIds, handleTesting }: IProps) => {
 
   const rowSelection = {
     onChange: (selectedRowKeys: React.Key[]) => {
-      handleTesting(selectedRowKeys as string[]);
+      //handleTesting(selectedRowKeys as string[]); remove due to #7753
       setSelectedDocumentIds(selectedRowKeys as string[]);
     },
     getCheckboxProps: (record: ITestingDocument) => ({


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/infiniflow/ragflow/issues/7753

The internal is due to when the selected row keys change will trigger a testing, but I do not know why.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

