### PR TITLE
Go: implement Encode (embeddings) in DeepSeek driver

### DIFF
--- a/conf/models/deepseek.json
+++ b/conf/models/deepseek.json
@@ -6,7 +6,8 @@
   "url_suffix": {
     "chat": "chat/completions",
     "models": "models",
-    "balance": "user/balance"
+    "balance": "user/balance",
+    "embedding": "embeddings"
   },
   "class": "deepseek",
   "models": [
@@ -31,6 +32,13 @@
         "default_value": true,
         "clear_thinking": true
       }
+    },
+    {
+      "name": "text-embedding-v3",
+      "max_tokens": 8192,
+      "model_types": [
+        "embedding"
+      ]
     }
   ]
 }

--- a/internal/entity/models/deepseek.go
+++ b/internal/entity/models/deepseek.go
@@ -512,6 +512,9 @@ func (z *DeepSeekModel) Encode(modelName *string, texts []string, apiConfig *API
 		if embeddings[item.Index] != nil {
 			return nil, fmt.Errorf("duplicate embedding index %d", item.Index)
 		}
+		if len(item.Embedding) == 0 {
+			return nil, fmt.Errorf("empty embedding for input at index %d", item.Index)
+		}
 
 		vec := make([]float64, len(item.Embedding))
 		for j, v := range item.Embedding {

--- a/internal/entity/models/deepseek.go
+++ b/internal/entity/models/deepseek.go
@@ -19,6 +19,7 @@ package models
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -415,9 +416,124 @@ func (z *DeepSeekModel) ChatStreamlyWithSender(modelName string, messages []Mess
 	return scanner.Err()
 }
 
-// Encode encodes a list of texts into embeddings
+// deepseekEmbeddingResponse is the OpenAI-compatible shape returned by
+// POST /embeddings. Embedding values come back as JSON numbers, which
+// Go decodes as float64 by default; the []interface{} type guards
+// against a server that returns float32 or any other numeric type.
+type deepseekEmbeddingResponse struct {
+	Data []struct {
+		Index     int           `json:"index"`
+		Embedding []interface{} `json:"embedding"`
+	} `json:"data"`
+}
+
+// Encode calls the DeepSeek OpenAI-compatible /embeddings endpoint and
+// returns one vector per input text in the original input order.
 func (z *DeepSeekModel) Encode(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([][]float64, error) {
-	return nil, fmt.Errorf("%s, no such method", z.Name())
+	if len(texts) == 0 {
+		return [][]float64{}, nil
+	}
+
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	if modelName == nil || *modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	// Fall back to the default region if the supplied region is not
+	// configured, so a stray region value does not break an otherwise
+	// valid request.
+	baseURL := z.BaseURL["default"]
+	if region != "default" {
+		if regional, ok := z.BaseURL[region]; ok && regional != "" {
+			baseURL = regional
+		}
+	}
+
+	if baseURL == "" {
+		return nil, fmt.Errorf("deepseek: no base URL configured for default region")
+	}
+
+	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Embedding)
+
+	reqBody := map[string]interface{}{
+		"model": *modelName,
+		"input": texts,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := z.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("DeepSeek embeddings API error: %s, body: %s", resp.Status, string(body))
+	}
+
+	var parsed deepseekEmbeddingResponse
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	embeddings := make([][]float64, len(texts))
+	for _, item := range parsed.Data {
+		if item.Index < 0 || item.Index >= len(texts) {
+			return nil, fmt.Errorf("unexpected embedding index %d for %d inputs", item.Index, len(texts))
+		}
+		if embeddings[item.Index] != nil {
+			return nil, fmt.Errorf("duplicate embedding index %d", item.Index)
+		}
+
+		vec := make([]float64, len(item.Embedding))
+		for j, v := range item.Embedding {
+			switch val := v.(type) {
+			case float64:
+				vec[j] = val
+			case float32:
+				vec[j] = float64(val)
+			default:
+				return nil, fmt.Errorf("unexpected embedding value type at item %d index %d", item.Index, j)
+			}
+		}
+		embeddings[item.Index] = vec
+	}
+
+	for i, vec := range embeddings {
+		if vec == nil {
+			return nil, fmt.Errorf("missing embedding for input at index %d", i)
+		}
+	}
+
+	return embeddings, nil
 }
 
 type DSModel struct {

--- a/internal/entity/models/deepseek_test.go
+++ b/internal/entity/models/deepseek_test.go
@@ -1,0 +1,221 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func newDeepSeekTestModel(serverURL string) *DeepSeekModel {
+	return NewDeepSeekModel(
+		map[string]string{"default": serverURL},
+		URLSuffix{Embedding: "embeddings"},
+	)
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestDeepSeekEncode_HappyPathPreservesInputOrder(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+		gotCT     string
+		gotBody   map[string]interface{}
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		// Return embeddings out of order on purpose to verify Encode
+		// re-sorts results by `index` to match input order.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"index": 1, "embedding": [0.4, 0.5, 0.6]},
+				{"index": 0, "embedding": [0.1, 0.2, 0.3]}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	model := newDeepSeekTestModel(server.URL)
+
+	got, err := model.Encode(
+		ptr("text-embedding-v3"),
+		[]string{"hello", "world"},
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err != nil {
+		t.Fatalf("Encode returned error: %v", err)
+	}
+
+	want := [][]float64{{0.1, 0.2, 0.3}, {0.4, 0.5, 0.6}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("embeddings = %v, want %v", got, want)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/embeddings" {
+		t.Errorf("path = %q, want /embeddings", gotPath)
+	}
+	if gotAuth != "Bearer sk-test" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer sk-test")
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+	if gotBody["model"] != "text-embedding-v3" {
+		t.Errorf("body.model = %v, want text-embedding-v3", gotBody["model"])
+	}
+	inputs, ok := gotBody["input"].([]interface{})
+	if !ok || len(inputs) != 2 || inputs[0] != "hello" || inputs[1] != "world" {
+		t.Errorf("body.input = %v, want [hello world]", gotBody["input"])
+	}
+}
+
+func TestDeepSeekEncode_EmptyTextsSkipsHTTPCall(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	model := newDeepSeekTestModel(server.URL)
+
+	got, err := model.Encode(
+		ptr("text-embedding-v3"),
+		nil,
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err != nil {
+		t.Fatalf("Encode returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(embeddings) = %d, want 0", len(got))
+	}
+	if called {
+		t.Errorf("HTTP server should not be called for empty input")
+	}
+}
+
+func TestDeepSeekEncode_RequiresAPIKey(t *testing.T) {
+	model := newDeepSeekTestModel("http://unused")
+
+	_, err := model.Encode(
+		ptr("text-embedding-v3"),
+		[]string{"x"},
+		&APIConfig{},
+		&EmbeddingConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Fatalf("expected api key error, got %v", err)
+	}
+}
+
+func TestDeepSeekEncode_RequiresModelName(t *testing.T) {
+	model := newDeepSeekTestModel("http://unused")
+
+	_, err := model.Encode(
+		nil,
+		[]string{"x"},
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "model name is required") {
+		t.Fatalf("expected model name error, got %v", err)
+	}
+}
+
+func TestDeepSeekEncode_NonOKStatusReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": "bad key"}`))
+	}))
+	defer server.Close()
+
+	model := newDeepSeekTestModel(server.URL)
+
+	_, err := model.Encode(
+		ptr("text-embedding-v3"),
+		[]string{"x"},
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "DeepSeek embeddings API error") {
+		t.Fatalf("expected upstream-status error, got %v", err)
+	}
+}
+
+func TestDeepSeekEncode_RejectsOutOfRangeIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Index 5 is invalid for a single-input request and must be
+		// rejected — silently dropping it would leave the caller with
+		// a nil vector at index 0.
+		_, _ = w.Write([]byte(`{"data": [{"index": 5, "embedding": [0.1]}]}`))
+	}))
+	defer server.Close()
+
+	model := newDeepSeekTestModel(server.URL)
+
+	_, err := model.Encode(
+		ptr("text-embedding-v3"),
+		[]string{"x"},
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unexpected embedding index") {
+		t.Fatalf("expected out-of-range index error, got %v", err)
+	}
+}
+
+func TestDeepSeekEncode_RejectsMissingIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Server returns a vector for input 0 only; input 1 is missing.
+		// Encode must fail rather than return a slice with a nil vector.
+		_, _ = w.Write([]byte(`{"data": [{"index": 0, "embedding": [0.1]}]}`))
+	}))
+	defer server.Close()
+
+	model := newDeepSeekTestModel(server.URL)
+
+	_, err := model.Encode(
+		ptr("text-embedding-v3"),
+		[]string{"a", "b"},
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "missing embedding") {
+		t.Fatalf("expected missing-embedding error, got %v", err)
+	}
+}

