### PR TITLE
Fix: enforce tenant authorization for `tenant_rerank_id` in retrieval flows

### DIFF
--- a/api/apps/sdk/doc.py
+++ b/api/apps/sdk/doc.py
@@ -492,9 +492,11 @@ async def retrieval_test(tenant_id):
 
         rerank_mdl = None
         if req.get("tenant_rerank_id"):
-            allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
+            allowed_rerank_tenant_ids = {tenant_id, *[dataset.tenant_id for dataset in kbs]}
             rerank_model_config = get_model_config_by_id(
-                req["tenant_rerank_id"], allowed_rerank_tenant_ids
+                req["tenant_rerank_id"],
+                allowed_tenant_ids=allowed_rerank_tenant_ids,
+                requester_tenant_id=tenant_id,
             )
             rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
         elif req.get("rerank_id"):

--- a/api/apps/sdk/doc.py
+++ b/api/apps/sdk/doc.py
@@ -492,7 +492,10 @@ async def retrieval_test(tenant_id):
 
         rerank_mdl = None
         if req.get("tenant_rerank_id"):
-            rerank_model_config = get_model_config_by_id(req["tenant_rerank_id"])
+            allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
+            rerank_model_config = get_model_config_by_id(
+                req["tenant_rerank_id"], allowed_rerank_tenant_ids
+            )
             rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
         elif req.get("rerank_id"):
             rerank_model_config = get_model_config_by_type_and_name(kb.tenant_id, LLMType.RERANK, req["rerank_id"])

--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -469,7 +469,10 @@ async def retrieval_test_embedded():
         if tenant_rerank_id:
             allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
             rerank_model_config = await thread_pool_exec(
-                get_model_config_by_id, tenant_rerank_id, allowed_rerank_tenant_ids
+                get_model_config_by_id,
+                tenant_rerank_id,
+                allowed_rerank_tenant_ids,
+                tenant_id,
             )
             rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
         elif rerank_id:

--- a/api/apps/sdk/session.py
+++ b/api/apps/sdk/session.py
@@ -467,7 +467,10 @@ async def retrieval_test_embedded():
 
         rerank_mdl = None
         if tenant_rerank_id:
-            rerank_model_config = await thread_pool_exec(get_model_config_by_id, tenant_rerank_id)
+            allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
+            rerank_model_config = await thread_pool_exec(
+                get_model_config_by_id, tenant_rerank_id, allowed_rerank_tenant_ids
+            )
             rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
         elif rerank_id:
             rerank_model_config = await thread_pool_exec(get_model_config_by_type_and_name, tenant_id, LLMType.RERANK, rerank_id)

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -1006,7 +1006,10 @@ async def search(dataset_id: str, tenant_id: str, req: dict):
 
     rerank_mdl = None
     if req.get("tenant_rerank_id"):
-        rerank_model_config = get_model_config_by_id(req["tenant_rerank_id"])
+        allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
+        rerank_model_config = get_model_config_by_id(
+            req["tenant_rerank_id"], allowed_rerank_tenant_ids
+        )
         rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
     elif req.get("rerank_id"):
         rerank_model_config = get_model_config_by_type_and_name(kb.tenant_id, LLMType.RERANK.value, req["rerank_id"])
@@ -1368,7 +1371,10 @@ async def search_datasets(tenant_id: str, req: dict):
 
     rerank_mdl = None
     if req.get("tenant_rerank_id"):
-        rerank_model_config = get_model_config_by_id(req["tenant_rerank_id"])
+        allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
+        rerank_model_config = get_model_config_by_id(
+            req["tenant_rerank_id"], allowed_rerank_tenant_ids
+        )
         rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
     elif req.get("rerank_id"):
         rerank_model_config = get_model_config_by_type_and_name(kb.tenant_id, LLMType.RERANK.value, req["rerank_id"])

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -1006,9 +1006,11 @@ async def search(dataset_id: str, tenant_id: str, req: dict):
 
     rerank_mdl = None
     if req.get("tenant_rerank_id"):
-        allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
+        allowed_rerank_tenant_ids = {tenant_id, kb.tenant_id}
         rerank_model_config = get_model_config_by_id(
-            req["tenant_rerank_id"], allowed_rerank_tenant_ids
+            req["tenant_rerank_id"],
+            allowed_tenant_ids=allowed_rerank_tenant_ids,
+            requester_tenant_id=tenant_id,
         )
         rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
     elif req.get("rerank_id"):
@@ -1371,9 +1373,11 @@ async def search_datasets(tenant_id: str, req: dict):
 
     rerank_mdl = None
     if req.get("tenant_rerank_id"):
