### PR TITLE
Fix: graphknowledge Tree structure not found for treeKey: combo (#7819)

### DIFF
--- a/web/src/pages/add-knowledge/components/knowledge-graph/util.ts
+++ b/web/src/pages/add-knowledge/components/knowledge-graph/util.ts
@@ -86,7 +86,9 @@ export const buildNodesAndCombos = (nodes: any[]) => {
   const nextNodes = nodes.map((x) => {
     return {
       ...x,
-      combo: combos.find((y) => y.data.label === findCombo(x?.communities))?.id,
+      combo:
+        combos.find((y) => y.data.label === findCombo(x?.communities))?.id ??
+        null,
     };
   });
 


### PR DESCRIPTION
### What problem does this PR solve?

Fixed graphknowledge Tree structure not found for treeKey.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
