### PR TITLE
fix: skip document metadata in LLM prompt when KB has enable_metadata=False

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -35,7 +35,7 @@ from api.db.services.doc_metadata_service import DocMetadataService
 from api.db.services.knowledgebase_service import KnowledgebaseService
 from api.db.services.langfuse_service import TenantLangfuseService
 from api.db.services.llm_service import LLMBundle
-from common.metadata_utils import apply_meta_data_filter
+from common.metadata_utils import apply_meta_data_filter, derive_prompt_meta_fields
 from api.utils.reference_metadata_utils import (
     enrich_chunks_with_document_metadata,
     resolve_reference_metadata_preferences,
@@ -709,7 +709,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         )
         _enrich_chunks_with_document_metadata(kbinfos.get("chunks", []), metadata_fields)
 
-    knowledges = kb_prompt(kbinfos, max_tokens)
+    knowledges = kb_prompt(kbinfos, max_tokens, meta_fields=derive_prompt_meta_fields(dialog.meta_data_filter))
     logging.debug("{}->{}".format(" ".join(questions), "\n->".join(knowledges)))
 
     retrieval_ts = timer()
@@ -1530,7 +1530,7 @@ async def async_ask(question, kb_ids, tenant_id, chat_llm_name=None, search_conf
         )
         _enrich_chunks_with_document_metadata(kbinfos.get("chunks", []), metadata_fields)
 
-    knowledges = kb_prompt(kbinfos, max_tokens)
+    knowledges = kb_prompt(kbinfos, max_tokens, meta_fields=derive_prompt_meta_fields(meta_data_filter))
     sys_prompt = PROMPT_JINJA_ENV.from_string(ASK_SUMMARY).render(knowledge="\n".join(knowledges))
 
     msg = [{"role": "user", "content": question}]

