### PR TITLE
feat: add multiple docker tags (latest, latest_full, latest_slim) to …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           context: .
           push: true
           tags: |
-            infiniflow/ragflow:${{ env.RELEASE_TAG }}-slim 
+            infiniflow/ragflow:${{ env.RELEASE_TAG }}-slim
             infiniflow/ragflow:latest-slim
           file: Dockerfile
           build-args: LIGHTEN=1


### PR DESCRIPTION
…release workflow (#10039)  
This change updates the GitHub Actions workflow to push additional stable tags alongside version tags, enabling automated update tools like Watchtower to detect and pull the latest images correctly.  
Refs: [https://github.com/infiniflow/ragflow/issues/10039](https://github.com/infiniflow/ragflow/issues/10039)

### What problem does this PR solve?  
Automated container update tools such as Watchtower rely on stable tags like `latest` to identify the newest images. Previously, only version-specific tags were pushed, which prevented these tools from detecting new releases automatically. This PR adds multiple stable tags (`latest-full`, `latest-slim`) alongside version tags to the Docker image publishing workflow, ensuring smooth and reliable automated updates without manual tag management.

### Type of change  
- [ ] Bug Fix (non-breaking change which fixes an issue)  
- [x] New Feature (non-breaking change which adds functionality)  
- [ ] Documentation Update  
- [ ] Refactoring  
- [ ] Performance Improvement  
- [ ] Other (please describe): 
