### PR TITLE
fix: entrypoint.sh typo for disable datasync command

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -71,7 +71,7 @@ for arg in "$@"; do
       ENABLE_TASKEXECUTOR=0
       shift
       ;;
-    --disable-datasyn)
+    --disable-datasync)
       ENABLE_DATASYNC=0
       shift
       ;;


### PR DESCRIPTION
### What problem does this PR solve?

There's a typo in `entrypoint.sh` on line 74: the case statement uses `--disable-datasyn)` (missing the 'c'), while the usage function and documentation correctly show `--disable-datasync` (with the 'c'). This mismatch causes the `--disable-datasync` flag to be unrecognized, triggering the usage message and causing containers to restart in a loop when this flag is used.

**Background:**
- Users following the documentation use `--disable-datasync` in their docker-compose.yml
- The entrypoint script doesn't recognize this flag due to the typo
- The script calls `usage()` and exits, causing Docker containers to restart continuously
- This makes it impossible to disable the data sync service as intended

**Example scenario:**
When a user adds `--disable-datasync` to their docker-compose command (as shown in examples), the container fails to start properly because the argument isn't recognized.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
### Proposed Solution

Fix the typo on line 74 of `entrypoint.sh` by changing:
```bash
    --disable-datasyn)
```
to:
```bash
    --disable-datasync)
```

This matches the spelling used in the usage function (line 9 and 13) and allows the flag to work as documented.

### Changes Made

- Fixed typo in `entrypoint.sh` line 74: changed `--disable-datasyn)` to `--disable-datasync)`
- This ensures the argument matches the documented flag name and usage function

---

**Code change:**

```bash
# Line 74 in entrypoint.sh
# Before:
    --disable-datasyn)
      ENABLE_DATASYNC=0
      shift
      ;;

# After:
    --disable-datasync)
      ENABLE_DATASYNC=0
      shift
      ;;
```

This is a simple one-character fix that resolves the argument parsing issue.