### PR TITLE
Fix the bug in enablePrologue under agent task mode

### DIFF
--- a/web/src/pages/agent/form/begin-form/index.tsx
+++ b/web/src/pages/agent/form/begin-form/index.tsx
@@ -15,7 +15,7 @@ import { FormTooltip } from '@/components/ui/tooltip';
 import { buildSelectOptions } from '@/utils/component-util';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -69,6 +69,12 @@ function BeginForm({ node }: INextOperatorForm) {
     control: form.control,
     name: 'enablePrologue',
   });
+
+  useEffect(() => {
+    if (mode === AgentDialogueMode.Task && enablePrologue) {
+      form.setValue('enablePrologue', false);
+    }
+  }, [mode, enablePrologue, form]);
 
   const {
     ok,

--- a/web/src/pages/agent/form/begin-form/index.tsx
+++ b/web/src/pages/agent/form/begin-form/index.tsx
@@ -15,7 +15,7 @@ import { FormTooltip } from '@/components/ui/tooltip';
 import { buildSelectOptions } from '@/utils/component-util';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus } from 'lucide-react';
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -70,11 +70,17 @@ function BeginForm({ node }: INextOperatorForm) {
     name: 'enablePrologue',
   });
 
+  const previousModeRef = useRef(mode);
+
   useEffect(() => {
-    if (mode === AgentDialogueMode.Task && enablePrologue) {
-      form.setValue('enablePrologue', false);
+    if (
+      previousModeRef.current === AgentDialogueMode.Task &&
+      mode === AgentDialogueMode.Conversational
+    ) {
+      form.setValue('enablePrologue', true);
     }
-  }, [mode, enablePrologue, form]);
+    previousModeRef.current = mode;
+  }, [mode, form]);
 
   const {
     ok,


### PR DESCRIPTION
### What problem does this PR solve?

There is a problem with the implementation of the Agent begin-form: although the enablePrologue switch and the prologue input box are hidden in Task mode, these values are still saved in the form data. If the user first enables the opening and sets the content in Conversational mode, and then switches to Task mode, these values will still be saved and may be used in some scenarios.
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
