### PR TITLE
feat(agent): add scenario planner draft generator

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include agent/templates/scenario_planner *.json

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -119,8 +119,19 @@ class ScenarioPlanner:
         nodes = graph.get("nodes")
         if not isinstance(edges, list) or not isinstance(nodes, list):
             raise ValueError("existing_dsl must be a valid canvas DSL with graph.edges and graph.nodes as lists")
+        if not all(isinstance(component, dict) for component in components.values()):
+            raise ValueError("existing_dsl must be a valid canvas DSL with dict component entries")
+        if not all(isinstance(node, dict) for node in nodes):
+            raise ValueError("existing_dsl must be a valid canvas DSL with dict graph.nodes entries")
+        if not all(isinstance(edge, dict) for edge in edges):
+            raise ValueError("existing_dsl must be a valid canvas DSL with dict graph.edges entries")
         if "begin" not in components or not any(node.get("id") == "begin" for node in nodes if isinstance(node, dict)):
             raise ValueError("existing_dsl must be a valid canvas DSL with a begin node in both components and graph.nodes")
+        for component in components.values():
+            downstream = component.get("downstream", [])
+            upstream = component.get("upstream", [])
+            if not isinstance(downstream, list) or not isinstance(upstream, list):
+                raise ValueError("existing_dsl must be a valid canvas DSL with list upstream/downstream component links")
         instruction_l = (instruction or "").strip().lower()
         operations: List[Dict[str, str]] = []
         warnings: List[str] = []
@@ -219,16 +230,26 @@ class ScenarioPlanner:
 
         return dsl, operations, warnings
 
-    def _get_output_reference(self, components: Dict[str, Dict[str, Any]], component_id: str) -> str:
+    def _get_output_reference(
+        self,
+        components: Dict[str, Dict[str, Any]],
+        component_id: str,
+        visited: Optional[set[str]] = None,
+    ) -> str:
+        if visited is None:
+            visited = set()
         if component_id == "begin":
             return "{sys.query}"
+        if component_id in visited:
+            return "{sys.query}"
+        visited.add(component_id)
         component = components.get(component_id, {})
         obj = component.get("obj", {})
         component_name = obj.get("component_name")
         if component_name == "Message":
             upstream = component.get("upstream", []) or []
             if upstream:
-                return self._get_output_reference(components, upstream[0])
+                return self._get_output_reference(components, upstream[0], visited)
         params = obj.get("params", {})
         outputs = params.get("outputs")
         if isinstance(outputs, dict) and outputs:
@@ -236,7 +257,7 @@ class ScenarioPlanner:
             return f"{{{component_id}@{preferred_field}}}"
         upstream = component.get("upstream", []) or []
         if upstream:
-            return self._get_output_reference(components, upstream[0])
+            return self._get_output_reference(components, upstream[0], visited)
         return "{sys.query}"
 
     def _get_tail_component_id(self, components: Dict[str, Dict[str, Any]]) -> Optional[str]:

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -112,10 +112,16 @@ class ScenarioPlanner:
 
     def _modify_existing_dsl(self, existing_dsl: Dict[str, Any], instruction: str) -> tuple[Dict[str, Any], List[Dict[str, str]], List[str]]:
         dsl = deepcopy(existing_dsl)
-        components = dsl.setdefault("components", {})
-        graph = dsl.setdefault("graph", {})
-        edges = graph.setdefault("edges", [])
-        nodes = graph.setdefault("nodes", [])
+        components = dsl.get("components")
+        graph = dsl.get("graph")
+        if not isinstance(components, dict) or not isinstance(graph, dict):
+            raise ValueError("existing_dsl must be a valid canvas DSL with dict components and graph sections")
+        if "begin" not in components:
+            raise ValueError("existing_dsl must be a valid canvas DSL with a begin node")
+        edges = graph.get("edges")
+        nodes = graph.get("nodes")
+        if not isinstance(edges, list) or not isinstance(nodes, list):
+            raise ValueError("existing_dsl must be a valid canvas DSL with graph.edges and graph.nodes as lists")
         instruction_l = (instruction or "").strip().lower()
         operations: List[Dict[str, str]] = []
         warnings: List[str] = []
@@ -172,8 +178,9 @@ class ScenarioPlanner:
             new_agent_id = f"Agent:{base_id}Analysis"
             if new_agent_id not in components:
                 upstream_id = tail_id or "begin"
+                tail_output_ref = self._get_output_reference(components, upstream_id)
                 components[new_agent_id] = self._agent_component(
-                    prompts=[{"role": "user", "content": "{sys.query}"}],
+                    prompts=[{"role": "user", "content": f"Analyze the following output:\n{tail_output_ref}\n\nOriginal request: {{sys.query}}"}],
                     sys_prompt="This is an appended analysis step. Users should refine the prompt and attach tools if needed.",
                     downstream=[],
                 )
@@ -195,9 +202,26 @@ class ScenarioPlanner:
 
         return dsl, operations, warnings
 
+    def _get_output_reference(self, components: Dict[str, Dict[str, Any]], component_id: str) -> str:
+        if component_id == "begin":
+            return "{sys.query}"
+        component = components.get(component_id, {})
+        component_name = component.get("obj", {}).get("component_name")
+        if component_name == "Message":
+            upstream = component.get("upstream", []) or []
+            if upstream:
+                return self._get_output_reference(components, upstream[0])
+        return f"{{{component_id}@content}}"
+
     def _get_tail_component_id(self, components: Dict[str, Dict[str, Any]]) -> Optional[str]:
+        """Return a deterministic tail node, preferring the main Message:Output when multiple tails exist."""
         tails = [component_id for component_id, component in components.items() if not component.get("downstream")]
-        return tails[-1] if tails else None
+        if not tails:
+            return None
+        for tail in tails:
+            if tail == "Message:Output" or "Message:Output" in tail:
+                return tail
+        return tails[-1]
 
     def _get_predecessor_ids(self, components: Dict[str, Dict[str, Any]], target_id: Optional[str]) -> List[str]:
         if not target_id:
@@ -214,19 +238,6 @@ class ScenarioPlanner:
             if edge.get("source") == source_id and edge.get("target") == old_target:
                 edge["target"] = new_target
                 edge["id"] = f"xy-edge__{source_id}{edge.get('sourceHandle', 'start')}-{new_target}{edge.get('targetHandle', 'end')}"
-
-    def _node(self, component_id: str, label: str, index: int) -> Dict[str, Any]:
-        return {
-            "id": component_id,
-            "data": {
-                "label": label,
-                "name": component_id,
-            },
-            "position": {
-                "x": 120 + index * 260,
-                "y": 160,
-            },
-        }
 
     def _classify(self, scenario: str) -> ScenarioMatch:
         text = (scenario or "").strip().lower()
@@ -263,32 +274,6 @@ class ScenarioPlanner:
             reason="No complex orchestration keyword detected; using a minimal QA skeleton.",
             warnings=[],
         )
-
-    def _base_dsl(self, components: Dict[str, Dict[str, Any]], edges: List[Dict[str, Any]]) -> Dict[str, Any]:
-        nodes = []
-        for index, (component_id, component) in enumerate(components.items()):
-            nodes.append(self._node(component_id, component["obj"]["component_name"], index))
-
-        return {
-            "components": components,
-            "globals": {
-                "sys.conversation_turns": 0,
-                "sys.date": "",
-                "sys.files": [],
-                "sys.history": [],
-                "sys.query": "",
-                "sys.user_id": "",
-            },
-            "graph": {
-                "edges": edges,
-                "nodes": nodes,
-            },
-            "history": [],
-            "messages": [],
-            "path": ["begin"],
-            "retrieval": {"chunks": [], "doc_aggs": []},
-            "variables": {},
-        }
 
     def _load_template(self, template_name: str) -> Dict[str, Any]:
         template_path = TEMPLATE_ROOT / f"{template_name}.json"

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -1,0 +1,447 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Scenario planner for drafting RAGFlow canvas DSL from natural language."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+DEFAULT_LLM_ID = "qwen-turbo@Tongyi-Qianwen"
+
+
+@dataclass(frozen=True)
+class ScenarioMatch:
+    archetype: str
+    reason: str
+    warnings: List[str]
+
+
+class ScenarioPlanner:
+    """Translate natural-language scenarios into editable canvas skeletons."""
+
+    ARCHETYPE_DESCRIPTIONS = {
+        "qa_basic": "Simple question answering or retrieval assistant.",
+        "interactive_research": "Two-stage research workflow with planning and human feedback.",
+        "monitor_notify": "Fetch/analyze/branch/notify skeleton for monitoring tasks.",
+        "batch_review": "Iteration-based batch processing workflow for repeated items.",
+    }
+
+    def plan(self, title: str, scenario: str, canvas_category: str = "Agent") -> Dict[str, Any]:
+        match = self._classify(scenario)
+        builder = getattr(self, f"_build_{match.archetype}")
+        dsl = builder(scenario)
+        return {
+            "title": title,
+            "canvas_type": canvas_category,
+            "archetype": match.archetype,
+            "summary": self.ARCHETYPE_DESCRIPTIONS[match.archetype],
+            "reason": match.reason,
+            "warnings": match.warnings,
+            "dsl": dsl,
+        }
+
+    def _classify(self, scenario: str) -> ScenarioMatch:
+        text = (scenario or "").strip().lower()
+        if not text:
+            return ScenarioMatch(
+                archetype="qa_basic",
+                reason="Empty scenario, defaulting to the smallest editable QA flow.",
+                warnings=["Scenario text is empty; the generated draft is only a placeholder."],
+            )
+
+        if any(token in text for token in ("monitor", "watch", "detect changes", "notify", "notification", "alert")):
+            return ScenarioMatch(
+                archetype="monitor_notify",
+                reason="Detected monitoring/notification intent.",
+                warnings=["The monitor skeleton is a draft. Users still need to wire the real fetch/extract tools."],
+            )
+
+        if any(token in text for token in ("batch", "each file", "for each", "every file", "multiple resumes", "all resumes")):
+            return ScenarioMatch(
+                archetype="batch_review",
+                reason="Detected repeated-item or batch-processing intent.",
+                warnings=[],
+            )
+
+        if any(token in text for token in ("research", "investigate", "analyze", "report", "compare", "deep search")):
+            return ScenarioMatch(
+                archetype="interactive_research",
+                reason="Detected multi-step research intent.",
+                warnings=[],
+            )
+
+        return ScenarioMatch(
+            archetype="qa_basic",
+            reason="No complex orchestration keyword detected; using a minimal QA skeleton.",
+            warnings=[],
+        )
+
+    def _base_dsl(self, components: Dict[str, Dict[str, Any]], edges: List[Dict[str, Any]]) -> Dict[str, Any]:
+        nodes = []
+        x = 120
+        for component_id, component in components.items():
+            nodes.append(
+                {
+                    "id": component_id,
+                    "data": {
+                        "label": component["obj"]["component_name"],
+                        "name": component_id,
+                    },
+                    "position": {"x": x, "y": 160},
+                }
+            )
+            x += 260
+
+        return {
+            "components": components,
+            "globals": {
+                "sys.conversation_turns": 0,
+                "sys.files": [],
+                "sys.query": "",
+                "sys.user_id": "",
+            },
+            "graph": {
+                "edges": edges,
+                "nodes": nodes,
+            },
+            "history": [],
+            "messages": [],
+            "path": ["begin"],
+            "retrieval": {"chunks": [], "doc_aggs": []},
+            "variables": {},
+        }
+
+    def _edge(self, source: str, target: str, source_handle: str = "start", target_handle: str = "end") -> Dict[str, Any]:
+        return {
+            "id": f"xy-edge__{source}{source_handle}-{target}{target_handle}",
+            "source": source,
+            "sourceHandle": source_handle,
+            "target": target,
+            "targetHandle": target_handle,
+            "data": {"isHovered": False},
+        }
+
+    def _begin_component(self, downstream: List[str], prologue: str) -> Dict[str, Any]:
+        return {
+            "downstream": downstream,
+            "obj": {
+                "component_name": "Begin",
+                "params": {
+                    "enablePrologue": True,
+                    "inputs": {},
+                    "mode": "conversational",
+                    "prologue": prologue,
+                },
+            },
+            "upstream": [],
+        }
+
+    def _agent_component(
+        self,
+        prompts: List[Dict[str, str]],
+        sys_prompt: str,
+        downstream: List[str],
+        tools: List[Dict[str, Any]] | None = None,
+        mcp: List[Dict[str, Any]] | None = None,
+        max_rounds: int = 1,
+    ) -> Dict[str, Any]:
+        return {
+            "downstream": downstream,
+            "obj": {
+                "component_name": "Agent",
+                "params": {
+                    "cite": True,
+                    "delay_after_error": 1,
+                    "description": "",
+                    "exception_default_value": "",
+                    "exception_goto": [],
+                    "exception_method": "",
+                    "frequencyPenaltyEnabled": False,
+                    "frequency_penalty": 0.7,
+                    "llm_id": DEFAULT_LLM_ID,
+                    "maxTokensEnabled": False,
+                    "max_retries": 3,
+                    "max_rounds": max_rounds,
+                    "max_tokens": 512,
+                    "mcp": mcp or [],
+                    "message_history_window_size": 12,
+                    "outputs": {
+                        "content": {"type": "string", "value": ""},
+                        "structured": {},
+                    },
+                    "presencePenaltyEnabled": False,
+                    "presence_penalty": 0.4,
+                    "prompts": prompts,
+                    "sys_prompt": sys_prompt,
+                    "temperature": 0.1,
+                    "temperatureEnabled": False,
+                    "tools": tools or [],
+                    "topPEnabled": False,
+                    "top_p": 0.3,
+                    "user_prompt": "",
+                    "visual_files_var": "",
+                },
+            },
+            "upstream": [],
+        }
+
+    def _message_component(self, content: List[str], upstream: List[str]) -> Dict[str, Any]:
+        return {
+            "downstream": [],
+            "obj": {
+                "component_name": "Message",
+                "params": {"content": content},
+            },
+            "upstream": upstream,
+        }
+
+    def _user_fillup_component(self, tips: str, downstream: List[str], upstream: List[str]) -> Dict[str, Any]:
+        io_schema = {
+            "instructions": {
+                "name": "instructions",
+                "optional": False,
+                "options": [],
+                "type": "paragraph",
+            }
+        }
+        return {
+            "downstream": downstream,
+            "obj": {
+                "component_name": "UserFillUp",
+                "params": {
+                    "enable_tips": True,
+                    "inputs": deepcopy(io_schema),
+                    "outputs": deepcopy(io_schema),
+                    "tips": tips,
+                },
+            },
+            "upstream": upstream,
+        }
+
+    def _switch_component(self, conditions: List[Dict[str, Any]], downstream: List[str], upstream: List[str], end_cpn_ids: List[str]) -> Dict[str, Any]:
+        return {
+            "downstream": downstream,
+            "obj": {
+                "component_name": "Switch",
+                "params": {
+                    "conditions": conditions,
+                    "end_cpn_ids": end_cpn_ids,
+                },
+            },
+            "upstream": upstream,
+        }
+
+    def _iteration_component(self, items_ref: str, output_ref: str, upstream: List[str]) -> Dict[str, Any]:
+        return {
+            "downstream": [],
+            "obj": {
+                "component_name": "Iteration",
+                "params": {
+                    "items_ref": items_ref,
+                    "outputs": {
+                        "evaluation": {
+                            "ref": output_ref,
+                            "type": "Array<string>",
+                        }
+                    },
+                },
+            },
+            "upstream": upstream,
+        }
+
+    def _iteration_item_component(self, parent_id: str, downstream: List[str]) -> Dict[str, Any]:
+        return {
+            "downstream": downstream,
+            "obj": {
+                "component_name": "IterationItem",
+                "params": {
+                    "outputs": {
+                        "index": {"type": "integer"},
+                        "item": {"type": "unknown"},
+                    }
+                },
+            },
+            "parent_id": parent_id,
+            "upstream": [],
+        }
+
+    def _build_qa_basic(self, scenario: str) -> Dict[str, Any]:
+        components = {
+            "begin": self._begin_component(["Agent:DraftAnswer"], "Hi! Describe the task you want this workflow to handle."),
+            "Agent:DraftAnswer": self._agent_component(
+                prompts=[{"role": "user", "content": "{sys.query}"}],
+                sys_prompt=(
+                    "You are a draft QA agent skeleton. "
+                    "Users should replace this prompt, attach tools, and refine citations or retrieval settings as needed."
+                ),
+                downstream=["Message:Output"],
+            ),
+            "Message:Output": self._message_component(["{Agent:DraftAnswer@content}"], ["Agent:DraftAnswer"]),
+        }
+        components["Agent:DraftAnswer"]["upstream"] = ["begin"]
+        edges = [
+            self._edge("begin", "Agent:DraftAnswer"),
+            self._edge("Agent:DraftAnswer", "Message:Output"),
+        ]
+        return self._base_dsl(components, edges)
+
+    def _build_interactive_research(self, scenario: str) -> Dict[str, Any]:
+        components = {
+            "begin": self._begin_component(["Agent:Plan"], "Hi! Describe the research task you want to automate."),
+            "Agent:Plan": self._agent_component(
+                prompts=[{"role": "user", "content": "User query:{sys.query}"}],
+                sys_prompt=(
+                    "You are the planning agent. Break the scenario into concrete research steps, "
+                    "define what evidence is needed, and prepare a short execution plan."
+                ),
+                downstream=["UserFillUp:ReviewPlan"],
+            ),
+            "UserFillUp:ReviewPlan": self._user_fillup_component(
+                tips="Here is the draft plan:\n{Agent:Plan@content}\nPlease refine or approve it before execution.",
+                downstream=["Agent:ExecuteResearch"],
+                upstream=["Agent:Plan"],
+            ),
+            "Agent:ExecuteResearch": self._agent_component(
+                prompts=[{"role": "user", "content": "Plan:{Agent:Plan@content}\nUser feedback:{UserFillUp:ReviewPlan@instructions}\nQuery:{sys.query}"}],
+                sys_prompt=(
+                    "You are the execution agent. Follow the approved plan, collect evidence, "
+                    "and draft a concise final answer with clear traceability."
+                ),
+                downstream=["Message:Output"],
+                max_rounds=3,
+            ),
+            "Message:Output": self._message_component(["{Agent:ExecuteResearch@content}"], ["Agent:ExecuteResearch"]),
+        }
+        components["Agent:Plan"]["upstream"] = ["begin"]
+        components["Agent:ExecuteResearch"]["upstream"] = ["UserFillUp:ReviewPlan"]
+        edges = [
+            self._edge("begin", "Agent:Plan"),
+            self._edge("Agent:Plan", "UserFillUp:ReviewPlan"),
+            self._edge("UserFillUp:ReviewPlan", "Agent:ExecuteResearch"),
+            self._edge("Agent:ExecuteResearch", "Message:Output"),
+        ]
+        return self._base_dsl(components, edges)
+
+    def _build_monitor_notify(self, scenario: str) -> Dict[str, Any]:
+        components = {
+            "begin": self._begin_component(["Agent:FetchState"], "Hi! Describe what should be monitored and how you want to be notified."),
+            "Agent:FetchState": self._agent_component(
+                prompts=[{"role": "user", "content": "Monitoring target:{sys.query}"}],
+                sys_prompt=(
+                    "You are the fetch step skeleton. Configure this node to collect the latest state "
+                    "from the monitored source before comparison."
+                ),
+                downstream=["Agent:CompareState"],
+            ),
+            "Agent:CompareState": self._agent_component(
+                prompts=[{"role": "user", "content": "Fetched state:{Agent:FetchState@content}\nOriginal task:{sys.query}"}],
+                sys_prompt=(
+                    "You are the comparison step skeleton. Decide whether there is a meaningful change. "
+                    "Return CHANGED or NO_CHANGE plus a short rationale."
+                ),
+                downstream=["Switch:Decision"],
+            ),
+            "Switch:Decision": self._switch_component(
+                conditions=[
+                    {
+                        "items": [
+                            {
+                                "cpn_id": "Agent:CompareState@content",
+                                "operator": "contains",
+                                "value": "CHANGED",
+                            }
+                        ],
+                        "logical_operator": "and",
+                        "to": ["Agent:Notify"],
+                    }
+                ],
+                downstream=["Agent:Notify", "Message:NoChange"],
+                upstream=["Agent:CompareState"],
+                end_cpn_ids=["Message:NoChange"],
+            ),
+            "Agent:Notify": self._agent_component(
+                prompts=[{"role": "user", "content": "Comparison result:{Agent:CompareState@content}\nTask:{sys.query}"}],
+                sys_prompt=(
+                    "You are the notification step skeleton. Prepare the alert payload, summary, "
+                    "or follow-up action when a change is detected."
+                ),
+                downstream=["Message:Output"],
+            ),
+            "Message:NoChange": self._message_component(["No meaningful change was detected."], ["Switch:Decision"]),
+            "Message:Output": self._message_component(["{Agent:Notify@content}"], ["Agent:Notify"]),
+        }
+        components["Agent:FetchState"]["upstream"] = ["begin"]
+        components["Agent:CompareState"]["upstream"] = ["Agent:FetchState"]
+        components["Agent:Notify"]["upstream"] = ["Switch:Decision"]
+        edges = [
+            self._edge("begin", "Agent:FetchState"),
+            self._edge("Agent:FetchState", "Agent:CompareState"),
+            self._edge("Agent:CompareState", "Switch:Decision"),
+            self._edge("Switch:Decision", "Agent:Notify"),
+            self._edge("Switch:Decision", "Message:NoChange"),
+            self._edge("Agent:Notify", "Message:Output"),
+        ]
+        return self._base_dsl(components, edges)
+
+    def _build_batch_review(self, scenario: str) -> Dict[str, Any]:
+        iteration_id = "Iteration:Items"
+        components = {
+            "begin": {
+                "downstream": [iteration_id],
+                "obj": {
+                    "component_name": "Begin",
+                    "params": {
+                        "enablePrologue": True,
+                        "inputs": {
+                            "task_instructions": {
+                                "name": "Task Instructions",
+                                "optional": False,
+                                "options": [],
+                                "type": "line",
+                            }
+                        },
+                        "mode": "conversational",
+                        "prologue": "Hi! Upload or provide the items you want to process in batch.",
+                    },
+                },
+                "upstream": [],
+            },
+            iteration_id: self._iteration_component("sys.files", "Agent:ReviewItem@content", ["begin"]),
+            "IterationItem:Current": self._iteration_item_component(iteration_id, ["Agent:ReviewItem"]),
+            "Agent:ReviewItem": self._agent_component(
+                prompts=[{"role": "user", "content": "Task:{begin@task_instructions}\nCurrent item:{IterationItem:Current@item}\nOriginal scenario:{sys.query}"}],
+                sys_prompt=(
+                    "You are the per-item batch processor. Review each item independently and "
+                    "produce a concise structured result."
+                ),
+                downstream=["Message:ItemOutput"],
+            ),
+            "Message:ItemOutput": self._message_component(["{Agent:ReviewItem@content}"], ["Agent:ReviewItem"]),
+        }
+        components["Agent:ReviewItem"]["parent_id"] = iteration_id
+        components["Agent:ReviewItem"]["upstream"] = ["IterationItem:Current"]
+        components["Message:ItemOutput"]["parent_id"] = iteration_id
+
+        edges = [
+            self._edge("begin", iteration_id),
+            self._edge("IterationItem:Current", "Agent:ReviewItem"),
+            self._edge("Agent:ReviewItem", "Message:ItemOutput"),
+        ]
+        dsl = self._base_dsl(components, edges)
+        return dsl

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -56,7 +56,7 @@ class ScenarioPlanner:
         existing_dsl: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         mode = "modify" if existing_dsl is not None else "create"
