### PR TITLE
fix: return type annotation for get_urls() in download_deps

### DIFF
--- a/download_deps.py
+++ b/download_deps.py
@@ -16,7 +16,7 @@ import os
 import urllib.request
 import argparse
 
-def get_urls(use_china_mirrors=False) -> Union[str, list[str]]:
+def get_urls(use_china_mirrors=False) -> list[Union[str, list[str]]]:
     if use_china_mirrors:
         return [
             "http://mirrors.tuna.tsinghua.edu.cn/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb",


### PR DESCRIPTION
### What problem does this PR solve?

Fixes the return type annotation for the `get_urls` function in `download_deps.py`

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)