### PR TITLE
Feat: Exclude operator_permission field from renaming chat fields #3221

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -2,7 +2,6 @@ import { Toaster as Sonner } from '@/components/ui/sonner';
 import { Toaster } from '@/components/ui/toaster';
 import i18n from '@/locales/config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { App, ConfigProvider, ConfigProviderProps, theme } from 'antd';
 import pt_BR from 'antd/lib/locale/pt_BR';
 import deDE from 'antd/locale/de_DE';
@@ -85,7 +84,7 @@ function Root({ children }: React.PropsWithChildren) {
         <Sonner position={'top-right'} expand richColors closeButton></Sonner>
         <Toaster />
       </ConfigProvider>
-      <ReactQueryDevtools buttonPosition={'top-left'} initialIsOpen={false} />
+      {/* <ReactQueryDevtools buttonPosition={'top-left'} initialIsOpen={false} /> */}
     </>
   );
 }

--- a/web/src/pages/next-chats/chat/app-settings/chat-settings.tsx
+++ b/web/src/pages/next-chats/chat/app-settings/chat-settings.tsx
@@ -9,6 +9,7 @@ import {
   setLLMSettingEnabledValues,
 } from '@/utils/form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { omit } from 'lodash';
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
@@ -69,7 +70,7 @@ export function ChatSettings({ switchSettingVisible }: ChatSettingsProps) {
         ? await transformFile2Base64(icon[0])
         : '';
     setDialog({
-      ...data,
+      ...omit(data, 'operator_permission'),
       ...nextValues,
       icon: avatar,
       dialog_id: id,

--- a/web/src/pages/next-chats/hooks/use-rename-chat.ts
+++ b/web/src/pages/next-chats/hooks/use-rename-chat.ts
@@ -48,7 +48,10 @@ export const useRenameChat = () => {
       const nextChat = {
         ...(isEmpty(chat)
           ? InitialData
-          : { ...omit(chat, 'nickname', 'tenant_avatar'), dialog_id: chat.id }),
+          : {
+              ...omit(chat, 'nickname', 'tenant_avatar', 'operator_permission'),
+              dialog_id: chat.id,
+            }),
         name,
       };
       const ret = await setDialog(nextChat);


### PR DESCRIPTION
### What problem does this PR solve?

Feat: Exclude operator_permission field from renaming chat fields #3221

### Type of change


- [x] New Feature (non-breaking change which adds functionality)
