### PR TITLE
fix(agent): pass top_k and fix similarity weight slider behavior

### DIFF
--- a/agent/tools/retrieval.py
+++ b/agent/tools/retrieval.py
@@ -201,6 +201,7 @@ class Retrieval(ToolBase, ABC):
                 self._param.top_n,
                 self._param.similarity_threshold,
                 1 - self._param.keywords_similarity_weight,
+                top=self._param.top_k,
                 doc_ids=doc_ids,
                 aggs=True,
                 rerank_mdl=rerank_mdl,

--- a/web/src/components/similarity-slider/index.tsx
+++ b/web/src/components/similarity-slider/index.tsx
@@ -16,7 +16,8 @@ import { NumberInput } from '../ui/input';
 
 interface SimilaritySliderFormFieldProps {
   similarityName?: string;
-  vectorSimilarityWeightName?: string;
+  similarityWeightName?: string;
+  similarityWeightType?: 'vector' | 'keyword';
   isTooltipShown?: boolean;
   numberInputClassName?: string;
 }
@@ -44,14 +45,21 @@ export const initialVectorSimilarityWeightValue = {
 
 export function SimilaritySliderFormField({
   similarityName = 'similarity_threshold',
-  vectorSimilarityWeightName = 'vector_similarity_weight',
+  similarityWeightName = 'vector_similarity_weight',
+  similarityWeightType = 'vector',
   isTooltipShown,
   numberInputClassName,
 }: SimilaritySliderFormFieldProps) {
   const { t } = useTranslate('knowledgeDetails');
   const form = useFormContext();
-  const isVector =
-    vectorSimilarityWeightName.indexOf('vector_similarity_weight') > -1;
+  const isVector = similarityWeightType === 'vector';
+  const normalizeWeight = (weight: number) => Number(weight.toFixed(2));
+  const getVectorWeight = (weight: number) =>
+    normalizeWeight(isVector ? weight : 1 - weight);
+  const getFullTextWeight = (weight: number) =>
+    normalizeWeight(isVector ? 1 - weight : weight);
+  const getStoredWeight = (vectorWeight: number) =>
+    normalizeWeight(isVector ? vectorWeight : 1 - vectorWeight);
 
   return (
     <>
@@ -66,7 +74,7 @@ export function SimilaritySliderFormField({
       ></SliderInputFormField>
       <FormField
         control={form.control}
-        name={vectorSimilarityWeightName}
+        name={similarityWeightName}
         defaultValue={0}
         render={({ field }) => (
           <FormItem
@@ -95,7 +103,7 @@ export function SimilaritySliderFormField({
                         vector
                       </label>
                       <span className="bg-bg-card rounded-md p-1 w-10 text-center text-xs">
-                        {field.value.toFixed(2)}
+                        {getVectorWeight(field.value).toFixed(2)}
                       </span>
                     </div>
                     <div className="flex  items-center gap-1">
@@ -103,12 +111,14 @@ export function SimilaritySliderFormField({
                         full-text
                       </label>
                       <span className="bg-bg-card rounded-md p-1 w-10 text-center text-xs">
-                        {(1 - field.value).toFixed(2)}
+                        {getFullTextWeight(field.value).toFixed(2)}
                       </span>
                     </div>
                   </div>
                   <SingleFormSlider
                     {...field}
+                    value={getVectorWeight(field.value)}
+                    onChange={(value) => field.onChange(getStoredWeight(value))}
                     max={1}
                     step={0.01}
                     min={0}
@@ -126,6 +136,8 @@ export function SimilaritySliderFormField({
                   min={0}
                   step={0.01}
                   {...field}
+                  value={getVectorWeight(field.value)}
+                  onChange={(value) => field.onChange(getStoredWeight(value))}
                 ></NumberInput>
               </FormControl>
             </div>

--- a/web/src/pages/agent/form/retrieval-form/next.tsx
+++ b/web/src/pages/agent/form/retrieval-form/next.tsx
@@ -169,7 +169,8 @@ function RetrievalForm({ node }: INextOperatorForm) {
         <Collapse title={<div>{t('flow.advancedSettings')}</div>}>
           <section className="space-y-5">
             <SimilaritySliderFormField
-              vectorSimilarityWeightName="keywords_similarity_weight"
+              similarityWeightName="keywords_similarity_weight"
+              similarityWeightType="keyword"
               isTooltipShown
             ></SimilaritySliderFormField>
             <TopNFormField></TopNFormField>

--- a/web/src/pages/agent/form/tool-form/retrieval-form/index.tsx
+++ b/web/src/pages/agent/form/tool-form/retrieval-form/index.tsx
@@ -48,7 +48,8 @@ const RetrievalForm = () => {
         <Collapse title={<div>{t('flow.advancedSettings')}</div>}>
           <FormContainer>
             <SimilaritySliderFormField
-              vectorSimilarityWeightName="keywords_similarity_weight"
+              similarityWeightName="keywords_similarity_weight"
+              similarityWeightType="keyword"
               isTooltipShown
             ></SimilaritySliderFormField>
             <TopNFormField></TopNFormField>

--- a/web/src/pages/next-search/search-setting.tsx
+++ b/web/src/pages/next-search/search-setting.tsx
@@ -417,7 +417,7 @@ const SearchSetting: React.FC<SearchSettingProps> = ({
             <SimilaritySliderFormField
               isTooltipShown
               similarityName="search_config.similarity_threshold"
-              vectorSimilarityWeightName="search_config.vector_similarity_weight"
+              similarityWeightName="search_config.vector_similarity_weight"
               numberInputClassName="rounded-sm"
             ></SimilaritySliderFormField>
             {/* Rerank Model */}


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes two issues in Agent Retrieval behavior and configuration UX:

1. `top_k` configured in Agent Retrieval was not passed down to the backend retriever call, so retrieval could ignore the configured vector recall limit.
2. Similarity weight slider semantics were confusing in Agent forms because the Agent field stores `keywords_similarity_weight` while UI interactions were interpreted as vector weight. This could cause displayed values and actual behavior to diverge.

This PR ensures Agent retrieval uses configured `top_k`, and makes the slider behavior consistent and explicit for both vector and keyword weight modes.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

