### PR TITLE
fix: skip tag query if tag kbs are invalid

### DIFF
--- a/rag/app/tag.py
+++ b/rag/app/tag.py
@@ -138,6 +138,8 @@ def label_question(question, kbs):
         else:
             all_tags = json.loads(all_tags)
         tag_kbs = KnowledgebaseService.get_by_ids(tag_kb_ids)
+        if not tag_kbs:
+            return tags
         tags = settings.retrievaler.tag_query(question,
                                               list(set([kb.tenant_id for kb in tag_kbs])),
                                               tag_kb_ids,


### PR DESCRIPTION
### What problem does this PR solve?

Skip `tag_query` step if `tag_kbs` are empty. 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
