### PR TITLE
Fix: opendal storage health attribute not found & remove duplicate operator scheme initialization

### DIFF
--- a/rag/utils/opendal_conn.py
+++ b/rag/utils/opendal_conn.py
@@ -58,9 +58,14 @@ class OpenDALStorage:
         if self._scheme == 'mysql':
             self.init_db_config()
             self.init_opendal_mysql_table()
-        self._operator = opendal.Operator(self._scheme, **self._kwargs)
+        self._operator = opendal.Operator(**self._kwargs)
 
         logging.info("OpenDALStorage initialized successfully")
+
+    def health(self):
+        bucket, fnm, binary = "txtxtxtxt1", "txtxtxtxt1", b"_t@@@1"
+        r = self._operator.write(f"{bucket}/{fnm}", binary)
+        return r
 
     def put(self, bucket, fnm, binary):
         self._operator.write(f"{bucket}/{fnm}", binary)


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes two issues in the OpenDAL storage connector:
 1. The ‎`health` method was missing, which prevented health checks on the storage backend.
 3. The initialization of the ‎`opendal.Operator` object included a redundant scheme parameter, causing unnecessary duplication and potential confusion.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

### Background
- The absence of a ‎`health` method made it difficult to verify the availability and reliability of the storage service.
- Initializing ‎`opendal.Operator` with both ‎`self._scheme` and unpacked ‎`**self._kwargs` could lead to errors or unexpected behavior if the scheme was already included in the kwargs.

### What is changed and how it works?
- Adds a ‎`health` method that writes a test file to verify storage availability.
- Removes the duplicate scheme parameter from the ‎`opendal.Operator` initialization to ensure clarity and prevent conflicts.

before:
<img width="762" alt="企业微信截图_46be646f-2e99-4e5e-be67-b1483426e77c" src="https://github.com/user-attachments/assets/acecbb8c-4810-457f-8342-6355148551ba" />
<img width="767" alt="image" src="https://github.com/user-attachments/assets/147cd5a2-dde3-466b-a9c1-d1d4f0819e5d" />

after:
<img width="1123" alt="企业微信截图_09d62997-8908-4985-b89f-7a78b5da55ac" src="https://github.com/user-attachments/assets/97dc88c9-0f4e-4d77-88b3-cd818e8da046" />
