### PR TITLE
fix(prompt-editor): resolve initial cursor position and auto-newline …

### DIFF
--- a/web/src/components/prompt-editor/variable-picker-plugin.tsx
+++ b/web/src/components/prompt-editor/variable-picker-plugin.tsx
@@ -224,6 +224,9 @@ export default function VariablePickerMenuPlugin({
       }
 
       $getRoot().clear().append(paragraph);
+      if ($isRangeSelection($getSelection())) {
+        $getRoot().selectEnd();
+      }
     },
     [findLabelByValue],
   );


### PR DESCRIPTION
### What problem does this PR solve?

In web folder's prompt-editor component, when entering content for the first time, the cursor position is abnormal and it will automatically wrap 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)