### PR TITLE
fix "out of memory" if slide.get_thumbnail() to a huge image

### DIFF
--- a/rag/app/presentation.py
+++ b/rag/app/presentation.py
@@ -42,7 +42,7 @@ class Ppt(PptParser):
                 try:
                     with BytesIO() as buffered:
                         slide.get_thumbnail(
-                            0.5, 0.5).save(
+                            0.1, 0.1).save(
                             buffered, drawing.imaging.ImageFormat.jpeg)
                         buffered.seek(0)
                         imgs.append(Image.open(buffered).copy())


### PR DESCRIPTION
### What problem does this PR solve?

fix "out of memory" if slide.get_thumbnail() to a huge image

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
