### PR TITLE
fix: save partial response when user stops streaming generation

### DIFF
--- a/api/apps/conversation_app.py
+++ b/api/apps/conversation_app.py
@@ -224,11 +224,14 @@ async def completion():
                 async for ans in async_chat(dia, msg, True, **req):
                     ans = structure_answer(conv, ans, message_id, conv.id)
                     yield "data:" + json.dumps({"code": 0, "message": "", "data": ans}, ensure_ascii=False) + "\n\n"
-                if not is_embedded:
-                    ConversationService.update_by_id(conv.id, conv.to_dict())
+            except GeneratorExit:
+                logging.info(f"Stream stopped by client for conversation {conv.id}")
             except Exception as e:
                 logging.exception(e)
                 yield "data:" + json.dumps({"code": 500, "message": str(e), "data": {"answer": "**ERROR**: " + str(e), "reference": []}}, ensure_ascii=False) + "\n\n"
+            finally:
+                if not is_embedded:
+                    ConversationService.update_by_id(conv.id, conv.to_dict())
             yield "data:" + json.dumps({"code": 0, "message": "", "data": True}, ensure_ascii=False) + "\n\n"
 
         if req.get("stream", True):

--- a/api/db/services/canvas_service.py
+++ b/api/db/services/canvas_service.py
@@ -233,22 +233,25 @@ async def completion(tenant_id, agent_id, session_id=None, **kwargs):
         "files": files
     })
     txt = ""
-    async for ans in canvas.run(query=query, files=files, user_id=user_id, inputs=inputs):
-        ans["session_id"] = session_id
-        if ans["event"] == "message":
-            txt += ans["data"]["content"]
-            if ans["data"].get("start_to_think", False):
-                txt += "<think>"
-            elif ans["data"].get("end_to_think", False):
-                txt += "</think>"
-        yield "data:" + json.dumps(ans, ensure_ascii=False) + "\n\n"
-
-    conv.message.append({"role": "assistant", "content": txt, "created_at": time.time(), "id": message_id})
-    conv.reference = canvas.get_reference()
-    conv.errors = canvas.error
-    conv.dsl = str(canvas)
-    conv = conv.to_dict()
-    API4ConversationService.append_message(conv["id"], conv)
+    try:
+        async for ans in canvas.run(query=query, files=files, user_id=user_id, inputs=inputs):
+            ans["session_id"] = session_id
+            if ans["event"] == "message":
+                txt += ans["data"]["content"]
+                if ans["data"].get("start_to_think", False):
+                    txt += "<think>"
+                elif ans["data"].get("end_to_think", False):
+                    txt += "</think>"
+            yield "data:" + json.dumps(ans, ensure_ascii=False) + "\n\n"
+    except GeneratorExit:
+        logging.info(f"Agent stream stopped by client for session {session_id}")
+    finally:
+        conv.message.append({"role": "assistant", "content": txt, "created_at": time.time(), "id": message_id})
+        conv.reference = canvas.get_reference()
+        conv.errors = canvas.error
+        conv.dsl = str(canvas)
+        conv = conv.to_dict()
+        API4ConversationService.append_message(conv["id"], conv)
 
 
 async def completion_openai(tenant_id, agent_id, question, session_id=None, stream=True, **kwargs):


### PR DESCRIPTION
## Summary

When a user clicks "Stop" during LLM streaming, the conversation turn (question + partial answer) was lost because the database save only executed after the full streaming loop completed. When the client disconnects, the generator terminates via `GeneratorExit` and the save call is never reached.

### Root cause
All streaming paths placed the `ConversationService.update_by_id()` / `API4ConversationService.append_message()` call **after** the `async for` loop, with no `finally` block. When the client disconnects mid-stream, `GeneratorExit` propagates up and the save is skipped entirely.

### Fix
Moved the conversation save into a `finally` block in all 4 independent streaming paths, ensuring the partial response is persisted regardless of how the generator terminates (normal completion, client disconnect, or error):

- **`api/apps/conversation_app.py`** — Main UI chat `stream()` function
- **`api/db/services/conversation_service.py`** — SDK `async_completion()` and iframe `async_iframe_completion()` 
- **`api/apps/canvas_app.py`** — Canvas agent `sse()` function
- **`api/db/services/canvas_service.py`** — Agent `completion()` function

Also added `GeneratorExit` handling to log when a stream is stopped by the client and properly cancel canvas tasks on disconnect.

Closes #13128