### PR TITLE
fix(html-parser): correct h4 heading mapping from ##### to ####

### DIFF
--- a/deepdoc/parser/html_parser.py
+++ b/deepdoc/parser/html_parser.py
@@ -33,7 +33,7 @@ BLOCK_TAGS = [
     "table", "pre", "code", "blockquote",
     "figure", "figcaption"
 ]
-TITLE_TAGS = {"h1": "#", "h2": "##", "h3": "###", "h4": "#####", "h5": "#####", "h6": "######"}
+TITLE_TAGS = {"h1": "#", "h2": "##", "h3": "###", "h4": "####", "h5": "#####", "h6": "######"}
 
 
 class RAGFlowHtmlParser:


### PR DESCRIPTION
## Summary

- Fix incorrect Markdown heading mapping for `h4` in `TITLE_TAGS` dictionary
- `h4` was mapped to `"#####"` (h5 level) instead of `"####"` (correct h4 level)

Closes #13819

## Details

In `deepdoc/parser/html_parser.py`, the `TITLE_TAGS` dictionary had a typo where `h4` was assigned 5 `#` characters instead of 4, causing h4 headings to be converted to h5-level Markdown headings during HTML parsing.

## Test plan

- [ ] Parse an HTML document containing `<h4>` tags and verify the output uses `####` (4 hashes)
- [ ] Verify other heading levels remain correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)