### PR TITLE
fix: use consistent filenames for chrome & chromedriver

### DIFF
--- a/download_deps.py
+++ b/download_deps.py
@@ -35,8 +35,8 @@ def get_urls(use_china_mirrors=False) -> Union[str, list[str]]:
             "https://repo1.maven.org/maven2/org/apache/tika/tika-server-standard/3.0.0/tika-server-standard-3.0.0.jar",
             "https://repo1.maven.org/maven2/org/apache/tika/tika-server-standard/3.0.0/tika-server-standard-3.0.0.jar.md5",
             "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken",
-            "https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.85/linux64/chrome-linux64.zip",
-            "https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.85/linux64/chromedriver-linux64.zip",
+            ["https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.85/linux64/chrome-linux64.zip", "chrome-linux64-121-0-6167-85"],
+            ["https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.85/linux64/chromedriver-linux64.zip", "chromedriver-linux64-121-0-6167-85"],
         ]
 
 repos = [


### PR DESCRIPTION
### What problem does this PR solve?

PR #8665 updated chrome and chromedriver sources, removing the appended version number. This PR resolves remaining filename inconsistencies that would cause `Dockerfile.deps` to fail to build when `--china-mirrors=False`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
