### PR TITLE
docs: add API examples for chat, document, and retrieval

### DIFF
--- a/example/http/chat_example.sh
+++ b/example/http/chat_example.sh
@@ -1,0 +1,107 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Replace the dataset_id, chat_id, and session_id with actual values from your instance.
+
+HOST="http://localhost:9380"
+API_KEY="ragflow-IzZmY1MGVhYTBhMjExZWZiYTdjMDI0Mm"
+
+# Create a chat assistant
+echo -e "\n-- Create a chat assistant"
+curl --request POST \
+     --url $HOST/api/v1/chats \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "name": "my_assistant",
+       "dataset_ids": ["YOUR_DATASET_ID"]
+     }'
+
+# Update the chat assistant
+echo -e "\n-- Update the chat assistant"
+curl --request PUT \
+     --url $HOST/api/v1/chats/YOUR_CHAT_ID \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "name": "updated_assistant"
+     }'
+
+# List chat assistants
+echo -e "\n-- List chat assistants"
+curl --request GET \
+     --url $HOST/api/v1/chats \
+     --header "Authorization: Bearer $API_KEY"
+
+# Delete chat assistants
+echo -e "\n-- Delete chat assistants"
+curl --request DELETE \
+     --url $HOST/api/v1/chats \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "ids": ["YOUR_CHAT_ID"]
+     }'
+
+# Create a session within the chat
+echo -e "\n-- Create a session"
+curl --request POST \
+     --url $HOST/api/v1/chats/YOUR_CHAT_ID/sessions \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "name": "test_session"
+     }'
+
+# List sessions
+echo -e "\n-- List sessions"
+curl --request GET \
+     --url $HOST/api/v1/chats/YOUR_CHAT_ID/sessions \
+     --header "Authorization: Bearer $API_KEY"
+
+# Chat completion (non-streaming)
+echo -e "\n-- Chat completion (non-streaming)"
+curl --request POST \
+     --url $HOST/api/v1/chats/YOUR_CHAT_ID/completions \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "question": "What is RAGFlow?",
+       "stream": false,
+       "session_id": "YOUR_SESSION_ID"
+     }'
+
+# Chat completion (streaming)
+echo -e "\n-- Chat completion (streaming)"
+curl --request POST \
+     --url $HOST/api/v1/chats/YOUR_CHAT_ID/completions \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "question": "How does RAGFlow work?",
+       "stream": true,
+       "session_id": "YOUR_SESSION_ID"
+     }'
+
+# Delete sessions
+echo -e "\n-- Delete sessions"
+curl --request DELETE \
+     --url $HOST/api/v1/chats/YOUR_CHAT_ID/sessions \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "ids": ["YOUR_SESSION_ID"]
+     }'

--- a/example/http/document_example.sh
+++ b/example/http/document_example.sh
@@ -1,0 +1,79 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Replace the dataset_id and document_id with actual values from your instance.
+
+HOST="http://localhost:9380"
+API_KEY="ragflow-IzZmY1MGVhYTBhMjExZWZiYTdjMDI0Mm"
+
+# Upload a document to a dataset
+echo -e "\n-- Upload a document"
+curl --request POST \
+     --url $HOST/api/v1/datasets/YOUR_DATASET_ID/documents \
+     --header "Authorization: Bearer $API_KEY" \
+     --form 'file=@/path/to/your/test.txt'
+
+# List documents in a dataset
+echo -e "\n-- List documents"
+curl --request GET \
+     --url $HOST/api/v1/datasets/YOUR_DATASET_ID/documents \
+     --header "Authorization: Bearer $API_KEY"
+
+# Update a document
+echo -e "\n-- Update a document"
+curl --request PUT \
+     --url $HOST/api/v1/datasets/YOUR_DATASET_ID/documents/YOUR_DOCUMENT_ID \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "name": "renamed_document.txt"
+     }'
+
+# Start parsing a document
+echo -e "\n-- Parse a document"
+curl --request POST \
+     --url $HOST/api/v1/datasets/YOUR_DATASET_ID/chunks \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "document_ids": ["YOUR_DOCUMENT_ID"]
+     }'
+
+# Stop parsing a document
+echo -e "\n-- Stop parsing a document"
+curl --request DELETE \
+     --url $HOST/api/v1/datasets/YOUR_DATASET_ID/chunks \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "document_ids": ["YOUR_DOCUMENT_ID"]
+     }'
+
+# List chunks of a document
+echo -e "\n-- List chunks"
+curl --request GET \
+     --url "$HOST/api/v1/datasets/YOUR_DATASET_ID/documents/YOUR_DOCUMENT_ID/chunks" \
+     --header "Authorization: Bearer $API_KEY"
+
+# Delete documents
+echo -e "\n-- Delete documents"
+curl --request DELETE \
+     --url $HOST/api/v1/datasets/YOUR_DATASET_ID/documents \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "ids": ["YOUR_DOCUMENT_ID"]
+     }'

