### PR TITLE
fix: replace broken assert with raise ValueError in variable_assigner and loop

### DIFF
--- a/agent/component/loop.py
+++ b/agent/component/loop.py
@@ -56,7 +56,7 @@ class Loop(ComponentBase, ABC):
 
         for item in self._param.loop_variables:
             if any([not item.get("variable"), not item.get("input_mode"), not item.get("value"),not item.get("type")]):
-                assert "Loop Variable is not complete."
+                raise ValueError("Loop Variable is not complete.")
             if item["input_mode"]=="variable":
                 self.set_output(item["variable"],self._canvas.get_variable_value(item["value"]))
             elif item["input_mode"]=="constant":

--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -48,7 +48,7 @@ class VariableAssigner(ComponentBase,ABC):
         else:
             for item in self._param.variables:
                 if any([not item.get("variable"), not item.get("operator"), not item.get("parameter")]):
-                    assert "Variable is not complete."
+                    raise ValueError("Variable is not complete.")
                 variable=item["variable"]
                 operator=item["operator"]
                 parameter=item["parameter"]


### PR DESCRIPTION
\`assert \"string\"\` always passes in Python because non-empty strings are truthy. This silently skips input validation:

- **variable_assigner.py line 51**: \`assert \"Variable is not complete.\"\` → \`raise ValueError(\"Variable is not complete.\")\`
- **loop.py line 59**: \`assert \"Loop Variable is not complete.\"\` → \`raise ValueError(\"Loop Variable is not complete.\")\`

Without this fix, incomplete variables pass validation silently and cause a confusing KeyError on the next line.