### PR TITLE
Update MinerU integration for 2.7.0+ with MinerU batch processing and backend optimization

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -234,7 +234,7 @@ MINERU_ENV_KEYS = ["MINERU_APISERVER", "MINERU_OUTPUT_DIR", "MINERU_BACKEND", "M
 MINERU_DEFAULT_CONFIG = {
     "MINERU_APISERVER": "",
     "MINERU_OUTPUT_DIR": "",
-    "MINERU_BACKEND": "pipeline",
+    "MINERU_BACKEND": "pipeline",  # Default backend, backward compatible; hybrid-auto-engine and hybrid are also supported
     "MINERU_SERVER_URL": "",
     "MINERU_DELETE_OUTPUT": 1,
 }

--- a/docs/guides/agent/agent_component_reference/parser.md
+++ b/docs/guides/agent/agent_component_reference/parser.md
@@ -47,7 +47,9 @@ Starting from v0.22.0, RAGFlow includes MinerU (&ge; 2.6.3) as an optional PDF p
 2. In the **.env** file or from the **Model providers** page in the UI, configure RAGFlow as a remote client to MinerU:
    - `MINERU_APISERVER`: The MinerU API endpoint (e.g., `http://mineru-host:8886`).
    - `MINERU_BACKEND`: The MinerU backend:
-      - `"pipeline"` (default)
+      - `"pipeline"` (default, backward compatible)
+      - `"hybrid-auto-engine"` (recommended for MinerU 2.7.0+)
+      - `"hybrid"` (hybrid backend combining multiple strategies)
       - `"vlm-http-client"`
       - `"vlm-transformers"`
       - `"vlm-vllm-engine"`

--- a/docs/guides/dataset/select_pdf_parser.md
+++ b/docs/guides/dataset/select_pdf_parser.md
@@ -47,7 +47,9 @@ Starting from v0.22.0, RAGFlow includes MinerU (&ge; 2.6.3) as an optional PDF p
 2. In the **.env** file or from the **Model providers** page in the UI, configure RAGFlow as a remote client to MinerU:
    - `MINERU_APISERVER`: The MinerU API endpoint (e.g., `http://mineru-host:8886`).
    - `MINERU_BACKEND`: The MinerU backend:
-      - `"pipeline"` (default)
+      - `"pipeline"` (default, backward compatible)
+      - `"hybrid-auto-engine"` (recommended for MinerU 2.7.0+)
+      - `"hybrid"` (hybrid backend combining multiple strategies)
       - `"vlm-http-client"`
       - `"vlm-transformers"`
       - `"vlm-vllm-engine"`
@@ -59,6 +61,16 @@ Starting from v0.22.0, RAGFlow includes MinerU (&ge; 2.6.3) as an optional PDF p
    - `MINERU_DELETE_OUTPUT`: Whether to delete temporary output when a temporary directory is used:
      - `1`: Delete.
      - `0`: Retain.
+
+   **Advanced Configuration (via UI parser_config):**
+   - `mineru_batch_size`: Number of pages per batch for large PDFs (default: 50). Set to 0 to disable batching.
+   - `mineru_start_page`: Starting page for manual pagination (0-based, optional).
+   - `mineru_end_page`: Ending page for manual pagination (0-based, optional).
+   - `mineru_parse_method`: Parse method - `"auto"` (default), `"txt"`, or `"ocr"`.
+   - `mineru_lang`: OCR language - `"English"` (default), `"Chinese"`, etc.
+   - `mineru_formula_enable`: Enable formula recognition (default: true).
+   - `mineru_table_enable`: Enable table recognition (default: true).
+
 3. In the web UI, navigate to your dataset's **Configuration** page and find the **Ingestion pipeline** section:  
    - If you decide to use a chunking method from the **Built-in** dropdown, ensure it supports PDF parsing, then select **MinerU** from the **PDF parser** dropdown.
    - If you use a custom ingestion pipeline instead, select **MinerU** in the **PDF parser** section of the **Parser** component.


### PR DESCRIPTION
### What problem does this PR solve?

MinerU parser lacked support for processing large PDFs efficiently and offered limited backend flexibility. Users could not process documents in batches or use newer MinerU backends like `hybrid-auto-engine`.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

---

## Changes

### Core Enhancements

**Batch Processing** - Added automatic and manual pagination for large PDFs:
- `_get_total_pages()`: Efficient page counting via pypdf (structure-only read)
- `_run_mineru_api()`: Auto-splits into batches based on `batch_size`
- `_run_mineru_api_single_batch()`: Processes individual batches with proper page offset
- Merges batch results with adjusted page indices

**New Backends** - Added `hybrid-auto-engine` and `hybrid` to `MinerUBackend` enum while keeping `pipeline` as default for backward compatibility.

**Error Handling** - Added specific exception types (`Timeout`, `RequestException`, `IOError`, `JSONDecodeError`) with contextual error messages.

### Configuration Options

Via `parser_config`:
```python
{
    'mineru_batch_size': 50,        # Pages per batch (0 disables)
    'mineru_start_page': 10,        # Manual pagination start (0-based)
    'mineru_end_page': 50,          # Manual pagination end (0-based)
    'mineru_parse_method': 'auto',  # auto|txt|ocr
    'mineru_lang': 'English',       # OCR language
    'mineru_formula_enable': True,  # Formula recognition
    'mineru_table_enable': True     # Table recognition
}
```

### Implementation Details

**Constants**: `MAX_PAGE_NUMBER`, `CROP_GAP_PIXELS`, `CROP_CONTEXT_LINES` for maintainability.

**Batch Logic**:
- Activates when `batch_size > 0` and no manual pagination specified
- First batch failure aborts; subsequent failures log warning and continue
- Manual pagination (`start_page`/`end_page`) overrides automatic batching

**Validation**: Input sanitization for all configuration options with fallback to safe defaults.

### Backward Compatibility

No breaking changes:
- Default backend remains `pipeline`
- Existing options and API unchanged
- UI components already compatible via `parser_config`
- `ocr_model.py` requires no changes

### Documentation

Updated:
- `docs/guides/dataset/select_pdf_parser.md`: Backend options and batch configuration
- `docs/guides/agent/agent_component_reference/parser.md`: New backend documentation
- `common/constants.py`: Backend comment clarification