### PR TITLE
Fix: handle invalid img_id format in chunk update

### DIFF
--- a/api/apps/chunk_app.py
+++ b/api/apps/chunk_app.py
@@ -178,8 +178,9 @@ async def set():
 
             # update image
             image_base64 = req.get("image_base64", None)
-            if image_base64:
-                bkt, name = req.get("img_id", "-").split("-")
+            img_id = req.get("img_id", "")
+            if image_base64 and img_id and "-" in img_id:
+                bkt, name = img_id.split("-", 1)
                 image_binary = base64.b64decode(image_base64)
                 settings.STORAGE_IMPL.put(bkt, name, image_binary)
             return get_json_result(data=True)


### PR DESCRIPTION
## Summary
- Fix ValueError when updating chunk with invalid/empty `img_id` format
- Add validation before splitting `img_id` by hyphen
- Use `split("-", 1)` to handle object names containing hyphens

## Test plan
- [x] Verify chunk update works with valid `img_id` (format: `bucket-objectname`)
- [x] Verify chunk update doesn't crash with empty `img_id`
- [x] Verify chunk update doesn't crash when `img_id` has no hyphen
- [x] Verify ruff check passes

Fixes #12035