### PR TITLE
Fix: Use lazy variable resolving to support envs like Swarm where nginx may not init properly at startup

### DIFF
--- a/docker/nginx/ragflow.conf
+++ b/docker/nginx/ragflow.conf
@@ -3,6 +3,8 @@ server {
     server_name _;
     root /ragflow/web/dist;
 
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
     gzip on;
     gzip_min_length 1k;
     gzip_comp_level 9;
@@ -11,7 +13,8 @@ server {
     gzip_disable "MSIE [1-6]\.";
 
     location ~ ^/(v1|api) {
-        proxy_pass http://ragflow:9380;
+        set $upstream ragflow:9380;
+        proxy_pass http://$upstream;
         include proxy.conf;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

When starting the ragflow image in a Swarm cluster, the corresponding Swarm service `ragflow` may not be created immediately. In such cases, `proxy_pass http://ragflow:9380;` can lead to a fatal error due to unresolved DNS.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
