### PR TITLE
Fix: can't upload image in ollama model #10447

### DIFF
--- a/api/apps/user_app.py
+++ b/api/apps/user_app.py
@@ -22,7 +22,7 @@ import secrets
 import time
 from datetime import datetime
 
-from flask import redirect, request, session, Response
+from flask import redirect, request, session, make_response
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -866,7 +866,9 @@ def forget_get_captcha():
     from captcha.image import ImageCaptcha
     image = ImageCaptcha(width=300, height=120, font_sizes=[50, 60, 70])
     img_bytes = image.generate(captcha_text).read()
-    return Response(img_bytes, mimetype="image/png")
+    response = make_response(img_bytes)
+    response.headers.set("Content-Type", "image/JPEG")
+    return response
 
 
 @manager.route("/forget/otp", methods=["POST"])  # noqa: F821


### PR DESCRIPTION
### What problem does this PR solve?

Fix: can't upload image in ollama model #10447

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)


### Change all `image=[]` to `image = None`

Changing `image=[]` to `images=None` avoids Python’s mutable default parameter issue.
If you keep `images=[]`, all calls share the same list, so modifying it (e.g., images.append()) will affect later calls.
Using images=None and creating a new list inside the function ensures each call is independent.
This change does not affect current behavior — it simply makes the code safer and more predictable.


把 `images=[]` 改成 `images=None` 是为了避免 Python 默认参数的可变对象问题。
如果保留 `images=[]`，所有调用都会共用同一个列表，一旦修改就会影响后续调用。
改成 None 并在函数内部重新创建列表，可以确保每次调用都是独立的。
这个修改不会影响现有运行结果，只是让代码更安全、更可控。