### PR TITLE
Fix: use jwks_uri from OIDC metadata for JWKS client

### DIFF
--- a/api/apps/auth/oidc.py
+++ b/api/apps/auth/oidc.py
@@ -68,8 +68,7 @@ class OIDCClient(OAuthClient):
             alg = headers.get("alg", "RS256")
 
             # Use PyJWT's PyJWKClient to fetch JWKS and find signing key
-            jwks_url = f"{self.issuer}/.well-known/jwks.json"
-            jwks_cli = jwt.PyJWKClient(jwks_url)
+            jwks_cli = jwt.PyJWKClient(self.jwks_uri)
             signing_key = jwks_cli.get_signing_key_from_jwt(id_token).key
 
             # Decode and verify signature


### PR DESCRIPTION
### What problem does this PR solve?
Issue: #8051

The current implementation assumes JWKS endpoints follow the standard `/.well-known/jwks.json` convention. This breaks authentication for OIDC providers that use non-standard JWKS paths, resulting in 404 errors during token validation.

Root Cause Analysis
- The OpenID Connect specification doesn't mandate a fixed path for JWKS endpoints
- Some identity providers (like certain Keycloak configurations) use custom endpoints
- Our previous approach constructed JWKS URLs by convention rather than discovery

### Solution Approach
Instead of constructing JWKS URLs by appending to the issuer URI, we now:
1. Properly leverage the `jwks_uri` from the OIDC discovery metadata
2. Honor the identity provider's actual configured endpoint

```python
# Before (fragile approach)
jwks_url = f"{self.issuer}/.well-known/jwks.json"

# After (standards-compliant)
jwks_cli = jwt.PyJWKClient(self.jwks_uri)  # Use discovered endpoint
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
