### PR TITLE
fix settings global docStoreConn for opensearch

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -163,7 +163,7 @@ def init_settings():
     elif lower_case_doc_engine == "infinity":
         docStoreConn = rag.utils.infinity_conn.InfinityConnection()
     elif lower_case_doc_engine == "opensearch":
-        docStoreConn = rag.utils.opensearch_coon.OSConnection()
+        docStoreConn = rag.utils.opensearch_conn.OSConnection()
     else:
         raise Exception(f"Not supported doc engine: {DOC_ENGINE}")
 


### PR DESCRIPTION
### What problem does this PR solve?
fix opensearch OSConnection init.
```
        docStoreConn = rag.utils.opensearch_conn.OSConnection()
```

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
