### PR TITLE
feat: add qdrant doc store backend

### DIFF
--- a/QDRANT_README.md
+++ b/QDRANT_README.md
@@ -1,0 +1,250 @@
+# Qdrant Backend Notes
+
+This document describes the Qdrant document-store backend for RAGFlow: what it supports, how it is wired, how to run it, and what differences remain versus Elasticsearch.
+
+## Overview
+
+The Qdrant backend adds:
+
+- a Qdrant storage adapter for the existing synchronous document-store interface
+- `DOC_ENGINE=qdrant` routing and settings support
+- upstream Docker wiring in `docker/.env`, `docker/service_conf.yaml.template`, `docker/docker-compose-base.yml`, and `docker/docker-compose.yml`
+- dense retrieval
+- optional sparse hybrid retrieval
+- admin config and health awareness
+
+The adapter is intended to replace Elasticsearch as the document/vector backend for normal RAGFlow usage. It does not try to reproduce Elasticsearch analyzer or BM25 behavior exactly.
+
+## Design
+
+### Storage model
+
+- one Qdrant collection per tenant for chunk data
+- one Qdrant collection per tenant for document metadata
+- original RAGFlow document and chunk IDs remain in payload
+- internal Qdrant point IDs are stored as deterministic UUIDs because Qdrant only accepts unsigned integers or UUIDs
+
+### Vector layout
+
+- named dense vector: `dense`
+- named sparse vector: `sparse`
+
+Collection schema shape:
+
+```python
+vectors_config = {
+    "dense": models.VectorParams(
+        size=dimension,
+        distance=models.Distance.COSINE,
+    ),
+    # Future ColPali / ColQwen extension point:
+    # "page_dense": models.VectorParams(
+    #     size=page_dimension,
+    #     distance=models.Distance.COSINE,
+    #     multivector_config=models.MultiVectorConfig(
+    #         comparator=models.MultiVectorComparator.MAX_SIM,
+    #     ),
+    # ),
+}
+
+sparse_vectors_config = {
+    "sparse": models.SparseVectorParams(
+        index=models.SparseIndexParams(
+            on_disk=False,
+        ),
+    ),
+}
+```
+
+### Retrieval
+
+- dense-only retrieval works with the `dense` named vector
+- hybrid retrieval uses dense prefetch + sparse prefetch + reciprocal-rank fusion
+- when no sparse model is configured, the backend silently falls back to dense-only retrieval
+- a text payload index is created on chunk text for simple keyword-oriented matching
+
+Hybrid query shape:
+
+```python
+result = client.query_points(
+    collection_name=collection,
+    prefetch=[
+        models.Prefetch(
+            query=models.NamedVector(
+                name="dense",
+                vector=dense_query,
+            ),
+            using="dense",
+            limit=similarity_top_k,
+            filter=query_filter,
+        ),
+        models.Prefetch(
+            query=models.NamedSparseVector(
+                name="sparse",
+                vector=models.SparseVector(
+                    indices=sparse_query.indices,
+                    values=sparse_query.values,
+                ),
+            ),
+            using="sparse",
+            limit=similarity_top_k,
+            filter=query_filter,
+        ),
+    ],
+    query=models.FusionQuery(
+        fusion=models.Fusion.RRF,
+    ),
+    limit=top_k,
+    with_payload=True,
+    with_vectors=False,
+)
+```
+
+### Compatibility notes
+
+- missing `available_int` is treated as available to match existing backend behavior
+- future inserts default `available_int=1`
+- admin-side config and health checks understand `qdrant`
+- backend error text should refer to the active backend instead of hardcoded `Elasticsearch/Infinity`
+
+## Setup
+
+There are two supported setup modes:
+
+1. standard upstream Docker setup from `docker/`
+2. custom deployment using your own compose/config stack
+
+### Standard upstream Docker setup
+
+Relevant files:
+
+- `docker/.env`
+- `docker/service_conf.yaml.template`
+- `docker/docker-compose-base.yml`
+- `docker/docker-compose.yml`
+
+Minimal dense-only startup:
+
+```bash
+cd docker
+DOC_ENGINE=qdrant docker compose -f docker-compose.yml up -d
+```
+
+Dense + sparse startup:
+
+```bash
+cd docker
+DOC_ENGINE=qdrant QDRANT_SPARSE_MODEL=token docker compose -f docker-compose.yml up -d
+```
+
+Important environment variables:
+
+```env
+DOC_ENGINE=qdrant
+QDRANT_HOST=qdrant
+QDRANT_HTTP_PORT=6333
+QDRANT_GRPC_PORT=6334
+QDRANT_SPARSE_MODEL=
+QDRANT_SPARSE_VOCAB_SIZE=131072
+QDRANT_TEXT_INDEX_TOKENIZER=multilingual
+```
+
+Set:
+
+- `QDRANT_SPARSE_MODEL=` for dense-only
+- `QDRANT_SPARSE_MODEL=token` for the built-in sparse path used here
+
+### Custom deployment setup
+
+If you do not use the repo Docker entrypoint directly, you still need:
+
+1. `DOC_ENGINE=qdrant`
+2. a `qdrant:` block in your runtime `service_conf.yaml`
+
+Example:
+
+```yaml
+qdrant:
+  host: qdrant
+  http_port: 6333
+  grpc_port: 6334
+  https: false
+  prefer_grpc: false
+  timeout: 10
+  sparse_model: ''
+  sparse_vocab_size: 131072
+  text_index_tokenizer: multilingual
+```
+
+For dense-only:
+
+```yaml
+sparse_model: ''
+```
+
+For hybrid:
+
+```yaml
+sparse_model: 'token'
+```
+
+## Validation
+
+Recommended smoke-test order:
+
+1. Start RAGFlow with `DOC_ENGINE=qdrant`
+2. Create a fresh test dataset
+3. Upload a small document
+4. Wait for indexing to finish
+5. Open the chunk list and confirm raw chunk content is shown
+6. Create a chat attached to that dataset
+7. Ask a question copied from a real chunk
+8. Confirm the answer references the ingested content
+
+Optional hybrid validation:
+
+1. enable `sparse_model: 'token'`
+2. restart the service
+3. retry retrieval with keyword-heavy queries
+
+## Troubleshooting
+
+If ingestion fails with an error that a point ID is invalid:
+
+- the backend is sending a non-UUID external RAGFlow ID directly to Qdrant
+- Qdrant requires an unsigned integer or UUID point ID
+- the adapter must keep the original RAGFlow ID in payload and use a deterministic UUID as the internal point ID
+
+If chat returns no knowledge despite successful indexing:
+
+- verify the conversation path is not applying an empty `doc_id` filter
+- no selected documents should behave like `doc_ids=None`, not `doc_ids=[]`
+
+If chunk text looks stemmed or truncated in the UI:
+
+- verify the API is returning raw `content_with_weight`
+- highlight/snippet text should be returned separately and must not replace the stored chunk text
+
+If Qdrant starts correctly but admin logs report `Unknown configuration key: qdrant`:
+
+- the admin config/status parser is missing Qdrant awareness
+- add `qdrant` to the supported config keys in the admin config path
+
+## Current limitations
+
+These are intentional or currently accepted limitations:
+
+- Qdrant is not a 1:1 Elasticsearch BM25/analyzer replacement
+- SQL retrieval is unsupported for `DOC_ENGINE=qdrant`
+- message store is unsupported for `DOC_ENGINE=qdrant`
+- the adapter is synchronous because the current storage contract is synchronous
+- ColPali / ColQwen visual RAG is not implemented here
+
+## Future extension point
+
+The collection schema and query path are prepared for a later multi-vector extension, but this work does not implement it. A future ColPali / ColQwen PR should:
+
+- add a separate page- or image-level named vector
+- enable multivector comparison for that field
+- extend ingestion to attach page/image vectors
+- extend retrieval and reranking so page-level visual hits can be returned cleanly

--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ RAGFlow uses Elasticsearch by default for storing full text and vectors. To swit
 > [!WARNING]
 > Switching to Infinity on a Linux/arm64 machine is not yet officially supported.
 
+### Qdrant backend notes
+
+For the Qdrant backend design, setup, validation, and operational notes, see [QDRANT_README.md](./QDRANT_README.md).
+
 ## 🔧 Build a Docker image
 
 This image is approximately 2 GB in size and relies on external LLM and embedding services.
