### PR TITLE
Clarify installation of pre-commit alongside uv in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
 
 ## 🔨 Launch service from source for development
 
-1. Install uv, or skip this step if it is already installed:
+1. Install `uv` and `pre-commit`, or skip this step if they are already installed:
 
    ```bash
    pipx install uv pre-commit

--- a/README_id.md
+++ b/README_id.md
@@ -271,7 +271,7 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
 
 ## 🔨 Menjalankan Aplikasi dari untuk Pengembangan
 
-1. Instal uv, atau lewati langkah ini jika sudah terinstal:
+1. Instal `uv` dan `pre-commit`, atau lewati langkah ini jika sudah terinstal:
 
    ```bash
    pipx install uv pre-commit

--- a/README_ja.md
+++ b/README_ja.md
@@ -266,7 +266,7 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
 
 ## 🔨 ソースコードからサービスを起動する方法
 
-1. uv をインストールする。すでにインストールされている場合は、このステップをスキップしてください:
+1. `uv` と `pre-commit` をインストールする。すでにインストールされている場合は、このステップをスキップしてください:
 
    ```bash
    pipx install uv pre-commit

--- a/README_ko.md
+++ b/README_ko.md
@@ -265,7 +265,7 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
 
 ## 🔨 소스 코드로 서비스를 시작합니다.
 
-1. uv를 설치하거나 이미 설치된 경우 이 단계를 건너뜁니다:
+1. `uv` 와 `pre-commit` 을 설치하거나, 이미 설치된 경우 이 단계를 건너뜁니다:
 
    ```bash
    pipx install uv pre-commit

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -289,7 +289,7 @@ docker build --platform linux/amd64 -f Dockerfile -t infiniflow/ragflow:nightly 
 
 ## 🔨 Lançar o serviço a partir do código-fonte para desenvolvimento
 
-1. Instale o `uv`, ou pule esta etapa se ele já estiver instalado:
+1. Instale o `uv` e o `pre-commit`, ou pule esta etapa se eles já estiverem instalados:
 
    ```bash
    pipx install uv pre-commit

--- a/README_tzh.md
+++ b/README_tzh.md
@@ -301,7 +301,7 @@ docker build --platform linux/amd64 --build-arg NEED_MIRROR=1 -f Dockerfile -t i
 
 ## 🔨 以原始碼啟動服務
 
-1. 安裝 uv。如已安裝，可跳過此步驟：
+1. 安裝 `uv` 和 `pre-commit`。如已安裝，可跳過此步驟：
 
    ```bash
    pipx install uv pre-commit

--- a/README_zh.md
+++ b/README_zh.md
@@ -301,7 +301,7 @@ docker build --platform linux/amd64 --build-arg NEED_MIRROR=1 -f Dockerfile -t i
 
 ## 🔨 以源代码启动服务
 
-1. 安装 uv。如已经安装，可跳过本步骤：
+1. 安装 `uv` 和 `pre-commit`。如已经安装，可跳过本步骤：
 
    ```bash
    pipx install uv pre-commit


### PR DESCRIPTION
### What problem does this PR solve?

Updates the installation step in README.md to explicitly include pre-commit alongside uv.

Applies the change to all localized versions: English, Chinese, Japanese, Korean, Indonesian, and Portuguese.
#### Why this is needed:

The installation instructions previously mentioned only uv, but pre-commit is also required for contributing.

Ensures consistency across all language versions and helps new contributors set up the environment correctly.

### Type of change

- [x] Documentation Update