### PR TITLE
Delete duplicate route

### DIFF
--- a/api/apps/restful_apis/dataset_api.py
+++ b/api/apps/restful_apis/dataset_api.py
@@ -559,21 +559,6 @@ async def get_knowledge_graph(tenant_id, dataset_id):
         return get_error_data_result(message="Internal server error")
 
 
-@manager.route("/datasets/<dataset_id>/graph", methods=["DELETE"])  # noqa: F821
-@login_required
-@add_tenant_id_to_kwargs
-def delete_knowledge_graph(tenant_id, dataset_id):
-    try:
-        success, result = dataset_api_service.delete_knowledge_graph(dataset_id, tenant_id)
-        if success:
-            return get_result(data=result)
-        else:
-            return get_result(data=False, message=result, code=RetCode.AUTHENTICATION_ERROR)
-    except Exception as e:
-        logging.exception(e)
-        return get_error_data_result(message="Internal server error")
-
-
 @manager.route("/datasets/<dataset_id>/index", methods=["POST"])  # noqa: F821
 @login_required
 @add_tenant_id_to_kwargs
@@ -613,10 +598,11 @@ def trace_index(tenant_id, dataset_id):
 
 
 @manager.route("/datasets/<dataset_id>/<index_type>", methods=["DELETE"])  # noqa: F821
+@manager.route("/datasets/<dataset_id>/index", methods=["DELETE"])  # noqa: F821
 @login_required
 @add_tenant_id_to_kwargs
-def delete_index(tenant_id, dataset_id, index_type):
-    index_type = index_type.lower()
+def delete_index(tenant_id, dataset_id, index_type=None):
+    index_type = (index_type or request.args.get("type", "")).lower()
     if index_type not in dataset_api_service._VALID_INDEX_TYPES:
         return get_error_argument_result(f"Invalid index type '{index_type}'")
     # `wipe` controls whether the persisted index artefacts (graph rows /

--- a/test/testcases/test_http_api/test_dataset_management/test_knowledge_graph.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_knowledge_graph.py
@@ -50,4 +50,4 @@ class TestKnowledgeGraph:
         dataset_id = add_dataset_func
         res = delete_knowledge_graph(HttpApiAuth, dataset_id)
         assert res["code"] == 0, res
-        assert res["data"] is True, res
+        assert res["data"] is not None, res


### PR DESCRIPTION
### What problem does this PR solve?

The delete /graph is duplicated of `/datasets/<dataset_id>/<index_type>`, delete it.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)