### PR TITLE
fix: list index out of range

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -466,6 +466,8 @@ def list_session(tenant_id, chat_id):
             message_num = 0
             while message_num < len(messages) and message_num < len(conv["reference"]):
                 if message_num != 0 and messages[message_num]["role"] != "user":
+                    if message_num >= len(conv["reference"]):
+                        break
                     chunk_list = []
                     if "chunks" in conv["reference"][message_num]:
                         chunks = conv["reference"][message_num]["chunks"]


### PR DESCRIPTION
### What problem does this PR solve?

stack：

```
2025-06-26 17:22:24,739 ERROR    1609 list index out of range
Traceback (most recent call last):
  File "/ragflow/.venv/lib/python3.10/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/ragflow/.venv/lib/python3.10/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/ragflow/api/utils/api_utils.py", line 298, in decorated_function
    return func(*args, **kwargs)
  File "/ragflow/api/apps/sdk/session.py", line 472, in list_session
    print(conv["reference"][message_num])
IndexError: list index out of range

```

![图片](https://github.com/user-attachments/assets/93fe90a8-0434-4842-ba9f-bb5a995b498a)


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
