### PR TITLE
fix: register WebDAVConnector in data_source __init__.py

### DIFF
--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -41,6 +41,7 @@ from .imap_connector import ImapConnector
 from .zendesk_connector import ZendeskConnector
 from .seafile_connector import SeaFileConnector
 from .rdbms_connector import RDBMSConnector
+from .webdav_connector import WebDAVConnector
 from .config import BlobType, DocumentSource
 from .models import Document, TextSection, ImageSection, BasicExpertInfo
 from .exceptions import (
@@ -81,4 +82,5 @@ __all__ = [
     "ZendeskConnector",
     "SeaFileConnector",
     "RDBMSConnector",
+    "WebDAVConnector",
 ]


### PR DESCRIPTION
What problem does this PR solve?
The sync_data_source.py module imports WebDAVConnector from common.data_source, but WebDAVConnector was never registered in the package's __init__.py. This causes an ImportError at startup, crashing the data sync service:
ImportError: cannot import name 'WebDAVConnector' from 'common.data_source'
The webdav_connector.py file already exists in the common/data_source/ directory — it just wasn't exported. This PR adds the import and registers it in __all__.
Type of change

 Bug Fix (non-breaking change which fixes an issue)