### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1301,6 +1301,20 @@
             "url": "https://api.minimaxi.com/v1",
             "llm": [
                 {
+                    "llm_name": "MiniMax-M2.7",
+                    "tags": "LLM,CHAT,200k",
+                    "max_tokens": 204800,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "MiniMax-M2.7-highspeed",
+                    "tags": "LLM,CHAT,200k",
+                    "max_tokens": 204800,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
                     "llm_name": "MiniMax-M2.5",
                     "tags": "LLM,CHAT,200k",
                     "max_tokens": 204800,


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M2.7 model.

## Changes
- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to the model selection list in `conf/llm_factories.json`
- Place M2.7 models at the top of the list as the recommended default
- Retain all previous models (M2.5, M2.5-highspeed, M2.1, M2) as available alternatives

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. This update ensures RAGFlow users can access the newest model while maintaining backward compatibility with existing configurations.

## Testing
- JSON config validated (well-formed)
- No existing MiniMax-specific unit tests affected
- Model entries follow the same structure as existing entries