### PR TITLE
Fix: handle missing dataset_ids when creating chat assistant

### DIFF
--- a/api/apps/sdk/chat.py
+++ b/api/apps/sdk/chat.py
@@ -139,7 +139,7 @@ def create(tenant_id):
     res["llm"] = res.pop("llm_setting")
     res["llm"]["model_name"] = res.pop("llm_id")
     del res["kb_ids"]
-    res["dataset_ids"] = req["dataset_ids"]
+    res["dataset_ids"] = req.get("dataset_ids", [])
     res["avatar"] = res.pop("icon")
     return get_result(data=res)
 


### PR DESCRIPTION
- Root cause: accessing req.get("dataset_ids") returns None when the key is absent, causing KeyError.
- Fix: use req.get("dataset_ids", []) to default to empty list.
