### PR TITLE
Feat: add authorization header for MCP server based on OAuth 2.1

### DIFF
--- a/mcp/client/client.py
+++ b/mcp/client/client.py
@@ -23,6 +23,9 @@ async def main():
     try:
         # To access RAGFlow server in `host` mode, you need to attach `api_key` for each request to indicate identification.
         # async with sse_client("http://localhost:9382/sse", headers={"api_key": "ragflow-IyMGI1ZDhjMTA2ZTExZjBiYTMyMGQ4Zm"}) as streams:
+        # Or follow the requirements of OAuth 2.1 Section 5 with Authorization header
+        # async with sse_client("http://localhost:9382/sse", headers={"Authorization": "Bearer ragflow-IyMGI1ZDhjMTA2ZTExZjBiYTMyMGQ4Zm"}) as streams:
+
         async with sse_client("http://localhost:9382/sse") as streams:
             async with ClientSession(
                 streams[0],


### PR DESCRIPTION
### What problem does this PR solve?

Add authorization header for MCP server based on [OAuth 2.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-5).

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
