### PR TITLE
fix: include missing modules in ragflow-cli PyPI package

### DIFF
--- a/admin/client/pyproject.toml
+++ b/admin/client/pyproject.toml
@@ -21,7 +21,7 @@ test = [
 ]
 
 [tool.setuptools]
-py-modules = ["ragflow_cli", "parser"]
+py-modules = ["ragflow_cli", "parser", "http_client", "ragflow_client", "user"]
 
 [project.scripts]
 ragflow-cli = "ragflow_cli:main"


### PR DESCRIPTION
## Problem

The `ragflow-cli` PyPI package (v0.24.0) is missing `http_client.py`, `ragflow_client.py`, and `user.py`, causing import errors when installed from PyPI.

## Root Cause

`pyproject.toml` only lists `ragflow_cli` and `parser` in `[tool.setuptools] py-modules`.

## Fix

Add the three missing modules to `py-modules`.

Fixes #13456