### PR TITLE
feat(raptor): add Psi tree builder option

### DIFF
--- a/api/utils/validation_utils.py
+++ b/api/utils/validation_utils.py
@@ -344,6 +344,7 @@ class RaptorConfig(Base):
     max_cluster: Annotated[int, Field(default=64, ge=1, le=1024)]
     random_seed: Annotated[int, Field(default=0, ge=0)]
     scope: Annotated[Literal["file", "dataset"], Field(default="file")]
+    tree_builder: Annotated[Literal["raptor", "psi", "ahc"], Field(default="raptor")]
     auto_disable_for_structured_data: Annotated[bool, Field(default=True)]
     ext: Annotated[dict, Field(default={})]
 

--- a/rag/raptor.py
+++ b/rag/raptor.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 #
 import asyncio
+from dataclasses import dataclass, field
 import logging
 import re
 
@@ -33,6 +34,110 @@ from rag.graphrag.utils import (
     set_llm_cache,
 )
 from common.misc_utils import thread_pool_exec
+from rag.utils.raptor_utils import (
+    PSI_TREE_BUILDER,
+    RAPTOR_TREE_BUILDER,
+    normalize_raptor_tree_builder,
+)
+
+
+@dataclass
+class _PsiTreeNode:
+    index: int
+    text: str = ""
+    embedding: np.ndarray | None = None
+    children: list["_PsiTreeNode"] = field(default_factory=list)
+    parent: "_PsiTreeNode | None" = None
+
+
+class _PsiUnionFind:
+    def __init__(self, n: int):
+        self._rank = [0 for _ in range(n)]
+        self._parent_chains = [[] for _ in range(n)]
+        self._node_ids = [[i] for i in range(n)]
+        self._tree = [-1 for _ in range(max(1, 2 * n - 1))]
+        self._next_id = n
+
+    @staticmethod
+    def _ordered_extend(target: list[int], values: list[int]):
+        seen = set(target)
+        for value in values:
+            if value not in seen:
+                target.append(value)
+                seen.add(value)
+
+    def _find(self, i: int) -> list[int]:
+        chain = self._parent_chains[i]
+        if not chain or (len(chain) == 1 and chain[0] == i):
+            return [i]
+        if chain[0] == i:
+            self._ordered_extend(chain, self._find(chain[1]))
+        else:
+            self._ordered_extend(chain, self._find(chain[0]))
+        return chain
+
+    def _rank_bisect_right(self, chain: list[int], rank: int) -> int:
+        idx = 0
+        while idx < len(chain) and self._rank[chain[idx]] <= rank:
+            idx += 1
+        return idx
+
+    def _build(self, i: int, j: int, insert_point: int | None = None):
+        if insert_point is not None:
+            parent_ids = self._node_ids[insert_point]
+            parent_rank_idx = self._rank[i] + 1
+            if parent_rank_idx >= len(parent_ids):
+                logging.warning(
+                    "RAPTOR Psi union fallback: rank index %d is out of bounds for node %d with %d parent ids",
+                    parent_rank_idx,
+                    insert_point,
+                    len(parent_ids),
+                )
+                parent_rank_idx = len(parent_ids) - 1
+            self._tree[self._node_ids[i][-1]] = parent_ids[parent_rank_idx]
+            return
+        self._tree[self._node_ids[i][-1]] = self._next_id
+        self._tree[self._node_ids[j][-1]] = self._next_id
+        self._node_ids[i].append(self._next_id)
+        self._next_id += 1
+
+    def union(self, i: int, j: int) -> bool:
+        root_i = self._find(i)[-1]
+        root_j = self._find(j)[-1]
+        if root_i == root_j:
+            return False
+
+        if self._rank[root_i] < self._rank[root_j]:
+            if not self._parent_chains[root_j]:
+                self._parent_chains[root_j].append(root_j)
+            chain = self._parent_chains[j]
+            higher_rank_idx = self._rank_bisect_right(chain, self._rank[root_i])
+            if higher_rank_idx >= len(chain):
+                higher_rank_idx = len(chain) - 1
+            insert_point = chain[higher_rank_idx]
+            self._ordered_extend(self._parent_chains[root_i], chain[higher_rank_idx:])
+            self._build(root_i, root_j, insert_point=insert_point)
+        elif self._rank[root_i] > self._rank[root_j]:
+            if not self._parent_chains[root_i]:
+                self._parent_chains[root_i].append(root_i)
+            chain = self._parent_chains[i]
+            higher_rank_idx = self._rank_bisect_right(chain, self._rank[root_j])
+            if higher_rank_idx >= len(chain):
+                higher_rank_idx = len(chain) - 1
+            insert_point = chain[higher_rank_idx]
+            self._ordered_extend(self._parent_chains[root_j], chain[higher_rank_idx:])
+            self._build(root_j, root_i, insert_point=insert_point)
+        else:
+            if not self._parent_chains[root_i]:
+                self._parent_chains[root_i].append(root_i)
+            self._ordered_extend(self._parent_chains[root_j], self._parent_chains[i][-1:])
+            self._rank[root_i] += 1
+            self._build(root_i, root_j)
+        return True
+
+    @property
+    def tree(self) -> list[int]:
+        return self._tree[:self._next_id]
 
 
 class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
@@ -45,6 +150,9 @@ class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
         max_token=512,
         threshold=0.1,
         max_errors=3,
+        tree_builder=RAPTOR_TREE_BUILDER,
+        psi_exact_max_leaves=4096,
+        psi_bucket_size=1024,
     ):
         self._max_cluster = max_cluster
         self._llm_model = llm_model
@@ -54,7 +162,10 @@ class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
         self._max_token = max_token
         self._max_errors = max(1, max_errors)
         self._error_count = 0
-        
+        self._tree_builder = normalize_raptor_tree_builder(tree_builder)
+        self._psi_exact_max_leaves = max(2, int(psi_exact_max_leaves or 4096))
+        self._psi_bucket_size = min(max(2, int(psi_bucket_size or 1024)), self._psi_exact_max_leaves)
+
     def _check_task_canceled(self, task_id: str, message: str = ""):
         if task_id and has_canceled(task_id):
             log_msg = f"Task {task_id} cancelled during RAPTOR {message}."
@@ -109,10 +220,335 @@ class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
         optimal_clusters = n_clusters[np.argmin(bics)]
         return optimal_clusters
 
