### PR TITLE
Update admin client default port to 9381

### DIFF
--- a/admin/client/admin_client.py
+++ b/admin/client/admin_client.py
@@ -473,7 +473,7 @@ class AdminCLI(Cmd):
     def parse_connection_args(self, args: List[str]) -> Dict[str, Any]:
         parser = argparse.ArgumentParser(description='Admin CLI Client', add_help=False)
         parser.add_argument('-h', '--host', default='localhost', help='Admin service host')
-        parser.add_argument('-p', '--port', type=int, default=8080, help='Admin service port')
+        parser.add_argument('-p', '--port', type=int, default=9381, help='Admin service port')
         parser.add_argument('-w', '--password', default='admin', type=str, help='Superuser password')
         parser.add_argument('command', nargs='?', help='Single command')
         try:


### PR DESCRIPTION
### What problem does this PR solve?

Now admin client default port is '8080', update it to '9381'

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
