### PR TITLE
Set the default value of env var 'NLTK_DATA' for local deployment

### DIFF
--- a/rag/utils/__init__.py
+++ b/rag/utils/__init__.py
@@ -75,8 +75,9 @@ def findMaxTm(fnm):
     return m
 
 
-tiktoken_cache_dir = get_project_base_directory()
-os.environ["TIKTOKEN_CACHE_DIR"] = tiktoken_cache_dir
+base_dir = get_project_base_directory()
+os.environ.setdefault("NLTK_DATA", os.path.join(base_dir, "nltk_data"))
+os.environ.setdefault("TIKTOKEN_CACHE_DIR", base_dir)
 # encoder = tiktoken.encoding_for_model("gpt-3.5-turbo")
 encoder = tiktoken.get_encoding("cl100k_base")
 


### PR DESCRIPTION
### What problem does this PR solve?

Set the default value of the environment variable `NLTK_DATA` for local deployment. Use `os.environ.setdefault` to avoid affecting existing script deployment logic.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): Local deployment optimization.
