### PR TITLE
[Feature] Add request body support to HTTP request tool for agents

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1642,6 +1642,7 @@ Example: Virtual Hosted Style`,
       url: 'Url',
       method: 'Method',
       timeout: 'Timeout',
+      requestBody: 'Request Body',
       headers: 'Headers',
       cleanHtml: 'Clean HTML',
       cleanHtmlTip:

--- a/web/src/pages/agent/constant/index.tsx
+++ b/web/src/pages/agent/constant/index.tsx
@@ -376,6 +376,7 @@ export const initialInvokeValues = {
   proxy: '',
   clean_html: false,
   variables: [],
+  request_body: '',
   outputs: {
     result: {
       value: '',

--- a/web/src/pages/agent/form/invoke-form/index.tsx
+++ b/web/src/pages/agent/form/invoke-form/index.tsx
@@ -160,6 +160,25 @@ function InvokeForm({ node }: INextOperatorForm) {
           />
           <FormField
             control={form.control}
+            name="request_body"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('flow.requestBody')}</FormLabel>
+                <FormControl>
+                  <Editor
+                    height={200}
+                    defaultLanguage="json"
+                    theme={isDarkTheme ? 'vs-dark' : undefined}
+                    {...field}
+                    placeholder='{"key": "value"}'
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
             name="proxy"
             render={({ field }) => (
               <FormItem>

--- a/web/src/pages/agent/form/invoke-form/schema.ts
+++ b/web/src/pages/agent/form/invoke-form/schema.ts
@@ -57,9 +57,10 @@ export const FormSchema = z.object({
   method: z.string(),
   timeout: z.number(),
   headers: z.string(),
-  proxy: z.string().url(),
+  proxy: z.string().url().or(z.literal('')),
   clean_html: z.boolean(),
   variables: z.array(VariableFormSchema),
+  request_body: z.string().optional(),
 });
 
 export type FormSchemaType = z.infer<typeof FormSchema>;


### PR DESCRIPTION
## Description
This PR adds request body support to the HTTP request (Invoke) component when used as an agent tool, resolving issue #12084.

## Changes
- **Backend**: Updated `invoke.py` to accept `request_body` parameter from kwargs or component params
- **Backend**: Added `get_input_form()` method to `InvokeParam` class
- **Frontend**: Added "Request Body" field to Invoke component configuration form
- **Frontend**: Updated form schema to include request_body validation
- **Translations**: Added "Request Body" label to English locale

## Technical Details
- Request body can be passed as JSON string or dict
- Supports variable substitution in request body strings
- Works with POST and PUT HTTP methods
- Field appears in UI between "Headers" and "Proxy" fields

## Testing
- ✅ Backend accepts request_body parameter
- ✅ Frontend displays Request Body field
- ✅ Component test run works correctly
- ✅ HTTP requests with body are functional

Fixes #12084


Contribution by Gittensor, learn more at https://gittensor.io/