### PR TITLE
Feat: support variable interpolation in headers

### DIFF
--- a/agent/component/invoke.py
+++ b/agent/component/invoke.py
@@ -108,10 +108,25 @@ class Invoke(ComponentBase, ABC):
         method = self._param.method.lower()
         headers = {}
         if self._param.headers:
-            headers = json.loads(self._param.headers)
-            for key in headers:
-                if isinstance(headers[key], str):
-                    headers[key] = re.sub(variable_pattern, replace_variable, headers[key])
+            try:
+                parsed_headers = json.loads(self._param.headers)
+            except json.JSONDecodeError as e:
+                logging.warning(
+                    "Invoke headers are not valid JSON, ignoring headers. raw=%r error=%s",
+                    self._param.headers,
+                    e,
+                )
+                parsed_headers = {}
+            if not isinstance(parsed_headers, dict):
+                logging.warning(
+                    "Invoke headers JSON is of type %s, expected an object; ignoring headers.",
+                    type(parsed_headers).__name__,
+                )
+                parsed_headers = {}
+            headers = parsed_headers
+            for key, value in list(headers.items()):
+                if isinstance(value, str):
+                    headers[key] = re.sub(variable_pattern, replace_variable, value)
         proxies = None
         if re.sub(r"https?:?/?/?", "", self._param.proxy):
             proxies = {"http": self._param.proxy, "https": self._param.proxy}

--- a/test/testcases/test_web_api/test_canvas_app/test_invoke_component_unit.py
+++ b/test/testcases/test_web_api/test_canvas_app/test_invoke_component_unit.py
@@ -149,10 +149,6 @@ def test_header_single_variable(monkeypatch):
         headers=json.dumps({"Authorization": "Bearer {auth_token}"}),
         variable_values={"auth_token": "secret123"},
     )
-    monkeypatch.setattr(module.requests, "get", lambda **kw: SimpleNamespace(text="ok"))
-    invoke._invoke()
-    # requests.get is monkeypatched, so check via output
-    # Instead, patch at module level and inspect call
     mock_get = MagicMock(return_value=SimpleNamespace(text="ok"))
     monkeypatch.setattr(module.requests, "get", mock_get)
     invoke._invoke()


### PR DESCRIPTION
Closes #13277

### What problem does this PR solve?

Adds `{variable_name}` (and `{component@variable}`) interpolation support to HTTP header values in the `Invoke` component, matching the existing URL interpolation behavior.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

<img width="1280" height="867" alt="image" src="https://github.com/user-attachments/assets/8ab7b4e9-7cc0-4a7f-8a5f-f838a15a5fda" />
