### PR TITLE
feat(elasticsearch): add configurable timeout and retry mechanisms

### DIFF
--- a/conf/service_conf.yaml
+++ b/conf/service_conf.yaml
@@ -18,6 +18,26 @@ es:
   hosts: 'http://localhost:1200'
   username: 'elastic'
   password: 'infini_rag_flow'
+  retry_attempts:
+    global: 2
+    # connect: 5
+    # exists: 2
+    # search: 3
+    # get: 2
+    # insert: 3
+    # update: 3
+    # delete: 2
+    # sql: 2
+  timeouts:
+    # default: 600        # Connection timeout (uses 600s if not set)
+    # exists: 10          # Index existence checks (uses 5s if not set)
+    # get: 10             # Single document retrieval
+    # search: 300         # Document search (uses 600s if not set)
+    # bulk: 60            # Bulk operations (uses 60s if not set)
+    # update: 30          # Document updates
+    # delete_by_query: 60 # Bulk document deletion
+    # sql: 10             # SQL queries (uses 2s if not set)
+    # health: 10          # Cluster health checks
 os:
   hosts: 'http://localhost:1201'
   username: 'admin'

--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -17,6 +17,26 @@ es:
   hosts: 'http://${ES_HOST:-es01}:9200'
   username: '${ES_USER:-elastic}'
   password: '${ELASTIC_PASSWORD:-infini_rag_flow}'
+  retry_attempts:
+    global: 2
+    # connect: 5
+    # exists: 2
+    # search: 3
+    # get: 2
+    # insert: 3
+    # update: 3
+    # delete: 2
+    # sql: 2
+  timeouts:
+    # default: 600        # Connection timeout (uses 600s if not set)
+    # exists: 10          # Index existence checks (uses 5s if not set)
+    # get: 10             # Single document retrieval  
+    # search: 300         # Document search (uses 600s if not set)
+    # bulk: 60            # Bulk operations (uses 60s if not set)
+    # update: 30          # Document updates
+    # delete_by_query: 60 # Bulk document deletion
+    # sql: 10             # SQL queries (uses 2s if not set)
+    # health: 10          # Cluster health checks
 os:
   hosts: 'http://${OS_HOST:-opensearch01}:9201'
   username: '${OS_USER:-admin}'

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -162,6 +162,63 @@ If you cannot download the RAGFlow Docker image, try the following mirrors.
 - `password`: The password for MinIO.
 - `host`: The MinIO serving IP *and* port inside the Docker container. Defaults to `minio:9000`.
 
+### `es`
+
+The Elasticsearch configuration for document storage and search functionality.
+
+- `hosts`: The Elasticsearch server endpoints. Defaults to `'http://localhost:1200'`.
+- `username`: The username for Elasticsearch authentication.
+- `password`: The password for Elasticsearch authentication.
+- `retry_attempts`: Configuration for retry attempts when Elasticsearch operations fail. This allows fine-tuning of retry behavior for different API operations.
+  - `global`: The default number of retry attempts for all Elasticsearch operations. Defaults to `2`.
+  - `connect`: Number of retry attempts for establishing connection to Elasticsearch.
+  - `exists`: Number of retry attempts for index existence checks.
+  - `search`: Number of retry attempts for document search operations.
+  - `get`: Number of retry attempts for single document retrieval.
+  - `insert`: Number of retry attempts for bulk document insertion.
+  - `update`: Number of retry attempts for document updates.
+  - `delete`: Number of retry attempts for document deletion.
+  - `sql`: Number of retry attempts for SQL query operations.
+- `timeouts`: Configuration for request timeout values (in seconds) when Elasticsearch operations may take longer than expected. This allows fine-tuning of timeout behavior for different API operations.
+  - `default`: Connection timeout. Defaults to `600` seconds if not configured.
+  - `exists`: Timeout for index existence checks.
+  - `get`: Timeout for single document retrieval.
+  - `search`: Timeout for document search operations. Defaults to `600` seconds if not configured.
+  - `bulk`: Timeout for bulk document operations. Defaults to `60` seconds if not configured.
+  - `update`: Timeout for document updates.
+  - `delete_by_query`: Timeout for bulk document deletion.
+  - `sql`: Timeout for SQL query operations. Defaults to `2` seconds if not configured.
+  - `health`: Timeout for cluster health checks.
+
+:::tip NOTE
+Both `retry_attempts` and `timeouts` configurations are optional.
+
+- For `retry_attempts`: If a specific API operation is not configured, it will use the `global` retry count. If `global` is not set, it defaults to `2` attempts.
+- For `timeouts`:
+  - Some operations have sensible defaults inherited from the previous hardcoded values: `search` (600s), `bulk` (60s), `sql` (2s), `exists` (5s), and connection `default` (600s).
+  - Other operations (`exists`, `get`, `update`, `delete_by_query`, `health`) will use the Elasticsearch client's default timeout if not configured.
+
+Example configuration:
+
+```yaml
+es:
+  hosts: 'http://elasticsearch:9200'
+  username: 'elastic'
+  password: 'your_password'
+  retry_attempts:
+    global: 2
+    connect: 5
+    search: 3
+    exists: 1
+  timeouts:
+    default: 300 # Custom connection timeout
+    exists: 10 # Custom index check timeout
+    search: 300 # Override default 600s search timeout
+    bulk: 60 # Keep default bulk timeout
+```
+
+:::
+
 ### `oauth`  
 
 The OAuth configuration for signing up or signing in to RAGFlow using a third-party account.


### PR DESCRIPTION
### What problem does this PR solve?

Currently, the retry attempts and timeout values for Elasticsearch (ES) requests are not configurable, and some APIs—such as exists—use an unreasonable default timeout of 600 seconds.

In the current implementation, the number of retries and the timeout duration for ES requests are hardcoded and cannot be adjusted through configuration. This means that all API operations, regardless of their nature, use the same default values. For example, the exists API, which is typically a quick check, also uses the default 600-second timeout. This is not appropriate, as such a long timeout is excessive for simple existence checks and can lead to inefficient resource usage and delayed error handling.

Making these parameters configurable allows for more fine-grained control, so each API can have retry and timeout settings that match its expected behavior and performance requirements.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
