### PR TITLE
[Bug] Don't display not used component status in admin status dashboard

### DIFF
--- a/admin/server/services.py
+++ b/admin/server/services.py
@@ -13,6 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
+import os
 import logging
 import re
 from werkzeug.security import check_password_hash
@@ -179,10 +181,14 @@ class ServiceMgr:
 
     @staticmethod
     def get_all_services():
+        doc_engine = os.getenv('DOC_ENGINE', 'elasticsearch')
         result = []
         configs = SERVICE_CONFIGS.configs
         for service_id, config in enumerate(configs):
             config_dict = config.to_dict()
+            if config_dict['service_type'] == 'retrieval':
+                if config_dict['extra']['retrieval_type'] != doc_engine:
+                    continue
             try:
                 service_detail = ServiceMgr.get_service_details(service_id)
                 if "status" in service_detail:


### PR DESCRIPTION
### What problem does this PR solve?

Currently, all components in configs are displayed even they are not used. This PR is to fix it.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
