### PR TITLE
Docs: 0.25.0 agent apps can be published.

### DIFF
--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -1685,7 +1685,7 @@ The parameters in `begin` component.
 
 Also supports:
 
-- `release` (`bool | str`, optional): Set to `True` (or `"true"`) to create the session in release mode (published version only).
+- `release` (`bool | str`, optional): When set to `True` (or `"true"`), creates a session with the published agent app only.
 
 #### Returns
 


### PR DESCRIPTION
### What problem does this PR solve?

Agent apps can be published.

### Type of change

- [x] Documentation Update

