### PR TITLE
feat: skip unchanged s3 objects by etag

### DIFF
--- a/api/db/services/connector_service.py
+++ b/api/db/services/connector_service.py
@@ -276,12 +276,21 @@ class SyncLogsService(CommonService):
             id: str
             filename: str
             blob: bytes
+            content_hash: str | None = None
 
             def read(self) -> bytes:
                 return self.blob
 
         errs = []
-        files = [FileObj(id=d["id"], filename=d["semantic_identifier"]+(f"{d['extension']}" if d["semantic_identifier"][::-1].find(d['extension'][::-1])<0 else ""), blob=d["blob"]) for d in docs]
+        files = [
+            FileObj(
+                id=d["id"],
+                filename=d["semantic_identifier"]+(f"{d['extension']}" if d["semantic_identifier"][::-1].find(d['extension'][::-1])<0 else ""),
+                blob=d["blob"],
+                content_hash=d.get("content_hash"),
+            )
+            for d in docs
+        ]
         doc_ids = []
         err, doc_blob_pairs = FileService.upload_document(kb, files, tenant_id, src)
         errs.extend(err)
@@ -369,4 +378,3 @@ class Connector2KbService(CommonService):
                         cls.model.kb_id==kb_id
                     ).dicts()
         )
-

--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -372,7 +372,7 @@ class DocumentService(CommonService):
     @classmethod
     @DB.connection_context()
     def list_doc_headers_by_kb_and_source_type(cls, kb_id, source_type, page_size=500):
-        fields = [cls.model.id, cls.model.kb_id, cls.model.source_type, cls.model.name]
+        fields = [cls.model.id, cls.model.kb_id, cls.model.source_type, cls.model.name, cls.model.content_hash]
         docs = cls.model.select(*fields).where(
             cls.model.kb_id == kb_id,
             cls.model.source_type == source_type,

--- a/api/db/services/file_service.py
+++ b/api/db/services/file_service.py
@@ -482,7 +482,7 @@ class FileService(CommonService):
                         err.append(file.filename + ": " + user_msg)
                         continue
                     blob = file.read()
-                    new_hash = xxhash.xxh128(blob).hexdigest()
+                    new_hash = getattr(file, "content_hash", None) or xxhash.xxh128(blob).hexdigest()
                     old_hash = doc.content_hash or ""
                     settings.STORAGE_IMPL.put(kb.id, doc.location, blob, kb.tenant_id)
                     doc.size = len(blob)
@@ -532,7 +532,7 @@ class FileService(CommonService):
                     "location": location,
                     "size": len(blob),
                     "thumbnail": thumbnail_location,
-                    "content_hash": xxhash.xxh128(blob).hexdigest(),
+                    "content_hash": getattr(file, "content_hash", None) or xxhash.xxh128(blob).hexdigest(),
                 }
                 DocumentService.insert(doc)
 

