### PR TITLE
feat(widget): add ASR (speech-to-text) support to Floating Widget

### DIFF
--- a/web/src/components/floating-chat-widget.tsx
+++ b/web/src/components/floating-chat-widget.tsx
@@ -1,5 +1,6 @@
 import PdfSheet from '@/components/pdf-drawer';
 import { useClickDrawer } from '@/components/pdf-drawer/hooks';
+import { AudioButton } from '@/components/ui/audio-button';
 import { MessageType, SharedFrom } from '@/constants/chat';
 import { useFetchExternalAgentInputs } from '@/hooks/use-agent-request';
 import { useFetchExternalChatInfo } from '@/hooks/use-chat-request';
@@ -477,7 +478,7 @@ const FloatingChatWidget = () => {
 
             {/* Input Area */}
             <div className="border-t border-gray-200 p-4">
-              <div className="flex items-end space-x-3">
+              <div className="flex items-end space-x-2">
                 <div className="flex-1">
                   <textarea
                     value={inputValue}
@@ -494,6 +495,11 @@ const FloatingChatWidget = () => {
                     disabled={hasError || sendLoading}
                   />
                 </div>
+                <AudioButton
+                  onOk={(transcript) => {
+                    setInputValue((prev) => prev + transcript);
+                  }}
+                />
                 <button
                   type="button"
                   onClick={handleSendMessage}
@@ -653,7 +659,7 @@ const FloatingChatWidget = () => {
 
               {/* Input Area */}
               <div className="border-t border-gray-200 p-4">
-                <div className="flex items-end space-x-3">
+                <div className="flex items-end space-x-2">
                   <div className="flex-1">
                     <textarea
                       value={inputValue}
@@ -671,6 +677,11 @@ const FloatingChatWidget = () => {
                       disabled={hasError || sendLoading}
                     />
                   </div>
+                  <AudioButton
+                    onOk={(transcript) => {
+                      setInputValue((prev) => prev + transcript);
+                    }}
+                  />
                   <button
                     type="button"
                     onClick={handleSendMessage}


### PR DESCRIPTION
## Summary

This PR adds ASR (Automatic Speech Recognition) support to the Floating Widget embedded chat, providing feature parity with the Fullscreen Chat.

## Related Issue

Fixes https://github.com/infiniflow/ragflow/issues/12709

## Changes

- Import `AudioButton` component into `floating-chat-widget.tsx`
- Add microphone button to **window mode** input area
- Add microphone button to **full mode** input area
- Transcribed text is appended to the input field (allowing users to edit before sending)

## Expected Behavior

- Microphone button appears next to the text input in the Floating Widget
- User can click to start/stop recording
- Transcribed text is inserted into the input field
- Graceful handling if microphone permission is denied (handled by existing `AudioButton` component)

## Screenshots

The implementation reuses the existing `AudioButton` component which already has:
- Voice visualizer during recording
- Recording timer
- Processing indicator
- API call to `/sequence2txt` endpoint

## Testing

1. Embed the Floating Widget on a page
2. Click the microphone button
3. Grant microphone permission
4. Speak and stop recording
5. Verify transcribed text appears in the input field

---

<!-- Gittensor Contribution Tag: @GlobalStar117 -->