### PR TITLE
Feat: add support for Anthropic third-party API

### DIFF
--- a/rag/llm/__init__.py
+++ b/rag/llm/__init__.py
@@ -68,6 +68,7 @@ FACTORY_DEFAULT_BASE_URL = {
     SupportedLiteLLMProvider.Lingyi_AI: "https://api.lingyiwanwu.com/v1",
     SupportedLiteLLMProvider.GiteeAI: "https://ai.gitee.com/v1/",
     SupportedLiteLLMProvider.AI_302: "https://api.302.ai/v1",
+    SupportedLiteLLMProvider.Anthropic: "https://api.anthropic.com/",
 }
 
 

--- a/web/src/pages/user-setting/setting-model/api-key-modal/index.tsx
+++ b/web/src/pages/user-setting/setting-model/api-key-modal/index.tsx
@@ -89,6 +89,18 @@ const ApiKeyModal = ({
             />
           </Form.Item>
         )}
+        {llmFactory?.toLowerCase() === 'Anthropic'.toLowerCase() && (
+          <Form.Item<FieldType>
+            label={t('baseUrl')}
+            name="base_url"
+            tooltip={t('baseUrlTip')}
+          >
+            <Input
+              placeholder="https://api.anthropic.com/v1"
+              onKeyDown={handleKeyDown}
+            />
+          </Form.Item>
+        )}
         {llmFactory?.toLowerCase() === 'Minimax'.toLowerCase() && (
           <Form.Item<FieldType> label={'Group ID'} name="group_id">
             <Input />


### PR DESCRIPTION
### What problem does this PR solve?
issue:
[Bug]: anthropic model have not baseurl selecting,need add #8546
change:
This PR adds support for using Anthropic models through a third-party API by allowing a custom base_url.
It ensures compatibility with both the official Anthropic endpoint and external providers.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)