### PR TITLE
Fix duplicate POSTGRES enum entry causing backend startup failure    

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -50,7 +50,6 @@ class TextFieldType(Enum):
     MYSQL = "LONGTEXT"
     OCEANBASE = "LONGTEXT"
     POSTGRES = "TEXT"
-    POSTGRES = "TEXT"
 
 
 class LongTextField(TextField):


### PR DESCRIPTION
  ### What problem does this PR solve?                                                                                           
                                                                                                                                 
  Fixes a duplicate POSTGRES entry in the TextFieldType enum that triggers TypeError: 'POSTGRES' already defined as 'TEXT' on    
  import, preventing the backend from starting and resulting in 502 errors on the frontend.                                      
                                                                                                                                 
  ### Type of change                                                                                                             
                                                                                                                                 
  - [x] Bug Fix (non-breaking change which fixes an issue)