### PR TITLE
feat(task_executor): add MAX_TASKS_PER_WORKER to recycle long-running workers

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -287,5 +287,12 @@ DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 # Used for ThreadPoolExecutor
 THREAD_POOL_MAX_WORKERS=128
 
+# Recycle the task_executor worker process after this many completed tasks
+# to release ONNX Runtime / CUDA arena fragmentation that accumulates over
+# the lifetime of the process. The supervisor loop in entrypoint.sh restarts
+# the worker automatically after a clean exit. Set to a small value (e.g. 20)
+# on low-VRAM GPUs where long-running workers eventually OOM. 0 disables.
+# MAX_TASKS_PER_WORKER=0
+
 #Option to disable login form for SSO
 DISABLE_PASSWORD_LOGIN=false

--- a/docker/.env
+++ b/docker/.env
@@ -438,6 +438,19 @@ LLM_POOL_RATE_LIMIT_RETRIES=3
 LLM_POOL_RATE_LIMIT_RETRY_BASE_DELAY=1.0
 LLM_POOL_RATE_LIMIT_RETRY_MAX_DELAY=30.0
 
+# Recycle the task_executor worker process after this many completed tasks, to
+# release the ONNX Runtime / CUDA arena fragmentation that builds up over the
+# lifetime of the process. The supervisor loop in entrypoint.sh restarts the
+# worker automatically after a clean exit. Set a small value (e.g. 20) on
+# low-VRAM GPUs where long-running workers eventually run out of memory.
+# The threshold is soft: tasks already in flight are allowed to finish, so up to
+# MAX_CONCURRENT_TASKS - 1 extra tasks may complete before the worker exits.
+# 0 disables recycling.
+# MAX_TASKS_PER_WORKER=0
+# How long (seconds) a recycling worker waits for in-flight tasks to finish
+# before cancelling them. Only has an effect when MAX_TASKS_PER_WORKER > 0.
+# RECYCLE_SHUTDOWN_TIMEOUT=300
+
 #Option to disable login form for SSO
 DISABLE_PASSWORD_LOGIN=false
 

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -124,6 +124,17 @@ CURRENT_TASKS = {}
 MAX_CONCURRENT_TASKS = int(os.environ.get('MAX_CONCURRENT_TASKS', "5"))
 MAX_CONCURRENT_CHUNK_BUILDERS = int(os.environ.get('MAX_CONCURRENT_CHUNK_BUILDERS', "1"))
 MAX_CONCURRENT_MINIO = int(os.environ.get('MAX_CONCURRENT_MINIO', '10'))
+# Recycle the worker process after this many completed tasks to release
+# unreclaimed memory held by long-lived libraries (notably ONNX Runtime's
+# BFCArena, which keeps allocated chunks until the InferenceSession is
+# destroyed). The supervisor loop in `docker/entrypoint.sh`
+# (`while true; do ... task_executor.py & wait; sleep 1; done`) restarts the
+# process automatically after a clean exit.
+# 0 disables recycling (legacy behaviour). A small value such as 20 is helpful
+# on lower-VRAM consumer GPUs where cumulative arena fragmentation eventually
+# manifests as "Available memory of 0" allocation failures.
+MAX_TASKS_PER_WORKER = int(os.environ.get('MAX_TASKS_PER_WORKER', '0'))
+_completed_task_count = 0
 task_limiter = asyncio.Semaphore(MAX_CONCURRENT_TASKS)
 chunk_limiter = asyncio.Semaphore(MAX_CONCURRENT_CHUNK_BUILDERS)
 embed_limiter = asyncio.Semaphore(MAX_CONCURRENT_CHUNK_BUILDERS)
@@ -1448,9 +1459,17 @@ async def report_status():
 
 
 async def task_manager():
+    global _completed_task_count
     try:
         await handle_task()
     finally:
