### PR TITLE
fix: allow multiple pipeline chunker nodes

### DIFF
--- a/web/src/pages/agent/canvas/node/dropdown/accordion-operators.tsx
+++ b/web/src/pages/agent/canvas/node/dropdown/accordion-operators.tsx
@@ -133,7 +133,7 @@ export function AccordionOperators({
   );
 }
 
-// Limit the number of operators of a certain type on the canvas to only one
+// Limit structural pipeline operators that must exist at most once.
 function useRestrictSingleOperatorOnCanvas() {
   const { findNodeByName } = useGraphStore((state) => state);
 
@@ -174,13 +174,8 @@ export function PipelineAccordionOperators({
   }, [restrictSingleOperatorOnCanvas]);
 
   const chunkerOperators = useMemo(() => {
-    return [
-      ...restrictSingleOperatorOnCanvas([
-        Operator.TokenChunker,
-        Operator.TitleChunker,
-      ]),
-    ];
-  }, [restrictSingleOperatorOnCanvas]);
+    return [Operator.TokenChunker, Operator.TitleChunker];
+  }, []);
 
   const showChunker = useMemo(() => {
     return (

--- a/web/src/pages/agent/constant/pipeline.tsx
+++ b/web/src/pages/agent/constant/pipeline.tsx
@@ -406,9 +406,4 @@ export const FileTypeSuffixMap = {
   ],
 };
 
-export const SingleOperators = [
-  Operator.Tokenizer,
-  Operator.TokenChunker,
-  Operator.TitleChunker,
-  Operator.Parser,
-];
+export const SingleOperators = [Operator.Tokenizer, Operator.Parser];


### PR DESCRIPTION
## What problem does this solve?

Closes #14772.

Pipeline workflows hid chunker nodes after one instance had already been added, which prevented users from adding multiple independently configured title/token chunking stages in the same pipeline.

## What is changed?

- Keep only structural pipeline nodes (`Parser`, `Tokenizer`) restricted to a single canvas instance.
- Keep `TokenChunker` and `TitleChunker` available in the pipeline operator menu after one is already present.
- Align the pipeline singleton operator list with that behavior.

## Behavior proof

- Before: `PipelineAccordionOperators` filtered `TokenChunker` and `TitleChunker` through `restrictSingleOperatorOnCanvas`, so the menu removed them once `findNodeByName()` found an existing node.
- After: the chunker menu always exposes `[Operator.TokenChunker, Operator.TitleChunker]`, while `Parser` and `Tokenizer` still go through the singleton filter.
- The DSL builder already keys components by unique node ID, so multiple chunker nodes can keep separate form configs and edges.

## Test plan

- [x] `git diff --check`
- [x] `cd web && npx eslint src/pages/agent/canvas/node/dropdown/accordion-operators.tsx src/pages/agent/constant/pipeline.tsx`
- [x] Commit hook ran `prettier --write --ignore-unknown` and `eslint` on staged files
- [ ] `cd web && npm run type-check -- --pretty false` currently fails on existing unrelated TypeScript errors outside this change, e.g. `src/components/document-preview/doc-preview.tsx`, `src/components/dynamic-form.tsx`, and `src/components/file-upload.tsx`.
