### PR TITLE
fix: unable to save ingestion pipeline config without modifying children delimiter

### DIFF
--- a/web/src/components/chunk-method-dialog/index.tsx
+++ b/web/src/components/chunk-method-dialog/index.tsx
@@ -209,7 +209,7 @@ export function ChunkMethodDialog({
         // Unset children delimiter if this option is not enabled
         children_delimiter: data.parser_config.enable_children
           ? data.parser_config.children_delimiter
-          : null,
+          : '',
         pages: data.parser_config?.pages?.map((x: any) => [x.from, x.to]) ?? [],
       },
     };

--- a/web/src/pages/dataset/dataset-setting/saving-button.tsx
+++ b/web/src/pages/dataset/dataset-setting/saving-button.tsx
@@ -72,7 +72,7 @@ export function SavingButton() {
                     // Unset children delimiter if this option is not enabled
                     children_delimiter: values.parser_config.enable_children
                       ? values.parser_config.children_delimiter
-                      : null,
+                      : '',
                   },
                 });
               })();


### PR DESCRIPTION
…ildren delimiter

### What problem does this PR solve?

Fix the issue of unable to save **Files > Ingestion Pipeline (Modal)** config without modifying children delimiter

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
