### PR TITLE
fix(infinity): escape single quotes in fulltext filter to prevent TokenError

### DIFF
--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -177,7 +177,8 @@ class InfinityConnection(InfinityConnectionBase):
                         matchExpr.extra_options.update({"filter": filter_cond})
                     matchExpr.fields = [self.convert_matching_field(field) for field in matchExpr.fields]
                     fields = ",".join(matchExpr.fields)
-                    filter_fulltext = f"filter_fulltext('{fields}', '{matchExpr.matching_text}')"
+                    escaped_matching_text = matchExpr.matching_text.replace("'", "''")
+                    filter_fulltext = f"filter_fulltext('{fields}', '{escaped_matching_text}')"
                     if filter_cond:
                         filter_fulltext = f"({filter_cond}) AND {filter_fulltext}"
                     minimum_should_match = matchExpr.extra_options.get("minimum_should_match", 0.0)


### PR DESCRIPTION
## Summary

Escape single quotes in `matchExpr.matching_text` before interpolating into the `filter_fulltext()` call in `InfinityConnection.search()`. Without this, user queries containing single quotes (e.g., `what's`) cause a `TokenError` from the Infinity query parser.

Split out from #13835 to keep PRs focused.

## Test plan

- [ ] Search with a query containing single quotes (e.g., `what's the meaning of life`)
- [ ] Verify no `TokenError` is raised and results are returned correctly