### PR TITLE
Fix Dify external retrieval by providing metadata.document_id

### DIFF
--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -166,6 +166,8 @@ async def retrieval(tenant_id):
             c.pop("vector", None)
             meta = getattr(doc, 'meta_fields', {})
             meta["doc_id"] = c["doc_id"]
+            # Dify expects metadata.document_id for external retrieval sources.
+            meta["document_id"] = c["doc_id"]
             records.append({
                 "content": c["content_with_weight"],
                 "score": c["similarity"],


### PR DESCRIPTION
### What problem does this PR solve?

## Summary                                                           
  Dify’s external retrieval expects `records[].metadata.document_id` to
  be a non-empty string.                                               
  RAGFlow currently only sets `metadata.doc_id`, which causes Dify     
  validation to fail.                                                  
                                                                       
  This PR adds `metadata.document_id` (mapped from `doc_id`) in the    
  Dify-compatible retrieval response.                                  
                                                                       
  ## Changes                                                           
  - Add `meta["document_id"] = c["doc_id"]` in `api/apps/sdk/dify_retrieval.py`                                                   
                                                                       
  ## Testing                                                           
  - Not run (logic-only change).

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)