### PR TITLE
fix: enforce read-only SQL allowlist in ExeSQL agent tool

### DIFF
--- a/agent/tools/exesql.py
+++ b/agent/tools/exesql.py
@@ -22,6 +22,8 @@ import pandas as pd
 import pymysql
 import psycopg2
 import pyodbc
+import sqlglot
+from sqlglot import expressions as exp
 from agent.tools.base import ToolParamBase, ToolBase, ToolMeta
 from common.connection_utils import timeout
 
@@ -77,6 +79,60 @@ class ExeSQLParam(ToolParamBase):
         }
 
 
+_ALLOWED_READ_EXPRESSIONS = (
+    exp.Select,
+    exp.Union,
+    exp.Except,
+    exp.Intersect,
+)
+
+
+def _strip_sql_code_fences(sql: str) -> str:
+    return sql.replace("```", "").strip()
+
+
+def _sqlglot_dialect(db_type: str) -> str | None:
+    return {
+        "mysql": "mysql",
+        "mariadb": "mysql",
+        "oceanbase": "mysql",
+        "postgres": "postgres",
+        "mssql": "tsql",
+        "trino": "trino",
+        "IBM DB2": None,
+    }.get(db_type)
+
+
+def _parse_sql_statements(sql: str, db_type: str) -> list[exp.Expression]:
+    dialect = _sqlglot_dialect(db_type)
+    try:
+        statements = [statement for statement in sqlglot.parse(sql, read=dialect) if statement]
+    except Exception as e:
+        raise ValueError(f"Invalid SQL statement: {e}")
+    return statements
+
+
+def _split_sql_statements(sql: str, db_type: str) -> list[str]:
+    statements = _parse_sql_statements(sql, db_type)
+    if len(statements) != 1:
+        raise ValueError("For security reasons, only one read-only SQL statement is supported.")
+    return [sql.strip()]
+
+
+def _ensure_read_only_sql(sql: str, db_type: str) -> None:
+    statements = _parse_sql_statements(sql, db_type)
+    if len(statements) != 1:
+        raise ValueError("For security reasons, only one read-only SQL statement is supported.")
+
+    statement = statements[0]
+    if not isinstance(statement, _ALLOWED_READ_EXPRESSIONS):
+        raise ValueError("For security reasons, only read-only SELECT statements are supported.")
+
+    unsafe = statement.find(exp.Insert, exp.Update, exp.Delete, exp.Drop, exp.Create, exp.Alter, exp.Command, exp.Lock)
+    if unsafe or statement.args.get("locks"):
+        raise ValueError("For security reasons, only read-only SELECT statements are supported.")
+
+
 class ExeSQL(ToolBase, ABC):
     component_name = "ExeSQL"
 
@@ -123,7 +179,7 @@ class ExeSQL(ToolBase, ABC):
         if self.check_if_canceled("ExeSQL processing"):
             return
 
-        sqls = sql.split(";")
+        sqls = _split_sql_statements(sql, self._param.db_type)
         if self._param.db_type in ["mysql", "mariadb"]:
             db = pymysql.connect(db=self._param.database, user=self._param.username, host=self._param.host,
                                  port=self._param.port, password=self._param.password)
@@ -203,10 +259,11 @@ class ExeSQL(ToolBase, ABC):
                     if self.check_if_canceled("ExeSQL processing"):
                         return
 
-                    single_sql = single_sql.replace("```", "").strip()
+                    single_sql = _strip_sql_code_fences(single_sql)
                     if not single_sql:
                         continue
                     single_sql = re.sub(r"\[ID:[0-9]+\]", "", single_sql)
+                    _ensure_read_only_sql(single_sql, self._param.db_type)
 
                     stmt = ibm_db.exec_immediate(conn, single_sql)
                     rows = []
@@ -251,14 +308,12 @@ class ExeSQL(ToolBase, ABC):
                 if self.check_if_canceled("ExeSQL processing"):
                     return
 
-                single_sql = single_sql.replace('```', '').strip()
+                single_sql = _strip_sql_code_fences(single_sql)
                 if not single_sql:
                     continue
                 single_sql = re.sub(r"\[ID:[0-9]+\]", "", single_sql)
-                if re.match(r"^(insert|update|delete)\b", single_sql, flags=re.IGNORECASE):
-                    sql_res.append({"content": "For security reasons, INSERT, UPDATE, and DELETE statements are not supported."})
-                    formalized_content.append("For security reasons, INSERT, UPDATE, and DELETE statements are not supported.")
-                    continue
+                _ensure_read_only_sql(single_sql, self._param.db_type)
+                # The SQL is user/LLM-provided, so validate the parsed statement above before execution.
                 cursor.execute(single_sql)
                 if cursor.rowcount == 0:
                     sql_res.append({"content": "No record in the database!"})

