### PR TITLE
fix: resolve "'bool' object has no attribute 'items'" in SDK enabled …

### DIFF
--- a/api/apps/sdk/doc.py
+++ b/api/apps/sdk/doc.py
@@ -321,9 +321,7 @@ async def update_doc(tenant_id, dataset_id, document_id):
             try:
                 if not DocumentService.update_by_id(doc.id, {"status": str(status)}):
                     return get_error_data_result(message="Database error (Document update)!")
-
                 settings.docStoreConn.update({"doc_id": doc.id}, {"available_int": status}, search.index_name(kb.tenant_id), doc.kb_id)
-                return get_result(data=True)
             except Exception as e:
                 return server_error_response(e)
 
@@ -350,12 +348,10 @@ async def update_doc(tenant_id, dataset_id, document_id):
     }
     renamed_doc = {}
     for key, value in doc.to_dict().items():
-        if key == "run":
-            renamed_doc["run"] = run_mapping.get(str(value))
         new_key = key_mapping.get(key, key)
         renamed_doc[new_key] = value
         if key == "run":
-            renamed_doc["run"] = run_mapping.get(value)
+            renamed_doc["run"] = run_mapping.get(str(value))
 
     return get_result(data=renamed_doc)
 


### PR DESCRIPTION
### What problem does this PR solve?
Fixes the `AttributeError: 'bool' object has no attribute 'items'` error when updating the `enabled` parameter of a document via the Python SDK (Issue #11721). 

Background: When calling `Document.update({"enabled": True/False})` through the SDK, the server-side API returned a boolean `data=True` in the response (instead of a dictionary). The SDK's `_update_from_dict` method (in `base.py`) expects a dictionary to iterate over with `.items()`, leading to an immediate AttributeError during response parsing. This prevented successful synchronization of the updated `enabled` status to the local SDK object, even if the server-side database/update index operations succeeded.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
### Additional Context (optional, for clarity)
- **Root Cause**: Server returned `data=True` (boolean) for `enabled` parameter updates, violating the SDK's expectation of a dictionary-type `data` field.
- **Fix Logic**: 
  1. Removed the separate `return get_result(data=True)` in the `enabled` update branch to unify response flow.
  2. 
- **Backward Compatibility**: No breaking changes—other update scenarios (e.g., renaming documents, modifying chunk methods) remain unaffected, and the response format stays consistent.
