### PR TITLE
Test: Refactor test fixtures to use HttpApiAuth naming consistently

### DIFF
--- a/test/testcases/test_http_api/conftest.py
+++ b/test/testcases/test_http_api/conftest.py
@@ -83,31 +83,31 @@ def ragflow_tmp_dir(request, tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def api_key(token):
+def HttpApiAuth(token):
     return RAGFlowHttpApiAuth(token)
 
 
 @pytest.fixture(scope="function")
-def clear_datasets(request, api_key):
+def clear_datasets(request, HttpApiAuth):
     def cleanup():
-        delete_datasets(api_key, {"ids": None})
+        delete_datasets(HttpApiAuth, {"ids": None})
 
     request.addfinalizer(cleanup)
 
 
 @pytest.fixture(scope="function")
-def clear_chat_assistants(request, api_key):
+def clear_chat_assistants(request, HttpApiAuth):
     def cleanup():
-        delete_chat_assistants(api_key)
+        delete_chat_assistants(HttpApiAuth)
 
     request.addfinalizer(cleanup)
 
 
 @pytest.fixture(scope="function")
-def clear_session_with_chat_assistants(request, api_key, add_chat_assistants):
+def clear_session_with_chat_assistants(request, HttpApiAuth, add_chat_assistants):
     def cleanup():
         for chat_assistant_id in chat_assistant_ids:
-            delete_session_with_chat_assistants(api_key, chat_assistant_id)
+            delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id)
 
     request.addfinalizer(cleanup)
 
@@ -115,51 +115,51 @@ def clear_session_with_chat_assistants(request, api_key, add_chat_assistants):
 
 
 @pytest.fixture(scope="class")
-def add_dataset(request, api_key):
+def add_dataset(request, HttpApiAuth):
     def cleanup():
-        delete_datasets(api_key, {"ids": None})
+        delete_datasets(HttpApiAuth, {"ids": None})
 
     request.addfinalizer(cleanup)
 
-    dataset_ids = batch_create_datasets(api_key, 1)
+    dataset_ids = batch_create_datasets(HttpApiAuth, 1)
     return dataset_ids[0]
 
 
 @pytest.fixture(scope="function")
-def add_dataset_func(request, api_key):
+def add_dataset_func(request, HttpApiAuth):
     def cleanup():
-        delete_datasets(api_key, {"ids": None})
+        delete_datasets(HttpApiAuth, {"ids": None})
 
     request.addfinalizer(cleanup)
 
-    return batch_create_datasets(api_key, 1)[0]
+    return batch_create_datasets(HttpApiAuth, 1)[0]
 
 
 @pytest.fixture(scope="class")
-def add_document(api_key, add_dataset, ragflow_tmp_dir):
+def add_document(HttpApiAuth, add_dataset, ragflow_tmp_dir):
     dataset_id = add_dataset
-    document_ids = bulk_upload_documents(api_key, dataset_id, 1, ragflow_tmp_dir)
+    document_ids = bulk_upload_documents(HttpApiAuth, dataset_id, 1, ragflow_tmp_dir)
     return dataset_id, document_ids[0]
 
 
 @pytest.fixture(scope="class")
-def add_chunks(api_key, add_document):
+def add_chunks(HttpApiAuth, add_document):
     dataset_id, document_id = add_document
-    parse_documents(api_key, dataset_id, {"document_ids": [document_id]})
-    condition(api_key, dataset_id)
-    chunk_ids = batch_add_chunks(api_key, dataset_id, document_id, 4)
+    parse_documents(HttpApiAuth, dataset_id, {"document_ids": [document_id]})
+    condition(HttpApiAuth, dataset_id)
+    chunk_ids = batch_add_chunks(HttpApiAuth, dataset_id, document_id, 4)
     sleep(1)  # issues/6487
     return dataset_id, document_id, chunk_ids
 
 
 @pytest.fixture(scope="class")
-def add_chat_assistants(request, api_key, add_document):
+def add_chat_assistants(request, HttpApiAuth, add_document):
     def cleanup():
-        delete_chat_assistants(api_key)
+        delete_chat_assistants(HttpApiAuth)
 
     request.addfinalizer(cleanup)
 
     dataset_id, document_id = add_document
-    parse_documents(api_key, dataset_id, {"document_ids": [document_id]})
-    condition(api_key, dataset_id)
-    return dataset_id, document_id, batch_create_chat_assistants(api_key, 5)
+    parse_documents(HttpApiAuth, dataset_id, {"document_ids": [document_id]})
+    condition(HttpApiAuth, dataset_id)
+    return dataset_id, document_id, batch_create_chat_assistants(HttpApiAuth, 5)

--- a/test/testcases/test_http_api/test_chat_assistant_management/conftest.py
+++ b/test/testcases/test_http_api/test_chat_assistant_management/conftest.py
@@ -28,13 +28,13 @@ def condition(_auth, _dataset_id):
 
 
 @pytest.fixture(scope="function")
-def add_chat_assistants_func(request, api_key, add_document):
+def add_chat_assistants_func(request, HttpApiAuth, add_document):
     def cleanup():
-        delete_chat_assistants(api_key)
+        delete_chat_assistants(HttpApiAuth)
 
     request.addfinalizer(cleanup)
 
     dataset_id, document_id = add_document
-    parse_documents(api_key, dataset_id, {"document_ids": [document_id]})
-    condition(api_key, dataset_id)
-    return dataset_id, document_id, batch_create_chat_assistants(api_key, 5)
+    parse_documents(HttpApiAuth, dataset_id, {"document_ids": [document_id]})
+    condition(HttpApiAuth, dataset_id)
+    return dataset_id, document_id, batch_create_chat_assistants(HttpApiAuth, 5)

--- a/test/testcases/test_http_api/test_chat_assistant_management/test_create_chat_assistant.py
+++ b/test/testcases/test_http_api/test_chat_assistant_management/test_create_chat_assistant.py
@@ -54,14 +54,14 @@ class TestChatAssistantCreate:
             ({"name": "case insensitive"}, 102, "Duplicated chat name in creating chat."),
         ],
     )
-    def test_name(self, api_key, add_chunks, payload, expected_code, expected_message):
+    def test_name(self, HttpApiAuth, add_chunks, payload, expected_code, expected_message):
         payload["dataset_ids"] = []  # issues/
         if payload["name"] == "duplicated_name":
-            create_chat_assistant(api_key, payload)
+            create_chat_assistant(HttpApiAuth, payload)
         elif payload["name"] == "case insensitive":
-            create_chat_assistant(api_key, {"name": payload["name"].upper()})
+            create_chat_assistant(HttpApiAuth, {"name": payload["name"].upper()})
 
-        res = create_chat_assistant(api_key, payload)
+        res = create_chat_assistant(HttpApiAuth, payload)
         assert res["code"] == expected_code, res
         if expected_code == 0:
             assert res["data"]["name"] == payload["name"]
@@ -78,7 +78,7 @@ class TestChatAssistantCreate:
             ("invalid_dataset_id", 102, "You don't own the dataset i"),
         ],
     )
-    def test_dataset_ids(self, api_key, add_chunks, dataset_ids, expected_code, expected_message):
+    def test_dataset_ids(self, HttpApiAuth, add_chunks, dataset_ids, expected_code, expected_message):
         dataset_id, _, _ = add_chunks
         payload = {"name": "ragflow test"}
         if callable(dataset_ids):
@@ -86,7 +86,7 @@ class TestChatAssistantCreate:
         else:
             payload["dataset_ids"] = dataset_ids
 
-        res = create_chat_assistant(api_key, payload)
+        res = create_chat_assistant(HttpApiAuth, payload)
         assert res["code"] == expected_code, res
         if expected_code == 0:
             assert res["data"]["name"] == payload["name"]
@@ -94,10 +94,10 @@ class TestChatAssistantCreate:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_avatar(self, api_key, tmp_path):
+    def test_avatar(self, HttpApiAuth, tmp_path):
         fn = create_image_file(tmp_path / "ragflow_test.png")
         payload = {"name": "avatar_test", "avatar": encode_avatar(fn), "dataset_ids": []}
-        res = create_chat_assistant(api_key, payload)
+        res = create_chat_assistant(HttpApiAuth, payload)
         assert res["code"] == 0
 
     @pytest.mark.p2
@@ -135,10 +135,10 @@ class TestChatAssistantCreate:
             pytest.param({"unknown": "unknown"}, 0, "", marks=pytest.mark.skip),
         ],
     )
-    def test_llm(self, api_key, add_chunks, llm, expected_code, expected_message):
+    def test_llm(self, HttpApiAuth, add_chunks, llm, expected_code, expected_message):
         dataset_id, _, _ = add_chunks
         payload = {"name": "llm_test", "dataset_ids": [dataset_id], "llm": llm}
-        res = create_chat_assistant(api_key, payload)
+        res = create_chat_assistant(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             if llm:
@@ -202,10 +202,10 @@ class TestChatAssistantCreate:
             pytest.param({"unknown": "unknown"}, 0, "", marks=pytest.mark.skip),
         ],
     )
-    def test_prompt(self, api_key, add_chunks, prompt, expected_code, expected_message):
+    def test_prompt(self, HttpApiAuth, add_chunks, prompt, expected_code, expected_message):
         dataset_id, _, _ = add_chunks
         payload = {"name": "prompt_test", "dataset_ids": [dataset_id], "prompt": prompt}
-        res = create_chat_assistant(api_key, payload)
+        res = create_chat_assistant(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             if prompt:
@@ -233,9 +233,9 @@ class TestChatAssistantCreate:
 
 class TestChatAssistantCreate2:
     @pytest.mark.p2
-    def test_unparsed_document(self, api_key, add_document):
+    def test_unparsed_document(self, HttpApiAuth, add_document):
         dataset_id, _ = add_document
         payload = {"name": "prompt_test", "dataset_ids": [dataset_id]}
-        res = create_chat_assistant(api_key, payload)
+        res = create_chat_assistant(HttpApiAuth, payload)
         assert res["code"] == 102
         assert "doesn't own parsed file" in res["message"]

--- a/test/testcases/test_http_api/test_chat_assistant_management/test_delete_chat_assistants.py
+++ b/test/testcases/test_http_api/test_chat_assistant_management/test_delete_chat_assistants.py
@@ -52,16 +52,16 @@ class TestChatAssistantsDelete:
             pytest.param(lambda r: {"ids": r}, 0, "", 0, marks=pytest.mark.p1),
         ],
     )
-    def test_basic_scenarios(self, api_key, add_chat_assistants_func, payload, expected_code, expected_message, remaining):
+    def test_basic_scenarios(self, HttpApiAuth, add_chat_assistants_func, payload, expected_code, expected_message, remaining):
         _, _, chat_assistant_ids = add_chat_assistants_func
         if callable(payload):
             payload = payload(chat_assistant_ids)
-        res = delete_chat_assistants(api_key, payload)
+        res = delete_chat_assistants(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if res["code"] != 0:
             assert res["message"] == expected_message
 
-        res = list_chat_assistants(api_key)
+        res = list_chat_assistants(HttpApiAuth)
         assert len(res["data"]) == remaining
 
     @pytest.mark.parametrize(
@@ -72,55 +72,55 @@ class TestChatAssistantsDelete:
             pytest.param(lambda r: {"ids": r + ["invalid_id"]}, marks=pytest.mark.p3),
         ],
     )
-    def test_delete_partial_invalid_id(self, api_key, add_chat_assistants_func, payload):
+    def test_delete_partial_invalid_id(self, HttpApiAuth, add_chat_assistants_func, payload):
         _, _, chat_assistant_ids = add_chat_assistants_func
         if callable(payload):
             payload = payload(chat_assistant_ids)
-        res = delete_chat_assistants(api_key, payload)
+        res = delete_chat_assistants(HttpApiAuth, payload)
         assert res["code"] == 0
         assert res["data"]["errors"][0] == "Assistant(invalid_id) not found."
         assert res["data"]["success_count"] == 5
 
-        res = list_chat_assistants(api_key)
+        res = list_chat_assistants(HttpApiAuth)
         assert len(res["data"]) == 0
 
     @pytest.mark.p3
-    def test_repeated_deletion(self, api_key, add_chat_assistants_func):
+    def test_repeated_deletion(self, HttpApiAuth, add_chat_assistants_func):
         _, _, chat_assistant_ids = add_chat_assistants_func
-        res = delete_chat_assistants(api_key, {"ids": chat_assistant_ids})
+        res = delete_chat_assistants(HttpApiAuth, {"ids": chat_assistant_ids})
         assert res["code"] == 0
 
-        res = delete_chat_assistants(api_key, {"ids": chat_assistant_ids})
+        res = delete_chat_assistants(HttpApiAuth, {"ids": chat_assistant_ids})
         assert res["code"] == 102
         assert "not found" in res["message"]
 
     @pytest.mark.p3
-    def test_duplicate_deletion(self, api_key, add_chat_assistants_func):
+    def test_duplicate_deletion(self, HttpApiAuth, add_chat_assistants_func):
         _, _, chat_assistant_ids = add_chat_assistants_func
-        res = delete_chat_assistants(api_key, {"ids": chat_assistant_ids + chat_assistant_ids})
+        res = delete_chat_assistants(HttpApiAuth, {"ids": chat_assistant_ids + chat_assistant_ids})
         assert res["code"] == 0
         assert "Duplicate assistant ids" in res["data"]["errors"][0]
         assert res["data"]["success_count"] == 5
 
-        res = list_chat_assistants(api_key)
+        res = list_chat_assistants(HttpApiAuth)
         assert res["code"] == 0
 
     @pytest.mark.p3
-    def test_concurrent_deletion(self, api_key):
+    def test_concurrent_deletion(self, HttpApiAuth):
         count = 100
-        ids = batch_create_chat_assistants(api_key, count)
+        ids = batch_create_chat_assistants(HttpApiAuth, count)
 
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(delete_chat_assistants, api_key, {"ids": ids[i : i + 1]}) for i in range(count)]
+            futures = [executor.submit(delete_chat_assistants, HttpApiAuth, {"ids": ids[i : i + 1]}) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
 
     @pytest.mark.p3
-    def test_delete_10k(self, api_key):
-        ids = batch_create_chat_assistants(api_key, 1_000)
-        res = delete_chat_assistants(api_key, {"ids": ids})
+    def test_delete_10k(self, HttpApiAuth):
+        ids = batch_create_chat_assistants(HttpApiAuth, 1_000)
+        res = delete_chat_assistants(HttpApiAuth, {"ids": ids})
         assert res["code"] == 0
 
-        res = list_chat_assistants(api_key)
+        res = list_chat_assistants(HttpApiAuth)
         assert len(res["data"]) == 0

--- a/test/testcases/test_http_api/test_chat_assistant_management/test_list_chat_assistants.py
+++ b/test/testcases/test_http_api/test_chat_assistant_management/test_list_chat_assistants.py
@@ -43,8 +43,8 @@ class TestAuthorization:
 @pytest.mark.usefixtures("add_chat_assistants")
 class TestChatAssistantsList:
     @pytest.mark.p1
-    def test_default(self, api_key):
-        res = list_chat_assistants(api_key)
+    def test_default(self, HttpApiAuth):
+        res = list_chat_assistants(HttpApiAuth)
         assert res["code"] == 0
         assert len(res["data"]) == 5
 
@@ -73,8 +73,8 @@ class TestChatAssistantsList:
             ),
         ],
     )
