### PR TITLE
BugFix:  AgentCreateBUGFix：required argument are missing: dsl;

### DIFF
--- a/web/src/pages/flow/list/agent-template-modal.tsx
+++ b/web/src/pages/flow/list/agent-template-modal.tsx
@@ -1,6 +1,7 @@
 import { IModalManagerChildrenProps } from '@/components/modal-manager';
 import { useSetModalState, useTranslate } from '@/hooks/common-hooks';
-import { useFetchFlowTemplates } from '@/hooks/flow-hooks';
+import { IFlowTemplate } from '@/interfaces/database/flow';
+// import { useFetchFlowTemplates } from '@/hooks/flow-hooks';
 import { useSelectItem } from '@/hooks/logic-hooks';
 import { Button, Card, Flex, List, Modal, Typography } from 'antd';
 import { useCallback, useState } from 'react';
@@ -15,11 +16,18 @@ interface IProps extends Omit<IModalManagerChildrenProps, 'showModal'> {
   loading: boolean;
   onOk: (name: string, templateId: string) => void;
   showModal?(): void;
+  templateList: IFlowTemplate[];
 }
 
-const AgentTemplateModal = ({ visible, hideModal, loading, onOk }: IProps) => {
+const AgentTemplateModal = ({
+  visible,
+  hideModal,
+  loading,
+  onOk,
+  templateList,
+}: IProps) => {
   const { t } = useTranslate('common');
-  const { data: list } = useFetchFlowTemplates();
+  // const { data: list } = useFetchFlowTemplates();
   const { selectedId, handleItemClick } = useSelectItem('');
   const [checkedId, setCheckedId] = useState<string>('');
 
@@ -62,7 +70,7 @@ const AgentTemplateModal = ({ visible, hideModal, loading, onOk }: IProps) => {
         </Title>
         <List
           grid={{ gutter: 16, column: 4 }}
-          dataSource={list}
+          dataSource={templateList}
           renderItem={(x) => (
             <List.Item>
               <Card

--- a/web/src/pages/flow/list/hooks.ts
+++ b/web/src/pages/flow/list/hooks.ts
@@ -88,6 +88,7 @@ export const useSaveFlow = () => {
     onFlowOk,
     flowSettingVisible,
     hideFlowSettingModal,
+    templateList: list,
     showFlowSettingModal: showFileRenameModal,
   };
 };

--- a/web/src/pages/flow/list/index.tsx
+++ b/web/src/pages/flow/list/index.tsx
@@ -24,6 +24,7 @@ const FlowList = () => {
     hideFlowSettingModal,
     flowSettingVisible,
     flowSettingLoading,
+    templateList,
     onFlowOk,
   } = useSaveFlow();
   const { t } = useTranslate('flow');
@@ -110,6 +111,7 @@ const FlowList = () => {
           onOk={onFlowOk}
           loading={flowSettingLoading}
           hideModal={hideFlowSettingModal}
+          templateList={templateList}
         ></AgentTemplateModal>
       )}
     </Flex>


### PR DESCRIPTION
 ### AgentCreateBUGFix
Because useFetchFlowTemplates is called both in the hooks and the AgentTemplateModal, and the ID of the empty template is generated via uuid, there may be cases where the IDs do not match.

Report a BUG as follows:
Prompt: 101
Required argument is missing: dsl;

<img width="472" height="121" alt="52d79682-4e50-4863-8486-f1e154003043" src="https://github.com/user-attachments/assets/c5d217c9-b6cc-4ef2-866b-694c8b9ab3ae" />

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

