### PR TITLE
fix: Increase timeout time of mysql to avoid false unhealthy check

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -158,8 +158,8 @@ services:
       - ragflow
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-uroot", "-p${MYSQL_PASSWORD}"]
-      interval: 10s
-      timeout: 10s
+      interval: 20s
+      timeout: 20s
       retries: 3
     restart: on-failure
 


### PR DESCRIPTION
fix #6511

### What problem does this PR solve?

A slow MySQL start time, potentially exceeding the 10-second timeout, can cause unwanted forced restarts and unhealthy status reports. This PR sets the MySQL health check `interval` and `timeout` to 20 seconds, ~~a change reported to be effective by [the community](https://github.com/infiniflow/ragflow/issues/6511).~~

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
