### PR TITLE
Fix: docx parse error.

### DIFF
--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -121,7 +121,7 @@ class Docx(DocxParser):
             if block_type != 'p':
                 continue
                 
-            if block.style and re.search(r"Heading\s*(\d+)", block.style.name, re.I):
+            if block.style and block.style.name and re.search(r"Heading\s*(\d+)", block.style.name, re.I):
                 try:
                     level_match = re.search(r"(\d+)", block.style.name)
                     if level_match:


### PR DESCRIPTION
### What problem does this PR solve?

docx parse error.
![image](https://github.com/user-attachments/assets/efbe6d1b-10c8-415e-b693-a86f73e1ffa6)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### What problem does this PR solve?

Some docx parse with naive cause error.   `block.style.name` in Function `__get_nearest_title` will be  None in some case.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
