### PR TITLE
Fixing WordNetCorpusReader object has no attribute _LazyCorpusLoader_…

### DIFF
--- a/rag/nlp/synonym.py
+++ b/rag/nlp/synonym.py
@@ -23,6 +23,13 @@ from nltk.corpus import wordnet
 from common.file_utils import get_project_base_directory
 
 
+# Forces NLTK to load the corpus synchronously once, preventing concurrent tasks
+# from triggering the lazy-loading race condition.
+try:
+    wordnet.ensure_loaded()
+except Exception:
+    logging.warning("Fail to load wordnet.ensure_loaded()")
+
 class Dealer:
     def __init__(self, redis=None):
 


### PR DESCRIPTION
### What problem does this PR solve?

Forces NLTK to load the corpus synchronously once, preventing concurrent tasks  from triggering the lazy-loading race condition that cause Fixing WordNetCorpusReader object has no attribute _LazyCorpusLoader_… #13590


### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)