-    def test_page(self, api_key, params, expected_code, expected_page_size, expected_message):
-        res = list_chat_assistants(api_key, params=params)
+    def test_page(self, HttpApiAuth, params, expected_code, expected_page_size, expected_message):
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_page_size
@@ -108,13 +108,13 @@ class TestChatAssistantsList:
     )
     def test_page_size(
         self,
-        api_key,
+        HttpApiAuth,
         params,
         expected_code,
         expected_page_size,
         expected_message,
     ):
-        res = list_chat_assistants(api_key, params=params)
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_page_size
@@ -146,13 +146,13 @@ class TestChatAssistantsList:
     )
     def test_orderby(
         self,
-        api_key,
+        HttpApiAuth,
         params,
         expected_code,
         assertions,
         expected_message,
     ):
-        res = list_chat_assistants(api_key, params=params)
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -183,13 +183,13 @@ class TestChatAssistantsList:
     )
     def test_desc(
         self,
-        api_key,
+        HttpApiAuth,
         params,
         expected_code,
         assertions,
         expected_message,
     ):
-        res = list_chat_assistants(api_key, params=params)
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -207,8 +207,8 @@ class TestChatAssistantsList:
             ({"name": "unknown"}, 102, 0, "The chat doesn't exist"),
         ],
     )
-    def test_name(self, api_key, params, expected_code, expected_num, expected_message):
-        res = list_chat_assistants(api_key, params=params)
+    def test_name(self, HttpApiAuth, params, expected_code, expected_num, expected_message):
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if params["name"] in [None, ""]:
@@ -230,7 +230,7 @@ class TestChatAssistantsList:
     )
     def test_id(
         self,
-        api_key,
+        HttpApiAuth,
         add_chat_assistants,
         chat_assistant_id,
         expected_code,
@@ -243,7 +243,7 @@ class TestChatAssistantsList:
         else:
             params = {"id": chat_assistant_id}
 
-        res = list_chat_assistants(api_key, params=params)
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if params["id"] in [None, ""]:
@@ -265,7 +265,7 @@ class TestChatAssistantsList:
     )
     def test_name_and_id(
         self,
-        api_key,
+        HttpApiAuth,
         add_chat_assistants,
         chat_assistant_id,
         name,
@@ -279,7 +279,7 @@ class TestChatAssistantsList:
         else:
             params = {"id": chat_assistant_id, "name": name}
 
-        res = list_chat_assistants(api_key, params=params)
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_num
@@ -287,27 +287,27 @@ class TestChatAssistantsList:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_concurrent_list(self, api_key):
+    def test_concurrent_list(self, HttpApiAuth):
         count = 100
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(list_chat_assistants, api_key) for i in range(count)]
+            futures = [executor.submit(list_chat_assistants, HttpApiAuth) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
 
     @pytest.mark.p3
-    def test_invalid_params(self, api_key):
+    def test_invalid_params(self, HttpApiAuth):
         params = {"a": "b"}
-        res = list_chat_assistants(api_key, params=params)
+        res = list_chat_assistants(HttpApiAuth, params=params)
         assert res["code"] == 0
         assert len(res["data"]) == 5
 
     @pytest.mark.p2
-    def test_list_chats_after_deleting_associated_dataset(self, api_key, add_chat_assistants):
+    def test_list_chats_after_deleting_associated_dataset(self, HttpApiAuth, add_chat_assistants):
         dataset_id, _, _ = add_chat_assistants
-        res = delete_datasets(api_key, {"ids": [dataset_id]})
+        res = delete_datasets(HttpApiAuth, {"ids": [dataset_id]})
         assert res["code"] == 0
 
-        res = list_chat_assistants(api_key)
+        res = list_chat_assistants(HttpApiAuth)
         assert res["code"] == 0
         assert len(res["data"]) == 5

--- a/test/testcases/test_http_api/test_chat_assistant_management/test_update_chat_assistant.py
+++ b/test/testcases/test_http_api/test_chat_assistant_management/test_update_chat_assistant.py
@@ -51,13 +51,13 @@ class TestChatAssistantUpdate:
             pytest.param({"name": "TEST_CHAT_ASSISTANT_1"}, 102, "Duplicated chat name in updating chat.", marks=pytest.mark.p3),
         ],
     )
-    def test_name(self, api_key, add_chat_assistants_func, payload, expected_code, expected_message):
+    def test_name(self, HttpApiAuth, add_chat_assistants_func, payload, expected_code, expected_message):
         _, _, chat_assistant_ids = add_chat_assistants_func
 
-        res = update_chat_assistant(api_key, chat_assistant_ids[0], payload)
+        res = update_chat_assistant(HttpApiAuth, chat_assistant_ids[0], payload)
         assert res["code"] == expected_code, res
         if expected_code == 0:
-            res = list_chat_assistants(api_key, {"id": chat_assistant_ids[0]})
+            res = list_chat_assistants(HttpApiAuth, {"id": chat_assistant_ids[0]})
             assert res["data"][0]["name"] == payload.get("name")
         else:
             assert res["message"] == expected_message
@@ -71,7 +71,7 @@ class TestChatAssistantUpdate:
             pytest.param("invalid_dataset_id", 102, "You don't own the dataset i", marks=pytest.mark.p3),
         ],
     )
-    def test_dataset_ids(self, api_key, add_chat_assistants_func, dataset_ids, expected_code, expected_message):
+    def test_dataset_ids(self, HttpApiAuth, add_chat_assistants_func, dataset_ids, expected_code, expected_message):
         dataset_id, _, chat_assistant_ids = add_chat_assistants_func
         payload = {"name": "ragflow test"}
         if callable(dataset_ids):
@@ -79,20 +79,20 @@ class TestChatAssistantUpdate:
         else:
             payload["dataset_ids"] = dataset_ids
 
-        res = update_chat_assistant(api_key, chat_assistant_ids[0], payload)
+        res = update_chat_assistant(HttpApiAuth, chat_assistant_ids[0], payload)
         assert res["code"] == expected_code, res
         if expected_code == 0:
-            res = list_chat_assistants(api_key, {"id": chat_assistant_ids[0]})
+            res = list_chat_assistants(HttpApiAuth, {"id": chat_assistant_ids[0]})
             assert res["data"][0]["name"] == payload.get("name")
         else:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_avatar(self, api_key, add_chat_assistants_func, tmp_path):
+    def test_avatar(self, HttpApiAuth, add_chat_assistants_func, tmp_path):
         dataset_id, _, chat_assistant_ids = add_chat_assistants_func
         fn = create_image_file(tmp_path / "ragflow_test.png")
         payload = {"name": "avatar_test", "avatar": encode_avatar(fn), "dataset_ids": [dataset_id]}
-        res = update_chat_assistant(api_key, chat_assistant_ids[0], payload)
+        res = update_chat_assistant(HttpApiAuth, chat_assistant_ids[0], payload)
         assert res["code"] == 0
 
     @pytest.mark.p3
@@ -130,13 +130,13 @@ class TestChatAssistantUpdate:
             pytest.param({"unknown": "unknown"}, 0, "", marks=pytest.mark.skip),
         ],
     )
-    def test_llm(self, api_key, add_chat_assistants_func, llm, expected_code, expected_message):
+    def test_llm(self, HttpApiAuth, add_chat_assistants_func, llm, expected_code, expected_message):
         dataset_id, _, chat_assistant_ids = add_chat_assistants_func
         payload = {"name": "llm_test", "dataset_ids": [dataset_id], "llm": llm}
-        res = update_chat_assistant(api_key, chat_assistant_ids[0], payload)
+        res = update_chat_assistant(HttpApiAuth, chat_assistant_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code == 0:
-            res = list_chat_assistants(api_key, {"id": chat_assistant_ids[0]})
+            res = list_chat_assistants(HttpApiAuth, {"id": chat_assistant_ids[0]})
             if llm:
                 for k, v in llm.items():
                     assert res["data"][0]["llm"][k] == v
@@ -198,13 +198,13 @@ class TestChatAssistantUpdate:
             pytest.param({"unknown": "unknown"}, 0, "", marks=pytest.mark.skip),
         ],
     )
-    def test_prompt(self, api_key, add_chat_assistants_func, prompt, expected_code, expected_message):
+    def test_prompt(self, HttpApiAuth, add_chat_assistants_func, prompt, expected_code, expected_message):
         dataset_id, _, chat_assistant_ids = add_chat_assistants_func
         payload = {"name": "prompt_test", "dataset_ids": [dataset_id], "prompt": prompt}
-        res = update_chat_assistant(api_key, chat_assistant_ids[0], payload)
+        res = update_chat_assistant(HttpApiAuth, chat_assistant_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code == 0:
-            res = list_chat_assistants(api_key, {"id": chat_assistant_ids[0]})
+            res = list_chat_assistants(HttpApiAuth, {"id": chat_assistant_ids[0]})
             if prompt:
                 for k, v in prompt.items():
                     if k == "keywords_similarity_weight":

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/conftest.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/conftest.py
@@ -32,16 +32,16 @@ def condition(_auth, _dataset_id):
 
 
 @pytest.fixture(scope="function")
-def add_chunks_func(request, api_key, add_document):
+def add_chunks_func(request, HttpApiAuth, add_document):
     def cleanup():
-        delete_chunks(api_key, dataset_id, document_id, {"chunk_ids": []})
+        delete_chunks(HttpApiAuth, dataset_id, document_id, {"chunk_ids": []})
 
     request.addfinalizer(cleanup)
 
     dataset_id, document_id = add_document
-    parse_documents(api_key, dataset_id, {"document_ids": [document_id]})
-    condition(api_key, dataset_id)
-    chunk_ids = batch_add_chunks(api_key, dataset_id, document_id, 4)
+    parse_documents(HttpApiAuth, dataset_id, {"document_ids": [document_id]})
+    condition(HttpApiAuth, dataset_id)
+    chunk_ids = batch_add_chunks(HttpApiAuth, dataset_id, document_id, 4)
     # issues/6487
     sleep(1)
     return dataset_id, document_id, chunk_ids

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_add_chunk.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_add_chunk.py
@@ -68,17 +68,17 @@ class TestAddChunk:
             ({"content": "\n!?。；！？\"'"}, 0, ""),
         ],
     )
-    def test_content(self, api_key, add_document, payload, expected_code, expected_message):
+    def test_content(self, HttpApiAuth, add_document, payload, expected_code, expected_message):
         dataset_id, document_id = add_document
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         chunks_count = res["data"]["doc"]["chunk_count"]
-        res = add_chunk(api_key, dataset_id, document_id, payload)
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             validate_chunk_details(dataset_id, document_id, payload, res)
-            res = list_chunks(api_key, dataset_id, document_id)
+            res = list_chunks(HttpApiAuth, dataset_id, document_id)
             if res["code"] != 0:
                 assert False, res
             assert res["data"]["doc"]["chunk_count"] == chunks_count + 1
@@ -101,17 +101,17 @@ class TestAddChunk:
             ({"content": "chunk test", "important_keywords": 123}, 102, "`important_keywords` is required to be a list"),
         ],
     )
-    def test_important_keywords(self, api_key, add_document, payload, expected_code, expected_message):
+    def test_important_keywords(self, HttpApiAuth, add_document, payload, expected_code, expected_message):
         dataset_id, document_id = add_document
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         chunks_count = res["data"]["doc"]["chunk_count"]
-        res = add_chunk(api_key, dataset_id, document_id, payload)
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             validate_chunk_details(dataset_id, document_id, payload, res)
-            res = list_chunks(api_key, dataset_id, document_id)
+            res = list_chunks(HttpApiAuth, dataset_id, document_id)
             if res["code"] != 0:
                 assert False, res
             assert res["data"]["doc"]["chunk_count"] == chunks_count + 1
@@ -130,19 +130,19 @@ class TestAddChunk:
             ({"content": "chunk test", "questions": 123}, 102, "`questions` is required to be a list"),
         ],
     )
-    def test_questions(self, api_key, add_document, payload, expected_code, expected_message):
+    def test_questions(self, HttpApiAuth, add_document, payload, expected_code, expected_message):
         dataset_id, document_id = add_document
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         chunks_count = res["data"]["doc"]["chunk_count"]
-        res = add_chunk(api_key, dataset_id, document_id, payload)
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             validate_chunk_details(dataset_id, document_id, payload, res)
             if res["code"] != 0:
                 assert False, res
-            res = list_chunks(api_key, dataset_id, document_id)
+            res = list_chunks(HttpApiAuth, dataset_id, document_id)
             assert res["data"]["doc"]["chunk_count"] == chunks_count + 1
         else:
             assert res["message"] == expected_message
@@ -161,14 +161,14 @@ class TestAddChunk:
     )
     def test_invalid_dataset_id(
         self,
-        api_key,
+        HttpApiAuth,
         add_document,
         dataset_id,
         expected_code,
         expected_message,
     ):
         _, document_id = add_document
-        res = add_chunk(api_key, dataset_id, document_id, {"content": "a"})
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, {"content": "a"})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -184,49 +184,49 @@ class TestAddChunk:
             ),
         ],
     )
-    def test_invalid_document_id(self, api_key, add_document, document_id, expected_code, expected_message):
+    def test_invalid_document_id(self, HttpApiAuth, add_document, document_id, expected_code, expected_message):
         dataset_id, _ = add_document
-        res = add_chunk(api_key, dataset_id, document_id, {"content": "chunk test"})
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, {"content": "chunk test"})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_repeated_add_chunk(self, api_key, add_document):
+    def test_repeated_add_chunk(self, HttpApiAuth, add_document):
         payload = {"content": "chunk test"}
         dataset_id, document_id = add_document
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         chunks_count = res["data"]["doc"]["chunk_count"]
-        res = add_chunk(api_key, dataset_id, document_id, payload)
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, payload)
         assert res["code"] == 0
         validate_chunk_details(dataset_id, document_id, payload, res)
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         assert res["data"]["doc"]["chunk_count"] == chunks_count + 1
 
-        res = add_chunk(api_key, dataset_id, document_id, payload)
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, payload)
         assert res["code"] == 0
         validate_chunk_details(dataset_id, document_id, payload, res)
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         assert res["data"]["doc"]["chunk_count"] == chunks_count + 2
 
     @pytest.mark.p2
-    def test_add_chunk_to_deleted_document(self, api_key, add_document):
+    def test_add_chunk_to_deleted_document(self, HttpApiAuth, add_document):
         dataset_id, document_id = add_document
