### PR TITLE
Fix: correct single base64 image handling in image prompt

### DIFF
--- a/rag/llm/cv_model.py
+++ b/rag/llm/cv_model.py
@@ -59,6 +59,10 @@ class Base(ABC):
     def _image_prompt(self, text, images):
         if not images:
             return text
+
+        if isinstance(images, str):
+            images = [images]
+
         pmpt = [{"type": "text", "text": text}]
         for img in images:
             pmpt.append({


### PR DESCRIPTION
### What problem does this PR solve?

Correct single base64 image handling in image prompt.

![img_v3_02or_ec4757c2-a9d4-4774-9a76-f7c6be633ebg](https://github.com/user-attachments/assets/872a86bf-e2a8-48d1-9b71-2a0c7a35ba9e)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)