### PR TITLE
Use uv run python3 x.py instead of uv run x.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. Launch the dependent services (MinIO, Elasticsearch, Redis, and MySQL) using Docker Compose:

--- a/README_ar.md
+++ b/README_ar.md
@@ -329,7 +329,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. قم بتشغيل الخدمات التابعة (MinIO وElasticsearch وRedis وMySQL) باستخدام Docker Compose:

--- a/README_fr.md
+++ b/README_fr.md
@@ -320,7 +320,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. Lancez les services dépendants (MinIO, Elasticsearch, Redis et MySQL) avec Docker Compose :

--- a/README_id.md
+++ b/README_id.md
@@ -303,7 +303,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. Jalankan aplikasi yang diperlukan (MinIO, Elasticsearch, Redis, dan MySQL) menggunakan Docker Compose:

--- a/README_ja.md
+++ b/README_ja.md
@@ -303,7 +303,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. Docker Compose を使用して依存サービス（MinIO、Elasticsearch、Redis、MySQL）を起動する:

--- a/README_ko.md
+++ b/README_ko.md
@@ -298,7 +298,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -320,7 +320,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # instala os módulos Python dependentes do RAGFlow
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. Inicie os serviços dependentes (MinIO, Elasticsearch, Redis e MySQL) usando Docker Compose:

--- a/README_tr.md
+++ b/README_tr.md
@@ -324,7 +324,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # RAGFlow'un bağımlı Python modüllerini yükler
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. Bağımlı hizmetleri (MinIO, Elasticsearch, Redis ve MySQL) Docker Compose kullanarak başlatın:

--- a/README_tzh.md
+++ b/README_tzh.md
@@ -330,7 +330,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 3. 透過 Docker Compose 啟動依賴的服務（MinIO, Elasticsearch, Redis, and MySQL）：

--- a/README_zh.md
+++ b/README_zh.md
@@ -330,7 +330,7 @@ docker build --platform linux/amd64 \
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
    uv sync --python 3.12 # install RAGFlow dependent python modules
-   uv run download_deps.py
+   uv run python3 download_deps.py
    pre-commit install
    ```
 


### PR DESCRIPTION
### Use uv run python3 x.py instead of uv run x.py

When directly call `uv run x.py` it will use the python in shebang, it does not work if the default python lack of some packages, so change it to best practices `uv run python3 x.py` 

### Type of change

- [x] Documentation Update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated development setup instructions across all README files (English and multiple language translations) to use explicit Python interpreter invocation for the dependency download command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->