### PR TITLE
fix: validate chunk type before processing to prevent AttributeError

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -562,6 +562,9 @@ def list_agent_session(tenant_id, agent_id):
                             "chunks" in conv["reference"][chunk_num]):
                         chunks = conv["reference"][chunk_num]["chunks"]
                         for chunk in chunks:
+                            # Ensure chunk is a dictionary before calling get method
+                            if not isinstance(chunk, dict):
+                                continue
                             new_chunk = {
                                 "id": chunk.get("chunk_id", chunk.get("id")),
                                 "content": chunk.get("content_with_weight", chunk.get("content")),


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes a critical bug in the session listing endpoint where the application crashes with an `AttributeError` when processing chunk data that contains non-dictionary objects.

**Error before fix:**
```json
{
  "code": 100,
  "data": null,
  "message": "AttributeError(\"'str' object has no attribute 'get'\")"
}
```

**Root cause:**
The code assumes all items in the `chunks` array are dictionary objects and directly calls the `.get()` method on them. However, in some cases, the chunks array contains string objects or other non-dictionary types, causing the application to crash when attempting to call `.get()` on a string.

**Solution:**
Added type validation to ensure each chunk is a dictionary before processing. Non-dictionary chunks are safely skipped, preventing the crash while maintaining functionality for valid chunk data.

This fix improves the robustness of the session listing endpoint and ensures users can retrieve their conversation sessions without encountering server errors due to data format inconsistencies.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)