-        delete_documents(api_key, dataset_id, {"ids": [document_id]})
-        res = add_chunk(api_key, dataset_id, document_id, {"content": "chunk test"})
+        delete_documents(HttpApiAuth, dataset_id, {"ids": [document_id]})
+        res = add_chunk(HttpApiAuth, dataset_id, document_id, {"content": "chunk test"})
         assert res["code"] == 102
         assert res["message"] == f"You don't own the document {document_id}."
 
     @pytest.mark.skip(reason="issues/6411")
-    def test_concurrent_add_chunk(self, api_key, add_document):
+    def test_concurrent_add_chunk(self, HttpApiAuth, add_document):
         count = 50
         dataset_id, document_id = add_document
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         chunks_count = res["data"]["doc"]["chunk_count"]
@@ -235,7 +235,7 @@ class TestAddChunk:
             futures = [
                 executor.submit(
                     add_chunk,
-                    api_key,
+                    HttpApiAuth,
                     dataset_id,
                     document_id,
                     {"content": f"chunk test {i}"},
@@ -245,7 +245,7 @@ class TestAddChunk:
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         if res["code"] != 0:
             assert False, res
         assert res["data"]["doc"]["chunk_count"] == chunks_count + count

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_list_chunks.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_list_chunks.py
@@ -54,9 +54,9 @@ class TestChunksList:
             pytest.param({"page": "a", "page_size": 2}, 100, 0, """ValueError("invalid literal for int() with base 10: \'a\'")""", marks=pytest.mark.skip),
         ],
     )
-    def test_page(self, api_key, add_chunks, params, expected_code, expected_page_size, expected_message):
+    def test_page(self, HttpApiAuth, add_chunks, params, expected_code, expected_page_size, expected_message):
         dataset_id, document_id, _ = add_chunks
-        res = list_chunks(api_key, dataset_id, document_id, params=params)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -77,9 +77,9 @@ class TestChunksList:
             pytest.param({"page_size": "a"}, 100, 0, """ValueError("invalid literal for int() with base 10: \'a\'")""", marks=pytest.mark.skip),
         ],
     )
-    def test_page_size(self, api_key, add_chunks, params, expected_code, expected_page_size, expected_message):
+    def test_page_size(self, HttpApiAuth, add_chunks, params, expected_code, expected_page_size, expected_message):
         dataset_id, document_id, _ = add_chunks
-        res = list_chunks(api_key, dataset_id, document_id, params=params)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -98,9 +98,9 @@ class TestChunksList:
             ({"keywords": "unknown"}, 0),
         ],
     )
-    def test_keywords(self, api_key, add_chunks, params, expected_page_size):
+    def test_keywords(self, HttpApiAuth, add_chunks, params, expected_page_size):
         dataset_id, document_id, _ = add_chunks
-        res = list_chunks(api_key, dataset_id, document_id, params=params)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id, params=params)
         assert res["code"] == 0
         assert len(res["data"]["chunks"]) == expected_page_size
 
@@ -116,7 +116,7 @@ class TestChunksList:
     )
     def test_id(
         self,
-        api_key,
+        HttpApiAuth,
         add_chunks,
         chunk_id,
         expected_code,
@@ -128,7 +128,7 @@ class TestChunksList:
             params = {"id": chunk_id(chunk_ids)}
         else:
             params = {"id": chunk_id}
-        res = list_chunks(api_key, dataset_id, document_id, params=params)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if params["id"] in [None, ""]:
@@ -139,35 +139,35 @@ class TestChunksList:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_invalid_params(self, api_key, add_chunks):
+    def test_invalid_params(self, HttpApiAuth, add_chunks):
         dataset_id, document_id, _ = add_chunks
         params = {"a": "b"}
-        res = list_chunks(api_key, dataset_id, document_id, params=params)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id, params=params)
         assert res["code"] == 0
         assert len(res["data"]["chunks"]) == 5
 
     @pytest.mark.p3
-    def test_concurrent_list(self, api_key, add_chunks):
+    def test_concurrent_list(self, HttpApiAuth, add_chunks):
         dataset_id, document_id, _ = add_chunks
         count = 100
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(list_chunks, api_key, dataset_id, document_id) for i in range(count)]
+            futures = [executor.submit(list_chunks, HttpApiAuth, dataset_id, document_id) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(len(future.result()["data"]["chunks"]) == 5 for future in futures)
 
     @pytest.mark.p1
-    def test_default(self, api_key, add_document):
+    def test_default(self, HttpApiAuth, add_document):
         dataset_id, document_id = add_document
 
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         chunks_count = res["data"]["doc"]["chunk_count"]
-        batch_add_chunks(api_key, dataset_id, document_id, 31)
+        batch_add_chunks(HttpApiAuth, dataset_id, document_id, 31)
         # issues/6487
         from time import sleep
 
         sleep(3)
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         assert res["code"] == 0
         assert len(res["data"]["chunks"]) == 30
         assert res["data"]["doc"]["chunk_count"] == chunks_count + 31
@@ -184,9 +184,9 @@ class TestChunksList:
             ),
         ],
     )
-    def test_invalid_dataset_id(self, api_key, add_chunks, dataset_id, expected_code, expected_message):
+    def test_invalid_dataset_id(self, HttpApiAuth, add_chunks, dataset_id, expected_code, expected_message):
         _, document_id, _ = add_chunks
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -202,8 +202,8 @@ class TestChunksList:
             ),
         ],
     )
-    def test_invalid_document_id(self, api_key, add_chunks, document_id, expected_code, expected_message):
+    def test_invalid_document_id(self, HttpApiAuth, add_chunks, document_id, expected_code, expected_message):
         dataset_id, _, _ = add_chunks
-        res = list_chunks(api_key, dataset_id, document_id)
+        res = list_chunks(HttpApiAuth, dataset_id, document_id)
         assert res["code"] == expected_code
         assert res["message"] == expected_message

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_retrieval_chunks.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_retrieval_chunks.py
@@ -54,13 +54,13 @@ class TestChunksRetrieval:
             ({"question": "chunk"}, 102, 0, "`dataset_ids` is required."),
         ],
     )
-    def test_basic_scenarios(self, api_key, add_chunks, payload, expected_code, expected_page_size, expected_message):
+    def test_basic_scenarios(self, HttpApiAuth, add_chunks, payload, expected_code, expected_page_size, expected_message):
         dataset_id, document_id, _ = add_chunks
         if "dataset_ids" in payload:
             payload["dataset_ids"] = [dataset_id]
         if "document_ids" in payload:
             payload["document_ids"] = [document_id]
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -104,10 +104,10 @@ class TestChunksRetrieval:
             ),
         ],
     )
-    def test_page(self, api_key, add_chunks, payload, expected_code, expected_page_size, expected_message):
+    def test_page(self, HttpApiAuth, add_chunks, payload, expected_code, expected_page_size, expected_message):
         dataset_id, _, _ = add_chunks
         payload.update({"question": "chunk", "dataset_ids": [dataset_id]})
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -139,11 +139,11 @@ class TestChunksRetrieval:
             ),
         ],
     )
-    def test_page_size(self, api_key, add_chunks, payload, expected_code, expected_page_size, expected_message):
+    def test_page_size(self, HttpApiAuth, add_chunks, payload, expected_code, expected_page_size, expected_message):
         dataset_id, _, _ = add_chunks
         payload.update({"question": "chunk", "dataset_ids": [dataset_id]})
 
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -166,10 +166,10 @@ class TestChunksRetrieval:
             ),
         ],
     )
-    def test_vector_similarity_weight(self, api_key, add_chunks, payload, expected_code, expected_page_size, expected_message):
+    def test_vector_similarity_weight(self, HttpApiAuth, add_chunks, payload, expected_code, expected_page_size, expected_message):
         dataset_id, _, _ = add_chunks
         payload.update({"question": "chunk", "dataset_ids": [dataset_id]})
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -218,10 +218,10 @@ class TestChunksRetrieval:
             ),
         ],
     )
-    def test_top_k(self, api_key, add_chunks, payload, expected_code, expected_page_size, expected_message):
+    def test_top_k(self, HttpApiAuth, add_chunks, payload, expected_code, expected_page_size, expected_message):
         dataset_id, _, _ = add_chunks
         payload.update({"question": "chunk", "dataset_ids": [dataset_id]})
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -236,10 +236,10 @@ class TestChunksRetrieval:
             pytest.param({"rerank_id": "unknown"}, 100, "LookupError('Model(unknown) not authorized')", marks=pytest.mark.skip),
         ],
     )
-    def test_rerank_id(self, api_key, add_chunks, payload, expected_code, expected_message):
+    def test_rerank_id(self, HttpApiAuth, add_chunks, payload, expected_code, expected_message):
         dataset_id, _, _ = add_chunks
         payload.update({"question": "chunk", "dataset_ids": [dataset_id]})
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) > 0
@@ -257,10 +257,10 @@ class TestChunksRetrieval:
             ({"keyword": None}, 0, 5, ""),
         ],
     )
-    def test_keyword(self, api_key, add_chunks, payload, expected_code, expected_page_size, expected_message):
+    def test_keyword(self, HttpApiAuth, add_chunks, payload, expected_code, expected_page_size, expected_message):
         dataset_id, _, _ = add_chunks
         payload.update({"question": "chunk test", "dataset_ids": [dataset_id]})
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["chunks"]) == expected_page_size
@@ -278,10 +278,10 @@ class TestChunksRetrieval:
             pytest.param({"highlight": None}, 0, False, "", marks=pytest.mark.skip(reason="issues/6648")),
         ],
     )
-    def test_highlight(self, api_key, add_chunks, payload, expected_code, expected_highlight, expected_message):
+    def test_highlight(self, HttpApiAuth, add_chunks, payload, expected_code, expected_highlight, expected_message):
         dataset_id, _, _ = add_chunks
         payload.update({"question": "chunk", "dataset_ids": [dataset_id]})
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == expected_code
         if expected_highlight:
             for chunk in res["data"]["chunks"]:
@@ -294,21 +294,21 @@ class TestChunksRetrieval:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_invalid_params(self, api_key, add_chunks):
+    def test_invalid_params(self, HttpApiAuth, add_chunks):
         dataset_id, _, _ = add_chunks
         payload = {"question": "chunk", "dataset_ids": [dataset_id], "a": "b"}
-        res = retrieval_chunks(api_key, payload)
+        res = retrieval_chunks(HttpApiAuth, payload)
         assert res["code"] == 0
         assert len(res["data"]["chunks"]) == 4
 
     @pytest.mark.p3
-    def test_concurrent_retrieval(self, api_key, add_chunks):
+    def test_concurrent_retrieval(self, HttpApiAuth, add_chunks):
         dataset_id, _, _ = add_chunks
         count = 100
         payload = {"question": "chunk", "dataset_ids": [dataset_id]}
 
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(retrieval_chunks, api_key, payload) for i in range(count)]
+            futures = [executor.submit(retrieval_chunks, HttpApiAuth, payload) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_update_chunk.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_update_chunk.py
@@ -69,9 +69,9 @@ class TestUpdatedChunk:
             ({"content": "\n!?。；！？\"'"}, 0, ""),
         ],
     )
-    def test_content(self, api_key, add_chunks, payload, expected_code, expected_message):
+    def test_content(self, HttpApiAuth, add_chunks, payload, expected_code, expected_message):
         dataset_id, document_id, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0], payload)
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code != 0:
             assert res["message"] == expected_message
@@ -88,9 +88,9 @@ class TestUpdatedChunk:
             ({"important_keywords": 123}, 102, "`important_keywords` should be a list"),
         ],
     )
-    def test_important_keywords(self, api_key, add_chunks, payload, expected_code, expected_message):
+    def test_important_keywords(self, HttpApiAuth, add_chunks, payload, expected_code, expected_message):
         dataset_id, document_id, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0], payload)
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code != 0:
             assert res["message"] == expected_message
@@ -107,9 +107,9 @@ class TestUpdatedChunk:
             ({"questions": 123}, 102, "`questions` should be a list"),
         ],
     )
-    def test_questions(self, api_key, add_chunks, payload, expected_code, expected_message):
+    def test_questions(self, HttpApiAuth, add_chunks, payload, expected_code, expected_message):
         dataset_id, document_id, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0], payload)
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code != 0:
             assert res["message"] == expected_message
@@ -128,14 +128,14 @@ class TestUpdatedChunk:
     )
     def test_available(
         self,
-        api_key,
+        HttpApiAuth,
         add_chunks,
         payload,
         expected_code,
         expected_message,
     ):
         dataset_id, document_id, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0], payload)
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code != 0:
             assert res["message"] == expected_message
@@ -149,9 +149,9 @@ class TestUpdatedChunk:
             pytest.param("invalid_dataset_id", 102, "Can't find this chunk", marks=pytest.mark.skipif(os.getenv("DOC_ENGINE") in [None, "opensearch", "elasticsearch"], reason="elasticsearch")),
         ],
     )
-    def test_invalid_dataset_id(self, api_key, add_chunks, dataset_id, expected_code, expected_message):
+    def test_invalid_dataset_id(self, HttpApiAuth, add_chunks, dataset_id, expected_code, expected_message):
         _, document_id, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0])
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0])
         assert res["code"] == expected_code
         assert expected_message in res["message"]
 
@@ -167,9 +167,9 @@ class TestUpdatedChunk:
             ),
         ],
     )
-    def test_invalid_document_id(self, api_key, add_chunks, document_id, expected_code, expected_message):
+    def test_invalid_document_id(self, HttpApiAuth, add_chunks, document_id, expected_code, expected_message):
         dataset_id, _, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0])
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0])
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -185,19 +185,19 @@ class TestUpdatedChunk:
             ),
         ],
     )
-    def test_invalid_chunk_id(self, api_key, add_chunks, chunk_id, expected_code, expected_message):
+    def test_invalid_chunk_id(self, HttpApiAuth, add_chunks, chunk_id, expected_code, expected_message):
         dataset_id, document_id, _ = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_id)
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_id)
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_repeated_update_chunk(self, api_key, add_chunks):
+    def test_repeated_update_chunk(self, HttpApiAuth, add_chunks):
         dataset_id, document_id, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0], {"content": "chunk test 1"})
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0], {"content": "chunk test 1"})
         assert res["code"] == 0
 
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0], {"content": "chunk test 2"})
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0], {"content": "chunk test 2"})
         assert res["code"] == 0
 
     @pytest.mark.p3
@@ -209,16 +209,16 @@ class TestUpdatedChunk:
             pytest.param(None, 100, """TypeError("argument of type \'NoneType\' is not iterable")""", marks=pytest.mark.skip),
         ],
     )
-    def test_invalid_params(self, api_key, add_chunks, payload, expected_code, expected_message):
+    def test_invalid_params(self, HttpApiAuth, add_chunks, payload, expected_code, expected_message):
         dataset_id, document_id, chunk_ids = add_chunks
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0], payload)
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code != 0:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
     @pytest.mark.skipif(os.getenv("DOC_ENGINE") == "infinity", reason="issues/6554")
-    def test_concurrent_update_chunk(self, api_key, add_chunks):
+    def test_concurrent_update_chunk(self, HttpApiAuth, add_chunks):
         count = 50
         dataset_id, document_id, chunk_ids = add_chunks
 
