### PR TITLE
Feat: expose admin service in helm configuration

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/templates/ragflow.yaml
+++ b/helm/templates/ragflow.yaml
@@ -40,11 +40,19 @@ spec:
         {{- with .Values.ragflow.image.pullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}
+        {{- if .Values.ragflow.admin.enabled }}
+        args:
+          - "--enable-adminserver"
+        {{- end }}
         ports:
           - containerPort: 80
             name: http
           - containerPort: 9380
             name: http-api
+          {{- if .Values.ragflow.admin.enabled }}
+          - containerPort: 9381
+            name: admin
+          {{- end }}
         volumeMounts:
           - mountPath: /etc/nginx/conf.d/ragflow.conf
             subPath: ragflow.conf
@@ -116,4 +124,25 @@ spec:
       targetPort: http-api
       name: http-api
   type: {{ .Values.ragflow.api.service.type }}
+{{- end }}
+
+{{- if .Values.ragflow.admin.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-admin
+  labels:
+    {{- include "ragflow.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ragflow
+spec:
+  selector:
+    {{- include "ragflow.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ragflow
+  ports:
+    - protocol: TCP
+      port: {{ .Values.ragflow.admin.port }}
+      targetPort: admin
+      name: admin
+  type: {{ .Values.ragflow.admin.serviceType }}
 {{- end }}

--- a/helm/templates/ragflow_config.yaml
+++ b/helm/templates/ragflow_config.yaml
@@ -31,6 +31,11 @@ data:
         gzip_vary on;
         gzip_disable "MSIE [1-6]\.";
 
+        location ~ ^/api/v1/admin {
+            proxy_pass http://localhost:9381;
+            include proxy.conf;
+        }
+
         location ~ ^/(v1|api) {
             proxy_pass http://localhost:9380;
             include proxy.conf;

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -109,6 +109,13 @@ ragflow:
   service:
     # Use LoadBalancer to expose the web interface externally
     type: ClusterIP
+  admin:
+    # Enable Admin Service
+    enabled: true
+    # Admin Service port configuration
+    port: 9381
+    # Admin Service type
+    serviceType: ClusterIP
   api:
     service:
       enabled: true


### PR DESCRIPTION
### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
        For helm deployment, there is also requirement to enable the Admin Service for administrative operations.
        So expose the ability of enable/disable this function by helm configuration.
        When it's enabled (by default),
<img width="486" height="190" alt="image" src="https://github.com/user-attachments/assets/4db0dc3d-bd94-4ad9-bb5d-a240aac5e1c5" />
        Admin access and operations would be feasible like below,
<img width="2530" height="876" alt="image" src="https://github.com/user-attachments/assets/3e948e1b-7522-4f8d-8dc0-c80a22242022" />
       Something like 'user management' is very much important for Ragflow User/Owner to control their clients.

