### PR TITLE
Revert port change to comply with EXPOSE_MYSQL_PORT

### DIFF
--- a/conf/service_conf.yaml
+++ b/conf/service_conf.yaml
@@ -9,7 +9,7 @@ mysql:
   user: 'root'
   password: 'infini_rag_flow'
   host: 'localhost'
-  port: 3306
+  port: 5455
   max_connections: 900
   stale_timeout: 300
   max_allowed_packet: 1073741824


### PR DESCRIPTION
### What problem does this PR solve?

This PR reverts the specified port in `conf/service_conf.yaml` to be compliant with the default values on `docker/.env`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
