### PR TITLE
Fix BUG about agent TextProcessing merge(\m)

### DIFF
--- a/agent/component/string_transform.py
+++ b/agent/component/string_transform.py
@@ -90,7 +90,9 @@ class StringTransform(Message, ABC):
         for k,v in kwargs.items():
             if not v:
                 v = ""
-            script = re.sub(k, v, script)
+            # Pass a lambda to repl to treat `v` as a literal string,
+            # preventing `re.sub` from processing backslash escapes in `v`.
+            script = re.sub(k, lambda match: v, script)
 
         self.set_output("result", script)
 


### PR DESCRIPTION
### What problem does this PR solve?
@KevinHuSh 

Hello, my submission this morning did not fully resolve this issue. After researching the knowledge, I have decided to delete the two lines of regular expression processing that were added this morning.

```
remote 2 line
modify 1 line
```
I have mounted the following code in Docker compose and verified that it will no longer report '\ m' errors

<img width="1050" height="447" alt="image" src="https://github.com/user-attachments/assets/2aaf1b86-04ac-45ce-a2f1-052fed620e80" />

[my before pull](https://github.com/infiniflow/ragflow/pull/10211) 

<img width="1000" height="603" alt="image" src="https://github.com/user-attachments/assets/fb3909ef-00ee-46c6-a26f-e64736777291" />

Thanks for your code Review

### Type of change

- [√ ] Bug Fix (non-breaking change which fixes an issue)
