### PR TITLE
fix: remove 10-item display limit in Agent Canvas configuration tables

### DIFF
--- a/web/src/pages/agent/form/begin-form/query-table.tsx
+++ b/web/src/pages/agent/form/begin-form/query-table.tsx
@@ -8,7 +8,6 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
-  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
@@ -135,7 +134,6 @@ export function QueryTable({ data = [], deleteRecord, showModal }: IProps) {
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,

--- a/web/src/pages/agent/form/invoke-form/variable-table.tsx
+++ b/web/src/pages/agent/form/invoke-form/variable-table.tsx
@@ -8,7 +8,6 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
-  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
@@ -135,7 +134,6 @@ export function VariableTable({
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,


### PR DESCRIPTION
## Description

This PR fixes an issue where the input and variable configuration tables in the Agent Canvas (specifically for **Begin**, **UserFillUp**, and **Invoke** nodes) were truncated at 10 items.

**Root Cause:**
The tables utilized `@tanstack/react-table` with `getPaginationRowModel()` enabled. Since the default page size is 10 and no pagination UI controls were implemented, users could not access items beyond the 10th row.

**Solution:**
Removed `getPaginationRowModel` from the table configurations. These lists (inputs/variables) are typically short, so rendering all items in a single scrollable view is the intended behavior.

* Modified `query-table.tsx`
* Modified `variable-table.tsx`


## How to verify

1. Create a **Begin**, **UserFillUp**, or **Invoke** node in the Agent Canvas.
2. Add more than 10 input items or variables.
3. Verify that all items are visible in the list and not truncated at the 10th item.

## What kind of change does this PR introduce?

* [x] Bugfix