### PR TITLE
fix(agent-session): handle dict-format reference from canvas.get_reference() in list_agent_session

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -701,13 +701,17 @@ async def list_agent_session(tenant_id, agent_id):
             if "prompt" in info:
                 info.pop("prompt")
         conv["agent_id"] = conv.pop("dialog_id")
-        # Fix for session listing endpoint
         if conv["reference"]:
             messages = conv["messages"]
             message_num = 0
             chunk_num = 0
-            # Ensure reference is a list type to prevent KeyError
-            if not isinstance(conv["reference"], list):
+            # canvas.get_reference() stores a dict {"chunks": ..., "doc_aggs": ...};
+            # wrap it in a list so the per-message loop below works uniformly.
+            # Previously this branch set conv["reference"] = [] when it was a dict,
+            # silently discarding all retrieval results (fixes #13541).
+            if isinstance(conv["reference"], dict):
+                conv["reference"] = [conv["reference"]]
+            elif not isinstance(conv["reference"], list):
                 conv["reference"] = []
             while message_num < len(messages):
                 if message_num != 0 and messages[message_num]["role"] != "user":


### PR DESCRIPTION
## Summary

Fixes #13541 — the `reference` field in `API4Conversation` always returns `[]` when listing agent sessions.

### Root cause

`canvas_service.py` saves retrieval results as:
```python
conv.reference = canvas.get_reference()
```

`canvas.get_reference()` returns a **dict**: `{"chunks": {...}, "doc_aggs": {...}}`.

The `list_agent_session` endpoint in `api/apps/sdk/session.py` had:
```python
if not isinstance(conv["reference"], list):
    conv["reference"] = []  # ← silently destroys all retrieval data
```

This unconditionally discarded the dict-format reference, so every assistant message returned `"reference": []`.

### Fix

When the stored value is a `dict`, wrap it in a list before the per-message iteration loop runs:

```python
if isinstance(conv["reference"], dict):
    conv["reference"] = [conv["reference"]]
elif not isinstance(conv["reference"], list):
    conv["reference"] = []
```

This makes the shape consistent with what the downstream chunk-extraction loop expects (`[{"chunks": ..., "doc_aggs": ...}]`) while still safely handling any unexpected types.

## Test plan

- [ ] Create an Agent with a Retrieval component connected to a knowledge base
- [ ] POST `/api/v1/agents/{agent_id}/sessions` to start a session
- [ ] POST `/api/v1/agents/{agent_id}/sessions/{session_id}/completions` with a question that triggers retrieval
- [ ] GET `/api/v1/agents/{agent_id}/sessions` — verify each assistant message now has a non-empty `reference` array containing chunk `id`, `content`, `document_id`, `document_name`, `dataset_id`, etc.
- [ ] Verify sessions with no retrieval results still return `"reference": []` (empty dict `{}` is falsy, so the `if conv["reference"]:` guard keeps the list empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)