### PR TITLE
Feat: add trino support

### DIFF
--- a/web/src/pages/agent/form/exesql-form/use-submit-form.ts
+++ b/web/src/pages/agent/form/exesql-form/use-submit-form.ts
@@ -8,14 +8,27 @@ export const ExeSQLFormSchema = {
   username: z.string().min(1),
   host: z.string().min(1),
   port: z.number(),
-  password: z.string().min(1),
+  password: z.string().optional().or(z.literal('')),
   max_records: z.number(),
 };
 
-export const FormSchema = z.object({
-  sql: z.string().optional(),
-  ...ExeSQLFormSchema,
-});
+export const FormSchema = z
+  .object({
+    sql: z.string().optional(),
+    ...ExeSQLFormSchema,
+  })
+  .superRefine((v, ctx) => {
+    if (
+      v.db_type !== 'trino' &&
+      !(v.password && v.password.trim().length > 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['password'],
+        message: 'String must contain at least 1 character(s)',
+      });
+    }
+  });
 
 export function useSubmitForm() {
   const { testDbConnect, loading } = useTestDbConnect();

--- a/web/src/pages/agent/options.ts
+++ b/web/src/pages/agent/options.ts
@@ -2139,6 +2139,7 @@ export const ExeSQLOptions = [
   'mariadb',
   'mssql',
   'IBM DB2',
+  'trino',
 ].map((x) => ({
   label: upperFirst(x),
   value: x,


### PR DESCRIPTION
### What problem does this PR solve?
issue:
[#10296](https://github.com/infiniflow/ragflow/issues/10296)
change:
- ExeSQL: support connecting to Trino.
- Validation: password can be empty only when db_type === "trino";
  all other database types keep the existing requirement (non-empty).

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

