### PR TITLE
Fix: replace eval() on tag_feas to prevent code injection

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -267,6 +267,53 @@ class Dealer:
 
         return res, seted
 
+    @staticmethod
+    def _extract_tag_feas(chunk_id, fields):
+        """Return TAG_FLD for a chunk as a sanitized ``{tag: number}`` dict, or
+        ``None`` if the field is missing or malformed. Callers should treat
+        ``None`` as "skip this chunk's rank-feature contribution".
+
+        Security invariant: TAG_FLD originates from the chunk create/update
+        API, which accepts it from request bodies with no schema validation.
+        Its contents must therefore be treated as untrusted — this function
+        must NEVER ``eval()`` / ``exec()`` its input, and must never fall
+        back to a code-evaluating parser such as ``ast.literal_eval()``.
+
+        Expected backend shapes:
+          * Elasticsearch / OpenSearch: native dict from the ``_source``
+            response, passed through unchanged by ``get_fields``.
+          * Infinity: native dict from the ``_feas`` read path, which
+            ``json.loads``-decodes during column post-processing. A
+            type-confused writer that supplied a bare string at ingestion
+            can still produce a string here, since ``json.dumps`` /
+            ``json.loads`` round-trip strings faithfully.
+          * OceanBase: JSON column returned by the driver as a raw string.
+
+        Accepts (a) a dict directly, or (b) a string that parses as JSON to
+        a dict. Everything else (non-dict JSON, malformed JSON, Python-repr
+        strings, raw non-string-non-dict values) is logged and rejected.
+        Values inside the dict are filtered to numbers so downstream
+        arithmetic can't be tripped by a poisoned score (e.g. a string that
+        would trigger string repetition).
+        """
+        raw = fields[chunk_id].get(TAG_FLD)
+        if not raw:
+            return None
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                logging.warning("Malformed %s for chunk %s; skipping", TAG_FLD, chunk_id)
+                return None
+        if not isinstance(raw, dict):
+            logging.warning("Unexpected %s type %s for chunk %s; skipping",
+                            TAG_FLD, type(raw).__name__, chunk_id)
+            return None
+        # bool is a subclass of int; explicitly exclude it so True/False can't
+        # pose as scores.
+        return {t: sc for t, sc in raw.items()
+                if isinstance(sc, (int, float)) and not isinstance(sc, bool)}
+
     def _rank_feature_scores(self, query_rfea, search_res):
         ## For rank feature(tag_fea) scores.
         rank_fea = []
@@ -281,10 +328,11 @@ class Dealer:
         q_denor = np.sqrt(np.sum([s * s for t, s in query_rfea.items() if t != PAGERANK_FLD]))
         for i in search_res.ids:
             nor, denor = 0, 0
-            if not search_res.field[i].get(TAG_FLD):
+            tag_feas = self._extract_tag_feas(i, search_res.field)
+            if tag_feas is None:
                 rank_fea.append(0)
                 continue
-            for t, sc in eval(search_res.field[i].get(TAG_FLD, "{}")).items():
+            for t, sc in tag_feas.items():
                 if t in query_rfea:
                     nor += query_rfea[t] * sc
                 denor += sc * sc

--- a/rag/utils/es_conn.py
+++ b/rag/utils/es_conn.py
@@ -601,6 +601,17 @@ class ESConnection(ESConnectionBase):
                 if n == "available_int" and isinstance(v, (int, float)):
                     m[n] = v
                     continue
+                # TAG_FLD is stored in ES as a rank_features object and comes
+                # back in _source as a native dict. Keep it a dict — the
+                # scorer in rag/nlp/search.py needs structured access to
+                # iterate tags and their weights. Previously this fell into
+                # the str() branch below, producing a single-quoted Python
+                # repr that only eval() could parse back; replacing eval()
+                # with json.loads means that path no longer round-trips, so
+                # we must avoid stringifying the dict in the first place.
+                if n == TAG_FLD and isinstance(v, dict):
+                    m[n] = v
+                    continue
                 if not isinstance(v, str):
                     m[n] = str(m[n])
                 # if n.find("tks") > 0:

--- a/rag/utils/opensearch_conn.py
+++ b/rag/utils/opensearch_conn.py
@@ -591,6 +591,17 @@ class OSConnection(DocStoreConnection):
                 if isinstance(v, list):
                     m[n] = v
                     continue
+                # TAG_FLD is stored as a rank_features object and comes back
+                # in _source as a native dict. Keep it a dict — the scorer
+                # in rag/nlp/search.py needs structured access to iterate
+                # tags and their weights. Previously this fell into the
+                # str() branch below, producing a single-quoted Python repr
+                # that only eval() could parse back; replacing eval() with
+                # json.loads means that path no longer round-trips, so we
+                # must avoid stringifying the dict in the first place.
+                if n == TAG_FLD and isinstance(v, dict):
+                    m[n] = v
+                    continue
                 if not isinstance(v, str):
                     m[n] = str(m[n])
                 # if n.find("tks") > 0:

