### PR TITLE
fix:update searxng_url logic

### DIFF
--- a/agent/tools/searxng.py
+++ b/agent/tools/searxng.py
@@ -85,7 +85,7 @@ class SearXNG(ToolBase, ABC):
             self.set_output("formalized_content", "")
             return ""
 
-        searxng_url = (kwargs.get("searxng_url") or getattr(self._param, "searxng_url", "") or "").strip()
+        searxng_url = (getattr(self._param, "searxng_url", "") or kwargs.get("searxng_url") or "").strip()
         # In try-run, if no URL configured, just return empty instead of raising
         if not searxng_url:
             self.set_output("formalized_content", "")


### PR DESCRIPTION
### What problem does this PR solve?
issue:
[#10417](https://github.com/infiniflow/ragflow/issues/10417)
change:
Adjusted the `searxng_url` priority logic to ensure the frontend-provided URL takes precedence over the model’s default configuration. This allows user-specified SearXNG endpoints to be correctly applied during execution, improving flexibility across different environments.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)