### PR TITLE
Fix(ci): Add error handling to Docker image removal in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -227,4 +227,4 @@ jobs:
         if: always()  # always run this step even if previous steps failed
         run: |
           sudo docker compose -f docker/docker-compose.yml -p ${GITHUB_RUN_ID} down -v
-          sudo docker rmi -f ${RAGFLOW_IMAGE}
+          sudo docker rmi -f ${RAGFLOW_IMAGE:-NO_IMAGE} || true


### PR DESCRIPTION
### What problem does this PR solve?

Add '|| true' to docker rmi command to prevent workflow failure when image removal fails. This ensures the CI pipeline continues even if the Docker image cannot be removed for any reason.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

