### PR TITLE
fix: add recursive fallback search for MinerU content_list.json output

### DIFF
--- a/deepdoc/parser/mineru_parser.py
+++ b/deepdoc/parser/mineru_parser.py
@@ -543,7 +543,18 @@ class MinerUParser(RAGFlowPdfParser):
                     json_file = nested_alt
 
         if not json_file:
-            raise FileNotFoundError(f"[MinerU] Missing output file, tried: {', '.join(str(p) for p in attempted)}")
+            # Fallback: recursively search for any *content_list.json file
+            # to handle MinerU versions that use different naming conventions
+            found = sorted(output_dir.rglob("*content_list.json"))
+            if found:
+                json_file = found[0]
+                subdir = json_file.parent
+                if len(found) > 1:
+                    self.logger.warning(f"[MinerU] Multiple content_list.json found, using: {json_file}")
+                else:
+                    self.logger.info(f"[MinerU] Found via recursive search: {json_file}")
+            else:
+                raise FileNotFoundError(f"[MinerU] Missing output file, tried: {', '.join(str(p) for p in attempted)}")
 
         with open(json_file, "r", encoding="utf-8") as f:
             data = json.load(f)


### PR DESCRIPTION
Fixes #13905

## Problem

When using the MinerU API server (`MINERU_APISERVER`), RAGFlow fails with `[MinerU] Missing output file` even though the API successfully returns a ZIP. This happens because the three-tier lookup in `_read_output` only tries specific paths:

1. `{file_stem}_content_list.json`
2. `{safe_stem}_content_list.json`
3. `{safe_stem}/{safe_stem}_content_list.json`

Newer versions of MinerU may place the JSON file in a different location within the ZIP, causing all three lookups to fail.

## Solution

Add a fourth fallback that recursively searches the extracted output directory for any file matching `*content_list.json`. This approach:

- Covers MinerU versions with different ZIP structures without breaking existing lookup order
- Logs a warning if multiple matches are found (uses the first sorted result)
- Only triggers if all three explicit lookups fail

## Testing

The existing logic is unchanged; the recursive search only activates as a last resort before raising `FileNotFoundError`.