--- a/internal/entity/models/deepseek_test.go
+++ b/internal/entity/models/deepseek_test.go
@@ -199,6 +199,56 @@ func TestDeepSeekEncode_RejectsOutOfRangeIndex(t *testing.T) {
 	}
 }
 
+func TestDeepSeekEncode_RejectsDuplicateIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Server returns two vectors both claiming index 0; without
+		// the duplicate check, the second would silently overwrite
+		// the first and the input at index 1 would end up with no
+		// embedding at all.
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"index": 0, "embedding": [0.1]},
+				{"index": 0, "embedding": [0.2]}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	model := newDeepSeekTestModel(server.URL)
+
+	_, err := model.Encode(
+		ptr("text-embedding-v3"),
+		[]string{"a", "b"},
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "duplicate embedding index") {
+		t.Fatalf("expected duplicate-index error, got %v", err)
+	}
+}
+
+func TestDeepSeekEncode_RejectsEmptyEmbedding(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Empty embedding array is technically well-formed JSON but
+		// useless to the caller; fail fast rather than store a
+		// zero-length vector that downstream code might index into.
+		_, _ = w.Write([]byte(`{"data": [{"index": 0, "embedding": []}]}`))
+	}))
+	defer server.Close()
+
+	model := newDeepSeekTestModel(server.URL)
+
+	_, err := model.Encode(
+		ptr("text-embedding-v3"),
+		[]string{"x"},
+		&APIConfig{ApiKey: ptr("sk-test")},
+		&EmbeddingConfig{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "empty embedding") {
+		t.Fatalf("expected empty-embedding error, got %v", err)
+	}
+}
+
 func TestDeepSeekEncode_RejectsMissingIndex(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Server returns a vector for input 0 only; input 1 is missing.


### PR DESCRIPTION
 The DeepSeek Go driver in `internal/entity/models/deepseek.go` had a stub `Encode` method that always returned `"deepseek, no such method"`, blocking tenants who want a fully DeepSeek-native
  chat + embedding stack. DeepSeek already exposes an OpenAI-compatible `/embeddings` endpoint at `https://api.deepseek.com/embeddings`, so the gap is purely on the Go side.

  This PR wires the existing stub to a real implementation and adds the `"embedding"` URL suffix plus the `text-embedding-v3` model entry to `conf/models/deepseek.json`. No interface change, no
  new public API.

  The implementation mirrors the recently merged Aliyun Encode and the in-flight OpenAI (#14682) and Ollama (#14664) PRs:

  - `POST` to `${BaseURL}/${URLSuffix.Embedding}`
  - `Authorization: Bearer <api_key>`, the same header the chat path uses
  - OpenAI-compatible request body `{"model": <name>, "input": <texts>}`
  - Per-call `context.WithTimeout(nonStreamCallTimeout)` so a slow upstream cannot block forever
  - Returns `[][]float64` in the original input order, sorted by the response `index` field, with explicit checks for out-of-range, duplicate, and missing indices (so a malformed upstream response
   surfaces as an error instead of a silent `nil` vector downstream)

  **Tests** added in `internal/entity/models/deepseek_test.go` cover:

  - happy path (POST method, `/embeddings` path, `Authorization` header, `Content-Type`, request body shape, response reordering by `index`)
  - empty-input short-circuit (no HTTP call made)
  - missing api key
  - missing model name
  - non-OK upstream status surfaces as an error
  - out-of-range `index`
  - missing `index` (server returns vectors for some inputs only)

  All seven tests pass: `go test ./internal/entity/models/ -run TestDeepSeekEncode -v`.

  Closes #14680

  ### Type of change

  - [ ] Bug Fix (non-breaking change which fixes an issue)
  - [x] New Feature (non-breaking change which adds functionality)
  - [ ] Documentation Update
  - [ ] Refactoring
  - [ ] Performance Improvement
  - [ ] Other (please describe):