### PR TITLE
fix: handle null response in LLM and improve JSON parsing in agent

### DIFF
--- a/agent/component/agent_with_tools.py
+++ b/agent/component/agent_with_tools.py
@@ -384,7 +384,10 @@ class Agent(LLM, ToolBase):
             token_count += tk or 0
             hist.append({"role": "assistant", "content": response})
             try:
-                functions = json_repair.loads(re.sub(r"```.*", "", response))
+                # Remove markdown code fences properly
+                cleaned_response = re.sub(r"^.*```json\s*", "", response, flags=re.DOTALL)
+                cleaned_response = re.sub(r"```\s*$", "", cleaned_response, flags=re.DOTALL)
+                functions = json_repair.loads(cleaned_response)
                 if not isinstance(functions, list):
                     raise TypeError(f"List should be returned, but `{functions}`")
                 for f in functions:

--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -265,6 +265,8 @@ class LLMBundle(LLM4Tenant):
             generation.end()
 
     def _remove_reasoning_content(self, txt: str) -> str:
+        if txt is None:
+            return None
         first_think_start = txt.find("<think>")
         if first_think_start == -1:
             return txt


### PR DESCRIPTION
Fixes AttributeError in _remove_reasoning_content() when LLM returns None, and improves JSON parsing regex for markdown code fences in agent_with_tools.py