### PR TITLE
feat(api): Add industry-related search keyword generation function

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -737,6 +737,7 @@ def related_questions(tenant_id):
     if not req.get("question"):
         return get_error_data_result("`question` is required.")
     question = req["question"]
+    industry = req.get("industry", "")
     chat_mdl = LLMBundle(tenant_id, LLMType.CHAT)
     prompt = """
 Objective: To generate search terms related to the user's search keywords, helping users find more valuable information.
@@ -746,7 +747,10 @@ Instructions:
  - Use common, general terms as much as possible, avoiding obscure words or technical jargon.
  - Keep the term length between 2-4 words, concise and clear.
  - DO NOT translate, use the language of the original keywords.
-
+"""
+    if industry:
+        prompt += f" - Ensure all search terms are relevant to the industry: {industry}.\n"
+    prompt += """
 ### Example:
 Keywords: Chinese football
 Related search terms:

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -3371,6 +3371,7 @@ The chat model autonomously determines the number of questions to generate based
   - `'Authorization: Bearer <YOUR_LOGIN_TOKEN>'`
 - Body:
   - `"question"`: `string`
+  - `"industry"`: `string`
 
 ##### Request example
 
@@ -3381,7 +3382,8 @@ curl --request POST \
      --header 'Authorization: Bearer <YOUR_LOGIN_TOKEN>' \
      --data '
      {
-          "question": "What are the key advantages of Neovim over Vim?"
+          "question": "What are the key advantages of Neovim over Vim?",
+          "industry": "software_development"
      }'
 ```
 
@@ -3389,6 +3391,8 @@ curl --request POST \
 
 - `"question"`: (*Body Parameter*), `string`
   The original user question.
+- `"industry"`: (*Body Parameter*), `string`
+  Industry of the question.
 
 #### Response
 


### PR DESCRIPTION
### What problem does this PR solve?
Add industry-related search keyword generation function
- When generating search keywords, support for specific industries has been added
- If the "industry" parameter is provided, industry-specific restrictions will be added to the prompt
- This change can help users generate more precise search keywords within specific industries

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [√] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