--- a/common/data_source/blob_connector.py
+++ b/common/data_source/blob_connector.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+import xxhash
 from common.data_source.utils import (
     create_s3_client,
     detect_bucket_region,
@@ -48,6 +49,30 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         self.size_threshold: int | None = BLOB_STORAGE_SIZE_THRESHOLD
         self.bucket_region: Optional[str] = None
         self.european_residency: bool = european_residency
+        self.existing_content_hashes: dict[str, str] = {}
+        self.latest_seen_doc_updated_at = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    @staticmethod
+    def _get_document_id(bucket_type: BlobType, bucket_name: str, key: str) -> str:
+        return f"{bucket_type}:{bucket_name}:{key}"
+
+    @staticmethod
+    def _get_stored_document_id(document_id: str) -> str:
+        return xxhash.xxh128(document_id).hexdigest()
+
+    @staticmethod
+    def _content_hash_from_etag(obj: dict[str, Any]) -> str | None:
+        etag = obj.get("ETag")
+        if not etag:
+            return None
+        normalized_etag = str(etag).strip().strip('"')
+        if not normalized_etag:
+            return None
+        return xxhash.xxh128(normalized_etag).hexdigest()
+
+    def set_existing_content_hashes(self, hashes: dict[str, str]) -> None:
+        """Set known hashes keyed by connector document id for unchanged-object skips."""
+        self.existing_content_hashes = hashes
 
     def set_allow_images(self, allow_images: bool) -> None:
         """Set whether to process images"""
@@ -133,8 +158,11 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         batch: list[Document] = []
         for obj in all_objects:
             last_modified = obj["LastModified"].replace(tzinfo=timezone.utc)
+            self.latest_seen_doc_updated_at = max(self.latest_seen_doc_updated_at, last_modified)
             file_name = os.path.basename(obj["Key"])
             key = obj["Key"]
+            doc_id = self._get_document_id(self.bucket_type, self.bucket_name, key)
+            content_hash = self._content_hash_from_etag(obj)
 
             size_bytes = extract_size_bytes(obj)
             if (
@@ -145,6 +173,10 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                 logging.warning(
                     f"{file_name} exceeds size threshold of {self.size_threshold}. Skipping."
                 )
+                continue
+
+            if content_hash and self.existing_content_hashes.get(self._get_stored_document_id(doc_id)) == content_hash:
+                logging.debug("Skipping unchanged blob object %s using ETag fingerprint.", key)
                 continue
 
             try:
@@ -158,13 +190,14 @@ class BlobStorageConnector(LoadConnector, PollConnector):
 
                 batch.append(
                     Document(
-                        id=f"{self.bucket_type}:{self.bucket_name}:{key}",
+                        id=doc_id,
                         blob=blob,
                         source=DocumentSource(self.bucket_type.value),
                         semantic_identifier=semantic_id,
                         extension=get_file_ext(file_name),
                         doc_updated_at=last_modified,
                         size_bytes=size_bytes if size_bytes else 0,
+                        content_hash=content_hash,
                     )
                 )
                 if len(batch) == self.batch_size:

--- a/common/data_source/models.py
+++ b/common/data_source/models.py
@@ -95,6 +95,7 @@ class Document(BaseModel):
     blob: bytes
     doc_updated_at: datetime
     size_bytes: int
+    content_hash: Optional[str] = None
     externale_access: Optional[ExternalAccess] = None
     primary_owners: Optional[list] = None
     metadata: Optional[dict[str, Any]] = None

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -211,6 +211,8 @@ class SyncBase:
                     "doc_updated_at": doc.doc_updated_at,
                     "blob": doc.blob,
                 }
+                if doc.content_hash:
+                    d["content_hash"] = doc.content_hash
                 if doc.metadata:
                     d["metadata"] = doc.metadata
                 docs.append(d)
@@ -244,6 +246,11 @@ class SyncBase:
 
                 failed_docs += len(docs)
                 continue
+
+        connector_instance = getattr(self, "connector", None)
+        connector_latest_update = getattr(connector_instance, "latest_seen_doc_updated_at", None)
+        if connector_latest_update:
+            next_update = max(next_update, connector_latest_update)
 
         prefix = self._get_source_prefix()
         prefix = f"{prefix} " if prefix else ""
@@ -311,6 +318,24 @@ class _BlobLikeBase(SyncBase):
         )
         self.connector.set_allow_images(self.conf.get("allow_images", False))
         self.connector.load_credentials(self.conf["credentials"])
+        if task["reindex"] != "1" and task["poll_range_start"]:
+            source_type = f"{self.SOURCE_NAME}/{task['connector_id']}"
+            existing_content_hashes = {
+                doc["id"]: doc["content_hash"]
+                for doc in DocumentService.list_doc_headers_by_kb_and_source_type(
+                    task["kb_id"],
+                    source_type,
+                )
+                if doc.get("content_hash")
+            }
+            sample_doc_ids = list(existing_content_hashes.keys())[:5]
+            logging.info(
+                "[%s] Loaded %d existing content hashes for ETag skip (sample_doc_ids=%s)",
+                self.SOURCE_NAME,
+                len(existing_content_hashes),
+                sample_doc_ids,
+            )
+            self.connector.set_existing_content_hashes(existing_content_hashes)
 
         file_list = None
         document_batch_generator = (

--- a/test/unit_test/rag/test_sync_data_source.py
+++ b/test/unit_test/rag/test_sync_data_source.py
@@ -82,6 +82,7 @@ _install_xgboost_stub_if_unavailable()
 _install_ollama_stub()
 
 sync_data_source = importlib.import_module("rag.svr.sync_data_source")
+blob_connector_module = importlib.import_module("common.data_source.blob_connector")
 
 
 class _FakeSync(sync_data_source.SyncBase):
@@ -103,6 +104,7 @@ def _make_fake_doc(doc_id="doc-1", updated_at=None):
         size_bytes=1,
         doc_updated_at=updated_at or datetime(2026, 1, 1, tzinfo=timezone.utc),
         blob=b"x",
+        content_hash=None,
         metadata=None,
     )
 
@@ -129,6 +131,127 @@ def _patch_common_dependencies(monkeypatch):
         "done",
         lambda *_args, **_kwargs: None,
     )
