### PR TITLE
Fix: Redis stream lag can be nil

### DIFF
--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -499,7 +499,7 @@ class DocumentService(CommonService):
         if not doc_id:
             return
         return doc_id[0]["id"]
-    
+
     @classmethod
     @DB.connection_context()
     def get_doc_ids_by_doc_names(cls, doc_names):
@@ -672,7 +672,7 @@ def queue_raptor_o_graphrag_tasks(doc, ty, priority):
 
 def get_queue_length(priority):
     group_info = REDIS_CONN.queue_info(get_svr_queue_name(priority), SVR_CONSUMER_GROUP_NAME)
-    return int(group_info.get("lag", 0))
+    return int(group_info.get("lag", 0) or 0)
 
 
 def doc_upload_and_parse(conversation_id, file_objs, user_id):


### PR DESCRIPTION
### What problem does this PR solve?

```bash
Traceback (most recent call last):
  File "/home/infiniflow/workspace/ragflow/api/db/services/document_service.py", line 635, in update_progress
    info["progress_msg"] = "%d tasks are ahead in the queue..."%get_queue_length(priority)
  File "/home/infiniflow/workspace/ragflow/api/db/services/document_service.py", line 686, in get_queue_length
    return int(group_info.get("lag", 0))
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```
This issue can happen very rare. When a `stream` is first created, the `lag` value may be nil, which can cause this issue. However, once any message is synced, the `lag` will become `0` afterwards.

```bash
> XINFO GROUPS rag_flow_svr_queue
1)  1) "name"
    2) "rag_flow_svr_task_broker"
    3) "consumers"
    4) (integer) 0
    5) "pending"
    6) (integer) 0
    7) "last-delivered-id"
    8) "1753952489937-0"
    9) "entries-read"
   10) (nil)
   11) "lag"
   12) (nil)
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)