### PR TITLE
My branch

### DIFF
--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -529,9 +529,13 @@ class ComponentBase(ABC):
     @staticmethod
     def string_format(content: str, kv: dict[str, str]) -> str:
         for n, v in kv.items():
-            content = re.sub(
-                r"\{%s\}" % re.escape(n), v, content
-            )
+            pattern = r"\{%s\}" % re.escape(n)
+            if callable(v):
+                repl_func = lambda m, func=v: str(func(m))
+            else:
+                repl_func = lambda m, val=v: str(val)
+
+            content = re.sub(pattern, repl_func, content)
         return content
 
     def exception_handler(self):


### PR DESCRIPTION
### What problem does this PR solve?

When calling HTTP to request data, if the JSON string returned by the interface contains an unasked back slash like '\u', Python's RE module will escape 'u' as Unicode, but there is no valid 4-digit hexadecimal number at the end, so it will directly report an error. Error: re. error: bad escape \ u at position 26
### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