--- a/test/unit_test/rag/test_search.py
+++ b/test/unit_test/rag/test_search.py
@@ -1,0 +1,214 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Unit tests for rag.nlp.search.
+
+The primary focus is regression coverage for the ``tag_feas`` RCE fix. The
+``TAG_FLD`` value reaching ``_rank_feature_scores`` is ultimately attacker-
+controllable via the chunk create/update API and at one point was passed to
+``eval()``. These tests pin the replacement ``_extract_tag_feas`` helper to
+its defensive contract so a future refactor can't re-introduce a code-eval
+sink silently.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from common.constants import PAGERANK_FLD, TAG_FLD
+from rag.nlp.search import Dealer
+
+# Critical-priority: these tests guard against re-introducing an RCE sink.
+# Matches the precedent set by test/unit_test/rag/prompts/test_generator_sandbox.py,
+# which is the closest analogue (also a security-sanitizer regression suite).
+pytestmark = pytest.mark.p1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mk_fields(**chunks):
+    """Build a `search_res.field`-shaped mapping: {chunk_id: {col: value, ...}}."""
+    return dict(chunks)
+
+
+def _mk_search_res(field):
+    """Build a minimal SearchResult the scorer will accept."""
+    return Dealer.SearchResult(total=len(field), ids=list(field.keys()), field=field)
+
+
+def _bare_dealer():
+    """Dealer instance without running __init__ (avoids pulling in the tokenizer)."""
+    return object.__new__(Dealer)
+
+
+# ---------------------------------------------------------------------------
+# _extract_tag_feas — sanitization contract
+# ---------------------------------------------------------------------------
+
+class TestExtractTagFeas:
+    """The helper must return a sanitized ``{str: number}`` dict or ``None``,
+    and must NEVER evaluate attacker-supplied content as code."""
+
+    def test_dict_passthrough(self):
+        fields = _mk_fields(c1={TAG_FLD: {"sec": 10, "perf": 2.5}})
+        assert Dealer._extract_tag_feas("c1", fields) == {"sec": 10, "perf": 2.5}
+
+    def test_dict_filters_non_numeric_values(self):
+        fields = _mk_fields(c1={TAG_FLD: {"ok": 1, "bad": "x", "also_bad": [1, 2]}})
+        assert Dealer._extract_tag_feas("c1", fields) == {"ok": 1}
+
+    def test_bool_values_rejected(self):
+        # bool is a subclass of int; we explicitly exclude True/False so a
+        # poisoned score can't pose as 1/0.
+        fields = _mk_fields(c1={TAG_FLD: {"flag_t": True, "flag_f": False, "real": 3}})
+        assert Dealer._extract_tag_feas("c1", fields) == {"real": 3}
+
+    def test_json_string_of_dict_parsed(self):
+        # OceanBase path returns the JSON column as a raw string.
+        fields = _mk_fields(c1={TAG_FLD: json.dumps({"sec": 20})})
+        assert Dealer._extract_tag_feas("c1", fields) == {"sec": 20}
+
+    def test_empty_string_returns_none(self):
+        fields = _mk_fields(c1={TAG_FLD: ""})
+        assert Dealer._extract_tag_feas("c1", fields) is None
+
+    def test_missing_field_returns_none(self):
+        fields = _mk_fields(c1={})
+        assert Dealer._extract_tag_feas("c1", fields) is None
+
+    def test_empty_dict_returns_empty_dict(self):
+        # "{}" is well-formed and semantically means "no tags" — caller treats
+        # {} the same as None for the zero-contribution outcome.
+        fields = _mk_fields(c1={TAG_FLD: "{}"})
+        assert Dealer._extract_tag_feas("c1", fields) == {}
+
+    def test_malformed_json_returns_none(self, caplog):
+        fields = _mk_fields(c1={TAG_FLD: "{not json"})
+        with caplog.at_level("WARNING"):
+            assert Dealer._extract_tag_feas("c1", fields) is None
+        assert any("Malformed" in rec.message for rec in caplog.records)
+
+    @pytest.mark.parametrize("payload", [
+        json.dumps([1, 2, 3]),     # JSON list
+        json.dumps(42),            # JSON number
+        json.dumps("hello"),       # JSON string (not a dict)
+    ])
+    def test_non_dict_json_returns_none(self, payload, caplog):
+        fields = _mk_fields(c1={TAG_FLD: payload})
+        with caplog.at_level("WARNING"):
+            assert Dealer._extract_tag_feas("c1", fields) is None
+        assert any("Unexpected" in rec.message for rec in caplog.records)
+
+    def test_non_string_non_dict_returns_none(self, caplog):
+        # e.g. a number or list somehow survived the backend read path.
+        fields = _mk_fields(c1={TAG_FLD: 42})
+        with caplog.at_level("WARNING"):
+            assert Dealer._extract_tag_feas("c1", fields) is None
+
+    # ------------------------------------------------------------------
+    # Security regressions — these are the tests that pin the fix.
+    # ------------------------------------------------------------------
+
+    def test_rce_payload_via_infinity_roundtrip_not_executed(self):
+        """Regression for the eval() RCE.
+
+        On the Infinity write path, ``_feas`` values are stored via
+        ``json.dumps(v)`` with no type check. An attacker who supplies a bare
+        string (not a dict) in the chunk create/update API gets that string
+        stored verbatim; on read it round-trips back through ``json.loads`` as
+        a ``str``. Historically this string was fed to ``eval()``.
+
+        The helper MUST reject it and MUST NOT evaluate it.
+        """
+        # If eval() ever runs this, the test will crash loudly by raising.
+        payload = 'raise RuntimeError("RCE: eval executed attacker payload")'
+        round_tripped = json.loads(json.dumps(payload))
+        assert isinstance(round_tripped, str)
+
+        fields = _mk_fields(c1={TAG_FLD: round_tripped})
+        assert Dealer._extract_tag_feas("c1", fields) is None
+
+    def test_single_quoted_repr_rejected(self):
+        """Previously, ``es_conn.get_fields`` / ``opensearch_conn.get_fields``
+        returned ``tag_feas`` as a stringified Python dict (e.g.
+        ``"{'sec': 10}"``) — the product of ``str(dict)`` on a native dict
+        from ``_source``. That representation is not valid JSON and could
+        only be converted back with a dangerous ``eval()`` call.
+
+        The connectors now pass ``tag_feas`` dicts through unchanged, and
+        the sanitizer's invariant is that any string-shaped input must be
+        parseable as JSON. Single-quoted Python repr is rejected by design
+        — the sanitizer deliberately does not fall back to ``eval()`` or
+        ``ast.literal_eval()``, since ``tag_feas`` is attacker-reachable
+        via the chunk create/update API and any code-evaluating parser
+        would restore the RCE this fix closes.
+        """
+        repr_str = "{'sec': 10}"  # Python repr, not JSON
+        fields = _mk_fields(c1={TAG_FLD: repr_str})
+        assert Dealer._extract_tag_feas("c1", fields) is None
+
+
+# ---------------------------------------------------------------------------
+# _rank_feature_scores — end-to-end sanity
+# ---------------------------------------------------------------------------
+
+class TestRankFeatureScores:
+    """Validate the scorer wires ``_extract_tag_feas`` + pagerank correctly."""
+
+    def test_empty_query_returns_pageranks_only(self):
+        fields = _mk_fields(
+            c1={PAGERANK_FLD: 2, TAG_FLD: {"sec": 5}},
+            c2={PAGERANK_FLD: 7, TAG_FLD: {"sec": 9}},
+        )
+        out = _bare_dealer()._rank_feature_scores({}, _mk_search_res(fields))
+        np.testing.assert_array_equal(out, np.array([2.0, 7.0]))
+
+    def test_matching_tag_contributes_score(self):
+        # One chunk tagged "sec"=1 vs query {"sec": 1}: cosine-ish score
+        # simplifies to 1.0, then the code multiplies by 10 and adds pagerank.
+        fields = _mk_fields(c1={PAGERANK_FLD: 0, TAG_FLD: {"sec": 1}})
+        out = _bare_dealer()._rank_feature_scores({"sec": 1}, _mk_search_res(fields))
+        assert out[0] == pytest.approx(10.0)
+
+    def test_non_matching_tag_scores_zero_plus_pagerank(self):
+        fields = _mk_fields(c1={PAGERANK_FLD: 3, TAG_FLD: {"other": 1}})
+        out = _bare_dealer()._rank_feature_scores({"sec": 1}, _mk_search_res(fields))
+        # no overlap with query → nor=0 → rank_fea=0, plus pagerank=3.
+        assert out[0] == pytest.approx(3.0)
+
+    def test_malformed_tag_feas_does_not_break_scorer(self):
+        """A poisoned chunk degrades its own score to 0 and leaves siblings
+        untouched — the whole search must not fail because of one bad row."""
+        fields = _mk_fields(
+            c_poisoned={PAGERANK_FLD: 0, TAG_FLD: "__import__('os').system('x')"},
+            c_good={PAGERANK_FLD: 0, TAG_FLD: {"sec": 1}},
+        )
+        out = _bare_dealer()._rank_feature_scores({"sec": 1}, _mk_search_res(fields))
+        assert out[0] == pytest.approx(0.0)   # poisoned chunk: no contribution
+        assert out[1] == pytest.approx(10.0)  # healthy chunk: scored normally
+
+    def test_json_string_tag_feas_scored_same_as_dict(self):
+        """Dict input and JSON-string input should produce identical scores —
+        this protects against a future backend change flipping the wire type.
+        """
+        fields_dict = _mk_fields(c1={PAGERANK_FLD: 0, TAG_FLD: {"sec": 2, "perf": 1}})
+        fields_str = _mk_fields(c1={PAGERANK_FLD: 0, TAG_FLD: json.dumps({"sec": 2, "perf": 1})})
+        q = {"sec": 2, "perf": 1}
+        a = _bare_dealer()._rank_feature_scores(q, _mk_search_res(fields_dict))
+        b = _bare_dealer()._rank_feature_scores(q, _mk_search_res(fields_str))
+        np.testing.assert_allclose(a, b)


