### PR TITLE
Fix: Add pagerank validation for non-elasticsearch doc engines

### DIFF
--- a/api/apps/kb_app.py
+++ b/api/apps/kb_app.py
@@ -124,6 +124,9 @@ def update():
             return get_data_error_result()
 
         if kb.pagerank != req.get("pagerank", 0):
+            if os.environ.get("DOC_ENGINE", "elasticsearch") != "elasticsearch":
+                return get_data_error_result(message="'pagerank' can only be set when doc_engine is elasticsearch")
+            
             if req.get("pagerank", 0) > 0:
                 settings.docStoreConn.update({"kb_id": kb.id}, {PAGERANK_FLD: req["pagerank"]},
                                          search.index_name(kb.tenant_id), kb.id)


### PR DESCRIPTION
### What problem does this PR solve?

Validate that pagerank updates are only allowed when using elasticsearch as the document engine. Return an error if pagerank is set while using a different doc engine, preventing potential inconsistencies in document scoring.

#8208

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)