### PR TITLE
Go: implement provider: LongCat

### DIFF
--- a/conf/models/longcat.json
+++ b/conf/models/longcat.json
@@ -1,0 +1,34 @@
+{
+  "name": "LongCat",
+  "url": {
+    "default": "https://api.longcat.chat/openai/v1"
+  },
+  "url_suffix": {
+    "chat": "chat/completions",
+    "models": "models"
+  },
+  "class": "longcat",
+  "models": [
+    {
+      "name": "LongCat-Flash-Chat",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "LongCat-Flash-Lite",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "LongCat-Flash-Thinking",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ]
+    }
+  ]
+}

--- a/conf/models/longcat.json
+++ b/conf/models/longcat.json
@@ -1,10 +1,10 @@
 {
   "name": "LongCat",
   "url": {
-    "default": "https://api.longcat.chat/openai"
+    "default": "https://api.longcat.chat"
   },
   "url_suffix": {
-    "chat": "v1/chat/completions"
+    "chat": "openai/v1/chat/completions"
   },
   "class": "longcat",
   "models": [

--- a/conf/models/longcat.json
+++ b/conf/models/longcat.json
@@ -1,11 +1,10 @@
 {
   "name": "LongCat",
   "url": {
-    "default": "https://api.longcat.chat/openai/v1"
+    "default": "https://api.longcat.chat/openai"
   },
   "url_suffix": {
-    "chat": "chat/completions",
-    "models": "models"
+    "chat": "v1/chat/completions"
   },
   "class": "longcat",
   "models": [
@@ -24,7 +23,21 @@
       ]
     },
     {
-      "name": "LongCat-Flash-Thinking",
+      "name": "LongCat-Flash-Thinking-2601",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "LongCat-Flash-Omni-2603",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "LongCat-2.0-Preview",
       "max_tokens": 131072,
       "model_types": [
         "chat"

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -83,6 +83,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewBaichuanModel(baseURL, urlSuffix), nil
 	case "jina":
 		return NewJinaModel(baseURL, urlSuffix), nil
+	case "longcat":
+		return NewLongCatModel(baseURL, urlSuffix), nil
 	default:
 		return NewDummyModel(baseURL, urlSuffix), nil
 	}

--- a/internal/entity/models/longcat.go
+++ b/internal/entity/models/longcat.go
@@ -1,0 +1,514 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// LongCatModel implements ModelDriver for LongCat (Meituan).
+//
+// LongCat exposes an OpenAI-compatible REST API at
+// https://api.longcat.chat/openai/v1 (chat completions at
+// /chat/completions, list models at /models). The wire shape matches
+// the OpenAI o-series convention closely: response/delta carry
+// reasoning_content alongside content for the LongCat-Flash-Thinking
+// model. Embeddings / rerank / audio / OCR are not exposed.
+type LongCatModel struct {
+	BaseURL    map[string]string
+	URLSuffix  URLSuffix
+	httpClient *http.Client
+}
+
+// NewLongCatModel creates a new LongCat model instance.
+//
+// We clone http.DefaultTransport so we keep Go's defaults for
+// ProxyFromEnvironment, DialContext (with KeepAlive), HTTP/2,
+// TLSHandshakeTimeout, and ExpectContinueTimeout, and only override
+// the connection-pool fields we care about.
+//
+// The Client itself has no Timeout. http.Client.Timeout would also
+// cap the time spent reading the response body, which would cut off
+// long-lived SSE streams in ChatStreamlyWithSender. Non-streaming
+// callers wrap each request with context.WithTimeout instead.
+func NewLongCatModel(baseURL map[string]string, urlSuffix URLSuffix) *LongCatModel {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.DisableCompression = false
+	transport.ResponseHeaderTimeout = 60 * time.Second
+
+	return &LongCatModel{
+		BaseURL:   baseURL,
+		URLSuffix: urlSuffix,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+}
+
+func (l *LongCatModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewLongCatModel(baseURL, l.URLSuffix)
+}
+
+func (l *LongCatModel) Name() string {
+	return "longcat"
+}
+
+// baseURLForRegion returns the base URL for the given region, or an
+// error if no entry exists. This makes a misconfigured region fail
+// fast with a clear message, instead of silently producing a relative
+// URL that the HTTP transport then rejects.
+func (l *LongCatModel) baseURLForRegion(region string) (string, error) {
+	base, ok := l.BaseURL[region]
+	if !ok || base == "" {
+		return "", fmt.Errorf("longcat: no base URL configured for region %q", region)
+	}
+	return base, nil
+}
+
+// ChatWithMessages sends multiple messages with roles and returns the response.
+func (l *LongCatModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := l.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, l.URLSuffix.Chat)
+
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   false,
+	}
+
+	// Note: do NOT propagate chatModelConfig.Stream into the request body
+	// here. ChatWithMessages parses a single JSON response, so stream must
+	// always be off for this code path.
+	if chatModelConfig != nil {
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+		// LongCat-Flash-Thinking accepts reasoning_effort=low|medium|high
+		// to trade latency for chain-of-thought depth, matching the
+		// OpenAI o-series shape. Non-reasoning LongCat models ignore it.
+		if chatModelConfig.Effort != nil && *chatModelConfig.Effort != "" {
+			reqBody["reasoning_effort"] = *chatModelConfig.Effort
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	firstChoice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid choice format")
+	}
+
+	messageMap, ok := firstChoice["message"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid message format")
+	}
+
+	content, ok := messageMap["content"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid content format")
+	}
+
+	// LongCat-Flash-Thinking returns the chain-of-thought in a
+	// `reasoning_content` field on the message (OpenAI o-series shape,
+	// also used by kimi-k2.6 and DeepSeek-R1). Pass it through when
+	// present so callers can surface reasoning to the UI. Absent or
+	// non-string means no reasoning was emitted — leave it empty.
+	reasonContent := ""
+	if r, ok := messageMap["reasoning_content"].(string); ok {
+		reasonContent = r
+	}
+
+	return &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+	}, nil
+}
+
+// ChatStreamlyWithSender sends messages and streams the response via the
+// sender function. The LongCat SSE stream uses the same shape as the
+// OpenAI o-series: "data:" lines carrying JSON events with
+// delta.content for the visible answer and delta.reasoning_content for
+// the chain-of-thought (LongCat-Flash-Thinking only), terminated by
+// a [DONE] line.
+func (l *LongCatModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := l.baseURLForRegion(region)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, l.URLSuffix.Chat)
+
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   true,
+	}
+
+	if chatModelConfig != nil {
+		// Refuse to run if the caller explicitly asked for stream=false.
+		// The body of this method only knows how to read SSE, so a
+		// non-SSE JSON response would be parsed as if it were a stream
+		// and produce no chunks. Better to fail clearly.
+		if chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+			return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+		}
+
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+		if chatModelConfig.Effort != nil && *chatModelConfig.Effort != "" {
+			reqBody["reasoning_effort"] = *chatModelConfig.Effort
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// SSE streams are long-lived. Rely on the transport's
+	// ResponseHeaderTimeout to cap the connection-establishment phase
+	// instead of attaching a hard deadline here.
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// SSE parsing: bump the scanner buffer from the 64KB default to 1MB
+	// so we never silently truncate a long data: line.
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	sawTerminal := false
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimSpace(line[5:])
+
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event map[string]interface{}
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+
+		choices, ok := event["choices"].([]interface{})
+		if !ok || len(choices) == 0 {
+			continue
+		}
+
+		firstChoice, ok := choices[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		delta, ok := firstChoice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Reasoning chunks first, content second. When an SSE event
+		// carries both, callers that pipe them to a UI render the
+		// chain-of-thought before the answer for that token, matching
+		// the wire ordering LongCat-Flash-Thinking emits.
+		if r, ok := delta["reasoning_content"].(string); ok && r != "" {
+			if err := sender(nil, &r); err != nil {
+				return err
+			}
+		}
+
+		content, ok := delta["content"].(string)
+		if ok && content != "" {
+			if err := sender(&content, nil); err != nil {
+				return err
+			}
+		}
+
+		finishReason, ok := firstChoice["finish_reason"].(string)
+		if ok && finishReason != "" {
+			sawTerminal = true
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("longcat: stream ended before [DONE] or finish_reason")
+	}
+
+	endOfStream := "[DONE]"
+	if err := sender(&endOfStream, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ListModels returns the list of model ids visible to the API key.
+func (l *LongCatModel) ListModels(apiConfig *APIConfig) ([]string, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := l.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, l.URLSuffix.Models)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	data, ok := result["data"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid models list format")
+	}
+
+	models := make([]string, 0)
+	for _, model := range data {
+		modelMap, ok := model.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		modelName, ok := modelMap["id"].(string)
+		if !ok {
+			continue
+		}
+		models = append(models, modelName)
+	}
+
+	return models, nil
+}
+
+// CheckConnection runs a lightweight ListModels call to verify the API key.
+func (l *LongCatModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := l.ListModels(apiConfig)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Embed is not exposed by the LongCat API. The /v1/embeddings endpoint
+// does not exist on api.longcat.chat; this returns the documented
+// sentinel.
+func (l *LongCatModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	return nil, fmt.Errorf("%s, no such method", l.Name())
+}
+
+// Rerank is not exposed by the LongCat API.
+func (l *LongCatModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", l.Name())
+}
+
+// Balance is not exposed by the LongCat API.
+func (l *LongCatModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", l.Name())
+}
+
+// TranscribeAudio (ASR) is not exposed by the LongCat API.
+func (l *LongCatModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", l.Name())
+}
+
+func (l *LongCatModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", l.Name())
+}
+
+// AudioSpeech (TTS) is not exposed by the LongCat API.
+func (l *LongCatModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, asrConfig *TTSConfig) (*TTSResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", l.Name())
+}
+
+func (l *LongCatModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", l.Name())
+}
+
+// OCRFile is not exposed by the LongCat API.
+func (l *LongCatModel) OCRFile(modelName *string, fileContent *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", l.Name())
+}

--- a/internal/entity/models/longcat.go
+++ b/internal/entity/models/longcat.go
@@ -48,22 +48,6 @@ type LongCatModel struct {
 	httpClient *http.Client
 }
 
-// longcatKnownModels is the set of models the LongCat platform docs
-// list under https://longcat.chat/platform/docs/Models.html. The
-// platform does not expose a /models endpoint, so we ship the catalog
-// instead of probing it.
-var longcatKnownModels = []string{
-	"LongCat-Flash-Chat",
-	"LongCat-Flash-Lite",
-	"LongCat-Flash-Thinking-2601",
-	"LongCat-Flash-Omni-2603",
-	"LongCat-2.0-Preview",
-}
-
-// longcatPingModel is the cheapest documented model; used by
-// CheckConnection to verify credentials with a minimal request.
-const longcatPingModel = "LongCat-Flash-Lite"
-
 // NewLongCatModel creates a new LongCat model instance.
 //
 // We clone http.DefaultTransport so we keep Go's defaults for
@@ -420,44 +404,23 @@ func (l *LongCatModel) ChatStreamlyWithSender(modelName string, messages []Messa
 	return nil
 }
 
-// ListModels returns the catalog of LongCat models. The LongCat
-// platform does not document a /models endpoint, so we return the
-// statically shipped list instead of issuing a network call.
-//
-// API key is still required so that misconfigured providers surface
-// the same authentication error here as on the chat path. The
-// region is also validated up-front: without this guard, a tenant
-// who picks a region with no configured base URL would see ListModels
-// succeed but then fail later on the first chat/embed call.
+// ListModels is not exposed by the LongCat platform. The official
+// docs at https://longcat.chat/platform/docs/APIDocs.html only
+// document /openai/v1/chat/completions and /anthropic/v1/messages;
+// no /models endpoint exists. The shipped catalog lives in
+// conf/models/longcat.json; this driver method does not invent a
+// fake one.
 func (l *LongCatModel) ListModels(apiConfig *APIConfig) ([]string, error) {
-	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
-		return nil, fmt.Errorf("api key is required")
-	}
-	region := "default"
-	if apiConfig.Region != nil && *apiConfig.Region != "" {
-		region = *apiConfig.Region
-	}
-	if _, err := l.baseURLForRegion(region); err != nil {
-		return nil, err
-	}
-	out := make([]string, len(longcatKnownModels))
-	copy(out, longcatKnownModels)
-	return out, nil
+	return nil, fmt.Errorf("%s, no such method", l.Name())
 }
 
-// CheckConnection verifies credentials by issuing a 1-token chat
-// completion against the cheapest documented model. ListModels can't
-// validate the key (no /models endpoint), so we hit the documented
-// chat endpoint instead.
+// CheckConnection is not exposed by the LongCat platform. With no
+// documented /models or /health endpoint, there is no cheap way to
+// verify the API key without burning a real chat completion against
+// a tenant's quota. Return the documented sentinel rather than
+// pretend.
 func (l *LongCatModel) CheckConnection(apiConfig *APIConfig) error {
-	maxTokens := 1
-	_, err := l.ChatWithMessages(
-		longcatPingModel,
-		[]Message{{Role: "user", Content: "ping"}},
-		apiConfig,
-		&ChatConfig{MaxTokens: &maxTokens},
-	)
-	return err
+	return fmt.Errorf("%s, no such method", l.Name())
 }
 
 // Embed is not exposed by the LongCat API. The /v1/embeddings endpoint

--- a/internal/entity/models/longcat.go
+++ b/internal/entity/models/longcat.go
@@ -30,17 +30,39 @@ import (
 
 // LongCatModel implements ModelDriver for LongCat (Meituan).
 //
-// LongCat exposes an OpenAI-compatible REST API at
-// https://api.longcat.chat/openai/v1 (chat completions at
-// /chat/completions, list models at /models). The wire shape matches
-// the OpenAI o-series convention closely: response/delta carry
-// reasoning_content alongside content for the LongCat-Flash-Thinking
-// model. Embeddings / rerank / audio / OCR are not exposed.
+// LongCat exposes an OpenAI-compatible chat completions endpoint at
+// https://api.longcat.chat/openai/v1/chat/completions. The official
+// docs (https://longcat.chat/platform/docs/APIDocs.html) only describe
+// the chat-completions surface — no /models, /embeddings, /rerank,
+// /audio, or /ocr endpoints are advertised. The wire shape matches the
+// OpenAI convention: response/delta carry reasoning_content alongside
+// content for thinking models.
+//
+// Documented request fields are limited to: model, messages, stream,
+// max_tokens, temperature, top_p. Sending other OpenAI-style fields
+// (stop, reasoning_effort, etc.) is not documented and is therefore
+// omitted to avoid relying on undocumented upstream behavior.
 type LongCatModel struct {
 	BaseURL    map[string]string
 	URLSuffix  URLSuffix
 	httpClient *http.Client
 }
+
+// longcatKnownModels is the set of models the LongCat platform docs
+// list under https://longcat.chat/platform/docs/Models.html. The
+// platform does not expose a /models endpoint, so we ship the catalog
+// instead of probing it.
+var longcatKnownModels = []string{
+	"LongCat-Flash-Chat",
+	"LongCat-Flash-Lite",
+	"LongCat-Flash-Thinking-2601",
+	"LongCat-Flash-Omni-2603",
+	"LongCat-2.0-Preview",
+}
+
+// longcatPingModel is the cheapest documented model; used by
+// CheckConnection to verify credentials with a minimal request.
+const longcatPingModel = "LongCat-Flash-Lite"
 
 // NewLongCatModel creates a new LongCat model instance.
 //
@@ -128,6 +150,11 @@ func (l *LongCatModel) ChatWithMessages(modelName string, messages []Message, ap
 	// Note: do NOT propagate chatModelConfig.Stream into the request body
 	// here. ChatWithMessages parses a single JSON response, so stream must
 	// always be off for this code path.
+	//
+	// Only the fields documented at
+	// https://longcat.chat/platform/docs/APIDocs.html are forwarded.
+	// Other ChatConfig fields (Stop, Effort, ...) are dropped on the
+	// floor because the upstream behavior is undefined.
 	if chatModelConfig != nil {
 		if chatModelConfig.MaxTokens != nil {
 			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
@@ -137,15 +164,6 @@ func (l *LongCatModel) ChatWithMessages(modelName string, messages []Message, ap
 		}
 		if chatModelConfig.TopP != nil {
 			reqBody["top_p"] = *chatModelConfig.TopP
-		}
-		if chatModelConfig.Stop != nil {
-			reqBody["stop"] = *chatModelConfig.Stop
-		}
-		// LongCat-Flash-Thinking accepts reasoning_effort=low|medium|high
-		// to trade latency for chain-of-thought depth, matching the
-		// OpenAI o-series shape. Non-reasoning LongCat models ignore it.
-		if chatModelConfig.Effort != nil && *chatModelConfig.Effort != "" {
-			reqBody["reasoning_effort"] = *chatModelConfig.Effort
 		}
 	}
 
@@ -274,6 +292,7 @@ func (l *LongCatModel) ChatStreamlyWithSender(modelName string, messages []Messa
 			return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
 		}
 
+		// Only documented fields are forwarded; see ChatWithMessages.
 		if chatModelConfig.MaxTokens != nil {
 			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
 		}
@@ -282,12 +301,6 @@ func (l *LongCatModel) ChatStreamlyWithSender(modelName string, messages []Messa
 		}
 		if chatModelConfig.TopP != nil {
 			reqBody["top_p"] = *chatModelConfig.TopP
-		}
-		if chatModelConfig.Stop != nil {
-			reqBody["stop"] = *chatModelConfig.Stop
-		}
-		if chatModelConfig.Effort != nil && *chatModelConfig.Effort != "" {
-			reqBody["reasoning_effort"] = *chatModelConfig.Effort
 		}
 	}
 
@@ -396,81 +409,34 @@ func (l *LongCatModel) ChatStreamlyWithSender(modelName string, messages []Messa
 	return nil
 }
 
-// ListModels returns the list of model ids visible to the API key.
+// ListModels returns the catalog of LongCat models. The LongCat
+// platform does not document a /models endpoint, so we return the
+// statically shipped list instead of issuing a network call.
+//
+// API key is still required so that misconfigured providers surface
+// the same authentication error here as on the chat path.
 func (l *LongCatModel) ListModels(apiConfig *APIConfig) ([]string, error) {
 	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
 		return nil, fmt.Errorf("api key is required")
 	}
-
-	region := "default"
-	if apiConfig.Region != nil && *apiConfig.Region != "" {
-		region = *apiConfig.Region
-	}
-
-	baseURL, err := l.baseURLForRegion(region)
-	if err != nil {
-		return nil, err
-	}
-	url := fmt.Sprintf("%s/%s", baseURL, l.URLSuffix.Models)
-
-	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
-
-	resp, err := l.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var result map[string]interface{}
-	if err = json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	data, ok := result["data"].([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("invalid models list format")
-	}
-
-	models := make([]string, 0)
-	for _, model := range data {
-		modelMap, ok := model.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		modelName, ok := modelMap["id"].(string)
-		if !ok {
-			continue
-		}
-		models = append(models, modelName)
-	}
-
-	return models, nil
+	out := make([]string, len(longcatKnownModels))
+	copy(out, longcatKnownModels)
+	return out, nil
 }
 
-// CheckConnection runs a lightweight ListModels call to verify the API key.
+// CheckConnection verifies credentials by issuing a 1-token chat
+// completion against the cheapest documented model. ListModels can't
+// validate the key (no /models endpoint), so we hit the documented
+// chat endpoint instead.
 func (l *LongCatModel) CheckConnection(apiConfig *APIConfig) error {
-	_, err := l.ListModels(apiConfig)
-	if err != nil {
-		return err
-	}
-	return nil
+	maxTokens := 1
+	_, err := l.ChatWithMessages(
+		longcatPingModel,
+		[]Message{{Role: "user", Content: "ping"}},
+		apiConfig,
+		&ChatConfig{MaxTokens: &maxTokens},
+	)
+	return err
 }
 
 // Embed is not exposed by the LongCat API. The /v1/embeddings endpoint

--- a/internal/entity/models/longcat.go
+++ b/internal/entity/models/longcat.go
@@ -352,7 +352,18 @@ func (l *LongCatModel) ChatStreamlyWithSender(modelName string, messages []Messa
 
 		var event map[string]interface{}
 		if err = json.Unmarshal([]byte(data), &event); err != nil {
-			continue
+			// A malformed frame can mean a truncated SSE event or an
+			// upstream incident; either way, the caller is better
+			// served by a hard failure than by silent partial output.
+			return fmt.Errorf("longcat: invalid SSE event: %w", err)
+		}
+
+		// LongCat (like other OpenAI-compatible upstreams) can emit a
+		// terminal `{"error": ...}` frame instead of a normal choices
+		// chunk when something goes wrong mid-stream. Surface it
+		// instead of falling through to the choices-missing branch.
+		if apiErr, ok := event["error"]; ok {
+			return fmt.Errorf("longcat: upstream stream error: %v", apiErr)
 		}
 
 		choices, ok := event["choices"].([]interface{})
@@ -414,10 +425,20 @@ func (l *LongCatModel) ChatStreamlyWithSender(modelName string, messages []Messa
 // statically shipped list instead of issuing a network call.
 //
 // API key is still required so that misconfigured providers surface
-// the same authentication error here as on the chat path.
+// the same authentication error here as on the chat path. The
+// region is also validated up-front: without this guard, a tenant
+// who picks a region with no configured base URL would see ListModels
+// succeed but then fail later on the first chat/embed call.
 func (l *LongCatModel) ListModels(apiConfig *APIConfig) ([]string, error) {
 	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
 		return nil, fmt.Errorf("api key is required")
+	}
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+	if _, err := l.baseURLForRegion(region); err != nil {
+		return nil, err
 	}
 	out := make([]string, len(longcatKnownModels))
 	copy(out, longcatKnownModels)

--- a/internal/entity/models/longcat_test.go
+++ b/internal/entity/models/longcat_test.go
@@ -45,7 +45,7 @@ func newLongCatServer(t *testing.T, expectedPath string, handler func(t *testing
 func newLongCatForTest(baseURL string) *LongCatModel {
 	return NewLongCatModel(
 		map[string]string{"default": baseURL},
-		URLSuffix{Chat: "chat/completions", Models: "models"},
+		URLSuffix{Chat: "v1/chat/completions"},
 	)
 }
 
@@ -56,7 +56,7 @@ func TestLongCatName(t *testing.T) {
 }
 
 func TestLongCatChatHappyPath(t *testing.T) {
-	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
 		if body["model"] != "LongCat-Flash-Chat" {
 			t.Errorf("model=%v", body["model"])
 		}
@@ -92,7 +92,7 @@ func TestLongCatChatExtractsReasoningContent(t *testing.T) {
 	// message.reasoning_content (OpenAI o-series shape). Live-probed
 	// against api.longcat.chat; the fixture mimics the actual response
 	// shape captured there.
-	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
 		if body["model"] != "LongCat-Flash-Thinking" {
 			t.Errorf("model=%v", body["model"])
 		}
@@ -124,10 +124,23 @@ func TestLongCatChatExtractsReasoningContent(t *testing.T) {
 	}
 }
 
-func TestLongCatChatPropagatesReasoningEffort(t *testing.T) {
-	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
-		if body["reasoning_effort"] != "high" {
-			t.Errorf("reasoning_effort=%v want high", body["reasoning_effort"])
+// TestLongCatChatDropsUndocumentedFields guards against re-introducing
+// stop / reasoning_effort / response_format / tools etc. The LongCat
+// docs only list model, messages, stream, max_tokens, temperature,
+// top_p — anything else is undocumented and must not be sent, since
+// the maintainer specifically flagged this on PR #14809.
+func TestLongCatChatDropsUndocumentedFields(t *testing.T) {
+	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		for _, k := range []string{"stop", "reasoning_effort", "response_format", "tools", "tool_choice", "presence_penalty", "frequency_penalty", "n", "logprobs"} {
+			if _, present := body[k]; present {
+				t.Errorf("undocumented field %q must not be sent: %v", k, body[k])
+			}
+		}
+		// Documented fields, on the other hand, MUST be forwarded when set.
+		for _, k := range []string{"model", "messages", "stream", "max_tokens", "temperature", "top_p"} {
+			if _, present := body[k]; !present {
+				t.Errorf("documented field %q missing from request body", k)
+			}
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"choices": []map[string]interface{}{{
@@ -139,35 +152,16 @@ func TestLongCatChatPropagatesReasoningEffort(t *testing.T) {
 
 	m := newLongCatForTest(srv.URL)
 	apiKey := "test-key"
+	mt := 32
+	temp := 0.7
+	topP := 0.9
+	stop := []string{"END"}
 	effort := "high"
-	_, err := m.ChatWithMessages("LongCat-Flash-Thinking",
-		[]Message{{Role: "user", Content: "x"}},
-		&APIConfig{ApiKey: &apiKey},
-		&ChatConfig{Effort: &effort})
-	if err != nil {
-		t.Fatalf("Chat: %v", err)
-	}
-}
-
-func TestLongCatChatOmitsReasoningEffortWhenUnset(t *testing.T) {
-	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
-		if _, present := body["reasoning_effort"]; present {
-			t.Errorf("reasoning_effort=%v should be absent", body["reasoning_effort"])
-		}
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"choices": []map[string]interface{}{{
-				"message": map[string]interface{}{"content": "ok"},
-			}},
-		})
-	})
-	defer srv.Close()
-
-	m := newLongCatForTest(srv.URL)
-	apiKey := "test-key"
 	_, err := m.ChatWithMessages("LongCat-Flash-Chat",
 		[]Message{{Role: "user", Content: "x"}},
 		&APIConfig{ApiKey: &apiKey},
-		&ChatConfig{})
+		// Deliberately pass Stop/Effort to prove they are filtered out.
+		&ChatConfig{MaxTokens: &mt, Temperature: &temp, TopP: &topP, Stop: &stop, Effort: &effort})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -193,7 +187,7 @@ func TestLongCatChatRequiresMessages(t *testing.T) {
 }
 
 func TestLongCatChatRejectsHTTPError(t *testing.T) {
-	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
 	})
@@ -337,26 +331,29 @@ func TestLongCatStreamFailsWithoutTerminal(t *testing.T) {
 	}
 }
 
-func TestLongCatListModelsHappyPath(t *testing.T) {
-	srv := newLongCatServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"data": []map[string]interface{}{
-				{"id": "LongCat-Flash-Chat"},
-				{"id": "LongCat-Flash-Lite"},
-				{"id": "LongCat-Flash-Thinking"},
-			},
-		})
-	})
-	defer srv.Close()
-
-	m := newLongCatForTest(srv.URL)
+// LongCat does not document a /models endpoint, so ListModels returns
+// a shipped catalog rather than hitting the network. This test pins the
+// known names so accidental edits to longcatKnownModels are caught.
+func TestLongCatListModelsReturnsKnownCatalog(t *testing.T) {
 	apiKey := "test-key"
-	ids, err := m.ListModels(&APIConfig{ApiKey: &apiKey})
+	ids, err := newLongCatForTest("http://unused").ListModels(&APIConfig{ApiKey: &apiKey})
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
 	}
-	if len(ids) != 3 {
-		t.Errorf("ids=%v", ids)
+	want := map[string]bool{
+		"LongCat-Flash-Chat":          true,
+		"LongCat-Flash-Lite":          true,
+		"LongCat-Flash-Thinking-2601": true,
+		"LongCat-Flash-Omni-2603":     true,
+		"LongCat-2.0-Preview":         true,
+	}
+	if len(ids) != len(want) {
+		t.Errorf("len(ids)=%d want %d (%v)", len(ids), len(want), ids)
+	}
+	for _, id := range ids {
+		if !want[id] {
+			t.Errorf("unexpected model id %q", id)
+		}
 	}
 }
 
@@ -367,14 +364,56 @@ func TestLongCatListModelsRequiresAPIKey(t *testing.T) {
 	}
 }
 
-func TestLongCatCheckConnectionDelegatesToListModels(t *testing.T) {
-	okSrv := newLongCatServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []map[string]interface{}{{"id": "x"}}})
+// CheckConnection must hit the documented chat endpoint, not /models,
+// since LongCat does not expose /models. A 1-token chat ping against
+// LongCat-Flash-Lite is what the maintainer asked for.
+func TestLongCatCheckConnectionChatPings(t *testing.T) {
+	var (
+		sawChat   bool
+		sawModel  string
+		sawTokens interface{}
+	)
+	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		sawChat = true
+		if m, ok := body["model"].(string); ok {
+			sawModel = m
+		}
+		sawTokens = body["max_tokens"]
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "ok"},
+			}},
+		})
 	})
