### PR TITLE
Add OpenSearch support to Helm chart

### DIFF
--- a/helm/templates/elasticsearch-config.yaml
+++ b/helm/templates/elasticsearch-config.yaml
@@ -10,4 +10,8 @@ data:
   xpack.security.enabled: "true"
   xpack.security.http.ssl.enabled: "false"
   xpack.security.transport.ssl.enabled: "false"
+  cluster.routing.allocation.disk.watermark.low: 5gb
+  cluster.routing.allocation.disk.watermark.high: 3gb
+  cluster.routing.allocation.disk.watermark.flood_stage: 2gb
+  TZ: {{ .Values.env.TIMEZONE }}
 {{- end -}}

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -43,6 +43,11 @@ stringData:
   ELASTIC_PASSWORD: {{ .Values.env.ELASTIC_PASSWORD | required "ELASTIC_PASSWORD is required" }}
   {{- else if eq .Values.env.DOC_ENGINE "infinity" }}
   INFINITY_HOST: {{ printf "%s-infinity.%s.svc" (include "ragflow.fullname" .) .Release.Namespace }}
+  {{- else if eq .Values.env.DOC_ENGINE "opensearch" }}
+  OS_HOST: {{ printf "%s-opensearch.%s.svc" (include "ragflow.fullname" .) .Release.Namespace }}
+  OS_PORT: "9201"
+  OPENSEARCH_PASSWORD: {{ .Values.env.OPENSEARCH_PASSWORD | required "OPENSEARCH_PASSWORD is required" }}
+  OPENSEARCH_INITIAL_ADMIN_PASSWORD: {{ .Values.env.OPENSEARCH_PASSWORD | required "OPENSEARCH_PASSWORD is required" }}
   {{- else }}
-  {{ fail "env.DOC_ENGINE must be either 'elasticsearch' or 'infinity'" }}
+  {{ fail "env.DOC_ENGINE must be either 'elasticsearch', 'opensearch' or 'infinity'" }}
   {{- end }}

--- a/helm/templates/opensearch-config.yaml
+++ b/helm/templates/opensearch-config.yaml
@@ -1,0 +1,18 @@
+{{- if eq .Values.env.DOC_ENGINE "opensearch" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ragflow.fullname" . }}-opensearch-config
+data:
+  node.name: opensearch01
+  bootstrap.memory_lock: "false"
+  discovery.type: single-node
+  plugins.security.disabled: "false"
+  plugins.security.ssl.http.enabled: "false"
+  plugins.security.ssl.transport.enabled: "true"
+  cluster.routing.allocation.disk.watermark.low: 5gb
+  cluster.routing.allocation.disk.watermark.high: 3gb
+  cluster.routing.allocation.disk.watermark.flood_stage: 2gb
+  TZ: {{ .Values.env.TIMEZONE }}
+  http.port: "9201"
+{{- end -}}

--- a/helm/templates/opensearch.yaml
+++ b/helm/templates/opensearch.yaml
@@ -1,0 +1,116 @@
+{{- if eq .Values.env.DOC_ENGINE "opensearch" -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ragflow.fullname" . }}-opensearch-data
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    {{- include "ragflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opensearch
+spec:
+  {{- with .Values.opensearch.storage.className }}
+  storageClassName: {{ . }}
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.opensearch.storage.capacity }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ragflow.fullname" . }}-opensearch
+  labels:
+    {{- include "ragflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opensearch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ragflow.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: opensearch
+  {{- with .Values.opensearch.deployment.strategy }}
+  strategy:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+      {{- include "ragflow.labels" . | nindent 8 }}
+        app.kubernetes.io/component: opensearch
+      annotations:
+        checksum/config-opensearch: {{ include (print $.Template.BasePath "/opensearch-config.yaml") . | sha256sum }}
+        checksum/config-env: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      - name: fix-data-volume-permissions
+        image: alpine
+        command:
+        - sh
+        - -c
+        - "chown -R 1000:0 /usr/share/opensearch/data"
+        volumeMounts:
+          - mountPath: /usr/share/opensearch/data
+            name: opensearch-data
+      - name: sysctl
+        image: busybox
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+      containers:
+      - name: opensearch
+        image: {{ .Values.opensearch.image.repository }}:{{ .Values.opensearch.image.tag }}
+        envFrom:
+          - secretRef:
+              name: {{ include "ragflow.fullname" . }}-env-config
+          - configMapRef:
+              name: {{ include "ragflow.fullname" . }}-opensearch-config
+        ports:
+          - containerPort: 9201
+            name: http
+        volumeMounts:
+          - mountPath: /usr/share/opensearch/data
+            name: opensearch-data
+        {{- with .Values.opensearch.deployment.resources }}
+        resources:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        securityContext:
+          capabilities:
+            add:
+              - "IPC_LOCK"
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9201
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 120
+      volumes:
+        - name: opensearch-data
+          persistentVolumeClaim:
+            claimName: {{ include "ragflow.fullname" . }}-opensearch-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ragflow.fullname" . }}-opensearch
+  labels:
+    {{- include "ragflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opensearch
+spec:
+  selector:
+    {{- include "ragflow.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: opensearch
+  ports:
+    - protocol: TCP
+      port: 9201
+      targetPort: http
+  type: {{ .Values.opensearch.service.type }}
+{{- end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,14 +4,20 @@ env:
   # Available options:
   # - `elasticsearch` (default)
   # - `infinity` (https://github.com/infiniflow/infinity)
+  # - `opensearch` (https://github.com/opensearch-project/OpenSearch)
   # DOC_ENGINE: elasticsearch
   DOC_ENGINE: infinity
+  # DOC_ENGINE: opensearch
 
   # The version of Elasticsearch.
   STACK_VERSION: "8.11.3"
 
   # The password for Elasticsearch
   ELASTIC_PASSWORD: infini_rag_flow_helm
+
+  # The password for OpenSearch.
+  # At least one uppercase letter, one lowercase letter, one digit, and one special character
+  OPENSEARCH_PASSWORD: infini_rag_flow_OS_01
 
   # The password for MySQL
   MYSQL_PASSWORD: infini_rag_flow_helm
@@ -118,6 +124,22 @@ infinity:
     type: ClusterIP
 
 elasticsearch:
+  storage:
+    className:
+    capacity: 20Gi
+  deployment:
+    strategy:
+    resources:
+      requests:
+        cpu: "4"
+        memory: "16Gi"
+  service:
+    type: ClusterIP
+
+opensearch:
+  image:
+    repository: opensearchproject/opensearch
+    tag: 2.19.1
   storage:
     className:
     capacity: 20Gi


### PR DESCRIPTION
### What problem does this PR solve?

Adds OpenSearch support to the RAGFlow Helm chart based on https://github.com/infiniflow/ragflow/pull/7140 and the existing Elasticsearch support in the Helm chart.

### Type of change
- [X] New Feature (non-breaking change which adds functionality)