### PR TITLE
Fix: use split_model_name_and_factory for rerank model validation

### DIFF
--- a/api/apps/sdk/chat.py
+++ b/api/apps/sdk/chat.py
@@ -80,7 +80,8 @@ async def create(tenant_id):
     req["rerank_id"] = req.get("rerank_id", "")
     if req.get("rerank_id"):
         value_rerank_model = ["BAAI/bge-reranker-v2-m3", "maidalun1020/bce-reranker-base_v1"]
-        if req["rerank_id"] not in value_rerank_model and not TenantLLMService.query(tenant_id=tenant_id, llm_name=req.get("rerank_id"), model_type="rerank"):
+        rerank_name, rerank_factory = TenantLLMService.split_model_name_and_factory(req["rerank_id"])
+        if req["rerank_id"] not in value_rerank_model and not TenantLLMService.query(tenant_id=tenant_id, llm_name=rerank_name, llm_factory=rerank_factory, model_type="rerank"):
             return get_error_data_result(f"`rerank_model` {req.get('rerank_id')} doesn't exist")
     if not req.get("llm_id"):
         req["llm_id"] = tenant.llm_id
@@ -200,7 +201,8 @@ async def update(tenant_id, chat_id):
     res = res.to_json()
     if req.get("rerank_id"):
         value_rerank_model = ["BAAI/bge-reranker-v2-m3", "maidalun1020/bce-reranker-base_v1"]
-        if req["rerank_id"] not in value_rerank_model and not TenantLLMService.query(tenant_id=tenant_id, llm_name=req.get("rerank_id"), model_type="rerank"):
+        rerank_name, rerank_factory = TenantLLMService.split_model_name_and_factory(req["rerank_id"])
+        if req["rerank_id"] not in value_rerank_model and not TenantLLMService.query(tenant_id=tenant_id, llm_name=rerank_name, llm_factory=rerank_factory, model_type="rerank"):
             return get_error_data_result(f"`rerank_model` {req.get('rerank_id')} doesn't exist")
     if "name" in req:
         if not req.get("name"):


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #11932

The rerank model validation in both `create` and `update` chat endpoints does not call `TenantLLMService.split_model_name_and_factory()` on the `rerank_id`, unlike the LLM validation which does. This causes rerank models with `@vendor` suffix (e.g., `qwen3-reranker@GPUStack`) to fail validation because the query searches for the full name including the factory suffix.

This PR applies the same `split_model_name_and_factory` logic to rerank model validation, passing both `llm_name` and `llm_factory` to the query.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):