### PR TITLE
Update routes.ts

### DIFF
--- a/web/src/routes.ts
+++ b/web/src/routes.ts
@@ -74,7 +74,7 @@ const routes = [
     path: Routes.Home,
     component: '@/layouts',
     layout: false,
-    redirect: '/knowledge',
+    redirect: '/',
   },
   {
     path: '/knowledge',


### PR DESCRIPTION
Change redirect target from /knowledge to /

### What problem does this PR solve?

After logging in, the user should be directed to the homepage instead of the knowledge base page. The redirect should go to `/` rather than `/knowledge`. I believe this is a bug.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
