### PR TITLE
additional step to configure in macos docker-compose base.

### DIFF
--- a/docs/develop/build_docker_image.mdx
+++ b/docs/develop/build_docker_image.mdx
@@ -77,7 +77,7 @@ After building the infiniflow/ragflow:nightly-slim image, you are ready to launc
 
 1. Edit Docker Compose Configuration
 
-Open the `docker/.env` file. Find the `RAGFLOW_IMAGE` setting and change the image reference from `infiniflow/ragflow:v0.19.0-slim` to `infiniflow/ragflow:nightly-slim` to use the pre-built image.
+Open the `docker/.env` file. Find the `RAGFLOW_IMAGE` setting and change the image reference from `infiniflow/ragflow:v0.19.0-slim` to `infiniflow/ragflow:nightly-slim` to use the pre-built image. find the `SANDBOX_EXECUTOR_MANAGER_IMAGE` and remove comment 
 
 
 2. Launch the Service


### PR DESCRIPTION
### What problem does this PR solve?

While i setup RAGFLOW at my macbook arm processor didnt build docker for macos because an error about SANDBOX_EXECUTOR_MANAGER_IMAGE was not found. and just removed the comment at docker/.env and become to works.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [X] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
