### PR TITLE
Docs: Image2text is supported by GPUStack.

### DIFF
--- a/docs/guides/models/supported_models.mdx
+++ b/docs/guides/models/supported_models.mdx
@@ -28,7 +28,7 @@ A complete list of models supported by RAGFlow, which will continue to expand.
 | Fish Audio            |                    |                    |                    | :heavy_check_mark: |                    |                    |                    |
 | Gemini                | :heavy_check_mark: | :heavy_check_mark: |                    |                    | :heavy_check_mark: |                    |                    |
 | Google Cloud          | :heavy_check_mark: |                    |                    |                    |                    |                    |                    |
-| GPUStack              | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |                    |
+| GPUStack              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |                    |
 | Groq                  | :heavy_check_mark: |                    |                    |                    |                    |                    |                    |
 | HuggingFace           | :heavy_check_mark: |                    |                    |                    | :heavy_check_mark: |                    |                    |
 | Jina                  |                    |                    |                    |                    | :heavy_check_mark: | :heavy_check_mark: |                    |


### PR DESCRIPTION
### What problem does this PR solve?

 Image2text is supported by GPUStack. #9515 

### Type of change

- [x] Documentation Update
