### PR TITLE
fix: DataFrame remained after _recursive_convert_obj_to_dict (#4588)

### DIFF
--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -98,6 +98,11 @@ class ComponentParamBase(ABC):
 
     def as_dict(self):
         def _recursive_convert_obj_to_dict(obj):
+            if isinstance(obj, pd.DataFrame):
+                return _recursive_convert_obj_to_dict(obj.to_dict(orient="records"))
+            if isinstance(obj, list):
+                return [_recursive_convert_obj_to_dict(item) for item in obj]
+
             ret_dict = {}
             if isinstance(obj, dict):
                 for k, v in obj.items():
@@ -113,7 +118,9 @@ class ComponentParamBase(ABC):
                 # get attr
                 attr = getattr(obj, attr_name)
                 if isinstance(attr, pd.DataFrame):
-                    ret_dict[attr_name] = attr.to_dict()
+                    ret_dict[attr_name] = _recursive_convert_obj_to_dict(
+                        attr.to_dict(orient="records")
+                    )
                     continue
                 if isinstance(attr, dict) or (attr and type(attr).__name__ not in dir(builtins)):
                     ret_dict[attr_name] = _recursive_convert_obj_to_dict(attr)

--- a/test/unit_test/agent/component/test_base.py
+++ b/test/unit_test/agent/component/test_base.py
@@ -1,0 +1,78 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import json
+
+import pandas as pd
+import pytest
+
+from agent.component.base import ComponentParamBase
+
+
+class _ParamWithDataFrame(ComponentParamBase):
+    """Minimal param class with a DataFrame attribute for testing."""
+
+    def __init__(self):
+        super().__init__()
+        self.data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    def check(self):
+        pass  # Minimal param for testing; no validation needed
+
+
+class _ParamWithDataFrameInOutputs(ComponentParamBase):
+    """Param with outputs dict containing a DataFrame as value (simulates agent output)."""
+
+    def __init__(self):
+        super().__init__()
+        self.outputs = {
+            "result": {"value": pd.DataFrame({"x": [10], "y": [20]}), "type": "DataFrame"}
+        }
+
+    def check(self):
+        pass  # Minimal param for testing; no validation needed
+
+
+class TestComponentParamBaseAsDictDataFrame:
+    """Tests for ComponentParamBase.as_dict() with pandas DataFrame (fixes #4588)."""
+
+    def test_dataframe_attribute_converted_to_json_serializable(self):
+        """DataFrame in param attribute is converted to list of dicts, not raw DataFrame."""
+        param = _ParamWithDataFrame()
+        result = param.as_dict()
+        assert "data" in result
+        assert result["data"] == [{"a": 1, "b": 3}, {"a": 2, "b": 4}]
+        # Must be JSON serializable (no DataFrame remains)
+        json_str = json.dumps(result, ensure_ascii=False)
+        parsed = json.loads(json_str)
+        assert parsed["data"] == [{"a": 1, "b": 3}, {"a": 2, "b": 4}]
+
+    def test_dataframe_in_outputs_converted_to_json_serializable(self):
+        """DataFrame in outputs dict (e.g. from agent output) is converted correctly."""
+        param = _ParamWithDataFrameInOutputs()
+        result = param.as_dict()
+        assert "outputs" in result
+        assert result["outputs"]["result"]["value"] == [{"x": 10, "y": 20}]
+        json_str = json.dumps(result, ensure_ascii=False)
+        parsed = json.loads(json_str)
+        assert parsed["outputs"]["result"]["value"] == [{"x": 10, "y": 20}]
+
+    def test_str_uses_as_dict_without_typeerror(self):
+        """__str__ (json.dumps(as_dict())) does not raise TypeError for DataFrame."""
+        param = _ParamWithDataFrame()
+        s = str(param)
+        parsed = json.loads(s)
+        assert parsed["data"] == [{"a": 1, "b": 3}, {"a": 2, "b": 4}]


### PR DESCRIPTION
## Summary

Fixes #4588.

**Root cause:** `_recursive_convert_obj_to_dict` did not handle top-level DataFrame, lists, or nested DataFrames; `attr.to_dict()` without `orient='records'` left non-JSON-serializable structures.

**Fix:** Add top-level handling for `pd.DataFrame` and `list`, and for DataFrame attributes use `_recursive_convert_obj_to_dict(attr.to_dict(orient="records"))`.

## Changes

- `agent/component/base.py`: Add DataFrame/list handling at top of `_recursive_convert_obj_to_dict`; use `orient="records"` for DataFrame attributes
- `test/unit_test/agent/component/test_base.py`: Add unit tests for DataFrame in attributes, nested outputs, and `__str__` serialization

## Testing

- Verified the fix addresses the reported scenario in #4588
- Added 3 tests covering: DataFrame attribute, DataFrame in nested outputs dict, `__str__` without TypeError
- Change is minimal and follows existing code patterns
- No unrelated changes included

Made with [Cursor](https://cursor.com)