### PR TITLE
Fix: SSRF via canvas invoke component execution

### DIFF
--- a/agent/component/invoke.py
+++ b/agent/component/invoke.py
@@ -19,6 +19,7 @@ from abc import ABC
 import requests
 from deepdoc.parser import HtmlParser
 from agent.component.base import ComponentBase, ComponentParamBase
+from api.utils.web_utils import is_valid_url
 
 
 class InvokeParam(ComponentParamBase):
@@ -74,6 +75,9 @@ class Invoke(ComponentBase, ABC):
         url = self._param.url.strip()
         if url.find("http") != 0:
             url = "http://" + url
+
+        if not is_valid_url(url):
+            return Invoke.be_output("Invalid URL: Access to private networks is restricted")
 
         method = self._param.method.lower()
         headers = {}


### PR DESCRIPTION
### Description

There is a Server-Side Request Forgery (SSRF) vulnerability in the canvas execution engine that allows authenticated users to make arbitrary HTTP requests from the server. The vulnerability exists in the Invoke component implementation, which performs HTTP requests to user-controlled URLs without proper validation or filtering of internal network addresses.

While RAGFlow implements URL validation in other components like Crawler (using is_valid_url() function), the Invoke component bypasses these protections and directly passes user-supplied URLs to the Python requests library. This allows attackers to access internal services, cloud metadata endpoints, and perform network reconnaissance from the server's perspective.

The vulnerability can be triggered through the canvas workflow system, where malicious URL parameters embedded in canvas configurations are executed server-side during canvas completion requests.

### Source - Sink Analysis

**Source:** User-controlled `url` parameter in canvas DSL configuration

**Call Chain:**
1. `save()` function in `api/apps/canvas_app.py:58` processes canvas DSL via `/v1/canvas/set`
2. Canvas configuration stored in database with attacker-controlled URL
3. `run()` function in `api/apps/canvas_app.py:110` executes canvas via `/v1/canvas/completion`
4. `Canvas.run()` in `agent/canvas.py:144` processes canvas components
5. `Invoke._run()` in `agent/component/invoke.py:44` extracts URL parameter
6. **Sink:** `requests.get/post/put()` in `agent/component/invoke.py:75-90` makes HTTP request to attacker URL

### Proof of Concept - Canvas Configuration

**Setup target server:**
``` bash
python3 -m http.server 8888
```

**Canvas creation steps:**
1. Open http://localhost in browser and login
2. Navigate to Agent/Canvas section  
3. Create new canvas with Invoke component
4. Configure Invoke component:
   - URL: `http://{HOST_IP}:8888/ssrf-test`
   - Method: GET
   - Headers: `{"User-Agent": "SSRF-PoC"}`
5. Save and execute the canvas

**Expected result:**
HTTP server logs show: "GET /ssrf-test HTTP/1.1" 404 -
This confirms the Docker container made a server-side request to the target URL.

**Note:** 
This demonstrates one method of triggering the SSRF via the web interface. The vulnerability can also be exploited directly through API calls to `/v1/canvas/set` and `/v1/canvas/completion` endpoints.

### Impact
-  Bypass firewall restrictions to access internal services
-  Access AWS/GCP/Azure metadata endpoints for credential theft  
-  Enumerate internal network services and open ports
-  Retrieve internal API responses and configuration data
-  Interact with internal HTTP services, potentially triggering actions
- *Map internal network topology from server perspective

**Version**: 0.19.0
**Score**: 8.5 (High)
CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:L

cc: @KevinHuSh @asiroliu @cike8899