### PR TITLE
Fix: clicks on Popover-based selects swallowed when nested in Dialog

### DIFF
--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -15,25 +15,17 @@ const Popover = ({
   onOpenChange,
   disableOutsideClick = false,
 }: PopoverProps) => {
-  const [open, setOpen] = React.useState(true);
-  React.useEffect(() => {
-    setOpen(!!openState);
-  }, [openState]);
   const handleOnOpenChange = React.useCallback(
     (e: boolean) => {
       if (disableOutsideClick && !e) {
         return;
       }
-
-      if (onOpenChange) {
-        onOpenChange?.(e);
-      }
-      setOpen(e);
+      onOpenChange?.(e);
     },
     [onOpenChange, disableOutsideClick],
   );
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={handleOnOpenChange}>
+    <PopoverPrimitive.Root open={openState} onOpenChange={handleOnOpenChange}>
       {children}
     </PopoverPrimitive.Root>
   );
@@ -52,9 +44,12 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'z-50 w-72 rounded-md border-0.5 border-border-button bg-bg-base p-4 text-text-primary shadow-lg outline-none',
+        // Force pointer events on so Popover content stays interactive when
+        // nested inside a Radix Dialog (which sets body pointer-events: none).
+        'pointer-events-auto',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
         'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-9',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}


### PR DESCRIPTION
### What problem does this PR solve?

Radix Dialog sets `body { pointer-events: none }` while open and
relies on the nested Popover's DismissableLayer to restore
`pointer-events: auto`. Two issues in `web/src/components/ui/popover.tsx`
broke that contract:

- The Popover wrapper mirrored `open` into a local `useState(true)`
  plus a sync effect, briefly mounting and unmounting PopoverContent
  on first render and racing the layer order. The popover ended up
  with `pointer-events: none`.
- PopoverContent had no explicit `pointer-events-auto` fallback.

The popover stayed visible but transparent to clicks; clicks fell through to the DialogHeader behind it, which Radix interpreted as an outside click and dismissed the popover. Affected the chunk method in the Create dataset dialog  and the model type dropdown in Model Providers, among others.

Fixes:
- Make `Popover` in `web/src/components/ui/popover.tsx` a thin pass-through over `PopoverPrimitive.Root`.
- Add `pointer-events-auto` to `PopoverContent`.
- Fix typo `zoom-in-9` -> `zoom-in-95` in the open animation class.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)