### PR TITLE
Feat: add cell type coercion for Excel export

### DIFF
--- a/agent/component/message.py
+++ b/agent/component/message.py
@@ -226,6 +226,38 @@ class Message(ComponentBase):
         
         rows = []
         headers = None
+
+        def _coerce_excel_cell_type(cell: str):
+            # Convert markdown cell text to native numeric types when safe,so Excel writes numeric cells instead of text.
+            if not isinstance(cell, str):
+                return cell
+
+            value = cell.strip()
+            if value == "":
+                return ""
+
+            # Keep values like "00123" as text to avoid losing leading zeros.
+            if re.match(r"^[+-]?0\d+$", value):
+                return cell
+
+            # Support thousand separators like 1,234 or 1,234.56
+            numeric_candidate = value
+            if re.match(r"^[+-]?\d{1,3}(,\d{3})+(\.\d+)?$", value):
+                numeric_candidate = value.replace(",", "")
+
+            if re.match(r"^[+-]?\d+$", numeric_candidate):
+                try:
+                    return int(numeric_candidate)
+                except ValueError:
+                    return cell
+
+            if re.match(r"^[+-]?(\d+\.\d+|\d+\.|\.\d+)([eE][+-]?\d+)?$", numeric_candidate) or re.match(r"^[+-]?\d+[eE][+-]?\d+$", numeric_candidate):
+                try:
+                    return float(numeric_candidate)
+                except ValueError:
+                    return cell
+
+            return cell
         
         for line in table_lines:
             # Split by | and clean up
@@ -236,6 +268,7 @@ class Message(ComponentBase):
             if headers is None:
                 headers = cells
             else:
+                cells = [_coerce_excel_cell_type(c) for c in cells]
                 rows.append(cells)
         
         if headers and rows:


### PR DESCRIPTION
### What problem does this PR solve?

- Implemented a helper function to convert markdown cell text to native numeric types for Excel output.
- Ensured that leading zeros are preserved and handled various numeric formats, including those with thousand separators and scientific notation.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
