### PR TITLE
.1470523137868652:b86e6f79b43cc60723aba93d0cd5ec8c_69f21e712b66bd8b806ce16e.69f21ed62b66bd8b806ce172.69f21ed693614b8edc02d83b:Trae CN.T(2026/4/29 23:08:06)

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -31,7 +31,145 @@ from common import settings
 
 from common.misc_utils import thread_pool_exec
 
+RETRIEVAL_DEBUG_TRACE_ENABLED = False
+
 def index_name(uid): return f"ragflow_{uid}"
+
+
+@dataclass
+class ChunkDebugInfo:
+    chunk_id: str
+    doc_id: str
+    doc_name: str
+    kb_id: str
+    initial_score: float = 0.0
+    term_similarity: float = 0.0
+    vector_similarity: float = 0.0
+    rerank_score: float = 0.0
+    filter_reason: str | None = None
+    final_position: int | None = None
+    content_preview: str = ""
+    is_pruned: bool = False
+    rank_feature_score: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "chunk_id": self.chunk_id,
+            "doc_id": self.doc_id,
+            "doc_name": self.doc_name,
+            "kb_id": self.kb_id,
+            "initial_score": self.initial_score,
+            "term_similarity": self.term_similarity,
+            "vector_similarity": self.vector_similarity,
+            "rerank_score": self.rerank_score,
+            "rank_feature_score": self.rank_feature_score,
+            "filter_reason": self.filter_reason,
+            "final_position": self.final_position,
+            "content_preview": self.content_preview[:100] if self.content_preview else "",
+            "is_pruned": self.is_pruned,
+        }
+
+
+@dataclass
+class RetrievalDebugTrace:
+    query: str
+    tenant_ids: list[str]
+    kb_ids: list[str]
+    top_k: int
+    top_n: int
+    similarity_threshold: float
+    vector_similarity_weight: float
+
+    initial_search_count: int = 0
+    pruned_count: int = 0
+    rerank_used: bool = False
+    rerank_model: str | None = None
+    filtered_by_threshold_count: int = 0
+    filtered_by_pagination_count: int = 0
+    final_chunks_count: int = 0
+    doc_engine_score_used: bool = False
+
+    all_chunks: list[ChunkDebugInfo] | None = None
+    final_chunks: list[ChunkDebugInfo] | None = None
+
+    def enable_detail(self):
+        self.all_chunks = []
+        self.final_chunks = []
+
+    def to_dict(self) -> dict:
+        result = {
+            "query": self.query,
+            "tenant_ids": self.tenant_ids,
+            "kb_ids": self.kb_ids,
+            "top_k": self.top_k,
+            "top_n": self.top_n,
+            "similarity_threshold": self.similarity_threshold,
+            "vector_similarity_weight": self.vector_similarity_weight,
+            "initial_search_count": self.initial_search_count,
+            "pruned_count": self.pruned_count,
+            "rerank_used": self.rerank_used,
+            "rerank_model": self.rerank_model,
+            "filtered_by_threshold_count": self.filtered_by_threshold_count,
+            "filtered_by_pagination_count": self.filtered_by_pagination_count,
+            "final_chunks_count": self.final_chunks_count,
+            "doc_engine_score_used": self.doc_engine_score_used,
+            "summary": {
+                "selected": self.final_chunks_count,
+                "pruned_deleted_docs": self.pruned_count,
+                "filtered_by_threshold": self.filtered_by_threshold_count,
+                "filtered_by_pagination": self.filtered_by_pagination_count,
+            }
+        }
+        if self.all_chunks is not None:
+            result["all_chunks"] = [c.to_dict() for c in self.all_chunks]
+        if self.final_chunks is not None:
+            result["final_chunks"] = [c.to_dict() for c in self.final_chunks]
+        return result
+
+    def log_summary(self):
+        summary_lines = [
+            "=" * 80,
+            "RETRIEVAL DEBUG TRACE SUMMARY",
+            "=" * 80,
+            f"Query: {self.query}",
+            f"Tenants: {self.tenant_ids}, KBs: {self.kb_ids}",
+            f"Params: top_k={self.top_k}, top_n={self.top_n}, threshold={self.similarity_threshold}, vs_weight={self.vector_similarity_weight}",
+            "-" * 80,
+            f"Initial search results: {self.initial_search_count} chunks",
+            f"Pruned (deleted docs): {self.pruned_count} chunks",
+            f"Rerank used: {self.rerank_used} (model: {self.rerank_model})",
+            f"Doc engine score used: {self.doc_engine_score_used}",
+            f"Filtered by threshold: {self.filtered_by_threshold_count} chunks",
+            f"Filtered by pagination: {self.filtered_by_pagination_count} chunks",
+            f"Final selected: {self.final_chunks_count} chunks",
+            "=" * 80,
+        ]
+        logging.info("\n".join(summary_lines))
+
+        if self.final_chunks:
+            logging.info("FINAL CHUNKS DETAIL:")
+            for i, chunk in enumerate(self.final_chunks):
+                logging.info(
+                    f"  [{i}] ID={chunk.chunk_id}, "
+                    f"doc={chunk.doc_name}, "
+                    f"term_sim={chunk.term_similarity:.4f}, "
+                    f"vec_sim={chunk.vector_similarity:.4f}, "
+                    f"rerank={chunk.rerank_score:.4f}"
+                )
+
+        if self.all_chunks:
+            filtered = [c for c in self.all_chunks if c.filter_reason]
+            if filtered:
+                logging.info("FILTERED CHUNKS:")
+                for chunk in filtered[:20]:
+                    logging.info(
+                        f"  ID={chunk.chunk_id}, "
+                        f"doc={chunk.doc_name}, "
+                        f"reason={chunk.filter_reason}, "
+                        f"scores: term={chunk.term_similarity:.4f}, vec={chunk.vector_similarity:.4f}, rerank={chunk.rerank_score:.4f}"
+                    )
+                if len(filtered) > 20:
+                    logging.info(f"  ... and {len(filtered) - 20} more filtered chunks")
 
 
 class Dealer:
