### PR TITLE
Fixed regression issue that unable to start the service

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -50,7 +50,6 @@ class TextFieldType(Enum):
     MYSQL = "LONGTEXT"
     OCEANBASE = "LONGTEXT"
     POSTGRES = "TEXT"
-    POSTGRES = "TEXT"
 
 
 class LongTextField(TextField):


### PR DESCRIPTION
### What problem does this PR solve?

Fixed the regression issue that unable to start the server as below details, which was related to this pr https://github.com/infiniflow/ragflow/pull/12926 looks like.
``` Error Trace
Traceback (most recent call last):
  File "/mnt/c/Workspace/ragflow/api/ragflow_server.py", line 33, in <module>
    from api.apps import app
  File "/mnt/c/Workspace/ragflow/api/apps/__init__.py", line 26, in <module>
Traceback (most recent call last):
  File "/mnt/c/Workspace/ragflow/rag/svr/task_executor.py", line 34, in <module>
    from api.db.db_models import close_connection, APIToken
  File "/mnt/c/Workspace/ragflow/api/db/db_models.py", line 49, in <module>
    from api.db.services.knowledgebase_service import KnowledgebaseService
  File "/mnt/c/Workspace/ragflow/api/db/services/__init__.py", line 19, in <module>
    class TextFieldType(Enum):
  File "/mnt/c/Workspace/ragflow/api/db/db_models.py", line 53, in TextFieldType
    from .user_service import UserService as UserService
  File "/mnt/c/Workspace/ragflow/api/db/services/user_service.py", line 24, in <module>
    POSTGRES = "TEXT"
    ^^^^^^^^
  File "/usr/lib/python3.12/enum.py", line 443, in __setitem__
    raise TypeError('%r already defined as %r' % (key, self[key]))
TypeError: 'POSTGRES' already defined as 'TEXT'
    from api.db.db_models import DB, UserTenant
  File "/mnt/c/Workspace/ragflow/api/db/db_models.py", line 49, in <module>
    class TextFieldType(Enum):
  File "/mnt/c/Workspace/ragflow/api/db/db_models.py", line 53, in TextFieldType
    POSTGRES = "TEXT"
    ^^^^^^^^
  File "/usr/lib/python3.12/enum.py", line 443, in __setitem__
    raise TypeError('%r already defined as %r' % (key, self[key]))
TypeError: 'POSTGRES' already defined as 'TEXT'
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
