### PR TITLE
Fix backquotes in text2sql causing execution errors

### DIFF
--- a/agent/component/exesql.py
+++ b/agent/component/exesql.py
@@ -105,6 +105,7 @@ class ExeSQL(Generate, ABC):
         sql_res = []
         for i in range(len(input_list)):
             single_sql = input_list[i]
+            single_sql = single_sql.replace('```','')
             while self._loop <= self._param.loop:
                 self._loop += 1
                 if not single_sql:


### PR DESCRIPTION
### What problem does this PR solve?
Remove the backquotes in the sql generated by LLM to prevent it from causing execution errors.
![image](https://github.com/user-attachments/assets/40d57ef7-b812-402a-b469-5793e466b83d)

![image](https://github.com/user-attachments/assets/d0a9bc17-ff5a-43cb-90cb-b2b3827b00b0)


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)