+        _completed_task_count += 1
+        if MAX_TASKS_PER_WORKER > 0 and _completed_task_count >= MAX_TASKS_PER_WORKER:
+            logging.warning(
+                f"[recycle] reached MAX_TASKS_PER_WORKER={MAX_TASKS_PER_WORKER}; "
+                f"signalling clean exit so the supervisor can restart the worker."
+            )
+            stop_event.set()
         task_limiter.release()
 
 
@@ -1499,6 +1518,12 @@ async def main():
     try:
         while not stop_event.is_set():
             await task_limiter.acquire()
+            if stop_event.is_set():
+                # A previous task_manager may have signalled shutdown while
+                # we were blocked on the semaphore; bail out cleanly so the
+                # supervisor can restart the worker.
+                task_limiter.release()
+                break
             t = asyncio.create_task(task_manager())
             tasks.append(t)
     finally:

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -134,6 +134,11 @@ MAX_CONCURRENT_MINIO = int(os.environ.get('MAX_CONCURRENT_MINIO', '10'))
 # on lower-VRAM consumer GPUs where cumulative arena fragmentation eventually
 # manifests as "Available memory of 0" allocation failures.
 MAX_TASKS_PER_WORKER = int(os.environ.get('MAX_TASKS_PER_WORKER', '0'))
+# Bounded grace period when shutting down: how long we wait for in-flight
+# task_managers to finish before cancelling them. Prevents an unresponsive
+# task from blocking the recycle indefinitely. The supervisor / orchestrator
+# can still SIGKILL after its own timeout if the cancel itself hangs.
+SHUTDOWN_TIMEOUT = float(os.environ.get('TASK_EXECUTOR_SHUTDOWN_TIMEOUT', '300'))
 _completed_task_count = 0
 task_limiter = asyncio.Semaphore(MAX_CONCURRENT_TASKS)
 chunk_limiter = asyncio.Semaphore(MAX_CONCURRENT_CHUNK_BUILDERS)
@@ -1542,9 +1547,20 @@ async def main():
             tasks.append(t)
     finally:
         # Wait for in-flight task_managers to finish so a recycle (or any
-        # other stop_event) preserves work already in progress. The supervisor
-        # / orchestrator can SIGKILL if a real forced shutdown is needed.
-        await asyncio.gather(*tasks, return_exceptions=True)
+        # other stop_event) preserves work already in progress, but bound the
+        # wait so a single hung task cannot block the worker from exiting.
+        # After the timeout, any still-running tasks are cancelled and we let
+        # the supervisor / orchestrator escalate to SIGKILL if needed.
+        if tasks:
+            _, pending = await asyncio.wait(tasks, timeout=SHUTDOWN_TIMEOUT)
+            if pending:
+                logging.warning(
+                    f"[recycle] {len(pending)} task(s) still running after "
+                    f"{SHUTDOWN_TIMEOUT}s grace; cancelling them."
+                )
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
         report_task.cancel()
         await asyncio.gather(report_task, return_exceptions=True)
     logging.error("BUG!!! You should not reach here!!!")

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -1320,12 +1320,19 @@ async def do_handle_task(task):
                     f"Remove doc({task_doc_id}) from docStore failed when task({task_id}) canceled, exception: {e}")
 
 
-async def handle_task():
+async def handle_task() -> bool:
+    """Pull one task off the queue and process it.
+
+    Returns True if a real task was processed (success or failure), False if
+    the queue was empty and the call was an idle poll. The return value lets
+    the caller distinguish work from idle so e.g. recycle counters do not
+    advance during quiet periods.
+    """
     global DONE_TASKS, FAILED_TASKS
     redis_msg, task = await collect()
     if not task:
         await asyncio.sleep(5)
-        return
+        return False
 
     task_type = task["task_type"]
     pipeline_task_type = TASK_TYPE_TO_PIPELINE_TASK_TYPE.get(task_type,
@@ -1367,6 +1374,7 @@ async def handle_task():
                                                                   task_id=task_id, referred_document_id=referred_document_id)
 
     redis_msg.ack()
