### PR TITLE
Fix Dify retrieval 405 by supporting GET and POST requests

### DIFF
--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -16,6 +16,12 @@
 import logging
 
 from quart import jsonify, request
+from werkzeug.exceptions import BadRequest as WerkzeugBadRequest
+
+try:
+    from quart.exceptions import BadRequest as QuartBadRequest
+except ImportError:  # pragma: no cover - optional dependency
+    QuartBadRequest = None
 
 from api.db.services.document_service import DocumentService
 from api.db.services.doc_metadata_service import DocMetadataService
@@ -191,9 +197,12 @@ async def retrieval(tenant_id):
       404:
         description: Knowledge base or document not found
     """
+    parse_exception_types = (AttributeError, TypeError, ValueError, WerkzeugBadRequest)
+    if QuartBadRequest is not None:
+        parse_exception_types = parse_exception_types + (QuartBadRequest,)
     try:
         req = await _read_retrieval_request()
-    except (AttributeError, TypeError, ValueError) as e:
+    except parse_exception_types as e:
         return build_error_result(
             message=f"required argument are missing: {str(e)}; ",
             code=RetCode.ARGUMENT_ERROR,

--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -67,6 +67,19 @@ async def _read_retrieval_request():
     return await get_request_json()
 
 
+def _parse_retrieval_options(retrieval_setting):
+    if retrieval_setting is None:
+        retrieval_setting = {}
+    if not isinstance(retrieval_setting, dict):
+        raise ValueError("retrieval_setting must be an object")
+    try:
+        similarity_threshold = float(retrieval_setting.get("score_threshold", 0.0))
+        top = int(retrieval_setting.get("top_k", 1024))
+    except (TypeError, ValueError):
+        raise ValueError("top_k must be integer and score_threshold must be numeric")
+    return retrieval_setting, similarity_threshold, top
+
+
 @manager.route('/dify/retrieval', methods=['POST', 'GET'])  # noqa: F821
 @apikey_required
 async def retrieval(tenant_id):
@@ -194,9 +207,13 @@ async def retrieval(tenant_id):
     question = req["query"]
     kb_id = req["knowledge_id"]
     use_kg = req.get("use_kg", False)
-    retrieval_setting = req.get("retrieval_setting", {})
-    similarity_threshold = float(retrieval_setting.get("score_threshold", 0.0))
-    top = int(retrieval_setting.get("top_k", 1024))
+    try:
+        retrieval_setting, similarity_threshold, top = _parse_retrieval_options(req.get("retrieval_setting", {}))
+    except ValueError as e:
+        return build_error_result(
+            message=f"required argument are missing: {str(e)}; ",
+            code=RetCode.ARGUMENT_ERROR,
+        )
     metadata_condition = req.get("metadata_condition", {}) or {}
     metas = DocMetadataService.get_flatted_meta_by_kbs([kb_id])
 

--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -15,7 +15,7 @@
 #
 import logging
 
-from quart import jsonify
+from quart import jsonify, request
 
 from api.db.services.document_service import DocumentService
 from api.db.services.doc_metadata_service import DocMetadataService
@@ -28,7 +28,28 @@ from rag.app.tag import label_question
 from common.constants import RetCode, LLMType
 from common import settings
 
-@manager.route('/dify/retrieval', methods=['POST'])  # noqa: F821
+async def _read_retrieval_request():
+    if request.method == "GET":
+        query_args = request.args
+        retrieval_setting = {}
+        top_k = query_args.get("top_k")
+        score_threshold = query_args.get("score_threshold")
+        if top_k is not None:
+            retrieval_setting["top_k"] = top_k
+        if score_threshold is not None:
+            retrieval_setting["score_threshold"] = score_threshold
+
+        req = {
+            "knowledge_id": query_args.get("knowledge_id"),
+            "query": query_args.get("query"),
+            "use_kg": str(query_args.get("use_kg", "")).lower() in {"1", "true", "yes", "on"},
+            "retrieval_setting": retrieval_setting,
+        }
+        return req
+    return await get_request_json()
+
+
+@manager.route('/dify/retrieval', methods=['POST', 'GET'])  # noqa: F821
 @apikey_required
 @validate_request("knowledge_id", "query")
 async def retrieval(tenant_id):
@@ -115,7 +136,7 @@ async def retrieval(tenant_id):
       404:
         description: Knowledge base or document not found
     """
-    req = await get_request_json()
+    req = await _read_retrieval_request()
     question = req["query"]
     kb_id = req["knowledge_id"]
     use_kg = req.get("use_kg", False)

--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -40,10 +40,13 @@ async def _read_retrieval_request():
         use_kg = str(query_args.get("use_kg", "")).lower() in {"1", "true", "yes", "on"}
         top_k = query_args.get("top_k")
         score_threshold = query_args.get("score_threshold")
