### PR TITLE
fix(web): correct initial chat variable enabled state

### DIFF
--- a/web/src/utils/chat.ts
+++ b/web/src/utils/chat.ts
@@ -73,7 +73,6 @@ export function replaceThinkToSection(text: string = '') {
 export function setInitialChatVariableEnabledFieldValue(
   field: ChatVariableEnabledField,
 ) {
-  return false;
   return field !== ChatVariableEnabledField.MaxTokensEnabled;
 }
 


### PR DESCRIPTION
## Summary

Fixes the initial enabled/disabled state of chat variable checkboxes by correcting a helper function that previously always returned .

## Problem

 in  had two  statements:



Because of the early , the function always returned , so all chat variable checkboxes were initially disabled regardless of the field. This also made the helper inconsistent with , which enables all fields by default except .

## Fix

Update  to use the same condition as :



This ensures:
- All chat variable checkboxes are enabled by default
-  remains the only field disabled by default
- Behavior is consistent between the helper and the checkbox map initialization in .

No API or backend changes are involved; this is a small, isolated frontend bugfix.
