### PR TITLE
Pass Form Instance to GoogleModal Form Component

### DIFF
--- a/web/src/pages/user-setting/setting-model/google-modal/index.tsx
+++ b/web/src/pages/user-setting/setting-model/google-modal/index.tsx
@@ -47,7 +47,7 @@ const GoogleModal = ({
       onCancel={hideModal}
       okButtonProps={{ loading }}
     >
-      <Form>
+      <Form form={form}>
         <Form.Item<FieldType>
           label={t('modelType')}
           name="model_type"


### PR DESCRIPTION
### What problem does this PR solve?

This PR enables the `Form` component within the `GoogleModal` to directly access and manipulate the form state by passing the form instance from the parent component. This enhances form control and data manipulation capabilities within the modal, improving the component's functionality and integration with the parent form.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)