### PR TITLE
Fix: kimi-latest is not authorized

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -584,6 +584,13 @@
             "status": "1",
             "llm": [
                 {
+                    "llm_name": "kimi-thinking-preview",
+                    "tags": "LLM,CHAT,1M",
+                    "max_tokens": 131072,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
                     "llm_name": "kimi-k2-0711-preview",
                     "tags": "LLM,CHAT,128k",
                     "max_tokens": 131072,
@@ -591,22 +598,8 @@
                     "is_tools": true
                 },
                 {
-                    "llm_name": "kimi-latest-8k",
-                    "tags": "LLM,CHAT,8k",
-                    "max_tokens": 8192,
-                    "model_type": "chat",
-                    "is_tools": true
-                },
-                {
-                    "llm_name": "kimi-latest-32k",
-                    "tags": "LLM,CHAT,32k",
-                    "max_tokens": 32768,
-                    "model_type": "chat",
-                    "is_tools": true
-                },
-                {
-                    "llm_name": "kimi-latest-128k",
-                    "tags": "LLM,CHAT,128k",
+                    "llm_name": "kimi-latest",
+                    "tags": "LLM,CHAT,8k,32k,128k",
                     "max_tokens": 131072,
                     "model_type": "chat",
                     "is_tools": true


### PR DESCRIPTION
### What problem does this PR solve?

Fix kimi-latest is not authorized.

Add kimi-thinking-preview.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)