### PR TITLE
refactor: move settings to the separate connection classes

### DIFF
--- a/api/db/services/user_service.py
+++ b/api/db/services/user_service.py
@@ -26,7 +26,6 @@ from api.db.db_models import User, Tenant
 from api.db.services.common_service import CommonService
 from api.utils import get_uuid, current_timestamp, datetime_format
 from api.db import StatusEnum
-from rag.settings import MINIO
 
 
 class UserService(CommonService):
@@ -190,7 +189,7 @@ class TenantService(CommonService):
     @DB.connection_context()
     def user_gateway(cls, tenant_id):
         hashobj = hashlib.sha256(tenant_id.encode("utf-8"))
-        return int(hashobj.hexdigest(), 16)%len(MINIO)
+        return int(hashobj.hexdigest(), 16)%3
 
 
 class UserTenantService(CommonService):

--- a/rag/settings.py
+++ b/rag/settings.py
@@ -13,48 +13,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-import os
 import logging
-from api.utils import get_base_config, decrypt_database_config
-from api.utils.file_utils import get_project_base_directory
+import os
 
-# Server
-RAG_CONF_PATH = os.path.join(get_project_base_directory(), "conf")
-
-# Get storage type and document engine from system environment variables
-STORAGE_IMPL_TYPE = os.getenv('STORAGE_IMPL', 'MINIO')
-DOC_ENGINE = os.getenv('DOC_ENGINE', 'elasticsearch')
-
-ES = {}
-INFINITY = {}
-AZURE = {}
-S3 = {}
-MINIO = {}
-OSS = {}
-OS = {}
-
-# Initialize the selected configuration data based on environment variables to solve the problem of initialization errors due to lack of configuration
-if DOC_ENGINE == 'elasticsearch':
-    ES = get_base_config("es", {})
-elif DOC_ENGINE == 'opensearch':
-    OS = get_base_config("os", {})
-elif DOC_ENGINE == 'infinity':
-    INFINITY = get_base_config("infinity", {"uri": "infinity:23817"})
-
-if STORAGE_IMPL_TYPE in ['AZURE_SPN', 'AZURE_SAS']:
-    AZURE = get_base_config("azure", {})
-elif STORAGE_IMPL_TYPE == 'AWS_S3':
-    S3 = get_base_config("s3", {})
-elif STORAGE_IMPL_TYPE == 'MINIO':
-    MINIO = decrypt_database_config(name="minio")
-elif STORAGE_IMPL_TYPE == 'OSS':
-    OSS = get_base_config("oss", {})
-
-try:
-    REDIS = decrypt_database_config(name="redis")
-except Exception:
-    REDIS = {}
-    pass
 DOC_MAXIMUM_SIZE = int(os.environ.get("MAX_CONTENT_LENGTH", 128 * 1024 * 1024))
 DOC_BULK_SIZE = int(os.environ.get("DOC_BULK_SIZE", 4))
 EMBEDDING_BATCH_SIZE = int(os.environ.get("EMBEDDING_BATCH_SIZE", 16))

--- a/rag/utils/azure_sas_conn.py
+++ b/rag/utils/azure_sas_conn.py
@@ -18,17 +18,20 @@ import logging
 import os
 import time
 from io import BytesIO
-from rag import settings
-from rag.utils import singleton
+
 from azure.storage.blob import ContainerClient
+
+from api.utils import get_base_config
+from rag.utils import singleton
 
 
 @singleton
 class RAGFlowAzureSasBlob:
     def __init__(self):
         self.conn = None
-        self.container_url = os.getenv('CONTAINER_URL', settings.AZURE["container_url"])
-        self.sas_token = os.getenv('SAS_TOKEN', settings.AZURE["sas_token"])
+        config = get_base_config("azure", {})
+        self.container_url = os.getenv('CONTAINER_URL', config["container_url"])
+        self.sas_token = os.getenv('SAS_TOKEN', config["sas_token"])
         self.__open__()
 
     def __open__(self):

--- a/rag/utils/azure_spn_conn.py
+++ b/rag/utils/azure_spn_conn.py
@@ -17,21 +17,24 @@
 import logging
 import os
 import time
-from rag import settings
-from rag.utils import singleton
+
 from azure.identity import ClientSecretCredential, AzureAuthorityHosts
 from azure.storage.filedatalake import FileSystemClient
+
+from api.utils import get_base_config
+from rag.utils import singleton
 
 
 @singleton
 class RAGFlowAzureSpnBlob:
     def __init__(self):
         self.conn = None
