### PR TITLE
Fix: Resolve JSON download errors in Document.download()

### DIFF
--- a/sdk/python/ragflow_sdk/modules/document.py
+++ b/sdk/python/ragflow_sdk/modules/document.py
@@ -63,9 +63,14 @@ class Document(Base):
 
     def download(self):
         res = self.get(f"/datasets/{self.dataset_id}/documents/{self.id}")
+        error_keys = set(["code", "message"])
         try:
-            res = res.json()
-            raise Exception(res.get("message"))
+            response = res.json()
+            actual_keys = set(response.keys())
+            if actual_keys == error_keys:
+                raise Exception(res.get("message"))
+            else:
+                return res.content
         except json.JSONDecodeError:
             return res.content
 


### PR DESCRIPTION
### What problem does this PR solve?

An exception is thrown only when the json file has only two keys, `code` and `message`. In other cases, response.content is returned normally.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)