### PR TITLE
Fix commit override from #14298 of api-key to api_key

### DIFF
--- a/test/testcases/test_web_api/test_connector_app/test_connector_oauth_contract.py
+++ b/test/testcases/test_web_api/test_connector_app/test_connector_oauth_contract.py
@@ -22,7 +22,7 @@ from configs import HOST_ADDRESS, VERSION
 
 CONNECTOR_BASE_URL = f"{HOST_ADDRESS}/api/{VERSION}/connectors"
 LLM_API_KEY_URL = f"{HOST_ADDRESS}/{VERSION}/llm/set_api_key"
-LANGFUSE_API_KEY_URL = f"{HOST_ADDRESS}/{VERSION}/langfuse/api_key"
+LANGFUSE_API_KEY_URL = f"{HOST_ADDRESS}/api/{VERSION}/langfuse/api-key"
 
 pytestmark = pytest.mark.p3
 

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -174,7 +174,7 @@ export default {
   createSystemToken: `${restAPIv1}/system/tokens`,
   removeSystemToken: `${restAPIv1}/system/tokens`,
   getSystemConfig: `${restAPIv1}/system/config`,
-  setLangfuseConfig: `${restAPIv1}/langfuse/api_key`,
+  setLangfuseConfig: `${restAPIv1}/langfuse/api-key`,
 
   // flow
   listTemplates: `${webAPI}/canvas/templates`,


### PR DESCRIPTION
### What problem does this PR solve?

Fix commit override from https://github.com/infiniflow/ragflow/pull/14298/ of `api-key` to `api_key`

### Type of change

- [x] Refactoring