### PR TITLE
fix(docs): correct broken knowledge graph construction link

### DIFF
--- a/docs/guides/dataset/run_retrieval_test.md
+++ b/docs/guides/dataset/run_retrieval_test.md
@@ -18,7 +18,7 @@ During a retrieval test, chunks created from your specified chunking method are 
 - If no rerank model is selected, weighted keyword similarity will be combined with weighted vector cosine similarity.
 - If a rerank model is selected, weighted keyword similarity will be combined with weighted vector reranking score.
 
-In contrast, chunks created from [knowledge graph construction](./construct_knowledge_graph.md) are retrieved solely using vector cosine similarity.
+In contrast, chunks created from [knowledge graph construction](./advanced/construct_knowledge_graph.md) are retrieved solely using vector cosine similarity.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes #13817

### What problem does this PR solve?

The "knowledge graph construction" link on line 21 of `docs/guides/dataset/run_retrieval_test.md` points to `./construct_knowledge_graph.md`, which doesn't exist. The actual file is at `./advanced/construct_knowledge_graph.md`.

### Type of change

- [x] Documentation Update