+    @timeout(60 * 20)
+    async def _summarize_texts(self, texts: list[str], callback=None, task_id: str = ""):
+        self._check_task_canceled(task_id, "summarization")
+
+        len_per_chunk = int((self._llm_model.max_length - self._max_token) / len(texts))
+        cluster_content = "\n".join([truncate(t, max(1, len_per_chunk)) for t in texts])
+        try:
+            async with chat_limiter:
+                self._check_task_canceled(task_id, "before LLM call")
+
+                cnt = await self._chat(
+                    "You're a helpful assistant.",
+                    [
+                        {
+                            "role": "user",
+                            "content": self._prompt.format(cluster_content=cluster_content),
+                        }
+                    ],
+                    {"max_tokens": max(self._max_token, 512)},  # fix issue:  #10235
+                )
+                cnt = re.sub(
+                    "(······\n由于长度的原因，回答被截断了，要继续吗？|For the content length reason, it stopped, continue?)",
+                    "",
+                    cnt,
+                )
+                logging.debug(f"SUM: {cnt}")
+
+                self._check_task_canceled(task_id, "before embedding")
+
+                embds = await self._embedding_encode(cnt)
+                return cnt, embds
+        except TaskCanceledException:
+            raise
+        except Exception as exc:
+            self._error_count += 1
+            warn_msg = f"[RAPTOR] Skip cluster ({len(texts)} chunks) due to error: {exc}"
+            logging.warning(warn_msg)
+            if callback:
+                callback(msg=warn_msg)
+            if self._error_count >= self._max_errors:
+                raise RuntimeError(f"RAPTOR aborted after {self._error_count} errors. Last error: {exc}") from exc
+            return None
+
+    @staticmethod
+    def _root(node: _PsiTreeNode) -> _PsiTreeNode:
+        while node.parent is not None:
+            node = node.parent
+        return node
+
+    def _rank_leaf_pairs(self, leaves: list[_PsiTreeNode]) -> np.ndarray:
+        node_embeddings = self._normalize_embeddings(np.asarray([leaf.embedding for leaf in leaves], dtype=np.float64))
+        similarities = node_embeddings @ node_embeddings.T
+        lower = np.tril_indices(len(leaves), -1)
+        ordered = np.argsort(similarities[lower], axis=0)[::-1]
+        return np.stack([lower[0][ordered], lower[1][ordered]], axis=-1)
+
+    @staticmethod
+    def _normalize_embeddings(node_embeddings: np.ndarray) -> np.ndarray:
+        node_embeddings = np.asarray(node_embeddings, dtype=np.float64)
+        norms = np.linalg.norm(node_embeddings, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return node_embeddings / norms
+
+    def _split_psi_buckets(self, nodes: list[_PsiTreeNode]) -> list[list[_PsiTreeNode]]:
+        if len(nodes) <= self._psi_bucket_size:
+            return [nodes]
+
+        node_embeddings = self._normalize_embeddings(np.asarray([node.embedding for node in nodes], dtype=np.float64))
+        groups = [np.arange(len(nodes), dtype=int)]
+        buckets = []
+
+        while groups:
+            group = np.asarray(groups.pop(), dtype=int)
+            if len(group) <= self._psi_bucket_size:
+                buckets.append(group.tolist())
+                continue
+
+            fanout = min(max(2, int(np.ceil(len(group) / self._psi_bucket_size))), len(group), 32)
+            group_embeddings = node_embeddings[group]
+            center_idx = np.linspace(0, len(group_embeddings) - 1, num=fanout, dtype=int)
+            centers = group_embeddings[center_idx].copy()
+
+            for _ in range(5):
+                labels = np.argmax(group_embeddings @ centers.T, axis=1)
+                for center_id in range(fanout):
+                    mask = labels == center_id
+                    if not np.any(mask):
+                        continue
+                    center = group_embeddings[mask].mean(axis=0)
+                    norm = np.linalg.norm(center)
+                    centers[center_id] = center / norm if norm > 0 else center
+
+            labels = np.argmax(group_embeddings @ centers.T, axis=1)
+            split_groups = [group[labels == center_id].tolist() for center_id in range(fanout)]
+            split_groups = [bucket for bucket in split_groups if bucket]
+            if len(split_groups) <= 1:
+                split_groups = [
+                    group[start:start + self._psi_bucket_size].tolist()
+                    for start in range(0, len(group), self._psi_bucket_size)
+                ]
+            groups.extend(split_groups)
+
+        buckets = [bucket for bucket in buckets if bucket]
+        buckets.sort(key=lambda bucket: (len(bucket), bucket[0]))
+        return [[nodes[idx] for idx in bucket] for bucket in buckets]
+
+    def _assign_prototype_embeddings(self, node: _PsiTreeNode) -> np.ndarray:
+        if not node.children:
+            return np.asarray(node.embedding, dtype=np.float64)
+        embeddings = np.asarray([self._assign_prototype_embeddings(child) for child in node.children], dtype=np.float64)
+        node.embedding = embeddings.mean(axis=0)
+        return node.embedding
+
+    @staticmethod
+    def _iter_nodes(root: _PsiTreeNode):
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            yield node
+            stack.extend(node.children)
+
+    def _create_psi_parent(self, index: int, children: list[_PsiTreeNode]) -> _PsiTreeNode:
+        parent = _PsiTreeNode(index=index, children=children)
+        for child in children:
+            child.parent = parent
+        return parent
+
+    def _rebalance_psi_tree(self, root: _PsiTreeNode, next_index: int) -> tuple[_PsiTreeNode, int]:
+        max_children = max(2, int(self._max_cluster or 2))
+
+        def rebalance(node: _PsiTreeNode):
+            nonlocal next_index
+
+            for child in list(node.children):
+                rebalance(child)
+
+            while len(node.children) > max_children:
+                original_children = len(node.children)
+                grouped_children = []
+                for start in range(0, len(node.children), max_children):
+                    batch = node.children[start:start + max_children]
+                    if len(batch) == 1:
+                        grouped_children.append(batch[0])
+                        batch[0].parent = node
+                    else:
+                        grouped_children.append(self._create_psi_parent(next_index, batch))
+                        grouped_children[-1].parent = node
+                        next_index += 1
+                node.children = grouped_children
+                logging.info(
+                    "RAPTOR Psi rebalance: node=%s children=%d grouped_to=%d max_cluster=%d",
+                    node.index,
+                    original_children,
+                    len(grouped_children),
+                    max_children,
+                )
+
+        rebalance(root)
+        return self._root(root), next_index
+
+    def _build_exact_psi_structure(
+        self,
+        nodes: list[_PsiTreeNode],
+        next_index: int,
+        task_id: str = "",
+    ) -> tuple[_PsiTreeNode, int, int]:
+        if len(nodes) == 1:
+            return nodes[0], next_index, 0
+
+        ranked_pairs = self._rank_leaf_pairs(nodes)
+        union_find = _PsiUnionFind(len(nodes))
+        merges = 0
+        for left_idx, right_idx in ranked_pairs:
+            self._check_task_canceled(task_id, "Psi tree construction")
+            if union_find.union(int(left_idx), int(right_idx)):
+                merges += 1
+            if merges == len(nodes) - 1:
+                break
+
+        tree = union_find.tree
+        local_nodes = {idx: node for idx, node in enumerate(nodes)}
+        for child_idx, parent_idx in enumerate(tree):
+            if child_idx not in local_nodes:
+                local_nodes[child_idx] = _PsiTreeNode(index=next_index)
+                next_index += 1
+            if parent_idx != -1 and parent_idx not in local_nodes:
+                local_nodes[parent_idx] = _PsiTreeNode(index=next_index)
+                next_index += 1
+
+        children_by_parent = {}
+        for child_idx, parent_idx in enumerate(tree):
+            if parent_idx == -1:
+                continue
+            children_by_parent.setdefault(parent_idx, []).append(child_idx)
+
+        for parent_idx, child_indices in children_by_parent.items():
+            parent = local_nodes[parent_idx]
+            parent.children = [local_nodes[child_idx] for child_idx in child_indices]
+            for child in parent.children:
+                child.parent = parent
+
+        roots = [local_nodes[idx] for idx, parent_idx in enumerate(tree) if parent_idx == -1 and idx in local_nodes]
+        root = max(roots, key=lambda node: node.index)
+        return root, next_index, merges
+
+    def _build_bucketed_psi_structure(
+        self,
+        nodes: list[_PsiTreeNode],
+        next_index: int,
+        task_id: str = "",
+    ) -> tuple[_PsiTreeNode, int, int]:
+        buckets = self._split_psi_buckets(nodes)
+        logging.info(
+            "RAPTOR Psi bucketed build: nodes=%d buckets=%d bucket_size=%d exact_max_leaves=%d",
+            len(nodes),
+            len(buckets),
+            self._psi_bucket_size,
+            self._psi_exact_max_leaves,
+        )
+
+        bucket_roots = []
+        merges = 0
+        for bucket in buckets:
+            bucket_root, next_index, bucket_merges = self._build_psi_structure_from_nodes(bucket, next_index, task_id)
+            self._assign_prototype_embeddings(bucket_root)
+            bucket_roots.append(bucket_root)
+            merges += bucket_merges
+
+        if len(bucket_roots) == 1:
+            return bucket_roots[0], next_index, merges
+
+        root, next_index, root_merges = self._build_psi_structure_from_nodes(bucket_roots, next_index, task_id)
+        return root, next_index, merges + root_merges
+
+    def _build_psi_structure_from_nodes(
+        self,
+        nodes: list[_PsiTreeNode],
+        next_index: int,
+        task_id: str = "",
+    ) -> tuple[_PsiTreeNode, int, int]:
+        if len(nodes) <= self._psi_exact_max_leaves:
+            return self._build_exact_psi_structure(nodes, next_index, task_id)
+        return self._build_bucketed_psi_structure(nodes, next_index, task_id)
+
+    def _build_psi_structure(self, chunks, task_id: str = "") -> tuple[_PsiTreeNode, list[_PsiTreeNode]]:
+        leaves = [
+            _PsiTreeNode(index=i, text=text, embedding=np.asarray(embd))
+            for i, (text, embd) in enumerate(chunks)
+        ]
+        if len(leaves) == 1:
+            return leaves[0], leaves
+
+        root, next_index, merges = self._build_psi_structure_from_nodes(leaves, len(leaves), task_id)
+        root, _ = self._rebalance_psi_tree(root, next_index)
+        logging.info(
+            "RAPTOR Psi tree built: leaves=%d merges=%d root_fanout=%d",
+            len(leaves),
+            merges,
+            len(root.children),
+        )
+        return root, leaves
+
+    @staticmethod
+    def _psi_layers(root: _PsiTreeNode) -> dict[int, list[_PsiTreeNode]]:
+        layers = {}
+
+        def height(node: _PsiTreeNode) -> int:
+            if not node.children:
+                return 0
+            node_height = max(height(child) for child in node.children) + 1
+            layers.setdefault(node_height, []).append(node)
+            return node_height
+
+        height(root)
+        return layers
+
+    async def _build_psi_layers(self, chunks, callback=None, task_id: str = ""):
+        layers = [(0, len(chunks))]
+        root, _ = self._build_psi_structure(chunks, task_id=task_id)
+
+        for layer_idx, (_, nodes) in enumerate(sorted(self._psi_layers(root).items()), start=1):
+            layer_start = len(chunks)
+
+            async def summarize_node(node: _PsiTreeNode):
+                texts = [child.text for child in node.children if child.text]
+                if not texts:
+                    raise RuntimeError(f"RAPTOR Psi node {node.index} has no child text to summarize")
+                result = await self._summarize_texts(texts, callback, task_id)
+                if result is None:
+                    raise RuntimeError(f"RAPTOR Psi node {node.index} summary failed")
+                node.text, node.embedding = result
+                return node
+
+            tasks = [asyncio.create_task(summarize_node(node)) for node in nodes]
+            try:
+                summarized_nodes = await asyncio.gather(*tasks, return_exceptions=False)
+            except Exception as e:
+                logging.error(f"Error in RAPTOR Psi tree processing: {e}")
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
+
+            for node in summarized_nodes:
+                chunks.append((node.text, node.embedding))
+
+            if len(chunks) > layer_start:
+                layers.append((layer_start, len(chunks)))
+                logging.info(
+                    "RAPTOR Psi layer materialized: layer=%d nodes=%d summaries=%d",
+                    layer_idx,
+                    len(nodes),
+                    len(chunks) - layer_start,
+                )
+                if callback:
+                    callback(msg="Build one Psi-RAG layer: {} -> {}".format(len(nodes), len(chunks) - layer_start))
+
+        return chunks, layers
+
     async def __call__(self, chunks, random_state, callback=None, task_id: str = ""):
         if len(chunks) <= 1:
             return [], []
         chunks = [(s, a) for s, a in chunks if s and a is not None and len(a) > 0]
+        if len(chunks) <= 1:
+            return chunks, [(0, len(chunks))]
+        if self._tree_builder == PSI_TREE_BUILDER:
+            logging.info("RAPTOR: using %s tree builder for %d chunks", self._tree_builder, len(chunks))
+            return await self._build_psi_layers(chunks, callback, task_id)
+
         layers = [(0, len(chunks))]
         start, end = 0, len(chunks)
 
@@ -120,46 +556,10 @@ class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
         async def summarize(ck_idx: list[int]):
             nonlocal chunks
 
-            self._check_task_canceled(task_id, "summarization")
-
             texts = [chunks[i][0] for i in ck_idx]
-            len_per_chunk = int((self._llm_model.max_length - self._max_token) / len(texts))
-            cluster_content = "\n".join([truncate(t, max(1, len_per_chunk)) for t in texts])
-            try:
-                async with chat_limiter:
-                    self._check_task_canceled(task_id, "before LLM call")
-
-                    cnt = await self._chat(
-                        "You're a helpful assistant.",
-                        [
-                            {
-                                "role": "user",
-                                "content": self._prompt.format(cluster_content=cluster_content),
-                            }
-                        ],
-                        {"max_tokens": max(self._max_token, 512)},  # fix issue:  #10235
-                    )
-                    cnt = re.sub(
-                        "(······\n由于长度的原因，回答被截断了，要继续吗？|For the content length reason, it stopped, continue?)",
-                        "",
-                        cnt,
-                    )
-                    logging.debug(f"SUM: {cnt}")
-
-                    self._check_task_canceled(task_id, "before embedding")
-
-                    embds = await self._embedding_encode(cnt)
-                    chunks.append((cnt, embds))
-            except TaskCanceledException:
-                raise
-            except Exception as exc:
-                self._error_count += 1
-                warn_msg = f"[RAPTOR] Skip cluster ({len(ck_idx)} chunks) due to error: {exc}"
-                logging.warning(warn_msg)
-                if callback:
-                    callback(msg=warn_msg)
-                if self._error_count >= self._max_errors:
-                    raise RuntimeError(f"RAPTOR aborted after {self._error_count} errors. Last error: {exc}") from exc
+            result = await self._summarize_texts(texts, callback, task_id)
+            if result is not None:
+                chunks.append(result)
 
         while end - start > 1:
             self._check_task_canceled(task_id, "layer processing")

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -36,7 +36,15 @@ from api.db.joint_services.memory_message_service import handle_save_to_memory_t
 from common.connection_utils import timeout
 from common.metadata_utils import turn2jsonschema, update_metadata_to
 from rag.utils.base64_image import image2id
-from rag.utils.raptor_utils import should_skip_raptor, get_skip_reason
+from rag.utils.raptor_utils import (
+    collect_raptor_chunk_ids,
+    collect_raptor_methods,
+    get_raptor_tree_builder,
+    get_skip_reason,
+    make_raptor_summary_chunk_id,
+    raptor_methods_require_cleanup,
+    should_skip_raptor,
+)
 from common.log_utils import init_root_logger
 from common.config_utils import show_configs
 from rag.graphrag.general.index import run_graphrag_for_kb
@@ -70,7 +78,10 @@ from api.db.db_models import close_connection
 from rag.app import laws, paper, presentation, manual, qa, table, book, resume, picture, naive, one, audio, \
     email, tag
 from rag.nlp import search, rag_tokenizer, add_positions
-from rag.raptor import RecursiveAbstractiveProcessing4TreeOrganizedRetrieval as Raptor
+from rag.raptor import (
+    RAPTOR_TREE_BUILDER,
+    RecursiveAbstractiveProcessing4TreeOrganizedRetrieval as Raptor,
+)
 from common.token_utils import num_tokens_from_string, truncate
 from rag.utils.redis_conn import REDIS_CONN, RedisDistributedLock
 from rag.graphrag.utils import chat_limiter
@@ -817,38 +828,83 @@ async def run_dataflow(task: dict):
                                        dsl=str(pipeline))
 
 
