### PR TITLE
An issue involving node.js OOM happened

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,9 @@ USER root
 
 WORKDIR /ragflow
 
+# Set Node.js memory limit for building
+ARG NODE_OPTIONS=--max-old-space-size=4096
+
 # install dependencies from uv.lock file
 COPY pyproject.toml uv.lock ./
 
@@ -159,6 +162,7 @@ RUN --mount=type=cache,id=ragflow_uv,target=/root/.cache/uv,sharing=locked \
 COPY web web
 COPY docs docs
 RUN --mount=type=cache,id=ragflow_npm,target=/root/.npm,sharing=locked \
+    export NODE_OPTIONS="--max-old-space-size=4096" && \
     cd web && npm install && npm run build
 
 COPY .git /ragflow/.git


### PR DESCRIPTION
### What problem does this PR solve?
The Node.js memory issue occurred due to JavaScript heap exhaustion during the Vite build process sometimes. Here's what happened:

Root Cause:

When building the web frontend with npm run build, Vite needs to bundle, transform, and optimize all JavaScript/TypeScript code
Node.js has a default maximum heap size of ~2GB
The RAGFlow web application is large enough that the build process exceeded this limit
This triggered garbage collection failures ("Ineffective mark-compacts near heap limit") and eventually crashed with exit code 134 (SIGABRT)

The solution I attempted:
I did not find a simple method to reduce the use of memory for node.js, so I added NODE_OPTIONS=--max-old-space-size=4096 to allocate 4GB heap memory for Node.js during the build.


 => ERROR [builder 6/8] RUN --mount=type=cache,id=ragflow_npm,target=/ro  53.3s
------
 > [builder 6/8] RUN --mount=type=cache,id=ragflow_npm,target=/root/.npm,sharing=locked     cd web && npm install && npm run build:
4.551 
4.551 > prepare
4.551 > cd .. && husky web/.husky
4.551 
4.810 .git can't be found
4.833 added 7 packages in 4s
4.833 
4.833 499 packages are looking for funding
4.833   run `npm fund` for details
5.206 
5.206 > build
5.206 > vite build --mode production
5.206 
5.939 vite v7.3.0 building client environment for production...
6.169 transforming...
6.472 
6.472  WARN 
6.472 
6.472 
6.472  WARN  warn - As of Tailwind CSS v3.3, the @tailwindcss/line-clamp plugin is now included by default.
6.472 
6.472 
6.472  WARN  warn - Remove it from the plugins array in your configuration to eliminate this warning.
6.472 
53.14 
53.14 <--- Last few GCs --->
53.14 
53.14 [41:0x55f82d0]    47673 ms: Scavenge (reduce) 2041.5 (2086.0) -> 2038.7 (2079.7) MB, 6.11 / 0.00 ms  (average mu = 0.330, current mu = 0.319) allocation failure; 
53.14 [41:0x55f82d0]    47727 ms: Scavenge (reduce) 2039.4 (2079.7) -> 2038.7 (2080.2) MB, 5.34 / 0.00 ms  (average mu = 0.330, current mu = 0.319) allocation failure; 
53.14 [41:0x55f82d0]    47809 ms: Scavenge (reduce) 2039.6 (2080.2) -> 2038.7 (2080.2) MB, 4.59 / 0.00 ms  (average mu = 0.330, current mu = 0.319) allocation failure; 
53.14 
53.14 
53.14 <--- JS stacktrace --->
53.14 
53.14 FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
53.14 ----- Native stack trace -----
53.14 
53.14  1: 0xb76db1 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
53.14  2: 0xee62f0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
53.14  3: 0xee65d7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
53.14  4: 0x10f82d5  [node]
53.14  5: 0x10f8864 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [node]
53.14  6: 0x110f754 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::internal::GarbageCollectionReason, char const*) [node]
53.14  7: 0x110ff6c v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
53.14  8: 0x11120ca v8::internal::Heap::HandleGCRequest() [node]
53.14  9: 0x107d737 v8::internal::StackGuard::HandleInterrupts() [node]
53.15 10: 0x151fb9a v8::internal::Runtime_StackGuard(int, unsigned long*, v8::internal::Isolate*) [node]
53.15 11: 0x1959ef6  [node]
53.22 Aborted
------
[+] up 0/1
 ⠙ Image docker-ragflow Building                                          58.0s 
Dockerfile:161

--------------------

 160 |     COPY docs docs

 161 | >>> RUN --mount=type=cache,id=ragflow_npm,target=/root/.npm,sharing=locked \

 162 | >>>     cd web && npm install && npm run build

 163 |     

--------------------

failed to solve: process "/bin/bash -c cd web && npm install && npm run build" did not complete successfully: exit code: 134



View build details: docker-desktop://dashboard/build/default/default/j68n2ke32cd8bte4y8fs471au

[Node_OOM.docx](https://github.com/user-attachments/files/24700592/Node_OOM.docx)


### Type of change

 Bug Fix (non-breaking change which fixes an issue)