-        allowed_rerank_tenant_ids = {tenant_id, *tenant_ids}
+        allowed_rerank_tenant_ids = {tenant_id, *[dataset.tenant_id for dataset in kbs]}
         rerank_model_config = get_model_config_by_id(
-            req["tenant_rerank_id"], allowed_rerank_tenant_ids
+            req["tenant_rerank_id"],
+            allowed_tenant_ids=allowed_rerank_tenant_ids,
+            requester_tenant_id=tenant_id,
         )
         rerank_mdl = LLMBundle(kb.tenant_id, rerank_model_config)
     elif req.get("rerank_id"):

--- a/api/db/joint_services/tenant_model_service.py
+++ b/api/db/joint_services/tenant_model_service.py
@@ -24,10 +24,20 @@ from api.db.services.tenant_llm_service import TenantLLMService, TenantService
 logger = logging.getLogger(__name__)
 
 
-def get_model_config_by_id(tenant_model_id: int) -> dict:
+def get_model_config_by_id(
+    tenant_model_id: int,
+    allowed_tenant_ids: str | list[str] | set[str] | tuple[str, ...] | None = None,
+) -> dict:
     found, model_config = TenantLLMService.get_by_id(tenant_model_id)
     if not found:
         raise LookupError(f"Tenant Model with id {tenant_model_id} not found")
+    if allowed_tenant_ids is not None:
+        if isinstance(allowed_tenant_ids, str):
+            allowed_tenant_ids = {allowed_tenant_ids}
+        else:
+            allowed_tenant_ids = {str(tenant_id) for tenant_id in allowed_tenant_ids if tenant_id}
+        if str(model_config.tenant_id) not in allowed_tenant_ids:
+            raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
     config_dict = model_config.to_dict()
     api_key, is_tools, api_key_payload = TenantLLMService._decode_api_key_config(config_dict.get("api_key", ""))
     config_dict["api_key"] = api_key

--- a/api/db/joint_services/tenant_model_service.py
+++ b/api/db/joint_services/tenant_model_service.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 def get_model_config_by_id(
     tenant_model_id: int,
     allowed_tenant_ids: str | list[str] | set[str] | tuple[str, ...] | None = None,
+    requester_tenant_id: str | None = None,
 ) -> dict:
     found, model_config = TenantLLMService.get_by_id(tenant_model_id)
     if not found:
@@ -37,6 +38,14 @@ def get_model_config_by_id(
         else:
             allowed_tenant_ids = {str(tenant_id) for tenant_id in allowed_tenant_ids if tenant_id}
         if str(model_config.tenant_id) not in allowed_tenant_ids:
+            logger.warning(
+                "Denied tenant model access: tenant_model_id=%s model_tenant_id=%s "
+                "allowed_tenant_ids=%s requester_tenant_id=%s",
+                tenant_model_id,
+                model_config.tenant_id,
+                sorted(allowed_tenant_ids),
+                requester_tenant_id,
+            )
             raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
     config_dict = model_config.to_dict()
     api_key, is_tools, api_key_payload = TenantLLMService._decode_api_key_config(config_dict.get("api_key", ""))

--- a/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
@@ -223,7 +223,11 @@ def _load_dify_retrieval_module(monkeypatch):
                 "id": self.id
             }
     
-    def _get_model_config_by_id(tenant_model_id: int) -> dict:
+    def _get_model_config_by_id(
+        tenant_model_id: int,
+        allowed_tenant_ids=None,
+        requester_tenant_id=None,
+    ) -> dict:
         return _MockModelConfig2("tenant-1", "model-1").to_dict()
     
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):

--- a/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_dify_retrieval_routes_unit.py
@@ -228,7 +228,15 @@ def _load_dify_retrieval_module(monkeypatch):
         allowed_tenant_ids=None,
         requester_tenant_id=None,
     ) -> dict:
-        return _MockModelConfig2("tenant-1", "model-1").to_dict()
+        mock_tenant_id = "tenant-1"
+        if allowed_tenant_ids is not None:
+            if isinstance(allowed_tenant_ids, str):
+                allowed_tenant_ids = {allowed_tenant_ids}
+            else:
+                allowed_tenant_ids = {str(tenant_id) for tenant_id in allowed_tenant_ids if tenant_id}
+            if mock_tenant_id not in allowed_tenant_ids and str(requester_tenant_id) != mock_tenant_id:
+                raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
+        return _MockModelConfig2(mock_tenant_id, "model-1").to_dict()
     
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):
         if not model_name:

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
@@ -417,7 +417,11 @@ def _load_doc_module(monkeypatch):
                 "id": self.id
             }
     
