### PR TITLE
OpenSource Resume is supported only with Elasticsearch.

### DIFF
--- a/rag/app/resume.py
+++ b/rag/app/resume.py
@@ -39,6 +39,8 @@ from io import BytesIO
 from typing import Optional
 import numpy as np
 
+from common import settings
+
 # tiktoken for long random string filtering (ref: SmartResume should_remove strategy)
 try:
     import tiktoken
@@ -2484,6 +2486,9 @@ def chunk(filename, binary, tenant_id, from_page=0, to_page=100000,
     """
     if callback is None:
         def callback(prog, msg): return None
+
+    if settings.DOC_ENGINE.lower() != "elasticsearch":
+        raise Exception("Resume is supported only with Elasticsearch.")
 
     try:
         callback(0.1, "Starting resume parsing...")


### PR DESCRIPTION
### What problem does this PR solve?

OpenSource Resume is supported only with Elasticsearch.

Now
<img width="1523" height="1005" alt="img_v3_0210u_37519504-78a6-48c3-bac9-bbc3cf47ce3g" src="https://github.com/user-attachments/assets/451f0dfa-fe81-4635-a6ac-f6de5782b8ba" />

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)