### PR TITLE
Fix(Go): correct Name() and region URL fallback in Aliyun driver

### DIFF
--- a/internal/entity/models/aliyun.go
+++ b/internal/entity/models/aliyun.go
@@ -71,14 +71,9 @@ func (z *AliyunModel) ChatWithMessages(modelName string, messages []Message, api
 		region = *apiConfig.Region
 	}
 
-	baseURL := z.BaseURL["default"]
-	if region != "default" {
-		if regional, ok := z.BaseURL[region]; ok && regional != "" {
-			baseURL = regional
-		}
-	}
-	if baseURL == "" {
-		return nil, fmt.Errorf("aliyun: no base URL configured for default region")
+	baseURL, ok := z.BaseURL[region]
+	if !ok || baseURL == "" {
+		return nil, fmt.Errorf("aliyun: no base URL configured for region %q", region)
 	}
 
 	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Chat)
@@ -217,14 +212,9 @@ func (z *AliyunModel) ChatStreamlyWithSender(modelName string, messages []Messag
 		region = *apiConfig.Region
 	}
 
-	baseURL := z.BaseURL["default"]
-	if region != "default" {
-		if regional, ok := z.BaseURL[region]; ok && regional != "" {
-			baseURL = regional
-		}
-	}
-	if baseURL == "" {
-		return fmt.Errorf("aliyun: no base URL configured for default region")
+	baseURL, ok := z.BaseURL[region]
+	if !ok || baseURL == "" {
+		return fmt.Errorf("aliyun: no base URL configured for region %q", region)
 	}
 
 	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Chat)
@@ -605,14 +595,9 @@ func (z *AliyunModel) ListModels(apiConfig *APIConfig) ([]string, error) {
 		region = *apiConfig.Region
 	}
 
-	baseURL := z.BaseURL["default"]
-	if region != "default" {
-		if regional, ok := z.BaseURL[region]; ok && regional != "" {
-			baseURL = regional
-		}
-	}
-	if baseURL == "" {
-		return nil, fmt.Errorf("aliyun: no base URL configured for default region")
+	baseURL, ok := z.BaseURL[region]
+	if !ok || baseURL == "" {
+		return nil, fmt.Errorf("aliyun: no base URL configured for region %q", region)
 	}
 
 	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Models)

--- a/internal/entity/models/aliyun.go
+++ b/internal/entity/models/aliyun.go
@@ -58,7 +58,7 @@ func (z *AliyunModel) NewInstance(baseURL map[string]string) ModelDriver {
 }
 
 func (z *AliyunModel) Name() string {
-	return "siliconflow"
+	return "aliyun"
 }
 
 func (z *AliyunModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
@@ -71,7 +71,17 @@ func (z *AliyunModel) ChatWithMessages(modelName string, messages []Message, api
 		region = *apiConfig.Region
 	}
 
-	url := fmt.Sprintf("%s/%s", z.BaseURL[region], z.URLSuffix.Chat)
+	baseURL := z.BaseURL["default"]
+	if region != "default" {
+		if regional, ok := z.BaseURL[region]; ok && regional != "" {
+			baseURL = regional
+		}
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf("aliyun: no base URL configured for default region")
+	}
+
+	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Chat)
 
 	// Convert messages to the format expected by API
 	apiMessages := make([]map[string]interface{}, len(messages))
@@ -207,7 +217,17 @@ func (z *AliyunModel) ChatStreamlyWithSender(modelName string, messages []Messag
 		region = *apiConfig.Region
 	}
 
-	url := fmt.Sprintf("%s/%s", z.BaseURL[region], z.URLSuffix.Chat)
+	baseURL := z.BaseURL["default"]
+	if region != "default" {
+		if regional, ok := z.BaseURL[region]; ok && regional != "" {
+			baseURL = regional
+		}
+	}
+	if baseURL == "" {
+		return fmt.Errorf("aliyun: no base URL configured for default region")
+	}
+
+	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Chat)
 
 	// Convert messages to API format
 	apiMessages := make([]map[string]interface{}, len(messages))
@@ -585,7 +605,17 @@ func (z *AliyunModel) ListModels(apiConfig *APIConfig) ([]string, error) {
 		region = *apiConfig.Region
 	}
 
-	url := fmt.Sprintf("%s/%s", z.BaseURL[region], z.URLSuffix.Models)
+	baseURL := z.BaseURL["default"]
+	if region != "default" {
+		if regional, ok := z.BaseURL[region]; ok && regional != "" {
+			baseURL = regional
+		}
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf("aliyun: no base URL configured for default region")
+	}
+
+	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Models)
 
 	// Build request body
 	reqBody := map[string]interface{}{}


### PR DESCRIPTION
### What problem does this PR solve?

Two bugs in the Aliyun Go driver:

1. **`Name()` returns `"siliconflow"`** — a copy-paste bug from when the driver was created. `Name()` is used in error messages and log output, so every Aliyun error incorrectly attributed itself to SiliconFlow.

2. **Silent empty URL for unknown regions in `ChatWithMessages`, `ChatStreamlyWithSender`, and `ListModels`** — all three methods construct the request URL as `z.BaseURL[region]` without checking whether the key exists. For an unrecognised region this returns `""`, producing a malformed URL like `"/chat/completions"` that the HTTP transport rejects with a confusing error. `Encode` and `Rerank` (already merged) correctly fall back to `"default"` and return a clear error. This PR applies the same pattern to the remaining three methods.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
