### PR TITLE
fix: normalize double-escaped LaTeX backslashes and HTML entities

### DIFF
--- a/web/src/utils/chat.ts
+++ b/web/src/utils/chat.ts
@@ -56,14 +56,23 @@ const BLOCK_MATH_RE = /\\\[([\s\S]*?)(?<![a-zA-Z])\\\]/g;
 const INLINE_MATH_RE = /\\\(([\s\S]*?)(?<![a-zA-Z])\\\)/g;
 
 export const preprocessLaTeX = (content: string) => {
-  const blockProcessedContent = content.replace(
+  const normalizedContent = content
+    .replace(/\\\\\[/g, '\\[')
+    .replace(/\\\\\(/g, '\\(')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+
+  const blockProcessedContent = normalizedContent.replace(
     BLOCK_MATH_RE,
     (_, equation) => `$$${equation}$$`,
   );
+
   const inlineProcessedContent = blockProcessedContent.replace(
     INLINE_MATH_RE,
     (_, equation) => `$${equation}$`,
   );
+
   return inlineProcessedContent;
 };
 

--- a/web/src/utils/chat.ts
+++ b/web/src/utils/chat.ts
@@ -59,6 +59,8 @@ export const preprocessLaTeX = (content: string) => {
   const normalizedContent = content
     .replace(/\\\\\[/g, '\\[')
     .replace(/\\\\\(/g, '\\(')
+    .replace(/\\\\\]/g, '\\]')
+    .replace(/\\\\\)/g, '\\)')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&amp;/g, '&');

--- a/web/src/utils/tests/chat.test.ts
+++ b/web/src/utils/tests/chat.test.ts
@@ -1,0 +1,21 @@
+import { preprocessLaTeX } from '../chat';
+
+test('handles double-escaped inline LaTeX', () => {
+  const result = preprocessLaTeX('\\\\(\\\\Delta\\\\)');
+  expect(result).toBe('$\\Delta$');
+});
+
+test('handles double-escaped block LaTeX', () => {
+  const result = preprocessLaTeX('\\\\[x = 1\\\\]');
+  expect(result).toBe('$$x = 1$$');
+});
+
+test('decodes HTML entities in equations', () => {
+  const result = preprocessLaTeX('x &lt; 0 and x &gt; 0');
+  expect(result).toBe('x < 0 and x > 0');
+});
+
+test('decodes &amp; HTML entity', () => {
+  const result = preprocessLaTeX('a &amp; b');
+  expect(result).toBe('a & b');
+});

--- a/web/src/utils/tests/chat.test.ts
+++ b/web/src/utils/tests/chat.test.ts
@@ -1,21 +1,26 @@
 import { preprocessLaTeX } from '../chat';
 
 test('handles double-escaped inline LaTeX', () => {
-  const result = preprocessLaTeX('\\\\(\\\\Delta\\\\)');
-  expect(result).toBe('$\\Delta$');
+  const result = preprocessLaTeX('\\\\(\\\\Delta = b^2\\\\)');
+  expect(result).toBe('$\\Delta = b^2$');
 });
 
 test('handles double-escaped block LaTeX', () => {
-  const result = preprocessLaTeX('\\\\[x = 1\\\\]');
-  expect(result).toBe('$$x = 1$$');
+  const result = preprocessLaTeX('\\\\[E = mc^2\\\\]');
+  expect(result).toBe('$$E = mc^2$$');
 });
 
-test('decodes HTML entities in equations', () => {
-  const result = preprocessLaTeX('x &lt; 0 and x &gt; 0');
-  expect(result).toBe('x < 0 and x > 0');
+test('decodes HTML entities', () => {
+  const result = preprocessLaTeX('a &lt; b &amp; c &gt; d');
+  expect(result).toBe('a < b & c > d');
 });
 
-test('decodes &amp; HTML entity', () => {
-  const result = preprocessLaTeX('a &amp; b');
-  expect(result).toBe('a & b');
+test('handles mixed double-escaped delimiters with HTML entities', () => {
+  const result = preprocessLaTeX('\\\\(x &lt; y\\\\)');
+  expect(result).toBe('$x < y$');
+});
+
+test('passes through already correct single-escaped delimiters unchanged', () => {
+  const result = preprocessLaTeX('\\(x = 1\\)');
+  expect(result).toBe('$x = 1$');
 });


### PR DESCRIPTION
Fixes #14562

## Problem
LLMs like DeepSeek V4 Flash and Qwen3-MAX return \\( and \\[ 
(double backslash) in LaTeX output. The preprocessLaTeX() function 
only handled single backslash delimiters, so equations showed as raw text.
HTML entities like &lt; and &gt; were also not decoded.

## Solution
Added normalization step before existing delimiter conversion:
- \\( → \(  and  \\[ → \[
- &lt; → <  and  &gt; → >  and  &amp; → &