### PR TITLE
Fix:Jina Embedding Models Fail with "Extra inputs are not permitted" Validation Error

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -363,7 +363,7 @@ class JinaEmbed(Base):
         ress = []
         token_count = 0
         for i in range(0, len(texts), batch_size):
-            data = {"model": self.model_name, "input": texts[i : i + batch_size], "encoding_type": "float"}
+            data = {"model": self.model_name, "input": texts[i : i + batch_size]}
             response = requests.post(self.base_url, headers=self.headers, json=data)
             try:
                 res = response.json()


### PR DESCRIPTION
### What problem does this PR solve?
https://github.com/infiniflow/ragflow/issues/11614
base on the payload in https://jina.ai/embeddings/#faq
and https://github.com/BerriAI/litellm/issues/6337
removed the useless property

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

