### PR TITLE
Chore(compose): remove unnecessary history_data_agent volume mount

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,7 +87,6 @@ services:
       - ./nginx/ragflow.conf:/etc/nginx/conf.d/ragflow.conf
       - ./nginx/proxy.conf:/etc/nginx/proxy.conf
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ../history_data_agent:/ragflow/history_data_agent
       - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
       - ./entrypoint.sh:/ragflow/entrypoint.sh
     env_file: .env


### PR DESCRIPTION
### What problem does this PR solve?

Removed the volume mount mapping ../history_data_agent:/ragflow/history_data_agent from docker-compose.yml as it appears to be no longer in use

### Type of change

- [x] Chore

