### PR TITLE
agents openai API add new way to get session_id

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -388,10 +388,10 @@ def agents_completion_openai_compatibility (tenant_id, agent_id):
     question = next((m["content"] for m in reversed(messages) if m["role"] == "user"), "")
     
     if req.get("stream", True):
-        return Response(completionOpenAI(tenant_id, agent_id, question, session_id=req.get("id", ""), stream=True), mimetype="text/event-stream")
+        return Response(completionOpenAI(tenant_id, agent_id, question, session_id=req.get("id", req.get("metadata", {}).get("id","")), stream=True), mimetype="text/event-stream")
     else:
         # For non-streaming, just return the response directly
-        response = next(completionOpenAI(tenant_id, agent_id, question, session_id=req.get("id", ""), stream=False))
+        response = next(completionOpenAI(tenant_id, agent_id, question, session_id=req.get("id", req.get("metadata", {}).get("id","")), stream=False))
         return jsonify(response)
     
 


### PR DESCRIPTION
### What problem does this PR solve?

SpringAI can only add session_id in metadata。so add new way to get session_id from "id" or "metadata.id"
![image](https://github.com/user-attachments/assets/0c698ebb-2228-46d8-94c5-2a291b6f70bf)

### Type of change

- [x] New Feature (non-breaking change which adds functionality)