### PR TITLE
Fix: Can't add more models

### DIFF
--- a/api/apps/llm_app.py
+++ b/api/apps/llm_app.py
@@ -128,7 +128,7 @@ def add_llm():
     api_key = req.get("api_key", "x")
     llm_name = req.get("llm_name")
 
-    if factory not in get_allowed_llm_factories():
+    if factory not in [f.name for f in get_allowed_llm_factories()]:
         return get_data_error_result(message=f"LLM factory {factory} is not allowed")
 
     def apikey_json(keys):


### PR DESCRIPTION
### What problem does this PR solve?

Currently we cannot add any models, since factory is a string, and the return type of get_allowed_llm_factories() is List[object] https://github.com/infiniflow/ragflow/pull/11003

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

