### PR TITLE
Fix Docker API server restart loop

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       # - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
       - ./entrypoint.sh:/ragflow/entrypoint.sh
+      - ./process_utils.sh:/ragflow/docker/process_utils.sh
     env_file: .env
     networks:
       - ragflow
@@ -91,6 +92,7 @@ services:
       # - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./service_conf.yaml.template:/ragflow/conf/service_conf.yaml.template
       - ./entrypoint.sh:/ragflow/entrypoint.sh
+      - ./process_utils.sh:/ragflow/docker/process_utils.sh
     env_file: .env
     networks:
       - ragflow

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -177,6 +177,7 @@ done < "${TEMPLATE_FILE}"
 
 export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/"
 PY=python3
+source /ragflow/docker/process_utils.sh
 
 # -----------------------------------------------------------------------------
 # Select Nginx Configuration based on API_PROXY_SCHEME
@@ -208,12 +209,8 @@ function task_exe() {
     local host_id="$2"
 
     JEMALLOC_PATH="$(pkg-config --variable=libdir jemalloc)/libjemalloc.so"
-    while true; do
-        LD_PRELOAD="$JEMALLOC_PATH" \
-        "$PY" rag/svr/task_executor.py "${host_id}_${consumer_id}"  &
-        wait;
-        sleep 1;
-    done
+    run_forever "task executor ${host_id}_${consumer_id}" \
+        env LD_PRELOAD="$JEMALLOC_PATH" "$PY" rag/svr/task_executor.py "${host_id}_${consumer_id}"
 }
 
 function start_mcp_server() {
@@ -242,24 +239,6 @@ function ensure_db_init() {
     echo "Database tables initialized."
 }
 
-function wait_for_server() {
-    local url="$1"
-    local server_name="$2"
-    local timeout=90
-    local interval=2
-    local start_time=$(date +%s)
-
-    echo "Waiting for $server_name to be ready at $url..."
-    while ! curl -f -s -o /dev/null "$url"; do
-        if [ $(($(date +%s) - start_time)) -gt $timeout ]; then
-            echo "Timeout waiting for $server_name after $timeout seconds"
-            return 1
-        fi
-        sleep $interval
-    done
-    echo "$server_name is ready."
-}
-
 # -----------------------------------------------------------------------------
 # Start components based on flags
 # -----------------------------------------------------------------------------
@@ -270,51 +249,27 @@ if [[ "${ENABLE_WEBSERVER}" -eq 1 ]]; then
     echo "Starting nginx..."
     /usr/sbin/nginx
 
-    while true; do
-        echo "Attempt to start RAGFlow server..."
-        "$PY" api/ragflow_server.py ${INIT_SUPERUSER_ARGS}
-        echo "RAGFlow python server started."
-        sleep 1;
-    done &
+    run_forever "RAGFlow server" "$PY" api/ragflow_server.py ${INIT_SUPERUSER_ARGS} &
 
     if [[ "${API_PROXY_SCHEME}" == "hybrid" ]]; then
-        while true; do
-            echo "Attempt to start RAGFlow go server..."
-            wait_for_server "http://127.0.0.1:9380/healthz" "ragflow_server"
-            echo "Starting RAGFlow go server..."
-            bin/server_main
-            sleep 1;
-        done &
+        run_forever "RAGFlow go server" bash -lc \
+            'source /ragflow/docker/process_utils.sh; wait_for_server "http://127.0.0.1:9380/healthz" "ragflow_server" && exec bin/server_main' &
     fi
 fi
 
 
 if [[ "${ENABLE_ADMIN_SERVER}" -eq 1 ]]; then
-    while true; do
-        echo "Attempt to start Admin python server..."
-        "$PY" admin/server/admin_server.py
-        echo "Admin python server started"
-        sleep 1;
-    done &
+    run_forever "Admin python server" "$PY" admin/server/admin_server.py &
 
     if [[ "${API_PROXY_SCHEME}" == "hybrid" ]]; then
-        while true; do
-            echo "Attempt to starting Admin go server..."
-            wait_for_server "http://127.0.0.1:9381/api/v1/admin/ping" "admin_server"
-            echo "Starting Admin go server..."
-            bin/admin_server
-            sleep 1;
-        done &
+        run_forever "Admin go server" bash -lc \
+            'source /ragflow/docker/process_utils.sh; wait_for_server "http://127.0.0.1:9381/api/v1/admin/ping" "admin_server" && exec bin/admin_server' &
     fi
 fi
 
 if [[ "${ENABLE_DATASYNC}" -eq 1 ]]; then
     echo "Starting data sync..."
-    while true; do
-        "$PY" rag/svr/sync_data_source.py &
-        wait;
-        sleep 1;
-    done &
+    run_forever "data sync" "$PY" rag/svr/sync_data_source.py &
 fi
 
 if [[ "${ENABLE_MCP_SERVER}" -eq 1 ]]; then

--- a/docker/process_utils.sh
+++ b/docker/process_utils.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+wait_for_server() {
+    local url="$1"
+    local server_name="$2"
+    local timeout=90
+    local interval=2
+    local start_time
+    start_time=$(date +%s)
+
+    echo "Waiting for ${server_name} to be ready at ${url}..."
+    while ! curl -f -s -o /dev/null "$url"; do
+        if [ $(($(date +%s) - start_time)) -gt $timeout ]; then
+            echo "Timeout waiting for ${server_name} after ${timeout} seconds"
+            return 1
+        fi
+        sleep "${interval}"
+    done
+    echo "${server_name} is ready."
+}
+
+run_forever() {
+    local name="$1"
+    local max_restarts="${RUN_FOREVER_MAX_RESTARTS:-0}"
+    local restarts=0
+    shift
+
+    while true; do
+        echo "Starting ${name}..."
+        if "$@"; then
+            exit_code=0
+            echo "${name} exited with code 0"
+        else
+            exit_code=$?
+            echo "${name} exited with code ${exit_code}"
+        fi
+
+        restarts=$((restarts + 1))
+        if [[ "${max_restarts}" -gt 0 && "${restarts}" -ge "${max_restarts}" ]]; then
+            return 0
+        fi
+
+        sleep 1
+    done
+}

--- a/test/unit_test/docker/test_process_utils.py
+++ b/test/unit_test/docker/test_process_utils.py
@@ -1,0 +1,29 @@
+import subprocess
+from pathlib import Path
+import unittest
+
+
+class ProcessUtilsTest(unittest.TestCase):
+    def test_run_forever_restarts_after_failure(self):
+        bash = Path(r"C:\Program Files\Git\bin\bash.exe")
+        self.assertTrue(bash.exists(), "Git Bash is required for this test")
+
+        cmd = [
+            str(bash),
+            "-lc",
+            (
+                "RUN_FOREVER_MAX_RESTARTS=2; "
+                "source docker/process_utils.sh; "
+                "run_forever demo bash -lc 'echo cycle; exit 1'"
+            ),
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.count("Starting demo..."), 2)
+        self.assertEqual(result.stdout.count("demo exited with code 1"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable shell helper for long-running Docker service processes
- make the Docker entrypoint restart the Python API and related services even after non-zero exits under set -e
- mount the new helper into compose and add a regression test for the restart guard

## Test Plan
- python test/unit_test/docker/test_process_utils.py
- docker compose -f docker/docker-compose.yml up -d ragflow-gpu
- verify /v1/user/info and /api/v1/datasets return backend responses instead of 502
- kill api/ragflow_server.py in the container and confirm it is restarted automatically