### PR TITLE
Remove duplicated tag_feas assignment in create route (api/apps/chunk_app.py)

### DIFF
--- a/api/apps/chunk_app.py
+++ b/api/apps/chunk_app.py
@@ -260,8 +260,6 @@ async def create():
     d["create_timestamp_flt"] = datetime.datetime.now().timestamp()
     if "tag_feas" in req:
         d["tag_feas"] = req["tag_feas"]
-    if "tag_feas" in req:
-        d["tag_feas"] = req["tag_feas"]
 
     try:
         def _create_sync():


### PR DESCRIPTION
### What problem does this PR solve?

This PR removes a duplicated assignment of `tag_feas` in the
`@manager.route('/create')` API handler located in `api/apps/chunk_app.py`.

The same conditional block was unintentionally repeated twice, which had no
functional impact but reduced code readability and maintainability.
This change eliminates the redundancy while preserving existing behavior.

### Type of change

- [x] Refactoring
