### PR TITLE
bug: fixed usage of postgresql -> postgres for db_type

### DIFF
--- a/agent/tools/exesql.py
+++ b/agent/tools/exesql.py
@@ -53,7 +53,7 @@ class ExeSQLParam(ToolParamBase):
         self.max_records = 1024
 
     def check(self):
-        self.check_valid_value(self.db_type, "Choose DB type", ['mysql', 'postgresql', 'mariadb', 'mssql'])
+        self.check_valid_value(self.db_type, "Choose DB type", ['mysql', 'postgres', 'mariadb', 'mssql'])
         self.check_empty(self.database, "Database name")
         self.check_empty(self.username, "database username")
         self.check_empty(self.host, "IP Address")
@@ -111,7 +111,7 @@ class ExeSQL(ToolBase, ABC):
         if self._param.db_type in ["mysql", "mariadb"]:
             db = pymysql.connect(db=self._param.database, user=self._param.username, host=self._param.host,
                                  port=self._param.port, password=self._param.password)
-        elif self._param.db_type == 'postgresql':
+        elif self._param.db_type == 'postgres':
             db = psycopg2.connect(dbname=self._param.database, user=self._param.username, host=self._param.host,
                                   port=self._param.port, password=self._param.password)
         elif self._param.db_type == 'mssql':

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -332,7 +332,7 @@ def test_db_connect():
         if req["db_type"] in ["mysql", "mariadb"]:
             db = MySQLDatabase(req["database"], user=req["username"], host=req["host"], port=req["port"],
                                password=req["password"])
-        elif req["db_type"] == 'postgresql':
+        elif req["db_type"] == 'postgres':
             db = PostgresqlDatabase(req["database"], user=req["username"], host=req["host"], port=req["port"],
                                     password=req["password"])
         elif req["db_type"] == 'mssql':

--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -702,6 +702,8 @@ def queue_raptor_o_graphrag_tasks(doc, ty, priority):
 
 def get_queue_length(priority):
     group_info = REDIS_CONN.queue_info(get_svr_queue_name(priority), SVR_CONSUMER_GROUP_NAME)
+    if not group_info:
+        return 0
     return int(group_info.get("lag", 0) or 0)
 
 

--- a/web/src/pages/agent/options.ts
+++ b/web/src/pages/agent/options.ts
@@ -2133,7 +2133,7 @@ export const QWeatherTimePeriodOptions = [
   '30d',
 ];
 
-export const ExeSQLOptions = ['mysql', 'postgresql', 'mariadb', 'mssql'].map(
+export const ExeSQLOptions = ['mysql', 'postgres', 'mariadb', 'mssql'].map(
   (x) => ({
     label: upperFirst(x),
     value: x,

--- a/web/src/pages/data-flow/options.ts
+++ b/web/src/pages/data-flow/options.ts
@@ -2133,7 +2133,7 @@ export const QWeatherTimePeriodOptions = [
   '30d',
 ];
 
-export const ExeSQLOptions = ['mysql', 'postgresql', 'mariadb', 'mssql'].map(
+export const ExeSQLOptions = ['mysql', 'postgres', 'mariadb', 'mssql'].map(
   (x) => ({
     label: upperFirst(x),
     value: x,

--- a/web/src/pages/flow/constant.tsx
+++ b/web/src/pages/flow/constant.tsx
@@ -2911,7 +2911,7 @@ export const QWeatherTimePeriodOptions = [
   '30d',
 ];
 
-export const ExeSQLOptions = ['mysql', 'postgresql', 'mariadb', 'mssql'].map(
+export const ExeSQLOptions = ['mysql', 'postgres', 'mariadb', 'mssql'].map(
   (x) => ({
     label: upperFirst(x),
     value: x,


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes incorrect naming for PostgreSQL usage by replacing all instances of `postgresql` with the correct `postgres` in the `db_type` field. This resolves potential configuration errors and ensures consistency when specifying the database type.

Also fixed handling of None for `get_queue_length`

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
