### PR TITLE
fix: harden ES SQL match-predicate rewriting against quote-escape injection

### DIFF
--- a/common/doc_store/es_conn_base.py
+++ b/common/doc_store/es_conn_base.py
@@ -34,6 +34,26 @@ from common import settings
 ATTEMPT_TIME = 2
 
 
+def _escape_sql_string_literal(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _rewrite_match_predicates(sql: str) -> str:
+    def replace(match: re.Match) -> str:
+        fld = match.group("field")
+        raw_value = match.group("value").replace("''", "'")
+        tokenized_value = rag_tokenizer.fine_grained_tokenize(rag_tokenizer.tokenize(raw_value))
+        tokenized_value = _escape_sql_string_literal(tokenized_value)
+        return " MATCH({}, '{}', 'operator=OR;minimum_should_match=30%') ".format(fld, tokenized_value)
+
+    return re.sub(
+        r" (?P<field>[a-z_]+_l?tks)(?P<operator> like | ?= ?)'(?P<value>(?:''|[^'])+)'",
+        replace,
+        sql,
+        flags=re.IGNORECASE,
+    )
+
+
 class ESConnectionBase(DocStoreConnection):
     def __init__(self, mapping_file_name: str="mapping.json", logger_name: str='ragflow.es_conn'):
         from common.doc_store.es_conn_pool import ES_CONN
@@ -299,20 +319,7 @@ class ESConnectionBase(DocStoreConnection):
         self.logger.debug(f"ESConnection.sql get sql: {sql}")
         sql = re.sub(r"[ `]+", " ", sql)
         sql = sql.replace("%", "")
-        replaces = []
-        for r in re.finditer(r" ([a-z_]+_l?tks)( like | ?= ?)'([^']+)'", sql):
-            fld, v = r.group(1), r.group(3)
-            match = " MATCH({}, '{}', 'operator=OR;minimum_should_match=30%') ".format(
-                fld, rag_tokenizer.fine_grained_tokenize(rag_tokenizer.tokenize(v)))
-            replaces.append(
-                ("{}{}'{}'".format(
-                    r.group(1),
-                    r.group(2),
-                    r.group(3)),
-                 match))
-
-        for p, r in replaces:
-            sql = sql.replace(p, r, 1)
+        sql = _rewrite_match_predicates(sql)
         self.logger.debug(f"ESConnection.sql to es: {sql}")
 
         for i in range(ATTEMPT_TIME):

--- a/test/unit_test/common/doc_store/test_es_conn_base_sql.py
+++ b/test/unit_test/common/doc_store/test_es_conn_base_sql.py
@@ -1,0 +1,158 @@
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = REPO_ROOT / "common/doc_store/es_conn_base.py"
+
+
+
+def _install_stubs():
+    common_pkg = sys.modules.setdefault("common", types.ModuleType("common"))
+    doc_store_pkg = sys.modules.setdefault("common.doc_store", types.ModuleType("common.doc_store"))
+    setattr(common_pkg, "doc_store", doc_store_pkg)
+
+    file_utils = types.ModuleType("common.file_utils")
+    file_utils.get_project_base_directory = lambda: str(REPO_ROOT)
+    sys.modules["common.file_utils"] = file_utils
+
+    misc_utils = types.ModuleType("common.misc_utils")
+    misc_utils.convert_bytes = lambda value: str(value)
+    sys.modules["common.misc_utils"] = misc_utils
+
+    doc_store_base = types.ModuleType("common.doc_store.doc_store_base")
+
+    class DocStoreConnection:
+        pass
+
+    class OrderByExpr:
+        pass
+
+    class MatchExpr:
+        pass
+
+    doc_store_base.DocStoreConnection = DocStoreConnection
+    doc_store_base.OrderByExpr = OrderByExpr
+    doc_store_base.MatchExpr = MatchExpr
+    sys.modules["common.doc_store.doc_store_base"] = doc_store_base
+
+    settings = types.ModuleType("common.settings")
+    settings.ES = {"hosts": "http://example.test"}
+    sys.modules["common.settings"] = settings
+    setattr(common_pkg, "settings", settings)
+
+    nlp_stub = types.ModuleType("rag.nlp")
+
+    class _Tokenizer:
+        @staticmethod
+        def tokenize(value):
+            return value
+
+        @staticmethod
+        def fine_grained_tokenize(value):
+            return value
+
+    nlp_stub.rag_tokenizer = _Tokenizer()
+    nlp_stub.is_english = lambda *_args, **_kwargs: True
+    sys.modules["rag.nlp"] = nlp_stub
+
+    elasticsearch_stub = types.ModuleType("elasticsearch")
+
+    class NotFoundError(Exception):
+        pass
+
+    elasticsearch_stub.NotFoundError = NotFoundError
+    sys.modules["elasticsearch"] = elasticsearch_stub
+
+    client_stub = types.ModuleType("elasticsearch.client")
+
+    class IndicesClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    client_stub.IndicesClient = IndicesClient
+    sys.modules["elasticsearch.client"] = client_stub
+
+    dsl_stub = types.ModuleType("elasticsearch_dsl")
+
+    class Index:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    dsl_stub.Index = Index
+    sys.modules["elasticsearch_dsl"] = dsl_stub
+
+    transport_stub = types.ModuleType("elastic_transport")
+
+    class ConnectionTimeout(Exception):
+        pass
+
+    transport_stub.ConnectionTimeout = ConnectionTimeout
+    sys.modules["elastic_transport"] = transport_stub
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def query(self, body, format, request_timeout):
+        self.calls.append({
+            "query": body["query"],
+            "fetch_size": body["fetch_size"],
+            "format": format,
+            "request_timeout": request_timeout,
+        })
+        return {"columns": [], "rows": []}
+
+
+class _FakeES:
+    def __init__(self):
+        self.sql = _Recorder()
+
+
+_install_stubs()
+spec = importlib.util.spec_from_file_location("tested_es_conn_base", MODULE_PATH)
+es_conn_base = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(es_conn_base)
+
+
+def test_sql_rewrite_consumes_embedded_quotes_in_match_literal():
+    conn = es_conn_base.ESConnectionBase.__new__(es_conn_base.ESConnectionBase)
+    conn.logger = logging.getLogger("test.es_conn_base")
+    conn.es = _FakeES()
+    conn._connect = lambda: True
+
+    conn.sql("select * from ragflow_t where content_tks = 'abc'' OR 1=1 --'", 64, "json")
+
+    assert conn.es.sql.calls[0]["query"] == (
+        "select * from ragflow_t where"
+        " MATCH(content_tks, 'abc'' OR 1=1 --', 'operator=OR;minimum_should_match=30%') "
+    )
+
+
+def test_sql_rewrite_escapes_tokenizer_output_before_match_literal():
+    class _QuotingTokenizer:
+        @staticmethod
+        def tokenize(value):
+            return value
+
+        @staticmethod
+        def fine_grained_tokenize(value):
+            return "token'value"
+
+    es_conn_base.rag_tokenizer = _QuotingTokenizer()
+
+    conn = es_conn_base.ESConnectionBase.__new__(es_conn_base.ESConnectionBase)
+    conn.logger = logging.getLogger("test.es_conn_base")
+    conn.es = _FakeES()
+    conn._connect = lambda: True
+
+    conn.sql("select * from ragflow_t where content_tks = 'safe'", 64, "json")
+
+    assert conn.es.sql.calls[0]["query"] == (
+        "select * from ragflow_t where"
+        " MATCH(content_tks, 'token''value', 'operator=OR;minimum_should_match=30%') "
+    )


### PR DESCRIPTION
## Summary

The regex in `common/doc_store/es_conn_base.py` that rewrites `WHERE field = 'value'` predicates into Elasticsearch `MATCH(...)` calls uses `[^']+` to capture the value. This pattern terminates at the first single quote, so a value containing an escaped quote (`''`) causes the regex to consume only the prefix — leaving attacker-controlled SQL fragments intact in the query forwarded to the ES SQL endpoint.

**CWE-89 (SQL Injection) — Moderate severity**

### Affected code

`common/doc_store/es_conn_base.py`, lines ~302–315 (the `sql()` method's match-predicate rewriting loop).

### Data flow

1. User submits a chat question to a dialog configured with `use_sql` retrieval.
2. The LLM generates SQL containing a crafted WHERE clause (prompt injection).
3. `sql_retrieval()` in `dialog_service.py` passes the SQL to `ESConnectionBase.sql()`.
4. The regex fails to capture the full value; trailing SQL (`OR 1=1 --`) survives rewriting.
5. `add_kb_filter` (tenant/KB scoping) is appended but neutralized by the injected clause.
6. The query executes against ES, potentially returning data from other tenants' indices.

### Fix description

- Replace `[^']+` with `(?:''|[^']+)+` so the regex correctly matches SQL-escaped quotes within string literals.
- Un-escape `''` → `'` before passing to the tokenizer.
- Re-escape any quotes produced by the tokenizer before interpolating into the MATCH literal.
- Extract the logic into a testable `_rewrite_match_predicates()` function.

### Tests

Added `test/unit_test/common/doc_store/test_es_conn_base_sql.py` with two test cases:
- Verifies that embedded escaped quotes are consumed by the regex (not left as trailing SQL).
- Verifies that tokenizer output containing quotes is properly escaped in the MATCH literal.

### Security analysis

The vulnerability requires: (1) an authenticated user, (2) a dialog with text-to-SQL enabled, and (3) the ability to prompt-inject the LLM into emitting a crafted WHERE clause. Impact is limited to read-only data exfiltration (ES SQL supports only SELECT, single statement) but can bypass tenant isolation enforced by `add_kb_filter`.

Before submitting, we verified that no existing mitigation prevents this. The `%` stripping and backtick removal do not affect single-quote handling. `add_kb_filter` is concatenated as plain text and is trivially neutralized by an injected `OR 1=1 --` suffix.