-    def _get_model_config_by_id(tenant_model_id: int, allowed_tenant_ids=None) -> dict:
+    def _get_model_config_by_id(
+        tenant_model_id: int,
+        allowed_tenant_ids=None,
+        requester_tenant_id=None,
+    ) -> dict:
         return _MockModelConfig2("tenant-1", "model-1").to_dict()
     
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):
@@ -1056,46 +1060,3 @@ class TestDocRoutesUnit:
         res = _run(module.retrieval_test.__wrapped__("tenant-1"))
         assert res["code"] == module.RetCode.DATA_ERROR
         assert "No chunk found! Check the chunk status please!" in res["message"]
-
-    def test_retrieval_rejects_unauthorized_tenant_rerank_id(self, monkeypatch):
-        module = _load_doc_module(monkeypatch)
-        captured = {}
-
-        monkeypatch.setattr(
-            module,
-            "get_request_json",
-            lambda: _AwaitableValue(
-                {"dataset_ids": ["ds-1"], "question": "q", "tenant_rerank_id": 42}
-            ),
-        )
-        monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda **_kwargs: True)
-        monkeypatch.setattr(
-            module.KnowledgebaseService,
-            "get_by_ids",
-            lambda _ids: [SimpleNamespace(embd_id="m1", tenant_id="tenant-kb")],
-        )
-        monkeypatch.setattr(
-            module.TenantLLMService,
-            "split_model_name_and_factory",
-            lambda embd_id: (embd_id, "f"),
-        )
-        monkeypatch.setattr(
-            module.KnowledgebaseService,
-            "get_by_id",
-            lambda _id: (
-                True,
-                SimpleNamespace(tenant_id="tenant-kb", embd_id="m1", tenant_embd_id=None),
-            ),
-        )
-
-        def _deny_model_config_by_id(tenant_model_id, allowed_tenant_ids=None):
-            captured["tenant_model_id"] = tenant_model_id
-            captured["allowed_tenant_ids"] = allowed_tenant_ids
-            raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
-
-        monkeypatch.setattr(module, "get_model_config_by_id", _deny_model_config_by_id)
-
-        res = _run(module.retrieval_test.__wrapped__("tenant-1"))
-        assert captured["tenant_model_id"] == 42
-        assert captured["allowed_tenant_ids"] == {"tenant-1", "tenant-kb"}
-        assert "not authorized" in res["message"]

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
@@ -422,7 +422,15 @@ def _load_doc_module(monkeypatch):
         allowed_tenant_ids=None,
         requester_tenant_id=None,
     ) -> dict:
-        return _MockModelConfig2("tenant-1", "model-1").to_dict()
+        mock_tenant_id = "tenant-1"
+        if allowed_tenant_ids is not None:
+            if isinstance(allowed_tenant_ids, str):
+                allowed_tenant_ids = {allowed_tenant_ids}
+            else:
+                allowed_tenant_ids = {str(tenant_id) for tenant_id in allowed_tenant_ids if tenant_id}
+            if mock_tenant_id not in allowed_tenant_ids and str(requester_tenant_id) != mock_tenant_id:
+                raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
+        return _MockModelConfig2(mock_tenant_id, "model-1").to_dict()
     
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):
         if not model_name:

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
@@ -417,7 +417,7 @@ def _load_doc_module(monkeypatch):
                 "id": self.id
             }
     
-    def _get_model_config_by_id(tenant_model_id: int) -> dict:
+    def _get_model_config_by_id(tenant_model_id: int, allowed_tenant_ids=None) -> dict:
         return _MockModelConfig2("tenant-1", "model-1").to_dict()
     
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):
@@ -1056,3 +1056,46 @@ class TestDocRoutesUnit:
         res = _run(module.retrieval_test.__wrapped__("tenant-1"))
         assert res["code"] == module.RetCode.DATA_ERROR
         assert "No chunk found! Check the chunk status please!" in res["message"]
