### PR TITLE
Fix: fix Trio nursery timeout after add chat and embedding model rate limit

### DIFF
--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -687,7 +687,7 @@ def timeout(seconds: float | int = None, attempts: int = 2, *, exception: Option
 
 
 async def is_strong_enough(chat_model, embedding_model):
-    @timeout(30, 2)
+    @timeout(300, 5)
     async def _is_strong_enough():
         nonlocal chat_model, embedding_model
         if embedding_model:


### PR DESCRIPTION
### What problem does this PR solve?

fix Trio nursery timeout after add chat and embedding model rate limit

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
