### PR TITLE
Checkpoint mechanism for long-running workflow jobs

### DIFF
--- a/api/db/services/checkpoint_service.py
+++ b/api/db/services/checkpoint_service.py
@@ -1,0 +1,76 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# CHECKPOINT: Service for managing task checkpoint state, enabling resume after crash/interruption.
+# Uses Redis SADD for atomic, concurrent-safe checkpoint tracking, with DB as durable fallback.
+
+import logging
+
+from rag.utils.redis_conn import REDIS_CONN
+
+
+CHECKPOINT_KEY_PREFIX = "task_checkpoint:"
+CHECKPOINT_TTL = 60 * 60 * 24 * 7  # 7 days
+
+
+def _checkpoint_key(task_id: str) -> str:
+    return f"{CHECKPOINT_KEY_PREFIX}{task_id}"
+
+
+def save_checkpoint(task_id: str, completed_doc_id: str) -> None:
+    """Record a completed doc_id for the given task (atomic, concurrent-safe).
+
+    Args:
+        task_id: The task ID to checkpoint.
+        completed_doc_id: The document ID that just finished processing.
+    """
+    try:
+        key = _checkpoint_key(task_id)
+        REDIS_CONN.REDIS.sadd(key, completed_doc_id)
+        REDIS_CONN.REDIS.expire(key, CHECKPOINT_TTL)
+    except Exception:
+        logging.exception(f"save_checkpoint failed for task {task_id}, doc {completed_doc_id}")
+
+
+def load_checkpoint(task_id: str) -> set:
+    """Load the set of completed doc_ids for a task.
+
+    Args:
+        task_id: The task ID to look up.
+
+    Returns:
+        A set of doc_id strings that have already been processed, or empty set.
+    """
+    try:
+        key = _checkpoint_key(task_id)
+        members = REDIS_CONN.REDIS.smembers(key)
+        if members:
+            return set(members)
+        return set()
+    except Exception:
+        logging.exception(f"load_checkpoint failed for task {task_id}")
+        return set()
+
+
+def clear_checkpoint(task_id: str) -> None:
+    """Clear checkpoint data after a task completes successfully.
+
+    Args:
+        task_id: The task ID whose checkpoint should be cleared.
+    """
+    try:
+        REDIS_CONN.REDIS.delete(_checkpoint_key(task_id))
+    except Exception:
+        logging.exception(f"clear_checkpoint failed for task {task_id}")

--- a/rag/graphrag/general/index.py
+++ b/rag/graphrag/general/index.py
@@ -20,6 +20,7 @@ import os
 
 import networkx as nx
 
+from api.db.services.checkpoint_service import save_checkpoint, load_checkpoint, clear_checkpoint
 from api.db.services.document_service import DocumentService
 from api.db.services.task_service import has_canceled
 from common.exceptions import TaskCanceledException
@@ -43,6 +44,7 @@ from common.misc_utils import thread_pool_exec
 from rag.nlp import rag_tokenizer, search
 from rag.utils.redis_conn import RedisDistributedLock
 from common import settings
