### PR TITLE
Fix: Manual/Naive outline tuple unpack crash

### DIFF
--- a/rag/app/manual.py
+++ b/rag/app/manual.py
@@ -270,7 +270,7 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
         if res and pdf_parser and getattr(pdf_parser, "outlines", None):
             res[0]["__outline__"] = [
                 {"title": title, "depth": depth}
-                for title, depth in pdf_parser.outlines
+                for title, depth, *_ in pdf_parser.outlines
             ]
         return res
 

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -1133,7 +1133,7 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
     if res and pdf_parser and getattr(pdf_parser, "outlines", None):
         res[0]["__outline__"] = [
             {"title": title, "depth": depth}
-            for title, depth in pdf_parser.outlines
+            for title, depth, *_ in pdf_parser.outlines
         ]
 
     return res


### PR DESCRIPTION
### What problem does this PR solve?

This fixes a crash in Manual and Naive parsing when PDF outlines include page numbers as a third tuple value. It makes outline unpacking accept extra values so parsing no longer fails. fixes #14411

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)