### PR TITLE
chore(tests): move oceanbase peewee test under test/ and fix enum check

### DIFF
--- a/test/unit_test/utils/test_oceanbase_peewee.py
+++ b/test/unit_test/utils/test_oceanbase_peewee.py
@@ -71,7 +71,7 @@ class TestOceanBaseDatabase:
     def test_database_lock_enum_values(self):
         """Test DatabaseLock enum has all expected values."""
         expected = {'MYSQL', 'OCEANBASE', 'POSTGRES'}
-        actual = {e.name for e in DatabaseLock}
+        actual = set(DatabaseLock.__members__.keys())
         assert expected.issubset(actual), f"Missing: {expected - actual}"
 
 


### PR DESCRIPTION
### What problem does this PR solve?

This mistake was made by PR #12926 
This PR makes the OceanBase peewee unit test discoverable by the default unit test runner/CI (by moving it under test/), so it’s included in the unified unit test suite.
It also fixes `test_database_lock_enum_values` to correctly handle Enum alias members (DatabaseLock uses the same value for MYSQL and OCEANBASE).

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
### Screenshots
The original `test_oceanbase_peewee.py` was placed under tests/, which isn’t included in the default unit test runner’s testpaths, so it wasn’t picked up by the unit test suite. So we need to move it to correct path.
<img width="670" height="540" alt="image" src="https://github.com/user-attachments/assets/69d39346-450f-46dc-8965-29c3d7b32bc9" />

When using old version in `test_oceanbase_peewee.py`:
```
    def test_database_lock_enum_values(self):
        """Test DatabaseLock enum has all expected values."""
        expected = {'MYSQL', 'OCEANBASE', 'POSTGRES'}
        actual = {e.name for e in DatabaseLock}
        assert expected.issubset(actual), f"Missing: {expected - actual}"
```
The old check iterated Enum members, so alias values were skipped and only `MYSQL/POSTGRES` were seen, making OCEANBASE appear missing.

<img width="1998" height="931" alt="65e2837f23b7b298980a410c7d5c2f09" src="https://github.com/user-attachments/assets/d8e98c5a-2cfa-4182-ae35-a3ef03554a27" />

and new version uses `DatabaseLock.__members__` and passes:
<img width="2024" height="1170" alt="1aa8c6facb28d24149270fe1bc4a9dd9" src="https://github.com/user-attachments/assets/d8688936-ccac-4a39-a389-23dc6f0fe276" />