@@ -226,7 +226,7 @@ class TestUpdatedChunk:
             futures = [
                 executor.submit(
                     update_chunk,
-                    api_key,
+                    HttpApiAuth,
                     dataset_id,
                     document_id,
                     chunk_ids[randint(0, 3)],
@@ -239,9 +239,9 @@ class TestUpdatedChunk:
         assert all(future.result()["code"] == 0 for future in futures)
 
     @pytest.mark.p3
-    def test_update_chunk_to_deleted_document(self, api_key, add_chunks):
+    def test_update_chunk_to_deleted_document(self, HttpApiAuth, add_chunks):
         dataset_id, document_id, chunk_ids = add_chunks
-        delete_documents(api_key, dataset_id, {"ids": [document_id]})
-        res = update_chunk(api_key, dataset_id, document_id, chunk_ids[0])
+        delete_documents(HttpApiAuth, dataset_id, {"ids": [document_id]})
+        res = update_chunk(HttpApiAuth, dataset_id, document_id, chunk_ids[0])
         assert res["code"] == 102
         assert res["message"] == f"Can't find this chunk {chunk_ids[0]}"

--- a/test/testcases/test_http_api/test_dataset_mangement/conftest.py
+++ b/test/testcases/test_http_api/test_dataset_mangement/conftest.py
@@ -20,20 +20,20 @@ from common import batch_create_datasets, delete_datasets
 
 
 @pytest.fixture(scope="class")
-def add_datasets(api_key, request):
+def add_datasets(HttpApiAuth, request):
     def cleanup():
-        delete_datasets(api_key, {"ids": None})
+        delete_datasets(HttpApiAuth, {"ids": None})
 
     request.addfinalizer(cleanup)
 
-    return batch_create_datasets(api_key, 5)
+    return batch_create_datasets(HttpApiAuth, 5)
 
 
 @pytest.fixture(scope="function")
-def add_datasets_func(api_key, request):
+def add_datasets_func(HttpApiAuth, request):
     def cleanup():
-        delete_datasets(api_key, {"ids": None})
+        delete_datasets(HttpApiAuth, {"ids": None})
 
     request.addfinalizer(cleanup)
 
-    return batch_create_datasets(api_key, 3)
+    return batch_create_datasets(HttpApiAuth, 3)

--- a/test/testcases/test_http_api/test_dataset_mangement/test_create_dataset.py
+++ b/test/testcases/test_http_api/test_dataset_mangement/test_create_dataset.py
@@ -48,9 +48,9 @@ class TestAuthorization:
 
 class TestRquest:
     @pytest.mark.p3
-    def test_content_type_bad(self, api_key):
+    def test_content_type_bad(self, HttpApiAuth):
         BAD_CONTENT_TYPE = "text/xml"
-        res = create_dataset(api_key, {"name": "bad_content_type"}, headers={"Content-Type": BAD_CONTENT_TYPE})
+        res = create_dataset(HttpApiAuth, {"name": "bad_content_type"}, headers={"Content-Type": BAD_CONTENT_TYPE})
         assert res["code"] == 101, res
         assert res["message"] == f"Unsupported content type: Expected application/json, got {BAD_CONTENT_TYPE}", res
 
@@ -63,8 +63,8 @@ class TestRquest:
         ],
         ids=["malformed_json_syntax", "invalid_request_payload_type"],
     )
-    def test_payload_bad(self, api_key, payload, expected_message):
-        res = create_dataset(api_key, data=payload)
+    def test_payload_bad(self, HttpApiAuth, payload, expected_message):
+        res = create_dataset(HttpApiAuth, data=payload)
         assert res["code"] == 101, res
         assert res["message"] == expected_message, res
 
@@ -72,17 +72,17 @@ class TestRquest:
 @pytest.mark.usefixtures("clear_datasets")
 class TestCapability:
     @pytest.mark.p3
-    def test_create_dataset_1k(self, api_key):
+    def test_create_dataset_1k(self, HttpApiAuth):
         for i in range(1_000):
             payload = {"name": f"dataset_{i}"}
-            res = create_dataset(api_key, payload)
+            res = create_dataset(HttpApiAuth, payload)
             assert res["code"] == 0, f"Failed to create dataset {i}"
 
     @pytest.mark.p3
-    def test_create_dataset_concurrent(self, api_key):
+    def test_create_dataset_concurrent(self, HttpApiAuth):
         count = 100
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(create_dataset, api_key, {"name": f"dataset_{i}"}) for i in range(count)]
+            futures = [executor.submit(create_dataset, HttpApiAuth, {"name": f"dataset_{i}"}) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
@@ -94,8 +94,8 @@ class TestDatasetCreate:
     @given(name=valid_names())
     @example("a" * 128)
     @settings(max_examples=20)
-    def test_name(self, api_key, name):
-        res = create_dataset(api_key, {"name": name})
+    def test_name(self, HttpApiAuth, name):
+        res = create_dataset(HttpApiAuth, {"name": name})
         assert res["code"] == 0, res
         assert res["data"]["name"] == name, res
 
@@ -111,49 +111,49 @@ class TestDatasetCreate:
         ],
         ids=["empty_name", "space_name", "too_long_name", "invalid_name", "None_name"],
     )
-    def test_name_invalid(self, api_key, name, expected_message):
+    def test_name_invalid(self, HttpApiAuth, name, expected_message):
         payload = {"name": name}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert expected_message in res["message"], res
 
     @pytest.mark.p3
-    def test_name_duplicated(self, api_key):
+    def test_name_duplicated(self, HttpApiAuth):
         name = "duplicated_name"
         payload = {"name": name}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
 
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 103, res
         assert res["message"] == f"Dataset name '{name}' already exists", res
 
     @pytest.mark.p3
-    def test_name_case_insensitive(self, api_key):
+    def test_name_case_insensitive(self, HttpApiAuth):
         name = "CaseInsensitive"
         payload = {"name": name.upper()}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
 
         payload = {"name": name.lower()}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 103, res
         assert res["message"] == f"Dataset name '{name.lower()}' already exists", res
 
     @pytest.mark.p2
-    def test_avatar(self, api_key, tmp_path):
+    def test_avatar(self, HttpApiAuth, tmp_path):
         fn = create_image_file(tmp_path / "ragflow_test.png")
         payload = {
             "name": "avatar",
             "avatar": f"data:image/png;base64,{encode_avatar(fn)}",
         }
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
 
     @pytest.mark.p2
-    def test_avatar_exceeds_limit_length(self, api_key):
+    def test_avatar_exceeds_limit_length(self, HttpApiAuth):
         payload = {"name": "avatar_exceeds_limit_length", "avatar": "a" * 65536}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "String should have at most 65535 characters" in res["message"], res
 
@@ -168,55 +168,55 @@ class TestDatasetCreate:
         ],
         ids=["empty_prefix", "missing_comma", "unsupported_mine_type", "invalid_mine_type"],
     )
-    def test_avatar_invalid_prefix(self, api_key, tmp_path, name, prefix, expected_message):
+    def test_avatar_invalid_prefix(self, HttpApiAuth, tmp_path, name, prefix, expected_message):
         fn = create_image_file(tmp_path / "ragflow_test.png")
         payload = {
             "name": name,
             "avatar": f"{prefix}{encode_avatar(fn)}",
         }
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert expected_message in res["message"], res
 
     @pytest.mark.p3
-    def test_avatar_unset(self, api_key):
+    def test_avatar_unset(self, HttpApiAuth):
         payload = {"name": "avatar_unset"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["avatar"] is None, res
 
     @pytest.mark.p3
-    def test_avatar_none(self, api_key):
+    def test_avatar_none(self, HttpApiAuth):
         payload = {"name": "avatar_none", "avatar": None}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["avatar"] is None, res
 
     @pytest.mark.p2
-    def test_description(self, api_key):
+    def test_description(self, HttpApiAuth):
         payload = {"name": "description", "description": "description"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["description"] == "description", res
 
     @pytest.mark.p2
-    def test_description_exceeds_limit_length(self, api_key):
+    def test_description_exceeds_limit_length(self, HttpApiAuth):
         payload = {"name": "description_exceeds_limit_length", "description": "a" * 65536}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "String should have at most 65535 characters" in res["message"], res
 
     @pytest.mark.p3
-    def test_description_unset(self, api_key):
+    def test_description_unset(self, HttpApiAuth):
         payload = {"name": "description_unset"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["description"] is None, res
 
     @pytest.mark.p3
-    def test_description_none(self, api_key):
+    def test_description_none(self, HttpApiAuth):
         payload = {"name": "description_none", "description": None}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["description"] is None, res
 
@@ -230,9 +230,9 @@ class TestDatasetCreate:
         ],
         ids=["builtin_baai", "builtin_youdao", "tenant_zhipu"],
     )
-    def test_embedding_model(self, api_key, name, embedding_model):
+    def test_embedding_model(self, HttpApiAuth, name, embedding_model):
         payload = {"name": name, "embedding_model": embedding_model}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["embedding_model"] == embedding_model, res
 
@@ -247,9 +247,9 @@ class TestDatasetCreate:
         ],
         ids=["unknown_llm_name", "unknown_llm_factory", "tenant_no_auth_default_tenant_llm", "tenant_no_auth"],
     )
-    def test_embedding_model_invalid(self, api_key, name, embedding_model):
+    def test_embedding_model_invalid(self, HttpApiAuth, name, embedding_model):
         payload = {"name": name, "embedding_model": embedding_model}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         if "tenant_no_auth" in name:
             assert res["message"] == f"Unauthorized model: <{embedding_model}>", res
@@ -268,9 +268,9 @@ class TestDatasetCreate:
         ],
         ids=["missing_at", "empty_model_name", "empty_provider", "whitespace_only_model_name", "whitespace_only_provider"],
     )
-    def test_embedding_model_format(self, api_key, name, embedding_model):
+    def test_embedding_model_format(self, HttpApiAuth, name, embedding_model):
         payload = {"name": name, "embedding_model": embedding_model}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         if name == "missing_at":
             assert "Embedding model identifier must follow <model_name>@<provider> format" in res["message"], res
@@ -278,16 +278,16 @@ class TestDatasetCreate:
             assert "Both model_name and provider must be non-empty strings" in res["message"], res
 
     @pytest.mark.p2
-    def test_embedding_model_unset(self, api_key):
+    def test_embedding_model_unset(self, HttpApiAuth):
         payload = {"name": "embedding_model_unset"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["embedding_model"] == "BAAI/bge-large-zh-v1.5@BAAI", res
 
     @pytest.mark.p2
-    def test_embedding_model_none(self, api_key):
+    def test_embedding_model_none(self, HttpApiAuth):
         payload = {"name": "embedding_model_none", "embedding_model": None}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "Input should be a valid string" in res["message"], res
 
@@ -303,9 +303,9 @@ class TestDatasetCreate:
         ],
         ids=["me", "team", "me_upercase", "team_upercase", "whitespace"],
     )
-    def test_permission(self, api_key, name, permission):
+    def test_permission(self, HttpApiAuth, name, permission):
         payload = {"name": name, "permission": permission}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["permission"] == permission.lower().strip(), res
 
@@ -319,23 +319,23 @@ class TestDatasetCreate:
         ],
         ids=["empty", "unknown", "type_error"],
     )
-    def test_permission_invalid(self, api_key, name, permission):
+    def test_permission_invalid(self, HttpApiAuth, name, permission):
         payload = {"name": name, "permission": permission}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101
         assert "Input should be 'me' or 'team'" in res["message"]
 
     @pytest.mark.p2
-    def test_permission_unset(self, api_key):
+    def test_permission_unset(self, HttpApiAuth):
         payload = {"name": "permission_unset"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["permission"] == "me", res
 
     @pytest.mark.p3
-    def test_permission_none(self, api_key):
+    def test_permission_none(self, HttpApiAuth):
         payload = {"name": "permission_none", "permission": None}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "Input should be 'me' or 'team'" in res["message"], res
 
@@ -358,9 +358,9 @@ class TestDatasetCreate:
         ],
         ids=["naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag"],
     )
-    def test_chunk_method(self, api_key, name, chunk_method):
+    def test_chunk_method(self, HttpApiAuth, name, chunk_method):
         payload = {"name": name, "chunk_method": chunk_method}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["chunk_method"] == chunk_method, res
 
@@ -374,23 +374,23 @@ class TestDatasetCreate:
         ],
         ids=["empty", "unknown", "type_error"],
     )
-    def test_chunk_method_invalid(self, api_key, name, chunk_method):
+    def test_chunk_method_invalid(self, HttpApiAuth, name, chunk_method):
         payload = {"name": name, "chunk_method": chunk_method}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table' or 'tag'" in res["message"], res
 
     @pytest.mark.p2
-    def test_chunk_method_unset(self, api_key):
+    def test_chunk_method_unset(self, HttpApiAuth):
         payload = {"name": "chunk_method_unset"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["chunk_method"] == "naive", res
 
     @pytest.mark.p3
-    def test_chunk_method_none(self, api_key):
+    def test_chunk_method_none(self, HttpApiAuth):
         payload = {"name": "chunk_method_none", "chunk_method": None}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table' or 'tag'" in res["message"], res
 
@@ -404,9 +404,9 @@ class TestDatasetCreate:
         ],
         ids=["min", "mid", "max"],
     )
-    def test_pagerank(self, api_key, name, pagerank):
+    def test_pagerank(self, HttpApiAuth, name, pagerank):
         payload = {"name": name, "pagerank": pagerank}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["pagerank"] == pagerank, res
 
@@ -419,23 +419,23 @@ class TestDatasetCreate:
         ],
         ids=["min_limit", "max_limit"],
     )
-    def test_pagerank_invalid(self, api_key, name, pagerank, expected_message):
+    def test_pagerank_invalid(self, HttpApiAuth, name, pagerank, expected_message):
         payload = {"name": name, "pagerank": pagerank}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert expected_message in res["message"], res
 
     @pytest.mark.p3
-    def test_pagerank_unset(self, api_key):
+    def test_pagerank_unset(self, HttpApiAuth):
         payload = {"name": "pagerank_unset"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["pagerank"] == 0, res
 
     @pytest.mark.p3
-    def test_pagerank_none(self, api_key):
+    def test_pagerank_none(self, HttpApiAuth):
         payload = {"name": "pagerank_unset", "pagerank": None}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "Input should be a valid integer" in res["message"], res
 
@@ -543,9 +543,9 @@ class TestDatasetCreate:
             "raptor_random_seed_min",
         ],
     )
-    def test_parser_config(self, api_key, name, parser_config):
+    def test_parser_config(self, HttpApiAuth, name, parser_config):
         payload = {"name": name, "parser_config": parser_config}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         for k, v in parser_config.items():
             if isinstance(v, dict):
@@ -670,16 +670,16 @@ class TestDatasetCreate:
             "parser_config_type_invalid",
         ],
     )
