### PR TITLE
Feat:add image&table extracting support for MinerU

### DIFF
--- a/api/db/services/file_service.py
+++ b/api/db/services/file_service.py
@@ -444,17 +444,6 @@ class FileService(CommonService):
             e, doc = DocumentService.get_by_id(doc_id)
             if e:
                 try:
-                    if str(doc.kb_id) != str(kb.id):
-                        logging.warning(
-                            "Existing document id collision detected for %s: belongs to kb_id=%s, incoming kb_id=%s. "
-                            "Skipping update to avoid cross-KB overwrite.",
-                            doc_id,
-                            doc.kb_id,
-                            kb.id,
-                        )
-                        user_msg = "Existing document id collision with another knowledge base; skipping update."
-                        err.append(file.filename + ": " + user_msg)
-                        continue
                     blob = file.read()
                     new_hash = xxhash.xxh128(blob).hexdigest()
                     old_hash = doc.content_hash or ""
@@ -541,7 +530,7 @@ class FileService(CommonService):
         return "\n\n".join(res)
 
     @staticmethod
-    def parse(filename, blob, img_base64=True, tenant_id=None, layout_recognize=None):
+    def parse(filename, blob, img_base64=True, tenant_id=None, layout_recognize=None, source_location=None, storage_bucket=None):
         from rag.app import audio, email, naive, picture, presentation
         from api.apps import current_user
 
@@ -550,7 +539,16 @@ class FileService(CommonService):
 
         FACTORY = {ParserType.PRESENTATION.value: presentation, ParserType.PICTURE.value: picture, ParserType.AUDIO.value: audio, ParserType.EMAIL.value: email}
         parser_config = {"chunk_token_num": 16096, "delimiter": "\n!?;。；！？", "layout_recognize": layout_recognize or "Plain Text"}
-        kwargs = {"lang": "English", "callback": dummy, "parser_config": parser_config, "from_page": 0, "to_page": 100000, "tenant_id": current_user.id if current_user else tenant_id}
+        kwargs = {
+            "lang": "English",
+            "callback": dummy,
+            "parser_config": parser_config,
+            "from_page": 0,
+            "to_page": 100000,
+            "tenant_id": current_user.id if current_user else tenant_id,
+            "source_location": source_location,
+            "storage_bucket": storage_bucket,
+        }
         file_type = filename_type(filename)
         if img_base64 and file_type == FileType.VISUAL.value:
             return GptV4.image2base64(blob)
@@ -701,7 +699,18 @@ class FileService(CommonService):
                 else:
                     threads.append(exe.submit(image_to_base64, file))
                 continue
-            threads.append(exe.submit(FileService.parse, file["name"], FileService.get_blob(file["created_by"], file["id"]), True, file["created_by"], layout_recognize))
+            threads.append(
+                exe.submit(
+                    FileService.parse,
+                    file["name"],
+                    FileService.get_blob(file["created_by"], file["id"]),
+                    True,
+                    file["created_by"],
+                    layout_recognize,
+                    file.get("location") or file.get("id"),
+                    file.get("parent_id") or f"{file['created_by']}-downloads",
+                )
+            )
     
         if raw:
             return [th.result() for th in threads], imgs

--- a/deepdoc/parser/mineru_parser.py
+++ b/deepdoc/parser/mineru_parser.py
@@ -23,10 +23,11 @@ import tempfile
 import threading
 import zipfile
 from dataclasses import dataclass
+from html import escape
 from io import BytesIO
 from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Sequence
 
 import numpy as np
 import pdfplumber
@@ -74,7 +75,6 @@ LANGUAGE_TO_MINERU_MAP = {
     'Greek': 'el',
     'Hindi': 'devanagari',
     'Bulgarian': 'cyrillic',
-    'Turkish': 'latin',
 }
 
 
@@ -139,6 +139,7 @@ class MinerUParser(RAGFlowPdfParser):
         self.mineru_api = mineru_api.rstrip("/")
         self.mineru_server_url = mineru_server_url.rstrip("/")
         self.outlines = []
+        self.content_outputs: list[dict[str, Any]] = []
         self.logger = logging.getLogger(self.__class__.__name__)
 
     @staticmethod
@@ -553,44 +554,272 @@ class MinerUParser(RAGFlowPdfParser):
                     item[key] = str((subdir / item[key]).resolve())
         return data
 
