### PR TITLE
Fix: cap ES/OpenSearch search offset to prevent result window overflow

### DIFF
--- a/rag/utils/es_conn.py
+++ b/rag/utils/es_conn.py
@@ -28,6 +28,7 @@ from common.float_utils import get_float
 from common.constants import PAGERANK_FLD, TAG_FLD
 
 ATTEMPT_TIME = 2
+ES_MAX_RESULT_WINDOW = 10000
 
 
 @singleton
@@ -140,6 +141,10 @@ class ESConnection(ESConnectionBase):
                 s.aggs.bucket(f'aggs_{fld}', 'terms', field=fld, size=1000000)
 
         if limit > 0:
+            if offset + limit > ES_MAX_RESULT_WINDOW:
+                limit = max(0, ES_MAX_RESULT_WINDOW - offset)
+                if limit <= 0:
+                    return {"hits": {"total": {"value": 0}, "hits": []}}
             s = s[offset:offset + limit]
         q = s.to_dict()
         self.logger.debug(f"ESConnection.search {str(index_names)} query: " + json.dumps(q))

--- a/rag/utils/opensearch_conn.py
+++ b/rag/utils/opensearch_conn.py
@@ -33,6 +33,7 @@ from common.constants import PAGERANK_FLD, TAG_FLD
 from common import settings
 
 ATTEMPT_TIME = 2
+OS_MAX_RESULT_WINDOW = 10000
 
 logger = logging.getLogger('ragflow.opensearch_conn')
 
@@ -238,6 +239,10 @@ class OSConnection(DocStoreConnection):
             s.aggs.bucket(f'aggs_{fld}', 'terms', field=fld, size=1000000)
 
         if limit > 0:
+            if offset + limit > OS_MAX_RESULT_WINDOW:
+                limit = max(0, OS_MAX_RESULT_WINDOW - offset)
+                if limit <= 0:
+                    return {"hits": {"total": {"value": 0}, "hits": []}}
             s = s[offset:offset + limit]
         q = s.to_dict()
         logger.debug(f"OSConnection.search {str(indexNames)} query: " + json.dumps(q))


### PR DESCRIPTION
### What problem does this PR solve?

Closes #8024

When paginating through large result sets, `from + size` can exceed Elasticsearch/OpenSearch's default `max_result_window` (10000), causing a `Result window is too large` error. This affects any pagination loop that may iterate beyond 10000 results (e.g., metadata service fetching all chunks, GraphRAG subgraph iteration).

### Solution

In both `ESConnection.search()` and `OSConnection.search()`, cap `offset + limit` to the default `max_result_window` (10000). When the offset alone exceeds the limit, return an empty result set, which naturally terminates callers' pagination loops.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
