### PR TITLE
Update service_conf.yaml.template

### DIFF
--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -12,7 +12,7 @@ mysql:
 minio:
   user: '${MINIO_USER:-rag_flow}'
   password: '${MINIO_PASSWORD:-infini_rag_flow}'
-  host: '${MINIO_HOST:-minio}:${MINIO_PORT:-9000}'
+  host: '${MINIO_HOST:-minio}:9000'
 es:
   hosts: 'http://${ES_HOST:-es01}:9200'
   username: '${ES_USER:-elastic}'
@@ -27,7 +27,7 @@ infinity:
 redis:
   db: 1
   password: '${REDIS_PASSWORD:-infini_rag_flow}'
-  host: '${REDIS_HOST:-redis}:${REDIS_PORT:-6379}'
+  host: '${REDIS_HOST:-redis}:6379'
 
 # postgres:
 #   name: '${POSTGRES_DBNAME:-rag_flow}'


### PR DESCRIPTION
fix: modify the connection ports of minio and redis in service_conf.yaml.template

### What problem does this PR solve?

If you modify the external ports of minio and redis in the .env file, it will also affect the connection ports inside the container in the service_conf.yaml.template file, which is unreasonable.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
