### PR TITLE
fix: inaccurate error message when uploading multiple files containing an unsupported file type

### DIFF
--- a/api/apps/document_app.py
+++ b/api/apps/document_app.py
@@ -87,6 +87,7 @@ async def upload():
 
     err, files = await asyncio.to_thread(FileService.upload_document, kb, file_objs, current_user.id)
     if err:
+        files = [f[0] for f in files] if files else []
         return get_json_result(data=files, message="\n".join(err), code=RetCode.SERVER_ERROR)
 
     if not files:


### PR DESCRIPTION

### What problem does this PR solve?

When uploading multiple files at once, if any of the files are of an unsupported type and the blob is not removed, it triggers a TypeError('Object of type bytes is not JSON serializable') exception. This prevents the frontend from responding properly.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
