### PR TITLE
Add test attribute to run_tests.py：命令行参数 --test 被解析但从未使用，指定单测文件/目录无效

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -42,7 +42,7 @@ class TestRunner:
         self.parallel = False
         self.verbose = False
         self.markers = ""
-
+        self.test = ""
         # Python interpreter path
         self.python = sys.executable
 
@@ -95,7 +95,8 @@ EXAMPLES:
 
     def build_pytest_command(self) -> List[str]:
         """Build the pytest command arguments"""
-        cmd = ["pytest", str(self.ut_dir)]
+        test_path = str(self.ut_dir / self.test) if self.test else str(self.ut_dir)
+        cmd = ["pytest", test_path]
 
         # Add test path
 
@@ -243,7 +244,7 @@ Examples:
             self.parallel = args.parallel
             self.verbose = args.verbose
             self.markers = args.markers
-
+            self.test = args.test
             return True
 
         except SystemExit:


### PR DESCRIPTION
问题：命令行参数 --test 被解析但从未使用，指定单测文件/目录无效

在 build_pytest_command() 中根据 self.test 拼出测试路径并传给 pytest，并在 __init__ 与 parse_arguments() 中正确设置 self.test


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