-async def has_raptor_chunks(doc_id: str, tenant_id: str, kb_id: str) -> bool:
-    """Return True if RAPTOR chunks already exist for doc_id in the doc store.
+RAPTOR_METHOD_SEARCH_LIMIT = 10000
 
-    Queries directly for raptor_kwd="raptor" rows so a non-RAPTOR leading
-    chunk cannot produce a false-negative result.  Uses thread_pool_exec so
-    the blocking doc-store call does not stall the event loop.
-    """
+
+async def get_raptor_chunk_field_map(doc_id: str, tenant_id: str, kb_id: str) -> dict:
     from common.doc_store.doc_store_base import OrderByExpr
     from rag.nlp import search as nlp_search
-    try:
-        condition = {"doc_id": doc_id, "raptor_kwd": ["raptor"]}
+
+    async def search_fields(fields: list[str], condition: dict, order_by=None):
         res = await thread_pool_exec(
             settings.docStoreConn.search,
-            ["raptor_kwd"], [], condition, [], OrderByExpr(),
-            0, 1, nlp_search.index_name(tenant_id), [kb_id]
+            fields, [], condition, [], order_by or OrderByExpr(),
+            0, RAPTOR_METHOD_SEARCH_LIMIT, nlp_search.index_name(tenant_id), [kb_id]
         )
-        field_map = settings.docStoreConn.get_fields(res, ["raptor_kwd"])
-        found = bool(field_map)
-        if found:
+        return settings.docStoreConn.get_fields(res, fields)
+
+    primary = await search_fields(["raptor_kwd", "extra"], {"doc_id": doc_id, "raptor_kwd": ["raptor"]})
+    if collect_raptor_chunk_ids(primary):
+        return primary
+
+    try:
+        return await search_fields(
+            ["raptor_kwd", "extra"],
+            {"doc_id": doc_id},
+            OrderByExpr().desc("create_timestamp_flt"),
+        )
+    except Exception:
+        logging.debug("RAPTOR fallback method lookup with extra field failed for doc %s", doc_id, exc_info=True)
+        return primary
+
+
+async def get_raptor_chunk_methods(doc_id: str, tenant_id: str, kb_id: str) -> set[str]:
+    """Return the RAPTOR tree builders already stored for doc_id.
+
+    Queries directly for raptor_kwd="raptor" rows so a non-RAPTOR leading
+    chunk cannot produce a false-negative result. Legacy summary chunks that
+    do not have extra.raptor_method are treated as the original RAPTOR builder.
+    """
+    try:
+        field_map = await get_raptor_chunk_field_map(doc_id, tenant_id, kb_id)
+        methods = collect_raptor_methods(field_map)
+        if methods:
             logging.info(
-                "Checkpoint hit: RAPTOR chunks for doc %s (tenant=%s kb=%s) already exist",
-                doc_id, tenant_id, kb_id,
+                "Checkpoint hit: RAPTOR chunks for doc %s (tenant=%s kb=%s methods=%s) already exist",
+                doc_id, tenant_id, kb_id, sorted(methods),
             )
         else:
             logging.info(
                 "Checkpoint miss: no RAPTOR chunks for doc %s (tenant=%s kb=%s)",
                 doc_id, tenant_id, kb_id,
             )
-        return found
+        return methods
     except Exception:
         logging.exception("Failed to check RAPTOR chunks for doc %s", doc_id)
-        return False
+        return set()
+
+
+async def has_raptor_chunks(doc_id: str, tenant_id: str, kb_id: str, tree_builder: str = RAPTOR_TREE_BUILDER) -> bool:
+    methods = await get_raptor_chunk_methods(doc_id, tenant_id, kb_id)
+    return tree_builder in methods
+
+
+async def delete_raptor_chunks(doc_id: str, tenant_id: str, kb_id: str, keep_method: str | None = None):
+    from rag.nlp import search as nlp_search
+
+    field_map = await get_raptor_chunk_field_map(doc_id, tenant_id, kb_id)
+    exclude_methods = {keep_method} if keep_method else None
+    chunk_ids = collect_raptor_chunk_ids(field_map, exclude_methods=exclude_methods)
+    if not chunk_ids:
+        return 0
+
+    await thread_pool_exec(
+        settings.docStoreConn.delete,
+        {"id": list(chunk_ids)},
+        nlp_search.index_name(tenant_id),
+        kb_id,
+    )
+    return len(chunk_ids)
 
 
 @timeout(3600)
