### PR TITLE
Fix: preserve field boundaries in chunked documents from MySQL…

### DIFF
--- a/common/data_source/rdbms_connector.py
+++ b/common/data_source/rdbms_connector.py
@@ -204,11 +204,11 @@ class RDBMSConnector(LoadConnector, PollConnector):
                 value = row_dict[col]
                 if isinstance(value, (dict, list)):
                     value = json.dumps(value, ensure_ascii=False)
-                # Use brackets around field name to ensure it's distinguishable
-                # after chunking (TxtParser strips \n delimiters during merge)
-                content_parts.append(f"【{col}】: {value}")
+                # Use brackets around field name and put value on a new line
+                # so that TxtParser preserves field boundaries after chunking.
+                content_parts.append(f"【{col}】:\n{value}")
         
-        content = "\n".join(content_parts)
+        content = "\n\n".join(content_parts)
         
         if self.id_column and self.id_column in row_dict:
             doc_id = f"{self.db_type}:{self.database}:{row_dict[self.id_column]}"

--- a/deepdoc/parser/txt_parser.py
+++ b/deepdoc/parser/txt_parser.py
@@ -40,7 +40,10 @@ class RAGFlowTxtParser:
                 cks.append(t)
                 tk_nums.append(tnum)
             else:
-                cks[-1] += t
+                if cks[-1]:
+                    cks[-1] += "\n" + t
+                else:
+                    cks[-1] += t
                 tk_nums[-1] += tnum
 
         dels = []


### PR DESCRIPTION
### What problem does this PR solve?

When multiple columns are used as content columns in RDBMS connector, the generated document text gets chunked by TxtParser which strips newline delimiters during merge. This causes field names and values from different columns to be concatenated without any separator, making the content unreadable.

Changes:
- txt_parser.py: restore newline separator when merging adjacent text segments within a chunk, so that split sections are not directly concatenated
- rdbms_connector.py: use double newline between fields and place field value on a new line after the field name bracket, giving TxtParser clearer boundaries to work with

Closes #13001

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
