### PR TITLE
Fix: reject empty Bearer tokens in MCP headers

### DIFF
--- a/common/mcp_tool_call_conn.py
+++ b/common/mcp_tool_call_conn.py
@@ -57,6 +57,17 @@ class MCPToolCallSession(ToolCallSession):
 
         asyncio.run_coroutine_threadsafe(self._mcp_server_loop(), self._event_loop)
 
+    @staticmethod
+    def _is_valid_header_value(header_name: str, header_value: str) -> bool:
+        name = (header_name or "").strip()
+        value = (header_value or "").strip()
+        if not name or not value:
+            return False
+        if name.lower() == "authorization" and value.lower().startswith("bearer"):
+            parts = value.split(None, 1)
+            return len(parts) == 2 and bool(parts[1].strip())
+        return True
+
     async def _mcp_server_loop(self) -> None:
         url = self._mcp_server.url.strip()
         raw_headers: dict[str, str] = self._mcp_server.headers or {}
@@ -66,13 +77,14 @@ class MCPToolCallSession(ToolCallSession):
         for h, v in raw_headers.items():
             nh = Template(h).safe_substitute(self._server_variables)
             nv = Template(v).safe_substitute(self._server_variables)
-            if nh.strip() and nv.strip().strip("Bearer"):
+            if self._is_valid_header_value(nh, nv):
                 headers[nh] = nv
 
         for h, v in custom_header.items():
             nh = Template(h).safe_substitute(custom_header)
             nv = Template(v).safe_substitute(custom_header)
-            headers[nh] = nv
+            if self._is_valid_header_value(nh, nv):
+                headers[nh] = nv
 
         if self._mcp_server.server_type == MCPServerType.SSE:
             # SSE transport


### PR DESCRIPTION
  ### What problem does this PR solve?

  This PR fixes the MCP header validation logic in `common/mcp_tool_call_conn.py`.

  Previously, the code used `nv.strip().strip("Bearer")` to decide whether a header value should be included. This is not a correct way to validate Bearer authentication because `strip("Bearer")` removes a character  
  set rather than a literal prefix, which can lead to incorrect filtering behavior.

  This PR replaces that logic with explicit validation:
  - reject empty header names and values
  - reject `Authorization: Bearer` headers with an empty token
  - keep valid `Authorization: Bearer <token>` headers unchanged
  - apply the same validation to both configured MCP headers and runtime custom headers

  This keeps the original intent while making the behavior explicit and correct.

  ### Type of change

  - [x] Bug Fix (non-breaking change which fixes an issue)
  - [ ] New Feature (non-breaking change which adds functionality)
  - [ ] Documentation Update
  - [ ] Refactoring
  - [ ] Performance Improvement
  - [ ] Other (please describe):