### PR TITLE
fix: require auth and tenant check on /thumbnails endpoint (CWE-287)

### DIFF
--- a/api/apps/restful_apis/document_api.py
+++ b/api/apps/restful_apis/document_api.py
@@ -23,7 +23,7 @@ from quart import request, make_response
 from peewee import OperationalError
 from pydantic import ValidationError
 
-from api.apps import login_required
+from api.apps import current_user, login_required
 from api.constants import FILE_NAME_LEN_LIMIT, IMG_BASE64_PREFIX
 from api.apps.services.document_api_service import validate_document_update_fields, map_doc_keys, \
     map_doc_keys_with_run_status, update_document_name_only, update_chunk_method, update_document_status_only, \
@@ -1180,6 +1180,7 @@ async def update_metadata_config(tenant_id, dataset_id, document_id):
 
 
 @manager.route("/thumbnails", methods=["GET"])  # noqa: F821
+@login_required
 def list_thumbnails():
     """
     Get thumbnails for documents.
@@ -1204,6 +1205,10 @@ def list_thumbnails():
     doc_ids = request.args.getlist("doc_ids")
     if not doc_ids:
         return get_json_result(data=False, message='Lack of "Document ID"', code=RetCode.ARGUMENT_ERROR)
+
+    for doc_id in doc_ids:
+        if not DocumentService.accessible(doc_id, current_user.id):
+            return get_json_result(data=False, message="No authorization.", code=RetCode.AUTHENTICATION_ERROR)
 
     try:
         docs = DocumentService.get_thumbnails(doc_ids)

--- a/api/apps/restful_apis/document_api.py
+++ b/api/apps/restful_apis/document_api.py
@@ -1208,6 +1208,10 @@ def list_thumbnails():
 
     for doc_id in doc_ids:
         if not DocumentService.accessible(doc_id, current_user.id):
+            logging.warning(
+                "thumbnail access denied: user_id=%s doc_id=%s path=%s",
+                current_user.id, doc_id, request.path,
+            )
             return get_json_result(data=False, message="No authorization.", code=RetCode.AUTHENTICATION_ERROR)
 
     try:


### PR DESCRIPTION
## Summary

The `GET /api/v1/thumbnails` endpoint introduced in #14344 (`api/apps/restful_apis/document_api.py`) is missing authentication. Every other route in the same file — and the equivalent route in the legacy `document_app.py` — is protected by `@login_required` and performs a tenant-scoped access check. This one isn't.

The result is that anyone who can reach the API can submit arbitrary `doc_ids` and receive a `{doc_id: thumbnail_path}` mapping, which leaks `kb_id` values, thumbnail filenames, and confirms the existence of document IDs across tenants. Because RAGFlow binds to `0.0.0.0` by default, this is reachable on internet-exposed deployments.

- **CWE-287** — Improper Authentication
- **File / function:** `api/apps/restful_apis/document_api.py` → `list_thumbnails()`
- **Severity:** Medium (unauthenticated information disclosure across tenants)
- **Introduced in:** #14344

## Fix

Two minimal changes, mirroring the patterns already used by neighboring routes in the same file:

1. Add `@login_required` to the route.
2. For each requested `doc_id`, call `DocumentService.accessible(doc_id, current_user.id)` and return `AUTHENTICATION_ERROR` if the current user does not have access to it.

```python
@manager.route("/thumbnails", methods=["GET"])  # noqa: F821
@login_required
def list_thumbnails():
    ...
    for doc_id in doc_ids:
        if not DocumentService.accessible(doc_id, current_user.id):
            return get_json_result(data=False, message="No authorization.", code=RetCode.AUTHENTICATION_ERROR)
```

This matches exactly how `DocumentService.accessible` is used throughout the rest of the codebase for per-document authorization.

Diff is 6 added / 1 changed line in a single file.

## What was tested

- Verified via `grep` that `list_thumbnails` was the only route in `restful_apis/document_api.py` without `@login_required`; the neighboring routes (`/list`, `/run`, `/change_status`, `/rm`, etc.) all use the same `login_required` + `DocumentService.accessible(...)` pattern this PR adopts.
- Confirmed `DocumentService.accessible(doc_id, current_user.id)` is the standard tenant-scoped check used by other endpoints in the file.
- Confirmed `current_user` is already exported from `api.apps` and used elsewhere in this module.
- Confirmed the legacy `api/apps/document_app.py` thumbnails endpoint (pre-migration) also required login, so this restores the prior security posture rather than changing intended behavior.

## Security analysis

Pre-fix, an unauthenticated attacker on the network can:
1. GET `/api/v1/thumbnails?doc_ids=<id>` with any document IDs (or enumerate via brute force / leaks from other endpoints).
2. Receive a JSON map of `{doc_id: "<kb_id>/<filename>"}` for any document ID that exists, regardless of which tenant owns it.

That gives the attacker:
- Confirmation of valid document IDs (oracle for further attacks).
- Knowledge base IDs (`kb_id`) belonging to other tenants.
- Thumbnail filenames stored in the object store.

Post-fix, the request requires a valid session and each `doc_id` must belong to a tenant the caller has access to.

### Adversarial review

Before submitting, we tried to disprove this. Specifically: (a) is there an upstream auth gate (e.g. nginx, a Quart `before_request`) that protects this route despite the missing decorator? There isn't — the other routes in this file rely solely on `@login_required`, and removing it from any of them would expose them too. (b) Are `doc_id` values unguessable enough to make this benign? They are UUID-like, but the endpoint still functions as an existence/enumeration oracle and leaks `kb_id` plus filenames once an ID is known (e.g. from logs, referrer leaks, or another endpoint), so it's a real issue independent of brute-force feasibility. (c) Does `DocumentService.get_thumbnails` itself enforce access? It does not — it's a plain DB lookup by ID.

## Notes

A previous version of this PR (#13822) was opened against an earlier commit and later closed for inactivity. This is a fresh submission rebased onto current `main` with the same minimal fix. Happy to adjust naming, error code, or split per reviewer preference.