-	defer okSrv.Close()
+	defer srv.Close()
 	apiKey := "test-key"
-	if err := newLongCatForTest(okSrv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
+	if err := newLongCatForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
 		t.Errorf("CheckConnection: %v", err)
+	}
+	if !sawChat {
+		t.Error("CheckConnection did not hit /v1/chat/completions")
+	}
+	if sawModel != "LongCat-Flash-Lite" {
+		t.Errorf("CheckConnection ping model=%q want LongCat-Flash-Lite", sawModel)
+	}
+	if mt, ok := sawTokens.(float64); !ok || mt != 1 {
+		t.Errorf("CheckConnection max_tokens=%v want 1", sawTokens)
+	}
+}
+
+// On 401 (bad key), CheckConnection must surface the upstream error
+// instead of silently returning nil — credentials are exactly what
+// this method exists to validate.
+func TestLongCatCheckConnectionPropagatesAuthError(t *testing.T) {
+	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	})
+	defer srv.Close()
+	apiKey := "test-key"
+	err := newLongCatForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey})
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 propagated, got %v", err)
 	}
 }
 

--- a/internal/entity/models/longcat_test.go
+++ b/internal/entity/models/longcat_test.go
@@ -21,8 +21,10 @@ func newLongCatServer(t *testing.T, expectedPath string, handler func(t *testing
 			return
 		}
 		if r.Method == http.MethodPost {
-			if got := r.Header.Get("Content-Type"); got != "application/json" {
-				t.Errorf("expected Content-Type=application/json, got %q", got)
+			// Accept "application/json" with or without a parameter
+			// suffix like "; charset=utf-8" — both are valid JSON.
+			if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+				t.Errorf("expected Content-Type to start with application/json, got %q", got)
 				return
 			}
 			raw, err := io.ReadAll(r.Body)
@@ -47,6 +49,34 @@ func newLongCatForTest(baseURL string) *LongCatModel {
 		map[string]string{"default": baseURL},
 		URLSuffix{Chat: "v1/chat/completions"},
 	)
+}
+
+// newLongCatSSEServer returns an httptest.Server that asserts the
+// request contract (POST + path + Authorization + Content-Type prefix)
+// before writing the supplied SSE payload. Used by the streaming tests
+// so a regression in the wire shape can't slip through unnoticed.
+func newLongCatSSEServer(t *testing.T, expectedPath, ssePayload string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			return
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+			t.Errorf("expected Content-Type to start with application/json, got %q", got)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ssePayload)
+	}))
 }
 
 func TestLongCatName(t *testing.T) {
@@ -78,6 +108,9 @@ func TestLongCatChatHappyPath(t *testing.T) {
 		&APIConfig{ApiKey: &apiKey}, nil)
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Answer == nil || resp.ReasonContent == nil {
+		t.Fatalf("Answer/ReasonContent must be non-nil pointers, got Answer=%v ReasonContent=%v", resp.Answer, resp.ReasonContent)
 	}
 	if *resp.Answer != "pong" {
 		t.Errorf("answer=%q want pong", *resp.Answer)
@@ -115,6 +148,9 @@ func TestLongCatChatExtractsReasoningContent(t *testing.T) {
 		&APIConfig{ApiKey: &apiKey}, nil)
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Answer == nil || resp.ReasonContent == nil {
+		t.Fatalf("Answer/ReasonContent must be non-nil pointers, got Answer=%v ReasonContent=%v", resp.Answer, resp.ReasonContent)
 	}
 	if *resp.Answer != "15% of 80 is 12." {
 		t.Errorf("Answer=%q", *resp.Answer)
@@ -204,15 +240,12 @@ func TestLongCatChatRejectsHTTPError(t *testing.T) {
 }
 
 func TestLongCatStreamHappyPath(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w,
-			`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
-				`data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`+"\n"+
-				`data: {"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n"+
-				`data: [DONE]`+"\n",
-		)
-	}))
+	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
 	defer srv.Close()
 
 	m := newLongCatForTest(srv.URL)
@@ -248,16 +281,13 @@ func TestLongCatStreamExtractsReasoningContent(t *testing.T) {
 	// Fixture matches the shape captured live from
 	// LongCat-Flash-Thinking against api.longcat.chat: deltas
 	// interleave reasoning_content and content within the stream.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w,
-			`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
-				`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 1. "}}]}`+"\n"+
-				`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 2."}}]}`+"\n"+
-				`data: {"choices":[{"index":0,"delta":{"content":"final answer"},"finish_reason":"stop"}]}`+"\n"+
-				`data: [DONE]`+"\n",
-		)
-	}))
+	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 1. "}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 2."}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"final answer"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
 	defer srv.Close()
 
 	m := newLongCatForTest(srv.URL)
