### PR TITLE
 Fix: model_type not passed in ensure_tenant_model_id_for_params causing wrong tenant model lookup

### DIFF
--- a/api/utils/tenant_utils.py
+++ b/api/utils/tenant_utils.py
@@ -13,12 +13,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from common.constants import LLMType
 from api.db.services.tenant_llm_service import TenantLLMService
+
+_KEY_TO_MODEL_TYPE = {
+    "llm_id": LLMType.CHAT,
+    "embd_id": LLMType.EMBEDDING,
+    "asr_id": LLMType.SPEECH2TEXT,
+    "img2txt_id": LLMType.IMAGE2TEXT,
+    "rerank_id": LLMType.RERANK,
+    "tts_id": LLMType.TTS,
+}
 
 def ensure_tenant_model_id_for_params(tenant_id: str, param_dict: dict) -> dict:
     for key in ["llm_id", "embd_id", "asr_id", "img2txt_id", "rerank_id", "tts_id"]:
         if param_dict.get(key) and not param_dict.get(f"tenant_{key}"):
-            tenant_model = TenantLLMService.get_api_key(tenant_id, param_dict[key])
+            model_type = _KEY_TO_MODEL_TYPE.get(key)
+            tenant_model = TenantLLMService.get_api_key(tenant_id, param_dict[key], model_type)
             if tenant_model:
                 param_dict.update({f"tenant_{key}": tenant_model.id})
             else:


### PR DESCRIPTION
  Summary

  When setting a default model for an OpenAI-API-Compatible provider, ensure_tenant_model_id_for_params called get_api_key 
  without a model_type filter. If the same model name was registered under multiple types (e.g., both chat and embedding), 
  it could return the wrong tenant_llm_id, leading to Model(@None) not authorized errors during chat.

  This applies the same type-scoped fix that PR #13569 introduced in get_model_config_by_type_and_name — now consistently  
  in tenant_utils.py as well.

  Changes

  - Added _KEY_TO_MODEL_TYPE mapping in tenant_utils.py
  - Each model key (llm_id, embd_id, etc.) now passes its correct LLMType to get_api_key

  Fixes #13775