### PR TITLE
Fix: Pass chat image uploads through vision pipeline instead of as plain text

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -183,20 +183,10 @@ class DialogService(CommonService):
 async def async_chat_solo(dialog, messages, stream=True):
     llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
     attachments = ""
-    image_attachments = []
     image_files = []
     if "files" in messages[-1]:
-        if llm_type == "chat":
-            text_attachments, image_attachments = split_file_attachments(messages[-1]["files"])
-        else:
-            text_attachments, image_files = split_file_attachments(messages[-1]["files"], raw=True)
+        text_attachments, image_files = split_file_attachments(messages[-1]["files"], raw=True)
         attachments = "\n\n".join(text_attachments)
-
-    if llm_type == "image2text":
-        llm_model_config = TenantLLMService.get_model_config(dialog.tenant_id, LLMType.IMAGE2TEXT, dialog.llm_id)
-    else:
-        llm_model_config = TenantLLMService.get_model_config(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
-    factory = llm_model_config.get("llm_factory", "") if llm_model_config else ""
 
     if llm_type == "image2text":
         chat_mdl = LLMBundle(dialog.tenant_id, LLMType.IMAGE2TEXT, dialog.llm_id)
@@ -210,13 +200,8 @@ async def async_chat_solo(dialog, messages, stream=True):
     msg = [{"role": m["role"], "content": re.sub(r"##\d+\$\$", "", m["content"])} for m in messages if m["role"] != "system"]
     if attachments and msg:
         msg[-1]["content"] += attachments
-    if llm_type == "chat" and image_attachments:
-        convert_last_user_msg_to_multimodal(msg, image_attachments, factory)
     if stream:
-        if llm_type == "chat":
-            stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting)
-        else:
-            stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
+        stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
         async for kind, value, state in _stream_with_think_delta(stream_iter):
             if kind == "marker":
                 flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}
@@ -224,10 +209,7 @@ async def async_chat_solo(dialog, messages, stream=True):
                 continue
             yield {"answer": value, "reference": {}, "audio_binary": tts(tts_mdl, value), "prompt": "", "created_at": time.time(), "final": False}
     else:
