### PR TITLE
Revert kb_id assignment to string for consistency

### DIFF
--- a/api/apps/chunk_app.py
+++ b/api/apps/chunk_app.py
@@ -234,7 +234,7 @@ def create():
         e, doc = DocumentService.get_by_id(req["doc_id"])
         if not e:
             return get_data_error_result(message="Document not found!")
-        d["kb_id"] = [doc.kb_id]
+        d["kb_id"] = doc.kb_id
         d["docnm_kwd"] = doc.name
         d["title_tks"] = rag_tokenizer.tokenize(doc.name)
         d["doc_id"] = doc.id


### PR DESCRIPTION
### What problem does this PR solve?

This change reverts the kb_id assignment in commit a997391... back to a direct string assignment (doc.kb_id) instead of a list ([doc.kb_id]). This aims to resolve the dataset_id format inconsistency in the /api/v1/retrieval API response.
Addresses issue #8052"

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
