### PR TITLE
Fix llm_id validation for image2text Gemini usage.

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -173,17 +173,18 @@ def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
 
     llm_name, llm_factory = TenantLLMService.split_model_name_and_factory(llm_id)
     model_type = (llm_setting or {}).get("model_type")
-    if model_type not in {"chat", "image2text"}:
-        model_type = "chat"
+    candidate_model_types = [model_type] if model_type in {"chat", "image2text"} else ["chat", "image2text"]
 
-    if not TenantLLMService.query(
-        tenant_id=tenant_id,
-        llm_name=llm_name,
-        llm_factory=llm_factory,
-        model_type=model_type,
-    ):
-        return f"`llm_id` {llm_id} doesn't exist"
-    return None
+    for current_model_type in candidate_model_types:
+        if TenantLLMService.query(
+            tenant_id=tenant_id,
+            llm_name=llm_name,
+            llm_factory=llm_factory,
+            model_type=current_model_type,
+        ):
+            return None
+
+    return f"`llm_id` {llm_id} doesn't exist"
 
 
 def _validate_rerank_id(rerank_id, tenant_id):

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -239,29 +239,65 @@ def _get_dialog_chat_model_config(dialog):
 
         for candidate_model_type in candidate_model_types:
             try:
-                return get_model_config_by_type_and_name(dialog.tenant_id, candidate_model_type, dialog.llm_id)
-            except LookupError:
+                model_config = get_model_config_by_type_and_name(
+                    dialog.tenant_id, candidate_model_type, dialog.llm_id
+                )
+                resolved_type = (
+                    candidate_model_type.value
+                    if hasattr(candidate_model_type, "value")
+                    else candidate_model_type
+                )
+                logging.info(
+                    "Resolved dialog llm_id=%s using model_type=%s",
+                    dialog.llm_id,
+                    resolved_type,
+                )
+                return model_config, resolved_type
+            except LookupError as exc:
+                candidate_type = (
+                    candidate_model_type.value
+                    if hasattr(candidate_model_type, "value")
+                    else candidate_model_type
+                )
+                logging.debug(
+                    "Dialog llm_id=%s not found as model_type=%s: %s",
+                    dialog.llm_id,
+                    candidate_type,
+                    exc,
+                )
                 continue
 
         raise LookupError(
             f"Tenant Model with name {dialog.llm_id} not found for supported types: chat,image2text"
         )
     if dialog.tenant_llm_id:
-        return get_model_config_by_id(dialog.tenant_llm_id)
-    return get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
+        model_config = get_model_config_by_id(dialog.tenant_llm_id)
+        model_type = model_config.get("model_type")
+        if hasattr(model_type, "value"):
+            model_type = model_type.value
+        resolved_type = model_type or LLMType.CHAT.value
+        logging.info(
+            "Resolved dialog tenant_llm_id=%s using model_type=%s",
+            dialog.tenant_llm_id,
+            resolved_type,
+        )
+        return model_config, resolved_type
 
-
-def _resolve_dialog_chat_model(dialog):
-    model_config = _get_dialog_chat_model_config(dialog)
+    model_config = get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
     model_type = model_config.get("model_type")
     if hasattr(model_type, "value"):
         model_type = model_type.value
-    llm_type = "image2text" if model_type == LLMType.IMAGE2TEXT.value else "chat"
-    return model_config, llm_type
+    resolved_type = model_type or LLMType.CHAT.value
+    logging.info(
+        "Resolved default tenant chat model for tenant_id=%s using model_type=%s",
+        dialog.tenant_id,
+        resolved_type,
+    )
+    return model_config, resolved_type
 
 
 async def async_chat_solo(dialog, messages, stream=True):
-    model_config, llm_type = _resolve_dialog_chat_model(dialog)
+    model_config, llm_type = _get_dialog_chat_model_config(dialog)
     attachments = ""
     image_attachments = []
     image_files = []
@@ -320,7 +356,7 @@ def get_models(dialog):
         if not embd_mdl:
             raise LookupError("Embedding model(%s) not found" % embedding_list[0])
 
-    chat_model_config = _get_dialog_chat_model_config(dialog)
+    chat_model_config, _ = _get_dialog_chat_model_config(dialog)
 
     chat_mdl = LLMBundle(dialog.tenant_id, chat_model_config)
 
