### PR TITLE
Add checksum/values annotation to ragflow.yaml

### DIFF
--- a/helm/templates/ragflow.yaml
+++ b/helm/templates/ragflow.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "ragflow.labels" . | nindent 8 }}
         app.kubernetes.io/component: ragflow
       annotations:
+        checksum/values: {{ .Values | toYaml | sha256sum }}
         checksum/config-env: {{ include (print $.Template.BasePath "/env.yaml") . | sha256sum }}
         checksum/config-ragflow: {{ include (print $.Template.BasePath "/ragflow_config.yaml") . | sha256sum }}
     spec:


### PR DESCRIPTION
Add checksum annotation for values in ragflow.yaml

### What problem does this PR solve?

This PR is about this ticket: #13408

Ragflow helm charts do not include the Values.yaml in the list of watched changes.
If you update the Values.yaml for an existing deployment, helm will not detect it and not update the deployment.

This PR fixes that.

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
