### PR TITLE
Add missing timeout to ragflow server health check

### DIFF
--- a/api/utils/health_utils.py
+++ b/api/utils/health_utils.py
@@ -293,7 +293,7 @@ def check_ragflow_server_alive():
         url = f'http://{settings.HOST_IP}:{settings.HOST_PORT}/api/v1/system/ping'
         if '0.0.0.0' in url:
             url = url.replace('0.0.0.0', '127.0.0.1')
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         if response.status_code == 200:
             return {"status": "alive", "message": f"Confirm elapsed: {(timer() - start_time) * 1000.0:.1f} ms."}
         else:


### PR DESCRIPTION
### What problem does this PR solve?

`check_ragflow_server_alive()` in `api/utils/health_utils.py` calls `requests.get(url)` without a `timeout` parameter. Unlike `check_minio_alive()` which correctly specifies `timeout=10`, this health check can hang indefinitely if the server is unresponsive.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Changes

Added `timeout=10` to the `requests.get()` call, consistent with `check_minio_alive()`.