### PR TITLE
Refactor:Standardize image conf and add private registry support

### DIFF
--- a/helm/templates/elasticsearch.yaml
+++ b/helm/templates/elasticsearch.yaml
@@ -44,9 +44,21 @@ spec:
         checksum/config-es: {{ include (print $.Template.BasePath "/elasticsearch-config.yaml") . | sha256sum }}
         checksum/config-env: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
     spec:
+      {{- if or .Values.imagePullSecrets .Values.elasticsearch.image.pullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.elasticsearch.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       initContainers:
       - name: fix-data-volume-permissions
-        image: alpine
+        image: {{ .Values.elasticsearch.initContainers.alpine.repository }}:{{ .Values.elasticsearch.initContainers.alpine.tag }}
+        {{- with .Values.elasticsearch.initContainers.alpine.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         command:
         - sh
         - -c
@@ -55,14 +67,20 @@ spec:
           - mountPath: /usr/share/elasticsearch/data
             name: es-data
       - name: sysctl
-        image: busybox
+        image: {{ .Values.elasticsearch.initContainers.busybox.repository }}:{{ .Values.elasticsearch.initContainers.busybox.tag }}
+        {{- with .Values.elasticsearch.initContainers.busybox.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         securityContext:
           privileged: true
           runAsUser: 0
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
       containers:
       - name: elasticsearch
-        image: elasticsearch:{{ .Values.env.STACK_VERSION }}
+        image: {{ .Values.elasticsearch.image.repository }}:{{ .Values.elasticsearch.image.tag }}
+        {{- with .Values.elasticsearch.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: {{ include "ragflow.fullname" . }}-env-config

--- a/helm/templates/infinity.yaml
+++ b/helm/templates/infinity.yaml
@@ -43,9 +43,21 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
     spec:
+      {{- if or .Values.imagePullSecrets .Values.infinity.image.pullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.infinity.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: infinity
         image: {{ .Values.infinity.image.repository }}:{{ .Values.infinity.image.tag }}
+        {{- with .Values.infinity.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: {{ include "ragflow.fullname" . }}-env-config

--- a/helm/templates/minio.yaml
+++ b/helm/templates/minio.yaml
@@ -43,9 +43,21 @@ spec:
         {{- include "ragflow.labels" . | nindent 8 }}
         app.kubernetes.io/component: minio
     spec:
+      {{- if or .Values.imagePullSecrets .Values.minio.image.pullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.minio.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: minio
         image: {{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}
+        {{- with .Values.minio.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: {{ include "ragflow.fullname" . }}-env-config

--- a/helm/templates/mysql.yaml
+++ b/helm/templates/mysql.yaml
@@ -44,9 +44,21 @@ spec:
         checksum/config-mysql: {{ include (print $.Template.BasePath "/mysql-config.yaml") . | sha256sum }}
         checksum/config-env: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
     spec:
+      {{- if or .Values.imagePullSecrets .Values.mysql.image.pullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.mysql.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: mysql
         image: {{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}
+        {{- with .Values.mysql.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: {{ include "ragflow.fullname" . }}-env-config

--- a/helm/templates/opensearch.yaml
+++ b/helm/templates/opensearch.yaml
@@ -44,9 +44,21 @@ spec:
         checksum/config-opensearch: {{ include (print $.Template.BasePath "/opensearch-config.yaml") . | sha256sum }}
         checksum/config-env: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
     spec:
+      {{- if or .Values.imagePullSecrets .Values.opensearch.image.pullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.opensearch.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       initContainers:
       - name: fix-data-volume-permissions
-        image: alpine
+        image: {{ .Values.opensearch.initContainers.alpine.repository }}:{{ .Values.opensearch.initContainers.alpine.tag }}
+        {{- with .Values.opensearch.initContainers.alpine.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         command:
         - sh
         - -c
@@ -55,7 +67,10 @@ spec:
           - mountPath: /usr/share/opensearch/data
             name: opensearch-data
       - name: sysctl
-        image: busybox
+        image: {{ .Values.opensearch.initContainers.busybox.repository }}:{{ .Values.opensearch.initContainers.busybox.tag }}
+        {{- with .Values.opensearch.initContainers.busybox.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         securityContext:
           privileged: true
           runAsUser: 0
@@ -63,6 +78,9 @@ spec:
       containers:
       - name: opensearch
         image: {{ .Values.opensearch.image.repository }}:{{ .Values.opensearch.image.tag }}
+        {{- with .Values.opensearch.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: {{ include "ragflow.fullname" . }}-env-config

--- a/helm/templates/ragflow.yaml
+++ b/helm/templates/ragflow.yaml
@@ -25,9 +25,21 @@ spec:
         checksum/config-env: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
         checksum/config-ragflow: {{ include (print $.Template.BasePath "/ragflow_config.yaml") . | sha256sum }}
     spec:
+      {{- if or .Values.imagePullSecrets .Values.ragflow.image.pullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.ragflow.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: ragflow
-        image: {{ .Values.env.RAGFLOW_IMAGE }}
+        image: {{ .Values.ragflow.image.repository }}:{{ .Values.ragflow.image.tag }}
+        {{- with .Values.ragflow.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         ports:
           - containerPort: 80
             name: http

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -40,10 +40,22 @@ spec:
       annotations:
         checksum/config-env: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
     spec:
+      {{- if or .Values.imagePullSecrets .Values.redis.image.pullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.redis.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       containers:
         - name: redis
           image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+          {{- with .Values.redis.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           command:
             - "sh"
             - "-c"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,4 +1,8 @@
 # Based on docker compose .env file
+
+# Global image pull secrets configuration
+imagePullSecrets: []
+
 env:
   # The type of doc engine to use.
   # Available options:
@@ -32,31 +36,6 @@ env:
   # The password for Redis
   REDIS_PASSWORD: infini_rag_flow_helm
 
-  # The RAGFlow Docker image to download.
-  # Defaults to the v0.20.1-slim edition, which is the RAGFlow Docker image without embedding models.
-  RAGFLOW_IMAGE: infiniflow/ragflow:v0.20.1-slim
-  #
-  # To download the RAGFlow Docker image with embedding models, uncomment the following line instead:
-  # RAGFLOW_IMAGE: infiniflow/ragflow:v0.20.1
-  #
-  # The Docker image of the v0.20.1 edition includes:
-  # - Built-in embedding models:
-  #   - BAAI/bge-large-zh-v1.5
-  #   - BAAI/bge-reranker-v2-m3
-  #   - maidalun1020/bce-embedding-base_v1
-  #   - maidalun1020/bce-reranker-base_v1
-  # - Embedding models that will be downloaded once you select them in the RAGFlow UI:
-  #   - BAAI/bge-base-en-v1.5
-  #   - BAAI/bge-large-en-v1.5
-  #   - BAAI/bge-small-en-v1.5
-  #   - BAAI/bge-small-zh-v1.5
-  #   - jinaai/jina-embeddings-v2-base-en
-  #   - jinaai/jina-embeddings-v2-small-en
-  #   - nomic-ai/nomic-embed-text-v1.5
-  #   - sentence-transformers/all-MiniLM-L6-v2
-  #
-  #
-
   # The local time zone.
   TIMEZONE: "Asia/Shanghai"
 
@@ -75,7 +54,11 @@ env:
   EMBEDDING_BATCH_SIZE: 16
 
 ragflow:
-
+  image:
+    repository: infiniflow/ragflow
+    tag: v0.20.1-slim
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   # Optional service configuration overrides
   # to be written to local.service_conf.yaml
   # inside the RAGFlow container
@@ -114,6 +97,8 @@ infinity:
   image:
     repository: infiniflow/infinity
     tag: v0.6.0-dev5
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   storage:
     className:
     capacity: 5Gi
@@ -124,6 +109,20 @@ infinity:
     type: ClusterIP
 
 elasticsearch:
+  image:
+    repository: elasticsearch
+    tag: "8.11.3"
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  initContainers:
+    alpine:
+      repository: alpine
+      tag: latest
+      pullPolicy: IfNotPresent
+    busybox:
+      repository: busybox
+      tag: latest
+      pullPolicy: IfNotPresent
   storage:
     className:
     capacity: 20Gi
@@ -140,6 +139,17 @@ opensearch:
   image:
     repository: opensearchproject/opensearch
     tag: 2.19.1
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  initContainers:
+    alpine:
+      repository: alpine
+      tag: latest
+      pullPolicy: IfNotPresent
+    busybox:
+      repository: busybox
+      tag: latest
+      pullPolicy: IfNotPresent
   storage:
     className:
     capacity: 20Gi
@@ -156,6 +166,8 @@ minio:
   image:
     repository: quay.io/minio/minio
     tag: RELEASE.2023-12-20T01-00-02Z
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   storage:
     className:
     capacity: 5Gi
@@ -169,6 +181,8 @@ mysql:
   image:
     repository: mysql
     tag: 8.0.39
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   storage:
     className:
     capacity: 5Gi
@@ -182,6 +196,8 @@ redis:
   image:
     repository: valkey/valkey
     tag: 8
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   storage:
     className:
     capacity: 5Gi


### PR DESCRIPTION
- Unified configuration format: All services now use the same image configuration structure for consistency.

- Private registry support: Added imagePullSecrets to enable pulling images from private registries.

-  Per-service flexibility: Each service can override image-related parameters independently.

### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