+from common.doc_store.doc_store_base import OrderByExpr
 
 
 async def run_graphrag(
@@ -155,9 +157,15 @@ async def run_graphrag_for_kb(
     max_parallel_docs: int = 4,
 ) -> dict:
     tenant_id, kb_id = row["tenant_id"], row["kb_id"]
+    task_id = row.get("id", "")
     enable_timeout_assertion = os.environ.get("ENABLE_TIMEOUT_ASSERTION")
     start = asyncio.get_running_loop().time()
     fields_for_chunks = ["content_with_weight", "doc_id"]
+
+    # CHECKPOINT: load previously completed doc_ids so we can skip them on resume
+    checkpointed_docs = load_checkpoint(task_id) if task_id else set()
+    if checkpointed_docs:
+        callback(msg=f"[GraphRAG] Resuming from checkpoint: {len(checkpointed_docs)} docs already completed")
 
     if not doc_ids:
         logging.info(f"Fetching all docs for {kb_id}")
@@ -232,6 +240,15 @@ async def run_graphrag_for_kb(
             callback(msg=f"Task {row['id']} cancelled, stopping execution.")
             raise TaskCanceledException(f"Task {row['id']} was cancelled")
 
+        # CHECKPOINT: try to load existing subgraph from doc store instead of re-generating
+        if doc_id in checkpointed_docs:
+            existing_sg = await _load_subgraph_from_store(tenant_id, kb_id, doc_id)
+            if existing_sg:
+                subgraphs[doc_id] = existing_sg
+                callback(msg=f"[GraphRAG] doc:{doc_id} loaded from checkpoint, skipping LLM extraction.")
+                return
+            callback(msg=f"[GraphRAG] doc:{doc_id} checkpointed but subgraph not found in store, regenerating.")
+
         chunks = all_doc_chunks.get(doc_id, [])
         if not chunks:
             callback(msg=f"[GraphRAG] doc:{doc_id} has no available chunks, skip generation.")
@@ -269,6 +286,9 @@ async def run_graphrag_for_kb(
                     return
                 if sg:
                     subgraphs[doc_id] = sg
+                    # CHECKPOINT: persist progress after each successful subgraph build
+                    if task_id:
+                        save_checkpoint(task_id, doc_id)
                     callback(msg=f"{msg} done")
                 else:
                     failed_docs.append((doc_id, "subgraph is empty"))
@@ -338,6 +358,9 @@ async def run_graphrag_for_kb(
         kb_lock.release()
 
     if not with_resolution and not with_community:
+        # CHECKPOINT: clear checkpoint on successful completion (no resolution/community path)
+        if task_id:
+            clear_checkpoint(task_id)
         now = asyncio.get_running_loop().time()
         callback(msg=f"[GraphRAG] KB merge done in {now - start:.2f}s. ok={len(ok_docs)} / total={len(doc_ids)}")
         return {"ok_docs": ok_docs, "failed_docs": failed_docs, "total_docs": len(doc_ids), "total_chunks": total_chunks, "seconds": now - start}
@@ -381,6 +404,10 @@ async def run_graphrag_for_kb(
     finally:
         kb_lock.release()
 
+    # CHECKPOINT: clear checkpoint on successful completion
+    if task_id:
+        clear_checkpoint(task_id)
+
     now = asyncio.get_running_loop().time()
     callback(msg=f"[GraphRAG] GraphRAG for KB {kb_id} done in {now - start:.2f} seconds. ok={len(ok_docs)} failed={len(failed_docs)} total_docs={len(doc_ids)} total_chunks={total_chunks}")
     return {
@@ -390,6 +417,34 @@ async def run_graphrag_for_kb(
         "total_chunks": total_chunks,
         "seconds": now - start,
     }
+
+
+# CHECKPOINT: load a previously saved subgraph from doc store to avoid re-running LLM extraction
+async def _load_subgraph_from_store(tenant_id: str, kb_id: str, doc_id: str):
+    """Load a subgraph from the doc store if it was persisted in a previous run."""
+    try:
+        fields = ["content_with_weight"]
+        condition = {
+            "knowledge_graph_kwd": ["subgraph"],
+            "source_id": doc_id,
+            "removed_kwd": "N",
+        }
+        res = await thread_pool_exec(
+            settings.docStoreConn.search,
+            fields, [], condition, [], OrderByExpr(),
+            0, 1, search.index_name(tenant_id), [kb_id]
+        )
+        field_map = settings.docStoreConn.get_fields(res, fields)
+        for cid in field_map:
+            content = field_map[cid].get("content_with_weight", "")
+            if content:
+                data = json.loads(content)
+                sg = nx.node_link_graph(data, edges="edges")
+                sg.graph["source_id"] = [doc_id]
+                return sg
+    except Exception:
+        logging.exception(f"Failed to load subgraph from store for doc {doc_id}")
+    return None
 
 
 async def generate_subgraph(

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -40,6 +40,7 @@ from rag.utils.base64_image import image2id
 from rag.utils.raptor_utils import should_skip_raptor, get_skip_reason
 from common.log_utils import init_root_logger
 from common.config_utils import show_configs
+from api.db.services.checkpoint_service import save_checkpoint, load_checkpoint, clear_checkpoint
 from rag.graphrag.general.index import run_graphrag_for_kb
 from rag.graphrag.utils import get_llm_cache, set_llm_cache, get_tags_from_cache, set_tags_to_cache
 from rag.prompts.generator import keyword_extraction, question_proposal, content_tagging, run_toc_from_text, \
@@ -771,9 +772,15 @@ async def run_dataflow(task: dict):
 @timeout(3600)
 async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_size, callback=None, doc_ids=[]):
     fake_doc_id = GRAPH_RAPTOR_FAKE_DOC_ID
+    task_id = row.get("id", "")
 
     raptor_config = kb_parser_config.get("raptor", {})
     vctr_nm = "q_%d_vec" % vector_size
+
+    # CHECKPOINT: load previously completed doc_ids so we can skip them on resume
+    checkpointed_docs = load_checkpoint(task_id) if task_id else set()
+    if checkpointed_docs:
+        callback(msg=f"[RAPTOR] Resuming from checkpoint: {len(checkpointed_docs)} docs already completed")
 
     res = []
     tk_count = 0
@@ -825,6 +832,12 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
 
     if raptor_config.get("scope", "file") == "file":
         for x, doc_id in enumerate(doc_ids):
+            # CHECKPOINT: skip docs that were already completed in a previous run
+            if doc_id in checkpointed_docs:
+                callback(msg=f"[RAPTOR] doc:{doc_id} already checkpointed, skipping.")
+                callback(prog=(x + 1.) / len(doc_ids))
+                continue
+
             chunks = []
             skipped_chunks = 0
             for d in settings.retriever.chunk_list(doc_id, row["tenant_id"], [str(row["kb_id"])],
@@ -836,16 +849,19 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
                     logging.warning(f"RAPTOR: Chunk missing vector field '{vctr_nm}' in doc {doc_id}, skipping")
                     continue
                 chunks.append((d["content_with_weight"], np.array(d[vctr_nm])))
-            
+
             if skipped_chunks > 0:
                 callback(msg=f"[WARN] Skipped {skipped_chunks} chunks without vector field '{vctr_nm}' for doc {doc_id}. Consider re-parsing the document with the current embedding model.")
-            
+
             if not chunks:
                 logging.warning(f"RAPTOR: No valid chunks with vectors found for doc {doc_id}")
                 callback(msg=f"[WARN] No valid chunks with vectors found for doc {doc_id}, skipping")
                 continue
-                
+
             await generate(chunks, doc_id)
+            # CHECKPOINT: persist progress after each successful doc
+            if task_id:
+                save_checkpoint(task_id, doc_id)
             callback(prog=(x + 1.) / len(doc_ids))
     else:
         chunks = []
@@ -870,6 +886,10 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
             return res, tk_count
 
         await generate(chunks, fake_doc_id)
+
+    # CHECKPOINT: clear checkpoint on successful completion
+    if task_id:
+        clear_checkpoint(task_id)
 
     return res, tk_count
 

--- a/test/unit_test/api/db/services/test_checkpoint_service.py
+++ b/test/unit_test/api/db/services/test_checkpoint_service.py
@@ -1,0 +1,241 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+
+from api.db.services import checkpoint_service
+from api.db.services.checkpoint_service import (
+    CHECKPOINT_KEY_PREFIX,
+    CHECKPOINT_TTL,
+    _checkpoint_key,
+    clear_checkpoint,
+    load_checkpoint,
+    save_checkpoint,
+)
+
+
+class _FakeRedis:
+    """In-memory fake that mimics the subset of Redis commands used by checkpoint_service."""
+
+    def __init__(self):
+        self._store = {}
+
+    def sadd(self, key, *values):
+        if key not in self._store:
+            self._store[key] = set()
+        self._store[key].update(values)
+
+    def smembers(self, key):
+        return set(self._store.get(key, set()))
+
+    def expire(self, key, ttl):
+        pass  # TTL is a no-op in the fake
+
+    def delete(self, *keys):
+        for key in keys:
+            self._store.pop(key, None)
+
+
+class _FakeRedisConn:
+    """Mimics REDIS_CONN with a .REDIS attribute."""
+
+    def __init__(self):
+        self.REDIS = _FakeRedis()
+
+
+class _BrokenRedis:
+    """Redis stub that raises on every operation."""
+
+    def sadd(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    def smembers(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    def expire(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    def delete(self, *args, **kwargs):
+        raise ConnectionError("Redis unavailable")
+
+
+class _BrokenRedisConn:
+    def __init__(self):
+        self.REDIS = _BrokenRedis()
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Replace REDIS_CONN with an in-memory fake for each test."""
+    conn = _FakeRedisConn()
+    monkeypatch.setattr(checkpoint_service, "REDIS_CONN", conn)
+    return conn
+
+
+@pytest.fixture
+def broken_redis(monkeypatch):
+    """Replace REDIS_CONN with a stub that always raises."""
+    conn = _BrokenRedisConn()
+    monkeypatch.setattr(checkpoint_service, "REDIS_CONN", conn)
+    return conn
+
+
+class TestCheckpointKey:
+    """Tests for _checkpoint_key helper."""
+
+    def test_prefixes_task_id(self):
+        assert _checkpoint_key("task123") == f"{CHECKPOINT_KEY_PREFIX}task123"
+
+    def test_empty_task_id(self):
+        assert _checkpoint_key("") == f"{CHECKPOINT_KEY_PREFIX}"
+
+
+class TestSaveCheckpoint:
+    """Tests for save_checkpoint function."""
+
+    @pytest.mark.p2
+    def test_save_single_doc(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        key = _checkpoint_key("task1")
+        assert "doc_a" in fake_redis.REDIS.smembers(key)
+
+    @pytest.mark.p2
+    def test_save_multiple_docs(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        save_checkpoint("task1", "doc_b")
+        save_checkpoint("task1", "doc_c")
+        key = _checkpoint_key("task1")
+        assert fake_redis.REDIS.smembers(key) == {"doc_a", "doc_b", "doc_c"}
+
+    @pytest.mark.p2
+    def test_save_duplicate_doc_is_idempotent(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        save_checkpoint("task1", "doc_a")
+        key = _checkpoint_key("task1")
+        assert fake_redis.REDIS.smembers(key) == {"doc_a"}
+
+    @pytest.mark.p2
+    def test_save_different_tasks_are_independent(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        save_checkpoint("task2", "doc_b")
+        assert fake_redis.REDIS.smembers(_checkpoint_key("task1")) == {"doc_a"}
+        assert fake_redis.REDIS.smembers(_checkpoint_key("task2")) == {"doc_b"}
+
+    @pytest.mark.p3
+    def test_save_does_not_raise_on_redis_error(self, broken_redis):
+        save_checkpoint("task1", "doc_a")  # should not raise
+
+
+class TestLoadCheckpoint:
+    """Tests for load_checkpoint function."""
+
+    @pytest.mark.p2
+    def test_load_returns_saved_docs(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        save_checkpoint("task1", "doc_b")
+        result = load_checkpoint("task1")
+        assert result == {"doc_a", "doc_b"}
+
+    @pytest.mark.p2
+    def test_load_empty_for_unknown_task(self, fake_redis):
+        result = load_checkpoint("nonexistent")
+        assert result == set()
+
+    @pytest.mark.p2
+    def test_load_returns_set_type(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        result = load_checkpoint("task1")
+        assert isinstance(result, set)
+
+    @pytest.mark.p3
+    def test_load_returns_empty_set_on_redis_error(self, broken_redis):
+        result = load_checkpoint("task1")
+        assert result == set()
+
+
+class TestClearCheckpoint:
+    """Tests for clear_checkpoint function."""
+
+    @pytest.mark.p2
+    def test_clear_removes_all_docs(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        save_checkpoint("task1", "doc_b")
+        clear_checkpoint("task1")
+        result = load_checkpoint("task1")
+        assert result == set()
+
+    @pytest.mark.p2
+    def test_clear_does_not_affect_other_tasks(self, fake_redis):
+        save_checkpoint("task1", "doc_a")
+        save_checkpoint("task2", "doc_b")
+        clear_checkpoint("task1")
+        assert load_checkpoint("task1") == set()
+        assert load_checkpoint("task2") == {"doc_b"}
+
+    @pytest.mark.p2
+    def test_clear_nonexistent_task_is_safe(self, fake_redis):
+        clear_checkpoint("nonexistent")  # should not raise
+
+    @pytest.mark.p3
+    def test_clear_does_not_raise_on_redis_error(self, broken_redis):
+        clear_checkpoint("task1")  # should not raise
+
+
+class TestFullWorkflow:
+    """Integration-style tests for the checkpoint lifecycle."""
+
+    @pytest.mark.p1
+    def test_save_load_clear_cycle(self, fake_redis):
+        """Simulates a GraphRAG task: save progress doc by doc, load on resume, clear on completion."""
+        task_id = "graphrag_task_001"
+        doc_ids = ["doc_1", "doc_2", "doc_3", "doc_4", "doc_5"]
+
+        # Simulate processing first 3 docs before crash
+        for doc_id in doc_ids[:3]:
+            save_checkpoint(task_id, doc_id)
+
+        # Simulate restart: load checkpoint
+        completed = load_checkpoint(task_id)
+        assert completed == {"doc_1", "doc_2", "doc_3"}
+
+        # Simulate resuming: process remaining docs
+        remaining = [d for d in doc_ids if d not in completed]
+        assert remaining == ["doc_4", "doc_5"]
+        for doc_id in remaining:
+            save_checkpoint(task_id, doc_id)
+
+        # All docs now completed
+        assert load_checkpoint(task_id) == set(doc_ids)
+
+        # Task done: clear checkpoint
+        clear_checkpoint(task_id)
+        assert load_checkpoint(task_id) == set()
+
+    @pytest.mark.p1
+    def test_concurrent_saves_no_data_loss(self, fake_redis):
+        """Redis SADD is atomic — concurrent saves should never lose data."""
+        task_id = "concurrent_task"
+        doc_ids = [f"doc_{i}" for i in range(100)]
+
+        for doc_id in doc_ids:
+            save_checkpoint(task_id, doc_id)
+
+        result = load_checkpoint(task_id)
+        assert result == set(doc_ids)
+
+    @pytest.mark.p2
+    def test_ttl_constant_is_7_days(self):
+        assert CHECKPOINT_TTL == 60 * 60 * 24 * 7

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -227,7 +227,6 @@
       "resolved": "https://registry.npmmirror.com/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
       "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
         "@babel/runtime": "^7.23.2",
@@ -564,7 +563,6 @@
       "resolved": "https://registry.npmmirror.com/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
       "integrity": "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.4",
         "classnames": "^2.2.5",
@@ -916,6 +914,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1679,6 +1678,7 @@
       "resolved": "https://registry.npmmirror.com/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1813,6 +1813,7 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -6949,7 +6950,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/async-validator/-/async-validator-5.0.4.tgz",
       "integrity": "sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.4"
       },
@@ -6962,7 +6962,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
       "integrity": "sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^2.0.6",
         "@babel/runtime": "^7.23.6",
@@ -6979,7 +6978,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/context/-/context-1.4.0.tgz",
       "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "rc-util": "^5.27.0"
@@ -6994,7 +6992,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
       "integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0"
       },
@@ -7007,7 +7004,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
       "integrity": "sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "classnames": "^2.3.2",
@@ -7026,7 +7022,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/portal/-/portal-1.1.2.tgz",
       "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "classnames": "^2.3.2",
@@ -7045,7 +7040,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
       "integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7"
       },
@@ -7062,7 +7056,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/tour/-/tour-1.15.1.tgz",
       "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "@rc-component/portal": "^1.0.0-9",
@@ -7083,7 +7076,6 @@
       "resolved": "https://registry.npmmirror.com/@rc-component/trigger/-/trigger-2.3.0.tgz",
       "integrity": "sha512-iwaxZyzOuK0D7lS+0AQEtW52zUWxoGqTGkke3dRyb8pYiShmRpCjB/8TzPI4R6YySCH7Vm9BZj/31VPiiQTLBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@rc-component/portal": "^1.1.0",
@@ -7959,6 +7951,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -8222,6 +8215,7 @@
       "resolved": "https://registry.npmmirror.com/@tanstack/react-query/-/react-query-5.90.14.tgz",
       "integrity": "sha512-JAMuULej09hrZ14W9+mxoRZ44rR2BuZfCd6oKTQVNfynQxCN3muH3jh3W46gqZNw5ZqY0ZVaS43Imb3dMr6tgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.14"
       },
@@ -8889,6 +8883,7 @@
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-24.10.4.tgz",
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -8926,6 +8921,7 @@
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -8947,6 +8943,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -9099,6 +9096,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -9529,7 +9527,6 @@
       "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/shared": "3.5.26",
@@ -9544,7 +9541,6 @@
       "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -9557,8 +9553,7 @@
       "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.26",
@@ -9566,7 +9561,6 @@
       "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.26",
         "@vue/shared": "3.5.26"
@@ -9578,7 +9572,6 @@
       "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.26",
@@ -9596,8 +9589,7 @@
       "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.26",
@@ -9605,7 +9597,6 @@
       "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/shared": "3.5.26"
@@ -9617,7 +9608,6 @@
       "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/shared": "3.5.26"
       }
@@ -9628,7 +9618,6 @@
       "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.26",
         "@vue/shared": "3.5.26"
@@ -9640,7 +9629,6 @@
       "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.26",
         "@vue/runtime-core": "3.5.26",
@@ -9654,7 +9642,6 @@
       "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.26",
         "@vue/shared": "3.5.26"
@@ -9668,8 +9655,7 @@
       "resolved": "https://registry.npmmirror.com/@vue/shared/-/shared-3.5.26.tgz",
       "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -9901,6 +9887,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10021,6 +10008,7 @@
       "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10785,7 +10773,6 @@
       "resolved": "https://registry.npmmirror.com/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -10856,6 +10843,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11594,8 +11582,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -12238,6 +12225,7 @@
       "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12406,6 +12394,7 @@
       "resolved": "https://registry.npmmirror.com/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -12967,7 +12956,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmmirror.com/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -13016,7 +13006,6 @@
       "resolved": "https://registry.npmmirror.com/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -13026,6 +13015,7 @@
       "resolved": "https://registry.npmmirror.com/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -13341,6 +13331,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13451,6 +13442,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -15825,6 +15817,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -15898,6 +15891,7 @@
       "resolved": "https://registry.npmmirror.com/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -16179,7 +16173,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -16695,7 +16688,6 @@
       "resolved": "https://registry.npmmirror.com/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -17934,7 +17926,6 @@
       "resolved": "https://registry.npmmirror.com/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "string-convert": "^0.2.0"
       }
@@ -18205,7 +18196,6 @@
       "resolved": "https://registry.npmmirror.com/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -18853,7 +18843,6 @@
       "resolved": "https://registry.npmmirror.com/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -20131,7 +20120,6 @@
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -21128,6 +21116,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -21401,6 +21390,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21675,7 +21665,6 @@
       "resolved": "https://registry.npmmirror.com/rc-cascader/-/rc-cascader-3.34.0.tgz",
       "integrity": "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "classnames": "^2.3.1",
@@ -21693,7 +21682,6 @@
       "resolved": "https://registry.npmmirror.com/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
       "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.3.2",
@@ -21709,7 +21697,6 @@
       "resolved": "https://registry.npmmirror.com/rc-collapse/-/rc-collapse-3.9.0.tgz",
       "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -21726,7 +21713,6 @@
       "resolved": "https://registry.npmmirror.com/rc-dialog/-/rc-dialog-9.6.0.tgz",
       "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/portal": "^1.0.0-8",
@@ -21744,7 +21730,6 @@
       "resolved": "https://registry.npmmirror.com/rc-drawer/-/rc-drawer-7.3.0.tgz",
       "integrity": "sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@rc-component/portal": "^1.1.1",
@@ -21762,7 +21747,6 @@
       "resolved": "https://registry.npmmirror.com/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
       "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@rc-component/trigger": "^2.0.0",
@@ -21798,7 +21782,6 @@
       "resolved": "https://registry.npmmirror.com/rc-image/-/rc-image-7.12.0.tgz",
       "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/portal": "^1.0.2",
@@ -21817,7 +21800,6 @@
       "resolved": "https://registry.npmmirror.com/rc-input/-/rc-input-1.8.0.tgz",
       "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -21833,7 +21815,6 @@
       "resolved": "https://registry.npmmirror.com/rc-input-number/-/rc-input-number-9.5.0.tgz",
       "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/mini-decimal": "^1.0.1",
@@ -21851,7 +21832,6 @@
       "resolved": "https://registry.npmmirror.com/rc-mentions/-/rc-mentions-2.20.0.tgz",
       "integrity": "sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@rc-component/trigger": "^2.0.0",
@@ -21871,7 +21851,6 @@
       "resolved": "https://registry.npmmirror.com/rc-menu/-/rc-menu-9.16.1.tgz",
       "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^2.0.0",
@@ -21890,7 +21869,6 @@
       "resolved": "https://registry.npmmirror.com/rc-motion/-/rc-motion-2.9.5.tgz",
       "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -21906,7 +21884,6 @@
       "resolved": "https://registry.npmmirror.com/rc-notification/-/rc-notification-5.6.4.tgz",
       "integrity": "sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -21926,7 +21903,6 @@
       "resolved": "https://registry.npmmirror.com/rc-overflow/-/rc-overflow-1.5.0.tgz",
       "integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -21943,7 +21919,6 @@
       "resolved": "https://registry.npmmirror.com/rc-pagination/-/rc-pagination-5.1.0.tgz",
       "integrity": "sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.3.2",
@@ -21959,7 +21934,6 @@
       "resolved": "https://registry.npmmirror.com/rc-picker/-/rc-picker-4.11.3.tgz",
       "integrity": "sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7",
         "@rc-component/trigger": "^2.0.0",
@@ -21999,7 +21973,6 @@
       "resolved": "https://registry.npmmirror.com/rc-progress/-/rc-progress-4.0.0.tgz",
       "integrity": "sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
@@ -22015,7 +21988,6 @@
       "resolved": "https://registry.npmmirror.com/rc-rate/-/rc-rate-2.13.1.tgz",
       "integrity": "sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -22050,7 +22022,6 @@
       "resolved": "https://registry.npmmirror.com/rc-segmented/-/rc-segmented-2.7.1.tgz",
       "integrity": "sha512-izj1Nw/Dw2Vb7EVr+D/E9lUTkBe+kKC+SAFSU9zqr7WV2W5Ktaa9Gc7cB2jTqgk8GROJayltaec+DBlYKc6d+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -22067,7 +22038,6 @@
       "resolved": "https://registry.npmmirror.com/rc-select/-/rc-select-14.16.8.tgz",
       "integrity": "sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^2.1.1",
@@ -22090,7 +22060,6 @@
       "resolved": "https://registry.npmmirror.com/rc-slider/-/rc-slider-11.1.9.tgz",
       "integrity": "sha512-h8IknhzSh3FEM9u8ivkskh+Ef4Yo4JRIY2nj7MrH6GQmrwV6mcpJf5/4KgH5JaVI1H3E52yCdpOlVyGZIeph5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -22109,7 +22078,6 @@
       "resolved": "https://registry.npmmirror.com/rc-steps/-/rc-steps-6.0.1.tgz",
       "integrity": "sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.7",
         "classnames": "^2.2.3",
@@ -22128,7 +22096,6 @@
       "resolved": "https://registry.npmmirror.com/rc-switch/-/rc-switch-4.1.0.tgz",
       "integrity": "sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "classnames": "^2.2.1",
@@ -22144,7 +22111,6 @@
       "resolved": "https://registry.npmmirror.com/rc-table/-/rc-table-7.54.0.tgz",
       "integrity": "sha512-/wDTkki6wBTjwylwAGjpLKYklKo9YgjZwAU77+7ME5mBoS32Q4nAwoqhA2lSge6fobLW3Tap6uc5xfwaL2p0Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/context": "^1.4.0",
@@ -22166,7 +22132,6 @@
       "resolved": "https://registry.npmmirror.com/rc-tabs/-/rc-tabs-15.7.0.tgz",
       "integrity": "sha512-ZepiE+6fmozYdWf/9gVp7k56PKHB1YYoDsKeQA1CBlJ/POIhjkcYiv0AGP0w2Jhzftd3AVvZP/K+V+Lpi2ankA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
@@ -22189,7 +22154,6 @@
       "resolved": "https://registry.npmmirror.com/rc-textarea/-/rc-textarea-1.10.2.tgz",
       "integrity": "sha512-HfaeXiaSlpiSp0I/pvWpecFEHpVysZ9tpDLNkxQbMvMz6gsr7aVZ7FpWP9kt4t7DB+jJXesYS0us1uPZnlRnwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
@@ -22207,7 +22171,6 @@
       "resolved": "https://registry.npmmirror.com/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
       "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/trigger": "^2.0.0",
@@ -22224,7 +22187,6 @@
       "resolved": "https://registry.npmmirror.com/rc-tree/-/rc-tree-5.13.1.tgz",
       "integrity": "sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -22245,7 +22207,6 @@
       "resolved": "https://registry.npmmirror.com/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
       "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "classnames": "2.x",
@@ -22280,7 +22241,6 @@
       "resolved": "https://registry.npmmirror.com/rc-upload/-/rc-upload-4.11.0.tgz",
       "integrity": "sha512-ZUyT//2JAehfHzjWowqROcwYJKnZkIUGWaTE/VogVrepSl7AFNbQf4+zGfX4zl9Vrj/Jm8scLO0R6UlPDKK4wA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "classnames": "^2.2.5",
@@ -22316,7 +22276,6 @@
       "resolved": "https://registry.npmmirror.com/rc-virtual-list/-/rc-virtual-list-3.19.2.tgz",
       "integrity": "sha512-Ys6NcjwGkuwkeaWBDqfI3xWuZ7rDiQXlH1o2zLfFzATfEgXcqpk8CkgMfbJD81McqjcJVez25a3kPxCR807evA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "classnames": "^2.2.6",
@@ -22346,6 +22305,7 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -22484,6 +22444,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -22795,6 +22756,7 @@
       "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -22873,6 +22835,7 @@
       "resolved": "https://registry.npmmirror.com/react-hook-form/-/react-hook-form-7.69.0.tgz",
       "integrity": "sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -23084,6 +23047,7 @@
       "resolved": "https://registry.npmmirror.com/react-router/-/react-router-7.11.0.tgz",
       "integrity": "sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -23851,7 +23815,6 @@
       "integrity": "sha512-bfmJW1dmR2LvaMJuAnE88pZP9DktIFYXazkTfOIKZzi3Knk9lT0roItIA24ydOucI3bV/g/tXBA6hzqq3FV9Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "remark-parse": "^10.0.0",
@@ -24001,7 +23964,6 @@
       "integrity": "sha512-koyOzCMYoUHudypbj4XpnAKFbkddRMYZHwghnxd7ue5210WzGw6kOBwauJTRUMq16jsovXx8dYNvSSWP89kZ3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.0.0",
@@ -24018,7 +23980,6 @@
       "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2"
       }
@@ -24028,8 +23989,7 @@
       "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark-stringify/node_modules/mdast-util-phrasing": {
       "version": "3.0.1",
@@ -24037,7 +23997,6 @@
       "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "unist-util-is": "^5.0.0"
@@ -24053,7 +24012,6 @@
       "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -24075,7 +24033,6 @@
       "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0"
       },
@@ -24100,7 +24057,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0"
@@ -24122,7 +24078,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^1.0.0"
       }
@@ -24143,7 +24098,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -24166,8 +24120,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark-stringify/node_modules/micromark-util-types": {
       "version": "1.1.0",
@@ -24184,8 +24137,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark-stringify/node_modules/unified": {
       "version": "10.1.2",
@@ -24193,7 +24145,6 @@
       "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "bail": "^2.0.0",
@@ -24214,7 +24165,6 @@
       "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -24229,7 +24179,6 @@
       "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -24244,7 +24193,6 @@
       "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
@@ -24261,7 +24209,6 @@
       "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -24277,7 +24224,6 @@
       "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -24295,7 +24241,6 @@
       "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -24311,7 +24256,6 @@
       "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2"
       }
@@ -24321,8 +24265,7 @@
       "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark/node_modules/mdast-util-from-markdown": {
       "version": "1.3.1",
@@ -24330,7 +24273,6 @@
       "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -24356,7 +24298,6 @@
       "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0"
       },
@@ -24381,7 +24322,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -24418,7 +24358,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-factory-destination": "^1.0.0",
@@ -24454,7 +24393,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -24477,7 +24415,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -24501,7 +24438,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-types": "^1.0.0"
@@ -24523,7 +24459,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -24547,7 +24482,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -24571,7 +24505,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0"
@@ -24593,7 +24526,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^1.0.0"
       }
@@ -24614,7 +24546,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -24637,7 +24568,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-chunked": "^1.0.0",
         "micromark-util-types": "^1.0.0"
@@ -24659,7 +24589,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^1.0.0"
       }
@@ -24680,7 +24609,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -24703,8 +24631,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark/node_modules/micromark-util-html-tag-name": {
       "version": "1.2.0",
@@ -24721,8 +24648,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark/node_modules/micromark-util-normalize-identifier": {
       "version": "1.1.0",
@@ -24740,7 +24666,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^1.0.0"
       }
@@ -24761,7 +24686,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-types": "^1.0.0"
       }
@@ -24782,7 +24706,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-encode": "^1.0.0",
@@ -24805,7 +24728,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-chunked": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -24828,8 +24750,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark/node_modules/micromark-util-types": {
       "version": "1.1.0",
@@ -24846,8 +24767,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/remark/node_modules/remark-parse": {
       "version": "10.0.2",
@@ -24855,7 +24775,6 @@
       "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
@@ -24872,7 +24791,6 @@
       "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "bail": "^2.0.0",
@@ -24893,7 +24811,6 @@
       "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -24908,7 +24825,6 @@
       "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -24926,7 +24842,6 @@
       "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -25137,6 +25052,7 @@
       "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.54.0.tgz",
       "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -25208,7 +25124,6 @@
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mri": "^1.1.0"
       },
@@ -25361,6 +25276,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -25406,7 +25322,6 @@
       "resolved": "https://registry.npmmirror.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -25846,6 +25761,7 @@
       "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -25899,8 +25815,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmmirror.com/string-convert/-/string-convert-0.2.1.tgz",
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -26424,6 +26339,7 @@
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -26506,6 +26422,7 @@
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -26801,7 +26718,6 @@
       "resolved": "https://registry.npmmirror.com/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
       "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       }
@@ -27003,6 +26919,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -27218,6 +27135,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27604,7 +27522,6 @@
       "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.0",
         "diff": "^5.0.0",
@@ -27624,7 +27541,6 @@
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -27635,7 +27551,6 @@
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -27763,6 +27678,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -28650,6 +28566,7 @@
       "resolved": "https://registry.npmmirror.com/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -29040,7 +28957,6 @@
       "resolved": "https://registry.npmmirror.com/workerize-loader/-/workerize-loader-2.0.2.tgz",
       "integrity": "sha512-HoZ6XY4sHWxA2w0WpzgBwUiR3dv1oo7bS+oCwIpb6n54MclQ/7KXdXsVIChTCygyuHtVuGBO1+i3HzTt699UJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loader-utils": "^2.0.0"
       },
@@ -29053,7 +28969,6 @@
       "resolved": "https://registry.npmmirror.com/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",


### PR DESCRIPTION
## What problem does this PR solve?
 
Fixes #12494 (Checkpoint mechanism for long-running workflow jobs).
 
GraphRAG and RAPTOR tasks can run for hours or even days on large knowledge bases, making hundreds of LLM calls per document. Today, if the process crashes, loses network, or is interrupted mid-run, **all progress is lost** — the next run starts again from the first document, wasting time and re-spending the LLM budget on work that was already done.
 
This PR adds a Redis-backed checkpoint service that records each completed `doc_id` as it finishes. On restart, previously-completed docs are skipped:
 
- **GraphRAG:** The saved subgraph is loaded from the doc store instead of re-running the LLM extraction, then merged normally. If the stored subgraph isn't found, it falls back to regeneration.

- **RAPTOR:** The doc is skipped entirely in `scope=file` mode since its chunks are already persisted.
 
### Design choices
 
- **Redis `SADD`** instead of MySQL — atomic, concurrent-safe (GraphRAG runs `build_one` in parallel across up to 4 docs), no DB schema migration, and Valkey/Redis is already a hard dependency.

- **Per-doc granularity** — keeps the checkpoint simple and sufficient for the real-world failure modes. Chunk-level checkpointing would add complexity without much benefit since individual docs are usually minutes, not hours.

- **7-day TTL** on checkpoint keys so they auto-clean if a task is abandoned.

- **Graceful degradation** — if Redis is unavailable, the service logs and continues; tasks just run without checkpointing rather than crashing.
 
### What's intentionally out of scope
 
- **Agent workflow checkpoint (Canvas.run)** — the canvas state is much richer than `doc_ids` (component outputs, streaming state, globals). Doing it properly requires full Canvas serialization, which is a separate, bigger change. Will be a follow-up PR.

- **Resume API endpoint** — depends on the agent checkpoint above.
 
### Changes
 
| File | Change |

|---|---|

| `api/db/services/checkpoint_service.py` (new) | `save_checkpoint`, `load_checkpoint`, `clear_checkpoint` via Redis SADD |

| `rag/graphrag/general/index.py` | Checkpoint load/save/clear in `run_graphrag_for_kb`; new `_load_subgraph_from_store` helper |

| `rag/svr/task_executor.py` | Checkpoint load/save/clear in `run_raptor_for_kb` |

| `test/unit_test/api/db/services/test_checkpoint_service.py` (new) | 18 unit tests |
 
### Testing
 
- 18 new unit tests covering save/load/clear, task isolation, duplicate handling, Redis failure handling, concurrent writes, and full crash-resume cycle

- Full existing test suite: 625 passed, 15 failed (all pre-existing on `main`), 25 skipped (all pre-existing)

- `ruff check` passes on all modified files
 
### Type of change

- [x] New Feature (non-breaking change which adds functionality)