### PR TITLE
Delete Corresponding Minio Bucket When Deleting a Knowledge Base

### DIFF
--- a/api/apps/kb_app.py
+++ b/api/apps/kb_app.py
@@ -34,6 +34,7 @@ from api import settings
 from rag.nlp import search
 from api.constants import DATASET_NAME_LIMIT
 from rag.settings import PAGERANK_FLD
+from rag.utils.storage_factory import STORAGE_IMPL
 
 
 @manager.route('/create', methods=['post'])  # noqa: F821
@@ -226,6 +227,8 @@ def rm():
         for kb in kbs:
             settings.docStoreConn.delete({"kb_id": kb.id}, search.index_name(kb.tenant_id), kb.id)
             settings.docStoreConn.deleteIdx(search.index_name(kb.tenant_id), kb.id)
+            if hasattr(STORAGE_IMPL, 'remove_bucket'):
+                STORAGE_IMPL.remove_bucket(kb.id)
         return get_json_result(data=True)
     except Exception as e:
         return server_error_response(e)

--- a/rag/utils/minio_conn.py
+++ b/rag/utils/minio_conn.py
@@ -118,3 +118,13 @@ class RAGFlowMinio:
                 time.sleep(1)
         return
 
+    def remove_bucket(self, bucket):
+        try:
+            if self.conn.bucket_exists(bucket):
+                objects_to_delete = self.conn.list_objects(bucket, recursive=True)
+                for obj in objects_to_delete:
+                    self.conn.remove_object(bucket, obj.object_name)
+                self.conn.remove_bucket(bucket)
+        except Exception:
+            logging.exception(f"Fail to remove bucket {bucket}")
+


### PR DESCRIPTION
### What problem does this PR solve?

Delete Corresponding Minio Bucket When Deleting a Knowledge Base
[issue #4113 ](https://github.com/infiniflow/ragflow/issues/4113)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)

@KevinHuSh 
