### PR TITLE
Update exesql.py

### DIFF
--- a/agent/component/exesql.py
+++ b/agent/component/exesql.py
@@ -105,6 +105,7 @@ class ExeSQL(Generate, ABC):
         sql_res = []
         for i in range(len(input_list)):
             single_sql = input_list[i]
+            single_sql = single_sql.replace('```','')
             while self._loop <= self._param.loop:
                 self._loop += 1
                 if not single_sql:

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -302,7 +302,7 @@ def chat(dialog, messages, stream=True, **kwargs):
     if "max_tokens" in gen_conf:
         gen_conf["max_tokens"] = min(gen_conf["max_tokens"], max_tokens - used_token_count)
 
-    def repair_bad_citation_formats(answer: str, kbinfos: dict, idx: dict):
+    def repair_bad_citation_formats(answer: str, kbinfos: dict, idx: set):
         max_index = len(kbinfos["chunks"])
 
         def safe_add(i):
@@ -623,4 +623,3 @@ def ask(question, kb_ids, tenant_id):
         answer = ans
         yield {"answer": answer, "reference": {}}
     yield decorate_answer(answer)
-

--- a/docker/.env
+++ b/docker/.env
@@ -169,6 +169,8 @@ REGISTER_ENABLED=1
 # SANDBOX_BASE_NODEJS_IMAGE=infiniflow/sandbox-base-nodejs:latest
 # SANDBOX_EXECUTOR_MANAGER_PORT=9385
 # SANDBOX_ENABLE_SECCOMP=false
+# SANDBOX_MAX_MEMORY=256m # b, k, m, g
+# SANDBOX_TIMEOUT=10s # s, m, 1m30s
 
 # Important: To enable sandbox, you must re-declare the compose profiles.
 # 1. Comment out the COMPOSE_PROFILES line above.

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -124,6 +124,8 @@ services:
       - SANDBOX_BASE_PYTHON_IMAGE=${SANDBOX_BASE_PYTHON_IMAGE:-infiniflow/sandbox-base-python:latest}
       - SANDBOX_BASE_NODEJS_IMAGE=${SANDBOX_BASE_NODEJS_IMAGE:-infiniflow/sandbox-base-nodejs:latest}
       - SANDBOX_ENABLE_SECCOMP=${SANDBOX_ENABLE_SECCOMP:-false}
+      - SANDBOX_MAX_MEMORY=${SANDBOX_MAX_MEMORY:-256m}
+      - SANDBOX_TIMEOUT=${SANDBOX_TIMEOUT:-10s}
     healthcheck:
       test: ["CMD", "curl", "http://localhost:9385/healthz"]
       interval: 10s


### PR DESCRIPTION
去除大模型生成sql里的反引号，导致执行报错

### What problem does this PR solve?
![image](https://github.com/user-attachments/assets/2fc3779c-3415-491c-aa66-d944709c1b0d)
检索完之后，生成组件中大模型生成的sql经常存在反引号，给sql组件执行的时候经常会报错
![image](https://github.com/user-attachments/assets/1b97057e-af32-4f90-b2bc-9834fe3df185)


_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):
