### PR TITLE
Fix: Move pagerank field from create to update dataset API

### DIFF
--- a/api/utils/validation_utils.py
+++ b/api/utils/validation_utils.py
@@ -383,7 +383,6 @@ class CreateDatasetReq(Base):
     embedding_model: Annotated[str, StringConstraints(strip_whitespace=True, max_length=255), Field(default="", serialization_alias="embd_id")]
     permission: PermissionEnum = Field(default=PermissionEnum.me, min_length=1, max_length=16)
     chunk_method: ChunkMethodnEnum = Field(default=ChunkMethodnEnum.naive, min_length=1, max_length=32, serialization_alias="parser_id")
-    pagerank: int = Field(default=0, ge=0, le=100)
     parser_config: ParserConfig | None = Field(default=None)
 
     @field_validator("avatar")
@@ -539,6 +538,7 @@ class CreateDatasetReq(Base):
 class UpdateDatasetReq(CreateDatasetReq):
     dataset_id: str = Field(...)
     name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=DATASET_NAME_LIMIT), Field(default="")]
+    pagerank: int = Field(default=0, ge=0, le=100)
 
     @field_validator("dataset_id", mode="before")
     @classmethod

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -343,7 +343,6 @@ Creates a dataset.
   - `"embedding_model"`: `string`
   - `"permission"`: `string`
   - `"chunk_method"`: `string`
-  - `"pagerank"`: `int`
   - `"parser_config"`: `object`
 
 ##### Request example
@@ -383,12 +382,6 @@ curl --request POST \
   Specifies who can access the dataset to create. Available options:  
   - `"me"`: (Default) Only you can manage the dataset.
   - `"team"`: All team members can manage the dataset.
