### PR TITLE
fix: add authentication and authorization to /thumbnails endpoint (CWE-287)

### DIFF
--- a/api/apps/document_app.py
+++ b/api/apps/document_app.py
@@ -495,11 +495,15 @@ async def update_metadata_setting():
 
 
 @manager.route("/thumbnails", methods=["GET"])  # noqa: F821
-# @login_required
-def thumbnails():
+@login_required
+async def thumbnails():
     doc_ids = request.args.getlist("doc_ids")
     if not doc_ids:
         return get_json_result(data=False, message='Lack of "Document ID"', code=RetCode.ARGUMENT_ERROR)
+
+    for doc_id in doc_ids:
+        if not DocumentService.accessible(doc_id, current_user.id):
+            return get_json_result(data=False, message="No authorization.", code=RetCode.AUTHENTICATION_ERROR)
 
     try:
         docs = DocumentService.get_thumbnails(doc_ids)


### PR DESCRIPTION
## Vulnerability Summary

**CWE-287: Improper Authentication** | **Severity: High**

The `GET /v1/document/thumbnails` endpoint in `api/apps/document_app.py` (line 498) has its `@login_required` decorator commented out (`# @login_required`), allowing **unauthenticated access** to document thumbnail data and metadata. This is inconsistent with 22 of 23 other endpoints in the same file that enforce authentication.

### Data Flow

1. Attacker sends unauthenticated `GET /v1/document/thumbnails?doc_ids=<id>` request
2. Server processes the request with no identity check
3. `DocumentService.get_thumbnails(doc_ids)` returns thumbnail data for any valid doc_id
4. Response contains either **inline base64 image data** or `/v1/document/image/{kb_id}-{filename}` URLs
5. Attacker obtains: document existence confirmation, knowledge base IDs, and thumbnail image content

### Network Exposure

- `conf/service_conf.yaml` binds on `0.0.0.0:9380` (all interfaces)
- Docker Compose exposes `${SVR_HTTP_PORT}:9380` externally
- NGINX is included but commented out by default in `docker-compose.yml`
- **The API is internet-facing in the default deployment configuration**

### Exploit Example

```bash
# No authentication needed — returns document thumbnails for any valid doc_id
curl "https://target-ragflow.example.com/v1/document/thumbnails?doc_ids=<known_doc_id>"
```

Response (before fix):
```json
{
  "data": {
    "abc123...": "data:image/jpeg;base64,/9j/4AAQSkZJR...",
    "def456...": "/v1/document/image/kb789-thumb_file.jpg"
  }
}
```

### Preconditions

1. Network access to the RAGFlow API (internet-facing by default)
2. Knowledge of at least one valid `doc_id` (UUID1 format, 32 hex chars)
3. No authentication required (the vulnerability itself)

---

## Fix Description

**Single file changed:** `api/apps/document_app.py` — 6 lines added, 2 lines removed.

The fix applies two layers of access control:

1. **Authentication:** Uncomments `@login_required` so the endpoint requires a valid session
2. **Authorization:** Adds per-document `DocumentService.accessible(doc_id, current_user.id)` check, ensuring the authenticated user actually has access to each requested document

This follows the exact same pattern used by the adjacent `doc_infos()` endpoint (line 430), which also calls `DocumentService.accessible()` for per-document authorization.

The function signature is also updated from `def` to `async def` to match the convention of all other authenticated endpoints in the file.

### Diff

```diff
 @manager.route("/thumbnails", methods=["GET"])  # noqa: F821
-# @login_required
-def thumbnails():
+@login_required
+async def thumbnails():
     doc_ids = request.args.getlist("doc_ids")
     if not doc_ids:
         return get_json_result(data=False, message='Lack of "Document ID"', code=RetCode.ARGUMENT_ERROR)
 
+    for doc_id in doc_ids:
+        if not DocumentService.accessible(doc_id, current_user.id):
+            return get_json_result(data=False, message="No authorization.", code=RetCode.AUTHENTICATION_ERROR)
+
     try:
         docs = DocumentService.get_thumbnails(doc_ids)
```

---

## Test Results Summary

- **Diff scope:** Exactly 1 file, 8 lines changed — minimal and surgical
- **No unrelated changes, no new dependencies, no config modifications**
- The `@login_required` decorator and `DocumentService.accessible()` are both well-established patterns used extensively throughout the codebase
- The `current_user` object is available via Flask-Login, already imported and used by all other authenticated endpoints in this file

---

## Disprove Analysis

We systematically attempted to invalidate this finding:

### Authentication Check ✅ Confirmed Vulnerable
`# @login_required` is explicitly commented out. 22 of 23 other endpoints in the same file have active `@login_required`. This is not a framework default — it is intentionally disabled auth.

### Network Reachability ✅ Confirmed Internet-Facing
API binds on `0.0.0.0`, Docker exposes the port externally, no VPN/service mesh requirement documented, NGINX config commented out by default.

### Deployment Context ✅ Confirmed No Compensating Controls
Docker Compose is the primary deployment method. No WAF, API gateway, or reverse proxy is configured by default.

### Caller Trace ✅ Confirmed Server-Side Gap
Frontend calls `/thumbnails` from `web/src/hooks/use-document-request.ts:541` and likely sends cookies. However, the server performs **zero authentication** — any HTTP client can bypass the frontend.

### Input Validation ✅ Confirmed No Access Control
`doc_ids` come directly from `request.args.getlist("doc_ids")` with no access-control filtering before reaching `DocumentService.get_thumbnails()`.

### Prior Reports ✅ No Prior Fix
No existing CVE or issue for this specific endpoint. The SECURITY.md only documents a `restricted_loads` pickle vulnerability.

### Recent Commits ✅ Not Recently Fixed
Only recent commit touching this file: `e705ac6 Add logout (#13796)` — unrelated.

### Fix Adequacy ✅ Fix Is Meaningful
- Blocks unauthenticated access to **inline base64 thumbnail data** (direct information leak)
- Blocks **document existence enumeration** (oracle for probing doc_ids)
- Blocks **knowledge base ID disclosure** (kb_id values in image URLs)
- Adds per-document authorization, not just authentication

### Existing Mitigations (Partial)
- Doc IDs use UUID1 (not sequential integers), making blind enumeration harder
- The endpoint requires attacker-supplied `doc_ids` — it does not list all documents

---

## Related Note

The `/image/<image_id>` endpoint at line 818 in the same file also has `# @login_required` commented out. This is a **separate but related** vulnerability with a different attack surface (requires knowing exact `kb_id-filename` pairs). It should be addressed in a follow-up.

---

**Verdict:** Confirmed valid (high confidence). The fix is minimal, follows established codebase patterns, and meaningfully reduces attack surface.