### PR TITLE
fix(rag): skip InfinityException 3052 during tag set search instead of crashing

### DIFF
--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -269,6 +269,8 @@ class InfinityConnection(InfinityConnectionBase):
                     try:
                         kb_res, extra_result = builder.option({"total_hits_count": True}).to_df()
                     except InfinityException as e:
+                        if e.error_code != 3052:
+                            raise
                         self.logger.warning(f"INFINITY search failed on table {table_name} (error {e.error_code}): {e}. Skipping.")
                         continue
                     if extra_result:


### PR DESCRIPTION
  Description:
  When Tag Set is enabled and documents are parsed with the Infinity backend,
  short Chinese text queries trigger InfinityException error code 3052 from
  Infinity's query planner. This caused the entire parsing process to crash.

  The fix wraps the `to_df()` call in a targeted try/except that only catches
  error code 3052 (query planner failure). The problematic table is skipped
  with a warning and parsing continues normally. All other InfinityException
  error codes (e.g. 3014 for invalid arguments) are still re-raised as expected.

  Fixes #13729
