### PR TITLE
FIX:Saving an RGBA image directly as JPEG will cause an error. If the…

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -293,6 +293,9 @@ async def build_chunks(task, progress_callback):
             if isinstance(d["image"], bytes):
                 output_buffer = BytesIO(d["image"])
             else:
+                # If the image is in RGBA mode, convert it to RGB mode before saving it in JPEG format.
+                if d["image"].mode in ("RGBA", "P"):
+                    d["image"] = d["image"].convert("RGB")
                 d["image"].save(output_buffer, format='JPEG')
             async with minio_limiter:
                 await trio.to_thread.run_sync(lambda: STORAGE_IMPL.put(task["kb_id"], d["id"], output_buffer.getvalue()))


### PR DESCRIPTION
Saving an RGBA image directly as JPEG will cause an error. If the image is in RGBA mode, convert it to RGB mode before saving it in JPG format.

### What problem does this PR solve?

During document parsing in the knowledge base, we occasionally encounter the error 'cannot write mode RGBA as JPEG.' This occurs because images in RGBA mode cannot be directly saved as JPEG. They must be converted first before saving.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)
