### PR TITLE
fix: close file handles when loading JSON mapping in doc store connectors

### DIFF
--- a/common/doc_store/es_conn_base.py
+++ b/common/doc_store/es_conn_base.py
@@ -48,7 +48,8 @@ class ESConnectionBase(DocStoreConnection):
             msg = f"Elasticsearch mapping file not found at {fp_mapping}"
             self.logger.error(msg)
             raise Exception(msg)
-        self.mapping = json.load(open(fp_mapping, "r"))
+        with open(fp_mapping, "r") as f:
+            self.mapping = json.load(f)
         self.logger.info(f"Elasticsearch {settings.ES['hosts']} is healthy.")
 
     def _connect(self):
@@ -150,7 +151,8 @@ class ESConnectionBase(DocStoreConnection):
                 self.logger.error(f"Document metadata mapping file not found at {fp_mapping}")
                 return False
 
-            doc_meta_mapping = json.load(open(fp_mapping, "r"))
+            with open(fp_mapping, "r") as f:
+                doc_meta_mapping = json.load(f)
             return IndicesClient(self.es).create(index=index_name,
                                                  settings=doc_meta_mapping["settings"],
                                                  mappings=doc_meta_mapping["mappings"])

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -73,7 +73,8 @@ class InfinityConnectionBase(DocStoreConnection):
         fp_mapping = os.path.join(get_project_base_directory(), "conf", self.mapping_file_name)
         if not os.path.exists(fp_mapping):
             raise Exception(f"Mapping file not found at {fp_mapping}")
-        schema = json.load(open(fp_mapping))
+        with open(fp_mapping) as f:
+            schema = json.load(f)
         table_names = inf_db.list_tables().table_names
         for table_name in table_names:
             inf_table = inf_db.get_table(table_name)
@@ -300,7 +301,8 @@ class InfinityConnectionBase(DocStoreConnection):
             if not os.path.exists(fp_mapping):
                 self.logger.error(f"Document metadata mapping file not found at {fp_mapping}")
                 return False
-            schema = json.load(open(fp_mapping))
+            with open(fp_mapping) as f:
+                schema = json.load(f)
             inf_db.create_table(
                 table_name,
                 schema,
@@ -547,7 +549,8 @@ class InfinityConnectionBase(DocStoreConnection):
             reverse_mapping = {}
             fp_mapping = os.path.join(get_project_base_directory(), "conf", self.mapping_file_name)
             if os.path.exists(fp_mapping):
-                schema = json.load(open(fp_mapping))
+                with open(fp_mapping) as f:
+                    schema = json.load(f)
                 for field_name, field_info in schema.items():
                     if "comment" in field_info:
                         # Parse comma-separated aliases from comment

--- a/rag/utils/opensearch_conn.py
+++ b/rag/utils/opensearch_conn.py
@@ -72,7 +72,8 @@ class OSConnection(DocStoreConnection):
             msg = f"OpenSearch mapping file not found at {fp_mapping}"
             logger.error(msg)
             raise Exception(msg)
-        self.mapping = json.load(open(fp_mapping, "r"))
+        with open(fp_mapping, "r") as f:
+            self.mapping = json.load(f)
         logger.info(f"OpenSearch {settings.OS['hosts']} is healthy.")
 
     """


### PR DESCRIPTION
**What problem does this PR solve?**

When loading JSON mapping/schema files, the code used json.load(open(path)) without closing the file. The file handle stayed open until garbage collection, which can leak file descriptors under load (e.g. repeated reconnects or migrations).

**Type of change**
[x] Bug Fix (non-breaking change which fixes an issue)
**Change**
Replaced json.load(open(...)) with a context manager so the file is closed after loading:
with open(fp_mapping, "r") as f:    ... = json.load(f)

**Files updated**
rag/utils/opensearch_conn.py – mapping load (1 place)
common/doc_store/es_conn_base.py – mapping load + doc_meta_mapping load (2 places)
common/doc_store/infinity_conn_base.py – schema loads in _migrate_db, doc metadata table creation, and SQL field mapping (4 places)
Behavior is unchanged; only resource handling is fixed.