### PR TITLE
refactor: optimize thread_pool_exec by removing redundant code

### DIFF
--- a/common/misc_utils.py
+++ b/common/misc_utils.py
@@ -127,7 +127,5 @@ def _thread_pool_executor():
 
 async def thread_pool_exec(func, *args, **kwargs):
     loop = asyncio.get_running_loop()
-    if kwargs:
-        func = functools.partial(func, *args, **kwargs)
-        return await loop.run_in_executor(_thread_pool_executor(), func)
-    return await loop.run_in_executor(_thread_pool_executor(), func, *args)
+    wrapped_func = functools.partial(func, *args, **kwargs)
+    return await loop.run_in_executor(_thread_pool_executor(), wrapped_func)


### PR DESCRIPTION
Optimize the `thread_pool_exec` function in `common/misc_utils.py`:
1. Remove redundant `if kwargs` conditional branch
2. Merge duplicate `loop.run_in_executor()` calls into one unified call
3. All original logic, async behavior and thread pool usage remain completely unchanged
4. Improve code conciseness and maintainability, 100% backward compatible

### What problem does this PR solve?
The original implementation has redundant conditional branching and duplicate `run_in_executor` invocation logic.
`functools.partial` natively supports both positional arguments (`*args`) and keyword arguments (`**kwargs`), so the separate `if kwargs` check is unnecessary and redundant.
This refactoring cleans up redundant code without altering any runtime behavior, function logic, or thread pool execution.

### Type of change
- [x] Refactoring