@@ -856,19 +912,43 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
     fake_doc_id = GRAPH_RAPTOR_FAKE_DOC_ID
 
     raptor_config = kb_parser_config.get("raptor", {})
+    raptor_ext_config = raptor_config.get("ext") or {}
+    tree_builder = get_raptor_tree_builder(raptor_config)
     vctr_nm = "q_%d_vec" % vector_size
 
     res = []
     tk_count = 0
+    cleanup_raptor_chunks = []
     max_errors = int(os.environ.get("RAPTOR_MAX_ERRORS", 3))
-    doc_name_by_id = {}
+    doc_info_by_id = {}
     for doc_id in set(doc_ids):
         ok, source_doc = DocumentService.get_by_id(doc_id)
         if not ok or not source_doc:
             continue
-        source_name = getattr(source_doc, "name", "")
-        if source_name:
-            doc_name_by_id[doc_id] = source_name
+        doc_info_by_id[doc_id] = {
+            "name": getattr(source_doc, "name", ""),
+            "type": getattr(source_doc, "type", ""),
+            "parser_id": getattr(source_doc, "parser_id", ""),
+            "parser_config": getattr(source_doc, "parser_config", {}) or {},
+        }
+
+    def schedule_raptor_cleanup(doc_id: str, keep_method: str | None = None):
+        cleanup_plan = (doc_id, keep_method)
+        if cleanup_plan not in cleanup_raptor_chunks:
+            cleanup_raptor_chunks.append(cleanup_plan)
+
+    def skip_raptor_doc(doc_id: str) -> bool:
+        doc_info = doc_info_by_id.get(doc_id, {})
+        file_type = doc_info.get("type") or row.get("type", "")
+        parser_id = doc_info.get("parser_id") or row.get("parser_id", "")
+        parser_config = doc_info.get("parser_config") or row.get("parser_config", {})
+        if should_skip_raptor(file_type, parser_id, parser_config, raptor_config):
+            skip_reason = get_skip_reason(file_type, parser_id, parser_config)
+            doc_name = doc_info.get("name") or doc_id
+            logging.info("Skipping Raptor for document %s: %s", doc_name, skip_reason)
+            callback(msg=f"[RAPTOR] doc:{doc_id} skipped: {skip_reason}")
+            return True
+        return False
 
     async def generate(chunks, did):
         nonlocal tk_count, res
@@ -880,16 +960,20 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
             raptor_config["max_token"],
             raptor_config["threshold"],
             max_errors=max_errors,
+            tree_builder=tree_builder,
+            psi_exact_max_leaves=raptor_ext_config.get("psi_exact_max_leaves", 4096),
+            psi_bucket_size=raptor_ext_config.get("psi_bucket_size", 1024),
         )
         original_length = len(chunks)
         chunks, layers = await raptor(chunks, kb_parser_config["raptor"]["random_seed"], callback, row["id"])
-        effective_doc_name = row["name"] if did == fake_doc_id else doc_name_by_id.get(did, row["name"])
+        effective_doc_name = row["name"] if did == fake_doc_id else doc_info_by_id.get(did, {}).get("name") or row["name"]
         doc = {
             "doc_id": did,
             "kb_id": [str(row["kb_id"])],
             "docnm_kwd": effective_doc_name,
             "title_tks": rag_tokenizer.tokenize(effective_doc_name),
-            "raptor_kwd": "raptor"
+            "raptor_kwd": "raptor",
+            "extra": {"raptor_method": tree_builder},
         }
         if row["pagerank"]:
             doc[PAGERANK_FLD] = int(row["pagerank"])
@@ -906,7 +990,7 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
 
         for idx, (content, vctr) in enumerate(chunks[original_length:], start=original_length):
             d = copy.deepcopy(doc)
-            d["id"] = xxhash.xxh64((content + str(fake_doc_id)).encode("utf-8")).hexdigest()
+            d["id"] = make_raptor_summary_chunk_id(content, did)
             d["create_time"] = str(datetime.now()).replace("T", " ")[:19]
             d["create_timestamp_flt"] = datetime.now().timestamp()
             d[vctr_nm] = vctr.tolist()
@@ -918,12 +1002,28 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
             tk_count += num_tokens_from_string(content)
 
     if raptor_config.get("scope", "file") == "file":
+        dataset_methods = await get_raptor_chunk_methods(fake_doc_id, row["tenant_id"], row["kb_id"])
+        remove_dataset_summaries = bool(dataset_methods)
+        has_file_level_target = False
+        if dataset_methods:
+            callback(msg="[RAPTOR] will remove dataset-level summaries after file-level summaries are available.")
+
         for x, doc_id in enumerate(doc_ids):
-            # CHECKPOINT: skip docs that already have RAPTOR chunks in the doc store
-            if await has_raptor_chunks(doc_id, row["tenant_id"], row["kb_id"]):
-                callback(msg=f"[RAPTOR] doc:{doc_id} already has RAPTOR chunks, skipping.")
+            if skip_raptor_doc(doc_id):
                 callback(prog=(x + 1.) / len(doc_ids))
                 continue
+            # CHECKPOINT: skip docs that already have RAPTOR chunks in the doc store
+            existing_methods = await get_raptor_chunk_methods(doc_id, row["tenant_id"], row["kb_id"])
+            if tree_builder in existing_methods:
+                has_file_level_target = True
+                if raptor_methods_require_cleanup(existing_methods, tree_builder):
+                    schedule_raptor_cleanup(doc_id, tree_builder)
+                    callback(msg=f"[RAPTOR] doc:{doc_id} will remove old RAPTOR summaries after insert.")
+                callback(msg=f"[RAPTOR] doc:{doc_id} already has {tree_builder} RAPTOR chunks, skipping.")
+                callback(prog=(x + 1.) / len(doc_ids))
+                continue
+            if existing_methods:
+                callback(msg=f"[RAPTOR] doc:{doc_id} will migrate RAPTOR summaries to {tree_builder} after insert.")
 
             chunks = []
             skipped_chunks = 0
@@ -945,12 +1045,52 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
                 callback(msg=f"[WARN] No valid chunks with vectors found for doc {doc_id}, skipping")
                 continue
 
+            before_generate = len(res)
             await generate(chunks, doc_id)
+            if len(res) > before_generate:
+                has_file_level_target = True
+                if existing_methods:
+                    schedule_raptor_cleanup(doc_id, tree_builder)
             callback(prog=(x + 1.) / len(doc_ids))
+
+        if remove_dataset_summaries:
+            if has_file_level_target:
+                schedule_raptor_cleanup(fake_doc_id)
+            else:
+                callback(msg="[RAPTOR] kept dataset-level summaries because no file-level summaries were built.")
     else:
+        migrated_file_docs = 0
+        file_cleanup_doc_ids = []
+        skipped_doc_ids = set()
+        for doc_id in set(doc_ids):
+            if skip_raptor_doc(doc_id):
+                skipped_doc_ids.add(doc_id)
+                continue
+            existing_methods = await get_raptor_chunk_methods(doc_id, row["tenant_id"], row["kb_id"])
+            if existing_methods:
+                file_cleanup_doc_ids.append(doc_id)
+                migrated_file_docs += 1
+        if migrated_file_docs:
+            callback(msg=f"[RAPTOR] will remove file-level summaries for {migrated_file_docs} docs after dataset-level build succeeds.")
+
+        existing_methods = await get_raptor_chunk_methods(fake_doc_id, row["tenant_id"], row["kb_id"])
+        if tree_builder in existing_methods:
+            if raptor_methods_require_cleanup(existing_methods, tree_builder):
+                schedule_raptor_cleanup(fake_doc_id, tree_builder)
+                callback(msg="[RAPTOR] will remove old dataset-level RAPTOR summaries after insert.")
+            for doc_id in file_cleanup_doc_ids:
+                schedule_raptor_cleanup(doc_id)
+            callback(msg=f"[RAPTOR] dataset-level {tree_builder} summaries already exist, skipping.")
+            return res, tk_count, cleanup_raptor_chunks
+        migrate_dataset_summaries = bool(existing_methods)
+        if migrate_dataset_summaries:
+            callback(msg=f"[RAPTOR] will migrate dataset-level RAPTOR summaries to {tree_builder} after insert.")
+
         chunks = []
         skipped_chunks = 0
         for doc_id in doc_ids:
+            if doc_id in skipped_doc_ids:
+                continue
             for d in settings.retriever.chunk_list(doc_id, row["tenant_id"], [str(row["kb_id"])],
                                                    fields=["content_with_weight", vctr_nm],
                                                    sort_by_position=True):
