### PR TITLE
Update logging for auto-generated SECRET_KEY

### DIFF
--- a/common/settings.py
+++ b/common/settings.py
@@ -139,7 +139,7 @@ def _get_or_create_secret_key():
     import logging
 
     new_key = secrets.token_hex(32)
-    logging.warning(f"SECURITY WARNING: Using auto-generated SECRET_KEY.")
+    logging.warning("SECURITY WARNING: Using auto-generated SECRET_KEY.")
     return new_key
 
 class StorageFactory:


### PR DESCRIPTION
Remove the code that exposes the generated key in the log, as it poses a security risk.
 
<img width="1170" height="269" alt="image" src="https://github.com/user-attachments/assets/03c42516-af1a-49a4-ade2-4ef3ee4b3cdd" />

