### PR TITLE
docs: Complete tool calling bash script in MCP client example

### DIFF
--- a/docs/develop/mcp/mcp_client_example.md
+++ b/docs/develop/mcp/mcp_client_example.md
@@ -158,7 +158,8 @@ curl -X POST "http://127.0.0.1:9382/messages/?session_id=$session_id" \
         "dataset_ids": ["DATASET_ID_HERE"],
         "document_ids": []
       }
-
+    }
+  }'
 ```
 
 #### Transport


### PR DESCRIPTION
### What problem does this PR solve?

- Fix incomplete curl command in section 5 'Tool calling', add missing closing braces and parentheses to complete the JSON payload

This resolves the incomplete bash script that was missing proper JSON structure closure.

### Type of change

- [x] Documentation Update
