### PR TITLE
Fix: chat module  update LLM defaults

### DIFF
--- a/sdk/python/ragflow_sdk/modules/chat.py
+++ b/sdk/python/ragflow_sdk/modules/chat.py
@@ -31,7 +31,7 @@ class Chat(Base):
 
     class LLM(Base):
         def __init__(self, rag, res_dict):
-            self.model_name = "deepseek-chat"
+            self.model_name = None
             self.temperature = 0.1
             self.top_p = 0.3
             self.presence_penalty = 0.4
@@ -59,8 +59,7 @@ class Chat(Base):
             super().__init__(rag, res_dict)
 
     def update(self, update_message: dict):
-        res = self.put(f'/chats/{self.id}',
-                       update_message)
+        res = self.put(f"/chats/{self.id}", update_message)
         res = res.json()
         if res.get("code") != 0:
             raise Exception(res["message"])
@@ -69,13 +68,11 @@ class Chat(Base):
         res = self.post(f"/chats/{self.id}/sessions", {"name": name})
         res = res.json()
         if res.get("code") == 0:
-            return Session(self.rag, res['data'])
+            return Session(self.rag, res["data"])
         raise Exception(res["message"])
 
-    def list_sessions(self, page: int = 1, page_size: int = 30, orderby: str = "create_time", desc: bool = True,
-                      id: str = None, name: str = None) -> list[Session]:
-        res = self.get(f'/chats/{self.id}/sessions',
-                       {"page": page, "page_size": page_size, "orderby": orderby, "desc": desc, "id": id, "name": name})
+    def list_sessions(self, page: int = 1, page_size: int = 30, orderby: str = "create_time", desc: bool = True, id: str = None, name: str = None) -> list[Session]:
+        res = self.get(f"/chats/{self.id}/sessions", {"page": page, "page_size": page_size, "orderby": orderby, "desc": desc, "id": id, "name": name})
         res = res.json()
         if res.get("code") == 0:
             result_list = []


### PR DESCRIPTION
### What problem does this PR solve?

Previously when LLM.model_name was not configured:
- System incorrectly defaulted to 'deepseek-chat' model
- This caused permission errors for unauthorized tenants

Now:
- Use tenant's default chat_model configuration first

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
