### PR TITLE
fix: Cross-tenant task cancellation via POST

### DIFF
--- a/api/apps/restful_apis/task_api.py
+++ b/api/apps/restful_apis/task_api.py
@@ -16,9 +16,11 @@
 import logging
 from datetime import datetime
 
-from api.apps import login_required
+from api.apps import current_user, login_required
+from api.db.services.document_service import DocumentService
 from api.db.services.task_service import TaskService, CANVAS_DEBUG_DOC_ID, GRAPH_RAPTOR_FAKE_DOC_ID
 from api.utils.api_utils import (
+    get_data_error_result,
     get_json_result,
     get_request_json,
     validate_request,
@@ -56,6 +58,13 @@ async def _cancel_task(task_id):
     Sets a Redis cancel flag, updates the task progress to -1 (cancelled),
         and marks the associated document's run status as CANCEL if applicable.
     """
+    exists, task = TaskService.get_by_id(task_id)
+    if not exists:
+        return get_json_result(data=True)
+
+    if not DocumentService.accessible(task.doc_id, current_user.id):
+        return get_data_error_result(message="No authorization.")
+
     try:
         REDIS_CONN.set(f"{task_id}-cancel", "x")
     except Exception as e:
@@ -64,10 +73,6 @@ async def _cancel_task(task_id):
             code=RetCode.CONNECTION_ERROR,
             message="Failed to stop task",
         )
-
-    exists, task = TaskService.get_by_id(task_id)
-    if not exists:
-        return get_json_result(data=True)
 
     # Append a cancellation message so the user can see it in progress_msg.
     try:
@@ -88,7 +93,6 @@ async def _cancel_task(task_id):
     # If the task belongs to a document, also mark the document's run status as
     # cancelled so that the UI reflects the state correctly.
     try:
-        from api.db.services.document_service import DocumentService
         doc_id = task.doc_id
         if doc_id and doc_id not in (CANVAS_DEBUG_DOC_ID, GRAPH_RAPTOR_FAKE_DOC_ID):
             _, doc = DocumentService.get_by_id(doc_id)


### PR DESCRIPTION
## Summary
This change fixes a cross-tenant IDOR vulnerability where any authenticated user could cancel another tenant’s task if they knew the `task_id`.

The fix adds ownership authorization before any cancellation side effects (Redis cancel flag, task progress update, document run-status update).
## Related Issue
Fixes: #14901 
## Change Type (select all)
- [x] Bug fix
- [x] Security fix
- [x] Backend API change
- [ ] New feature
- [ ] Refactor only
- [ ] Breaking API contract
- [ ] Docs only
- [ ] Test only

## Related Issue
- https://github.com/infiniflow/ragflow/issues/14901

## Root Cause
`task_api.py` cancellation handlers were only protected by `@login_required` and did not verify whether the task/document belonged to the caller’s tenant scope.
## Real Behavior Proof
### Before fix
Any authenticated user could:
1. Call `POST /api/v1/tasks/<victim_task_id>/cancel` or `PATCH /api/v1/tasks/<victim_task_id>` with `{"action":"stop"}`.
2. Trigger:
   - Redis cancel flag write
   - task progress update (`progress=-1`)
   - document run status cancellation

No ownership check blocked cross-tenant requests.

### After fix
For existing task IDs:
- If caller lacks access to `task.doc_id`:
  - request is denied with `No authorization.`
  - no Redis cancel flag written
  - no task/document cancellation state update

If caller has access:
- cancellation proceeds as before.

## Validation / Verification
- [x] Endpoint logic reviewed for both routes:
  - `POST /tasks/<task_id>/cancel`
  - `PATCH /tasks/<task_id>` (`action=stop`)
- [x] Ownership check confirmed present before side effects
- [x] Syntax validation passed:
  - `python3 -m py_compile api/apps/restful_apis/task_api.py`
- [ ] Automated regression tests added
- [ ] Multi-tenant integration test executed


## Checklist
- [x] Reproduced/validated issue by code inspection
- [x] Added authorization check in cancellation path
- [x] Ensured authorization runs before Redis/DB side effects
- [x] Kept existing authorized cancellation flow intact
- [x] Passed syntax check
- [ ] Added regression tests for unauthorized cross-tenant cancel attempts
- [ ] Added release-note/changelog entry (if required)

