### PR TITLE
fix: layout structure to use main tag

### DIFF
--- a/web/src/layouts/next.tsx
+++ b/web/src/layouts/next.tsx
@@ -3,9 +3,9 @@ import { Header } from './next-header';
 
 export default function NextLayout() {
   return (
-    <section className="h-full flex flex-col">
-      <Header></Header>
+    <main className="h-full flex flex-col">
+      <Header />
       <Outlet />
-    </section>
+    </main>
   );
 }


### PR DESCRIPTION
### What problem does this PR solve?

For proper semantics Layout should use HTML `<main>` element to wrap the Header and Outlet which produce`<section>` HTML elements.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)