-    def test_parser_config_invalid(self, api_key, name, parser_config, expected_message):
+    def test_parser_config_invalid(self, HttpApiAuth, name, parser_config, expected_message):
         payload = {"name": name, "parser_config": parser_config}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert expected_message in res["message"], res
 
     @pytest.mark.p2
-    def test_parser_config_empty(self, api_key):
+    def test_parser_config_empty(self, HttpApiAuth):
         payload = {"name": "parser_config_empty", "parser_config": {}}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["parser_config"] == {
             "chunk_token_num": 128,
@@ -690,9 +690,9 @@ class TestDatasetCreate:
         }, res
 
     @pytest.mark.p2
-    def test_parser_config_unset(self, api_key):
+    def test_parser_config_unset(self, HttpApiAuth):
         payload = {"name": "parser_config_unset"}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["parser_config"] == {
             "chunk_token_num": 128,
@@ -703,9 +703,9 @@ class TestDatasetCreate:
         }, res
 
     @pytest.mark.p3
-    def test_parser_config_none(self, api_key):
+    def test_parser_config_none(self, HttpApiAuth):
         payload = {"name": "parser_config_none", "parser_config": None}
-        res = create_dataset(api_key, payload)
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 0, res
         assert res["data"]["parser_config"] == {
             "chunk_token_num": 128,
@@ -733,7 +733,7 @@ class TestDatasetCreate:
             {"name": "unknown_field", "unknown_field": "unknown_field"},
         ],
     )
-    def test_unsupported_field(self, api_key, payload):
-        res = create_dataset(api_key, payload)
+    def test_unsupported_field(self, HttpApiAuth, payload):
+        res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
         assert "Extra inputs are not permitted" in res["message"], res

--- a/test/testcases/test_http_api/test_dataset_mangement/test_list_datasets.py
+++ b/test/testcases/test_http_api/test_dataset_mangement/test_list_datasets.py
@@ -43,10 +43,10 @@ class TestAuthorization:
 
 class TestCapability:
     @pytest.mark.p3
-    def test_concurrent_list(self, api_key):
+    def test_concurrent_list(self, HttpApiAuth):
         count = 100
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(list_datasets, api_key) for i in range(count)]
+            futures = [executor.submit(list_datasets, HttpApiAuth) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
@@ -55,14 +55,14 @@ class TestCapability:
 @pytest.mark.usefixtures("add_datasets")
 class TestDatasetsList:
     @pytest.mark.p1
-    def test_params_unset(self, api_key):
-        res = list_datasets(api_key, None)
+    def test_params_unset(self, HttpApiAuth):
+        res = list_datasets(HttpApiAuth, None)
         assert res["code"] == 0, res
         assert len(res["data"]) == 5, res
 
     @pytest.mark.p2
-    def test_params_empty(self, api_key):
-        res = list_datasets(api_key, {})
+    def test_params_empty(self, HttpApiAuth):
+        res = list_datasets(HttpApiAuth, {})
         assert res["code"] == 0, res
         assert len(res["data"]) == 5, res
 
@@ -78,8 +78,8 @@ class TestDatasetsList:
         ],
         ids=["normal_middle_page", "normal_last_partial_page", "beyond_max_page", "string_page_number", "full_data_single_page"],
     )
-    def test_page(self, api_key, params, expected_page_size):
-        res = list_datasets(api_key, params)
+    def test_page(self, HttpApiAuth, params, expected_page_size):
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == expected_page_size, res
 
@@ -92,15 +92,15 @@ class TestDatasetsList:
         ],
         ids=["page_0", "page_a"],
     )
-    def test_page_invalid(self, api_key, params, expected_code, expected_message):
-        res = list_datasets(api_key, params=params)
+    def test_page_invalid(self, HttpApiAuth, params, expected_code, expected_message):
+        res = list_datasets(HttpApiAuth, params=params)
         assert res["code"] == expected_code, res
         assert expected_message in res["message"], res
 
     @pytest.mark.p2
-    def test_page_none(self, api_key):
+    def test_page_none(self, HttpApiAuth):
         params = {"page": None}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == 5, res
 
@@ -116,8 +116,8 @@ class TestDatasetsList:
         ],
         ids=["min_valid_page_size", "medium_page_size", "page_size_equals_total", "page_size_exceeds_total", "string_type_page_size"],
     )
-    def test_page_size(self, api_key, params, expected_page_size):
-        res = list_datasets(api_key, params)
+    def test_page_size(self, HttpApiAuth, params, expected_page_size):
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == expected_page_size, res
 
@@ -129,15 +129,15 @@ class TestDatasetsList:
             ({"page_size": "a"}, 101, "Input should be a valid integer, unable to parse string as an integer"),
         ],
     )
-    def test_page_size_invalid(self, api_key, params, expected_code, expected_message):
-        res = list_datasets(api_key, params)
+    def test_page_size_invalid(self, HttpApiAuth, params, expected_code, expected_message):
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == expected_code, res
         assert expected_message in res["message"], res
 
     @pytest.mark.p2
-    def test_page_size_none(self, api_key):
+    def test_page_size_none(self, HttpApiAuth):
         params = {"page_size": None}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == 5, res
 
@@ -153,8 +153,8 @@ class TestDatasetsList:
         ],
         ids=["orderby_create_time", "orderby_update_time", "orderby_create_time_upper", "orderby_update_time_upper", "whitespace"],
     )
-    def test_orderby(self, api_key, params, assertions):
-        res = list_datasets(api_key, params)
+    def test_orderby(self, HttpApiAuth, params, assertions):
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         if callable(assertions):
             assert assertions(res), res
@@ -168,15 +168,15 @@ class TestDatasetsList:
         ],
         ids=["empty", "unknown"],
     )
-    def test_orderby_invalid(self, api_key, params):
-        res = list_datasets(api_key, params)
+    def test_orderby_invalid(self, HttpApiAuth, params):
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 101, res
         assert "Input should be 'create_time' or 'update_time'" in res["message"], res
 
     @pytest.mark.p3
-    def test_orderby_none(self, api_key):
+    def test_orderby_none(self, HttpApiAuth):
         params = {"orderby": None}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert is_sorted(res["data"], "create_time", True), res
 
@@ -197,8 +197,8 @@ class TestDatasetsList:
         ],
         ids=["desc=True", "desc=False", "desc=true", "desc=false", "desc=1", "desc=0", "desc=yes", "desc=no", "desc=y", "desc=n"],
     )
-    def test_desc(self, api_key, params, assertions):
-        res = list_datasets(api_key, params)
+    def test_desc(self, HttpApiAuth, params, assertions):
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         if callable(assertions):
             assert assertions(res), res
@@ -212,88 +212,88 @@ class TestDatasetsList:
         ],
         ids=["empty", "unknown"],
     )
-    def test_desc_invalid(self, api_key, params):
-        res = list_datasets(api_key, params)
+    def test_desc_invalid(self, HttpApiAuth, params):
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 101, res
         assert "Input should be a valid boolean, unable to interpret input" in res["message"], res
 
     @pytest.mark.p3
-    def test_desc_none(self, api_key):
+    def test_desc_none(self, HttpApiAuth):
         params = {"desc": None}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert is_sorted(res["data"], "create_time", True), res
 
     @pytest.mark.p1
-    def test_name(self, api_key):
+    def test_name(self, HttpApiAuth):
         params = {"name": "dataset_1"}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == 1, res
         assert res["data"][0]["name"] == "dataset_1", res
 
     @pytest.mark.p2
-    def test_name_wrong(self, api_key):
+    def test_name_wrong(self, HttpApiAuth):
         params = {"name": "wrong name"}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 108, res
         assert "lacks permission for dataset" in res["message"], res
 
     @pytest.mark.p2
-    def test_name_empty(self, api_key):
+    def test_name_empty(self, HttpApiAuth):
         params = {"name": ""}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == 5, res
 
     @pytest.mark.p2
-    def test_name_none(self, api_key):
+    def test_name_none(self, HttpApiAuth):
         params = {"name": None}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == 5, res
 
     @pytest.mark.p1
-    def test_id(self, api_key, add_datasets):
+    def test_id(self, HttpApiAuth, add_datasets):
         dataset_ids = add_datasets
         params = {"id": dataset_ids[0]}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0
         assert len(res["data"]) == 1
         assert res["data"][0]["id"] == dataset_ids[0]
 
     @pytest.mark.p2
-    def test_id_not_uuid(self, api_key):
+    def test_id_not_uuid(self, HttpApiAuth):
         params = {"id": "not_uuid"}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 101, res
         assert "Invalid UUID1 format" in res["message"], res
 
     @pytest.mark.p2
-    def test_id_not_uuid1(self, api_key):
+    def test_id_not_uuid1(self, HttpApiAuth):
         params = {"id": uuid.uuid4().hex}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 101, res
         assert "Invalid UUID1 format" in res["message"], res
 
     @pytest.mark.p2
-    def test_id_wrong_uuid(self, api_key):
+    def test_id_wrong_uuid(self, HttpApiAuth):
         params = {"id": "d94a8dc02c9711f0930f7fbc369eab6d"}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 108, res
         assert "lacks permission for dataset" in res["message"], res
 
     @pytest.mark.p2
-    def test_id_empty(self, api_key):
+    def test_id_empty(self, HttpApiAuth):
         params = {"id": ""}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 101, res
         assert "Invalid UUID1 format" in res["message"], res
 
     @pytest.mark.p2
-    def test_id_none(self, api_key):
+    def test_id_none(self, HttpApiAuth):
         params = {"id": None}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == 5, res
 
@@ -306,11 +306,11 @@ class TestDatasetsList:
         ],
         ids=["name_and_id_match", "name_and_id_mismatch"],
     )
-    def test_name_and_id(self, api_key, add_datasets, func, name, expected_num):
+    def test_name_and_id(self, HttpApiAuth, add_datasets, func, name, expected_num):
         dataset_ids = add_datasets
         if callable(func):
             params = {"id": func(dataset_ids), "name": name}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 0, res
         assert len(res["data"]) == expected_num, res
 
@@ -323,19 +323,19 @@ class TestDatasetsList:
         ],
         ids=["name", "id"],
     )
-    def test_name_and_id_wrong(self, api_key, add_datasets, dataset_id, name):
+    def test_name_and_id_wrong(self, HttpApiAuth, add_datasets, dataset_id, name):
         dataset_ids = add_datasets
         if callable(dataset_id):
             params = {"id": dataset_id(dataset_ids), "name": name}
         else:
             params = {"id": dataset_id, "name": name}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 108, res
         assert "lacks permission for dataset" in res["message"], res
 
     @pytest.mark.p2
-    def test_field_unsupported(self, api_key):
+    def test_field_unsupported(self, HttpApiAuth):
         params = {"unknown_field": "unknown_field"}
-        res = list_datasets(api_key, params)
+        res = list_datasets(HttpApiAuth, params)
         assert res["code"] == 101, res
         assert "Extra inputs are not permitted" in res["message"], res

--- a/test/testcases/test_http_api/test_file_management_within_dataset/conftest.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/conftest.py
@@ -20,33 +20,33 @@ from common import bulk_upload_documents, delete_documents
 
 
 @pytest.fixture(scope="function")
-def add_document_func(request, api_key, add_dataset, ragflow_tmp_dir):
+def add_document_func(request, HttpApiAuth, add_dataset, ragflow_tmp_dir):
     def cleanup():
-        delete_documents(api_key, dataset_id, {"ids": None})
+        delete_documents(HttpApiAuth, dataset_id, {"ids": None})
 
     request.addfinalizer(cleanup)
 
     dataset_id = add_dataset
-    return dataset_id, bulk_upload_documents(api_key, dataset_id, 1, ragflow_tmp_dir)[0]
+    return dataset_id, bulk_upload_documents(HttpApiAuth, dataset_id, 1, ragflow_tmp_dir)[0]
 
 
 @pytest.fixture(scope="class")
-def add_documents(request, api_key, add_dataset, ragflow_tmp_dir):
+def add_documents(request, HttpApiAuth, add_dataset, ragflow_tmp_dir):
     def cleanup():
-        delete_documents(api_key, dataset_id, {"ids": None})
+        delete_documents(HttpApiAuth, dataset_id, {"ids": None})
 
     request.addfinalizer(cleanup)
 
     dataset_id = add_dataset
-    return dataset_id, bulk_upload_documents(api_key, dataset_id, 5, ragflow_tmp_dir)
+    return dataset_id, bulk_upload_documents(HttpApiAuth, dataset_id, 5, ragflow_tmp_dir)
 
 
 @pytest.fixture(scope="function")
-def add_documents_func(request, api_key, add_dataset_func, ragflow_tmp_dir):
+def add_documents_func(request, HttpApiAuth, add_dataset_func, ragflow_tmp_dir):
     def cleanup():
-        delete_documents(api_key, dataset_id, {"ids": None})
+        delete_documents(HttpApiAuth, dataset_id, {"ids": None})
 
     request.addfinalizer(cleanup)
 
     dataset_id = add_dataset_func
-    return dataset_id, bulk_upload_documents(api_key, dataset_id, 3, ragflow_tmp_dir)
+    return dataset_id, bulk_upload_documents(HttpApiAuth, dataset_id, 3, ragflow_tmp_dir)

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_delete_documents.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_delete_documents.py
@@ -65,7 +65,7 @@ class TestDocumentsDeletion:
     )
     def test_basic_scenarios(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents_func,
         payload,
         expected_code,
@@ -75,12 +75,12 @@ class TestDocumentsDeletion:
         dataset_id, document_ids = add_documents_func
         if callable(payload):
             payload = payload(document_ids)
-        res = delete_documents(api_key, dataset_id, payload)
+        res = delete_documents(HttpApiAuth, dataset_id, payload)
         assert res["code"] == expected_code
         if res["code"] != 0:
             assert res["message"] == expected_message
 
-        res = list_documents(api_key, dataset_id)
+        res = list_documents(HttpApiAuth, dataset_id)
         assert len(res["data"]["docs"]) == remaining
         assert res["data"]["total"] == remaining
 
@@ -96,9 +96,9 @@ class TestDocumentsDeletion:
             ),
         ],
     )
-    def test_invalid_dataset_id(self, api_key, add_documents_func, dataset_id, expected_code, expected_message):
+    def test_invalid_dataset_id(self, HttpApiAuth, add_documents_func, dataset_id, expected_code, expected_message):
         _, document_ids = add_documents_func
-        res = delete_documents(api_key, dataset_id, {"ids": document_ids[:1]})
+        res = delete_documents(HttpApiAuth, dataset_id, {"ids": document_ids[:1]})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -111,52 +111,52 @@ class TestDocumentsDeletion:
             lambda r: {"ids": r + ["invalid_id"]},
         ],
     )
-    def test_delete_partial_invalid_id(self, api_key, add_documents_func, payload):
+    def test_delete_partial_invalid_id(self, HttpApiAuth, add_documents_func, payload):
         dataset_id, document_ids = add_documents_func
         if callable(payload):
             payload = payload(document_ids)
-        res = delete_documents(api_key, dataset_id, payload)
+        res = delete_documents(HttpApiAuth, dataset_id, payload)
         assert res["code"] == 102
         assert res["message"] == "Documents not found: ['invalid_id']"
 