--- a/example/http/retrieval_example.sh
+++ b/example/http/retrieval_example.sh
@@ -1,0 +1,36 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Replace the dataset_id with actual values from your instance.
+
+HOST="http://localhost:9380"
+API_KEY="ragflow-IzZmY1MGVhYTBhMjExZWZiYTdjMDI0Mm"
+
+# Retrieval (semantic search across datasets)
+echo -e "\n-- Retrieval"
+curl --request POST \
+     --url $HOST/api/v1/retrieval \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $API_KEY" \
+     --data '{
+       "dataset_ids": ["YOUR_DATASET_ID"],
+       "question": "What is RAGFlow?",
+       "page": 1,
+       "page_size": 10,
+       "similarity_threshold": 0.2,
+       "vector_similarity_weight": 0.3,
+       "top_k": 1024
+     }'

--- a/example/sdk/chat_example.py
+++ b/example/sdk/chat_example.py
@@ -1,0 +1,94 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+This example demonstrates how to create a chat assistant, manage sessions,
+and perform chat completions using the RAGFlow SDK.
+
+Prerequisites:
+  - A running RAGFlow instance
+  - A valid API key
+  - At least one dataset with parsed documents
+"""
+
+from ragflow_sdk import RAGFlow
+import sys
+
+HOST_ADDRESS = "http://127.0.0.1"
+API_KEY = "ragflow-IzZmY1MGVhYTBhMjExZWZiYTdjMDI0Mm"
+
+try:
+    ragflow = RAGFlow(api_key=API_KEY, base_url=HOST_ADDRESS)
+
+    # --- Chat CRUD ---
+
+    # Create a dataset and use it for the chat assistant
+    dataset = ragflow.create_dataset(name="chat_example_dataset")
+
+    # Create a chat assistant linked to the dataset
+    chat = ragflow.create_chat(
+        name="my_assistant",
+        dataset_ids=[dataset.id],
+    )
+    print(f"Created chat: {chat.name} (id={chat.id})")
+
+    # Update the chat assistant
+    chat.update({"name": "updated_assistant"})
+    print(f"Updated chat name: {chat.name}")
+
+    # List all chat assistants
+    chats = ragflow.list_chats()
+    print(f"Total chats: {len(chats)}")
+
+    # --- Session management ---
+
+    # Create a session within the chat
+    session = chat.create_session(name="test_session")
+    print(f"Created session: {session.name} (id={session.id})")
+
+    # List sessions
+    sessions = chat.list_sessions()
+    print(f"Total sessions: {len(sessions)}")
+
+    # --- Chat completion (non-streaming) ---
+
+    answer = session.ask("What is RAGFlow?", stream=False)
+    print(f"Answer: {answer}")
+
+    # --- Chat completion (streaming) ---
+
+    print("Streaming answer:")
+    for chunk in session.ask("How does RAGFlow work?", stream=True):
+        print(chunk, end="", flush=True)
+    print()
+
+    # --- Cleanup ---
+
+    # Delete sessions
+    chat.delete_sessions(ids=[session.id])
+
+    # Delete chat
+    ragflow.delete_chats(ids=[chat.id])
+
+    # Delete dataset
+    ragflow.delete_datasets(ids=[dataset.id])
+
+    print("test done")
+    sys.exit(0)
+
+except Exception as e:
+    print(str(e))
+    sys.exit(-1)

--- a/example/sdk/document_example.py
+++ b/example/sdk/document_example.py
@@ -1,0 +1,113 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+This example demonstrates document upload, listing, parsing, and chunk
+management within a dataset using the RAGFlow SDK.
+
+Prerequisites:
+  - A running RAGFlow instance
+  - A valid API key
+  - A test file (e.g., a .txt or .pdf file) for uploading
+"""
+
+from ragflow_sdk import RAGFlow
+import sys
+import os
+import tempfile
+
+HOST_ADDRESS = "http://127.0.0.1"
+API_KEY = "ragflow-IzZmY1MGVhYTBhMjExZWZiYTdjMDI0Mm"
+
+try:
+    ragflow = RAGFlow(api_key=API_KEY, base_url=HOST_ADDRESS)
+
+    # Create a dataset
+    dataset = ragflow.create_dataset(name="doc_example_dataset")
+    print(f"Created dataset: {dataset.name} (id={dataset.id})")
+
+    # --- Upload documents ---
+
+    # Create a temporary test file
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+    tmp.write("RAGFlow is an open-source RAG engine based on deep document understanding.")
+    tmp.close()
+
+    dataset.upload_documents([{"display_name": "test.txt", "blob": open(tmp.name, "rb")}])
+    print("Uploaded document: test.txt")
+    os.unlink(tmp.name)
+
+    # --- List documents ---
+
+    docs = dataset.list_documents()
+    print(f"Total documents: {len(docs)}")
+    doc = docs[0]
+    print(f"Document: {doc.name} (id={doc.id})")
+
+    # --- Parse documents (start chunking) ---
+
+    dataset.async_parse_documents(document_ids=[doc.id])
+    print(f"Started parsing document: {doc.name}")
+
+    # Wait for parsing to complete
+    import time
+    for _ in range(30):
+        time.sleep(2)
+        docs = dataset.list_documents()
+        progress = docs[0].progress
+        print(f"Parsing progress: {progress}")
+        if progress == 1.0 or progress == -1:
+            break
+
+    # --- List chunks ---
+
+    chunks = doc.list_chunks()
+    print(f"Total chunks: {len(chunks)}")
+    if chunks:
+        chunk = chunks[0]
+        print(f"First chunk: {chunk.content[:100]}...")
+
+    # --- Add a chunk ---
+
+    new_chunk = doc.add_chunk(content="This is a manually added chunk for testing.")
+    print(f"Added chunk: {new_chunk.id}")
+
+    # --- Update a chunk ---
+
+    new_chunk.update({"content": "This is an updated chunk."})
+    print("Updated chunk content")
+
+    # --- Delete chunks ---
+
+    doc.delete_chunks(chunk_ids=[new_chunk.id])
+    print("Deleted the added chunk")
+
+    # --- Delete documents ---
+
+    dataset.delete_documents(ids=[doc.id])
+    print("Deleted the uploaded document")
+
+    # --- Cleanup ---
+
+    ragflow.delete_datasets(ids=[dataset.id])
+    print("Deleted dataset")
+
+    print("test done")
+    sys.exit(0)
+
+except Exception as e:
+    print(str(e))
+    sys.exit(-1)

