### PR TITLE
fix: ListOperations _head/_tail return slice instead of single item

### DIFF
--- a/agent/component/list_operations.py
+++ b/agent/component/list_operations.py
@@ -88,7 +88,7 @@ class ListOperations(ComponentBase,ABC):
     def _head(self):
         n = self._coerce_n()
         if 1 <= n <= len(self.inputs):
-            outputs = [self.inputs[n - 1]]
+            outputs = self.inputs[:n]
         else:
             outputs = []
         self._set_outputs(outputs)
@@ -96,7 +96,7 @@ class ListOperations(ComponentBase,ABC):
     def _tail(self):
         n = self._coerce_n()
         if 1 <= n <= len(self.inputs):
-            outputs = [self.inputs[-n]]
+            outputs = self.inputs[-n:]
         else:
             outputs = []
         self._set_outputs(outputs)


### PR DESCRIPTION
## Summary

Fixes a bug in `agent/component/list_operations.py` where `_head(n)` and `_tail(n)` returned a single-element list instead of a slice of `n` elements.

## Root cause

- `_head`: `outputs = [self.inputs[n - 1]]` — picks the element **at index n-1** (e.g. n=3 → index 2, the 3rd item only)
- `_tail`: `outputs = [self.inputs[-n]]` — picks the element **at index -n** (e.g. n=2 → index -2, the 2nd-to-last item only)

## Fix

```python
# _head: first n items
outputs = self.inputs[:n]

# _tail: last n items
outputs = self.inputs[-n:]
```

## Testing

```python
inputs = [1, 2, 3, 4, 5]
# head(3): before → [3],    after → [1, 2, 3]  ✓
# tail(2): before → [4],    after → [4, 5]      ✓
```

Closes #14278

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>