### PR TITLE
fix: include missing modules in ragflow-cli package

### DIFF
--- a/admin/client/MANIFEST.in
+++ b/admin/client/MANIFEST.in
@@ -1,0 +1,1 @@
+include admin/client/*.py


### PR DESCRIPTION
## Summary
This PR fixes the PyPI packaging issue where the ragflow-cli package is missing critical Python modules after installation.

## Problem
The ragflow-cli package on PyPI is missing:
- `http_client.py`
- `ragflow_client.py`
- `user.py`

Users installing via `pip install ragflow-cli` get only the entry point without the client libraries.

## Root Cause
The pyproject.toml correctly lists all modules in `py-modules`, but the package distribution (sdist/wheel) doesn't include all Python files from the admin/client/ directory.

## Solution
Added `MANIFEST.in` to ensure all `*.py` files in admin/client/ are included in the package distribution:

```
include admin/client/*.py
```

## Testing
The fix ensures that all modules (ragflow_cli, parser, http_client, ragflow_client, user) are included when the package is built and distributed.

Fixes #13456