### PR TITLE
Disable flask and quart debug

### DIFF
--- a/admin/server/admin_server.py
+++ b/admin/server/admin_server.py
@@ -21,7 +21,6 @@ import os
 import signal
 import logging
 import threading
-import traceback
 import faulthandler
 
 from flask import Flask
@@ -77,8 +76,8 @@ if __name__ == '__main__':
             use_reloader=False,
             use_debugger=False,
         )
-    except Exception:
-        traceback.print_exc()
+    except Exception as e:
+        logging.exception(f"Unhandled exception: {e}")
         stop_event.set()
         time.sleep(1)
         os.kill(os.getpid(), signal.SIGKILL)

--- a/admin/server/admin_server.py
+++ b/admin/server/admin_server.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
             application=app,
             threaded=True,
             use_reloader=False,
-            use_debugger=True,
+            use_debugger=False,
         )
     except Exception:
         traceback.print_exc()

--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     # start http server
     try:
         logging.info(f"RAGFlow server is ready after {time.time() - start_ts}s initialization.")
-        app.run(host=settings.HOST_IP, port=settings.HOST_PORT, use_reloader=RuntimeConfig.DEBUG, debug=RuntimeConfig.DEBUG)
+        app.run(host=settings.HOST_IP, port=settings.HOST_PORT, use_reloader=RuntimeConfig.DEBUG, debug=False, use_debugger=False)
     except Exception as e:
         logging.exception(f"Unhandled exception: {e}")
         stop_event.set()

--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
     # start http server
     try:
         logging.info(f"RAGFlow server is ready after {time.time() - start_ts}s initialization.")
-        app.run(host=settings.HOST_IP, port=settings.HOST_PORT)
+        app.run(host=settings.HOST_IP, port=settings.HOST_PORT, use_reloader=RuntimeConfig.DEBUG, debug=RuntimeConfig.DEBUG)
     except Exception:
         traceback.print_exc()
         stop_event.set()

--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     # start http server
     try:
         logging.info(f"RAGFlow server is ready after {time.time() - start_ts}s initialization.")
-        app.run(host=settings.HOST_IP, port=settings.HOST_PORT, use_reloader=RuntimeConfig.DEBUG, debug=False, use_debugger=False)
+        app.run(host=settings.HOST_IP, port=settings.HOST_PORT, use_reloader=RuntimeConfig.DEBUG, debug=False)
     except Exception as e:
         logging.exception(f"Unhandled exception: {e}")
         stop_event.set()

--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -23,7 +23,6 @@ import logging
 import os
 import signal
 import sys
-import traceback
 import threading
 import uuid
 import faulthandler
@@ -147,8 +146,8 @@ if __name__ == '__main__':
     try:
         logging.info(f"RAGFlow server is ready after {time.time() - start_ts}s initialization.")
         app.run(host=settings.HOST_IP, port=settings.HOST_PORT, use_reloader=RuntimeConfig.DEBUG, debug=RuntimeConfig.DEBUG)
-    except Exception:
-        traceback.print_exc()
+    except Exception as e:
+        logging.exception(f"Unhandled exception: {e}")
         stop_event.set()
         stop_event.wait(1)
         os.kill(os.getpid(), signal.SIGKILL)

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -654,7 +654,7 @@ def create_starlette_app():
         )
 
     return Starlette(
-        debug=True,
+        debug=False,
         routes=routes,
         middleware=middleware,
         lifespan=streamablehttp_lifespan,

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -1422,4 +1422,8 @@ async def main():
 if __name__ == "__main__":
     faulthandler.enable()
     init_root_logger(CONSUMER_NAME)
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except Exception as e:
+        logging.exception(f"Unhandled exception: {e}")
+        sys.exit(1)


### PR DESCRIPTION
### What problem does this PR solve?

Visit `http://127.0.0.1:9381/?__debugger__=yes&cmd=resource&f=debugger.js` will expose the flask code:
```
docReady(() => {
  if (!EVALEX_TRUSTED) {
    initPinBox();
  }
  // if we are in console mode, show the console.
  if (CONSOLE_MODE && EVALEX) {
    createInteractiveConsole();
  }

  const frames = document.querySelectorAll("div.traceback div.frame");
  if (EVALEX) {
    addConsoleIconToFrames(frames);
  }
  addEventListenersToElements(document.querySelectorAll("div.detail"), "click", () =>
    document.querySelector("div.traceback").scrollIntoView(false)
  );
  addToggleFrameTraceback(frames);
  addToggleTraceTypesOnClick(document.querySelectorAll("h2.traceback"));
  addInfoPrompt(document.querySelectorAll("span.nojavascript"));
  wrapPlainTraceback();
});

function addToggleFrameTraceback(frames) {
  frames.forEach((frame) => {
    frame.addEventListener("click", () => {
      frame.getElementsByTagName("pre")[0].parentElement.classList.toggle("expanded");
    });
  })
}

```

### Type of change

- [x] Other (please describe): Fix security risk
