### PR TITLE
Do not bypass threshold for rerank when metadata filter is enabled

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -536,11 +536,6 @@ class Dealer:
         # When vector_similarity_weight is 0, similarity_threshold is not meaningful for term-only scores.
         post_threshold = 0.0 if vector_similarity_weight <= 0 else similarity_threshold
 
-        # When doc_ids is explicitly provided (metadata or document filtering), bypass threshold
-        # User wants those specific documents regardless of their relevance score
-        if doc_ids:
-            post_threshold = 0.0
-
         valid_idx = [int(i) for i in sorted_idx if sim_np[i] >= post_threshold]
         filtered_count = len(valid_idx)
         ranks["total"] = int(filtered_count)


### PR DESCRIPTION
### What problem does this PR solve?

Do not bypass threshold for rerank when metadata filter is enabled

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
