### PR TITLE
fix(_handle_entity_relation_summary): correctly calculate the descriptions_list

### DIFF
--- a/graphrag/general/extractor.py
+++ b/graphrag/general/extractor.py
@@ -227,7 +227,7 @@ class Extractor:
     async def _handle_entity_relation_summary(self, entity_or_relation_name: str, description: str) -> str:
         summary_max_tokens = 512
         use_description = truncate(description, summary_max_tokens)
-        description_list = (use_description.split(GRAPH_FIELD_SEP),)
+        description_list = use_description.split(GRAPH_FIELD_SEP)
         if len(description_list) <= 12:
             return use_description
         prompt_template = SUMMARIZE_DESCRIPTIONS_PROMPT


### PR DESCRIPTION
### What problem does this PR solve?

Since `description_list` was a tuple containing a single element (which was the actual list of descriptions), `len(description_list)` was always **1**.

The subsequent check:
`if len(description_list) <= 12:` always evaluated to `True` (since $1 \le 12$), even if the inner list contained more than 12 descriptions. This prevented the necessary summarization logic from running for long lists.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)