### PR TITLE
fix a bug when using huggingface embedding api

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -871,14 +871,11 @@ class HuggingFaceEmbed(Base):
                 headers={'Content-Type': 'application/json'}
             )
             if response.status_code == 200:
-                try:
-                    embedding = response.json()
-                    embeddings.append(embedding[0])
-                    return np.array(embeddings), sum([num_tokens_from_string(text) for text in texts])
-                except Exception as _e:
-                    log_exception(_e, response)
+                embedding = response.json()
+                embeddings.append(embedding[0])
             else:
                 raise Exception(f"Error: {response.status_code} - {response.text}")
+        return np.array(embeddings), sum([num_tokens_from_string(text) for text in texts])
 
     def encode_queries(self, text):
         response = requests.post(
@@ -887,11 +884,8 @@ class HuggingFaceEmbed(Base):
             headers={'Content-Type': 'application/json'}
         )
         if response.status_code == 200:
-            try:
-                embedding = response.json()
-                return np.array(embedding[0]), num_tokens_from_string(text)
-            except Exception as _e:
-                log_exception(_e, response)
+            embedding = response.json()
+            return np.array(embedding[0]), num_tokens_from_string(text)
         else:
             raise Exception(f"Error: {response.status_code} - {response.text}")
 


### PR DESCRIPTION
### What problem does this PR solve?

image_version: v0.19.1
This PR fixes a bug in the HuggingFaceEmBedding API method that was causing AssertionError: assert len(vects) == len(docs) during the document embedding process.

#### Problem
The HuggingFaceEmbed.encode() method had an early return statement inside the for loop, causing it to return after processing only the first text input instead of processing all texts in the input list.

**Error Messenge**
```python
AssertionError: assert len(vects) == len(docs) # input chunks  != embedded  vectors from embedding api
File "/ragflow/rag/svr/task_executor.py", line 442, in embedding
```



**Buggy code(/ragflow/rag/llm/embedding_model.py)**
```python
class HuggingFaceEmbed(Base):
    def __init__(self, key, model_name, base_url=None):
        if not model_name:
            raise ValueError("Model name cannot be None")
        self.key = key
        self.model_name = model_name.split("___")[0]
        self.base_url = base_url or "http://127.0.0.1:8080"
        def encode(self, texts: list):
            embeddings = []
            for text in texts:
                response = requests.post(...)
                if response.status_code == 200:
                    try:
                        embedding = response.json()
                        embeddings.append(embedding[0])
                        # ❌ Early return
                        return np.array(embeddings), sum([num_tokens_from_string(text) for text in texts]) 
                    except Exception as _e:
                        log_exception(_e, response)
                else:
                    raise Exception(...)
```
**Fixed Code(I just Rollback this function to the v0.19.0 version)**
```python
Class HuggingFaceEmbed(Base):
    def __init__(self, key, model_name, base_url=None):
        if not model_name:
            raise ValueError("Model name cannot be None")
        self.key = key
        self.model_name = model_name.split("___")[0]
        self.base_url = base_url or "http://127.0.0.1:8080"
        def encode(self, texts: list):
            embeddings = []
            for text in texts:
                response = requests.post(...)
                if response.status_code == 200:
                    embedding = response.json()
                    embeddings.append(embedding[0])  # ✅ Only append, no return
                else:
                    raise Exception(...)
            return np.array(embeddings), sum([num_tokens_from_string(text) for text in texts])  # ✅ Return after processing all
```
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
