### PR TITLE
fix base_url handling in HuggingfaceRerank

### DIFF
--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -407,14 +407,14 @@ class HuggingfaceRerank(Base):
     _FACTORY_NAME = "HuggingFace"
 
     @staticmethod
-    def post(query: str, texts: list, url="127.0.0.1"):
+    def post(query: str, texts: list, url: str):
         exc = None
         scores = [0 for _ in range(len(texts))]
         batch_size = 8
         for i in range(0, len(texts), batch_size):
             try:
                 res = requests.post(
-                    f"http://{url}/rerank", headers={"Content-Type": "application/json"}, json={"query": query, "texts": texts[i : i + batch_size], "raw_scores": False, "truncate": True}
+                    f"{url}/rerank", headers={"Content-Type": "application/json"}, json={"query": query, "texts": texts[i : i + batch_size], "raw_scores": False, "truncate": True}
                 )
 
                 for o in res.json():

--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -407,7 +407,6 @@ class HuggingfaceRerank(Base):
     _FACTORY_NAME = "HuggingFace"
 
     @staticmethod
-    `@staticmethod`
     def post(query: str, texts: list, url: str = "http://127.0.0.1"):
         exc = None
         scores = [0 for _ in range(len(texts))]

--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -415,7 +415,14 @@ class HuggingfaceRerank(Base):
         for i in range(0, len(texts), batch_size):
             try:
                 res = requests.post(
-                    f"{url}/rerank", headers={"Content-Type": "application/json"}, json={"query": query, "texts": texts[i : i + batch_size], "raw_scores": False, "truncate": True}
+                endpoint = (url or "").rstrip("/")
+                if not endpoint.endswith("/rerank"):
+                    endpoint = f"{endpoint}/rerank"
+                res = requests.post(
+                    endpoint,
+                    headers={"Content-Type": "application/json"},
+                    json={"query": query, "texts": texts[i : i + batch_size], "raw_scores": False, "truncate": True},
+                )
                 )
 
                 for o in res.json():

--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -413,17 +413,15 @@ class HuggingfaceRerank(Base):
         batch_size = 8
         for i in range(0, len(texts), batch_size):
             try:
-                res = requests.post(
                 endpoint = (url or "").rstrip("/")
+
                 if not endpoint.endswith("/rerank"):
                     endpoint = f"{endpoint}/rerank"
                 res = requests.post(
                     endpoint,
-                    headers={"Content-Type": "application/json"},
-                    json={"query": query, "texts": texts[i : i + batch_size], "raw_scores": False, "truncate": True},
+                    headers = {"Content-Type": "application/json"},
+                    json = {"query": query, "texts": texts[i: i + batch_size], "raw_scores": False, "truncate": True},
                 )
-                )
-
                 for o in res.json():
                     scores[o["index"] + i] = o["score"]
             except Exception as e:

--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -407,7 +407,8 @@ class HuggingfaceRerank(Base):
     _FACTORY_NAME = "HuggingFace"
 
     @staticmethod
-    def post(query: str, texts: list, url: str):
+    `@staticmethod`
+    def post(query: str, texts: list, url: str = "http://127.0.0.1"):
         exc = None
         scores = [0 for _ in range(len(texts))]
         batch_size = 8


### PR DESCRIPTION
### What problem does this PR solve?

HuggingfaceRerank.post() unconditionally prepends `http://` to base_url, which already contains a protocol. This creates invalid URLs like http://http://127.0.0.1:8080/rerank, breaking all requests. The fix normalizes URL handling to match the rest of the codebase, removing redunant `http://`. 

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Related Issues
- #7318 
- #7796 