### PR TITLE
Potential fix for code scanning alert no. 58: Clear-text logging of sensitive information

### DIFF
--- a/common/http_client.py
+++ b/common/http_client.py
@@ -153,13 +153,13 @@ async def async_request(
                 if attempt >= retries:
                     if not _is_sensitive_url(url):
                         log_url = _redact_sensitive_url_params(url)
-                        logger.warning(f"async_request exhausted retries for {method} {log_url}")
+                        logger.warning(f"async_request exhausted retries for {method}")
                     raise
                 delay = _get_delay(backoff_factor, attempt)
                 if not _is_sensitive_url(url):
                     log_url = _redact_sensitive_url_params(url)
                     logger.warning(
-                        f"async_request attempt {attempt + 1}/{retries + 1} failed for {method} {log_url}; retrying in {delay:.2f}s"
+                        f"async_request attempt {attempt + 1}/{retries + 1} failed for {method}; retrying in {delay:.2f}s"
                     )
                 await asyncio.sleep(delay)
         raise last_exc  # pragma: no cover


### PR DESCRIPTION
Potential fix for [https://github.com/infiniflow/ragflow/security/code-scanning/58](https://github.com/infiniflow/ragflow/security/code-scanning/58)

General approach: avoid logging potentially sensitive URLs (especially at warning level) or ensure they are fully and robustly redacted before logging. Since this client is shared and used with OAuth endpoints, the safest minimal-change fix is to stop including the URL in warning logs (retries exhausted and retry attempts) and only log the HTTP method and a generic message. Debug logs can continue using the existing redaction helper for non-sensitive URLs if desired.

Best concrete fix without changing functionality: in `common/http_client.py`, in `async_request`, change the retry-exhausted and retry-attempt warning log statements so that they no longer interpolate `log_url` (and thus the tainted `url`). We can still compute `log_url` if needed elsewhere, but the log string itself should not contain `log_url`. This directly removes the tainted data from the sink while preserving information about errors and retry behavior. No changes are required in `common/settings.py` or `api/apps/user_app.py`, and we do not need new imports or helpers.

Specifically:
- In `common/http_client.py`, around line 152–163, replace the two warning logs:
  - `logger.warning(f"async_request exhausted retries for {method} {log_url}")`
  - `logger.warning(f"async_request attempt {attempt + 1}/{retries + 1} failed for {method} {log_url}; retrying in {delay:.2f}s")`
  with versions that omit `{log_url}`, such as:
  - `logger.warning(f"async_request exhausted retries for {method}")`
  - `logger.warning(f"async_request attempt {attempt + 1}/{retries + 1} failed for {method}; retrying in {delay:.2f}s")`

This ensures no URL-derived data flows into these warning logs, addressing all variants of the alert, since they all trace to the same sink.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
