### PR TITLE
feat: MinerU integration enhancement

### DIFF
--- a/api/apps/llm_app.py
+++ b/api/apps/llm_app.py
@@ -193,7 +193,14 @@ async def add_llm():
         api_key = apikey_json(["api_key", "provider_order"])
 
     elif factory == "MinerU":
-        api_key = apikey_json(["api_key", "provider_order"])
+        api_key = apikey_json([
+            "llm_name",
+            "mineru_apiserver",
+            "mineru_output_dir",
+            "mineru_backend",
+            "mineru_server_url",
+            "mineru_delete_output",
+        ])
 
     llm = {
         "tenant_id": current_user.id,

--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -5496,14 +5496,6 @@
                     "model_type": "reranker"
                 }
             ]
-        },
-        {
-            "name": "MinerU",
-            "logo": "",
-            "tags": "OCR",
-            "status": "1",
-            "rank": "900",
-            "llm": []
         }
     ]
 }

--- a/web/src/components/mineru-config-form-field.tsx
+++ b/web/src/components/mineru-config-form-field.tsx
@@ -1,0 +1,156 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from './ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select';
+import { Switch } from './ui/switch';
+
+// MinerU OCR language options with human-readable labels
+const MINERU_LANG_OPTIONS = [
+  { value: 'ch', label: 'Chinese (Simplified)' },
+  { value: 'en', label: 'English' },
+  { value: 'cyrillic', label: 'Cyrillic (Russian, Ukrainian, etc.)' },
+  { value: 'latin', label: 'Latin (French, German, Spanish, etc.)' },
+  { value: 'korean', label: 'Korean' },
+  { value: 'japan', label: 'Japanese' },
+  { value: 'arabic', label: 'Arabic' },
+  { value: 'th', label: 'Thai' },
+  { value: 'el', label: 'Greek' },
+  { value: 'devanagari', label: 'Hindi (Devanagari)' },
+  { value: 'ta', label: 'Tamil' },
+  { value: 'te', label: 'Telugu' },
+  { value: 'ka', label: 'Georgian/Kannada' },
+  { value: 'chinese_cht', label: 'Chinese (Traditional)' },
+];
+
+/**
+ * Check if the current layout recognizer is MinerU
+ */
+function useIsMineruSelected() {
+  const form = useFormContext();
+  const layoutRecognize = useWatch({
+    control: form.control,
+    name: 'parser_config.layout_recognize',
+  });
+
+  // MinerU models have format like "model-name@MinerU"
+  return (
+    typeof layoutRecognize === 'string' &&
+    (layoutRecognize.toLowerCase().includes('mineru') ||
+      layoutRecognize.toLowerCase().endsWith('@mineru'))
+  );
+}
+
+export function MineruConfigFormField() {
+  const form = useFormContext();
+  const isMineruSelected = useIsMineruSelected();
+
+  if (!isMineruSelected) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4 p-4 border rounded-lg bg-muted/50">
+      <div className="text-sm font-medium text-foreground">
+        MinerU OCR Settings
+      </div>
+
+      {/* MinerU Language Selection */}
+      <FormField
+        control={form.control}
+        name="parser_config.mineru_lang"
+        render={({ field }) => (
+          <FormItem className="items-center space-y-0">
+            <div className="flex items-center">
+              <FormLabel className="text-sm text-text-secondary whitespace-wrap w-1/3">
+                OCR Language
+              </FormLabel>
+              <div className="w-2/3">
+                <FormControl>
+                  <Select
+                    value={field.value || 'latin'}
+                    onValueChange={field.onChange}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select language" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {MINERU_LANG_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+              </div>
+            </div>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* Formula Recognition Toggle */}
+      <FormField
+        control={form.control}
+        name="parser_config.mineru_formula_enable"
+        render={({ field }) => (
+          <FormItem className="items-center space-y-0">
+            <div className="flex items-center">
+              <FormLabel className="text-sm text-text-secondary whitespace-wrap w-1/3">
+                Formula Recognition
+              </FormLabel>
+              <div className="w-2/3">
+                <FormControl>
+                  <Switch
+                    checked={field.value ?? true}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+              </div>
+            </div>
+            <div className="text-xs text-muted-foreground mt-1 ml-[33.33%]">
+              Disable for Cyrillic/stylized fonts to avoid incorrect LaTeX
+              conversion
+            </div>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* Table Recognition Toggle */}
+      <FormField
+        control={form.control}
+        name="parser_config.mineru_table_enable"
+        render={({ field }) => (
+          <FormItem className="items-center space-y-0">
+            <div className="flex items-center">
+              <FormLabel className="text-sm text-text-secondary whitespace-wrap w-1/3">
+                Table Recognition
+              </FormLabel>
+              <div className="w-2/3">
+                <FormControl>
+                  <Switch
+                    checked={field.value ?? true}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+              </div>
+            </div>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+}

--- a/web/src/interfaces/database/knowledge.ts
+++ b/web/src/interfaces/database/knowledge.ts
@@ -67,6 +67,11 @@ export interface ParserConfig {
   tag_kb_ids?: string[];
   topn_tags?: number;
   graphrag?: { use_graphrag?: boolean };
+  // MinerU-specific settings
+  mineru_lang?: string;
+  mineru_formula_enable?: boolean;
+  mineru_table_enable?: boolean;
+  mineru_parse_method?: string;
 }
 
 export interface IKnowledgeFileParserConfig {

--- a/web/src/pages/dataset/dataset-setting/configuration/book.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/book.tsx
@@ -3,6 +3,7 @@ import {
   AutoQuestionsFormField,
 } from '@/components/auto-keywords-form-field';
 import { LayoutRecognizeFormField } from '@/components/layout-recognize-form-field';
+import { MineruConfigFormField } from '@/components/mineru-config-form-field';
 import {
   ConfigurationFormContainer,
   MainContainer,
@@ -13,6 +14,7 @@ export function BookConfiguration() {
     <MainContainer>
       <ConfigurationFormContainer>
         <LayoutRecognizeFormField></LayoutRecognizeFormField>
+        <MineruConfigFormField></MineruConfigFormField>
       </ConfigurationFormContainer>
 
       <ConfigurationFormContainer>

--- a/web/src/pages/dataset/dataset-setting/configuration/naive.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/naive.tsx
@@ -6,6 +6,7 @@ import { DelimiterFormField } from '@/components/delimiter-form-field';
 import { ExcelToHtmlFormField } from '@/components/excel-to-html-form-field';
 import { LayoutRecognizeFormField } from '@/components/layout-recognize-form-field';
 import { MaxTokenNumberFormField } from '@/components/max-token-number-from-field';
+import { MineruConfigFormField } from '@/components/mineru-config-form-field';
 import {
   ConfigurationFormContainer,
   MainContainer,
@@ -17,6 +18,7 @@ export function NaiveConfiguration() {
     <MainContainer>
       <ConfigurationFormContainer>
         <LayoutRecognizeFormField></LayoutRecognizeFormField>
+        <MineruConfigFormField></MineruConfigFormField>
         <MaxTokenNumberFormField initialValue={512}></MaxTokenNumberFormField>
         <DelimiterFormField></DelimiterFormField>
         <EnableTocToggle />

--- a/web/src/pages/dataset/dataset-setting/configuration/paper.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/paper.tsx
@@ -3,6 +3,7 @@ import {
   AutoQuestionsFormField,
 } from '@/components/auto-keywords-form-field';
 import { LayoutRecognizeFormField } from '@/components/layout-recognize-form-field';
+import { MineruConfigFormField } from '@/components/mineru-config-form-field';
 import {
   ConfigurationFormContainer,
   MainContainer,
@@ -13,6 +14,7 @@ export function PaperConfiguration() {
     <MainContainer>
       <ConfigurationFormContainer>
         <LayoutRecognizeFormField></LayoutRecognizeFormField>
+        <MineruConfigFormField></MineruConfigFormField>
       </ConfigurationFormContainer>
 
       <ConfigurationFormContainer>

--- a/web/src/pages/dataset/dataset-setting/form-schema.ts
+++ b/web/src/pages/dataset/dataset-setting/form-schema.ts
@@ -30,6 +30,10 @@ export const formSchema = z
         topn_tags: z.number().optional(),
         toc_extraction: z.boolean().optional(),
         overlapped_percent: z.number().optional(),
+        // MinerU-specific settings
+        mineru_lang: z.string().optional(),
+        mineru_formula_enable: z.boolean().optional(),
+        mineru_table_enable: z.boolean().optional(),
         raptor: z
           .object({
             use_raptor: z.boolean().optional(),

--- a/web/src/pages/dataset/dataset-setting/saving-button.tsx
+++ b/web/src/pages/dataset/dataset-setting/saving-button.tsx
@@ -58,7 +58,7 @@ export function SavingButton() {
       onClick={() => {
         (async () => {
           try {
-            let beValid = await form.formControl.trigger();
+            let beValid = await form.trigger();
             if (beValid) {
               form.handleSubmit(async (values) => {
                 console.log('saveKnowledgeConfiguration: ', values);


### PR DESCRIPTION
- Add per-dataset MinerU settings: language, formula/table recognition
- Add MinerU config form fields in Knowledge Base settings

### What problem does this PR solve?

### Problem

When using MinerU for PDF parsing with Cyrillic documents (Russian, Ukrainian, etc.),The default language setting received from RagFlow on the MinerU API is English, which causes poor OCR results. Additionally, there is no way to:

2. Set per-dataset OCR language for proper Cyrillic text recognition(and another languages also)
3. Disable formula recognition (which incorrectly converts Cyrillic text to LaTeX)
4. Disable table recognition when not needed

### Solution

This PR adds comprehensive MinerU configuration support:

#### Per-Dataset Settings (Knowledge Base Configuration)
Added new fields to dataset/Knowledge Base settings:
- **OCR Language** - Select appropriate language for OCR (Cyrillic, Latin, Chinese, etc.)
- **Formula Recognition** - Toggle on/off (disable for Cyrillic to avoid incorrect LaTeX conversion)
- **Table Recognition** - Toggle on/off

### Changes

- `deepdoc/parser/mineru_parser.py` - MinerU parser with API and CLI support
- `rag/llm/ocr_model.py` - OCR model wrapper using environment variables
- `rag/app/naive.py` - Pass MinerU settings from parser_config
- `web/src/components/mineru-config-form-field.tsx` - New form component for MinerU settings

### Usage

1. Set environment variable: `MINERU_APISERVER=http://your-mineru-server:8080`
2. Create/edit Knowledge Base
3. Select "MinerU" as PDF parser
4. Configure OCR language (e.g., "Cyrillic" for Russian/Ukrainian)
5. Optionally disable formula recognition for better Cyrillic text extraction



### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
