### PR TITLE
feat(go): add MiniMax embeddings support

### DIFF
--- a/conf/models/minimax.json
+++ b/conf/models/minimax.json
@@ -8,7 +8,8 @@
     "chat": "v1/text/chatcompletion_v2",
     "models": "v1/models",
     "tts": "v1/t2a_v2",
-    "files": "v1/files/list"
+    "files": "v1/files/list",
+    "embedding": "v1/embeddings"
   },
   "class": "minimax",
   "models": [
@@ -99,6 +100,13 @@
         "default_value": true,
         "clear_thinking": true
       }
+    },
+    {
+      "name": "embo-01",
+      "max_tokens": 4096,
+      "model_types": [
+        "embedding"
+      ]
     }
   ]
 }

--- a/internal/entity/models/minimax.go
+++ b/internal/entity/models/minimax.go
@@ -19,14 +19,36 @@ package models
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"ragflow/internal/common"
 	"strings"
 	"time"
 )
+
+const minimaxEmbeddingTimeout = 30 * time.Second
+
+type minimaxEmbeddingRequest struct {
+	Model string   `json:"model"`
+	Type  string   `json:"type"`
+	Texts []string `json:"texts"`
+}
+
+type minimaxBaseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+type minimaxEmbeddingResponse struct {
+	Vectors     [][]float64     `json:"vectors"`
+	Model       string          `json:"model"`
+	TotalTokens int             `json:"total_tokens"`
+	BaseResp    minimaxBaseResp `json:"base_resp"`
+}
 
 // MinimaxModel implements ModelDriver for Minimax
 type MinimaxModel struct {
@@ -53,7 +75,7 @@ func NewMinimaxModel(baseURL map[string]string, urlSuffix URLSuffix) *MinimaxMod
 }
 
 func (z *MinimaxModel) NewInstance(baseURL map[string]string) ModelDriver {
-	return nil
+	return NewMinimaxModel(baseURL, z.URLSuffix)
 }
 
 func (z *MinimaxModel) Name() string {
@@ -346,7 +368,103 @@ func (z *MinimaxModel) ChatStreamlyWithSender(modelName string, messages []Messa
 
 // Encode encodes a list of texts into embeddings
 func (z *MinimaxModel) Encode(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([][]float64, error) {
-	return nil, fmt.Errorf("not implemented")
+	if len(texts) == 0 {
+		return [][]float64{}, nil
+	}
+
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	if modelName == nil || *modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL := z.BaseURL["default"]
+	if region != "default" {
+		if regional, ok := z.BaseURL[region]; ok && regional != "" {
+			baseURL = regional
+		}
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf("minimax: no base URL configured for default region")
+	}
+
+	embeddingType := EmbeddingTypeDB
+	if embeddingConfig != nil && embeddingConfig.Type != "" {
+		embeddingType = embeddingConfig.Type
+	}
+	if embeddingType != EmbeddingTypeDB && embeddingType != EmbeddingTypeQuery {
+		return nil, fmt.Errorf("minimax: unsupported embedding type %q", embeddingType)
+	}
+
+	endpoint := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), z.URLSuffix.Embedding)
+	parsedURL, err := neturl.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse embedding URL: %w", err)
+	}
+	if region == "default" && apiConfig.GroupID != nil && *apiConfig.GroupID != "" {
+		query := parsedURL.Query()
+		query.Set("GroupId", *apiConfig.GroupID)
+		parsedURL.RawQuery = query.Encode()
+	}
+
+	reqBody := minimaxEmbeddingRequest{
+		Model: *modelName,
+		Type:  embeddingType,
+		Texts: texts,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), minimaxEmbeddingTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", parsedURL.String(), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := z.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("MiniMax embeddings API error: %s, body: %s", resp.Status, string(body))
+	}
+
+	var parsed minimaxEmbeddingResponse
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if parsed.BaseResp.StatusCode != 0 {
+		return nil, fmt.Errorf("MiniMax embeddings API error %d: %s", parsed.BaseResp.StatusCode, parsed.BaseResp.StatusMsg)
+	}
+
+	if len(parsed.Vectors) != len(texts) {
+		return nil, fmt.Errorf("MiniMax embeddings response returned %d vectors for %d inputs", len(parsed.Vectors), len(texts))
+	}
+
+	return parsed.Vectors, nil
 }
 
 func (z *MinimaxModel) ListModels(apiConfig *APIConfig) ([]string, error) {

--- a/internal/entity/models/minimax_test.go
+++ b/internal/entity/models/minimax_test.go
@@ -1,0 +1,139 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMinimaxEncodeDefaultsToDBAndAppendsGroupID(t *testing.T) {
+	apiKey := "test-key"
+	groupID := "group-123"
+	modelName := "embo-01"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/embeddings" {
+			t.Fatalf("expected /v1/embeddings, got %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("GroupId"); got != groupID {
+			t.Fatalf("expected GroupId %q, got %q", groupID, got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiKey {
+			t.Fatalf("expected bearer token, got %q", got)
+		}
+
+		var req minimaxEmbeddingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Model != modelName {
+			t.Fatalf("expected model %q, got %q", modelName, req.Model)
+		}
+		if req.Type != EmbeddingTypeDB {
+			t.Fatalf("expected default type %q, got %q", EmbeddingTypeDB, req.Type)
+		}
+		if len(req.Texts) != 2 || req.Texts[0] != "alpha" || req.Texts[1] != "beta" {
+			t.Fatalf("unexpected texts: %#v", req.Texts)
+		}
+
+		if err := json.NewEncoder(w).Encode(minimaxEmbeddingResponse{
+			Vectors: [][]float64{{0.1, 0.2}, {0.3, 0.4}},
+			BaseResp: minimaxBaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	driver := NewMinimaxModel(map[string]string{"default": server.URL}, URLSuffix{Embedding: "v1/embeddings"})
+	vectors, err := driver.Encode(&modelName, []string{"alpha", "beta"}, &APIConfig{
+		ApiKey:  &apiKey,
+		GroupID: &groupID,
+	}, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(vectors) != 2 || len(vectors[0]) != 2 || vectors[1][1] != 0.4 {
+		t.Fatalf("unexpected vectors: %#v", vectors)
+	}
+}
+
+func TestMinimaxEncodeSupportsQueryEmbeddingsWithoutGroupIDOnGlobal(t *testing.T) {
+	apiKey := "test-key"
+	groupID := "group-123"
+	modelName := "embo-01"
+	region := "global"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+		if got := r.URL.Query().Get("GroupId"); got != "" {
+			t.Fatalf("expected no GroupId for global region, got %q", got)
+		}
+
+		var req minimaxEmbeddingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Type != EmbeddingTypeQuery {
+			t.Fatalf("expected query type, got %q", req.Type)
+		}
+
+		if err := json.NewEncoder(w).Encode(minimaxEmbeddingResponse{
+			Vectors: [][]float64{{0.9, 0.8}},
+			BaseResp: minimaxBaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	driver := NewMinimaxModel(map[string]string{
+		"default": "https://api.minimaxi.com",
+		"global":  server.URL,
+	}, URLSuffix{Embedding: "v1/embeddings"})
+	vectors, err := driver.Encode(&modelName, []string{"question"}, &APIConfig{
+		ApiKey:  &apiKey,
+		Region:  &region,
+		GroupID: &groupID,
+	}, &EmbeddingConfig{Type: EmbeddingTypeQuery})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(vectors) != 1 || len(vectors[0]) != 2 || vectors[0][0] != 0.9 {
+		t.Fatalf("unexpected vectors: %#v", vectors)
+	}
+}
+
+func TestMinimaxEncodeReturnsBaseRespErrors(t *testing.T) {
+	apiKey := "test-key"
+	modelName := "embo-01"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(minimaxEmbeddingResponse{
+			BaseResp: minimaxBaseResp{
+				StatusCode: 1004,
+				StatusMsg:  "invalid request",
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	driver := NewMinimaxModel(map[string]string{"default": server.URL}, URLSuffix{Embedding: "v1/embeddings"})
+	_, err := driver.Encode(&modelName, []string{"alpha"}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || err.Error() != "MiniMax embeddings API error 1004: invalid request" {
+		t.Fatalf("expected base_resp error, got %v", err)
+	}
+}

--- a/internal/entity/models/types.go
+++ b/internal/entity/models/types.go
@@ -88,11 +88,18 @@ type ChatConfig struct {
 type APIConfig struct {
 	ApiKey *string
 	Region *string
+	GroupID *string
 }
 
 type EmbeddingConfig struct {
 	Dimension int
+	Type      string
 }
+
+const (
+	EmbeddingTypeDB    = "db"
+	EmbeddingTypeQuery = "query"
+)
 
 type RerankConfig struct {
 	TopN int

--- a/internal/handler/providers.go
+++ b/internal/handler/providers.go
@@ -243,6 +243,7 @@ type CreateProviderInstanceRequest struct {
 	InstanceName string `json:"instance_name" binding:"required"`
 	APIKey       string `json:"api_key"`
 	BaseURL      string `json:"base_url"`
+	GroupID      string `json:"group_id"`
 	Region       string `json:"region"`
 }
 
@@ -267,7 +268,7 @@ func (h *ProviderHandler) CreateProviderInstance(c *gin.Context) {
 
 	userID := c.GetString("user_id")
 
-	_, err := h.modelProviderService.CreateProviderInstance(providerName, req.InstanceName, req.APIKey, req.BaseURL, req.Region, userID)
+	_, err := h.modelProviderService.CreateProviderInstance(providerName, req.InstanceName, req.APIKey, req.BaseURL, req.GroupID, req.Region, userID)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"code":    common.CodeServerError,

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -213,7 +213,7 @@ func (m *ModelProviderService) ListSupportedModels(providerName, instanceName, u
 	return driver.ListModels(apiConfig)
 }
 
-func (m *ModelProviderService) CreateProviderInstance(providerName, instanceName, apiKey, baseURL, region, userID string) (common.ErrorCode, error) {
+func (m *ModelProviderService) CreateProviderInstance(providerName, instanceName, apiKey, baseURL, groupID, region, userID string) (common.ErrorCode, error) {
 	// Get tenant ID from user
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(userID, "owner")
 	if err != nil {
@@ -240,6 +240,7 @@ func (m *ModelProviderService) CreateProviderInstance(providerName, instanceName
 	extra := make(map[string]string)
 	extra["region"] = region
 	extra["base_url"] = baseURL
+	extra["group_id"] = groupID
 	// convert extra to string
 	extraByte, err := json.Marshal(extra)
 	if err != nil {
@@ -948,9 +949,23 @@ func (m *ModelProviderService) EmbedText(providerName, instanceName, modelName, 
 		region := extra["region"]
 		apiConfig.Region = &region
 		apiConfig.ApiKey = &instance.APIKey
+		if groupID := extra["group_id"]; groupID != "" {
+			apiConfig.GroupID = &groupID
+		}
+
+		driver := providerInfo.ModelDriver
+		if baseURL := extra["base_url"]; baseURL != "" {
+			regionKey := region
+			if regionKey == "" {
+				regionKey = "default"
+			}
+			driver = driver.NewInstance(map[string]string{
+				regionKey: baseURL,
+			})
+		}
 
 		var embeddingList [][]float64
-		embeddingList, err = providerInfo.ModelDriver.Encode(&modelName, texts, apiConfig, modelConfig)
+		embeddingList, err = driver.Encode(&modelName, texts, apiConfig, modelConfig)
 		if err != nil {
 			return nil, common.CodeServerError, err
 		}
@@ -988,9 +1003,16 @@ func (m *ModelProviderService) EmbedText(providerName, instanceName, modelName, 
 		region := extra["region"]
 		apiConfig.Region = &region
 		apiConfig.ApiKey = &instance.APIKey
+		if groupID := extra["group_id"]; groupID != "" {
+			apiConfig.GroupID = &groupID
+		}
 
+		regionKey := region
+		if regionKey == "" {
+			regionKey = "default"
+		}
 		newURL := map[string]string{
-			region: extra["base_url"],
+			regionKey: extra["base_url"],
 		}
 		newProviderInfo := providerInfo.ModelDriver.NewInstance(newURL)
 
@@ -1253,6 +1275,10 @@ func (m *ModelProviderService) getModelConfig(tenantID, compositeModelName strin
 		return nil, "", nil, 0, err
 	}
 	region := extra["region"]
+	regionKey := region
+	if regionKey == "" {
+		regionKey = "default"
+	}
 
 	providerInfo := dao.GetModelProviderManager().FindProvider(providerName)
 	if providerInfo == nil {
@@ -1274,9 +1300,29 @@ func (m *ModelProviderService) getModelConfig(tenantID, compositeModelName strin
 		}
 
 		apiConfig := &modelModule.APIConfig{ApiKey: &instance.APIKey, Region: &region}
-		return providerInfo.ModelDriver, modelName, apiConfig, maxTokens, nil
+		if groupID := extra["group_id"]; groupID != "" {
+			apiConfig.GroupID = &groupID
+		}
+
+		driver := providerInfo.ModelDriver
+		if baseURL := extra["base_url"]; baseURL != "" {
+			driver = driver.NewInstance(map[string]string{
+				regionKey: baseURL,
+			})
+		}
+		return driver, modelName, apiConfig, maxTokens, nil
 	}
 
 	apiConfig := &modelModule.APIConfig{ApiKey: &instance.APIKey, Region: &region}
-	return providerInfo.ModelDriver, modelName, apiConfig, maxTokens, nil
+	if groupID := extra["group_id"]; groupID != "" {
+		apiConfig.GroupID = &groupID
+	}
+
+	driver := providerInfo.ModelDriver
+	if baseURL := extra["base_url"]; baseURL != "" {
+		driver = driver.NewInstance(map[string]string{
+			regionKey: baseURL,
+		})
+	}
+	return driver, modelName, apiConfig, maxTokens, nil
 }

--- a/internal/service/nlp/retrieval.go
+++ b/internal/service/nlp/retrieval.go
@@ -607,7 +607,9 @@ func (s *RetrievalService) Search(ctx context.Context, req *RetrievalSearchReque
 
 // GetVector computes query vector and returns MatchDenseExpr for hybrid search
 func (s *RetrievalService) GetVector(txt string, embModel *models.EmbeddingModel, topk int, similarity float64) (*types.MatchDenseExpr, error) {
-	embeddings, err := embModel.ModelDriver.Encode(embModel.ModelName, []string{txt}, embModel.APIConfig, nil)
+	embeddings, err := embModel.ModelDriver.Encode(embModel.ModelName, []string{txt}, embModel.APIConfig, &models.EmbeddingConfig{
+		Type: models.EmbeddingTypeQuery,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/skill_indexer.go
+++ b/internal/service/skill_indexer.go
@@ -25,6 +25,7 @@ import (
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
 	"ragflow/internal/entity"
+	"ragflow/internal/entity/models"
 	"ragflow/internal/storage"
 	"ragflow/internal/tokenizer"
 	"strings"
@@ -932,7 +933,9 @@ func (s *SkillIndexerService) generateEmbedding(ctx context.Context, text, embdI
 	}
 	truncatedText := truncate(text, maxLen-10)
 
-	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, []string{truncatedText}, embeddingModel.APIConfig, nil)
+	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, []string{truncatedText}, embeddingModel.APIConfig, &models.EmbeddingConfig{
+		Type: models.EmbeddingTypeDB,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode text: %w", err)
 	}
@@ -975,7 +978,9 @@ func (s *SkillIndexerService) generateEmbeddings(ctx context.Context, texts []st
 
 	common.Info(fmt.Sprintf("Encoding %d texts", len(truncatedTexts)))
 	// Use batch encode API (consistent with Python's encode(texts: list))
-	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, truncatedTexts, embeddingModel.APIConfig, nil)
+	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, truncatedTexts, embeddingModel.APIConfig, &models.EmbeddingConfig{
+		Type: models.EmbeddingTypeDB,
+	})
 	if err != nil {
 		common.Error(fmt.Sprintf("Failed to encode texts: %v", err), err)
 		return nil, fmt.Errorf("failed to encode texts: %w", err)
@@ -1021,7 +1026,9 @@ func (s *SkillIndexerService) getEmbeddingDimension(ctx context.Context, tenantI
 
 	// Use simple test text like Python does: embedding_model.encode(["ok"])
 	testText := "ok"
-	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, []string{testText}, embeddingModel.APIConfig, nil)
+	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, []string{testText}, embeddingModel.APIConfig, &models.EmbeddingConfig{
+		Type: models.EmbeddingTypeDB,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to encode test text: %w", err)
 	}

--- a/internal/service/skill_search.go
+++ b/internal/service/skill_search.go
@@ -27,6 +27,7 @@ import (
 	"ragflow/internal/engine"
 	"ragflow/internal/engine/types"
 	"ragflow/internal/entity"
+	"ragflow/internal/entity/models"
 	"ragflow/internal/utility"
 	"strings"
 
@@ -679,7 +680,9 @@ func (s *SkillSearchService) getEmbedding(ctx context.Context, text, embdID, ten
 	}
 	truncatedText := truncate(text, maxLen-10)
 
-	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, []string{truncatedText}, embeddingModel.APIConfig, nil)
+	vectors, err := embeddingModel.ModelDriver.Encode(embeddingModel.ModelName, []string{truncatedText}, embeddingModel.APIConfig, &models.EmbeddingConfig{
+		Type: models.EmbeddingTypeQuery,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode query: %w", err)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #14716

This PR adds missing MiniMax embedding support in the Go model driver so MiniMax can be used for a full RAG workflow, not just chat.

Before this change, `internal/entity/models/minimax.go` had an `Encode` stub that always returned `not implemented`, and `conf/models/minimax.json` did not expose any embedding endpoint or embedding model. That meant tenants using MiniMax could configure chat successfully but were blocked when trying to embed document chunks for indexing or generate query embeddings for retrieval.

This PR implements MiniMax’s non-standard embeddings API in the Go driver, including its `texts` + `type` request body, `vectors` response parsing, `base_resp.status_code` success check, and a per-call timeout. It also adds the `embo-01` embedding model and the embedding URL suffix to the MiniMax model config, and wires `group_id` through provider instance config so the CN endpoint can send `?GroupId=...` when required. In addition, embedding call sites now pass the correct MiniMax embedding type: `db` for indexing and `query` for retrieval.

### Type of change

* [ ] Bug Fix (non-breaking change which fixes an issue)
* [x] New Feature (non-breaking change which adds functionality)
* [ ] Documentation Update
* [ ] Refactoring
* [ ] Performance Improvement
* [ ] Other (please describe):