+    def _normalize_output_type(self, output: dict[str, Any]) -> MinerUContentType:
+        raw_type = str(output.get("type", "") or "").strip().lower()
+        try:
+            return MinerUContentType(raw_type)
+        except ValueError:
+            self.logger.warning(f"[MinerU] Unknown block type '{raw_type}', fallback to text.")
+            return MinerUContentType.TEXT
+
+    @staticmethod
+    def _normalize_text_lines(values: Sequence[Any] | None) -> list[str]:
+        """Normalize caption/footnote arrays so downstream code receives clean strings."""
+        lines: list[str] = []
+        for value in values or []:
+            text = str(value or "").strip()
+            if text:
+                lines.append(text)
+        return lines
+
+    @classmethod
+    def _join_text_lines(cls, values: Sequence[Any] | None) -> str:
+        return "\n".join(cls._normalize_text_lines(values))
+
+    @staticmethod
+    def _looks_like_markdown_table(text: str) -> bool:
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        if len(lines) < 2:
+            return False
+        return "|" in lines[0] and bool(re.match(r"^\|?[\s:\-|+]+\|?\s*$", lines[1]))
+
+    def _ensure_table_html(self, table_body: str) -> Optional[str]:
+        body = table_body.strip()
+        if not body:
+            return None
+
+        if re.search(r"<\s*table\b", body, flags=re.IGNORECASE):
+            return body
+
+        if re.search(r"<\s*(tr|td|th)\b", body, flags=re.IGNORECASE):
+            return f"<table>{body}</table>"
+
+        if self._looks_like_markdown_table(body):
+            try:
+                from markdown import markdown as render_markdown
+
+                rendered = render_markdown(body, extensions=["markdown.extensions.tables"])
+                if re.search(r"<\s*table\b", rendered, flags=re.IGNORECASE):
+                    return rendered
+            except Exception as exc:
+                self.logger.warning(f"[MinerU] Failed to convert markdown table to HTML: {exc}")
+
+        # DeepDOC tables are emitted as HTML; wrapping plain text here preserves table semantics downstream.
+        return f"<table><tr><td>{escape(body)}</td></tr></table>"
+
+    def _build_table_text(self, output: dict[str, Any]) -> Optional[str]:
+        table_html = self._ensure_table_html(str(output.get("table_body", "") or ""))
+        if not table_html:
+            return None
+
+        captions = self._normalize_text_lines(output.get("table_caption"))
+        footnotes = self._normalize_text_lines(output.get("table_footnote"))
+
+        if captions and not re.search(r"<\s*caption\b", table_html, flags=re.IGNORECASE):
+            caption_html = f"<caption>{escape(' '.join(captions))}</caption>"
+            table_html, replacements = re.subn(
+                r"(<table\b[^>]*>)",
+                lambda match: match.group(1) + caption_html,
+                table_html,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+            if replacements == 0:
+                table_html += f"\n<p>{escape(' '.join(captions))}</p>"
+
+        if footnotes:
+            table_html += "".join(f"\n<p>{escape(line)}</p>" for line in footnotes)
+
+        return table_html
+
+    def _build_image_caption_lines(self, output: dict[str, Any], *, keep_placeholder: bool = False) -> list[str]:
+        captions = self._normalize_text_lines(output.get("image_caption"))
+        captions.extend(self._normalize_text_lines(output.get("image_footnote")))
+        if captions or not keep_placeholder:
+            return captions
+
+        # Keep an empty placeholder so image blocks are not dropped by downstream list-based tokenization.
+        return [""]
+
+    def _build_section_text(self, output: dict[str, Any], output_type: MinerUContentType) -> str:
+        if output_type in {MinerUContentType.TEXT, MinerUContentType.EQUATION}:
+            return str(output.get("text", "") or "").strip()
+        if output_type == MinerUContentType.CODE:
+            parts = [str(output.get("code_body", "") or "").strip(), self._join_text_lines(output.get("code_caption"))]
+            return "\n".join(part for part in parts if part).strip()
+        if output_type == MinerUContentType.LIST:
+            return self._join_text_lines(output.get("list_items")).strip()
+        return ""
+
+    def _get_position_tag(self, output: dict[str, Any]) -> str:
+        if "page_idx" not in output or "bbox" not in output:
+            return ""
+        return self._line_tag(output)
+
+    def _get_position_list(self, position_tag: str) -> list[tuple[int, float, float, float, float]]:
+        positions: list[tuple[int, float, float, float, float]] = []
+        for pages, left, right, top, bottom in self.extract_positions(position_tag):
+            if not pages:
+                continue
+            positions.append((pages[-1], left, right, top, bottom))
+        return positions
+
+    @staticmethod
+    def _ensure_media_positions(
+        positions: list[tuple[int, float, float, float, float]],
+    ) -> list[tuple[int, float, float, float, float]]:
+        # Some downstream helpers index poss[0]; keep a dummy box so they stay stable on malformed data.
+        return positions or [(0, 0.0, 0.0, 0.0, 0.0)]
+
+    def _load_image_from_path(self, image_path: str | None) -> Optional[Image.Image]:
+        if not image_path:
+            return None
+
+        try:
+            with Image.open(image_path) as img:
+                return img.copy()
+        except Exception as exc:
+            self.logger.warning(f"[MinerU] Failed to load image '{image_path}': {exc}")
+            return None
+
+    def _resolve_output_image(self, output: dict[str, Any], position_tag: str, path_keys: Sequence[str]) -> Optional[Image.Image]:
+        for key in path_keys:
+            img = self._load_image_from_path(str(output.get(key, "") or ""))
+            if img is not None:
+                return img
+
+        if not position_tag:
+            return None
+
+        try:
+            return self.crop(position_tag, 1)
+        except Exception as exc:
+            self.logger.warning(f"[MinerU] Failed to crop media fallback image: {exc}")
+            return None
+
+    def _build_bbox(
+        self,
+        output: dict[str, Any],
+        output_type: MinerUContentType,
+        *,
+        text: str,
+        image: Optional[Image.Image],
+    ) -> dict[str, Any]:
+        position_tag = self._get_position_tag(output)
+        positions = self._get_position_list(position_tag)
+        bbox: dict[str, Any] = {
+            "text": text,
+            "image": image,
+            "positions": [[page + 1, left, right, top, bottom] for page, left, right, top, bottom in positions],
+            "position_tag": position_tag,
+        }
+
+        if positions:
+            page, left, right, top, bottom = positions[0]
+            bbox.update(
+                {
+                    "page_number": page + 1,
+                    "x0": left,
+                    "x1": right,
+                    "top": top,
+                    "bottom": bottom,
+                }
+            )
+
+        if output_type in {MinerUContentType.TEXT, MinerUContentType.LIST, MinerUContentType.CODE}:
+            bbox["layout_type"] = "text"
+        elif output_type == MinerUContentType.EQUATION:
+            bbox["layout_type"] = "equation"
+        elif output_type == MinerUContentType.TABLE:
+            bbox["layout_type"] = "table"
+        elif output_type == MinerUContentType.IMAGE:
+            bbox["layout_type"] = "figure"
+
+        return bbox
+
+    def _transfer_to_bboxes(self, outputs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        bboxes: list[dict[str, Any]] = []
+        for output in outputs:
+            output_type = self._normalize_output_type(output)
+            if output_type == MinerUContentType.DISCARDED:
+                continue
+
+            position_tag = self._get_position_tag(output)
+            text = self._build_section_text(output, output_type)
+            image: Optional[Image.Image]
+
+            if output_type == MinerUContentType.TABLE:
+                text = self._build_table_text(output)
+                if not text:
+                    continue
+                image = self._resolve_output_image(output, position_tag, ("table_img_path", "img_path"))
+            elif output_type == MinerUContentType.IMAGE:
+                text = "\n".join(self._build_image_caption_lines(output))
+                image = self._resolve_output_image(output, position_tag, ("img_path", "table_img_path"))
+            else:
+                image = self.crop(position_tag, 1) if position_tag else None
+
+            bboxes.append(self._build_bbox(output, output_type, text=text, image=image))
+
+        return bboxes
+
     def _transfer_to_sections(self, outputs: list[dict[str, Any]], parse_method: str = None):
         sections = []
         for output in outputs:
-            match output["type"]:
-                case MinerUContentType.TEXT:
-                    section = output.get("text", "")
-                case MinerUContentType.TABLE:
-                    section = output.get("table_body", "") + "\n".join(output.get("table_caption", [])) + "\n".join(
-                        output.get("table_footnote", []))
-                    if not section.strip():
-                        section = "FAILED TO PARSE TABLE"
-                case MinerUContentType.IMAGE:
-                    section = "".join(output.get("image_caption", [])) + "\n" + "".join(
-                        output.get("image_footnote", []))
-                case MinerUContentType.EQUATION:
-                    section = output.get("text", "")
-                case MinerUContentType.CODE:
-                    section = output.get("code_body", "") + "\n".join(output.get("code_caption", []))
-                case MinerUContentType.LIST:
-                    section = "\n".join(output.get("list_items", []))
-                case MinerUContentType.DISCARDED:
-                    continue  # Skip discarded blocks entirely
+            output_type = self._normalize_output_type(output)
+            if output_type in {MinerUContentType.TABLE, MinerUContentType.IMAGE, MinerUContentType.DISCARDED}:
+                continue
+
+            section = self._build_section_text(output, output_type)
+            if not section:
+                continue
+
+            position_tag = self._get_position_tag(output)
 
             if section and parse_method == "manual":
-                sections.append((section, output["type"], self._line_tag(output)))
+                sections.append((section, output_type.value, position_tag))
             elif section and parse_method == "paper":
-                sections.append((section + self._line_tag(output), output["type"]))
+                sections.append((section + position_tag, output_type.value))
             else:
-                sections.append((section, self._line_tag(output)))
+                sections.append((section, position_tag))
         return sections
 
     def _transfer_to_tables(self, outputs: list[dict[str, Any]]):
-        return []
+        tables = []
+        for output in outputs:
+            output_type = self._normalize_output_type(output)
+            position_tag = self._get_position_tag(output)
+            positions = self._ensure_media_positions(self._get_position_list(position_tag))
+
+            if output_type == MinerUContentType.TABLE:
+                table_text = self._build_table_text(output)
+                if not table_text:
+                    continue
+                table_image = self._resolve_output_image(output, position_tag, ("table_img_path", "img_path"))
+                tables.append(((table_image, table_text), positions))
+            elif output_type == MinerUContentType.IMAGE:
+                image_texts = self._build_image_caption_lines(output, keep_placeholder=True)
+                image = self._resolve_output_image(output, position_tag, ("img_path", "table_img_path"))
+                tables.append(((image, image_texts), positions))
+
+        return tables
+
+    def parse_into_bboxes(
+        self,
+        filepath: str | PathLike[str],
+        binary: BytesIO | bytes | None = None,
+        callback: Optional[Callable] = None,
+        *,
+        parse_method: str = "raw",
+        **kwargs,
+    ) -> list[dict[str, Any]]:
+        self.parse_pdf(filepath=filepath, binary=binary, callback=callback, parse_method=parse_method, **kwargs)
+        return self._transfer_to_bboxes(self.content_outputs)
 
     def parse_pdf(
             self,
             filepath: str | PathLike[str],
-            binary: BytesIO | bytes,
+            binary: BytesIO | bytes | None,
             callback: Optional[Callable] = None,
             *,
             output_dir: Optional[str] = None,
@@ -648,6 +877,7 @@ class MinerUParser(RAGFlowPdfParser):
             callback(0.15, f"[MinerU] Output directory: {out_dir}")
 
         self.__images__(pdf, zoomin=1)
+        self.content_outputs = []
 
         try:
             options = MinerUParseOptions(
@@ -662,6 +892,7 @@ class MinerUParser(RAGFlowPdfParser):
             )
             final_out_dir = self._run_mineru(pdf, out_dir, options, callback=callback)
             outputs = self._read_output(final_out_dir, pdf.stem, method=mineru_method_raw_str, backend=backend)
+            self.content_outputs = outputs
             self.logger.info(f"[MinerU] Parsed {len(outputs)} blocks from PDF.")
             if callback:
                 callback(0.75, f"[MinerU] Parsed {len(outputs)} blocks from PDF.")

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -19,6 +19,7 @@ import re
 import os
 from functools import reduce
 from io import BytesIO
+from pathlib import Path
 from timeit import default_timer as timer
 from docx import Document
 from docx.opc.pkgreader import _SerializedRelationships, _SerializedRelationship
@@ -30,10 +31,11 @@ from PIL import Image
 from common.token_utils import num_tokens_from_string
 
 from common.constants import LLMType
+from common import settings
 from api.db.services.llm_service import LLMBundle
 from api.db.joint_services.tenant_model_service import get_model_config_by_type_and_name, get_tenant_default_model_by_type
 from rag.utils.file_utils import extract_embed_file, extract_links_from_pdf, extract_links_from_docx, extract_html
-from deepdoc.parser import DocxParser, EpubParser, ExcelParser, HtmlParser, JsonParser, MarkdownElementExtractor, MarkdownParser, PdfParser, TxtParser
+from deepdoc.parser import DocxParser, ExcelParser, HtmlParser, JsonParser, MarkdownElementExtractor, MarkdownParser, PdfParser, TxtParser
 from deepdoc.parser.figure_parser import VisionFigureParser, vision_figure_parser_docx_wrapper_naive, vision_figure_parser_pdf_wrapper
 from deepdoc.parser.pdf_parser import PlainParser, VisionParser
 from deepdoc.parser.docling_parser import DoclingParser
@@ -81,6 +83,63 @@ def _normalize_section_text_for_rtl_presentation_forms(sections):
         normalized_sections.append(normalize_arabic_presentation_forms(section))
 
     return normalized_sections
+
+
+def _get_section_text(section):
+    if isinstance(section, (tuple, list)):
+        return section[0]
+    return section
+
+
+def _replace_section_text(section, text):
+    if isinstance(section, tuple):
+        return (text, *section[1:])
+    if isinstance(section, list):
+        return [text, *section[1:]]
+    return text
+
+
+def _stringify_vision_description(description):
+    if isinstance(description, str):
+        return description.strip()
+    if isinstance(description, list):
+        return "\n".join([str(item).strip() for item in description if str(item).strip()]).strip()
+    return ""
+
+
+def enhance_markdown_sections_with_vision(sections, section_images, callback=None, **kwargs):
+    callback = callback or (lambda prog=None, msg="": None)
+
+    try:
+        vision_model_config = get_tenant_default_model_by_type(kwargs["tenant_id"], LLMType.IMAGE2TEXT)
+        vision_model = LLMBundle(kwargs["tenant_id"], vision_model_config)
+        callback(0.2, "Visual model detected. Attempting to enhance figure extraction...")
+    except Exception as e:
+        logging.warning(f"Failed to detect figure extraction: {e}")
+        return sections, section_images
+
+    for idx, section in enumerate(sections):
+        if not section_images or len(section_images) <= idx or section_images[idx] is None:
+            continue
+
+        combined_image = section_images[idx]
+        markdown_vision_parser = VisionFigureParser(
+            vision_model=vision_model,
+            figures_data=[((combined_image, ["markdown image"]), [(0, 0, 0, 0, 0)])],
+            **kwargs,
+        )
+        boosted_figures = markdown_vision_parser(callback=callback)
+        descriptions = []
+        for fig in boosted_figures:
+            description = _stringify_vision_description(fig[0][1])
+            if description:
+                descriptions.append(description)
+
+        if descriptions:
+            section_text = _get_section_text(section)
+            sections[idx] = _replace_section_text(section, section_text + "\n\n" + "\n\n".join(descriptions))
+
+    return sections, section_images
 
 
 def by_deepdoc(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", callback=None, pdf_cls=None, **kwargs):
@@ -595,13 +654,14 @@ class Markdown(MarkdownParser):
         return []
 
     def extract_image_urls_with_lines(self, text):
-        md_img_re = re.compile(r"!\[[^\]]*\]\(([^)\s]+)")
+        md_img_re = re.compile(r'!\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))(?:\s+(?:"[^"]*"|\'[^\']*\'))?\s*\)')
         html_img_re = re.compile(r'src=["\\\']([^"\\\'>\\s]+)', re.IGNORECASE)
         urls = []
         seen = set()
         lines = text.splitlines()
         for idx, line in enumerate(lines):
-            for url in md_img_re.findall(line):
+            for angle_wrapped_url, plain_url in md_img_re.findall(line):
+                url = angle_wrapped_url or plain_url
                 if (url, idx) not in seen:
                     urls.append({"url": url, "line": idx})
                     seen.add((url, idx))
@@ -671,6 +731,26 @@ class Markdown(MarkdownParser):
         return images, cache
 
     def __call__(self, filename, binary=None, separate_tables=True, delimiter=None, return_section_images=False):
+        self._base_dir = None
+        self._storage_bucket = None
+        self._source_location = None
+        if filename:
+            try:
+                markdown_path = Path(filename)
+                if markdown_path.exists():
+                    self._base_dir = markdown_path.resolve().parent
+                elif markdown_path.parent != Path("."):
+                    self._base_dir = markdown_path.parent.resolve()
+            except Exception as e:
+                logging.warning(f"Failed to resolve markdown base directory for {filename}: {e}")
+
+        storage_bucket = getattr(self, "_storage_bucket_hint", None) or getattr(self, "_kb_id", None)
+        source_location = getattr(self, "_source_location_hint", None)
+        if storage_bucket:
+            self._storage_bucket = str(storage_bucket)
+        if source_location:
+            self._source_location = str(source_location)
+
         if binary:
             encoding = find_codec(binary)
             txt = binary.decode(encoding, errors="ignore")
@@ -678,9 +758,7 @@ class Markdown(MarkdownParser):
             with open(filename, "r") as f:
                 txt = f.read()
 
-        remainder, tables = self.extract_tables_and_remainder(f"{txt}\n", separate_tables=separate_tables)
-        # To eliminate duplicate tables in chunking result, uncomment code below and set separate_tables to True in line 410.
-        # extractor = MarkdownElementExtractor(remainder)
+        _, tables = self.extract_tables_and_remainder(f"{txt}\n", separate_tables=separate_tables)
         extractor = MarkdownElementExtractor(txt)
         image_refs = self.extract_image_urls_with_lines(txt)
         element_sections = extractor.extract_elements(delimiter, include_meta=True)
@@ -690,6 +768,11 @@ class Markdown(MarkdownParser):
         image_cache = {}
         for element in element_sections:
             content = element["content"]
+            if separate_tables:
+                # Remove table bodies from section text while keeping original line ranges
+                # so image-to-section matching still uses the markdown source positions.
+                content, _ = self.extract_tables_and_remainder(f"{content}\n", separate_tables=True)
+                content = content.strip()
             start_line = element["start_line"]
             end_line = element["end_line"]
             urls_in_section = [ref["url"] for ref in image_refs if start_line <= ref["line"] <= end_line]
@@ -699,6 +782,8 @@ class Markdown(MarkdownParser):
             combined_image = None
             if imgs:
                 combined_image = reduce(concat_img, imgs) if len(imgs) > 1 else imgs[0]
+            if not content and combined_image is None:
+                continue
             sections.append((content, ""))
             section_images.append(combined_image)
 
@@ -896,10 +981,12 @@ def chunk(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", ca
     elif re.search(r"\.(md|markdown|mdx)$", filename, re.IGNORECASE):
         callback(0.1, "Start to parse.")
         markdown_parser = Markdown(int(parser_config.get("chunk_token_num", 128)))
+        markdown_parser._storage_bucket_hint = kwargs.get("storage_bucket") or kwargs.get("kb_id")
+        markdown_parser._source_location_hint = kwargs.get("source_location")
         sections, tables, section_images = markdown_parser(
             filename,
             binary,
-            separate_tables=False,
+            separate_tables=True,
             delimiter=parser_config.get("delimiter", "\n!?;。；！？"),
             return_section_images=True,
         )
@@ -907,35 +994,12 @@ def chunk(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", ca
 
         is_markdown = True
 
-        try:
-            vision_model_config = get_tenant_default_model_by_type(kwargs["tenant_id"], LLMType.IMAGE2TEXT)
-            vision_model = LLMBundle(kwargs["tenant_id"], vision_model_config)
-            callback(0.2, "Visual model detected. Attempting to enhance figure extraction...")
-        except Exception as e:
-            logging.warning(f"Failed to detect figure extraction: {e}")
-            vision_model = None
-
-        if vision_model:
-            # Process images for each section
-            for idx, (section_text, _) in enumerate(sections):
-                images = []
-                if section_images and len(section_images) > idx and section_images[idx] is not None:
-                    images.append(section_images[idx])
-
-                if images and len(images) > 0:
-                    # If multiple images found, combine them using concat_img
-                    combined_image = reduce(concat_img, images) if len(images) > 1 else images[0]
-                    if section_images:
-                        section_images[idx] = combined_image
-                    else:
-                        section_images = [None] * len(sections)
-                        section_images[idx] = combined_image
-                    markdown_vision_parser = VisionFigureParser(vision_model=vision_model, figures_data=[((combined_image, ["markdown image"]), [(0, 0, 0, 0, 0)])], **kwargs)
-                    boosted_figures = markdown_vision_parser(callback=callback)
-                    sections[idx] = (section_text + "\n\n" + "\n\n".join([fig[0][1] for fig in boosted_figures]), sections[idx][1])
-
-        else:
-            logging.warning("No visual model detected. Skipping figure parsing enhancement.")
+        sections, section_images = enhance_markdown_sections_with_vision(
+            sections,
+            section_images,
+            callback=callback,
+            **kwargs,
+        )
 
         if parser_config.get("hyperlink_urls", False) and is_root:
             for idx, (section_text, _) in enumerate(sections):
@@ -949,14 +1013,6 @@ def chunk(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", ca
         callback(0.1, "Start to parse.")
         chunk_token_num = int(parser_config.get("chunk_token_num", 128))
         sections = HtmlParser()(filename, binary, chunk_token_num)
-        sections = [(_, "") for _ in sections if _]
-        sections = _normalize_section_text_for_rtl_presentation_forms(sections)
-        callback(0.8, "Finish parsing.")
-
-    elif re.search(r"\.epub$", filename, re.IGNORECASE):
-        callback(0.1, "Start to parse.")
-        chunk_token_num = int(parser_config.get("chunk_token_num", 128))
-        sections = EpubParser()(filename, binary, chunk_token_num)
         sections = [(_, "") for _ in sections if _]
         sections = _normalize_section_text_for_rtl_presentation_forms(sections)
         callback(0.8, "Finish parsing.")

--- a/rag/flow/parser/parser.py
+++ b/rag/flow/parser/parser.py
@@ -43,8 +43,9 @@ from rag.nlp import BULLET_PATTERN, bullets_category, docx_question_level, not_b
 from rag.utils.base64_image import image2id
 
 
-from common.misc_utils import thread_pool_exec
 
+
+from common.misc_utils import thread_pool_exec
 
 class ParserParam(ProcessParamBase):
     def __init__(self):
@@ -81,10 +82,6 @@ class ParserParam(ProcessParamBase):
                 "json",
             ],
             "video": [],
-            "epub": [
-                "text",
-                "json",
-            ],
         }
 
         self.setups = {
@@ -169,12 +166,6 @@ class ParserParam(ProcessParamBase):
                 "output_format": "text",
                 "prompt": "",
             },
-            "epub": {
-                "suffix": [
-                    "epub",
-                ],
-                "output_format": "json",
-            },
         }
 
     def check(self):
@@ -227,11 +218,6 @@ class ParserParam(ProcessParamBase):
         if email_config:
             email_output_format = email_config.get("output_format", "")
             self.check_valid_value(email_output_format, "Email output format abnormal.", self.allowed_output_format["email"])
-
-        epub_config = self.setups.get("epub", "")
-        if epub_config:
-            epub_output_format = epub_config.get("output_format", "")
-            self.check_valid_value(epub_output_format, "EPUB output format abnormal.", self.allowed_output_format["epub"])
 
     def get_input_form(self) -> dict[str, dict]:
         return {}
@@ -371,21 +357,14 @@ class Parser(ProcessBase):
             ocr_model = LLMBundle(tenant_id, ocr_model_config, lang=conf.get("lang", "Chinese"))
             pdf_parser = ocr_model.mdl
 
-            lines, _ = pdf_parser.parse_pdf(
+            # MinerU now exposes DeepDOC-style structured bboxes so Flow can reuse the existing output logic.
+            bboxes = pdf_parser.parse_into_bboxes(
                 filepath=name,
                 binary=blob,
                 callback=self.callback,
                 parse_method=conf.get("mineru_parse_method", "raw"),
                 lang=conf.get("lang", "Chinese"),
             )
-            bboxes = []
-            for t, poss in lines:
-                box = {
-                    "image": pdf_parser.crop(poss, 1),
-                    "positions": [[pos[0][-1], *pos[1:]] for pos in pdf_parser.extract_positions(poss)],
-                    "text": t,
-                }
-                bboxes.append(box)
         elif parse_method.lower() == "docling":
             pdf_parser = DoclingParser(docling_server_url=os.environ.get("DOCLING_SERVER_URL", ""))
             lines, _ = pdf_parser.parse_pdf(
@@ -404,7 +383,9 @@ class Parser(ProcessBase):
                 box = {
                     "text": text,
                     "image": pdf_parser.crop(poss, 1) if isinstance(poss, str) and poss else None,
-                    "positions": [[pos[0][-1], *pos[1:]] for pos in pdf_parser.extract_positions(poss)] if isinstance(poss, str) and poss else [],
+                    "positions": [[pos[0][-1], *pos[1:]] for pos in pdf_parser.extract_positions(poss)]
+                    if isinstance(poss, str) and poss
+                    else [],
                 }
                 bboxes.append(box)
         elif parse_method.lower() == "tcadp parser":
@@ -710,6 +691,7 @@ class Parser(ProcessBase):
             markdown_text = docx_parser.to_markdown(name, binary=blob)
             self.set_output("markdown", markdown_text)
 
+
     def _slides(self, name, blob, **kwargs):
         self.callback(random.randint(1, 5) / 100.0, "Start to work on a PowerPoint Document")
 
@@ -778,7 +760,7 @@ class Parser(ProcessBase):
     def _markdown(self, name, blob, **kwargs):
         from functools import reduce
 
-        from rag.app.naive import Markdown as naive_markdown_parser
+        from rag.app.naive import Markdown as naive_markdown_parser, enhance_markdown_sections_with_vision
         from rag.nlp import concat_img
 
         self.callback(random.randint(1, 5) / 100.0, "Start to work on a markdown.")
@@ -786,12 +768,28 @@ class Parser(ProcessBase):
         self.set_output("output_format", conf["output_format"])
 
         markdown_parser = naive_markdown_parser()
+        file_info = kwargs.get("file") or {}
+        storage_bucket = kwargs.get("storage_bucket")
+        source_location = kwargs.get("source_location")
+        if isinstance(file_info, dict):
+            storage_bucket = storage_bucket or file_info.get("parent_id")
+            if not storage_bucket and file_info.get("created_by"):
+                storage_bucket = f"{file_info['created_by']}-downloads"
+            source_location = source_location or file_info.get("location") or file_info.get("id")
+        markdown_parser._storage_bucket_hint = storage_bucket
+        markdown_parser._source_location_hint = source_location
         sections, tables, section_images = markdown_parser(
             name,
             blob,
-            separate_tables=False,
+            separate_tables=True,
             delimiter=conf.get("delimiter"),
             return_section_images=True,
+        )
+        sections, section_images = enhance_markdown_sections_with_vision(
+            sections,
+            section_images,
+            callback=self.callback,
+            tenant_id=self._canvas.get_tenant_id(),
         )
 
         if conf.get("output_format") == "json":
@@ -817,9 +815,15 @@ class Parser(ProcessBase):
 
                 json_results.append(json_result)
 
+            for table in tables:
+                table_text = table[0][1] if table and table[0] else ""
+                if table_text:
+                    json_results.append({"text": table_text, "doc_type_kwd": "table"})
+
             self.set_output("json", json_results)
         else:
-            self.set_output("text", "\n".join([section_text for section_text, _ in sections]))
+            table_texts = [table[0][1] for table in tables if table and table[0] and table[0][1]]
+            self.set_output("text", "\n".join([section_text for section_text, _ in sections] + table_texts))
 
     def _image(self, name, blob, **kwargs):
         from deepdoc.vision import OCR
@@ -850,13 +854,11 @@ class Parser(ProcessBase):
             else:
                 txt = cv_model.describe(img_binary.read())
 
-        json_result = [
-            {
-                "text": txt,
-                "image": img,
-                "doc_type_kwd": "image",
-            }
-        ]
+        json_result = [{
+            "text": txt,
+            "image": img,
+            "doc_type_kwd": "image",
+        }]
         self.set_output("json", json_result)
 
     def _audio(self, name, blob, **kwargs):
@@ -1026,22 +1028,6 @@ class Parser(ProcessBase):
                             content_txt += fb
             self.set_output("text", content_txt)
 
-    def _epub(self, name, blob, **kwargs):
-        from deepdoc.parser import EpubParser
-
-        self.callback(random.randint(1, 5) / 100.0, "Start to work on an EPUB.")
-        conf = self._param.setups["epub"]
-        self.set_output("output_format", conf["output_format"])
-
-        epub_parser = EpubParser()
-        sections = epub_parser(name, binary=blob)
-
-        if conf.get("output_format") == "json":
-            json_results = [{"text": s} for s in sections if s]
-            self.set_output("json", json_results)
-        else:
-            self.set_output("text", "\n".join(s for s in sections if s))
-
     async def _invoke(self, **kwargs):
         function_map = {
             "pdf": self._pdf,
@@ -1053,7 +1039,6 @@ class Parser(ProcessBase):
             "audio": self._audio,
             "video": self._video,
             "email": self._email,
-            "epub": self._epub,
         }
 
         try:
@@ -1063,11 +1048,18 @@ class Parser(ProcessBase):
             return
 
         name = from_upstream.name
+        storage_bucket = None
+        source_location = None
         if self._canvas._doc_id:
-            b, n = File2DocumentService.get_storage_address(doc_id=self._canvas._doc_id)
-            blob = settings.STORAGE_IMPL.get(b, n)
+            storage_bucket, source_location = File2DocumentService.get_storage_address(doc_id=self._canvas._doc_id)
+            blob = settings.STORAGE_IMPL.get(storage_bucket, source_location)
         else:
             blob = FileService.get_blob(from_upstream.file["created_by"], from_upstream.file["id"])
+            if from_upstream.file:
+                storage_bucket = from_upstream.file.get("parent_id")
+                if not storage_bucket and from_upstream.file.get("created_by"):
+                    storage_bucket = f"{from_upstream.file['created_by']}-downloads"
+                source_location = from_upstream.file.get("location") or from_upstream.file.get("id")
 
         done = False
         for p_type, conf in self._param.setups.items():
@@ -1076,6 +1068,8 @@ class Parser(ProcessBase):
             call_kwargs = dict(kwargs)
             call_kwargs.pop("name", None)
             call_kwargs.pop("blob", None)
+            call_kwargs["storage_bucket"] = storage_bucket
+            call_kwargs["source_location"] = source_location
 
             await thread_pool_exec(function_map[p_type], name, blob, **call_kwargs)
             done = True

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -281,6 +281,7 @@ async def build_chunks(task, progress_callback):
                 kb_id=task["kb_id"],
                 parser_config=task["parser_config"],
                 tenant_id=task["tenant_id"],
+                source_location=task.get("location", ""),
             )
         logging.info("Chunking({}) {}/{} done".format(timer() - st, task["location"], task["name"]))
     except TaskCanceledException:


### PR DESCRIPTION
### What problem does this PR solve?

add the VLM enhancement to MinerU parser from issue #13342 

Set chunk method to `manual ` to enable it.
### Type of change

- [✅] New Feature (non-breaking change which adds functionality)

**New MinerU parser**:
<img width="1408" height="667" alt="新MinerU解析器1" src="https://github.com/user-attachments/assets/f3613bd3-f6fb-42ee-a0ff-7ba2c2151d14" />

**Origin MinerU parser**:
<img width="1125" height="466" alt="原MinerU解析器无法描述图像" src="https://github.com/user-attachments/assets/b13b37c9-1ad9-4bc0-bb59-930c96897b0e" />

