### PR TITLE
docs: fix API key guide typo

### DIFF
--- a/docs/develop/acquire_ragflow_api_key.md
+++ b/docs/develop/acquire_ragflow_api_key.md
@@ -7,7 +7,7 @@ sidebar_custom_props: {
 ---
 # Acquire RAGFlow API key
 
-An API key is required for the RAGFlow server to authenticate your HTTP/Python or MCP requests. This documents provides instructions on obtaining a RAGFlow API key.
+An API key is required for the RAGFlow server to authenticate your HTTP/Python or MCP requests. This document provides instructions on obtaining a RAGFlow API key.
 
 1. Click your avatar in the top right corner of the RAGFlow UI to access the configuration page.
 2. Click **API** to switch to the **API** page.


### PR DESCRIPTION
Fixes a small typo in the RAGFlow API key guide: `This documents provides` -> `This document provides`.