### PR TITLE
Fix: parent child config

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -458,9 +458,6 @@ async def patch_chat(chat_id):
             return get_data_error_result(message="Chat not found!")
         current_chat = current_chat.to_dict()
 
-        if req.get("tenant_id"):
-            return get_data_error_result(message="`tenant_id` must not be provided.")
-
         if "name" in req:
             name, err = _validate_name(req.get("name"), required=False)
             if err:

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -206,17 +206,20 @@ async def update_dataset(tenant_id: str, dataset_id: str, req: dict):
         del req["connectors"]
 
     if req.get("parser_config"):
-        parser_config = req["parser_config"]
-        req_ext_fields = parser_config.pop("ext", {})
-        parser_config.update(req_ext_fields)
-        req["parser_config"] = deep_merge(kb.parser_config, parser_config)
-
         # Flatten parent_child config into children_delimiter for the execution layer
         pc = req["parser_config"].get("parent_child", {})
         if pc.get("use_parent_child"):
             req["parser_config"]["children_delimiter"] = pc.get("children_delimiter", "\n")
-        elif pc:
+            req["parser_config"]["enable_children"] = pc.get("use_parent_child", True)
+        else:
             req["parser_config"]["children_delimiter"] = ""
+            req["parser_config"]["enable_children"] = False
+            req["parser_config"]["parent_child"] = {}
+
+        parser_config = req["parser_config"]
+        req_ext_fields = parser_config.pop("ext", {})
+        parser_config.update(req_ext_fields)
+        req["parser_config"] = deep_merge(kb.parser_config, parser_config)
 
     if (chunk_method := req.get("parser_id")) and chunk_method != kb.parser_id:
         if not req.get("parser_config"):

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -323,9 +323,7 @@ export const useUpdateKnowledge = (shouldFetchList = false) => {
       task_page_size,
       pages,
       parent_child:
-        children_delimiter !== undefined ||
-        use_parent_child !== undefined ||
-        enable_children !== undefined
+        children_delimiter !== undefined || use_parent_child !== undefined
           ? {
               children_delimiter,
               use_parent_child: use_parent_child ?? enable_children,

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -322,13 +322,12 @@ export const useUpdateKnowledge = (shouldFetchList = false) => {
       filename_embd_weight,
       task_page_size,
       pages,
-      parent_child:
-        children_delimiter !== undefined || use_parent_child !== undefined
-          ? {
-              children_delimiter,
-              use_parent_child: use_parent_child ?? enable_children,
-            }
-          : undefined,
+      parent_child: enable_children
+        ? {
+            children_delimiter,
+            use_parent_child: use_parent_child ?? enable_children,
+          }
+        : undefined,
       ext: { ...ext, ...parserExt },
     };
   };


### PR DESCRIPTION
### What problem does this PR solve?

Correctly set and display parent-child config in parser_config, and allow to pass `tenant_id` in PATCH `/api/v1/chats`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)