### PR TITLE
 Fix session deletion leaking chat-upload blobs

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -47,6 +47,7 @@ from api.utils.api_utils import (
 )
 from api.utils.tenant_utils import ensure_tenant_model_id_for_params
 from common.constants import LLMType, RetCode, StatusEnum
+from common import settings
 from common.misc_utils import get_uuid, thread_pool_exec
 from rag.prompts.generator import chunks_format
 from rag.prompts.template import load_prompt
@@ -794,6 +795,18 @@ async def delete_sessions(chat_id):
             if not ConversationService.query(id=sid, dialog_id=chat_id):
                 errors.append(f"The chat doesn't own the session {sid}")
                 continue
+            ok, conv = ConversationService.get_by_id(sid)
+            if ok:
+                for msg in conv.message or []:
+                    for file in msg.get("files") or []:
+                        file_id = file.get("id")
+                        created_by = file.get("created_by")
+                        if not file_id or not created_by:
+                            continue
+                        try:
+                            settings.STORAGE_IMPL.rm(f"{created_by}-downloads", file_id)
+                        except Exception:
+                            logging.warning("Failed to delete chat upload blob %s/%s", created_by, file_id)
             ConversationService.delete_by_id(sid)
             success_count += 1
         all_errors = errors + duplicate_messages

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -800,13 +800,12 @@ async def delete_sessions(chat_id):
                 for msg in conv.message or []:
                     for file in msg.get("files") or []:
                         file_id = file.get("id")
-                        created_by = file.get("created_by")
-                        if not file_id or not created_by:
+                        if not file_id:
                             continue
                         try:
-                            settings.STORAGE_IMPL.rm(f"{created_by}-downloads", file_id)
+                            settings.STORAGE_IMPL.rm(f"{current_user.id}-downloads", file_id)
                         except Exception:
-                            logging.warning("Failed to delete chat upload blob %s/%s", created_by, file_id)
+                            logging.warning("Failed to delete chat upload blob %s/%s", current_user.id, file_id)
             ConversationService.delete_by_id(sid)
             success_count += 1
         all_errors = errors + duplicate_messages


### PR DESCRIPTION
### What problem does this PR solve?

This fixes a bug where files uploaded in chat were left in storage after the session was deleted. It now removes those chat-uploaded blobs during session deletion. fixes #14965

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)