### PR TITLE
Fix: langfuse connection error handling #12621

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -296,10 +296,14 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
     langfuse_keys = TenantLangfuseService.filter_by_tenant(tenant_id=dialog.tenant_id)
     if langfuse_keys:
         langfuse = Langfuse(public_key=langfuse_keys.public_key, secret_key=langfuse_keys.secret_key, host=langfuse_keys.host)
-        if langfuse.auth_check():
-            langfuse_tracer = langfuse
-            trace_id = langfuse_tracer.create_trace_id()
-            trace_context = {"trace_id": trace_id}
+        try:
+            if langfuse.auth_check():
+                langfuse_tracer = langfuse
+                trace_id = langfuse_tracer.create_trace_id()
+                trace_context = {"trace_id": trace_id}
+        except Exception:
+            # Skip langfuse tracing if connection fails
+            pass
 
     check_langfuse_tracer_ts = timer()
     kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)

--- a/api/db/services/tenant_llm_service.py
+++ b/api/db/services/tenant_llm_service.py
@@ -392,7 +392,11 @@ class LLM4Tenant:
         self.langfuse = None
         if langfuse_keys:
             langfuse = Langfuse(public_key=langfuse_keys.public_key, secret_key=langfuse_keys.secret_key, host=langfuse_keys.host)
-            if langfuse.auth_check():
-                self.langfuse = langfuse
-                trace_id = self.langfuse.create_trace_id()
-                self.trace_context = {"trace_id": trace_id}
+            try:
+                if langfuse.auth_check():
+                    self.langfuse = langfuse
+                    trace_id = self.langfuse.create_trace_id()
+                    self.trace_context = {"trace_id": trace_id}
+            except Exception:
+                # Skip langfuse tracing if connection fails
+                pass


### PR DESCRIPTION
## Description

Fixes connection error handling when langfuse service is unavailable. The application now gracefully handles connection failures instead of crashing.

## Changes

- Wrapped `langfuse.auth_check()` calls in try-except blocks in:
  - `api/db/services/dialog_service.py`
  - `api/db/services/tenant_llm_service.py`

## Problem

When langfuse service is unavailable or connection is refused, `langfuse.auth_check()` throws `httpx.ConnectError: [Errno 111] Connection refused`, causing the application to crash during document parsing or dialog operations.

## Solution

Added try-except blocks around `langfuse.auth_check()` calls to catch connection errors and gracefully skip langfuse tracing instead of crashing. The application continues functioning normally even when langfuse is unavailable.

## Related Issue

Fixes #12621

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=158349177