-        res = list_documents(api_key, dataset_id)
+        res = list_documents(HttpApiAuth, dataset_id)
         assert len(res["data"]["docs"]) == 0
         assert res["data"]["total"] == 0
 
     @pytest.mark.p2
-    def test_repeated_deletion(self, api_key, add_documents_func):
+    def test_repeated_deletion(self, HttpApiAuth, add_documents_func):
         dataset_id, document_ids = add_documents_func
-        res = delete_documents(api_key, dataset_id, {"ids": document_ids})
+        res = delete_documents(HttpApiAuth, dataset_id, {"ids": document_ids})
         assert res["code"] == 0
 
-        res = delete_documents(api_key, dataset_id, {"ids": document_ids})
+        res = delete_documents(HttpApiAuth, dataset_id, {"ids": document_ids})
         assert res["code"] == 102
         assert "Documents not found" in res["message"]
 
     @pytest.mark.p2
-    def test_duplicate_deletion(self, api_key, add_documents_func):
+    def test_duplicate_deletion(self, HttpApiAuth, add_documents_func):
         dataset_id, document_ids = add_documents_func
-        res = delete_documents(api_key, dataset_id, {"ids": document_ids + document_ids})
+        res = delete_documents(HttpApiAuth, dataset_id, {"ids": document_ids + document_ids})
         assert res["code"] == 0
         assert "Duplicate document ids" in res["data"]["errors"][0]
         assert res["data"]["success_count"] == 3
 
-        res = list_documents(api_key, dataset_id)
+        res = list_documents(HttpApiAuth, dataset_id)
         assert len(res["data"]["docs"]) == 0
         assert res["data"]["total"] == 0
 
 
 @pytest.mark.p3
-def test_concurrent_deletion(api_key, add_dataset, tmp_path):
+def test_concurrent_deletion(HttpApiAuth, add_dataset, tmp_path):
     count = 100
     dataset_id = add_dataset
-    document_ids = bulk_upload_documents(api_key, dataset_id, count, tmp_path)
+    document_ids = bulk_upload_documents(HttpApiAuth, dataset_id, count, tmp_path)
 
     with ThreadPoolExecutor(max_workers=5) as executor:
         futures = [
             executor.submit(
                 delete_documents,
-                api_key,
+                HttpApiAuth,
                 dataset_id,
                 {"ids": document_ids[i : i + 1]},
             )
@@ -168,15 +168,15 @@ def test_concurrent_deletion(api_key, add_dataset, tmp_path):
 
 
 @pytest.mark.p3
-def test_delete_1k(api_key, add_dataset, tmp_path):
+def test_delete_1k(HttpApiAuth, add_dataset, tmp_path):
     documents_num = 1_000
     dataset_id = add_dataset
-    document_ids = bulk_upload_documents(api_key, dataset_id, documents_num, tmp_path)
-    res = list_documents(api_key, dataset_id)
+    document_ids = bulk_upload_documents(HttpApiAuth, dataset_id, documents_num, tmp_path)
+    res = list_documents(HttpApiAuth, dataset_id)
     assert res["data"]["total"] == documents_num
 
-    res = delete_documents(api_key, dataset_id, {"ids": document_ids})
+    res = delete_documents(HttpApiAuth, dataset_id, {"ids": document_ids})
     assert res["code"] == 0
 
-    res = list_documents(api_key, dataset_id)
+    res = list_documents(HttpApiAuth, dataset_id)
     assert res["data"]["total"] == 0

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_download_document.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_download_document.py
@@ -63,14 +63,14 @@ class TestAuthorization:
     ],
     indirect=True,
 )
-def test_file_type_validation(api_key, add_dataset, generate_test_files, request):
+def test_file_type_validation(HttpApiAuth, add_dataset, generate_test_files, request):
     dataset_id = add_dataset
     fp = generate_test_files[request.node.callspec.params["generate_test_files"]]
-    res = upload_documents(api_key, dataset_id, [fp])
+    res = upload_documents(HttpApiAuth, dataset_id, [fp])
     document_id = res["data"][0]["id"]
 
     res = download_document(
-        api_key,
+        HttpApiAuth,
         dataset_id,
         document_id,
         fp.with_stem("ragflow_test_download"),
@@ -94,10 +94,10 @@ class TestDocumentDownload:
             ),
         ],
     )
-    def test_invalid_document_id(self, api_key, add_documents, tmp_path, document_id, expected_code, expected_message):
+    def test_invalid_document_id(self, HttpApiAuth, add_documents, tmp_path, document_id, expected_code, expected_message):
         dataset_id, _ = add_documents
         res = download_document(
-            api_key,
+            HttpApiAuth,
             dataset_id,
             document_id,
             tmp_path / "ragflow_test_download_1.txt",
@@ -120,10 +120,10 @@ class TestDocumentDownload:
             ),
         ],
     )
-    def test_invalid_dataset_id(self, api_key, add_documents, tmp_path, dataset_id, expected_code, expected_message):
+    def test_invalid_dataset_id(self, HttpApiAuth, add_documents, tmp_path, dataset_id, expected_code, expected_message):
         _, document_ids = add_documents
         res = download_document(
-            api_key,
+            HttpApiAuth,
             dataset_id,
             document_ids[0],
             tmp_path / "ragflow_test_download_1.txt",
@@ -135,12 +135,12 @@ class TestDocumentDownload:
         assert response_json["message"] == expected_message
 
     @pytest.mark.p3
-    def test_same_file_repeat(self, api_key, add_documents, tmp_path, ragflow_tmp_dir):
+    def test_same_file_repeat(self, HttpApiAuth, add_documents, tmp_path, ragflow_tmp_dir):
         num = 5
         dataset_id, document_ids = add_documents
         for i in range(num):
             res = download_document(
-                api_key,
+                HttpApiAuth,
                 dataset_id,
                 document_ids[0],
                 tmp_path / f"ragflow_test_download_{i}.txt",
@@ -153,16 +153,16 @@ class TestDocumentDownload:
 
 
 @pytest.mark.p3
-def test_concurrent_download(api_key, add_dataset, tmp_path):
+def test_concurrent_download(HttpApiAuth, add_dataset, tmp_path):
     count = 20
     dataset_id = add_dataset
-    document_ids = bulk_upload_documents(api_key, dataset_id, count, tmp_path)
+    document_ids = bulk_upload_documents(HttpApiAuth, dataset_id, count, tmp_path)
 
     with ThreadPoolExecutor(max_workers=5) as executor:
         futures = [
             executor.submit(
                 download_document,
-                api_key,
+                HttpApiAuth,
                 dataset_id,
                 document_ids[i],
                 tmp_path / f"ragflow_test_download_{i}.txt",

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_list_documents.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_list_documents.py
@@ -42,9 +42,9 @@ class TestAuthorization:
 
 class TestDocumentsList:
     @pytest.mark.p1
-    def test_default(self, api_key, add_documents):
+    def test_default(self, HttpApiAuth, add_documents):
         dataset_id, _ = add_documents
-        res = list_documents(api_key, dataset_id)
+        res = list_documents(HttpApiAuth, dataset_id)
         assert res["code"] == 0
         assert len(res["data"]["docs"]) == 5
         assert res["data"]["total"] == 5
@@ -61,8 +61,8 @@ class TestDocumentsList:
             ),
         ],
     )
-    def test_invalid_dataset_id(self, api_key, dataset_id, expected_code, expected_message):
-        res = list_documents(api_key, dataset_id)
+    def test_invalid_dataset_id(self, HttpApiAuth, dataset_id, expected_code, expected_message):
+        res = list_documents(HttpApiAuth, dataset_id)
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -93,7 +93,7 @@ class TestDocumentsList:
     )
     def test_page(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         params,
         expected_code,
@@ -101,7 +101,7 @@ class TestDocumentsList:
         expected_message,
     ):
         dataset_id, _ = add_documents
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["docs"]) == expected_page_size
@@ -136,7 +136,7 @@ class TestDocumentsList:
     )
     def test_page_size(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         params,
         expected_code,
@@ -144,7 +144,7 @@ class TestDocumentsList:
         expected_message,
     ):
         dataset_id, _ = add_documents
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]["docs"]) == expected_page_size
@@ -164,7 +164,7 @@ class TestDocumentsList:
     )
     def test_orderby(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         params,
         expected_code,
@@ -172,7 +172,7 @@ class TestDocumentsList:
         expected_message,
     ):
         dataset_id, _ = add_documents
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -197,7 +197,7 @@ class TestDocumentsList:
     )
     def test_desc(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         params,
         expected_code,
@@ -205,7 +205,7 @@ class TestDocumentsList:
         expected_message,
     ):
         dataset_id, _ = add_documents
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -224,9 +224,9 @@ class TestDocumentsList:
             ({"keywords": "unknown"}, 0),
         ],
     )
-    def test_keywords(self, api_key, add_documents, params, expected_num):
+    def test_keywords(self, HttpApiAuth, add_documents, params, expected_num):
         dataset_id, _ = add_documents
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         assert res["code"] == 0
         assert len(res["data"]["docs"]) == expected_num
         assert res["data"]["total"] == expected_num
@@ -248,7 +248,7 @@ class TestDocumentsList:
     )
     def test_name(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         params,
         expected_code,
@@ -256,7 +256,7 @@ class TestDocumentsList:
         expected_message,
     ):
         dataset_id, _ = add_documents
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if params["name"] in [None, ""]:
@@ -278,7 +278,7 @@ class TestDocumentsList:
     )
     def test_id(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         document_id,
         expected_code,
@@ -290,7 +290,7 @@ class TestDocumentsList:
             params = {"id": document_id(document_ids)}
         else:
             params = {"id": document_id}
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
 
         assert res["code"] == expected_code
         if expected_code == 0:
@@ -319,7 +319,7 @@ class TestDocumentsList:
     )
     def test_name_and_id(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         document_id,
         name,
@@ -333,27 +333,27 @@ class TestDocumentsList:
         else:
             params = {"id": document_id, "name": name}
 
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         if expected_code == 0:
             assert len(res["data"]["docs"]) == expected_num
         else:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_concurrent_list(self, api_key, add_documents):
+    def test_concurrent_list(self, HttpApiAuth, add_documents):
         dataset_id, _ = add_documents
         count = 100
 
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(list_documents, api_key, dataset_id) for i in range(count)]
+            futures = [executor.submit(list_documents, HttpApiAuth, dataset_id) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
 
     @pytest.mark.p3
-    def test_invalid_params(self, api_key, add_documents):
+    def test_invalid_params(self, HttpApiAuth, add_documents):
         dataset_id, _ = add_documents
         params = {"a": "b"}
-        res = list_documents(api_key, dataset_id, params=params)
+        res = list_documents(HttpApiAuth, dataset_id, params=params)
         assert res["code"] == 0
         assert len(res["data"]["docs"]) == 5

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_stop_parse_documents.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_stop_parse_documents.py
@@ -75,7 +75,7 @@ class TestDocumentsParseStop:
             pytest.param(lambda r: {"document_ids": r}, 0, "", marks=pytest.mark.p1),
         ],
     )
-    def test_basic_scenarios(self, api_key, add_documents_func, payload, expected_code, expected_message):
+    def test_basic_scenarios(self, HttpApiAuth, add_documents_func, payload, expected_code, expected_message):
         @wait_for(10, 1, "Document parsing timeout")
         def condition(_auth, _dataset_id, _document_ids):
             for _document_id in _document_ids:
@@ -85,20 +85,20 @@ class TestDocumentsParseStop:
             return True
 
         dataset_id, document_ids = add_documents_func
-        parse_documents(api_key, dataset_id, {"document_ids": document_ids})
+        parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
 
         if callable(payload):
             payload = payload(document_ids)
 
-        res = stop_parse_documents(api_key, dataset_id, payload)
+        res = stop_parse_documents(HttpApiAuth, dataset_id, payload)
         assert res["code"] == expected_code
         if expected_code != 0:
             assert res["message"] == expected_message
         else:
             completed_document_ids = list(set(document_ids) - set(payload["document_ids"]))
-            condition(api_key, dataset_id, completed_document_ids)
-            validate_document_parse_cancel(api_key, dataset_id, payload["document_ids"])
-            validate_document_parse_done(api_key, dataset_id, completed_document_ids)
+            condition(HttpApiAuth, dataset_id, completed_document_ids)
+            validate_document_parse_cancel(HttpApiAuth, dataset_id, payload["document_ids"])
+            validate_document_parse_done(HttpApiAuth, dataset_id, completed_document_ids)
 
     @pytest.mark.p3
     @pytest.mark.parametrize(
@@ -114,15 +114,15 @@ class TestDocumentsParseStop:
     )
     def test_invalid_dataset_id(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents_func,
         invalid_dataset_id,
         expected_code,
         expected_message,
     ):
         dataset_id, document_ids = add_documents_func
-        parse_documents(api_key, dataset_id, {"document_ids": document_ids})
-        res = stop_parse_documents(api_key, invalid_dataset_id, {"document_ids": document_ids})
+        parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
+        res = stop_parse_documents(HttpApiAuth, invalid_dataset_id, {"document_ids": document_ids})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -135,63 +135,63 @@ class TestDocumentsParseStop:
             lambda r: {"document_ids": r + ["invalid_id"]},
         ],
     )
-    def test_stop_parse_partial_invalid_document_id(self, api_key, add_documents_func, payload):
+    def test_stop_parse_partial_invalid_document_id(self, HttpApiAuth, add_documents_func, payload):
         dataset_id, document_ids = add_documents_func
-        parse_documents(api_key, dataset_id, {"document_ids": document_ids})
+        parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
 
         if callable(payload):
             payload = payload(document_ids)
-        res = stop_parse_documents(api_key, dataset_id, payload)
+        res = stop_parse_documents(HttpApiAuth, dataset_id, payload)
         assert res["code"] == 102
         assert res["message"] == "You don't own the document invalid_id."
 
-        validate_document_parse_cancel(api_key, dataset_id, document_ids)
+        validate_document_parse_cancel(HttpApiAuth, dataset_id, document_ids)
 
     @pytest.mark.p3
-    def test_repeated_stop_parse(self, api_key, add_documents_func):
+    def test_repeated_stop_parse(self, HttpApiAuth, add_documents_func):
         dataset_id, document_ids = add_documents_func
-        parse_documents(api_key, dataset_id, {"document_ids": document_ids})
-        res = stop_parse_documents(api_key, dataset_id, {"document_ids": document_ids})
+        parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
+        res = stop_parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
         assert res["code"] == 0
 
-        res = stop_parse_documents(api_key, dataset_id, {"document_ids": document_ids})
+        res = stop_parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
         assert res["code"] == 102
         assert res["message"] == "Can't stop parsing document with progress at 0 or 1"
 
     @pytest.mark.p3
-    def test_duplicate_stop_parse(self, api_key, add_documents_func):
+    def test_duplicate_stop_parse(self, HttpApiAuth, add_documents_func):
         dataset_id, document_ids = add_documents_func