@@ -515,7 +551,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         return
 
     chat_start_ts = timer()
-    llm_model_config, llm_type = _resolve_dialog_chat_model(dialog)
+    llm_model_config, llm_type = _get_dialog_chat_model_config(dialog)
 
     factory = llm_model_config.get("llm_factory", "") if llm_model_config else ""
     max_tokens = llm_model_config.get("max_tokens", 8192)

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -231,11 +231,21 @@ class DialogService(CommonService):
 
 
 def _get_dialog_chat_model_config(dialog):
-    llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
-    target_model_type = LLMType.IMAGE2TEXT if llm_type == "image2text" else LLMType.CHAT
-
     if dialog.llm_id:
-        return get_model_config_by_type_and_name(dialog.tenant_id, target_model_type, dialog.llm_id)
+        llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
+        candidate_model_types = [LLMType.CHAT, LLMType.IMAGE2TEXT]
+        if llm_type == "image2text":
+            candidate_model_types = [LLMType.IMAGE2TEXT, LLMType.CHAT]
+
+        for candidate_model_type in candidate_model_types:
+            try:
+                return get_model_config_by_type_and_name(dialog.tenant_id, candidate_model_type, dialog.llm_id)
+            except LookupError:
+                continue
+
+        raise LookupError(
+            f"Tenant Model with name {dialog.llm_id} not found for supported types: chat,image2text"
+        )
     if dialog.tenant_llm_id:
         return get_model_config_by_id(dialog.tenant_llm_id)
     return get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -251,8 +251,17 @@ def _get_dialog_chat_model_config(dialog):
     return get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
 
 
+def _resolve_dialog_chat_model(dialog):
+    model_config = _get_dialog_chat_model_config(dialog)
+    model_type = model_config.get("model_type")
+    if hasattr(model_type, "value"):
+        model_type = model_type.value
+    llm_type = "image2text" if model_type == LLMType.IMAGE2TEXT.value else "chat"
+    return model_config, llm_type
+
+
 async def async_chat_solo(dialog, messages, stream=True):
-    llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
+    model_config, llm_type = _resolve_dialog_chat_model(dialog)
     attachments = ""
     image_attachments = []
     image_files = []
@@ -263,8 +272,6 @@ async def async_chat_solo(dialog, messages, stream=True):
             text_attachments, image_files = split_file_attachments(messages[-1]["files"], raw=True)
         attachments = "\n\n".join(text_attachments)
     
-    model_config = _get_dialog_chat_model_config(dialog)
-
     chat_mdl = LLMBundle(dialog.tenant_id, model_config)
     factory = model_config.get("llm_factory", "") if model_config else ""
 
@@ -508,11 +515,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         return
 
     chat_start_ts = timer()
