### PR TITLE
Removing value={field} from EditTag

### DIFF
--- a/web/src/components/entity-types-item.tsx
+++ b/web/src/components/entity-types-item.tsx
@@ -25,7 +25,7 @@ const EntityTypesItem = ({
       rules={[{ required: true }]}
       initialValue={initialEntityTypes}
     >
-      <EditTag value={field}></EditTag>
+      <EditTag />
     </Form.Item>
   );
 };


### PR DESCRIPTION
### What problem does this PR solve?

Could not delete Entity Types from the Knowledge Graph settings. The list was not updated on pressing the X on a tag.

What I think happened:
- value={field} was passing ['parser_config','entity_types'] to EditTag instead of the real tags.
- That blocked AntD Form from injecting the right value/onChange.
- Clicking X filtered the wrong “value,” so no visible change.

Fix:
- Remove value={field} and let Form.Item control EditTag.
- EditTag now gets the real tags array and emits onChange(tags), Form captures it.


Now it works.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