+
+
+class _FakePaginator:
+    def __init__(self, objects):
+        self.objects = objects
+
+    def paginate(self, **_kwargs):
+        return [{"Contents": self.objects}]
+
+
+class _FakeS3Client:
+    def __init__(self, objects):
+        self.objects = objects
+
+    def get_paginator(self, _name):
+        return _FakePaginator(self.objects)
+
+
+class _FakeBlobStorageConnector(blob_connector_module.BlobStorageConnector):
+    instance = None
+    objects = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        _FakeBlobStorageConnector.instance = self
+
+    def load_credentials(self, credentials):
+        self.credentials = credentials
+        self.s3_client = _FakeS3Client(_FakeBlobStorageConnector.objects)
+        return None
+
+
+@pytest.mark.p2
+def test_blob_connector_skips_unchanged_etag_without_download(monkeypatch):
+    updated_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    key = "docs/a.txt"
+    raw_doc_id = "s3:bucket-1:docs/a.txt"
+    etag_hash = blob_connector_module.BlobStorageConnector._content_hash_from_etag({"ETag": '"etag-1"'})
+    connector = blob_connector_module.BlobStorageConnector("s3", "bucket-1")
+    connector.s3_client = _FakeS3Client(
+        [{"Key": key, "LastModified": updated_at, "ETag": '"etag-1"', "Size": 8}]
+    )
+    connector.set_existing_content_hashes(
+        {sync_data_source.hash128(raw_doc_id): etag_hash}
+    )
+
+    def _fail_download(*_args, **_kwargs):
+        raise AssertionError("unchanged object should not be downloaded")
+
+    monkeypatch.setattr(blob_connector_module, "download_object", _fail_download)
+
+    assert list(connector.poll_source(0, updated_at.timestamp())) == []
+    assert connector.latest_seen_doc_updated_at == updated_at
+
+
+@pytest.mark.anyio
+@pytest.mark.p2
+async def test_blob_generate_passes_stored_hashes_to_connector_for_etag_skip(monkeypatch):
+    poll_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    updated_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    key = "docs/a.txt"
+    raw_doc_id = "s3:bucket-1:docs/a.txt"
+    stored_doc_id = sync_data_source.hash128(raw_doc_id)
+    etag_hash = blob_connector_module.BlobStorageConnector._content_hash_from_etag(
+        {"ETag": '"etag-1"'}
+    )
+    _FakeBlobStorageConnector.instance = None
+    _FakeBlobStorageConnector.objects = [
+        {"Key": key, "LastModified": updated_at, "ETag": '"etag-1"', "Size": 8}
+    ]
+
+    monkeypatch.setattr(sync_data_source, "BlobStorageConnector", _FakeBlobStorageConnector)
+    monkeypatch.setattr(
+        sync_data_source.DocumentService,
+        "list_doc_headers_by_kb_and_source_type",
+        lambda *_args, **_kwargs: [{"id": stored_doc_id, "content_hash": etag_hash}],
+    )
+
+    def _fail_download(*_args, **_kwargs):
+        raise AssertionError("unchanged object should not be downloaded")
+
+    monkeypatch.setattr(blob_connector_module, "download_object", _fail_download)
+
+    task = {
+        **_make_task(),
+        "reindex": "0",
+        "poll_range_start": poll_start,
+        "skip_connection_log": True,
+    }
+    sync = sync_data_source.S3(
+        {
+            "bucket_name": "bucket-1",
+            "credentials": {},
+            "prefix": "",
+        }
+    )
+
+    document_generator, file_list = await sync._generate(task)
+    connector = _FakeBlobStorageConnector.instance
+
+    assert connector is not None
+    assert connector.existing_content_hashes == {stored_doc_id: etag_hash}
+    assert list(document_generator) == []
+    assert file_list is None
+    assert connector.latest_seen_doc_updated_at == updated_at
+
+
+@pytest.mark.p2
+def test_blob_connector_attaches_etag_fingerprint_to_changed_doc(monkeypatch):
+    updated_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    connector = blob_connector_module.BlobStorageConnector("s3", "bucket-1")
+    connector.s3_client = _FakeS3Client(
+        [{"Key": "docs/a.txt", "LastModified": updated_at, "ETag": '"etag-2"', "Size": 8}]
+    )
+    monkeypatch.setattr(blob_connector_module, "download_object", lambda *_args, **_kwargs: b"changed")
+
+    batches = list(connector.poll_source(0, updated_at.timestamp()))
+
+    assert len(batches) == 1
+    assert batches[0][0].content_hash == blob_connector_module.BlobStorageConnector._content_hash_from_etag({"ETag": '"etag-2"'})
+    assert batches[0][0].blob == b"changed"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #14628.

S3-like incremental syncs previously downloaded objects even when their remote content had not changed. This adds ETag-based fingerprints for blob storage documents, stores the normalized fingerprint in the existing document `content_hash`, and skips downloading objects whose listed ETag fingerprint matches the stored hash. The sync watermark still advances when all objects in the poll window are skipped as unchanged.

Note: I attempted to branch from `upstream/test`, but the upstream repository currently advertises only `main` and `main_backup`, so this PR targets `main`.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

### Validation / real behavior proof

- `python3 -m compileall common/data_source/blob_connector.py common/data_source/models.py api/db/services/document_service.py api/db/services/file_service.py api/db/services/connector_service.py rag/svr/sync_data_source.py test/unit_test/rag/test_sync_data_source.py`
- `git diff --check`
- Added unit coverage proving an unchanged S3 object with a matching ETag fingerprint is not downloaded, and changed objects carry the ETag fingerprint forward.
- Attempted `uv run pytest test/unit_test/rag/test_sync_data_source.py -q`, but `uv` is not installed in this environment.
- Attempted `python3 -m pytest test/unit_test/rag/test_sync_data_source.py -q`, but the environment lacks project dependencies (`peewee` is the first missing import).