+    return True
 
 
 async def get_server_ip() -> str:
@@ -1460,16 +1468,18 @@ async def report_status():
 
 async def task_manager():
     global _completed_task_count
+    processed = False
     try:
-        await handle_task()
+        processed = await handle_task()
     finally:
-        _completed_task_count += 1
-        if MAX_TASKS_PER_WORKER > 0 and _completed_task_count >= MAX_TASKS_PER_WORKER:
-            logging.warning(
-                f"[recycle] reached MAX_TASKS_PER_WORKER={MAX_TASKS_PER_WORKER}; "
-                f"signalling clean exit so the supervisor can restart the worker."
-            )
-            stop_event.set()
+        if processed:
+            _completed_task_count += 1
+            if MAX_TASKS_PER_WORKER > 0 and _completed_task_count >= MAX_TASKS_PER_WORKER:
+                logging.warning(
+                    f"[recycle] reached MAX_TASKS_PER_WORKER={MAX_TASKS_PER_WORKER}; "
+                    f"signalling clean exit so the supervisor can restart the worker."
+                )
+                stop_event.set()
         task_limiter.release()
 
 
@@ -1522,13 +1532,18 @@ async def main():
                 # A previous task_manager may have signalled shutdown while
                 # we were blocked on the semaphore; bail out cleanly so the
                 # supervisor can restart the worker.
+                logging.info(
+                    "[recycle] stop_event observed after acquiring task_limiter; "
+                    "releasing semaphore and exiting main loop."
+                )
                 task_limiter.release()
                 break
             t = asyncio.create_task(task_manager())
             tasks.append(t)
     finally:
-        for t in tasks:
-            t.cancel()
+        # Wait for in-flight task_managers to finish so a recycle (or any
+        # other stop_event) preserves work already in progress. The supervisor
+        # / orchestrator can SIGKILL if a real forced shutdown is needed.
         await asyncio.gather(*tasks, return_exceptions=True)
         report_task.cancel()
         await asyncio.gather(report_task, return_exceptions=True)

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -173,6 +173,23 @@ FAILED_TASKS = 0
 CURRENT_TASKS = {}
 
 WORKER_HEARTBEAT_TIMEOUT = int(os.environ.get("WORKER_HEARTBEAT_TIMEOUT", "120"))
+# Recycle the worker process after this many completed tasks to release memory
+# that long-lived libraries cannot reclaim on their own -- notably ONNX
+# Runtime's BFCArena, which holds every chunk it allocates until the
+# InferenceSession is destroyed. The supervisor loop in `docker/entrypoint.sh`
+# (`while true; do ... task_executor.py & wait; sleep 1; done`) restarts the
+# process automatically after a clean exit.
+# 0 disables recycling and preserves the existing behaviour. A small value such
+# as 20 helps on lower-VRAM consumer GPUs where cumulative arena fragmentation
+# eventually surfaces as "Available memory of 0" allocation failures.
+# The threshold is a soft one: tasks already in flight when it is reached are
+# allowed to finish, so a worker may complete up to MAX_CONCURRENT_TASKS - 1
+# extra tasks before it exits.
+MAX_TASKS_PER_WORKER = int(os.environ.get("MAX_TASKS_PER_WORKER", "0"))
+# Only used when recycling is enabled: how long to let in-flight task_managers
+# finish before cancelling them, so a single hung task cannot block the exit.
+RECYCLE_SHUTDOWN_TIMEOUT = float(os.environ.get("RECYCLE_SHUTDOWN_TIMEOUT", "300"))
+_completed_task_count = 0
 stop_event = threading.Event()
 
 
@@ -1746,12 +1763,18 @@ async def do_handle_task(task):
                 logging.exception(f"Remove doc({task_doc_id}) from docStore failed when task({task_id}) canceled, exception: {e}")
 
 
