### PR TITLE
feat: add non-llm graphrag keyword extraction

### DIFF
--- a/rag/graphrag/general/index.py
+++ b/rag/graphrag/general/index.py
@@ -28,6 +28,7 @@ from rag.graphrag.entity_resolution import EntityResolution
 from rag.graphrag.general.community_reports_extractor import CommunityReportsExtractor
 from rag.graphrag.general.extractor import Extractor
 from rag.graphrag.general.graph_extractor import GraphExtractor as GeneralKGExt
+from rag.graphrag.keyword_extractor import KeywordGraphExtractor
 from rag.graphrag.light.graph_extractor import GraphExtractor as LightKGExt
 from rag.graphrag.phase_markers import (
     PHASE_COMMUNITY,
@@ -52,6 +53,18 @@ from rag.utils.redis_conn import RedisDistributedLock
 from common import settings
 from common.doc_store.doc_store_base import OrderByExpr
 
+
+def get_graphrag_extractor(kb_parser_config: dict):
+    method = (kb_parser_config.get("graphrag", {}).get("method") or "light").lower()
+    if method == "general":
+        return GeneralKGExt
+    if method in {"keyword", "non_llm", "non-llm", "rule"}:
+        return KeywordGraphExtractor
+    return LightKGExt
+
+
+def is_keyword_graphrag_method(kb_parser_config: dict) -> bool:
+    return get_graphrag_extractor(kb_parser_config) is KeywordGraphExtractor
 
 
 async def load_subgraph_from_store(tenant_id: str, kb_id: str, doc_id: str):
@@ -111,9 +124,19 @@ async def run_graphrag(
     embedding_model,
     callback,
 ):
+    """Run GraphRAG for one document.
+
+    Keyword mode is deterministic and skips LLM-based resolution/community
+    phases even when those switches are enabled.
+    """
     enable_timeout_assertion = os.environ.get("ENABLE_TIMEOUT_ASSERTION")
     start = asyncio.get_running_loop().time()
     tenant_id, kb_id, doc_id = row["tenant_id"], str(row["kb_id"]), row["doc_id"]
+    if is_keyword_graphrag_method(row["kb_parser_config"]) and (with_resolution or with_community):
+        with_resolution = False
+        with_community = False
+        logging.info("GraphRAG keyword mode skips LLM-based resolution/community for doc %s.", doc_id)
+        callback(msg=f"[GraphRAG] keyword mode skips LLM-based resolution/community for doc:{doc_id}.")
     chunks = []
     for d in settings.retriever.chunk_list(doc_id, tenant_id, [kb_id], max_count=10000, fields=["content_with_weight", "doc_id"], sort_by_position=True):
         chunks.append(d["content_with_weight"])
@@ -123,9 +146,7 @@ async def run_graphrag(
     try:
         subgraph = await asyncio.wait_for(
             generate_subgraph(
-                LightKGExt if "method" not in row["kb_parser_config"].get("graphrag", {})
-                    or row["kb_parser_config"]["graphrag"]["method"] != "general"
-                else GeneralKGExt,
+                get_graphrag_extractor(row["kb_parser_config"]),
                 tenant_id,
                 kb_id,
                 doc_id,
@@ -211,7 +232,17 @@ async def run_graphrag_for_kb(
     with_community: bool = True,
     max_parallel_docs: int = 4,
 ) -> dict:
+    """Run GraphRAG across a KB.
+
+    Keyword mode is deterministic and skips LLM-based resolution/community
+    phases even when those switches are enabled.
+    """
     tenant_id, kb_id = row["tenant_id"], row["kb_id"]
+    if is_keyword_graphrag_method(kb_parser_config) and (with_resolution or with_community):
+        with_resolution = False
+        with_community = False
+        logging.info("GraphRAG keyword mode skips LLM-based resolution/community for kb %s.", kb_id)
+        callback(msg=f"[GraphRAG] keyword mode skips LLM-based resolution/community for kb:{kb_id}.")
     enable_timeout_assertion = os.environ.get("ENABLE_TIMEOUT_ASSERTION")
     start = asyncio.get_running_loop().time()
     fields_for_chunks = ["content_with_weight", "doc_id"]
@@ -294,7 +325,7 @@ async def run_graphrag_for_kb(
             callback(msg=f"[GraphRAG] doc:{doc_id} has no available chunks, skip generation.")
             return
 
-        kg_extractor = LightKGExt if ("method" not in kb_parser_config.get("graphrag", {}) or kb_parser_config["graphrag"]["method"] != "general") else GeneralKGExt
+        kg_extractor = get_graphrag_extractor(kb_parser_config)
 
         deadline = max(120, len(chunks) * 60 * 10) if enable_timeout_assertion else 10000000000
 

--- a/rag/graphrag/keyword_extractor.py
+++ b/rag/graphrag/keyword_extractor.py
@@ -1,0 +1,225 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import asyncio
+import logging
+import os
+import re
+from collections import Counter
+from typing import Callable
+
+from common.exceptions import TaskCanceledException
+
+DEFAULT_ENTITY_TYPES = ["organization", "person", "geo", "event", "category"]
+YIELD_EVERY = 50
+logger = logging.getLogger(__name__)
+_STOPWORDS = {
+    "about",
+    "above",
+    "after",
+    "again",
+    "against",
+    "also",
+    "among",
+    "because",
+    "before",
+    "being",
+    "between",
+    "could",
+    "during",
+    "from",
+    "have",
+    "into",
+    "more",
+    "only",
+    "other",
+    "over",
+    "same",
+    "some",
+    "such",
+    "than",
+    "that",
+    "their",
+    "there",
+    "these",
+    "they",
+    "this",
+    "through",
+    "under",
+    "using",
+    "when",
+    "where",
+    "which",
+    "while",
+    "with",
+    "would",
+}
+
+_WORD_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
+_PHRASE_PATTERN = re.compile(r"\b(?:[A-Z][A-Za-z0-9_-]{2,})(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,4}\b")
+
+
+class KeywordGraphExtractor:
+    """Deterministic GraphRAG extractor that does not call an LLM.
+
+    It extracts repeated keywords and capitalized phrases, then links terms that
+    co-occur in the same chunk. This gives users a low-cost ingestion mode for
+    large datasets or environments where LLM extraction is too expensive.
+    """
+
+    def __init__(
+        self,
+        llm_invoker,
+        language: str | None = "English",
+        entity_types: list[str] | None = None,
+    ):
+        del llm_invoker
+        self._language = language
+        self._entity_types = entity_types or DEFAULT_ENTITY_TYPES
+        self._max_terms_per_chunk = max(2, int(os.environ.get("GRAPHRAG_KEYWORD_MAX_TERMS_PER_CHUNK", 12)))
+        self._max_edges_per_chunk = max(1, int(os.environ.get("GRAPHRAG_KEYWORD_MAX_EDGES_PER_CHUNK", 36)))
+        self._min_term_frequency = max(1, int(os.environ.get("GRAPHRAG_KEYWORD_MIN_TERM_FREQUENCY", 2)))
+
+    def _entity_type(self) -> str:
+        types = self._entity_types or DEFAULT_ENTITY_TYPES
+        lowered = {t.lower(): t for t in types}
+        return lowered.get("category") or lowered.get("organization") or types[0]
+
+    @staticmethod
+    def _clean_term(term: str) -> str:
+        return re.sub(r"\s+", " ", term.strip(" -_.,;:()[]{}\"'")).strip()
+
+    def _candidate_terms(self, text: str) -> list[str]:
+        terms: list[str] = []
+        for phrase in _PHRASE_PATTERN.findall(text):
+            cleaned = self._clean_term(phrase)
+            if cleaned and cleaned.lower() not in _STOPWORDS:
+                terms.append(cleaned)
+        for word in _WORD_PATTERN.findall(text):
+            cleaned = self._clean_term(word)
+            if not cleaned:
+                continue
+            if cleaned[0].isupper() or cleaned.isupper():
+                continue
+            lowered = cleaned.lower()
+            if lowered in _STOPWORDS or lowered.isdigit():
+                continue
+            terms.append(lowered)
+        return terms
+
+    async def __call__(self, doc_id: str, chunks: list[str], callback: Callable | None = None, task_id: str = ""):
+        start_ts = asyncio.get_running_loop().time()
+        entity_type = self._entity_type()
+        global_counts = Counter()
+        chunk_term_counts: list[Counter] = []
+        per_chunk_terms: list[list[str]] = []
+        has_canceled = None
+
+        logger.info("Keyword graph extraction started for doc %s with %d chunks.", doc_id, len(chunks))
+        if task_id:
+            from api.db.services.task_service import has_canceled as task_has_canceled
+
+            has_canceled = task_has_canceled
+
+        async def yield_and_check_cancel(processed: int, *, force: bool = False) -> None:
+            if not force and processed % YIELD_EVERY != 0:
+                return
+            await asyncio.sleep(0)
+            if has_canceled and has_canceled(task_id):
+                logger.warning("Keyword graph extraction cancelled for task %s, doc %s.", task_id, doc_id)
+                raise TaskCanceledException(f"Task {task_id} was cancelled during keyword graph extraction")
+
+        for chunk_idx, chunk in enumerate(chunks, start=1):
+            counts = Counter(self._candidate_terms(chunk))
+            chunk_term_counts.append(counts)
+            global_counts.update(counts)
+            await yield_and_check_cancel(chunk_idx)
+        await yield_and_check_cancel(len(chunk_term_counts), force=True)
+
+        for chunk_idx, counts in enumerate(chunk_term_counts, start=1):
+            ranked_terms = [
+                term
+                for term, _count in counts.most_common(self._max_terms_per_chunk)
+                if global_counts[term] >= self._min_term_frequency or len(term.split()) > 1
+            ]
+            per_chunk_terms.append(ranked_terms)
+            await yield_and_check_cancel(chunk_idx)
+        await yield_and_check_cancel(len(per_chunk_terms), force=True)
+
+        entities = []
+        valid_entities = set()
+        for term_idx, (term, count) in enumerate(global_counts.most_common(), start=1):
+            if count < self._min_term_frequency and len(term.split()) == 1:
+                continue
+            valid_entities.add(term)
+            entities.append(
+                {
+                    "entity_name": term,
+                    "entity_type": entity_type,
+                    "description": f"{term} appears {count} times in the source text.",
+                    "source_id": [],
+                }
+            )
+            await yield_and_check_cancel(term_idx)
+        await yield_and_check_cancel(len(global_counts), force=True)
+
+        edge_counts = Counter()
+        for chunk_idx, terms in enumerate(per_chunk_terms, start=1):
+            uniq_terms = list(dict.fromkeys(terms))
+            edge_num = 0
+            for i, src in enumerate(uniq_terms):
+                for tgt in uniq_terms[i + 1 :]:
+                    edge_counts[tuple(sorted((src, tgt)))] += 1
+                    edge_num += 1
+                    if edge_num >= self._max_edges_per_chunk:
+                        break
+                if edge_num >= self._max_edges_per_chunk:
+                    break
+            await yield_and_check_cancel(chunk_idx)
+        await yield_and_check_cancel(len(per_chunk_terms), force=True)
+
+        relations = []
+        for edge_idx, ((src, tgt), weight) in enumerate(edge_counts.items(), start=1):
+            if src in valid_entities and tgt in valid_entities:
+                relations.append(
+                    {
+                        "src_id": src,
+                        "tgt_id": tgt,
+                        "description": f"{src} and {tgt} co-occur in {weight} chunk(s).",
+                        "keywords": ["co-occurrence", "keyword"],
+                        "weight": float(weight),
+                        "source_id": [],
+                    }
+                )
+            await yield_and_check_cancel(edge_idx)
+        await yield_and_check_cancel(len(edge_counts), force=True)
+
+        now = asyncio.get_running_loop().time()
+        msg = (
+            f"Keyword graph extraction done, {len(entities)} nodes, "
+            f"{len(relations)} edges, 0 tokens, {now - start_ts:.2f}s."
+        )
+        logger.info(
+            "Keyword graph extraction finished for doc %s: %d entities, %d relations, %.2fs.",
+            doc_id,
+            len(entities),
+            len(relations),
+            now - start_ts,
+        )
+        if callback:
+            callback(msg=msg)
+
+        return entities, relations

--- a/test/unit_test/rag/test_keyword_graph_extractor.py
+++ b/test/unit_test/rag/test_keyword_graph_extractor.py
@@ -1,0 +1,66 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+
+from rag.graphrag.keyword_extractor import KeywordGraphExtractor
+
+
+@pytest.mark.asyncio
+@pytest.mark.p2
+async def test_keyword_graph_extractor_builds_graph_without_llm_calls():
+    class _FailingLLM:
+        async def async_chat(self, *_args, **_kwargs):
+            raise AssertionError("keyword extraction must not call the LLM")
+
+    extractor = KeywordGraphExtractor(_FailingLLM(), entity_types=["category"])
+
+    entities, relations = await extractor(
+        "doc-1",
+        [
+            "GraphRAG connects Alice and OpenAI. Alice studies GraphRAG retrieval.",
+            "OpenAI builds retrieval systems. GraphRAG improves retrieval for Alice.",
+        ],
+    )
+
+    entity_names = {entity["entity_name"] for entity in entities}
+    assert "GraphRAG" in entity_names
+    assert "Alice" in entity_names
+    assert relations
+    assert all(relation["weight"] > 0 for relation in relations)
+
+
+@pytest.mark.asyncio
+@pytest.mark.p2
+async def test_keyword_graph_extractor_counts_edges_with_final_term_frequency():
+    extractor = KeywordGraphExtractor(None, entity_types=["category"])
+
+    entities, relations = await extractor(
+        "doc-1",
+        [
+            "North Harbor neural",
+            "neural systems",
+        ],
+    )
+
+    entity_names = {entity["entity_name"] for entity in entities}
+    relation_pairs = {
+        frozenset((relation["src_id"], relation["tgt_id"]))
+        for relation in relations
+    }
+
+    assert {"North Harbor", "neural"}.issubset(entity_names)
+    assert frozenset(("North Harbor", "neural")) in relation_pairs

--- a/web/src/components/parse-configuration/graph-rag-form-fields.tsx
+++ b/web/src/components/parse-configuration/graph-rag-form-fields.tsx
@@ -34,6 +34,7 @@ export const showTagItems = (parserId: DocumentParserType) => {
 
 const enum MethodValue {
   General = 'general',
+  Keyword = 'keyword',
   Light = 'light',
 }
 
@@ -122,7 +123,7 @@ const GraphRagItems = ({
   });
 
   const methodOptions = useMemo(() => {
-    return [MethodValue.Light, MethodValue.General].map((x) => ({
+    return [MethodValue.Light, MethodValue.General, MethodValue.Keyword].map((x) => ({
       value: x,
       label: upperFirst(x),
     }));

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -881,7 +881,8 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       graphRagMethod: 'Method',
       graphRagMethodTip: `
       Light: (Default) Use prompts provided by github.com/HKUDS/LightRAG to extract entities and relationships. This option consumes fewer tokens, less memory, and fewer computational resources.</br>
-      General: Use prompts provided by github.com/microsoft/graphrag to extract entities and relationships`,
+      General: Use prompts provided by github.com/microsoft/graphrag to extract entities and relationships.</br>
+      Keyword: Extract a deterministic co-occurrence graph from repeated terms without LLM calls. Entity resolution and community reports are skipped in this mode.`,
       resolution: 'Entity resolution',
       resolutionTip: `An entity deduplication switch. When enabled, the LLM will combine similar entities - e.g., '2025' and 'the year of 2025', or 'IT' and 'Information Technology' - to construct a more accurate graph`,
       community: 'Community reports',

--- a/web/src/pages/dataset/dataset-setting/index.tsx
+++ b/web/src/pages/dataset/dataset-setting/index.tsx
@@ -56,6 +56,7 @@ const initialEntityTypes = [
 
 const enum MethodValue {
   General = 'general',
+  Keyword = 'keyword',
   Light = 'light',
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #14617.

Adds a third GraphRAG ingestion method, `keyword`, for non-LLM graph extraction. The new extractor builds a deterministic term co-occurrence graph from repeated keywords and capitalized phrases, producing entities and relationships without chat model calls. Existing `light` and `general` GraphRAG modes remain unchanged, and the dataset settings method selector now exposes the new Keyword option.

Note: I attempted to branch from `upstream/test`, but the upstream repository currently advertises only `main` and `main_backup`, so this PR targets `main`.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

### Validation / real behavior proof

- `python3 -m pytest test/unit_test/rag/test_keyword_graph_extractor.py -q` passed.
- `python3 -m compileall rag/graphrag/keyword_extractor.py rag/graphrag/general/index.py test/unit_test/rag/test_keyword_graph_extractor.py` passed.
- `git diff --check` passed.
- Manual behavior proof: instantiated `KeywordGraphExtractor` with a failing dummy LLM; extraction returned nodes/edges from sample GraphRAG text without invoking `async_chat`.
- Frontend lint could not be run because this environment has Node (`v12.22.9`) but no `npm` binary.
