### PR TITLE
Add huggingface-hub dependency

### DIFF
--- a/download_deps.py
+++ b/download_deps.py
@@ -5,6 +5,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #   "nltk",
+#   "huggingface-hub"
 # ]
 # ///
 


### PR DESCRIPTION


### What problem does this PR solve?

When a script has a block like this at the top, then uv run download_deps.py ignores the [project].dependencies in pyproject.toml and only uses that dependencies = [...] list.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
