### PR TITLE
Fix kb isolation infinity conn

### DIFF
--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -67,7 +67,7 @@ def equivalent_condition_to_str(condition: dict, table_instance=None) -> str | N
 
     cond = list()
     for k, v in condition.items():
-        if not isinstance(k, str) or k in ["kb_id"] or not v:
+        if not isinstance(k, str) or not v:
             continue
         if field_keyword(k):
             if isinstance(v, list):

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -80,10 +80,13 @@ class RAGFlowS3:
                 s3_params['region_name'] = self.region_name
             if self.endpoint_url:
                 s3_params['endpoint_url'] = self.endpoint_url
+            
+            # Configure signature_version and addressing_style through Config object
             if self.signature_version:
-                s3_params['signature_version'] = self.signature_version
+                config_kwargs['signature_version'] = self.signature_version
             if self.addressing_style:
-                s3_params['addressing_style'] = self.addressing_style
+                config_kwargs['s3'] = {'addressing_style': self.addressing_style}
+            
             if config_kwargs:
                 s3_params['config'] = Config(**config_kwargs)
             

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -80,12 +80,10 @@ class RAGFlowS3:
                 s3_params['region_name'] = self.region_name
             if self.endpoint_url:
                 s3_params['endpoint_url'] = self.endpoint_url
-            
             if self.signature_version:
                 s3_params['signature_version'] = self.signature_version
             if self.addressing_style:
                 s3_params['addressing_style'] = self.addressing_style
-            
             if config_kwargs:
                 s3_params['config'] = Config(**config_kwargs)
             

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -81,11 +81,10 @@ class RAGFlowS3:
             if self.endpoint_url:
                 s3_params['endpoint_url'] = self.endpoint_url
             
-            # Configure signature_version and addressing_style through Config object
             if self.signature_version:
-                config_kwargs['signature_version'] = self.signature_version
+                s3_params['signature_version'] = self.signature_version
             if self.addressing_style:
-                config_kwargs['s3'] = {'addressing_style': self.addressing_style}
+                s3_params['addressing_style'] = self.addressing_style
             
             if config_kwargs:
                 s3_params['config'] = Config(**config_kwargs)


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes a critical bug in the knowledge base isolation feature where chat responses were referencing documents from incorrect knowledge bases. The issue was in the `infinity_conn.py` file where the `equivalent_condition_to_str()` function was incorrectly skipping `kb_id` filtering, causing documents from unintended knowledge bases to be included in search results.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