-async def handle_task():
+async def handle_task() -> bool:
+    """Pull one task off the queue and process it.
+
+    Returns True if a real task was processed (success or failure), False if the
+    queue was empty and the call was an idle poll, so callers can tell work apart
+    from idling and e.g. avoid advancing the recycle counter during quiet periods.
+    """
     global DONE_TASKS, FAILED_TASKS
     redis_msg, task = await collect()
     if not task:
         await asyncio.sleep(5)
-        return
+        return False
 
     logging.info(f"handle_task begin for task {json.dumps(task)}")
 
@@ -1814,6 +1837,7 @@ async def handle_task():
             get_recording_context().save_func_return_value("PipelineOperationLogService.record_pipeline_operation", ret)
 
     redis_msg.ack()
+    return True
 
 
 async def get_server_ip() -> str:
@@ -1909,9 +1933,16 @@ async def report_status():
 
 
 async def task_manager():
+    global _completed_task_count
+    processed = False
     try:
-        await handle_task()
+        processed = await handle_task()
     finally:
+        if processed and MAX_TASKS_PER_WORKER > 0:
+            _completed_task_count += 1
+            if _completed_task_count >= MAX_TASKS_PER_WORKER:
+                logging.warning(f"[recycle] reached MAX_TASKS_PER_WORKER={MAX_TASKS_PER_WORKER}; signalling a clean exit so the supervisor can restart the worker.")
+                stop_event.set()
         task_limiter.release()
 
 
@@ -1960,9 +1991,24 @@ async def main():
     try:
         while not stop_event.is_set():
             await task_limiter.acquire()
+            if stop_event.is_set():
+                # Another task_manager signalled shutdown while we were blocked
+                # on the semaphore; bail out cleanly instead of picking up one
+                # more task, so the supervisor can restart the worker.
+                logging.info("[recycle] stop_event observed after acquiring task_limiter; releasing the semaphore and exiting the main loop.")
+                task_limiter.release()
+                break
             t = asyncio.create_task(task_manager())
             tasks.append(t)
     finally:
+        if MAX_TASKS_PER_WORKER > 0 and tasks:
+            # Recycling is a planned exit, so let in-flight task_managers finish
+            # instead of discarding their work -- but bound the wait so a single
+            # hung task cannot keep the worker alive forever.
+            _, pending = await asyncio.wait(tasks, timeout=RECYCLE_SHUTDOWN_TIMEOUT)
+            if pending:
+                logging.warning(f"[recycle] {len(pending)} task(s) still running after {RECYCLE_SHUTDOWN_TIMEOUT}s grace; cancelling them.")
+            tasks = list(pending)
         for t in tasks:
             t.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
### Summary

Adds an opt-in `MAX_TASKS_PER_WORKER` environment variable that recycles the `task_executor` worker process after a configurable number of completed tasks, releasing memory that long-lived libraries cannot reclaim on their own.

