### PR TITLE
RAGFlow service_conf using .env  variable

### DIFF
--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -12,7 +12,7 @@ mysql:
 minio:
   user: '${MINIO_USER:-rag_flow}'
   password: '${MINIO_PASSWORD:-infini_rag_flow}'
-  host: '${MINIO_HOST:-minio}:9000'
+  host: '${MINIO_HOST:-minio}:${MINIO_PORT:-9000}'
 es:
   hosts: 'http://${ES_HOST:-es01}:9200'
   username: '${ES_USER:-elastic}'
@@ -27,7 +27,7 @@ infinity:
 redis:
   db: 1
   password: '${REDIS_PASSWORD:-infini_rag_flow}'
-  host: '${REDIS_HOST:-redis}:6379'
+  host: '${REDIS_HOST:-redis}:${REDIS_PORT:-6379}'
 
 # postgres:
 #   name: '${POSTGRES_DBNAME:-rag_flow}'


### PR DESCRIPTION
### What problem does this PR solve?
Fix: when using external components, it is impossible to specify the port, because the variables in the `docker/.env` variable were not referenced by `docker/service_conf.yaml.template`.
https://github.com/infiniflow/ragflow/blob/382d2d0373fea9554982a0718fc8eaf5fe8a5807/docker/.env#L85

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

