### PR TITLE
fix: replace eval() with json.loads() in search tag field parsing

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -283,7 +283,7 @@ class Dealer:
             if not search_res.field[i].get(TAG_FLD):
                 rank_fea.append(0)
                 continue
-            for t, sc in eval(search_res.field[i].get(TAG_FLD, "{}")).items():
+            for t, sc in json.loads(search_res.field[i].get(TAG_FLD, "{}")).items():
                 if t in query_rfea:
                     nor += query_rfea[t] * sc
                 denor += sc * sc


### PR DESCRIPTION
## Summary
- Replace `eval()` with `json.loads()` in `rag/nlp/search.py` for parsing TAG_FLD values
- `eval()` on search field data is an arbitrary code execution risk if malformed data enters the store
- `json.loads()` is safer and sufficient since the data is dict-formatted

## Test plan
- [x] Verify search results parse correctly with json.loads()
- [x] No behavior change for well-formed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)