### PR TITLE
Chore(config): remove Youdao and BAAI embedding model providers

### DIFF
--- a/api/apps/llm_app.py
+++ b/api/apps/llm_app.py
@@ -368,7 +368,7 @@ def my_llms():
 @manager.route('/list', methods=['GET'])  # noqa: F821
 @login_required
 def list_app():
-    self_deployed = ["Youdao", "FastEmbed", "BAAI", "Ollama", "Xinference", "LocalAI", "LM-Studio", "GPUStack"]
+    self_deployed = ["FastEmbed", "Ollama", "Xinference", "LocalAI", "LM-Studio", "GPUStack"]
     weighted = []
     model_type = request.args.get("model_type")
     try:

--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -975,20 +975,6 @@
             "llm": []
         },
         {
-            "name": "Youdao",
-            "logo": "",
-            "tags": "TEXT EMBEDDING",
-            "status": "1",
-            "llm": [
-                {
-                    "llm_name": "maidalun1020/bce-embedding-base_v1",
-                    "tags": "TEXT EMBEDDING,",
-                    "max_tokens": 512,
-                    "model_type": "embedding"
-                }
-            ]
-        },
-        {
             "name": "DeepSeek",
             "logo": "",
             "tags": "LLM",
@@ -1136,20 +1122,6 @@
                     "llm_name": "jina-embeddings-v3",
                     "tags": "TEXT EMBEDDING",
                     "max_tokens": 8196,
-                    "model_type": "embedding"
-                }
-            ]
-        },
-        {
-            "name": "BAAI",
-            "logo": "",
-            "tags": "TEXT EMBEDDING",
-            "status": "1",
-            "llm": [
-                {
-                    "llm_name": "BAAI/bge-large-zh-v1.5",
-                    "tags": "TEXT EMBEDDING,",
-                    "max_tokens": 1024,
                     "model_type": "embedding"
                 }
             ]


### PR DESCRIPTION
### What problem does this PR solve?

This commit removes the Youdao and BAAI entries from the LLM factories configuration as they are no longer needed or supported.

### Type of change

- [x] Config update