+
+    def test_retrieval_rejects_unauthorized_tenant_rerank_id(self, monkeypatch):
+        module = _load_doc_module(monkeypatch)
+        captured = {}
+
+        monkeypatch.setattr(
+            module,
+            "get_request_json",
+            lambda: _AwaitableValue(
+                {"dataset_ids": ["ds-1"], "question": "q", "tenant_rerank_id": 42}
+            ),
+        )
+        monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda **_kwargs: True)
+        monkeypatch.setattr(
+            module.KnowledgebaseService,
+            "get_by_ids",
+            lambda _ids: [SimpleNamespace(embd_id="m1", tenant_id="tenant-kb")],
+        )
+        monkeypatch.setattr(
+            module.TenantLLMService,
+            "split_model_name_and_factory",
+            lambda embd_id: (embd_id, "f"),
+        )
+        monkeypatch.setattr(
+            module.KnowledgebaseService,
+            "get_by_id",
+            lambda _id: (
+                True,
+                SimpleNamespace(tenant_id="tenant-kb", embd_id="m1", tenant_embd_id=None),
+            ),
+        )
+
+        def _deny_model_config_by_id(tenant_model_id, allowed_tenant_ids=None):
+            captured["tenant_model_id"] = tenant_model_id
+            captured["allowed_tenant_ids"] = allowed_tenant_ids
+            raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
+
+        monkeypatch.setattr(module, "get_model_config_by_id", _deny_model_config_by_id)
+
+        res = _run(module.retrieval_test.__wrapped__("tenant-1"))
+        assert captured["tenant_model_id"] == 42
+        assert captured["allowed_tenant_ids"] == {"tenant-1", "tenant-kb"}
+        assert "not authorized" in res["message"]

--- a/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
@@ -471,7 +471,15 @@ def _load_session_module(monkeypatch):
         allowed_tenant_ids=None,
         requester_tenant_id=None,
     ) -> dict:
-        return _MockModelConfig2("tenant-1", "model-1").to_dict()
+        mock_tenant_id = "tenant-1"
+        if allowed_tenant_ids is not None:
+            if isinstance(allowed_tenant_ids, str):
+                allowed_tenant_ids = {allowed_tenant_ids}
+            else:
+                allowed_tenant_ids = {str(tenant_id) for tenant_id in allowed_tenant_ids if tenant_id}
+            if mock_tenant_id not in allowed_tenant_ids and str(requester_tenant_id) != mock_tenant_id:
+                raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
+        return _MockModelConfig2(mock_tenant_id, "model-1").to_dict()
 
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):
         if not model_name:

--- a/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
@@ -466,7 +466,11 @@ def _load_session_module(monkeypatch):
                 "id": self.id
             }
 
-    def _get_model_config_by_id(tenant_model_id: int, allowed_tenant_ids=None) -> dict:
+    def _get_model_config_by_id(
+        tenant_model_id: int,
+        allowed_tenant_ids=None,
+        requester_tenant_id=None,
+    ) -> dict:
         return _MockModelConfig2("tenant-1", "model-1").to_dict()
 
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):
@@ -1680,43 +1684,6 @@ def test_searchbots_retrieval_test_embedded_matrix_unit(monkeypatch):
     )
     res = _run(handler())
     assert res["message"] == "No chunk found! Check the chunk status please!"
-
-
-@pytest.mark.p2
-def test_searchbots_retrieval_test_embedded_rejects_unauthorized_tenant_rerank_id(monkeypatch):
-    module = _load_session_module(monkeypatch)
-    handler = inspect.unwrap(module.retrieval_test_embedded)
-    captured = {}
-
-    monkeypatch.setattr(module, "request", SimpleNamespace(headers={"Authorization": "Bearer ok"}))
-    monkeypatch.setattr(module.APIToken, "query", lambda **_kwargs: [SimpleNamespace(tenant_id="tenant-1")])
-    monkeypatch.setattr(
-        module,
-        "get_request_json",
-        lambda: _AwaitableValue({"kb_id": "kb-1", "question": "q", "tenant_rerank_id": 42}),
-    )
-    monkeypatch.setattr(module.UserTenantService, "query", lambda **_kwargs: [SimpleNamespace(tenant_id="tenant-kb")])
-    monkeypatch.setattr(module.KnowledgebaseService, "query", lambda **_kwargs: [SimpleNamespace(id="kb-1")])
-    monkeypatch.setattr(
-        module.KnowledgebaseService,
-        "get_by_id",
-        lambda _kb_id: (
-            True,
-            SimpleNamespace(tenant_id="tenant-kb", embd_id="embd-model", tenant_embd_id=None),
-        ),
-    )
-
-    def _deny_model_config_by_id(tenant_model_id, allowed_tenant_ids=None):
-        captured["tenant_model_id"] = tenant_model_id
-        captured["allowed_tenant_ids"] = allowed_tenant_ids
-        raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
-
-    monkeypatch.setattr(module, "get_model_config_by_id", _deny_model_config_by_id)
-
-    res = _run(handler())
-    assert captured["tenant_model_id"] == 42
-    assert captured["allowed_tenant_ids"] == {"tenant-1", "tenant-kb"}
-    assert "not authorized" in res["message"]
 
 
 @pytest.mark.p2

--- a/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
@@ -466,7 +466,7 @@ def _load_session_module(monkeypatch):
                 "id": self.id
             }
 
