### PR TITLE
fix: adding GPUStack chat model requires v1 suffix

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -1625,7 +1625,7 @@ class LiteLLMBase(ABC):
         elif self.provider == SupportedLiteLLMProvider.GPUStack:
             completion_args.update(
                 {
-                    "api_base": self.base_url,
+                    "api_base": urljoin(self.base_url, "v1"),
                 }
             )
         elif self.provider == SupportedLiteLLMProvider.Azure_OpenAI:


### PR DESCRIPTION
### What problem does this PR solve?

Refer to issue: #13236
The base url for GPUStack chat model requires `/v1` suffix. For the other model type like `Embedding` or `Rerank`, the `/v1` suffix is not required and will be appended in code.
So keep the same logic for chat model as other model type.

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
