### PR TITLE
docs: fix broken internal links in guides

### DIFF
--- a/docs/develop/mcp/launch_mcp_server.md
+++ b/docs/develop/mcp/launch_mcp_server.md
@@ -196,7 +196,7 @@ docker logs docker-ragflow-cpu-1
 
 ## Security considerations
 
-As MCP technology is still at early stage and no official best practices for authentication or authorization have been established, RAGFlow currently uses [API key](./acquire_ragflow_api_key.md) to validate identity for the operations described earlier. However, in public environments, this makeshift solution could expose your MCP server to potential network attacks. Therefore, when running a local SSE server, it is recommended to bind only to localhost (`127.0.0.1`) rather than to all interfaces (`0.0.0.0`). 
+As MCP technology is still at early stage and no official best practices for authentication or authorization have been established, RAGFlow currently uses [API key](../acquire_ragflow_api_key.md) to validate identity for the operations described earlier. However, in public environments, this makeshift solution could expose your MCP server to potential network attacks. Therefore, when running a local SSE server, it is recommended to bind only to localhost (`127.0.0.1`) rather than to all interfaces (`0.0.0.0`). 
 
 For further guidance, see the [official MCP documentation](https://modelcontextprotocol.io/docs/concepts/transports#security-considerations).
 

--- a/docs/guides/dataset/run_retrieval_test.md
+++ b/docs/guides/dataset/run_retrieval_test.md
@@ -18,7 +18,7 @@ During a retrieval test, chunks created from your specified chunking method are 
 - If no rerank model is selected, weighted keyword similarity will be combined with weighted vector cosine similarity.
 - If a rerank model is selected, weighted keyword similarity will be combined with weighted vector reranking score.
 
-In contrast, chunks created from [knowledge graph construction](./construct_knowledge_graph.md) are retrieved solely using vector cosine similarity.
+In contrast, chunks created from [knowledge graph construction](./advanced/construct_knowledge_graph.md) are retrieved solely using vector cosine similarity.
 
 ## Prerequisites
 


### PR DESCRIPTION
### What problem does this PR solve?

This fixes two broken internal documentation links in the guides:

- `docs/develop/mcp/launch_mcp_server.md` linked `./acquire_ragflow_api_key.md`, but the target page lives one level up as `../acquire_ragflow_api_key.md`.
- `docs/guides/dataset/run_retrieval_test.md` linked `./construct_knowledge_graph.md`, but the actual page lives under `./advanced/construct_knowledge_graph.md`.

These broken links make it harder to follow the MCP and retrieval-test docs from the local docs tree.

### Type of change

- [x] Documentation Update

