### PR TITLE
Correct the text of `vectorSimilarityWeight` in zh.ts

### DIFF
--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -155,7 +155,7 @@ export default {
       similarityThreshold: '相似度阈值',
       similarityThresholdTip:
         '我们使用混合相似度得分来评估两行文本之间的距离。 它是加权关键词相似度和向量余弦相似度。 如果查询和块之间的相似度小于此阈值，则该块将被过滤掉。默认设置为 0.2，也就是说文本块的混合相似度得分至少 20 才会被召回。',
-      vectorSimilarityWeight: '相似度相似度权重',
+      vectorSimilarityWeight: '向量相似度权重',
       vectorSimilarityWeightTip:
         '我们使用混合相似性评分来评估两行文本之间的距离。它是加权关键字相似性和矢量余弦相似性或rerank得分（0〜1）。两个权重的总和为1.0。',
       keywordSimilarityWeight: '关键词相似度权重',


### PR DESCRIPTION
### What problem does this PR solve?

The original text for vectorSimilarityWeight in Chinese version was "相似度相似度权重," which is obviously a malformed phrase. It has now been changed to "向量相似度权重". Also, align it with the English version 'Vector similarity weight'.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)