### PR TITLE
feat(memory): support memory_type filtering in List/Search/Recent message APIs

### DIFF
--- a/api/apps/restful_apis/memory_api.py
+++ b/api/apps/restful_apis/memory_api.py
@@ -164,9 +164,11 @@ async def get_memory_messages(memory_id):
     keywords = keywords.strip()
     page = int(args.get("page", 1))
     page_size = int(args.get("page_size", 50))
+    memory_type = args.get("memory_type", "")
+    memory_types = [t.strip() for t in memory_type.split(",") if t.strip()] or None
     try:
         res = await memory_api_service.get_memory_messages(
-            memory_id, agent_ids, keywords, page, page_size
+            memory_id, agent_ids, keywords, page, page_size, memory_types=memory_types
         )
         return get_json_result(message=True, data=res)
     except NotFoundException as not_found_exception:
@@ -251,6 +253,9 @@ async def search_message():
     session_id = args.get("session_id", "")
     user_id = args.get("user_id", "")
 
+    memory_type = args.get("memory_type", "")
+    memory_types = [t.strip() for t in memory_type.split(",") if t.strip()] or None
+
     filter_dict = {
         "memory_id": memory_ids,
         "agent_id": agent_id,
@@ -263,7 +268,7 @@ async def search_message():
         "keywords_similarity_weight": keywords_similarity_weight,
         "top_n": top_n
     }
-    res = await memory_api_service.search_message(filter_dict, params)
+    res = await memory_api_service.search_message(filter_dict, params, memory_types=memory_types)
     return get_json_result(message=True, data=res)
 
 @manager.route("/messages", methods=["GET"]) # noqa: F821
@@ -276,10 +281,12 @@ async def get_messages():
     agent_id = args.get("agent_id", "")
     session_id = args.get("session_id", "")
     limit = int(args.get("limit", 10))
+    memory_type = args.get("memory_type", "")
+    memory_types = [t.strip() for t in memory_type.split(",") if t.strip()] or None
     if not memory_ids:
         return get_error_argument_result("memory_ids is required.")
     try:
-        res = await memory_api_service.get_messages(memory_ids, agent_id, session_id, limit)
+        res = await memory_api_service.get_messages(memory_ids, agent_id, session_id, limit, memory_types=memory_types)
         return get_json_result(message=True, data=res)
     except Exception as e:
         logging.error(e)

--- a/api/apps/services/memory_api_service.py
+++ b/api/apps/services/memory_api_service.py
@@ -217,12 +217,12 @@ async def get_memory_config(memory_id):
     return format_ret_data_from_memory(memory)
 
 
-async def get_memory_messages(memory_id, agent_ids: list[str], keywords: str, page: int=1, page_size: int = 50):
+async def get_memory_messages(memory_id, agent_ids: list[str], keywords: str, page: int=1, page_size: int = 50, memory_types: list[str] = None):
     memory = MemoryService.get_by_memory_id(memory_id)
     if not memory:
         raise NotFoundException(f"Memory '{memory_id}' not found.")
     messages = MessageService.list_message(
-        memory.tenant_id, memory_id, agent_ids, keywords, page, page_size)
+        memory.tenant_id, memory_id, agent_ids, keywords, page, page_size, memory_types=memory_types)
     agent_name_mapping = {}
     extract_task_mapping = {}
     if messages["message_list"]:
@@ -285,7 +285,7 @@ async def update_message_status(memory_id: str, message_id: int, status: bool):
     raise Exception(f"Failed to set status for message '{message_id}' in memory '{memory_id}'.")
 
 
-async def search_message(filter_dict: dict, params: dict):
+async def search_message(filter_dict: dict, params: dict, memory_types: list[str] = None):
     """
     :param filter_dict: {
         "memory_id": list[str],
@@ -299,11 +299,14 @@ async def search_message(filter_dict: dict, params: dict):
         "keywords_similarity_weight": float,
         "top_n": int
     }
+    :param memory_types: optional list of memory type strings for filtering
     """
+    if memory_types:
+        filter_dict["message_type"] = memory_types
     return query_message(filter_dict, params)
 
 
-async def get_messages(memory_ids: list[str], agent_id: str = "", session_id: str = "", limit: int = 10):
+async def get_messages(memory_ids: list[str], agent_id: str = "", session_id: str = "", limit: int = 10, memory_types: list[str] = None):
     """
     Get recent messages from specified memories.
 
@@ -311,6 +314,7 @@ async def get_messages(memory_ids: list[str], agent_id: str = "", session_id: st
     :param agent_id: optional agent ID for filtering
     :param session_id: optional session ID for filtering
     :param limit: maximum number of messages to return
+    :param memory_types: optional list of memory type strings for filtering
     :return: list of recent messages
     """
     memory_list = MemoryService.get_by_ids(memory_ids)
