### PR TITLE
Add Redis data retention policy config options

### DIFF
--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -64,6 +64,15 @@ spec:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
   {{- if .Values.redis.persistence.enabled }}
+  {{- with .Values.redis.persistence.retentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- with .whenDeleted }}
+    whenDeleted: {{ . }}
+    {{- end }}
+    {{- with .whenScaled }}
+    whenScaled: {{ . }}
+    {{- end }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: redis-data

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -187,6 +187,11 @@ redis:
     capacity: 5Gi
   persistence:
     enabled: true
+    # Set's the retention policy for the persistent storage (only available in k8s 1.32 or later)
+    # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    # retentionPolicy:
+      # whenDeleted: Delete
+      # whenScaled: Delete
   deployment:
     strategy:
     resources:


### PR DESCRIPTION
### What problem does this PR solve?

Adds configuration options to the RAGFlow Helm chart to set the Redis data retention policies. By default this feature is disabled to maintain support with older Kubernetes versions.
https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
