### PR TITLE
feat: Add Astraflow (UCloud ModelVerse) provider support

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -6294,6 +6294,124 @@
             ]
         },
         {
+            "name": "Astraflow",
+            "logo": "",
+            "tags": "LLM,TEXT EMBEDDING",
+            "status": "1",
+            "rank": "200",
+            "url": "https://api-us-ca.umodelverse.ai/v1",
+            "llm": [
+                {
+                    "llm_name": "deepseek-v3",
+                    "tags": "LLM,CHAT,64K",
+                    "max_tokens": 65536,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "deepseek-r1",
+                    "tags": "LLM,CHAT,64K",
+                    "max_tokens": 65536,
+                    "model_type": "chat",
+                    "is_tools": false
+                },
+                {
+                    "llm_name": "gpt-4o",
+                    "tags": "LLM,CHAT,128K,IMAGE2TEXT",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "gpt-4o-mini",
+                    "tags": "LLM,CHAT,128K,IMAGE2TEXT",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "claude-3-5-sonnet-20241022",
+                    "tags": "LLM,CHAT,200K",
+                    "max_tokens": 200000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "gemini-2.0-flash",
+                    "tags": "LLM,CHAT,1M",
+                    "max_tokens": 1048576,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "text-embedding-3-small",
+                    "tags": "TEXT EMBEDDING,8K",
+                    "max_tokens": 8191,
+                    "model_type": "embedding",
+                    "is_tools": false
+                },
+                {
+                    "llm_name": "text-embedding-3-large",
+                    "tags": "TEXT EMBEDDING,8K",
+                    "max_tokens": 8191,
+                    "model_type": "embedding",
+                    "is_tools": false
+                }
+            ]
+        },
+        {
+            "name": "Astraflow-CN",
+            "logo": "",
+            "tags": "LLM,TEXT EMBEDDING",
+            "status": "1",
+            "rank": "199",
+            "url": "https://api.modelverse.cn/v1",
+            "llm": [
+                {
+                    "llm_name": "deepseek-v3",
+                    "tags": "LLM,CHAT,64K",
+                    "max_tokens": 65536,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "deepseek-r1",
+                    "tags": "LLM,CHAT,64K",
+                    "max_tokens": 65536,
+                    "model_type": "chat",
+                    "is_tools": false
+                },
+                {
+                    "llm_name": "qwen3-235b-a22b",
+                    "tags": "LLM,CHAT,128K",
+                    "max_tokens": 131072,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "qwen3-30b-a3b",
+                    "tags": "LLM,CHAT,128K",
+                    "max_tokens": 131072,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "text-embedding-3-small",
+                    "tags": "TEXT EMBEDDING,8K",
+                    "max_tokens": 8191,
+                    "model_type": "embedding",
+                    "is_tools": false
+                },
+                {
+                    "llm_name": "text-embedding-3-large",
+                    "tags": "TEXT EMBEDDING,8K",
+                    "max_tokens": 8191,
+                    "model_type": "embedding",
+                    "is_tools": false
+                }
+            ]
+        },
+        {
             "name": "Avian",
             "logo": "",
             "tags": "LLM",

--- a/rag/llm/__init__.py
+++ b/rag/llm/__init__.py
@@ -59,6 +59,8 @@ class SupportedLiteLLMProvider(StrEnum):
     n1n = "n1n"
     HunYuan = "Tencent Hunyuan"
     Avian = "Avian"
+    Astraflow = "Astraflow"
+    Astraflow_CN = "Astraflow-CN"
 
 
 FACTORY_DEFAULT_BASE_URL = {
@@ -87,6 +89,8 @@ FACTORY_DEFAULT_BASE_URL = {
     SupportedLiteLLMProvider.n1n: "https://api.n1n.ai/v1",
     SupportedLiteLLMProvider.HunYuan: "https://api.hunyuan.cloud.tencent.com/v1",
     SupportedLiteLLMProvider.Avian: "https://api.avian.io/v1",
+    SupportedLiteLLMProvider.Astraflow: "https://api-us-ca.umodelverse.ai/v1",
+    SupportedLiteLLMProvider.Astraflow_CN: "https://api.modelverse.cn/v1",
 }
 
 
@@ -127,6 +131,8 @@ LITELLM_PROVIDER_PREFIX = {
     SupportedLiteLLMProvider.n1n: "openai/",
     SupportedLiteLLMProvider.HunYuan: "openai/",
     SupportedLiteLLMProvider.Avian: "openai/",
+    SupportedLiteLLMProvider.Astraflow: "openai/",
+    SupportedLiteLLMProvider.Astraflow_CN: "openai/",
 }
 
 ChatModel = globals().get("ChatModel", {})

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -1208,6 +1208,24 @@ class AvianChat(Base):
         super().__init__(key, model_name, base_url, **kwargs)
 
 
+class AstraflowChat(Base):
+    _FACTORY_NAME = "Astraflow"
+
+    def __init__(self, key, model_name, base_url="https://api-us-ca.umodelverse.ai/v1", **kwargs):
+        if not base_url:
+            base_url = "https://api-us-ca.umodelverse.ai/v1"
+        super().__init__(key, model_name, base_url, **kwargs)
+
+
+class AstraflowCNChat(Base):
+    _FACTORY_NAME = "Astraflow-CN"
+
+    def __init__(self, key, model_name, base_url="https://api.modelverse.cn/v1", **kwargs):
+        if not base_url:
+            base_url = "https://api.modelverse.cn/v1"
+        super().__init__(key, model_name, base_url, **kwargs)
+
+
 class LiteLLMBase(ABC):
     _FACTORY_NAME = [
         "Tongyi-Qianwen",

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -170,6 +170,24 @@ class BaiChuanEmbed(OpenAIEmbed):
         super().__init__(key, model_name, base_url)
 
 
+class AstraflowEmbed(OpenAIEmbed):
+    _FACTORY_NAME = "Astraflow"
+
+    def __init__(self, key, model_name, base_url="https://api-us-ca.umodelverse.ai/v1"):
+        if not base_url:
+            base_url = "https://api-us-ca.umodelverse.ai/v1"
+        super().__init__(key, model_name, base_url)
+
+
+class AstraflowCNEmbed(OpenAIEmbed):
+    _FACTORY_NAME = "Astraflow-CN"
+
+    def __init__(self, key, model_name, base_url="https://api.modelverse.cn/v1"):
+        if not base_url:
+            base_url = "https://api.modelverse.cn/v1"
+        super().__init__(key, model_name, base_url)
+
+
 class QWenEmbed(Base):
     _FACTORY_NAME = "Tongyi-Qianwen"
 

--- a/web/src/constants/llm.ts
+++ b/web/src/constants/llm.ts
@@ -64,6 +64,8 @@ export enum LLMFactory {
   PaddleOCR = 'PaddleOCR',
   N1n = 'n1n',
   Avian = 'Avian',
+  Astraflow = 'Astraflow',
+  AstraflowCN = 'Astraflow-CN',
   RAGcon = 'RAGcon',
   Perplexity = 'Perplexity',
 }
@@ -135,6 +137,8 @@ export const IconMap = {
   [LLMFactory.PaddleOCR]: 'paddleocr',
   [LLMFactory.N1n]: 'n1n',
   [LLMFactory.Avian]: 'avian',
+  [LLMFactory.Astraflow]: 'astraflow',
+  [LLMFactory.AstraflowCN]: 'astraflow',
   [LLMFactory.RAGcon]: 'ragcon',
   [LLMFactory.Perplexity]: 'perplexity',
 };
@@ -190,6 +194,8 @@ export const APIMapUrl = {
   [LLMFactory.PaddleOCR]: 'https://www.paddleocr.ai/latest/',
   [LLMFactory.N1n]: 'https://docs.n1n.ai',
   [LLMFactory.Avian]: 'https://avian.io',
+  [LLMFactory.Astraflow]: 'https://astraflow.ucloud.cn/',
+  [LLMFactory.AstraflowCN]: 'https://astraflow.ucloud.cn/',
   [LLMFactory.Perplexity]:
     'https://docs.perplexity.ai/docs/embeddings/quickstart',
 };


### PR DESCRIPTION
## Summary

This PR adds **Astraflow** (by UCloud / 优刻得) as a new LLM provider to RAGFlow.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, operated by UCloud.

### Endpoints
| Region | Base URL | Env var |
|--------|----------|---------|
| Global | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China  | `https://api.modelverse.cn/v1`        | `ASTRAFLOW_CN_API_KEY` |

API key signup: https://astraflow.ucloud.cn/

### Changes

| File | What changed |
|------|-------------|
| `rag/llm/__init__.py` | Added `Astraflow` and `Astraflow_CN` to `SupportedLiteLLMProvider`, `FACTORY_DEFAULT_BASE_URL`, and `LITELLM_PROVIDER_PREFIX` |
| `rag/llm/chat_model.py` | Added `AstraflowChat` and `AstraflowCNChat` classes |
| `rag/llm/embedding_model.py` | Added `AstraflowEmbed` and `AstraflowCNEmbed` classes |
| `conf/llm_factories.json` | Added Astraflow and Astraflow-CN factory entries with representative models |
| `web/src/constants/llm.ts` | Added `Astraflow` / `AstraflowCN` to `LLMFactory` enum, `IconMap`, and `APIMapUrl` |

### Design decisions
- Follows the exact same pattern as existing OpenAI-compatible providers (`n1n`, `Avian`, `DeerAPI`, `CometAPI`)
- Uses `"openai/"` LiteLLM prefix (OpenAI-compatible wire protocol)
- Two separate factory entries (global + China) mirror how other providers with regional endpoints are handled
- No new dependencies required
