### PR TITLE
Docs: Update HTTP API reference with new response fields

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -2632,9 +2632,11 @@ data:{
                     "document_name": "1.txt",
                     "dataset_id": "8e83e57a884611ef9d760242ac120006",
                     "image_id": "",
+                    "url": null,
                     "similarity": 0.7,
                     "vector_similarity": 0.0,
                     "term_similarity": 1.0,
+                    "doc_type": [],
                     "positions": [
                         ""
                     ]
@@ -2649,6 +2651,7 @@ data:{
             ]
         },
         "prompt": "xxxxxxxxxxx",
+        "created_at": 1755055623.6401553,
         "id": "a84c5dd4-97b4-4624-8c3b-974012c8000d",
         "session_id": "82b0ab2a9c1911ef9d870242ac120006"
     }


### PR DESCRIPTION
### What problem does this PR solve?

Add `url`, `doc_type`, and `created_at` fields to the API response example in the documentation.

### Type of change

- [x] Documentation Update

