### PR TITLE
feature:Add OceanBase Support to Text-to-SQL Agent

### DIFF
--- a/agent/tools/exesql.py
+++ b/agent/tools/exesql.py
@@ -53,7 +53,7 @@ class ExeSQLParam(ToolParamBase):
         self.max_records = 1024
 
     def check(self):
-        self.check_valid_value(self.db_type, "Choose DB type", ['mysql', 'postgres', 'mariadb', 'mssql', 'IBM DB2', 'trino'])
+        self.check_valid_value(self.db_type, "Choose DB type", ['mysql', 'postgres', 'mariadb', 'mssql', 'IBM DB2', 'trino', 'oceanbase'])
         self.check_empty(self.database, "Database name")
         self.check_empty(self.username, "database username")
         self.check_empty(self.host, "IP Address")
@@ -126,6 +126,9 @@ class ExeSQL(ToolBase, ABC):
         if self._param.db_type in ["mysql", "mariadb"]:
             db = pymysql.connect(db=self._param.database, user=self._param.username, host=self._param.host,
                                  port=self._param.port, password=self._param.password)
+        elif self._param.db_type == 'oceanbase':
+            db = pymysql.connect(db=self._param.database, user=self._param.username, host=self._param.host,
+                                 port=self._param.port, password=self._param.password, charset='utf8mb4')
         elif self._param.db_type == 'postgres':
             db = psycopg2.connect(dbname=self._param.database, user=self._param.username, host=self._param.host,
                                   port=self._param.port, password=self._param.password)

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -326,6 +326,9 @@ async def test_db_connect():
         if req["db_type"] in ["mysql", "mariadb"]:
             db = MySQLDatabase(req["database"], user=req["username"], host=req["host"], port=req["port"],
                                password=req["password"])
+        elif req["db_type"] == "oceanbase":
+            db = MySQLDatabase(req["database"], user=req["username"], host=req["host"], port=req["port"],
+                               password=req["password"], charset="utf8mb4")
         elif req["db_type"] == 'postgres':
             db = PostgresqlDatabase(req["database"], user=req["username"], host=req["host"], port=req["port"],
                                     password=req["password"])

--- a/web/src/pages/agent/options.ts
+++ b/web/src/pages/agent/options.ts
@@ -2140,6 +2140,7 @@ export const ExeSQLOptions = [
   'mssql',
   'IBM DB2',
   'trino',
+  'oceanbase',
 ].map((x) => ({
   label: upperFirst(x),
   value: x,


### PR DESCRIPTION
### What problem does this PR solve?

Close #12768.

This PR adds OceanBase support to RAGFlow’s Text-to-SQL (ExeSQL) component.  
OceanBase is integrated via MySQL compatibility mode, and the UI `db_type` options are updated accordingly.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

### Changes

**Backend**
- Add `oceanbase` `db_type` validation and connection logic in `exesql.py` and reuse existing MySQL compatibility mode

**Frontend**
- Add OceanBase option to the ExeSQL `db_type` selector

### How to test
1. Configure OceanBase connection in ExeSQL node (host/port/user/password/database)
2. Input: “Show 10 rows from test table”
3. Generated SQL: `SELECT * FROM test LIMIT 10;`
4. Query executes successfully and results are returned

### Screenshots
- ExeSQL db_type includes OceanBase
<img width="649" height="1015" alt="2" src="https://github.com/user-attachments/assets/e0a5f7b9-e282-402a-8639-64c1aef8fce6" />

- ExeSQL test OceanBase connection
<img width="2247" height="1140" alt="test_ob" src="https://github.com/user-attachments/assets/f16ebd93-b48e-4d18-b53f-8496581e755d" />



- Query results from OceanBase shown in UI
<img width="2550" height="1351" alt="1" src="https://github.com/user-attachments/assets/b44163dc-baab-420d-b31e-b644bdcb77a9" />
