### PR TITLE
fix: silence deprecation in huggingface snapshot_download function

### DIFF
--- a/download_deps.py
+++ b/download_deps.py
@@ -50,7 +50,7 @@ repos = [
 def download_model(repo_id):
     local_dir = os.path.abspath(os.path.join("huggingface.co", repo_id))
     os.makedirs(local_dir, exist_ok=True)
-    snapshot_download(repo_id=repo_id, local_dir=local_dir, local_dir_use_symlinks=False)
+    snapshot_download(repo_id=repo_id, local_dir=local_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What problem does this PR solve?

fixes the following deprecation emitted from `download_deps.py`: 

```
UserWarning: `local_dir_use_symlinks` parameter is deprecated and will be ignored. The process to download files to a local folder has been updated and do not rely on symlinks anymore. You only need to pass a destination folder as`local_dir`
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