-        parse_documents(api_key, dataset_id, {"document_ids": document_ids})
-        res = stop_parse_documents(api_key, dataset_id, {"document_ids": document_ids + document_ids})
+        parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
+        res = stop_parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids + document_ids})
         assert res["code"] == 0
         assert res["data"]["success_count"] == 3
         assert f"Duplicate document ids: {document_ids[0]}" in res["data"]["errors"]
 
 
 @pytest.mark.skip(reason="unstable")
-def test_stop_parse_100_files(api_key, add_dataset_func, tmp_path):
+def test_stop_parse_100_files(HttpApiAuth, add_dataset_func, tmp_path):
     document_num = 100
     dataset_id = add_dataset_func
-    document_ids = bulk_upload_documents(api_key, dataset_id, document_num, tmp_path)
-    parse_documents(api_key, dataset_id, {"document_ids": document_ids})
+    document_ids = bulk_upload_documents(HttpApiAuth, dataset_id, document_num, tmp_path)
+    parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
     sleep(1)
-    res = stop_parse_documents(api_key, dataset_id, {"document_ids": document_ids})
+    res = stop_parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
     assert res["code"] == 0
-    validate_document_parse_cancel(api_key, dataset_id, document_ids)
+    validate_document_parse_cancel(HttpApiAuth, dataset_id, document_ids)
 
 
 @pytest.mark.skip(reason="unstable")
-def test_concurrent_parse(api_key, add_dataset_func, tmp_path):
+def test_concurrent_parse(HttpApiAuth, add_dataset_func, tmp_path):
     document_num = 50
     dataset_id = add_dataset_func
-    document_ids = bulk_upload_documents(api_key, dataset_id, document_num, tmp_path)
-    parse_documents(api_key, dataset_id, {"document_ids": document_ids})
+    document_ids = bulk_upload_documents(HttpApiAuth, dataset_id, document_num, tmp_path)
+    parse_documents(HttpApiAuth, dataset_id, {"document_ids": document_ids})
 
     with ThreadPoolExecutor(max_workers=5) as executor:
         futures = [
             executor.submit(
                 stop_parse_documents,
-                api_key,
+                HttpApiAuth,
                 dataset_id,
                 {"document_ids": document_ids[i : i + 1]},
             )
@@ -199,4 +199,4 @@ def test_concurrent_parse(api_key, add_dataset_func, tmp_path):
         ]
     responses = [f.result() for f in futures]
     assert all(r["code"] == 0 for r in responses)
-    validate_document_parse_cancel(api_key, dataset_id, document_ids)
+    validate_document_parse_cancel(HttpApiAuth, dataset_id, document_ids)

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_update_document.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_update_document.py
@@ -82,12 +82,12 @@ class TestDocumentsUpdated:
             ),
         ],
     )
-    def test_name(self, api_key, add_documents, name, expected_code, expected_message):
+    def test_name(self, HttpApiAuth, add_documents, name, expected_code, expected_message):
         dataset_id, document_ids = add_documents
-        res = update_document(api_key, dataset_id, document_ids[0], {"name": name})
+        res = update_document(HttpApiAuth, dataset_id, document_ids[0], {"name": name})
         assert res["code"] == expected_code
         if expected_code == 0:
-            res = list_documents(api_key, dataset_id, {"id": document_ids[0]})
+            res = list_documents(HttpApiAuth, dataset_id, {"id": document_ids[0]})
             assert res["data"]["docs"][0]["name"] == name
         else:
             assert res["message"] == expected_message
@@ -104,9 +104,9 @@ class TestDocumentsUpdated:
             ),
         ],
     )
-    def test_invalid_document_id(self, api_key, add_documents, document_id, expected_code, expected_message):
+    def test_invalid_document_id(self, HttpApiAuth, add_documents, document_id, expected_code, expected_message):
         dataset_id, _ = add_documents
-        res = update_document(api_key, dataset_id, document_id, {"name": "new_name.txt"})
+        res = update_document(HttpApiAuth, dataset_id, document_id, {"name": "new_name.txt"})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -122,9 +122,9 @@ class TestDocumentsUpdated:
             ),
         ],
     )
-    def test_invalid_dataset_id(self, api_key, add_documents, dataset_id, expected_code, expected_message):
+    def test_invalid_dataset_id(self, HttpApiAuth, add_documents, dataset_id, expected_code, expected_message):
         _, document_ids = add_documents
-        res = update_document(api_key, dataset_id, document_ids[0], {"name": "new_name.txt"})
+        res = update_document(HttpApiAuth, dataset_id, document_ids[0], {"name": "new_name.txt"})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -133,11 +133,11 @@ class TestDocumentsUpdated:
         "meta_fields, expected_code, expected_message",
         [({"test": "test"}, 0, ""), ("test", 102, "meta_fields must be a dictionary")],
     )
-    def test_meta_fields(self, api_key, add_documents, meta_fields, expected_code, expected_message):
+    def test_meta_fields(self, HttpApiAuth, add_documents, meta_fields, expected_code, expected_message):
         dataset_id, document_ids = add_documents
-        res = update_document(api_key, dataset_id, document_ids[0], {"meta_fields": meta_fields})
+        res = update_document(HttpApiAuth, dataset_id, document_ids[0], {"meta_fields": meta_fields})
         if expected_code == 0:
-            res = list_documents(api_key, dataset_id, {"id": document_ids[0]})
+            res = list_documents(HttpApiAuth, dataset_id, {"id": document_ids[0]})
             assert res["data"]["docs"][0]["meta_fields"] == meta_fields
         else:
             assert res["message"] == expected_message
@@ -167,12 +167,12 @@ class TestDocumentsUpdated:
             ),
         ],
     )
-    def test_chunk_method(self, api_key, add_documents, chunk_method, expected_code, expected_message):
+    def test_chunk_method(self, HttpApiAuth, add_documents, chunk_method, expected_code, expected_message):
         dataset_id, document_ids = add_documents
-        res = update_document(api_key, dataset_id, document_ids[0], {"chunk_method": chunk_method})
+        res = update_document(HttpApiAuth, dataset_id, document_ids[0], {"chunk_method": chunk_method})
         assert res["code"] == expected_code
         if expected_code == 0:
-            res = list_documents(api_key, dataset_id, {"id": document_ids[0]})
+            res = list_documents(HttpApiAuth, dataset_id, {"id": document_ids[0]})
             if chunk_method != "":
                 assert res["data"]["docs"][0]["chunk_method"] == chunk_method
             else:
@@ -287,14 +287,14 @@ class TestDocumentsUpdated:
     )
     def test_invalid_field(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         payload,
         expected_code,
         expected_message,
     ):
         dataset_id, document_ids = add_documents
-        res = update_document(api_key, dataset_id, document_ids[0], payload)
+        res = update_document(HttpApiAuth, dataset_id, document_ids[0], payload)
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -515,7 +515,7 @@ class TestUpdateDocumentParserConfig:
     )
     def test_parser_config(
         self,
-        api_key,
+        HttpApiAuth,
         add_documents,
         chunk_method,
         parser_config,
@@ -524,14 +524,14 @@ class TestUpdateDocumentParserConfig:
     ):
         dataset_id, document_ids = add_documents
         res = update_document(
-            api_key,
+            HttpApiAuth,
             dataset_id,
             document_ids[0],
             {"chunk_method": chunk_method, "parser_config": parser_config},
         )
         assert res["code"] == expected_code
         if expected_code == 0:
-            res = list_documents(api_key, dataset_id, {"id": document_ids[0]})
+            res = list_documents(HttpApiAuth, dataset_id, {"id": document_ids[0]})
             if parser_config != {}:
                 for k, v in parser_config.items():
                     assert res["data"]["docs"][0]["parser_config"][k] == v

--- a/test/testcases/test_http_api/test_session_management/conftest.py
+++ b/test/testcases/test_http_api/test_session_management/conftest.py
@@ -18,24 +18,24 @@ from common import batch_add_sessions_with_chat_assistant, delete_session_with_c
 
 
 @pytest.fixture(scope="class")
-def add_sessions_with_chat_assistant(request, api_key, add_chat_assistants):
+def add_sessions_with_chat_assistant(request, HttpApiAuth, add_chat_assistants):
     def cleanup():
         for chat_assistant_id in chat_assistant_ids:
-            delete_session_with_chat_assistants(api_key, chat_assistant_id)
+            delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id)
 
     request.addfinalizer(cleanup)
 
     _, _, chat_assistant_ids = add_chat_assistants
-    return chat_assistant_ids[0], batch_add_sessions_with_chat_assistant(api_key, chat_assistant_ids[0], 5)
+    return chat_assistant_ids[0], batch_add_sessions_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], 5)
 
 
 @pytest.fixture(scope="function")
-def add_sessions_with_chat_assistant_func(request, api_key, add_chat_assistants):
+def add_sessions_with_chat_assistant_func(request, HttpApiAuth, add_chat_assistants):
     def cleanup():
         for chat_assistant_id in chat_assistant_ids:
-            delete_session_with_chat_assistants(api_key, chat_assistant_id)
+            delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id)
 
     request.addfinalizer(cleanup)
 
     _, _, chat_assistant_ids = add_chat_assistants
-    return chat_assistant_ids[0], batch_add_sessions_with_chat_assistant(api_key, chat_assistant_ids[0], 5)
+    return chat_assistant_ids[0], batch_add_sessions_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], 5)

--- a/test/testcases/test_http_api/test_session_management/test_create_session_with_chat_assistant.py
+++ b/test/testcases/test_http_api/test_session_management/test_create_session_with_chat_assistant.py
@@ -53,14 +53,14 @@ class TestSessionWithChatAssistantCreate:
             ({"name": "case insensitive"}, 0, ""),
         ],
     )
-    def test_name(self, api_key, add_chat_assistants, payload, expected_code, expected_message):
+    def test_name(self, HttpApiAuth, add_chat_assistants, payload, expected_code, expected_message):
         _, _, chat_assistant_ids = add_chat_assistants
         if payload["name"] == "duplicated_name":
-            create_session_with_chat_assistant(api_key, chat_assistant_ids[0], payload)
+            create_session_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], payload)
         elif payload["name"] == "case insensitive":
-            create_session_with_chat_assistant(api_key, chat_assistant_ids[0], {"name": payload["name"].upper()})
+            create_session_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], {"name": payload["name"].upper()})
 
-        res = create_session_with_chat_assistant(api_key, chat_assistant_ids[0], payload)
+        res = create_session_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], payload)
         assert res["code"] == expected_code, res
         if expected_code == 0:
             assert res["data"]["name"] == payload["name"]
@@ -76,16 +76,16 @@ class TestSessionWithChatAssistantCreate:
             ("invalid_chat_assistant_id", 102, "You do not own the assistant."),
         ],
     )
-    def test_invalid_chat_assistant_id(self, api_key, chat_assistant_id, expected_code, expected_message):
-        res = create_session_with_chat_assistant(api_key, chat_assistant_id, {"name": "valid_name"})
+    def test_invalid_chat_assistant_id(self, HttpApiAuth, chat_assistant_id, expected_code, expected_message):
+        res = create_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, {"name": "valid_name"})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_concurrent_create_session(self, api_key, add_chat_assistants):
+    def test_concurrent_create_session(self, HttpApiAuth, add_chat_assistants):
         count = 1000
         _, _, chat_assistant_ids = add_chat_assistants
-        res = list_session_with_chat_assistants(api_key, chat_assistant_ids[0])
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_ids[0])
         if res["code"] != 0:
             assert False, res
         sessions_count = len(res["data"])
@@ -94,7 +94,7 @@ class TestSessionWithChatAssistantCreate:
             futures = [
                 executor.submit(
                     create_session_with_chat_assistant,
-                    api_key,
+                    HttpApiAuth,
                     chat_assistant_ids[0],
                     {"name": f"session with chat assistant test {i}"},
                 )
@@ -103,16 +103,16 @@ class TestSessionWithChatAssistantCreate:
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
-        res = list_session_with_chat_assistants(api_key, chat_assistant_ids[0], {"page_size": count * 2})
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_ids[0], {"page_size": count * 2})
         if res["code"] != 0:
             assert False, res
         assert len(res["data"]) == sessions_count + count
 
     @pytest.mark.p3
-    def test_add_session_to_deleted_chat_assistant(self, api_key, add_chat_assistants):
+    def test_add_session_to_deleted_chat_assistant(self, HttpApiAuth, add_chat_assistants):
         _, _, chat_assistant_ids = add_chat_assistants
-        res = delete_chat_assistants(api_key, {"ids": [chat_assistant_ids[0]]})
+        res = delete_chat_assistants(HttpApiAuth, {"ids": [chat_assistant_ids[0]]})
         assert res["code"] == 0
-        res = create_session_with_chat_assistant(api_key, chat_assistant_ids[0], {"name": "valid_name"})
+        res = create_session_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], {"name": "valid_name"})
         assert res["code"] == 102
         assert res["message"] == "You do not own the assistant."

--- a/test/testcases/test_http_api/test_session_management/test_delete_sessions_with_chat_assistant.py
+++ b/test/testcases/test_http_api/test_session_management/test_delete_sessions_with_chat_assistant.py
@@ -52,9 +52,9 @@ class TestSessionWithChatAssistantDelete:
             ),
         ],
     )
-    def test_invalid_chat_assistant_id(self, api_key, add_sessions_with_chat_assistant_func, chat_assistant_id, expected_code, expected_message):
+    def test_invalid_chat_assistant_id(self, HttpApiAuth, add_sessions_with_chat_assistant_func, chat_assistant_id, expected_code, expected_message):
         _, session_ids = add_sessions_with_chat_assistant_func
-        res = delete_session_with_chat_assistants(api_key, chat_assistant_id, {"ids": session_ids})
+        res = delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, {"ids": session_ids})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -66,54 +66,54 @@ class TestSessionWithChatAssistantDelete:
             pytest.param(lambda r: {"ids": r + ["invalid_id"]}, marks=pytest.mark.p3),
         ],
     )
-    def test_delete_partial_invalid_id(self, api_key, add_sessions_with_chat_assistant_func, payload):
+    def test_delete_partial_invalid_id(self, HttpApiAuth, add_sessions_with_chat_assistant_func, payload):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
         if callable(payload):
             payload = payload(session_ids)
-        res = delete_session_with_chat_assistants(api_key, chat_assistant_id, payload)
+        res = delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, payload)
         assert res["code"] == 0
         assert res["data"]["errors"][0] == "The chat doesn't own the session invalid_id"
 
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id)
         if res["code"] != 0:
             assert False, res
         assert len(res["data"]) == 0
 
     @pytest.mark.p3
-    def test_repeated_deletion(self, api_key, add_sessions_with_chat_assistant_func):
+    def test_repeated_deletion(self, HttpApiAuth, add_sessions_with_chat_assistant_func):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
         payload = {"ids": session_ids}
-        res = delete_session_with_chat_assistants(api_key, chat_assistant_id, payload)
+        res = delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, payload)
         assert res["code"] == 0
 
