### PR TITLE
Fix: agent application can not show Cite

### DIFF
--- a/agent/tools/retrieval.py
+++ b/agent/tools/retrieval.py
@@ -196,7 +196,7 @@ class Retrieval(ToolBase, ABC):
                 self._param.similarity_threshold,
                 1 - self._param.keywords_similarity_weight,
                 doc_ids=doc_ids,
-                aggs=False,
+                aggs=True,
                 rerank_mdl=rerank_mdl,
                 rank_feature=label_question(query, kbs),
             )


### PR DESCRIPTION
Close #14018

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Problem
In Agent applications, even with the cite option enabled, only inline [ID: x] citation markers are visible (showing chunk content on hover). The Agent does not display the referenced file cards below the response, unlike Chat applications.

### Root Cause
The Agent's Retrieval tool (agent/tools/retrieval.py) calls retriever.retrieval() with aggs=False, which means the retrieval results do not include doc_aggs (document aggregation) data. Without doc_aggs, the frontend ReferenceDocumentList component has no data to render the file cards.

In contrast, the Chat application (api/db/services/dialog_service.py) calls the same retriever.retrieval() method with aggs=True.

### Fix
Changed aggs=False to aggs=True in agent/tools/retrieval.py so that document aggregation data is returned along with the retrieved chunks.