-    llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
-    if llm_type == "image2text":
-        llm_model_config = TenantLLMService.get_model_config(dialog.tenant_id, LLMType.IMAGE2TEXT, dialog.llm_id)
-    else:
-        llm_model_config = TenantLLMService.get_model_config(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
+    llm_model_config, llm_type = _resolve_dialog_chat_model(dialog)
 
     factory = llm_model_config.get("llm_factory", "") if llm_model_config else ""
     max_tokens = llm_model_config.get("max_tokens", 8192)

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -230,6 +230,17 @@ class DialogService(CommonService):
         return list(objs)
 
 
+def _get_dialog_chat_model_config(dialog):
+    llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
+    target_model_type = LLMType.IMAGE2TEXT if llm_type == "image2text" else LLMType.CHAT
+
+    if dialog.llm_id:
+        return get_model_config_by_type_and_name(dialog.tenant_id, target_model_type, dialog.llm_id)
+    if dialog.tenant_llm_id:
+        return get_model_config_by_id(dialog.tenant_llm_id)
+    return get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
+
+
 async def async_chat_solo(dialog, messages, stream=True):
     llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
     attachments = ""
@@ -242,12 +253,7 @@ async def async_chat_solo(dialog, messages, stream=True):
             text_attachments, image_files = split_file_attachments(messages[-1]["files"], raw=True)
         attachments = "\n\n".join(text_attachments)
     
-    if dialog.llm_id:
-        model_config = get_model_config_by_type_and_name(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
-    elif dialog.tenant_llm_id:
-        model_config = get_model_config_by_id(dialog.tenant_llm_id)
-    else:
-        model_config = get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
+    model_config = _get_dialog_chat_model_config(dialog)
 
     chat_mdl = LLMBundle(dialog.tenant_id, model_config)
     factory = model_config.get("llm_factory", "") if model_config else ""
@@ -297,12 +303,7 @@ def get_models(dialog):
         if not embd_mdl:
             raise LookupError("Embedding model(%s) not found" % embedding_list[0])
 
-    if dialog.llm_id:
-        chat_model_config = get_model_config_by_type_and_name(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
-    elif dialog.tenant_llm_id:
-        chat_model_config = get_model_config_by_id(dialog.tenant_llm_id)
-    else:
-        chat_model_config = get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
+    chat_model_config = _get_dialog_chat_model_config(dialog)
 
     chat_mdl = LLMBundle(dialog.tenant_id, chat_model_config)
 

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -342,7 +342,7 @@ async def async_chat_solo(dialog, messages, stream=True):
         yield {"answer": answer, "reference": {}, "audio_binary": tts(tts_mdl, answer), "prompt": "", "created_at": time.time()}
 
 
-def get_models(dialog):
+def get_models(dialog, llm_model_config=None, llm_type=None):
     embd_mdl, chat_mdl, rerank_mdl, tts_mdl = None, None, None, None
     kbs = KnowledgebaseService.get_by_ids(dialog.kb_ids)
     embedding_list = list(set([kb.embd_id for kb in kbs]))
@@ -356,9 +356,10 @@ def get_models(dialog):
         if not embd_mdl:
             raise LookupError("Embedding model(%s) not found" % embedding_list[0])
 
-    chat_model_config, _ = _get_dialog_chat_model_config(dialog)
+    if llm_model_config is None or llm_type is None:
+        llm_model_config, llm_type = _get_dialog_chat_model_config(dialog)
 
-    chat_mdl = LLMBundle(dialog.tenant_id, chat_model_config)
+    chat_mdl = LLMBundle(dialog.tenant_id, llm_model_config)
 
     if dialog.rerank_id:
         rerank_model_config = get_model_config_by_type_and_name(dialog.tenant_id, LLMType.RERANK, dialog.rerank_id)
@@ -440,12 +441,16 @@ def convert_last_user_msg_to_multimodal(msg: list[dict], image_data_uris: list[s
         text = _normalize_text_from_content(original_content)
 
         if factory_norm == "gemini":
+            # LiteLLM validates OpenAI-compatible content blocks before provider-specific mapping.
+            # Keep Gemini inputs in OpenAI shape to avoid "invalid content type=None".
             parts = []
             if text:
-                parts.append({"text": text})
+                parts.append({"type": "text", "text": text})
             for image in image_data_uris:
-                mime, b64 = _parse_data_uri_or_b64(str(image), default_mime="image/png")
-                parts.append({"inline_data": {"mime_type": mime, "data": b64}})
+                image_url = image if isinstance(image, str) else str(image)
+                if not image_url.startswith("data:"):
+                    image_url = f"data:image/png;base64,{image_url}"
+                parts.append({"type": "image_url", "image_url": {"url": image_url}})
             msg[idx]["content"] = parts
             return
 
@@ -573,7 +578,9 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             pass
 
     check_langfuse_tracer_ts = timer()
-    kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
+    kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(
+        dialog, llm_model_config=llm_model_config, llm_type=llm_type
+    )
     toolcall_session, tools = kwargs.get("toolcall_session"), kwargs.get("tools")
     if toolcall_session and tools:
         chat_mdl.bind_tools(toolcall_session, tools)


### PR DESCRIPTION
Allow chat assistant llm_id validation to accept image2text models and resolve chat model config using actual llm type so Gemini vision models no longer fail with misleading doesn't-exist errors.

Made-with: Cursor

### What problem does this PR solve?

RAGFlow currently validates chat assistant llm_id too strictly against model_type=chat, causing code 102 ("llm_id ... doesn't exist") when users configure Gemini as image2text. This PR allows llm_id validation to accept both chat and image2text, and resolves runtime model config based on the actual llm type, so Gemini vision models can be used without misleading validation errors.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
