### PR TITLE
feat: display name instead of key in user fillup form submission

### DIFF
--- a/web/src/pages/agent/chat/use-send-agent-message.ts
+++ b/web/src/pages/agent/chat/use-send-agent-message.ts
@@ -327,7 +327,7 @@ export const useSendAgentMessage = ({
     async (body: { id?: string; inputs: Record<string, BeginQuery> }) => {
       addNewestOneQuestion({
         content: Object.entries(body.inputs)
-          .map(([key, val]) => `${key}: ${val.value}`)
+          .map(([, val]) => `${val.name}: ${val.value}`)
           .join('<br/>'),
         role: MessageType.User,
       });


### PR DESCRIPTION
### What problem does this PR solve?

- Change the message format from 'key: value' to 'name: value' when user submits the fillup form in agent chat. 
- This resolves #11865
- I think this change makes sense, better aligning the form and the replied message.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
