### PR TITLE
fix(ob_conn): ignore duplicate errors when executing 'create_idx'

### DIFF
--- a/rag/utils/ob_conn.py
+++ b/rag/utils/ob_conn.py
@@ -329,6 +329,14 @@ def _try_with_lock(lock_name: str, process_func, check_func, timeout: int = None
             try:
                 process_func()
                 return
+            except Exception as e:
+                if "Duplicate" in str(e):
+                    # In some cases, the schema may change after the lock is acquired, so if the error message
+                    # indicates that the column or index is duplicated, it should be assumed that 'process_func'
+                    # has been executed correctly.
+                    logger.warning(f"Skip processing {lock_name} due to duplication: {str(e)}")
+                    return
+                raise
             finally:
                 lock.release()
 


### PR DESCRIPTION
### What problem does this PR solve?

Skip duplicate errors to avoid 'create_idx' failures caused by slow metadata refresh or external modifications.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
