### PR TITLE
Feat: Surpport dynamically add knowledge basees for retrieval while u…

### DIFF
--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -123,6 +123,8 @@ def completion(tenant_id, chat_id, question, name="New session", session_id=None
     message_id = msg[-1].get("id")
     e, dia = DialogService.get_by_id(conv.dialog_id)
 
+    kb_ids = kwargs.get("kb_ids",[])
+    dia.kb_ids = list(set(dia.kb_ids + kb_ids))
     if not conv.reference:
         conv.reference = []
     conv.message.append({"role": "assistant", "content": "", "id": message_id})


### PR DESCRIPTION
…sing the SDK chat API

### What problem does this PR solve?

When using the SDK for chat, you can include the IDs of additional knowledge bases you want to use in the request. This way, you don’t need to repeatedly create new assistants to support various combinations of knowledge bases. This is especially useful when there are many knowledge bases with different content. If users clearly know which knowledge base contains the information they need and select accordingly, the recall accuracy will be greatly improved.

Users only need to add an extra field, a kb_ids array, in the HTTP request. The content of this field can be determined by the client fetching the list of knowledge bases and letting the user select from it.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
