### PR TITLE
fix: Correct gitlab_url access in sync_data_source.py

### DIFF
--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -1096,7 +1096,7 @@ class Gitlab(SyncBase):
         self.connector.load_credentials(
             {
                 "gitlab_access_token": self.conf.get("credentials", {}).get("gitlab_access_token"),
-                "gitlab_url": self.conf.get("credentials", {}).get("gitlab_url"),
+                "gitlab_url": self.conf.get("gitlab_url"),
             }
         )
 


### PR DESCRIPTION
### What problem does this PR solve?

Correct gitlab_url access. See https://github.com/infiniflow/ragflow/blob/main/web/src/pages/user-setting/data-source/constant/index.tsx#L660-L666

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
