### PR TITLE
Fix: codeExec return types & error handling; Update Spark model mappings

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -799,7 +799,8 @@ class SparkChat(Base):
             base_url = "https://spark-api-open.xf-yun.com/v1"
         model2version = {
             "Spark-Max": "generalv3.5",
-            "Spark-Lite": "general",
+            "Spark-Max-32K": "max-32k",
+            "Spark-Lite": "lite",
             "Spark-Pro": "generalv3",
             "Spark-Pro-128K": "pro-128k",
             "Spark-4.0-Ultra": "4.0Ultra",


### PR DESCRIPTION
## What problem does this PR solve?

This PR addresses three specific issues to improve agent reliability and model support:

1. **`codeExec` Output Limitation**: Previously, the `codeExec` tool was strictly limited to returning `string` types. I updated the output constraint to `object` to support structured data (Dicts, Lists, etc.) required for complex downstream tasks.
2. **`codeExec` Error Handling**: Improved the execution logic so that when runtime errors occur, the tool captures the exception and returns the error message as the output instead of causing the process to abort or fail silently.
3. **Spark Model Configuration**:
    - Added support for the `MAX-32k` model variant.
    - Fixed the `Spark-Lite` mapping from `general` to `lite` to match the latest API specifications.

## Type of change

- [x] Bug Fix (fixes execution logic and model mapping)
- [x] New Feature / Enhancement (adds model support and improves tool flexibility)

## Key Changes

### `agent/tools/code_exec.py`
- Changed the output type definition from `string` to `object`.
- Refactored the execution flow to gracefully catch exceptions and return error messages as part of the tool output.

### `rag/llm/chat_model.py`
- Added `"Spark-Max-32K": "max-32k"` to the model list.
- Updated `"Spark-Lite"` value from `"general"` to `"lite"`.

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.