-        self.account_url = os.getenv('ACCOUNT_URL', settings.AZURE["account_url"])
-        self.client_id = os.getenv('CLIENT_ID', settings.AZURE["client_id"])
-        self.secret = os.getenv('SECRET', settings.AZURE["secret"])
-        self.tenant_id = os.getenv('TENANT_ID', settings.AZURE["tenant_id"])
-        self.container_name = os.getenv('CONTAINER_NAME', settings.AZURE["container_name"])
+        config = get_base_config("azure", {})
+        self.account_url = os.getenv('ACCOUNT_URL', config["account_url"])
+        self.client_id = os.getenv('CLIENT_ID', config["client_id"])
+        self.secret = os.getenv('SECRET', config["secret"])
+        self.tenant_id = os.getenv('TENANT_ID', config["tenant_id"])
+        self.container_name = os.getenv('CONTAINER_NAME', config["container_name"])
         self.__open__()
 
     def __open__(self):

--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -14,23 +14,24 @@
 #  limitations under the License.
 #
 
+import copy
+import json
 import logging
 import os
 import re
-import json
 import time
-import copy
+
 import infinity
+import pandas as pd
 from infinity.common import ConflictType, InfinityException, SortType
-from infinity.index import IndexInfo, IndexType
 from infinity.connection_pool import ConnectionPool
 from infinity.errors import ErrorCode
-from rag import settings
+from infinity.index import IndexInfo, IndexType
+
+from api.utils import get_base_config
+from api.utils.file_utils import get_project_base_directory
 from rag.settings import PAGERANK_FLD
 from rag.utils import singleton
