### PR TITLE
Fix auto metadata field type preservation

### DIFF
--- a/common/metadata_utils.py
+++ b/common/metadata_utils.py
@@ -19,6 +19,22 @@ from typing import Any, Callable, Dict
 
 import json_repair
 
+SUPPORTED_METADATA_TYPES = {"string", "list", "time", "number"}
+
+
+def _metadata_type_to_json_schema(field_type: str | None) -> Dict[str, Any]:
+    """Map UI auto-metadata types to JSON Schema fragments."""
+    if field_type not in SUPPORTED_METADATA_TYPES:
+        field_type = "string"
+    if field_type == "list":
+        return {"type": "array", "items": {"type": "string"}}
+    if field_type == "time":
+        return {"type": "string", "format": "date-time"}
+    if field_type == "number":
+        return {"type": "number"}
+    return {"type": "string"}
+
+
 def convert_conditions(metadata_condition):
     if metadata_condition is None:
         metadata_condition = {}
@@ -300,6 +316,10 @@ def dedupe_list(values: list) -> list:
     return deduped
 
 
+def _is_supported_metadata_value(value) -> bool:
+    return isinstance(value, (str, int, float))
+
+
 def update_metadata_to(metadata, meta):
     if not meta:
         return metadata
@@ -314,11 +334,11 @@ def update_metadata_to(metadata, meta):
 
     for k, v in meta.items():
         if isinstance(v, list):
-            v = [vv for vv in v if isinstance(vv, str)]
+            v = [vv for vv in v if _is_supported_metadata_value(vv)]
             if not v:
                 continue
             v = dedupe_list(v)
-        if not isinstance(v, list) and not isinstance(v, str):
+        if not isinstance(v, list) and not _is_supported_metadata_value(v):
             continue
         if k not in metadata:
             metadata[k] = v
@@ -346,11 +366,16 @@ def metadata_schema(metadata: dict|list|None) -> Dict[str, Any]:
             continue
 
         prop_schema = {
-            "description": item.get("description", "")
+            **_metadata_type_to_json_schema(item.get("type")),
+            "description": item.get("description", ""),
         }
         if "enum" in item and item["enum"]:
-            prop_schema["enum"] = item["enum"]
-            prop_schema["type"] = "string"
+            if prop_schema.get("type") == "array":
+                prop_schema.setdefault("items", {"type": "string"})["enum"] = item[
+                    "enum"
+                ]
+            else:
+                prop_schema["enum"] = item["enum"]
 
         properties[key] = prop_schema
 
@@ -382,6 +407,8 @@ def _is_metadata_list(obj: list) -> bool:
             return False
         if "enum" in item and not isinstance(item["enum"], list):
             return False
+        if "type" in item and item["type"] not in SUPPORTED_METADATA_TYPES:
+            return False
         if "description" in item and not isinstance(item["description"], str):
             return False
         if "descriptions" in item and not isinstance(item["descriptions"], str):
@@ -398,6 +425,7 @@ def turn2jsonschema(obj: dict | list) -> Dict[str, Any]:
             description = item.get("description", item.get("descriptions", ""))
             normalized_item = {
                 "key": item.get("key"),
+                "type": item.get("type", "string"),
                 "description": description,
             }
             if "enum" in item:

--- a/web/src/pages/dataset/components/metedata/hooks/use-manage-modal.ts
+++ b/web/src/pages/dataset/components/metedata/hooks/use-manage-modal.ts
@@ -20,6 +20,7 @@ import {
 } from '../constant';
 import {
   IBuiltInMetadataItem,
+  IMetaDataJsonSchemaProperty,
   IMetaDataReturnJSONSettings,
   IMetaDataReturnJSONType,
   IMetaDataReturnType,
@@ -29,6 +30,29 @@ import {
   ShowManageMetadataModalProps,
   UpdateOperation,
 } from '../interface';
+
+const normalizeMetadataValueType = (type?: string): MetadataValueType => {
+  if (type === 'array') return metadataValueTypeEnum.list;
+  if (
+    type === metadataValueTypeEnum.string ||
+    type === metadataValueTypeEnum.list ||
+    type === metadataValueTypeEnum.time ||
+    type === metadataValueTypeEnum.number
+  ) {
+    return type;
+  }
+  return DEFAULT_VALUE_TYPE;
+};
+
+const getValueTypeFromJsonSchemaProperty = (
+  property: IMetaDataJsonSchemaProperty,
+): MetadataValueType => {
+  if (property.type === 'array') return metadataValueTypeEnum.list;
+  if (property.format === 'date-time' || property.format === 'date') {
+    return metadataValueTypeEnum.time;
+  }
+  return normalizeMetadataValueType(property.type);
+};
 
 export const util = {
   changeToMetaDataTableData(data: IMetaDataReturnType): IMetaDataTableData[] {
@@ -116,13 +140,13 @@ export const util = {
           description: item.description,
           values: item.enum || [],
           restrictDefinedValues: !!item.enum?.length,
-          valueType: DEFAULT_VALUE_TYPE,
+          valueType: normalizeMetadataValueType(item.type),
         } as IMetaDataTableData;
       });
     }
     const properties = data.properties || {};
     return Object.entries(properties).map(([key, property]) => {
-      const valueType = 'string';
+      const valueType = getValueTypeFromJsonSchemaProperty(property);
       const values = property.enum || property.items?.enum || [];
       return {
         field: key,

--- a/web/src/pages/dataset/components/metedata/interface.ts
+++ b/web/src/pages/dataset/components/metedata/interface.ts
@@ -12,6 +12,7 @@ export type IMetaDataReturnJSONType = Record<
 
 export interface IMetaDataReturnJSONSettingItem {
   key: string;
+  type?: MetadataValueType;
   description?: string;
   enum?: string[];
 }


### PR DESCRIPTION
Closes #32

## Summary
- Preserve non-string auto metadata field types when reopening metadata generation settings.
- Preserve supported metadata field types when building the backend metadata generation schema.
- Allow generated numeric metadata values to be stored as numeric values instead of being discarded.

## Validation
- Confirmed through the RAGFlow UI that Number fields stay as Number after saving/reopening.
- Confirmed generated `price` metadata is stored as numeric values.