> **Rebased onto current `main`** and squashed to a single commit. The branch had fallen ~3k commits behind; the only conflict was the constant block, whose anchor moved into `rag/svr/task_executor_limiter.py` during the task executor refactors (#15154 / #15471).

## Motivation

`task_executor.py` lazily loads multiple ONNX Runtime sessions (OCR, layout recognition, table structure recognition, etc.) over the lifetime of the process. ONNX Runtime's `BFCArena` allocator keeps every chunk it grabs until the `InferenceSession` is destroyed, so on lower-VRAM consumer GPUs the cumulative arena fragmentation eventually starves new allocations:

```
[ONNXRuntimeError] : 1 : FAIL : BFCArena::AllocateRawInternal:
Available memory of 0 is smaller than requested bytes of 8478720
```

Once the worker is in this state, every subsequent task fails until the process is restarted. There are existing reports of this exact symptom (e.g. #5863).

The supervisor loop in `docker/entrypoint.sh` already restarts the worker after a clean exit:

```bash
while true; do
    LD_PRELOAD="$JEMALLOC_PATH" \
    "$PY" rag/svr/task_executor.py -i "${host_id}_${consumer_id}" -t "common" &
    wait;
    sleep 1;
done
```

…so all that is missing is a way for the worker to ask to be recycled — the same pattern Celery (`max-tasks-per-child`) and Gunicorn (`max-requests`) already use.

## What this PR does

- Adds `MAX_TASKS_PER_WORKER` (default `0` = disabled).
- `handle_task()` now reports whether it did real work, so idle polls against an empty queue do not advance the counter.
- `task_manager()` counts completions and sets `stop_event` once the threshold is reached, so `main()` exits cleanly and the supervisor restarts the process.
- The main loop re-checks `stop_event` immediately after `task_limiter.acquire()`, so a worker that was blocked on the semaphore doesn't pick up one extra task after the shutdown signal fires.
- **When recycling is enabled**, in-flight `task_manager`s are drained rather than cancelled, bounded by `RECYCLE_SHUTDOWN_TIMEOUT` (default `300`s) so a single hung task cannot block the exit.
- Documents both variables in `docker/.env`.

With `MAX_TASKS_PER_WORKER=0` nothing changes: the counter is never incremented, `stop_event` is never set from this path, and the shutdown branch falls through to the existing `cancel()` + `gather()` unchanged. The drain is deliberately gated on the feature being on, so this PR does not alter the SIGTERM/SIGINT shutdown semantics of a normally configured deployment.

### On the threshold being soft

`MAX_CONCURRENT_TASKS` tasks run concurrently, so when the Nth task completes there can be up to `MAX_CONCURRENT_TASKS - 1` others already in flight; those are allowed to finish. A worker therefore completes between `N` and `N + MAX_CONCURRENT_TASKS - 1` tasks before exiting. This mirrors how Celery's `max-tasks-per-child` behaves with prefetch, and it is called out in both the code comment and `docker/.env` so the number isn't surprising in practice.

## Validation

Originally reproduced on a single-GPU RTX 4060 (8 GB VRAM) ingesting ~200 PDF papers via the `paper` parser with full DeepDOC. With the default `MAX_TASKS_PER_WORKER=0` the worker started failing every subsequent task with `Available memory of 0` after ~30 documents. With `MAX_TASKS_PER_WORKER=20` the worker exits cleanly (visible as `[recycle] reached MAX_TASKS_PER_WORKER=20` in the logs), the supervisor restarts it, VRAM usage drops back to baseline, and the queue continues without arena failures.

After rebasing onto the refactored `main`, the recycle logic was re-verified with a standalone asyncio harness mirroring `main()` / `task_manager()` / `handle_task()` with stubs:

| scenario | result |
| --- | --- |
| `MAX=3`, concurrency 5 | exits after 3–7 completions, nothing cancelled |
| `MAX=3`, concurrency 1 | exits after exactly 3 |
| `MAX=3` with idle polls interleaved | only real work advances the counter |
| `MAX=2`, one task hangs | bounded grace, then cancelled — a hang cannot block the exit |
| `MAX=0` + external stop | legacy path, no drain |

`ruff check` and `ruff format --check` are clean on both changed files, with no new violations relative to `main`.

## Test plan

- [x] `MAX_TASKS_PER_WORKER` unset or `0` — no behaviour change (verified pre-rebase; post-rebase the shutdown path is gated so it is unchanged from `main` by construction).
- [x] `MAX_TASKS_PER_WORKER=N` — the worker logs `[recycle] reached MAX_TASKS_PER_WORKER=N` and is restarted by the supervisor (verified pre-rebase on hardware, and post-rebase with the harness above).
- [x] Long ingestion run on a low-VRAM GPU no longer accumulates `Available memory of 0` failures (verified pre-rebase on the RTX 4060).
- [ ] Repository CI — as a fork PR this needs the `ci` label to run.
