### PR TITLE
fix: use context managers for file handles to prevent resource leaks

### DIFF
--- a/api/utils/crypt.py
+++ b/api/utils/crypt.py
@@ -17,6 +17,7 @@
 import base64
 import os
 import sys
+from pathlib import Path
 from Cryptodome.PublicKey import RSA
 from Cryptodome.Cipher import PKCS1_v1_5 as Cipher_pkcs1_v1_5
 from common.file_utils import get_project_base_directory
@@ -27,7 +28,7 @@ def crypt(line):
     decrypt(crypt(input_string)) == base64(input_string), which frontend and ragflow_cli use.
     """
     file_path = os.path.join(get_project_base_directory(), "conf", "public.pem")
-    rsa_key = RSA.importKey(open(file_path).read(), "Welcome")
+    rsa_key = RSA.importKey(Path(file_path).read_text(), "Welcome")
     cipher = Cipher_pkcs1_v1_5.new(rsa_key)
     password_base64 = base64.b64encode(line.encode('utf-8')).decode("utf-8")
     encrypted_password = cipher.encrypt(password_base64.encode())
@@ -36,7 +37,7 @@ def crypt(line):
 
 def decrypt(line):
     file_path = os.path.join(get_project_base_directory(), "conf", "private.pem")
-    rsa_key = RSA.importKey(open(file_path).read(), "Welcome")
+    rsa_key = RSA.importKey(Path(file_path).read_text(), "Welcome")
     cipher = Cipher_pkcs1_v1_5.new(rsa_key)
     return cipher.decrypt(base64.b64decode(line), "Fail to decrypt password!").decode('utf-8')
 
@@ -51,7 +52,7 @@ def decrypt2(crypt_text):
         decode_data = b16decode(hex_fixed.upper())
 
     file_path = os.path.join(get_project_base_directory(), "conf", "private.pem")
-    pem = open(file_path).read()
+    pem = Path(file_path).read_text()
     rsa_key = RSA.importKey(pem, "Welcome")
     cipher = Cipher_PKCS1_v1_5.new(rsa_key)
     decrypt_text = cipher.decrypt(decode_data, None)

--- a/deepdoc/vision/__init__.py
+++ b/deepdoc/vision/__init__.py
@@ -60,9 +60,8 @@ def init_in_out(args):
             pdf_pages(fnm)
             return
         try:
-            fp = open(fnm, "rb")
-            binary = fp.read()
-            fp.close()
+            with open(fnm, "rb") as fp:
+                binary = fp.read()
             images.append(Image.open(io.BytesIO(binary)).convert("RGB"))
             outputs.append(os.path.split(fnm)[-1])
         except Exception:

--- a/rag/llm/sequence2txt_model.py
+++ b/rag/llm/sequence2txt_model.py
@@ -37,8 +37,8 @@ class Base(ABC):
         pass
 
     def transcription(self, audio_path, **kwargs):
-        audio_file = open(audio_path, "rb")
-        transcription = self.client.audio.transcriptions.create(model=self.model_name, file=audio_file)
+        with open(audio_path, "rb") as audio_file:
+            transcription = self.client.audio.transcriptions.create(model=self.model_name, file=audio_file)
         return transcription.text.strip(), num_tokens_from_string(transcription.text.strip())
 
     def audio2base64(self, audio):
@@ -172,8 +172,8 @@ class XinferenceSeq2txt(Base):
 
     def transcription(self, audio, language="zh", prompt=None, response_format="json", temperature=0.7):
         if isinstance(audio, str):
-            audio_file = open(audio, "rb")
-            audio_data = audio_file.read()
+            with open(audio, "rb") as audio_file:
+                audio_data = audio_file.read()
             audio_file_name = audio.split("/")[-1]
         else:
             audio_data = audio

--- a/rag/nlp/term_weight.py
+++ b/rag/nlp/term_weight.py
@@ -60,16 +60,16 @@ class Dealer:
 
         def load_dict(fnm):
             res = {}
-            f = open(fnm, "r")
-            while True:
-                line = f.readline()
-                if not line:
-                    break
-                arr = line.replace("\n", "").split("\t")
-                if len(arr) < 2:
-                    res[arr[0]] = 0
-                else:
-                    res[arr[0]] = int(arr[1])
+            with open(fnm, "r") as f:
+                while True:
+                    line = f.readline()
+                    if not line:
+                        break
+                    arr = line.replace("\n", "").split("\t")
+                    if len(arr) < 2:
+                        res[arr[0]] = 0
+                    else:
+                        res[arr[0]] = int(arr[1])
 
             c = 0
             for _, v in res.items():
@@ -81,7 +81,8 @@ class Dealer:
         fnm = os.path.join(get_project_base_directory(), "rag/res")
         self.ne, self.df = {}, {}
         try:
-            self.ne = json.load(open(os.path.join(fnm, "ner.json"), "r"))
+            with open(os.path.join(fnm, "ner.json"), "r") as f:
+                self.ne = json.load(f)
         except Exception:
             logging.warning("Load ner.json FAIL!")
         try:


### PR DESCRIPTION
## Summary
- Convert bare `open()` calls to `with` context managers or `Path.read_text()`
- File handles leak if not properly closed, especially on exceptions
- Fixes in crypt.py, sequence2txt_model.py, term_weight.py, deepdoc/vision/__init__.py

## Test plan
- [x] File operations work correctly with context managers
- [x] Resources properly cleaned up on exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)