### PR TITLE
Fix: Fixed the issue GraphRAG indexing model in dataset parser_config doesn't take effect. ([#13030](https://github.com/infiniflow/ragflow/issues/13030))

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -960,7 +960,11 @@ async def do_handle_task(task):
     task_tenant_id = task["tenant_id"]
     task_embedding_id = task["embd_id"]
     task_language = task["language"]
-    task_llm_id = task["parser_config"].get("llm_id") or task["llm_id"]
+    # LLM selection priority: kb_parser_config > doc_parser_config > tenant_default
+    kb_llm_id = task.get("kb_parser_config", {}).get("llm_id")
+    doc_llm_id = task["parser_config"].get("llm_id")
+    tenant_llm_id = task["llm_id"]
+    task_llm_id = kb_llm_id or doc_llm_id or tenant_llm_id
     task["llm_id"] = task_llm_id
     task_dataset_id = task["kb_id"]
     task_doc_id = task["doc_id"]


### PR DESCRIPTION
… doesn't take effect.

### What problem does this PR solve?

Fix: Fixed When configuring a dataset's parsing settings, changing the "Global Index Model" (for GraphRAG) in parser_config.graphrag.llm_id doesn't take effect during document processing. The system always uses the tenant's default chat model instead.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)