### PR TITLE
Fix: Set Output In Category Component

### DIFF
--- a/agent/component/categorize.py
+++ b/agent/component/categorize.py
@@ -99,9 +99,13 @@ class Categorize(Generate, ABC):
         # If a category is found, return the category with the highest count.
         if any(category_counts.values()):
             max_category = max(category_counts.items(), key=lambda x: x[1])
-            return Categorize.be_output(self._param.category_description[max_category[0]]["to"])
+            res = Categorize.be_output(self._param.category_description[max_category[0]]["to"])
+            self.set_output(res)
+            return res
 
-        return Categorize.be_output(list(self._param.category_description.items())[-1][1]["to"])
+        res = Categorize.be_output(list(self._param.category_description.items())[-1][1]["to"])
+        self.set_output(res)
+        return res
 
     def debug(self, **kwargs):
         df = self._run([], **kwargs)


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/infiniflow/ragflow/issues/8006
The category should work well, but the category's downstream seems to be unable to get the upstream output.
Add the category's output as an attribute.
However, in base.py, there is logic
` if self.component_name.lower().find("switch") < 0 and self.get_component_name(u) in ["relevant", "categorize"]:
                continue`
  If goto this cases will not tried to get output from Category (but I do not have full context about this if logic).         



### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

