### PR TITLE
fix: enable GitHub connector to sync PRs and issues by default

### DIFF
--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -964,8 +964,8 @@ class Github(SyncBase):
         self.connector = GithubConnector(
             repo_owner=self.conf.get("repository_owner"),
             repositories=self.conf.get("repository_name"),
-            include_prs=self.conf.get("include_pull_requests", False),
-            include_issues=self.conf.get("include_issues", False),
+            include_prs=self.conf.get("include_pull_requests", True),
+            include_issues=self.conf.get("include_issues", True),
         )
 
         credentials = self.conf.get("credentials", {})

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -870,18 +870,18 @@ export const DataSourceFormFields = {
       required: true,
     },
     {
-      label: 'Inlcude Pull Requests',
+      label: 'Include Pull Requests',
       name: 'config.include_pull_requests',
       type: FormFieldType.Checkbox,
       required: false,
-      defaultValue: false,
+      defaultValue: true,
     },
     {
-      label: 'Inlcude Issues',
+      label: 'Include Issues',
       name: 'config.include_issues',
       type: FormFieldType.Checkbox,
       required: false,
-      defaultValue: false,
+      defaultValue: true,
     },
   ],
   [DataSourceKey.IMAP]: [
@@ -1354,8 +1354,8 @@ export const DataSourceFormDefaultValues = {
     config: {
       repository_owner: '',
       repository_name: '',
-      include_pull_requests: false,
-      include_issues: false,
+      include_pull_requests: true,
+      include_issues: true,
       credentials: {
         github_access_token: '',
       },


### PR DESCRIPTION
Fixes #13975

## Problem
The GitHub data source connector had both `include_pull_requests` and `include_issues` defaulting to `false` in both the frontend form and the backend sync code. This meant that with the default configuration, **no content was synced at all** from a GitHub repository — silently producing zero results.

Additionally, the form field labels contained a typo: "Inlcude" instead of "Include".

## Solution
- Changed `include_pull_requests` default from `false` to `true` in the frontend form fields and default values
- Changed `include_issues` default from `false` to `true` in the frontend form fields and default values  
- Changed both backend defaults in `sync_data_source.py` from `False` to `True`
- Fixed label typos: "Inlcude Pull Requests" → "Include Pull Requests" and "Inlcude Issues" → "Include Issues"

This makes the GitHub connector consistent with the GitLab connector, which already defaults `include_mrs`, `include_issues`, and `include_code_files` all to `true`.

## Testing
- The connector now syncs both pull requests and issues by default when a new GitHub data source is created
- Users who want to exclude PRs or issues can uncheck the corresponding checkboxes in the form