### PR TITLE
Fix: streaming response reference mismatch with answer

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -765,7 +765,6 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             final = decorate_answer(thought + full_answer)
             final["final"] = True
             final["audio_binary"] = None
-            final["answer"] = ""
             yield final
     else:
         if llm_type == "chat":
@@ -1435,7 +1434,6 @@ async def async_ask(question, kb_ids, tenant_id, chat_llm_name=None, search_conf
     full_answer = last_state.full_text if last_state else ""
     final = decorate_answer(full_answer)
     final["final"] = True
-    final["answer"] = ""
     yield final
 
 


### PR DESCRIPTION
## Summary

Fixes #13828 — streaming response references are mismatched with the answer, while chat history references are correct.

### Root Cause

In `async_chat()` (`api/db/services/dialog_service.py`), the streaming code path:

1. Sends intermediate SSE events with `reference: {}` (empty) — expected, since references are computed after the full answer is available.
2. After streaming completes, calls `decorate_answer()` which:
   - Inserts citation markers (`##N$$`) into the answer text
   - Filters `doc_aggs` based on which chunks were actually cited
   - Returns the decorated answer with matching references
3. **Bug**: The final SSE event then blanks the answer (`final["answer"] = ""`), discarding the citation-processed text while keeping the citation-filtered references.

This means the client accumulates raw answer text (no citation markers) from delta events, but receives references filtered based on citation analysis it never sees — causing the mismatch reported in the issue.

Chat history is unaffected because `structure_answer()` correctly persists `conv.reference[-1]` from the final event's reference data.

### Fix

Remove `final["answer"] = ""` so the final SSE event includes the full decorated answer (with citation markers) alongside its matching references. This is consistent with the non-streaming code path behavior.

### Behavior Change

Previously, the final streaming SSE event had `answer: ""`. After this fix, it contains the complete citation-processed answer. Clients that accumulate delta text should use the final event's answer as the authoritative text (replacing accumulated deltas), which is the same pattern used in the non-streaming response.

## Test plan

- [ ] Call `POST /api/v1/chats/{chat_id}/completions` with `stream=true` and citation enabled
- [ ] Verify the final SSE event contains both the decorated answer and matching references
- [ ] Verify the references in the streaming response match those in the chat history
- [ ] Verify non-streaming (`stream=false`) behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update:** Also fixes the same issue in `async_ask()`. The `infinity_conn.py` escaping fix has been moved to a separate PR (#14053) to keep this one focused on the streaming reference mismatch.