### PR TITLE
Fix: SSRF via LLM provider configuration

### DIFF
--- a/api/apps/llm_app.py
+++ b/api/apps/llm_app.py
@@ -25,6 +25,7 @@ from api.db import StatusEnum, LLMType
 from api.db.db_models import TenantLLM
 from api.utils.api_utils import get_json_result
 from api.utils.file_utils import get_project_base_directory
+from api.utils.web_utils import is_valid_url
 from rag.llm import EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel
 
 
@@ -55,6 +56,11 @@ def factories():
 @validate_request("llm_factory", "api_key")
 def set_api_key():
     req = request.json
+    
+    base_url = req.get("base_url")
+    if base_url and not is_valid_url(base_url):
+        return get_data_error_result(message="Invalid base URL: Access to private networks is restricted")
+    
     # test if api key works
     chat_passed, embd_passed, rerank_passed = False, False, False
     factory = req["llm_factory"]
@@ -137,6 +143,11 @@ def set_api_key():
 @validate_request("llm_factory")
 def add_llm():
     req = request.json
+    
+    api_base = req.get("api_base")
+    if api_base and not is_valid_url(api_base):
+        return get_data_error_result(message="Invalid base URL: Access to private networks is restricted")
+    
     factory = req["llm_factory"]
     api_key = req.get("api_key", "x")
     llm_name = req.get("llm_name")


### PR DESCRIPTION
### Description

RAGFlow contains a SSRF vulnerability in the LLM provider configuration system that allows authenticated users to make arbitrary HTTP requests from the server. The vulnerability exists in the `set_api_key` endpoint implementation, which performs HTTP requests to user-controlled URLs without proper validation or filtering of internal network addresses.

While RAGFlow implements URL validation in other components like Crawler (using is_valid_url() function), the LLM configuration endpoint bypasses these protections and directly passes user-supplied base URLs to various model clients. This allows attackers to access internal services, cloud metadata endpoints, and perform network reconnaissance from the server's perspective.

The vulnerability can be triggered through the model configuration interface, where malicious `base_url` parameters are used to test API connectivity during LLM provider setup.

### Source - Sink Analysis

**Source:** User-controlled `base_url` parameter in LLM configuration request

**Call Chain:**
1. `set_api_key()` function in `api/apps/llm_app.py:47` processes request via `/v1/llm/set_api_key`
2. `req.get("base_url")` extracts user-controlled URL without validation
3. Model instances created with attacker-controlled base_url:
   - `EmbeddingModel[factory](req["api_key"], llm.llm_name, base_url=req.get("base_url"))` at line 54
   - `ChatModel[factory](req["api_key"], llm.llm_name, base_url=req.get("base_url"))` at line 63  
   - `RerankModel[factory](req["api_key"], llm.llm_name, base_url=req.get("base_url"))` at line 72
4. Model constructors create HTTP clients using user-controlled base_url
5. API testing methods called: `mdl.encode()`, `mdl.chat()`, `mdl.similarity()`
6. **Sink:** HTTP requests made to attacker-controlled URLs via OpenAI client, requests library, and other HTTP clients in model implementations

### Proof of Concept

Setup target server:
```bash
python3 -m http.server 9999
```

**LLM configuration steps:**
1. Open http://localhost in browser and login
2. Navigate to User Settings → Model
3. Click "Add Model" 
4. Configure LLM provider:
   - LLM Factory: OpenAI
   - API Key: fake_key_123
   - API Base URL: http://host.docker.internal:9999 (or any other target server)
5. Click "Save" to trigger API testing

**Expected result:**
HTTP server logs show: "POST /chat/completions HTTP/1.1" 501 -
This confirms the Docker container made server-side requests to the target URL.

### Impact
- Bypass firewall restrictions to access internal services
- Access AWS/GCP/Azure metadata endpoints for credential theft
- Enumerate internal network services and open ports  
- Retrieve internal API responses disclosed in error messages
- Interact with internal HTTP services, potentially triggering actions
- Map internal network topology from server perspective

**Version**: 0.19.0
**Score**: 8.5 (High)
CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:L

cc: @KevinHuSh @asiroliu @cike8899