### PR TITLE
Auto-inject knowledge parameter in async_chat when prompt_config is missing it

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -554,9 +554,13 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             logging.debug("SQL failed or returned no results, falling back to vector search")
 
     param_keys = [p["key"] for p in prompt_config.get("parameters", [])]
+    if dialog.kb_ids and "knowledge" not in param_keys and "{knowledge}" in prompt_config.get("system", ""):
+        logging.warning("prompt_config['parameters'] is missing 'knowledge' entry despite kb_ids being set; auto-fixing.")
+        prompt_config.setdefault("parameters", []).append({"key": "knowledge", "optional": False})
+        param_keys.append("knowledge")
     logging.debug(f"attachments={attachments}, param_keys={param_keys}, embd_mdl={embd_mdl}")
 
-    for p in prompt_config["parameters"]:
+    for p in prompt_config.get("parameters", []):
         if p["key"] == "knowledge":
             continue
         if p["key"] not in kwargs and not p["optional"]:


### PR DESCRIPTION
### What problem does this PR solve?

Resolve #14115 .

## Problem

On the shared chat link page (`/chats/share?shared_id=...`), querying the knowledge base returns "no relevant information was found", while the same query works correctly on the editor chat page.

## Root Cause

Knowledge base retrieval in `async_chat()` is gated by the check `if "knowledge" in param_keys` (line 598), where `param_keys` is derived from `prompt_config["parameters"]`. If `parameters` is empty or missing the `{"key": "knowledge", "optional": false}` entry, retrieval is entirely skipped.

This can happen because `_apply_prompt_defaults()` — which ensures `parameters` contains the `knowledge` entry — is only called in the `create` (POST) and `update_chat` (PUT) handlers, but **not** in `patch_chat` (PATCH). If a chat's `prompt_config` was updated via PATCH without including `parameters`, the `knowledge` entry would be absent. Additionally, `prompt_config["parameters"]` would raise a `KeyError` if the key was missing entirely.

## Fix

Added a defensive safety net in `async_chat()` (`api/db/services/dialog_service.py`) that auto-injects the `knowledge` parameter when:
- `dialog.kb_ids` is set (knowledge bases are configured)
- `"knowledge"` is not already in `param_keys`
- `{knowledge}` placeholder exists in the system prompt

Also changed `prompt_config["parameters"]` to `prompt_config.get("parameters", [])` to prevent `KeyError` when the key is absent.

## Files Changed

- `api/db/services/dialog_service.py` — added auto-injection of `knowledge` parameter and safe `.get()` access for `parameters`


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
