### PR TITLE
fix: add missing env vars and default values of service_conf.yaml

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -62,6 +62,8 @@ MYSQL_DBNAME=rag_flow
 # The port used to expose the MySQL service to the host machine,
 # allowing EXTERNAL access to the MySQL database running inside the Docker container.
 MYSQL_PORT=5455
+# The maximum size of communication packets sent to the MySQL server
+MYSQL_MAX_PACKET=1073741824
 
 # The hostname where the MinIO service is exposed
 MINIO_HOST=minio

--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -9,6 +9,7 @@ mysql:
   port: 3306
   max_connections: 900
   stale_timeout: 300
+  max_allowed_packet: ${MYSQL_MAX_PACKET:-1073741824}
 minio:
   user: '${MINIO_USER:-rag_flow}'
   password: '${MINIO_PASSWORD:-infini_rag_flow}'

--- a/rag/utils/opendal_conn.py
+++ b/rag/utils/opendal_conn.py
@@ -23,7 +23,7 @@ SET GLOBAL max_allowed_packet={}
 def get_opendal_config():
     try:
         opendal_config = get_base_config('opendal', {})
-        if opendal_config.get("scheme") == 'mysql':
+        if opendal_config.get("scheme", "mysql") == 'mysql':
             mysql_config = get_base_config('mysql', {})
             max_packet = mysql_config.get("max_allowed_packet", 134217728)
             kwargs = {
@@ -33,7 +33,7 @@ def get_opendal_config():
                 "user": mysql_config.get("user", "root"),
                 "password": mysql_config.get("password", ""),
                 "database": mysql_config.get("name", "test_open_dal"),
-                "table": opendal_config.get("config").get("oss_table", "opendal_storage"),
+                "table": opendal_config.get("config", {}).get("oss_table", "opendal_storage"),
                 "max_allowed_packet": str(max_packet)
             }
             kwargs["connection_string"] = f"mysql://{kwargs['user']}:{quote_plus(kwargs['password'])}@{kwargs['host']}:{kwargs['port']}/{kwargs['database']}?max_allowed_packet={max_packet}"


### PR DESCRIPTION
### What problem does this PR solve?

Add missing env var `MYSQL_MAX_PACKET` to service_conf.yaml.template, and add default values to opendal config to fix npe.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
