### PR TITLE
make dirs with 'exist_ok=True'

### DIFF
--- a/rag/llm/cv_model.py
+++ b/rag/llm/cv_model.py
@@ -240,7 +240,7 @@ class QWenCV(Base):
         # stupid as hell
         tmp_dir = get_project_base_directory("tmp")
         if not os.path.exists(tmp_dir):
-            os.mkdir(tmp_dir)
+            os.makedirs(tmp_dir, exist_ok=True)
         path = os.path.join(tmp_dir, "%s.jpg" % get_uuid())
         Image.open(io.BytesIO(binary)).save(path)
         return [
@@ -262,7 +262,7 @@ class QWenCV(Base):
         # stupid as hell
         tmp_dir = get_project_base_directory("tmp")
         if not os.path.exists(tmp_dir):
-            os.mkdir(tmp_dir)
+            os.makedirs(tmp_dir, exist_ok=True)
         path = os.path.join(tmp_dir, "%s.jpg" % get_uuid())
         Image.open(io.BytesIO(binary)).save(path)
 


### PR DESCRIPTION
### What problem does this PR solve?

The following error occurred during local testing, which should be fixed by configuring 'exist_ok=True'.

```log
set_progress(7461edc2535c11f0a2aa0242c0a82009), progress: -1, progress_msg: 21:41:41 Page(1~100000001): [ERROR][Errno 17] File exists: '/ragflow/tmp'
```

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
