### PR TITLE
Fix: unify opendal config key from ‎`schema` to ‎`scheme`

### DIFF
--- a/conf/service_conf.yaml
+++ b/conf/service_conf.yaml
@@ -29,7 +29,6 @@ redis:
   db: 1
   password: 'infini_rag_flow'
   host: 'localhost:6379'
-
 # postgres:
 #   name: 'rag_flow'
 #   user: 'rag_flow'
@@ -61,7 +60,7 @@ redis:
 #   container_name: 'container_name'
 # The OSS object storage uses the MySQL configuration above by default. If you need to switch to another object storage service, please uncomment and configure the following parameters.
 # opendal:
-#   schema: 'mysql'  # Storage type, such as s3, oss, azure, etc.
+#   scheme: 'mysql'  # Storage type, such as s3, oss, azure, etc.
 #   config:
 #     oss_table: 'your_table_name'
 # user_default_llm:

--- a/rag/utils/opendal_conn.py
+++ b/rag/utils/opendal_conn.py
@@ -27,10 +27,10 @@ def get_opendal_config_from_yaml(yaml_path=SERVICE_CONF_PATH):
 
         opendal_config = config.get('opendal', {})
         kwargs = {}
-        if opendal_config.get("schema") == 'mysql':
+        if opendal_config.get("scheme") == 'mysql':
             mysql_config = config.get('mysql', {})
             kwargs = {
-                "schema": "mysql",
+                "scheme": "mysql",
                 "host": mysql_config.get("host", "127.0.0.1"),
                 "port": str(mysql_config.get("port", 3306)),
                 "user": mysql_config.get("user", "root"),
@@ -40,9 +40,9 @@ def get_opendal_config_from_yaml(yaml_path=SERVICE_CONF_PATH):
             }
             kwargs["connection_string"] = f"mysql://{kwargs['user']}:{kwargs['password']}@{kwargs['host']}:{kwargs['port']}/{kwargs['database']}"
         else:
-            schema = opendal_config.get("schema")
+            scheme = opendal_config.get("scheme")
             config_data = opendal_config.get("config", {})
-            kwargs = {"schema": schema, **config_data}
+            kwargs = {"scheme": scheme, **config_data}
         logging.info("Loaded OpenDAL configuration from yaml: %s", kwargs)
         return kwargs
     except Exception as e:
@@ -54,11 +54,11 @@ def get_opendal_config_from_yaml(yaml_path=SERVICE_CONF_PATH):
 class OpenDALStorage:
     def __init__(self):
         self._kwargs = get_opendal_config_from_yaml()
-        self._schema = self._kwargs.get('schema', 'mysql')
-        if self._schema == 'mysql':
+        self._scheme = self._kwargs.get('scheme', 'mysql')
+        if self._scheme == 'mysql':
             self.init_db_config()
             self.init_opendal_mysql_table()
-        self._operator = opendal.Operator(self._schema, **self._kwargs)
+        self._operator = opendal.Operator(self._scheme, **self._kwargs)
 
         logging.info("OpenDALStorage initialized successfully")
 


### PR DESCRIPTION
### What problem does this PR solve?

This PR resolves the inconsistency in the opendal configuration where both ‎`schema` and ‎`scheme` were used as keys. The code and configuration file now consistently use ‎`scheme`, which helps prevent configuration errors and runtime issues. This change improves code clarity and maintainability.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Additional context
- Updated both ‎`conf/service_conf.yaml` and ‎`rag/utils/opendal_conn.py` to use ‎`scheme` instead of ‎`schema`
- No breaking changes to other configuration fields