@@ -320,7 +324,8 @@ async def get_messages(memory_ids: list[str], agent_id: str = "", session_id: st
         memory_ids,
         agent_id,
         session_id,
-        limit
+        limit,
+        memory_types=memory_types
     )
     return res
 

--- a/memory/services/messages.py
+++ b/memory/services/messages.py
@@ -63,7 +63,7 @@ class MessageService:
         return settings.msgStoreConn.delete(condition, index, memory_id)
 
     @classmethod
-    def list_message(cls, uid: str, memory_id: str, agent_ids: List[str]=None, keywords: str=None, page: int=1, page_size: int=50):
+    def list_message(cls, uid: str, memory_id: str, agent_ids: List[str]=None, keywords: str=None, page: int=1, page_size: int=50, memory_types: List[str]=None):
         index = index_name(uid)
         filter_dict = {}
         if agent_ids:
@@ -79,7 +79,7 @@ class MessageService:
         res, total_count = settings.msgStoreConn.search(
             select_fields=select_fields,
             highlight_fields=[],
-            condition={**filter_dict, "message_type": MemoryType.RAW.name.lower()},
+            condition={**filter_dict, "message_type": memory_types if memory_types else MemoryType.RAW.name.lower()},
             match_expressions=[], order_by=order_by,
             offset=(page-1)*page_size, limit=page_size,
             index_names=index, memory_ids=[memory_id], agg_fields=[], hide_forgotten=False
@@ -118,12 +118,14 @@ class MessageService:
         }
 
     @classmethod
-    def get_recent_messages(cls, uid_list: List[str], memory_ids: List[str], agent_id: str, session_id: str, limit: int):
+    def get_recent_messages(cls, uid_list: List[str], memory_ids: List[str], agent_id: str, session_id: str, limit: int, memory_types: List[str]=None):
         index_names = [index_name(uid) for uid in uid_list]
         condition_dict = {
             "agent_id": agent_id,
             "session_id": session_id
         }
+        if memory_types:
+            condition_dict["message_type"] = memory_types
         order_by = OrderByExpr()
         order_by.desc("valid_at")
         res, total_count = settings.msgStoreConn.search(
@@ -147,11 +149,13 @@ class MessageService:
         return list(doc_mapping.values())
 
     @classmethod
-    def search_message(cls, memory_ids: List[str], condition_dict: dict, uid_list: List[str], match_expressions:list[MatchExpr], top_n: int):
+    def search_message(cls, memory_ids: List[str], condition_dict: dict, uid_list: List[str], match_expressions:list[MatchExpr], top_n: int, memory_types: List[str]=None):
         index_names = [index_name(uid) for uid in uid_list]
         # filter only valid messages by default
         if "status" not in condition_dict:
             condition_dict["status"] = 1
+        if memory_types:
+            condition_dict["message_type"] = memory_types
 
         order_by = OrderByExpr()
         order_by.desc("valid_at")


### PR DESCRIPTION
## Summary

Closes #13730

- Add optional `memory_type` query parameter to three message API endpoints: `GET /memories/<memory_id>`, `GET /messages/search`, and `GET /messages`
- Support filtering messages by type (`raw`, `semantic`, `episodic`, `procedural`) server-side, eliminating the need for client-side filtering
- Backward compatible: when `memory_type` is not provided, behavior remains unchanged

## Changes

| File | Change |
|------|--------|
| `api/apps/restful_apis/memory_api.py` | Parse `memory_type` query param (comma-separated) in 3 endpoints |
| `api/apps/services/memory_api_service.py` | Pass `memory_types` through service layer to MessageService |
| `memory/services/messages.py` | Add `memory_types` filtering in `list_message`, `get_recent_messages`, `search_message` |

## Usage

```bash
# Filter by single type
GET /memories/<id>?memory_type=raw

# Filter by multiple types
GET /messages/search?memory_id=xxx&query=hello&memory_type=raw,semantic

# Recent messages filtered by type
GET /messages?memory_id=xxx&memory_type=episodic
```

## Test plan

- [ ] Verify `GET /memories/<id>` returns only messages matching the specified `memory_type`
- [ ] Verify `GET /messages/search` filters search results by `memory_type`
- [ ] Verify `GET /messages` filters recent messages by `memory_type`
- [ ] Verify all three endpoints work correctly without `memory_type` param (backward compatibility)
- [ ] Verify comma-separated `memory_type` values work (e.g., `raw,semantic`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)