--- a/example/sdk/retrieval_example.py
+++ b/example/sdk/retrieval_example.py
@@ -1,0 +1,89 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+This example demonstrates how to use the RAGFlow SDK to perform
+cross-dataset retrieval (semantic search) over parsed documents.
+
+Prerequisites:
+  - A running RAGFlow instance
+  - A valid API key
+  - At least one dataset with parsed documents
+"""
+
+from ragflow_sdk import RAGFlow
+import sys
+import tempfile
+import os
+import time
+
+HOST_ADDRESS = "http://127.0.0.1"
+API_KEY = "ragflow-IzZmY1MGVhYTBhMjExZWZiYTdjMDI0Mm"
+
+try:
+    ragflow = RAGFlow(api_key=API_KEY, base_url=HOST_ADDRESS)
+
+    # Create a dataset and upload a document
+    dataset = ragflow.create_dataset(name="retrieval_example_dataset")
+
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+    tmp.write(
+        "RAGFlow is an open-source RAG engine based on deep document understanding. "
+        "It provides chunking, retrieval, and generation capabilities for building "
+        "retrieval-augmented generation applications."
+    )
+    tmp.close()
+
+    dataset.upload_documents([{"display_name": "ragflow_intro.txt", "blob": open(tmp.name, "rb")}])
+    os.unlink(tmp.name)
+
+    docs = dataset.list_documents()
+    doc = docs[0]
+
+    # Parse the document
+    dataset.async_parse_documents(document_ids=[doc.id])
+    for _ in range(30):
+        time.sleep(2)
+        docs = dataset.list_documents()
+        if docs[0].progress == 1.0 or docs[0].progress == -1:
+            break
+    print(f"Document parsed: {doc.name}")
+
+    # --- Retrieval ---
+
+    results = ragflow.retrieve(
+        dataset_ids=[dataset.id],
+        question="What is RAGFlow?",
+        page=1,
+        page_size=10,
+        similarity_threshold=0.2,
+        vector_similarity_weight=0.3,
+        top_k=1024,
+    )
+    print(f"Retrieved {len(results)} chunks:")
+    for i, chunk in enumerate(results):
+        print(f"  [{i+1}] score={chunk.get('similarity', 'N/A'):.4f} content={chunk.get('content', '')[:80]}...")
+
+    # --- Cleanup ---
+
+    ragflow.delete_datasets(ids=[dataset.id])
+
+    print("test done")
+    sys.exit(0)
+
+except Exception as e:
+    print(str(e))
+    sys.exit(-1)


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses #4310 by adding API usage examples for the RAGFlow SDK and HTTP API.

Although RAGFlow already has API documentation, concrete examples make it much easier for developers to get started. Currently, only dataset examples exist (`example/sdk/dataset_example.py` and `example/http/dataset_example.sh`). This PR adds examples covering the other core API resources:

**Python SDK examples** (`example/sdk/`):
- `chat_example.py` — Chat assistant CRUD, session management, and chat completions (streaming and non-streaming)
- `document_example.py` — Document upload, listing, parsing, and chunk management
- `retrieval_example.py` — Cross-dataset semantic search

**HTTP API (cURL) examples** (`example/http/`):
- `chat_example.sh` — Chat CRUD, sessions, and completions via cURL
- `document_example.sh` — Document upload, parsing, and chunk operations via cURL
- `retrieval_example.sh` — Retrieval endpoint usage via cURL

### Type of change

- [x] Documentation Update