### PR TITLE
adding platform: linux/amd64 to the mac build

### DIFF
--- a/docker/docker-compose-macos.yml
+++ b/docker/docker-compose-macos.yml
@@ -3,6 +3,7 @@ include:
 
 services:
   ragflow:
+    platform: linux/amd64
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
### What problem does this PR solve?

Mac OS build fails on M4. Docker compose requires platform to be specified to build correctly

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
