### PR TITLE
fix(docker): remove unnecessary mounts in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,8 +39,11 @@ services:
       - ./nginx/ragflow.conf:/etc/nginx/conf.d/ragflow.conf
       - ./nginx/proxy.conf:/etc/nginx/proxy.conf
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
-      - ./entrypoint.sh:/ragflow/entrypoint.sh
+      # The following files are already included in the Dockerfile. Only mount locally if you really need to override for testing.
+      # Be aware: mounting entrypoint.sh may cause permission issues. (Templates are read-only and generally safe.)
+      # For local testing, consider using a docker-compose.override.yml instead of mounting directly.
+      # - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
+      # - ./entrypoint.sh:/ragflow/entrypoint.sh
     env_file: .env
     networks:
       - ragflow
@@ -87,8 +90,11 @@ services:
       - ./nginx/ragflow.conf:/etc/nginx/conf.d/ragflow.conf
       - ./nginx/proxy.conf:/etc/nginx/proxy.conf
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
-      - ./entrypoint.sh:/ragflow/entrypoint.sh
+      # The following files are already included in the Dockerfile. Only mount locally if you really need to override for testing.
+      # Be aware: mounting entrypoint.sh may cause permission issues. (Templates are read-only and generally safe.)
+      # For local testing, consider using a docker-compose.override.yml instead of mounting directly.
+      # - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
+      # - ./entrypoint.sh:/ragflow/entrypoint.sh
     env_file: .env
     networks:
       - ragflow


### PR DESCRIPTION
### What problem does this PR solve?

This PR removes the unnecessary volume mounts of `entrypoint.sh` and `service_conf.yaml.template` in docker-compose. 
Both files are already included in the Dockerfile, so mounting them is not needed. 
Mounting entrypoint.sh in particular may cause permission issues.

- service_conf.yaml.template mount is kept commented for optional local override.
- For local testing, consider using docker-compose.override.yml instead of mounting directly.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)