### PR TITLE
docs: improve "build docker image" website docs 

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -92,10 +92,16 @@ SVR_HTTP_PORT=9380
 
 # The RAGFlow Docker image to download.
 # Defaults to the v0.19.1-slim edition, which is the RAGFlow Docker image without embedding models.
-RAGFLOW_IMAGE=infiniflow/ragflow:v0.19.1-slim
+# RAGFLOW_IMAGE=infiniflow/ragflow:v0.19.1-slim
+#
+# - For the `nightly-slim` edition, uncomment the following:
+RAGFLOW_IMAGE=infiniflow/ragflow:nightly-slim
 #
 # To download the RAGFlow Docker image with embedding models, uncomment the following line instead:
 # RAGFLOW_IMAGE=infiniflow/ragflow:v0.19.1
+#
+# - For the `nightly` edition, uncomment the following:
+# RAGFLOW_IMAGE=infiniflow/ragflow:nightly
 #
 # The Docker image of the v0.19.1 edition includes built-in embedding models:
 #   - BAAI/bge-large-zh-v1.5

--- a/docs/develop/build_docker_image.mdx
+++ b/docs/develop/build_docker_image.mdx
@@ -47,6 +47,17 @@ docker build -f Dockerfile.deps -t infiniflow/ragflow_deps .
 docker build --build-arg LIGHTEN=1 -f Dockerfile -t infiniflow/ragflow:nightly-slim .
 ```
 
+## Launch the RAGFlow Service with Docker
+
+After building the `infiniflow/ragflow:nightly` image, you are ready to launch a fully-functional RAGFlow service with all the required components, such as Elasticsearch, MySQL, MinIO, Redis, and more.
+
+1. Update Docker Compose configuration
+
+    Open the `docker/.env` file. Find the `RAGFLOW_IMAGE` setting and change which value is uncommented to use the pre-built image:
+
+    ```
+    RAGFLOW_IMAGE=infiniflow/ragflow:nightly-slim
+    ```
 
   </TabItem>
   <TabItem value="including">
@@ -66,27 +77,37 @@ docker build -f Dockerfile.deps -t infiniflow/ragflow_deps .
 docker build -f Dockerfile -t infiniflow/ragflow:nightly .
 ```
 
+## Launch the RAGFlow Service with Docker
+
+After building the `infiniflow/ragflow:nightly` image, you are ready to launch a fully-functional RAGFlow service with all the required components, such as Elasticsearch, MySQL, MinIO, Redis, and more.
+
+1. Update Docker Compose configuration
+
+    Open the `docker/.env` file. Find the `RAGFLOW_IMAGE` setting and change which value is uncommented to use the pre-built image:
+
+    ```
+    RAGFLOW_IMAGE=infiniflow/ragflow:nightly
+    ```
+
   </TabItem>
 </Tabs>
 
-## Launch a RAGFlow Service from Docker for MacOS
+2. Launch the RAGFlow Service:
 
-After building the infiniflow/ragflow:nightly-slim image, you are ready to launch a fully-functional RAGFlow service with all the required components, such as Elasticsearch, MySQL, MinIO, Redis, and more.
+    ```bash
+    docker compose -f docker/docker-compose.yml up -d
+    ```
 
-## Example: Apple M2 Pro (Sequoia)
+    ...or for MacOS (arm64):
 
-1. Edit Docker Compose Configuration
-
-Open the `docker/.env` file. Find the `RAGFLOW_IMAGE` setting and change the image reference from `infiniflow/ragflow:v0.19.1-slim` to `infiniflow/ragflow:nightly-slim` to use the pre-built image.
-
-
-2. Launch the Service
-
-```bash
-cd docker
-$ docker compose -f docker-compose-macos.yml up -d
-```
+    ```bash
+    docker compose -f docker/docker-compose-macos.yml up -d
+    ```
 
 3. Access the RAGFlow Service
 
-Once the setup is complete, open your web browser and navigate to http://127.0.0.1 or your server's \<IP_ADDRESS\>; (the default port is \<PORT\> = 80). You will be directed to the RAGFlow welcome page. Enjoy!🍻
+    Once the setup is complete, open your web browser and navigate to http://127.0.0.1
+
+    > `http://127.0.0.1:<YOUR_SERVING_PORT>` if the server's HTTP serving port has been changed from the default `80:80` to `<YOUR_SERVING_PORT>:80` in `docker-compose.yml` (or `docker-compose-macos.yml` for MacOS/arm64).
+
+    You will be directed to the RAGFlow welcome page. Enjoy!🍻

--- a/docs/develop/mcp/launch_mcp_server.md
+++ b/docs/develop/mcp/launch_mcp_server.md
@@ -179,7 +179,7 @@ docker logs ragflow-server
 
 ## Security considerations
 
-As MCP technology is still at early stage and no official best practices for authentication or authorization have been established, RAGFlow currently uses [API key](./acquire_ragflow_api_key.md) to validate identity for the operations described earlier. However, in public environments, this makeshift solution could expose your MCP server to potential network attacks. Therefore, when running a local SSE server, it is recommended to bind only to localhost (`127.0.0.1`) rather than to all interfaces (`0.0.0.0`). 
+As MCP technology is still at early stage and no official best practices for authentication or authorization have been established, RAGFlow currently uses [API key](../acquire_ragflow_api_key.md) to validate identity for the operations described earlier. However, in public environments, this makeshift solution could expose your MCP server to potential network attacks. Therefore, when running a local SSE server, it is recommended to bind only to localhost (`127.0.0.1`) rather than to all interfaces (`0.0.0.0`). 
 
 For further guidance, see the [official MCP documentation](https://modelcontextprotocol.io/docs/concepts/transports#security-considerations).
 


### PR DESCRIPTION
### What problem does this PR solve?

- adds options for local build `RAGFLOW_IMAGE` nightly[-slim] values to `docker/.env` to facilitate referencing in "build docker image" docs
- moves `RAGFLOW_IMAGE` instruction into tabs to support displaying the relevant image tag (full/slim) value
- adds docker compose step for both mac and linux
- clarifies where the server port setting is set in docker compose files
- fix: docs markdown link couldn't be resolved
  - due to invalid relative path for `acquire_ragflow_api_key.md` in `launch_mcp_server.md`


### Type of change

- [x] Documentation Update
