### PR TITLE
Fix OpenSearch liveness probe

### DIFF
--- a/helm/templates/opensearch.yaml
+++ b/helm/templates/opensearch.yaml
@@ -85,13 +85,14 @@ spec:
           runAsUser: 1000
           allowPrivilegeEscalation: false
         livenessProbe:
-          httpGet:
-            path: /
-            port: 9201
+          exec:
+            command:
+              - sh
+              - -c
+              - curl -u admin:$OPENSEARCH_PASSWORD localhost:9201
           initialDelaySeconds: 30
           periodSeconds: 10
-          timeoutSeconds: 10
-          failureThreshold: 120
+          failureThreshold: 6
       volumes:
         - name: opensearch-data
           persistentVolumeClaim:


### PR DESCRIPTION
### What problem does this PR solve?

Fix Kubernetes liveness probe on the OpenSearch container. The previous HTTP probe received an 401 response from the OpenSearch API which treated as a failure and caused the container to be restarted every 20 minutes.

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)