### PR TITLE
fix(session): type-guard non-streaming OpenAI-compat path

### DIFF
--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -434,9 +434,12 @@ async def chat_completion_openai_like(tenant_id, chat_id):
             chat_kwargs["doc_ids"] = doc_ids_str
         async for ans in async_chat(dia, msg, False, **chat_kwargs):
             # focus answer content only
-            answer = ans
+            if isinstance(ans, dict):
+                answer = ans
             break
-        content = answer["answer"]
+        if not isinstance(answer, dict):
+            return get_error_data_result("Unexpected response format from chat engine.")
+        content = answer.get("answer", "")
 
         response = {
             "id": f"chatcmpl-{chat_id}",
@@ -466,8 +469,11 @@ async def chat_completion_openai_like(tenant_id, chat_id):
             ],
         }
         if need_reference:
+            reference = answer.get("reference", {})
+            if not isinstance(reference, dict):
+                reference = {}
             response["choices"][0]["message"]["reference"] = _build_reference_chunks(
-                answer.get("reference", {}),
+                reference,
                 include_metadata=include_reference_metadata,
                 metadata_fields=metadata_fields,
             )


### PR DESCRIPTION
## Summary

Fixes #13453 — `stream: false` on the `/api/v1/chats_openai/{chat_id}/chat/completions` endpoint crashes with `AttributeError: 'list' object has no attribute 'get'`.

**Root cause:** In the non-streaming branch of `chat_completion_openai_like`, `async_chat` can yield a non-`dict` value (e.g. a bare list) and the `reference` field inside the answer dict can be a `list` instead of a `dict`. Downstream code calls `.get()` on these values, causing the `AttributeError`.

**Changes to `api/apps/sdk/session.py`:**
- Guard the assignment `answer = ans` with `isinstance(ans, dict)` so only valid dict responses are accepted.
- After the loop, return a structured error when `answer` is not a `dict` instead of crashing.
- Use `answer.get("answer", "")` instead of `answer["answer"]` to avoid a `KeyError` if the key is absent.
- Normalise the `reference` value to `{}` when it is not a `dict` before passing it to `_build_reference_chunks`, preventing the `AttributeError` that was originally reported.

## Test plan

- [ ] Call `/api/v1/chats_openai/{chat_id}/chat/completions` with `"stream": false` and `"extra_body": {"reference": true}` — should return a valid JSON response instead of a 500 error.
- [ ] Call the same endpoint with `"stream": false` and no `reference` field — should still work correctly.
- [ ] Existing unit tests in `test_session_sdk_routes_unit.py` (including `test_openai_nonstream_branch_unit`) continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)