### PR TITLE
Update API reference to use 'title' instead of 'name' for listing agents

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -3811,7 +3811,7 @@ Lists agents.
 #### Request
 
 - Method: GET
-- URL: `/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&name={agent_name}&id={agent_id}`
+- URL: `/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&title={agent_name}&id={agent_id}`
 - Headers:
   - `'Authorization: Bearer <YOUR_API_KEY>'`
 
@@ -3819,7 +3819,7 @@ Lists agents.
 
 ```bash
 curl --request GET \
-     --url http://{address}/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&name={agent_name}&id={agent_id} \
+     --url http://{address}/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&title={agent_name}&id={agent_id} \
      --header 'Authorization: Bearer <YOUR_API_KEY>'
 ```
 
@@ -3837,7 +3837,7 @@ curl --request GET \
   Indicates whether the retrieved agents should be sorted in descending order. Defaults to `true`.
 - `id`: (*Filter parameter*), `string`  
   The ID of the agent to retrieve.
-- `name`: (*Filter parameter*), `string`  
+- `title`: (*Filter parameter*), `string`  
   The name of the agent to retrieve.
 
 #### Response


### PR DESCRIPTION
### What problem does this PR solve?

HTTP API documentation incorrectly refers `agent_name` as `name` instead of `title`. This PR updates that documentation with the correct terms.  
As per the codebase, the GET request for listing agents is accepting `title` as a parameter:
https://github.com/infiniflow/ragflow/blob/9b026fc5b6f234a3abdf954f359bc2f9e99d9ba8/api/apps/sdk/agent.py#L32
This is referred to as `name` parameter in the HTTP API documentation ([link](https://ragflow.io/docs/dev/http_api_reference#list-documents)) 
```
GET /api/v1/datasets/{dataset_id}/documents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&keywords={keywords}&id={document_id}&name={document_name}&create_time_from={timestamp}&create_time_to={timestamp}
```
Meanwhile, it is correctly mentioned in the Python API docs ([link](https://ragflow.io/docs/dev/python_api_reference#list-agents)):
```
RAGFlow.list_agents(
    page: int = 1, 
    page_size: int = 30, 
    orderby: str = "create_time", 
    desc: bool = True,
    id: str = None,
    title: str = None
) -> List[Agent]
```
### Type of change

- [x] Documentation Update
