### PR TITLE
Fix upload stream handling to prevent truncated files

### DIFF
--- a/internal/service/file.go
+++ b/internal/service/file.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"io"
 	"mime/multipart"
 	"os"
 	"path/filepath"
@@ -343,8 +344,8 @@ func (s *FileService) UploadFile(tenantID, parentID string, files []*multipart.F
 		}
 		defer src.Close()
 
-		data := make([]byte, fileHeader.Size)
-		if _, err := src.Read(data); err != nil {
+		data, err := io.ReadAll(src)
+		if err != nil {
 			return nil, fmt.Errorf("failed to read file data: %w", err)
 		}
 


### PR DESCRIPTION
## Summary
- Replace single `Read()` call in Go upload service with `io.ReadAll()`.
- Prevent potential truncated/corrupted file content during multipart upload.
- Keep existing API behavior unchanged while fixing data integrity risk.

## Root Cause
`io.Reader.Read()` may return fewer bytes than requested without an error. The previous implementation read once into a full buffer and assumed all bytes were populated.

## Test plan
- Upload files of multiple sizes and verify uploaded content integrity.
- Confirm upload endpoint still returns successful responses.
- Verify downstream document parsing works on uploaded files.

## Issues
Closes #14266 