### PR TITLE
MinerU supports for the new backend vlm-mlx-engine

### DIFF
--- a/deepdoc/parser/mineru_parser.py
+++ b/deepdoc/parser/mineru_parser.py
@@ -106,7 +106,7 @@ class MinerUParser(RAGFlowPdfParser):
     def check_installation(self, backend: str = "pipeline", server_url: Optional[str] = None) -> tuple[bool, str]:
         reason = ""
 
-        valid_backends = ["pipeline", "vlm-http-client", "vlm-transformers", "vlm-vllm-engine"]
+        valid_backends = ["pipeline", "vlm-http-client", "vlm-transformers", "vlm-vllm-engine", "vlm-mlx-engine"]
         if backend not in valid_backends:
             reason = "[MinerU] Invalid backend '{backend}'. Valid backends are: {valid_backends}"
             self.logger.warning(reason)


### PR DESCRIPTION
### What problem does this PR solve?

MinerU new version supports for the new backend vlm-mlx-engine，https://github.com/opendatalab/MinerU .

### Type of change
- [ x ] New Feature (non-breaking change which adds functionality)
