### PR TITLE
fix: preserve raw chunk content in chunk APIs

### DIFF
--- a/api/apps/chunk_app.py
+++ b/api/apps/chunk_app.py
@@ -74,9 +74,7 @@ async def list_chunk():
         for id in sres.ids:
             d = {
                 "chunk_id": id,
-                "content_with_weight": remove_redundant_spaces(sres.highlight[id]) if question and id in sres.highlight else sres.field[
-                    id].get(
-                    "content_with_weight", ""),
+                "content_with_weight": sres.field[id].get("content_with_weight", ""),
                 "doc_id": sres.field[id]["doc_id"],
                 "docnm_kwd": sres.field[id]["docnm_kwd"],
                 "important_kwd": sres.field[id].get("important_kwd", []),
@@ -86,6 +84,8 @@ async def list_chunk():
                 "positions": sres.field[id].get("position_int", []),
                 "doc_type_kwd": sres.field[id].get("doc_type_kwd")
             }
+            if question and id in sres.highlight:
+                d["highlight"] = remove_redundant_spaces(sres.highlight[id]).strip()
             assert isinstance(d["positions"], list)
             assert len(d["positions"]) == 0 or (isinstance(d["positions"][0], list) and len(d["positions"][0]) == 5)
             res["chunks"].append(d)

--- a/api/apps/sdk/doc.py
+++ b/api/apps/sdk/doc.py
@@ -1137,7 +1137,7 @@ async def list_chunks(tenant_id, dataset_id, document_id):
         for id in sres.ids:
             d = {
                 "id": id,
-                "content": (remove_redundant_spaces(sres.highlight[id]) if question and id in sres.highlight else sres.field[id].get("content_with_weight", "")),
+                "content": sres.field[id].get("content_with_weight", ""),
                 "document_id": sres.field[id]["doc_id"],
                 "docnm_kwd": sres.field[id]["docnm_kwd"],
                 "important_keywords": sres.field[id].get("important_kwd", []),
@@ -1147,6 +1147,8 @@ async def list_chunks(tenant_id, dataset_id, document_id):
                 "available": bool(int(sres.field[id].get("available_int", "1"))),
                 "positions": sres.field[id].get("position_int", []),
             }
+            if question and id in sres.highlight:
+                d["highlight"] = remove_redundant_spaces(sres.highlight[id]).strip()
             res["chunks"].append(d)
             _ = Chunk(**d)  # validate the chunk
     return get_result(data=res)

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
@@ -146,6 +146,9 @@ def _load_doc_module(monkeypatch):
     deepdoc_excel_module = ModuleType("deepdoc.parser.excel_parser")
     deepdoc_excel_module.RAGFlowExcelParser = _StubExcelParser
     monkeypatch.setitem(sys.modules, "deepdoc.parser.excel_parser", deepdoc_excel_module)
+    deepdoc_mineru_module = ModuleType("deepdoc.parser.mineru_parser")
+    deepdoc_mineru_module.MinerUParser = _StubPdfParser
+    monkeypatch.setitem(sys.modules, "deepdoc.parser.mineru_parser", deepdoc_mineru_module)
     deepdoc_parser_utils = ModuleType("deepdoc.parser.utils")
     deepdoc_parser_utils.get_text = lambda *_args, **_kwargs: ""
     monkeypatch.setitem(sys.modules, "deepdoc.parser.utils", deepdoc_parser_utils)
@@ -217,13 +220,14 @@ def _load_doc_module(monkeypatch):
                     import numpy as np
                     return [np.array([0.2, 0.8]), np.array([0.3, 0.7])], 1
             return _EmbedModel()
-    
-    tenant_llm_service_mod.TenantService = _StubTenantService
-    tenant_llm_service_mod.TenantLLMService = _StubTenantLLMService
 
     class _StubLLMFactoriesService:
-        pass
+        @staticmethod
+        def get_all():
+            return []
 
+    tenant_llm_service_mod.TenantService = _StubTenantService
+    tenant_llm_service_mod.TenantLLMService = _StubTenantLLMService
     tenant_llm_service_mod.LLMFactoriesService = _StubLLMFactoriesService
     monkeypatch.setitem(sys.modules, "api.db.services.tenant_llm_service", tenant_llm_service_mod)
 
