### PR TITLE
fix: correct attribute name typo model_speciess to model_species

### DIFF
--- a/deepdoc/parser/pdf_parser.py
+++ b/deepdoc/parser/pdf_parser.py
@@ -77,8 +77,8 @@ class RAGFlowPdfParser:
         if layout_recognizer_type not in ["onnx", "ascend"]:
             raise RuntimeError("Unsupported layout recognizer type.")
 
-        if hasattr(self, "model_speciess"):
-            recognizer_domain = "layout." + self.model_speciess
+        if hasattr(self, "model_species"):
+            recognizer_domain = "layout." + self.model_species
         else:
             recognizer_domain = "layout"
 

--- a/rag/app/laws.py
+++ b/rag/app/laws.py
@@ -95,7 +95,7 @@ class Docx(DocxParser):
 
 class Pdf(PdfParser):
     def __init__(self):
-        self.model_speciess = ParserType.LAWS.value
+        self.model_species = ParserType.LAWS.value
         super().__init__()
 
     def __call__(self, filename, binary=None, from_page=0, to_page=100000, zoomin=3, callback=None):

--- a/rag/app/manual.py
+++ b/rag/app/manual.py
@@ -32,7 +32,7 @@ from common.parser_config_utils import normalize_layout_recognizer
 
 class Pdf(PdfParser):
     def __init__(self):
-        self.model_speciess = ParserType.MANUAL.value
+        self.model_species = ParserType.MANUAL.value
         super().__init__()
 
     def __call__(self, filename, binary=None, from_page=0, to_page=100000, zoomin=3, callback=None):

--- a/rag/app/paper.py
+++ b/rag/app/paper.py
@@ -30,7 +30,7 @@ from common.parser_config_utils import normalize_layout_recognizer
 
 class Pdf(PdfParser):
     def __init__(self):
-        self.model_speciess = ParserType.PAPER.value
+        self.model_species = ParserType.PAPER.value
         super().__init__()
 
     def __call__(self, filename, binary=None, from_page=0,


### PR DESCRIPTION
## Summary
- Rename misspelled attribute `model_speciess` to `model_species` across 4 files
- The extra `s` is a typo — `species` is already plural

## Test plan
- [ ] Verify PDF parsing with laws/manual/paper parser types still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)