### PR TITLE
fix: close file handles properly in json.load() calls

### DIFF
--- a/api/db/init_data.py
+++ b/api/db/init_data.py
@@ -168,7 +168,8 @@ def add_graph_templates():
 
     for fnm in os.listdir(dir):
         try:
-            cnvs = json.load(open(os.path.join(dir, fnm), "r",encoding="utf-8"))
+            with open(os.path.join(dir, fnm), "r", encoding="utf-8") as f:
+                cnvs = json.load(f)
             try:
                 CanvasTemplateService.save(**cnvs)
             except Exception:

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -270,7 +270,8 @@ class InfinityConnectionBase(DocStoreConnection):
             fp_mapping = os.path.join(get_project_base_directory(), "conf", self.mapping_file_name)
             if not os.path.exists(fp_mapping):
                 raise Exception(f"Mapping file not found at {fp_mapping}")
-            schema = json.load(open(fp_mapping))
+            with open(fp_mapping) as f:
+                schema = json.load(f)
 
             if parser_id is not None:
                 from common.constants import ParserType


### PR DESCRIPTION
## Summary

Fixes #13996

Replace `json.load(open(...))` with `with open(...) as f: json.load(f)` in two files to ensure file descriptors are properly closed.

**Affected files:**
- `common/doc_store/infinity_conn_base.py` — schema loading for Infinity doc store
- `api/db/init_data.py` — agent template loading at startup

## Why this matters

In a long-running server process like RAGFlow, leaked file descriptors from `json.load(open(...))` can accumulate over time. While CPython's refcounting usually cleans these up, it's not guaranteed (especially under memory pressure or with alternative Python runtimes), and can lead to `OSError: [Errno 24] Too many open files`.

## Test plan

- [ ] Verify Infinity doc store schema loading still works correctly
- [ ] Verify agent templates load correctly on startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file handling in internal data processing to ensure proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->