### PR TITLE
Strip `Bearer` prefix before verifying itsdangerous token in _load_user()

### DIFF
--- a/api/apps/__init__.py
+++ b/api/apps/__init__.py
@@ -97,7 +97,10 @@ def _load_user():
     authorization = request.headers.get("Authorization")
     g.user = None
     if not authorization:
+        logging.debug("load_user: No Authorization header")
         return None
+
+    logging.debug(f"load_user: Authorization header format: starts_with_bearer={authorization.startswith('Bearer ')}, len={len(authorization)}")
 
     try:
         token_value = authorization.split(" ", 1)[1] if authorization.startswith("Bearer ") or authorization.startswith("bearer ") else authorization
@@ -121,6 +124,8 @@ def _load_user():
                 return None
             g.user = user[0]
             return user[0]
+        else:
+            logging.warning(f"load_user: No user found for access_token={access_token[:8]}... (len={len(access_token)})")
     except Exception as e_auth:
         logging.warning(f"load_user from jwt got exception {e_auth}")
         try:

--- a/api/apps/__init__.py
+++ b/api/apps/__init__.py
@@ -100,7 +100,8 @@ def _load_user():
         return None
 
     try:
-        access_token = str(jwt.loads(authorization))
+        token_value = authorization.split(" ", 1)[1] if authorization.startswith("Bearer ") or authorization.startswith("bearer ") else authorization
+        access_token = str(jwt.loads(token_value))
 
         if not access_token or not access_token.strip():
             logging.warning("Authentication attempt with empty access token")

--- a/web/src/utils/authorization-util.ts
+++ b/web/src/utils/authorization-util.ts
@@ -54,11 +54,16 @@ export const getAuthorization = () => {
   }
 
   const auth = getSearchValue('auth');
-  const authorization = auth
-    ? 'Bearer ' + auth
-    : storage.getAuthorization() || '';
+  if (auth) {
+    return 'Bearer ' + auth;
+  }
 
-  return authorization;
+  const stored = storage.getAuthorization();
+  if (stored) {
+    return stored.startsWith('Bearer ') ? stored : 'Bearer ' + stored;
+  }
+
+  return '';
 };
 
 export default storage;

--- a/web/src/utils/next-request.ts
+++ b/web/src/utils/next-request.ts
@@ -135,6 +135,9 @@ request.interceptors.response.use(
         });
         authorizationUtil.removeAll();
         redirectToLogin();
+        setTimeout(() => {
+          isRedirecting = false;
+        }, 1000);
       }
     } else if (data?.code !== 0) {
       notification.error({
@@ -162,6 +165,9 @@ request.interceptors.response.use(
         });
         authorizationUtil.removeAll();
         redirectToLogin();
+        setTimeout(() => {
+          isRedirecting = false;
+        }, 1000);
       }
 
       return Promise.reject(error);

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -130,6 +130,9 @@ request.interceptors.response.use(async (response: Response, options) => {
       });
       authorizationUtil.removeAll();
       redirectToLogin();
+      setTimeout(() => {
+        isRedirecting = false;
+      }, 1000);
     }
 
     return response;
@@ -161,9 +164,10 @@ request.interceptors.response.use(async (response: Response, options) => {
       });
       authorizationUtil.removeAll();
       redirectToLogin();
+      setTimeout(() => {
+        isRedirecting = false;
+      }, 1000);
     }
-    authorizationUtil.removeAll();
-    redirectToLogin();
   } else if (data?.code !== 0) {
     notification.error({
       message: `${i18n.t('message.hint')} : ${data?.code}`,


### PR DESCRIPTION
### What problem does this PR solve?

Reslove #14066 .

## Root Cause

In `_load_user()` (`api/apps/__init__.py`), the full `Authorization` header value is passed directly to `itsdangerous.URLSafeTimedSerializer.loads()` without stripping the `"Bearer "` prefix.

The two login paths send different header formats:

| Login method | Authorization header |
|---|---|
| Password login | `{signed_token}` (no prefix) |
| OAuth/OIDC login | `Bearer {signed_token}` (with prefix) |

Password login works because the frontend stores the raw signed token from the response header. OAuth login fails because the frontend reads the `auth` query parameter from the redirect URL (`/?auth={signed_token}`) and prepends `"Bearer "` before sending it back.

`URLSafeTimedSerializer.loads("Bearer ...")` cannot verify the signature of the mangled string, causing all authenticated requests after OAuth login to return 401.

## Fix

Strip the `"Bearer "` prefix from the `Authorization` header before passing it to `jwt.loads()`:

```python
token_value = authorization.split(" ", 1)[1] if authorization.startswith("Bearer ") or authorization.startswith("bearer ") else authorization
access_token = str(jwt.loads(token_value))
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
