### PR TITLE
Ensure Redis volumeClaimTemplate labels are deterministic

### DIFF
--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -68,7 +68,7 @@ spec:
     - metadata:
         name: redis-data
         labels:
-          {{- include "ragflow.labels" . | nindent 10 }}
+          {{- include "ragflow.selectorLabels" . | nindent 10 }}
           app.kubernetes.io/component: redis
       spec:
         accessModes:


### PR DESCRIPTION
### What problem does this PR solve?

Previous version created labels which were dependent on the specific Helm chart version such as:
```
volumeClaimTemplates:
- metadata:
    name: redis-data
    labels:
      helm.sh/chart: ragflow-0.2.3-dev.0.opensearch-test.4
      app.kubernetes.io/name: ragflow
      app.kubernetes.io/instance: test-1
      app.kubernetes.io/version: "9a04408"
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/component: redis
```
which causes `helm upgrade` commands to fail with
```
Upgrade "test-1" failed: cannot patch "test-1-ragflow-redis" with
kind StatefulSet: StatefulSet.apps "test-1-ragflow-redis" is
invalid: spec: Forbidden: updates to statefulset spec for fields
other than 'replicas', 'ordinals', 'template', 'updateStrategy',
'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are
forbidden
```
because the labels changed on upgrade.

This fix uses a reduced set of labels to prevent upgrade failures.

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
