### PR TITLE
fix: obfuscate additional server secrets values

### DIFF
--- a/api/utils/__init__.py
+++ b/api/utils/__init__.py
@@ -76,6 +76,22 @@ def show_configs():
             if "secret_key" in v:
                 v = copy.deepcopy(v)
                 v["secret_key"] = "*" * 8
+            if "secret" in v:
+                v = copy.deepcopy(v)
+                v["secret"] = "*" * 8
+            if "sas_token" in v:
+                v = copy.deepcopy(v)
+                v["sas_token"] = "*" * 8
+            if "oauth" in k:
+                v =  copy.deepcopy(v)
+                for key, val in v.items():
+                  if "client_secret" in val:
+                      val["client_secret"] = "*" * 8
+            if "authentication" in k:
+                v =  copy.deepcopy(v)
+                for key, val in v.items():
+                  if "http_secret_key" in val:
+                      val["http_secret_key"] = "*" * 8
         msg += f"\n\t{k}: {v}"
     logging.info(msg)
 


### PR DESCRIPTION
### What problem does this PR solve?

Obfuscates additional secrets values on ragflow_server startup to prevent leakage: 
* `secret` (azure)
* `client_secret` (oauth)
* `http_secret_key` (authentication)
* `sas_token` (azure)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
