### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 13 * * *'  # This schedule runs every 13:00:00Z(21:00:00+08:00)


### PR DESCRIPTION
Potential fix for [https://github.com/infiniflow/ragflow/security/code-scanning/62](https://github.com/infiniflow/ragflow/security/code-scanning/62)

In general, the fix is to explicitly declare a `permissions:` block so the GITHUB_TOKEN used by this workflow only has the scopes required: read access to repository contents and write access to contents/releases. Since this workflow creates or moves tags and creates/overwrites releases via `softprops/action-gh-release`, it needs `contents: write`. There is no evidence that it needs other elevated scopes (issues, pull-requests, actions, etc.), so these should remain at their default of `none` by omission.

The best minimal fix without changing existing functionality is to add a workflow-level `permissions:` block near the top of `.github/workflows/release.yml`, after `name:` and before `on:` (or anywhere at the root level, but this is conventional). This will apply to all jobs (there is only `jobs.release`) and ensure that the GITHUB_TOKEN has only `contents: write`. No additional imports or methods are needed because this is a YAML configuration change only.

Concretely:
- Edit `.github/workflows/release.yml`.
- Insert:

```yaml
permissions:
  contents: write
```

between line 2 (empty line after `name: release`) and line 3 (`on:`). No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