-        res = delete_session_with_chat_assistants(api_key, chat_assistant_id, payload)
+        res = delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, payload)
         assert res["code"] == 102
         assert "The chat doesn't own the session" in res["message"]
 
     @pytest.mark.p3
-    def test_duplicate_deletion(self, api_key, add_sessions_with_chat_assistant_func):
+    def test_duplicate_deletion(self, HttpApiAuth, add_sessions_with_chat_assistant_func):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
-        res = delete_session_with_chat_assistants(api_key, chat_assistant_id, {"ids": session_ids * 2})
+        res = delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, {"ids": session_ids * 2})
         assert res["code"] == 0
         assert "Duplicate session ids" in res["data"]["errors"][0]
         assert res["data"]["success_count"] == 5
 
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id)
         if res["code"] != 0:
             assert False, res
         assert len(res["data"]) == 0
 
     @pytest.mark.p3
-    def test_concurrent_deletion(self, api_key, add_chat_assistants):
+    def test_concurrent_deletion(self, HttpApiAuth, add_chat_assistants):
         count = 100
         _, _, chat_assistant_ids = add_chat_assistants
-        session_ids = batch_add_sessions_with_chat_assistant(api_key, chat_assistant_ids[0], count)
+        session_ids = batch_add_sessions_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], count)
 
         with ThreadPoolExecutor(max_workers=5) as executor:
             futures = [
                 executor.submit(
                     delete_session_with_chat_assistants,
-                    api_key,
+                    HttpApiAuth,
                     chat_assistant_ids[0],
                     {"ids": session_ids[i : i + 1]},
                 )
@@ -124,15 +124,15 @@ class TestSessionWithChatAssistantDelete:
         assert all(future.result()["code"] == 0 for future in futures)
 
     @pytest.mark.p3
-    def test_delete_1k(self, api_key, add_chat_assistants):
+    def test_delete_1k(self, HttpApiAuth, add_chat_assistants):
         sessions_num = 1_000
         _, _, chat_assistant_ids = add_chat_assistants
-        session_ids = batch_add_sessions_with_chat_assistant(api_key, chat_assistant_ids[0], sessions_num)
+        session_ids = batch_add_sessions_with_chat_assistant(HttpApiAuth, chat_assistant_ids[0], sessions_num)
 
-        res = delete_session_with_chat_assistants(api_key, chat_assistant_ids[0], {"ids": session_ids})
+        res = delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_ids[0], {"ids": session_ids})
         assert res["code"] == 0
 
-        res = list_session_with_chat_assistants(api_key, chat_assistant_ids[0])
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_ids[0])
         if res["code"] != 0:
             assert False, res
         assert len(res["data"]) == 0
@@ -150,7 +150,7 @@ class TestSessionWithChatAssistantDelete:
     )
     def test_basic_scenarios(
         self,
-        api_key,
+        HttpApiAuth,
         add_sessions_with_chat_assistant_func,
         payload,
         expected_code,
@@ -160,12 +160,12 @@ class TestSessionWithChatAssistantDelete:
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
         if callable(payload):
             payload = payload(session_ids)
-        res = delete_session_with_chat_assistants(api_key, chat_assistant_id, payload)
+        res = delete_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, payload)
         assert res["code"] == expected_code
         if res["code"] != 0:
             assert res["message"] == expected_message
 
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id)
         if res["code"] != 0:
             assert False, res
         assert len(res["data"]) == remaining

--- a/test/testcases/test_http_api/test_session_management/test_list_sessions_with_chat_assistant.py
+++ b/test/testcases/test_http_api/test_session_management/test_list_sessions_with_chat_assistant.py
@@ -54,9 +54,9 @@ class TestSessionsWithChatAssistantList:
             pytest.param({"page": "a", "page_size": 2}, 100, 0, """ValueError("invalid literal for int() with base 10: \'a\'")""", marks=pytest.mark.skip),
         ],
     )
-    def test_page(self, api_key, add_sessions_with_chat_assistant, params, expected_code, expected_page_size, expected_message):
+    def test_page(self, HttpApiAuth, add_sessions_with_chat_assistant, params, expected_code, expected_page_size, expected_message):
         chat_assistant_id, _ = add_sessions_with_chat_assistant
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_page_size
@@ -76,9 +76,9 @@ class TestSessionsWithChatAssistantList:
             pytest.param({"page_size": "a"}, 100, 0, """ValueError("invalid literal for int() with base 10: \'a\'")""", marks=pytest.mark.skip),
         ],
     )
-    def test_page_size(self, api_key, add_sessions_with_chat_assistant, params, expected_code, expected_page_size, expected_message):
+    def test_page_size(self, HttpApiAuth, add_sessions_with_chat_assistant, params, expected_code, expected_page_size, expected_message):
         chat_assistant_id, _ = add_sessions_with_chat_assistant
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_page_size
@@ -98,7 +98,7 @@ class TestSessionsWithChatAssistantList:
     )
     def test_orderby(
         self,
-        api_key,
+        HttpApiAuth,
         add_sessions_with_chat_assistant,
         params,
         expected_code,
@@ -106,7 +106,7 @@ class TestSessionsWithChatAssistantList:
         expected_message,
     ):
         chat_assistant_id, _ = add_sessions_with_chat_assistant
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -131,7 +131,7 @@ class TestSessionsWithChatAssistantList:
     )
     def test_desc(
         self,
-        api_key,
+        HttpApiAuth,
         add_sessions_with_chat_assistant,
         params,
         expected_code,
@@ -139,7 +139,7 @@ class TestSessionsWithChatAssistantList:
         expected_message,
     ):
         chat_assistant_id, _ = add_sessions_with_chat_assistant
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if callable(assertions):
@@ -157,9 +157,9 @@ class TestSessionsWithChatAssistantList:
             ({"name": "unknown"}, 0, 0, ""),
         ],
     )
-    def test_name(self, api_key, add_sessions_with_chat_assistant, params, expected_code, expected_num, expected_message):
+    def test_name(self, HttpApiAuth, add_sessions_with_chat_assistant, params, expected_code, expected_num, expected_message):
         chat_assistant_id, _ = add_sessions_with_chat_assistant
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if params["name"] != "session_with_chat_assistant_1":
@@ -179,14 +179,14 @@ class TestSessionsWithChatAssistantList:
             ("unknown", 0, 0, "The chat doesn't exist"),
         ],
     )
-    def test_id(self, api_key, add_sessions_with_chat_assistant, session_id, expected_code, expected_num, expected_message):
+    def test_id(self, HttpApiAuth, add_sessions_with_chat_assistant, session_id, expected_code, expected_num, expected_message):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant
         if callable(session_id):
             params = {"id": session_id(session_ids)}
         else:
             params = {"id": session_id}
 
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             if params["id"] != session_ids[0]:
@@ -206,14 +206,14 @@ class TestSessionsWithChatAssistantList:
             ("id", "session_with_chat_assistant_0", 0, 0, ""),
         ],
     )
-    def test_name_and_id(self, api_key, add_sessions_with_chat_assistant, session_id, name, expected_code, expected_num, expected_message):
+    def test_name_and_id(self, HttpApiAuth, add_sessions_with_chat_assistant, session_id, name, expected_code, expected_num, expected_message):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant
         if callable(session_id):
             params = {"id": session_id(session_ids), "name": name}
         else:
             params = {"id": session_id, "name": name}
 
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == expected_code
         if expected_code == 0:
             assert len(res["data"]) == expected_num
@@ -221,29 +221,29 @@ class TestSessionsWithChatAssistantList:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_concurrent_list(self, api_key, add_sessions_with_chat_assistant):
+    def test_concurrent_list(self, HttpApiAuth, add_sessions_with_chat_assistant):
         count = 100
         chat_assistant_id, _ = add_sessions_with_chat_assistant
         with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(list_session_with_chat_assistants, api_key, chat_assistant_id) for i in range(count)]
+            futures = [executor.submit(list_session_with_chat_assistants, HttpApiAuth, chat_assistant_id) for i in range(count)]
         responses = list(as_completed(futures))
         assert len(responses) == count, responses
         assert all(future.result()["code"] == 0 for future in futures)
 
     @pytest.mark.p3
-    def test_invalid_params(self, api_key, add_sessions_with_chat_assistant):
+    def test_invalid_params(self, HttpApiAuth, add_sessions_with_chat_assistant):
         chat_assistant_id, _ = add_sessions_with_chat_assistant
         params = {"a": "b"}
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id, params=params)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, params=params)
         assert res["code"] == 0
         assert len(res["data"]) == 5
 
     @pytest.mark.p3
-    def test_list_chats_after_deleting_associated_chat_assistant(self, api_key, add_sessions_with_chat_assistant):
+    def test_list_chats_after_deleting_associated_chat_assistant(self, HttpApiAuth, add_sessions_with_chat_assistant):
         chat_assistant_id, _ = add_sessions_with_chat_assistant
-        res = delete_chat_assistants(api_key, {"ids": [chat_assistant_id]})
+        res = delete_chat_assistants(HttpApiAuth, {"ids": [chat_assistant_id]})
         assert res["code"] == 0
 
-        res = list_session_with_chat_assistants(api_key, chat_assistant_id)
+        res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id)
         assert res["code"] == 102
         assert "You don't own the assistant" in res["message"]

--- a/test/testcases/test_http_api/test_session_management/test_update_session_with_chat_assistant.py
+++ b/test/testcases/test_http_api/test_session_management/test_update_session_with_chat_assistant.py
@@ -52,17 +52,17 @@ class TestSessionWithChatAssistantUpdate:
             pytest.param({"name": "case insensitive"}, 0, "", marks=pytest.mark.p3),
         ],
     )
-    def test_name(self, api_key, add_sessions_with_chat_assistant_func, payload, expected_code, expected_message):
+    def test_name(self, HttpApiAuth, add_sessions_with_chat_assistant_func, payload, expected_code, expected_message):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
         if payload["name"] == "duplicated_name":
-            update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], payload)
+            update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], payload)
         elif payload["name"] == "case insensitive":
-            update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], {"name": payload["name"].upper()})
+            update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], {"name": payload["name"].upper()})
 
-        res = update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], payload)
+        res = update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], payload)
         assert res["code"] == expected_code, res
         if expected_code == 0:
-            res = list_session_with_chat_assistants(api_key, chat_assistant_id, {"id": session_ids[0]})
+            res = list_session_with_chat_assistants(HttpApiAuth, chat_assistant_id, {"id": session_ids[0]})
             assert res["data"][0]["name"] == payload["name"]
         else:
             assert res["message"] == expected_message
@@ -75,9 +75,9 @@ class TestSessionWithChatAssistantUpdate:
             pytest.param("invalid_chat_assistant_id", 102, "Session does not exist", marks=pytest.mark.skip(reason="issues/")),
         ],
     )
-    def test_invalid_chat_assistant_id(self, api_key, add_sessions_with_chat_assistant_func, chat_assistant_id, expected_code, expected_message):
+    def test_invalid_chat_assistant_id(self, HttpApiAuth, add_sessions_with_chat_assistant_func, chat_assistant_id, expected_code, expected_message):
         _, session_ids = add_sessions_with_chat_assistant_func
-        res = update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], {"name": "valid_name"})
+        res = update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], {"name": "valid_name"})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
@@ -89,19 +89,19 @@ class TestSessionWithChatAssistantUpdate:
             ("invalid_session_id", 102, "Session does not exist"),
         ],
     )
-    def test_invalid_session_id(self, api_key, add_sessions_with_chat_assistant_func, session_id, expected_code, expected_message):
+    def test_invalid_session_id(self, HttpApiAuth, add_sessions_with_chat_assistant_func, session_id, expected_code, expected_message):
         chat_assistant_id, _ = add_sessions_with_chat_assistant_func
-        res = update_session_with_chat_assistant(api_key, chat_assistant_id, session_id, {"name": "valid_name"})
+        res = update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_id, {"name": "valid_name"})
         assert res["code"] == expected_code
         assert res["message"] == expected_message
 
     @pytest.mark.p3
-    def test_repeated_update_session(self, api_key, add_sessions_with_chat_assistant_func):
+    def test_repeated_update_session(self, HttpApiAuth, add_sessions_with_chat_assistant_func):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
-        res = update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], {"name": "valid_name_1"})
+        res = update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], {"name": "valid_name_1"})
         assert res["code"] == 0
 
-        res = update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], {"name": "valid_name_2"})
+        res = update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], {"name": "valid_name_2"})
         assert res["code"] == 0
 
     @pytest.mark.p3
@@ -113,15 +113,15 @@ class TestSessionWithChatAssistantUpdate:
             pytest.param(None, 100, "TypeError", marks=pytest.mark.skip),
         ],
     )
-    def test_invalid_params(self, api_key, add_sessions_with_chat_assistant_func, payload, expected_code, expected_message):
+    def test_invalid_params(self, HttpApiAuth, add_sessions_with_chat_assistant_func, payload, expected_code, expected_message):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
-        res = update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], payload)
+        res = update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], payload)
         assert res["code"] == expected_code
         if expected_code != 0:
             assert expected_message in res["message"]
 
     @pytest.mark.p3
-    def test_concurrent_update_session(self, api_key, add_sessions_with_chat_assistant_func):
+    def test_concurrent_update_session(self, HttpApiAuth, add_sessions_with_chat_assistant_func):
         count = 50
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
 
@@ -129,7 +129,7 @@ class TestSessionWithChatAssistantUpdate:
             futures = [
                 executor.submit(
                     update_session_with_chat_assistant,
-                    api_key,
+                    HttpApiAuth,
                     chat_assistant_id,
                     session_ids[randint(0, 4)],
                     {"name": f"update session test {i}"},
@@ -141,9 +141,9 @@ class TestSessionWithChatAssistantUpdate:
         assert all(future.result()["code"] == 0 for future in futures)
 
     @pytest.mark.p3
-    def test_update_session_to_deleted_chat_assistant(self, api_key, add_sessions_with_chat_assistant_func):
+    def test_update_session_to_deleted_chat_assistant(self, HttpApiAuth, add_sessions_with_chat_assistant_func):
         chat_assistant_id, session_ids = add_sessions_with_chat_assistant_func
-        delete_chat_assistants(api_key, {"ids": [chat_assistant_id]})
-        res = update_session_with_chat_assistant(api_key, chat_assistant_id, session_ids[0], {"name": "valid_name"})
+        delete_chat_assistants(HttpApiAuth, {"ids": [chat_assistant_id]})
+        res = update_session_with_chat_assistant(HttpApiAuth, chat_assistant_id, session_ids[0], {"name": "valid_name"})
         assert res["code"] == 102
         assert res["message"] == "You do not own the session"


### PR DESCRIPTION
### What problem does this PR solve?

- Rename `api_key` fixture to `HttpApiAuth` across all test files
- Update all dependent fixtures and test cases to use new naming
- Maintain same functionality while improving naming clarity

The rename better reflects the fixture's purpose as an HTTP API authentication helper rather than just an API key.

### Type of change

- [x] Refactoring

