### PR TITLE
Fix: parser bug

### DIFF
--- a/web/src/pages/dataset/dataset/use-bulk-operate-dataset.tsx
+++ b/web/src/pages/dataset/dataset/use-bulk-operate-dataset.tsx
@@ -44,10 +44,12 @@ export function useBulkOperateDataset({
     if (!documents.length) {
       return 0;
     }
-    return documents.reduce((acc, cur) => {
-      return acc + cur.chunk_num;
-    }, 0);
-  }, [documents]);
+    return documents
+      .filter((item) => selectedRowKeys.includes(item.id) && item.id)
+      ?.reduce((acc, cur) => {
+        return acc + cur.chunk_num;
+      }, 0);
+  }, [documents, selectedRowKeys]);
 
   const runDocument = useCallback(
     async (run: number, option?: { delete: boolean; apply_kb: boolean }) => {


### PR DESCRIPTION
…, clicking "Parse" will still ask if you want to clear the chunks of the already parsed files.

### What problem does this PR solve?

Fix: After selecting all and then unchecking the already parsed files, clicking "Parse" will still ask if you want to clear the chunks of the already parsed files.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
