### PR TITLE
`fix(agent): prevent event-loop blocking in Canvas.run by async-ifying batch, file & stream operations`

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -471,7 +471,7 @@ class Canvas(Graph):
                             try:
                                 for item in gen:
                                     loop.call_soon_threadsafe(q.put_nowait, item)
-                            except Exception as e:
+                            except Exception:
                                 logging.exception("Error in generator producer")
                             finally:
                                 loop.call_soon_threadsafe(q.put_nowait, None)


### PR DESCRIPTION
### What problem does this PR solve?  
While executing long-running Agent tasks (e.g. `Canvas.run`), the Quart async event-loop is blocked by several synchronous calls:

1. `_run_batch` waits on `ThreadPoolExecutor.submit(...).result()` in the main thread.  
2. `get_files` uses the same pattern, stalling concurrent uploads.  
3. The Message component iterates a **synchronous** generator inside `async for`, freezing the loop until the whole LLM stream ends.  

As a result, simple HTTP requests such as Edge-browser login often time out under load.

### How does this PR fix it?  
- Make `_run_batch` async → await `asyncio.wrap_future(executor.submit(...))`.  
- Make `get_files` async → gather all parse jobs via `asyncio.gather(*[loop.run_in_executor(...)])`.  
- Off-load sync generator consumption to a thread and feed tokens back through `asyncio.Queue`, so the main loop stays responsive.

### Type of change  
- [x] Bug Fix (non-breaking change which fixes an issue)  


### Backward compatibility  
No breaking changes; public signatures remain unchanged.