### PR TITLE
fixed contains metadata filters

### DIFF
--- a/common/metadata_utils.py
+++ b/common/metadata_utils.py
@@ -62,9 +62,10 @@ def meta_filter(metas: dict, filters: list[dict], logic: str = "and"):
             matched = False
             try:
                 if operator == "contains":
-                    matched = input in value if not isinstance(input, list) else all(i in value for i in input)
+                    # Check if filter value is a substring of the metadata value
+                    matched = value in str(input) if not isinstance(input, list) else any(value in str(i) for i in input)
                 elif operator == "not contains":
-                    matched = input not in value if not isinstance(input, list) else all(i not in value for i in input)
+                    matched = value not in str(input) if not isinstance(input, list) else all(value not in str(i) for i in input)
                 elif operator == "in":
                     matched = input in value if not isinstance(input, list) else all(i in value for i in input)
                 elif operator == "not in":


### PR DESCRIPTION
### What problem does this PR solve?

Changed common/metadata_utils.py so contains/not contains now look for the filter value inside the metadata (checking any list item) instead of the previous behavior where metadata had to be a substring of the filter value; in/not in remain unchanged to keep membership semantics. 
Before this change, both operator pairs (contain/in and not_contain/not_in) were identical, and contains was unintuitively backwards.
This fix restores distinct, expected semantics for those filters.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
