### PR TITLE
fix: remove duplicate .wav and .aac in audio supported extensions list

### DIFF
--- a/rag/app/audio.py
+++ b/rag/app/audio.py
@@ -35,8 +35,8 @@ def chunk(filename, binary, tenant_id, lang, callback=None, **kwargs):
         if not ext:
             raise RuntimeError("No extension detected.")
 
-        if ext not in [".da", ".wave", ".wav", ".mp3", ".wav", ".aac", ".flac", ".ogg", ".aiff", ".au", ".midi", ".wma",
-                       ".realaudio", ".vqf", ".oggvorbis", ".aac", ".ape"]:
+        if ext not in [".da", ".wave", ".wav", ".mp3", ".aac", ".flac", ".ogg", ".aiff", ".au", ".midi", ".wma",
+                       ".realaudio", ".vqf", ".oggvorbis", ".ape"]:
             raise RuntimeError(f"Extension {ext} is not supported yet.")
 
         tmp_path = ""


### PR DESCRIPTION
What problem does this PR solve?

In rag/app/audio.py, the supported audio extensions list contains duplicate entries: .wav appears twice (positions 3 and 5) and .aac appears twice (positions 6 and 14). While this does not affect runtime
behavior, it is redundant and makes the code harder to maintain.

This PR removes the duplicate entries to keep the list clean and consistent.

Type of change

 - [X]  Bug Fix (non-breaking change which fixes an issue)