### PR TITLE
feat: add Redis username support

### DIFF
--- a/conf/service_conf.yaml
+++ b/conf/service_conf.yaml
@@ -38,6 +38,7 @@ oceanbase:
     port: 2881
 redis:
   db: 1
+  username: ''
   password: 'infini_rag_flow'
   host: 'localhost:6379'
 task_executor:

--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -38,6 +38,7 @@ oceanbase:
     port: ${OCEANBASE_PORT:-2881}
 redis:
   db: 1
+  username: '${REDIS_USERNAME:-}'
   password: '${REDIS_PASSWORD:-infini_rag_flow}'
   host: '${REDIS_HOST:-redis}:6379'
 user_default_llm:

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -89,6 +89,8 @@ RAGFlow utilizes MinIO as its object storage solution, leveraging its scalabilit
 
 - `REDIS_PORT`
   The port used to expose the Redis service to the host machine, allowing **external** access to the Redis service running inside the Docker container. Defaults to `6379`.
+- `REDIS_USERNAME`
+  Optional Redis ACL username when using Redis 6+ authentication.
 - `REDIS_PASSWORD`
   The password for Redis.
 
@@ -159,6 +161,13 @@ If you cannot download the RAGFlow Docker image, try the following mirrors.
 - `user`: The username for MinIO.
 - `password`: The password for MinIO.
 - `host`: The MinIO serving IP *and* port inside the Docker container. Defaults to `minio:9000`.
+
+### `redis`
+
+- `host`: The Redis serving IP *and* port inside the Docker container. Defaults to `redis:6379`.
+- `db`: The Redis database index to use. Defaults to `1`.
+- `username`: Optional Redis ACL username (Redis 6+).
+- `password`: The password for the specified Redis user.
 
 ### `oauth`
 

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -86,6 +86,9 @@ class RedisDB:
                 "db": int(self.config.get("db", 1)),
                 "decode_responses": True,
             }
+            username = self.config.get("username")
+            if username:
+                conn_params["username"] = username
             password = self.config.get("password")
             if password:
                 conn_params["password"] = password


### PR DESCRIPTION
### What problem does this PR solve?

Support for Redis 6+ ACL authentication (username)

close #11606 

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update