### PR TITLE
fix: correct nested path traversal in set_variable_param_value

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -263,7 +263,7 @@ class Graph:
         keys = path.split('.')
         if not path:
             return value
-        for key in keys:
+        for key in keys[:-1]:
             if key not in cur or not isinstance(cur[key], dict):
                 cur[key] = {}
             cur = cur[key]


### PR DESCRIPTION
## Summary

`Graph.set_variable_param_value()` in `agent/canvas.py` has a bug in its nested path traversal logic. The `for` loop iterates through **all** keys in the path (including the last one), descending into every level. After the loop, it then tries to set `cur[keys[-1]] = value`, but `cur` has already descended one level too deep.

**Example:** For `path = "a.b"`, `value = "hello"`:
- **Before (bug):** `obj["a"]["b"]` becomes `{"b": "hello"}` instead of `"hello"`
- **After (fix):** `obj["a"]["b"]` becomes `"hello"` as expected

The fix changes `for key in keys:` to `for key in keys[:-1]:`, so the loop only navigates to the parent dict, and the final key is set directly. This is consistent with how the read-side counterpart `get_variable_param_value()` works.

This method is called by `set_variable_value()` when assigning to nested variable paths (e.g., `component@root.nested.key`), which is used by the `VariableAssigner` component.

## Test plan
- [ ] Create a canvas with a VariableAssigner that writes to a nested path (e.g., `component@obj.nested.key`)
- [ ] Verify the value is set correctly at the expected path, not wrapped in an extra dict layer
- [ ] Verify single-key paths (e.g., `component@key`) still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug in variable parameter assignment where nested structures were being incorrectly modified, ensuring values are now properly set at their intended locations without unintended overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->