### PR TITLE
fix: escape single quotes in Infinity SQL filter conditions

### DIFF
--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -207,7 +207,8 @@ class InfinityConnectionBase(DocStoreConnection):
                         if kk == "exists":
                             cond.append("NOT (%s)" % exists(vv))
             elif isinstance(v, str):
-                cond.append(f"{k}='{v.replace(\"'\", \"''\")}'")
+                escaped_v = v.replace("'", "''")
+                cond.append(f"{k}='{escaped_v}'")
             elif k == "exists":
                 cond.append(exists(v))
             else:

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -187,7 +187,7 @@ class InfinityConnectionBase(DocStoreConnection):
                         strInCond = f"({strInCond})"
                         cond.append(strInCond)
                 else:
-                    cond.append(f"filter_fulltext('{self.convert_matching_field(k)}', '{v}')")
+                    cond.append(f"filter_fulltext('{self.convert_matching_field(k)}', '{v.replace(\"'\", \"''\")}')")
             elif isinstance(v, list):
                 inCond = list()
                 for item in v:
@@ -206,7 +206,7 @@ class InfinityConnectionBase(DocStoreConnection):
                         if kk == "exists":
                             cond.append("NOT (%s)" % exists(vv))
             elif isinstance(v, str):
-                cond.append(f"{k}='{v}'")
+                cond.append(f"{k}='{v.replace(\"'\", \"''\")}'")
             elif k == "exists":
                 cond.append(exists(v))
             else:

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -187,7 +187,8 @@ class InfinityConnectionBase(DocStoreConnection):
                         strInCond = f"({strInCond})"
                         cond.append(strInCond)
                 else:
-                    cond.append(f"filter_fulltext('{self.convert_matching_field(k)}', '{v.replace(\"'\", \"''\")}')")
+                    escaped_v = str(v).replace("'", "''")
+                    cond.append(f"filter_fulltext('{self.convert_matching_field(k)}', '{escaped_v}')")
             elif isinstance(v, list):
                 inCond = list()
                 for item in v:


### PR DESCRIPTION
### What problem does this PR solve?

## Summary

Fixes #5939

Entity names containing single quotes (e.g., `投影直线L'`) caused SQL syntax errors when building filter conditions for Infinity queries, due to unescaped string interpolation in `equivalent_condition_to_str`.

## Changes

In `common/doc_store/infinity_conn_base.py`, added `.replace("'", "''")` escaping for string values in two branches of `equivalent_condition_to_str` where it was missing:

1. **`field_keyword` branch with non-list value** (line 190): The list branch already escaped single quotes on line 183, but the single-string branch did not.
2. **Plain string value branch** (line 209): Direct f-string interpolation `{k}='{v}'` was vulnerable to unescaped quotes.

Both fixes use the same SQL-standard escape pattern (`'` → `''`) already applied elsewhere in this method.

## How to Test

1. Upload a document containing entity names with single quotes.
2. Enable Knowledge Graph (GraphRAG) in the parsing configuration.
3. Initiate document parsing — it should complete without SQL syntax errors.

## Note

The original issue also reported a typo (`dge_graph_kwd` instead of `knowledge_graph_kwd`), which has already been fixed in the current codebase.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
