### PR TITLE
Chore(docker): add standard HTTP/HTTPS and MCP ports to .env configuration

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -99,8 +99,11 @@ REDIS_PASSWORD=infini_rag_flow
 
 # The port used to expose RAGFlow's HTTP API service to the host machine,
 # allowing EXTERNAL access to the service running inside the Docker container.
+SVR_WEB_HTTP_PORT=80
+SVR_WEB_HTTPS_PORT=443
 SVR_HTTP_PORT=9380
 ADMIN_SVR_HTTP_PORT=9381
+SVR_MCP_PORT=9382
 
 # The RAGFlow Docker image to download. v0.22+ doesn't include embedding models.
 # Defaults to the v0.21.1-slim edition, which is the RAGFlow Docker image without embedding models.


### PR DESCRIPTION
### What problem does this PR solve?

Added SVR_WEB_HTTP_PORT=80, SVR_WEB_HTTPS_PORT=443, and SVR_MCP_PORT=9382 to the Docker environment configuration to support standard web ports and Model Control Protocol access.

### Type of change

- [x] Update config
