### PR TITLE
Add TEI/Builtin embedding model support in Go server

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -497,7 +497,80 @@ func Init(configPath string) error {
 		}
 	}
 
+	loadEmbeddingConfigFromEnv()
+
 	return nil
+}
+
+// Load embedding config from docker/.env (overrides service_conf.yaml)
+func loadEmbeddingConfigFromEnv() {
+	envFile := "docker/.env"
+
+	// Check if file exists
+	if _, err := os.Stat(envFile); os.IsNotExist(err) {
+		// Try alternative paths
+		altPaths := []string{
+			"../docker/.env",
+			"../../docker/.env",
+			".env",
+		}
+		for _, p := range altPaths {
+			if _, err := os.Stat(p); err == nil {
+				envFile = p
+				break
+			}
+		}
+	}
+
+	// Read .env file
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		// Silently skip if .env not found - service_conf.yaml values will be used
+		return
+	}
+
+	// Parse key=value pairs
+	envVars := make(map[string]string)
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if idx := strings.Index(line, "="); idx > 0 {
+			key := strings.TrimSpace(line[:idx])
+			value := strings.TrimSpace(line[idx+1:])
+			// Remove quotes
+			value = strings.Trim(value, "\"")
+			envVars[key] = value
+		}
+	}
+
+	// Check if TEI is enabled (COMPOSE_PROFILES contains tei-cpu or tei-gpu)
+	composeProfiles := envVars["COMPOSE_PROFILES"]
+	teiEnabled := strings.Contains(composeProfiles, "tei-")
+
+	if !teiEnabled || globalConfig == nil {
+		return
+	}
+
+	// Get TEI_MODEL from env
+	teiModel := envVars["TEI_MODEL"]
+	if teiModel == "" {
+		teiModel = "BAAI/bge-small-en-v1.5" // default fallback
+	}
+
+	// Update model name with @Builtin suffix
+	// Note: base_url is NOT overridden - keeps value from service_conf.yaml
+	modelName := teiModel + "@Builtin"
+	globalConfig.UserDefaultLLM.DefaultModels.EmbeddingModel.Name = modelName
+	globalConfig.UserDefaultLLM.DefaultModels.EmbeddingModel.Factory = "Builtin"
+
+	zap.L().Info("Loaded embedding model from docker/.env",
+		zap.String("model", teiModel),
+		zap.String("provider", "Builtin"),
+		zap.String("name_with_provider", modelName),
+	)
 }
 
 // Get get global configuration

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"ragflow/internal/dao"
+	"ragflow/internal/server"
 	"strings"
 	"time"
 
@@ -65,6 +67,22 @@ func parseModelName(compositeName string) (modelName, provider string, err error
 	}
 }
 
