### PR TITLE
Fix: Set default rerank_model to empty string in Chat class

### DIFF
--- a/sdk/python/ragflow_sdk/modules/chat.py
+++ b/sdk/python/ragflow_sdk/modules/chat.py
@@ -46,7 +46,7 @@ class Chat(Base):
             self.top_n = 8
             self.top_k = 1024
             self.variables = [{"key": "knowledge", "optional": True}]
-            self.rerank_model = None
+            self.rerank_model = ""
             self.empty_response = None
             self.opener = "Hi! I'm your assistant, what can I do for you?"
             self.show_quote = True


### PR DESCRIPTION
### What problem does this PR solve?

Previously when LLM.rerank_model was not configured:
- SDK would pass None as the value
- Database field with null=False constraint would reject it
- Caused storage failures for unset rerank_model cases

Now:
- SDK checks for None value before database operations
- Provides empty string as default when rerank_model is unset

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
