### PR TITLE
Fix: Adds newest Gemini models to fit google's standard API rate limits

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1093,9 +1093,10 @@
                 },
                 {
                     "llm_name": "gemini-2.5-pro",
-                    "tags": "LLM,IMAGE2TEXT,1024K",
+                    "tags": "LLM,CHAT,IMAGE2TEXT,1024K",
                     "max_tokens": 1048576,
-                    "model_type": "image2text"
+                    "model_type": "image2text",
+                    "is_tools": true
                 },
                 {
                     "llm_name": "gemini-2.5-flash-preview-05-20",

--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1085,6 +1085,19 @@
             "status": "1",
             "llm": [
                 {
+                    "llm_name": "gemini-2.5-flash",
+                    "tags": "LLM,CHAT,1024K,IMAGE2TEXT",
+                    "max_tokens": 1048576,
+                    "model_type": "image2text",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "gemini-2.5-pro",
+                    "tags": "LLM,IMAGE2TEXT,1024K",
+                    "max_tokens": 1048576,
+                    "model_type": "image2text"
+                },
+                {
                     "llm_name": "gemini-2.5-flash-preview-05-20",
                     "tags": "LLM,CHAT,1024K,IMAGE2TEXT",
                     "max_tokens": 1048576,


### PR DESCRIPTION
What problem does this PR solve?
This PR adds support for the latest Gemini 2.5 models in the llm_factories.json configuration.
By including gemini-2.5-flash and gemini-2.5-pro, users can now select and utilize these new models for LLM and image-to-text tasks.
This update ensures the system stays up-to-date with the latest Gemini model offerings and provides more options for downstream applications.

### Type of change

- [O] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