-        if top_k is not None:
-            retrieval_setting["top_k"] = top_k
-        if score_threshold is not None:
-            retrieval_setting["score_threshold"] = score_threshold
+        try:
+            if top_k not in (None, ""):
+                retrieval_setting["top_k"] = int(top_k)
+            if score_threshold not in (None, ""):
+                retrieval_setting["score_threshold"] = float(score_threshold)
+        except (TypeError, ValueError):
+            raise ValueError("top_k must be integer and score_threshold must be numeric")
         safe_query = f"len={len(query)}" if isinstance(query, str) else "len=0"
         logger.debug(
             "Dify retrieval GET normalization: knowledge_id=%s query=%s use_kg=%s top_k=%s score_threshold=%s",
@@ -175,7 +178,13 @@ async def retrieval(tenant_id):
       404:
         description: Knowledge base or document not found
     """
-    req = await _read_retrieval_request()
+    try:
+        req = await _read_retrieval_request()
+    except (AttributeError, TypeError, ValueError) as e:
+        return build_error_result(
+            message=f"required argument are missing: {str(e)}; ",
+            code=RetCode.ARGUMENT_ERROR,
+        )
     missing = [field for field in ("knowledge_id", "query") if not req.get(field)]
     if missing:
         return build_error_result(

--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -38,7 +38,12 @@ logger = logging.getLogger(__name__)
 
 
 async def _read_retrieval_request():
-    if request.method == "GET":
+    try:
+        method = request.method
+    except RuntimeError:
+        # Unit tests may call the handler directly without a request context.
+        method = "POST"
+    if method == "GET":
         query_args = request.args
         retrieval_setting = {}
         knowledge_id = query_args.get("knowledge_id")
@@ -204,13 +209,13 @@ async def retrieval(tenant_id):
         req = await _read_retrieval_request()
     except parse_exception_types as e:
         return build_error_result(
-            message=f"required argument are missing: {str(e)}; ",
+            message=f"invalid or malformed arguments: {str(e)}; ",
             code=RetCode.ARGUMENT_ERROR,
         )
     missing = [field for field in ("knowledge_id", "query") if not req.get(field)]
     if missing:
         return build_error_result(
-            message=f"required argument are missing: {','.join(missing)}; ",
+            message=f"required arguments are missing: {','.join(missing)}; ",
             code=RetCode.ARGUMENT_ERROR,
         )
     question = req["query"]
@@ -220,7 +225,7 @@ async def retrieval(tenant_id):
         retrieval_setting, similarity_threshold, top = _parse_retrieval_options(req.get("retrieval_setting", {}))
     except ValueError as e:
         return build_error_result(
-            message=f"required argument are missing: {str(e)}; ",
+            message=f"invalid or malformed arguments: {str(e)}; ",
             code=RetCode.ARGUMENT_ERROR,
         )
     metadata_condition = req.get("metadata_condition", {}) or {}

--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -23,26 +23,41 @@ from api.db.services.knowledgebase_service import KnowledgebaseService
 from api.db.services.llm_service import LLMBundle
 from api.db.joint_services.tenant_model_service import get_model_config_by_id, get_model_config_by_type_and_name, get_tenant_default_model_by_type
 from common.metadata_utils import meta_filter, convert_conditions
-from api.utils.api_utils import apikey_required, build_error_result, get_request_json, validate_request
+from api.utils.api_utils import apikey_required, build_error_result, get_request_json
 from rag.app.tag import label_question
 from common.constants import RetCode, LLMType
 from common import settings
+
+logger = logging.getLogger(__name__)
+
 
 async def _read_retrieval_request():
     if request.method == "GET":
         query_args = request.args
         retrieval_setting = {}
+        knowledge_id = query_args.get("knowledge_id")
+        query = query_args.get("query")
+        use_kg = str(query_args.get("use_kg", "")).lower() in {"1", "true", "yes", "on"}
         top_k = query_args.get("top_k")
         score_threshold = query_args.get("score_threshold")
         if top_k is not None:
             retrieval_setting["top_k"] = top_k
         if score_threshold is not None:
             retrieval_setting["score_threshold"] = score_threshold
+        safe_query = f"len={len(query)}" if isinstance(query, str) else "len=0"
+        logger.debug(
+            "Dify retrieval GET normalization: knowledge_id=%s query=%s use_kg=%s top_k=%s score_threshold=%s",
+            knowledge_id,
+            safe_query,
+            use_kg,
+            retrieval_setting.get("top_k"),
+            retrieval_setting.get("score_threshold"),
+        )
 
         req = {
-            "knowledge_id": query_args.get("knowledge_id"),
-            "query": query_args.get("query"),
-            "use_kg": str(query_args.get("use_kg", "")).lower() in {"1", "true", "yes", "on"},
+            "knowledge_id": knowledge_id,
+            "query": query,
+            "use_kg": use_kg,
             "retrieval_setting": retrieval_setting,
         }
         return req
@@ -51,7 +66,6 @@ async def _read_retrieval_request():
 
 @manager.route('/dify/retrieval', methods=['POST', 'GET'])  # noqa: F821
 @apikey_required
-@validate_request("knowledge_id", "query")
 async def retrieval(tenant_id):
     """
     Dify-compatible retrieval API
@@ -61,9 +75,34 @@ async def retrieval(tenant_id):
     security:
       - ApiKeyAuth: []
     parameters:
+      - in: query
+        name: knowledge_id
+        required: false
+        type: string
+        description: Knowledge base ID (for GET requests)
+      - in: query
+        name: query
+        required: false
+        type: string
+        description: Query text (for GET requests)
+      - in: query
+        name: use_kg
+        required: false
+        type: boolean
+        description: Whether to use knowledge graph (for GET requests)
+      - in: query
+        name: top_k
+        required: false
+        type: integer
+        description: Number of results to return (for GET requests)
+      - in: query
+        name: score_threshold
+        required: false
+        type: number
+        description: Similarity threshold (for GET requests)
       - in: body
         name: body
-        required: true
+        required: false
         schema:
           type: object
           required:
@@ -137,6 +176,12 @@ async def retrieval(tenant_id):
         description: Knowledge base or document not found
     """
     req = await _read_retrieval_request()
+    missing = [field for field in ("knowledge_id", "query") if not req.get(field)]
+    if missing:
+        return build_error_result(
+            message=f"required argument are missing: {','.join(missing)}; ",
+            code=RetCode.ARGUMENT_ERROR,
+        )
     question = req["query"]
     kb_id = req["knowledge_id"]
     use_kg = req.get("use_kg", False)

--- a/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
@@ -352,3 +352,40 @@ def test_retrieval_generic_exception_mapping(monkeypatch):
     res = _run(inspect.unwrap(module.retrieval)("tenant-1"))
     assert res["code"] == module.RetCode.SERVER_ERROR, res
     assert "boom" in res["message"], res
+
+
+@pytest.mark.p2
+def test_read_retrieval_request_from_get_args(monkeypatch):
+    module = _load_dify_retrieval_module(monkeypatch)
+    monkeypatch.setattr(
+        module,
+        "request",
+        SimpleNamespace(
+            method="GET",
+            args={
+                "knowledge_id": "kb-1",
+                "query": "hello",
+                "use_kg": "true",
+                "top_k": "12",
+                "score_threshold": "0.66",
+            },
+        ),
+    )
+
+    req = _run(module._read_retrieval_request())
+    assert req["knowledge_id"] == "kb-1", req
+    assert req["query"] == "hello", req
+    assert req["use_kg"] is True, req
+    assert req["retrieval_setting"]["top_k"] == "12", req
+    assert req["retrieval_setting"]["score_threshold"] == "0.66", req
+
+
+@pytest.mark.p2
+def test_read_retrieval_request_from_post_json(monkeypatch):
+    module = _load_dify_retrieval_module(monkeypatch)
+    payload = {"knowledge_id": "kb-1", "query": "hello"}
+    monkeypatch.setattr(module, "request", SimpleNamespace(method="POST", args={}))
+    monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue(payload))
+
+    req = _run(module._read_retrieval_request())
+    assert req == payload, req

--- a/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
@@ -376,8 +376,8 @@ def test_read_retrieval_request_from_get_args(monkeypatch):
     assert req["knowledge_id"] == "kb-1", req
     assert req["query"] == "hello", req
     assert req["use_kg"] is True, req
-    assert req["retrieval_setting"]["top_k"] == "12", req
-    assert req["retrieval_setting"]["score_threshold"] == "0.66", req
+    assert req["retrieval_setting"]["top_k"] == 12, req
+    assert req["retrieval_setting"]["score_threshold"] == 0.66, req
 
 
 @pytest.mark.p2


### PR DESCRIPTION
## Summary

This PR fixes issue #13788 where Dify integration can hit `405 Method Not Allowed` on the retrieval endpoint.

### What changed

- Updated `api/apps/sdk/dify_retrieval.py`:
  - Added support for both `GET` and `POST` on `/dify/retrieval`
  - Added request normalization helper to:
    - read query params for `GET` requests
    - preserve existing JSON body behavior for `POST` requests
- Added regression tests in:
  - `test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py`
  - New tests cover:
    - GET arg parsing (`knowledge_id`, `query`, `use_kg`, `top_k`, `score_threshold`)
    - POST JSON passthrough behavior

## Why

Some Dify call paths/proxies can issue GET-style calls. Previously, the endpoint was POST-only, which caused a 405 and broke retrieval flow.

## Impact

- Backward compatible for existing POST clients
- Adds GET compatibility for Dify integrations
- Reduces method-mismatch failures in production integrations

## Test Plan

- Unit tests added for request parsing in both GET and POST modes
- Syntax/lint checks passed on modified files