### PR TITLE
Fix TypeError in meta_filter when using numeric metadata

### DIFF
--- a/common/metadata_utils.py
+++ b/common/metadata_utils.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import ast
 import logging
 from typing import Any, Callable, Dict
 
@@ -49,8 +50,8 @@ def meta_filter(metas: dict, filters: list[dict], logic: str = "and"):
                 try:
                     if isinstance(input, list):
                         input = input[0]
-                    input = float(input)
-                    value = float(value)
+                    input = ast.literal_eval(input)
+                    value = ast.literal_eval(value)
                 except Exception:
                     pass
             if isinstance(input, str):
@@ -69,9 +70,9 @@ def meta_filter(metas: dict, filters: list[dict], logic: str = "and"):
                 elif operator == "not in":
                     matched = input not in value if not isinstance(input, list) else all(i not in value for i in input)
                 elif operator == "start with":
-                    matched = str(input).lower().startswith(str(value).lower()) if not isinstance(input, list) else "".join(str(i).lower() for i in input).startswith(str(value).lower())
+                    matched = str(input).lower().startswith(str(value).lower()) if not isinstance(input, list) else "".join([str(i).lower() for i in input]).startswith(str(value).lower())
                 elif operator == "end with":
-                    matched = str(input).lower().endswith(str(value).lower()) if not isinstance(input, list) else "".join(str(i).lower() for i in input).endswith(str(value).lower())
+                    matched = str(input).lower().endswith(str(value).lower()) if not isinstance(input, list) else "".join([str(i).lower() for i in input]).endswith(str(value).lower())
                 elif operator == "empty":
                     matched = not input
                 elif operator == "not empty":


### PR DESCRIPTION
The filter_out function in metadata_utils.py was using a list of tuples to evaluate conditions. Python eagerly evaluates all tuple elements when constructing the list, causing "input in value" to be evaluated even when the operator is "=". When input and value are floats (after numeric conversion), this causes TypeError: "argument of type 'float' is not iterable".

This change replaces the tuple list with if-elif chain, ensuring only the matching condition is evaluated.

### What problem does this PR solve?

Fixes #12285

When using comparison operators like `=`, `>`, `<` with numeric metadata, the `filter_out` function throws `TypeError("argument of type 'float' is not iterable")`. This is because Python eagerly evaluates all tuple elements when constructing a list, causing `input in value` to be evaluated even when the operator is `=`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
