### PR TITLE
[issue-11572]fix:metadata_condition filtering failed

### DIFF
--- a/api/apps/sdk/doc.py
+++ b/api/apps/sdk/doc.py
@@ -1446,6 +1446,9 @@ async def retrieval_test(tenant_id):
         metadata_condition = req.get("metadata_condition", {}) or {}
         metas = DocumentService.get_meta_by_kbs(kb_ids)
         doc_ids = meta_filter(metas, convert_conditions(metadata_condition), metadata_condition.get("logic", "and"))
+        # If metadata_condition has conditions but no docs match, return empty result
+        if not doc_ids and metadata_condition.get("conditions"):
+            return get_result(data={"total": 0, "chunks": [], "doc_aggs": {}})
         if metadata_condition and not doc_ids:
             doc_ids = ["-999"]
     similarity_threshold = float(req.get("similarity_threshold", 0.2))


### PR DESCRIPTION
### What problem does this PR solve?

When using the 'metadata_condition' for metadata filtering, if no documents match the filtering criteria, the system will return the search results of all documents instead of returning an empty result. 

When the metadata_condition has conditions but no matching documents, simply return an empty result.
#11572

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

