### PR TITLE
Test: update test cases for chunk retrieval pagination

### DIFF
--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_retrieval_chunks.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_retrieval_chunks.py
@@ -83,7 +83,7 @@ class TestChunksRetrieval:
                 "ValueError('Search does not support negative slicing.')",
                 marks=pytest.mark.skip,
             ),
-            pytest.param({"page": 2, "page_size": 2}, 0, 2, "", marks=pytest.mark.skip(reason="issues/6646")),
+            ({"page": 2, "page_size": 2}, 0, 2, ""),
             ({"page": 3, "page_size": 2}, 0, 0, ""),
             ({"page": "3", "page_size": 2}, 0, 0, ""),
             pytest.param(
@@ -124,9 +124,9 @@ class TestChunksRetrieval:
                 marks=pytest.mark.skip,
             ),
             # ({"page_size": 0}, 0, 0, ""),
-            ({"page_size": 1}, 0, 1, ""),
+            pytest.param({"page_size": 1}, 0, 1, "", marks=pytest.mark.skip(reason="issues/10692")),
             ({"page_size": 5}, 0, 4, ""),
-            ({"page_size": "1"}, 0, 1, ""),
+            pytest.param({"page_size": "1"}, 0, 1, "", marks=pytest.mark.skip(reason="issues/10692")),
             # ({"page_size": -1}, 0, 0, ""),
             pytest.param(
                 {"page_size": "a"},


### PR DESCRIPTION
### What problem does this PR solve?

Updated test cases in test_retrieval_chunks.py to:
- Remove skip mark from page pagination test case (#6646 resolved)
- Add skip marks for page_size=1 tests due to new issue (#10692)

### Type of change

- [x] Test