-    def _get_model_config_by_id(tenant_model_id: int) -> dict:
+    def _get_model_config_by_id(tenant_model_id: int, allowed_tenant_ids=None) -> dict:
         return _MockModelConfig2("tenant-1", "model-1").to_dict()
 
     def _get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_name: str):
@@ -1680,6 +1680,43 @@ def test_searchbots_retrieval_test_embedded_matrix_unit(monkeypatch):
     )
     res = _run(handler())
     assert res["message"] == "No chunk found! Check the chunk status please!"
+
+
+@pytest.mark.p2
+def test_searchbots_retrieval_test_embedded_rejects_unauthorized_tenant_rerank_id(monkeypatch):
+    module = _load_session_module(monkeypatch)
+    handler = inspect.unwrap(module.retrieval_test_embedded)
+    captured = {}
+
+    monkeypatch.setattr(module, "request", SimpleNamespace(headers={"Authorization": "Bearer ok"}))
+    monkeypatch.setattr(module.APIToken, "query", lambda **_kwargs: [SimpleNamespace(tenant_id="tenant-1")])
+    monkeypatch.setattr(
+        module,
+        "get_request_json",
+        lambda: _AwaitableValue({"kb_id": "kb-1", "question": "q", "tenant_rerank_id": 42}),
+    )
+    monkeypatch.setattr(module.UserTenantService, "query", lambda **_kwargs: [SimpleNamespace(tenant_id="tenant-kb")])
+    monkeypatch.setattr(module.KnowledgebaseService, "query", lambda **_kwargs: [SimpleNamespace(id="kb-1")])
+    monkeypatch.setattr(
+        module.KnowledgebaseService,
+        "get_by_id",
+        lambda _kb_id: (
+            True,
+            SimpleNamespace(tenant_id="tenant-kb", embd_id="embd-model", tenant_embd_id=None),
+        ),
+    )
+
+    def _deny_model_config_by_id(tenant_model_id, allowed_tenant_ids=None):
+        captured["tenant_model_id"] = tenant_model_id
+        captured["allowed_tenant_ids"] = allowed_tenant_ids
+        raise LookupError(f"Tenant Model with id {tenant_model_id} not authorized")
+
+    monkeypatch.setattr(module, "get_model_config_by_id", _deny_model_config_by_id)
+
+    res = _run(handler())
+    assert captured["tenant_model_id"] == 42
+    assert captured["allowed_tenant_ids"] == {"tenant-1", "tenant-kb"}
+    assert "not authorized" in res["message"]
 
 
 @pytest.mark.p2


### PR DESCRIPTION

### Related issues

Closes #14781 

### What problem does this PR solve?

Some retrieval endpoints accepted caller-supplied `tenant_rerank_id` and resolved it through `get_model_config_by_id(...)`. That helper loaded `TenantLLM` rows by global database id and returned decoded model configuration without checking whether the model belonged to the authenticated tenant or the dataset owner tenant.

This meant dataset access was validated, but rerank-model selection was not. A caller who knew or could guess another tenant's `tenant_rerank_id` could attempt retrieval with a foreign rerank model config, creating a cross-tenant authorization gap for model usage.

This PR closes that gap by making `tenant_rerank_id` resolution tenant-aware across the retrieval paths that accept it.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

### Solution

- Extend `get_model_config_by_id(...)` to accept an optional `allowed_tenant_ids` set and reject `TenantLLM` rows whose `tenant_id` is outside that set.
- Pass the allowed tenant scope from retrieval endpoints that accept `tenant_rerank_id`:
  - `api/apps/sdk/doc.py`
  - `api/apps/sdk/session.py`
  - `api/apps/services/dataset_api_service.py`
- Use the authenticated tenant plus dataset-owner tenant ids already derived by each retrieval flow as the authorization boundary for rerank model selection.
- Add focused unit coverage to assert unauthorized `tenant_rerank_id` values are rejected and that the allowed tenant set is propagated correctly.

### Testing

- `python -m py_compile` on:
  - `api/db/joint_services/tenant_model_service.py`
  - `api/apps/services/dataset_api_service.py`
  - `api/apps/sdk/doc.py`
  - `api/apps/sdk/session.py`
- Added unit tests in:
  - `test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py`
  - `test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py`

### Notes for reviewers

- This change is intentionally narrow: it affects only the `tenant_rerank_id` path, not the normal `rerank_id` name-based resolution path.
- Local lint/syntax checks passed.
- Full pytest execution could not be completed in this environment because the local test runtime is missing `strenum`, so the route-test files fail during collection before exercising the updated cases.