### PR TITLE
Fix：Incorrect ingestion pipeline template

### DIFF
--- a/agent/templates/advanced_ingestion_pipeline.json
+++ b/agent/templates/advanced_ingestion_pipeline.json
@@ -193,7 +193,7 @@
                         "presence_penalty": 0.4,
                         "prompts": [
                             {
-                                "content": "Text Content:\n{Splitter:NineTiesSin@chunks}\n",
+                                "content": "Text Content:\n{Extractor:NineTiesSin@chunks}\n",
                                 "role": "user"
                             }
                         ],
@@ -226,7 +226,7 @@
                         "presence_penalty": 0.4,
                         "prompts": [
                             {
-                                "content": "Text Content:\n\n{Splitter:TastyPointsLay@chunks}\n",
+                                "content": "Text Content:\n\n{Extractor:TastyPointsLay@chunks}\n",
                                 "role": "user"
                             }
                         ],
@@ -259,7 +259,7 @@
                         "presence_penalty": 0.4,
                         "prompts": [
                             {
-                                "content": "Content: \n\n{Splitter:CuteBusesBet@chunks}",
+                                "content": "Content: \n\n{Extractor:BlueResultsWink@chunks}",
                                 "role": "user"
                             }
                         ],
@@ -485,7 +485,7 @@
                             "outputs": {},
                             "presencePenaltyEnabled": false,
                             "presence_penalty": 0.4,
-                            "prompts": "Text Content:\n{Splitter:NineTiesSin@chunks}\n",
+                            "prompts": "Text Content:\n{Extractor:NineTiesSin@chunks}\n",
                             "sys_prompt": "Role\nYou are a text analyzer.\n\nTask\nExtract the most important keywords/phrases of a given piece of text content.\n\nRequirements\n- Summarize the text content, and give the top 5 important keywords/phrases.\n- The keywords MUST be in the same language as the given piece of text content.\n- The keywords are delimited by ENGLISH COMMA.\n- Output keywords ONLY.",
                             "temperature": 0.1,
                             "temperatureEnabled": false,
@@ -522,7 +522,7 @@
                             "outputs": {},
                             "presencePenaltyEnabled": false,
                             "presence_penalty": 0.4,
-                            "prompts": "Text Content:\n\n{Splitter:TastyPointsLay@chunks}\n",
+                            "prompts": "Text Content:\n\n{Extractor:TastyPointsLay@chunks}\n",
                             "sys_prompt": "Role\nYou are a text analyzer.\n\nTask\nPropose 3 questions about a given piece of text content.\n\nRequirements\n- Understand and summarize the text content, and propose the top 3 important questions.\n- The questions SHOULD NOT have overlapping meanings.\n- The questions SHOULD cover the main content of the text as much as possible.\n- The questions MUST be in the same language as the given piece of text content.\n- One question per line.\n- Output questions ONLY.",
                             "temperature": 0.1,
                             "temperatureEnabled": false,
@@ -559,7 +559,7 @@
                             "outputs": {},
                             "presencePenaltyEnabled": false,
                             "presence_penalty": 0.4,
-                            "prompts": "Content: \n\n{Splitter:BlueResultsWink@chunks}",
+                            "prompts": "Content: \n\n{Extractor:BlueResultsWink@chunks}",
                             "sys_prompt": "Extract important structured information from the given content. Output ONLY a valid JSON string with no additional text. If no important structured information is found, output an empty JSON object: {}.\n\nImportant structured information may include: names, dates, locations, events, key facts, numerical data, or other extractable entities.",
                             "temperature": 0.1,
                             "temperatureEnabled": false,


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes an incorrect variable reference in the Advanced Ingestion Pipeline template, which causes a runtime failure in the Auto Keywords stage.

When creating a pipeline using the `advanced ingestion pipeline` template, the **Auto Keywords** stage fails with the following error: 
Can't find variable: 'Splitter:NineTiesSin@chunks'

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