-        if llm_type == "chat":
-            answer = await chat_mdl.async_chat(prompt_config.get("system", ""), msg, dialog.llm_setting)
-        else:
-            answer = await chat_mdl.async_chat(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
+        answer = await chat_mdl.async_chat(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
         user_content = msg[-1].get("content", "[content not available]")
         logging.debug("User: {}|Assistant: {}".format(user_content, answer))
         yield {"answer": answer, "reference": {}, "audio_binary": tts(tts_mdl, answer), "prompt": "", "created_at": time.time()}
@@ -443,7 +425,6 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
     else:
         llm_model_config = TenantLLMService.get_model_config(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
 
-    factory = llm_model_config.get("llm_factory", "") if llm_model_config else ""
     max_tokens = llm_model_config.get("max_tokens", 8192)
 
     check_llm_ts = timer()
@@ -473,15 +454,11 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
     questions = [m["content"] for m in messages if m["role"] == "user"][-3:]
     attachments = kwargs["doc_ids"].split(",") if "doc_ids" in kwargs else []
     attachments_= ""
-    image_attachments = []
     image_files = []
     if "doc_ids" in messages[-1]:
         attachments = messages[-1]["doc_ids"]
     if "files" in messages[-1]:
-        if llm_type == "chat":
-            text_attachments, image_attachments = split_file_attachments(messages[-1]["files"])
-        else:
-            text_attachments, image_files = split_file_attachments(messages[-1]["files"], raw=True)
+        text_attachments, image_files = split_file_attachments(messages[-1]["files"], raw=True)
         attachments_ = "\n\n".join(text_attachments)
 
     prompt_config = dialog.prompt_config
@@ -627,8 +604,6 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         prompt4citation = citation_prompt()
     msg.extend([{"role": m["role"], "content": re.sub(r"##\d+\$\$", "", m["content"])} for m in messages if m["role"] != "system"])
     used_token_count, msg = message_fit_in(msg, int(max_tokens * 0.95))
-    if llm_type == "chat" and image_attachments:
-        convert_last_user_msg_to_multimodal(msg, image_attachments, factory)
     assert len(msg) >= 2, f"message_fit_in has bug: {msg}"
     prompt = msg[0]["content"]
 
@@ -721,10 +696,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         )
 
     if stream:
-        if llm_type == "chat":
-            stream_iter = chat_mdl.async_chat_streamly_delta(prompt + prompt4citation, msg[1:], gen_conf)
-        else:
-            stream_iter = chat_mdl.async_chat_streamly_delta(prompt + prompt4citation, msg[1:], gen_conf, images=image_files)
+        stream_iter = chat_mdl.async_chat_streamly_delta(prompt + prompt4citation, msg[1:], gen_conf, images=image_files)
         last_state = None
         async for kind, value, state in _stream_with_think_delta(stream_iter):
             last_state = state
@@ -741,10 +713,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             final["answer"] = ""
             yield final
     else:
-        if llm_type == "chat":
-            answer = await chat_mdl.async_chat(prompt + prompt4citation, msg[1:], gen_conf)
-        else:
-            answer = await chat_mdl.async_chat(prompt + prompt4citation, msg[1:], gen_conf, images=image_files)
+        answer = await chat_mdl.async_chat(prompt + prompt4citation, msg[1:], gen_conf, images=image_files)
         user_content = msg[-1].get("content", "[content not available]")
         logging.debug("User: {}|Assistant: {}".format(user_content, answer))
         res = decorate_answer(answer)

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 #
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -58,6 +59,58 @@ class ReActMode(StrEnum):
 ERROR_PREFIX = "**ERROR**"
 LENGTH_NOTIFICATION_CN = "······\n由于大模型的上下文窗口大小限制，回答已经被大模型截断。"
 LENGTH_NOTIFICATION_EN = "...\nThe answer is truncated by your chosen LLM due to its limitation on context length."
+
+
+def _apply_vision_images(history, images):
+    """Convert the last user message to multimodal format with vision images.
+
+    Modifies *history* in-place so that the most recent ``user`` message
+    carries the supplied *images* using the OpenAI Vision ``image_url``
+    content-block format.  Providers that need a different wire format
+    (Anthropic, Gemini, Ollama …) are expected to translate from this
+    canonical representation in their own transport layer (e.g. LiteLLM
+    does this automatically when ``drop_params=True``).
+
+    Accepts images as raw ``bytes``, data-URI strings, or plain base-64
+    strings.
+    """
+    if not images:
+        return
+
+    for idx in range(len(history) - 1, -1, -1):
+        if history[idx].get("role") != "user":
+            continue
+
+        content = history[idx].get("content", "")
+        if isinstance(content, list):
+            blocks = list(content)
+        else:
+            text = "" if content is None else str(content)
+            blocks = [{"type": "text", "text": text}] if text else []
+
+        for img in images:
+            if isinstance(img, (bytes, bytearray, memoryview)):
+                raw = bytes(img) if not isinstance(img, bytes) else img
+                b64 = base64.b64encode(raw).decode("utf-8")
+                mime = "image/jpeg" if raw[:2] == b"\xff\xd8" else "image/png"
+                url = f"data:{mime};base64,{b64}"
+            elif isinstance(img, str):
+                url = img.strip()
+                if not url.startswith(("data:", "http://", "https://")):
+                    url = f"data:image/png;base64,{url}"
+            elif isinstance(img, dict):
+                url = (
+                    img.get("image_url", {}).get("url", "")
+                    or img.get("url", "")
+                )
+                if not url:
+                    continue
+            else:
+                continue
+            blocks.append({"type": "image_url", "image_url": {"url": url}})
+
+        history[idx]["content"] = blocks
+        return
 
 
 class Base(ABC):
@@ -135,6 +188,9 @@ class Base(ABC):
         return gen_conf
 
     async def _async_chat_streamly(self, history, gen_conf, **kwargs):
+        images = kwargs.pop("images", None)
+        if images:
+            _apply_vision_images(history, images)
         logging.info("[HISTORY STREAMLY]" + json.dumps(history, ensure_ascii=False, indent=4))
         reasoning_start = False
 
@@ -441,6 +497,9 @@ class Base(ABC):
         assert False, "Shouldn't be here."
 
     async def _async_chat(self, history, gen_conf, **kwargs):
+        images = kwargs.pop("images", None)
+        if images:
+            _apply_vision_images(history, images)
         logging.info("[HISTORY]" + json.dumps(history, ensure_ascii=False, indent=2))
         if self.model_name.lower().find("qwq") >= 0:
             logging.info(f"[INFO] {self.model_name} detected as reasoning model, using async_chat_streamly")
@@ -1217,10 +1276,13 @@ class LiteLLMBase(ABC):
         return gen_conf
 
     async def async_chat(self, system, history, gen_conf, **kwargs):
+        images = kwargs.pop("images", None)
         hist = list(history) if history else []
         if system:
             if not hist or hist[0].get("role") != "system":
                 hist.insert(0, {"role": "system", "content": system})
+        if images:
+            _apply_vision_images(hist, images)
 
         logging.info("[HISTORY]" + json.dumps(hist, ensure_ascii=False, indent=2))
         if self.model_name.lower().find("qwen3") >= 0:
@@ -1251,8 +1313,11 @@ class LiteLLMBase(ABC):
         assert False, "Shouldn't be here."
 
     async def async_chat_streamly(self, system, history, gen_conf, **kwargs):
+        images = kwargs.pop("images", None)
         if system and history and history[0].get("role") != "system":
             history.insert(0, {"role": "system", "content": system})
+        if images:
+            _apply_vision_images(history, images)
         logging.info("[HISTORY STREAMLY]" + json.dumps(history, ensure_ascii=False, indent=4))
         gen_conf = self._clean_conf(gen_conf)
         reasoning_start = False


### PR DESCRIPTION
## Summary

Images uploaded in chat were handled differently based on `llm_type`:
- **image2text** models received raw images via the `images` parameter
- **chat** models had images formatted at the service layer via `convert_last_user_msg_to_multimodal()`, which only handled OpenAI/Anthropic/Gemini formats

This caused vision-capable chat models (e.g. llama.cpp with `--mmproj`, Ollama vision models) to receive base64 image data as **plain text**, inflating token usage from ~279 to **340,000+ tokens** per image.

## Changes

- **`api/db/services/dialog_service.py`**: Removed `llm_type`-based branching for image handling in both `async_chat_solo()` and `async_chat()`. All models now consistently pass images via the `images=image_files` parameter. Removed unused `factory` variable and `image_attachments` / `convert_last_user_msg_to_multimodal()` usage.
- **`rag/llm/chat_model.py`**: Added `_apply_vision_images()` helper that converts images (bytes, base64 strings, data URIs, or dicts) into OpenAI Vision `image_url` content blocks on the last user message. Integrated into `_async_chat_streamly()`, `_async_chat()`, and the `VolcEngineChat` overrides. LiteLLM-based providers automatically translate this canonical format to their native wire format.

Closes #13347

## Test plan

- [ ] Upload an image in chat with a vision-capable chat model (e.g. GPT-4o, Claude Sonnet) and verify the model correctly describes the image
- [ ] Upload an image with an image2text model and verify it still works as before
- [ ] Upload an image with an Ollama vision model or llama.cpp with `--mmproj` and verify it no longer inflates token usage
- [ ] Test chat without any image uploads to ensure no regression