### PR TITLE
fix(compose): use official opensearch image instead of hub.icert.top mirror

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -36,7 +36,7 @@ services:
   opensearch01:
     profiles:
       - opensearch
-    image: hub.icert.top/opensearchproject/opensearch:2.19.1
+    image: opensearchproject/opensearch:2.19.1
     volumes:
       - osdata01:/usr/share/opensearch/data
     ports:


### PR DESCRIPTION

### What problem does this PR solve?

The Docker Compose configuration was using hub.icert.top as the registry for the OpenSearch image. That registry is not reachable in our environment, which causes podman pull and docker compose pull to fail with a connection refused error. As a result, the application cannot start because the OpenSearch image cannot be downloaded.

This PR updates the image reference to use the official Docker Hub image (opensearchproject/opensearch:2.19.1) instead of the hub.icert.top mirror. After this change, the image pulls successfully and the services start as expected.

![photo_2026-02-12_15-11-56](https://github.com/user-attachments/assets/6db736a5-b701-450f-96c1-9c23f092c3ab)


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
