### PR TITLE
Fix : API /document/thumbnails using wrong method to get ''doc_ids'

### DIFF
--- a/api/apps/document_app.py
+++ b/api/apps/document_app.py
@@ -288,7 +288,7 @@ def docinfos():
 @manager.route("/thumbnails", methods=["GET"])  # noqa: F821
 # @login_required
 def thumbnails():
-    doc_ids = request.args.get("doc_ids").split(",")
+    doc_ids = request.args.getlist("doc_ids")
     if not doc_ids:
         return get_json_result(data=False, message='Lack of "Document ID"', code=settings.RetCode.ARGUMENT_ERROR)
 


### PR DESCRIPTION
### What problem does this PR solve?

doc_ids is a list , should use request.args.getlist("doc_ids")

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
