### PR TITLE
fix: close file handles in resume entity loaders using with statement

### DIFF
--- a/deepdoc/parser/resume/entities/corporations.py
+++ b/deepdoc/parser/resume/entities/corporations.py
@@ -29,12 +29,12 @@ GOODS = pd.read_csv(
 ).fillna(0)
 GOODS["cid"] = GOODS["cid"].astype(str)
 GOODS = GOODS.set_index(["cid"])
-CORP_TKS = json.load(
-    open(os.path.join(current_file_path, "res/corp.tks.freq.json"), "r",encoding="utf-8")
-)
-GOOD_CORP = json.load(open(os.path.join(current_file_path, "res/good_corp.json"), "r",encoding="utf-8"))
-CORP_TAG = json.load(open(os.path.join(current_file_path, "res/corp_tag.json"), "r",encoding="utf-8"))
-
+with open(os.path.join(current_file_path, "res/corp.tks.freq.json"), "r", encoding="utf-8") as f:
+    CORP_TKS = json.load(f)
+with open(os.path.join(current_file_path, "res/good_corp.json"), "r", encoding="utf-8") as f:
+    GOOD_CORP = json.load(f)
+with open(os.path.join(current_file_path, "res/corp_tag.json"), "r", encoding="utf-8") as f:
+    CORP_TAG = json.load(f)
 
 def baike(cid, default_v=0):
     global GOODS

--- a/deepdoc/parser/resume/entities/schools.py
+++ b/deepdoc/parser/resume/entities/schools.py
@@ -25,8 +25,10 @@ TBL = pd.read_csv(
     os.path.join(current_file_path, "res/schools.csv"), sep="\t", header=0
 ).fillna("")
 TBL["name_en"] = TBL["name_en"].map(lambda x: x.lower().strip())
-GOOD_SCH = json.load(open(os.path.join(current_file_path, "res/good_sch.json"), "r",encoding="utf-8"))
-GOOD_SCH = set([re.sub(r"[,. &（）()]+", "", c) for c in GOOD_SCH])
+
+with open(os.path.join(current_file_path, "res/good_sch.json"), "r", encoding="utf-8") as f:
+    GOOD_SCH = json.load(f)
+    GOOD_SCH = set([re.sub(r"[,. &（）()]+", "", c) for c in GOOD_SCH])
 
 
 def loadRank(fnm):


### PR DESCRIPTION
### What problem does this PR solve?

Fixes additional instances of the file handle leak pattern reported in #13996.

Several places in `deepdoc/parser/resume/entities/` used `json.load(open(...))` 
without explicitly closing the file handle. In long-running server processes, 
leaked file descriptors can accumulate and cause `OSError: Too many open files`.

Affected files:
- `deepdoc/parser/resume/entities/corporations.py` (3 instances)
- `deepdoc/parser/resume/entities/schools.py` (1 instance)

Replaced all bare `open()` calls with `with` statements to ensure proper 
file handle cleanup.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
