### PR TITLE
feat: add Ollama rerank model support

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -911,7 +911,7 @@
         {
             "name": "Ollama",
             "logo": "",
-            "tags": "LLM,TEXT EMBEDDING,SPEECH2TEXT,MODERATION",
+            "tags": "LLM,TEXT EMBEDDING,TEXT RE-RANK,SPEECH2TEXT,MODERATION",
             "status": "1",
             "rank": "830",
             "llm": []

--- a/docs/references/supported_models.mdx
+++ b/docs/references/supported_models.mdx
@@ -41,7 +41,7 @@ A complete list of models supported by RAGFlow, which will continue to expand.
 | Moonshot              | :heavy_check_mark: | :heavy_check_mark: |                    |                    |                    |                    |                    |
 | NovitaAI              | :heavy_check_mark: |                    |                    |                    | :heavy_check_mark: |                    |                    |
 | NVIDIA                | :heavy_check_mark: | :heavy_check_mark: |                    |                    | :heavy_check_mark: | :heavy_check_mark: |                    |
-| Ollama                | :heavy_check_mark: | :heavy_check_mark: |                    |                    | :heavy_check_mark: |                    |                    |
+| Ollama                | :heavy_check_mark: | :heavy_check_mark: |                    |                    | :heavy_check_mark: | :heavy_check_mark: |                    |
 | OpenAI                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |                    |                    |
 | OpenAI-API-Compatible | :heavy_check_mark: | :heavy_check_mark: |                    |                    | :heavy_check_mark: | :heavy_check_mark: |                    |
 | OpenRouter            | :heavy_check_mark: | :heavy_check_mark: |                    |                    |                    |                    |                    |

--- a/web/src/pages/user-setting/setting-model/modal/ollama-modal/index.tsx
+++ b/web/src/pages/user-setting/setting-model/modal/ollama-modal/index.tsx
@@ -73,6 +73,13 @@ const OllamaModal = ({
       'embedding',
       'image2text',
     ]),
+    [LLMFactory.Ollama]: buildModelTypeOptions([
+      'chat',
+      'embedding',
+      'rerank',
+      'image2text',
+      'speech2text',
+    ]),
     [LLMFactory.Xinference]: buildModelTypeOptions([
       'chat',
       'embedding',


### PR DESCRIPTION
## Summary

Adds rerank model support for the Ollama provider, enabling users to use Ollama-hosted reranking models (e.g., via llama.cpp's `/v1/rerank` endpoint or compatible servers).

### Changes
- **`rag/llm/rerank_model.py`** — Added `OllamaRerank` class implementing the `Base` rerank interface using Ollama's `/v1/rerank` HTTP endpoint. Supports optional API key authentication and follows the same pattern as `XInferenceRerank` and `LocalAIRerank`.
- **`conf/llm_factories.json`** — Added `TEXT RE-RANK` to the Ollama factory's tags so it appears as a rerank-capable provider in the UI.
- **`web/src/pages/user-setting/setting-model/modal/ollama-modal/index.tsx`** — Added explicit `LLMFactory.Ollama` entry to the `optionsMap` with `rerank` as a supported model type, rather than relying on the `Default` fallback.
- **`docs/references/supported_models.mdx`** — Added rerank checkmark for Ollama in the supported models table.

### How it works
The `OllamaRerank` class uses the `/v1/rerank` API endpoint (compatible with llama.cpp server, Ollama community forks, and other OpenAI-compatible rerank servers). It sends a POST request with the query and documents, and parses the `results` array containing `index` and `relevance_score` fields.

Closes #4406
Closes #3680