### PR TITLE
Fix Infinity transaction conflicts during concurrent chunk updates

### DIFF
--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -17,6 +17,7 @@
 import re
 import json
 import copy
+import time
 from infinity.common import InfinityException, SortType
 from infinity.errors import ErrorCode
 from common.decorator import singleton
@@ -86,6 +87,16 @@ class InfinityConnection(InfinityConnectionBase):
             field = "tag_kwd@ft_tag_kwd_whitespace__"
         tokens[0] = field
         return "^".join(tokens)
+
+    @staticmethod
+    def _is_transaction_conflict(exc: InfinityException) -> bool:
+        error_code = getattr(exc, "error_code", None)
+        error_msg = str(exc).lower()
+        if error_code == 4002:
+            return True
+        return "txn conflict" in error_msg or (
+            "transaction:" in error_msg and "conflict" in error_msg
+        )
 
     """
     CRUD operations
@@ -475,126 +486,166 @@ class InfinityConnection(InfinityConnectionBase):
         self.logger.debug(f"INFINITY inserted into {table_name} {str_ids}.")
         return []
 
-    def update(self, condition: dict, new_value: dict, index_name: str, knowledgebase_id: str) -> bool:
+    def update(
+        self,
+        condition: dict,
+        new_value: dict,
+        index_name: str,
+        knowledgebase_id: str,
+        max_retries: int = 3,
+        retry_delay: float = 0.05,
+    ) -> bool:
         # if 'position_int' in newValue:
         #     logger.info(f"update position_int: {newValue['position_int']}")
-        inf_conn = self.connPool.get_conn()
-        try:
-            db_instance = inf_conn.get_database(self.dbName)
-            if index_name.startswith("ragflow_doc_meta_"):
-                table_name = index_name
-            else:
-                table_name = f"{index_name}_{knowledgebase_id}"
-            table_instance = db_instance.get_table(table_name)
-            # if "exists" in condition:
-            #    del condition["exists"]
+        base_new_value = copy.deepcopy(new_value)
+        table_name = index_name if index_name.startswith("ragflow_doc_meta_") else f"{index_name}_{knowledgebase_id}"
 
-            clmns = {}
-            if table_instance:
-                for n, ty, de, _ in table_instance.show_columns().rows():
-                    clmns[n] = (ty, de)
-            filter = self.equivalent_condition_to_str(condition, table_instance)
-            removeValue = {}
-            for k, v in list(new_value.items()):
-                if k == "docnm_kwd":
-                    new_value["docnm"] = self.list2str(v)
-                elif k == "title_kwd":
-                    if not new_value.get("docnm_kwd"):
-                        new_value["docnm"] = self.list2str(v)
-                elif k == "title_sm_tks":
-                    if not new_value.get("docnm_kwd"):
-                        new_value["docnm"] = v
-                elif k == "important_kwd":
-                    if isinstance(v, list):
-                        empty_count = sum(1 for kw in v if kw == "")
-                        tokens = [kw for kw in v if kw != ""]
-                        new_value["important_keywords"] = self.list2str(tokens, ",")
-                        new_value["important_kwd_empty_count"] = empty_count
+        for attempt in range(max_retries + 1):
+            inf_conn = self.connPool.get_conn()
+            filter_expr = None
+            try:
+                db_instance = inf_conn.get_database(self.dbName)
+                table_instance = db_instance.get_table(table_name)
+                current_new_value = copy.deepcopy(base_new_value)
+
+                clmns = {}
+                if table_instance:
+                    for n, ty, de, _ in table_instance.show_columns().rows():
+                        clmns[n] = (ty, de)
+                filter_expr = self.equivalent_condition_to_str(condition, table_instance)
+                removeValue = {}
+                for k, v in list(current_new_value.items()):
+                    if k == "docnm_kwd":
+                        current_new_value["docnm"] = self.list2str(v)
+                    elif k == "title_kwd":
+                        if not current_new_value.get("docnm_kwd"):
+                            current_new_value["docnm"] = self.list2str(v)
+                    elif k == "title_sm_tks":
+                        if not current_new_value.get("docnm_kwd"):
+                            current_new_value["docnm"] = v
+                    elif k == "important_kwd":
+                        if isinstance(v, list):
+                            empty_count = sum(1 for kw in v if kw == "")
+                            tokens = [kw for kw in v if kw != ""]
+                            current_new_value["important_keywords"] = self.list2str(tokens, ",")
+                            current_new_value["important_kwd_empty_count"] = empty_count
+                        else:
+                            current_new_value["important_keywords"] = self.list2str(v, ",")
+                    elif k == "important_tks":
+                        if not current_new_value.get("important_kwd"):
+                            current_new_value["important_keywords"] = v
+                    elif k == "content_with_weight":
+                        current_new_value["content"] = v
+                    elif k == "content_ltks":
+                        if not current_new_value.get("content_with_weight"):
+                            current_new_value["content"] = v
+                    elif k == "content_sm_ltks":
+                        if not current_new_value.get("content_with_weight"):
+                            current_new_value["content"] = v
+                    elif k == "authors_tks":
+                        current_new_value["authors"] = v
+                    elif k == "authors_sm_tks":
+                        if not current_new_value.get("authors_tks"):
+                            current_new_value["authors"] = v
+                    elif k == "question_kwd":
+                        current_new_value["questions"] = "\n".join(v)
+                    elif k == "question_tks":
+                        if not current_new_value.get("question_kwd"):
+                            current_new_value["questions"] = self.list2str(v)
+                    elif self.field_keyword(k):
+                        if isinstance(v, list):
+                            current_new_value[k] = "###".join(v)
+                        else:
+                            current_new_value[k] = v
+                    elif re.search(r"_feas$", k):
+                        current_new_value[k] = json.dumps(v)
+                    elif k == "kb_id":
+                        if isinstance(current_new_value[k], list):
+                            current_new_value[k] = current_new_value[k][0]  # since d[k] is a list, but we need a str
+                    elif k == "position_int":
+                        assert isinstance(v, list)
+                        arr = [num for row in v for num in row]
+                        current_new_value[k] = "_".join(f"{num:08x}" for num in arr)
+                    elif k in ["page_num_int", "top_int"]:
+                        assert isinstance(v, list)
+                        current_new_value[k] = "_".join(f"{num:08x}" for num in v)
+                    elif k == "remove":
+                        if isinstance(v, str):
+                            assert v in clmns, f"'{v}' should be in '{clmns}'."
+                            ty, de = clmns[v]
+                            if ty.lower().find("cha"):
+                                if not de:
+                                    de = ""
+                            current_new_value[v] = de
+                        else:
+                            for kk, vv in v.items():
+                                removeValue[kk] = vv
+                            del current_new_value[k]
                     else:
-                        new_value["important_keywords"] = self.list2str(v, ",")
-                elif k == "important_tks":
-                    if not new_value.get("important_kwd"):
-                        new_value["important_keywords"] = v
-                elif k == "content_with_weight":
-                    new_value["content"] = v
-                elif k == "content_ltks":
-                    if not new_value.get("content_with_weight"):
-                        new_value["content"] = v
-                elif k == "content_sm_ltks":
-                    if not new_value.get("content_with_weight"):
-                        new_value["content"] = v
-                elif k == "authors_tks":
-                    new_value["authors"] = v
-                elif k == "authors_sm_tks":
-                    if not new_value.get("authors_tks"):
-                        new_value["authors"] = v
-                elif k == "question_kwd":
-                    new_value["questions"] = "\n".join(v)
-                elif k == "question_tks":
-                    if not new_value.get("question_kwd"):
-                        new_value["questions"] = self.list2str(v)
-                elif self.field_keyword(k):
-                    if isinstance(v, list):
-                        new_value[k] = "###".join(v)
-                    else:
-                        new_value[k] = v
-                elif re.search(r"_feas$", k):
-                    new_value[k] = json.dumps(v)
-                elif k == "kb_id":
-                    if isinstance(new_value[k], list):
-                        new_value[k] = new_value[k][0]  # since d[k] is a list, but we need a str
-                elif k == "position_int":
-                    assert isinstance(v, list)
-                    arr = [num for row in v for num in row]
-                    new_value[k] = "_".join(f"{num:08x}" for num in arr)
-                elif k in ["page_num_int", "top_int"]:
-                    assert isinstance(v, list)
-                    new_value[k] = "_".join(f"{num:08x}" for num in v)
-                elif k == "remove":
-                    if isinstance(v, str):
-                        assert v in clmns, f"'{v}' should be in '{clmns}'."
-                        ty, de = clmns[v]
-                        if ty.lower().find("cha"):
-                            if not de:
-                                de = ""
-                        new_value[v] = de
-                    else:
-                        for kk, vv in v.items():
-                            removeValue[kk] = vv
-                        del new_value[k]
-                else:
-                    new_value[k] = v
-            for k in ["docnm_kwd", "title_tks", "title_sm_tks", "important_kwd", "important_tks", "content_with_weight",
-                      "content_ltks", "content_sm_ltks", "authors_tks", "authors_sm_tks", "question_kwd", "question_tks"]:
-                if k in new_value:
-                    del new_value[k]
+                        current_new_value[k] = v
+                for k in [
+                    "docnm_kwd",
+                    "title_tks",
+                    "title_sm_tks",
+                    "important_kwd",
+                    "important_tks",
+                    "content_with_weight",
+                    "content_ltks",
+                    "content_sm_ltks",
+                    "authors_tks",
+                    "authors_sm_tks",
+                    "question_kwd",
+                    "question_tks",
+                ]:
+                    if k in current_new_value:
+                        del current_new_value[k]
 
-            remove_opt = {}  # "[k,new_value]": [id_to_update, ...]
-            if removeValue:
-                col_to_remove = list(removeValue.keys())
-                row_to_opt = table_instance.output(col_to_remove + ["id"]).filter(filter).to_df()
-                self.logger.debug(f"INFINITY search table {str(table_name)}, filter {filter}, result: {str(row_to_opt[0])}")
-                row_to_opt = self.get_fields(row_to_opt, col_to_remove)
-                for id, old_v in row_to_opt.items():
-                    for k, remove_v in removeValue.items():
-                        if remove_v in old_v[k]:
-                            new_v = old_v[k].copy()
-                            new_v.remove(remove_v)
-                            kv_key = json.dumps([k, new_v])
-                            if kv_key not in remove_opt:
-                                remove_opt[kv_key] = [id]
-                            else:
-                                remove_opt[kv_key].append(id)
+                remove_opt = {}  # "[k,new_value]": [id_to_update, ...]
+                if removeValue:
+                    col_to_remove = list(removeValue.keys())
+                    row_to_opt = table_instance.output(col_to_remove + ["id"]).filter(filter_expr).to_df()
+                    self.logger.debug(
+                        f"INFINITY search table {str(table_name)}, filter {filter_expr}, result: {str(row_to_opt[0])}"
+                    )
+                    row_to_opt = self.get_fields(row_to_opt, col_to_remove)
+                    for id, old_v in row_to_opt.items():
+                        for k, remove_v in removeValue.items():
+                            if remove_v in old_v[k]:
+                                new_v = old_v[k].copy()
+                                new_v.remove(remove_v)
+                                kv_key = json.dumps([k, new_v])
+                                if kv_key not in remove_opt:
+                                    remove_opt[kv_key] = [id]
+                                else:
+                                    remove_opt[kv_key].append(id)
 
-            self.logger.debug(f"INFINITY update table {table_name}, filter {filter}, newValue {new_value}.")
-            for update_kv, ids in remove_opt.items():
-                k, v = json.loads(update_kv)
-                table_instance.update(filter + " AND id in ({0})".format(",".join([f"'{id}'" for id in ids])),
-                                      {k: "###".join(v)})
+                self.logger.debug(
+                    f"INFINITY update table {table_name}, filter {filter_expr}, newValue {current_new_value}."
+                )
+                for update_kv, ids in remove_opt.items():
+                    k, v = json.loads(update_kv)
+                    table_instance.update(
+                        filter_expr + " AND id in ({0})".format(",".join([f"'{id}'" for id in ids])),
+                        {k: "###".join(v)},
+                    )
 
-            table_instance.update(filter, new_value)
-        finally:
-            self.connPool.release_conn(inf_conn)
+                table_instance.update(filter_expr, current_new_value)
+                return True
+            except InfinityException as e:
+                if attempt < max_retries and self._is_transaction_conflict(e):
+                    self.logger.warning(
+                        "INFINITY update conflict on %s with filter %s (attempt %s/%s): %s",
+                        table_name,
+                        filter_expr or condition,
+                        attempt + 1,
+                        max_retries + 1,
+                        e,
+                    )
+                    time.sleep(retry_delay * (2 ** attempt))
+                    continue
+                raise
+            finally:
+                self.connPool.release_conn(inf_conn)
         return True
 
     def adjust_chunk_pagerank_fea(

--- a/test/testcases/test_http_api/test_chunk_management_within_dataset/test_update_chunk.py
+++ b/test/testcases/test_http_api/test_chunk_management_within_dataset/test_update_chunk.py
@@ -224,7 +224,6 @@ class TestUpdatedChunk:
             assert res["message"] == expected_message
 
     @pytest.mark.p3
-    @pytest.mark.skipif(os.getenv("DOC_ENGINE") == "infinity", reason="issues/6554")
     def test_concurrent_update_chunk(self, HttpApiAuth, add_chunks):
         count = 50
         dataset_id, document_id, chunk_ids = add_chunks

--- a/test/testcases/test_sdk_api/test_chunk_management_within_dataset/test_update_chunk.py
+++ b/test/testcases/test_sdk_api/test_chunk_management_within_dataset/test_update_chunk.py
@@ -149,7 +149,6 @@ class TestUpdatedChunk:
         chunk.update({"content": "chunk test 2"})
 
     @pytest.mark.p3
-    @pytest.mark.skipif(os.getenv("DOC_ENGINE") == "infinity", reason="issues/6554")
     def test_concurrent_update_chunk(self, add_chunks):
         count = 50
         _, _, chunks = add_chunks

--- a/test/testcases/test_web_api/test_chunk_app/test_infinity_conn_retry_unit.py
+++ b/test/testcases/test_web_api/test_chunk_app/test_infinity_conn_retry_unit.py
@@ -1,0 +1,226 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.messages = {"debug": [], "warning": [], "error": [], "info": []}
+
+    def debug(self, *args, **kwargs):
+        self.messages["debug"].append((args, kwargs))
+
+    def warning(self, *args, **kwargs):
+        self.messages["warning"].append((args, kwargs))
+
+    def error(self, *args, **kwargs):
+        self.messages["error"].append((args, kwargs))
+
+    def info(self, *args, **kwargs):
+        self.messages["info"].append((args, kwargs))
+
+
+class _FakeColumns:
+    def rows(self):
+        return []
+
+
+class _FakeTable:
+    def __init__(self, outcomes):
+        self._outcomes = list(outcomes)
+        self.update_calls = []
+
+    def show_columns(self):
+        return _FakeColumns()
+
+    def update(self, filter_expr, payload):
+        self.update_calls.append((filter_expr, payload))
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class _FakeDatabase:
+    def __init__(self, table):
+        self._table = table
+
+    def get_table(self, _name):
+        return self._table
+
+
+class _FakeConn:
+    def __init__(self, table):
+        self._db = _FakeDatabase(table)
+
+    def get_database(self, _db_name):
+        return self._db
+
+
+class _FakeConnPool:
+    def __init__(self, table):
+        self._conn = _FakeConn(table)
+        self.release_count = 0
+
+    def get_conn(self):
+        return self._conn
+
+    def release_conn(self, _conn):
+        self.release_count += 1
+
+
+def _load_infinity_module(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[4]
+
+    common_pkg = ModuleType("common")
+    common_pkg.__path__ = [str(repo_root / "common")]
+    monkeypatch.setitem(sys.modules, "common", common_pkg)
+
+    decorator_mod = ModuleType("common.decorator")
+    decorator_mod.singleton = lambda cls, *args, **kwargs: cls
+    monkeypatch.setitem(sys.modules, "common.decorator", decorator_mod)
+
+    doc_store_pkg = ModuleType("common.doc_store")
+    doc_store_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "common.doc_store", doc_store_pkg)
+
+    doc_store_base_mod = ModuleType("common.doc_store.doc_store_base")
+    doc_store_base_mod.MatchExpr = type("MatchExpr", (), {})
+    doc_store_base_mod.MatchTextExpr = type("MatchTextExpr", (), {})
+    doc_store_base_mod.MatchDenseExpr = type("MatchDenseExpr", (), {})
+    doc_store_base_mod.FusionExpr = type("FusionExpr", (), {})
+    doc_store_base_mod.OrderByExpr = type("OrderByExpr", (), {})
+    monkeypatch.setitem(sys.modules, "common.doc_store.doc_store_base", doc_store_base_mod)
+
+    infinity_base_mod = ModuleType("common.doc_store.infinity_conn_base")
+
+    class _InfinityConnectionBase:
+        @staticmethod
+        def list2str(lst, sep=" "):
+            if isinstance(lst, str):
+                return lst
+            return sep.join(lst)
+
+        def equivalent_condition_to_str(self, condition, _table_instance=None):
+            clauses = []
+            for key, value in condition.items():
+                if isinstance(value, str):
+                    clauses.append(f"{key}='{value}'")
+                else:
+                    clauses.append(f"{key}={value}")
+            return " AND ".join(clauses) if clauses else "1=1"
+
+    infinity_base_mod.InfinityConnectionBase = _InfinityConnectionBase
+    monkeypatch.setitem(sys.modules, "common.doc_store.infinity_conn_base", infinity_base_mod)
+
+    constants_mod = ModuleType("common.constants")
+    constants_mod.PAGERANK_FLD = "pagerank_flt"
+    constants_mod.TAG_FLD = "tag_kwd"
+    monkeypatch.setitem(sys.modules, "common.constants", constants_mod)
+
+    infinity_pkg = ModuleType("infinity")
+    monkeypatch.setitem(sys.modules, "infinity", infinity_pkg)
+
+    infinity_common_mod = ModuleType("infinity.common")
+
+    class _FakeInfinityException(Exception):
+        def __init__(self, error_code, error_msg):
+            super().__init__(error_msg)
+            self.error_code = error_code
+            self.error_msg = error_msg
+
+    infinity_common_mod.InfinityException = _FakeInfinityException
+    infinity_common_mod.SortType = SimpleNamespace(Asc="asc", Desc="desc")
+    monkeypatch.setitem(sys.modules, "infinity.common", infinity_common_mod)
+
+    infinity_errors_mod = ModuleType("infinity.errors")
+    infinity_errors_mod.ErrorCode = SimpleNamespace(OK=0)
+    monkeypatch.setitem(sys.modules, "infinity.errors", infinity_errors_mod)
+
+    module_name = "test_infinity_conn_retry_unit_target"
+    spec = importlib.util.spec_from_file_location(
+        module_name, repo_root / "rag" / "utils" / "infinity_conn.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_connection(module, table):
+    conn = module.InfinityConnection.__new__(module.InfinityConnection)
+    conn.dbName = "default_db"
+    conn.connPool = _FakeConnPool(table)
+    conn.logger = _FakeLogger()
+    return conn
+
+
+def test_update_retries_on_transaction_conflict(monkeypatch):
+    module = _load_infinity_module(monkeypatch)
+    table = _FakeTable(
+        [
+            module.InfinityException(4002, "Txn conflict reason: Conflict with candidate_txn 10168"),
+            True,
+        ]
+    )
+    conn = _build_connection(module, table)
+
+    ok = conn.update(
+        {"id": "chunk-1"},
+        {"content_with_weight": "updated content"},
+        "ragflow_tenant",
+        "kb-1",
+        max_retries=2,
+        retry_delay=0,
+    )
+
+    assert ok is True
+    assert table.update_calls == [
+        ("id='chunk-1'", {"content": "updated content"}),
+        ("id='chunk-1'", {"content": "updated content"}),
+    ]
+    assert len(conn.logger.messages["warning"]) == 1
+    assert conn.connPool.release_count == 2
+
+
+def test_update_does_not_retry_non_conflict_exception(monkeypatch):
+    module = _load_infinity_module(monkeypatch)
+    table = _FakeTable(
+        [module.InfinityException(5001, "table not found")]
+    )
+    conn = _build_connection(module, table)
+
+    with pytest.raises(module.InfinityException, match="table not found"):
+        conn.update(
+            {"id": "chunk-1"},
+            {"content_with_weight": "updated content"},
+            "ragflow_tenant",
+            "kb-1",
+            max_retries=2,
+            retry_delay=0,
+        )
+
+    assert table.update_calls == [
+        ("id='chunk-1'", {"content": "updated content"})
+    ]
+    assert conn.logger.messages["warning"] == []
+    assert conn.connPool.release_count == 1

--- a/test/testcases/test_web_api/test_chunk_app/test_update_chunk.py
+++ b/test/testcases/test_web_api/test_chunk_app/test_update_chunk.py
@@ -231,7 +231,6 @@ class TestUpdateChunk:
             assert res["message"] == expected_message, res
 
     @pytest.mark.p3
-    @pytest.mark.skipif(os.getenv("DOC_ENGINE") == "infinity", reason="issues/6554")
     def test_concurrent_update_chunk(self, WebApiAuth, add_chunks):
         count = 50
         _, doc_id, chunk_ids = add_chunks


### PR DESCRIPTION
## Summary
- retry Infinity doc-store updates when the backend returns a transaction-conflict error
- keep retries scoped to conflict errors so non-conflict failures still surface immediately
- re-enable the concurrent chunk update regression tests and add a focused unit test for the retry path

## Testing
- python -m pytest --noconftest test/testcases/test_web_api/test_chunk_app/test_infinity_conn_retry_unit.py -q
- python -m py_compile rag/utils/infinity_conn.py test/testcases/test_web_api/test_chunk_app/test_infinity_conn_retry_unit.py test/testcases/test_http_api/test_chunk_management_within_dataset/test_update_chunk.py test/testcases/test_web_api/test_chunk_app/test_update_chunk.py test/testcases/test_sdk_api/test_chunk_management_within_dataset/test_update_chunk.py

Closes #6554