### PR TITLE
Docs: Update error message example in HTTP API reference

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -621,7 +621,7 @@ Failure:
 ```json
 {
     "code": 101,
-    "message": "Dataset name 'RAGFlow example' already exists"
+    "message": "Field: <name> - Message: <String should have at least 1 character> - Value: <>"
 }
 ```
 


### PR DESCRIPTION
### What problem does this PR solve?

Changed the error message example in the HTTP API reference documentation from a duplicate dataset name error to a validation error about string length requirements. This update reflects the current behavior of the API when validation fails.

### Type of change

- [x] Documentation Update
