### PR TITLE
chore(docs): tips for installing CN fonts

### DIFF
--- a/agent/sandbox/README.md
+++ b/agent/sandbox/README.md
@@ -193,7 +193,7 @@ Pre-installed packages: `requests`, `numpy`, `pandas`, `matplotlib`.
 
 > `matplotlib` uses the `Agg` (non-interactive) backend by default in the sandbox (`MPLBACKEND=Agg`). No display server is available, so always save figures to files (e.g. `fig.savefig("artifacts/chart.png")`) rather than calling `plt.show()`.
 >
-> Tip: if Chinese text renders as missing boxes/squares in `matplotlib`, install Debian package `fonts-noto-cjk` in your custom image. We do not preinstall it by default to keep the base image smaller. After the font is installed, the RAGFlow Code component will detect available CJK fonts and automatically configure `matplotlib` font settings for generated Python plotting code.
+> Tip: if Chinese text renders as missing boxes/squares in `matplotlib`, install Debian package `fonts-noto-cjk` in your custom image. We do not preinstall it by default to keep the base image smaller. The sandbox base image ships a `matplotlibrc` that already lists common CJK fonts in the `font.sans-serif` fallback chain, so no code-level font configuration is needed — just install the font package and rebuild the image.
 >
 > Example:
 >

--- a/agent/sandbox/README.md
+++ b/agent/sandbox/README.md
@@ -192,6 +192,14 @@ Currently, the following languages are officially supported:
 Pre-installed packages: `requests`, `numpy`, `pandas`, `matplotlib`.
 
 > `matplotlib` uses the `Agg` (non-interactive) backend by default in the sandbox (`MPLBACKEND=Agg`). No display server is available, so always save figures to files (e.g. `fig.savefig("artifacts/chart.png")`) rather than calling `plt.show()`.
+>
+> Tip: if Chinese text renders as missing boxes/squares in `matplotlib`, install Debian package `fonts-noto-cjk` in your custom image. We do not preinstall it by default to keep the base image smaller.
+>
+> Example:
+>
+> ```dockerfile
+> RUN apt-get update && apt-get install -y --no-install-recommends fonts-noto-cjk && rm -rf /var/lib/apt/lists/*
+> ```
 
 To add more dependencies, edit:
 

--- a/agent/sandbox/README.md
+++ b/agent/sandbox/README.md
@@ -193,7 +193,7 @@ Pre-installed packages: `requests`, `numpy`, `pandas`, `matplotlib`.
 
 > `matplotlib` uses the `Agg` (non-interactive) backend by default in the sandbox (`MPLBACKEND=Agg`). No display server is available, so always save figures to files (e.g. `fig.savefig("artifacts/chart.png")`) rather than calling `plt.show()`.
 >
-> Tip: if Chinese text renders as missing boxes/squares in `matplotlib`, install Debian package `fonts-noto-cjk` in your custom image. We do not preinstall it by default to keep the base image smaller.
+> Tip: if Chinese text renders as missing boxes/squares in `matplotlib`, install Debian package `fonts-noto-cjk` in your custom image. We do not preinstall it by default to keep the base image smaller. After the font is installed, the RAGFlow Code component will detect available CJK fonts and automatically configure `matplotlib` font settings for generated Python plotting code.
 >
 > Example:
 >

--- a/agent/sandbox/sandbox_base_image/python/Dockerfile
+++ b/agent/sandbox/sandbox_base_image/python/Dockerfile
@@ -4,8 +4,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.7.5 /uv /uvx /bin/
 ENV UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 ENV MPLBACKEND=Agg
 ENV MPLCONFIGDIR=/tmp/matplotlib
+ENV MATPLOTLIBRC=/usr/local/etc/matplotlibrc
 
 COPY requirements.txt .
+COPY matplotlibrc /usr/local/etc/matplotlibrc
 
 RUN grep -rl 'deb.debian.org' /etc/apt/ | xargs sed -i 's|http[s]*://deb.debian.org|https://mirrors.tuna.tsinghua.edu.cn|g' && \
     apt-get update && \

