### PR TITLE
fix(web): fix incomplete Docx preview in citation reference

### DIFF
--- a/web/src/components/document-preview/doc-preview.tsx
+++ b/web/src/components/document-preview/doc-preview.tsx
@@ -118,7 +118,7 @@ export const DocPreviewer: React.FC<DocPreviewerProps> = ({
   return (
     <div
       className={classNames(
-        'relative w-full h-full p-4 bg-background-paper border border-border-normal rounded-md',
+        'relative w-full h-full p-4 bg-background-paper border border-border-normal rounded-md overflow-auto',
         className,
       )}
     >


### PR DESCRIPTION
This PR fixes a UI issue where the .docx document preview was displayed incompletely when clicking on a citation/reference link during a knowledge base conversation.

### What problem does this PR solve?

The Issue:
In the chat interface, when a user clicks the source citation at the end of an answer, the DocPreviewer opens. However, for .docx files, if the content exceeded the window height, it was truncated and unscrollable, preventing users from reading the full referenced text.

Changes:
web/src/components/document-preview/doc-preview.tsx: Added the overflow-auto Tailwind class to the DocPreviewer root container to ensure scrollbars appear automatically when content overflows.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)