### PR TITLE
fix: add missing chunk_data column to OceanBase schema migration

### DIFF
--- a/rag/utils/ob_conn.py
+++ b/rag/utils/ob_conn.py
@@ -127,7 +127,7 @@ FTS_COLUMNS_TKS: list[str] = [
 ]
 
 # Extra columns to add after table creation (for migration)
-EXTRA_COLUMNS: list[Column] = [column_order_id, column_group_id, column_mom_id]
+EXTRA_COLUMNS: list[Column] = [column_order_id, column_group_id, column_mom_id, column_chunk_data]
 
 
 class SearchResult(BaseModel):


### PR DESCRIPTION
### What problem does this PR solve?

When using OceanBase as the document storage engine, parsing and inserting chunks with chunk_data (e.g., table parser row data) fails with the following error:
```
[ERROR][Exception]: Insert chunk error: ['Unconsumed column names: chunk_data']
This happens because the chunk_data column was recently introduced but was omitted from the EXTRA_COLUMNS list in 
rag/utils/ob_conn.py
```
As a result, the automatic schema migration for existing OceanBase tables does not append the missing chunk_data column, causing the underlying pyobvector or SQLAlchemy to raise an unconsumed column names error during data insertion.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### What is the solution?
Added column_chunk_data to the EXTRA_COLUMNS list in 
```
rag/utils/ob_conn.py
```
This ensures that the OceanBase connection wrapper can correctly detect the missing column and automatically alter existing chunk tables to include the chunk_data field during initialization.