### PR TITLE
Fix: set output for Message template

### DIFF
--- a/agent/component/message.py
+++ b/agent/component/message.py
@@ -40,7 +40,9 @@ class Message(ComponentBase, ABC):
         if kwargs.get("stream"):
             return partial(self.stream_output)
 
-        return Message.be_output(random.choice(self._param.messages))
+        res = Message.be_output(random.choice(self._param.messages))
+        self.set_output(res)
+        return res
 
     def stream_output(self):
         res = None


### PR DESCRIPTION
### What problem does this PR solve?
now Streamning logic is not match with none streaming logic, which may introduce down stream can not find upstream components.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