--- a/agent/tools/exesql.py
+++ b/agent/tools/exesql.py
@@ -15,6 +15,7 @@
 #
 import contextlib
 import json
+import logging
 import os
 import re
 from abc import ABC
@@ -26,6 +27,8 @@ import sqlglot
 from sqlglot import expressions as exp
 from agent.tools.base import ToolParamBase, ToolBase, ToolMeta
 from common.connection_utils import timeout
+
+logger = logging.getLogger(__name__)
 
 
 class ExeSQLParam(ToolParamBase):
@@ -86,12 +89,26 @@ _ALLOWED_READ_EXPRESSIONS = (
     exp.Intersect,
 )
 
+_CODE_FENCE_RE = re.compile(r"^\s*```(?:\w+)?\s*\n?(.*?)\n?```\s*$", re.DOTALL)
+_ID_MARKER_RE = re.compile(r"\[ID:[0-9]+\]")
+
+
+def _normalize_sql(sql: str) -> str:
+    """Strip code fences (including language tags) and ID markers from SQL."""
+    sql = sql.strip()
+    match = _CODE_FENCE_RE.match(sql)
+    if match:
+        sql = match.group(1).strip()
+    return _ID_MARKER_RE.sub("", sql).strip()
+
 
 def _strip_sql_code_fences(sql: str) -> str:
-    return sql.replace("```", "").strip()
+    """Strip SQL code fences from a string."""
+    return _normalize_sql(sql)
 
 
 def _sqlglot_dialect(db_type: str) -> str | None:
+    """Map database type to sqlglot dialect."""
     return {
         "mysql": "mysql",
         "mariadb": "mysql",
@@ -104,6 +121,7 @@ def _sqlglot_dialect(db_type: str) -> str | None:
 
 
 def _parse_sql_statements(sql: str, db_type: str) -> list[exp.Expression]:
+    """Parse SQL string into a list of sqlglot expression statements."""
     dialect = _sqlglot_dialect(db_type)
     try:
         statements = [statement for statement in sqlglot.parse(sql, read=dialect) if statement]
@@ -113,23 +131,31 @@ def _parse_sql_statements(sql: str, db_type: str) -> list[exp.Expression]:
 
 
 def _split_sql_statements(sql: str, db_type: str) -> list[str]:
+    """Split and validate that SQL contains exactly one statement."""
+    sql = _normalize_sql(sql)
     statements = _parse_sql_statements(sql, db_type)
     if len(statements) != 1:
         raise ValueError("For security reasons, only one read-only SQL statement is supported.")
-    return [sql.strip()]
+    return [sql]
 
 
 def _ensure_read_only_sql(sql: str, db_type: str) -> None:
+    """Validate that SQL is a single read-only SELECT statement."""
     statements = _parse_sql_statements(sql, db_type)
     if len(statements) != 1:
+        logger.warning("SQL validation rejected: db_type=%s, stage=parse, reason=multiple_statements", db_type)
         raise ValueError("For security reasons, only one read-only SQL statement is supported.")
 
     statement = statements[0]
     if not isinstance(statement, _ALLOWED_READ_EXPRESSIONS):
+        logger.warning("SQL validation rejected: db_type=%s, stage=type_check, statement_type=%s",
+                        db_type, type(statement).__name__)
         raise ValueError("For security reasons, only read-only SELECT statements are supported.")
 
-    unsafe = statement.find(exp.Insert, exp.Update, exp.Delete, exp.Drop, exp.Create, exp.Alter, exp.Command, exp.Lock)
+    unsafe = statement.find(exp.Insert, exp.Update, exp.Delete, exp.Drop, exp.Create, exp.Alter, exp.Command, exp.Lock, exp.Into)
     if unsafe or statement.args.get("locks"):
+        reason = f"unsafe_node={type(unsafe).__name__}" if unsafe else "locks_present"
+        logger.warning("SQL validation rejected: db_type=%s, stage=safety_check, %s", db_type, reason)
         raise ValueError("For security reasons, only read-only SELECT statements are supported.")
 
 
@@ -259,10 +285,9 @@ class ExeSQL(ToolBase, ABC):
                     if self.check_if_canceled("ExeSQL processing"):
                         return
 
-                    single_sql = _strip_sql_code_fences(single_sql)
+                    single_sql = _normalize_sql(single_sql)
                     if not single_sql:
                         continue
-                    single_sql = re.sub(r"\[ID:[0-9]+\]", "", single_sql)
                     _ensure_read_only_sql(single_sql, self._param.db_type)
 
                     stmt = ibm_db.exec_immediate(conn, single_sql)
@@ -308,10 +333,9 @@ class ExeSQL(ToolBase, ABC):
                 if self.check_if_canceled("ExeSQL processing"):
                     return
 
-                single_sql = _strip_sql_code_fences(single_sql)
+                single_sql = _normalize_sql(single_sql)
                 if not single_sql:
                     continue
-                single_sql = re.sub(r"\[ID:[0-9]+\]", "", single_sql)
                 _ensure_read_only_sql(single_sql, self._param.db_type)
                 # The SQL is user/LLM-provided, so validate the parsed statement above before execution.
                 cursor.execute(single_sql)

--- a/agent/tools/exesql.py
+++ b/agent/tools/exesql.py
@@ -25,6 +25,7 @@ import psycopg2
 import pyodbc
 import sqlglot
 from sqlglot import expressions as exp
+from sqlglot.errors import SqlglotError
 from agent.tools.base import ToolParamBase, ToolBase, ToolMeta
 from common.connection_utils import timeout
 
@@ -102,9 +103,6 @@ def _normalize_sql(sql: str) -> str:
     return _ID_MARKER_RE.sub("", sql).strip()
 
 
-def _strip_sql_code_fences(sql: str) -> str:
-    """Strip SQL code fences from a string."""
-    return _normalize_sql(sql)
 
 
 def _sqlglot_dialect(db_type: str) -> str | None:
@@ -125,7 +123,8 @@ def _parse_sql_statements(sql: str, db_type: str) -> list[exp.Expression]:
     dialect = _sqlglot_dialect(db_type)
     try:
         statements = [statement for statement in sqlglot.parse(sql, read=dialect) if statement]
-    except Exception as e:
+    except SqlglotError as e:
+        logger.warning("SQL validation rejected: db_type=%s, stage=parse, reason=%s", db_type, type(e).__name__)
         raise ValueError(f"Invalid SQL statement: {e}")
     return statements
 


### PR DESCRIPTION
## Summary

The `ExeSQL` agent tool executes SQL statements derived from LLM output, which is influenced by user input. The existing SQL filtering has two gaps:

1. **IBM DB2 code path** — no SQL statement filtering at all. Any SQL (DROP, ALTER, DELETE, etc.) is passed directly to `ibm_db.exec_immediate()`.
2. **Generic code path** (MySQL, PostgreSQL, MSSQL, etc.) — uses a regex that only blocks `INSERT`, `UPDATE`, and `DELETE`, missing destructive statements like `DROP`, `ALTER`, `CREATE`, `TRUNCATE`, `GRANT`, etc.

This is **CWE-89 (SQL Injection)** — an attacker who can influence the LLM prompt (e.g., via crafted natural-language queries to a ragflow agent with ExeSQL configured) can cause the LLM to emit destructive SQL that bypasses the incomplete blocklist.

**Affected file:** `agent/tools/exesql.py`

## Fix

Replace the regex-based blocklist with a robust **allowlist** approach using `sqlglot` for SQL parsing:

- Parse the SQL using `sqlglot` with dialect awareness (MySQL, PostgreSQL, TSQL, etc.)
- Enforce exactly **one statement** (no query stacking via `;`)
- Allow only read-only expression types: `SELECT`, `UNION`, `EXCEPT`, `INTERSECT`
- Reject any statement containing write/destructive subexpressions (`INSERT`, `UPDATE`, `DELETE`, `DROP`, `CREATE`, `ALTER`, `LOCK`, etc.)
- Apply this validation consistently to **all** database backends, including IBM DB2

## Testing

- Verified that valid `SELECT` and `UNION SELECT` queries pass validation
- Verified that `DROP TABLE`, `DELETE FROM`, `ALTER TABLE`, `CREATE TABLE`, `INSERT INTO`, `TRUNCATE`, and `UPDATE` statements are rejected with a clear error message
- Verified that query-stacking attempts (`SELECT 1; DROP TABLE users`) are rejected
- Verified that subquery-based attacks (`SELECT * FROM (DELETE FROM users RETURNING *)`) are caught by the subexpression scan

## Security Analysis

The ExeSQL tool is designed to let agents query databases in response to user questions. The SQL is generated by an LLM based on user input, making it attacker-influenced. An attacker with access to a ragflow agent using ExeSQL can craft prompts that cause the LLM to emit destructive SQL. The previous regex blocklist was trivially bypassable (e.g., `DROP TABLE`, `GRANT`, or any statement not in the short deny list). The IBM DB2 path had no protection at all.

Before submitting, we considered whether existing mitigations would prevent exploitation — specifically whether the LLM would refuse to generate destructive SQL. LLMs are reliably manipulable via prompt injection, and the ExeSQL tool passes LLM output directly to the database cursor without any structural validation. The regex filter on the generic path was incomplete by design (missing most DDL/DCL), so the risk is real.

The `sqlglot`-based allowlist is a defense-in-depth measure that works regardless of LLM behavior, covering all supported database dialects.