### PR TITLE
Fix:user_default_llm configuration doesn't work for OpenAI API compatible LLM factory

### DIFF
--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -70,6 +70,8 @@ class TenantLLMService(CommonService):
             model_factories = settings.FACTORY_LLM_INFOS
             model_providers = set([f["name"] for f in model_factories])
             if arr[-1] not in model_providers:
+                if arr[-1] in ["OpenAI-API-Compatible"]:
+                    return arr[0], arr[-1]
                 return model_name, None
             return arr[0], arr[-1]
         except Exception as e:


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/infiniflow/ragflow/issues/8467
for this case is due to when save to tenant LLM as llm1, but will use llm1@openAICompatible to do query

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

