### PR TITLE
fix "TypeError: '<' not supported between instances of 'Emu' and 'Non…

### DIFF
--- a/deepdoc/parser/ppt_parser.py
+++ b/deepdoc/parser/ppt_parser.py
@@ -87,7 +87,7 @@ class RAGFlowPptParser:
                 break
             texts = []
             for shape in sorted(
-                    slide.shapes, key=lambda x: ((x.top if x.top is not None else 0) // 10, x.left)):
+                    slide.shapes, key=lambda x: ((x.top if x.top is not None else 0) // 10, x.left if x.left is not None else 0)):
                 try:
                     txt = self.__extract(shape)
                     if txt:


### PR DESCRIPTION
…eType'"

### What problem does this PR solve?

 fix "TypeError: '<' not supported between instances of 'Emu' and 'NoneType'"

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
