### PR TITLE
fix: guard against missing/malformed Authorization header in apikey_required

### DIFF
--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -252,7 +252,13 @@ def get_json_result(code: RetCode = RetCode.SUCCESS, message="success", data=Non
 def apikey_required(func):
     @wraps(func)
     async def decorated_function(*args, **kwargs):
-        token = request.headers.get("Authorization").split()[1]
+        authorization = request.headers.get("Authorization")
+        if not authorization:
+            return build_error_result(message="Authorization header is missing!", code=RetCode.FORBIDDEN)
+        parts = authorization.split()
+        if len(parts) < 2:
+            return build_error_result(message="Please check your authorization format.", code=RetCode.FORBIDDEN)
+        token = parts[1]
         objs = APIToken.query(token=token)
         if not objs:
             return build_error_result(message="API-KEY is invalid!", code=RetCode.FORBIDDEN)


### PR DESCRIPTION

### What problem does this PR solve?

Previously, `apikey_required` called `request.headers.get('Authorization').split()[1]` without checking for None or insufficient parts, causing an unhandled AttributeError or IndexError (500) instead of a proper 403 JSON response.

This applies the same guarding pattern already used by `token_required` in the same file.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
