### PR TITLE
Fix: fix typo in OpenAI error logging message

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -124,7 +124,7 @@ class Base(ABC):
         return ans + LENGTH_NOTIFICATION_EN
 
     def _exceptions(self, e, attempt):
-        logging.exception("OpenAI cat_with_tools")
+        logging.exception("OpenAI chat_with_tools")
         # Classify the error
         error_code = self._classify_error(e)
 


### PR DESCRIPTION
### What problem does this PR solve?

Correct the logging message from "OpenAI cat_with_tools" to "OpenAI chat_with_tools" in the `_exceptions` method of the `Base` class to accurately reflect the method name and improve error traceability.

### Type of change

- [x] Typo
