### PR TITLE
Round float value of minimum_should_match

### DIFF
--- a/rag/nlp/query.py
+++ b/rag/nlp/query.py
@@ -232,5 +232,5 @@ class FulltextQueryer(QueryBase):
                 keywords.append(f"{tk}^{w}")
 
         return MatchTextExpr(self.query_fields, " ".join(keywords), 100,
-                             {"minimum_should_match": min(3, len(keywords) / 10),
+                             {"minimum_should_match": min(3, round(len(keywords) / 10)),
                               "original_query": " ".join(origin_keywords)})


### PR DESCRIPTION
### What problem does this PR solve?

In paragraph()  of class FulltextQueryer,  "len(keywords) / 10" should be rounded to integer before set to minimum_should_match.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
