### PR TITLE
Fix: ensure update_progress loop always waits between iterations

### DIFF
--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -59,11 +59,14 @@ def update_progress():
             if redis_lock.acquire():
                 DocumentService.update_progress()
                 redis_lock.release()
-            stop_event.wait(6)
         except Exception:
             logging.exception("update_progress exception")
         finally:
-            redis_lock.release()
+            try:
+                redis_lock.release()
+            except Exception:
+                logging.exception("update_progress exception")
+            stop_event.wait(6)
 
 def signal_handler(sig, frame):
     logging.info("Received interrupt signal, shutting down...")


### PR DESCRIPTION
Move stop_event.wait(6) into finally block so that even when an exception occurs, the loop still sleeps before retrying. This prevents busy looping and excessive error logs when Redis connection fails.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
