### PR TITLE
feat(rdbms): support deleted-file sync via slim snapshot for MySQL and PostgreSQL

### DIFF
--- a/common/data_source/rdbms_connector.py
+++ b/common/data_source/rdbms_connector.py
@@ -93,6 +93,10 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             base = self._build_query_with_time_filter(None, None).strip().rstrip(";")
             return [f"SELECT DISTINCT {id_col} FROM ({base}) AS _ragflow_slim"]
         tables = self._get_tables()
+        if len(tables) > 1:
+            raise ConnectorValidationError(
+                "Deleted-file sync for queryless RDBMS connectors requires a single-table query or table-scoped document IDs."
+            )
         return [
             f"SELECT DISTINCT {id_col} FROM {self._quote_identifier(table)}"
             for table in tables

--- a/common/data_source/rdbms_connector.py
+++ b/common/data_source/rdbms_connector.py
@@ -12,8 +12,9 @@ from common.data_source.exceptions import (
     ConnectorMissingCredentialError,
     ConnectorValidationError,
 )
-from common.data_source.interfaces import LoadConnector, PollConnector, SecondsSinceUnixEpoch
-from common.data_source.models import Document
+
+from common.data_source.interfaces import LoadConnector, PollConnector, SecondsSinceUnixEpoch, SlimConnectorWithPermSync
+from common.data_source.models import Document, GenerateSlimDocumentOutput, SlimDocument
 
 
 class DatabaseType(str, Enum):
@@ -22,7 +23,7 @@ class DatabaseType(str, Enum):
     POSTGRESQL = "postgresql"
 
 
-class RDBMSConnector(LoadConnector, PollConnector):
+class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
     """
     RDBMS connector for importing data from MySQL and PostgreSQL databases.
     
@@ -73,6 +74,73 @@ class RDBMSConnector(LoadConnector, PollConnector):
         
         self._connection = None
         self._credentials: Dict[str, Any] = {}
+
+    def _quote_identifier(self, name: str) -> str:
+        if self.db_type == DatabaseType.MYSQL:
+            return "`" + name.replace("`", "") + "`"
+        return '"' + name.replace('"', "") + '"'
+
+    def _logical_document_id(self, pk: Any) -> str:
+        return f"{self.db_type}:{self.database}:{pk}"
+
+    def _slim_snapshot_sql_list(self) -> list[str]:
+        if not self.id_column:
+            raise ConnectorValidationError(
+                "RDBMS slim snapshot requires id_column so document IDs match ingestion."
+            )
+        id_col = self._quote_identifier(self.id_column)
+        if self.query:
+            base = self._build_query_with_time_filter(None, None).strip().rstrip(";")
+            return [f"SELECT DISTINCT {id_col} FROM ({base}) AS _ragflow_slim"]
+        tables = self._get_tables()
+        return [
+            f"SELECT DISTINCT {id_col} FROM {self._quote_identifier(table)}"
+            for table in tables
+        ]
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        callback: Any = None,
+    ) -> GenerateSlimDocumentOutput:
+        """
+        List primary-key values for rows matching the connector query (no content fetch).
+
+        Requires ``id_column``; IDs match :meth:`_row_to_document`.
+        """
+        del callback
+        logging.info(
+            "RDBMS slim snapshot (%s) database=%s id_column=%s",
+            self.db_type.value,
+            self.database,
+            self.id_column,
+        )
+        batch: list[SlimDocument] = []
+        try:
+            sql_list = self._slim_snapshot_sql_list()
+            connection = self._get_connection()
+            for sql in sql_list:
+                cursor = connection.cursor()
+                try:
+                    logging.debug("RDBMS slim snapshot SQL: %s", sql[:300])
+                    cursor.execute(sql)
+                    for row in cursor:
+                        pk = row[0]
+                        if pk is None:
+                            continue
+                        batch.append(SlimDocument(id=self._logical_document_id(pk)))
+                        if len(batch) >= self.batch_size:
+                            yield batch
+                            batch = []
+                finally:
+                    try:
+                        cursor.fetchall()
+                    except Exception:
+                        pass
+                    cursor.close()
+            if batch:
+                yield batch
+        finally:
+            self._close_connection()
 
     def load_credentials(self, credentials: Dict[str, Any]) -> Dict[str, Any] | None:
         """Load database credentials."""
@@ -211,7 +279,7 @@ class RDBMSConnector(LoadConnector, PollConnector):
         content = "\n\n".join(content_parts)
         
         if self.id_column and self.id_column in row_dict:
-            doc_id = f"{self.db_type}:{self.database}:{row_dict[self.id_column]}"
+            doc_id = self._logical_document_id(row_dict[self.id_column])
         else:
             content_hash = hashlib.md5(content.encode()).hexdigest()
             doc_id = f"{self.db_type}:{self.database}:{content_hash}"

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -1521,6 +1521,14 @@ class MySQL(SyncBase):
     SOURCE_NAME: str = FileSource.MYSQL
 
     async def _generate(self, task: dict):
+        raw_batch_size = self.conf.get("batch_size", INDEX_BATCH_SIZE)
+        try:
+            batch_size = int(raw_batch_size)
+        except (TypeError, ValueError):
+            batch_size = INDEX_BATCH_SIZE
+        if batch_size <= 0:
+            batch_size = INDEX_BATCH_SIZE
+
         self.connector = RDBMSConnector(
             db_type="mysql",
             host=self.conf.get("host", "localhost"),
@@ -1531,7 +1539,7 @@ class MySQL(SyncBase):
             metadata_columns=self.conf.get("metadata_columns", ""),
             id_column=self.conf.get("id_column") or None,
             timestamp_column=self.conf.get("timestamp_column") or None,
-            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+            batch_size=batch_size,
         )
 
         credentials = self.conf.get("credentials")
@@ -1541,25 +1549,55 @@ class MySQL(SyncBase):
         self.connector.load_credentials(credentials)
         self.connector.validate_connector_settings()
 
+        file_list = None
         if task["reindex"] == "1" or not task["poll_range_start"]:
             document_generator = self.connector.load_from_state()
             _begin_info = "totally"
         else:
             poll_start = task["poll_range_start"]
+            end_ts = datetime.now(timezone.utc).timestamp()
+            if self.conf.get("sync_deleted_files"):
+                file_list = []
+                logging.info(
+                    "MySQL: fetching slim snapshot for stale-document reconciliation "
+                    "(connector_id=%s, kb_id=%s, database=%s)",
+                    task["connector_id"],
+                    task["kb_id"],
+                    self.conf.get("database"),
+                )
+                try:
+                    for slim_batch in self.connector.retrieve_all_slim_docs_perm_sync():
+                        file_list.extend(slim_batch)
+                except Exception:
+                    logging.exception(
+                        "MySQL slim snapshot failed; continuing without stale-document cleanup "
+                        "(connector_id=%s, kb_id=%s)",
+                        task["connector_id"],
+                        task["kb_id"],
+                    )
+                    file_list = None
             document_generator = self.connector.poll_source(
                 poll_start.timestamp(),
-                datetime.now(timezone.utc).timestamp()
+                end_ts,
             )
             _begin_info = f"from {poll_start}"
 
         self.log_connection("MySQL", f"{self.conf.get('host')}:{self.conf.get('database')}", task)
-        return document_generator
+        return document_generator, file_list
 
 
 class PostgreSQL(SyncBase):
     SOURCE_NAME: str = FileSource.POSTGRESQL
 
     async def _generate(self, task: dict):
+        raw_batch_size = self.conf.get("batch_size", INDEX_BATCH_SIZE)
+        try:
+            batch_size = int(raw_batch_size)
+        except (TypeError, ValueError):
+            batch_size = INDEX_BATCH_SIZE
+        if batch_size <= 0:
+            batch_size = INDEX_BATCH_SIZE
+
         self.connector = RDBMSConnector(
             db_type="postgresql",
             host=self.conf.get("host", "localhost"),
@@ -1570,7 +1608,7 @@ class PostgreSQL(SyncBase):
             metadata_columns=self.conf.get("metadata_columns", ""),
             id_column=self.conf.get("id_column") or None,
             timestamp_column=self.conf.get("timestamp_column") or None,
-            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+            batch_size=batch_size,
         )
 
         credentials = self.conf.get("credentials")
@@ -1580,19 +1618,41 @@ class PostgreSQL(SyncBase):
         self.connector.load_credentials(credentials)
         self.connector.validate_connector_settings()
 
+        file_list = None
         if task["reindex"] == "1" or not task["poll_range_start"]:
             document_generator = self.connector.load_from_state()
             _begin_info = "totally"
         else:
             poll_start = task["poll_range_start"]
+            end_ts = datetime.now(timezone.utc).timestamp()
+            if self.conf.get("sync_deleted_files"):
+                file_list = []
+                logging.info(
+                    "PostgreSQL: fetching slim snapshot for stale-document reconciliation "
+                    "(connector_id=%s, kb_id=%s, database=%s)",
+                    task["connector_id"],
+                    task["kb_id"],
+                    self.conf.get("database"),
+                )
+                try:
+                    for slim_batch in self.connector.retrieve_all_slim_docs_perm_sync():
+                        file_list.extend(slim_batch)
+                except Exception:
+                    logging.exception(
+                        "PostgreSQL slim snapshot failed; continuing without stale-document cleanup "
+                        "(connector_id=%s, kb_id=%s)",
+                        task["connector_id"],
+                        task["kb_id"],
+                    )
+                    file_list = None
             document_generator = self.connector.poll_source(
                 poll_start.timestamp(),
-                datetime.now(timezone.utc).timestamp()
+                end_ts,
             )
             _begin_info = f"from {poll_start}"
 
         self.log_connection("PostgreSQL", f"{self.conf.get('host')}:{self.conf.get('database')}", task)
-        return document_generator
+        return document_generator, file_list
 
 
 func_factory = {

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -105,6 +105,12 @@ export const DataSourceFeatureVisibilityMap: Partial<
   [DataSourceKey.AIRTABLE]: {
     syncDeletedFiles: true,
   },
+  [DataSourceKey.MYSQL]: {
+    syncDeletedFiles: true,
+  },
+  [DataSourceKey.POSTGRESQL]: {
+    syncDeletedFiles: true,
+  },
   [DataSourceKey.SEAFILE]: {
     syncDeletedFiles: true,
   },


### PR DESCRIPTION
### What problem does this PR solve?

Incremental MySQL and PostgreSQL datasource sync could ingest updated rows but did not remove knowledge-base documents when corresponding rows were deleted in the database. This aligns with #14362 (coordinated “sync deleted files” across datasource connectors).

This PR adds a **slim snapshot** (`retrieve_all_slim_docs_perm_sync` on `RDBMSConnector`) that enumerates **distinct primary-key values** for the configured dataset **without fetching document content**, using the same logical document IDs as full ingest (`mysql:<database>:<pk>` / `postgresql:<database>:<pk>` via `_logical_document_id`). When **`sync_deleted_files`** is enabled on incremental runs, **`MySQL._generate`** and **`PostgreSQL._generate`** return **`(document_generator, file_list)`** so **`SyncBase`** runs **`cleanup_stale_documents_for_task`** and drops KB rows no longer present in the snapshot.

### Requirements / limitations

- **Deleted-file sync requires `id_column`.** Without it, ingest may use content-hash IDs; the slim path raises **`ConnectorValidationError`** and sync sets **`file_list = None`** so cleanup is skipped (fail-safe).
- For a **custom SQL query**, the wrapped **`SELECT DISTINCT id_column FROM (<user query>) AS _ragflow_slim`** must be valid for the target engine and the inner query must expose **`id_column`**.
- **Empty snapshot (`file_list == []`)**: existing **`SyncBase`** behavior skips cleanup with a warning (avoids mass-delete on ambiguous empty results).

### Design notes

- **`end_ts`** is captured before slim snapshot + **`poll_source`** so the poll window matches other connectors.
- **`batch_size`** from config is coerced to a positive **`int`**.
- Slim snapshot errors are caught in **`_generate`**; **`file_list = None`** avoids cleanup on failure.
- **`retrieve_all_slim_docs_perm_sync`** uses **`try`/`finally`** with **`_close_connection()`** so connections are not leaked when **`_slim_snapshot_sql_list()`** touches the DB (e.g. table discovery).

### Type of change

- [x] New Feature (non-breaking change which adds functionality)


### Files changed (summary)

| Area | Change |
|------|--------|
| `common/data_source/rdbms_connector.py` | `SlimConnectorWithPermSync`, `_slim_snapshot_sql_list`, `retrieve_all_slim_docs_perm_sync`, `_logical_document_id` shared with `_row_to_document` |
| `rag/svr/sync_data_source.py` | `MySQL` / `PostgreSQL` `_generate`: slim snapshot + tuple return; `batch_size` coercion; shared `end_ts` with `poll_source` |
| `web/src/pages/user-setting/data-source/constant/index.tsx` | `syncDeletedFiles` for `MYSQL` and `POSTGRESQL` in `DataSourceFeatureVisibilityMap` |

Relates to: #14362