### PR TITLE
Test: adjust test priority markers for API tests

### DIFF
--- a/test/testcases/test_http_api/test_chat_management/test_table_parser_dataset_chat.py
+++ b/test/testcases/test_http_api/test_chat_management/test_table_parser_dataset_chat.py
@@ -156,7 +156,7 @@ class TestTableParserDatasetChat:
             except Exception as e:
                 print(f"[Teardown] Warning: Failed to delete chat assistant: {e}")
 
-    @pytest.mark.p1
+    @pytest.mark.p3
     @pytest.mark.parametrize(
         "question, expected_answer_pattern",
         [

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_delete_chunks.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_delete_chunks.py
@@ -71,7 +71,7 @@ class TestChunksDeletion:
         "payload",
         [
             pytest.param(lambda r: {"chunk_ids": ["invalid_id"] + r}, marks=pytest.mark.p3),
-            pytest.param(lambda r: {"chunk_ids": r[:1] + ["invalid_id"] + r[1:4]}, marks=pytest.mark.p1),
+            pytest.param(lambda r: {"chunk_ids": r[:1] + ["invalid_id"] + r[1:4]}, marks=pytest.mark.p3),
             pytest.param(lambda r: {"chunk_ids": r + ["invalid_id"]}, marks=pytest.mark.p3),
         ],
     )

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_retrieval_chunks.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_retrieval_chunks.py
@@ -175,7 +175,7 @@ class TestChunksRetrieval:
         else:
             assert res["message"] == expected_message
 
-    @pytest.mark.p2
+    @pytest.mark.p3
     @pytest.mark.parametrize(
         "payload, expected_code, expected_page_size, expected_message",
         [


### PR DESCRIPTION
### What problem does this PR solve?

Changed test priority markers from p1/p2 to p3 in three test files:
- test_table_parser_dataset_chat.py: Adjusted priority for table parser dataset chat test
- test_delete_chunks.py: Updated priority for chunk deletion test with invalid IDs
- test_retrieval_chunks.py: Modified priority for chunks retrieval pagination test

These changes demote the priority of specific test cases to p3, indicating they are lower priority tests that can run later in the test suite execution.

### Type of change

- [x] Test update