@@ -315,9 +345,9 @@ func TestLongCatStreamRequiresSender(t *testing.T) {
 }
 
 func TestLongCatStreamFailsWithoutTerminal(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"half"}}]}`+"\n")
-	}))
+	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+		`data: {"choices":[{"delta":{"content":"half"}}]}`+"\n",
+	)
 	defer srv.Close()
 
 	m := newLongCatForTest(srv.URL)
@@ -328,6 +358,51 @@ func TestLongCatStreamFailsWithoutTerminal(t *testing.T) {
 		func(*string, *string) error { return nil })
 	if err == nil || !strings.Contains(err.Error(), "stream ended before") {
 		t.Errorf("expected truncation error, got %v", err)
+	}
+}
+
+// A malformed SSE frame (invalid JSON) used to be silently skipped,
+// which masked truncated or corrupted streams. The driver must now
+// fail hard with a "longcat: invalid SSE event" wrapper.
+func TestLongCatStreamRejectsMalformedFrame(t *testing.T) {
+	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+		`data: {"choices":[{"delta":{"content":"ok"}}]}`+"\n"+
+			`data: {this is not valid json}`+"\n",
+	)
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	err := m.ChatStreamlyWithSender("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "invalid SSE event") {
+		t.Errorf("expected invalid-SSE error, got %v", err)
+	}
+}
+
+// An upstream {"error": ...} frame mid-stream used to fall through to
+// the "no choices" continue and leave the caller with a generic
+// truncation error. The driver must surface the upstream error verbatim.
+func TestLongCatStreamSurfacesUpstreamError(t *testing.T) {
+	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+		`data: {"choices":[{"delta":{"content":"partial "}}]}`+"\n"+
+			`data: {"error":{"message":"rate limit exceeded","type":"rate_limit_error"}}`+"\n",
+	)
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	err := m.ChatStreamlyWithSender("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "upstream stream error") {
+		t.Errorf("expected upstream-error surfacing, got %v", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("expected upstream message included, got %v", err)
 	}
 }
 
@@ -361,6 +436,19 @@ func TestLongCatListModelsRequiresAPIKey(t *testing.T) {
 	m := newLongCatForTest("http://unused")
 	if _, err := m.ListModels(&APIConfig{}); err == nil || !strings.Contains(err.Error(), "api key is required") {
 		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+// Even though ListModels does not hit the network, a region with no
+// configured base URL is a misconfiguration that the caller deserves
+// to see now instead of on the first chat request.
+func TestLongCatListModelsRejectsUnknownRegion(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	apiKey := "test-key"
+	region := "atlantis"
+	_, err := m.ListModels(&APIConfig{ApiKey: &apiKey, Region: &region})
+	if err == nil || !strings.Contains(err.Error(), "no base URL configured") {
+		t.Errorf("expected region-not-configured error, got %v", err)
 	}
 }
 

--- a/internal/entity/models/longcat_test.go
+++ b/internal/entity/models/longcat_test.go
@@ -1,0 +1,419 @@
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newLongCatServer(t *testing.T, expectedPath string, handler func(t *testing.T, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		if r.Method == http.MethodPost {
+			if got := r.Header.Get("Content-Type"); got != "application/json" {
+				t.Errorf("expected Content-Type=application/json, got %q", got)
+				return
+			}
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+				return
+			}
+			var body map[string]interface{}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Errorf("unmarshal: %v\nraw=%s", err, string(raw))
+				return
+			}
+			handler(t, body, w)
+			return
+		}
+		handler(t, nil, w)
+	}))
+}
+
+func newLongCatForTest(baseURL string) *LongCatModel {
+	return NewLongCatModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{Chat: "chat/completions", Models: "models"},
+	)
+}
+
+func TestLongCatName(t *testing.T) {
+	if got := newLongCatForTest("http://unused").Name(); got != "longcat" {
+		t.Errorf("Name()=%q, want %q", got, "longcat")
+	}
+}
+
+func TestLongCatChatHappyPath(t *testing.T) {
+	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "LongCat-Flash-Chat" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if body["stream"] != false {
+			t.Errorf("stream=%v want false", body["stream"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "pong"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	resp, err := m.ChatWithMessages("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if *resp.Answer != "pong" {
+		t.Errorf("answer=%q want pong", *resp.Answer)
+	}
+	if *resp.ReasonContent != "" {
+		t.Errorf("ReasonContent=%q want empty", *resp.ReasonContent)
+	}
+}
+
+func TestLongCatChatExtractsReasoningContent(t *testing.T) {
+	// LongCat-Flash-Thinking returns the chain-of-thought in
+	// message.reasoning_content (OpenAI o-series shape). Live-probed
+	// against api.longcat.chat; the fixture mimics the actual response
+	// shape captured there.
+	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "LongCat-Flash-Thinking" {
+			t.Errorf("model=%v", body["model"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"role":              "assistant",
+					"content":           "15% of 80 is 12.",
+					"reasoning_content": "We need to compute 15% of 80. 0.15 * 80 = 12.",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	resp, err := m.ChatWithMessages("LongCat-Flash-Thinking",
+		[]Message{{Role: "user", Content: "15% of 80?"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if *resp.Answer != "15% of 80 is 12." {
+		t.Errorf("Answer=%q", *resp.Answer)
+	}
+	if *resp.ReasonContent != "We need to compute 15% of 80. 0.15 * 80 = 12." {
+		t.Errorf("ReasonContent=%q", *resp.ReasonContent)
+	}
+}
+
+func TestLongCatChatPropagatesReasoningEffort(t *testing.T) {
+	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["reasoning_effort"] != "high" {
+			t.Errorf("reasoning_effort=%v want high", body["reasoning_effort"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "ok"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	effort := "high"
+	_, err := m.ChatWithMessages("LongCat-Flash-Thinking",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Effort: &effort})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+}
+
+func TestLongCatChatOmitsReasoningEffortWhenUnset(t *testing.T) {
+	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if _, present := body["reasoning_effort"]; present {
+			t.Errorf("reasoning_effort=%v should be absent", body["reasoning_effort"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "ok"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	_, err := m.ChatWithMessages("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+}
+
+func TestLongCatChatRequiresAPIKey(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	_, err := m.ChatWithMessages("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestLongCatChatRequiresMessages(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	apiKey := "test-key"
+	_, err := m.ChatWithMessages("LongCat-Flash-Chat", nil, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "messages is empty") {
+		t.Errorf("expected messages-empty error, got %v", err)
+	}
+}
+
+func TestLongCatChatRejectsHTTPError(t *testing.T) {
+	srv := newLongCatServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	})
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	_, err := m.ChatWithMessages("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 propagated, got %v", err)
+	}
+}
+
+func TestLongCatStreamHappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+				`data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`+"\n"+
+				`data: {"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n"+
+				`data: [DONE]`+"\n",
+		)
+	}))
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	var chunks []string
+	var sawDone bool
+	err := m.ChatStreamlyWithSender("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, _ *string) error {
+			if c == nil {
+				return nil
+			}
+			if *c == "[DONE]" {
+				sawDone = true
+				return nil
+			}
+			chunks = append(chunks, *c)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if strings.Join(chunks, "") != "Hello world" {
+		t.Errorf("content=%v", chunks)
+	}
+	if !sawDone {
+		t.Error("expected [DONE] sentinel")
+	}
+}
+
+func TestLongCatStreamExtractsReasoningContent(t *testing.T) {
+	// Fixture matches the shape captured live from
+	// LongCat-Flash-Thinking against api.longcat.chat: deltas
+	// interleave reasoning_content and content within the stream.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+				`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 1. "}}]}`+"\n"+
+				`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 2."}}]}`+"\n"+
+				`data: {"choices":[{"index":0,"delta":{"content":"final answer"},"finish_reason":"stop"}]}`+"\n"+
+				`data: [DONE]`+"\n",
+		)
+	}))
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	var content, reasoning []string
+	err := m.ChatStreamlyWithSender("LongCat-Flash-Thinking",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, r *string) error {
+			if c != nil && r != nil {
+				t.Errorf("sender called with both args non-nil")
+			}
+			if r != nil && *r != "" {
+				reasoning = append(reasoning, *r)
+			}
+			if c != nil && *c != "" && *c != "[DONE]" {
+				content = append(content, *c)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if got := strings.Join(reasoning, ""); got != "step 1. step 2." {
+		t.Errorf("reasoning=%q", got)
+	}
+	if got := strings.Join(content, ""); got != "final answer" {
+		t.Errorf("content=%q", got)
+	}
+}
+
+func TestLongCatStreamRejectsExplicitFalse(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	apiKey := "test-key"
+	stream := false
+	err := m.ChatStreamlyWithSender("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Stream: &stream},
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream must be true") {
+		t.Errorf("expected stream-true guard, got %v", err)
+	}
+}
+
+func TestLongCatStreamRequiresSender(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	apiKey := "test-key"
+	err := m.ChatStreamlyWithSender("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "sender is required") {
+		t.Errorf("expected sender-required error, got %v", err)
+	}
+}
+
+func TestLongCatStreamFailsWithoutTerminal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"half"}}]}`+"\n")
+	}))
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	err := m.ChatStreamlyWithSender("LongCat-Flash-Chat",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream ended before") {
+		t.Errorf("expected truncation error, got %v", err)
+	}
+}
+
+func TestLongCatListModelsHappyPath(t *testing.T) {
+	srv := newLongCatServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "LongCat-Flash-Chat"},
+				{"id": "LongCat-Flash-Lite"},
+				{"id": "LongCat-Flash-Thinking"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	m := newLongCatForTest(srv.URL)
+	apiKey := "test-key"
+	ids, err := m.ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Errorf("ids=%v", ids)
+	}
+}
+
+func TestLongCatListModelsRequiresAPIKey(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	if _, err := m.ListModels(&APIConfig{}); err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestLongCatCheckConnectionDelegatesToListModels(t *testing.T) {
+	okSrv := newLongCatServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []map[string]interface{}{{"id": "x"}}})
+	})
+	defer okSrv.Close()
+	apiKey := "test-key"
+	if err := newLongCatForTest(okSrv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
+		t.Errorf("CheckConnection: %v", err)
+	}
+}
+
+func TestLongCatEmbedReturnsNoSuchMethod(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	model := "x"
+	_, err := m.Embed(&model, []string{"a"}, &APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Embed: want 'no such method', got %v", err)
+	}
+}
+
+func TestLongCatRerankReturnsNoSuchMethod(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	model := "x"
+	_, err := m.Rerank(&model, "q", []string{"a"}, &APIConfig{}, &RerankConfig{TopN: 1})
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Rerank: want 'no such method', got %v", err)
+	}
+}
+
+func TestLongCatBalanceReturnsNoSuchMethod(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	_, err := m.Balance(&APIConfig{})
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Balance: want 'no such method', got %v", err)
+	}
+}
+
+func TestLongCatAudioOCRReturnNoSuchMethod(t *testing.T) {
+	m := newLongCatForTest("http://unused")
+	model := "x"
+	if _, err := m.TranscribeAudio(&model, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("TranscribeAudio: want 'no such method', got %v", err)
+	}
+	if _, err := m.AudioSpeech(&model, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("AudioSpeech: want 'no such method', got %v", err)
+	}
+	if _, err := m.OCRFile(&model, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("OCRFile: want 'no such method', got %v", err)
+	}
+}

--- a/internal/entity/models/longcat_test.go
+++ b/internal/entity/models/longcat_test.go
@@ -47,7 +47,7 @@ func newLongCatServer(t *testing.T, expectedPath string, handler func(t *testing
 func newLongCatForTest(baseURL string) *LongCatModel {
 	return NewLongCatModel(
 		map[string]string{"default": baseURL},
-		URLSuffix{Chat: "v1/chat/completions"},
+		URLSuffix{Chat: "openai/v1/chat/completions"},
 	)
 }
 
@@ -86,7 +86,7 @@ func TestLongCatName(t *testing.T) {
 }
 
 func TestLongCatChatHappyPath(t *testing.T) {
-	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+	srv := newLongCatServer(t, "/openai/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
 		if body["model"] != "LongCat-Flash-Chat" {
 			t.Errorf("model=%v", body["model"])
 		}
@@ -125,7 +125,7 @@ func TestLongCatChatExtractsReasoningContent(t *testing.T) {
 	// message.reasoning_content (OpenAI o-series shape). Live-probed
 	// against api.longcat.chat; the fixture mimics the actual response
 	// shape captured there.
-	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+	srv := newLongCatServer(t, "/openai/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
 		if body["model"] != "LongCat-Flash-Thinking" {
 			t.Errorf("model=%v", body["model"])
 		}
@@ -166,7 +166,7 @@ func TestLongCatChatExtractsReasoningContent(t *testing.T) {
 // top_p — anything else is undocumented and must not be sent, since
 // the maintainer specifically flagged this on PR #14809.
 func TestLongCatChatDropsUndocumentedFields(t *testing.T) {
-	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+	srv := newLongCatServer(t, "/openai/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
 		for _, k := range []string{"stop", "reasoning_effort", "response_format", "tools", "tool_choice", "presence_penalty", "frequency_penalty", "n", "logprobs"} {
 			if _, present := body[k]; present {
 				t.Errorf("undocumented field %q must not be sent: %v", k, body[k])
@@ -223,7 +223,7 @@ func TestLongCatChatRequiresMessages(t *testing.T) {
 }
 
 func TestLongCatChatRejectsHTTPError(t *testing.T) {
-	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+	srv := newLongCatServer(t, "/openai/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
 	})
@@ -240,7 +240,7 @@ func TestLongCatChatRejectsHTTPError(t *testing.T) {
 }
 
 func TestLongCatStreamHappyPath(t *testing.T) {
-	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+	srv := newLongCatSSEServer(t, "/openai/v1/chat/completions",
 		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
 			`data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`+"\n"+
 			`data: {"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n"+
@@ -281,7 +281,7 @@ func TestLongCatStreamExtractsReasoningContent(t *testing.T) {
 	// Fixture matches the shape captured live from
 	// LongCat-Flash-Thinking against api.longcat.chat: deltas
 	// interleave reasoning_content and content within the stream.
-	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+	srv := newLongCatSSEServer(t, "/openai/v1/chat/completions",
 		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
 			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 1. "}}]}`+"\n"+
 			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 2."}}]}`+"\n"+
@@ -345,7 +345,7 @@ func TestLongCatStreamRequiresSender(t *testing.T) {
 }
 
 func TestLongCatStreamFailsWithoutTerminal(t *testing.T) {
-	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+	srv := newLongCatSSEServer(t, "/openai/v1/chat/completions",
 		`data: {"choices":[{"delta":{"content":"half"}}]}`+"\n",
 	)
 	defer srv.Close()
@@ -365,7 +365,7 @@ func TestLongCatStreamFailsWithoutTerminal(t *testing.T) {
 // which masked truncated or corrupted streams. The driver must now
 // fail hard with a "longcat: invalid SSE event" wrapper.
 func TestLongCatStreamRejectsMalformedFrame(t *testing.T) {
-	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+	srv := newLongCatSSEServer(t, "/openai/v1/chat/completions",
 		`data: {"choices":[{"delta":{"content":"ok"}}]}`+"\n"+
 			`data: {this is not valid json}`+"\n",
 	)
@@ -386,7 +386,7 @@ func TestLongCatStreamRejectsMalformedFrame(t *testing.T) {
 // the "no choices" continue and leave the caller with a generic
 // truncation error. The driver must surface the upstream error verbatim.
 func TestLongCatStreamSurfacesUpstreamError(t *testing.T) {
-	srv := newLongCatSSEServer(t, "/v1/chat/completions",
+	srv := newLongCatSSEServer(t, "/openai/v1/chat/completions",
 		`data: {"choices":[{"delta":{"content":"partial "}}]}`+"\n"+
 			`data: {"error":{"message":"rate limit exceeded","type":"rate_limit_error"}}`+"\n",
 	)
@@ -406,102 +406,23 @@ func TestLongCatStreamSurfacesUpstreamError(t *testing.T) {
 	}
 }
 
-// LongCat does not document a /models endpoint, so ListModels returns
-// a shipped catalog rather than hitting the network. This test pins the
-// known names so accidental edits to longcatKnownModels are caught.
-func TestLongCatListModelsReturnsKnownCatalog(t *testing.T) {
+// LongCat does not document /models or /health endpoints, so per
+// maintainer guidance ListModels and CheckConnection both return the
+// "no such method" sentinel rather than inventing fake catalogs or
+// burning chat completions for connection checks.
+func TestLongCatListModelsReturnsNoSuchMethod(t *testing.T) {
 	apiKey := "test-key"
-	ids, err := newLongCatForTest("http://unused").ListModels(&APIConfig{ApiKey: &apiKey})
-	if err != nil {
-		t.Fatalf("ListModels: %v", err)
-	}
-	want := map[string]bool{
-		"LongCat-Flash-Chat":          true,
-		"LongCat-Flash-Lite":          true,
-		"LongCat-Flash-Thinking-2601": true,
-		"LongCat-Flash-Omni-2603":     true,
-		"LongCat-2.0-Preview":         true,
-	}
-	if len(ids) != len(want) {
-		t.Errorf("len(ids)=%d want %d (%v)", len(ids), len(want), ids)
-	}
-	for _, id := range ids {
-		if !want[id] {
-			t.Errorf("unexpected model id %q", id)
-		}
+	_, err := newLongCatForTest("http://unused").ListModels(&APIConfig{ApiKey: &apiKey})
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("ListModels: want 'no such method', got %v", err)
 	}
 }
 
-func TestLongCatListModelsRequiresAPIKey(t *testing.T) {
-	m := newLongCatForTest("http://unused")
-	if _, err := m.ListModels(&APIConfig{}); err == nil || !strings.Contains(err.Error(), "api key is required") {
-		t.Errorf("expected api-key error, got %v", err)
-	}
-}
-
-// Even though ListModels does not hit the network, a region with no
-// configured base URL is a misconfiguration that the caller deserves
-// to see now instead of on the first chat request.
-func TestLongCatListModelsRejectsUnknownRegion(t *testing.T) {
-	m := newLongCatForTest("http://unused")
+func TestLongCatCheckConnectionReturnsNoSuchMethod(t *testing.T) {
 	apiKey := "test-key"
-	region := "atlantis"
-	_, err := m.ListModels(&APIConfig{ApiKey: &apiKey, Region: &region})
-	if err == nil || !strings.Contains(err.Error(), "no base URL configured") {
-		t.Errorf("expected region-not-configured error, got %v", err)
-	}
-}
-
-// CheckConnection must hit the documented chat endpoint, not /models,
-// since LongCat does not expose /models. A 1-token chat ping against
-// LongCat-Flash-Lite is what the maintainer asked for.
-func TestLongCatCheckConnectionChatPings(t *testing.T) {
-	var (
-		sawChat   bool
-		sawModel  string
-		sawTokens interface{}
-	)
-	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
-		sawChat = true
-		if m, ok := body["model"].(string); ok {
-			sawModel = m
-		}
-		sawTokens = body["max_tokens"]
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"choices": []map[string]interface{}{{
-				"message": map[string]interface{}{"content": "ok"},
-			}},
-		})
-	})
-	defer srv.Close()
-	apiKey := "test-key"
-	if err := newLongCatForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
-		t.Errorf("CheckConnection: %v", err)
-	}
-	if !sawChat {
-		t.Error("CheckConnection did not hit /v1/chat/completions")
-	}
-	if sawModel != "LongCat-Flash-Lite" {
-		t.Errorf("CheckConnection ping model=%q want LongCat-Flash-Lite", sawModel)
-	}
-	if mt, ok := sawTokens.(float64); !ok || mt != 1 {
-		t.Errorf("CheckConnection max_tokens=%v want 1", sawTokens)
-	}
-}
-
-// On 401 (bad key), CheckConnection must surface the upstream error
-// instead of silently returning nil — credentials are exactly what
-// this method exists to validate.
-func TestLongCatCheckConnectionPropagatesAuthError(t *testing.T) {
-	srv := newLongCatServer(t, "/v1/chat/completions", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
-	})
-	defer srv.Close()
-	apiKey := "test-key"
-	err := newLongCatForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey})
-	if err == nil || !strings.Contains(err.Error(), "401") {
-		t.Errorf("expected 401 propagated, got %v", err)
+	err := newLongCatForTest("http://unused").CheckConnection(&APIConfig{ApiKey: &apiKey})
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("CheckConnection: want 'no such method', got %v", err)
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Add a Go driver for LongCat (Meituan, https://longcat.chat), one of the unchecked providers on the umbrella tracking issue #14736. LongCat exposes an OpenAI-compatible REST API at `https://api.longcat.chat/openai/v1` with three public chat models including `LongCat-Flash-Thinking`, a reasoning model that returns chain-of-thought in `reasoning_content` (OpenAI o-series shape).

Until this PR, a tenant who configured `longcat` as a model provider in the Go layer fell through to the default branch of `internal/entity/models/factory.go` and got the dummy driver.

### What this PR includes

- New `internal/entity/models/longcat.go` with a `LongCatModel` implementing the `ModelDriver` interface.
- New `conf/models/longcat.json` with the 3 public chat models (Flash-Chat, Flash-Lite, Flash-Thinking) and `url_suffix` for `chat` and `models`.
- `factory.go`: route `"longcat"` to `NewLongCatModel`.

Method coverage:

- `ChatWithMessages`: `POST /openai/v1/chat/completions`, non-streaming
- `ChatStreamlyWithSender`: SSE stream against the same endpoint
- `ListModels` / `CheckConnection`: `GET /openai/v1/models`
- **Reasoning extraction**: `message.reasoning_content` (non-stream) and `delta.reasoning_content` (stream) flow into `ChatResponse.ReasonContent` / the sender's second arg. Matches the OpenAI o-series convention also used by kimi-k2.6 and DeepSeek-R1.
- **`reasoning_effort` propagation**: `ChatConfig.Effort` → request body `reasoning_effort` (LongCat-Flash-Thinking honors it; non-reasoning models ignore it).
- `Embed` / `Rerank` / `Balance` / `TranscribeAudio` / `AudioSpeech` / `OCRFile` return `"no such method"` (LongCat does not expose any of these surfaces).

No interface change. No new dependencies.

### How was this tested?

**21 unit tests** in `internal/entity/models/longcat_test.go` — all pass:

```
$ go test -vet=off -run TestLongCat -count=1 -v ./internal/entity/models/...
=== RUN   TestLongCatName
--- PASS: TestLongCatName (0.00s)
=== RUN   TestLongCatChatHappyPath
--- PASS: TestLongCatChatHappyPath (0.00s)
=== RUN   TestLongCatChatExtractsReasoningContent
--- PASS: TestLongCatChatExtractsReasoningContent (0.00s)
=== RUN   TestLongCatChatPropagatesReasoningEffort
--- PASS: TestLongCatChatPropagatesReasoningEffort (0.00s)
=== RUN   TestLongCatChatOmitsReasoningEffortWhenUnset
--- PASS: TestLongCatChatOmitsReasoningEffortWhenUnset (0.00s)
=== RUN   TestLongCatChatRequiresAPIKey
--- PASS: TestLongCatChatRequiresAPIKey (0.00s)
=== RUN   TestLongCatChatRequiresMessages
--- PASS: TestLongCatChatRequiresMessages (0.00s)
=== RUN   TestLongCatChatRejectsHTTPError
--- PASS: TestLongCatChatRejectsHTTPError (0.00s)
=== RUN   TestLongCatStreamHappyPath
--- PASS: TestLongCatStreamHappyPath (0.00s)
=== RUN   TestLongCatStreamExtractsReasoningContent
--- PASS: TestLongCatStreamExtractsReasoningContent (0.00s)
=== RUN   TestLongCatStreamRejectsExplicitFalse
--- PASS: TestLongCatStreamRejectsExplicitFalse (0.00s)
=== RUN   TestLongCatStreamRequiresSender
--- PASS: TestLongCatStreamRequiresSender (0.00s)
=== RUN   TestLongCatStreamFailsWithoutTerminal
--- PASS: TestLongCatStreamFailsWithoutTerminal (0.00s)
=== RUN   TestLongCatListModelsHappyPath
--- PASS: TestLongCatListModelsHappyPath (0.00s)
=== RUN   TestLongCatListModelsRequiresAPIKey
--- PASS: TestLongCatListModelsRequiresAPIKey (0.00s)
=== RUN   TestLongCatCheckConnectionDelegatesToListModels
--- PASS: TestLongCatCheckConnectionDelegatesToListModels (0.00s)
=== RUN   TestLongCatEmbedReturnsNoSuchMethod
--- PASS: TestLongCatEmbedReturnsNoSuchMethod (0.00s)
=== RUN   TestLongCatRerankReturnsNoSuchMethod
--- PASS: TestLongCatRerankReturnsNoSuchMethod (0.00s)
=== RUN   TestLongCatBalanceReturnsNoSuchMethod
--- PASS: TestLongCatBalanceReturnsNoSuchMethod (0.00s)
=== RUN   TestLongCatAudioOCRReturnNoSuchMethod
--- PASS: TestLongCatAudioOCRReturnNoSuchMethod (0.00s)
PASS
ok      ragflow/internal/entity/models  0.020s
```

`go build ./internal/entity/models/...` exits 0 on go 1.25.

**Live integration test** against `api.longcat.chat`:

```
=== RUN   TestLongCatLiveSmoke
    [OK] Name() = "longcat"
    [OK] CheckConnection
    [OK] ListModels: 5 models -> [LongCat-Flash-Lite LongCat-Flash-Chat LongCat-Flash-Thinking-2601 LongCat-Flash-Omni-2603 LongCat-2.0-Preview]
    [OK] Chat (Flash-Chat) answer="Got it! Let me know if you" reason=""
    [OK] Chat (Flash-Thinking) answer len=443 head="To find 15 % of 80, follow these steps:\n\n1. **Convert the percentage to a frac..."
                  ReasonContent len=557 head="The user asks: \"15% of 80?\" They want step by step reasoning and final answer in \\boxed{}. So we need to compute 15% of ..."
    [OK] Stream content: 78 chunks, 351 chars
    [OK] Stream reasoning: 107 chunks, 537 chars
    [OK] Balance returns longcat, no such method
    [OK] Embed returns longcat, no such method
    [OK] Rerank returns longcat, no such method

LONGCAT LIVE SMOKE PASSED
--- PASS: TestLongCatLiveSmoke (31.01s)
```

What the live run proves on the wire:

- Auth header (`Bearer <key>`) is accepted by `api.longcat.chat`.
- `/openai/v1/models` parser handles the real 5-model response (note: live API returns versioned aliases `LongCat-Flash-Thinking-2601`, `LongCat-Flash-Omni-2603`, `LongCat-2.0-Preview` plus the un-versioned `LongCat-Flash-Chat` and `LongCat-Flash-Lite`).
- Non-stream chat against `LongCat-Flash-Chat`: visible answer parses correctly, `ReasonContent` correctly empty.
- Non-stream chat against `LongCat-Flash-Thinking`: 443-char answer flows into `Answer`, 557-char chain-of-thought flows into `ReasonContent` via the new `message.reasoning_content` extraction.
- Streaming chat against `LongCat-Flash-Thinking`: 107 reasoning chunks (537 chars) reach the sender's second arg via `delta.reasoning_content`; 78 content chunks (351 chars) reach the first arg. Before this code, the reasoning chunks would have been silently dropped.
- All sentinel methods (Balance, Embed, Rerank, audio/OCR) return the documented `"no such method"` strings.

### Note on PR history

This branch was previously named for LocalAI work which is now consolidated into PR #14813. The branch was reset to `upstream/main` and rebuilt for LongCat. The diff against `main` is a clean +969 lines across 4 files.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

Tracking: #14736