### PR DESCRIPTION
### What problem does this PR solve?

Replaces `eval()` at `rag/nlp/search.py:286` with a JSON-only sanitizer. The
`eval()` call evaluates the `tag_feas` (`TAG_FLD`) value of each chunk during
rank-feature scoring, and that value is attacker-reachable via the chunk
create/update API (`POST /v1/chunk/create` accepts `tag_feas` from the
request body with no type or schema validation). An authenticated user can
therefore store a Python expression in a chunk and trigger code execution in
the RAGFlow server process the next time a retrieval query exercises
tag-feature rerank.

#### Why it reaches the sink on every backend

`tag_feas` reaches the scorer in different shapes depending on the document
store, but historically all three paths fed `eval()`:

- **Elasticsearch / OpenSearch** — `tag_feas` is indexed as `rank_features`
  and comes back in `_source` as a native dict. `get_fields` then
  stringifies it via `str(dict)` (the generic non-list/non-str branch),
  producing a Python repr with single quotes like `"{'sec': 10.0}"`. The
  scorer previously relied on `eval()` to turn that repr back into a dict.
  `rank_features` type enforcement prevents an RCE payload from landing
  via ES/OS ingestion itself.
- **Infinity** — the write path does `json.dumps(v)` on `_feas` columns
  (`rag/utils/infinity_conn.py:405-406`) with no type check, and the read
  path does `json.loads(v)` (`infinity_conn.py:627-628`). `json.dumps`
  happily serializes a bare string, so an attacker who posts `tag_feas` as
  a string (not an object) round-trips faithfully and the string reaches
  `eval()`. **This is the exploitable path.**