-import pandas as pd
-from api.utils.file_utils import get_project_base_directory
-
 from rag.utils.doc_store_conn import (
     DocStoreConnection,
     MatchExpr,
@@ -127,8 +128,9 @@ def concat_dataframes(df_list: list[pd.DataFrame], selectFields: list[str]) -> p
 @singleton
 class InfinityConnection(DocStoreConnection):
     def __init__(self):
-        self.dbName = settings.INFINITY.get("db_name", "default_db")
-        infinity_uri = settings.INFINITY["uri"]
+        config = get_base_config("infinity", {"uri": "infinity:23817"})
+        self.dbName = config.get("db_name", "default_db")
+        infinity_uri = config["uri"]
         if ":" in infinity_uri:
             host, port = infinity_uri.split(":")
             infinity_uri = infinity.common.NetworkAddress(host, int(port))

--- a/rag/utils/minio_conn.py
+++ b/rag/utils/minio_conn.py
@@ -16,10 +16,12 @@
 
 import logging
 import time
+from io import BytesIO
+
 from minio import Minio
 from minio.error import S3Error
-from io import BytesIO
-from rag import settings
+
+from api.utils import decrypt_database_config
 from rag.utils import singleton
 
 
@@ -36,15 +38,16 @@ class RAGFlowMinio:
         except Exception:
             pass
 
+        config = decrypt_database_config(name="minio")
+
         try:
-            self.conn = Minio(settings.MINIO["host"],
-                              access_key=settings.MINIO["user"],
-                              secret_key=settings.MINIO["password"],
+            self.conn = Minio(config["host"],
+                              access_key=config["user"],
+                              secret_key=config["password"],
                               secure=False
                               )
         except Exception:
-            logging.exception(
-                "Fail to connect %s " % settings.MINIO["host"])
+            logging.exception("Fail to connect %s " % config["host"])
 
     def __close__(self):
         del self.conn

--- a/rag/utils/opensearch_conn.py
+++ b/rag/utils/opensearch_conn.py
@@ -14,23 +14,24 @@
 #  limitations under the License.
 #
 
-import logging
-import re
-import json
-import time
-import os
-
 import copy
+import json
+import logging
+import os
+import re
+import time
+
+from opensearchpy import ConnectionTimeout
 from opensearchpy import OpenSearch, NotFoundError
 from opensearchpy import UpdateByQuery, Q, Search, Index
-from opensearchpy import ConnectionTimeout
-from rag import settings
+
+from api.utils import get_base_config
+from api.utils.file_utils import get_project_base_directory
+from rag.nlp import is_english, rag_tokenizer
 from rag.settings import TAG_FLD, PAGERANK_FLD
 from rag.utils import singleton
-from api.utils.file_utils import get_project_base_directory
 from rag.utils.doc_store_conn import DocStoreConnection, MatchExpr, OrderByExpr, MatchTextExpr, MatchDenseExpr, \
     FusionExpr
-from rag.nlp import is_english, rag_tokenizer
 
 ATTEMPT_TIME = 2
 
@@ -41,13 +42,14 @@ logger = logging.getLogger('ragflow.opensearch_conn')
 class OSConnection(DocStoreConnection):
     def __init__(self):
         self.info = {}
-        logger.info(f"Use OpenSearch {settings.OS['hosts']} as the doc engine.")
+        config = get_base_config("os", {})
+        logger.info(f"Use OpenSearch {config['hosts']} as the doc engine.")
         for _ in range(ATTEMPT_TIME):
             try:
                 self.os = OpenSearch(
-                    settings.OS["hosts"].split(","),
-                    http_auth=(settings.OS["username"], settings.OS[
-                        "password"]) if "username" in settings.OS and "password" in settings.OS else None,
+                    config["hosts"].split(","),
+                    http_auth=(config["username"], config[
+                        "password"]) if "username" in config and "password" in config else None,
                     verify_certs=False,
                     timeout=600
                 )
@@ -55,10 +57,10 @@ class OSConnection(DocStoreConnection):
                     self.info = self.os.info()
                     break
             except Exception as e:
-                logger.warning(f"{str(e)}. Waiting OpenSearch {settings.OS['hosts']} to be healthy.")
+                logger.warning(f"{str(e)}. Waiting OpenSearch {config['hosts']} to be healthy.")
                 time.sleep(5)
         if not self.os.ping():
-            msg = f"OpenSearch {settings.OS['hosts']} is unhealthy in 120s."
+            msg = f"OpenSearch {config['hosts']} is unhealthy in 120s."
             logger.error(msg)
             raise Exception(msg)
         v = self.info.get("version", {"number": "2.18.0"})
@@ -73,7 +75,7 @@ class OSConnection(DocStoreConnection):
             logger.error(msg)
             raise Exception(msg)
         self.mapping = json.load(open(fp_mapping, "r"))
-        logger.info(f"OpenSearch {settings.OS['hosts']} is healthy.")
+        logger.info(f"OpenSearch {config['hosts']} is healthy.")
 
     """
     Database operations

--- a/rag/utils/oss_conn.py
+++ b/rag/utils/oss_conn.py
@@ -14,20 +14,22 @@
 #  limitations under the License.
 
 import logging
-import boto3
-from botocore.exceptions import ClientError
-from botocore.config import Config
 import time
 from io import BytesIO
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from api.utils import get_base_config
 from rag.utils import singleton
-from rag import settings
 
 
 @singleton
 class RAGFlowOSS:
     def __init__(self):
         self.conn = None
-        self.oss_config = settings.OSS
+        self.oss_config = get_base_config("oss", {})
         self.access_key = self.oss_config.get('access_key', None)
         self.secret_key = self.oss_config.get('secret_key', None)
         self.endpoint_url = self.oss_config.get('endpoint_url', None)

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -14,15 +14,17 @@
 #  limitations under the License.
 #
 
-import logging
 import json
+import logging
 import uuid
 
-import valkey as redis
-from rag import settings
-from rag.utils import singleton
-from valkey.lock import Lock
 import trio
+import valkey as redis
+from valkey.lock import Lock
+
+from api.utils import decrypt_database_config
+from rag.utils import singleton
+
 
 class RedisMsg:
     def __init__(self, consumer, queue_name, group_name, msg_id, message):
@@ -61,7 +63,7 @@ class RedisDB:
 
     def __init__(self):
         self.REDIS = None
-        self.config = settings.REDIS
+        self.config = decrypt_database_config(name="redis")
         self.__open__()
 
     def register_scripts(self) -> None:

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -15,19 +15,22 @@
 #
 
 import logging
-import boto3
-from botocore.exceptions import ClientError
-from botocore.config import Config
 import time
 from io import BytesIO
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from api.utils import get_base_config
 from rag.utils import singleton
-from rag import settings
+
 
 @singleton
 class RAGFlowS3:
     def __init__(self):
         self.conn = None
-        self.s3_config = settings.S3
+        self.s3_config = get_base_config("s3", {})
         self.access_key = self.s3_config.get('access_key', None)
         self.secret_key = self.s3_config.get('secret_key', None)
         self.region = self.s3_config.get('region', None)


### PR DESCRIPTION
### What problem does this PR solve?

Now the database is started at `api/settings.py`, but the configuration loading is in `rag/settings.py`, so there are two branch judgment logic. In this PR, I moved the configuration loading step to the init method of each connection class.


### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
