### PR TITLE
Feat:to create a option let agent has independent histoy

### DIFF
--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -46,6 +46,7 @@ class ComponentParamBase(ABC):
         self.exception_default_value = None
         self.exception_goto = None
         self.debug_inputs = {}
+        self.history_independent = False
 
     def set_name(self, name: str):
         self._name = name

--- a/agent/component/llm.py
+++ b/agent/component/llm.py
@@ -141,7 +141,7 @@ class LLM(ComponentBase):
             self.set_input_value(k, args[k])
 
         if hasattr(self._param, 'history_independent') and self._param.history_independent:
-            msg = self._canvas.get_agent_history(self._id, self._param.message_history_window_size)[:-1]
+            msg = self._canvas.get_agent_history(self._id, self._param.message_history_window_size)
         else:
             msg = self._canvas.get_history(self._param.message_history_window_size)[:-1]
         msg.extend(deepcopy(self._param.prompts))

--- a/agent/component/llm.py
+++ b/agent/component/llm.py
@@ -140,7 +140,6 @@ class LLM(ComponentBase):
                     args[k] = str(args[k])
             self.set_input_value(k, args[k])
 
-        # 根据history_independent参数选择历史记录来源
         if hasattr(self._param, 'history_independent') and self._param.history_independent:
             msg = self._canvas.get_agent_history(self._id, self._param.message_history_window_size)[:-1]
         else:

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -915,6 +915,9 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       messageHistoryWindowSize: 'Message window size',
       messageHistoryWindowSizeTip:
         'The window size of conversation history visible to the LLM. Larger is better, but be mindful of the maximum token limit of LLM.',
+      historyIndependent: 'Independent history',
+      historyIndependentTip:
+        'Enable independent history for this agent. When enabled, this agent will have its own conversation history separate from other agents, preventing context pollution in multi-agent workflows.',
       wikipedia: 'Wikipedia',
       pubMed: 'PubMed',
       pubMedDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -874,6 +874,9 @@ General：实体和关系提取提示来自 GitHub - microsoft/graphrag：基于
       messageHistoryWindowSize: '历史消息窗口大小',
       messageHistoryWindowSizeTip:
         'LLM 需要查看的对话历史窗口大小。越大越好。但要注意 LLM 的最大 Token 数。',
+      historyIndependent: '独立历史',
+      historyIndependentTip:
+        '启用此代理的独立历史记录。启用后，此代理将拥有与其他代理分离的自己的对话历史，防止多代理工作流中的上下文污染。',
       wikipedia: '维基百科',
       emailTip:
         '此组件用于从 https://pubmed.ncbi.nlm.nih.gov/ 获取搜索结果。通常，它作为知识库的补充。Top N 指定您需要调整的搜索结果数。电子邮件是必填字段。',

--- a/web/src/pages/agent/canvas/node/agent-node.tsx
+++ b/web/src/pages/agent/canvas/node/agent-node.tsx
@@ -84,7 +84,14 @@ function InnerAgentNode({
         <NodeHeader id={id} name={data.name} label={data.label}></NodeHeader>
         <section className="flex flex-col gap-2">
           <div className={'bg-bg-card rounded-sm p-1'}>
-            <LLMLabel value={get(data, 'form.llm_id')}></LLMLabel>
+            <div className="flex items-center justify-between">
+              <LLMLabel value={get(data, 'form.llm_id')}></LLMLabel>
+              {get(data, 'form.history_independent', false) && (
+                <div className="ml-2 text-xs bg-green-500 text-white px-2 py-1 rounded-full" title="Independent History">
+                  🗂️
+                </div>
+              )}
+            </div>
           </div>
           {(isGotoMethod ||
             exceptionMethod === AgentExceptionMethod.Comment) && (

--- a/web/src/pages/agent/constant.tsx
+++ b/web/src/pages/agent/constant.tsx
@@ -642,6 +642,7 @@ export const initialAgentValues = {
 </instructions>`,
   prompts: [{ role: PromptRole.User, content: `{${AgentGlobals.SysQuery}}` }],
   message_history_window_size: 12,
+  history_independent: false,
   max_retries: 3,
   delay_after_error: 1,
   visual_files_var: '',

--- a/web/src/pages/agent/form/agent-form/index.tsx
+++ b/web/src/pages/agent/form/agent-form/index.tsx
@@ -188,23 +188,6 @@ function AgentForm({ node }: INextOperatorForm) {
             <MessageHistoryWindowSizeFormField></MessageHistoryWindowSizeFormField>
             <FormField
               control={form.control}
-              name={`history_independent`}
-              render={({ field }) => (
-                <FormItem className="flex-1">
-                  <FormLabel tooltip={t('flow.historyIndependentTip')}>
-                    {t('flow.historyIndependent')}
-                  </FormLabel>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
               name={`max_retries`}
               render={({ field }) => (
                 <FormItem className="flex-1">
@@ -250,6 +233,23 @@ function AgentForm({ node }: INextOperatorForm) {
                       {...field}
                       options={ExceptionMethodOptions}
                       allowClear
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name={`history_independent`}
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel tooltip={t('flow.historyIndependentTip')}>
+                    {t('flow.historyIndependent')}
+                  </FormLabel>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
                     />
                   </FormControl>
                 </FormItem>

--- a/web/src/pages/agent/form/agent-form/index.tsx
+++ b/web/src/pages/agent/form/agent-form/index.tsx
@@ -15,6 +15,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Input, NumberInput } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import { LlmModelType } from '@/constants/knowledge';
 import { useFindLlmByUuid } from '@/hooks/use-llm-request';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -55,6 +56,7 @@ const FormSchema = z.object({
   //   )
   //   .optional(),
   message_history_window_size: z.coerce.number(),
+  history_independent: z.boolean().optional(),
   tools: z
     .array(
       z.object({
@@ -184,6 +186,23 @@ function AgentForm({ node }: INextOperatorForm) {
         <Collapse title={<div>Advanced Settings</div>}>
           <FormContainer>
             <MessageHistoryWindowSizeFormField></MessageHistoryWindowSizeFormField>
+            <FormField
+              control={form.control}
+              name={`history_independent`}
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel tooltip={t('flow.historyIndependentTip')}>
+                    {t('flow.historyIndependent')}
+                  </FormLabel>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
             <FormField
               control={form.control}
               name={`max_retries`}

--- a/web/src/pages/flow/canvas/node/index.less
+++ b/web/src/pages/flow/canvas/node/index.less
@@ -150,6 +150,19 @@
   border-radius: 3px;
   min-height: 22px;
   .textEllipsis();
+  
+  .independentHistoryBadge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 6px;
+    background: #28a745;
+    color: white;
+    border-radius: 12px;
+    font-size: 10px;
+    line-height: 1;
+    vertical-align: middle;
+    cursor: help;
+  }
 }
 
 .nodeHeader {


### PR DESCRIPTION
### What problem does this PR solve?

when create mutiagent in a workflow ,In the second round and subsequent dialogues, the agent will default to using the content output from the last message, which can sometimes affect the quality of generation. Therefore, an option should be established for the agent to only read the historical information from its own.

### Type of change
- [x] New Feature
