### PR TITLE
Update package.json

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "@hookform/resolvers": "^3.9.1",
     "@js-preview/excel": "^1.7.8",
     "@lexical/react": "^0.23.1",
+    "monaco-editor": "^0.52.2",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.4",


### PR DESCRIPTION
fix bug :
When installing dependencies using yarn(version 1.22.22), the following error occurs on startup: unable to locate '/../web/node_modules/monaco-editor/min/vs' glob

### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
