### PR TITLE
fix: add explicit bash entrypoint to resolve exec format error on App…

### DIFF
--- a/docker/docker-compose-macos.yml
+++ b/docker/docker-compose-macos.yml
@@ -7,6 +7,7 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+    entrypoint: ["/bin/bash", "./entrypoint.sh"]
     build:
       context: ../
       dockerfile: Dockerfile


### PR DESCRIPTION
**### What problem does this PR solve?**
On Apple Silicon Macs (M1/M2/M3/M4), the RAGFlow container built via docker-compose-macos.yml fails to start with exec format error on the entrypoint, causing an infinite restart loop (exit code 255). This happens because Docker's exec form tries to run entrypoint.sh directly as a binary, and the amd64 /usr/bin/env binary fails under Rosetta emulation even when Rosetta is enabled in Docker Desktop.
Adding an explicit /bin/bash entrypoint bypasses the shebang resolution issue and allows the container to start and run correctly.
### **Type of change**

 Bug Fix (non-breaking change which fixes an issue)