### PR TITLE
Replace MinIO official image with pgsty/minio fork

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -202,7 +202,7 @@ services:
     restart: unless-stopped
 
   minio:
-    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
+    image: pgsty/minio:RELEASE.2026-03-25T00-00-00Z
     command: ["server", "--console-address", ":9001", "/data"]
     ports:
       - ${MINIO_PORT}:9000


### PR DESCRIPTION
## Summary

- Replace `quay.io/minio/minio` with `pgsty/minio` community fork in `docker/docker-compose-base.yml`

MinIO stopped distributing pre-built Docker images and changed its license. The pgsty/minio fork provides drop-in compatible images under AGPLv3.

Closes #13840

## Test plan

- [x] Verify `docker compose -f docker/docker-compose-base.yml up -d` pulls the pgsty/minio image successfully
- [ ] Verify MinIO console accessible on port 9001
- [ ] Verify RAGFlow backend can connect to MinIO and perform file operations normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)