@@ -462,10 +600,25 @@ class Dealer:
             rerank_mdl=None,
             highlight=False,
             rank_feature: dict | None = {PAGERANK_FLD: 10},
+            debug: bool = False,
     ):
         ranks = {"total": 0, "chunks": [], "doc_aggs": {}}
         if not question:
             return ranks
+
+        debug_trace = None
+        if debug or RETRIEVAL_DEBUG_TRACE_ENABLED:
+            debug_trace = RetrievalDebugTrace(
+                query=question,
+                tenant_ids=list(tenant_ids) if isinstance(tenant_ids, (list, str)) else [],
+                kb_ids=list(kb_ids) if isinstance(kb_ids, list) else [],
+                top_k=top,
+                top_n=page_size,
+                similarity_threshold=similarity_threshold,
+                vector_similarity_weight=vector_similarity_weight,
+            )
+            if debug:
+                debug_trace.enable_detail()
 
         # Keep the historical windowing strategy by default, but when an external
         # reranker is enabled cap candidate count by both top_k and provider-safe 64.
@@ -493,14 +646,30 @@ class Dealer:
 
         sres = await self.search(req, [index_name(tid) for tid in tenant_ids], kb_ids, embd_mdl, highlight,
                            rank_feature=rank_feature)
+        
+        if debug_trace:
+            debug_trace.initial_search_count = len(sres.ids) if sres.ids else 0
+        
         # Temporary retrieval-side guard: prune chunks whose parent document no
         # longer exists before reranking and returning results.
+        original_count = sres.total
         sres = await self._prune_deleted_chunks(sres)
+        
+        if debug_trace and original_count > sres.total:
+            debug_trace.pruned_count = original_count - sres.total
+        
         if sres.total == 0:
             ranks["doc_aggs"] = []
+            if debug_trace and debug:
+                if RETRIEVAL_DEBUG_TRACE_ENABLED or debug:
+                    debug_trace.log_summary()
+                ranks["debug_trace"] = debug_trace.to_dict()
             return ranks
 
         if rerank_mdl and sres.total > 0:
+            if debug_trace:
+                debug_trace.rerank_used = True
+                debug_trace.rerank_model = getattr(rerank_mdl, "llm_name", str(rerank_mdl))
             sim, tsim, vsim = self.rerank_by_model(
                 rerank_mdl,
                 sres,
@@ -511,6 +680,8 @@ class Dealer:
             )
         else:
             if settings.DOC_ENGINE_INFINITY:
+                if debug_trace:
+                    debug_trace.doc_engine_score_used = True
                 # Don't need rerank here since Infinity normalizes each way score before fusion.
                 sim = [sres.field[id].get("_score", 0.0) for id in sres.ids]
                 sim = [s if s is not None else 0.0 for s in sim]
@@ -529,6 +700,10 @@ class Dealer:
         sim_np = np.array(sim, dtype=np.float64)
         if sim_np.size == 0:
             ranks["doc_aggs"] = []
+            if debug_trace and debug:
+                if RETRIEVAL_DEBUG_TRACE_ENABLED or debug:
+                    debug_trace.log_summary()
+                ranks["debug_trace"] = debug_trace.to_dict()
             return ranks
 
         sorted_idx = np.argsort(sim_np * -1)
@@ -545,19 +720,30 @@ class Dealer:
         filtered_count = len(valid_idx)
         ranks["total"] = int(filtered_count)
 
+        if debug_trace:
+            debug_trace.filtered_by_threshold_count = len(sorted_idx) - len(valid_idx)
+
         if filtered_count == 0:
             ranks["doc_aggs"] = []
+            if debug_trace and debug:
+                if RETRIEVAL_DEBUG_TRACE_ENABLED or debug:
+                    debug_trace.log_summary()
+                ranks["debug_trace"] = debug_trace.to_dict()
             return ranks
 
         begin = global_offset % RERANK_LIMIT
         end = begin + page_size
         page_idx = valid_idx[begin:end]
 
+        if debug_trace:
+            debug_trace.filtered_by_pagination_count = len(valid_idx) - len(page_idx)
+            debug_trace.final_chunks_count = len(page_idx)
+
         dim = len(sres.query_vector)
         vector_column = f"q_{dim}_vec"
         zero_vector = [0.0] * dim
 
-        for i in page_idx:
+        for pos_in_page, i in enumerate(page_idx):
             id = sres.ids[i]
             chunk = sres.field[id]
             dnm = chunk.get("docnm_kwd", "")
@@ -590,6 +776,55 @@ class Dealer:
                     d["highlight"] = d["content_with_weight"]
             ranks["chunks"].append(d)
 
+            if debug_trace and debug_trace.final_chunks is not None:
+                chunk_debug = ChunkDebugInfo(
+                    chunk_id=id,
+                    doc_id=did,
+                    doc_name=dnm,
+                    kb_id=chunk.get("kb_id", ""),
+                    initial_score=float(chunk.get("_score", 0.0)),
+                    term_similarity=float(tsim[i]),
+                    vector_similarity=float(vsim[i]),
+                    rerank_score=float(sim_np[i]),
+                    final_position=pos_in_page,
+                    content_preview=chunk.get("content_ltks", "")[:200],
+                    is_pruned=False,
+                )
+                debug_trace.final_chunks.append(chunk_debug)
+
+        if debug_trace and debug_trace.all_chunks is not None:
+            for sorted_pos, i in enumerate(sorted_idx):
+                id = sres.ids[i]
+                chunk = sres.field[id]
+                dnm = chunk.get("docnm_kwd", "")
+                did = chunk.get("doc_id", "")
+
+                filter_reason = None
+                final_pos = None
+
+                if i not in valid_idx:
+                    filter_reason = "threshold"
+                elif sorted_pos < begin or sorted_pos >= begin + page_size:
+                    filter_reason = "pagination"
+                else:
+                    final_pos = sorted_pos - begin
+
+                chunk_debug = ChunkDebugInfo(
+                    chunk_id=id,
+                    doc_id=did,
+                    doc_name=dnm,
+                    kb_id=chunk.get("kb_id", ""),
+                    initial_score=float(chunk.get("_score", 0.0)),
+                    term_similarity=float(tsim[i]),
+                    vector_similarity=float(vsim[i]),
+                    rerank_score=float(sim_np[i]),
+                    filter_reason=filter_reason,
+                    final_position=final_pos,
+                    content_preview=chunk.get("content_ltks", "")[:200],
+                    is_pruned=False,
+                )
+                debug_trace.all_chunks.append(chunk_debug)
+
         if aggs:
             for i in valid_idx:
                 id = sres.ids[i]
@@ -613,6 +848,12 @@ class Dealer:
             ]
         else:
             ranks["doc_aggs"] = []
+
+        if debug_trace:
+            if RETRIEVAL_DEBUG_TRACE_ENABLED or debug:
+                debug_trace.log_summary()
+            if debug:
+                ranks["debug_trace"] = debug_trace.to_dict()
 
         return ranks
 