- **OceanBase** — `tag_feas` is a `JSON` column; the driver returns it as a
  raw string and `ob_conn.get_fields` passes it through unchanged, giving
  a second exploitable path.

#### What this PR changes

1. **`rag/nlp/search.py`** — extracts a `Dealer._extract_tag_feas` helper
   that accepts a dict directly, or a string that parses as JSON to a
   dict; rejects everything else (non-dict JSON, malformed JSON, Python
   repr) with a `logging.warning` and returns `None`. Values inside the
   returned dict are filtered to numbers (excluding `bool`) so a poisoned
   score can't reach the arithmetic downstream. `_rank_feature_scores`
   uses the helper and treats `None` as "skip this chunk's rank-feature
   contribution" — matching the append-zero-and-continue pattern it
   already had for missing `tag_feas`. A single poisoned chunk therefore
   degrades its own rank contribution to zero instead of cascading into a
   search-wide failure.

2. **`rag/utils/es_conn.py`** and **`rag/utils/opensearch_conn.py`** —
   `get_fields` now passes `tag_feas` through as a dict instead of
   calling `str()` on it. Without this, replacing `eval()` with
   `json.loads` would regress ES / OS rerank, since the sanitizer rejects
   single-quoted Python repr. The change matches the existing whitelist
   pattern (`available_int` already has a similar passthrough).

3. **`test/unit_test/rag/test_search.py`** — 19 new unit tests covering
   the sanitizer contract. The key regression test
   (`test_rce_payload_via_infinity_roundtrip_not_executed`) uses a
   payload that `raise`s if ever `eval()`'d, so a future refactor that
   reintroduces `eval()` here fails the test loudly. Another test
   (`test_single_quoted_repr_rejected`) pins defense-in-depth behavior:
   even if a future path reintroduces `str(dict)` upstream, the
   sanitizer will refuse the result rather than fall back to
   `ast.literal_eval` / `eval`.

#### Scope / follow-ups (not in this PR)

- **Write-side validation.** `api/apps/chunk_app.py` (lines 163-164 and
  330-331) and `api/apps/sdk/doc.py` (lines 1077-1078 and 1316-1317) all
  accept `tag_feas` from the request body unchecked. A defense-in-depth
  change would reject anything that isn't `{str: number}` at ingestion so
  poisoned values never land in the store. Happy to add it to this PR or
  file a follow-up — let me know your preference.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
