### PR TITLE
fix: create chunk with random uuid, no increase count num if index error

### DIFF
--- a/graphrag/general/index.py
+++ b/graphrag/general/index.py
@@ -29,7 +29,6 @@ from graphrag.utils import (
     graph_merge,
     get_graph,
     set_graph,
-    chunk_id,
     does_graph_contains,
     tidy_graph,
     GraphChange,
@@ -179,7 +178,7 @@ async def generate_subgraph(
         "available_int": 0,
         "removed_kwd": "N",
     }
-    cid = chunk_id(chunk)
+    cid = get_uuid()
     await trio.to_thread.run_sync(
         lambda: settings.docStoreConn.delete(
             {"knowledge_graph_kwd": "subgraph", "source_id": doc_id}, search.index_name(tenant_id), kb_id

--- a/graphrag/utils.py
+++ b/graphrag/utils.py
@@ -297,10 +297,6 @@ def is_float_regex(value):
     return bool(re.match(r"^[-+]?[0-9]*\.?[0-9]+$", value))
 
 
-def chunk_id(chunk):
-    return xxhash.xxh64((chunk["content_with_weight"] + chunk["kb_id"]).encode("utf-8")).hexdigest()
-
-
 async def graph_node_to_chunk(kb_id, embd_mdl, ent_name, meta, chunks):
     chunk = {
         "id": get_uuid(),

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -22,6 +22,7 @@ import threading
 import time
 
 from api.utils.log_utils import initRootLogger, get_project_base_directory
+from api.utils.api_utils import get_uuid
 from graphrag.general.index import run_graphrag
 from graphrag.utils import get_llm_cache, set_llm_cache, get_tags_from_cache, set_tags_to_cache
 from rag.prompts import keyword_extraction, question_proposal, content_tagging
@@ -30,7 +31,6 @@ import logging
 import os
 from datetime import datetime
 import json
-import xxhash
 import copy
 import re
 from functools import partial
@@ -280,7 +280,7 @@ async def build_chunks(task, progress_callback):
         try:
             d = copy.deepcopy(document)
             d.update(chunk)
-            d["id"] = xxhash.xxh64((chunk["content_with_weight"] + str(d["doc_id"])).encode("utf-8")).hexdigest()
+            d["id"] = get_uuid()
             d["create_time"] = str(datetime.now()).replace("T", " ")[:19]
             d["create_timestamp_flt"] = datetime.now().timestamp()
             if not d.get("image"):
@@ -477,7 +477,7 @@ async def run_raptor(row, chat_mdl, embd_mdl, vector_size, callback=None):
     tk_count = 0
     for content, vctr in chunks[original_length:]:
         d = copy.deepcopy(doc)
-        d["id"] = xxhash.xxh64((content + str(d["doc_id"])).encode("utf-8")).hexdigest()
+        d["id"] = get_uuid()
         d["create_time"] = str(datetime.now()).replace("T", " ")[:19]
         d["create_timestamp_flt"] = datetime.now().timestamp()
         d[vctr_nm] = vctr.tolist()


### PR DESCRIPTION
### What problem does this PR solve?

Addresses issue by  https://github.com/infiniflow/ragflow/issues/7150#issuecomment-2976432979 , aligned with dify behavior:

1. no increase chunk count / token count if index error;
2. set chunk id with a random uuid rather than using the hash string (one issue here is that ragflow is using uuid1 rather than uuid4, open for discussion)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