--- a/rag/prompts/generator.py
+++ b/rag/prompts/generator.py
@@ -109,6 +109,7 @@ def kb_prompt(kbinfos, max_tokens, hash_id=False):
     kwlg_len = len(knowledges)
     used_token_count = 0
     chunks_num = 0
+    truncated_by_token = False
     for i, c in enumerate(knowledges):
         if not c:
             continue
@@ -116,8 +117,26 @@ def kb_prompt(kbinfos, max_tokens, hash_id=False):
         chunks_num += 1
         if max_tokens * 0.97 < used_token_count:
             knowledges = knowledges[:i]
+            truncated_by_token = True
+            chunks_num = i
             logging.warning(f"Not all the retrieval into prompt: {len(knowledges)}/{kwlg_len}")
             break
+
+    if truncated_by_token and "debug_trace" in kbinfos:
+        debug_trace = kbinfos["debug_trace"]
+        if "prompt_truncation" not in debug_trace:
+            debug_trace["prompt_truncation"] = {}
+        debug_trace["prompt_truncation"]["max_tokens"] = max_tokens
+        debug_trace["prompt_truncation"]["prompt_token_limit"] = int(max_tokens * 0.97)
+        debug_trace["prompt_truncation"]["used_tokens"] = used_token_count
+        debug_trace["prompt_truncation"]["available_chunks"] = kwlg_len
+        debug_trace["prompt_truncation"]["selected_chunks"] = chunks_num
+        debug_trace["prompt_truncation"]["truncated_chunks"] = kwlg_len - chunks_num
+        logging.info(
+            f"[Retrieval Debug] Prompt truncated: used_tokens={used_token_count}, "
+            f"limit={int(max_tokens * 0.97)}, "
+            f"selected={chunks_num}/{kwlg_len} chunks"
+        )
 
     docs = DocumentService.get_by_ids([get_value(ck, "doc_id", "document_id") for ck in kbinfos["chunks"][:chunks_num]])
 

