### PR TITLE
Fix: skip XML comments/processing instructions when iterating docx bo…

### DIFF
--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -94,6 +94,8 @@ class Docx(DocxParser):
         try:
             # Iterate through all paragraphs and tables in document order
             for i, block in enumerate(self.doc._element.body):
+                if callable(block.tag):  # Skip comments/processing instructions
+                    continue
                 if block.tag.endswith('p'):  # Paragraph
                     p = Paragraph(block, self.doc)
                     blocks.append(('p', i, p))


### PR DESCRIPTION
Prevents AttributeError when block.tag is callable (e.g., lxml Comment nodes).

### What problem does this PR solve?

Error when parse docx files:
 [ERROR]Internal server error while chunking: _cython_3_0_12.cython_function_or_method object has no attribute endswith 14:21:22 [ERROR][Exception]: '_cython_3_0_12.cython_function_or_method' object has no attribute 'endswith'

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
