### PR TITLE
docs(sandbox): update /etc/hosts entry to include required services

### DIFF
--- a/docs/guides/agent/sandbox_quickstart.md
+++ b/docs/guides/agent/sandbox_quickstart.md
@@ -63,7 +63,7 @@ docker build -t sandbox-executor-manager:latest ./executor_manager
 3. Add the following entry to your /etc/hosts file to resolve the executor manager service:
 
 ```bash
-127.0.0.1 sandbox-executor-manager
+127.0.0.1 es01 infinity mysql minio redis sandbox-executor-manager
 ```
 
 4. Start the RAGFlow service as usual.


### PR DESCRIPTION
Fixes an issue where running the sandbox fails due to unresolved hostnames. Added missing service names (es01, infinity, mysql, minio, redis) to 127.0.0.1 in the /etc/hosts example.

Reference: https://github.com/infiniflow/ragflow/issues/8226

## What this PR does

Updates the sandbox quickstart documentation to fix a known issue where the sandbox fails to resolve required service hostnames.

## Why

Following the original instruction leads to a `Failed to resolve 'none'` error, as discussed in issue #8226. Adding the missing service names to `127.0.0.1` resolves the problem.

## Related issue

https://github.com/infiniflow/ragflow/issues/8226


### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
