### PR TITLE
fix: update DoclingParser return type hint

### DIFF
--- a/deepdoc/parser/docling_parser.py
+++ b/deepdoc/parser/docling_parser.py
@@ -194,8 +194,8 @@ class DoclingParser(RAGFlowPdfParser):
                         bbox = _BBox(int(pn), bb[0], bb[1], bb[2], bb[3])
                 yield (DoclingContentType.EQUATION.value, text, bbox)
 
-    def _transfer_to_sections(self, doc, parse_method: str) -> list[tuple[str, str]]:
-        sections: list[tuple[str, str]] = []
+    def _transfer_to_sections(self, doc, parse_method: str) -> list[tuple[str, ...]]:
+        sections: list[tuple[str, ...]] = []
         for typ, payload, bbox in self._iter_doc_items(doc):
             if typ == DoclingContentType.TEXT.value:
                 section = payload.strip()


### PR DESCRIPTION
### What problem does this PR solve?

The _transfer_to_sections method was throwing a type hint violation because it occasionally returns 3-item tuples instead of 2. Adjusted to list[tuple[str, ...]] to prevent runtime crashes.

Error: 

20:53:21 Page(1~10): [ERROR]Internal server error while chunking: Method[1m[35m deepdoc.parser.docling_parser.DoclingParser._transfer_to_sections()[0m return [1m[31m[(1. JIRA Nasıl Kullanılır?, text, @@1\t70.8\t194.9\t70.9\t85.5##), (1.1. Proje O...##)][0m violates type hint [1m[32mlist[tuple[str, str]][0m, as [1m[33mlist [0mindex [1m[33m15[0m item tuple [1m[33mtuple [0m[1m[31m(Gelen ekran üzerinden alanları isterlerine göre doldurduğunuz taktirde Create düğmesi i...##)[0m length 3 != 2.
20:53:21 [ERROR][Exception]: Method[1m[35m deepdoc.parser.docling_parser.DoclingParser._transfer_to_sections()[0m return [1m[31m[('1. JIRA Nasıl Kullanılır?', 'text', '@@1\t70.8\t194.9\t70.9\t85.5##'), ('1.1. Proje O...##')][0m violates type hint [1m[32mlist[tuple[str, str]][0m, as [1m[33mlist [0mindex [1m[33m15[0m item tuple [1m[33mtuple [0m[1m[31m('Gelen ekran üzerinden alanları isterlerine göre doldurduğunuz taktirde Create düğmesi i...##')[0m length 3 != 2. 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
