### PR TITLE
Fix: correct allowed factory check in add_llm()

### DIFF
--- a/api/apps/llm_app.py
+++ b/api/apps/llm_app.py
@@ -128,7 +128,8 @@ def add_llm():
     api_key = req.get("api_key", "x")
     llm_name = req.get("llm_name")
 
-    if factory not in [f.name for f in get_allowed_llm_factories()]:
+    allowed = {f.name for f in get_allowed_llm_factories()}
+    if factory not in allowed:
         return get_data_error_result(message=f"LLM factory {factory} is not allowed")
 
     def apikey_json(keys):


### PR DESCRIPTION
### What problem does this PR solve?
Fixes a bug in api/apps/llm_app.py where [add_llm()](https://github.com/infiniflow/ragflow/blob/main/api/apps/llm_app.py#L131-L132) compared a string factory name against a list of ORM objects, causing all factories to be rejected with “LLM factory X is not allowed” (hint: 102).

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._
[get_allowed_llm_factories()](https://github.com/infiniflow/ragflow/blob/main/api/utils/api_utils.py#L627-L632) returns a list of factory objects ([LLMFactories](https://github.com/infiniflow/ragflow/blob/main/api/db/db_models.py#L668-L678) model instances), while `factory` is a string (for example, "VLLM"). A string will never be equal to an object, so this condition is always true. As a result, any factory value will trigger the error: "LLM factory X is not allowed".

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
