### PR TITLE
feat: increase chatbot top n limit to 200

### DIFF
--- a/web/src/components/top-n-item.tsx
+++ b/web/src/components/top-n-item.tsx
@@ -11,7 +11,7 @@ export const topnSchema = {
   top_n: z.number().optional(),
 };
 
-export function TopNFormField({ max = 30 }: SimilaritySliderFormFieldProps) {
+export function TopNFormField({ max = 200 }: SimilaritySliderFormFieldProps) {
   const { t } = useTranslate('chat');
 
   return (

--- a/web/src/components/top-n-item.tsx
+++ b/web/src/components/top-n-item.tsx
@@ -7,13 +7,17 @@ interface SimilaritySliderFormFieldProps {
   max?: number;
 }
 
-const TOP_N_MAX = 200;
+export const DEFAULT_TOP_N_MAX = 200;
 
-export const topnSchema = {
-  top_n: z.number().max(TOP_N_MAX).optional(),
-};
+export const createTopNSchema = (max = DEFAULT_TOP_N_MAX) => ({
+  top_n: z.number().max(max).optional(),
+});
 
-export function TopNFormField({ max = TOP_N_MAX }: SimilaritySliderFormFieldProps) {
+export const topnSchema = createTopNSchema();
+
+export function TopNFormField({
+  max = DEFAULT_TOP_N_MAX,
+}: SimilaritySliderFormFieldProps) {
   const { t } = useTranslate('chat');
 
   return (

--- a/web/src/components/top-n-item.tsx
+++ b/web/src/components/top-n-item.tsx
@@ -7,11 +7,13 @@ interface SimilaritySliderFormFieldProps {
   max?: number;
 }
 
+const TOP_N_MAX = 200;
+
 export const topnSchema = {
-  top_n: z.number().optional(),
+  top_n: z.number().max(TOP_N_MAX).optional(),
 };
 
-export function TopNFormField({ max = 200 }: SimilaritySliderFormFieldProps) {
+export function TopNFormField({ max = TOP_N_MAX }: SimilaritySliderFormFieldProps) {
   const { t } = useTranslate('chat');
 
   return (

--- a/web/src/pages/agent/form/arxiv-form/index.tsx
+++ b/web/src/pages/agent/form/arxiv-form/index.tsx
@@ -1,6 +1,6 @@
 import { FormContainer } from '@/components/form-container';
 import { SelectWithSearch } from '@/components/originui/select-with-search';
-import { TopNFormField } from '@/components/top-n-item';
+import { createTopNSchema, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -24,7 +24,7 @@ import { Output } from '../components/output';
 import { QueryVariable } from '../components/query-variable';
 
 export const ArXivFormPartialSchema = {
-  top_n: z.number(),
+  top_n: createTopNSchema().top_n.unwrap(),
   sort_by: z.string(),
 };
 

--- a/web/src/pages/agent/form/bing-form/index.tsx
+++ b/web/src/pages/agent/form/bing-form/index.tsx
@@ -1,5 +1,5 @@
 import { SelectWithSearch } from '@/components/originui/select-with-search';
-import { TopNFormField } from '@/components/top-n-item';
+import { createTopNSchema, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -27,7 +27,7 @@ export const BingFormSchema = {
   api_key: z.string(),
   country: z.string(),
   language: z.string(),
-  top_n: z.number(),
+  top_n: createTopNSchema().top_n.unwrap(),
 };
 
 export const FormSchema = z.object({

--- a/web/src/pages/agent/form/duckduckgo-form/index.tsx
+++ b/web/src/pages/agent/form/duckduckgo-form/index.tsx
@@ -1,5 +1,5 @@
 import { FormContainer } from '@/components/form-container';
-import { TopNFormField } from '@/components/top-n-item';
+import { DEFAULT_TOP_N_MAX, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -24,7 +24,11 @@ import { Output } from '../components/output';
 import { QueryVariable } from '../components/query-variable';
 
 export const DuckDuckGoFormPartialSchema = {
-  top_n: z.string(),
+  top_n: z
+    .string()
+    .refine((value) => Number(value) <= DEFAULT_TOP_N_MAX, {
+      message: `Top N must be less than or equal to ${DEFAULT_TOP_N_MAX}`,
+    }),
   channel: z.string(),
 };
 

--- a/web/src/pages/agent/form/github-form/index.tsx
+++ b/web/src/pages/agent/form/github-form/index.tsx
@@ -1,5 +1,5 @@
 import { FormContainer } from '@/components/form-container';
-import { TopNFormField } from '@/components/top-n-item';
+import { createTopNSchema, TopNFormField } from '@/components/top-n-item';
 import { Form } from '@/components/ui/form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { memo } from 'react';
@@ -16,7 +16,7 @@ import { QueryVariable } from '../components/query-variable';
 
 export const FormSchema = z.object({
   query: z.string(),
-  top_n: z.number(),
+  top_n: createTopNSchema().top_n.unwrap(),
 });
 
 const outputList = buildOutputList(initialGithubValues.outputs);

--- a/web/src/pages/agent/form/google-scholar-form/index.tsx
+++ b/web/src/pages/agent/form/google-scholar-form/index.tsx
@@ -1,6 +1,6 @@
 import { FormContainer } from '@/components/form-container';
 import { SelectWithSearch } from '@/components/originui/select-with-search';
-import { TopNFormField } from '@/components/top-n-item';
+import { DEFAULT_TOP_N_MAX, TopNFormField } from '@/components/top-n-item';
 import { DatePicker } from '@/components/ui/date-picker';
 import {
   Form,
@@ -114,7 +114,7 @@ export function GoogleScholarFormWidgets() {
 }
 
 export const GoogleScholarFormPartialSchema = {
-  top_n: z.number(),
+  top_n: z.number().max(DEFAULT_TOP_N_MAX),
   sort_by: z.string(),
   year_low: z.number(),
   year_high: z.number(),

--- a/web/src/pages/agent/form/pubmed-form/index.tsx
+++ b/web/src/pages/agent/form/pubmed-form/index.tsx
@@ -1,5 +1,5 @@
 import { FormContainer } from '@/components/form-container';
-import { TopNFormField } from '@/components/top-n-item';
+import { createTopNSchema, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -24,7 +24,7 @@ import { Output } from '../components/output';
 import { QueryVariable } from '../components/query-variable';
 
 export const PubMedFormPartialSchema = {
-  top_n: z.number(),
+  top_n: createTopNSchema().top_n.unwrap(),
   email: z.string().email(),
 };
 

--- a/web/src/pages/agent/form/pubmed-form/index.tsx
+++ b/web/src/pages/agent/form/pubmed-form/index.tsx
@@ -9,10 +9,10 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { useTranslate } from '@/hooks/common-hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { memo } from 'react';
 import { useForm, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import { initialPubMedValues } from '../../constant';
 import { useFormValues } from '../../hooks/use-form-values';
@@ -35,7 +35,7 @@ export const FormSchema = z.object({
 
 export function PubMedFormWidgets() {
   const form = useFormContext();
-  const { t } = useTranslate('flow');
+  const { t } = useTranslation('flow');
 
   return (
     <>

--- a/web/src/pages/agent/form/retrieval-form/next.tsx
+++ b/web/src/pages/agent/form/retrieval-form/next.tsx
@@ -10,7 +10,7 @@ import { RAGFlowFormItem } from '@/components/ragflow-form';
 import { RerankFormFields } from '@/components/rerank';
 import { SimilaritySliderFormField } from '@/components/similarity-slider';
 import { TOCEnhanceFormField } from '@/components/toc-enhance-form-field';
-import { TopNFormField } from '@/components/top-n-item';
+import { DEFAULT_TOP_N_MAX, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -44,7 +44,7 @@ import { useValues } from './use-values';
 export const RetrievalPartialSchema = {
   similarity_threshold: z.coerce.number(),
   keywords_similarity_weight: z.coerce.number(),
-  top_n: z.coerce.number(),
+  top_n: z.coerce.number().max(DEFAULT_TOP_N_MAX),
   top_k: z.coerce.number(),
   dataset_ids: z.array(z.string()),
   rerank_id: z.string(),

--- a/web/src/pages/agent/form/searxng-form/index.tsx
+++ b/web/src/pages/agent/form/searxng-form/index.tsx
@@ -1,5 +1,5 @@
 import { FormContainer } from '@/components/form-container';
-import { TopNFormField } from '@/components/top-n-item';
+import { DEFAULT_TOP_N_MAX, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -26,7 +26,11 @@ import { QueryVariable } from '../components/query-variable';
 const FormSchema = z.object({
   query: z.string(),
   searxng_url: z.string().min(1),
-  top_n: z.string(),
+  top_n: z
+    .string()
+    .refine((value) => Number(value) <= DEFAULT_TOP_N_MAX, {
+      message: `Top N must be less than or equal to ${DEFAULT_TOP_N_MAX}`,
+    }),
 });
 
 const outputList = buildOutputList(initialSearXNGValues.outputs);

--- a/web/src/pages/agent/form/searxng-form/index.tsx
+++ b/web/src/pages/agent/form/searxng-form/index.tsx
@@ -9,7 +9,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { useTranslate } from '@/hooks/common-hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { memo } from 'react';
 import { useForm } from 'react-hook-form';
@@ -26,17 +25,14 @@ import { QueryVariable } from '../components/query-variable';
 const FormSchema = z.object({
   query: z.string(),
   searxng_url: z.string().min(1),
-  top_n: z
-    .string()
-    .refine((value) => Number(value) <= DEFAULT_TOP_N_MAX, {
-      message: `Top N must be less than or equal to ${DEFAULT_TOP_N_MAX}`,
-    }),
+  top_n: z.string().refine((value) => Number(value) <= DEFAULT_TOP_N_MAX, {
+    message: `Top N must be less than or equal to ${DEFAULT_TOP_N_MAX}`,
+  }),
 });
 
 const outputList = buildOutputList(initialSearXNGValues.outputs);
 
 function SearXNGForm({ node }: INextOperatorForm) {
-  const { t } = useTranslate('flow');
   const defaultValues = useFormValues(initialSearXNGValues, node);
 
   const form = useForm<z.infer<typeof FormSchema>>({

--- a/web/src/pages/agent/form/tool-form/searxng-form/index.tsx
+++ b/web/src/pages/agent/form/tool-form/searxng-form/index.tsx
@@ -9,7 +9,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { useTranslate } from '@/hooks/common-hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { memo } from 'react';
 import { useForm } from 'react-hook-form';
@@ -19,11 +18,12 @@ import { useWatchFormChange } from '../use-watch-change';
 
 const FormSchema = z.object({
   searxng_url: z.string().min(1),
-  top_n: z.string(),
+  top_n: z.string().refine((value) => Number(value) <= DEFAULT_TOP_N_MAX, {
+    message: `Top N must be less than or equal to ${DEFAULT_TOP_N_MAX}`,
+  }),
 });
 
 function SearXNGForm() {
-  const { t } = useTranslate('flow');
   const values = useValues();
 
   const form = useForm<z.infer<typeof FormSchema>>({

--- a/web/src/pages/agent/form/tool-form/searxng-form/index.tsx
+++ b/web/src/pages/agent/form/tool-form/searxng-form/index.tsx
@@ -1,5 +1,5 @@
 import { FormContainer } from '@/components/form-container';
-import { TopNFormField } from '@/components/top-n-item';
+import { DEFAULT_TOP_N_MAX, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,

--- a/web/src/pages/agent/form/wencai-form/index.tsx
+++ b/web/src/pages/agent/form/wencai-form/index.tsx
@@ -1,5 +1,5 @@
 import { FormContainer } from '@/components/form-container';
-import { TopNFormField } from '@/components/top-n-item';
+import { createTopNSchema, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -24,8 +24,10 @@ import { FormWrapper } from '../components/form-wrapper';
 import { Output } from '../components/output';
 import { QueryVariable } from '../components/query-variable';
 
+const WENCAI_TOP_N_MAX = 99;
+
 export const WenCaiPartialSchema = {
-  top_n: z.number(),
+  top_n: createTopNSchema(WENCAI_TOP_N_MAX).top_n.unwrap(),
   query_type: z.string(),
 };
 
@@ -47,7 +49,7 @@ export function WenCaiFormWidgets() {
 
   return (
     <>
-      <TopNFormField max={99}></TopNFormField>
+      <TopNFormField max={WENCAI_TOP_N_MAX}></TopNFormField>
       <FormField
         control={form.control}
         name="query_type"

--- a/web/src/pages/agent/form/wencai-form/index.tsx
+++ b/web/src/pages/agent/form/wencai-form/index.tsx
@@ -24,10 +24,10 @@ import { FormWrapper } from '../components/form-wrapper';
 import { Output } from '../components/output';
 import { QueryVariable } from '../components/query-variable';
 
-const WENCAI_TOP_N_MAX = 99;
+const WenCaiTopNMax = 99;
 
 export const WenCaiPartialSchema = {
-  top_n: createTopNSchema(WENCAI_TOP_N_MAX).top_n.unwrap(),
+  top_n: createTopNSchema(WenCaiTopNMax).top_n.unwrap(),
   query_type: z.string(),
 };
 
@@ -49,7 +49,7 @@ export function WenCaiFormWidgets() {
 
   return (
     <>
-      <TopNFormField max={WENCAI_TOP_N_MAX}></TopNFormField>
+      <TopNFormField max={WenCaiTopNMax}></TopNFormField>
       <FormField
         control={form.control}
         name="query_type"

--- a/web/src/pages/agent/form/wikipedia-form/index.tsx
+++ b/web/src/pages/agent/form/wikipedia-form/index.tsx
@@ -1,6 +1,6 @@
 import { FormContainer } from '@/components/form-container';
 import { SelectWithSearch } from '@/components/originui/select-with-search';
-import { TopNFormField } from '@/components/top-n-item';
+import { DEFAULT_TOP_N_MAX, TopNFormField } from '@/components/top-n-item';
 import {
   Form,
   FormControl,
@@ -25,7 +25,9 @@ import { Output } from '../components/output';
 import { QueryVariable } from '../components/query-variable';
 
 export const WikipediaFormPartialSchema = {
-  top_n: z.string(),
+  top_n: z.string().refine((value) => Number(value) <= DEFAULT_TOP_N_MAX, {
+    message: `Top N must be less than or equal to ${DEFAULT_TOP_N_MAX}`,
+  }),
   language: z.string(),
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

frontend explicitly capped the input at 30 in the shared TopNFormField component default props (web/src/components/top-n-item.tsx) and this was blocking me from sending more chunks to the llm

Updated web/src/components/top-n-item.tsx to set the default max value of the slider to 200 instead of 30, seamlessly enabling the configuration of higher values up to 200 for the Top N field in the chatbot settings and other relevant agent forms.

- [x] Other (frontend explicitly capped the input at 30 in the shared TopNFormField component default props (web/src/components/top-n-item.tsx) so I changed that to 200):