@@ -251,6 +255,24 @@ def _load_doc_module(monkeypatch):
     )
     llm_service_mod.LLMBundle = _StubLLMBundle
     monkeypatch.setitem(sys.modules, "api.db.services.llm_service", llm_service_mod)
+
+    file_service_mod = ModuleType("api.db.services.file_service")
+
+    class _StubFileService:
+        @staticmethod
+        def upload_document(*_args, **_kwargs):
+            return [], []
+
+        @staticmethod
+        def get_root_folder(_tenant):
+            return {"id": "pf-1"}
+
+        @staticmethod
+        def init_knowledgebase_docs(*_args, **_kwargs):
+            return None
+
+    file_service_mod.FileService = _StubFileService
+    monkeypatch.setitem(sys.modules, "api.db.services.file_service", file_service_mod)
 
     # Mock tenant_model_service to ensure it uses mocked services
     tenant_model_service_mod = ModuleType("api.db.joint_services.tenant_model_service")
@@ -860,6 +882,32 @@ class TestDocRoutesUnit:
         assert res["code"] == 0
         assert res["data"]["total"] == 1
         assert res["data"]["chunks"][0]["id"] == "chunk-1"
+
+        class _SRes:
+            total = 1
+            ids = ["chunk-1"]
+            field = {
+                "chunk-1": {
+                    "content_with_weight": "raw chunk content",
+                    "doc_id": "doc-1",
+                    "docnm_kwd": "doc",
+                    "available_int": 1,
+                    "position_int": [[1, 2, 3, 4, 5]],
+                }
+            }
+            highlight = {"chunk-1": " highlighted  content "}
+
+        class _Retriever:
+            async def search(self, *_args, **_kwargs):
+                return _SRes()
+
+        monkeypatch.setattr(module, "request", SimpleNamespace(args=_DummyArgs({"keywords": "content"})))
+        _patch_docstore(monkeypatch, module, index_exist=lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(module.settings, "retriever", _Retriever())
+        res = _run(module.list_chunks.__wrapped__("tenant-1", "ds-1", "doc-1"))
+        assert res["code"] == 0
+        assert res["data"]["chunks"][0]["content"] == "raw chunk content"
+        assert res["data"]["chunks"][0]["highlight"] == "highlighted content"
 
     def test_add_chunk_access_guard(self, monkeypatch):
         module = _load_doc_module(monkeypatch)

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
@@ -221,14 +221,9 @@ def _load_doc_module(monkeypatch):
                     return [np.array([0.2, 0.8]), np.array([0.3, 0.7])], 1
             return _EmbedModel()
 
-    class _StubLLMFactoriesService:
-        @staticmethod
-        def get_all():
-            return []
-
     tenant_llm_service_mod.TenantService = _StubTenantService
     tenant_llm_service_mod.TenantLLMService = _StubTenantLLMService
-    tenant_llm_service_mod.LLMFactoriesService = _StubLLMFactoriesService
+    tenant_llm_service_mod.LLMFactoriesService = SimpleNamespace(get_all=lambda: [])
     monkeypatch.setitem(sys.modules, "api.db.services.tenant_llm_service", tenant_llm_service_mod)
 
     # Mock LLMService
@@ -257,21 +252,11 @@ def _load_doc_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "api.db.services.llm_service", llm_service_mod)
 
     file_service_mod = ModuleType("api.db.services.file_service")
-
-    class _StubFileService:
-        @staticmethod
-        def upload_document(*_args, **_kwargs):
-            return [], []
-
-        @staticmethod
-        def get_root_folder(_tenant):
-            return {"id": "pf-1"}
-
-        @staticmethod
-        def init_knowledgebase_docs(*_args, **_kwargs):
-            return None
-
-    file_service_mod.FileService = _StubFileService
+    file_service_mod.FileService = SimpleNamespace(
+        upload_document=lambda *_args, **_kwargs: ([], []),
+        get_root_folder=lambda _tenant: {"id": "pf-1"},
+        init_knowledgebase_docs=lambda *_args, **_kwargs: None,
+    )
     monkeypatch.setitem(sys.modules, "api.db.services.file_service", file_service_mod)
 
     # Mock tenant_model_service to ensure it uses mocked services

