### PR TITLE
fix: OCR.detect() returns truthy None-tuple causing NoneType subscript crash

### DIFF
--- a/deepdoc/vision/ocr.py
+++ b/deepdoc/vision/ocr.py
@@ -670,19 +670,13 @@ class OCR:
         if device_id is None:
             device_id = 0
 
-        time_dict = {'det': 0, 'rec': 0, 'cls': 0, 'all': 0}
-
         if img is None:
-            return None, None, time_dict
+            return None
 
-        start = time.time()
-        dt_boxes, elapse = self.text_detector[device_id](img)
-        time_dict['det'] = elapse
+        dt_boxes, _ = self.text_detector[device_id](img)
 
         if dt_boxes is None:
-            end = time.time()
-            time_dict['all'] = end - start
-            return None, None, time_dict
+            return None
 
         return zip(self.sorted_boxes(dt_boxes), [
                    ("", 0) for _ in range(len(dt_boxes))])


### PR DESCRIPTION
Fixes #13851

## Problem

`OCR.detect()` in `deepdoc/vision/ocr.py` returns `None, None, time_dict` (a truthy 3-tuple) when the text detector fails or receives a `None` image. However, the caller in `pdf_parser.py:__ocr()` checks:

```python
bxs = self.ocr.detect(np.array(img), device_id)
if not bxs:  # False! (None, None, time_dict) is a non-empty tuple → truthy
    self.boxes.append([])
    return
bxs = [(line[0], line[1][0]) for line in bxs]  # iterates (None, None, time_dict)
# line = None → None[0] → TypeError: 'NoneType' object is not subscriptable
```

This causes the `NoneType object is not subscriptable` error that appears after "OCR started" in the chunking pipeline when using PDF + General parser.

## Solution

Simplified `OCR.detect()` to return `None` (falsy) instead of `None, None, time_dict` on failure. The `time_dict` was unused by the only caller of this method. The early-return guard `if not bxs:` in `pdf_parser.py` then correctly catches it.

## Testing

- The method's only caller (`pdf_parser.py:__ocr`) already has a `if not bxs:` guard that handles the `None` return correctly.
- No other callers of `OCR.detect()` exist in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified OCR detection function return behavior to streamline output. The function now returns detection results only, without timing metadata. Error cases now return `None` instead of empty tuple values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->