-        logger.info("scenario_planner plan start title=%s mode=%s", title, mode)
+        logger.info("scenario_planner plan start mode=%s", mode)
         if existing_dsl is not None:
             dsl, operations, warnings = self._modify_existing_dsl(existing_dsl, scenario)
             result = {
@@ -75,8 +75,7 @@ class ScenarioPlanner:
                 "dsl": dsl,
             }
             logger.info(
-                "scenario_planner plan complete title=%s mode=%s archetype=%s operations=%s warnings=%s",
-                title,
+                "scenario_planner plan complete mode=%s archetype=%s operations=%s warnings=%s",
                 mode,
                 result["archetype"],
                 len(result.get("operations", []) or []),
@@ -102,8 +101,7 @@ class ScenarioPlanner:
             "dsl": dsl,
         }
         logger.info(
-            "scenario_planner plan complete title=%s mode=%s archetype=%s operations=%s warnings=%s",
-            title,
+            "scenario_planner plan complete mode=%s archetype=%s operations=%s warnings=%s",
             mode,
             result["archetype"],
             len(result.get("operations", []) or []),
@@ -126,15 +124,13 @@ class ScenarioPlanner:
         instruction_l = (instruction or "").strip().lower()
         operations: List[Dict[str, str]] = []
         warnings: List[str] = []
-
-        tail_id = self._get_tail_component_id(components)
-        predecessor_ids = self._get_predecessor_ids(components, tail_id)
-        base_id = (tail_id or "begin").replace(":", "_")
         recognized_any = False
         applied_any = False
 
         if any(token in instruction_l for token in ("notify", "notification", "alert")):
             recognized_any = True
+            tail_id = self._get_tail_component_id(components)
+            base_id = (tail_id or "begin").replace(":", "_")
             new_message_id = f"Message:{base_id}Notify"
             if new_message_id not in components:
                 applied_any = True
@@ -154,6 +150,9 @@ class ScenarioPlanner:
 
         if any(token in instruction_l for token in ("review", "approve", "human", "feedback")):
             recognized_any = True
+            tail_id = self._get_tail_component_id(components)
+            predecessor_ids = self._get_predecessor_ids(components, tail_id)
+            base_id = (tail_id or "begin").replace(":", "_")
             fillup_id = f"UserFillUp:{base_id}Review"
             if fillup_id not in components:
                 applied_any = True
@@ -185,6 +184,8 @@ class ScenarioPlanner:
 
         if any(token in instruction_l for token in ("add analysis", "analyze", "summarize", "summary")):
             recognized_any = True
+            tail_id = self._get_tail_component_id(components)
+            base_id = (tail_id or "begin").replace(":", "_")
             new_agent_id = f"Agent:{base_id}Analysis"
             if new_agent_id not in components:
                 applied_any = True

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-"""Scenario planner for drafting RAGFlow canvas DSL from natural language."""
+"""Scenario planner for drafting and editing RAGFlow canvas DSL from natural language."""
 
 from __future__ import annotations
 
@@ -49,7 +49,7 @@ class ScenarioPlanner:
         canvas_category: str = "Agent",
         existing_dsl: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        if existing_dsl:
+        if existing_dsl is not None:
             dsl, operations, warnings = self._modify_existing_dsl(existing_dsl, scenario)
             return {
                 "title": title,
@@ -92,16 +92,9 @@ class ScenarioPlanner:
         operations: List[Dict[str, str]] = []
         warnings: List[str] = []
 
-        last_message_id = None
-        last_agent_id = None
-        for component_id, component in components.items():
-            name = component.get("obj", {}).get("component_name")
-            if name == "Message":
-                last_message_id = component_id
-            elif name == "Agent":
-                last_agent_id = component_id
-
-        base_id = (last_message_id or last_agent_id or "begin").replace(":", "_")
+        tail_id = self._get_tail_component_id(components)
+        predecessor_ids = self._get_predecessor_ids(components, tail_id)
+        base_id = (tail_id or "begin").replace(":", "_")
         matched_any = False
 
         if any(token in instruction_l for token in ("notify", "notification", "alert")):
@@ -110,13 +103,13 @@ class ScenarioPlanner:
             if new_message_id not in components:
                 components[new_message_id] = self._message_component(
                     ["A notification step should be configured here."],
-                    [last_agent_id or "begin"],
+                    [tail_id or "begin"],
                 )
-                if last_agent_id and last_agent_id in components:
-                    downstream = components[last_agent_id].setdefault("downstream", [])
+                if tail_id and tail_id in components:
+                    downstream = components[tail_id].setdefault("downstream", [])
                     if new_message_id not in downstream:
                         downstream.append(new_message_id)
-                edges.append(self._edge(last_agent_id or "begin", new_message_id))
+                edges.append(self._edge(tail_id or "begin", new_message_id))
                 nodes.append(self._node(new_message_id, "Message", len(nodes)))
                 operations.append({"type": "append_notification", "target": new_message_id})
 
@@ -126,14 +119,23 @@ class ScenarioPlanner:
             if fillup_id not in components:
                 components[fillup_id] = self._user_fillup_component(
                     tips="Review the current output and provide feedback before continuing.",
-                    downstream=[],
-                    upstream=[last_agent_id or "begin"],
+                    downstream=[tail_id] if tail_id else [],
+                    upstream=predecessor_ids or [tail_id or "begin"],
                 )
-                if last_agent_id and last_agent_id in components:
-                    downstream = components[last_agent_id].setdefault("downstream", [])
-                    if fillup_id not in downstream:
-                        downstream.append(fillup_id)
-                edges.append(self._edge(last_agent_id or "begin", fillup_id))
+                if tail_id and predecessor_ids:
+                    for predecessor_id in predecessor_ids:
+                        downstream = components[predecessor_id].setdefault("downstream", [])
+                        downstream[:] = [fillup_id if item == tail_id else item for item in downstream]
+                        self._replace_edge_target(edges, predecessor_id, tail_id, fillup_id)
+                    components[tail_id]["upstream"] = [fillup_id]
+                    edges.append(self._edge(fillup_id, tail_id))
+                else:
+                    anchor = tail_id or "begin"
+                    if anchor in components:
+                        downstream = components[anchor].setdefault("downstream", [])
+                        if fillup_id not in downstream:
+                            downstream.append(fillup_id)
+                    edges.append(self._edge(anchor, fillup_id))
                 nodes.append(self._node(fillup_id, "UserFillUp", len(nodes)))
                 operations.append({"type": "insert_human_review", "target": fillup_id})
 
@@ -141,7 +143,7 @@ class ScenarioPlanner:
             matched_any = True
             new_agent_id = f"Agent:{base_id}Analysis"
             if new_agent_id not in components:
-                upstream_id = last_message_id or last_agent_id or "begin"
+                upstream_id = tail_id or "begin"
                 components[new_agent_id] = self._agent_component(
                     prompts=[{"role": "user", "content": "{sys.query}"}],
                     sys_prompt="This is an appended analysis step. Users should refine the prompt and attach tools if needed.",
@@ -164,6 +166,26 @@ class ScenarioPlanner:
             operations.append({"type": "no_op", "target": ""})
 
         return dsl, operations, warnings
+
+    def _get_tail_component_id(self, components: Dict[str, Dict[str, Any]]) -> Optional[str]:
+        tails = [component_id for component_id, component in components.items() if not component.get("downstream")]
+        return tails[-1] if tails else None
+
+    def _get_predecessor_ids(self, components: Dict[str, Dict[str, Any]], target_id: Optional[str]) -> List[str]:
+        if not target_id:
+            return []
+        predecessors = []
+        for component_id, component in components.items():
+            downstream = component.get("downstream", []) or []
+            if target_id in downstream:
+                predecessors.append(component_id)
+        return predecessors
+
+    def _replace_edge_target(self, edges: List[Dict[str, Any]], source_id: str, old_target: str, new_target: str) -> None:
+        for edge in edges:
+            if edge.get("source") == source_id and edge.get("target") == old_target:
+                edge["target"] = new_target
+                edge["id"] = f"xy-edge__{source_id}{edge.get('sourceHandle', 'start')}-{new_target}{edge.get('targetHandle', 'end')}"
 
     def _node(self, component_id: str, label: str, index: int) -> Dict[str, Any]:
         return {

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, List, Optional
 
 
 DEFAULT_LLM_ID = "qwen-turbo@Tongyi-Qianwen"
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -49,12 +51,14 @@ class ScenarioPlanner:
         canvas_category: str = "Agent",
         existing_dsl: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
+        mode = "modify" if existing_dsl is not None else "create"
+        logger.info("scenario_planner plan start title=%s mode=%s", title, mode)
         if existing_dsl is not None:
             dsl, operations, warnings = self._modify_existing_dsl(existing_dsl, scenario)
-            return {
+            result = {
                 "title": title,
                 "canvas_type": canvas_category,
-                "mode": "modify",
+                "mode": mode,
                 "archetype": "modify_existing",
                 "summary": "Modify an existing workflow draft based on natural-language instructions.",
                 "reason": "Detected an existing DSL payload; applying incremental graph edits.",
@@ -66,14 +70,26 @@ class ScenarioPlanner:
                 "operations": operations,
                 "dsl": dsl,
             }
+            logger.info(
+                "scenario_planner plan complete title=%s mode=%s archetype=%s operations=%s warnings=%s",
+                title,
+                mode,
+                result["archetype"],
+                len(result.get("operations", []) or []),
+                len(result.get("warnings", []) or []),
+            )
+            return result
 
         match = self._classify(scenario)
-        builder = getattr(self, f"_build_{match.archetype}")
+        builder = getattr(self, f"_build_{match.archetype}", None)
+        if builder is None:
+            logger.error("scenario_planner missing builder for archetype=%s", match.archetype)
+            raise ValueError(f"No builder implemented for archetype: {match.archetype}")
         dsl = builder(scenario)
-        return {
+        result = {
             "title": title,
             "canvas_type": canvas_category,
-            "mode": "create",
+            "mode": mode,
             "archetype": match.archetype,
             "summary": self.ARCHETYPE_DESCRIPTIONS[match.archetype],
             "reason": match.reason,
@@ -81,6 +97,15 @@ class ScenarioPlanner:
             "operations": [{"type": "create_draft", "archetype": match.archetype}],
             "dsl": dsl,
         }
+        logger.info(
+            "scenario_planner plan complete title=%s mode=%s archetype=%s operations=%s warnings=%s",
+            title,
+            mode,
+            result["archetype"],
+            len(result.get("operations", []) or []),
+            len(result.get("warnings", []) or []),
+        )
+        return result
 
     def _modify_existing_dsl(self, existing_dsl: Dict[str, Any], instruction: str) -> tuple[Dict[str, Any], List[Dict[str, str]], List[str]]:
         dsl = deepcopy(existing_dsl)
@@ -245,7 +270,9 @@ class ScenarioPlanner:
             "components": components,
             "globals": {
                 "sys.conversation_turns": 0,
+                "sys.date": "",
                 "sys.files": [],
+                "sys.history": [],
                 "sys.query": "",
                 "sys.user_id": "",
             },

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -50,17 +50,20 @@ class ScenarioPlanner:
         existing_dsl: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         if existing_dsl:
-            dsl = self._modify_existing_dsl(existing_dsl, scenario)
+            dsl, operations, warnings = self._modify_existing_dsl(existing_dsl, scenario)
             return {
                 "title": title,
                 "canvas_type": canvas_category,
+                "mode": "modify",
                 "archetype": "modify_existing",
                 "summary": "Modify an existing workflow draft based on natural-language instructions.",
                 "reason": "Detected an existing DSL payload; applying incremental graph edits.",
                 "warnings": [
                     "Only a minimal edit set is supported in V1.",
                     "Users should review node wiring before execution.",
+                    *warnings,
                 ],
+                "operations": operations,
                 "dsl": dsl,
             }
 
@@ -70,20 +73,24 @@ class ScenarioPlanner:
         return {
             "title": title,
             "canvas_type": canvas_category,
+            "mode": "create",
             "archetype": match.archetype,
             "summary": self.ARCHETYPE_DESCRIPTIONS[match.archetype],
             "reason": match.reason,
             "warnings": match.warnings,
+            "operations": [{"type": "create_draft", "archetype": match.archetype}],
             "dsl": dsl,
         }
 
-    def _modify_existing_dsl(self, existing_dsl: Dict[str, Any], instruction: str) -> Dict[str, Any]:
+    def _modify_existing_dsl(self, existing_dsl: Dict[str, Any], instruction: str) -> tuple[Dict[str, Any], List[Dict[str, str]], List[str]]:
         dsl = deepcopy(existing_dsl)
         components = dsl.setdefault("components", {})
         graph = dsl.setdefault("graph", {})
         edges = graph.setdefault("edges", [])
         nodes = graph.setdefault("nodes", [])
         instruction_l = (instruction or "").strip().lower()
+        operations: List[Dict[str, str]] = []
+        warnings: List[str] = []
 
         last_message_id = None
         last_agent_id = None
@@ -95,8 +102,10 @@ class ScenarioPlanner:
                 last_agent_id = component_id
 
         base_id = (last_message_id or last_agent_id or "begin").replace(":", "_")
+        matched_any = False
 
         if any(token in instruction_l for token in ("notify", "notification", "alert")):
+            matched_any = True
             new_message_id = f"Message:{base_id}Notify"
             if new_message_id not in components:
                 components[new_message_id] = self._message_component(
@@ -109,8 +118,10 @@ class ScenarioPlanner:
                         downstream.append(new_message_id)
                 edges.append(self._edge(last_agent_id or "begin", new_message_id))
                 nodes.append(self._node(new_message_id, "Message", len(nodes)))
+                operations.append({"type": "append_notification", "target": new_message_id})
 
         if any(token in instruction_l for token in ("review", "approve", "human", "feedback")):
+            matched_any = True
             fillup_id = f"UserFillUp:{base_id}Review"
             if fillup_id not in components:
                 components[fillup_id] = self._user_fillup_component(
@@ -124,8 +135,10 @@ class ScenarioPlanner:
                         downstream.append(fillup_id)
                 edges.append(self._edge(last_agent_id or "begin", fillup_id))
                 nodes.append(self._node(fillup_id, "UserFillUp", len(nodes)))
+                operations.append({"type": "insert_human_review", "target": fillup_id})
 
         if any(token in instruction_l for token in ("add analysis", "analyze", "summarize", "summary")):
+            matched_any = True
             new_agent_id = f"Agent:{base_id}Analysis"
             if new_agent_id not in components:
                 upstream_id = last_message_id or last_agent_id or "begin"
@@ -142,8 +155,15 @@ class ScenarioPlanner:
                         upstream_downstream.append(new_agent_id)
                 edges.append(self._edge(upstream_id, new_agent_id))
                 nodes.append(self._node(new_agent_id, "Agent", len(nodes)))
+                operations.append({"type": "append_analysis", "target": new_agent_id})
 
-        return dsl
+        if not matched_any:
+            warnings.append(
+                "No supported edit operation was detected. V1 currently supports notification, review, and analysis-oriented edits."
+            )
+            operations.append({"type": "no_op", "target": ""})
+
+        return dsl, operations, warnings
 
     def _node(self, component_id: str, label: str, index: int) -> Dict[str, Any]:
         return {

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
+from functools import lru_cache
 import logging
 import json
 from pathlib import Path
@@ -129,12 +130,14 @@ class ScenarioPlanner:
         tail_id = self._get_tail_component_id(components)
         predecessor_ids = self._get_predecessor_ids(components, tail_id)
         base_id = (tail_id or "begin").replace(":", "_")
-        matched_any = False
+        recognized_any = False
+        applied_any = False
 
         if any(token in instruction_l for token in ("notify", "notification", "alert")):
-            matched_any = True
+            recognized_any = True
             new_message_id = f"Message:{base_id}Notify"
             if new_message_id not in components:
+                applied_any = True
                 components[new_message_id] = self._message_component(
                     ["A notification step should be configured here."],
                     [tail_id or "begin"],
@@ -146,11 +149,14 @@ class ScenarioPlanner:
                 edges.append(self._edge(tail_id or "begin", new_message_id))
                 nodes.append(self._node(new_message_id, "Message", len(nodes)))
                 operations.append({"type": "append_notification", "target": new_message_id})
+            else:
+                operations.append({"type": "already_present", "target": new_message_id})
 
         if any(token in instruction_l for token in ("review", "approve", "human", "feedback")):
-            matched_any = True
+            recognized_any = True
             fillup_id = f"UserFillUp:{base_id}Review"
             if fillup_id not in components:
+                applied_any = True
                 review_downstream = [tail_id] if tail_id and tail_id != "begin" else []
                 review_upstream = predecessor_ids or ([tail_id] if tail_id and tail_id != "begin" else ["begin"])
                 components[fillup_id] = self._user_fillup_component(
@@ -174,11 +180,14 @@ class ScenarioPlanner:
                     edges.append(self._edge(anchor, fillup_id))
                 nodes.append(self._node(fillup_id, "UserFillUp", len(nodes)))
                 operations.append({"type": "insert_human_review", "target": fillup_id})
+            else:
+                operations.append({"type": "already_present", "target": fillup_id})
 
         if any(token in instruction_l for token in ("add analysis", "analyze", "summarize", "summary")):
-            matched_any = True
+            recognized_any = True
             new_agent_id = f"Agent:{base_id}Analysis"
             if new_agent_id not in components:
+                applied_any = True
                 upstream_id = tail_id or "begin"
                 tail_output_ref = self._get_output_reference(components, upstream_id)
                 components[new_agent_id] = self._agent_component(
@@ -195,8 +204,13 @@ class ScenarioPlanner:
                 edges.append(self._edge(upstream_id, new_agent_id))
                 nodes.append(self._node(new_agent_id, "Agent", len(nodes)))
                 operations.append({"type": "append_analysis", "target": new_agent_id})
+            else:
+                operations.append({"type": "already_present", "target": new_agent_id})
 
-        if not matched_any:
+        if recognized_any and not applied_any:
+            warnings.append("Requested edit matched a supported operation, but no graph changes were applied.")
+            operations.append({"type": "no_op", "target": ""})
+        elif not recognized_any:
             warnings.append(
                 "No supported edit operation was detected. V1 currently supports notification, review, and analysis-oriented edits."
             )
@@ -287,12 +301,17 @@ class ScenarioPlanner:
             warnings=[],
         )
 
-    def _load_template(self, template_name: str) -> Dict[str, Any]:
+    @staticmethod
+    @lru_cache(maxsize=8)
+    def _load_template_payload(template_name: str) -> Dict[str, Any]:
         template_path = TEMPLATE_ROOT / f"{template_name}.json"
         if not template_path.exists():
             raise ValueError(f"Scenario planner template not found: {template_name}")
         payload = json.loads(template_path.read_text(encoding="utf-8"))
-        return deepcopy(payload.get("dsl", payload))
+        return payload.get("dsl", payload)
+
+    def _load_template(self, template_name: str) -> Dict[str, Any]:
+        return deepcopy(self._load_template_payload(template_name))
 
     def _edge(self, source: str, target: str, source_handle: str = "start", target_handle: str = "end") -> Dict[str, Any]:
         return {

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import dataclass
 import logging
+import json
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
 DEFAULT_LLM_ID = "qwen-turbo@Tongyi-Qianwen"
 logger = logging.getLogger(__name__)
+TEMPLATE_ROOT = Path(__file__).resolve().parent / "templates" / "scenario_planner"
 
 
 @dataclass(frozen=True)
@@ -287,6 +290,13 @@ class ScenarioPlanner:
             "variables": {},
         }
 
+    def _load_template(self, template_name: str) -> Dict[str, Any]:
+        template_path = TEMPLATE_ROOT / f"{template_name}.json"
+        if not template_path.exists():
+            raise ValueError(f"Scenario planner template not found: {template_name}")
+        payload = json.loads(template_path.read_text(encoding="utf-8"))
+        return deepcopy(payload.get("dsl", payload))
+
     def _edge(self, source: str, target: str, source_handle: str = "start", target_handle: str = "end") -> Dict[str, Any]:
         return {
             "id": f"xy-edge__{source}{source_handle}-{target}{target_handle}",
@@ -297,19 +307,17 @@ class ScenarioPlanner:
             "data": {"isHovered": False},
         }
 
-    def _begin_component(self, downstream: List[str], prologue: str) -> Dict[str, Any]:
+    def _node(self, component_id: str, label: str, index: int) -> Dict[str, Any]:
         return {
-            "downstream": downstream,
-            "obj": {
-                "component_name": "Begin",
-                "params": {
-                    "enablePrologue": True,
-                    "inputs": {},
-                    "mode": "conversational",
-                    "prologue": prologue,
-                },
+            "id": component_id,
+            "data": {
+                "label": label,
+                "name": component_id,
             },
-            "upstream": [],
+            "position": {
+                "x": 120 + index * 260,
+                "y": 160,
+            },
         }
 
     def _agent_component(
@@ -317,8 +325,6 @@ class ScenarioPlanner:
         prompts: List[Dict[str, str]],
         sys_prompt: str,
         downstream: List[str],
-        tools: List[Dict[str, Any]] | None = None,
-        mcp: List[Dict[str, Any]] | None = None,
         max_rounds: int = 1,
     ) -> Dict[str, Any]:
         return {
@@ -339,7 +345,7 @@ class ScenarioPlanner:
                     "max_retries": 3,
                     "max_rounds": max_rounds,
                     "max_tokens": 512,
-                    "mcp": mcp or [],
+                    "mcp": [],
                     "message_history_window_size": 12,
                     "outputs": {
                         "content": {"type": "string", "value": ""},
@@ -351,7 +357,7 @@ class ScenarioPlanner:
                     "sys_prompt": sys_prompt,
                     "temperature": 0.1,
                     "temperatureEnabled": False,
-                    "tools": tools or [],
+                    "tools": [],
                     "topPEnabled": False,
                     "top_p": 0.3,
                     "user_prompt": "",
@@ -394,214 +400,14 @@ class ScenarioPlanner:
             "upstream": upstream,
         }
 
-    def _switch_component(self, conditions: List[Dict[str, Any]], downstream: List[str], upstream: List[str], end_cpn_ids: List[str]) -> Dict[str, Any]:
-        return {
-            "downstream": downstream,
-            "obj": {
-                "component_name": "Switch",
-                "params": {
-                    "conditions": conditions,
-                    "end_cpn_ids": end_cpn_ids,
-                },
-            },
-            "upstream": upstream,
-        }
-
-    def _iteration_component(self, items_ref: str, output_ref: str, upstream: List[str]) -> Dict[str, Any]:
-        return {
-            "downstream": [],
-            "obj": {
-                "component_name": "Iteration",
-                "params": {
-                    "items_ref": items_ref,
-                    "outputs": {
-                        "evaluation": {
-                            "ref": output_ref,
-                            "type": "Array<string>",
-                        }
-                    },
-                },
-            },
-            "upstream": upstream,
-        }
-
-    def _iteration_item_component(self, parent_id: str, downstream: List[str]) -> Dict[str, Any]:
-        return {
-            "downstream": downstream,
-            "obj": {
-                "component_name": "IterationItem",
-                "params": {
-                    "outputs": {
-                        "index": {"type": "integer"},
-                        "item": {"type": "unknown"},
-                    }
-                },
-            },
-            "parent_id": parent_id,
-            "upstream": [],
-        }
-
     def _build_qa_basic(self, scenario: str) -> Dict[str, Any]:
-        components = {
-            "begin": self._begin_component(["Agent:DraftAnswer"], "Hi! Describe the task you want this workflow to handle."),
-            "Agent:DraftAnswer": self._agent_component(
-                prompts=[{"role": "user", "content": "{sys.query}"}],
-                sys_prompt=(
-                    "You are a draft QA agent skeleton. "
-                    "Users should replace this prompt, attach tools, and refine citations or retrieval settings as needed."
-                ),
-                downstream=["Message:Output"],
-            ),
-            "Message:Output": self._message_component(["{Agent:DraftAnswer@content}"], ["Agent:DraftAnswer"]),
-        }
-        components["Agent:DraftAnswer"]["upstream"] = ["begin"]
-        edges = [
-            self._edge("begin", "Agent:DraftAnswer"),
-            self._edge("Agent:DraftAnswer", "Message:Output"),
-        ]
-        return self._base_dsl(components, edges)
+        return self._load_template("qa_basic")
 
     def _build_interactive_research(self, scenario: str) -> Dict[str, Any]:
-        components = {
-            "begin": self._begin_component(["Agent:Plan"], "Hi! Describe the research task you want to automate."),
-            "Agent:Plan": self._agent_component(
-                prompts=[{"role": "user", "content": "User query:{sys.query}"}],
-                sys_prompt=(
-                    "You are the planning agent. Break the scenario into concrete research steps, "
-                    "define what evidence is needed, and prepare a short execution plan."
-                ),
-                downstream=["UserFillUp:ReviewPlan"],
-            ),
-            "UserFillUp:ReviewPlan": self._user_fillup_component(
-                tips="Here is the draft plan:\n{Agent:Plan@content}\nPlease refine or approve it before execution.",
-                downstream=["Agent:ExecuteResearch"],
-                upstream=["Agent:Plan"],
-            ),
-            "Agent:ExecuteResearch": self._agent_component(
-                prompts=[{"role": "user", "content": "Plan:{Agent:Plan@content}\nUser feedback:{UserFillUp:ReviewPlan@instructions}\nQuery:{sys.query}"}],
-                sys_prompt=(
-                    "You are the execution agent. Follow the approved plan, collect evidence, "
-                    "and draft a concise final answer with clear traceability."
-                ),
-                downstream=["Message:Output"],
-                max_rounds=3,
-            ),
-            "Message:Output": self._message_component(["{Agent:ExecuteResearch@content}"], ["Agent:ExecuteResearch"]),
-        }
-        components["Agent:Plan"]["upstream"] = ["begin"]
-        components["Agent:ExecuteResearch"]["upstream"] = ["UserFillUp:ReviewPlan"]
-        edges = [
-            self._edge("begin", "Agent:Plan"),
-            self._edge("Agent:Plan", "UserFillUp:ReviewPlan"),
-            self._edge("UserFillUp:ReviewPlan", "Agent:ExecuteResearch"),
-            self._edge("Agent:ExecuteResearch", "Message:Output"),
-        ]
-        return self._base_dsl(components, edges)
+        return self._load_template("interactive_research")
 
     def _build_monitor_notify(self, scenario: str) -> Dict[str, Any]:
-        components = {
-            "begin": self._begin_component(["Agent:FetchState"], "Hi! Describe what should be monitored and how you want to be notified."),
-            "Agent:FetchState": self._agent_component(
-                prompts=[{"role": "user", "content": "Monitoring target:{sys.query}"}],
-                sys_prompt=(
-                    "You are the fetch step skeleton. Configure this node to collect the latest state "
-                    "from the monitored source before comparison."
-                ),
-                downstream=["Agent:CompareState"],
-            ),
-            "Agent:CompareState": self._agent_component(
-                prompts=[{"role": "user", "content": "Fetched state:{Agent:FetchState@content}\nOriginal task:{sys.query}"}],
-                sys_prompt=(
-                    "You are the comparison step skeleton. Decide whether there is a meaningful change. "
-                    "Return CHANGED or NO_CHANGE plus a short rationale."
-                ),
-                downstream=["Switch:Decision"],
-            ),
-            "Switch:Decision": self._switch_component(
-                conditions=[
-                    {
-                        "items": [
-                            {
-                                "cpn_id": "Agent:CompareState@content",
-                                "operator": "contains",
-                                "value": "CHANGED",
-                            }
-                        ],
-                        "logical_operator": "and",
-                        "to": ["Agent:Notify"],
-                    }
-                ],
-                downstream=["Agent:Notify", "Message:NoChange"],
-                upstream=["Agent:CompareState"],
-                end_cpn_ids=["Message:NoChange"],
-            ),
-            "Agent:Notify": self._agent_component(
-                prompts=[{"role": "user", "content": "Comparison result:{Agent:CompareState@content}\nTask:{sys.query}"}],
-                sys_prompt=(
-                    "You are the notification step skeleton. Prepare the alert payload, summary, "
-                    "or follow-up action when a change is detected."
-                ),
-                downstream=["Message:Output"],
-            ),
-            "Message:NoChange": self._message_component(["No meaningful change was detected."], ["Switch:Decision"]),
-            "Message:Output": self._message_component(["{Agent:Notify@content}"], ["Agent:Notify"]),
-        }
-        components["Agent:FetchState"]["upstream"] = ["begin"]
-        components["Agent:CompareState"]["upstream"] = ["Agent:FetchState"]
-        components["Agent:Notify"]["upstream"] = ["Switch:Decision"]
-        edges = [
-            self._edge("begin", "Agent:FetchState"),
-            self._edge("Agent:FetchState", "Agent:CompareState"),
-            self._edge("Agent:CompareState", "Switch:Decision"),
-            self._edge("Switch:Decision", "Agent:Notify"),
-            self._edge("Switch:Decision", "Message:NoChange"),
-            self._edge("Agent:Notify", "Message:Output"),
-        ]
-        return self._base_dsl(components, edges)
+        return self._load_template("monitor_notify")
 
     def _build_batch_review(self, scenario: str) -> Dict[str, Any]:
-        iteration_id = "Iteration:Items"
-        components = {
-            "begin": {
-                "downstream": [iteration_id],
-                "obj": {
-                    "component_name": "Begin",
-                    "params": {
-                        "enablePrologue": True,
-                        "inputs": {
-                            "task_instructions": {
-                                "name": "Task Instructions",
-                                "optional": False,
-                                "options": [],
-                                "type": "line",
-                            }
-                        },
-                        "mode": "conversational",
-                        "prologue": "Hi! Upload or provide the items you want to process in batch.",
-                    },
-                },
-                "upstream": [],
-            },
-            iteration_id: self._iteration_component("sys.files", "Agent:ReviewItem@content", ["begin"]),
-            "IterationItem:Current": self._iteration_item_component(iteration_id, ["Agent:ReviewItem"]),
-            "Agent:ReviewItem": self._agent_component(
-                prompts=[{"role": "user", "content": "Task:{begin@task_instructions}\nCurrent item:{IterationItem:Current@item}\nOriginal scenario:{sys.query}"}],
-                sys_prompt=(
-                    "You are the per-item batch processor. Review each item independently and "
-                    "produce a concise structured result."
-                ),
-                downstream=["Message:ItemOutput"],
-            ),
-            "Message:ItemOutput": self._message_component(["{Agent:ReviewItem@content}"], ["Agent:ReviewItem"]),
-        }
-        components["Agent:ReviewItem"]["parent_id"] = iteration_id
-        components["Agent:ReviewItem"]["upstream"] = ["IterationItem:Current"]
-        components["Message:ItemOutput"]["parent_id"] = iteration_id
-
-        edges = [
-            self._edge("begin", iteration_id),
-            self._edge("IterationItem:Current", "Agent:ReviewItem"),
-            self._edge("Agent:ReviewItem", "Message:ItemOutput"),
-        ]
-        dsl = self._base_dsl(components, edges)
-        return dsl
+        return self._load_template("batch_review")

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -208,17 +208,21 @@ class ScenarioPlanner:
         if component_id == "begin":
             return "{sys.query}"
         component = components.get(component_id, {})
-        component_name = component.get("obj", {}).get("component_name")
+        obj = component.get("obj", {})
+        component_name = obj.get("component_name")
         if component_name == "Message":
             upstream = component.get("upstream", []) or []
             if upstream:
                 return self._get_output_reference(components, upstream[0])
-        params = component.get("obj", {}).get("params", {})
+        params = obj.get("params", {})
         outputs = params.get("outputs")
         if isinstance(outputs, dict) and outputs:
             preferred_field = "content" if "content" in outputs else next(iter(outputs))
             return f"{{{component_id}@{preferred_field}}}"
-        return f"{{{component_id}@result}}"
+        upstream = component.get("upstream", []) or []
+        if upstream:
+            return self._get_output_reference(components, upstream[0])
+        return "{sys.query}"
 
     def _get_tail_component_id(self, components: Dict[str, Dict[str, Any]]) -> Optional[str]:
         """Return a deterministic tail node, preferring the main Message:Output when multiple tails exist."""

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 DEFAULT_LLM_ID = "qwen-turbo@Tongyi-Qianwen"
@@ -42,7 +42,28 @@ class ScenarioPlanner:
         "batch_review": "Iteration-based batch processing workflow for repeated items.",
     }
 
-    def plan(self, title: str, scenario: str, canvas_category: str = "Agent") -> Dict[str, Any]:
+    def plan(
+        self,
+        title: str,
+        scenario: str,
+        canvas_category: str = "Agent",
+        existing_dsl: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if existing_dsl:
+            dsl = self._modify_existing_dsl(existing_dsl, scenario)
+            return {
+                "title": title,
+                "canvas_type": canvas_category,
+                "archetype": "modify_existing",
+                "summary": "Modify an existing workflow draft based on natural-language instructions.",
+                "reason": "Detected an existing DSL payload; applying incremental graph edits.",
+                "warnings": [
+                    "Only a minimal edit set is supported in V1.",
+                    "Users should review node wiring before execution.",
+                ],
+                "dsl": dsl,
+            }
+
         match = self._classify(scenario)
         builder = getattr(self, f"_build_{match.archetype}")
         dsl = builder(scenario)
@@ -54,6 +75,87 @@ class ScenarioPlanner:
             "reason": match.reason,
             "warnings": match.warnings,
             "dsl": dsl,
+        }
+
+    def _modify_existing_dsl(self, existing_dsl: Dict[str, Any], instruction: str) -> Dict[str, Any]:
+        dsl = deepcopy(existing_dsl)
+        components = dsl.setdefault("components", {})
+        graph = dsl.setdefault("graph", {})
+        edges = graph.setdefault("edges", [])
+        nodes = graph.setdefault("nodes", [])
+        instruction_l = (instruction or "").strip().lower()
+
+        last_message_id = None
+        last_agent_id = None
+        for component_id, component in components.items():
+            name = component.get("obj", {}).get("component_name")
+            if name == "Message":
+                last_message_id = component_id
+            elif name == "Agent":
+                last_agent_id = component_id
+
+        base_id = (last_message_id or last_agent_id or "begin").replace(":", "_")
+
+        if any(token in instruction_l for token in ("notify", "notification", "alert")):
+            new_message_id = f"Message:{base_id}Notify"
+            if new_message_id not in components:
+                components[new_message_id] = self._message_component(
+                    ["A notification step should be configured here."],
+                    [last_agent_id or "begin"],
+                )
+                if last_agent_id and last_agent_id in components:
+                    downstream = components[last_agent_id].setdefault("downstream", [])
+                    if new_message_id not in downstream:
+                        downstream.append(new_message_id)
+                edges.append(self._edge(last_agent_id or "begin", new_message_id))
+                nodes.append(self._node(new_message_id, "Message", len(nodes)))
+
+        if any(token in instruction_l for token in ("review", "approve", "human", "feedback")):
+            fillup_id = f"UserFillUp:{base_id}Review"
+            if fillup_id not in components:
+                components[fillup_id] = self._user_fillup_component(
+                    tips="Review the current output and provide feedback before continuing.",
+                    downstream=[],
+                    upstream=[last_agent_id or "begin"],
+                )
+                if last_agent_id and last_agent_id in components:
+                    downstream = components[last_agent_id].setdefault("downstream", [])
+                    if fillup_id not in downstream:
+                        downstream.append(fillup_id)
+                edges.append(self._edge(last_agent_id or "begin", fillup_id))
+                nodes.append(self._node(fillup_id, "UserFillUp", len(nodes)))
+
+        if any(token in instruction_l for token in ("add analysis", "analyze", "summarize", "summary")):
+            new_agent_id = f"Agent:{base_id}Analysis"
+            if new_agent_id not in components:
+                upstream_id = last_message_id or last_agent_id or "begin"
+                components[new_agent_id] = self._agent_component(
+                    prompts=[{"role": "user", "content": "{sys.query}"}],
+                    sys_prompt="This is an appended analysis step. Users should refine the prompt and attach tools if needed.",
+                    downstream=[],
+                )
+                components[new_agent_id]["upstream"] = [upstream_id]
+                if upstream_id in components:
+                    upstream_component = components[upstream_id]
+                    upstream_downstream = upstream_component.setdefault("downstream", [])
+                    if new_agent_id not in upstream_downstream:
+                        upstream_downstream.append(new_agent_id)
+                edges.append(self._edge(upstream_id, new_agent_id))
+                nodes.append(self._node(new_agent_id, "Agent", len(nodes)))
+
+        return dsl
+
+    def _node(self, component_id: str, label: str, index: int) -> Dict[str, Any]:
+        return {
+            "id": component_id,
+            "data": {
+                "label": label,
+                "name": component_id,
+            },
+            "position": {
+                "x": 120 + index * 260,
+                "y": 160,
+            },
         }
 
     def _classify(self, scenario: str) -> ScenarioMatch:
@@ -94,19 +196,8 @@ class ScenarioPlanner:
 
     def _base_dsl(self, components: Dict[str, Dict[str, Any]], edges: List[Dict[str, Any]]) -> Dict[str, Any]:
         nodes = []
-        x = 120
-        for component_id, component in components.items():
-            nodes.append(
-                {
-                    "id": component_id,
-                    "data": {
-                        "label": component["obj"]["component_name"],
-                        "name": component_id,
-                    },
-                    "position": {"x": x, "y": 160},
-                }
-            )
-            x += 260
+        for index, (component_id, component) in enumerate(components.items()):
+            nodes.append(self._node(component_id, component["obj"]["component_name"], index))
 
         return {
             "components": components,

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -116,12 +116,12 @@ class ScenarioPlanner:
         graph = dsl.get("graph")
         if not isinstance(components, dict) or not isinstance(graph, dict):
             raise ValueError("existing_dsl must be a valid canvas DSL with dict components and graph sections")
-        if "begin" not in components:
-            raise ValueError("existing_dsl must be a valid canvas DSL with a begin node")
         edges = graph.get("edges")
         nodes = graph.get("nodes")
         if not isinstance(edges, list) or not isinstance(nodes, list):
             raise ValueError("existing_dsl must be a valid canvas DSL with graph.edges and graph.nodes as lists")
+        if "begin" not in components or not any(node.get("id") == "begin" for node in nodes if isinstance(node, dict)):
+            raise ValueError("existing_dsl must be a valid canvas DSL with a begin node in both components and graph.nodes")
         instruction_l = (instruction or "").strip().lower()
         operations: List[Dict[str, str]] = []
         warnings: List[str] = []
@@ -151,12 +151,14 @@ class ScenarioPlanner:
             matched_any = True
             fillup_id = f"UserFillUp:{base_id}Review"
             if fillup_id not in components:
+                review_downstream = [tail_id] if tail_id and tail_id != "begin" else []
+                review_upstream = predecessor_ids or ([tail_id] if tail_id and tail_id != "begin" else ["begin"])
                 components[fillup_id] = self._user_fillup_component(
                     tips="Review the current output and provide feedback before continuing.",
-                    downstream=[tail_id] if tail_id else [],
-                    upstream=predecessor_ids or [tail_id or "begin"],
+                    downstream=review_downstream,
+                    upstream=review_upstream,
                 )
-                if tail_id and predecessor_ids:
+                if tail_id and tail_id != "begin" and predecessor_ids:
                     for predecessor_id in predecessor_ids:
                         downstream = components[predecessor_id].setdefault("downstream", [])
                         downstream[:] = [fillup_id if item == tail_id else item for item in downstream]
@@ -164,7 +166,7 @@ class ScenarioPlanner:
                     components[tail_id]["upstream"] = [fillup_id]
                     edges.append(self._edge(fillup_id, tail_id))
                 else:
-                    anchor = tail_id or "begin"
+                    anchor = "begin"
                     if anchor in components:
                         downstream = components[anchor].setdefault("downstream", [])
                         if fillup_id not in downstream:
@@ -211,7 +213,12 @@ class ScenarioPlanner:
             upstream = component.get("upstream", []) or []
             if upstream:
                 return self._get_output_reference(components, upstream[0])
-        return f"{{{component_id}@content}}"
+        params = component.get("obj", {}).get("params", {})
+        outputs = params.get("outputs")
+        if isinstance(outputs, dict) and outputs:
+            preferred_field = "content" if "content" in outputs else next(iter(outputs))
+            return f"{{{component_id}@{preferred_field}}}"
+        return f"{{{component_id}@result}}"
 
     def _get_tail_component_id(self, components: Dict[str, Dict[str, Any]]) -> Optional[str]:
         """Return a deterministic tail node, preferring the main Message:Output when multiple tails exist."""
@@ -219,7 +226,8 @@ class ScenarioPlanner:
         if not tails:
             return None
         for tail in tails:
-            if tail == "Message:Output" or "Message:Output" in tail:
+            component_name = components.get(tail, {}).get("obj", {}).get("component_name")
+            if component_name == "Message" and (tail == "Message:Output" or tail.startswith("Message:Output")):
                 return tail
         return tails[-1]
 

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -121,6 +121,13 @@ class ScenarioPlanner:
             raise ValueError("existing_dsl must be a valid canvas DSL with graph.edges and graph.nodes as lists")
         if not all(isinstance(component, dict) for component in components.values()):
             raise ValueError("existing_dsl must be a valid canvas DSL with dict component entries")
+        for component in components.values():
+            obj = component.get("obj", {})
+            if obj is not None and not isinstance(obj, dict):
+                raise ValueError("existing_dsl components must use object metadata")
+            params = obj.get("params", {}) if isinstance(obj, dict) else {}
+            if params is not None and not isinstance(params, dict):
+                raise ValueError("existing_dsl component params must be objects")
         if not all(isinstance(node, dict) for node in nodes):
             raise ValueError("existing_dsl must be a valid canvas DSL with dict graph.nodes entries")
         if not all(isinstance(edge, dict) for edge in edges):
@@ -167,14 +174,15 @@ class ScenarioPlanner:
             fillup_id = f"UserFillUp:{base_id}Review"
             if fillup_id not in components:
                 applied_any = True
-                review_downstream = [tail_id] if tail_id and tail_id != "begin" else []
+                insert_before_tail = bool(tail_id and tail_id != "begin" and predecessor_ids)
+                review_downstream = [tail_id] if insert_before_tail else []
                 review_upstream = predecessor_ids or ([tail_id] if tail_id and tail_id != "begin" else ["begin"])
                 components[fillup_id] = self._user_fillup_component(
                     tips="Review the current output and provide feedback before continuing.",
                     downstream=review_downstream,
                     upstream=review_upstream,
                 )
-                if tail_id and tail_id != "begin" and predecessor_ids:
+                if insert_before_tail:
                     for predecessor_id in predecessor_ids:
                         downstream = components[predecessor_id].setdefault("downstream", [])
                         downstream[:] = [fillup_id if item == tail_id else item for item in downstream]
@@ -182,7 +190,7 @@ class ScenarioPlanner:
                     components[tail_id]["upstream"] = [fillup_id]
                     edges.append(self._edge(fillup_id, tail_id))
                 else:
-                    anchor = "begin"
+                    anchor = tail_id if tail_id and tail_id != "begin" else "begin"
                     if anchor in components:
                         downstream = components[anchor].setdefault("downstream", [])
                         if fillup_id not in downstream:

--- a/agent/scenario_planner.py
+++ b/agent/scenario_planner.py
@@ -48,6 +48,13 @@ class ScenarioPlanner:
         "batch_review": "Iteration-based batch processing workflow for repeated items.",
     }
 
+    CANVAS_TYPE_BY_CATEGORY = {
+        "Agent": "Agent",
+        "agent_canvas": "Agent",
+        "DataFlow": "Ingestion Pipeline",
+        "dataflow_canvas": "Ingestion Pipeline",
+    }
+
     def plan(
         self,
         title: str,
@@ -61,7 +68,7 @@ class ScenarioPlanner:
             dsl, operations, warnings = self._modify_existing_dsl(existing_dsl, scenario)
             result = {
                 "title": title,
-                "canvas_type": canvas_category,
+                "canvas_type": existing_dsl.get("canvas_type") or self._canvas_type_for_category(canvas_category),
                 "mode": mode,
                 "archetype": "modify_existing",
                 "summary": "Modify an existing workflow draft based on natural-language instructions.",
@@ -91,7 +98,7 @@ class ScenarioPlanner:
         dsl = builder(scenario)
         result = {
             "title": title,
-            "canvas_type": canvas_category,
+            "canvas_type": self._canvas_type_for_category(canvas_category),
             "mode": mode,
             "archetype": match.archetype,
             "summary": self.ARCHETYPE_DESCRIPTIONS[match.archetype],
@@ -123,10 +130,10 @@ class ScenarioPlanner:
             raise ValueError("existing_dsl must be a valid canvas DSL with dict component entries")
         for component in components.values():
             obj = component.get("obj", {})
-            if obj is not None and not isinstance(obj, dict):
+            if not isinstance(obj, dict):
                 raise ValueError("existing_dsl components must use object metadata")
-            params = obj.get("params", {}) if isinstance(obj, dict) else {}
-            if params is not None and not isinstance(params, dict):
+            params = obj.get("params", {})
+            if not isinstance(params, dict):
                 raise ValueError("existing_dsl component params must be objects")
         if not all(isinstance(node, dict) for node in nodes):
             raise ValueError("existing_dsl must be a valid canvas DSL with dict graph.nodes entries")
@@ -152,15 +159,16 @@ class ScenarioPlanner:
             new_message_id = f"Message:{base_id}Notify"
             if new_message_id not in components:
                 applied_any = True
+                anchor = tail_id or "begin"
                 components[new_message_id] = self._message_component(
                     ["A notification step should be configured here."],
-                    [tail_id or "begin"],
+                    [anchor],
                 )
-                if tail_id and tail_id in components:
-                    downstream = components[tail_id].setdefault("downstream", [])
+                if anchor in components:
+                    downstream = components[anchor].setdefault("downstream", [])
                     if new_message_id not in downstream:
                         downstream.append(new_message_id)
-                edges.append(self._edge(tail_id or "begin", new_message_id))
+                edges.append(self._edge(anchor, new_message_id))
                 nodes.append(self._node(new_message_id, "Message", len(nodes)))
                 operations.append({"type": "append_notification", "target": new_message_id})
             else:
@@ -342,6 +350,9 @@ class ScenarioPlanner:
 
     def _load_template(self, template_name: str) -> Dict[str, Any]:
         return deepcopy(self._load_template_payload(template_name))
+
+    def _canvas_type_for_category(self, canvas_category: str) -> str:
+        return self.CANVAS_TYPE_BY_CATEGORY.get(str(canvas_category), "Agent")
 
     def _edge(self, source: str, target: str, source_handle: str = "start", target_handle: str = "end") -> Dict[str, Any]:
         return {

--- a/agent/templates/scenario_planner/batch_review.json
+++ b/agent/templates/scenario_planner/batch_review.json
@@ -1,0 +1,253 @@
+{
+  "id": 0,
+  "title": {
+    "en": "batch_review",
+    "zh": "batch_review"
+  },
+  "description": {
+    "en": "Iteration-based batch processing workflow for repeated items.",
+    "zh": "Iteration-based batch processing workflow for repeated items."
+  },
+  "canvas_type": "Agent",
+  "dsl": {
+    "components": {
+      "begin": {
+        "downstream": [
+          "Iteration:Items"
+        ],
+        "obj": {
+          "component_name": "Begin",
+          "params": {
+            "enablePrologue": true,
+            "inputs": {
+              "task_instructions": {
+                "name": "Task Instructions",
+                "optional": false,
+                "options": [],
+                "type": "line"
+              }
+            },
+            "mode": "conversational",
+            "prologue": "Hi! Upload or provide the items you want to process in batch."
+          }
+        },
+        "upstream": []
+      },
+      "Iteration:Items": {
+        "downstream": [],
+        "obj": {
+          "component_name": "Iteration",
+          "params": {
+            "items_ref": "sys.files",
+            "outputs": {
+              "evaluation": {
+                "ref": "Agent:ReviewItem@content",
+                "type": "Array<string>"
+              }
+            }
+          }
+        },
+        "upstream": [
+          "begin"
+        ]
+      },
+      "IterationItem:Current": {
+        "downstream": [
+          "Agent:ReviewItem"
+        ],
+        "obj": {
+          "component_name": "IterationItem",
+          "params": {
+            "outputs": {
+              "index": {
+                "type": "integer"
+              },
+              "item": {
+                "type": "unknown"
+              }
+            }
+          }
+        },
+        "parent_id": "Iteration:Items",
+        "upstream": []
+      },
+      "Agent:ReviewItem": {
+        "downstream": [
+          "Message:ItemOutput"
+        ],
+        "obj": {
+          "component_name": "Agent",
+          "params": {
+            "cite": true,
+            "delay_after_error": 1,
+            "description": "",
+            "exception_default_value": "",
+            "exception_goto": [],
+            "exception_method": "",
+            "frequencyPenaltyEnabled": false,
+            "frequency_penalty": 0.7,
+            "llm_id": "qwen-turbo@Tongyi-Qianwen",
+            "maxTokensEnabled": false,
+            "max_retries": 3,
+            "max_rounds": 1,
+            "max_tokens": 512,
+            "mcp": [],
+            "message_history_window_size": 12,
+            "outputs": {
+              "content": {
+                "type": "string",
+                "value": ""
+              },
+              "structured": {}
+            },
+            "presencePenaltyEnabled": false,
+            "presence_penalty": 0.4,
+            "prompts": [
+              {
+                "role": "user",
+                "content": "Task:{begin@task_instructions}\nCurrent item:{IterationItem:Current@item}\nOriginal scenario:{sys.query}"
+              }
+            ],
+            "sys_prompt": "You are the per-item batch processor. Review each item independently and produce a concise structured result.",
+            "temperature": 0.1,
+            "temperatureEnabled": false,
+            "tools": [],
+            "topPEnabled": false,
+            "top_p": 0.3,
+            "user_prompt": "",
+            "visual_files_var": ""
+          }
+        },
+        "upstream": [
+          "IterationItem:Current"
+        ],
+        "parent_id": "Iteration:Items"
+      },
+      "Message:ItemOutput": {
+        "downstream": [],
+        "obj": {
+          "component_name": "Message",
+          "params": {
+            "content": [
+              "{Agent:ReviewItem@content}"
+            ]
+          }
+        },
+        "upstream": [
+          "Agent:ReviewItem"
+        ],
+        "parent_id": "Iteration:Items"
+      }
+    },
+    "globals": {
+      "sys.conversation_turns": 0,
+      "sys.date": "",
+      "sys.files": [],
+      "sys.history": [],
+      "sys.query": "",
+      "sys.user_id": ""
+    },
+    "graph": {
+      "edges": [
+        {
+          "id": "xy-edge__beginstart-Iteration:Itemsend",
+          "source": "begin",
+          "sourceHandle": "start",
+          "target": "Iteration:Items",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__IterationItem:Currentstart-Agent:ReviewItemend",
+          "source": "IterationItem:Current",
+          "sourceHandle": "start",
+          "target": "Agent:ReviewItem",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Agent:ReviewItemstart-Message:ItemOutputend",
+          "source": "Agent:ReviewItem",
+          "sourceHandle": "start",
+          "target": "Message:ItemOutput",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        }
+      ],
+      "nodes": [
+        {
+          "id": "begin",
+          "data": {
+            "label": "Begin",
+            "name": "begin"
+          },
+          "position": {
+            "x": 120,
+            "y": 160
+          }
+        },
+        {
+          "id": "Iteration:Items",
+          "data": {
+            "label": "Iteration",
+            "name": "Iteration:Items"
+          },
+          "position": {
+            "x": 380,
+            "y": 160
+          }
+        },
+        {
+          "id": "IterationItem:Current",
+          "data": {
+            "label": "IterationItem",
+            "name": "IterationItem:Current"
+          },
+          "position": {
+            "x": 640,
+            "y": 160
+          }
+        },
+        {
+          "id": "Agent:ReviewItem",
+          "data": {
+            "label": "Agent",
+            "name": "Agent:ReviewItem"
+          },
+          "position": {
+            "x": 900,
+            "y": 160
+          }
+        },
+        {
+          "id": "Message:ItemOutput",
+          "data": {
+            "label": "Message",
+            "name": "Message:ItemOutput"
+          },
+          "position": {
+            "x": 1160,
+            "y": 160
+          }
+        }
+      ]
+    },
+    "history": [],
+    "messages": [],
+    "path": [
+      "begin"
+    ],
+    "retrieval": {
+      "chunks": [],
+      "doc_aggs": []
+    },
+    "variables": {}
+  },
+  "avatar": ""
+}

--- a/agent/templates/scenario_planner/interactive_research.json
+++ b/agent/templates/scenario_planner/interactive_research.json
@@ -1,0 +1,298 @@
+{
+  "id": 0,
+  "title": {
+    "en": "interactive_research",
+    "zh": "interactive_research"
+  },
+  "description": {
+    "en": "Two-stage research workflow with planning and human feedback.",
+    "zh": "Two-stage research workflow with planning and human feedback."
+  },
+  "canvas_type": "Agent",
+  "dsl": {
+    "components": {
+      "begin": {
+        "downstream": [
+          "Agent:Plan"
+        ],
+        "obj": {
+          "component_name": "Begin",
+          "params": {
+            "enablePrologue": true,
+            "inputs": {},
+            "mode": "conversational",
+            "prologue": "Hi! Describe the research task you want to automate."
+          }
+        },
+        "upstream": []
+      },
+      "Agent:Plan": {
+        "downstream": [
+          "UserFillUp:ReviewPlan"
+        ],
+        "obj": {
+          "component_name": "Agent",
+          "params": {
+            "cite": true,
+            "delay_after_error": 1,
+            "description": "",
+            "exception_default_value": "",
+            "exception_goto": [],
+            "exception_method": "",
+            "frequencyPenaltyEnabled": false,
+            "frequency_penalty": 0.7,
+            "llm_id": "qwen-turbo@Tongyi-Qianwen",
+            "maxTokensEnabled": false,
+            "max_retries": 3,
+            "max_rounds": 1,
+            "max_tokens": 512,
+            "mcp": [],
+            "message_history_window_size": 12,
+            "outputs": {
+              "content": {
+                "type": "string",
+                "value": ""
+              },
+              "structured": {}
+            },
+            "presencePenaltyEnabled": false,
+            "presence_penalty": 0.4,
+            "prompts": [
+              {
+                "role": "user",
+                "content": "User query:{sys.query}"
+              }
+            ],
+            "sys_prompt": "You are the planning agent. Break the scenario into concrete research steps, define what evidence is needed, and prepare a short execution plan.",
+            "temperature": 0.1,
+            "temperatureEnabled": false,
+            "tools": [],
+            "topPEnabled": false,
+            "top_p": 0.3,
+            "user_prompt": "",
+            "visual_files_var": ""
+          }
+        },
+        "upstream": [
+          "begin"
+        ]
+      },
+      "UserFillUp:ReviewPlan": {
+        "downstream": [
+          "Agent:ExecuteResearch"
+        ],
+        "obj": {
+          "component_name": "UserFillUp",
+          "params": {
+            "enable_tips": true,
+            "inputs": {
+              "instructions": {
+                "name": "instructions",
+                "optional": false,
+                "options": [],
+                "type": "paragraph"
+              }
+            },
+            "outputs": {
+              "instructions": {
+                "name": "instructions",
+                "optional": false,
+                "options": [],
+                "type": "paragraph"
+              }
+            },
+            "tips": "Here is the draft plan:\n{Agent:Plan@content}\nPlease refine or approve it before execution."
+          }
+        },
+        "upstream": [
+          "Agent:Plan"
+        ]
+      },
+      "Agent:ExecuteResearch": {
+        "downstream": [
+          "Message:Output"
+        ],
+        "obj": {
+          "component_name": "Agent",
+          "params": {
+            "cite": true,
+            "delay_after_error": 1,
+            "description": "",
+            "exception_default_value": "",
+            "exception_goto": [],
+            "exception_method": "",
+            "frequencyPenaltyEnabled": false,
+            "frequency_penalty": 0.7,
+            "llm_id": "qwen-turbo@Tongyi-Qianwen",
+            "maxTokensEnabled": false,
+            "max_retries": 3,
+            "max_rounds": 3,
+            "max_tokens": 512,
+            "mcp": [],
+            "message_history_window_size": 12,
+            "outputs": {
+              "content": {
+                "type": "string",
+                "value": ""
+              },
+              "structured": {}
+            },
+            "presencePenaltyEnabled": false,
+            "presence_penalty": 0.4,
+            "prompts": [
+              {
+                "role": "user",
+                "content": "Plan:{Agent:Plan@content}\nUser feedback:{UserFillUp:ReviewPlan@instructions}\nQuery:{sys.query}"
+              }
+            ],
+            "sys_prompt": "You are the execution agent. Follow the approved plan, collect evidence, and draft a concise final answer with clear traceability.",
+            "temperature": 0.1,
+            "temperatureEnabled": false,
+            "tools": [],
+            "topPEnabled": false,
+            "top_p": 0.3,
+            "user_prompt": "",
+            "visual_files_var": ""
+          }
+        },
+        "upstream": [
+          "UserFillUp:ReviewPlan"
+        ]
+      },
+      "Message:Output": {
+        "downstream": [],
+        "obj": {
+          "component_name": "Message",
+          "params": {
+            "content": [
+              "{Agent:ExecuteResearch@content}"
+            ]
+          }
+        },
+        "upstream": [
+          "Agent:ExecuteResearch"
+        ]
+      }
+    },
+    "globals": {
+      "sys.conversation_turns": 0,
+      "sys.date": "",
+      "sys.files": [],
+      "sys.history": [],
+      "sys.query": "",
+      "sys.user_id": ""
+    },
+    "graph": {
+      "edges": [
+        {
+          "id": "xy-edge__beginstart-Agent:Planend",
+          "source": "begin",
+          "sourceHandle": "start",
+          "target": "Agent:Plan",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Agent:Planstart-UserFillUp:ReviewPlanend",
+          "source": "Agent:Plan",
+          "sourceHandle": "start",
+          "target": "UserFillUp:ReviewPlan",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__UserFillUp:ReviewPlanstart-Agent:ExecuteResearchend",
+          "source": "UserFillUp:ReviewPlan",
+          "sourceHandle": "start",
+          "target": "Agent:ExecuteResearch",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Agent:ExecuteResearchstart-Message:Outputend",
+          "source": "Agent:ExecuteResearch",
+          "sourceHandle": "start",
+          "target": "Message:Output",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        }
+      ],
+      "nodes": [
+        {
+          "id": "begin",
+          "data": {
+            "label": "Begin",
+            "name": "begin"
+          },
+          "position": {
+            "x": 120,
+            "y": 160
+          }
+        },
+        {
+          "id": "Agent:Plan",
+          "data": {
+            "label": "Agent",
+            "name": "Agent:Plan"
+          },
+          "position": {
+            "x": 380,
+            "y": 160
+          }
+        },
+        {
+          "id": "UserFillUp:ReviewPlan",
+          "data": {
+            "label": "UserFillUp",
+            "name": "UserFillUp:ReviewPlan"
+          },
+          "position": {
+            "x": 640,
+            "y": 160
+          }
+        },
+        {
+          "id": "Agent:ExecuteResearch",
+          "data": {
+            "label": "Agent",
+            "name": "Agent:ExecuteResearch"
+          },
+          "position": {
+            "x": 900,
+            "y": 160
+          }
+        },
+        {
+          "id": "Message:Output",
+          "data": {
+            "label": "Message",
+            "name": "Message:Output"
+          },
+          "position": {
+            "x": 1160,
+            "y": 160
+          }
+        }
+      ]
+    },
+    "history": [],
+    "messages": [],
+    "path": [
+      "begin"
+    ],
+    "retrieval": {
+      "chunks": [],
+      "doc_aggs": []
+    },
+    "variables": {}
+  },
+  "avatar": ""
+}

--- a/agent/templates/scenario_planner/monitor_notify.json
+++ b/agent/templates/scenario_planner/monitor_notify.json
@@ -1,0 +1,406 @@
+{
+  "id": 0,
+  "title": {
+    "en": "monitor_notify",
+    "zh": "monitor_notify"
+  },
+  "description": {
+    "en": "Fetch/analyze/branch/notify skeleton for monitoring tasks.",
+    "zh": "Fetch/analyze/branch/notify skeleton for monitoring tasks."
+  },
+  "canvas_type": "Agent",
+  "dsl": {
+    "components": {
+      "begin": {
+        "downstream": [
+          "Agent:FetchState"
+        ],
+        "obj": {
+          "component_name": "Begin",
+          "params": {
+            "enablePrologue": true,
+            "inputs": {},
+            "mode": "conversational",
+            "prologue": "Hi! Describe what should be monitored and how you want to be notified."
+          }
+        },
+        "upstream": []
+      },
+      "Agent:FetchState": {
+        "downstream": [
+          "Agent:CompareState"
+        ],
+        "obj": {
+          "component_name": "Agent",
+          "params": {
+            "cite": true,
+            "delay_after_error": 1,
+            "description": "",
+            "exception_default_value": "",
+            "exception_goto": [],
+            "exception_method": "",
+            "frequencyPenaltyEnabled": false,
+            "frequency_penalty": 0.7,
+            "llm_id": "qwen-turbo@Tongyi-Qianwen",
+            "maxTokensEnabled": false,
+            "max_retries": 3,
+            "max_rounds": 1,
+            "max_tokens": 512,
+            "mcp": [],
+            "message_history_window_size": 12,
+            "outputs": {
+              "content": {
+                "type": "string",
+                "value": ""
+              },
+              "structured": {}
+            },
+            "presencePenaltyEnabled": false,
+            "presence_penalty": 0.4,
+            "prompts": [
+              {
+                "role": "user",
+                "content": "Monitoring target:{sys.query}"
+              }
+            ],
+            "sys_prompt": "You are the fetch step skeleton. Configure this node to collect the latest state from the monitored source before comparison.",
+            "temperature": 0.1,
+            "temperatureEnabled": false,
+            "tools": [],
+            "topPEnabled": false,
+            "top_p": 0.3,
+            "user_prompt": "",
+            "visual_files_var": ""
+          }
+        },
+        "upstream": [
+          "begin"
+        ]
+      },
+      "Agent:CompareState": {
+        "downstream": [
+          "Switch:Decision"
+        ],
+        "obj": {
+          "component_name": "Agent",
+          "params": {
+            "cite": true,
+            "delay_after_error": 1,
+            "description": "",
+            "exception_default_value": "",
+            "exception_goto": [],
+            "exception_method": "",
+            "frequencyPenaltyEnabled": false,
+            "frequency_penalty": 0.7,
+            "llm_id": "qwen-turbo@Tongyi-Qianwen",
+            "maxTokensEnabled": false,
+            "max_retries": 3,
+            "max_rounds": 1,
+            "max_tokens": 512,
+            "mcp": [],
+            "message_history_window_size": 12,
+            "outputs": {
+              "content": {
+                "type": "string",
+                "value": ""
+              },
+              "structured": {}
+            },
+            "presencePenaltyEnabled": false,
+            "presence_penalty": 0.4,
+            "prompts": [
+              {
+                "role": "user",
+                "content": "Fetched state:{Agent:FetchState@content}\nOriginal task:{sys.query}"
+              }
+            ],
+            "sys_prompt": "You are the comparison step skeleton. Decide whether there is a meaningful change. Return CHANGED or NO_CHANGE plus a short rationale.",
+            "temperature": 0.1,
+            "temperatureEnabled": false,
+            "tools": [],
+            "topPEnabled": false,
+            "top_p": 0.3,
+            "user_prompt": "",
+            "visual_files_var": ""
+          }
+        },
+        "upstream": [
+          "Agent:FetchState"
+        ]
+      },
+      "Switch:Decision": {
+        "downstream": [
+          "Agent:Notify",
+          "Message:NoChange"
+        ],
+        "obj": {
+          "component_name": "Switch",
+          "params": {
+            "conditions": [
+              {
+                "items": [
+                  {
+                    "cpn_id": "Agent:CompareState@content",
+                    "operator": "contains",
+                    "value": "CHANGED"
+                  }
+                ],
+                "logical_operator": "and",
+                "to": [
+                  "Agent:Notify"
+                ]
+              }
+            ],
+            "end_cpn_ids": [
+              "Message:NoChange"
+            ]
+          }
+        },
+        "upstream": [
+          "Agent:CompareState"
+        ]
+      },
+      "Agent:Notify": {
+        "downstream": [
+          "Message:Output"
+        ],
+        "obj": {
+          "component_name": "Agent",
+          "params": {
+            "cite": true,
+            "delay_after_error": 1,
+            "description": "",
+            "exception_default_value": "",
+            "exception_goto": [],
+            "exception_method": "",
+            "frequencyPenaltyEnabled": false,
+            "frequency_penalty": 0.7,
+            "llm_id": "qwen-turbo@Tongyi-Qianwen",
+            "maxTokensEnabled": false,
+            "max_retries": 3,
+            "max_rounds": 1,
+            "max_tokens": 512,
+            "mcp": [],
+            "message_history_window_size": 12,
+            "outputs": {
+              "content": {
+                "type": "string",
+                "value": ""
+              },
+              "structured": {}
+            },
+            "presencePenaltyEnabled": false,
+            "presence_penalty": 0.4,
+            "prompts": [
+              {
+                "role": "user",
+                "content": "Comparison result:{Agent:CompareState@content}\nTask:{sys.query}"
+              }
+            ],
+            "sys_prompt": "You are the notification step skeleton. Prepare the alert payload, summary, or follow-up action when a change is detected.",
+            "temperature": 0.1,
+            "temperatureEnabled": false,
+            "tools": [],
+            "topPEnabled": false,
+            "top_p": 0.3,
+            "user_prompt": "",
+            "visual_files_var": ""
+          }
+        },
+        "upstream": [
+          "Switch:Decision"
+        ]
+      },
+      "Message:NoChange": {
+        "downstream": [],
+        "obj": {
+          "component_name": "Message",
+          "params": {
+            "content": [
+              "No meaningful change was detected."
+            ]
+          }
+        },
+        "upstream": [
+          "Switch:Decision"
+        ]
+      },
+      "Message:Output": {
+        "downstream": [],
+        "obj": {
+          "component_name": "Message",
+          "params": {
+            "content": [
+              "{Agent:Notify@content}"
+            ]
+          }
+        },
+        "upstream": [
+          "Agent:Notify"
+        ]
+      }
+    },
+    "globals": {
+      "sys.conversation_turns": 0,
+      "sys.date": "",
+      "sys.files": [],
+      "sys.history": [],
+      "sys.query": "",
+      "sys.user_id": ""
+    },
+    "graph": {
+      "edges": [
+        {
+          "id": "xy-edge__beginstart-Agent:FetchStateend",
+          "source": "begin",
+          "sourceHandle": "start",
+          "target": "Agent:FetchState",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Agent:FetchStatestart-Agent:CompareStateend",
+          "source": "Agent:FetchState",
+          "sourceHandle": "start",
+          "target": "Agent:CompareState",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Agent:CompareStatestart-Switch:Decisionend",
+          "source": "Agent:CompareState",
+          "sourceHandle": "start",
+          "target": "Switch:Decision",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Switch:Decisionstart-Agent:Notifyend",
+          "source": "Switch:Decision",
+          "sourceHandle": "start",
+          "target": "Agent:Notify",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Switch:Decisionstart-Message:NoChangeend",
+          "source": "Switch:Decision",
+          "sourceHandle": "start",
+          "target": "Message:NoChange",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Agent:Notifystart-Message:Outputend",
+          "source": "Agent:Notify",
+          "sourceHandle": "start",
+          "target": "Message:Output",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        }
+      ],
+      "nodes": [
+        {
+          "id": "begin",
+          "data": {
+            "label": "Begin",
+            "name": "begin"
+          },
+          "position": {
+            "x": 120,
+            "y": 160
+          }
+        },
+        {
+          "id": "Agent:FetchState",
+          "data": {
+            "label": "Agent",
+            "name": "Agent:FetchState"
+          },
+          "position": {
+            "x": 380,
+            "y": 160
+          }
+        },
+        {
+          "id": "Agent:CompareState",
+          "data": {
+            "label": "Agent",
+            "name": "Agent:CompareState"
+          },
+          "position": {
+            "x": 640,
+            "y": 160
+          }
+        },
+        {
+          "id": "Switch:Decision",
+          "data": {
+            "label": "Switch",
+            "name": "Switch:Decision"
+          },
+          "position": {
+            "x": 900,
+            "y": 160
+          }
+        },
+        {
+          "id": "Agent:Notify",
+          "data": {
+            "label": "Agent",
+            "name": "Agent:Notify"
+          },
+          "position": {
+            "x": 1160,
+            "y": 160
+          }
+        },
+        {
+          "id": "Message:NoChange",
+          "data": {
+            "label": "Message",
+            "name": "Message:NoChange"
+          },
+          "position": {
+            "x": 1420,
+            "y": 160
+          }
+        },
+        {
+          "id": "Message:Output",
+          "data": {
+            "label": "Message",
+            "name": "Message:Output"
+          },
+          "position": {
+            "x": 1680,
+            "y": 160
+          }
+        }
+      ]
+    },
+    "history": [],
+    "messages": [],
+    "path": [
+      "begin"
+    ],
+    "retrieval": {
+      "chunks": [],
+      "doc_aggs": []
+    },
+    "variables": {}
+  },
+  "avatar": ""
+}

--- a/agent/templates/scenario_planner/qa_basic.json
+++ b/agent/templates/scenario_planner/qa_basic.json
@@ -1,0 +1,174 @@
+{
+  "id": 0,
+  "title": {
+    "en": "qa_basic",
+    "zh": "qa_basic"
+  },
+  "description": {
+    "en": "Simple question answering or retrieval assistant.",
+    "zh": "Simple question answering or retrieval assistant."
+  },
+  "canvas_type": "Agent",
+  "dsl": {
+    "components": {
+      "begin": {
+        "downstream": [
+          "Agent:DraftAnswer"
+        ],
+        "obj": {
+          "component_name": "Begin",
+          "params": {
+            "enablePrologue": true,
+            "inputs": {},
+            "mode": "conversational",
+            "prologue": "Hi! Describe the task you want this workflow to handle."
+          }
+        },
+        "upstream": []
+      },
+      "Agent:DraftAnswer": {
+        "downstream": [
+          "Message:Output"
+        ],
+        "obj": {
+          "component_name": "Agent",
+          "params": {
+            "cite": true,
+            "delay_after_error": 1,
+            "description": "",
+            "exception_default_value": "",
+            "exception_goto": [],
+            "exception_method": "",
+            "frequencyPenaltyEnabled": false,
+            "frequency_penalty": 0.7,
+            "llm_id": "qwen-turbo@Tongyi-Qianwen",
+            "maxTokensEnabled": false,
+            "max_retries": 3,
+            "max_rounds": 1,
+            "max_tokens": 512,
+            "mcp": [],
+            "message_history_window_size": 12,
+            "outputs": {
+              "content": {
+                "type": "string",
+                "value": ""
+              },
+              "structured": {}
+            },
+            "presencePenaltyEnabled": false,
+            "presence_penalty": 0.4,
+            "prompts": [
+              {
+                "role": "user",
+                "content": "{sys.query}"
+              }
+            ],
+            "sys_prompt": "You are a draft QA agent skeleton. Users should replace this prompt, attach tools, and refine citations or retrieval settings as needed.",
+            "temperature": 0.1,
+            "temperatureEnabled": false,
+            "tools": [],
+            "topPEnabled": false,
+            "top_p": 0.3,
+            "user_prompt": "",
+            "visual_files_var": ""
+          }
+        },
+        "upstream": [
+          "begin"
+        ]
+      },
+      "Message:Output": {
+        "downstream": [],
+        "obj": {
+          "component_name": "Message",
+          "params": {
+            "content": [
+              "{Agent:DraftAnswer@content}"
+            ]
+          }
+        },
+        "upstream": [
+          "Agent:DraftAnswer"
+        ]
+      }
+    },
+    "globals": {
+      "sys.conversation_turns": 0,
+      "sys.date": "",
+      "sys.files": [],
+      "sys.history": [],
+      "sys.query": "",
+      "sys.user_id": ""
+    },
+    "graph": {
+      "edges": [
+        {
+          "id": "xy-edge__beginstart-Agent:DraftAnswerend",
+          "source": "begin",
+          "sourceHandle": "start",
+          "target": "Agent:DraftAnswer",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        },
+        {
+          "id": "xy-edge__Agent:DraftAnswerstart-Message:Outputend",
+          "source": "Agent:DraftAnswer",
+          "sourceHandle": "start",
+          "target": "Message:Output",
+          "targetHandle": "end",
+          "data": {
+            "isHovered": false
+          }
+        }
+      ],
+      "nodes": [
+        {
+          "id": "begin",
+          "data": {
+            "label": "Begin",
+            "name": "begin"
+          },
+          "position": {
+            "x": 120,
+            "y": 160
+          }
+        },
+        {
+          "id": "Agent:DraftAnswer",
+          "data": {
+            "label": "Agent",
+            "name": "Agent:DraftAnswer"
+          },
+          "position": {
+            "x": 380,
+            "y": 160
+          }
+        },
+        {
+          "id": "Message:Output",
+          "data": {
+            "label": "Message",
+            "name": "Message:Output"
+          },
+          "position": {
+            "x": 640,
+            "y": 160
+          }
+        }
+      ]
+    },
+    "history": [],
+    "messages": [],
+    "path": [
+      "begin"
+    ],
+    "retrieval": {
+      "chunks": [],
+      "doc_aggs": []
+    },
+    "variables": {}
+  },
+  "avatar": ""
+}

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -64,12 +64,30 @@ def templates():
 @login_required
 async def scenario_plan():
     req = await get_request_json()
+    existing_dsl = req.get("existing_dsl")
+    if existing_dsl is not None and not isinstance(existing_dsl, dict):
+        return get_data_error_result(message="existing_dsl must be a JSON object.")
+
+    requested_mode = "modify" if existing_dsl is not None else "create"
+    logging.info(
+        "scenario_plan request user_id=%s mode=%s title=%s",
+        current_user.id,
+        requested_mode,
+        req.get("title", ""),
+    )
     planner = ScenarioPlanner()
     draft = planner.plan(
         title=req["title"],
         scenario=req["scenario"],
         canvas_category=req.get("canvas_category", CanvasCategory.Agent),
-        existing_dsl=req.get("existing_dsl"),
+        existing_dsl=existing_dsl,
+    )
+    logging.info(
+        "scenario_plan result user_id=%s mode=%s archetype=%s operations=%s",
+        current_user.id,
+        draft.get("mode"),
+        draft.get("archetype"),
+        len(draft.get("operations", []) or []),
     )
     return get_json_result(data=draft)
 

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -67,6 +67,9 @@ async def scenario_plan():
     existing_dsl = req.get("existing_dsl")
     if existing_dsl is not None and not isinstance(existing_dsl, dict):
         return get_data_error_result(message="existing_dsl must be a JSON object.")
+    canvas_category = req.get("canvas_category", CanvasCategory.Agent)
+    if canvas_category not in {CanvasCategory.Agent, CanvasCategory.DataFlow}:
+        return get_data_error_result(message="canvas_category must be one of: agent_canvas, dataflow_canvas.")
 
     requested_mode = "modify" if existing_dsl is not None else "create"
     logging.info(
@@ -79,7 +82,7 @@ async def scenario_plan():
         draft = planner.plan(
             title=req["title"],
             scenario=req["scenario"],
-            canvas_category=req.get("canvas_category", CanvasCategory.Agent),
+            canvas_category=canvas_category,
             existing_dsl=existing_dsl,
         )
     except ValueError as e:

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -40,6 +40,7 @@ from api.utils.api_utils import (
 )
 from agent.canvas import Canvas
 from agent.dsl_migration import normalize_chunker_dsl
+from agent.scenario_planner import ScenarioPlanner
 from peewee import MySQLDatabase, PostgresqlDatabase
 from api.db.db_models import APIToken, Task
 
@@ -56,6 +57,20 @@ from api.db.services.canvas_service import completion as agent_completion
 @login_required
 def templates():
     return get_json_result(data=[c.to_dict() for c in CanvasTemplateService.get_all()])
+
+
+@manager.route('/scenario_plan', methods=['POST'])  # noqa: F821
+@validate_request("title", "scenario")
+@login_required
+async def scenario_plan():
+    req = await get_request_json()
+    planner = ScenarioPlanner()
+    draft = planner.plan(
+        title=req["title"],
+        scenario=req["scenario"],
+        canvas_category=req.get("canvas_category", CanvasCategory.Agent),
+    )
+    return get_json_result(data=draft)
 
 
 @manager.route('/rm', methods=['POST'])  # noqa: F821

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -69,6 +69,7 @@ async def scenario_plan():
         title=req["title"],
         scenario=req["scenario"],
         canvas_category=req.get("canvas_category", CanvasCategory.Agent),
+        existing_dsl=req.get("existing_dsl"),
     )
     return get_json_result(data=draft)
 

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -83,6 +83,12 @@ async def scenario_plan():
             existing_dsl=existing_dsl,
         )
     except ValueError as e:
+        logging.warning(
+            "scenario_plan validation_failed user_id=%s mode=%s error=%s",
+            current_user.id,
+            requested_mode,
+            str(e),
+        )
         return get_data_error_result(message=str(e))
     logging.info(
         "scenario_plan result user_id=%s mode=%s archetype=%s operations=%s",

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -70,10 +70,9 @@ async def scenario_plan():
 
     requested_mode = "modify" if existing_dsl is not None else "create"
     logging.info(
-        "scenario_plan request user_id=%s mode=%s title=%s",
+        "scenario_plan request user_id=%s mode=%s",
         current_user.id,
         requested_mode,
-        req.get("title", ""),
     )
     planner = ScenarioPlanner()
     draft = planner.plan(

--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -75,12 +75,15 @@ async def scenario_plan():
         requested_mode,
     )
     planner = ScenarioPlanner()
-    draft = planner.plan(
-        title=req["title"],
-        scenario=req["scenario"],
-        canvas_category=req.get("canvas_category", CanvasCategory.Agent),
-        existing_dsl=existing_dsl,
-    )
+    try:
+        draft = planner.plan(
+            title=req["title"],
+            scenario=req["scenario"],
+            canvas_category=req.get("canvas_category", CanvasCategory.Agent),
+            existing_dsl=existing_dsl,
+        )
+    except ValueError as e:
+        return get_data_error_result(message=str(e))
     logging.info(
         "scenario_plan result user_id=%s mode=%s archetype=%s operations=%s",
         current_user.id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,11 @@ packages = [
     'sdk.python.ragflow_sdk',
 ]
 
+[tool.setuptools.package-data]
+agent = [
+    "templates/scenario_planner/*.json",
+]
+
 [tool.ruff]
 line-length = 200
 exclude = [".venv", "rag/svr/discord_svr.py"]

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 #
 from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
@@ -205,6 +206,36 @@ def test_plan_reports_noop_for_unsupported_edit():
     assert edited["warnings"]
 
 
+def test_plan_reports_already_present_when_recognized_edit_is_skipped():
+    planner = ScenarioPlanner()
+    base = planner.plan(
+        title="Research Draft",
+        scenario="Research the market, compare sources, and produce a short report.",
+    )["dsl"]
+    first_edit = planner.plan(
+        title="Research Draft",
+        scenario="Insert a human review step before continuing.",
+        existing_dsl=base,
+    )
+    first_snapshot = deepcopy(first_edit["dsl"])
+    review_target = next(op for op in first_edit["operations"] if op["type"] == "insert_human_review")["target"]
+
+    second_edit = planner.plan(
+        title="Research Draft",
+        scenario="Insert a human review step before continuing.",
+        existing_dsl=first_edit["dsl"],
+    )
+
+    assert second_edit["dsl"] == first_snapshot
+    assert {"type": "already_present", "target": review_target} in second_edit["operations"]
+    assert {"type": "no_op", "target": ""} in second_edit["operations"]
+    assert second_edit["warnings"] == [
+        "Only a minimal edit set is supported in V1.",
+        "Users should review node wiring before execution.",
+        "Requested edit matched a supported operation, but no graph changes were applied.",
+    ]
+
+
 def test_plan_can_modify_existing_dsl_with_analysis():
     planner = ScenarioPlanner()
     base = planner.plan(
@@ -351,6 +382,30 @@ def test_plan_analysis_avoids_result_placeholder_for_outputless_tail():
 
     assert "@result" not in prompt
     assert "Analyze the following output:\n{sys.query}" in prompt
+
+
+def test_load_template_uses_cached_payload(monkeypatch):
+    planner = ScenarioPlanner()
+    ScenarioPlanner._load_template_payload.cache_clear()
+
+    original_read_text = Path.read_text
+    calls = {"count": 0}
+
+    def tracked_read_text(self, *args, **kwargs):
+        if self.name == "qa_basic.json":
+            calls["count"] += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+
+    first = planner._load_template("qa_basic")
+    second = planner._load_template("qa_basic")
+
+    assert calls["count"] == 1
+    assert first == second
+    assert first is not second
+
+    ScenarioPlanner._load_template_payload.cache_clear()
 
 
 def test_plan_raises_clear_error_for_missing_builder(monkeypatch):

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -151,3 +151,20 @@ def test_plan_can_modify_existing_dsl_with_analysis():
 
     assert edited["mode"] == "modify"
     assert any(op["type"] == "append_analysis" for op in edited["operations"])
+
+
+def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
+    planner = ScenarioPlanner()
+
+    monkeypatch.setattr(
+        planner,
+        "_classify",
+        lambda scenario: type(
+            "Match",
+            (),
+            {"archetype": "missing_builder", "reason": "test", "warnings": []},
+        )(),
+    )
+
+    with pytest.raises(ValueError, match="No builder implemented for archetype: missing_builder"):
+        planner.plan(title="Broken", scenario="test")

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -69,3 +69,40 @@ def test_plan_selects_batch_review():
     assert "Iteration:Items" in components
     assert "IterationItem:Current" in components
     assert components["Agent:ReviewItem"]["parent_id"] == "Iteration:Items"
+
+
+def test_plan_can_modify_existing_dsl_with_notification():
+    planner = ScenarioPlanner()
+    base = planner.plan(
+        title="Base Draft",
+        scenario="Answer questions about an internal handbook.",
+    )["dsl"]
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Add a notification step after the current flow.",
+        existing_dsl=base,
+    )
+
+    assert edited["archetype"] == "modify_existing"
+    components = edited["dsl"]["components"]
+    assert any(component["obj"]["component_name"] == "Message" for component in components.values())
+    assert any("Notify" in component_id for component_id in components.keys())
+
+
+def test_plan_can_modify_existing_dsl_with_human_review():
+    planner = ScenarioPlanner()
+    base = planner.plan(
+        title="Research Draft",
+        scenario="Research the market, compare sources, and produce a short report.",
+    )["dsl"]
+
+    edited = planner.plan(
+        title="Research Draft",
+        scenario="Insert a human review step before continuing.",
+        existing_dsl=base,
+    )
+
+    assert edited["archetype"] == "modify_existing"
+    components = edited["dsl"]["components"]
+    assert any(component["obj"]["component_name"] == "UserFillUp" for component in components.values())

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -13,7 +13,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import pytest
+
 from agent.scenario_planner import ScenarioPlanner
+
+
+pytestmark = pytest.mark.p2
 
 
 def test_plan_defaults_to_qa_basic():
@@ -129,3 +134,20 @@ def test_plan_reports_noop_for_unsupported_edit():
     assert edited["mode"] == "modify"
     assert edited["operations"] == [{"type": "no_op", "target": ""}]
     assert edited["warnings"]
+
+
+def test_plan_can_modify_existing_dsl_with_analysis():
+    planner = ScenarioPlanner()
+    base = planner.plan(
+        title="Base Draft",
+        scenario="Answer questions about an internal handbook.",
+    )["dsl"]
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Add analysis after the current flow.",
+        existing_dsl=base,
+    )
+
+    assert edited["mode"] == "modify"
+    assert any(op["type"] == "append_analysis" for op in edited["operations"])

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -24,6 +24,8 @@ def test_plan_defaults_to_qa_basic():
     )
 
     assert draft["archetype"] == "qa_basic"
+    assert draft["mode"] == "create"
+    assert draft["operations"] == [{"type": "create_draft", "archetype": "qa_basic"}]
     assert "dsl" in draft
     assert draft["dsl"]["path"] == ["begin"]
     assert "Agent:DraftAnswer" in draft["dsl"]["components"]
@@ -85,6 +87,8 @@ def test_plan_can_modify_existing_dsl_with_notification():
     )
 
     assert edited["archetype"] == "modify_existing"
+    assert edited["mode"] == "modify"
+    assert any(op["type"] == "append_notification" for op in edited["operations"])
     components = edited["dsl"]["components"]
     assert any(component["obj"]["component_name"] == "Message" for component in components.values())
     assert any("Notify" in component_id for component_id in components.keys())
@@ -104,5 +108,24 @@ def test_plan_can_modify_existing_dsl_with_human_review():
     )
 
     assert edited["archetype"] == "modify_existing"
+    assert any(op["type"] == "insert_human_review" for op in edited["operations"])
     components = edited["dsl"]["components"]
     assert any(component["obj"]["component_name"] == "UserFillUp" for component in components.values())
+
+
+def test_plan_reports_noop_for_unsupported_edit():
+    planner = ScenarioPlanner()
+    base = planner.plan(
+        title="Base Draft",
+        scenario="Answer questions about an internal handbook.",
+    )["dsl"]
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Change the whole graph into a fully autonomous planner.",
+        existing_dsl=base,
+    )
+
+    assert edited["mode"] == "modify"
+    assert edited["operations"] == [{"type": "no_op", "target": ""}]
+    assert edited["warnings"]

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 #
 from copy import deepcopy
+import logging
 from pathlib import Path
 
 import pytest
@@ -41,6 +42,20 @@ def test_plan_defaults_to_qa_basic():
     assert "dsl" in draft
     assert draft["dsl"]["path"] == ["begin"]
     assert "Agent:DraftAnswer" in draft["dsl"]["components"]
+
+
+def test_plan_logs_without_raw_title(caplog):
+    planner = ScenarioPlanner()
+
+    with caplog.at_level(logging.INFO, logger="agent.scenario_planner"):
+        planner.plan(
+            title="Secret Strategy 2027",
+            scenario="Answer questions about an internal handbook.",
+        )
+
+    assert "Secret Strategy 2027" not in caplog.text
+    assert "scenario_planner plan start mode=create" in caplog.text
+    assert "scenario_planner plan complete mode=create archetype=qa_basic" in caplog.text
 
 
 def test_plan_selects_interactive_research():
@@ -119,6 +134,30 @@ def test_plan_can_modify_existing_dsl_with_notification():
     assert target_id in components["Message:Output"]["downstream"]
     assert ("Message:Output", target_id) in _edge_pairs(edited["dsl"])
     assert target_id in {node["id"] for node in graph["nodes"]}
+
+
+def test_plan_multi_edit_refreshes_tail_between_supported_operations():
+    planner = ScenarioPlanner()
+    base = planner.plan(
+        title="Base Draft",
+        scenario="Answer questions about an internal handbook.",
+    )["dsl"]
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Add a notification step and summarize after the current flow.",
+        existing_dsl=base,
+    )
+
+    notification_id = next(op["target"] for op in edited["operations"] if op["type"] == "append_notification")
+    analysis_id = next(op["target"] for op in edited["operations"] if op["type"] == "append_analysis")
+    components = edited["dsl"]["components"]
+
+    assert components[notification_id]["upstream"] == ["Message:Output"]
+    assert components[analysis_id]["upstream"] == [notification_id]
+    assert analysis_id in components[notification_id]["downstream"]
+    assert ("Message:Output", notification_id) in _edge_pairs(edited["dsl"])
+    assert (notification_id, analysis_id) in _edge_pairs(edited["dsl"])
 
 
 def test_plan_notification_prefers_message_output_tail_for_multi_terminal_graph():

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -120,6 +120,30 @@ def test_plan_can_modify_existing_dsl_with_notification():
     assert target_id in {node["id"] for node in graph["nodes"]}
 
 
+def test_plan_notification_prefers_message_output_tail_for_multi_terminal_graph():
+    planner = ScenarioPlanner()
+    base = planner.plan(
+        title="Monitor Draft",
+        scenario="Monitor a website, detect changes, and notify me if anything changes.",
+    )["dsl"]
+
+    edited = planner.plan(
+        title="Edited Monitor Draft",
+        scenario="Add a notification step after the current flow.",
+        existing_dsl=base,
+    )
+
+    op = next(op for op in edited["operations"] if op["type"] == "append_notification")
+    target_id = op["target"]
+    components = edited["dsl"]["components"]
+
+    assert components[target_id]["upstream"] == ["Message:Output"]
+    assert target_id in components["Message:Output"]["downstream"]
+    assert target_id not in components["Message:NoChange"]["downstream"]
+    assert ("Message:Output", target_id) in _edge_pairs(edited["dsl"])
+    assert ("Message:NoChange", target_id) not in _edge_pairs(edited["dsl"])
+
+
 def test_plan_can_modify_existing_dsl_with_human_review():
     planner = ScenarioPlanner()
     base = planner.plan(
@@ -219,6 +243,116 @@ def test_plan_can_modify_existing_dsl_with_analysis():
     assert "{Message:Output@content}" not in prompts[0]["content"]
 
 
+def test_output_reference_falls_back_to_upstream_or_query():
+    planner = ScenarioPlanner()
+    components = {
+        "Agent:WithOutput": planner._agent_component(
+            prompts=[{"role": "user", "content": "{sys.query}"}],
+            sys_prompt="Draft an answer.",
+            downstream=["Switch:Decision"],
+        ),
+        "Switch:Decision": {
+            "downstream": [],
+            "obj": {
+                "component_name": "Switch",
+                "params": {},
+            },
+            "upstream": ["Agent:WithOutput"],
+        },
+        "Switch:NoUpstream": {
+            "downstream": [],
+            "obj": {
+                "component_name": "Switch",
+                "params": {},
+            },
+            "upstream": [],
+        },
+    }
+
+    assert planner._get_output_reference(components, "Switch:Decision") == "{Agent:WithOutput@content}"
+    assert planner._get_output_reference(components, "Switch:NoUpstream") == "{sys.query}"
+
+
+def test_plan_analysis_uses_user_fillup_output_reference():
+    planner = ScenarioPlanner()
+    existing = {
+        "components": {
+            "begin": {
+                "downstream": ["UserFillUp:Review"],
+                "obj": {"component_name": "Begin", "params": {}},
+                "upstream": [],
+            },
+            "UserFillUp:Review": planner._user_fillup_component(
+                tips="Review the draft.",
+                downstream=[],
+                upstream=["begin"],
+            ),
+        },
+        "graph": {
+            "nodes": [
+                {"id": "begin"},
+                {"id": "UserFillUp:Review"},
+            ],
+            "edges": [
+                {"source": "begin", "target": "UserFillUp:Review"},
+            ],
+        },
+    }
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Add analysis after the current flow.",
+        existing_dsl=existing,
+    )
+
+    op = next(op for op in edited["operations"] if op["type"] == "append_analysis")
+    target_id = op["target"]
+    prompt = edited["dsl"]["components"][target_id]["obj"]["params"]["prompts"][0]["content"]
+
+    assert "{UserFillUp:Review@instructions}" in prompt
+    assert "{UserFillUp:Review@content}" not in prompt
+
+
+def test_plan_analysis_avoids_result_placeholder_for_outputless_tail():
+    planner = ScenarioPlanner()
+    existing = {
+        "components": {
+            "begin": {
+                "downstream": ["Switch:Decision"],
+                "obj": {"component_name": "Begin", "params": {}},
+                "upstream": [],
+            },
+            "Switch:Decision": {
+                "downstream": [],
+                "obj": {"component_name": "Switch", "params": {}},
+                "upstream": ["begin"],
+            },
+        },
+        "graph": {
+            "nodes": [
+                {"id": "begin"},
+                {"id": "Switch:Decision"},
+            ],
+            "edges": [
+                planner._edge("begin", "Switch:Decision"),
+            ],
+        },
+    }
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Add analysis after the current flow.",
+        existing_dsl=existing,
+    )
+
+    op = next(op for op in edited["operations"] if op["type"] == "append_analysis")
+    target_id = op["target"]
+    prompt = edited["dsl"]["components"][target_id]["obj"]["params"]["prompts"][0]["content"]
+
+    assert "@result" not in prompt
+    assert "Analyze the following output:\n{sys.query}" in prompt
+
+
 def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
     planner = ScenarioPlanner()
 
@@ -241,6 +375,7 @@ def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
     [
         ({}, "dict components and graph sections"),
         ({"components": {}, "graph": {"edges": [], "nodes": []}}, "begin node"),
+        ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": [{"id": "Agent:DraftAnswer"}]}}, "begin node"),
         ({"components": {"begin": {}}, "graph": {"edges": {}, "nodes": []}}, "graph.edges and graph.nodes as lists"),
         ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": {}}}, "graph.edges and graph.nodes as lists"),
     ],

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -13,12 +13,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from copy import deepcopy
+
 import pytest
 
 from agent.scenario_planner import ScenarioPlanner
 
 
 pytestmark = pytest.mark.p2
+
+
+def _edge_pairs(dsl):
+    return {(edge["source"], edge["target"]) for edge in dsl["graph"]["edges"]}
 
 
 def test_plan_defaults_to_qa_basic():
@@ -84,6 +90,10 @@ def test_plan_can_modify_existing_dsl_with_notification():
         title="Base Draft",
         scenario="Answer questions about an internal handbook.",
     )["dsl"]
+    base_snapshot = deepcopy(base)
+    base_components = base["components"]
+    base_nodes = base["graph"]["nodes"]
+    base_edges = base["graph"]["edges"]
 
     edited = planner.plan(
         title="Edited Draft",
@@ -93,10 +103,21 @@ def test_plan_can_modify_existing_dsl_with_notification():
 
     assert edited["archetype"] == "modify_existing"
     assert edited["mode"] == "modify"
-    assert any(op["type"] == "append_notification" for op in edited["operations"])
+    op = next(op for op in edited["operations"] if op["type"] == "append_notification")
+    target_id = op["target"]
     components = edited["dsl"]["components"]
-    assert any(component["obj"]["component_name"] == "Message" for component in components.values())
-    assert any("Notify" in component_id for component_id in components.keys())
+    graph = edited["dsl"]["graph"]
+
+    assert base == base_snapshot
+    assert target_id not in base_components
+    assert len(components) == len(base_components) + 1
+    assert len(graph["nodes"]) == len(base_nodes) + 1
+    assert len(graph["edges"]) == len(base_edges) + 1
+    assert components[target_id]["obj"]["component_name"] == "Message"
+    assert components[target_id]["upstream"] == ["Message:Output"]
+    assert target_id in components["Message:Output"]["downstream"]
+    assert ("Message:Output", target_id) in _edge_pairs(edited["dsl"])
+    assert target_id in {node["id"] for node in graph["nodes"]}
 
 
 def test_plan_can_modify_existing_dsl_with_human_review():
@@ -105,6 +126,12 @@ def test_plan_can_modify_existing_dsl_with_human_review():
         title="Research Draft",
         scenario="Research the market, compare sources, and produce a short report.",
     )["dsl"]
+    base_snapshot = deepcopy(base)
+    base_components = base["components"]
+    base_nodes = base["graph"]["nodes"]
+    base_edges = base["graph"]["edges"]
+    tail_id = "Message:Output"
+    predecessor_ids = list(base_components[tail_id]["upstream"])
 
     edited = planner.plan(
         title="Research Draft",
@@ -113,9 +140,27 @@ def test_plan_can_modify_existing_dsl_with_human_review():
     )
 
     assert edited["archetype"] == "modify_existing"
-    assert any(op["type"] == "insert_human_review" for op in edited["operations"])
+    op = next(op for op in edited["operations"] if op["type"] == "insert_human_review")
+    target_id = op["target"]
     components = edited["dsl"]["components"]
-    assert any(component["obj"]["component_name"] == "UserFillUp" for component in components.values())
+    graph = edited["dsl"]["graph"]
+
+    assert base == base_snapshot
+    assert target_id not in base_components
+    assert len(components) == len(base_components) + 1
+    assert len(graph["nodes"]) == len(base_nodes) + 1
+    assert len(graph["edges"]) == len(base_edges) + 1
+    assert components[target_id]["obj"]["component_name"] == "UserFillUp"
+    assert components[target_id]["upstream"] == predecessor_ids
+    assert components[target_id]["downstream"] == [tail_id]
+    assert components[tail_id]["upstream"] == [target_id]
+    for predecessor_id in predecessor_ids:
+        assert target_id in components[predecessor_id]["downstream"]
+        assert tail_id not in components[predecessor_id]["downstream"]
+        assert (predecessor_id, target_id) in _edge_pairs(edited["dsl"])
+        assert (predecessor_id, tail_id) not in _edge_pairs(edited["dsl"])
+    assert (target_id, tail_id) in _edge_pairs(edited["dsl"])
+    assert target_id in {node["id"] for node in graph["nodes"]}
 
 
 def test_plan_reports_noop_for_unsupported_edit():
@@ -142,6 +187,10 @@ def test_plan_can_modify_existing_dsl_with_analysis():
         title="Base Draft",
         scenario="Answer questions about an internal handbook.",
     )["dsl"]
+    base_snapshot = deepcopy(base)
+    base_components = base["components"]
+    base_nodes = base["graph"]["nodes"]
+    base_edges = base["graph"]["edges"]
 
     edited = planner.plan(
         title="Edited Draft",
@@ -150,12 +199,24 @@ def test_plan_can_modify_existing_dsl_with_analysis():
     )
 
     assert edited["mode"] == "modify"
-    assert any(op["type"] == "append_analysis" for op in edited["operations"])
-    analysis_nodes = [cid for cid in edited["dsl"]["components"] if cid.endswith("Analysis")]
-    assert analysis_nodes
-    prompts = edited["dsl"]["components"][analysis_nodes[0]]["obj"]["params"]["prompts"]
+    op = next(op for op in edited["operations"] if op["type"] == "append_analysis")
+    target_id = op["target"]
+    components = edited["dsl"]["components"]
+    graph = edited["dsl"]["graph"]
+    prompts = components[target_id]["obj"]["params"]["prompts"]
+
+    assert base == base_snapshot
+    assert target_id not in base_components
+    assert len(components) == len(base_components) + 1
+    assert len(graph["nodes"]) == len(base_nodes) + 1
+    assert len(graph["edges"]) == len(base_edges) + 1
+    assert components[target_id]["upstream"] == ["Message:Output"]
+    assert target_id in components["Message:Output"]["downstream"]
+    assert ("Message:Output", target_id) in _edge_pairs(edited["dsl"])
+    assert target_id in {node["id"] for node in graph["nodes"]}
     assert "Original request: {sys.query}" in prompts[0]["content"]
-    assert "@content" in prompts[0]["content"]
+    assert "{Agent:DraftAnswer@content}" in prompts[0]["content"]
+    assert "{Message:Output@content}" not in prompts[0]["content"]
 
 
 def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
@@ -175,12 +236,21 @@ def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
         planner.plan(title="Broken", scenario="test")
 
 
-def test_plan_rejects_invalid_existing_dsl_structure():
+@pytest.mark.parametrize(
+    ("invalid_dsl", "message"),
+    [
+        ({}, "dict components and graph sections"),
+        ({"components": {}, "graph": {"edges": [], "nodes": []}}, "begin node"),
+        ({"components": {"begin": {}}, "graph": {"edges": {}, "nodes": []}}, "graph.edges and graph.nodes as lists"),
+        ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": {}}}, "graph.edges and graph.nodes as lists"),
+    ],
+)
+def test_plan_rejects_invalid_existing_dsl_structure(invalid_dsl, message):
     planner = ScenarioPlanner()
 
-    with pytest.raises(ValueError, match="existing_dsl must be a valid canvas DSL"):
+    with pytest.raises(ValueError, match=message):
         planner.plan(
             title="Broken",
             scenario="Add a notification step",
-            existing_dsl={},
+            existing_dsl=invalid_dsl,
         )

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -423,6 +423,24 @@ def test_plan_analysis_avoids_result_placeholder_for_outputless_tail():
     assert "Analyze the following output:\n{sys.query}" in prompt
 
 
+def test_output_reference_returns_query_when_upstream_cycle_is_detected():
+    planner = ScenarioPlanner()
+    components = {
+        "Agent:A": {
+            "downstream": [],
+            "obj": {"component_name": "Agent", "params": {}},
+            "upstream": ["Agent:B"],
+        },
+        "Agent:B": {
+            "downstream": [],
+            "obj": {"component_name": "Agent", "params": {}},
+            "upstream": ["Agent:A"],
+        },
+    }
+
+    assert planner._get_output_reference(components, "Agent:A") == "{sys.query}"
+
+
 def test_load_template_uses_cached_payload(monkeypatch):
     planner = ScenarioPlanner()
     ScenarioPlanner._load_template_payload.cache_clear()
@@ -470,6 +488,10 @@ def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
         ({}, "dict components and graph sections"),
         ({"components": {}, "graph": {"edges": [], "nodes": []}}, "begin node"),
         ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": [{"id": "Agent:DraftAnswer"}]}}, "begin node"),
+        ({"components": {"begin": []}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "dict component entries"),
+        ({"components": {"begin": {}}, "graph": {"edges": [1], "nodes": [{"id": "begin"}]}}, "dict graph.edges entries"),
+        ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": [1]}}, "dict graph.nodes entries"),
+        ({"components": {"begin": {"downstream": "Message:Output"}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "list upstream/downstream"),
         ({"components": {"begin": {}}, "graph": {"edges": {}, "nodes": []}}, "graph.edges and graph.nodes as lists"),
         ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": {}}}, "graph.edges and graph.nodes as lists"),
     ],

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -1,0 +1,71 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from agent.scenario_planner import ScenarioPlanner
+
+
+def test_plan_defaults_to_qa_basic():
+    planner = ScenarioPlanner()
+    draft = planner.plan(
+        title="QA Draft",
+        scenario="Answer questions about an internal handbook.",
+    )
+
+    assert draft["archetype"] == "qa_basic"
+    assert "dsl" in draft
+    assert draft["dsl"]["path"] == ["begin"]
+    assert "Agent:DraftAnswer" in draft["dsl"]["components"]
+
+
+def test_plan_selects_interactive_research():
+    planner = ScenarioPlanner()
+    draft = planner.plan(
+        title="Research Draft",
+        scenario="Research the market, compare sources, and produce a short report.",
+    )
+
+    assert draft["archetype"] == "interactive_research"
+    components = draft["dsl"]["components"]
+    assert "Agent:Plan" in components
+    assert "UserFillUp:ReviewPlan" in components
+    assert "Agent:ExecuteResearch" in components
+
+
+def test_plan_selects_monitor_notify():
+    planner = ScenarioPlanner()
+    draft = planner.plan(
+        title="Monitor Draft",
+        scenario="Monitor a website, detect changes, and notify me if anything changes.",
+    )
+
+    assert draft["archetype"] == "monitor_notify"
+    assert draft["warnings"]
+    components = draft["dsl"]["components"]
+    assert "Switch:Decision" in components
+    assert "Agent:Notify" in components
+
+
+def test_plan_selects_batch_review():
+    planner = ScenarioPlanner()
+    draft = planner.plan(
+        title="Batch Draft",
+        scenario="For each uploaded resume, review it and summarize the fit.",
+    )
+
+    assert draft["archetype"] == "batch_review"
+    components = draft["dsl"]["components"]
+    assert "Iteration:Items" in components
+    assert "IterationItem:Current" in components
+    assert components["Agent:ReviewItem"]["parent_id"] == "Iteration:Items"

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -151,6 +151,11 @@ def test_plan_can_modify_existing_dsl_with_analysis():
 
     assert edited["mode"] == "modify"
     assert any(op["type"] == "append_analysis" for op in edited["operations"])
+    analysis_nodes = [cid for cid in edited["dsl"]["components"] if cid.endswith("Analysis")]
+    assert analysis_nodes
+    prompts = edited["dsl"]["components"][analysis_nodes[0]]["obj"]["params"]["prompts"]
+    assert "Original request: {sys.query}" in prompts[0]["content"]
+    assert "@content" in prompts[0]["content"]
 
 
 def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
@@ -168,3 +173,14 @@ def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
 
     with pytest.raises(ValueError, match="No builder implemented for archetype: missing_builder"):
         planner.plan(title="Broken", scenario="test")
+
+
+def test_plan_rejects_invalid_existing_dsl_structure():
+    planner = ScenarioPlanner()
+
+    with pytest.raises(ValueError, match="existing_dsl must be a valid canvas DSL"):
+        planner.plan(
+            title="Broken",
+            scenario="Add a notification step",
+            existing_dsl={},
+        )

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -37,6 +37,7 @@ def test_plan_defaults_to_qa_basic():
     )
 
     assert draft["archetype"] == "qa_basic"
+    assert draft["canvas_type"] == "Agent"
     assert draft["mode"] == "create"
     assert draft["operations"] == [{"type": "create_draft", "archetype": "qa_basic"}]
     assert "dsl" in draft
@@ -134,6 +135,47 @@ def test_plan_can_modify_existing_dsl_with_notification():
     assert target_id in components["Message:Output"]["downstream"]
     assert ("Message:Output", target_id) in _edge_pairs(edited["dsl"])
     assert target_id in {node["id"] for node in graph["nodes"]}
+
+
+def test_plan_notification_updates_begin_downstream_when_no_tail_exists():
+    planner = ScenarioPlanner()
+    existing = {
+        "components": {
+            "begin": {
+                "downstream": ["Agent:Loop"],
+                "obj": {"component_name": "Begin", "params": {}},
+                "upstream": ["Agent:Loop"],
+            },
+            "Agent:Loop": {
+                "downstream": ["begin"],
+                "obj": {"component_name": "Agent", "params": {"outputs": {"content": {"type": "string", "value": ""}}}},
+                "upstream": ["begin"],
+            },
+        },
+        "graph": {
+            "nodes": [
+                {"id": "begin"},
+                {"id": "Agent:Loop"},
+            ],
+            "edges": [
+                planner._edge("begin", "Agent:Loop"),
+                planner._edge("Agent:Loop", "begin"),
+            ],
+        },
+    }
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Add a notification step after the current flow.",
+        existing_dsl=existing,
+    )
+
+    target_id = next(op["target"] for op in edited["operations"] if op["type"] == "append_notification")
+    components = edited["dsl"]["components"]
+
+    assert components[target_id]["upstream"] == ["begin"]
+    assert target_id in components["begin"]["downstream"]
+    assert ("begin", target_id) in _edge_pairs(edited["dsl"])
 
 
 def test_plan_multi_edit_refreshes_tail_between_supported_operations():
@@ -528,7 +570,9 @@ def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
         ({"components": {}, "graph": {"edges": [], "nodes": []}}, "begin node"),
         ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": [{"id": "Agent:DraftAnswer"}]}}, "begin node"),
         ({"components": {"begin": []}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "dict component entries"),
+        ({"components": {"begin": {"obj": None}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "object metadata"),
         ({"components": {"begin": {"obj": []}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "object metadata"),
+        ({"components": {"begin": {"obj": {"params": None}}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "params must be objects"),
         ({"components": {"begin": {"obj": {"params": []}}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "params must be objects"),
         ({"components": {"begin": {}}, "graph": {"edges": [1], "nodes": [{"id": "begin"}]}}, "dict graph.edges entries"),
         ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": [1]}}, "dict graph.nodes entries"),

--- a/test/unit_test/agent/test_scenario_planner.py
+++ b/test/unit_test/agent/test_scenario_planner.py
@@ -227,6 +227,45 @@ def test_plan_can_modify_existing_dsl_with_human_review():
     assert target_id in {node["id"] for node in graph["nodes"]}
 
 
+def test_plan_human_review_uses_tail_anchor_when_no_predecessor_exists():
+    planner = ScenarioPlanner()
+    existing = {
+        "components": {
+            "begin": {
+                "downstream": [],
+                "obj": {"component_name": "Begin", "params": {}},
+                "upstream": [],
+            },
+            "Message:Output": planner._message_component(
+                ["Existing output."],
+                upstream=["begin"],
+            ),
+        },
+        "graph": {
+            "nodes": [
+                {"id": "begin"},
+                {"id": "Message:Output"},
+            ],
+            "edges": [],
+        },
+    }
+
+    edited = planner.plan(
+        title="Edited Draft",
+        scenario="Insert a human review step before continuing.",
+        existing_dsl=existing,
+    )
+
+    target_id = next(op["target"] for op in edited["operations"] if op["type"] == "insert_human_review")
+    components = edited["dsl"]["components"]
+
+    assert components[target_id]["upstream"] == ["Message:Output"]
+    assert components[target_id]["downstream"] == []
+    assert target_id in components["Message:Output"]["downstream"]
+    assert ("Message:Output", target_id) in _edge_pairs(edited["dsl"])
+    assert ("begin", target_id) not in _edge_pairs(edited["dsl"])
+
+
 def test_plan_reports_noop_for_unsupported_edit():
     planner = ScenarioPlanner()
     base = planner.plan(
@@ -489,6 +528,8 @@ def test_plan_raises_clear_error_for_missing_builder(monkeypatch):
         ({"components": {}, "graph": {"edges": [], "nodes": []}}, "begin node"),
         ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": [{"id": "Agent:DraftAnswer"}]}}, "begin node"),
         ({"components": {"begin": []}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "dict component entries"),
+        ({"components": {"begin": {"obj": []}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "object metadata"),
+        ({"components": {"begin": {"obj": {"params": []}}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "params must be objects"),
         ({"components": {"begin": {}}, "graph": {"edges": [1], "nodes": [{"id": "begin"}]}}, "dict graph.edges entries"),
         ({"components": {"begin": {}}, "graph": {"edges": [], "nodes": [1]}}, "dict graph.nodes entries"),
         ({"components": {"begin": {"downstream": "Message:Output"}}, "graph": {"edges": [], "nodes": [{"id": "begin"}]}}, "list upstream/downstream"),

--- a/test/unit_test/agent/test_scenario_planner_api.py
+++ b/test/unit_test/agent/test_scenario_planner_api.py
@@ -1,0 +1,254 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import asyncio
+import importlib.util
+import inspect
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+class _DummyManager:
+    def route(self, *_args, **_kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _set_request_json(monkeypatch, module, payload):
+    async def _req():
+        return payload
+    monkeypatch.setattr(module, "get_request_json", _req)
+
+
+def _load_canvas_module(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(repo_root))
+
+    common_pkg = ModuleType("common")
+    common_pkg.__path__ = [str(repo_root / "common")]
+    monkeypatch.setitem(sys.modules, "common", common_pkg)
+
+    settings_mod = ModuleType("common.settings")
+    settings_mod.docStoreConn = SimpleNamespace(index_exist=lambda *_a, **_k: False, delete=lambda *_a, **_k: True)
+    common_pkg.settings = settings_mod
+    monkeypatch.setitem(sys.modules, "common.settings", settings_mod)
+
+    constants_mod = ModuleType("common.constants")
+    constants_mod.RetCode = SimpleNamespace(SUCCESS=0, DATA_ERROR=102, OPERATING_ERROR=103, EXCEPTION_ERROR=100)
+    monkeypatch.setitem(sys.modules, "common.constants", constants_mod)
+
+    misc_utils_mod = ModuleType("common.misc_utils")
+    misc_utils_mod.get_uuid = lambda: "uuid-1"
+
+    async def _thread_pool_exec(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    misc_utils_mod.thread_pool_exec = _thread_pool_exec
+    monkeypatch.setitem(sys.modules, "common.misc_utils", misc_utils_mod)
+
+    api_pkg = ModuleType("api")
+    api_pkg.__path__ = [str(repo_root / "api")]
+    monkeypatch.setitem(sys.modules, "api", api_pkg)
+
+    db_pkg = ModuleType("api.db")
+    db_pkg.__path__ = [str(repo_root / "api" / "db")]
+    db_pkg.CanvasCategory = SimpleNamespace(Agent="Agent", DataFlow="DataFlow")
+    monkeypatch.setitem(sys.modules, "api.db", db_pkg)
+
+    apps_mod = ModuleType("api.apps")
+    apps_mod.__path__ = []
+    apps_mod.current_user = SimpleNamespace(id="user-1")
+    apps_mod.login_required = lambda func: func
+    monkeypatch.setitem(sys.modules, "api.apps", apps_mod)
+
+    apps_services_pkg = ModuleType("api.apps.services")
+    apps_services_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "api.apps.services", apps_services_pkg)
+
+    canvas_replica_mod = ModuleType("api.apps.services.canvas_replica_service")
+    canvas_replica_mod.CanvasReplicaService = SimpleNamespace(
+        normalize_dsl=lambda dsl: dsl,
+        bootstrap=lambda *_a, **_k: {},
+        load_for_run=lambda *_a, **_k: None,
+        commit_after_run=lambda *_a, **_k: True,
+        replace_for_set=lambda *_a, **_k: True,
+        create_if_absent=lambda *_a, **_k: {},
+    )
+    monkeypatch.setitem(sys.modules, "api.apps.services.canvas_replica_service", canvas_replica_mod)
+
+    services_pkg = ModuleType("api.db.services")
+    services_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "api.db.services", services_pkg)
+
+    canvas_service_mod = ModuleType("api.db.services.canvas_service")
+    canvas_service_mod.CanvasTemplateService = SimpleNamespace(get_all=lambda: [])
+    canvas_service_mod.UserCanvasService = SimpleNamespace(
+        accessible=lambda *_a, **_k: True,
+        delete_by_id=lambda *_a, **_k: True,
+        query=lambda *_a, **_k: [],
+        save=lambda **_k: True,
+        update_by_id=lambda *_a, **_k: True,
+        get_by_canvas_id=lambda cid: (True, {"id": cid}),
+        get_by_id=lambda cid: (True, SimpleNamespace(id=cid, user_id="user-1", dsl="{}", canvas_category="Agent", to_dict=lambda: {"id": cid})),
+        get_by_tenant_ids=lambda *_a, **_k: ([], 0),
+    )
+    canvas_service_mod.API4ConversationService = SimpleNamespace()
+    canvas_service_mod.completion = lambda *_a, **_k: iter(())
+    monkeypatch.setitem(sys.modules, "api.db.services.canvas_service", canvas_service_mod)
+
+    for name in [
+        "document_service",
+        "file_service",
+        "knowledgebase_service",
+        "pipeline_operation_log_service",
+        "task_service",
+        "user_service",
+        "user_canvas_version",
+    ]:
+        mod = ModuleType(f"api.db.services.{name}")
+        monkeypatch.setitem(sys.modules, f"api.db.services.{name}", mod)
+
+    sys.modules["api.db.services.document_service"].DocumentService = SimpleNamespace(clear_chunk_num_when_rerun=lambda *_a, **_k: True, update_by_id=lambda *_a, **_k: True)
+    sys.modules["api.db.services.file_service"].FileService = SimpleNamespace(upload_info=lambda *_a, **_k: {"ok": True}, get_blob=lambda *_a, **_k: b"")
+    sys.modules["api.db.services.knowledgebase_service"].KnowledgebaseService = SimpleNamespace(query=lambda **_k: [])
+    sys.modules["api.db.services.pipeline_operation_log_service"].PipelineOperationLogService = SimpleNamespace(get_documents_info=lambda *_a, **_k: [], update_by_id=lambda *_a, **_k: True)
+    sys.modules["api.db.services.task_service"].queue_dataflow = lambda *_a, **_k: (True, "")
+    sys.modules["api.db.services.task_service"].CANVAS_DEBUG_DOC_ID = "debug-doc"
+    sys.modules["api.db.services.task_service"].TaskService = SimpleNamespace(filter_delete=lambda *_a, **_k: True)
+    sys.modules["api.db.services.user_service"].TenantService = SimpleNamespace(get_joined_tenants_by_user_id=lambda *_a, **_k: [])
+    sys.modules["api.db.services.user_canvas_version"].UserCanvasVersionService = SimpleNamespace(
+        list_by_canvas_id=lambda *_a, **_k: [],
+        get_by_id=lambda *_a, **_k: (True, None),
+        save_or_replace_latest=lambda *_a, **_k: True,
+        build_version_title=lambda *_a, **_k: "stub_version_title",
+    )
+
+    db_models_mod = ModuleType("api.db.db_models")
+    db_models_mod.APIToken = SimpleNamespace(query=lambda **_k: [])
+    db_models_mod.Task = SimpleNamespace(doc_id=SimpleNamespace(__eq__=lambda self, other: ("eq", other)))
+    monkeypatch.setitem(sys.modules, "api.db.db_models", db_models_mod)
+
+    peewee_mod = ModuleType("peewee")
+    peewee_mod.MySQLDatabase = type("MySQLDatabase", (), {})
+    peewee_mod.PostgresqlDatabase = type("PostgresqlDatabase", (), {})
+    monkeypatch.setitem(sys.modules, "peewee", peewee_mod)
+
+    api_utils_mod = ModuleType("api.utils.api_utils")
+    api_utils_mod.get_json_result = lambda code=0, message="success", data=None: {"code": code, "message": message, "data": data}
+    api_utils_mod.server_error_response = lambda exc: {"code": 100, "message": repr(exc), "data": None}
+    api_utils_mod.validate_request = lambda *_a, **_k: (lambda func: func)
+    api_utils_mod.get_data_error_result = lambda code=102, message="Sorry! Data missing!": {"code": code, "message": message}
+    api_utils_mod.get_request_json = lambda: {}
+    monkeypatch.setitem(sys.modules, "api.utils.api_utils", api_utils_mod)
+
+    rag_pkg = ModuleType("rag")
+    rag_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "rag", rag_pkg)
+    rag_flow_pkg = ModuleType("rag.flow")
+    rag_flow_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "rag.flow", rag_flow_pkg)
+    pipeline_mod = ModuleType("rag.flow.pipeline")
+    pipeline_mod.Pipeline = lambda *_a, **_k: None
+    monkeypatch.setitem(sys.modules, "rag.flow.pipeline", pipeline_mod)
+    rag_nlp_mod = ModuleType("rag.nlp")
+    rag_nlp_mod.search = SimpleNamespace(index_name=lambda tenant_id: f"idx-{tenant_id}")
+    monkeypatch.setitem(sys.modules, "rag.nlp", rag_nlp_mod)
+    rag_utils_pkg = ModuleType("rag.utils")
+    rag_utils_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "rag.utils", rag_utils_pkg)
+    redis_mod = ModuleType("rag.utils.redis_conn")
+    redis_mod.REDIS_CONN = SimpleNamespace(set=lambda *_a, **_k: True, get=lambda *_a, **_k: None)
+    monkeypatch.setitem(sys.modules, "rag.utils.redis_conn", redis_mod)
+
+    agent_pkg = ModuleType("agent")
+    agent_pkg.__path__ = [str(repo_root / "agent")]
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+
+    agent_component_mod = ModuleType("agent.component")
+    agent_component_mod.LLM = type("_StubLLM", (), {})
+    monkeypatch.setitem(sys.modules, "agent.component", agent_component_mod)
+
+    agent_canvas_mod = ModuleType("agent.canvas")
+    agent_canvas_mod.Canvas = type(
+        "_StubCanvas",
+        (),
+        {
+            "__init__": lambda self, dsl, _user_id, _agent_id=None, canvas_id=None: None,
+            "run": lambda self, **_kwargs: iter(()),
+            "cancel_task": lambda self: None,
+            "reset": lambda self: None,
+            "get_component_input_form": lambda self, _component_id: {},
+            "get_component": lambda self, _component_id: {"obj": SimpleNamespace(reset=lambda: None, invoke=lambda **_k: None, output=lambda: {})},
+            "__str__": lambda self: "{}",
+        },
+    )
+    monkeypatch.setitem(sys.modules, "agent.canvas", agent_canvas_mod)
+
+    dsl_mod = ModuleType("agent.dsl_migration")
+    dsl_mod.normalize_chunker_dsl = lambda dsl: dsl
+    monkeypatch.setitem(sys.modules, "agent.dsl_migration", dsl_mod)
+
+    quart_mod = ModuleType("quart")
+    quart_mod.request = SimpleNamespace(headers={}, args={}, files={}, method="POST", content_length=0)
+    quart_mod.Response = lambda body, mimetype=None, content_type=None: {"body": body, "mimetype": mimetype, "content_type": content_type}
+    quart_mod.make_response = lambda blob: {"blob": blob}
+    monkeypatch.setitem(sys.modules, "quart", quart_mod)
+
+    module_path = repo_root / "api" / "apps" / "canvas_app.py"
+    spec = importlib.util.spec_from_file_location("scenario_plan_canvas_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    module.manager = _DummyManager()
+    monkeypatch.setitem(sys.modules, "scenario_plan_canvas_module", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_scenario_plan_route_create_and_modify(monkeypatch):
+    module = _load_canvas_module(monkeypatch)
+    planner_calls = []
+
+    class _Planner:
+        def plan(self, **kwargs):
+            planner_calls.append(kwargs)
+            return {
+                "title": kwargs["title"],
+                "mode": "modify" if kwargs.get("existing_dsl") else "create",
+                "archetype": "modify_existing" if kwargs.get("existing_dsl") else "qa_basic",
+                "operations": [{"type": "stub"}],
+                "warnings": [],
+                "dsl": {"components": {}, "graph": {}},
+            }
+
+    monkeypatch.setattr(module, "ScenarioPlanner", _Planner)
+
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Answer questions"})
+    res = _run(inspect.unwrap(module.scenario_plan)())
+    assert res["code"] == 0
+    assert res["data"]["mode"] == "create"
+    assert planner_calls[-1]["existing_dsl"] is None
+
+    existing = {"components": {"begin": {}}, "graph": {"edges": [], "nodes": []}}
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Add a notification step", "existing_dsl": existing, "canvas_category": "Agent"})
+    res = _run(inspect.unwrap(module.scenario_plan)())
+    assert res["code"] == 0
+    assert res["data"]["mode"] == "modify"
+    assert planner_calls[-1]["existing_dsl"] == existing

--- a/test/unit_test/agent/test_scenario_planner_api.py
+++ b/test/unit_test/agent/test_scenario_planner_api.py
@@ -235,8 +235,8 @@ def test_scenario_plan_route_create_and_modify(monkeypatch):
             planner_calls.append(kwargs)
             return {
                 "title": kwargs["title"],
-                "mode": "modify" if kwargs.get("existing_dsl") else "create",
-                "archetype": "modify_existing" if kwargs.get("existing_dsl") else "qa_basic",
+                "mode": "modify" if kwargs.get("existing_dsl") is not None else "create",
+                "archetype": "modify_existing" if kwargs.get("existing_dsl") is not None else "qa_basic",
                 "operations": [{"type": "stub"}],
                 "warnings": [],
                 "dsl": {"components": {}, "graph": {}},
@@ -257,10 +257,28 @@ def test_scenario_plan_route_create_and_modify(monkeypatch):
     assert res["data"]["mode"] == "modify"
     assert planner_calls[-1]["existing_dsl"] == existing
 
+    empty_existing = {}
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Refine the existing flow", "existing_dsl": empty_existing})
+    res = _run(inspect.unwrap(module.scenario_plan)())
+    assert res["code"] == 0
+    assert res["data"]["mode"] == "modify"
+    assert planner_calls[-1]["existing_dsl"] is empty_existing
+
 
 def test_scenario_plan_route_rejects_non_object_existing_dsl(monkeypatch):
     module = _load_canvas_module(monkeypatch)
-    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Add a notification step", "existing_dsl": "not-a-dict"})
+    planner_calls = []
+
+    class _Planner:
+        def plan(self, **kwargs):
+            planner_calls.append(kwargs)
+            return {"mode": "create"}
+
+    monkeypatch.setattr(module, "ScenarioPlanner", _Planner)
+
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Add a notification step", "existing_dsl": "not-a-dsl"})
     res = _run(inspect.unwrap(module.scenario_plan)())
+
     assert res["code"] == 102
-    assert "existing_dsl must be a JSON object" in res["message"]
+    assert "JSON object" in res["message"]
+    assert planner_calls == []

--- a/test/unit_test/agent/test_scenario_planner_api.py
+++ b/test/unit_test/agent/test_scenario_planner_api.py
@@ -17,6 +17,7 @@ import asyncio
 import importlib.util
 import inspect
 import json
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -298,3 +299,20 @@ def test_scenario_plan_route_maps_planner_value_error_to_data_error(monkeypatch)
 
     assert res["code"] == 102
     assert res["message"] == "bad existing_dsl"
+
+
+def test_scenario_plan_route_logs_validation_failure(monkeypatch, caplog):
+    module = _load_canvas_module(monkeypatch)
+
+    class _Planner:
+        def plan(self, **_kwargs):
+            raise ValueError("bad existing_dsl")
+
+    monkeypatch.setattr(module, "ScenarioPlanner", _Planner)
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Add a notification step", "existing_dsl": {"components": {}, "graph": {}}})
+
+    with caplog.at_level(logging.WARNING):
+        res = _run(inspect.unwrap(module.scenario_plan)())
+
+    assert res["code"] == 102
+    assert "scenario_plan validation_failed user_id=user-1 mode=modify error=bad existing_dsl" in caplog.text

--- a/test/unit_test/agent/test_scenario_planner_api.py
+++ b/test/unit_test/agent/test_scenario_planner_api.py
@@ -21,6 +21,7 @@ import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
 
 class _DummyManager:
     def route(self, *_args, **_kwargs):
@@ -222,6 +223,9 @@ def _load_canvas_module(monkeypatch):
     return module
 
 
+pytestmark = pytest.mark.p2
+
+
 def test_scenario_plan_route_create_and_modify(monkeypatch):
     module = _load_canvas_module(monkeypatch)
     planner_calls = []
@@ -252,3 +256,11 @@ def test_scenario_plan_route_create_and_modify(monkeypatch):
     assert res["code"] == 0
     assert res["data"]["mode"] == "modify"
     assert planner_calls[-1]["existing_dsl"] == existing
+
+
+def test_scenario_plan_route_rejects_non_object_existing_dsl(monkeypatch):
+    module = _load_canvas_module(monkeypatch)
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Add a notification step", "existing_dsl": "not-a-dict"})
+    res = _run(inspect.unwrap(module.scenario_plan)())
+    assert res["code"] == 102
+    assert "existing_dsl must be a JSON object" in res["message"]

--- a/test/unit_test/agent/test_scenario_planner_api.py
+++ b/test/unit_test/agent/test_scenario_planner_api.py
@@ -282,3 +282,19 @@ def test_scenario_plan_route_rejects_non_object_existing_dsl(monkeypatch):
     assert res["code"] == 102
     assert "JSON object" in res["message"]
     assert planner_calls == []
+
+
+def test_scenario_plan_route_maps_planner_value_error_to_data_error(monkeypatch):
+    module = _load_canvas_module(monkeypatch)
+
+    class _Planner:
+        def plan(self, **_kwargs):
+            raise ValueError("bad existing_dsl")
+
+    monkeypatch.setattr(module, "ScenarioPlanner", _Planner)
+
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Add a notification step", "existing_dsl": {"components": {}, "graph": {}}})
+    res = _run(inspect.unwrap(module.scenario_plan)())
+
+    assert res["code"] == 102
+    assert res["message"] == "bad existing_dsl"

--- a/test/unit_test/agent/test_scenario_planner_api.py
+++ b/test/unit_test/agent/test_scenario_planner_api.py
@@ -43,7 +43,7 @@ def _set_request_json(monkeypatch, module, payload):
 
 def _load_canvas_module(monkeypatch):
     repo_root = Path(__file__).resolve().parents[3]
-    sys.path.insert(0, str(repo_root))
+    monkeypatch.syspath_prepend(str(repo_root))
 
     common_pkg = ModuleType("common")
     common_pkg.__path__ = [str(repo_root / "common")]
@@ -316,3 +316,22 @@ def test_scenario_plan_route_logs_validation_failure(monkeypatch, caplog):
 
     assert res["code"] == 102
     assert "scenario_plan validation_failed user_id=user-1 mode=modify error=bad existing_dsl" in caplog.text
+
+
+def test_scenario_plan_route_rejects_invalid_canvas_category(monkeypatch):
+    module = _load_canvas_module(monkeypatch)
+    planner_calls = []
+
+    class _Planner:
+        def plan(self, **kwargs):
+            planner_calls.append(kwargs)
+            return {"mode": "create"}
+
+    monkeypatch.setattr(module, "ScenarioPlanner", _Planner)
+    _set_request_json(monkeypatch, module, {"title": "Draft", "scenario": "Answer questions", "canvas_category": "bad_canvas"})
+
+    res = _run(inspect.unwrap(module.scenario_plan)())
+
+    assert res["code"] == 102
+    assert "canvas_category must be one of" in res["message"]
+    assert planner_calls == []


### PR DESCRIPTION
### What problem does this PR solve?

This PR addresses the usability gap described in `#14043`: users currently need to do too much manual orchestration to get from a natural-language task description to a usable agent canvas.

Instead of changing the workflow runtime, this PR adds a small, deterministic `ScenarioPlanner` that can:

- create an editable canvas draft from a natural-language scenario
- apply a small set of natural-language edits to an existing canvas DSL

It is also aligned with the follow-up discussion around `next-ai-draw-io` style create/modify flows: the output is structured canvas DSL that users can inspect and continue editing manually.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [x] Refactoring
- [x] Performance Improvement
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Documentation Update
- [ ] Other (please describe):

## Summary

This PR adds a minimal `ScenarioPlanner` for RAGFlow agent canvases.

The planner keeps scope intentionally small:

- it does not replace the current workflow engine
- it does not introduce new runtime semantics
- it only generates or incrementally edits canvas DSL drafts that remain fully user-editable

## What is included

- new planner core: `agent/scenario_planner.py`
- archetype DSL templates moved to `agent/templates/scenario_planner/`
- package-data / sdist inclusion for `agent/templates/scenario_planner/*.json`
- new API endpoint: `POST /api/v1/canvas/scenario_plan`
- support for:
  - scenario -> draft workflow skeleton
  - scenario instruction + existing DSL -> edited workflow draft
- explicit planner metadata in response:
  - `mode: create | modify`
  - `operations: [...]`
  - `warnings: [...]`
- deterministic edit support for:
  - append notification
  - insert human review
  - append analysis
  - unsupported edit -> explicit no-op warning
- stronger output-reference handling for appended analysis steps:
  - reuse upstream output when the tail node does not expose outputs
  - avoid unresolved `@result` placeholders
- graph-edit correctness fixes for multi-intent instructions:
  - recompute tail / predecessor anchors between supported edit branches
- privacy-oriented logging cleanup:
  - do not log raw user titles in planner or route logs
- unit tests for planner behavior and edit-path graph mutations
- lightweight API contract coverage for `scenario_plan`

## What is intentionally out of scope

- no new runtime execution semantics
- no workflow DSL rewrite
- no automatic runtime replanning
- no UI changes in this PR
- no LLM-based graph editing yet; V1 is deterministic and template/rule driven

## Why this approach

RAGFlow already has:

- a canvas DSL
- reusable agent/workflow components
- a canvas API surface

What seems missing for this scenario is a way to produce a first-pass workflow draft from user intent, and then let users iteratively refine it.

This PR keeps the blast radius small by only generating editable DSL drafts that users can still inspect and change manually. The planner core is separated from the archetype payloads, with templates stored under `agent/templates/scenario_planner/`.

## Example API I/O

### Create draft

Request:

```json
{
  "title": "Website Monitor",
  "scenario": "Monitor a website, detect changes, summarize them, and notify me.",
  "canvas_category": "Agent"
}
```

Response shape:

```json
{
  "mode": "create",
  "archetype": "monitor_notify",
  "operations": [
    {"type": "create_draft", "archetype": "monitor_notify"}
  ],
  "warnings": [...],
  "dsl": {"components": {...}, "graph": {...}}
}
```

### Modify existing draft

Request:

```json
{
  "title": "Website Monitor",
  "scenario": "Add a notification step after the current flow.",
  "canvas_category": "Agent",
  "existing_dsl": {"components": {...}, "graph": {...}}
}
```

Response shape:

```json
{
  "mode": "modify",
  "archetype": "modify_existing",
  "operations": [
    {"type": "append_notification", "target": "Message:...Notify"}
  ],
  "warnings": [...],
  "dsl": {"components": {...}, "graph": {...}}
}
```

## Validation

Executed:

```bash
cd /tmp/ragflow_repo
python3 -m pytest test/unit_test/agent/test_scenario_planner.py test/unit_test/agent/test_scenario_planner_api.py -q
```

Result:

- `24 passed`

## Follow-ups

If this direction is useful, next steps could be:

1. enrich planner archetypes
2. support more edit operations on existing DSL
3. add a small canvas-side UI entry for scenario-to-draft generation
4. attach installed tools / MCP server hints to planner output