--- a/test/testcases/test_web_api/test_chunk_app/test_chunk_routes_unit.py
+++ b/test/testcases/test_web_api/test_chunk_app/test_chunk_routes_unit.py
@@ -260,15 +260,6 @@ def _load_chunk_module(monkeypatch):
     rag_nlp_mod.search = SimpleNamespace(index_name=lambda tenant_id: f"idx-{tenant_id}")
     monkeypatch.setitem(sys.modules, "rag.nlp", rag_nlp_mod)
 
-    rag_utils_pkg = ModuleType("rag.utils")
-    rag_utils_pkg.__path__ = []
-    monkeypatch.setitem(sys.modules, "rag.utils", rag_utils_pkg)
-
-    rag_sparse_vector_mod = ModuleType("rag.utils.sparse_vector")
-    rag_sparse_vector_mod.attach_sparse_vector = lambda *_args, **_kwargs: False
-    rag_sparse_vector_mod.build_sparse_text = lambda *parts: "\n".join(str(part) for part in parts if part is not None)
-    monkeypatch.setitem(sys.modules, "rag.utils.sparse_vector", rag_sparse_vector_mod)
-
     rag_prompts_pkg = ModuleType("rag.prompts")
     rag_prompts_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "rag.prompts", rag_prompts_pkg)

--- a/test/testcases/test_web_api/test_chunk_app/test_chunk_routes_unit.py
+++ b/test/testcases/test_web_api/test_chunk_app/test_chunk_routes_unit.py
@@ -260,6 +260,15 @@ def _load_chunk_module(monkeypatch):
     rag_nlp_mod.search = SimpleNamespace(index_name=lambda tenant_id: f"idx-{tenant_id}")
     monkeypatch.setitem(sys.modules, "rag.nlp", rag_nlp_mod)
 
+    rag_utils_pkg = ModuleType("rag.utils")
+    rag_utils_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "rag.utils", rag_utils_pkg)
+
+    rag_sparse_vector_mod = ModuleType("rag.utils.sparse_vector")
+    rag_sparse_vector_mod.attach_sparse_vector = lambda *_args, **_kwargs: False
+    rag_sparse_vector_mod.build_sparse_text = lambda *parts: "\n".join(str(part) for part in parts if part is not None)
+    monkeypatch.setitem(sys.modules, "rag.utils.sparse_vector", rag_sparse_vector_mod)
+
     rag_prompts_pkg = ModuleType("rag.prompts")
     rag_prompts_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "rag.prompts", rag_prompts_pkg)
@@ -472,6 +481,8 @@ def test_list_chunk_exception_branches_unit(monkeypatch):
     assert res["code"] == 0, res
     assert res["data"]["total"] == 1, res
     assert res["data"]["chunks"][0]["available_int"] == 1, res
+    assert res["data"]["chunks"][0]["content_with_weight"] == "chunk content", res
+    assert res["data"]["chunks"][0]["highlight"] == "highlighted content", res
 
     monkeypatch.setattr(module.DocumentService, "get_tenant_id", lambda _doc_id: "")
     _set_request_json(monkeypatch, module, {"doc_id": "doc-1"})


### PR DESCRIPTION
## Summary
Preserve raw chunk content in chunk list APIs and return search snippets separately as highlights.

## Root Cause
When chunk search used keywords, the API replaced the stored raw chunk body with the highlight/snippet value. That exposed tokenized or stemmed text to users instead of the original content.

## Changes
- always return raw `content_with_weight` / `content`
- attach the search snippet as a separate `highlight` field
- trim and normalize the highlight output
- add targeted regression coverage for both web and SDK chunk list routes

## Validation
- `env PYTHONPATH=/home/jo/rf/ragflow .venv/bin/python -m pytest --noconftest -W ignore::UserWarning test/testcases/test_web_api/test_chunk_app/test_chunk_routes_unit.py::test_list_chunk_exception_branches_unit`
- `env PYTHONPATH=/home/jo/rf/ragflow .venv/bin/python -m pytest --noconftest -W ignore::UserWarning test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py::TestDocRoutesUnit::test_list_chunks_branches`
- manually verified that chunk views show raw content while keyword hits appear in `highlight`
