### PR TITLE
Fix: add compatibility route for document download under /v1

### DIFF
--- a/api/apps/backward_compat.py
+++ b/api/apps/backward_compat.py
@@ -31,6 +31,7 @@ Deprecated APIs and their replacements:
 - POST /api/v1/file/* -> POST /api/v1/files*
 - GET /api/v1/document/get/{doc_id} -> GET /api/v1/documents/{doc_id}/preview
 - GET /api/v1/document/download/{doc_id} -> GET /api/v1/documents/{doc_id}/download
+- GET /v1/document/download/{attachment_id} -> GET /api/v1/documents/{attachment_id}/download
 - POST /api/v1/sessions/related_questions -> POST /api/v1/chat/recommandation
 - PUT (chunk update) -> PATCH (chunk update)
 """
@@ -45,6 +46,7 @@ from api.apps.services import file_api_service
 from api.utils.api_utils import get_data_error_result, get_json_result, add_tenant_id_to_kwargs
 
 manager = Blueprint("backward_compat", __name__)
+document_download_manager = Blueprint("backward_compat_document_download", __name__)
 
 
 # =============================================================================
@@ -434,6 +436,23 @@ async def deprecated_document_download(doc_id):
     )
     return await document_api.download_attachment(doc_id=doc_id)
 
+
+@document_download_manager.route("/document/download/<attachment_id>", methods=["GET"])
+@login_required
+async def document_download_v1(attachment_id):
+    """
+    Compatibility alias for document download under /v1.
+
+    Old path: GET /v1/document/download/{attachment_id}
+    New path: GET /api/v1/documents/{attachment_id}/download
+    """
+    logging.warning(
+        "API endpoint /v1/document/download/%s is deprecated. "
+        "Please use /api/v1/documents/%s/download instead.",
+        attachment_id, attachment_id,
+    )
+    return await document_api.download_attachment(attachment_id=attachment_id)
+
 # =============================================================================
 # Agent Chat API
 # =============================================================================
@@ -460,4 +479,5 @@ def register_backward_compat_routes(app_instance):
     Register all backward compatibility routes with the app.
     """
     app_instance.register_blueprint(manager, url_prefix="/api/v1")
+    app_instance.register_blueprint(document_download_manager, url_prefix="/v1")
     logging.info("Backward compatibility routes registered successfully.")

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -6882,7 +6882,7 @@ Failure:
 **GET** `/api/v1/documents/{doc_id}/download`
 
 :::caution DEPRECATED
-The previous endpoint `GET /api/v1/document/download/{doc_id}` is deprecated. Please use this endpoint instead.
+The previous endpoint `GET /v1/document/download/{doc_id}` is deprecated. Please use this endpoint instead.
 :::
 
 Downloads a runtime attachment previously uploaded via the [Upload document](#upload-document) method.


### PR DESCRIPTION
### What problem does this PR solve?

add compatibility route for document download under /v1

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

