### PR TITLE
fix(canvas): use doc["id"] instead of builtin id in rerun endpoint

### DIFF
--- a/api/apps/canvas_app.py
+++ b/api/apps/canvas_app.py
@@ -329,8 +329,8 @@ async def rerun():
     doc["chunk_num"] = 0
     doc["token_num"] = 0
     DocumentService.clear_chunk_num_when_rerun(doc["id"])
-    DocumentService.update_by_id(id, doc)
-    TaskService.filter_delete([Task.doc_id == id])
+    DocumentService.update_by_id(doc["id"], doc)
+    TaskService.filter_delete([Task.doc_id == doc["id"]])
 
     dsl = req["dsl"]
     dsl["path"] = [req["component_id"]]


### PR DESCRIPTION
### What problem does this PR solve?

In the `rerun` endpoint (`api/apps/canvas_app.py`), lines 332-333 pass Python's **builtin `id` function** instead of `doc["id"]` to `DocumentService.update_by_id()` and `TaskService.filter_delete()`.

This means:
- `update_by_id` receives a function object as the document ID — the database row is never matched, so the document is **not updated**
- `filter_delete` compares `Task.doc_id` against a function object — no tasks are **ever deleted**

The rerun silently fails to reset document/task state.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Change

Replace bare `id` with `doc["id"]` on both lines, consistent with the surrounding code (lines 327, 331, 338) which already uses `doc["id"]` correctly.

```diff
-    DocumentService.update_by_id(id, doc)
-    TaskService.filter_delete([Task.doc_id == id])
+    DocumentService.update_by_id(doc["id"], doc)
+    TaskService.filter_delete([Task.doc_id == doc["id"]])
```