### PR TITLE
Test: handle duplicate names by appending "(1)"

### DIFF
--- a/test/testcases/test_http_api/test_dataset_mangement/test_create_dataset.py
+++ b/test/testcases/test_http_api/test_dataset_mangement/test_create_dataset.py
@@ -16,14 +16,15 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
-from common import create_dataset
-from configs import DATASET_NAME_LIMIT, INVALID_API_TOKEN
+from configs import DATASET_NAME_LIMIT, DEFAULT_PARSER_CONFIG, INVALID_API_TOKEN
 from hypothesis import example, given, settings
 from libs.auth import RAGFlowHttpApiAuth
 from utils import encode_avatar
 from utils.file_utils import create_image_file
 from utils.hypothesis_utils import valid_names
-from configs import DEFAULT_PARSER_CONFIG
+
+from common import create_dataset
+
 
 @pytest.mark.usefixtures("clear_datasets")
 class TestAuthorization:
@@ -125,8 +126,8 @@ class TestDatasetCreate:
         assert res["code"] == 0, res
 
         res = create_dataset(HttpApiAuth, payload)
-        assert res["code"] == 103, res
-        assert res["message"] == f"Dataset name '{name}' already exists", res
+        assert res["code"] == 0, res
+        assert res["data"]["name"] == name + "(1)", res
 
     @pytest.mark.p3
     def test_name_case_insensitive(self, HttpApiAuth):
@@ -137,8 +138,8 @@ class TestDatasetCreate:
 
         payload = {"name": name.lower()}
         res = create_dataset(HttpApiAuth, payload)
-        assert res["code"] == 103, res
-        assert res["message"] == f"Dataset name '{name.lower()}' already exists", res
+        assert res["code"] == 0, res
+        assert res["data"]["name"] == name.lower() + "(1)", res
 
     @pytest.mark.p2
     def test_avatar(self, HttpApiAuth, tmp_path):

--- a/test/testcases/test_sdk_api/test_dataset_mangement/test_create_dataset.py
+++ b/test/testcases/test_sdk_api/test_dataset_mangement/test_create_dataset.py
@@ -17,13 +17,13 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from operator import attrgetter
 
 import pytest
-from configs import DATASET_NAME_LIMIT, HOST_ADDRESS, INVALID_API_TOKEN
+from configs import DATASET_NAME_LIMIT, DEFAULT_PARSER_CONFIG, HOST_ADDRESS, INVALID_API_TOKEN
 from hypothesis import example, given, settings
 from ragflow_sdk import DataSet, RAGFlow
 from utils import encode_avatar
 from utils.file_utils import create_image_file
 from utils.hypothesis_utils import valid_names
-from configs import DEFAULT_PARSER_CONFIG
+
 
 @pytest.mark.usefixtures("clear_datasets")
 class TestAuthorization:
@@ -95,9 +95,8 @@ class TestDatasetCreate:
         payload = {"name": name}
         client.create_dataset(**payload)
 
-        with pytest.raises(Exception) as excinfo:
-            client.create_dataset(**payload)
-        assert str(excinfo.value) == f"Dataset name '{name}' already exists", str(excinfo.value)
+        dataset = client.create_dataset(**payload)
+        assert dataset.name == name + "(1)", str(dataset)
 
     @pytest.mark.p3
     def test_name_case_insensitive(self, client):
@@ -106,9 +105,8 @@ class TestDatasetCreate:
         client.create_dataset(**payload)
 
         payload = {"name": name.lower()}
-        with pytest.raises(Exception) as excinfo:
-            client.create_dataset(**payload)
-        assert str(excinfo.value) == f"Dataset name '{name.lower()}' already exists", str(excinfo.value)
+        dataset = client.create_dataset(**payload)
+        assert dataset.name == name.lower() + "(1)", str(dataset)
 
     @pytest.mark.p2
     def test_avatar(self, client, tmp_path):


### PR DESCRIPTION
### What problem does this PR solve?

- Updated tests to reflect new behavior of handling duplicate dataset names
- Instead of returning an error, the system now appends "(1)" to duplicate names
- This problem was introduced by PR #10960

### Type of change

- [x] Testcase update
