### PR TITLE
Refa: revert to original task message collection logic

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -21,8 +21,6 @@ import sys
 import threading
 import time
 
-from valkey import RedisError
-
 from api.utils.log_utils import initRootLogger, get_project_base_directory
 from graphrag.general.index import run_graphrag
 from graphrag.utils import get_llm_cache, set_llm_cache, get_tags_from_cache, set_tags_to_cache


### PR DESCRIPTION
### What problem does this PR solve?

Get rid of 'RedisDB.get_unacked_iterator queue rag_flow_svr_queue_1 doesn't exist'

----

Edit: revert to original message collection logic.

### Type of change

- [x] Refactoring