### PR TITLE
fix(search.py):remove hard page_size

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -380,15 +380,14 @@ class Dealer:
                 rank_feature=rank_feature)
         # Already paginated in search function
         idx = np.argsort(sim * -1)[(page - 1) * page_size:page * page_size]
-            
         dim = len(sres.query_vector)
         vector_column = f"q_{dim}_vec"
         zero_vector = [0.0] * dim
         sim_np = np.array(sim)
+        if doc_ids:
+            similarity_threshold = 0 
         filtered_count = (sim_np >= similarity_threshold).sum()    
         ranks["total"] = int(filtered_count) # Convert from np.int64 to Python int otherwise JSON serializable error
-        if doc_ids:
-            similarity_threshold = 0
         for i in idx:
             if sim[i] < similarity_threshold:
                 break


### PR DESCRIPTION
### What problem does this PR solve?

Fix the restriction of forcing similarity_threshold=0 and page_size=30 when doc_ids is not empty

#8228
