### PR TITLE
fix: prevent list index out of range in chat streaming

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -163,7 +163,7 @@ class Base(ABC):
             response = self.client.responses.create(model=self.model_name, messages=history, stream=True, **gen_conf)
         
         for resp in response:
-            if not resp.choices or len(resp.choices) == 0:
+            if not resp.choices:
                 continue
             if not resp.choices[0].delta.content:
                 resp.choices[0].delta.content = ""


### PR DESCRIPTION
### What problem does this PR solve?
issue:
[Bug]: ERROR: list index out of range #10188
change:
fix a potential list index out of range error in chat response parsing by adding explicit checks for empty choices.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)