### PR TITLE
Fix: use configured OrderByExpr in _community_retrieval_

### DIFF
--- a/rag/graphrag/search.py
+++ b/rag/graphrag/search.py
@@ -299,7 +299,7 @@ class KGSearch(Dealer):
         fltr["knowledge_graph_kwd"] = "community_report"
         fltr["entities_kwd"] = entities
         comm_res = self.dataStore.search(fields, [], fltr, [],
-                                         OrderByExpr(), 0, topn, idxnms, kb_ids)
+                                         odr, 0, topn, idxnms, kb_ids)
         comm_res_fields = self.dataStore.get_fields(comm_res, fields)
         txts = []
         for ii, (_, row) in enumerate(comm_res_fields.items()):


### PR DESCRIPTION
The `odr` variable was configured with `desc("weight_flt")` but a new empty `OrderByExpr()` was passed to `dataStore.search()` instead, causing the descending sort to have no effect.

### What problem does this PR solve?

In `_community_retrieval_`, the configured `OrderByExpr` with `desc("weight_flt")` was discarded — a new empty `OrderByExpr()` was passed to `dataStore.search()` instead, so community reports were never sorted by weight.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
