### PR TITLE
fix(infinity): escape single quotes in fulltext filter to prevent TokenError

### DIFF
--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -177,7 +177,8 @@ class InfinityConnection(InfinityConnectionBase):
                         matchExpr.extra_options.update({"filter": filter_cond})
                     matchExpr.fields = [self.convert_matching_field(field) for field in matchExpr.fields]
                     fields = ",".join(matchExpr.fields)
-                    filter_fulltext = f"filter_fulltext('{fields}', '{matchExpr.matching_text}')"
+                    escaped_matching_text = matchExpr.matching_text.replace("'", "''")
+                    filter_fulltext = f"filter_fulltext('{fields}', '{escaped_matching_text}')"
                     if filter_cond:
                         filter_fulltext = f"({filter_cond}) AND {filter_fulltext}"
                     minimum_should_match = matchExpr.extra_options.get("minimum_should_match", 0.0)


### PR DESCRIPTION
## Summary

- Fixes `TokenError` when searching words like "cat" that trigger synonym expansion (e.g., "big cat", "computerized tomography")
- Root cause: `filter_fulltext()` in `infinity_conn.py` embeds `matching_text` inside single quotes, but the synonym-expanded query text can contain single quotes that break sqlglot's SQL tokenizer
- Fix: escape single quotes using standard SQL convention (`'` -> `''`) before string interpolation

## Root Cause Analysis

1. Searching "cat" triggers the Chinese query path in `query.py` because `is_chinese()` returns `True` for inputs with <= 3 tokens
2. The Chinese path looks up synonyms ("big cat", "computerized tomography") and builds a query with `OR` operators and boost factors like `^0.7`
3. This query string is embedded in `filter_fulltext('{fields}', '{matching_text}')` at `infinity_conn.py:180`
4. The `filter_fulltext` string is passed as a filter option to `match_dense`, where Infinity's SDK parses it with sqlglot
5. Unescaped single quotes in the matching text cause sqlglot's tokenizer to fail with `TokenError: Missing '`

## Test plan

- [ ] Search for "cat" in retrieval testing with Infinity as document store — should no longer throw `TokenError`
- [ ] Search for words with apostrophes (e.g., "it's", "don't") — should work without errors
- [ ] Verify synonym-expanded searches still return correct results

Closes #13823

🤖 Generated with [Claude Code](https://claude.com/claude-code)