--- a/agent/sandbox/sandbox_base_image/python/matplotlibrc
+++ b/agent/sandbox/sandbox_base_image/python/matplotlibrc
@@ -1,0 +1,11 @@
+## RAGFlow sandbox – matplotlib defaults
+## Only overrides are listed; all other settings use matplotlib built-in defaults.
+
+# Prefer CJK-capable fonts so Chinese / Japanese / Korean text renders correctly.
+# matplotlib silently skips fonts that are not installed, falling back to the
+# next entry in the list, so this is safe even without any CJK font package.
+font.family: sans-serif
+font.sans-serif: Noto Sans CJK SC, Noto Sans CJK TC, Noto Sans CJK JP, Noto Sans CJK KR, Source Han Sans SC, Source Han Sans CN, WenQuanYi Zen Hei, Microsoft YaHei, SimHei, PingFang SC, Heiti SC, STHeiti, Arial Unicode MS, DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
+
+# Use ASCII hyphen-minus for the minus sign so it renders correctly with any font.
+axes.unicode_minus: False

--- a/agent/tools/code_exec.py
+++ b/agent/tools/code_exec.py
@@ -46,31 +46,6 @@ SYSTEM_OUTPUT_KEYS = frozenset(
     }
 )
 
-_AUTO_MPL_FONT_MARKER = "# [CodeExec] Auto matplotlib font defaults"
-_AUTO_MPL_FONT_DETECTION_LINES = [
-    "    from matplotlib import font_manager as _rf_font_manager",
-    "    _rf_available_font_names = {f.name for f in _rf_font_manager.fontManager.ttflist}",
-    "    _rf_cjk_candidates = [",
-    '        "Noto Sans CJK SC",',
-    '        "Noto Sans CJK TC",',
-    '        "Noto Sans CJK JP",',
-    '        "Noto Sans CJK KR",',
-    '        "Source Han Sans SC",',
-    '        "Source Han Sans CN",',
-    '        "WenQuanYi Zen Hei",',
-    '        "Microsoft YaHei",',
-    '        "SimHei",',
-    '        "PingFang SC",',
-    '        "Heiti SC",',
-    '        "STHeiti",',
-    '        "Arial Unicode MS",',
-    "    ]",
-    "    _rf_selected_cjk_font = next((name for name in _rf_cjk_candidates if name in _rf_available_font_names), None)",
-    "    if _rf_selected_cjk_font:",
-    '        matplotlib.rcParams["font.family"] = [_rf_selected_cjk_font, "DejaVu Sans"]',
-]
-_AUTO_MPL_UNICODE_MINUS_LINE = '    matplotlib.rcParams["axes.unicode_minus"] = False'
-
 
 class ContractError(ValueError):
     pass
@@ -377,7 +352,6 @@ class CodeExec(ToolBase, ABC):
             return self.output()
 
         timeout_seconds = int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60))
-        code = self._prepare_code_for_execution(language=language, code=code)
 
         try:
             # Try using the new sandbox provider system first
@@ -449,31 +423,6 @@ class CodeExec(ToolBase, ABC):
             self.set_output("_ERROR", "Exception executing code: " + str(e))
 
         return self.output()
-
-    def _prepare_code_for_execution(self, language: str, code: str) -> str:
-        lang = str(language or "").lower()
-        if lang not in {"python", "python3"}:
-            return code
-        if _AUTO_MPL_FONT_MARKER in code:
-            return code
-
-        lower_code = code.lower()
-        need_font_family = "font.family" not in lower_code
-        need_unicode_minus = "axes.unicode_minus" not in lower_code
-        if not need_font_family and not need_unicode_minus:
-            return code
-
-        bootstrap_lines = [
-            _AUTO_MPL_FONT_MARKER,
-            "try:",
-            "    import matplotlib",
-        ]
-        if need_font_family:
-            bootstrap_lines.extend(_AUTO_MPL_FONT_DETECTION_LINES)
-        if need_unicode_minus:
-            bootstrap_lines.append(_AUTO_MPL_UNICODE_MINUS_LINE)
-        bootstrap_lines.extend(["except Exception:", "    pass", ""])
-        return "\n".join(bootstrap_lines) + code
 
     def _process_execution_result(
         self,

--- a/agent/tools/code_exec.py
+++ b/agent/tools/code_exec.py
@@ -46,6 +46,31 @@ SYSTEM_OUTPUT_KEYS = frozenset(
     }
 )
 
