### PR TITLE
Fix: Update test assertions and add GraphRAG config in dataset tests

### DIFF
--- a/test/testcases/test_sdk_api/test_chunk_management_within_dataset/test_update_chunk.py
+++ b/test/testcases/test_sdk_api/test_chunk_management_within_dataset/test_update_chunk.py
@@ -151,4 +151,4 @@ class TestUpdatedChunk:
 
         with pytest.raises(Exception) as excinfo:
             chunks[0].update({})
-        assert f"Can't find this chunk {chunks[0].id}" in str(excinfo.value), str(excinfo.value)
+        assert f"You don't own the document {chunks[0].document_id}" in str(excinfo.value), str(excinfo.value)

--- a/test/testcases/test_sdk_api/test_dataset_mangement/test_update_dataset.py
+++ b/test/testcases/test_sdk_api/test_dataset_mangement/test_update_dataset.py
@@ -693,6 +693,7 @@ class TestDatasetUpdate:
             client,
             {
                 "raptor": {"use_raptor": False},
+                "graphrag": {"use_graphrag": False},
             },
         )
         dataset.update({"chunk_method": "qa"})
@@ -708,6 +709,7 @@ class TestDatasetUpdate:
             client,
             {
                 "raptor": {"use_raptor": False},
+                "graphrag": {"use_graphrag": False},
             },
         )
         dataset.update({"chunk_method": "qa", "parser_config": None})


### PR DESCRIPTION
### What problem does this PR solve?

- Modify error message assertion in chunk update test to check for document ownership
- Add GraphRAG configuration with `use_graphrag: False` in dataset update tests
- Fix actions: https://github.com/infiniflow/ragflow/actions/runs/16863637898/job/47767511582
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
