### PR TITLE
Refa: Update Minio image to specific release version in docker-compose-base.yml

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -164,7 +164,7 @@ services:
     restart: on-failure
 
   minio:
-    image: quay.io/minio/minio
+    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
     container_name: ragflow-minio
     command: server --console-address ":9001" /data
     ports:


### PR DESCRIPTION
### What problem does this PR solve?

- Ensure consistent Minio deployment by pinning the image to a specific release version (RELEASE.2025-06-13T11-33-47Z) for stability and reproducibility.
- #8672

### Type of change

- [x] Refactoring

