### PR TITLE
fix: reset chat state when creating new dialog

### DIFF
--- a/web/src/pages/next-chats/hooks/use-rename-chat.ts
+++ b/web/src/pages/next-chats/hooks/use-rename-chat.ts
@@ -68,6 +68,8 @@ export const useRenameChat = () => {
     (record?: IDialog) => {
       if (record) {
         setChat(record);
+      } else {
+        setChat({} as IDialog);
       }
       showChatRenameModal();
     },


### PR DESCRIPTION
### What problem does this PR solve?
issue:
[Question]: New Chat Creation Renames Edited Chat Instead of Creating a New One #10373
change:
reset chat state when creating new dialog

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