@@ -390,6 +394,7 @@ docker build --platform linux/amd64 \
 
 - [Quickstart](https://ragflow.io/docs/dev/)
 - [Configuration](https://ragflow.io/docs/dev/configurations)
+- [Qdrant backend notes](./QDRANT_README.md)
 - [Release notes](https://ragflow.io/docs/dev/release_notes)
 - [User guides](https://ragflow.io/docs/category/user-guides)
 - [Developer guides](https://ragflow.io/docs/category/developer-guides)

--- a/admin/server/config.py
+++ b/admin/server/config.py
@@ -121,6 +121,23 @@ class InfinityConfig(RetrievalConfig):
         return result
 
 
+class QdrantConfig(RetrievalConfig):
+    grpc_port: int
+    https: bool
+    prefer_grpc: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        result = super().to_dict()
+        if 'extra' not in result:
+            result['extra'] = dict()
+        extra_dict = result['extra'].copy()
+        extra_dict['grpc_port'] = self.grpc_port
+        extra_dict['https'] = self.https
+        extra_dict['prefer_grpc'] = self.prefer_grpc
+        result['extra'] = extra_dict
+        return result
+
+
 class ElasticsearchConfig(RetrievalConfig):
     username: str
     password: str
@@ -221,6 +238,16 @@ class MinioConfig(FileStoreConfig):
         return result
 
 
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in ("true", "1", "yes", "on")
+    return bool(value)
+
+
 def load_configurations(config_path: str) -> list[BaseConfig]:
     raw_configs = read_config(config_path)
     configurations = []
@@ -262,6 +289,18 @@ def load_configurations(config_path: str) -> list[BaseConfig]:
                 config = InfinityConfig(id=id_count, name=name, host=host, port=port, service_type="retrieval",
                                         retrieval_type="infinity",
                                         db_name=database, detail_func_name="get_infinity_status")
+                configurations.append(config)
+                id_count += 1
+            case "qdrant":
+                name: str = 'qdrant'
+                host: str = v.get('host', 'qdrant')
+                http_port: int = int(v.get('http_port', 6333))
+                grpc_port: int = int(v.get('grpc_port', 6334))
+                https: bool = _as_bool(v.get('https', False))
+                prefer_grpc: bool = _as_bool(v.get('prefer_grpc', False))
+                config = QdrantConfig(id=id_count, name=name, host=host, port=http_port, service_type="retrieval",
+                                      retrieval_type="qdrant", grpc_port=grpc_port, https=https,
+                                      prefer_grpc=prefer_grpc, detail_func_name="get_qdrant_status")
                 configurations.append(config)
                 id_count += 1
             case "minio":

--- a/api/apps/chunk_app.py
+++ b/api/apps/chunk_app.py
@@ -40,6 +40,7 @@ from api.utils.api_utils import (
 from common.misc_utils import thread_pool_exec
 from rag.app.qa import beAdoc, rmPrefix
 from rag.app.tag import label_question
+from rag.utils.sparse_vector import attach_sparse_vector, build_sparse_text
 from rag.nlp import rag_tokenizer, search
 from rag.prompts.generator import cross_languages, keyword_extraction
 from common.string_utils import remove_redundant_spaces
@@ -195,6 +196,10 @@ async def set():
             v, c = embd_mdl.encode([doc.name, content_with_weight if not _d.get("question_kwd") else "\n".join(_d["question_kwd"])])
             v = 0.1 * v[0] + 0.9 * v[1] if doc.parser_id != ParserType.QA else v[1]
             _d["q_%d_vec" % len(v)] = v.tolist()
+            if embd_mdl.supports_sparse():
+                sparse_query = build_sparse_text(doc.name, _d.get("question_kwd") or content_with_weight)
+                sparse_vector, _ = embd_mdl.encode_sparse_queries(sparse_query)
+                attach_sparse_vector(_d, sparse_vector)
             settings.docStoreConn.update({"id": req["chunk_id"]}, _d, search.index_name(tenant_id), doc.kb_id)
 
             # update image
@@ -374,6 +379,10 @@ async def create():
             v, c = embd_mdl.encode([doc.name, req["content_with_weight"] if not d["question_kwd"] else "\n".join(d["question_kwd"])])
             v = 0.1 * v[0] + 0.9 * v[1]
             d["q_%d_vec" % len(v)] = v.tolist()
+            if embd_mdl.supports_sparse():
+                sparse_query = build_sparse_text(doc.name, d["question_kwd"] or req["content_with_weight"])
+                sparse_vector, _ = embd_mdl.encode_sparse_queries(sparse_query)
+                attach_sparse_vector(d, sparse_vector)
             settings.docStoreConn.insert([d], search.index_name(tenant_id), doc.kb_id)
 
             if image_base64:

--- a/api/apps/sdk/doc.py
+++ b/api/apps/sdk/doc.py
@@ -42,6 +42,7 @@ from api.utils.api_utils import check_duplicate_ids, construct_json_result, get_
     get_request_json
 from rag.app.qa import beAdoc, rmPrefix
 from rag.app.tag import label_question
+from rag.utils.sparse_vector import attach_sparse_vector, build_sparse_text
 from rag.nlp import rag_tokenizer, search
 from rag.prompts.generator import cross_languages, keyword_extraction
 from common.string_utils import remove_redundant_spaces
@@ -1274,6 +1275,10 @@ async def add_chunk(tenant_id, dataset_id, document_id):
     v, c = embd_mdl.encode([doc.name, req["content"] if not d["question_kwd"] else "\n".join(d["question_kwd"])])
     v = 0.1 * v[0] + 0.9 * v[1]
     d["q_%d_vec" % len(v)] = v.tolist()
+    if embd_mdl.supports_sparse():
+        sparse_query = build_sparse_text(doc.name, d["question_kwd"] or req["content"])
+        sparse_vector, _ = embd_mdl.encode_sparse_queries(sparse_query)
+        attach_sparse_vector(d, sparse_vector)
     settings.docStoreConn.insert([d], search.index_name(tenant_id), dataset_id)
 
     if image_base64:
@@ -1503,6 +1508,10 @@ async def update_chunk(tenant_id, dataset_id, document_id, chunk_id):
     v, c = embd_mdl.encode([doc.name, d["content_with_weight"] if not d.get("question_kwd") else "\n".join(d["question_kwd"])])
     v = 0.1 * v[0] + 0.9 * v[1] if doc.parser_id != ParserType.QA else v[1]
     d["q_%d_vec" % len(v)] = v.tolist()
+    if embd_mdl.supports_sparse():
+        sparse_query = build_sparse_text(doc.name, d.get("question_kwd") or d["content_with_weight"])
+        sparse_vector, _ = embd_mdl.encode_sparse_queries(sparse_query)
+        attach_sparse_vector(d, sparse_vector)
     settings.docStoreConn.update({"id": chunk_id}, d, search.index_name(tenant_id), dataset_id)
     return get_result()
 

--- a/api/db/joint_services/memory_message_service.py
+++ b/api/db/joint_services/memory_message_service.py
@@ -261,6 +261,9 @@ def query_message(filter_dict: dict, params: dict):
 
 
 def init_message_id_sequence():
+    if not getattr(settings.msgStoreConn, "supported", True):
+        logging.info("Message store is not supported for DOC_ENGINE=%s, skipping message_id initialization.", settings.DOC_ENGINE)
+        return
     message_id_redis_key = "id_generator:memory"
     if REDIS_CONN.exist(message_id_redis_key):
         current_max_id = REDIS_CONN.get(message_id_redis_key)
@@ -309,6 +312,9 @@ def decrease_memory_size_cache(memory_id: str, size: int):
 
 
 def init_memory_size_cache():
+    if not getattr(settings.msgStoreConn, "supported", True):
+        logging.info("Message store is not supported for DOC_ENGINE=%s, skipping memory size cache initialization.", settings.DOC_ENGINE)
+        return
     memory_list = MemoryService.get_all_memory()
     if not memory_list:
         logging.info("No memory found, no need to init memory size.")

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -788,6 +788,9 @@ async def use_sql(question, field_map, tenant_id, chat_mdl, quota=True, kb_ids=N
         doc_engine = "infinity"
     elif settings.DOC_ENGINE_OCEANBASE:
         doc_engine = "oceanbase"
+    elif settings.DOC_ENGINE.strip().lower() == "qdrant":
+        logging.info("use_sql: Qdrant backend does not support SQL retrieval.")
+        return None
     else:
         doc_engine = "es"
 

--- a/api/db/services/doc_metadata_service.py
+++ b/api/db/services/doc_metadata_service.py
@@ -386,7 +386,7 @@ class DocMetadataService:
                 logging.error(f"Failed to insert metadata for document {doc_id}: {result}")
                 return False
             # Force ES refresh to make metadata immediately available for search
-            if not settings.DOC_ENGINE_INFINITY:
+            if hasattr(settings.docStoreConn, "es"):
                 try:
                     settings.docStoreConn.es.indices.refresh(index=index_name)
                     logging.debug(f"Refreshed metadata index: {index_name}")
@@ -438,7 +438,7 @@ class DocMetadataService:
 
             logging.debug(f"[update_document_metadata] Updating doc_id: {doc_id}, kb_id: {kb_id}, meta_fields: {processed_meta}")
 
-            # For Elasticsearch, use efficient partial update
+            # For engines with document-level update support, update in place.
             if not settings.DOC_ENGINE_INFINITY and not settings.DOC_ENGINE_OCEANBASE:
                 # Check if index exists first
                 index_exists = settings.docStoreConn.index_exist(index_name, "")
@@ -453,21 +453,17 @@ class DocMetadataService:
 
                 # Index exists - check if document exists
                 try:
-                    doc_exists = settings.docStoreConn.get(
-                        index_name=index_name,
-                        id=doc_id,
-                        kb_id=kb_id
-                    )
+                    doc_exists = settings.docStoreConn.get(doc_id, index_name, [""])
                     if doc_exists:
-                        # Document exists - use partial update
-                        settings.docStoreConn.es.update(
-                            index=index_name,
-                            id=doc_id,
-                            refresh=True,
-                            doc={"meta_fields": processed_meta}
+                        updated = settings.docStoreConn.update(
+                            {"id": doc_id},
+                            {"meta_fields": processed_meta},
+                            index_name,
+                            kb_id,
                         )
-                        logging.debug(f"Successfully updated metadata for document {doc_id} using ES partial update")
-                        return True
+                        if updated:
+                            logging.debug(f"Successfully updated metadata for document {doc_id}")
+                        return updated
                 except Exception as e:
                     logging.debug(f"Document {doc_id} not found in index, will insert: {e}")
 
@@ -574,59 +570,20 @@ class DocMetadataService:
 
             logging.debug(f"[DROP EMPTY TABLE] Table {index_name} exists, checking if empty...")
 
-            # Use ES count API for accurate count
-            # Note: No need to refresh since delete operation already uses refresh=True
-            try:
-                count_response = settings.docStoreConn.es.count(index=index_name)
-                total_count = count_response['count']
-                logging.debug(f"[DROP EMPTY TABLE] ES count API result: {total_count} documents")
-                is_empty = (total_count == 0)
-            except Exception as e:
-                logging.warning(f"[DROP EMPTY TABLE] Count API failed, falling back to search: {e}")
-                # Fallback to search if count fails
-                results = settings.docStoreConn.search(
-                    select_fields=["id"],
-                    highlight_fields=[],
-                    condition={},
-                    match_expressions=[],
-                    order_by=OrderByExpr(),
-                    offset=0,
-                    limit=1,  # Only need 1 result to know if table is non-empty
-                    index_names=index_name,
-                    knowledgebase_ids=[""]  # Metadata tables don't filter by KB
-                )
-
-                logging.debug(f"[DROP EMPTY TABLE] Search results type: {type(results)}, results: {results}")
-
-                # Check if empty based on return type (fallback search only)
-                if isinstance(results, tuple) and len(results) == 2:
-                    # Infinity returns (DataFrame, int)
-                    df, total = results
-                    logging.debug(f"[DROP EMPTY TABLE] Infinity format - total: {total}, df length: {len(df) if hasattr(df, '__len__') else 'N/A'}")
-                    is_empty = (total == 0 or (hasattr(df, '__len__') and len(df) == 0))
-                elif hasattr(results, 'get') and 'hits' in results:
-                    # ES format - MUST check this before hasattr(results, '__len__')
-                    # because ES response objects also have __len__
-                    total = results.get('hits', {}).get('total', {})
-                    hits = results.get('hits', {}).get('hits', [])
-
-                    # ES 7.x+: total is a dict like {'value': 0, 'relation': 'eq'}
-                    # ES 6.x: total is an int
-                    if isinstance(total, dict):
-                        total_count = total.get('value', 0)
-                    else:
-                        total_count = total
-
-                    logging.debug(f"[DROP EMPTY TABLE] ES format - total: {total_count}, hits count: {len(hits)}")
-                    is_empty = (total_count == 0 or len(hits) == 0)
-                elif hasattr(results, '__len__'):
-                    # DataFrame or list (check this AFTER ES format)
-                    result_len = len(results)
-                    logging.debug(f"[DROP EMPTY TABLE] List/DataFrame format - length: {result_len}")
-                    is_empty = result_len == 0
-                else:
-                    logging.warning(f"[DROP EMPTY TABLE] Unknown result format: {type(results)}")
-                    is_empty = False
+            results = settings.docStoreConn.search(
+                select_fields=["id"],
+                highlight_fields=[],
+                condition={},
+                match_expressions=[],
+                order_by=OrderByExpr(),
+                offset=0,
+                limit=1,
+                index_names=index_name,
+                knowledgebase_ids=[""],
+            )
+            total_count = settings.docStoreConn.get_total(results) if results is not None else 0
+            logging.debug(f"[DROP EMPTY TABLE] Generic count result: {total_count} documents")
+            is_empty = (total_count == 0)
 
             if is_empty:
                 logging.debug(f"[DROP EMPTY TABLE] Metadata table {index_name} is empty, dropping it")

--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -36,6 +36,7 @@ from api.db.services.doc_metadata_service import DocMetadataService
 from common.misc_utils import get_uuid
 from common.time_utils import current_timestamp, get_format_time
 from common.constants import LLMType, ParserType, StatusEnum, TaskStatus, SVR_CONSUMER_GROUP_NAME
+from rag.utils.sparse_vector import attach_sparse_vector
 from rag.nlp import rag_tokenizer, search
 from rag.utils.redis_conn import REDIS_CONN
 from common.doc_store.doc_store_base import OrderByExpr
@@ -1088,12 +1089,16 @@ def doc_upload_and_parse(conversation_id, file_objs, user_id):
     def embedding(doc_id, cnts, batch_size=16):
         nonlocal embd_mdl, chunk_counts, token_counts
         vectors = []
+        sparse_vectors = []
         for i in range(0, len(cnts), batch_size):
             vts, c = embd_mdl.encode(cnts[i : i + batch_size])
             vectors.extend(vts.tolist())
+            if embd_mdl.supports_sparse():
+                sparse_vts, _ = embd_mdl.encode_sparse(cnts[i : i + batch_size])
+                sparse_vectors.extend(sparse_vts)
             chunk_counts[doc_id] += len(cnts[i : i + batch_size])
             token_counts[doc_id] += c
-        return vectors
+        return vectors, sparse_vectors
 
     idxnm = search.index_name(kb.tenant_id)
     try_create_idx = True
@@ -1128,11 +1133,13 @@ def doc_upload_and_parse(conversation_id, file_objs, user_id):
             except Exception:
                 logging.exception("Mind map generation error")
 
-        vectors = embedding(doc_id, [c["content_with_weight"] for c in cks])
+        vectors, sparse_vectors = embedding(doc_id, [c["content_with_weight"] for c in cks])
         assert len(cks) == len(vectors)
         for i, d in enumerate(cks):
             v = vectors[i]
             d["q_%d_vec" % len(v)] = v
+            if sparse_vectors:
+                attach_sparse_vector(d, sparse_vectors[i])
         for b in range(0, len(cks), es_bulk_size):
             if try_create_idx:
                 if not settings.docStoreConn.index_exist(idxnm, kb_id):

--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -133,6 +133,19 @@ class LLMBundle(LLM4Tenant):
 
         return emd, used_tokens
 
+    def supports_sparse(self) -> bool:
+        return hasattr(self.mdl, "supports_sparse") and self.mdl.supports_sparse()
+
+    def encode_sparse(self, texts: list):
+        if not self.supports_sparse():
+            return [], 0
+        return self.mdl.encode_sparse(texts)
+
+    def encode_sparse_queries(self, query: str):
+        if not self.supports_sparse():
+            return None, 0
+        return self.mdl.encode_sparse_queries(query)
+
     def similarity(self, query: str, texts: list):
         if self.langfuse:
             generation = self.langfuse.start_generation(trace_context=self.trace_context, name="similarity", model=self.model_config["llm_name"], input={"query": query, "texts": texts})

--- a/api/utils/health_utils.py
+++ b/api/utils/health_utils.py
@@ -101,6 +101,22 @@ def get_infinity_status():
         }
 
 
+def get_qdrant_status():
+    doc_engine = os.getenv('DOC_ENGINE', 'elasticsearch')
+    if doc_engine != 'qdrant':
+        raise Exception("Qdrant is not in use.")
+    try:
+        return {
+            "status": "alive",
+            "message": settings.docStoreConn.health()
+        }
+    except Exception as e:
+        return {
+            "status": "timeout",
+            "message": f"error: {str(e)}",
+        }
+
+
 def get_oceanbase_status():
     """
     Get OceanBase health status and performance metrics.

--- a/common/settings.py
+++ b/common/settings.py
@@ -289,7 +289,7 @@ def init_settings():
         OS = get_base_config("os", {})
         docStoreConn = rag.utils.opensearch_conn.OSConnection()
     elif lower_case_doc_engine == "qdrant":
-        import rag.utils.qdrant_conn
+        from rag.utils import qdrant_conn as qdrant_conn_module
 
         QDRANT = get_base_config("qdrant", {
             "host": "qdrant",
@@ -302,7 +302,7 @@ def init_settings():
             "sparse_vocab_size": 131072,
             "text_index_tokenizer": "multilingual",
         })
-        docStoreConn = rag.utils.qdrant_conn.QdrantConnection()
+        docStoreConn = qdrant_conn_module.QdrantConnection()
     elif lower_case_doc_engine == "oceanbase":
         OB = get_base_config("oceanbase", {})
         docStoreConn = rag.utils.ob_conn.OBConnection()

--- a/common/settings.py
+++ b/common/settings.py
@@ -81,6 +81,7 @@ OAUTH_CONFIG = None
 DOC_ENGINE = os.getenv('DOC_ENGINE', 'elasticsearch')
 DOC_ENGINE_INFINITY = (DOC_ENGINE.lower() == "infinity")
 DOC_ENGINE_OCEANBASE = (DOC_ENGINE.lower() == "oceanbase")
+DOC_ENGINE_QDRANT = (DOC_ENGINE.lower() == "qdrant")
 
 
 docStoreConn = None
@@ -119,6 +120,7 @@ OB = {}
 OSS = {}
 OS = {}
 GCS = {}
+QDRANT = {}
 
 DOC_MAXIMUM_SIZE: int = 128 * 1024 * 1024
 DOC_BULK_SIZE: int = 4
@@ -128,6 +130,16 @@ PARALLEL_DEVICES: int = 0
 
 STORAGE_IMPL_TYPE = os.getenv('STORAGE_IMPL', 'MINIO')
 STORAGE_IMPL = None
+
+
+class UnsupportedMessageStoreConnection:
+    supported = False
+
+    def __init__(self, doc_engine: str):
+        self.doc_engine = doc_engine
+
+    def __getattr__(self, name):
+        raise NotImplementedError(f"Message store is not supported for DOC_ENGINE={self.doc_engine}.")
 
 def get_svr_queue_name(priority: int) -> str:
     if priority == 0:
@@ -257,10 +269,11 @@ def init_settings():
     FEISHU_OAUTH = get_base_config("oauth", {}).get("feishu")
     OAUTH_CONFIG = get_base_config("oauth", {})
 
-    global DOC_ENGINE, DOC_ENGINE_INFINITY, DOC_ENGINE_OCEANBASE, docStoreConn, ES, OB, OS, INFINITY
+    global DOC_ENGINE, DOC_ENGINE_INFINITY, DOC_ENGINE_OCEANBASE, DOC_ENGINE_QDRANT, docStoreConn, ES, OB, OS, INFINITY, QDRANT
     DOC_ENGINE = os.environ.get("DOC_ENGINE", "elasticsearch").strip()
     DOC_ENGINE_INFINITY = (DOC_ENGINE.lower() == "infinity")
     DOC_ENGINE_OCEANBASE = (DOC_ENGINE.lower() == "oceanbase")
+    DOC_ENGINE_QDRANT = (DOC_ENGINE.lower() == "qdrant")
     lower_case_doc_engine = DOC_ENGINE.lower()
     if lower_case_doc_engine == "elasticsearch":
         ES = get_base_config("es", {})
@@ -275,6 +288,21 @@ def init_settings():
     elif lower_case_doc_engine == "opensearch":
         OS = get_base_config("os", {})
         docStoreConn = rag.utils.opensearch_conn.OSConnection()
+    elif lower_case_doc_engine == "qdrant":
+        import rag.utils.qdrant_conn
+
+        QDRANT = get_base_config("qdrant", {
+            "host": "qdrant",
+            "http_port": 6333,
+            "grpc_port": 6334,
+            "https": False,
+            "prefer_grpc": False,
+            "timeout": 10,
+            "sparse_model": "",
+            "sparse_vocab_size": 131072,
+            "text_index_tokenizer": "multilingual",
+        })
+        docStoreConn = rag.utils.qdrant_conn.QdrantConnection()
     elif lower_case_doc_engine == "oceanbase":
         OB = get_base_config("oceanbase", {})
         docStoreConn = rag.utils.ob_conn.OBConnection()
@@ -286,18 +314,22 @@ def init_settings():
 
     global msgStoreConn
     # use the same engine for message store
-    if DOC_ENGINE == "elasticsearch":
+    if lower_case_doc_engine == "elasticsearch":
         ES = get_base_config("es", {})
         msgStoreConn = memory_es_conn.ESConnection()
-    elif DOC_ENGINE == "infinity":
+    elif lower_case_doc_engine == "infinity":
         INFINITY = get_base_config("infinity", {
             "uri": "infinity:23817",
             "postgres_port": 5432,
             "db_name": "default_db"
         })
         msgStoreConn = memory_infinity_conn.InfinityConnection()
+    elif lower_case_doc_engine == "qdrant":
+        msgStoreConn = UnsupportedMessageStoreConnection(DOC_ENGINE)
     elif lower_case_doc_engine in ["oceanbase", "seekdb"]:
         msgStoreConn = memory_ob_conn.OBConnection()
+    else:
+        msgStoreConn = None
 
     global AZURE, S3, MINIO, OSS, GCS
     if STORAGE_IMPL_TYPE in ['AZURE_SPN', 'AZURE_SAS']:
@@ -410,4 +442,3 @@ def _resolve_per_model_config(entry_dict, backup_factory, backup_api_key, backup
 def print_rag_settings():
     logging.info(f"MAX_CONTENT_LENGTH: {DOC_MAXIMUM_SIZE}")
     logging.info(f"MAX_FILE_COUNT_PER_USER: {int(os.environ.get('MAX_FILE_NUM_PER_USER', 0))}")
-

--- a/docker/.env
+++ b/docker/.env
@@ -14,6 +14,7 @@
 # Available options:
 # - `elasticsearch` (default)
 # - `infinity` (https://github.com/infiniflow/infinity)
+# - `qdrant` (https://qdrant.tech/)
 # - `oceanbase` (https://github.com/oceanbase/oceanbase)
 # - `opensearch` (https://github.com/opensearch-project/OpenSearch)
 # - `seekdb` (https://github.com/oceanbase/seekdb)
@@ -71,6 +72,16 @@ INFINITY_HOST=infinity
 INFINITY_THRIFT_PORT=23817
 INFINITY_HTTP_PORT=23820
 INFINITY_PSQL_PORT=5432
+
+# The hostname where the Qdrant service is exposed
+QDRANT_HOST=qdrant
+# Ports to expose Qdrant HTTP and gRPC APIs
+QDRANT_HTTP_PORT=6333
+QDRANT_GRPC_PORT=6334
+# Optional sparse retrieval support for the Qdrant backend. Leave empty for dense-only.
+QDRANT_SPARSE_MODEL=
+QDRANT_SPARSE_VOCAB_SIZE=131072
+QDRANT_TEXT_INDEX_TOKENIZER=multilingual
 
 # The hostname where the OceanBase service is exposed
 OCEANBASE_HOST=oceanbase

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -96,6 +96,25 @@ services:
       retries: 120
     restart: unless-stopped
 
+  qdrant:
+    profiles:
+      - qdrant
+    image: qdrant/qdrant:latest
+    ports:
+      - ${QDRANT_HTTP_PORT}:6333
+      - ${QDRANT_GRPC_PORT}:6334
+    env_file: .env
+    volumes:
+      - qdrant_data:/qdrant/storage
+    networks:
+      - ragflow
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/collections"]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+    restart: unless-stopped
+
   oceanbase:
     profiles:
       - oceanbase
@@ -304,6 +323,8 @@ volumes:
   osdata01:
     driver: local
   infinity_data:
+    driver: local
+  qdrant_data:
     driver: local
   ob_data:
     driver: local

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,7 @@
 include:
   - ./docker-compose-base.yml
 # To ensure that the container processes the locally modified `service_conf.yaml.template` instead of the one included in its image, you need to mount the local `service_conf.yaml.template` to the container.
+# Set `DOC_ENGINE=qdrant` to activate the Qdrant profile declared in `docker-compose-base.yml`.
 services:
   ragflow-cpu:
     depends_on:

--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -35,6 +35,16 @@ infinity:
   uri: '${INFINITY_HOST:-infinity}:23817'
   postgres_port: 5432
   db_name: 'default_db'
+qdrant:
+  host: '${QDRANT_HOST:-qdrant}'
+  http_port: ${QDRANT_HTTP_PORT:-6333}
+  grpc_port: ${QDRANT_GRPC_PORT:-6334}
+  https: false
+  prefer_grpc: false
+  timeout: 10
+  sparse_model: '${QDRANT_SPARSE_MODEL:-}'
+  sparse_vocab_size: ${QDRANT_SPARSE_VOCAB_SIZE:-131072}
+  text_index_tokenizer: '${QDRANT_TEXT_INDEX_TOKENIZER:-multilingual}'
 oceanbase:
   scheme: 'oceanbase' # set 'mysql' to create connection using mysql config
   config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dependencies = [
     "python-pptx>=1.0.2,<2.0.0",
     # "pywencai>=0.13.1,<1.0.0",  # Temporarily disabled: conflicts with agentrun-sdk (pydash>=8), needed for agent/tools/wencai.py
     "qianfan==0.4.6",
+    "qdrant-client>=1.11.0,<2.0.0",
     "quart-auth==0.11.0",
     "quart-cors==0.8.0",
     "ranx==0.3.20",

--- a/rag/graphrag/general/index.py
+++ b/rag/graphrag/general/index.py
@@ -598,7 +598,8 @@ async def extract_community(
     for b in range(0, len(chunks), es_bulk_size):
         doc_store_result = await thread_pool_exec(settings.docStoreConn.insert,chunks[b : b + es_bulk_size],search.index_name(tenant_id),kb_id,)
         if doc_store_result:
-            error_message = f"Insert chunk error: {doc_store_result}, please check log file and Elasticsearch/Infinity status!"
+            doc_engine = getattr(settings, "DOC_ENGINE", "") or "doc engine"
+            error_message = f"Insert chunk error: {doc_store_result}, please check log file and {doc_engine} status!"
             raise Exception(error_message)
 
     if task_id and has_canceled(task_id):

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -570,7 +570,8 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
         if b % 100 == es_bulk_size and callback:
             callback(msg=f"Insert chunks: {b}/{len(chunks)}")
         if doc_store_result:
-            error_message = f"Insert chunk error: {doc_store_result}, please check log file and Elasticsearch/Infinity status!"
+            doc_engine = getattr(settings, "DOC_ENGINE", "") or "doc engine"
+            error_message = f"Insert chunk error: {doc_store_result}, please check log file and {doc_engine} status!"
             raise Exception(error_message)
     now = asyncio.get_running_loop().time()
     if callback:

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -32,6 +32,8 @@ from common import settings
 import logging
 import base64
 
+from rag.utils.sparse_vector import get_sparse_embedding_model
+
 
 class Base(ABC):
     def __init__(self, key, model_name, **kwargs):
@@ -47,6 +49,21 @@ class Base(ABC):
 
     def encode_queries(self, text: str):
         raise NotImplementedError("Please implement encode method!")
+
+    def supports_sparse(self) -> bool:
+        return get_sparse_embedding_model() is not None
+
+    def encode_sparse(self, texts: list):
+        model = get_sparse_embedding_model()
+        if model is None:
+            return [], 0
+        return model.encode(texts)
+
+    def encode_sparse_queries(self, text: str):
+        model = get_sparse_embedding_model()
+        if model is None:
+            return None, 0
+        return model.encode_queries(text)
 
 
 class BuiltinEmbed(Base):

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -22,7 +22,8 @@ from dataclasses import dataclass
 
 from rag.nlp import rag_tokenizer, query
 import numpy as np
-from common.doc_store.doc_store_base import MatchDenseExpr, FusionExpr, OrderByExpr, DocStoreConnection
+from common.doc_store.doc_store_base import MatchDenseExpr, FusionExpr, MatchSparseExpr, OrderByExpr, DocStoreConnection
+from rag.utils.sparse_vector import SPARSE_VECTOR_NAME, dense_vector_field_name
 from common.string_utils import remove_redundant_spaces
 from common.float_utils import get_float
 from common.constants import PAGERANK_FLD, TAG_FLD
@@ -43,11 +44,14 @@ class Dealer:
         total: int
         ids: list[str]
         query_vector: list[float] | None = None
+        query_sparse_vector: object | None = None
+        retrieval_vector_field: str | None = None
         field: dict | None = None
         highlight: dict | None = None
         aggregation: list | dict | None = None
         keywords: list[str] | None = None
         group_docs: list[list] | None = None
+        backend_ranked: bool = False
 
     async def get_vector(self, txt, emb_mdl, topk=10, similarity=0.1):
         qv, _ = await thread_pool_exec(emb_mdl.encode_queries, txt)
@@ -56,7 +60,7 @@ class Dealer:
             raise Exception(
                 f"Dealer.get_vector returned array's shape {shape} doesn't match expectation(exact one dimension).")
         embedding_data = [get_float(v) for v in qv]
-        vector_column_name = f"q_{len(embedding_data)}_vec"
+        vector_column_name = dense_vector_field_name(len(embedding_data))
         return MatchDenseExpr(vector_column_name, embedding_data, 'float', 'cosine', topk, {"similarity": similarity})
 
     def get_filters(self, req):
@@ -97,6 +101,9 @@ class Dealer:
 
         qst = req.get("question", "")
         q_vec = []
+        q_sparse_vec = None
+        retrieval_vector_field = None
+        backend_ranked = False
         if not qst:
             if req.get("sort"):
                 orderBy.asc("page_num_int")
@@ -121,11 +128,25 @@ class Dealer:
             else:
                 matchDense = await self.get_vector(qst, emb_mdl, topk, req.get("similarity", 0.1))
                 q_vec = matchDense.embedding_data
+                retrieval_vector_field = matchDense.vector_column_name
                 if not settings.DOC_ENGINE_INFINITY:
-                    src.append(f"q_{len(q_vec)}_vec")
+                    src.append(retrieval_vector_field)
 
-                fusionExpr = FusionExpr("weighted_sum", topk, {"weights": "0.05,0.95"})
-                matchExprs = [matchText, matchDense, fusionExpr]
+                matchExprs = [matchText, matchDense]
+                if settings.DOC_ENGINE_QDRANT and hasattr(emb_mdl, "supports_sparse") and emb_mdl.supports_sparse():
+                    # ColPali/ColQwen PR hook:
+                    # add the visual query object here and mark the result as a
+                    # backend-ranked multimodal retrieval instead of text hybrid.
+                    q_sparse_vec, _ = await thread_pool_exec(emb_mdl.encode_sparse_queries, qst)
+                    if q_sparse_vec is not None and getattr(q_sparse_vec, "indices", None):
+                        matchExprs.append(MatchSparseExpr(SPARSE_VECTOR_NAME, q_sparse_vec, "dot", topk))
+                        fusionExpr = FusionExpr("rrf", topk)
+                        backend_ranked = True
+                    else:
+                        fusionExpr = FusionExpr("weighted_sum", topk, {"weights": "0.05,0.95"})
+                else:
+                    fusionExpr = FusionExpr("weighted_sum", topk, {"weights": "0.05,0.95"})
+                matchExprs.append(fusionExpr)
 
                 res = await thread_pool_exec(self.dataStore.search, src, highlightFields, filters, matchExprs, orderBy, offset, limit,
                                             idx_names, kb_ids, rank_feature=rank_feature)
@@ -140,7 +161,11 @@ class Dealer:
                     else:
                         matchText, _ = self.qryr.question(qst, min_match=0.1)
                         matchDense.extra_options["similarity"] = 0.17
-                        res = await thread_pool_exec(self.dataStore.search, src, highlightFields, filters, [matchText, matchDense, fusionExpr],
+                        retry_exprs = [matchText, matchDense]
+                        if q_sparse_vec is not None and getattr(q_sparse_vec, "indices", None):
+                            retry_exprs.append(MatchSparseExpr(SPARSE_VECTOR_NAME, q_sparse_vec, "dot", topk))
+                        retry_exprs.append(fusionExpr)
+                        res = await thread_pool_exec(self.dataStore.search, src, highlightFields, filters, retry_exprs,
                                                     orderBy, offset, limit, idx_names, kb_ids,
                                                     rank_feature=rank_feature)
                         total = self.dataStore.get_total(res)
@@ -164,10 +189,13 @@ class Dealer:
             total=total,
             ids=ids,
             query_vector=q_vec,
+            query_sparse_vector=q_sparse_vec,
+            retrieval_vector_field=retrieval_vector_field,
             aggregation=aggs,
             highlight=highlight,
             field=self.dataStore.get_fields(res, src + ["_score"]),
-            keywords=keywords
+            keywords=keywords,
+            backend_ranked=backend_ranked,
         )
 
     @staticmethod
@@ -298,9 +326,10 @@ class Dealer:
                rank_feature: dict | None = None
                ):
         _, keywords = self.qryr.question(query)
-        vector_size = len(sres.query_vector)
-        vector_column = f"q_{vector_size}_vec"
-        zero_vector = [0.0] * vector_size
+        if not sres.query_vector:
+            return [], [], []
+        vector_column = sres.retrieval_vector_field or dense_vector_field_name(len(sres.query_vector))
+        zero_vector = [0.0] * len(sres.query_vector)
         ins_embd = []
         for chunk_id in sres.ids:
             vector = sres.field[chunk_id].get(vector_column, zero_vector)
@@ -413,7 +442,7 @@ class Dealer:
                 rank_feature=rank_feature,
             )
         else:
-            if settings.DOC_ENGINE_INFINITY:
+            if settings.DOC_ENGINE_INFINITY or (settings.DOC_ENGINE_QDRANT and sres.backend_ranked):
                 # Don't need rerank here since Infinity normalizes each way score before fusion.
                 sim = [sres.field[id].get("_score", 0.0) for id in sres.ids]
                 sim = [s if s is not None else 0.0 for s in sim]
@@ -458,9 +487,8 @@ class Dealer:
         end = begin + page_size
         page_idx = valid_idx[begin:end]
 
-        dim = len(sres.query_vector)
-        vector_column = f"q_{dim}_vec"
-        zero_vector = [0.0] * dim
+        vector_column = sres.retrieval_vector_field
+        zero_vector = [0.0] * len(sres.query_vector or [])
 
         for i in page_idx:
             id = sres.ids[i]
@@ -481,7 +509,11 @@ class Dealer:
                 "similarity": float(sim_np[i]),
                 "vector_similarity": float(vsim[i]),
                 "term_similarity": float(tsim[i]),
-                "vector": chunk.get(vector_column, zero_vector),
+                # ColPali/ColQwen PR hook:
+                # visual retrieval may not expose a single dense vector here.
+                # populate a page/image result payload alongside or instead of
+                # this field once the multimodal response contract is defined.
+                "vector": chunk.get(vector_column, zero_vector) if vector_column else zero_vector,
                 "positions": position_int,
                 "doc_type_kwd": chunk.get("doc_type_kwd", ""),
                 "mom_id": chunk.get("mom_id", ""),

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -134,9 +134,7 @@ class Dealer:
 
                 matchExprs = [matchText, matchDense]
                 if settings.DOC_ENGINE_QDRANT and hasattr(emb_mdl, "supports_sparse") and emb_mdl.supports_sparse():
-                    # ColPali/ColQwen PR hook:
-                    # add the visual query object here and mark the result as a
-                    # backend-ranked multimodal retrieval instead of text hybrid.
+                    # Future multivector retrieval should add the visual query object here.
                     q_sparse_vec, _ = await thread_pool_exec(emb_mdl.encode_sparse_queries, qst)
                     if q_sparse_vec is not None and getattr(q_sparse_vec, "indices", None):
                         matchExprs.append(MatchSparseExpr(SPARSE_VECTOR_NAME, q_sparse_vec, "dot", topk))
@@ -509,10 +507,7 @@ class Dealer:
                 "similarity": float(sim_np[i]),
                 "vector_similarity": float(vsim[i]),
                 "term_similarity": float(tsim[i]),
-                # ColPali/ColQwen PR hook:
-                # visual retrieval may not expose a single dense vector here.
-                # populate a page/image result payload alongside or instead of
-                # this field once the multimodal response contract is defined.
+                # Future multivector retrieval may replace this single dense vector field.
                 "vector": chunk.get(vector_column, zero_vector) if vector_column else zero_vector,
                 "positions": position_int,
                 "doc_type_kwd": chunk.get("doc_type_kwd", ""),

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -631,9 +631,7 @@ async def embedding(docs, mdl, parser_config=None, callback=None):
         v = vects[i].tolist()
         vector_size = len(v)
         d["q_%d_vec" % len(v)] = v
-        # ColPali/ColQwen PR hook:
-        # attach page/image vectors here before insert so the adapter can store
-        # both textual and visual retrieval features for the same chunk/page.
+        # Future multivector ingestion should attach page/image vectors here alongside text vectors.
         if sparse_vectors:
             attach_sparse_vector(d, sparse_vectors[i])
     return tk_count, vector_size
@@ -717,9 +715,7 @@ async def run_dataflow(task: dict):
             for i, ck in enumerate(chunks):
                 v = vects[i].tolist()
                 ck["q_%d_vec" % len(v)] = v
-                # ColPali/ColQwen PR hook:
-                # dataflow outputs will need to add visual vectors here once page
-                # rendering or image-region embeddings are available.
+                # Future multivector ingestion should add visual vectors here for dataflow outputs.
                 if sparse_vectors:
                     attach_sparse_vector(ck, sparse_vectors[i])
         except TaskCanceledException:

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -955,7 +955,8 @@ async def insert_chunks(task_id, task_tenant_id, task_dataset_id, chunks, progre
         if b % 128 == 0:
             progress_callback(prog=0.8 + 0.1 * (b + 1) / len(chunks), msg="")
         if doc_store_result:
-            error_message = f"Insert chunk error: {doc_store_result}, please check log file and Elasticsearch/Infinity status!"
+            doc_engine = getattr(settings, "DOC_ENGINE", "") or "doc engine"
+            error_message = f"Insert chunk error: {doc_store_result}, please check log file and {doc_engine} status!"
             progress_callback(-1, msg=error_message)
             raise Exception(error_message)
         chunk_ids = [chunk["id"] for chunk in chunks[:b + settings.DOC_BULK_SIZE]]

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -71,6 +71,7 @@ from api.db.db_models import close_connection
 from rag.app import laws, paper, presentation, manual, qa, table, book, resume, picture, naive, one, audio, \
     email, tag
 from rag.nlp import search, rag_tokenizer, add_positions
+from rag.utils.sparse_vector import attach_sparse_vector, build_sparse_text
 from rag.raptor import RecursiveAbstractiveProcessing4TreeOrganizedRetrieval as Raptor
 from common.token_utils import num_tokens_from_string, truncate
 from rag.utils.redis_conn import REDIS_CONN, RedisDistributedLock
@@ -585,6 +586,8 @@ async def embedding(docs, mdl, parser_config=None, callback=None):
         if not c:
             c = "None"
         cnts.append(c)
+    title_texts = list(tts)
+    content_texts = list(cnts)
 
     tk_count = 0
     if len(tts) == len(cnts):
@@ -617,12 +620,22 @@ async def embedding(docs, mdl, parser_config=None, callback=None):
     else:
         vects = cnts
 
+    sparse_vectors = []
+    if hasattr(mdl, "supports_sparse") and mdl.supports_sparse():
+        sparse_inputs = [build_sparse_text(title, content) for title, content in zip(title_texts, content_texts)]
+        sparse_vectors, _ = await thread_pool_exec(mdl.encode_sparse, sparse_inputs)
+
     assert len(vects) == len(docs)
     vector_size = 0
     for i, d in enumerate(docs):
         v = vects[i].tolist()
         vector_size = len(v)
         d["q_%d_vec" % len(v)] = v
+        # ColPali/ColQwen PR hook:
+        # attach page/image vectors here before insert so the adapter can store
+        # both textual and visual retrieval features for the same chunk/page.
+        if sparse_vectors:
+            attach_sparse_vector(d, sparse_vectors[i])
     return tk_count, vector_size
 
 
@@ -698,9 +711,17 @@ async def run_dataflow(task: dict):
                     set_progress(task_id, prog=prog, msg=f"{i + 1} / {len(texts) // settings.EMBEDDING_BATCH_SIZE}")
 
             assert len(vects) == len(chunks)
+            sparse_vectors = []
+            if embedding_model.supports_sparse():
+                sparse_vectors, _ = await thread_pool_exec(embedding_model.encode_sparse, texts)
             for i, ck in enumerate(chunks):
                 v = vects[i].tolist()
                 ck["q_%d_vec" % len(v)] = v
+                # ColPali/ColQwen PR hook:
+                # dataflow outputs will need to add visual vectors here once page
+                # rendering or image-region embeddings are available.
+                if sparse_vectors:
+                    attach_sparse_vector(ck, sparse_vectors[i])
         except TaskCanceledException:
             raise
         except Exception as e:

--- a/rag/utils/qdrant_conn.py
+++ b/rag/utils/qdrant_conn.py
@@ -29,7 +29,6 @@ from common.constants import PAGERANK_FLD, TAG_FLD
 from common.doc_store.doc_store_base import DocStoreConnection, FusionExpr, MatchDenseExpr, MatchExpr, MatchSparseExpr, MatchTextExpr, OrderByExpr, SparseVector
 from rag.utils.sparse_vector import (
     DENSE_VECTOR_NAME,
-    MULTIVECTOR_PLACEHOLDER_NAME,
     SPARSE_VECTOR_FIELD,
     SPARSE_VECTOR_NAME,
     dense_vector_field_name,
@@ -188,15 +187,7 @@ class QdrantConnection(DocStoreConnection):
         vectors_config = {
             DENSE_VECTOR_NAME: models.VectorParams(size=vector_size, distance=models.Distance.COSINE),
         }
-        # ColPali/ColQwen PR hook:
-        # add a second named vector or switch to a multivector config here, e.g.
-        # vectors_config[MULTIVECTOR_PLACEHOLDER_NAME] = models.VectorParams(
-        #     size=page_vector_size,
-        #     distance=models.Distance.COSINE,
-        #     multivector_config=models.MultiVectorConfig(
-        #         comparator=models.MultiVectorComparator.MAX_SIM,
-        #     ),
-        # )
+        # Future multivector extension point for ColPali/ColQwen-style page vectors.
         return vectors_config
 
     @staticmethod
@@ -476,9 +467,7 @@ class QdrantConnection(DocStoreConnection):
         query_filter = self._build_filter(condition, dataset_ids, collection_name)
         dense_options = dense_expr.extra_options or {}
         dense_similarity = dense_options.get("similarity")
-        # ColPali/ColQwen PR hook:
-        # route visual late-interaction retrieval through a sibling helper that
-        # swaps this dense+sparse RRF prefetch for the multivector query path.
+        # Future multivector retrieval should branch here instead of dense+sparse RRF.
         prefetch = [
             models.Prefetch(
                 query=list(dense_expr.embedding_data),
@@ -586,9 +575,7 @@ class QdrantConnection(DocStoreConnection):
                 dense_vector = self._metadata_vector()
             else:
                 raise ValueError(f"{point_id}:missing_dense_vector")
-        # ColPali/ColQwen PR hook:
-        # extend this vector builder with page/image vectors instead of replacing
-        # the primary dense text vector branch.
+        # Future multivector ingestion should add page/image vectors alongside the primary dense text vector.
         vector = {DENSE_VECTOR_NAME: list(dense_vector)} if self._is_metadata_index(collection_name) else self._default_named_vectors(dense_vector, sparse_vector)
         return point_id, vector_field, models.PointStruct(id=storage_point_id, vector=vector, payload=payload)
 
@@ -601,9 +588,7 @@ class QdrantConnection(DocStoreConnection):
             dense_vector = vectors.get(DENSE_VECTOR_NAME)
         elif vectors is not None:
             dense_vector = vectors
-        # ColPali/ColQwen PR hook:
-        # map additional named vectors or page-level multivector summaries back
-        # into response fields here when visual retrieval starts returning them.
+        # Future multivector retrieval should map page/image vectors back into response fields here.
         score = self._extract_point_score(point)
         score += self._rank_feature_score(payload, rank_feature)
         source = self._payload_with_vector_alias(payload, requested_vector_field, dense_vector, score)
@@ -750,7 +735,6 @@ class QdrantConnection(DocStoreConnection):
             if not records:
                 return None
             point = records[0]
-            payload = self._extract_payload(point)
             vector_field = None
             if not self._is_metadata_index(index_name):
                 dense_size = len((self._extract_vectors(point) or {}).get(DENSE_VECTOR_NAME, [])) if isinstance(self._extract_vectors(point), dict) else None
@@ -965,9 +949,7 @@ class QdrantConnection(DocStoreConnection):
                     payload[key] = value
                 vector = {DENSE_VECTOR_NAME: list(dense_vector or self._metadata_vector())}
                 if not self._is_metadata_index(index_name):
-                    # ColPali/ColQwen PR hook:
-                    # preserve any future page/image vectors here on partial
-                    # updates so text edits do not drop visual retrieval state.
+                    # Future multivector updates should preserve page/image vectors on partial updates.
                     vector[SPARSE_VECTOR_NAME] = sparse_vector if sparse_vector is not None else self._empty_sparse_vector()
                 updated_points.append(
                     models.PointStruct(

--- a/rag/utils/qdrant_conn.py
+++ b/rag/utils/qdrant_conn.py
@@ -1,0 +1,1049 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import copy
+import logging
+import re
+import time
+from typing import Any
+
+from qdrant_client import QdrantClient, models
+
+from common import settings
+from common.constants import PAGERANK_FLD, TAG_FLD
+from common.doc_store.doc_store_base import DocStoreConnection, FusionExpr, MatchDenseExpr, MatchExpr, MatchSparseExpr, MatchTextExpr, OrderByExpr, SparseVector
+from rag.utils.sparse_vector import (
+    DENSE_VECTOR_NAME,
+    MULTIVECTOR_PLACEHOLDER_NAME,
+    SPARSE_VECTOR_FIELD,
+    SPARSE_VECTOR_NAME,
+    dense_vector_field_name,
+)
+from rag.nlp import is_english, rag_tokenizer
+
+ATTEMPT_TIME = 2
+INIT_ATTEMPT_TIME = 24
+DEFAULT_SCROLL_BATCH_SIZE = 256
+METADATA_VECTOR_SIZE = 1
+METADATA_INDEX_PREFIX = "ragflow_doc_meta_"
+DEFAULT_TEXT_TOKENIZER = "multilingual"
+TEXT_INDEX_FIELDS = ("content_with_weight",)
+VECTOR_FIELD_RE = re.compile(r"q_(\d+)_vec$")
+
+
+class QdrantConnection(DocStoreConnection):
+    def __init__(self):
+        self.logger = logging.getLogger("ragflow.qdrant_conn")
+        conf = getattr(settings, "QDRANT", {}) or {}
+        scheme = "https" if self._to_bool(conf.get("https", False)) else "http"
+        host = conf.get("host", "qdrant")
+        http_port = int(conf.get("http_port", 6333))
+        self.prefer_grpc = self._to_bool(conf.get("prefer_grpc", False))
+        self.timeout = int(conf.get("timeout", 10))
+        api_key = conf.get("api_key") or None
+        self.url = conf.get("url") or f"{scheme}://{host}:{http_port}"
+        self.client = QdrantClient(
+            url=self.url,
+            api_key=api_key,
+            prefer_grpc=self.prefer_grpc,
+            timeout=self.timeout,
+        )
+        self._wait_until_healthy()
+        self.logger.info(f"Use Qdrant {self.url} as the doc engine.")
+
+    def _wait_until_healthy(self):
+        last_error = None
+        for _ in range(INIT_ATTEMPT_TIME):
+            try:
+                self.client.get_collections()
+                return
+            except Exception as error:
+                last_error = error
+                self.logger.warning(f"{error}. Waiting Qdrant {self.url} to be healthy.")
+                time.sleep(5)
+        msg = f"Qdrant {self.url} is unhealthy in 120s."
+        self.logger.error(msg)
+        raise Exception(msg) from last_error
+
+    @staticmethod
+    def _to_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    @staticmethod
+    def _is_metadata_index(index_name: str) -> bool:
+        return index_name.startswith(METADATA_INDEX_PREFIX)
+
+    @staticmethod
+    def _empty_response(agg_fields: list[str] | None = None):
+        res = {"hits": {"total": {"value": 0}, "hits": []}}
+        if agg_fields:
+            res["aggregations"] = {f"aggs_{fld}": {"buckets": []} for fld in agg_fields}
+        return res
+
+    @staticmethod
+    def _get_attr(obj: Any, *names: str):
+        cur = obj
+        for name in names:
+            if cur is None:
+                return None
+            if isinstance(cur, dict):
+                cur = cur.get(name)
+            else:
+                cur = getattr(cur, name, None)
+        return cur
+
+    @staticmethod
+    def _extract_payload(point: Any) -> dict:
+        payload = getattr(point, "payload", None)
+        if payload is None and isinstance(point, dict):
+            payload = point.get("payload")
+        return copy.deepcopy(payload or {})
+
+    @staticmethod
+    def _extract_point_id(point: Any):
+        if isinstance(point, dict):
+            return point.get("id")
+        return getattr(point, "id", None)
+
+    @staticmethod
+    def _extract_point_score(point: Any) -> float:
+        if isinstance(point, dict):
+            return float(point.get("score", 0.0) or 0.0)
+        score = getattr(point, "score", 0.0)
+        return float(score or 0.0)
+
+    @staticmethod
+    def _extract_vectors(point: Any):
+        if isinstance(point, dict):
+            return point.get("vector")
+        return getattr(point, "vector", None)
+
+    @classmethod
+    def _extract_dense_vector(cls, payload: dict):
+        for key in list(payload.keys()):
+            if not VECTOR_FIELD_RE.fullmatch(key):
+                continue
+            vector = payload.pop(key)
+            return key, vector
+        return None, None
+
+    @staticmethod
+    def _extract_sparse_vector(payload: dict) -> SparseVector | None:
+        raw = payload.pop(SPARSE_VECTOR_FIELD, None)
+        if raw is None:
+            return None
+        if isinstance(raw, SparseVector):
+            return raw
+        if isinstance(raw, dict) and "indices" in raw:
+            return SparseVector.from_dict(raw)
+        raise ValueError(f"Invalid sparse vector payload for field `{SPARSE_VECTOR_FIELD}`.")
+
+    @staticmethod
+    def _metadata_vector() -> list[float]:
+        return [0.0] * METADATA_VECTOR_SIZE
+
+    @staticmethod
+    def _named_vectors_config(vector_size: int):
+        vectors_config = {
+            DENSE_VECTOR_NAME: models.VectorParams(size=vector_size, distance=models.Distance.COSINE),
+        }
+        # ColPali/ColQwen PR hook:
+        # add a second named vector or switch to a multivector config here, e.g.
+        # vectors_config[MULTIVECTOR_PLACEHOLDER_NAME] = models.VectorParams(
+        #     size=page_vector_size,
+        #     distance=models.Distance.COSINE,
+        #     multivector_config=models.MultiVectorConfig(
+        #         comparator=models.MultiVectorComparator.MAX_SIM,
+        #     ),
+        # )
+        return vectors_config
+
+    @staticmethod
+    def _default_named_vectors(dense_vector: list[float], sparse_vector: SparseVector | dict | None = None):
+        vectors = {
+            DENSE_VECTOR_NAME: list(dense_vector),
+        }
+        vectors[SPARSE_VECTOR_NAME] = QdrantConnection._to_qdrant_sparse_vector(sparse_vector)
+        return vectors
+
+    @staticmethod
+    def _empty_sparse_vector():
+        return models.SparseVector(indices=[], values=[])
+
+    @staticmethod
+    def _to_qdrant_sparse_vector(sparse_vector: SparseVector | dict | None):
+        if sparse_vector is None:
+            return QdrantConnection._empty_sparse_vector()
+        if isinstance(sparse_vector, dict):
+            sparse_vector = SparseVector.from_dict(sparse_vector)
+        return models.SparseVector(indices=list(sparse_vector.indices), values=list(sparse_vector.values or []))
+
+    @classmethod
+    def _payload_with_vector_alias(cls, payload: dict, vector_name: str | None, vector: Any, score: float) -> dict:
+        doc = copy.deepcopy(payload)
+        if vector_name and vector is not None:
+            doc[vector_name] = vector
+        doc["_score"] = score
+        return doc
+
+    @staticmethod
+    def _requested_vector_field(select_fields: list[str]) -> str | None:
+        for field in select_fields:
+            if VECTOR_FIELD_RE.fullmatch(field):
+                return field
+        return None
+
+    @staticmethod
+    def _parse_field_weight(field_name: str) -> tuple[str, float]:
+        if "^" not in field_name:
+            return field_name, 1.0
+        base, weight = field_name.split("^", 1)
+        try:
+            return base, float(weight)
+        except Exception:
+            return base, 1.0
+
+    @staticmethod
+    def _normalize_text(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return " ".join(str(v) for v in value)
+        return str(value)
+
+    def _text_index_tokenizer(self):
+        tokenizer = str((getattr(settings, "QDRANT", {}) or {}).get("text_index_tokenizer", DEFAULT_TEXT_TOKENIZER)).strip().lower()
+        tokenizer_map = {
+            "prefix": models.TokenizerType.PREFIX,
+            "whitespace": models.TokenizerType.WHITESPACE,
+            "word": models.TokenizerType.WORD,
+            "multilingual": models.TokenizerType.MULTILINGUAL,
+        }
+        return tokenizer_map.get(tokenizer, models.TokenizerType.MULTILINGUAL)
+
+    @staticmethod
+    def _sparse_vector_params():
+        return models.SparseVectorParams(
+            index=models.SparseIndexParams(on_disk=True),
+            modifier=models.Modifier.IDF,
+        )
+
+    def _text_index_params(self):
+        return models.TextIndexParams(
+            type=models.TextIndexType.TEXT,
+            tokenizer=self._text_index_tokenizer(),
+            lowercase=True,
+            on_disk=True,
+        )
+
+    @classmethod
+    def _query_terms(cls, match_expr: MatchTextExpr | None) -> tuple[str, list[str]]:
+        if not match_expr:
+            return "", []
+        original = ""
+        if isinstance(match_expr.extra_options, dict):
+            original = match_expr.extra_options.get("original_query", "")
+        original = original or match_expr.matching_text or ""
+        tokens = [tk for tk in rag_tokenizer.tokenize(original).split() if tk]
+        return original, tokens
+
+    @classmethod
+    def _text_score(cls, payload: dict, match_expr: MatchTextExpr | None) -> float:
+        if not match_expr:
+            return 0.0
+        original_query, query_terms = cls._query_terms(match_expr)
+        if not original_query and not query_terms:
+            return 0.0
+        score = 0.0
+        original_lc = original_query.lower().strip()
+        for field in match_expr.fields:
+            base_field, weight = cls._parse_field_weight(field)
+            text = cls._normalize_text(payload.get(base_field)).lower()
+            if not text:
+                continue
+            token_hits = sum(1 for term in query_terms if term.lower() in text)
+            phrase_bonus = 1 if original_lc and original_lc in text else 0
+            score += weight * (token_hits + phrase_bonus)
+        return score
+
+    @staticmethod
+    def _rank_feature_score(payload: dict, rank_feature: dict | None) -> float:
+        if not rank_feature:
+            return 0.0
+        score = 0.0
+        for field, weight in rank_feature.items():
+            if field == PAGERANK_FLD:
+                value = payload.get(field, 0.0)
+                try:
+                    score += float(value) * float(weight)
+                except Exception:
+                    continue
+                continue
+            tag_values = payload.get(TAG_FLD, {})
+            if not isinstance(tag_values, dict):
+                continue
+            try:
+                score += float(tag_values.get(field, 0.0)) * float(weight)
+            except Exception:
+                continue
+        return score
+
+    @classmethod
+    def _match_field_condition(cls, point_id: str, payload: dict, key: str, value: Any) -> bool:
+        if key == "id":
+            if isinstance(value, list):
+                return point_id in value
+            return point_id == value
+        field_value = payload.get(key)
+        if key == "available_int":
+            try:
+                field_value_num = float(field_value or 0)
+                if value == 0:
+                    return field_value_num < 1
+                return field_value_num >= 1
+            except Exception:
+                return False
+        if isinstance(value, list):
+            return field_value in value
+        return field_value == value
+
+    @classmethod
+    def _matches_condition(cls, point_id: str, payload: dict, condition: dict) -> bool:
+        for key, value in (condition or {}).items():
+            if key == "exists":
+                if value not in payload:
+                    return False
+                continue
+            if key == "must_not":
+                if not isinstance(value, dict):
+                    continue
+                for sub_key, sub_value in value.items():
+                    if sub_key == "exists" and sub_value in payload:
+                        return False
+                    if sub_key in payload and payload.get(sub_key) == sub_value:
+                        return False
+                continue
+            if value is None:
+                continue
+            if not cls._match_field_condition(point_id, payload, key, value):
+                return False
+        return True
+
+    @staticmethod
+    def _sortable_value(value: Any):
+        if value is None:
+            return (1, None)
+        if isinstance(value, list):
+            return (0, tuple(value))
+        return (0, value)
+
+    @classmethod
+    def _sort_hits(cls, hits: list[dict], order_by: OrderByExpr | None) -> list[dict]:
+        if not order_by or not order_by.fields:
+            return hits
+        sorted_hits = hits
+        for field, direction in reversed(order_by.fields):
+            reverse = direction == 1
+            sorted_hits = sorted(
+                sorted_hits,
+                key=lambda hit: cls._sortable_value(hit["_source"].get(field)),
+                reverse=reverse,
+            )
+        return sorted_hits
+
+    @classmethod
+    def _highlight_hit(cls, payload: dict, highlight_fields: list[str], query_terms: list[str]) -> dict | None:
+        if not highlight_fields or not query_terms:
+            return None
+        highlights = {}
+        for field in highlight_fields:
+            raw_text = cls._normalize_text(payload.get(field))
+            if not raw_text:
+                continue
+            if not any(term.lower() in raw_text.lower() for term in query_terms):
+                continue
+            highlighted = raw_text
+            for term in query_terms[:16]:
+                highlighted = re.sub(re.escape(term), f"<em>{term}</em>", highlighted, flags=re.IGNORECASE)
+            highlights[field] = [highlighted]
+        return highlights or None
+
+    def _build_filter(self, condition: dict, dataset_ids: list[str], index_name: str):
+        must = []
+        must_not = []
+        if not self._is_metadata_index(index_name):
+            if dataset_ids:
+                condition = {**condition, "kb_id": dataset_ids}
+        for key, value in (condition or {}).items():
+            if value is None or key in {"exists", "must_not", "id"}:
+                continue
+            if key == "available_int":
+                if value == 0:
+                    must.append(models.FieldCondition(key=key, range=models.Range(lt=1)))
+                else:
+                    must_not.append(models.FieldCondition(key=key, range=models.Range(lt=1)))
+                continue
+            if isinstance(value, list):
+                must.append(models.FieldCondition(key=key, match=models.MatchAny(any=value)))
+            elif isinstance(value, (str, int, float, bool)):
+                must.append(models.FieldCondition(key=key, match=models.MatchValue(value=value)))
+            else:
+                raise Exception(
+                    f"Condition `{str(key)}={str(value)}` value type is {str(type(value))}, expected to be int, str or list."
+                )
+        if not must and not must_not:
+            return None
+        return models.Filter(must=must or None, must_not=must_not or None)
+
+    def _search_points(self, collection_name: str, dense_expr: MatchDenseExpr, condition: dict, dataset_ids: list[str], with_vectors: bool, limit: int):
+        query_filter = self._build_filter(condition, dataset_ids, collection_name)
+        query_vector = (DENSE_VECTOR_NAME, list(dense_expr.embedding_data))
+        extra_options = dense_expr.extra_options or {}
+        similarity = extra_options.get("similarity")
+        kwargs = {
+            "collection_name": collection_name,
+            "query_vector": query_vector,
+            "query_filter": query_filter,
+            "limit": limit,
+            "with_payload": True,
+            "with_vectors": [DENSE_VECTOR_NAME] if with_vectors else False,
+        }
+        if similarity is not None:
+            kwargs["score_threshold"] = similarity
+        return self.client.search(**kwargs)
+
+    @staticmethod
+    def _response_points(query_response: Any):
+        return QdrantConnection._get_attr(query_response, "points") or []
+
+    def _query_points_hybrid(
+        self,
+        collection_name: str,
+        dense_expr: MatchDenseExpr,
+        sparse_expr: MatchSparseExpr,
+        condition: dict,
+        dataset_ids: list[str],
+        with_vectors: bool,
+        limit: int,
+    ):
+        query_filter = self._build_filter(condition, dataset_ids, collection_name)
+        dense_options = dense_expr.extra_options or {}
+        dense_similarity = dense_options.get("similarity")
+        # ColPali/ColQwen PR hook:
+        # route visual late-interaction retrieval through a sibling helper that
+        # swaps this dense+sparse RRF prefetch for the multivector query path.
+        prefetch = [
+            models.Prefetch(
+                query=list(dense_expr.embedding_data),
+                using=DENSE_VECTOR_NAME,
+                filter=query_filter,
+                score_threshold=dense_similarity,
+                limit=max(limit, dense_expr.topn, 1),
+            ),
+            models.Prefetch(
+                query=self._to_qdrant_sparse_vector(sparse_expr.sparse_data),
+                using=SPARSE_VECTOR_NAME,
+                filter=query_filter,
+                limit=max(limit, sparse_expr.topn, 1),
+            ),
+        ]
+        return self.client.query_points(
+            collection_name=collection_name,
+            query=models.FusionQuery(fusion=models.Fusion.RRF),
+            prefetch=prefetch,
+            limit=limit,
+            with_payload=True,
+            with_vectors=[DENSE_VECTOR_NAME] if with_vectors else False,
+        )
+
+    def _scroll_points(self, collection_name: str, condition: dict, dataset_ids: list[str], with_vectors: bool):
+        points = []
+        q_filter = self._build_filter(condition, dataset_ids, collection_name)
+        next_offset = None
+        while True:
+            scroll_kwargs = {
+                "collection_name": collection_name,
+                "scroll_filter": q_filter,
+                "limit": DEFAULT_SCROLL_BATCH_SIZE,
+                "with_payload": True,
+                "with_vectors": [DENSE_VECTOR_NAME] if with_vectors else False,
+            }
+            if next_offset is not None:
+                scroll_kwargs["offset"] = next_offset
+            batch_points, next_offset = self.client.scroll(**scroll_kwargs)
+            if not batch_points:
+                break
+            points.extend(batch_points)
+            if next_offset is None:
+                break
+        return points
+
+    def _collection_dense_size(self, collection_name: str) -> int | None:
+        info = self.client.get_collection(collection_name)
+        vectors = self._get_attr(info, "config", "params", "vectors")
+        if vectors is None:
+            return None
+        if isinstance(vectors, dict):
+            dense = vectors.get(DENSE_VECTOR_NAME)
+            if dense is None and vectors:
+                dense = next(iter(vectors.values()))
+            return self._get_attr(dense, "size")
+        return self._get_attr(vectors, "size")
+
+    def _collection_has_sparse_vector(self, collection_name: str) -> bool:
+        info = self.client.get_collection(collection_name)
+        sparse_vectors = self._get_attr(info, "config", "params", "sparse_vectors")
+        if isinstance(sparse_vectors, dict):
+            return SPARSE_VECTOR_NAME in sparse_vectors
+        return bool(sparse_vectors)
+
+    def _ensure_sparse_schema(self, collection_name: str):
+        if self._is_metadata_index(collection_name):
+            return
+        if self._collection_has_sparse_vector(collection_name):
+            return
+        self._retry(
+            self.client.update_collection,
+            collection_name=collection_name,
+            sparse_vectors_config={SPARSE_VECTOR_NAME: self._sparse_vector_params()},
+        )
+
+    def _ensure_text_indexes(self, collection_name: str):
+        if self._is_metadata_index(collection_name):
+            return
+        for field_name in TEXT_INDEX_FIELDS:
+            try:
+                self._retry(
+                    self.client.create_payload_index,
+                    collection_name=collection_name,
+                    field_name=field_name,
+                    field_schema=self._text_index_params(),
+                    wait=True,
+                )
+            except Exception as error:
+                self.logger.debug("Skipping payload index %s on %s: %s", field_name, collection_name, error)
+
+    def _make_point(self, collection_name: str, row: dict, dataset_id: str):
+        assert "_id" not in row
+        assert "id" in row
+        payload = copy.deepcopy(row)
+        payload["kb_id"] = dataset_id
+        point_id = payload.pop("id")
+        vector_field, dense_vector = self._extract_dense_vector(payload)
+        sparse_vector = self._extract_sparse_vector(payload)
+        if dense_vector is None:
+            if self._is_metadata_index(collection_name):
+                dense_vector = self._metadata_vector()
+            else:
+                raise ValueError(f"{point_id}:missing_dense_vector")
+        # ColPali/ColQwen PR hook:
+        # extend this vector builder with page/image vectors instead of replacing
+        # the primary dense text vector branch.
+        vector = {DENSE_VECTOR_NAME: list(dense_vector)} if self._is_metadata_index(collection_name) else self._default_named_vectors(dense_vector, sparse_vector)
+        return point_id, vector_field, models.PointStruct(id=point_id, vector=vector, payload=payload)
+
+    def _point_to_hit(self, point: Any, requested_vector_field: str | None, text_expr: MatchTextExpr | None, highlight_fields: list[str], rank_feature: dict | None = None):
+        payload = self._extract_payload(point)
+        point_id = self._extract_point_id(point)
+        vectors = self._extract_vectors(point)
+        dense_vector = None
+        if isinstance(vectors, dict):
+            dense_vector = vectors.get(DENSE_VECTOR_NAME)
+        elif vectors is not None:
+            dense_vector = vectors
+        # ColPali/ColQwen PR hook:
+        # map additional named vectors or page-level multivector summaries back
+        # into response fields here when visual retrieval starts returning them.
+        score = self._extract_point_score(point)
+        score += self._rank_feature_score(payload, rank_feature)
+        source = self._payload_with_vector_alias(payload, requested_vector_field, dense_vector, score)
+        highlight = self._highlight_hit(source, highlight_fields, self._query_terms(text_expr)[1])
+        hit = {"_id": point_id, "_score": score, "_source": source}
+        if highlight:
+            hit["highlight"] = highlight
+        return hit
+
+    def _normalize_dense_scores(self, hits: list[dict]):
+        max_score = max((hit.get("_score", 0.0) for hit in hits), default=0.0)
+        if max_score <= 0:
+            return {hit["_id"]: 0.0 for hit in hits}
+        return {hit["_id"]: hit.get("_score", 0.0) / max_score for hit in hits}
+
+    def _combine_dense_text_scores(self, hits: list[dict], text_expr: MatchTextExpr | None, fusion_expr: FusionExpr | None):
+        if not hits:
+            return hits
+        dense_scores = self._normalize_dense_scores(hits)
+        text_scores = {hit["_id"]: self._text_score(hit["_source"], text_expr) for hit in hits}
+        max_text_score = max(text_scores.values(), default=0.0)
+        if max_text_score > 0:
+            text_scores = {doc_id: score / max_text_score for doc_id, score in text_scores.items()}
+        else:
+            text_scores = {doc_id: 0.0 for doc_id in text_scores}
+        text_weight = 0.0
+        dense_weight = 1.0
+        if fusion_expr and fusion_expr.method == "weighted_sum" and fusion_expr.fusion_params and fusion_expr.fusion_params.get("weights"):
+            try:
+                text_weight, dense_weight = [float(v) for v in fusion_expr.fusion_params["weights"].split(",", 1)]
+            except Exception:
+                text_weight, dense_weight = 0.0, 1.0
+        for hit in hits:
+            hit["_score"] = dense_scores.get(hit["_id"], 0.0) * dense_weight + text_scores.get(hit["_id"], 0.0) * text_weight
+            hit["_source"]["_score"] = hit["_score"]
+        return sorted(hits, key=lambda hit: hit.get("_score", 0.0), reverse=True)
+
+    def _aggregate_hits(self, hits: list[dict], agg_fields: list[str] | None):
+        if not agg_fields:
+            return None
+        aggregations = {}
+        for field in agg_fields:
+            buckets = {}
+            for hit in hits:
+                value = hit["_source"].get(field)
+                values = value if isinstance(value, list) else [value]
+                for item in values:
+                    if item in (None, ""):
+                        continue
+                    buckets[item] = buckets.get(item, 0) + 1
+            aggregations[f"aggs_{field}"] = {
+                "buckets": [{"key": key, "doc_count": count} for key, count in sorted(buckets.items(), key=lambda item: (-item[1], item[0]))]
+            }
+        return aggregations
+
+    def _retry(self, func, *args, **kwargs):
+        last_error = None
+        for _ in range(ATTEMPT_TIME):
+            try:
+                return func(*args, **kwargs)
+            except Exception as error:
+                last_error = error
+                self.logger.warning(f"Qdrant request failed: {error}")
+                time.sleep(1)
+                continue
+        raise last_error
+
+    def db_type(self) -> str:
+        return "qdrant"
+
+    def health(self) -> dict:
+        info = self._retry(self.client.get_collections)
+        collections = self._get_attr(info, "collections") or []
+        return {
+            "type": "qdrant",
+            "status": "green",
+            "url": self.url,
+            "collections": len(collections),
+        }
+
+    def get_cluster_stats(self):
+        stats = self.health()
+        stats["cluster_name"] = "qdrant"
+        return stats
+
+    def create_idx(self, index_name: str, dataset_id: str, vector_size: int, parser_id: str = None):
+        if self.index_exist(index_name, dataset_id):
+            current_size = self._collection_dense_size(index_name)
+            if current_size is not None and current_size != vector_size:
+                raise Exception(
+                    f"Qdrant collection {index_name} already exists with dense size {current_size}, but {vector_size} was requested."
+                )
+            self._ensure_sparse_schema(index_name)
+            self._ensure_text_indexes(index_name)
+            return True
+        created = self._retry(
+            self.client.create_collection,
+            collection_name=index_name,
+            vectors_config=self._named_vectors_config(vector_size),
+            sparse_vectors_config={
+                SPARSE_VECTOR_NAME: self._sparse_vector_params(),
+            },
+            on_disk_payload=True,
+        )
+        self._ensure_text_indexes(index_name)
+        return created
+
+    def create_doc_meta_idx(self, index_name: str):
+        if self.index_exist(index_name, ""):
+            return True
+        return self._retry(
+            self.client.create_collection,
+            collection_name=index_name,
+            vectors_config=self._named_vectors_config(METADATA_VECTOR_SIZE),
+            on_disk_payload=True,
+        )
+
+    def delete_idx(self, index_name: str, dataset_id: str):
+        if len(dataset_id) > 0:
+            return
+        if not self.index_exist(index_name, dataset_id):
+            return
+        try:
+            self._retry(self.client.delete_collection, collection_name=index_name)
+        except Exception:
+            self.logger.exception("QdrantConnection.delete_idx error %s" % index_name)
+
+    def index_exist(self, index_name: str, dataset_id: str = None) -> bool:
+        try:
+            return bool(self._retry(self.client.collection_exists, collection_name=index_name))
+        except Exception as error:
+            self.logger.exception(error)
+            return False
+
+    def get(self, data_id: str, index_name: str, dataset_ids: list[str]) -> dict | None:
+        try:
+            records = self._retry(
+                self.client.retrieve,
+                collection_name=index_name,
+                ids=[data_id],
+                with_payload=True,
+                with_vectors=[DENSE_VECTOR_NAME],
+            )
+            if not records:
+                return None
+            point = records[0]
+            payload = self._extract_payload(point)
+            vector_field = None
+            if not self._is_metadata_index(index_name):
+                dense_size = len((self._extract_vectors(point) or {}).get(DENSE_VECTOR_NAME, [])) if isinstance(self._extract_vectors(point), dict) else None
+                if dense_size:
+                    vector_field = dense_vector_field_name(dense_size)
+            doc = self._point_to_hit(point, vector_field, None, [])
+            doc_source = doc["_source"]
+            doc_source["id"] = data_id
+            return doc_source
+        except Exception as error:
+            self.logger.exception(f"QdrantConnection.get({data_id}) got exception")
+            raise error
+
+    def search(
+        self,
+        select_fields: list[str],
+        highlight_fields: list[str],
+        condition: dict,
+        match_expressions: list[MatchExpr],
+        order_by: OrderByExpr,
+        offset: int,
+        limit: int,
+        index_names: str | list[str],
+        knowledgebase_ids: list[str],
+        agg_fields: list[str] | None = None,
+        rank_feature: dict | None = None,
+    ):
+        if isinstance(index_names, str):
+            index_names = index_names.split(",")
+        assert isinstance(index_names, list) and len(index_names) > 0
+        assert "_id" not in condition
+
+        existing_indexes = [index_name for index_name in index_names if self.index_exist(index_name, "")]
+        if not existing_indexes:
+            return self._empty_response(agg_fields)
+
+        dense_expr = next((expr for expr in match_expressions if isinstance(expr, MatchDenseExpr)), None)
+        sparse_expr = next((expr for expr in match_expressions if isinstance(expr, MatchSparseExpr)), None)
+        text_expr = next((expr for expr in match_expressions if isinstance(expr, MatchTextExpr)), None)
+        fusion_expr = next((expr for expr in match_expressions if isinstance(expr, FusionExpr)), None)
+        requested_vector_field = self._requested_vector_field(select_fields)
+        need_vectors = requested_vector_field is not None
+
+        all_hits = []
+        for index_name in existing_indexes:
+            if dense_expr is not None:
+                query_limit = max(limit + offset, dense_expr.topn, sparse_expr.topn if sparse_expr else 0, fusion_expr.topn if fusion_expr else 0, 1)
+                if sparse_expr is not None and not self._is_metadata_index(index_name):
+                    self._ensure_sparse_schema(index_name)
+                    self._ensure_text_indexes(index_name)
+                    points = self._response_points(
+                        self._retry(
+                            self._query_points_hybrid,
+                            index_name,
+                            dense_expr,
+                            sparse_expr,
+                            condition,
+                            knowledgebase_ids,
+                            need_vectors,
+                            query_limit,
+                        )
+                    )
+                else:
+                    points = self._retry(
+                        self._search_points,
+                        index_name,
+                        dense_expr,
+                        condition,
+                        knowledgebase_ids,
+                        need_vectors,
+                        query_limit,
+                    )
+                full_condition = {
+                    **condition,
+                    **(
+                        {"kb_id": knowledgebase_ids}
+                        if not self._is_metadata_index(index_name) and knowledgebase_ids
+                        else {}
+                    ),
+                }
+                index_hits = [
+                    self._point_to_hit(point, requested_vector_field, text_expr, highlight_fields, rank_feature=rank_feature)
+                    for point in points
+                    if self._matches_condition(
+                        self._extract_point_id(point),
+                        self._extract_payload(point),
+                        full_condition,
+                    )
+                ]
+                if sparse_expr is None:
+                    index_hits = self._combine_dense_text_scores(index_hits, text_expr, fusion_expr)
+            else:
+                points = self._retry(self._scroll_points, index_name, condition, knowledgebase_ids, need_vectors)
+                index_hits = []
+                for point in points:
+                    payload = self._extract_payload(point)
+                    point_id = self._extract_point_id(point)
+                    full_condition = {**condition, **({"kb_id": knowledgebase_ids} if not self._is_metadata_index(index_name) and knowledgebase_ids else {})}
+                    if not self._matches_condition(point_id, payload, full_condition):
+                        continue
+                    score = self._text_score(payload, text_expr)
+                    if text_expr and score <= 0:
+                        continue
+                    hit = self._point_to_hit(point, requested_vector_field, text_expr, highlight_fields, rank_feature=rank_feature)
+                    if text_expr:
+                        hit["_score"] = score + self._rank_feature_score(payload, rank_feature)
+                        hit["_source"]["_score"] = hit["_score"]
+                    index_hits.append(hit)
+                if text_expr:
+                    index_hits = sorted(index_hits, key=lambda hit: hit.get("_score", 0.0), reverse=True)
+                else:
+                    index_hits = self._sort_hits(index_hits, order_by)
+            all_hits.extend(index_hits)
+
+        if dense_expr is not None or text_expr is not None:
+            all_hits = sorted(all_hits, key=lambda hit: hit.get("_score", 0.0), reverse=True)
+        elif order_by and order_by.fields:
+            all_hits = self._sort_hits(all_hits, order_by)
+
+        total = len(all_hits)
+        if limit > 0:
+            hits = all_hits[offset:offset + limit]
+        else:
+            hits = []
+
+        res = {
+            "hits": {
+                "total": {"value": total},
+                "hits": hits,
+            }
+        }
+        aggregations = self._aggregate_hits(all_hits, agg_fields)
+        if aggregations is not None:
+            res["aggregations"] = aggregations
+        return res
+
+    def insert(self, documents: list[dict], index_name: str, knowledgebase_id: str = None) -> list[str]:
+        res = []
+        points = []
+        if not self._is_metadata_index(index_name) and self.index_exist(index_name, knowledgebase_id):
+            self._ensure_sparse_schema(index_name)
+            self._ensure_text_indexes(index_name)
+        try:
+            for doc in documents:
+                _, _, point = self._make_point(index_name, doc, knowledgebase_id)
+                points.append(point)
+        except Exception as error:
+            return [str(error)]
+
+        for _ in range(ATTEMPT_TIME):
+            try:
+                self.client.upsert(collection_name=index_name, points=points, wait=False)
+                return res
+            except Exception as error:
+                res = [str(error)]
+                self.logger.warning("QdrantConnection.insert got exception: " + str(error))
+                time.sleep(1)
+                continue
+        return res
+
+    def update(self, condition: dict, new_value: dict, index_name: str, knowledgebase_id: str) -> bool:
+        doc = copy.deepcopy(new_value)
+        doc.pop("id", None)
+        full_condition = copy.deepcopy(condition)
+        if not self._is_metadata_index(index_name):
+            full_condition["kb_id"] = knowledgebase_id
+            if self.index_exist(index_name, knowledgebase_id):
+                self._ensure_sparse_schema(index_name)
+                self._ensure_text_indexes(index_name)
+        try:
+            points = self._scroll_points(index_name, full_condition, [], True)
+            matched = []
+            for point in points:
+                payload = self._extract_payload(point)
+                point_id = self._extract_point_id(point)
+                if not self._matches_condition(point_id, payload, full_condition):
+                    continue
+                matched.append(point)
+            if not matched:
+                return False if isinstance(condition.get("id"), str) else True
+
+            updated_points = []
+            for point in matched:
+                payload = self._extract_payload(point)
+                vectors = self._extract_vectors(point) or {}
+                dense_vector = vectors.get(DENSE_VECTOR_NAME) if isinstance(vectors, dict) else vectors
+                sparse_vector = vectors.get(SPARSE_VECTOR_NAME) if isinstance(vectors, dict) else None
+                for key, value in doc.items():
+                    if key == "remove":
+                        if isinstance(value, str):
+                            payload.pop(value, None)
+                        elif isinstance(value, dict):
+                            for rm_key, rm_val in value.items():
+                                if isinstance(payload.get(rm_key), list):
+                                    payload[rm_key] = [item for item in payload.get(rm_key, []) if item != rm_val]
+                        continue
+                    if key == "add":
+                        if isinstance(value, dict):
+                            for add_key, add_val in value.items():
+                                payload.setdefault(add_key, [])
+                                if isinstance(payload[add_key], list):
+                                    payload[add_key].append(add_val.strip() if isinstance(add_val, str) else add_val)
+                        continue
+                    if (not isinstance(key, str) or not value) and key != "available_int":
+                        continue
+                    if VECTOR_FIELD_RE.fullmatch(key):
+                        dense_vector = list(value)
+                        continue
+                    if key == SPARSE_VECTOR_FIELD:
+                        sparse_vector = self._to_qdrant_sparse_vector(value)
+                        continue
+                    payload[key] = value
+                vector = {DENSE_VECTOR_NAME: list(dense_vector or self._metadata_vector())}
+                if not self._is_metadata_index(index_name):
+                    # ColPali/ColQwen PR hook:
+                    # preserve any future page/image vectors here on partial
+                    # updates so text edits do not drop visual retrieval state.
+                    vector[SPARSE_VECTOR_NAME] = sparse_vector if sparse_vector is not None else self._empty_sparse_vector()
+                updated_points.append(
+                    models.PointStruct(
+                        id=self._extract_point_id(point),
+                        vector=vector,
+                        payload=payload,
+                    )
+                )
+            self.client.upsert(collection_name=index_name, points=updated_points, wait=True)
+            return True
+        except Exception as error:
+            self.logger.error("QdrantConnection.update got exception: " + str(error))
+            return False
+
+    def delete(self, condition: dict, index_name: str, knowledgebase_id: str) -> int:
+        assert "_id" not in condition
+        full_condition = copy.deepcopy(condition)
+        if not self._is_metadata_index(index_name):
+            full_condition["kb_id"] = knowledgebase_id
+        try:
+            points = self._scroll_points(index_name, full_condition, [], False)
+            point_ids = []
+            for point in points:
+                payload = self._extract_payload(point)
+                point_id = self._extract_point_id(point)
+                if self._matches_condition(point_id, payload, full_condition):
+                    point_ids.append(point_id)
+            if not point_ids:
+                return 0
+            self.client.delete(collection_name=index_name, points_selector=point_ids, wait=True)
+            return len(point_ids)
+        except Exception as error:
+            self.logger.warning("QdrantConnection.delete got exception: " + str(error))
+            if re.search(r"(not_found)", str(error), re.IGNORECASE):
+                return 0
+            return 0
+
+    def get_total(self, res):
+        if isinstance(res["hits"]["total"], dict):
+            return res["hits"]["total"].get("value", 0)
+        return res["hits"]["total"]
+
+    def get_doc_ids(self, res):
+        return [doc["_id"] for doc in res["hits"]["hits"]]
+
+    def _get_source(self, res):
+        sources = []
+        for hit in res["hits"]["hits"]:
+            doc = copy.deepcopy(hit["_source"])
+            doc["id"] = hit["_id"]
+            doc["_score"] = hit["_score"]
+            sources.append(doc)
+        return sources
+
+    def get_fields(self, res, fields: list[str]) -> dict[str, dict]:
+        res_fields = {}
+        if not fields:
+            return {}
+        for doc in self._get_source(res):
+            if fields == ["*"]:
+                res_fields[doc["id"]] = doc
+                continue
+            mapped = {name: doc.get(name) for name in fields if doc.get(name) is not None}
+            for name, value in list(mapped.items()):
+                if isinstance(value, list):
+                    continue
+                if name == "available_int" and isinstance(value, (int, float)):
+                    continue
+                if not isinstance(value, str):
+                    mapped[name] = str(value)
+            if mapped:
+                res_fields[doc["id"]] = mapped
+        return res_fields
+
+    def get_highlight(self, res, keywords: list[str], field_name: str):
+        ans = {}
+        for hit in res["hits"]["hits"]:
+            highlights = hit.get("highlight")
+            if not highlights:
+                continue
+            txt = "...".join([part for part in list(highlights.items())[0][1]])
+            if not is_english(txt.split()):
+                ans[hit["_id"]] = txt
+                continue
+            raw_txt = hit["_source"].get(field_name, "")
+            raw_txt = re.sub(r"[\r\n]", " ", raw_txt, flags=re.IGNORECASE | re.MULTILINE)
+            txt_list = []
+            for sentence in re.split(r"[.?!;\n]", raw_txt):
+                for keyword in keywords:
+                    sentence = re.sub(
+                        r"(^|[ .?/'\"\(\)!,:;-])(%s)([ .?/'\"\(\)!,:;-])" % re.escape(keyword),
+                        r"\1<em>\2</em>\3",
+                        sentence,
+                        flags=re.IGNORECASE | re.MULTILINE,
+                    )
+                if not re.search(r"<em>[^<>]+</em>", sentence, flags=re.IGNORECASE | re.MULTILINE):
+                    continue
+                txt_list.append(sentence)
+            ans[hit["_id"]] = "...".join(txt_list) if txt_list else txt
+        return ans
+
+    def get_aggregation(self, res, field_name: str):
+        agg_field = f"aggs_{field_name}"
+        if "aggregations" not in res or agg_field not in res["aggregations"]:
+            return []
+        buckets = res["aggregations"][agg_field]["buckets"]
+        return [(bucket["key"], bucket["doc_count"]) for bucket in buckets]
+
+    def sql(self, sql: str, fetch_size: int, format: str):
+        raise Exception(f"SQL error: Qdrant does not support SQL.\n\nSQL: {sql}")

--- a/rag/utils/qdrant_conn.py
+++ b/rag/utils/qdrant_conn.py
@@ -16,8 +16,10 @@
 
 import copy
 import logging
+from numbers import Integral
 import re
 import time
+from uuid import NAMESPACE_URL, UUID, uuid5
 from typing import Any
 
 from qdrant_client import QdrantClient, models
@@ -118,9 +120,31 @@ class QdrantConnection(DocStoreConnection):
 
     @staticmethod
     def _extract_point_id(point: Any):
+        payload = QdrantConnection._extract_payload(point)
+        if isinstance(payload, dict) and payload.get("id") is not None:
+            return payload.get("id")
+        return QdrantConnection._extract_storage_point_id(point)
+
+    @staticmethod
+    def _extract_storage_point_id(point: Any):
         if isinstance(point, dict):
             return point.get("id")
         return getattr(point, "id", None)
+
+    @staticmethod
+    def _to_qdrant_point_id(external_id: Any):
+        if external_id is None:
+            raise ValueError("missing_document_id")
+        if isinstance(external_id, Integral) and not isinstance(external_id, bool):
+            if int(external_id) < 0:
+                raise ValueError(f"{external_id}:invalid_negative_id")
+            return int(external_id)
+        external_id = str(external_id).strip()
+        try:
+            UUID(external_id)
+            return external_id
+        except Exception:
+            return str(uuid5(NAMESPACE_URL, f"ragflow:{external_id}"))
 
     @staticmethod
     def _extract_point_score(point: Any) -> float:
@@ -316,7 +340,11 @@ class QdrantConnection(DocStoreConnection):
         field_value = payload.get(key)
         if key == "available_int":
             try:
-                field_value_num = float(field_value or 0)
+                # ES treats a missing availability flag as available because the
+                # `must_not range lt 1` filter does not exclude missing fields.
+                # Mirror that behavior here so legacy chunks without
+                # `available_int` remain searchable under Qdrant.
+                field_value_num = 1.0 if field_value is None else float(field_value)
                 if value == 0:
                     return field_value_num < 1
                 return field_value_num >= 1
@@ -394,7 +422,7 @@ class QdrantConnection(DocStoreConnection):
             if dataset_ids:
                 condition = {**condition, "kb_id": dataset_ids}
         for key, value in (condition or {}).items():
-            if value is None or key in {"exists", "must_not", "id"}:
+            if value is None or key in {"exists", "must_not"}:
                 continue
             if key == "available_int":
                 if value == 0:
@@ -547,7 +575,10 @@ class QdrantConnection(DocStoreConnection):
         assert "id" in row
         payload = copy.deepcopy(row)
         payload["kb_id"] = dataset_id
-        point_id = payload.pop("id")
+        if not self._is_metadata_index(collection_name):
+            payload.setdefault("available_int", 1)
+        point_id = payload.get("id")
+        storage_point_id = self._to_qdrant_point_id(point_id)
         vector_field, dense_vector = self._extract_dense_vector(payload)
         sparse_vector = self._extract_sparse_vector(payload)
         if dense_vector is None:
@@ -559,7 +590,7 @@ class QdrantConnection(DocStoreConnection):
         # extend this vector builder with page/image vectors instead of replacing
         # the primary dense text vector branch.
         vector = {DENSE_VECTOR_NAME: list(dense_vector)} if self._is_metadata_index(collection_name) else self._default_named_vectors(dense_vector, sparse_vector)
-        return point_id, vector_field, models.PointStruct(id=point_id, vector=vector, payload=payload)
+        return point_id, vector_field, models.PointStruct(id=storage_point_id, vector=vector, payload=payload)
 
     def _point_to_hit(self, point: Any, requested_vector_field: str | None, text_expr: MatchTextExpr | None, highlight_fields: list[str], rank_feature: dict | None = None):
         payload = self._extract_payload(point)
@@ -712,7 +743,7 @@ class QdrantConnection(DocStoreConnection):
             records = self._retry(
                 self.client.retrieve,
                 collection_name=index_name,
-                ids=[data_id],
+                ids=[self._to_qdrant_point_id(data_id)],
                 with_payload=True,
                 with_vectors=[DENSE_VECTOR_NAME],
             )
@@ -727,7 +758,7 @@ class QdrantConnection(DocStoreConnection):
                     vector_field = dense_vector_field_name(dense_size)
             doc = self._point_to_hit(point, vector_field, None, [])
             doc_source = doc["_source"]
-            doc_source["id"] = data_id
+            doc_source["id"] = self._extract_point_id(point)
             return doc_source
         except Exception as error:
             self.logger.exception(f"QdrantConnection.get({data_id}) got exception")
@@ -940,7 +971,7 @@ class QdrantConnection(DocStoreConnection):
                     vector[SPARSE_VECTOR_NAME] = sparse_vector if sparse_vector is not None else self._empty_sparse_vector()
                 updated_points.append(
                     models.PointStruct(
-                        id=self._extract_point_id(point),
+                        id=self._extract_storage_point_id(point),
                         vector=vector,
                         payload=payload,
                     )
@@ -963,7 +994,7 @@ class QdrantConnection(DocStoreConnection):
                 payload = self._extract_payload(point)
                 point_id = self._extract_point_id(point)
                 if self._matches_condition(point_id, payload, full_condition):
-                    point_ids.append(point_id)
+                    point_ids.append(self._extract_storage_point_id(point))
             if not point_ids:
                 return 0
             self.client.delete(collection_name=index_name, points_selector=point_ids, wait=True)
@@ -1011,6 +1042,15 @@ class QdrantConnection(DocStoreConnection):
                 res_fields[doc["id"]] = mapped
         return res_fields
 
+    @staticmethod
+    def _raw_highlight_fallback(raw_text: str) -> str:
+        if not raw_text:
+            return ""
+        raw_text = re.sub(r"[\r\n]+", " ", raw_text, flags=re.IGNORECASE | re.MULTILINE).strip()
+        if len(raw_text) <= 280:
+            return raw_text
+        return raw_text[:280].rstrip() + "..."
+
     def get_highlight(self, res, keywords: list[str], field_name: str):
         ans = {}
         for hit in res["hits"]["hits"]:
@@ -1035,7 +1075,7 @@ class QdrantConnection(DocStoreConnection):
                 if not re.search(r"<em>[^<>]+</em>", sentence, flags=re.IGNORECASE | re.MULTILINE):
                     continue
                 txt_list.append(sentence)
-            ans[hit["_id"]] = "...".join(txt_list) if txt_list else txt
+            ans[hit["_id"]] = "...".join(txt_list) if txt_list else self._raw_highlight_fallback(raw_txt) or txt
         return ans
 
     def get_aggregation(self, res, field_name: str):

--- a/rag/utils/sparse_vector.py
+++ b/rag/utils/sparse_vector.py
@@ -25,7 +25,7 @@ from rag.nlp import rag_tokenizer
 SPARSE_VECTOR_NAME = "sparse"
 SPARSE_VECTOR_FIELD = "q_sparse_vec"
 DENSE_VECTOR_NAME = "dense"
-MULTIVECTOR_PLACEHOLDER_NAME = "colpali"
+MULTIVECTOR_VECTOR_NAME = "colpali"
 DEFAULT_SPARSE_MODEL = ""
 DEFAULT_SPARSE_VOCAB_SIZE = 131072
 ENABLED_SPARSE_MODELS = {"token", "builtin"}
@@ -121,9 +121,7 @@ def attach_sparse_vector(row: dict, sparse_vector: SparseVector | dict | None):
 
 
 def build_sparse_text(*parts: Any) -> str:
-    # ColPali/ColQwen PR hook:
-    # keep visual/page embeddings on a separate path instead of overloading this
-    # text-only sparse helper.
+    # Future multivector extension should keep visual/page inputs separate from this text-only sparse helper.
     values = []
     for part in parts:
         if part is None:

--- a/rag/utils/sparse_vector.py
+++ b/rag/utils/sparse_vector.py
@@ -1,0 +1,139 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import hashlib
+import math
+from typing import Any
+
+from common import settings
+from common.doc_store.doc_store_base import SparseVector
+from rag.nlp import rag_tokenizer
+
+SPARSE_VECTOR_NAME = "sparse"
+SPARSE_VECTOR_FIELD = "q_sparse_vec"
+DENSE_VECTOR_NAME = "dense"
+MULTIVECTOR_PLACEHOLDER_NAME = "colpali"
+DEFAULT_SPARSE_MODEL = ""
+DEFAULT_SPARSE_VOCAB_SIZE = 131072
+ENABLED_SPARSE_MODELS = {"token", "builtin"}
+
+_CACHED_MODEL = None
+_CACHED_CONFIG = None
+
+
+class TokenSparseEmbeddingModel:
+    def __init__(self, vocab_size: int = DEFAULT_SPARSE_VOCAB_SIZE):
+        self.vocab_size = max(int(vocab_size), 1024)
+
+    @staticmethod
+    def _normalize_text(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return "\n".join(str(v) for v in value if v is not None)
+        return str(value)
+
+    def _token_to_index(self, token: str) -> int:
+        digest = hashlib.blake2b(token.encode("utf-8", "ignore"), digest_size=8).digest()
+        return int.from_bytes(digest, byteorder="big", signed=False) % self.vocab_size
+
+    def _encode_text(self, text: Any) -> SparseVector:
+        normalized = self._normalize_text(text)
+        tokens = [token for token in rag_tokenizer.tokenize(normalized).split() if token]
+        if not tokens:
+            return SparseVector(indices=[], values=[])
+        weights = {}
+        counts = {}
+        for token in tokens:
+            counts[token] = counts.get(token, 0) + 1
+        for token, count in counts.items():
+            index = self._token_to_index(token)
+            weights[index] = weights.get(index, 0.0) + (1.0 + math.log1p(count))
+        indices = sorted(weights.keys())
+        values = [weights[index] for index in indices]
+        return SparseVector(indices=indices, values=values)
+
+    def encode(self, texts: list[Any]):
+        return [self._encode_text(text) for text in texts], 0
+
+    def encode_queries(self, text: Any):
+        return self._encode_text(text), 0
+
+
+def _sparse_config() -> tuple[bool, str, int]:
+    conf = getattr(settings, "QDRANT", {}) or {}
+    model_name = str(conf.get("sparse_model", DEFAULT_SPARSE_MODEL) or "").strip().lower()
+    vocab_size = int(conf.get("sparse_vocab_size", DEFAULT_SPARSE_VOCAB_SIZE) or DEFAULT_SPARSE_VOCAB_SIZE)
+    enabled = bool(getattr(settings, "DOC_ENGINE_QDRANT", False)) and model_name in ENABLED_SPARSE_MODELS
+    return enabled, model_name, vocab_size
+
+
+
+def get_sparse_embedding_model():
+    global _CACHED_MODEL, _CACHED_CONFIG
+
+    enabled, model_name, vocab_size = _sparse_config()
+    config = (enabled, model_name, vocab_size)
+    if config == _CACHED_CONFIG:
+        return _CACHED_MODEL
+    _CACHED_CONFIG = config
+    _CACHED_MODEL = TokenSparseEmbeddingModel(vocab_size=vocab_size) if enabled else None
+    return _CACHED_MODEL
+
+
+
+def sparse_vector_to_payload(sparse_vector: SparseVector | dict | None) -> dict | None:
+    if sparse_vector is None:
+        return None
+    if isinstance(sparse_vector, dict):
+        if "indices" in sparse_vector:
+            return sparse_vector
+        return None
+    if not sparse_vector.indices:
+        return None
+    return sparse_vector.to_dict_old()
+
+
+
+def attach_sparse_vector(row: dict, sparse_vector: SparseVector | dict | None):
+    payload = sparse_vector_to_payload(sparse_vector)
+    if payload is None:
+        row.pop(SPARSE_VECTOR_FIELD, None)
+        return False
+    row[SPARSE_VECTOR_FIELD] = payload
+    return True
+
+
+
+def build_sparse_text(*parts: Any) -> str:
+    # ColPali/ColQwen PR hook:
+    # keep visual/page embeddings on a separate path instead of overloading this
+    # text-only sparse helper.
+    values = []
+    for part in parts:
+        if part is None:
+            continue
+        if isinstance(part, list):
+            values.extend(str(item) for item in part if item is not None)
+        else:
+            values.append(str(part))
+    return "\n".join(value for value in values if value)
+
+
+def dense_vector_field_name(vector_size: int) -> str:
+    return f"q_{int(vector_size)}_vec"

--- a/test/unit_test/admin/server/test_config_qdrant.py
+++ b/test/unit_test/admin/server/test_config_qdrant.py
@@ -1,0 +1,42 @@
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("JOBLIB_MULTIPROCESSING", "0")
+
+from admin.server import config as admin_config
+from api.utils import health_utils
+
+
+def test_load_configurations_includes_qdrant(monkeypatch):
+    monkeypatch.setattr(admin_config, "read_config", lambda _: {
+        "qdrant": {
+            "host": "qdrant",
+            "http_port": 6333,
+            "grpc_port": 6334,
+            "https": False,
+            "prefer_grpc": True,
+        }
+    })
+
+    configs = admin_config.load_configurations("service_conf.yaml")
+
+    assert len(configs) == 1
+    config = configs[0]
+    assert config.name == "qdrant"
+    assert config.retrieval_type == "qdrant"
+    assert config.host == "qdrant"
+    assert config.port == 6333
+    assert config.grpc_port == 6334
+    assert config.prefer_grpc is True
+    assert config.detail_func_name == "get_qdrant_status"
+
+
+def test_get_qdrant_status_uses_docstore_health(monkeypatch):
+    expected = {"type": "qdrant", "status": "green"}
+
+    monkeypatch.setenv("DOC_ENGINE", "qdrant")
+    monkeypatch.setattr(health_utils.settings, "docStoreConn", SimpleNamespace(health=lambda: expected))
+
+    status = health_utils.get_qdrant_status()
+
+    assert status == {"status": "alive", "message": expected}

--- a/test/unit_test/api/db/services/test_dialog_service_use_sql_source_columns.py
+++ b/test/unit_test/api/db/services/test_dialog_service_use_sql_source_columns.py
@@ -314,3 +314,23 @@ def test_async_chat_uses_all_docs_when_no_doc_ids_selected(monkeypatch):
     assert retriever.calls[0]["kwargs"]["doc_ids"] is None
     assert "Chunk text from dataset." in chat_model.calls[0]["system_prompt"]
     assert result[0]["answer"] == "stub answer"
+
+
+@pytest.mark.p2
+def test_use_sql_returns_none_for_qdrant(monkeypatch, force_es_engine):
+    chat_model = _StubChatModel([])
+    monkeypatch.setattr(dialog_service.settings, "DOC_ENGINE", "qdrant", raising=False)
+
+    result = asyncio.run(
+        dialog_service.use_sql(
+            question="show me column of product",
+            field_map={"product_tks": "product"},
+            tenant_id="tenant-id",
+            chat_mdl=chat_model,
+            quota=True,
+            kb_ids=None,
+        )
+    )
+
+    assert result is None
+    assert chat_model.calls == []

--- a/test/unit_test/rag/nlp/test_search_qdrant_stage2.py
+++ b/test/unit_test/rag/nlp/test_search_qdrant_stage2.py
@@ -15,8 +15,6 @@
 #
 import asyncio
 
-import pytest
-
 from common.doc_store.doc_store_base import MatchSparseExpr, MatchTextExpr, SparseVector
 from rag.nlp import search as search_module
 

--- a/test/unit_test/rag/nlp/test_search_qdrant_stage2.py
+++ b/test/unit_test/rag/nlp/test_search_qdrant_stage2.py
@@ -1,0 +1,222 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import asyncio
+
+import pytest
+
+from common.doc_store.doc_store_base import MatchSparseExpr, MatchTextExpr, SparseVector
+from rag.nlp import search as search_module
+
+
+class _FakeQueryer:
+    def question(self, text, min_match=0.3):
+        return MatchTextExpr(["content_ltks^2"], text, 100, {"original_query": text, "minimum_should_match": min_match}), ["alpha"]
+
+    def hybrid_similarity(self, *_args, **_kwargs):
+        return [0.1, 0.9], [0.1, 0.9], [0.1, 0.9]
+
+    def token_similarity(self, *_args, **_kwargs):
+        return [0.1, 0.9]
+
+
+class _FakeStore:
+    def __init__(self):
+        self.last_match_expressions = None
+
+    def search(self, _src, _highlight_fields, _filters, match_expressions, *_args, **_kwargs):
+        self.last_match_expressions = match_expressions
+        return {
+            "hits": {
+                "total": {"value": 1},
+                "hits": [
+                    {
+                        "_id": "doc-1",
+                        "_score": 0.9,
+                        "_source": {
+                            "content_ltks": "alpha",
+                            "content_with_weight": "alpha",
+                            "kb_id": "kb-1",
+                            "doc_id": "doc-1",
+                            "docnm_kwd": "Doc 1",
+                            "q_2_vec": [1.0, 0.0],
+                        },
+                    }
+                ],
+            }
+        }
+
+    @staticmethod
+    def get_total(res):
+        return res["hits"]["total"]["value"]
+
+    @staticmethod
+    def get_doc_ids(res):
+        return [hit["_id"] for hit in res["hits"]["hits"]]
+
+    @staticmethod
+    def get_highlight(_res, _keywords, _field_name):
+        return {}
+
+    @staticmethod
+    def get_aggregation(_res, _field_name):
+        return []
+
+    @staticmethod
+    def get_fields(res, fields):
+        result = {}
+        for hit in res["hits"]["hits"]:
+            result[hit["_id"]] = {field: hit["_source"].get(field) for field in fields if field in hit["_source"]}
+            result[hit["_id"]]["_score"] = hit["_score"]
+        return result
+
+
+class _DenseOnlyEmbeddingModel:
+    max_length = 8192
+
+    @staticmethod
+    def encode_queries(_text):
+        return [1.0, 0.0], 0
+
+    @staticmethod
+    def supports_sparse():
+        return False
+
+
+class _HybridEmbeddingModel(_DenseOnlyEmbeddingModel):
+    @staticmethod
+    def supports_sparse():
+        return True
+
+    @staticmethod
+    def encode_sparse_queries(_text):
+        return SparseVector(indices=[7], values=[1.0]), 0
+
+
+def test_qdrant_search_uses_sparse_rrf_when_available(monkeypatch):
+    monkeypatch.setattr(search_module.settings, "DOC_ENGINE_QDRANT", True, raising=False)
+    monkeypatch.setattr(search_module.settings, "DOC_ENGINE_INFINITY", False, raising=False)
+    monkeypatch.setattr(search_module.query, "FulltextQueryer", _FakeQueryer)
+
+    async def _thread_pool_exec(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(search_module, "thread_pool_exec", _thread_pool_exec)
+
+    store = _FakeStore()
+    dealer = search_module.Dealer(store)
+
+    result = asyncio.run(
+        dealer.search(
+            {"question": "alpha", "page": 1, "size": 5, "topk": 5, "similarity": 0.1},
+            "ragflow_tenant",
+            ["kb-1"],
+            emb_mdl=_HybridEmbeddingModel(),
+        )
+    )
+
+    assert any(isinstance(expr, MatchSparseExpr) for expr in store.last_match_expressions)
+    assert store.last_match_expressions[-1].method == "rrf"
+    assert result.backend_ranked is True
+    assert result.query_sparse_vector.indices == [7]
+
+
+def test_qdrant_search_falls_back_to_dense_only_when_sparse_disabled(monkeypatch):
+    monkeypatch.setattr(search_module.settings, "DOC_ENGINE_QDRANT", True, raising=False)
+    monkeypatch.setattr(search_module.settings, "DOC_ENGINE_INFINITY", False, raising=False)
+    monkeypatch.setattr(search_module.query, "FulltextQueryer", _FakeQueryer)
+
+    async def _thread_pool_exec(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(search_module, "thread_pool_exec", _thread_pool_exec)
+
+    store = _FakeStore()
+    dealer = search_module.Dealer(store)
+
+    result = asyncio.run(
+        dealer.search(
+            {"question": "alpha", "page": 1, "size": 5, "topk": 5, "similarity": 0.1},
+            "ragflow_tenant",
+            ["kb-1"],
+            emb_mdl=_DenseOnlyEmbeddingModel(),
+        )
+    )
+
+    assert not any(isinstance(expr, MatchSparseExpr) for expr in store.last_match_expressions)
+    assert store.last_match_expressions[-1].method == "weighted_sum"
+    assert result.backend_ranked is False
+
+
+def test_qdrant_retrieval_preserves_backend_rrf_scores(monkeypatch):
+    monkeypatch.setattr(search_module.settings, "DOC_ENGINE_QDRANT", True, raising=False)
+    monkeypatch.setattr(search_module.settings, "DOC_ENGINE_INFINITY", False, raising=False)
+    monkeypatch.setattr(search_module.query, "FulltextQueryer", _FakeQueryer)
+
+    dealer = search_module.Dealer(_FakeStore())
+
+    async def _fake_search(*_args, **_kwargs):
+        return search_module.Dealer.SearchResult(
+            total=2,
+            ids=["doc-2", "doc-1"],
+            query_vector=[1.0, 0.0],
+            field={
+                "doc-2": {
+                    "_score": 0.9,
+                    "content_ltks": "alpha",
+                    "content_with_weight": "alpha second",
+                    "kb_id": "kb-1",
+                    "doc_id": "doc-2",
+                    "docnm_kwd": "Doc 2",
+                    "q_2_vec": [0.8, 0.2],
+                    "position_int": [],
+                },
+                "doc-1": {
+                    "_score": 0.5,
+                    "content_ltks": "alpha alpha alpha",
+                    "content_with_weight": "alpha first",
+                    "kb_id": "kb-1",
+                    "doc_id": "doc-1",
+                    "docnm_kwd": "Doc 1",
+                    "q_2_vec": [1.0, 0.0],
+                    "position_int": [],
+                },
+            },
+            highlight={},
+            aggregation=[],
+            keywords=["alpha"],
+            backend_ranked=True,
+        )
+
+    monkeypatch.setattr(dealer, "search", _fake_search)
+
+    result = asyncio.run(
+        dealer.retrieval(
+            question="alpha",
+            embd_mdl=_HybridEmbeddingModel(),
+            tenant_ids=["tenant-1"],
+            kb_ids=["kb-1"],
+            page=1,
+            page_size=2,
+            similarity_threshold=0.0,
+            vector_similarity_weight=0.7,
+            top=5,
+            rerank_mdl=None,
+            aggs=False,
+            rank_feature={},
+        )
+    )
+
+    assert [chunk["chunk_id"] for chunk in result["chunks"]] == ["doc-2", "doc-1"]

--- a/test/unit_test/rag/utils/test_qdrant_conn.py
+++ b/test/unit_test/rag/utils/test_qdrant_conn.py
@@ -20,6 +20,7 @@ import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from uuid import UUID
 
 import pytest
 
@@ -196,6 +197,7 @@ class _FakeQdrantClient:
     def upsert(self, collection_name, points, wait=False):
         collection = self.collections[collection_name]
         for point in points:
+            self._validate_point_id(point.id)
             collection["points"][point.id] = {
                 "id": point.id,
                 "payload": copy.deepcopy(point.payload),
@@ -370,6 +372,17 @@ class _FakeQdrantClient:
             score += left_map.get(int(idx), 0.0) * float(value)
         return score
 
+    @staticmethod
+    def _validate_point_id(point_id):
+        if isinstance(point_id, int) and point_id >= 0:
+            return
+        if isinstance(point_id, str):
+            UUID(point_id)
+            return
+        raise ValueError(
+            f"{point_id} is not a valid point ID, valid values are either an unsigned integer or a UUID"
+        )
+
 
 def _load_qdrant_module(monkeypatch):
     import common
@@ -507,6 +520,94 @@ def test_insert_get_update_and_delete_document(monkeypatch):
 
     assert conn.delete({"id": "doc-1"}, "ragflow_tenant", "kb-1") == 1
     assert conn.get("doc-1", "ragflow_tenant", ["kb-1"]) is None
+
+
+@pytest.mark.p2
+def test_missing_available_flag_is_treated_as_available(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+
+    errors = conn.insert(
+        [
+            _make_doc(
+                "doc-1",
+                [1.0, 0.0, 0.0],
+                title_tks="alpha",
+                content_ltks="alpha content",
+            )
+        ],
+        "ragflow_tenant",
+        "kb-1",
+    )
+    assert errors == []
+
+    stored = conn.get("doc-1", "ragflow_tenant", ["kb-1"])
+    assert stored["available_int"] == 1
+
+    result = conn.search(
+        select_fields=["title_tks", "available_int"],
+        highlight_fields=[],
+        condition={"available_int": 1},
+        match_expressions=[],
+        order_by=OrderByExpr(),
+        offset=0,
+        limit=10,
+        index_names="ragflow_tenant",
+        knowledgebase_ids=["kb-1"],
+    )
+
+    assert conn.get_doc_ids(result) == ["doc-1"]
+    fields = conn.get_fields(result, ["available_int"])
+    assert fields["doc-1"]["available_int"] == 1
+
+
+@pytest.mark.p2
+def test_string_ids_are_mapped_to_qdrant_uuids(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+
+    raw_id = "8d6b7a4e2b9d9780"
+    errors = conn.insert([_make_doc(raw_id, [1.0, 0.0, 0.0], title_tks="alpha")], "ragflow_tenant", "kb-1")
+
+    assert errors == []
+    stored_points = conn.client.collections["ragflow_tenant"]["points"]
+    assert list(stored_points) != [raw_id]
+    stored_point_id = next(iter(stored_points))
+    UUID(str(stored_point_id))
+    assert stored_points[stored_point_id]["payload"]["id"] == raw_id
+    assert conn.get(raw_id, "ragflow_tenant", ["kb-1"])["id"] == raw_id
+
+
+@pytest.mark.p2
+def test_highlight_falls_back_to_raw_chunk_text(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+
+    result = {
+        "hits": {
+            "hits": [
+                {
+                    "_id": "doc-1",
+                    "_source": {
+                        "content_with_weight": "Placidus conforms to our zeitgeist, which is characterized by relativity and perspectivism.",
+                    },
+                    "highlight": {
+                        "content_ltks": [
+                            "placidus conform to our zeitgeist which is character by relativ and perspectivu"
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+
+    highlight = conn.get_highlight(result, ["relativ"], "content_with_weight")
+
+    assert "relativity" in highlight["doc-1"].lower()
+    assert "perspectivism" in highlight["doc-1"].lower()
+    assert "perspectivu" not in highlight["doc-1"].lower()
 
 
 @pytest.mark.p2

--- a/test/unit_test/rag/utils/test_qdrant_conn.py
+++ b/test/unit_test/rag/utils/test_qdrant_conn.py
@@ -1,0 +1,693 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import copy
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from common.doc_store.doc_store_base import FusionExpr, MatchDenseExpr, MatchSparseExpr, OrderByExpr, SparseVector
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = REPO_ROOT / "rag" / "utils" / "qdrant_conn.py"
+
+
+class _Distance:
+    COSINE = "cosine"
+
+
+class _VectorParams:
+    def __init__(self, size, distance):
+        self.size = size
+        self.distance = distance
+
+
+class _SparseIndexParams:
+    def __init__(self, on_disk=None, full_scan_threshold=None, datatype=None):
+        self.on_disk = on_disk
+        self.full_scan_threshold = full_scan_threshold
+        self.datatype = datatype
+
+
+class _Modifier:
+    IDF = "idf"
+
+
+class _SparseVectorParams:
+    def __init__(self, index=None, modifier=None):
+        self.index = index
+        self.modifier = modifier
+
+
+class _SparseVector:
+    def __init__(self, indices, values):
+        self.indices = list(indices)
+        self.values = list(values)
+
+
+class _Range:
+    def __init__(self, lt=None):
+        self.lt = lt
+
+
+class _MatchAny:
+    def __init__(self, any):
+        self.any = any
+
+
+class _MatchValue:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FieldCondition:
+    def __init__(self, key, match=None, range=None):
+        self.key = key
+        self.match = match
+        self.range = range
+
+
+class _Filter:
+    def __init__(self, must=None, must_not=None, should=None):
+        self.must = must or []
+        self.must_not = must_not or []
+        self.should = should or []
+
+
+class _PointStruct:
+    def __init__(self, id, vector, payload):
+        self.id = id
+        self.vector = vector
+        self.payload = payload
+
+
+class _Prefetch:
+    def __init__(self, query=None, using=None, filter=None, score_threshold=None, limit=None, **_kwargs):
+        self.query = query
+        self.using = using
+        self.filter = filter
+        self.score_threshold = score_threshold
+        self.limit = limit
+
+
+class _Fusion:
+    RRF = "rrf"
+
+
+class _FusionQuery:
+    def __init__(self, fusion):
+        self.fusion = fusion
+
+
+class _TextIndexType:
+    TEXT = "text"
+
+
+class _TokenizerType:
+    PREFIX = "prefix"
+    WHITESPACE = "whitespace"
+    WORD = "word"
+    MULTILINGUAL = "multilingual"
+
+
+class _TextIndexParams:
+    def __init__(self, type, tokenizer=None, lowercase=None, on_disk=None, **_kwargs):
+        self.type = type
+        self.tokenizer = tokenizer
+        self.lowercase = lowercase
+        self.on_disk = on_disk
+
+
+class _FakeQdrantClient:
+    def __init__(self, **kwargs):
+        self.url = kwargs.get("url")
+        self.collections = {}
+
+    def get_collections(self):
+        return SimpleNamespace(collections=[SimpleNamespace(name=name) for name in self.collections])
+
+    def create_collection(self, collection_name, vectors_config, sparse_vectors_config=None, on_disk_payload=True):
+        dense_cfg = vectors_config["dense"]
+        self.collections[collection_name] = {
+            "size": dense_cfg.size,
+            "distance": dense_cfg.distance,
+            "points": {},
+            "sparse_vectors": copy.deepcopy(sparse_vectors_config or {}),
+            "payload_indexes": {},
+        }
+        return True
+
+    def update_collection(self, collection_name, sparse_vectors_config=None, **_kwargs):
+        if sparse_vectors_config:
+            self.collections[collection_name]["sparse_vectors"].update(copy.deepcopy(sparse_vectors_config))
+        return True
+
+    def create_payload_index(self, collection_name, field_name, field_schema=None, wait=True):
+        self.collections[collection_name]["payload_indexes"][field_name] = field_schema
+        return True
+
+    def delete_collection(self, collection_name):
+        self.collections.pop(collection_name, None)
+        return True
+
+    def collection_exists(self, collection_name):
+        return collection_name in self.collections
+
+    def get_collection(self, collection_name):
+        collection = self.collections[collection_name]
+        vectors = {"dense": _VectorParams(collection["size"], collection["distance"])}
+        sparse_vectors = copy.deepcopy(collection["sparse_vectors"])
+        return SimpleNamespace(config=SimpleNamespace(params=SimpleNamespace(vectors=vectors, sparse_vectors=sparse_vectors)))
+
+    def retrieve(self, collection_name, ids, with_payload=True, with_vectors=False):
+        collection = self.collections[collection_name]
+        result = []
+        for point_id in ids:
+            if point_id not in collection["points"]:
+                continue
+            stored = collection["points"][point_id]
+            result.append(
+                SimpleNamespace(
+                    id=stored["id"],
+                    payload=copy.deepcopy(stored["payload"]) if with_payload else None,
+                    vector=self._select_vectors(stored["vector"], with_vectors),
+                )
+            )
+        return result
+
+    def upsert(self, collection_name, points, wait=False):
+        collection = self.collections[collection_name]
+        for point in points:
+            collection["points"][point.id] = {
+                "id": point.id,
+                "payload": copy.deepcopy(point.payload),
+                "vector": copy.deepcopy(point.vector),
+            }
+        return True
+
+    def delete(self, collection_name, points_selector, wait=True):
+        collection = self.collections[collection_name]
+        for point_id in points_selector:
+            collection["points"].pop(point_id, None)
+        return True
+
+    def scroll(self, collection_name, scroll_filter=None, limit=256, with_payload=True, with_vectors=False, offset=None):
+        collection = self.collections[collection_name]
+        filtered = [
+            point
+            for point in collection["points"].values()
+            if self._matches_filter(point["payload"], scroll_filter)
+        ]
+        start = int(offset or 0)
+        end = start + limit
+        batch = filtered[start:end]
+        next_offset = end if end < len(filtered) else None
+        points = [
+            SimpleNamespace(
+                id=stored["id"],
+                payload=copy.deepcopy(stored["payload"]) if with_payload else None,
+                vector=self._select_vectors(stored["vector"], with_vectors),
+            )
+            for stored in batch
+        ]
+        return points, next_offset
+
+    def search(self, collection_name, query_vector, query_filter=None, limit=10, with_payload=True, with_vectors=False, score_threshold=None):
+        vector_name, query = query_vector
+        result = self._vector_search(
+            collection_name,
+            vector_name,
+            query,
+            query_filter,
+            limit,
+            with_payload,
+            with_vectors,
+            score_threshold,
+        )
+        return result
+
+    def query_points(self, collection_name, query, prefetch=None, limit=10, with_payload=True, with_vectors=False, **_kwargs):
+        assert query.fusion == _Fusion.RRF
+        rankings = []
+        for current in prefetch or []:
+            if current.using == "dense":
+                ranking = self._vector_search(
+                    collection_name,
+                    current.using,
+                    current.query,
+                    current.filter,
+                    current.limit or limit,
+                    with_payload,
+                    with_vectors,
+                    current.score_threshold,
+                )
+            else:
+                ranking = self._sparse_search(
+                    collection_name,
+                    current.using,
+                    current.query,
+                    current.filter,
+                    current.limit or limit,
+                    with_payload,
+                    with_vectors,
+                )
+            rankings.append(ranking)
+
+        fused_scores = {}
+        points_by_id = {}
+        for ranking in rankings:
+            for idx, point in enumerate(ranking):
+                point_id = point.id
+                fused_scores[point_id] = fused_scores.get(point_id, 0.0) + 1.0 / (60 + idx + 1)
+                points_by_id[point_id] = point
+        points = []
+        for point_id, score in sorted(fused_scores.items(), key=lambda item: item[1], reverse=True)[:limit]:
+            point = points_by_id[point_id]
+            points.append(
+                SimpleNamespace(
+                    id=point.id,
+                    payload=copy.deepcopy(point.payload) if with_payload else None,
+                    vector=self._select_vectors(point.vector, with_vectors),
+                    score=score,
+                )
+            )
+        return SimpleNamespace(points=points)
+
+    def _vector_search(self, collection_name, vector_name, query, query_filter, limit, with_payload, with_vectors, score_threshold=None):
+        collection = self.collections[collection_name]
+        result = []
+        for stored in collection["points"].values():
+            if not self._matches_filter(stored["payload"], query_filter):
+                continue
+            vector = stored["vector"].get(vector_name)
+            if vector_name == "dense":
+                score = self._cosine_similarity(query, vector)
+            else:
+                score = self._sparse_similarity(query, vector)
+            if score_threshold is not None and score < score_threshold:
+                continue
+            result.append(
+                SimpleNamespace(
+                    id=stored["id"],
+                    payload=copy.deepcopy(stored["payload"]) if with_payload else None,
+                    vector=self._select_vectors(stored["vector"], with_vectors),
+                    score=score,
+                )
+            )
+        result.sort(key=lambda point: point.score, reverse=True)
+        return result[:limit]
+
+    def _sparse_search(self, collection_name, vector_name, query, query_filter, limit, with_payload, with_vectors):
+        points = self._vector_search(collection_name, vector_name, query, query_filter, limit, with_payload, with_vectors)
+        return [point for point in points if point.score > 0][:limit]
+
+    @staticmethod
+    def _select_vectors(vectors, with_vectors):
+        if with_vectors is False:
+            return None
+        if with_vectors is True or with_vectors is None:
+            return copy.deepcopy(vectors)
+        if isinstance(with_vectors, list):
+            return {name: copy.deepcopy(vectors[name]) for name in with_vectors if name in vectors}
+        return None
+
+    @staticmethod
+    def _matches_condition(payload, condition):
+        if condition.match is not None:
+            if hasattr(condition.match, "any"):
+                return payload.get(condition.key) in condition.match.any
+            return payload.get(condition.key) == condition.match.value
+        if condition.range is not None:
+            value = payload.get(condition.key, 0)
+            return value < condition.range.lt
+        return True
+
+    def _matches_filter(self, payload, query_filter):
+        if query_filter is None:
+            return True
+        for condition in query_filter.must:
+            if not self._matches_condition(payload, condition):
+                return False
+        for condition in query_filter.must_not:
+            if self._matches_condition(payload, condition):
+                return False
+        return True
+
+    @staticmethod
+    def _cosine_similarity(left, right):
+        numerator = sum(float(a) * float(b) for a, b in zip(left, right))
+        left_norm = math.sqrt(sum(float(a) * float(a) for a in left))
+        right_norm = math.sqrt(sum(float(b) * float(b) for b in right))
+        if left_norm == 0 or right_norm == 0:
+            return 0.0
+        return numerator / (left_norm * right_norm)
+
+    @staticmethod
+    def _sparse_similarity(left, right):
+        left_map = {int(i): float(v) for i, v in zip(left.indices, left.values)}
+        right_indices = getattr(right, "indices", []) or []
+        right_values = getattr(right, "values", []) or []
+        score = 0.0
+        for idx, value in zip(right_indices, right_values):
+            score += left_map.get(int(idx), 0.0) * float(value)
+        return score
+
+
+def _load_qdrant_module(monkeypatch):
+    import common
+
+    fake_settings = types.ModuleType("common.settings")
+    fake_settings.QDRANT = {
+        "host": "qdrant",
+        "http_port": 6333,
+        "grpc_port": 6334,
+        "https": False,
+        "prefer_grpc": False,
+        "timeout": 10,
+        "text_index_tokenizer": "multilingual",
+    }
+    monkeypatch.setitem(sys.modules, "common.settings", fake_settings)
+    monkeypatch.setattr(common, "settings", fake_settings, raising=False)
+
+    rag_pkg = types.ModuleType("rag")
+    rag_pkg.__path__ = []
+    utils_pkg = types.ModuleType("rag.utils")
+    utils_pkg.__path__ = []
+    sparse_mod = types.ModuleType("rag.utils.sparse_vector")
+    sparse_mod.DENSE_VECTOR_NAME = "dense"
+    sparse_mod.MULTIVECTOR_PLACEHOLDER_NAME = "colpali"
+    sparse_mod.SPARSE_VECTOR_FIELD = "q_sparse_vec"
+    sparse_mod.SPARSE_VECTOR_NAME = "sparse"
+    sparse_mod.dense_vector_field_name = lambda size: f"q_{int(size)}_vec"
+    nlp_mod = types.ModuleType("rag.nlp")
+    nlp_mod.is_english = lambda _tokens: True
+    nlp_mod.rag_tokenizer = SimpleNamespace(
+        tokenize=lambda text: " ".join(str(text).lower().split()),
+        fine_grained_tokenize=lambda text: " ".join(str(text).lower().split()),
+    )
+    monkeypatch.setitem(sys.modules, "rag", rag_pkg)
+    monkeypatch.setitem(sys.modules, "rag.utils", utils_pkg)
+    monkeypatch.setitem(sys.modules, "rag.utils.sparse_vector", sparse_mod)
+    monkeypatch.setitem(sys.modules, "rag.nlp", nlp_mod)
+
+    fake_models = SimpleNamespace(
+        Distance=_Distance,
+        VectorParams=_VectorParams,
+        SparseVectorParams=_SparseVectorParams,
+        SparseIndexParams=_SparseIndexParams,
+        Modifier=_Modifier,
+        SparseVector=_SparseVector,
+        Range=_Range,
+        MatchAny=_MatchAny,
+        MatchValue=_MatchValue,
+        FieldCondition=_FieldCondition,
+        Filter=_Filter,
+        PointStruct=_PointStruct,
+        Prefetch=_Prefetch,
+        FusionQuery=_FusionQuery,
+        Fusion=_Fusion,
+        TextIndexParams=_TextIndexParams,
+        TextIndexType=_TextIndexType,
+        TokenizerType=_TokenizerType,
+    )
+    fake_qdrant_client = types.ModuleType("qdrant_client")
+    fake_qdrant_client.QdrantClient = _FakeQdrantClient
+    fake_qdrant_client.models = fake_models
+    monkeypatch.setitem(sys.modules, "qdrant_client", fake_qdrant_client)
+
+    module_name = "test_qdrant_conn_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_doc(doc_id, vector, sparse=None, **payload):
+    doc = {
+        "id": doc_id,
+        f"q_{len(vector)}_vec": vector,
+        **payload,
+    }
+    if sparse is not None:
+        doc["q_sparse_vec"] = sparse
+    return doc
+
+
+@pytest.mark.p2
+def test_collection_crud_and_health(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+
+    assert conn.db_type() == "qdrant"
+    assert conn.health()["status"] == "green"
+    assert conn.create_idx("ragflow_tenant", "kb-1", 3) is True
+    assert conn.index_exist("ragflow_tenant", "kb-1") is True
+    assert conn.client.collections["ragflow_tenant"]["sparse_vectors"]["sparse"].modifier == _Modifier.IDF
+    assert "content_with_weight" in conn.client.collections["ragflow_tenant"]["payload_indexes"]
+    assert conn.create_doc_meta_idx("ragflow_doc_meta_tenant") is True
+    assert conn.index_exist("ragflow_doc_meta_tenant", "") is True
+
+    conn.delete_idx("ragflow_tenant", "")
+    assert conn.index_exist("ragflow_tenant", "") is False
+
+
+@pytest.mark.p2
+def test_insert_get_update_and_delete_document(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+
+    errors = conn.insert(
+        [
+            _make_doc(
+                "doc-1",
+                [1.0, 0.0, 0.0],
+                sparse={"indices": [1, 3], "values": [1.0, 0.5]},
+                title_tks="alpha",
+                content_ltks="alpha content",
+                available_int=1,
+                tag_kwd=["one", "two"],
+            )
+        ],
+        "ragflow_tenant",
+        "kb-1",
+    )
+    assert errors == []
+
+    stored = conn.get("doc-1", "ragflow_tenant", ["kb-1"])
+    assert stored["id"] == "doc-1"
+    assert stored["kb_id"] == "kb-1"
+    assert stored["q_3_vec"] == [1.0, 0.0, 0.0]
+
+    assert conn.update({"id": "doc-1"}, {"title_tks": "beta", "remove": {"tag_kwd": "one"}}, "ragflow_tenant", "kb-1") is True
+    updated = conn.get("doc-1", "ragflow_tenant", ["kb-1"])
+    assert updated["title_tks"] == "beta"
+    assert updated["tag_kwd"] == ["two"]
+
+    assert conn.delete({"id": "doc-1"}, "ragflow_tenant", "kb-1") == 1
+    assert conn.get("doc-1", "ragflow_tenant", ["kb-1"]) is None
+
+
+@pytest.mark.p2
+def test_dense_retrieval_returns_ranked_hits(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+    conn.insert(
+        [
+            _make_doc("doc-1", [1.0, 0.0, 0.0], title_tks="alpha"),
+            _make_doc("doc-2", [0.0, 1.0, 0.0], title_tks="beta"),
+        ],
+        "ragflow_tenant",
+        "kb-1",
+    )
+
+    result = conn.search(
+        select_fields=["title_tks", "q_3_vec"],
+        highlight_fields=[],
+        condition={},
+        match_expressions=[
+            MatchDenseExpr("q_3_vec", [1.0, 0.0, 0.0], "float", "cosine", topn=2, extra_options={}),
+        ],
+        order_by=OrderByExpr(),
+        offset=0,
+        limit=2,
+        index_names="ragflow_tenant",
+        knowledgebase_ids=["kb-1"],
+    )
+
+    assert conn.get_total(result) == 2
+    assert conn.get_doc_ids(result) == ["doc-1", "doc-2"]
+    fields = conn.get_fields(result, ["title_tks", "q_3_vec"])
+    assert fields["doc-1"]["title_tks"] == "alpha"
+    assert fields["doc-1"]["q_3_vec"] == [1.0, 0.0, 0.0]
+
+
+@pytest.mark.p2
+def test_hybrid_retrieval_uses_rrf(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+    conn.insert(
+        [
+            _make_doc("doc-1", [1.0, 0.0, 0.0], title_tks="dense-first", sparse={"indices": [], "values": []}),
+            _make_doc("doc-2", [0.8, 0.2, 0.0], title_tks="hybrid-first", sparse={"indices": [7], "values": [2.0]}),
+            _make_doc("doc-3", [0.0, 1.0, 0.0], title_tks="other", sparse={"indices": [99], "values": [1.0]}),
+        ],
+        "ragflow_tenant",
+        "kb-1",
+    )
+
+    result = conn.search(
+        select_fields=["title_tks", "q_3_vec"],
+        highlight_fields=[],
+        condition={},
+        match_expressions=[
+            MatchDenseExpr("q_3_vec", [1.0, 0.0, 0.0], "float", "cosine", topn=3, extra_options={}),
+            MatchSparseExpr("sparse", SparseVector(indices=[7], values=[1.0]), "dot", topn=3),
+            FusionExpr("rrf", 3),
+        ],
+        order_by=OrderByExpr(),
+        offset=0,
+        limit=3,
+        index_names="ragflow_tenant",
+        knowledgebase_ids=["kb-1"],
+    )
+
+    assert conn.get_doc_ids(result)[:2] == ["doc-2", "doc-1"]
+
+
+@pytest.mark.p2
+def test_tenant_isolation_filters_by_kb_id(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+    conn.insert([_make_doc("doc-1", [1.0, 0.0, 0.0], title_tks="tenant-one")], "ragflow_tenant", "kb-1")
+    conn.insert([_make_doc("doc-2", [1.0, 0.0, 0.0], title_tks="tenant-two")], "ragflow_tenant", "kb-2")
+
+    result = conn.search(
+        select_fields=["title_tks"],
+        highlight_fields=[],
+        condition={},
+        match_expressions=[],
+        order_by=OrderByExpr(),
+        offset=0,
+        limit=10,
+        index_names="ragflow_tenant",
+        knowledgebase_ids=["kb-1"],
+    )
+
+    assert conn.get_total(result) == 1
+    assert conn.get_doc_ids(result) == ["doc-1"]
+
+
+@pytest.mark.p2
+def test_scroll_pagination_works_past_batch_boundary(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+    conn.insert(
+        [_make_doc(f"doc-{idx}", [1.0, 0.0, 0.0], sort_int=idx) for idx in range(300)],
+        "ragflow_tenant",
+        "kb-1",
+    )
+
+    order_by = OrderByExpr()
+    order_by.asc("sort_int")
+    result = conn.search(
+        select_fields=["sort_int"],
+        highlight_fields=[],
+        condition={},
+        match_expressions=[],
+        order_by=order_by,
+        offset=260,
+        limit=20,
+        index_names="ragflow_tenant",
+        knowledgebase_ids=["kb-1"],
+    )
+
+    assert conn.get_total(result) == 300
+    page = conn.get_fields(result, ["sort_int"])
+    assert [page[f"doc-{idx}"]["sort_int"] for idx in range(260, 280)] == [str(idx) for idx in range(260, 280)]
+
+
+@pytest.mark.p2
+def test_bulk_upsert_overwrites_existing_documents(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+    conn.insert(
+        [
+            _make_doc("doc-1", [1.0, 0.0, 0.0], title_tks="first"),
+            _make_doc("doc-2", [0.0, 1.0, 0.0], title_tks="second"),
+        ],
+        "ragflow_tenant",
+        "kb-1",
+    )
+    conn.insert(
+        [
+            _make_doc("doc-1", [0.5, 0.5, 0.0], title_tks="first-updated"),
+            _make_doc("doc-3", [0.0, 0.0, 1.0], title_tks="third"),
+        ],
+        "ragflow_tenant",
+        "kb-1",
+    )
+
+    result = conn.search(
+        select_fields=["title_tks"],
+        highlight_fields=[],
+        condition={},
+        match_expressions=[],
+        order_by=OrderByExpr(),
+        offset=0,
+        limit=10,
+        index_names="ragflow_tenant",
+        knowledgebase_ids=["kb-1"],
+    )
+
+    assert conn.get_total(result) == 3
+    fields = conn.get_fields(result, ["title_tks"])
+    assert fields["doc-1"]["title_tks"] == "first-updated"
+    assert fields["doc-3"]["title_tks"] == "third"
+
+
+@pytest.mark.p2
+def test_error_handling_matches_stage1_expectations(monkeypatch):
+    module = _load_qdrant_module(monkeypatch)
+    monkeypatch.setattr(module.time, "sleep", lambda *_args, **_kwargs: None)
+    conn = module.QdrantConnection()
+    conn.create_idx("ragflow_tenant", "kb-1", 3)
+
+    with pytest.raises(Exception, match="dense size 3"):
+        conn.create_idx("ragflow_tenant", "kb-1", 4)
+
+    def _raise_upsert(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(conn.client, "upsert", _raise_upsert)
+    errors = conn.insert([_make_doc("doc-1", [1.0, 0.0, 0.0], title_tks="alpha")], "ragflow_tenant", "kb-1")
+    assert errors == ["boom"]
+
+    with pytest.raises(Exception, match="Qdrant does not support SQL"):
+        conn.sql("SELECT * FROM ragflow_tenant", 10, "json")

--- a/test/unit_test/rag/utils/test_qdrant_conn.py
+++ b/test/unit_test/rag/utils/test_qdrant_conn.py
@@ -14,130 +14,18 @@
 #  limitations under the License.
 #
 import copy
-import importlib.util
 import math
-import sys
-import types
-from pathlib import Path
 from types import SimpleNamespace
 from uuid import UUID
 
 import pytest
+from qdrant_client import models
 
 from common.doc_store.doc_store_base import FusionExpr, MatchDenseExpr, MatchSparseExpr, OrderByExpr, SparseVector
+from rag.utils import qdrant_conn
 
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-MODULE_PATH = REPO_ROOT / "rag" / "utils" / "qdrant_conn.py"
-
-
-class _Distance:
-    COSINE = "cosine"
-
-
-class _VectorParams:
-    def __init__(self, size, distance):
-        self.size = size
-        self.distance = distance
-
-
-class _SparseIndexParams:
-    def __init__(self, on_disk=None, full_scan_threshold=None, datatype=None):
-        self.on_disk = on_disk
-        self.full_scan_threshold = full_scan_threshold
-        self.datatype = datatype
-
-
-class _Modifier:
-    IDF = "idf"
-
-
-class _SparseVectorParams:
-    def __init__(self, index=None, modifier=None):
-        self.index = index
-        self.modifier = modifier
-
-
-class _SparseVector:
-    def __init__(self, indices, values):
-        self.indices = list(indices)
-        self.values = list(values)
-
-
-class _Range:
-    def __init__(self, lt=None):
-        self.lt = lt
-
-
-class _MatchAny:
-    def __init__(self, any):
-        self.any = any
-
-
-class _MatchValue:
-    def __init__(self, value):
-        self.value = value
-
-
-class _FieldCondition:
-    def __init__(self, key, match=None, range=None):
-        self.key = key
-        self.match = match
-        self.range = range
-
-
-class _Filter:
-    def __init__(self, must=None, must_not=None, should=None):
-        self.must = must or []
-        self.must_not = must_not or []
-        self.should = should or []
-
-
-class _PointStruct:
-    def __init__(self, id, vector, payload):
-        self.id = id
-        self.vector = vector
-        self.payload = payload
-
-
-class _Prefetch:
-    def __init__(self, query=None, using=None, filter=None, score_threshold=None, limit=None, **_kwargs):
-        self.query = query
-        self.using = using
-        self.filter = filter
-        self.score_threshold = score_threshold
-        self.limit = limit
-
-
-class _Fusion:
-    RRF = "rrf"
-
-
-class _FusionQuery:
-    def __init__(self, fusion):
-        self.fusion = fusion
-
-
-class _TextIndexType:
-    TEXT = "text"
-
-
-class _TokenizerType:
-    PREFIX = "prefix"
-    WHITESPACE = "whitespace"
-    WORD = "word"
-    MULTILINGUAL = "multilingual"
-
-
-class _TextIndexParams:
-    def __init__(self, type, tokenizer=None, lowercase=None, on_disk=None, **_kwargs):
-        self.type = type
-        self.tokenizer = tokenizer
-        self.lowercase = lowercase
-        self.on_disk = on_disk
-
-
-class _FakeQdrantClient:
+class FakeQdrantClient:
     def __init__(self, **kwargs):
         self.url = kwargs.get("url")
         self.collections = {}
@@ -146,7 +34,7 @@ class _FakeQdrantClient:
         return SimpleNamespace(collections=[SimpleNamespace(name=name) for name in self.collections])
 
     def create_collection(self, collection_name, vectors_config, sparse_vectors_config=None, on_disk_payload=True):
-        dense_cfg = vectors_config["dense"]
+        dense_cfg = vectors_config[qdrant_conn.DENSE_VECTOR_NAME]
         self.collections[collection_name] = {
             "size": dense_cfg.size,
             "distance": dense_cfg.distance,
@@ -174,9 +62,18 @@ class _FakeQdrantClient:
 
     def get_collection(self, collection_name):
         collection = self.collections[collection_name]
-        vectors = {"dense": _VectorParams(collection["size"], collection["distance"])}
+        vectors = {
+            qdrant_conn.DENSE_VECTOR_NAME: models.VectorParams(
+                size=collection["size"],
+                distance=collection["distance"],
+            )
+        }
         sparse_vectors = copy.deepcopy(collection["sparse_vectors"])
-        return SimpleNamespace(config=SimpleNamespace(params=SimpleNamespace(vectors=vectors, sparse_vectors=sparse_vectors)))
+        return SimpleNamespace(
+            config=SimpleNamespace(
+                params=SimpleNamespace(vectors=vectors, sparse_vectors=sparse_vectors)
+            )
+        )
 
     def retrieve(self, collection_name, ids, with_payload=True, with_vectors=False):
         collection = self.collections[collection_name]
@@ -234,7 +131,7 @@ class _FakeQdrantClient:
 
     def search(self, collection_name, query_vector, query_filter=None, limit=10, with_payload=True, with_vectors=False, score_threshold=None):
         vector_name, query = query_vector
-        result = self._vector_search(
+        return self._vector_search(
             collection_name,
             vector_name,
             query,
@@ -244,13 +141,12 @@ class _FakeQdrantClient:
             with_vectors,
             score_threshold,
         )
-        return result
 
     def query_points(self, collection_name, query, prefetch=None, limit=10, with_payload=True, with_vectors=False, **_kwargs):
-        assert query.fusion == _Fusion.RRF
+        assert query.fusion == models.Fusion.RRF
         rankings = []
         for current in prefetch or []:
-            if current.using == "dense":
+            if current.using == qdrant_conn.DENSE_VECTOR_NAME:
                 ranking = self._vector_search(
                     collection_name,
                     current.using,
@@ -280,6 +176,7 @@ class _FakeQdrantClient:
                 point_id = point.id
                 fused_scores[point_id] = fused_scores.get(point_id, 0.0) + 1.0 / (60 + idx + 1)
                 points_by_id[point_id] = point
+
         points = []
         for point_id, score in sorted(fused_scores.items(), key=lambda item: item[1], reverse=True)[:limit]:
             point = points_by_id[point_id]
@@ -300,7 +197,7 @@ class _FakeQdrantClient:
             if not self._matches_filter(stored["payload"], query_filter):
                 continue
             vector = stored["vector"].get(vector_name)
-            if vector_name == "dense":
+            if vector_name == qdrant_conn.DENSE_VECTOR_NAME:
                 score = self._cosine_similarity(query, vector)
             else:
                 score = self._sparse_similarity(query, vector)
@@ -334,7 +231,7 @@ class _FakeQdrantClient:
     @staticmethod
     def _matches_condition(payload, condition):
         if condition.match is not None:
-            if hasattr(condition.match, "any"):
+            if isinstance(condition.match, models.MatchAny):
                 return payload.get(condition.key) in condition.match.any
             return payload.get(condition.key) == condition.match.value
         if condition.range is not None:
@@ -345,10 +242,10 @@ class _FakeQdrantClient:
     def _matches_filter(self, payload, query_filter):
         if query_filter is None:
             return True
-        for condition in query_filter.must:
+        for condition in query_filter.must or []:
             if not self._matches_condition(payload, condition):
                 return False
-        for condition in query_filter.must_not:
+        for condition in query_filter.must_not or []:
             if self._matches_condition(payload, condition):
                 return False
         return True
@@ -384,76 +281,24 @@ class _FakeQdrantClient:
         )
 
 
-def _load_qdrant_module(monkeypatch):
-    import common
-
-    fake_settings = types.ModuleType("common.settings")
-    fake_settings.QDRANT = {
-        "host": "qdrant",
-        "http_port": 6333,
-        "grpc_port": 6334,
-        "https": False,
-        "prefer_grpc": False,
-        "timeout": 10,
-        "text_index_tokenizer": "multilingual",
-    }
-    monkeypatch.setitem(sys.modules, "common.settings", fake_settings)
-    monkeypatch.setattr(common, "settings", fake_settings, raising=False)
-
-    rag_pkg = types.ModuleType("rag")
-    rag_pkg.__path__ = []
-    utils_pkg = types.ModuleType("rag.utils")
-    utils_pkg.__path__ = []
-    sparse_mod = types.ModuleType("rag.utils.sparse_vector")
-    sparse_mod.DENSE_VECTOR_NAME = "dense"
-    sparse_mod.MULTIVECTOR_PLACEHOLDER_NAME = "colpali"
-    sparse_mod.SPARSE_VECTOR_FIELD = "q_sparse_vec"
-    sparse_mod.SPARSE_VECTOR_NAME = "sparse"
-    sparse_mod.dense_vector_field_name = lambda size: f"q_{int(size)}_vec"
-    nlp_mod = types.ModuleType("rag.nlp")
-    nlp_mod.is_english = lambda _tokens: True
-    nlp_mod.rag_tokenizer = SimpleNamespace(
-        tokenize=lambda text: " ".join(str(text).lower().split()),
-        fine_grained_tokenize=lambda text: " ".join(str(text).lower().split()),
+@pytest.fixture
+def qdrant_connection(monkeypatch):
+    monkeypatch.setattr(qdrant_conn, "QdrantClient", FakeQdrantClient)
+    monkeypatch.setattr(
+        qdrant_conn.settings,
+        "QDRANT",
+        {
+            "host": "qdrant",
+            "http_port": 6333,
+            "grpc_port": 6334,
+            "https": False,
+            "prefer_grpc": False,
+            "timeout": 10,
+            "text_index_tokenizer": "multilingual",
+        },
+        raising=False,
     )
-    monkeypatch.setitem(sys.modules, "rag", rag_pkg)
-    monkeypatch.setitem(sys.modules, "rag.utils", utils_pkg)
-    monkeypatch.setitem(sys.modules, "rag.utils.sparse_vector", sparse_mod)
-    monkeypatch.setitem(sys.modules, "rag.nlp", nlp_mod)
-
-    fake_models = SimpleNamespace(
-        Distance=_Distance,
-        VectorParams=_VectorParams,
-        SparseVectorParams=_SparseVectorParams,
-        SparseIndexParams=_SparseIndexParams,
-        Modifier=_Modifier,
-        SparseVector=_SparseVector,
-        Range=_Range,
-        MatchAny=_MatchAny,
-        MatchValue=_MatchValue,
-        FieldCondition=_FieldCondition,
-        Filter=_Filter,
-        PointStruct=_PointStruct,
-        Prefetch=_Prefetch,
-        FusionQuery=_FusionQuery,
-        Fusion=_Fusion,
-        TextIndexParams=_TextIndexParams,
-        TextIndexType=_TextIndexType,
-        TokenizerType=_TokenizerType,
-    )
-    fake_qdrant_client = types.ModuleType("qdrant_client")
-    fake_qdrant_client.QdrantClient = _FakeQdrantClient
-    fake_qdrant_client.models = fake_models
-    monkeypatch.setitem(sys.modules, "qdrant_client", fake_qdrant_client)
-
-    module_name = "test_qdrant_conn_under_test"
-    sys.modules.pop(module_name, None)
-    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
+    return qdrant_conn.QdrantConnection()
 
 
 def _make_doc(doc_id, vector, sparse=None, **payload):
@@ -463,20 +308,19 @@ def _make_doc(doc_id, vector, sparse=None, **payload):
         **payload,
     }
     if sparse is not None:
-        doc["q_sparse_vec"] = sparse
+        doc[qdrant_conn.SPARSE_VECTOR_FIELD] = sparse
     return doc
 
 
 @pytest.mark.p2
-def test_collection_crud_and_health(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_collection_crud_and_health(qdrant_connection):
+    conn = qdrant_connection
 
     assert conn.db_type() == "qdrant"
     assert conn.health()["status"] == "green"
     assert conn.create_idx("ragflow_tenant", "kb-1", 3) is True
     assert conn.index_exist("ragflow_tenant", "kb-1") is True
-    assert conn.client.collections["ragflow_tenant"]["sparse_vectors"]["sparse"].modifier == _Modifier.IDF
+    assert conn.client.collections["ragflow_tenant"]["sparse_vectors"][qdrant_conn.SPARSE_VECTOR_NAME].modifier == models.Modifier.IDF
     assert "content_with_weight" in conn.client.collections["ragflow_tenant"]["payload_indexes"]
     assert conn.create_doc_meta_idx("ragflow_doc_meta_tenant") is True
     assert conn.index_exist("ragflow_doc_meta_tenant", "") is True
@@ -486,9 +330,8 @@ def test_collection_crud_and_health(monkeypatch):
 
 
 @pytest.mark.p2
-def test_insert_get_update_and_delete_document(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_insert_get_update_and_delete_document(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
 
     errors = conn.insert(
@@ -523,9 +366,8 @@ def test_insert_get_update_and_delete_document(monkeypatch):
 
 
 @pytest.mark.p2
-def test_missing_available_flag_is_treated_as_available(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_missing_available_flag_is_treated_as_available(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
 
     errors = conn.insert(
@@ -563,9 +405,8 @@ def test_missing_available_flag_is_treated_as_available(monkeypatch):
 
 
 @pytest.mark.p2
-def test_string_ids_are_mapped_to_qdrant_uuids(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_string_ids_are_mapped_to_qdrant_uuids(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
 
     raw_id = "8d6b7a4e2b9d9780"
@@ -581,9 +422,9 @@ def test_string_ids_are_mapped_to_qdrant_uuids(monkeypatch):
 
 
 @pytest.mark.p2
-def test_highlight_falls_back_to_raw_chunk_text(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_highlight_falls_back_to_raw_chunk_text(monkeypatch, qdrant_connection):
+    conn = qdrant_connection
+    monkeypatch.setattr(qdrant_conn, "is_english", lambda _tokens: True)
 
     result = {
         "hits": {
@@ -611,9 +452,8 @@ def test_highlight_falls_back_to_raw_chunk_text(monkeypatch):
 
 
 @pytest.mark.p2
-def test_dense_retrieval_returns_ranked_hits(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_dense_retrieval_returns_ranked_hits(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
     conn.insert(
         [
@@ -646,9 +486,8 @@ def test_dense_retrieval_returns_ranked_hits(monkeypatch):
 
 
 @pytest.mark.p2
-def test_hybrid_retrieval_uses_rrf(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_hybrid_retrieval_uses_rrf(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
     conn.insert(
         [
@@ -680,9 +519,8 @@ def test_hybrid_retrieval_uses_rrf(monkeypatch):
 
 
 @pytest.mark.p2
-def test_tenant_isolation_filters_by_kb_id(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_tenant_isolation_filters_by_kb_id(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
     conn.insert([_make_doc("doc-1", [1.0, 0.0, 0.0], title_tks="tenant-one")], "ragflow_tenant", "kb-1")
     conn.insert([_make_doc("doc-2", [1.0, 0.0, 0.0], title_tks="tenant-two")], "ragflow_tenant", "kb-2")
@@ -704,9 +542,8 @@ def test_tenant_isolation_filters_by_kb_id(monkeypatch):
 
 
 @pytest.mark.p2
-def test_scroll_pagination_works_past_batch_boundary(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_scroll_pagination_works_past_batch_boundary(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
     conn.insert(
         [_make_doc(f"doc-{idx}", [1.0, 0.0, 0.0], sort_int=idx) for idx in range(300)],
@@ -734,9 +571,8 @@ def test_scroll_pagination_works_past_batch_boundary(monkeypatch):
 
 
 @pytest.mark.p2
-def test_bulk_upsert_overwrites_existing_documents(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    conn = module.QdrantConnection()
+def test_bulk_upsert_overwrites_existing_documents(qdrant_connection):
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
     conn.insert(
         [
@@ -774,10 +610,9 @@ def test_bulk_upsert_overwrites_existing_documents(monkeypatch):
 
 
 @pytest.mark.p2
-def test_error_handling_matches_stage1_expectations(monkeypatch):
-    module = _load_qdrant_module(monkeypatch)
-    monkeypatch.setattr(module.time, "sleep", lambda *_args, **_kwargs: None)
-    conn = module.QdrantConnection()
+def test_error_handling_matches_stage1_expectations(monkeypatch, qdrant_connection):
+    monkeypatch.setattr(qdrant_conn.time, "sleep", lambda *_args, **_kwargs: None)
+    conn = qdrant_connection
     conn.create_idx("ragflow_tenant", "kb-1", 3)
 
     with pytest.raises(Exception, match="dense size 3"):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -6318,6 +6318,7 @@ dependencies = [
     { name = "python-docx" },
     { name = "python-gitlab" },
     { name = "python-pptx" },
+    { name = "qdrant-client" },
     { name = "qianfan" },
     { name = "quart-auth" },
     { name = "quart-cors" },
@@ -6457,6 +6458,7 @@ requires-dist = [
     { name = "python-docx", specifier = ">=1.1.2,<2.0.0" },
     { name = "python-gitlab", specifier = ">=7.0.0" },
     { name = "python-pptx", specifier = ">=1.0.2,<2.0.0" },
+    { name = "qdrant-client", specifier = ">=1.11.0,<2.0.0" },
     { name = "qianfan", specifier = "==0.4.6" },
     { name = "quart-auth", specifier = "==0.11.0" },
     { name = "quart-cors", specifier = "==0.8.0" },


### PR DESCRIPTION
## Summary
Add Qdrant as an opt-in experimental document store backend for RAGFlow, including dense retrieval, optional sparse hybrid retrieval, Docker/config wiring, and follow-up hardening from live validation.

## Included
- Qdrant document-store adapter with interface parity for the current storage contract
- dense retrieval and optional sparse hybrid retrieval with RRF fusion
- factory/settings/config/Docker wiring for `DOC_ENGINE=qdrant`
- Qdrant-aware admin health/config integration
- live-validation hardening for Qdrant point IDs, availability defaults, and backend-specific error reporting
- unit coverage for adapter behavior and search flow

## Follow-up Hardening Included In This PR
- map legacy string chunk IDs to valid Qdrant point UUIDs while preserving the external RAGFlow IDs
- treat missing `available_int` like the existing backend behavior during filtering
- replace hardcoded `Elasticsearch/Infinity` error text with the active backend name in affected ingestion paths
- add admin/server support for `qdrant` service config inspection

## Validation
- `python3 -m py_compile admin/server/config.py api/utils/health_utils.py rag/graphrag/general/index.py rag/graphrag/utils.py rag/svr/task_executor.py rag/utils/qdrant_conn.py test/unit_test/rag/utils/test_qdrant_conn.py test/unit_test/admin/server/test_config_qdrant.py`
- `.venv/bin/python -m pytest test/unit_test/rag/utils/test_qdrant_conn.py test/unit_test/admin/server/test_config_qdrant.py`
- live manual validation against a running Qdrant container for indexing, chunk browsing, and chat retrieval

## Notes
- This PR is intentionally scoped as an opt-in experimental backend addition, not as a claim of full Elasticsearch feature parity.
- Existing Elasticsearch/Infinity behavior is unchanged unless users explicitly select `DOC_ENGINE=qdrant`.
- The broader Qdrant-first multimodal / Vision-RAG direction is a separate roadmap discussion; this PR is only the backend groundwork for that path.
- The generic chat retrieval fix and the generic chunk raw-content fix are submitted separately in dedicated PRs.