### PR TITLE
fix: support Azure OpenAI reasoning models (o1/o3/o4-mini) by removing unsupported parameters

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1526,6 +1526,34 @@
                     "tags": "LLM,CHAT,IMAGE2TEXT",
                     "max_tokens": 765,
                     "model_type": "image2text"
+                },
+                {
+                    "llm_name": "o1",
+                    "tags": "LLM,CHAT,200K,IMAGE2TEXT",
+                    "max_tokens": 200000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "o3",
+                    "tags": "LLM,CHAT,200K,IMAGE2TEXT",
+                    "max_tokens": 200000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "o3-mini",
+                    "tags": "LLM,CHAT,200K",
+                    "max_tokens": 200000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "o4-mini",
+                    "tags": "LLM,CHAT,200K,IMAGE2TEXT",
+                    "max_tokens": 200000,
+                    "model_type": "chat",
+                    "is_tools": true
                 }
             ]
         },

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -85,6 +85,23 @@ def _apply_model_family_policies(
                 sanitized_gen_conf.pop(key, None)
                 sanitized_kwargs.pop(key, None)
 
+        # Reasoning models (o1, o3, o4-mini, codex-mini) do not support:
+        # temperature, top_p, presence_penalty, frequency_penalty,
+        # logprobs, top_logprobs, logit_bias, max_tokens.
+        # Only max_completion_tokens is supported for token limits.
+        if provider in {SupportedLiteLLMProvider.OpenAI, SupportedLiteLLMProvider.Azure_OpenAI}:
+            # Model name may be prefixed (e.g. "azure/o1", "openai/o3-mini").
+            # Strip the provider prefix to get the base model name.
+            base_name = model_name_lower.split("/")[-1]
+            is_reasoning_model = any(
+                base_name == p or base_name.startswith(p + "-")
+                for p in ("o1", "o3", "o4-mini", "codex-mini")
+            )
+            if is_reasoning_model:
+                for key in ("temperature", "top_p", "presence_penalty", "frequency_penalty", "logprobs", "top_logprobs", "logit_bias"):
+                    sanitized_gen_conf.pop(key, None)
+                    sanitized_kwargs.pop(key, None)
+
         if provider == SupportedLiteLLMProvider.HunYuan:
             for key in ("presence_penalty", "frequency_penalty"):
                 sanitized_gen_conf.pop(key, None)


### PR DESCRIPTION
### What problem does this PR solve?

## Summary

Fixes #6063

Users were unable to add Azure OpenAI reasoning models (o1, o3, o3-mini, o4-mini) due to unsupported parameter errors. When the backend sent a validation request with `temperature: 0.9`, these models rejected it because reasoning models do not support `temperature`, `top_p`, `max_tokens`, and other legacy parameters.

## Root Cause

1. **Missing model definitions**: The Azure-OpenAI factory in `llm_factories.json` did not include any reasoning models (o1/o3/o4-mini), so users had to manually enter model names.

2. **Unsupported parameters sent to reasoning models**: The `_apply_model_family_policies()` function in `chat_model.py` only handled parameter stripping for `gpt-5` models. Reasoning models (o1/o3/o4-mini/codex-mini) require the same treatment — they do not support `temperature`, `top_p`, `presence_penalty`, `frequency_penalty`, `logprobs`, `top_logprobs`, `logit_bias`, or `max_tokens`. Only `max_completion_tokens` is supported for controlling output length.

## Changes

### `rag/llm/chat_model.py`
- Extended `_apply_model_family_policies()` to detect OpenAI/Azure reasoning models (o1, o3, o4-mini, codex-mini) by matching the base model name (stripping provider prefix like `azure/` or `openai/`).
- These models now automatically have unsupported parameters (`temperature`, `top_p`, `presence_penalty`, `frequency_penalty`, `logprobs`, `top_logprobs`, `logit_bias`) removed before the API call.

### `conf/llm_factories.json`
- Added reasoning models to the Azure-OpenAI factory:
  - `o1` (200K context, image input, tool support)
  - `o3` (200K context, image input, tool support)
  - `o3-mini` (200K context, tool support)
  - `o4-mini` (200K context, image input, tool support)

## Verification

Confirmed against [Azure OpenAI reasoning models documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning) and [model retirement schedule](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/model-retirements):

> The following are currently unsupported with reasoning models:
> `temperature`, `top_p`, `presence_penalty`, `frequency_penalty`, `logprobs`, `top_logprobs`, `logit_bias`, `max_tokens`

All four models are Generally Available (GA) on Azure OpenAI.

## Testing

```python
# Verified model name detection logic
"azure/o1"       -> reasoning=True
"azure/o3-mini"  -> reasoning=True
"azure/o4-mini"  -> reasoning=True
"openai/o1"      -> reasoning=True
"azure/gpt-4o"   -> reasoning=False
"openai/gpt-5"   -> reasoning=False


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
