### PR TITLE
Fix: Remove default dataset_ids from Chat class initialization

### DIFF
--- a/sdk/python/ragflow_sdk/modules/chat.py
+++ b/sdk/python/ragflow_sdk/modules/chat.py
@@ -24,7 +24,6 @@ class Chat(Base):
         self.id = ""
         self.name = "assistant"
         self.avatar = "path/to/avatar"
-        self.dataset_ids = ["kb1"]
         self.llm = Chat.LLM(rag, {})
         self.prompt = Chat.Prompt(rag, {})
         super().__init__(rag, res_dict)


### PR DESCRIPTION
### What problem does this PR solve?

- The default dataset_ids "kb1" was removed from the Chat class. 
- The HTTP API response does not include the dataset_ids field.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
