### PR TITLE
Fix: safe argument guard and remove redundant redis call

### DIFF
--- a/api/apps/restful_apis/user_api.py
+++ b/api/apps/restful_apis/user_api.py
@@ -806,16 +806,15 @@ async def forget_reset_password():
     new_pwd = req.get("new_password")
     new_pwd2 = req.get("confirm_new_password")
 
-    new_pwd_base64 = decrypt(new_pwd)
-    new_pwd_string = base64.b64decode(new_pwd_base64).decode('utf-8')
-    new_pwd2_string = base64.b64decode(decrypt(new_pwd2)).decode('utf-8')
+    if not all([email, new_pwd, new_pwd2]):
+        return get_json_result(data=False, code=RetCode.ARGUMENT_ERROR, message="email and passwords are required")
 
-    REDIS_CONN.get(_verified_key(email))
     if not REDIS_CONN.get(_verified_key(email)):
         return get_json_result(data=False, code=RetCode.AUTHENTICATION_ERROR, message="email not verified")
 
-    if not all([email, new_pwd, new_pwd2]):
-        return get_json_result(data=False, code=RetCode.ARGUMENT_ERROR, message="email and passwords are required")
+    new_pwd_base64 = decrypt(new_pwd)
+    new_pwd_string = base64.b64decode(new_pwd_base64).decode('utf-8')
+    new_pwd2_string = base64.b64decode(decrypt(new_pwd2)).decode('utf-8')
 
     if new_pwd_string != new_pwd2_string:
         return get_json_result(data=False, code=RetCode.ARGUMENT_ERROR, message="passwords do not match")

--- a/api/apps/restful_apis/user_api.py
+++ b/api/apps/restful_apis/user_api.py
@@ -810,6 +810,7 @@ async def forget_reset_password():
     new_pwd_string = base64.b64decode(new_pwd_base64).decode('utf-8')
     new_pwd2_string = base64.b64decode(decrypt(new_pwd2)).decode('utf-8')
 
+    REDIS_CONN.get(_verified_key(email))
     if not REDIS_CONN.get(_verified_key(email)):
         return get_json_result(data=False, code=RetCode.AUTHENTICATION_ERROR, message="email not verified")
 


### PR DESCRIPTION
### What problem does this PR solve?

- Moved if not all([email, new_pwd, new_pwd2]) guard to the top, before any decryption that could crash on None value
- Removed the redundant REDIS_CONN.get() call — one call is sufficient

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