+_AUTO_MPL_FONT_MARKER = "# [CodeExec] Auto matplotlib font defaults"
+_AUTO_MPL_FONT_DETECTION_LINES = [
+    "    from matplotlib import font_manager as _rf_font_manager",
+    "    _rf_available_font_names = {f.name for f in _rf_font_manager.fontManager.ttflist}",
+    "    _rf_cjk_candidates = [",
+    '        "Noto Sans CJK SC",',
+    '        "Noto Sans CJK TC",',
+    '        "Noto Sans CJK JP",',
+    '        "Noto Sans CJK KR",',
+    '        "Source Han Sans SC",',
+    '        "Source Han Sans CN",',
+    '        "WenQuanYi Zen Hei",',
+    '        "Microsoft YaHei",',
+    '        "SimHei",',
+    '        "PingFang SC",',
+    '        "Heiti SC",',
+    '        "STHeiti",',
+    '        "Arial Unicode MS",',
+    "    ]",
+    "    _rf_selected_cjk_font = next((name for name in _rf_cjk_candidates if name in _rf_available_font_names), None)",
+    "    if _rf_selected_cjk_font:",
+    '        matplotlib.rcParams["font.family"] = [_rf_selected_cjk_font, "DejaVu Sans"]',
+]
+_AUTO_MPL_UNICODE_MINUS_LINE = '    matplotlib.rcParams["axes.unicode_minus"] = False'
+
 
 class ContractError(ValueError):
     pass
@@ -352,6 +377,7 @@ class CodeExec(ToolBase, ABC):
             return self.output()
 
         timeout_seconds = int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60))
+        code = self._prepare_code_for_execution(language=language, code=code)
 
         try:
             # Try using the new sandbox provider system first
@@ -423,6 +449,31 @@ class CodeExec(ToolBase, ABC):
             self.set_output("_ERROR", "Exception executing code: " + str(e))
 
         return self.output()
+
+    def _prepare_code_for_execution(self, language: str, code: str) -> str:
+        lang = str(language or "").lower()
+        if lang not in {"python", "python3"}:
+            return code
+        if _AUTO_MPL_FONT_MARKER in code:
+            return code
+
+        lower_code = code.lower()
+        need_font_family = "font.family" not in lower_code
+        need_unicode_minus = "axes.unicode_minus" not in lower_code
+        if not need_font_family and not need_unicode_minus:
+            return code
+
+        bootstrap_lines = [
+            _AUTO_MPL_FONT_MARKER,
+            "try:",
+            "    import matplotlib",
+        ]
+        if need_font_family:
+            bootstrap_lines.extend(_AUTO_MPL_FONT_DETECTION_LINES)
+        if need_unicode_minus:
+            bootstrap_lines.append(_AUTO_MPL_UNICODE_MINUS_LINE)
+        bootstrap_lines.extend(["except Exception:", "    pass", ""])
+        return "\n".join(bootstrap_lines) + code
 
     def _process_execution_result(
         self,


### PR DESCRIPTION
### What problem does this PR solve?
Add tips for installing Chinse fonts under code sandbox. Otherwise, `matplotlib `won't render Chinese correctly.

<img width="2082" height="1186" alt="sales_analysis" src="https://github.com/user-attachments/assets/57e675ab-1e92-4662-9aeb-ad72a6121eb5" />



### Type of change

- [x] Documentation Update