--- a/test/unit_test/rag/test_retrieval_debug_trace.py
+++ b/test/unit_test/rag/test_retrieval_debug_trace.py
@@ -1,0 +1,431 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import sys
+import types
+import logging
+
+import numpy as np
+
+from common.constants import PAGERANK_FLD, TAG_FLD
+
+
+class _DummyTokenizer:
+    def tag(self, *args, **kwargs):
+        return []
+
+    def freq(self, *args, **kwargs):
+        return 0
+
+    def _tradi2simp(self, text):
+        return text
+
+    def _strQ2B(self, text):
+        return text
+
+
+fake_infinity = types.ModuleType("infinity")
+fake_infinity_tokenizer = types.ModuleType("infinity.rag_tokenizer")
+fake_infinity_tokenizer.RagTokenizer = _DummyTokenizer
+fake_infinity_tokenizer.is_chinese = lambda text: False
+fake_infinity_tokenizer.is_number = lambda text: False
+fake_infinity_tokenizer.is_alphabet = lambda text: True
+fake_infinity_tokenizer.naive_qie = lambda text: text.split()
+fake_infinity.rag_tokenizer = fake_infinity_tokenizer
+sys.modules.setdefault("infinity", fake_infinity)
+sys.modules.setdefault("infinity.rag_tokenizer", fake_infinity_tokenizer)
+
+fake_query = types.ModuleType("rag.nlp.query")
+
+
+class _DummyFulltextQueryer:
+    pass
+
+
+fake_query.FulltextQueryer = _DummyFulltextQueryer
+sys.modules.setdefault("rag.nlp.query", fake_query)
+
+fake_settings = types.ModuleType("common.settings")
+fake_settings.DOC_ENGINE_INFINITY = False
+fake_settings.DOC_ENGINE_OCEANBASE = False
+sys.modules.setdefault("common.settings", fake_settings)
+
+from rag.nlp.search import (
+    ChunkDebugInfo,
+    RetrievalDebugTrace,
+    RETRIEVAL_DEBUG_TRACE_ENABLED,
+)
+
+
+class TestChunkDebugInfo:
+    def test_to_dict_returns_correct_structure(self):
+        chunk = ChunkDebugInfo(
+            chunk_id="chunk_001",
+            doc_id="doc_001",
+            doc_name="test_document.pdf",
+            kb_id="kb_001",
+            initial_score=0.85,
+            term_similarity=0.75,
+            vector_similarity=0.90,
+            rerank_score=0.82,
+            rank_feature_score=0.1,
+            filter_reason=None,
+            final_position=0,
+            content_preview="This is a test document content for retrieval.",
+            is_pruned=False,
+        )
+
+        result = chunk.to_dict()
+
+        assert result["chunk_id"] == "chunk_001"
+        assert result["doc_id"] == "doc_001"
+        assert result["doc_name"] == "test_document.pdf"
+        assert result["kb_id"] == "kb_001"
+        assert result["initial_score"] == 0.85
+        assert result["term_similarity"] == 0.75
+        assert result["vector_similarity"] == 0.90
+        assert result["rerank_score"] == 0.82
+        assert result["rank_feature_score"] == 0.1
+        assert result["filter_reason"] is None
+        assert result["final_position"] == 0
+        assert "test document" in result["content_preview"]
+        assert result["is_pruned"] is False
+
+    def test_to_dict_truncates_long_content_preview(self):
+        long_content = "a" * 200
+        chunk = ChunkDebugInfo(
+            chunk_id="chunk_001",
+            doc_id="doc_001",
+            doc_name="test.pdf",
+            kb_id="kb_001",
+            content_preview=long_content,
+        )
+
+        result = chunk.to_dict()
+
+        assert len(result["content_preview"]) == 100
+
+    def test_filter_reason_set_correctly(self):
+        chunk_threshold = ChunkDebugInfo(
+            chunk_id="c1",
+            doc_id="d1",
+            doc_name="test.pdf",
+            kb_id="kb1",
+            filter_reason="threshold",
+        )
+        assert chunk_threshold.to_dict()["filter_reason"] == "threshold"
+
+        chunk_pagination = ChunkDebugInfo(
+            chunk_id="c2",
+            doc_id="d2",
+            doc_name="test2.pdf",
+            kb_id="kb1",
+            filter_reason="pagination",
+        )
+        assert chunk_pagination.to_dict()["filter_reason"] == "pagination"
+
+
+class TestRetrievalDebugTrace:
+    def test_initialization_with_basic_params(self):
+        trace = RetrievalDebugTrace(
+            query="test query",
+            tenant_ids=["tenant_001"],
+            kb_ids=["kb_001", "kb_002"],
+            top_k=1024,
+            top_n=6,
+            similarity_threshold=0.2,
+            vector_similarity_weight=0.3,
+        )
+
+        assert trace.query == "test query"
+        assert trace.tenant_ids == ["tenant_001"]
+        assert trace.kb_ids == ["kb_001", "kb_002"]
+        assert trace.top_k == 1024
+        assert trace.top_n == 6
+        assert trace.similarity_threshold == 0.2
+        assert trace.vector_similarity_weight == 0.3
+        assert trace.initial_search_count == 0
+        assert trace.pruned_count == 0
+        assert trace.rerank_used is False
+        assert trace.rerank_model is None
+        assert trace.filtered_by_threshold_count == 0
+        assert trace.filtered_by_pagination_count == 0
+        assert trace.final_chunks_count == 0
+        assert trace.doc_engine_score_used is False
+        assert trace.all_chunks is None
+        assert trace.final_chunks is None
+
+    def test_enable_detail_sets_lists(self):
+        trace = RetrievalDebugTrace(
+            query="test",
+            tenant_ids=["t1"],
+            kb_ids=["kb1"],
+            top_k=10,
+            top_n=5,
+            similarity_threshold=0.1,
+            vector_similarity_weight=0.5,
+        )
+
+        assert trace.all_chunks is None
+        assert trace.final_chunks is None
+
+        trace.enable_detail()
+
+        assert trace.all_chunks == []
+        assert trace.final_chunks == []
+
+    def test_to_dict_returns_summary_without_detail(self):
+        trace = RetrievalDebugTrace(
+            query="test query",
+            tenant_ids=["t1"],
+            kb_ids=["kb1"],
+            top_k=10,
+            top_n=5,
+            similarity_threshold=0.2,
+            vector_similarity_weight=0.3,
+        )
+
+        trace.initial_search_count = 100
+        trace.pruned_count = 5
+        trace.rerank_used = True
+        trace.rerank_model = "bge-reranker"
+        trace.filtered_by_threshold_count = 30
+        trace.filtered_by_pagination_count = 60
+        trace.final_chunks_count = 5
+
+        result = trace.to_dict()
+
+        assert result["query"] == "test query"
+        assert result["tenant_ids"] == ["t1"]
+        assert result["kb_ids"] == ["kb1"]
+        assert result["initial_search_count"] == 100
+        assert result["pruned_count"] == 5
+        assert result["rerank_used"] is True
+        assert result["rerank_model"] == "bge-reranker"
+        assert result["filtered_by_threshold_count"] == 30
+        assert result["filtered_by_pagination_count"] == 60
+        assert result["final_chunks_count"] == 5
+
+        assert result["summary"]["selected"] == 5
+        assert result["summary"]["pruned_deleted_docs"] == 5
+        assert result["summary"]["filtered_by_threshold"] == 30
+        assert result["summary"]["filtered_by_pagination"] == 60
+
+        assert "all_chunks" not in result
+        assert "final_chunks" not in result
+
+    def test_to_dict_includes_detail_when_enabled(self):
+        trace = RetrievalDebugTrace(
+            query="test",
+            tenant_ids=["t1"],
+            kb_ids=["kb1"],
+            top_k=10,
+            top_n=5,
+            similarity_threshold=0.2,
+            vector_similarity_weight=0.3,
+        )
+        trace.enable_detail()
+
+        chunk1 = ChunkDebugInfo(
+            chunk_id="c1",
+            doc_id="d1",
+            doc_name="doc1.pdf",
+            kb_id="kb1",
+            term_similarity=0.8,
+            vector_similarity=0.7,
+            rerank_score=0.75,
+            final_position=0,
+        )
+        chunk2 = ChunkDebugInfo(
+            chunk_id="c2",
+            doc_id="d2",
+            doc_name="doc2.pdf",
+            kb_id="kb1",
+            term_similarity=0.3,
+            vector_similarity=0.4,
+            rerank_score=0.35,
+            filter_reason="threshold",
+        )
+
+        trace.final_chunks.append(chunk1)
+        trace.all_chunks.extend([chunk1, chunk2])
+        trace.final_chunks_count = 1
+
+        result = trace.to_dict()
+
+        assert "all_chunks" in result
+        assert "final_chunks" in result
+        assert len(result["all_chunks"]) == 2
+        assert len(result["final_chunks"]) == 1
+        assert result["all_chunks"][0]["chunk_id"] == "c1"
+        assert result["all_chunks"][1]["filter_reason"] == "threshold"
+
+    def test_doc_engine_score_used_flag(self):
+        trace_infinity = RetrievalDebugTrace(
+            query="test",
+            tenant_ids=["t1"],
+            kb_ids=["kb1"],
+            top_k=10,
+            top_n=5,
+            similarity_threshold=0.2,
+            vector_similarity_weight=0.3,
+        )
+        trace_infinity.doc_engine_score_used = True
+
+        result = trace_infinity.to_dict()
+        assert result["doc_engine_score_used"] is True
+
+    def test_log_summary_outputs_expected_format(self, caplog):
+        trace = RetrievalDebugTrace(
+            query="test search query",
+            tenant_ids=["tenant_123"],
+            kb_ids=["kb_456", "kb_789"],
+            top_k=1024,
+            top_n=6,
+            similarity_threshold=0.2,
+            vector_similarity_weight=0.3,
+        )
+
+        trace.initial_search_count = 50
+        trace.pruned_count = 2
+        trace.rerank_used = True
+        trace.rerank_model = "bge-reranker-v2-m3"
+        trace.doc_engine_score_used = False
+        trace.filtered_by_threshold_count = 15
+        trace.filtered_by_pagination_count = 27
+        trace.final_chunks_count = 6
+
+        trace.enable_detail()
+        chunk = ChunkDebugInfo(
+            chunk_id="chunk_001",
+            doc_id="doc_001",
+            doc_name="sample_doc.pdf",
+            kb_id="kb_456",
+            term_similarity=0.85,
+            vector_similarity=0.92,
+            rerank_score=0.89,
+            final_position=0,
+            content_preview="This is sample content for testing.",
+        )
+        trace.final_chunks.append(chunk)
+
+        with caplog.at_level(logging.INFO):
+            trace.log_summary()
+
+        log_output = caplog.text
+
+        assert "RETRIEVAL DEBUG TRACE SUMMARY" in log_output
+        assert "test search query" in log_output
+        assert "Initial search results: 50 chunks" in log_output
+        assert "Pruned (deleted docs): 2 chunks" in log_output
+        assert "Rerank used: True" in log_output
+        assert "bge-reranker-v2-m3" in log_output
+        assert "Filtered by threshold: 15 chunks" in log_output
+        assert "Filtered by pagination: 27 chunks" in log_output
+        assert "Final selected: 6 chunks" in log_output
+
+        assert "FINAL CHUNKS DETAIL" in log_output
+        assert "chunk_001" in log_output
+        assert "sample_doc.pdf" in log_output
+        assert "term_sim=0.8500" in log_output
+        assert "vec_sim=0.9200" in log_output
+        assert "rerank=0.8900" in log_output
+
+    def test_log_summary_shows_filtered_chunks(self, caplog):
+        trace = RetrievalDebugTrace(
+            query="test",
+            tenant_ids=["t1"],
+            kb_ids=["kb1"],
+            top_k=10,
+            top_n=2,
+            similarity_threshold=0.5,
+            vector_similarity_weight=0.3,
+        )
+
+        trace.enable_detail()
+
+        filtered1 = ChunkDebugInfo(
+            chunk_id="filtered_001",
+            doc_id="d1",
+            doc_name="filtered_doc1.pdf",
+            kb_id="kb1",
+            term_similarity=0.3,
+            vector_similarity=0.25,
+            rerank_score=0.27,
+            filter_reason="threshold",
+        )
+        filtered2 = ChunkDebugInfo(
+            chunk_id="filtered_002",
+            doc_id="d2",
+            doc_name="filtered_doc2.pdf",
+            kb_id="kb1",
+            term_similarity=0.6,
+            vector_similarity=0.7,
+            rerank_score=0.65,
+            filter_reason="pagination",
+        )
+
+        trace.all_chunks.extend([filtered1, filtered2])
+
+        with caplog.at_level(logging.INFO):
+            trace.log_summary()
+
+        log_output = caplog.text
+
+        assert "FILTERED CHUNKS" in log_output
+        assert "filtered_001" in log_output
+        assert "filtered_002" in log_output
+        assert "reason=threshold" in log_output
+        assert "reason=pagination" in log_output
+
+    def test_log_summary_limits_filtered_chunks_display(self, caplog):
+        trace = RetrievalDebugTrace(
+            query="test",
+            tenant_ids=["t1"],
+            kb_ids=["kb1"],
+            top_k=100,
+            top_n=5,
+            similarity_threshold=0.5,
+            vector_similarity_weight=0.3,
+        )
+
+        trace.enable_detail()
+
+        for i in range(25):
+            chunk = ChunkDebugInfo(
+                chunk_id=f"filtered_{i:03d}",
+                doc_id=f"d_{i}",
+                doc_name=f"doc_{i}.pdf",
+                kb_id="kb1",
+                term_similarity=0.3,
+                vector_similarity=0.25,
+                rerank_score=0.27,
+                filter_reason="threshold",
+            )
+            trace.all_chunks.append(chunk)
+
+        with caplog.at_level(logging.INFO):
+            trace.log_summary()
+
+        log_output = caplog.text
+
+        assert "filtered_000" in log_output
+        assert "filtered_019" in log_output
+        assert "and 5 more filtered chunks" in log_output
+
+
+class TestRetrievalDebugTraceConstant:
+    def test_retrieval_debug_trace_enabled_is_false_by_default(self):
+        assert RETRIEVAL_DEBUG_TRACE_ENABLED is False


### PR DESCRIPTION
在 search.py 里新增了 RetrievalDebugTrace 和 ChunkDebugInfo，并把它接入到 retrieval() 主流程，记录初始召回、删除文档裁剪、rerank、阈值过滤、分页过滤，以及最终返回 chunk 的分数和去留信息；在开启 debug 时，会把这些调试信息挂到返回结果里的 debug_trace，同时支持输出摘要日志。

在 generator.py 里补了 prompt 组装阶段的 token 截断记录，当检索结果因为 token 上限被裁剪时，会把可用 chunk 数、最终选中数、截断数等信息写进 debug_trace["prompt_truncation"]。另外还新增了 test_retrieval_debug_trace.py 用来覆盖这些调试数据结构和日志输出逻辑。