### PR TITLE
executor_manager updated docker version

### DIFF
--- a/sandbox/executor_manager/Dockerfile
+++ b/sandbox/executor_manager/Dockerfile
@@ -5,7 +5,7 @@ RUN grep -rl 'deb.debian.org' /etc/apt/ | xargs sed -i 's|http[s]*://deb.debian.
     apt-get install -y curl gcc && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://mirrors.aliyun.com/docker-ce/linux/static/stable/x86_64/docker-24.0.7.tgz -o docker.tgz && \
+RUN curl -fsSL https://mirrors.aliyun.com/docker-ce/linux/static/stable/x86_64/docker-29.1.0.tgz -o docker.tgz && \
     tar -xzf docker.tgz && \
     mv docker/docker /usr/bin/docker && \
     rm -rf docker docker.tgz


### PR DESCRIPTION
### What problem does this PR solve?

The docker version(24.0.7) installed in the executor manager image is incompatible with the latest stable docker (29.1.3). The minmum api v29.1.3 can use is 1.4.4 api version, but 24.0.7 uses api version 1.4.3.

### Type of change

- [X] Other (please describe):

This could break things for people who still have an old docker installed on their system. A better approach could be a setting to share
