### PR TITLE
Add MIME types for PPT and PPTX files

### DIFF
--- a/api/utils/web_utils.py
+++ b/api/utils/web_utils.py
@@ -87,8 +87,8 @@ CONTENT_TYPE_MAP = {
     "avif": "image/avif",
     "heic": "image/heic",
     # PPTX
-    "ppt"： "application/vnd.ms-powerpoint"，
-    "pptx"："application/vnd.openxmLformats-officedocument.presentationml.presentation"，
+    "ppt": "application/vnd.ms-powerpoint",
+    "pptx": "application/vnd.openxmLformats-officedocument.presentationml.presentation",
 }
 
 


### PR DESCRIPTION
Otherwise, slide files cannot be opened in Chat module

### What problem does this PR solve?

Backend Reason (API): In the api/utils/web_utils.py file of the backend, the CONTENT_TYPE_MAP dictionary is missing ppt and pptx.
MIME type mapping. This means that when the frontend requests a PPTX file, the backend cannot correctly inform the browser that it is a PPTX file, resulting in the file being displayed incorrectly.
Type identification error.

### Type of change

-  Bug Fix (non-breaking change which fixes an issue)
