### PR TITLE
Fix: PlainParser using fix in presentation

### DIFF
--- a/rag/app/presentation.py
+++ b/rag/app/presentation.py
@@ -135,7 +135,8 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
             sections = pdf_parser(filename, binary, from_page=from_page, to_page=to_page, callback=callback)
         elif layout_recognizer == "Plain Text":
             pdf_parser = PlainParser()
-            sections, _ = pdf_parser(filename, binary, from_page=from_page, to_page=to_page, callback=callback)
+            sections, _ = pdf_parser(filename if not binary else binary, from_page=from_page, to_page=to_page,
+                                      callback=callback)
         else:
             vision_model = LLMBundle(kwargs["tenant_id"], LLMType.IMAGE2TEXT, llm_name=layout_recognizer, lang=lang)
             pdf_parser = VisionParser(vision_model=vision_model, **kwargs)


### PR DESCRIPTION
### What problem does this PR solve?

tiny fix about the using of `deepdoc.pdf_parser.PlainParser` in `rag.app.presentation.chunk`, I referred to other ways of using this class.
So tiny the fix is, a issue seems unnecessary.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
