### PR TITLE
Fixed the bug that passing an empty array will not update

### DIFF
--- a/api/apps/sdk/chat.py
+++ b/api/apps/sdk/chat.py
@@ -169,6 +169,8 @@ def update(tenant_id, chat_id):
         if len(embd_count) > 1:
             return get_result(message='Datasets use different embedding models."', code=settings.RetCode.AUTHENTICATION_ERROR)
         req["kb_ids"] = ids
+    else:
+        req["kb_ids"] = []
     llm = req.get("llm")
     if llm:
         if "model_name" in llm:


### PR DESCRIPTION
### What problem does this PR solve?
Fixed the bug that the "dataset_ids" field will not be updated if an empty array is passed when updating the assistant

### Type of change

- [*] Bug Fix (non-breaking change which fixes an issue)
