### PR TITLE
Fix: Adds newest Gemini models to fit google's standard API rate limits

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1093,9 +1093,10 @@
                 },
                 {
                     "llm_name": "gemini-2.5-pro",
-                    "tags": "LLM,IMAGE2TEXT,1024K",
+                    "tags": "LLM,CHAT,IMAGE2TEXT,1024K",
                     "max_tokens": 1048576,
-                    "model_type": "image2text"
+                    "model_type": "image2text",
+                    "is_tools": true
                 },
                 {
                     "llm_name": "gemini-2.5-flash-preview-05-20",

--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1085,6 +1085,19 @@
             "status": "1",
             "llm": [
                 {
+                    "llm_name": "gemini-2.5-flash",
+                    "tags": "LLM,CHAT,1024K,IMAGE2TEXT",
+                    "max_tokens": 1048576,
+                    "model_type": "image2text",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "gemini-2.5-pro",
+                    "tags": "LLM,IMAGE2TEXT,1024K",
+                    "max_tokens": 1048576,
+                    "model_type": "image2text"
+                },
+                {
                     "llm_name": "gemini-2.5-flash-preview-05-20",
                     "tags": "LLM,CHAT,1024K,IMAGE2TEXT",
                     "max_tokens": 1048576,


### PR DESCRIPTION
### What problem does this PR solve?

Adds configurations for gemini-2.5-flash and Gemini 2.5-pro models, including tags, maximum token limits, and model types.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
