### PR TITLE
Fix AttributeError in getsse when Authorization header is missing

### DIFF
--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -167,7 +167,10 @@ def get(canvas_id):
 
 @manager.route('/getsse/<canvas_id>', methods=['GET'])  # type: ignore # noqa: F821
 def getsse(canvas_id):
-    token = request.headers.get('Authorization').split()
+    auth_header = request.headers.get('Authorization')
+    if not auth_header:
+        return get_data_error_result(message='Authorization is not valid!')
+    token = auth_header.split()
     if len(token) != 2:
         return get_data_error_result(message='Authorization is not valid!')
     token = token[1]


### PR DESCRIPTION
### What problem does this PR solve?

The `getsse` endpoint at `canvas_app.py:170` calls `.split()` directly on the return value of `request.headers.get('Authorization')`. When the `Authorization` header is missing, `get()` returns `None`, and `None.split()` raises an `AttributeError`, crashing the endpoint with a 500 error.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Changes

Added a null check for the `Authorization` header before calling `.split()`. Returns a proper error response when the header is missing, consistent with the existing validation for invalid tokens.