-
-- `"pagerank"`: (*Body parameter*), `int`  
-  refer to [Set page rank](https://ragflow.io/docs/dev/set_page_rank)
-  - Default: `0`
-  - Minimum: `0`
-  - Maximum: `100`
 
 - `"chunk_method"`: (*Body parameter*), `enum<string>`  
   The chunking method of the dataset to create. Available options:  

--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -100,7 +100,6 @@ RAGFlow.create_dataset(
     embedding_model: Optional[str] = "BAAI/bge-large-zh-v1.5@BAAI",
     permission: str = "me", 
     chunk_method: str = "naive",
-    pagerank: int = 0,
     parser_config: DataSet.ParserConfig = None
 ) -> DataSet
 ```
@@ -147,10 +146,6 @@ The chunking method of the dataset to create. Available options:
 - `"picture"`: Picture
 - `"one"`: One
 - `"email"`: Email
-
-##### pagerank, `int`
-
-The pagerank of the dataset to create. Defaults to `0`.
 
 ##### parser_config
 

--- a/sdk/python/ragflow_sdk/ragflow.py
+++ b/sdk/python/ragflow_sdk/ragflow.py
@@ -56,7 +56,6 @@ class RAGFlow:
         embedding_model: Optional[str] = "BAAI/bge-large-zh-v1.5@BAAI",
         permission: str = "me",
         chunk_method: str = "naive",
-        pagerank: int = 0,
         parser_config: Optional[DataSet.ParserConfig] = None,
     ) -> DataSet:
         payload = {
@@ -66,7 +65,6 @@ class RAGFlow:
             "embedding_model": embedding_model,
             "permission": permission,
             "chunk_method": chunk_method,
-            "pagerank": pagerank,
         }
         if parser_config is not None:
             payload["parser_config"] = parser_config.to_json()

--- a/test/testcases/test_http_api/test_dataset_mangement/test_create_dataset.py
+++ b/test/testcases/test_http_api/test_dataset_mangement/test_create_dataset.py
@@ -394,51 +394,6 @@ class TestDatasetCreate:
         assert res["code"] == 101, res
         assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table' or 'tag'" in res["message"], res
 
-    @pytest.mark.p2
-    @pytest.mark.parametrize(
-        "name, pagerank",
-        [
-            ("pagerank_min", 0),
-            ("pagerank_mid", 50),
-            ("pagerank_max", 100),
-        ],
-        ids=["min", "mid", "max"],
-    )
-    def test_pagerank(self, HttpApiAuth, name, pagerank):
-        payload = {"name": name, "pagerank": pagerank}
-        res = create_dataset(HttpApiAuth, payload)
-        assert res["code"] == 0, res
-        assert res["data"]["pagerank"] == pagerank, res
-
-    @pytest.mark.p3
-    @pytest.mark.parametrize(
-        "name, pagerank, expected_message",
-        [
-            ("pagerank_min_limit", -1, "Input should be greater than or equal to 0"),
-            ("pagerank_max_limit", 101, "Input should be less than or equal to 100"),
-        ],
-        ids=["min_limit", "max_limit"],
-    )
-    def test_pagerank_invalid(self, HttpApiAuth, name, pagerank, expected_message):
-        payload = {"name": name, "pagerank": pagerank}
-        res = create_dataset(HttpApiAuth, payload)
-        assert res["code"] == 101, res
-        assert expected_message in res["message"], res
-
-    @pytest.mark.p3
-    def test_pagerank_unset(self, HttpApiAuth):
-        payload = {"name": "pagerank_unset"}
-        res = create_dataset(HttpApiAuth, payload)
-        assert res["code"] == 0, res
-        assert res["data"]["pagerank"] == 0, res
-
-    @pytest.mark.p3
-    def test_pagerank_none(self, HttpApiAuth):
-        payload = {"name": "pagerank_unset", "pagerank": None}
-        res = create_dataset(HttpApiAuth, payload)
-        assert res["code"] == 101, res
-        assert "Input should be a valid integer" in res["message"], res
-
     @pytest.mark.p1
     @pytest.mark.parametrize(
         "name, parser_config",
@@ -730,6 +685,7 @@ class TestDatasetCreate:
             {"name": "chunk_count", "chunk_count": 1},
             {"name": "token_num", "token_num": 1},
             {"name": "status", "status": "1"},
+            {"name": "pagerank", "pagerank": 50},
             {"name": "unknown_field", "unknown_field": "unknown_field"},
         ],
     )

--- a/test/testcases/test_sdk_api/test_dataset_mangement/test_create_dataset.py
+++ b/test/testcases/test_sdk_api/test_dataset_mangement/test_create_dataset.py
@@ -344,49 +344,6 @@ class TestDatasetCreate:
             client.create_dataset(**payload)
         assert "not instance of" in str(excinfo.value), str(excinfo.value)
 
-    @pytest.mark.p2
-    @pytest.mark.parametrize(
-        "name, pagerank",
-        [
-            ("pagerank_min", 0),
-            ("pagerank_mid", 50),
-            ("pagerank_max", 100),
-        ],
-        ids=["min", "mid", "max"],
-    )
-    def test_pagerank(self, client, name, pagerank):
-        payload = {"name": name, "pagerank": pagerank}
-        dataset = client.create_dataset(**payload)
-        assert dataset.pagerank == pagerank, str(dataset)
-
-    @pytest.mark.p3
-    @pytest.mark.parametrize(
-        "name, pagerank, expected_message",
-        [
-            ("pagerank_min_limit", -1, "Input should be greater than or equal to 0"),
-            ("pagerank_max_limit", 101, "Input should be less than or equal to 100"),
-        ],
-        ids=["min_limit", "max_limit"],
-    )
-    def test_pagerank_invalid(self, client, name, pagerank, expected_message):
-        payload = {"name": name, "pagerank": pagerank}
-        with pytest.raises(Exception) as excinfo:
-            client.create_dataset(**payload)
-        assert expected_message in str(excinfo.value), str(excinfo.value)
-
-    @pytest.mark.p3
-    def test_pagerank_unset(self, client):
-        payload = {"name": "pagerank_unset"}
-        dataset = client.create_dataset(**payload)
-        assert dataset.pagerank == 0, str(dataset)
-
-    @pytest.mark.p3
-    def test_pagerank_none(self, client):
-        payload = {"name": "pagerank_unset", "pagerank": None}
-        with pytest.raises(Exception) as excinfo:
-            client.create_dataset(**payload)
-        assert "not instance of" in str(excinfo.value), str(excinfo.value)
-
     @pytest.mark.p1
     @pytest.mark.parametrize(
         "name, parser_config",
@@ -689,6 +646,7 @@ class TestDatasetCreate:
             {"name": "chunk_count", "chunk_count": 1},
             {"name": "token_num", "token_num": 1},
             {"name": "status", "status": "1"},
+            {"name": "pagerank", "pagerank": 50},
             {"name": "unknown_field", "unknown_field": "unknown_field"},
         ],
     )


### PR DESCRIPTION
### What problem does this PR solve?

- Remove pagerank from CreateDatasetReq and add to UpdateDatasetReq
- Add pagerank update logic in dataset update endpoint
- Update API documentation to reflect changes
- Modify related test cases and SDK references

#8208

This change makes pagerank a mutable property that can only be set after dataset creation, and only when using elasticsearch as the doc engine.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
