### PR TITLE
fix: correct typo in IterationItem name check and incomplete error message

### DIFF
--- a/agent/component/iterationitem.py
+++ b/agent/component/iterationitem.py
@@ -69,7 +69,7 @@ class IterationItem(ComponentBase, ABC):
             if p._id != pid:
                 continue
 
-            if p.component_name.lower() in ["categorize", "message", "switch", "userfillup", "interationitem"]:
+            if p.component_name.lower() in ["categorize", "message", "switch", "userfillup", "iterationitem"]:
                 continue
 
             for k, o in p._param.outputs.items():

--- a/rag/raptor.py
+++ b/rag/raptor.py
@@ -91,7 +91,7 @@ class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
             return response
         embds, _ = await thread_pool_exec(self._embd_model.encode, [txt])
         if len(embds) < 1 or len(embds[0]) < 1:
-            raise Exception("Embedding error: ")
+            raise Exception("Embedding error: empty embeddings returned")
         embds = embds[0]
         await thread_pool_exec(set_embed_cache, self._embd_model.llm_name, txt, embds)
         return embds


### PR DESCRIPTION
Two small fixes:

1. **iterationitem.py line 72**: Typo "interationitem" → "iterationitem" (missing 't'). The component name check never matched IterationItem components.

2. **raptor.py line 94**: Error message "Embedding error: " had a trailing colon with no details. Changed to "Embedding error: empty embeddings returned".