### PR TITLE
fix: List Chunks API fails to return the correct document status.

### DIFF
--- a/rag/utils/es_conn.py
+++ b/rag/utils/es_conn.py
@@ -483,6 +483,9 @@ class ESConnection(DocStoreConnection):
                 if isinstance(v, list):
                     m[n] = v
                     continue
+                if n == "available_int" and isinstance(v, (int, float)):
+                    m[n] = v
+                    continue
                 if not isinstance(v, str):
                     m[n] = str(m[n])
                 # if n.find("tks") > 0:


### PR DESCRIPTION
### What problem does this PR solve?

The existing /api/v1/datasets/{dataset_id}/documents/{document_id}/chunks endpoint fails to accurately return a document's chunk status. Even when a chunk is explicitly marked as unavailable, the API still returns true.
![img_v3_02nc_3458a1b7-609e-4f20-8cb7-2156a489848g](https://github.com/user-attachments/assets/ab3b8f69-1284-49c1-8af3-bdfae3416583)
![img_v3_02nc_82f1d96e-7596-4def-ba75-5a2bd10d56cg](https://github.com/user-attachments/assets/a8a4162b-b50d-4dfc-af72-e1d7812a0a93)
