### PR TITLE
fix: preserve raptor scope field when saving dataset configuration

### DIFF
--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -267,6 +267,7 @@ export const useUpdateKnowledge = (shouldFetchList = false) => {
       threshold,
       max_cluster,
       random_seed,
+      scope,
       auto_disable_for_structured_data,
       ext,
       ...raptorExt
@@ -278,6 +279,7 @@ export const useUpdateKnowledge = (shouldFetchList = false) => {
       threshold,
       max_cluster,
       random_seed,
+      scope,
       auto_disable_for_structured_data,
       ext: { ...ext, ...raptorExt },
     };


### PR DESCRIPTION
Fixes #13999

## Problem

When saving dataset configuration with RAPTOR scope set to Entire Library (dataset), the setting reverts back to Single File (file) after saving.

The root cause is in extractRaptorConfigExt in web/src/hooks/use-knowledge-request.ts. The scope field was not included in the explicit destructuring list, so it fell through into the ...raptorExt rest spread and ended up nested under ext.scope instead of being a top-level field raptor.scope.

As a result: the backend received ext.scope: dataset instead of scope: dataset. task_executor.py reads raptor_config.get(scope, file) at the top level and could not find the value, defaulting to file. Subsequent fetches of the KB configuration also returned no top-level scope, so the UI always showed Single File.

## Solution

Add scope to the explicit destructuring and return it as a top-level field in extractRaptorConfigExt, consistent with all other RAPTOR configuration fields.

## Testing

- Create a dataset and navigate to dataset settings
- Set RAPTOR generation scope to Entire Library
- Save settings
- Verify the scope remains Entire Library after reload