+// isTEIFallback checks if the fallback to global config should happen
+func isTEIFallback(provider, modelName string) bool {
+	if provider != "Builtin" {
+		return false
+	}
+
+	composeProfiles := os.Getenv("COMPOSE_PROFILES")
+	if !strings.Contains(composeProfiles, "tei-") {
+		return false
+	}
+
+	teiModel := os.Getenv("TEI_MODEL")
+
+	return modelName == teiModel
+}
+
 // GetEmbeddingModel returns an embedding model for the given tenant
 func (p *ModelProviderImpl) GetEmbeddingModel(ctx context.Context, tenantID string, compositeModelName string) (model.EmbeddingModel, error) {
 	// Parse composite model name to extract model name and provider
@@ -73,25 +91,63 @@ func (p *ModelProviderImpl) GetEmbeddingModel(ctx context.Context, tenantID stri
 		return nil, err
 	}
 
-	// Get API key and configuration
+	// Try to get from tenant-specific configuration first
 	embeddingModel, err := dao.NewTenantLLMDAO().GetByTenantFactoryAndModelName(tenantID, provider, modelName)
-	if err != nil {
-		return nil, err
+	if err == nil && embeddingModel != nil {
+		// Found tenant-specific model
+		apiKey := embeddingModel.APIKey
+		if apiKey != nil && *apiKey != "" {
+			// Get API base from model provider configuration
+			providerDAO := dao.NewModelProviderDAO()
+			providerConfig := providerDAO.GetProviderByName(provider)
+			if providerConfig == nil || providerConfig.DefaultEmbeddingURL == "" {
+				return nil, fmt.Errorf("no API base found for provider %s", provider)
+			}
+			apiBase := providerConfig.DefaultEmbeddingURL
+			return models.CreateEmbeddingModel(provider, *apiKey, apiBase, modelName, p.httpClient)
+		}
 	}
 
-	apiKey := embeddingModel.APIKey
-	if apiKey == nil || *apiKey == "" {
-		return nil, fmt.Errorf("no API key found for tenant %s and model %s", tenantID, compositeModelName)
+	// Fallback to global config
+	if !isTEIFallback(provider, modelName) {
+		return nil, fmt.Errorf("model %s not found for tenant %s (and not eligible for TEI fallback)", compositeModelName, tenantID)
 	}
-	// Always get API base from model provider configuration
-	providerDAO := dao.NewModelProviderDAO()
-	providerConfig := providerDAO.GetProviderByName(provider)
-	if providerConfig == nil || providerConfig.DefaultEmbeddingURL == "" {
-		return nil, fmt.Errorf("no API base found for provider %s", provider)
-	}
-	apiBase := providerConfig.DefaultEmbeddingURL
 
-	return models.CreateEmbeddingModel(provider, *apiKey, apiBase, modelName, p.httpClient)
+	config := server.GetConfig()
+	if config == nil || config.UserDefaultLLM.DefaultModels.EmbeddingModel.Name == "" {
+		return nil, fmt.Errorf("no embedding model found for tenant %s (and no global config)", tenantID)
+	}
+
+	globalModel := config.UserDefaultLLM.DefaultModels.EmbeddingModel
+	globalModelName, globalProvider, _ := parseModelName(globalModel.Name)
+	if globalModelName == "" {
+		globalModelName = modelName
+	}
+	if globalProvider == "" {
+		globalProvider = provider
+	}
+
+	// Use global config values
+	apiKey := ""
+	if globalModel.APIKey != "" {
+		apiKey = globalModel.APIKey
+	}
+
+	apiBase := globalModel.BaseURL
+	if apiBase == "" {
+    	// Fallback to provider default
+		providerDAO := dao.NewModelProviderDAO()
+		providerConfig := providerDAO.GetProviderByName(globalProvider)
+		if providerConfig != nil {
+			apiBase = providerConfig.DefaultEmbeddingURL
+		}
+	}
+
+	if apiBase == "" {
+		return nil, fmt.Errorf("no API base found for provider %s", globalProvider)
+	}
+
+	return models.CreateEmbeddingModel(globalProvider, apiKey, apiBase, globalModelName, p.httpClient)
 }
 
 // GetChatModel returns a chat model for the given tenant

--- a/internal/service/models/builtin_model.go
+++ b/internal/service/models/builtin_model.go
@@ -1,0 +1,127 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"ragflow/internal/model"
+)
+
+// builtinEmbeddingModel implements EmbeddingModel for Builtin/TEI provider
+// This is used for local TEI (Text Embeddings Inference) endpoints
+type builtinEmbeddingModel struct {
+	apiKey     string
+	apiBase    string
+	model      string
+	httpClient *http.Client
+}
+
+// Register Builtin provider for TEI embeddings
+func init() {
+	RegisterEmbeddingModelFactory("Builtin", func(apiKey, apiBase, modelName string, httpClient *http.Client) model.EmbeddingModel {
+		return &builtinEmbeddingModel{
+			apiKey:     apiKey,
+			apiBase:    apiBase,
+			model:      modelName,
+			httpClient: httpClient,
+		}
+	})
+}
+
+// Encode encodes a list of texts into embeddings using TEI (OpenAI-compatible API)
+func (m *builtinEmbeddingModel) Encode(texts []string) ([][]float64, error) {
+	if len(texts) == 0 {
+		return [][]float64{}, nil
+	}
+
+	reqBody := map[string]interface{}{
+		"input": texts,
+	}
+	if m.model != "" {
+		reqBody["model"] = m.model
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := m.apiBase + "/v1/embeddings"
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if m.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+m.apiKey)
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("embedding request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Data []struct {
+			Embedding []float64 `json:"embedding"`
+			Index     int       `json:"index"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	embeddings := make([][]float64, len(texts))
+	for _, d := range result.Data {
+		embeddings[d.Index] = d.Embedding
+	}
+
+	return embeddings, nil
+}
+
+// EncodeQueries encodes queries into embeddings using TEI
+func (m *builtinEmbeddingModel) EncodeQueries(queries []string) ([][]float64, error) {
+	return m.Encode(queries)
+}
+
+// EncodeQuery encodes a single query string into embedding
+func (m *builtinEmbeddingModel) EncodeQuery(query string) ([]float64, error) {
+	embeddings, err := m.Encode([]string{query})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embedding returned")
+	}
+	return embeddings[0], nil
+}


### PR DESCRIPTION
### What problem does this PR solve?
Add TEI/Builtin embedding model support in Go server

Fix the following issue.
```
ragflow > list datasets;
...
 BAAI/bge-small-en-v1.5@Builtin | 9b21b7121cf611f1b06084ba59049aa3 | English  | es   | 
...
+--------+-----------+-------------+---------+--------------------------------+----------------------------------+----------+------+----------+-----------+------------+---------------+----------------------------------+
ragflow> search "曹操" on datasets 'es';
Fail to search datasets: ['es'], code: 500, message: failed to get embedding model: record not found
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
