### PR TITLE
fix: properly clean up child nodes when deleting Iteration Box

### DIFF
--- a/web/src/pages/agent/hooks/use-before-delete.tsx
+++ b/web/src/pages/agent/hooks/use-before-delete.tsx
@@ -1,4 +1,4 @@
-import { RAGFlowNodeType } from '@/interfaces/database/flow';
+import { RAGFlowNodeType } from '@/interfaces/database/agent';
 import { Node, OnBeforeDelete } from '@xyflow/react';
 import { Operator } from '../constant';
 import useGraphStore from '../store';
@@ -7,7 +7,7 @@ import { deleteAllDownstreamAgentsAndTool } from '../utils/delete-node';
 const UndeletableNodes = [Operator.Begin, Operator.IterationStart];
 
 export function useBeforeDelete() {
-  const { getOperatorTypeFromId, getNode } = useGraphStore((state) => state);
+  const { getOperatorTypeFromId, getNode, nodes: allNodes } = useGraphStore((state) => state);
 
   const agentPredicate = (node: Node) => {
     return getOperatorTypeFromId(node.id) === Operator.Agent;
@@ -32,6 +32,22 @@ export function useBeforeDelete() {
 
       return true;
     });
+
+    // Include child nodes of Iteration boxes being deleted
+    const deletedIterationIds = new Set(
+      toBeDeletedNodes
+        .filter((node) => (node.data?.label as Operator) === Operator.Iteration)
+        .map((node) => node.id),
+    );
+    if (deletedIterationIds.size > 0) {
+      allNodes
+        .filter((node) => node.parentId && deletedIterationIds.has(node.parentId))
+        .forEach((child) => {
+          if (toBeDeletedNodes.every((x) => x.id !== child.id)) {
+            toBeDeletedNodes.push(child);
+          }
+        });
+    }
 
     const toBeDeletedEdges = edges.filter((edge) => {
       const sourceType = getOperatorTypeFromId(edge.source) as Operator;

--- a/web/src/pages/agent/store.ts
+++ b/web/src/pages/agent/store.ts
@@ -1,5 +1,5 @@
 import type { IAgentForm } from '@/interfaces/database/agent';
-import { IAgentNode, RAGFlowNodeType } from '@/interfaces/database/flow';
+import { RAGFlowNodeType } from '@/interfaces/database/agent';
 import type {} from '@redux-devtools/extension';
 import {
   Connection,
@@ -115,7 +115,8 @@ export type RFState = {
   ) => void; // Deleting a condition of a classification operator will delete the related edge
   findAgentToolNodeById: (id: string | null) => string | undefined;
   selectNodeIds: (nodeIds: string[]) => void;
-  hasChildNode: (nodeId: string) => boolean;
+  hasDownstreamNode: (nodeId: string) => boolean;
+  hasUpstreamNode: (nodeId: string) => boolean;
 };
 
 // this is our useStore hook that we can use in our components to get parts of the store and call actions
@@ -414,7 +415,7 @@ const useGraphStore = create<RFState>()(
               edge.source !== id &&
               edge.target !== id &&
               !children.some(
-                (child) => edge.source === child.id && edge.target === child.id,
+                (child) => edge.source === child.id || edge.target === child.id,
               ),
           ),
         });
@@ -469,7 +470,7 @@ const useGraphStore = create<RFState>()(
         const { updateNodeForm, edges, getOperatorTypeFromId } = get();
         if (sourceHandle) {
           // A handle will connect to multiple downstream nodes
-          let currentHandleTargets = edges
+          const currentHandleTargets = edges
             .filter(
               (x) =>
                 x.source === source &&
@@ -528,9 +529,7 @@ const useGraphStore = create<RFState>()(
         return generateNodeNamesWithIncreasingIndex(name, nodes);
       },
       generateAgentToolName: (id: string, name: string) => {
-        const node = get().nodes.find(
-          (x) => x.id === id,
-        ) as IAgentNode<IAgentForm>;
+        const node = get().nodes.find((x) => x.id === id) as RAGFlowNodeType;
 
         if (!node) {
           return '';
@@ -649,9 +648,13 @@ const useGraphStore = create<RFState>()(
           })),
         );
       },
-      hasChildNode: (nodeId) => {
+      hasDownstreamNode: (nodeId) => {
         const { edges } = get();
         return edges.some((edge) => edge.source === nodeId);
+      },
+      hasUpstreamNode: (nodeId) => {
+        const { edges } = get();
+        return edges.some((edge) => edge.target === nodeId);
       },
     })),
     { name: 'graph', trace: true },


### PR DESCRIPTION
Fixes #13889

## Problem

When an Iteration Box container is deleted (via keyboard Delete/Backspace), child nodes inside it are not properly cleaned up. They remain in the underlying data structure and the exported JSON file, which causes workflow editing instability, inability to link/connect nodes, node/edge rendering failures, and browser console exceptions.

There is also a secondary bug in `deleteIterationNodeById` (toolbar delete button): the edge filter uses `&&` instead of `||`, so edges connected to child nodes are never removed.

## Solution

**Fix 1: `use-before-delete.tsx`** — When keyboard deletion triggers `handleBeforeDelete`, explicitly collect all child nodes (nodes with `parentId` matching the deleted Iteration Box ID) and include them in `toBeDeletedNodes`.

**Fix 2: `store.ts` — `deleteIterationNodeById`** — Fixed the edge filter from `&&` to `||`:
```ts
// Before (always false — no edge has source === target):
!children.some((child) => edge.source === child.id && edge.target === child.id)
// After:
!children.some((child) => edge.source === child.id || edge.target === child.id)
```

## Testing

1. Create an agent workflow with an Iteration Box containing nodes inside.
2. Select the Iteration Box and press Delete/Backspace — child nodes should also be removed.
3. Export the workflow JSON and verify no orphaned child nodes remain.
4. Use toolbar delete button on Iteration Box — verify no dangling edges remain.