### PR TITLE
Fix Chinese text retrieval with Infinity engine

### DIFF
--- a/rag/nlp/rag_tokenizer.py
+++ b/rag/nlp/rag_tokenizer.py
@@ -15,21 +15,18 @@
 #
 
 import infinity.rag_tokenizer
-class RagTokenizer(infinity.rag_tokenizer.RagTokenizer):
 
+
+class RagTokenizer(infinity.rag_tokenizer.RagTokenizer):
     def tokenize(self, line: str) -> str:
-        from common import settings # moved from the top of the file to avoid circular import
-        if settings.DOC_ENGINE_INFINITY:
-            return line
-        else:
-            return super().tokenize(line)
+        # Always tokenize using Infinity's tokenizer regardless of doc engine
+        # The Infinity Python SDK's tokenizer properly handles Chinese characters
+        return super().tokenize(line)
 
     def fine_grained_tokenize(self, tks: str) -> str:
-        from common import settings # moved from the top of the file to avoid circular import
-        if settings.DOC_ENGINE_INFINITY:
-            return tks
-        else:
-            return super().fine_grained_tokenize(tks)
+        # Always tokenize using Infinity's tokenizer regardless of doc engine
+        # The Infinity Python SDK's tokenizer properly handles Chinese characters
+        return super().fine_grained_tokenize(tks)
 
 
 def is_chinese(s):


### PR DESCRIPTION


### What problem does this PR solve?

Fixes #13041
 Always tokenize using Infinity's tokenizer regardless of doc engine setting. This ensures proper Chinese character handling for search operations.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
