### PR TITLE
Switch to StatefulSet resources for stateful components

### DIFF
--- a/helm/templates/elasticsearch.yaml
+++ b/helm/templates/elasticsearch.yaml
@@ -19,7 +19,7 @@ spec:
       storage: {{ .Values.elasticsearch.storage.capacity }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "ragflow.fullname" . }}-es
   labels:

--- a/helm/templates/infinity.yaml
+++ b/helm/templates/infinity.yaml
@@ -19,7 +19,7 @@ spec:
       storage: {{ .Values.infinity.storage.capacity }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "ragflow.fullname" . }}-infinity
   labels:

--- a/helm/templates/minio.yaml
+++ b/helm/templates/minio.yaml
@@ -19,9 +19,9 @@ spec:
       storage: {{ .Values.minio.storage.capacity }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: ragflow-minio-deployment
+  name: {{ include "ragflow.fullname" . }}-minio
   labels:
     {{- include "ragflow.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/helm/templates/mysql.yaml
+++ b/helm/templates/mysql.yaml
@@ -19,7 +19,7 @@ spec:
       storage: {{ .Values.mysql.storage.capacity }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "ragflow.fullname" . }}-mysql
   labels:

--- a/helm/templates/opensearch.yaml
+++ b/helm/templates/opensearch.yaml
@@ -19,7 +19,7 @@ spec:
       storage: {{ .Values.opensearch.storage.capacity }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "ragflow.fullname" . }}-opensearch
   labels:


### PR DESCRIPTION
### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

Switch to Kubernetes StatefulSet resources for MySQL, Minio and vector DB since these are stateful application components. This makes operations such as helm upgrade smoother since the default container update strategy becomes a sequential rolling update of each pod.

Also fixes a bug in the name template for the Minio stateful set resource to align it with the naming convention used for other components.

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
