### PR TITLE
Fix: list tags api by using tenant id instead of user id

### DIFF
--- a/api/apps/kb_app.py
+++ b/api/apps/kb_app.py
@@ -247,7 +247,10 @@ def list_tags(kb_id):
             code=settings.RetCode.AUTHENTICATION_ERROR
         )
 
-    tags = settings.retrievaler.all_tags(current_user.id, [kb_id])
+    tenants = UserTenantService.get_tenants_by_user_id(current_user.id)
+    tags = []
+    for tenant in tenants:
+        tags += settings.retrievaler.all_tags(tenant["tenant_id"], [kb_id])
     return get_json_result(data=tags)
 
 
@@ -263,7 +266,10 @@ def list_tags_from_kbs():
                 code=settings.RetCode.AUTHENTICATION_ERROR
             )
 
-    tags = settings.retrievaler.all_tags(current_user.id, kb_ids)
+    tenants = UserTenantService.get_tenants_by_user_id(current_user.id)
+    tags = []
+    for tenant in tenants:
+        tags += settings.retrievaler.all_tags(tenant["tenant_id"], kb_ids)
     return get_json_result(data=tags)
 
 


### PR DESCRIPTION
### What problem does this PR solve?

The index name of the tag chunks is generated by the tenant id of the knowledge base, so it should use the tenant id instead of the current user id in the listing tags API.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
