### PR TITLE
Fix: graphrag, raptor can be null for api created kb issue

### DIFF
--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -564,10 +564,10 @@ class DocumentService(CommonService):
                     prg = -1
                     status = TaskStatus.FAIL.value
                 elif finished:
-                    if d["parser_config"].get("raptor", {}).get("use_raptor") and not has_raptor:
+                    if (d["parser_config"].get("raptor") or {}).get("use_raptor") and not has_raptor:
                         queue_raptor_o_graphrag_tasks(d, "raptor", priority)
                         prg = 0.98 * len(tsks) / (len(tsks) + 1)
-                    elif d["parser_config"].get("graphrag", {}).get("use_graphrag") and not has_graphrag:
+                    elif (d["parser_config"].get("graphrag") or {}).get("use_graphrag") and not has_graphrag:
                         queue_raptor_o_graphrag_tasks(d, "graphrag", priority)
                         prg = 0.98 * len(tsks) / (len(tsks) + 1)
                     else:


### PR DESCRIPTION
### What problem does this PR solve?

When knowledgebase/dataset created by API, graphrag and raptor can be null, and will trigger NoneType error when reach to this code, causing chunking task not able to finish.
![image](https://github.com/user-attachments/assets/998a63e9-611b-4301-8808-24839a05be8a)

Proposed solution will result in None and pass the condition check without error.
![image](https://github.com/user-attachments/assets/184374fb-e06a-46e6-b8ac-d66a3fd93b59)


### Type of change

-  ✅ Bug Fix (non-breaking change which fixes an issue)
