### PR TITLE
Update default Docling version to 2.71.0 to resolve table parsing issues

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -207,7 +207,7 @@ function start_mcp_server() {
 
 function ensure_docling() {
     [[ "${USE_DOCLING}" == "true" ]] || { echo "[docling] disabled by USE_DOCLING"; return 0; }
-    DOCLING_PIN="${DOCLING_VERSION:-==2.58.0}"
+    DOCLING_PIN="${DOCLING_VERSION:-==2.71.0}"
     "$PY" -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('docling') else 1)" \
       || uv pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --extra-index-url https://pypi.org/simple --no-cache-dir "docling${DOCLING_PIN}"
 }


### PR DESCRIPTION

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)