### PR TITLE
fix: set default embedding model for TEI profile in Docker deployment

### DIFF
--- a/common/settings.py
+++ b/common/settings.py
@@ -210,7 +210,10 @@ def init_settings():
     IMAGE2TEXT_CFG = _resolve_per_model_config(image2text_entry, LLM_FACTORY, API_KEY, LLM_BASE_URL)
 
     CHAT_MDL = CHAT_CFG.get("model", "") or ""
-    EMBEDDING_MDL = os.getenv("TEI_MODEL", "BAAI/bge-small-en-v1.5") if "tei-" in os.getenv("COMPOSE_PROFILES", "") else ""
+    EMBEDDING_MDL = EMBEDDING_CFG.get("model", "") or ""
+    compose_profiles = os.getenv("COMPOSE_PROFILES", "")
+    if "tei-" in compose_profiles:
+        EMBEDDING_MDL = os.getenv("TEI_MODEL", EMBEDDING_MDL or "BAAI/bge-small-en-v1.5")
     RERANK_MDL = RERANK_CFG.get("model", "") or ""
     ASR_MDL = ASR_CFG.get("model", "") or ""
     IMAGE2TEXT_MDL = IMAGE2TEXT_CFG.get("model", "") or ""


### PR DESCRIPTION
## What's changed
fix: unify embedding model fallback logic for both TEI and non-TEI Docker deployments

>  This fix targets **Docker / `docker-compose` deployments**, ensuring a valid default embedding model is always set—regardless of the compose profile used.

##  Changes

| Scenario | New Behavior |
|--------|--------------|
| **Non-`tei-` profile** (e.g., default deployment) | `EMBEDDING_MDL` is now correctly initialized from `EMBEDDING_CFG` (derived from `user_default_llm`), ensuring custom defaults like `bge-m3@Ollama` are properly applied to new tenants. |
| **`tei-` profile** (`COMPOSE_PROFILES` contains `tei-`) | Still respects the `TEI_MODEL` environment variable. If unset, falls back to `EMBEDDING_CFG`. Only when both are empty does it use the built-in default (`BAAI/bge-small-en-v1.5`), preventing an empty embedding model. |

##  Why This Change?

- **In non-TEI mode**: The previous logic would reset `EMBEDDING_MDL` to an empty string, causing pre-configured defaults (e.g., `bge-m3@Ollama` in the Docker image) to be ignored—leading to tenant initialization failures or silent misconfigurations.
- **In TEI mode**: Users need the ability to override the model via `TEI_MODEL`, but without a safe fallback, missing configuration could break the system. The new logic adopts a **“config-first, env-var-override”** strategy for robustness in containerized environments.

##  Implementation

- Updated the assignment logic for `EMBEDDING_MDL` in `rag/common/settings.py` to follow a unified fallback chain:

EMBEDDING_CFG → TEI_MODEL (if tei- profile active) → built-in default


##  Testing

Verified in Docker deployments:

1. **`COMPOSE_PROFILES=`** (no TEI)  
 → New tenants get `bge-m3@Ollama` as the default embedding model 
2. **`COMPOSE_PROFILES=tei-gpu` with no `TEI_MODEL` set**  
 → Falls back to `BAAI/bge-small-en-v1.5`   
3. **`COMPOSE_PROFILES=tei-gpu` with `TEI_MODEL=my-model`**  
 → New tenants use `my-model` as the embedding model   

Closes #8916 
fix #11522 
fix #11306