### PR TITLE
Python SDK: add meta_fields to Document class

### DIFF
--- a/sdk/python/ragflow_sdk/modules/document.py
+++ b/sdk/python/ragflow_sdk/modules/document.py
@@ -44,6 +44,7 @@ class Document(Base):
         self.process_duration = 0.0
         self.run = "0"
         self.status = "1"
+        self.meta_fields = {}
         for k in list(res_dict.keys()):
             if k not in self.__dict__:
                 res_dict.pop(k)


### PR DESCRIPTION
### What problem does this PR solve?

Python class Document was missing "meta_fields", e.g. when querying, the document instances came without meta_fields

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
