### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: ragflow
+
 include:
   - ./docker-compose-base.yml
 


### PR DESCRIPTION
If the name field is not specified, Docker Compose will default to using `docker` as the project name. This may cause conflicts with other default projects, leading to unintended operations when executing `docker compose` commands.

### What problem does this PR solve?

When executing Docker Compose commands, interference occurs between multiple default projects, leading to operational chaos.​

### Type of change

- [x] Other (please describe):
