### PR TITLE
Fix PDF Generator output variables not appearing in subsequent agent steps

### DIFF
--- a/web/src/pages/agent/constant/index.tsx
+++ b/web/src/pages/agent/constant/index.tsx
@@ -1016,10 +1016,10 @@ export const initialPDFGeneratorValues = {
   watermark_text: '',
   enable_toc: false,
   outputs: {
-    file_path: { type: 'string', value: '' },
-    pdf_base64: { type: 'string', value: '' },
-    download: { type: 'string', value: '' },
-    success: { type: 'boolean', value: false },
+    file_path: { type: 'string' },
+    pdf_base64: { type: 'string' },
+    download: { type: 'string' },
+    success: { type: 'boolean' },
   },
 };
 

--- a/web/src/pages/agent/form/components/output.tsx
+++ b/web/src/pages/agent/form/components/output.tsx
@@ -14,7 +14,10 @@ type OutputProps = {
   isFormRequired?: boolean;
 } & PropsWithChildren;
 
-export function transferOutputs(outputs: Record<string, any>) {
+export function transferOutputs(outputs: Record<string, any> | undefined) {
+  if (!outputs) {
+    return [];
+  }
   return Object.entries(outputs).map(([key, value]) => ({
     title: key,
     type: value?.type,
@@ -35,7 +38,7 @@ export function Output({
       <div className="text-sm flex items-center justify-between">
         {t('flow.output')} <span>{children}</span>
       </div>
-      <ul>
+      <ul className="space-y-1">
         {list.map((x, idx) => (
           <li
             key={idx}

--- a/web/src/pages/agent/form/pdf-generator-form/index.tsx
+++ b/web/src/pages/agent/form/pdf-generator-form/index.tsx
@@ -64,13 +64,12 @@ function PDFGeneratorForm({ node }: INextOperatorForm) {
     add_timestamp: z.boolean(),
     watermark_text: z.string().optional(),
     enable_toc: z.boolean(),
-    outputs: z
-      .object({
-        file_path: z.object({ type: z.string() }),
-        pdf_base64: z.object({ type: z.string() }),
-        success: z.object({ type: z.string() }),
-      })
-      .optional(),
+    outputs: z.object({
+      file_path: z.object({ type: z.string() }),
+      pdf_base64: z.object({ type: z.string() }),
+      download: z.object({ type: z.string() }),
+      success: z.object({ type: z.string() }),
+    }),
   });
 
   const form = useForm<z.infer<typeof FormSchema>>({
@@ -78,9 +77,11 @@ function PDFGeneratorForm({ node }: INextOperatorForm) {
     resolver: zodResolver(FormSchema),
   });
 
+  const formOutputs = form.watch('outputs');
+
   const outputList = useMemo(() => {
-    return transferOutputs(values.outputs);
-  }, [values.outputs]);
+    return transferOutputs(formOutputs ?? values.outputs);
+  }, [formOutputs, values.outputs]);
 
   useWatchFormChange(node?.id, form);
 

--- a/web/src/pages/agent/hooks/use-add-node.ts
+++ b/web/src/pages/agent/hooks/use-add-node.ts
@@ -48,6 +48,7 @@ import {
   initialVariableAssignerValues,
   initialWaitingDialogueValues,
   initialWenCaiValues,
+  initialPDFGeneratorValues,
   initialWikipediaValues,
   initialYahooFinanceValues,
 } from '../constant';
@@ -179,7 +180,7 @@ export const useInitializeOperatorParams = () => {
       [Operator.Loop]: initialLoopValues,
       [Operator.LoopStart]: {},
       [Operator.ExitLoop]: {},
-      [Operator.PDFGenerator]: {},
+      [Operator.PDFGenerator]: initialPDFGeneratorValues,
       [Operator.ExcelProcessor]: {},
     };
   }, [llmId]);


### PR DESCRIPTION
This commit fixes multiple issues preventing PDF Generator (Docs Generator) output variables from being visible in the Output section and available to downstream nodes.

### What problem does this PR solve?

Issues Fixed:
1. PDF Generator nodes initialized with empty object instead of proper initial values
2. Output structure mismatch (had 'value' property that system doesn't expect)
3. Missing 'download' output in form schema
4. Output list computed from static values instead of form state
5. Added null/undefined guard to transferOutputs function

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
Changes:
- web/src/pages/agent/constant/index.tsx: Fixed output structure in initialPDFGeneratorValues
- web/src/pages/agent/hooks/use-add-node.ts: Initialize PDF Generator with proper values
- web/src/pages/agent/form/pdf-generator-form/index.tsx: Fixed schema and use form.watch
- web/src/pages/agent/form/components/output.tsx: Added null guard and spacing