### PR TITLE
Fix: add default output method for ComponentParamBase

### DIFF
--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -46,6 +46,9 @@ class ComponentParamBase(ABC):
 
     def check(self):
         raise NotImplementedError("Parameter Object should be checked.")
+    
+    def output(self):
+        return None
 
     @classmethod
     def _get_or_init_deprecated_params_set(cls):


### PR DESCRIPTION
### What problem does this PR solve?
https://github.com/infiniflow/ragflow/issues/7908
For the code
` _, out = cpn.output(allow_partial=False)`

` def output(self, allow_partial=True) -> Tuple[str, Union[pd.DataFrame, partial]]:
        o = getattr(self._param, self._param.output_var_name)`

need to call this method
But I do not have a full context.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)

