### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -6804,6 +6804,96 @@
                     "model_type": "embedding"
                 }
             ]
+        },
+        {
+            "name": "Astraflow",
+            "logo": "",
+            "tags": "LLM",
+            "status": "1",
+            "rank": "100",
+            "url": "https://api-us-ca.umodelverse.ai/v1",
+            "llm": [
+                {
+                    "llm_name": "deepseek-ai/DeepSeek-V3",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "deepseek-ai/DeepSeek-R1",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": false
+                },
+                {
+                    "llm_name": "Qwen/Qwen3-235B-A22B",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                }
+            ]
+        },
+        {
+            "name": "Astraflow-CN",
+            "logo": "",
+            "tags": "LLM",
+            "status": "1",
+            "rank": "99",
+            "url": "https://api.modelverse.cn/v1",
+            "llm": [
+                {
+                    "llm_name": "deepseek-ai/DeepSeek-V3",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "deepseek-ai/DeepSeek-R1",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": false
+                },
+                {
+                    "llm_name": "Qwen/Qwen3-235B-A22B",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+                    "tags": "LLM,CHAT,128k",
+                    "max_tokens": 128000,
+                    "model_type": "chat",
+                    "is_tools": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
### What problem does this PR solve?

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider in RAGFlow. Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. This PR registers both the global and China endpoints so users can select Astraflow as a provider directly within RAGFlow.

Changes made:
- **`rag/llm/__init__.py`** — Already contains `Astraflow` and `Astraflow_CN` enum entries, their `FACTORY_DEFAULT_BASE_URL` mappings, and `LITELLM_PROVIDER_PREFIX` entries (these were pre-existing).
- **`conf/llm_factories.json`** — Added two new factory entries:
  - **`Astraflow`** — global endpoint (`https://api-us-ca.umodelverse.ai/v1`), uses `ASTRAFLOW_API_KEY`
  - **`Astraflow-CN`** — China endpoint (`https://api.modelverse.cn/v1`), uses `ASTRAFLOW_CN_API_KEY`

Because Astraflow is fully OpenAI-compatible, no new SDK or subpackage is needed — the existing `LiteLLMBase` with `openai/` prefix handles all calls.

Bundled starter models (both endpoints):
- `deepseek-ai/DeepSeek-V3` (chat, 128k, tools)
- `deepseek-ai/DeepSeek-R1` (chat, 128k)
- `Qwen/Qwen3-235B-A22B` (chat, 128k, tools)
- `meta-llama/Llama-4-Scout-17B-16E-Instruct` (chat, 128k, tools)
- `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` (chat, 128k, tools)

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):