### PR TITLE
Fix: pass Redis connection to synonym.Dealer() in FulltextQueryer

### DIFF
--- a/rag/nlp/query.py
+++ b/rag/nlp/query.py
@@ -22,12 +22,13 @@ from collections import defaultdict
 from common.query_base import QueryBase
 from common.doc_store.doc_store_base import MatchTextExpr
 from rag.nlp import rag_tokenizer, term_weight, synonym
+from rag.utils.redis_conn import REDIS_CONN
 
 
 class FulltextQueryer(QueryBase):
     def __init__(self):
         self.tw = term_weight.Dealer()
-        self.syn = synonym.Dealer()
+        self.syn = synonym.Dealer(REDIS_CONN if REDIS_CONN.is_alive() else None)
         self.query_fields = [
             "title_tks^10",
             "title_sm_tks^5",


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #10590

`FulltextQueryer.__init__()` in `rag/nlp/query.py` instantiates `synonym.Dealer()` without passing the Redis connection, causing realtime synonym functionality to always be disabled even when Redis is properly configured and healthy.

This PR imports `REDIS_CONN` from `rag.utils.redis_conn` and passes it to `synonym.Dealer()` with a health check, so that realtime synonym lookup is enabled when Redis is available.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
