### PR TITLE
Fix: reset document status to RUNNING when tasks recover from transient error

### DIFF
--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -816,6 +816,8 @@ class DocumentService(CommonService):
                 elif finished:
                     prg = 1
                     status = TaskStatus.DONE.value
+                elif not finished:
+                    status = TaskStatus.RUNNING.value
 
                 # only for special task and parsed docs and unfinished
                 freeze_progress = special_task_running and doc_progress >= 1 and not finished

--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -831,7 +831,7 @@ class DocumentService(CommonService):
                 info = {
                     "process_duration": max(datetime.timestamp(datetime.now()) - begin_at.timestamp(), 0),
                     "run": status}
-                if prg != 0 and not freeze_progress:
+                if (prg != 0 or doc_progress < 0) and not freeze_progress:
                     info["progress"] = prg
                 if msg:
                     info["progress_msg"] = msg

--- a/api/db/services/task_service.py
+++ b/api/db/services/task_service.py
@@ -304,9 +304,10 @@ class TaskService(CommonService):
 
         Update Rules:
             - progress_msg: Always appends the new message to the existing one, and trims the result to max 3000 lines.
-            - progress: Only updates if the current progress is not -1 AND
-                        (the new progress is -1 OR greater than the existing progress),
-                        to avoid overwriting valid progress with invalid or regressive values.
+            - progress: Only updates if (a) new progress >= 1 (task complete),
+                        (b) new progress is -1 (transient error), or
+                        (c) new progress is greater than the existing progress.
+                        This allows recovery from error state (-1) while preventing regressive updates.
 
         Args:
             id (str): The unique identifier of the task to update.
@@ -327,10 +328,7 @@ class TaskService(CommonService):
                 prog = info["progress"]
                 cls.model.update(progress=prog).where(
                     (cls.model.id == id) &
-                    (
-                            (cls.model.progress != -1) &
-                            ((prog == -1) | (prog > cls.model.progress))
-                    )
+                    ((prog >= 1) | (prog == -1) | (prog > cls.model.progress))
                 ).execute()
         else:
             with DB.lock("update_progress", -1):
@@ -341,10 +339,7 @@ class TaskService(CommonService):
                     prog = info["progress"]
                     cls.model.update(progress=prog).where(
                         (cls.model.id == id) &
-                        (
-                            (cls.model.progress != -1) &
-                            ((prog == -1) | (prog > cls.model.progress))
-                        )
+                        ((prog >= 1) | (prog == -1) | (prog > cls.model.progress))
                     ).execute()
 
         process_duration = (datetime.now() - task.begin_at).total_seconds()


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #13285

When a parsing task encounters a transient error (e.g., LLM overloaded), it temporarily sets `task.progress = -1`. If the periodic `_sync_progress` runs during this window, it marks the document as FAIL (`doc.run = TaskStatus.FAIL`). When the task recovers and continues processing (e.g., `task.progress = 0.5`), the next `_sync_progress` iteration reads `status = doc.run` (which is FAIL) as the default. Since `finished = False` (task is still running), neither the FAIL nor DONE branch updates the status, leaving the document stuck at FAIL even though processing is actively continuing.

This PR adds an explicit `else` clause in `_sync_progress` to reset the document status back to `RUNNING` when there are still unfinished tasks.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)