### PR TITLE
Fix missing vision model for QA docx parsing and preserve document or…

### DIFF
--- a/rag/app/manual.py
+++ b/rag/app/manual.py
@@ -25,6 +25,8 @@ from common.token_utils import num_tokens_from_string
 from deepdoc.parser import PdfParser, DocxParser
 from deepdoc.parser.figure_parser import vision_figure_parser_pdf_wrapper, vision_figure_parser_docx_wrapper
 from docx import Document
+from docx.table import Table as DocxTable
+from docx.text.paragraph import Paragraph
 from PIL import Image
 from rag.app.naive import by_plaintext, PARSERS
 from common.parser_config_utils import normalize_layout_recognizer
@@ -116,61 +118,67 @@ class Docx(DocxParser):
         last_answer, last_image = "", None
         question_stack, level_stack = [], []
         ti_list = []
-        for p in self.doc.paragraphs:
+        for block in self.doc._element.body:
             if pn > to_page:
                 break
-            question_level, p_text = 0, ""
-            if from_page <= pn < to_page and p.text.strip():
-                question_level, p_text = docx_question_level(p)
-            if not question_level or question_level > 6:  # not a question
-                last_answer = f"{last_answer}\n{p_text}"
-                current_image = self.get_picture(self.doc, p)
-                last_image = self.concat_img(last_image, current_image)
-            else:  # is a question
-                if last_answer or last_image:
-                    sum_question = "\n".join(question_stack)
-                    if sum_question:
-                        ti_list.append((f"{sum_question}\n{last_answer}", last_image))
-                    last_answer, last_image = "", None
 
-                i = question_level
-                while question_stack and i <= level_stack[-1]:
-                    question_stack.pop()
-                    level_stack.pop()
-                question_stack.append(p_text)
-                level_stack.append(question_level)
-            for run in p.runs:
-                if "lastRenderedPageBreak" in run._element.xml:
-                    pn += 1
-                    continue
-                if "w:br" in run._element.xml and 'type="page"' in run._element.xml:
-                    pn += 1
+            if block.tag.endswith("p"):
+                p = Paragraph(block, self.doc)
+                question_level, p_text = 0, ""
+                if from_page <= pn < to_page and p.text.strip():
+                    question_level, p_text = docx_question_level(p)
+                if not question_level or question_level > 6:  # not a question
+                    last_answer = f"{last_answer}\n{p_text}"
+                    current_image = self.get_picture(self.doc, p)
+                    last_image = self.concat_img(last_image, current_image)
+                else:  # is a question
+                    if last_answer or last_image:
+                        sum_question = "\n".join(question_stack)
+                        if sum_question:
+                            ti_list.append((f"{sum_question}\n{last_answer}", last_image))
+                        last_answer, last_image = "", None
+
+                    i = question_level
+                    while question_stack and i <= level_stack[-1]:
+                        question_stack.pop()
+                        level_stack.pop()
+                    question_stack.append(p_text)
+                    level_stack.append(question_level)
+                for run in p.runs:
+                    if "lastRenderedPageBreak" in run._element.xml:
+                        pn += 1
+                        continue
+                    if "w:br" in run._element.xml and 'type="page"' in run._element.xml:
+                        pn += 1
+
+            elif block.tag.endswith("tbl"):
+                if from_page <= pn < to_page:
+                    tb = DocxTable(block, self.doc)
+                    html = "<table>"
+                    for r in tb.rows:
+                        html += "<tr>"
+                        col_idx = 0
+                        while col_idx < len(r.cells):
+                            span = 1
+                            c = r.cells[col_idx]
+                            for j in range(col_idx + 1, len(r.cells)):
+                                if c.text == r.cells[j].text:
+                                    span += 1
+                                    col_idx = j
+                                else:
+                                    break
+                            col_idx += 1
+                            html += f"<td>{c.text}</td>" if span == 1 else f"<td colspan='{span}'>{c.text}</td>"
+                        html += "</tr>"
+                    html += "</table>"
+                    last_answer = f"{last_answer}\n{html}"
+
         if last_answer:
             sum_question = "\n".join(question_stack)
             if sum_question:
                 ti_list.append((f"{sum_question}\n{last_answer}", last_image))
 
-        tbls = []
-        for tb in self.doc.tables:
-            html = "<table>"
-            for r in tb.rows:
-                html += "<tr>"
-                i = 0
-                while i < len(r.cells):
-                    span = 1
-                    c = r.cells[i]
-                    for j in range(i + 1, len(r.cells)):
-                        if c.text == r.cells[j].text:
-                            span += 1
-                            i = j
-                        else:
-                            break
-                    i += 1
-                    html += f"<td>{c.text}</td>" if span == 1 else f"<td colspan='{span}'>{c.text}</td>"
-                html += "</tr>"
-            html += "</table>"
-            tbls.append(((None, html), ""))
-        return ti_list, tbls
+        return ti_list, []
 
 
 def chunk(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", callback=None, **kwargs):

--- a/rag/app/qa.py
+++ b/rag/app/qa.py
@@ -26,6 +26,7 @@ from deepdoc.parser.utils import get_text
 from rag.nlp import is_english, random_choices, qbullets_category, add_positions, has_qbullet, docx_question_level
 from rag.nlp import rag_tokenizer, tokenize_table, concat_img
 from deepdoc.parser import PdfParser, ExcelParser, DocxParser
+from deepdoc.parser.figure_parser import vision_figure_parser_docx_wrapper
 from docx import Document
 from PIL import Image
 from markdown import markdown
@@ -462,6 +463,8 @@ def chunk(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", ca
         docx_parser = Docx()
         qai_list, tbls = docx_parser(filename, binary,
                                      from_page=0, to_page=10000, callback=callback)
+        sections_for_vision = [(f"{q}\n{a}", image) for q, a, image in qai_list]
+        tbls = vision_figure_parser_docx_wrapper(sections=sections_for_vision, tbls=tbls, callback=callback, **kwargs)
         res = tokenize_table(tbls, doc, eng)
         for i, (q, a, image) in enumerate(qai_list):
             res.append(beAdocDocx(deepcopy(doc), q, a, eng, image, i))


### PR DESCRIPTION
### What problem does this PR solve?

Fixes two inconsistencies in how Word documents are parsed compared to PDFs:

1. **QA strategy ignores vision model for docx** - The QA parser calls vision enhancement for PDF figures but skips it entirely for docx. Other strategies (manual, naive, book) all call `vision_figure_parser_docx_wrapper` for docx files. This PR adds the same call to QA.

2. **Manual strategy breaks document order for docx** - Tables are parsed in a separate loop after all paragraphs, so they always end up at the top of the chunk list regardless of where they appear in the document. This PR switches to iterating `self.doc._element.body` (same approach as `naive.Docx`), which naturally keeps tables in their original position within heading sections.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)


### Closes: #13330