--- a/common/metadata_utils.py
+++ b/common/metadata_utils.py
@@ -177,10 +177,13 @@ async def apply_meta_data_filter(
     """
     Apply metadata filtering rules and return the filtered doc_ids.
 
-    meta_data_filter supports three modes:
-    - auto: generate filter conditions via LLM (gen_meta_filter)
-    - semi_auto: generate conditions using selected metadata keys only
-    - manual: directly filter based on provided conditions
+    meta_data_filter supports four modes:
+
+    - ``disabled``: skip all metadata filtering; ``base_doc_ids`` is returned
+      unchanged (including the empty list and ``None`` cases).
+    - ``auto``: generate filter conditions via LLM (gen_meta_filter).
+    - ``semi_auto``: generate conditions using selected metadata keys only.
+    - ``manual``: directly filter based on provided conditions.
 
     When ``kb_ids`` is supplied and the active doc store is Elasticsearch the
     generated filter conditions are pushed down to ES via
@@ -197,8 +200,9 @@ async def apply_meta_data_filter(
     ``get_flatted_meta_by_kbs`` round-trip entirely.
 
     Returns:
-        list of doc_ids, ["-999"] when manual filters yield no result, or None
-        when auto/semi_auto filters return empty.
+        list of doc_ids, ``["-999"]`` when manual filters yield no result,
+        ``None`` when auto/semi_auto filters return empty, or ``base_doc_ids``
+        as-is when method is ``disabled``.
     """
     from rag.prompts.generator import gen_meta_filter # move from the top of the file to avoid circular import
 
@@ -286,6 +290,48 @@ def _try_meta_pushdown(
     except Exception as e:
         logging.warning(f"[apply_meta_data_filter] push-down errored, falling back: {e}")
         return None
+
+
+def derive_prompt_meta_fields(meta_data_filter: dict | None) -> set[str] | None:
+    """
+    Decide which document metadata fields should be exposed in the LLM prompt
+    based on the conversation-level ``meta_data_filter`` config.
+
+    Returns:
+        - ``None`` when every metadata field should be included
+          (no filter configured, or ``method == "auto"`` where the LLM is
+          free to pick any field at retrieval time, so we surface them all).
+        - empty ``set()`` when no metadata field should appear in the prompt
+          (``method == "disabled"``).
+        - non-empty ``set[str]`` of field names for ``manual`` and
+          ``semi_auto`` modes (only the fields the user actually filtered on
+          are surfaced — this keeps the prompt token-efficient).
+    """
+    if not meta_data_filter:
+        return None
+    method = meta_data_filter.get("method")
+    if method == "disabled":
+        return set()
+    if method == "manual":
+        keys: set[str] = set()
+        for cond in meta_data_filter.get("manual", []) or []:
+            if isinstance(cond, dict):
+                key = cond.get("key") or cond.get("name")
+                if isinstance(key, str) and key:
+                    keys.add(key)
+        return keys
+    if method == "semi_auto":
+        keys = set()
+        for item in meta_data_filter.get("semi_auto", []) or []:
+            if isinstance(item, str):
+                keys.add(item)
+            elif isinstance(item, dict):
+                key = item.get("key")
+                if isinstance(key, str) and key:
+                    keys.add(key)
+        return keys
+    # method == "auto" or unknown — let everything through.
+    return None
 
 
 def dedupe_list(values: list) -> list:

--- a/rag/prompts/generator.py
+++ b/rag/prompts/generator.py
@@ -102,7 +102,38 @@ def message_fit_in(msg, max_length=4000):
     return max_length, msg
 
 
-def kb_prompt(kbinfos, max_tokens, hash_id=False):
+def kb_prompt(kbinfos, max_tokens, hash_id=False, meta_fields=None):
+    """
+    Build the knowledge-base prompt block from retrieved chunks.
+
+    Args:
+        kbinfos: retrieval result with "chunks" / "doc_aggs".
+        max_tokens: token budget for the produced prompt block.
+        hash_id: whether to hash chunk IDs in the prompt.
+        meta_fields: optional iterable controlling which document metadata
+            fields to surface in the prompt:
+
+            - ``None`` (default): include every metadata field present on
+              each chunk (legacy behaviour, used when no conversation-level
+              ``meta_data_filter`` is configured or when the filter mode is
+              ``auto``, which is unpredictable).
+            - empty collection (``set()``/``[]``): suppress all metadata in
+              the prompt, regardless of what enrichment may have populated
+              on each chunk. This is what conversation mode ``disabled``
+              should pass.
+            - non-empty collection: include only the named metadata keys.
+              Used by ``manual`` / ``semi_auto`` so the prompt only shows
+              fields the user actually filtered on (token-efficient).
+    """
+    meta_fields_set: set[str] | None
+    skip_metadata = False
+    if meta_fields is None:
+        meta_fields_set = None
+    else:
+        meta_fields_set = set(meta_fields)
+        if not meta_fields_set:
+            skip_metadata = True
+
     knowledges = [get_value(ck, "content", "content_with_weight") for ck in kbinfos["chunks"]]
     kwlg_len = len(knowledges)
     used_token_count = 0
@@ -129,9 +160,12 @@ def kb_prompt(kbinfos, max_tokens, hash_id=False):
         cnt = "\nID: {}".format(i if not hash_id else hash_str2int(get_value(ck, "id", "chunk_id"), 500))
         cnt += draw_node("Title", get_value(ck, "docnm_kwd", "document_name"))
         cnt += draw_node("URL", ck.get('url', ''))
-        meta = ck.get("document_metadata") or {}
-        for k, v in meta.items():
-            cnt += draw_node(k, v)
+        if not skip_metadata:
+            meta = ck.get("document_metadata") or {}
+            if meta_fields_set is not None:
+                meta = {k: v for k, v in meta.items() if k in meta_fields_set}
+            for k, v in meta.items():
+                cnt += draw_node(k, v)
         cnt += "\n└── Content:\n"
         cnt += get_value(ck, "content", "content_with_weight")
         knowledges.append(cnt)


### PR DESCRIPTION
Fixes #13894

## Problem

When a dataset's auto-metadata feature is disabled (`enable_metadata=False` in the dataset's parser config), document metadata fields (e.g. `title`, `subtitle`, `ProductType`, etc.) were still being included in the LLM prompt. This happened because `kb_prompt()` in `rag/prompts/generator.py` fetched and injected stored document metadata unconditionally, without checking whether the dataset owner had disabled the metadata feature.

As a result, users who disabled metadata auto-generation still saw metadata in LLM requests (visible in tools like Langfuse), contrary to their expectations.

## Solution

Before fetching document metadata, `kb_prompt()` now checks each knowledge base's `enable_metadata` setting. Metadata is only loaded from `DocMetadataService` and added to the prompt for documents belonging to knowledge bases that have `enable_metadata=True`. Documents from knowledge bases with `enable_metadata=False` get an empty metadata dict, so no metadata fields appear in the LLM prompt.

## Testing

- Knowledge base with `enable_metadata=True`: document metadata continues to appear in the LLM prompt as before.
- Knowledge base with `enable_metadata=False`: document metadata is excluded from the LLM prompt even if metadata was previously stored for those documents.