### PR TITLE
fix(ob_conn): avoid reusing SQLAlchemy Column objects in DDL

### DIFF
--- a/rag/utils/ob_conn.py
+++ b/rag/utils/ob_conn.py
@@ -658,7 +658,7 @@ class OBConnection(DocStoreConnection):
 
         self.client.create_table(
             table_name=table_name,
-            columns=column_definitions,
+            columns=[c.copy() for c in column_definitions],
             **table_options,
         )
         logger.info(f"Created table '{table_name}'.")
@@ -711,7 +711,7 @@ class OBConnection(DocStoreConnection):
         try:
             self.client.add_columns(
                 table_name=table_name,
-                columns=[column],
+                columns=[column.copy()],
             )
             logger.info(f"Added column '{column.name}' to table '{table_name}'.")
         except Exception as e:


### PR DESCRIPTION
### What problem does this PR solve?

When there are multiple users, parsing a document for a new user can trigger the reuse of column objects, leading to the error `sqlalchemy.exc.ArgumentError: Column object 'id' already assigned to Table xxx`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