@@ -965,13 +1105,22 @@ async def run_raptor_for_kb(row, kb_parser_config, chat_mdl, embd_mdl, vector_si
             callback(msg=f"[WARN] Skipped {skipped_chunks} chunks without vector field '{vctr_nm}'. Consider re-parsing documents with the current embedding model.")
 
         if not chunks:
+            if skipped_doc_ids and len(skipped_doc_ids) == len(set(doc_ids)):
+                callback(msg="[RAPTOR] all documents were skipped by RAPTOR auto-disable rules.")
+                return res, tk_count, cleanup_raptor_chunks
             logging.error(f"RAPTOR: No valid chunks with vectors found in any document for kb {row['kb_id']}")
             callback(msg=f"[ERROR] No valid chunks with vectors found. Please ensure documents are parsed with the current embedding model (vector size: {vector_size}).")
-            return res, tk_count
+            return res, tk_count, cleanup_raptor_chunks
 
+        before_generate = len(res)
         await generate(chunks, fake_doc_id)
+        if len(res) > before_generate:
+            for doc_id in file_cleanup_doc_ids:
+                schedule_raptor_cleanup(doc_id)
+            if migrate_dataset_summaries:
+                schedule_raptor_cleanup(fake_doc_id, tree_builder)
 
-    return res, tk_count
+    return res, tk_count, cleanup_raptor_chunks
 
 
 async def delete_image(kb_id, chunk_id):
@@ -1088,6 +1237,7 @@ async def do_handle_task(task):
     task_parser_config = task["parser_config"]
     task_start_ts = timer()
     toc_thread = None
+    raptor_cleanup_chunks = []
 
     # prepare the progress callback function
     progress_callback = partial(set_progress, task_id, task_from_page, task_to_page)
@@ -1143,23 +1293,12 @@ async def do_handle_task(task):
                 progress_callback(prog=-1.0, msg="Internal error: Invalid RAPTOR configuration")
                 return
 
-        # Check if Raptor should be skipped for structured data
-        file_type = task.get("type", "")
-        parser_id = task.get("parser_id", "")
-        raptor_config = kb_parser_config.get("raptor", {})
-
-        if should_skip_raptor(file_type, parser_id, task_parser_config, raptor_config):
-            skip_reason = get_skip_reason(file_type, parser_id, task_parser_config)
-            logging.info(f"Skipping Raptor for document {task_document_name}: {skip_reason}")
-            progress_callback(prog=1.0, msg=f"Raptor skipped: {skip_reason}")
-            return
-
         # bind LLM for raptor
         chat_model_config = get_model_config_by_type_and_name(task_tenant_id, LLMType.CHAT, kb_task_llm_id)
         chat_model = LLMBundle(task_tenant_id, chat_model_config, lang=task_language)
         # run RAPTOR
         async with kg_limiter:
-            chunks, token_count = await run_raptor_for_kb(
+            chunks, token_count, raptor_cleanup_chunks = await run_raptor_for_kb(
                 row=task,
                 kb_parser_config=kb_parser_config,
                 chat_mdl=chat_model,
@@ -1267,6 +1406,18 @@ async def do_handle_task(task):
         if has_canceled(task_id):
             progress_callback(-1, msg="Task has been canceled.")
             return
+
+        if raptor_cleanup_chunks:
+            cleaned_chunks = 0
+            for cleanup_doc_id, keep_method in raptor_cleanup_chunks:
+                cleaned_chunks += await delete_raptor_chunks(
+                    cleanup_doc_id,
+                    task_tenant_id,
+                    task_dataset_id,
+                    keep_method=keep_method,
+                )
+            if cleaned_chunks:
+                progress_callback(msg=f"Cleaned up {cleaned_chunks} stale RAPTOR chunks.")
 
         logging.info(
             "Indexing doc({}), page({}-{}), chunks({}), elapsed: {:.2f}".format(

--- a/rag/utils/ob_conn.py
+++ b/rag/utils/ob_conn.py
@@ -46,6 +46,8 @@ column_order_id = Column("_order_id", Integer, nullable=True, comment="chunk ord
 column_group_id = Column("group_id", String(256), nullable=True, comment="group id for external retrieval")
 column_mom_id = Column("mom_id", String(256), nullable=True, comment="parent chunk id")
 column_chunk_data = Column("chunk_data", JSON, nullable=True, comment="table parser row data")
+column_raptor_kwd = Column("raptor_kwd", String(256), nullable=True, comment="RAPTOR summary marker")
+column_raptor_layer_int = Column("raptor_layer_int", Integer, nullable=True, comment="RAPTOR summary layer")
 
 column_definitions: list[Column] = [
     Column("id", String(256), primary_key=True, comment="chunk id"),
@@ -86,6 +88,8 @@ column_definitions: list[Column] = [
     Column("rank_flt", Double, nullable=True, comment="rank of this entity"),
     Column("removed_kwd", String(256), nullable=True, index=True, server_default="'N'",
            comment="whether it has been deleted"),
+    column_raptor_kwd,
+    column_raptor_layer_int,
     column_chunk_data,
     Column("metadata", JSON, nullable=True, comment="metadata for this chunk"),
     Column("extra", JSON, nullable=True, comment="extra information of non-general chunk"),
@@ -127,7 +131,14 @@ FTS_COLUMNS_TKS: list[str] = [
 ]
 
 # Extra columns to add after table creation (for migration)
-EXTRA_COLUMNS: list[Column] = [column_order_id, column_group_id, column_mom_id, column_chunk_data]
+EXTRA_COLUMNS: list[Column] = [
+    column_order_id,
+    column_group_id,
+    column_mom_id,
+    column_chunk_data,
+    column_raptor_kwd,
+    column_raptor_layer_int,
+]
 
 
 class SearchResult(BaseModel):

--- a/rag/utils/raptor_utils.py
+++ b/rag/utils/raptor_utils.py
@@ -18,13 +18,114 @@
 Utility functions for Raptor processing decisions.
 """
 
+import json
 import logging
 from typing import Optional
+
+import xxhash
+
+RAPTOR_TREE_BUILDER = "raptor"
+PSI_TREE_BUILDER = "psi"
+AHC_TREE_BUILDER = "ahc"
+SUPPORTED_TREE_BUILDERS = {RAPTOR_TREE_BUILDER, PSI_TREE_BUILDER, AHC_TREE_BUILDER}
 
 # File extensions for structured data types
 EXCEL_EXTENSIONS = {".xls", ".xlsx", ".xlsm", ".xlsb"}
 CSV_EXTENSIONS = {".csv", ".tsv"}
 STRUCTURED_EXTENSIONS = EXCEL_EXTENSIONS | CSV_EXTENSIONS
+
+
+def normalize_raptor_tree_builder(tree_builder: str | None) -> str:
+    tree_builder = tree_builder or RAPTOR_TREE_BUILDER
+    if tree_builder == AHC_TREE_BUILDER:
+        return PSI_TREE_BUILDER
+    if tree_builder not in SUPPORTED_TREE_BUILDERS:
+        raise ValueError(f"Unsupported RAPTOR tree builder: {tree_builder}")
+    return tree_builder
+
+
+def get_raptor_tree_builder(raptor_config: dict | None) -> str:
+    raptor_config = raptor_config or {}
+    ext = raptor_config.get("ext") or {}
+    tree_builder = raptor_config.get("tree_builder") or ext.get("tree_builder") or RAPTOR_TREE_BUILDER
+    return normalize_raptor_tree_builder(tree_builder)
+
+
+def raptor_methods_require_cleanup(existing_methods: set[str], tree_builder: str) -> bool:
+    return bool(set(existing_methods) - {tree_builder})
+
+
+def _normalize_stored_raptor_method(method) -> str:
+    try:
+        return normalize_raptor_tree_builder(str(method))
+    except ValueError:
+        logging.warning("Unknown stored RAPTOR tree builder method: %s", method)
+        return str(method)
+
+
+def _as_extra_dict(extra) -> dict:
+    if isinstance(extra, dict):
+        return extra
+    if isinstance(extra, str) and extra:
+        try:
+            parsed = json.loads(extra)
+        except json.JSONDecodeError:
+            logging.warning(
+                "Ignoring malformed RAPTOR extra payload while collecting chunk metadata: %s",
+                extra[:200],
+                exc_info=True,
+            )
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _has_raptor_marker(marker) -> bool:
+    if isinstance(marker, list):
+        return any(str(item) == RAPTOR_TREE_BUILDER for item in marker)
+    return str(marker) == RAPTOR_TREE_BUILDER
+
+
+def _raptor_methods_from_fields(fields: dict, extra: dict | None = None) -> set[str]:
+    extra = extra if extra is not None else _as_extra_dict(fields.get("extra"))
+    method = (
+        extra.get("raptor_method")
+        or fields.get("raptor_method_kwd")
+        or extra.get("raptor_method_kwd")
+        or RAPTOR_TREE_BUILDER
+    )
+    if isinstance(method, list):
+        return {_normalize_stored_raptor_method(item) for item in method if item}
+    return {_normalize_stored_raptor_method(method)} if method else set()
+
+
+def collect_raptor_methods(field_map: dict) -> set[str]:
+    methods = set()
+    for fields in field_map.values():
+        extra = _as_extra_dict(fields.get("extra"))
+        marker = fields.get("raptor_kwd") or extra.get("raptor_kwd")
+        if not _has_raptor_marker(marker):
+            continue
+
+        methods.update(_raptor_methods_from_fields(fields, extra))
+    return methods
+
+
+def collect_raptor_chunk_ids(field_map: dict, exclude_methods: set[str] | None = None) -> set[str]:
+    chunk_ids = set()
+    exclude_methods = exclude_methods or set()
+    for chunk_id, fields in field_map.items():
+        extra = _as_extra_dict(fields.get("extra"))
+        marker = fields.get("raptor_kwd") or extra.get("raptor_kwd")
+        if _has_raptor_marker(marker):
+            if _raptor_methods_from_fields(fields, extra).issubset(exclude_methods):
+                continue
+            chunk_ids.add(chunk_id)
+    return chunk_ids
+
+
+def make_raptor_summary_chunk_id(content: str, doc_id: str) -> str:
+    return xxhash.xxh64((content + str(doc_id)).encode("utf-8")).hexdigest()
 
 
 def is_structured_file_type(file_type: Optional[str]) -> bool:

--- a/test/testcases/test_http_api/test_dataset_management/test_update_dataset.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_update_dataset.py
@@ -583,6 +583,9 @@ class TestDatasetUpdate:
             {"raptor": {"max_cluster": 512}},
             {"raptor": {"max_cluster": 1024}},
             {"raptor": {"random_seed": 0}},
+            {"raptor": {"tree_builder": "raptor"}},
+            {"raptor": {"tree_builder": "psi"}},
+            {"raptor": {"tree_builder": "ahc"}},
         ],
         ids=[
             "auto_keywords_min",
@@ -633,6 +636,9 @@ class TestDatasetUpdate:
             "raptor_max_cluster_mid",
             "raptor_max_cluster_max",
             "raptor_random_seed_min",
+            "raptor_tree_builder_raptor",
+            "raptor_tree_builder_psi",
+            "raptor_tree_builder_ahc",
         ],
     )
     def test_parser_config(self, HttpApiAuth, add_dataset_func, parser_config):
@@ -707,6 +713,8 @@ class TestDatasetUpdate:
             ({"raptor": {"random_seed": -1}}, "Input should be greater than or equal to 0"),
             ({"raptor": {"random_seed": 3.14}}, "Input should be a valid integer"),
             ({"raptor": {"random_seed": "string"}}, "Input should be a valid integer"),
+            ({"raptor": {"tree_builder": "unknown"}}, "Input should be 'raptor', 'psi' or 'ahc'"),
+            ({"raptor": {"tree_builder": None}}, "Input should be 'raptor', 'psi' or 'ahc'"),
             ({"delimiter": "a" * 65536}, "Parser config exceeds size limit (max 65,535 characters)"),
         ],
         ids=[
@@ -763,6 +771,8 @@ class TestDatasetUpdate:
             "raptor_random_seed_min_limit",
             "raptor_random_seed_float_not_allowed",
             "raptor_random_seed_type_invalid",
+            "raptor_tree_builder_invalid",
+            "raptor_tree_builder_none_invalid",
             "parser_config_type_invalid",
         ],
     )

--- a/test/unit_test/rag/test_raptor_psi_tree_builder.py
+++ b/test/unit_test/rag/test_raptor_psi_tree_builder.py
@@ -1,0 +1,319 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import importlib
+import sys
+import types
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from api.utils.validation_utils import RaptorConfig
+from pydantic import ValidationError
+
+
+@pytest.fixture()
+def raptor_module(monkeypatch):
+    class TaskCanceledException(Exception):
+        pass
+
+    class DummyLimiter:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyGaussianMixture:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def fit(self, embeddings):
+            return self
+
+        def bic(self, embeddings):
+            return 0
+
+        def predict_proba(self, embeddings):
+            return np.ones((len(embeddings), 1))
+
+    class DummyUMAP:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def fit_transform(self, embeddings):
+            raise AssertionError("Psi tree builder must use original embeddings, not UMAP")
+
+    sklearn_module = types.ModuleType("sklearn")
+    mixture_module = types.ModuleType("sklearn.mixture")
+    mixture_module.GaussianMixture = DummyGaussianMixture
+    umap_module = types.ModuleType("umap")
+    umap_module.UMAP = DummyUMAP
+    task_service_module = types.ModuleType("api.db.services.task_service")
+    task_service_module.has_canceled = lambda task_id: False
+    connection_utils_module = types.ModuleType("common.connection_utils")
+    connection_utils_module.timeout = lambda seconds: lambda fn: fn
+    exceptions_module = types.ModuleType("common.exceptions")
+    exceptions_module.TaskCanceledException = TaskCanceledException
+    token_utils_module = types.ModuleType("common.token_utils")
+    token_utils_module.truncate = lambda text, max_len: text[:max_len]
+    graphrag_utils_module = types.ModuleType("rag.graphrag.utils")
+    graphrag_utils_module.chat_limiter = DummyLimiter()
+    graphrag_utils_module.get_embed_cache = lambda *args, **kwargs: None
+    graphrag_utils_module.get_llm_cache = lambda *args, **kwargs: None
+    graphrag_utils_module.set_embed_cache = lambda *args, **kwargs: None
+    graphrag_utils_module.set_llm_cache = lambda *args, **kwargs: None
+
+    async def thread_pool_exec(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    misc_utils_module = types.ModuleType("common.misc_utils")
+    misc_utils_module.thread_pool_exec = thread_pool_exec
+
+    monkeypatch.setitem(sys.modules, "sklearn", sklearn_module)
+    monkeypatch.setitem(sys.modules, "sklearn.mixture", mixture_module)
+    monkeypatch.setitem(sys.modules, "umap", umap_module)
+    monkeypatch.setitem(sys.modules, "api.db.services.task_service", task_service_module)
+    monkeypatch.setitem(sys.modules, "common.connection_utils", connection_utils_module)
+    monkeypatch.setitem(sys.modules, "common.exceptions", exceptions_module)
+    monkeypatch.setitem(sys.modules, "common.token_utils", token_utils_module)
+    monkeypatch.setitem(sys.modules, "rag.graphrag.utils", graphrag_utils_module)
+    monkeypatch.setitem(sys.modules, "common.misc_utils", misc_utils_module)
+    monkeypatch.delitem(sys.modules, "rag.raptor", raising=False)
+    module = importlib.import_module("rag.raptor")
+    yield module
+    monkeypatch.delitem(sys.modules, "rag.raptor", raising=False)
+
+
+class FakeChatModel:
+    llm_name = "fake-chat"
+    max_length = 4096
+
+    def __init__(self):
+        self.calls = []
+
+    async def async_chat(self, system, history, gen_conf):
+        self.calls.append(history[0]["content"])
+        return f"summary-{len(self.calls)}"
+
+
+class FakeEmbeddingModel:
+    llm_name = "fake-embedding"
+
+    def encode(self, texts):
+        embeddings = []
+        for text in texts:
+            checksum = sum(ord(ch) for ch in text)
+            embeddings.append(np.array([len(text), checksum % 17 + 1], dtype=float))
+        return embeddings, len(texts)
+
+
+_DEFAULT_TREE_BUILDER = object()
+
+
+def _make_raptor(raptor_module, max_cluster=64, tree_builder=_DEFAULT_TREE_BUILDER):
+    kwargs = {}
+    if tree_builder is _DEFAULT_TREE_BUILDER:
+        kwargs["tree_builder"] = raptor_module.PSI_TREE_BUILDER
+    elif tree_builder is not None:
+        kwargs["tree_builder"] = tree_builder
+    return raptor_module.RecursiveAbstractiveProcessing4TreeOrganizedRetrieval(
+        max_cluster,
+        FakeChatModel(),
+        FakeEmbeddingModel(),
+        "{cluster_content}",
+        max_token=32,
+        threshold=0.1,
+        **kwargs,
+    )
+
+
+def _chunks():
+    return [
+        ("alpha first", np.array([1.0, 0.0])),
+        ("alpha second", np.array([0.99, 0.01])),
+        ("alpha third", np.array([0.98, 0.02])),
+    ]
+
+
+def test_default_tree_builder_remains_original_raptor(raptor_module):
+    raptor = _make_raptor(raptor_module, tree_builder=None)
+
+    assert raptor._tree_builder == raptor_module.RAPTOR_TREE_BUILDER
+
+
+def test_unknown_tree_builder_is_rejected(raptor_module):
+    with pytest.raises(ValueError, match="Unsupported RAPTOR tree builder"):
+        _make_raptor(raptor_module, tree_builder="unknown")
+
+
+def test_ahc_tree_builder_alias_uses_psi_path(raptor_module):
+    raptor = _make_raptor(raptor_module, tree_builder="ahc")
+
+    assert raptor._tree_builder == raptor_module.PSI_TREE_BUILDER
+
+
+def test_raptor_config_accepts_hidden_psi_tree_builder():
+    assert RaptorConfig().tree_builder == "raptor"
+    assert RaptorConfig(tree_builder="psi").tree_builder == "psi"
+    assert RaptorConfig(tree_builder="ahc").tree_builder == "ahc"
+
+    with pytest.raises(ValidationError):
+        RaptorConfig(tree_builder="unknown")
+
+
+def test_psi_tree_builder_ranks_all_leaf_pairs_by_original_cosine_similarity(raptor_module):
+    raptor = _make_raptor(raptor_module)
+    leaves = [
+        raptor_module._PsiTreeNode(index=0, embedding=np.array([1.0, 0.0])),
+        raptor_module._PsiTreeNode(index=1, embedding=np.array([0.0, 1.0])),
+        raptor_module._PsiTreeNode(index=2, embedding=np.array([0.99, 0.01])),
+        raptor_module._PsiTreeNode(index=3, embedding=np.array([-1.0, 0.0])),
+    ]
+
+    ranked_pairs = raptor._rank_leaf_pairs(leaves)
+
+    assert len(ranked_pairs) == 6
+    assert tuple(ranked_pairs[0]) == (2, 0)
+
+
+def test_psi_tree_builder_uses_cosine_similarity_not_vector_magnitude(raptor_module):
+    raptor = _make_raptor(raptor_module)
+    leaves = [
+        raptor_module._PsiTreeNode(index=0, embedding=np.array([100.0, 0.0])),
+        raptor_module._PsiTreeNode(index=1, embedding=np.array([1.0, 1.0])),
+        raptor_module._PsiTreeNode(index=2, embedding=np.array([0.1, 0.0])),
+    ]
+
+    ranked_pairs = raptor._rank_leaf_pairs(leaves)
+
+    assert tuple(ranked_pairs[0]) == (2, 0)
+
+
+def test_psi_tree_builder_handles_zero_vectors_in_cosine_ranking(raptor_module):
+    raptor = _make_raptor(raptor_module)
+    leaves = [
+        raptor_module._PsiTreeNode(index=0, embedding=np.array([0.0, 0.0])),
+        raptor_module._PsiTreeNode(index=1, embedding=np.array([1.0, 0.0])),
+        raptor_module._PsiTreeNode(index=2, embedding=np.array([0.9, 0.1])),
+    ]
+
+    ranked_pairs = raptor._rank_leaf_pairs(leaves)
+
+    assert tuple(ranked_pairs[0]) == (2, 1)
+
+
+def test_psi_tree_builder_collapses_leaf_into_ranked_pair_parent(raptor_module):
+    raptor = _make_raptor(raptor_module, max_cluster=64)
+
+    root, leaves = raptor._build_psi_structure(_chunks())
+
+    assert len(root.children) == 3
+    assert {child.index for child in root.children} == {0, 1, 2}
+    assert all(leaf.parent is root for leaf in leaves)
+
+
+def test_psi_tree_builder_collapses_leaf_at_matching_rank(monkeypatch, raptor_module):
+    raptor = _make_raptor(raptor_module, max_cluster=64)
+    chunks = [
+        ("node 0", np.array([1.0, 0.0])),
+        ("node 1", np.array([0.9, 0.1])),
+        ("node 2", np.array([-1.0, 0.0])),
+        ("node 3", np.array([-0.9, -0.1])),
+        ("node 4", np.array([0.8, 0.2])),
+    ]
+    monkeypatch.setattr(
+        raptor,
+        "_rank_leaf_pairs",
+        lambda _leaves: np.array([[0, 1], [2, 3], [0, 2], [4, 0]]),
+    )
+
+    root, leaves = raptor._build_psi_structure(chunks)
+
+    assert leaves[4].parent is leaves[0].parent
+    assert leaves[4].parent is not root
+    assert len(root.children) == 2
+
+
+def test_psi_union_find_rank_fallback_is_bounded(caplog, raptor_module):
+    union_find = raptor_module._PsiUnionFind(2)
+    union_find._rank[0] = 4
+
+    with caplog.at_level("WARNING"):
+        union_find._build(0, 1, insert_point=1)
+
+    assert union_find.tree[0] == 1
+    assert "rank index 5 is out of bounds" in caplog.text
+
+
+def test_psi_tree_builder_rebalances_nodes_over_max_children(raptor_module):
+    raptor = _make_raptor(raptor_module, max_cluster=2)
+
+    root, _ = raptor._build_psi_structure(_chunks())
+
+    assert all(len(node.children) <= 2 for node in raptor._iter_nodes(root))
+    assert len(root.children) == 2
+    assert any(child.children for child in root.children)
+
+
+def test_psi_tree_builder_uses_bucketed_structure_for_large_inputs(monkeypatch, raptor_module):
+    raptor = _make_raptor(raptor_module, max_cluster=3)
+    raptor._psi_exact_max_leaves = 3
+    raptor._psi_bucket_size = 2
+    ranked_sizes = []
+    original_rank = raptor._rank_leaf_pairs
+
+    def track_rank(nodes):
+        ranked_sizes.append(len(nodes))
+        return original_rank(nodes)
+
+    monkeypatch.setattr(raptor, "_rank_leaf_pairs", track_rank)
+    chunks = [(f"node {idx}", np.array([float(idx), float(idx % 3 + 1)])) for idx in range(8)]
+
+    root, leaves = raptor._build_psi_structure(chunks)
+
+    assert len(leaves) == 8
+    assert len(list(raptor._iter_nodes(root))) > len(leaves)
+    assert max(ranked_sizes) <= 3
+    assert all(len(node.children) <= 3 for node in raptor._iter_nodes(root))
+
+
+@pytest.mark.asyncio
+async def test_psi_tree_builder_materializes_rebalanced_summary_layers_without_umap(monkeypatch, raptor_module):
+    def fail_umap(*args, **kwargs):
+        raise AssertionError("Psi tree builder must use original embeddings, not UMAP")
+
+    monkeypatch.setattr(raptor_module.umap, "UMAP", fail_umap)
+    raptor = _make_raptor(raptor_module, max_cluster=2)
+
+    chunks, layers = await raptor(_chunks(), random_state=0)
+
+    assert layers == [(0, 3), (3, 4), (4, 5)]
+    assert [chunk[0] for chunk in chunks[3:]] == ["summary-1", "summary-2"]
+
+
+@pytest.mark.asyncio
+async def test_psi_tree_builder_aborts_when_required_summary_fails(monkeypatch, raptor_module):
+    raptor = _make_raptor(raptor_module, max_cluster=2)
+
+    async def fail_summary(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(raptor, "_summarize_texts", fail_summary)
+
+    with pytest.raises(RuntimeError, match="RAPTOR Psi node .* summary failed"):
+        await raptor(_chunks(), random_state=0)

--- a/test/unit_test/rag/utils/test_raptor_utils.py
+++ b/test/unit_test/rag/utils/test_raptor_utils.py
@@ -18,15 +18,23 @@
 Unit tests for Raptor utility functions.
 """
 
+import logging
+
 import pytest
 from rag.utils.raptor_utils import (
+    CSV_EXTENSIONS,
+    EXCEL_EXTENSIONS,
+    STRUCTURED_EXTENSIONS,
+    collect_raptor_chunk_ids,
+    collect_raptor_methods,
+    get_raptor_tree_builder,
+    get_skip_reason,
     is_structured_file_type,
     is_tabular_pdf,
+    make_raptor_summary_chunk_id,
+    normalize_raptor_tree_builder,
+    raptor_methods_require_cleanup,
     should_skip_raptor,
-    get_skip_reason,
-    EXCEL_EXTENSIONS,
-    CSV_EXTENSIONS,
-    STRUCTURED_EXTENSIONS
 )
 
 
@@ -281,6 +289,114 @@ class TestIntegrationScenarios:
         
         # Should NOT skip when explicitly disabled
         assert should_skip_raptor(file_type, raptor_config=raptor_config) is False
+
+
+class TestRaptorTreeBuilderConfig:
+    """Test RAPTOR tree builder config resolution"""
+
+    def test_defaults_to_original_raptor_builder(self):
+        assert get_raptor_tree_builder({}) == "raptor"
+        assert get_raptor_tree_builder(None) == "raptor"
+
+    def test_reads_top_level_tree_builder(self):
+        assert get_raptor_tree_builder({"tree_builder": "psi"}) == "psi"
+        assert get_raptor_tree_builder({"tree_builder": "ahc"}) == "psi"
+
+    def test_reads_legacy_ext_tree_builder(self):
+        assert get_raptor_tree_builder({"ext": {"tree_builder": "psi"}}) == "psi"
+        assert get_raptor_tree_builder({"ext": {"tree_builder": "ahc"}}) == "psi"
+
+    def test_normalizes_ahc_alias_to_psi(self):
+        assert normalize_raptor_tree_builder("ahc") == "psi"
+
+    def test_rejects_unknown_tree_builder(self):
+        with pytest.raises(ValueError, match="Unsupported RAPTOR tree builder"):
+            get_raptor_tree_builder({"tree_builder": "unknown"})
+
+
+class TestRaptorMethodCollection:
+    """Test RAPTOR summary method extraction from doc-store fields"""
+
+    def test_legacy_summary_without_method_is_original_raptor(self):
+        field_map = {"chunk_1": {"raptor_kwd": "raptor"}}
+
+        assert collect_raptor_methods(field_map) == {"raptor"}
+        assert collect_raptor_chunk_ids(field_map) == {"chunk_1"}
+
+    def test_explicit_method_is_preserved(self):
+        field_map = {"chunk_1": {"raptor_kwd": "raptor", "extra": {"raptor_method": "psi"}}}
+
+        assert collect_raptor_methods(field_map) == {"psi"}
+        assert collect_raptor_chunk_ids(field_map) == {"chunk_1"}
+
+    def test_stored_ahc_method_is_treated_as_psi(self):
+        field_map = {"chunk_1": {"raptor_kwd": "raptor", "extra": {"raptor_method": "ahc"}}}
+
+        assert collect_raptor_methods(field_map) == {"psi"}
+
+    def test_extra_field_supports_oceanbase_rows(self):
+        field_map = {
+            "chunk_1": {
+                "extra": {
+                    "raptor_kwd": "raptor",
+                    "raptor_method": "psi",
+                }
+            },
+            "chunk_2": {
+                "extra": "{\"raptor_kwd\": \"raptor\"}",
+            },
+            "chunk_3": {
+                "extra": {"raptor_kwd": ""},
+            },
+        }
+
+        assert collect_raptor_methods(field_map) == {"psi", "raptor"}
+        assert collect_raptor_chunk_ids(field_map) == {"chunk_1", "chunk_2"}
+
+    def test_legacy_method_column_is_still_read(self):
+        field_map = {"chunk_1": {"raptor_kwd": "raptor", "raptor_method_kwd": "psi"}}
+
+        assert collect_raptor_methods(field_map) == {"psi"}
+
+    def test_non_raptor_rows_are_ignored(self):
+        field_map = {
+            "chunk_1": {"raptor_kwd": ""},
+            "chunk_2": {"extra": {"raptor_kwd": "graph"}},
+            "chunk_3": {},
+        }
+
+        assert collect_raptor_methods(field_map) == set()
+        assert collect_raptor_chunk_ids(field_map) == set()
+
+    def test_malformed_extra_payload_is_logged_and_ignored(self, caplog):
+        field_map = {"chunk_1": {"extra": "{bad json"}}
+
+        with caplog.at_level(logging.WARNING):
+            assert collect_raptor_methods(field_map) == set()
+            assert collect_raptor_chunk_ids(field_map) == set()
+
+        assert "Ignoring malformed RAPTOR extra payload" in caplog.text
+
+    def test_chunk_id_collection_can_preserve_current_method(self):
+        field_map = {
+            "legacy": {"raptor_kwd": "raptor"},
+            "old": {"raptor_kwd": "raptor", "extra": {"raptor_method": "raptor"}},
+            "current": {"raptor_kwd": "raptor", "extra": {"raptor_method": "psi"}},
+        }
+
+        assert collect_raptor_chunk_ids(field_map, exclude_methods={"psi"}) == {"legacy", "old"}
+        assert collect_raptor_chunk_ids(field_map, exclude_methods={"raptor"}) == {"current"}
+
+    def test_summary_chunk_ids_include_real_document_id(self):
+        content = "same generated summary"
+
+        assert make_raptor_summary_chunk_id(content, "doc-a") != make_raptor_summary_chunk_id(content, "doc-b")
+
+    def test_cleanup_is_required_only_for_non_target_methods(self):
+        assert raptor_methods_require_cleanup({"psi"}, "psi") is False
+        assert raptor_methods_require_cleanup({"raptor", "psi"}, "psi") is True
+        assert raptor_methods_require_cleanup({"raptor"}, "psi") is True
+        assert raptor_methods_require_cleanup(set(), "psi") is False
 
 
 if __name__ == "__main__":

--- a/web/src/hooks/parser-config-utils.ts
+++ b/web/src/hooks/parser-config-utils.ts
@@ -21,6 +21,7 @@ export const extractRaptorConfigExt = (
     max_cluster,
     random_seed,
     scope,
+    tree_builder,
     auto_disable_for_structured_data,
     ext,
     ...raptorExt
@@ -33,6 +34,7 @@ export const extractRaptorConfigExt = (
     max_cluster,
     random_seed,
     scope,
+    tree_builder,
     auto_disable_for_structured_data,
     ext: { ...ext, ...raptorExt },
   };

--- a/web/src/interfaces/database/dataset.ts
+++ b/web/src/interfaces/database/dataset.ts
@@ -77,7 +77,9 @@ interface Raptor {
   max_token: number;
   prompt: string;
   random_seed: number;
+  scope?: string;
   threshold: number;
+  tree_builder?: 'raptor' | 'psi' | 'ahc';
   use_raptor: boolean;
 }
 

--- a/web/src/interfaces/database/document.ts
+++ b/web/src/interfaces/database/document.ts
@@ -63,6 +63,7 @@ export interface IParserConfig {
 }
 
 interface Raptor {
+  tree_builder?: 'raptor' | 'psi' | 'ahc';
   use_raptor: boolean;
 }
 

--- a/web/src/pages/dataset/dataset-setting/form-schema.ts
+++ b/web/src/pages/dataset/dataset-setting/form-schema.ts
@@ -47,6 +47,7 @@ export const formSchema = z
             max_cluster: z.number().optional(),
             random_seed: z.number().optional(),
             scope: z.string().optional(),
+            tree_builder: z.enum(['raptor', 'psi', 'ahc']).optional(),
           })
           .refine(
             (data) => {

--- a/web/src/pages/dataset/dataset-setting/index.tsx
+++ b/web/src/pages/dataset/dataset-setting/index.tsx
@@ -95,6 +95,7 @@ export default function DatasetSettings() {
           max_cluster: 64,
           random_seed: 0,
           scope: 'file',
+          tree_builder: 'raptor',
           prompt: t('knowledgeConfiguration.promptText'),
         },
         graphrag: {


### PR DESCRIPTION
### What problem does this PR solve?


RAPTOR currently builds summary layers with the original layer-by-layer GMM clustering path. This PR adds a configurable Psi/AHC-style tree builder while keeping the existing RAPTOR behavior as the default.

### What changed

- Added `parser_config.raptor.tree_builder` with supported values:
  - `raptor`: default, preserves the existing GMM/UMAP RAPTOR behavior.
  - `psi`: builds a rank-aware Psi-style tree from original embedding-space cosine similarities, then materializes summaries through the existing LLM/embedding flow.
  - `ahc`: accepted as the issue-aligned API alias and normalized internally to `psi`.
- Added deterministic bucketed Psi construction for larger inputs via `raptor.ext.psi_exact_max_leaves` and `raptor.ext.psi_bucket_size`, avoiding one required full `n x n` similarity matrix for very large runs.
- Stored generated summary method metadata in existing `extra.raptor_method` instead of adding a new DB/index field. Legacy summaries without this metadata are treated as original `raptor` summaries.
- Kept `raptor_kwd` and `raptor_layer_int` for summary detection/layer tracking, and removed the dedicated `raptor_method_kwd` schema/mapping change.
- Added cleanup/idempotency logic so reruns skip same-method summaries and remove old-method summaries only after replacement summaries are generated.
- Preserved `tree_builder` through the web parser config path without adding a visible UI switch.
- Added a defensive Psi union-find rank bounds check for the collapse path.
- Made Psi layer materialization fail fast when an internal node cannot produce its required summary, preventing incomplete Psi trees from being silently indexed.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

### Tests run

- `uv run --with numpy==1.26.4 --with pytest --with pytest-asyncio python -m pytest test/unit_test/rag/test_raptor_psi_tree_builder.py test/unit_test/rag/utils/test_raptor_utils.py -q` -> `73 passed`
- `uv run --with numpy==1.26.4 python /tmp/raptor_quality_eval.py` -> passed targeted cross-document eval
- `uv run ruff check rag/raptor.py rag/svr/task_executor.py rag/utils/raptor_utils.py rag/utils/ob_conn.py api/utils/validation_utils.py test/unit_test/rag/test_raptor_psi_tree_builder.py test/unit_test/rag/utils/test_raptor_utils.py test/testcases/test_http_api/test_dataset_management/test_update_dataset.py` -> passed
- `python3 -m py_compile rag/raptor.py rag/svr/task_executor.py rag/utils/raptor_utils.py rag/utils/ob_conn.py api/utils/validation_utils.py test/unit_test/rag/test_raptor_psi_tree_builder.py test/unit_test/rag/utils/test_raptor_utils.py` -> passed
- `git diff --check` -> passed

### Notes

- A reproducible offline structural RAPTOR result and a targeted cross-document quality eval were attached in the PR conversation. They verify that the new Psi path builds layered summaries without UMAP/GMM, respects `max_cluster` fanout, and avoids mixed-topic first-layer summaries in the tested failure case.
- A larger real-world retrieval-quality comparison (`raptor` vs `psi/ahc`) on a labeled or representative dataset is still recommended for broader empirical evidence.