### PR TITLE
fix: correct RAGconEmbed default base URL to ragcon.ai

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -1114,7 +1114,7 @@ class RAGconEmbed(OpenAIEmbed):
 
     def __init__(self, key, model_name="text-embedding-3-small", base_url=None):
         if not base_url:
-            base_url = "https://connect.ragcon.com/v1"
+            base_url = "https://connect.ragcon.ai/v1"
 
         super().__init__(key, model_name, base_url)
 


### PR DESCRIPTION
## Description
Correct the default base URL for RAGconEmbed embedding model from incorrect domain to the correct `ragcon.ai` domain.

## Related Issue
N/A - independent bug fix

## Test Plan
- [ ] Existing tests pass
- [ ] Verified the base URL is now correctly set to ragcon.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)