### PR TITLE
Don't use '，' (U+FF0C) but ', ' (U+2C U+20)

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -900,7 +900,7 @@ curl --request PUT \
 - `document_id`: (*Path parameter*)  
   The ID of the document to update.
 - `"name"`: (*Body parameter*), `string`
-- `"meta_fields"`: (*Body parameter*)， `dict[str, Any]` The meta fields of the document.
+- `"meta_fields"`: (*Body parameter*), `dict[str, Any]` The meta fields of the document.
 - `"chunk_method"`: (*Body parameter*), `string`  
   The parsing method to apply to the document:  
   - `"naive"`: General
@@ -2142,7 +2142,7 @@ Success:
         "id": "4606b4ec87ad11efbc4f0242ac120006",
         "messages": [
             {
-                "content": "Hi! I am your assistant，can I help you?",
+                "content": "Hi! I am your assistant, can I help you?",
                 "role": "assistant"
             }
         ],
@@ -2283,7 +2283,7 @@ Success:
             "id": "578d541e87ad11ef96b90242ac120006",
             "messages": [
                 {
-                    "content": "Hi! I am your assistant，can I help you?",
+                    "content": "Hi! I am your assistant, can I help you?",
                     "role": "assistant"
                 }
             ],

--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -1238,7 +1238,7 @@ The name of the chat session to create.
 - Success: A `Session` object containing the following attributes:
   - `id`: `str` The auto-generated unique identifier of the created session.
   - `name`: `str` The name of the created session.
-  - `message`: `list[Message]` The opening message of the created session. Default: `[{"role": "assistant", "content": "Hi! I am your assistant，can I help you?"}]`
+  - `message`: `list[Message]` The opening message of the created session. Default: `[{"role": "assistant", "content": "Hi! I am your assistant, can I help you?"}]`
   - `chat_id`: `str` The ID of the associated chat assistant.
 - Failure: `Exception`
 
@@ -1497,7 +1497,7 @@ The parameters in `begin` component.
 
 - Success: A `Session` object containing the following attributes:
   - `id`: `str` The auto-generated unique identifier of the created session.
-  - `message`: `list[Message]` The messages of the created session assistant. Default: `[{"role": "assistant", "content": "Hi! I am your assistant，can I help you?"}]`
+  - `message`: `list[Message]` The messages of the created session assistant. Default: `[{"role": "assistant", "content": "Hi! I am your assistant, can I help you?"}]`
   - `agent_id`: `str` The ID of the associated agent.
 - Failure: `Exception`
 

--- a/sdk/python/ragflow_sdk/modules/session.py
+++ b/sdk/python/ragflow_sdk/modules/session.py
@@ -23,7 +23,7 @@ class Session(Base):
     def __init__(self, rag, res_dict):
         self.id = None
         self.name = "New session"
-        self.messages = [{"role": "assistant", "content": "Hi! I am your assistant，can I help you?"}]
+        self.messages = [{"role": "assistant", "content": "Hi! I am your assistant, can I help you?"}]
         for key, value in res_dict.items():
             if key == "chat_id" and value is not None:
                 self.chat_id = None
@@ -100,7 +100,7 @@ class Session(Base):
 
 class Message(Base):
     def __init__(self, rag, res_dict):
-        self.content = "Hi! I am your assistant，can I help you?"
+        self.content = "Hi! I am your assistant, can I help you?"
         self.reference = None
         self.role = "assistant"
         self.prompt = None

--- a/web/src/interfaces/request/base.ts
+++ b/web/src/interfaces/request/base.ts
@@ -1,7 +1,7 @@
 export interface IPaginationRequestBody {
   keywords?: string;
   page?: number;
-  page_size?: number; // name|create|doc_num|create_time|update_time，default：create_time
+  page_size?: number; // name|create|doc_num|create_time|update_time, default：create_time
   orderby?: string;
   desc?: string;
 }


### PR DESCRIPTION
The Unicode codepoint '，' (U+FF0C) is meant to be used in Chinese text, but this is English text. It looks like a comma followed by a space, but isn't. Of course I didn't change actual Chinese text.

### What problem does this PR solve?

Mixup of Unicode characters. This is probably unnoticed by most users, but I wonder if screen readers would read it out differently or if LLMs would trip up on it.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
