### PR TITLE
Fix: add secure connection configuration for MinIO

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -88,6 +88,8 @@ MINIO_USER=rag_flow
 # The password for MinIO.
 # When updated, you must revise the `minio.password` entry in service_conf.yaml accordingly.
 MINIO_PASSWORD=infini_rag_flow
+# Whether to use secure connection (HTTPS) for MinIO.
+MINIO_SECURE=false
 
 # The hostname where the Redis service is exposed
 REDIS_HOST=redis

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,6 +32,8 @@ env:
   MINIO_ROOT_USER: rag_flow
   # The password for MinIO
   MINIO_PASSWORD: infini_rag_flow_helm
+  # Whether to use secure connection (HTTPS) for MinIO.
+  MINIO_SECURE: false
 
   # The password for Redis
   REDIS_PASSWORD: infini_rag_flow_helm

--- a/rag/utils/minio_conn.py
+++ b/rag/utils/minio_conn.py
@@ -41,7 +41,7 @@ class RAGFlowMinio:
             self.conn = Minio(settings.MINIO["host"],
                               access_key=settings.MINIO["user"],
                               secret_key=settings.MINIO["password"],
-                              secure=False
+                              secure=str(settings.MINIO.get("secure", False)).lower() == "true"
                               )
         except Exception:
             logging.exception(


### PR DESCRIPTION
### What problem does this PR solve?

Ragflow can't be used with a minio instance that uses a secure connection. Added an environment variable that activate and deactivate the secure connection in the minio instance in the code.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)