### PR TITLE
Fix:limit random sampling range in check_embedding

### DIFF
--- a/api/apps/kb_app.py
+++ b/api/apps/kb_app.py
@@ -819,7 +819,7 @@ def check_embedding():
             return []
 
         n = min(n, total)
-        offsets = sorted(random.sample(range(total), n))
+        offsets = sorted(random.sample(range(min(total,1000)), n))
         out = []
 
         for off in offsets:


### PR DESCRIPTION
### What problem does this PR solve?
issue:
[#11319](https://github.com/infiniflow/ragflow/issues/11319)
change:
limit random sampling range in check_embedding

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)