### PR TITLE
Fix: include usage tokens in streaming LLM calls to avoid inaccurate estimation

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -1319,6 +1319,7 @@ class LiteLLMBase(ABC):
                     **completion_args,
                     drop_params=True,
                     timeout=self.timeout,
+                    stream_options={"include_usage": True},
                 )
 
                 async for resp in stream:


### PR DESCRIPTION
### What problem does this PR solve?

Previously, token usage statistics could be inaccurate when calling LLMs
in the async_chat_streamly method of chat_model.py.

The root cause: the streaming LLM request did not include the parameter:

stream_options={"include_usage": True}

As a result, the model response did not contain actual usage token
information. The system then fell back to estimating token usage via
tiktoken.

However, tiktoken-based estimation is not reliable for non-OpenAI models,
leading to discrepancies in reported token usage.

This PR fixes the issue by explicitly enabling usage reporting in
streaming requests. With include_usage=True, the model returns accurate
token usage data, eliminating the need for approximation and improving
cost/statistics accuracy.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
