### PR TITLE
fix(dao): allowlist orderby fields to prevent SQL injection

### DIFF
--- a/internal/dao/chat.go
+++ b/internal/dao/chat.go
@@ -74,12 +74,13 @@ func (dao *ChatDAO) ListByTenantIDs(tenantIDs []string, userID string, page, pag
 		query = query.Where("LOWER(dialog.name) LIKE ?", "%"+strings.ToLower(keywords)+"%")
 	}
 
-	// Apply ordering
+	// Apply ordering (allowlist only; qualify columns for user JOIN)
 	orderDirection := "ASC"
 	if desc {
 		orderDirection = "DESC"
 	}
-	query = query.Order(orderby + " " + orderDirection)
+	orderCol := sanitizeDialogListOrderBy(orderby)
+	query = query.Order(orderCol + " " + orderDirection)
 
 	// Count total
 	if err := query.Count(&total).Error; err != nil {
@@ -123,12 +124,13 @@ func (dao *ChatDAO) ListByOwnerIDs(ownerIDs []string, userID string, orderby str
 	// Filter by owner IDs (additional filter to ensure tenant_id is in ownerIDs)
 	query = query.Where("dialog.tenant_id IN ?", ownerIDs)
 
-	// Apply ordering
+	// Apply ordering (allowlist only; qualify columns for user JOIN)
 	orderDirection := "ASC"
 	if desc {
 		orderDirection = "DESC"
 	}
-	query = query.Order(orderby + " " + orderDirection)
+	orderCol := sanitizeDialogListOrderBy(orderby)
+	query = query.Order(orderCol + " " + orderDirection)
 
 	// Get all matching records
 	if err := query.Find(&chats).Error; err != nil {

--- a/internal/dao/file.go
+++ b/internal/dao/file.go
@@ -59,12 +59,13 @@ func (dao *FileDAO) GetByPfID(tenantID, pfID string, page, pageSize int, orderby
 		return nil, 0, err
 	}
 
-	// Apply ordering
+	// Apply ordering (allowlist only; never concatenate raw user input)
 	orderDirection := "ASC"
 	if desc {
 		orderDirection = "DESC"
 	}
-	query = query.Order(orderby + " " + orderDirection)
+	orderCol := sanitizeFileListOrderBy(orderby)
+	query = query.Order(orderCol + " " + orderDirection)
 
 	// Apply pagination
 	if page > 0 && pageSize > 0 {

--- a/internal/dao/kb.go
+++ b/internal/dao/kb.go
@@ -169,10 +169,11 @@ func (dao *KnowledgebaseDAO) GetByTenantIDs(tenantIDs []string, userID string, p
 		query = query.Where("knowledgebase.parser_id = ?", parserID)
 	}
 
+	orderCol := sanitizeKnowledgebaseJoinedOrderBy(orderby)
 	if desc {
-		query = query.Order("knowledgebase." + orderby + " DESC")
+		query = query.Order("knowledgebase." + orderCol + " DESC")
 	} else {
-		query = query.Order("knowledgebase." + orderby + " ASC")
+		query = query.Order("knowledgebase." + orderCol + " ASC")
 	}
 
 	if err := query.Count(&total).Error; err != nil {
@@ -456,10 +457,11 @@ func (dao *KnowledgebaseDAO) GetList(tenantIDs []string, userID string, pageNumb
 		query = query.Where("name = ?", name)
 	}
 
+	orderCol := sanitizeKnowledgebasePlainOrderBy(orderby)
 	if desc {
-		query = query.Order(orderby + " DESC")
+		query = query.Order(orderCol + " DESC")
 	} else {
-		query = query.Order(orderby + " ASC")
+		query = query.Order(orderCol + " ASC")
 	}
 
 	if err := query.Count(&total).Error; err != nil {

--- a/internal/dao/order_by.go
+++ b/internal/dao/order_by.go
@@ -14,10 +14,15 @@
 //  limitations under the License.
 //
 
+// order_by.go contains helpers that map user-facing sort keys to fixed SQL column
+// expressions for ORDER BY clauses. This avoids passing raw request strings into SQL.
 package dao
 
 import "strings"
 
+// pickOrderByExpr resolves a client-provided sort key to a safe SQL column expression.
+// It trims and lowercases requested, looks it up in allowed, and returns the matching
+// expression; if requested is empty or not in allowed, it returns defaultExpr.
 func pickOrderByExpr(allowed map[string]string, requested, defaultExpr string) string {
 	k := strings.TrimSpace(strings.ToLower(requested))
 	if k == "" {
@@ -29,6 +34,7 @@ func pickOrderByExpr(allowed map[string]string, requested, defaultExpr string) s
 	return defaultExpr
 }
 
+// fileListOrderByAllowed maps API sort parameter values to unqualified column names on file.
 var fileListOrderByAllowed = map[string]string{
 	"create_time": "create_time",
 	"update_time": "update_time",
@@ -38,11 +44,13 @@ var fileListOrderByAllowed = map[string]string{
 	"id":          "id",
 }
 
+// sanitizeFileListOrderBy returns a safe ORDER BY column for file list queries.
+// Unknown keys fall back to create_time.
 func sanitizeFileListOrderBy(requested string) string {
 	return pickOrderByExpr(fileListOrderByAllowed, requested, "create_time")
 }
 
-// dialog table (Chat model); qualify columns for JOINs with user.
+// dialogListOrderByAllowed maps API sort keys to qualified dialog columns (Chat uses dialog table).
 var dialogListOrderByAllowed = map[string]string{
 	"create_time": "dialog.create_time",
 	"update_time": "dialog.update_time",
@@ -50,10 +58,13 @@ var dialogListOrderByAllowed = map[string]string{
 	"id":          "dialog.id",
 }
 
+// sanitizeDialogListOrderBy returns a safe ORDER BY expression for dialog (chat) list queries
+// when joined with user. Unknown keys fall back to dialog.create_time.
 func sanitizeDialogListOrderBy(requested string) string {
 	return pickOrderByExpr(dialogListOrderByAllowed, requested, "dialog.create_time")
 }
 
+// searchListOrderByAllowed maps API sort keys to qualified search table columns.
 var searchListOrderByAllowed = map[string]string{
 	"create_time": "search.create_time",
 	"update_time": "search.update_time",
@@ -61,11 +72,14 @@ var searchListOrderByAllowed = map[string]string{
 	"id":          "search.id",
 }
 
+// sanitizeSearchListOrderBy returns a safe ORDER BY expression for search list queries
+// when joined with user. Unknown keys fall back to search.create_time.
 func sanitizeSearchListOrderBy(requested string) string {
 	return pickOrderByExpr(searchListOrderByAllowed, requested, "search.create_time")
 }
 
-// Column name only; prefixed with knowledgebase. by caller.
+// knowledgebaseJoinedOrderByAllowed maps sort keys to knowledgebase column names only;
+// callers prefix with "knowledgebase." in joined queries.
 var knowledgebaseJoinedOrderByAllowed = map[string]string{
 	"create_time": "create_time",
 	"update_time": "update_time",
@@ -76,10 +90,14 @@ var knowledgebaseJoinedOrderByAllowed = map[string]string{
 	"id":          "id",
 }
 
+// sanitizeKnowledgebaseJoinedOrderBy returns a safe column name suffix for ORDER BY on
+// knowledgebase in queries that already qualify the table as knowledgebase.
 func sanitizeKnowledgebaseJoinedOrderBy(requested string) string {
 	return pickOrderByExpr(knowledgebaseJoinedOrderByAllowed, requested, "create_time")
 }
 
+// knowledgebasePlainOrderByAllowed maps sort keys to unqualified knowledgebase columns
+// for queries without table alias ambiguity.
 var knowledgebasePlainOrderByAllowed = map[string]string{
 	"create_time": "create_time",
 	"update_time": "update_time",
@@ -90,10 +108,12 @@ var knowledgebasePlainOrderByAllowed = map[string]string{
 	"id":          "id",
 }
 
+// sanitizeKnowledgebasePlainOrderBy returns a safe ORDER BY column for knowledgebase-only queries.
 func sanitizeKnowledgebasePlainOrderBy(requested string) string {
 	return pickOrderByExpr(knowledgebasePlainOrderByAllowed, requested, "create_time")
 }
 
+// userCanvasOrderByAllowed maps API sort keys to user_canvas table columns.
 var userCanvasOrderByAllowed = map[string]string{
 	"create_time": "create_time",
 	"update_time": "update_time",
@@ -101,6 +121,7 @@ var userCanvasOrderByAllowed = map[string]string{
 	"id":          "id",
 }
 
+// sanitizeUserCanvasOrderBy returns a safe ORDER BY column for user_canvas list queries.
 func sanitizeUserCanvasOrderBy(requested string) string {
 	return pickOrderByExpr(userCanvasOrderByAllowed, requested, "create_time")
 }

--- a/internal/dao/order_by.go
+++ b/internal/dao/order_by.go
@@ -1,0 +1,106 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package dao
+
+import "strings"
+
+func pickOrderByExpr(allowed map[string]string, requested, defaultExpr string) string {
+	k := strings.TrimSpace(strings.ToLower(requested))
+	if k == "" {
+		return defaultExpr
+	}
+	if expr, ok := allowed[k]; ok {
+		return expr
+	}
+	return defaultExpr
+}
+
+var fileListOrderByAllowed = map[string]string{
+	"create_time": "create_time",
+	"update_time": "update_time",
+	"name":        "name",
+	"size":        "size",
+	"type":        "type",
+	"id":          "id",
+}
+
+func sanitizeFileListOrderBy(requested string) string {
+	return pickOrderByExpr(fileListOrderByAllowed, requested, "create_time")
+}
+
+// dialog table (Chat model); qualify columns for JOINs with user.
+var dialogListOrderByAllowed = map[string]string{
+	"create_time": "dialog.create_time",
+	"update_time": "dialog.update_time",
+	"name":        "dialog.name",
+	"id":          "dialog.id",
+}
+
+func sanitizeDialogListOrderBy(requested string) string {
+	return pickOrderByExpr(dialogListOrderByAllowed, requested, "dialog.create_time")
+}
+
+var searchListOrderByAllowed = map[string]string{
+	"create_time": "search.create_time",
+	"update_time": "search.update_time",
+	"name":        "search.name",
+	"id":          "search.id",
+}
+
+func sanitizeSearchListOrderBy(requested string) string {
+	return pickOrderByExpr(searchListOrderByAllowed, requested, "search.create_time")
+}
+
+// Column name only; prefixed with knowledgebase. by caller.
+var knowledgebaseJoinedOrderByAllowed = map[string]string{
+	"create_time": "create_time",
+	"update_time": "update_time",
+	"name":        "name",
+	"doc_num":     "doc_num",
+	"token_num":   "token_num",
+	"chunk_num":   "chunk_num",
+	"id":          "id",
+}
+
+func sanitizeKnowledgebaseJoinedOrderBy(requested string) string {
+	return pickOrderByExpr(knowledgebaseJoinedOrderByAllowed, requested, "create_time")
+}
+
+var knowledgebasePlainOrderByAllowed = map[string]string{
+	"create_time": "create_time",
+	"update_time": "update_time",
+	"name":        "name",
+	"doc_num":     "doc_num",
+	"token_num":   "token_num",
+	"chunk_num":   "chunk_num",
+	"id":          "id",
+}
+
+func sanitizeKnowledgebasePlainOrderBy(requested string) string {
+	return pickOrderByExpr(knowledgebasePlainOrderByAllowed, requested, "create_time")
+}
+
+var userCanvasOrderByAllowed = map[string]string{
+	"create_time": "create_time",
+	"update_time": "update_time",
+	"title":       "title",
+	"id":          "id",
+}
+
+func sanitizeUserCanvasOrderBy(requested string) string {
+	return pickOrderByExpr(userCanvasOrderByAllowed, requested, "create_time")
+}

--- a/internal/dao/search.go
+++ b/internal/dao/search.go
@@ -49,12 +49,13 @@ func (dao *SearchDAO) ListByTenantIDs(tenantIDs []string, userID string, page, p
 		query = query.Where("LOWER(search.name) LIKE ?", "%"+strings.ToLower(keywords)+"%")
 	}
 
-	// Apply ordering
+	// Apply ordering (allowlist only; qualify columns for user JOIN)
 	orderDirection := "ASC"
 	if desc {
 		orderDirection = "DESC"
 	}
-	query = query.Order(orderby + " " + orderDirection)
+	orderCol := sanitizeSearchListOrderBy(orderby)
+	query = query.Order(orderCol + " " + orderDirection)
 
 	// Count total
 	if err := query.Count(&total).Error; err != nil {
@@ -98,12 +99,13 @@ func (dao *SearchDAO) ListByOwnerIDs(ownerIDs []string, userID string, orderby s
 	// Filter by owner IDs (additional filter to ensure tenant_id is in ownerIDs)
 	query = query.Where("search.tenant_id IN ?", ownerIDs)
 
-	// Apply ordering
+	// Apply ordering (allowlist only; qualify columns for user JOIN)
 	orderDirection := "ASC"
 	if desc {
 		orderDirection = "DESC"
 	}
-	query = query.Order(orderby + " " + orderDirection)
+	orderCol := sanitizeSearchListOrderBy(orderby)
+	query = query.Order(orderCol + " " + orderDirection)
 
 	// Get all matching records
 	if err := query.Find(&searches).Error; err != nil {

--- a/internal/dao/user_canvas.go
+++ b/internal/dao/user_canvas.go
@@ -80,11 +80,12 @@ func (dao *UserCanvasDAO) GetList(
 		query = query.Where("canvas_category = ?", "agent_canvas")
 	}
 
-	// Order by
+	// Order by (allowlist only)
+	orderCol := sanitizeUserCanvasOrderBy(orderby)
 	if desc {
-		query = query.Order(orderby + " DESC")
+		query = query.Order(orderCol + " DESC")
 	} else {
-		query = query.Order(orderby + " ASC")
+		query = query.Order(orderCol + " ASC")
 	}
 
 	// Pagination


### PR DESCRIPTION
## Summary
- Add centralized allowlists for `orderby` query parameters used in list DAOs.
- Replace string concatenation of raw user input into `ORDER BY` with mapped, fixed column expressions.
- Qualify `dialog.*` / `search.*` sort columns when joining `user` to avoid ambiguity.

## Affected areas
- `internal/dao/file.go` — file listing
- `internal/dao/chat.go` — dialog (chat) listing
- `internal/dao/search.go` — search listing
- `internal/dao/kb.go` — knowledgebase list queries (joined and plain)
- `internal/dao/user_canvas.go` — canvas listing

## Test plan
- [ ] List files/chats/searches/datasets with default and alternate allowed `orderby` values.
- [ ] Request with invalid `orderby` falls back to safe default (e.g. `create_time`).
- [ ] No SQL errors from ambiguous columns on joined chat/search queries.

## Issues
Closes #14268