### PR TITLE
chore: add bin and internal dirs to .gitignore for Go server build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,4 +222,5 @@ docker/launch_backend_service_windows.sh
 
 # Go server build output
 bin/
-internal/
+internal/cpp/cmake-build-release/
+internal/cpp/cmake-build-debug/


### PR DESCRIPTION
### What problem does this PR solve?

add bin and internal dirs to .gitignore for Go server build output
