### PR TITLE
Fix: Spaces cannot be entered in the code editor of the code operator.

### DIFF
--- a/web/src/pages/agent/canvas/index.tsx
+++ b/web/src/pages/agent/canvas/index.tsx
@@ -331,6 +331,7 @@ function AgentCanvas({ drawerVisible, hideDrawer }: IProps) {
           }}
           deleteKeyCode={['Delete', 'Backspace']}
           onBeforeDelete={handleBeforeDelete}
+          panActivationKeyCode={null}
         >
           <AgentBackground></AgentBackground>
           <Spotlight className="z-0" opcity={0.7} coverage={70} />


### PR DESCRIPTION
### What problem does this PR solve?

Fix: Spaces cannot be entered in the code editor of the code operator.

[Monaco Editor with XYFlow fails to accept most space bar keypresses, who is at fault? #5204](https://github.com/microsoft/monaco-editor/discussions/5204)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

