### PR TITLE
fix: check isinstance before len in VariableAssigner _remove_first/_remove_last

### DIFF
--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -141,20 +141,18 @@ class VariableAssigner(ComponentBase,ABC):
             return variable + parameter
 
     def _remove_first(self,variable):
-        if len(variable)==0:
-            return variable
         if not isinstance(variable,list):
             return "ERROR:VARIABLE_NOT_LIST"
-        else:
-            return variable[1:]
+        if len(variable)==0:
+            return variable
+        return variable[1:]
 
     def _remove_last(self,variable):
-        if len(variable)==0:
-            return variable
         if not isinstance(variable,list):
             return "ERROR:VARIABLE_NOT_LIST"
-        else:
-            return variable[:-1]
+        if len(variable)==0:
+            return variable
+        return variable[:-1]
 
     def is_number(self, value):
         if isinstance(value, bool):


### PR DESCRIPTION
## Summary

Fixes a bug in `agent/component/variable_assigner.py` where `_remove_first` and `_remove_last` perform `len(variable) == 0` **before** `isinstance(variable, list)`, allowing non-list types with `__len__` to bypass the type error.

## Root cause

```python
def _remove_first(self, variable):
    if len(variable) == 0:       # ← runs before isinstance check
        return variable           # silently returns "" or {} for empty non-lists
    if not isinstance(variable, list):
        return "ERROR:VARIABLE_NOT_LIST"
```

For an empty string (`""`) or empty dict (`{}`), `len() == 0` is `True`, so the function returns the non-list variable silently — the type guard is never reached.

## Fix

Swap the order — `isinstance` first, empty check second:

```python
def _remove_first(self, variable):
    if not isinstance(variable, list):
        return "ERROR:VARIABLE_NOT_LIST"
    if len(variable) == 0:
        return variable
    return variable[1:]
```

Same fix applied to `_remove_last`.

Closes #14280

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>