### PR TITLE
Fix nginx startup failure in HTTPS mode (host not found)

### DIFF
--- a/docker/nginx/ragflow.https.conf
+++ b/docker/nginx/ragflow.https.conf
@@ -23,12 +23,12 @@ server {
     gzip_disable "MSIE [1-6]\.";
 
     location ~ ^/api/v1/admin {
-        proxy_pass http://ragflow:9381;
+        proxy_pass http://localhost:9381;
         include proxy.conf;
     }
 
     location ~ ^/(v1|api) {
-        proxy_pass http://ragflow:9380;
+        proxy_pass http://localhost:9380;
         include proxy.conf;
     }
 


### PR DESCRIPTION
### Description
This PR fixes a bug where Nginx fails to start when using the `ragflow.https.conf` configuration. The upstream host `ragflow` was not resolving correctly inside the container context, causing an `[emerg] host not found` error.

### Changes
- Updated `docker/nginx/ragflow.https.conf`: Changed upstream host from `ragflow` to `localhost` for both the admin API and the main API.

### Related Issue
Fixes #11453

### Testing
- [x] Enabled HTTPS config in Docker.
- [x] Verified Nginx starts successfully without "host not found" errors.
- [x] Verified API accessibility.