### PR TITLE
Fix: add missing "mom" field to infinity_mapping.json for parent-child chunker

### DIFF
--- a/conf/infinity_mapping.json
+++ b/conf/infinity_mapping.json
@@ -3,6 +3,7 @@
 	"doc_id": {"type": "varchar", "default": ""},
 	"kb_id": {"type": "varchar", "default": "", "index_type": {"type": "secondary", "cardinality": "low"}},
 	"mom_id": {"type": "varchar", "default": ""},
+	"mom": {"type": "varchar", "default": ""},
 	"create_time": {"type": "varchar", "default": ""},
 	"create_timestamp_flt": {"type": "float", "default": 0.0},
 	"img_id": {"type": "varchar", "default": ""},


### PR DESCRIPTION
### What problem does this PR solve?

When using Infinity as DOC_ENGINE with parent-child chunker enabled, vector insertion fails because the "mom" field is missing from the index mapping. This fix adds the required field to resolve the issue.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)