### PR TITLE
Refactor: speed up ragflow server, save startup memory

### DIFF
--- a/api/apps/llm_app.py
+++ b/api/apps/llm_app.py
@@ -25,8 +25,21 @@ from api.db.services.llm_service import LLMService
 from api.utils.api_utils import get_allowed_llm_factories, get_data_error_result, get_json_result, get_request_json, server_error_response, validate_request
 from common.constants import StatusEnum, LLMType
 from api.db.db_models import TenantLLM
-from rag.utils.base64_image import test_image
-from rag.llm import EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel, OcrModel, Seq2txtModel
+
+
+def _llm_registries():
+    # rag.llm imports provider implementations and optional native ML stacks.
+    # Most LLM settings endpoints only list database metadata, so defer the
+    # heavy import until verification/instantiation is requested.
+    from rag.llm import EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel, OcrModel, Seq2txtModel
+
+    return EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel, OcrModel, Seq2txtModel
+
+
+def _test_image():
+    from rag.utils.base64_image import test_image
+
+    return test_image
 
 
 def _resolve_my_llm_is_tools(o_dict: dict) -> bool:
@@ -78,6 +91,7 @@ def factories():
 @validate_request("llm_factory", "api_key")
 async def set_api_key():
     req = await get_request_json()
+    EmbeddingModel, ChatModel, RerankModel, _, _, _, _ = _llm_registries()
     # test if api key works
     chat_passed, embd_passed, rerank_passed = False, False, False
     factory = req["llm_factory"]
@@ -178,6 +192,7 @@ async def set_api_key():
 @validate_request("llm_factory")
 async def add_llm():
     req = await get_request_json()
+    EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel, OcrModel, Seq2txtModel = _llm_registries()
     factory = req["llm_factory"]
     api_key = req.get("api_key", "x")
     llm_name = req.get("llm_name")
@@ -321,7 +336,7 @@ async def add_llm():
             assert factory in CvModel, f"Image to text model from {factory} is not supported yet."
             mdl = CvModel[factory](key=model_api_key, model_name=mdl_nm, base_url=model_base_url)
             try:
-                image_data = test_image
+                image_data = _test_image()
                 m, tc = await asyncio.wait_for(
                     asyncio.to_thread(mdl.describe, image_data),
                     timeout=timeout_seconds,

--- a/api/apps/llm_app.py
+++ b/api/apps/llm_app.py
@@ -27,21 +27,6 @@ from common.constants import StatusEnum, LLMType
 from api.db.db_models import TenantLLM
 
 
-def _llm_registries():
-    # rag.llm imports provider implementations and optional native ML stacks.
-    # Most LLM settings endpoints only list database metadata, so defer the
-    # heavy import until verification/instantiation is requested.
-    from rag.llm import EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel, OcrModel, Seq2txtModel
-
-    return EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel, OcrModel, Seq2txtModel
-
-
-def _test_image():
-    from rag.utils.base64_image import test_image
-
-    return test_image
-
-
 def _resolve_my_llm_is_tools(o_dict: dict) -> bool:
     decode_api_key_config = getattr(TenantLLMService, "_decode_api_key_config", None)
     if callable(decode_api_key_config):
@@ -91,7 +76,8 @@ def factories():
 @validate_request("llm_factory", "api_key")
 async def set_api_key():
     req = await get_request_json()
-    EmbeddingModel, ChatModel, RerankModel, _, _, _, _ = _llm_registries()
+    from rag.llm import ChatModel, EmbeddingModel, RerankModel
+
     # test if api key works
     chat_passed, embd_passed, rerank_passed = False, False, False
     factory = req["llm_factory"]
@@ -192,7 +178,8 @@ async def set_api_key():
 @validate_request("llm_factory")
 async def add_llm():
     req = await get_request_json()
-    EmbeddingModel, ChatModel, RerankModel, CvModel, TTSModel, OcrModel, Seq2txtModel = _llm_registries()
+    from rag.llm import ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel
+
     factory = req["llm_factory"]
     api_key = req.get("api_key", "x")
     llm_name = req.get("llm_name")
@@ -333,10 +320,12 @@ async def add_llm():
                 msg += f"\nFail to access model({factory}/{mdl_nm})." + str(e)
 
         case LLMType.IMAGE2TEXT.value:
+            from rag.utils.base64_image import test_image
+
             assert factory in CvModel, f"Image to text model from {factory} is not supported yet."
             mdl = CvModel[factory](key=model_api_key, model_name=mdl_nm, base_url=model_base_url)
             try:
-                image_data = _test_image()
+                image_data = test_image
                 m, tc = await asyncio.wait_for(
                     asyncio.to_thread(mdl.describe, image_data),
                     timeout=timeout_seconds,

--- a/api/apps/restful_apis/agent_api.py
+++ b/api/apps/restful_apis/agent_api.py
@@ -62,42 +62,6 @@ from common.misc_utils import get_uuid, thread_pool_exec
 from peewee import MySQLDatabase, PostgresqlDatabase
 
 
-def _canvas_cls():
-    from agent.canvas import Canvas
-
-    return Canvas
-
-
-def _llm_cls():
-    from agent.component import LLM
-
-    return LLM
-
-
-def _normalize_chunker_dsl(dsl):
-    from agent.dsl_migration import normalize_chunker_dsl
-
-    return normalize_chunker_dsl(dsl)
-
-
-def _pipeline_cls():
-    from rag.flow.pipeline import Pipeline
-
-    return Pipeline
-
-
-def _search():
-    from rag.nlp import search
-
-    return search
-
-
-def _redis_conn():
-    from rag.utils.redis_conn import REDIS_CONN
-
-    return REDIS_CONN
-
-
 def _require_canvas_access_sync(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -224,7 +188,8 @@ def list_agent_sessions(agent_id, tenant_id):
 @add_tenant_id_to_kwargs
 @_require_canvas_access_async
 async def create_agent_session(agent_id, tenant_id):
-    Canvas = _canvas_cls()
+    from agent.canvas import Canvas
+
     req = await get_request_json()
     user_id = req.get("user_id") or request.args.get("user_id", tenant_id)
     release_mode = bool(req.get("release", request.args.get("release", False)))
@@ -552,7 +517,8 @@ async def upload_agent_file(agent_id, tenant_id):
 @_require_canvas_access_sync
 def get_agent_component_input_form(agent_id, component_id, tenant_id):
     try:
-        Canvas = _canvas_cls()
+        from agent.canvas import Canvas
+
         exists, user_canvas = UserCanvasService.get_by_id(agent_id)
         if not exists:
             return get_data_error_result(message="canvas not found.")
@@ -570,8 +536,9 @@ def get_agent_component_input_form(agent_id, component_id, tenant_id):
 async def debug_agent_component(agent_id, component_id, tenant_id):
     req = await get_request_json()
     try:
-        Canvas = _canvas_cls()
-        LLM = _llm_cls()
+        from agent.canvas import Canvas
+        from agent.component import LLM
+
         _, user_canvas = UserCanvasService.get_by_id(agent_id)
         canvas = Canvas(json.dumps(user_canvas.dsl), tenant_id, canvas_id=user_canvas.id)
         canvas.reset()
@@ -630,7 +597,9 @@ def get_agent(agent_id, tenant_id):
             released_versions.sort(key=lambda version: version.update_time, reverse=True)
             last_publish_time = released_versions[0].update_time
 
-    canvas["dsl"] = _normalize_chunker_dsl(canvas.get("dsl", {}))
+    from agent.dsl_migration import normalize_chunker_dsl
+
+    canvas["dsl"] = normalize_chunker_dsl(canvas.get("dsl", {}))
     canvas["last_publish_time"] = last_publish_time
 
     if canvas.get("canvas_category") == CanvasCategory.DataFlow:
@@ -675,7 +644,8 @@ def get_agent_version(agent_id, version_id, tenant_id):
 @_require_canvas_access_async
 async def get_agent_logs(agent_id, message_id, tenant_id):
     try:
-        REDIS_CONN = _redis_conn()
+        from rag.utils.redis_conn import REDIS_CONN
+
         binary = await thread_pool_exec(REDIS_CONN.get, f"{agent_id}-{message_id}-logs")
         if not binary:
             return get_json_result(data={})
@@ -753,7 +723,8 @@ async def update_agent(agent_id, tenant_id):
 @_require_canvas_access_async
 async def reset_agent(agent_id, tenant_id):
     try:
-        Canvas = _canvas_cls()
+        from agent.canvas import Canvas
+
         exists, user_canvas = UserCanvasService.get_by_id(agent_id)
         if not exists:
             return get_data_error_result(message="canvas not found.")
@@ -782,7 +753,8 @@ async def reset_agent(agent_id, tenant_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def rerun_agent(tenant_id):
-    search = _search()
+    from rag.nlp import search
+
     req = await get_request_json()
     doc = PipelineOperationLogService.get_documents_info(req["id"])
     if not doc:
@@ -1063,7 +1035,8 @@ async def agent_chat_completion(tenant_id, agent_id=None):
         dsl_str = json.dumps(replica_dsl, ensure_ascii=False)
 
         if cvs.canvas_category == CanvasCategory.DataFlow:
-            Pipeline = _pipeline_cls()
+            from rag.flow.pipeline import Pipeline
+
             task_id = get_uuid()
             Pipeline(
                 dsl_str,
@@ -1086,7 +1059,8 @@ async def agent_chat_completion(tenant_id, agent_id=None):
             return get_json_result(data={"message_id": task_id})
 
         try:
-            Canvas = _canvas_cls()
+            from agent.canvas import Canvas
+
             canvas = Canvas(dsl_str, str(tenant_id), canvas_id=agent_id, custom_header=custom_header)
         except Exception as exc:
             return server_error_response(exc)
@@ -1372,7 +1346,8 @@ async def webhook(agent_id: str):
         now = time.time()
 
         try:
-            REDIS_CONN = _redis_conn()
+            from rag.utils.redis_conn import REDIS_CONN
+
             res = REDIS_CONN.lua_token_bucket(
                 keys=[key],
                 args=[capacity, rate, now, cost],
@@ -1480,7 +1455,8 @@ async def webhook(agent_id: str):
     if not isinstance(cvs.dsl, str):
         dsl = json.dumps(cvs.dsl, ensure_ascii=False)
     try:
-        Canvas = _canvas_cls()
+        from agent.canvas import Canvas
+
         canvas = Canvas(dsl, cvs.user_id, agent_id, canvas_id=agent_id)
     except Exception as e:
         resp=get_data_error_result(code=RetCode.BAD_REQUEST,message=str(e))
@@ -1734,7 +1710,8 @@ async def webhook(agent_id: str):
     response_cfg = webhook_cfg.get("response", {})
 
     def append_webhook_trace(agent_id: str, start_ts: float,event: dict, ttl=600):
-        REDIS_CONN = _redis_conn()
+        from rag.utils.redis_conn import REDIS_CONN
+
         key = f"webhook-trace-{agent_id}-logs"
 
         raw = REDIS_CONN.get(key)
@@ -1934,7 +1911,8 @@ async def webhook_trace(agent_id: str):
     webhook_id = request.args.get("webhook_id")
 
     key = f"webhook-trace-{agent_id}-logs"
-    REDIS_CONN = _redis_conn()
+    from rag.utils.redis_conn import REDIS_CONN
+
     raw = REDIS_CONN.get(key)
 
     if since_ts is None:

--- a/api/apps/restful_apis/agent_api.py
+++ b/api/apps/restful_apis/agent_api.py
@@ -29,9 +29,6 @@ from functools import partial, wraps
 import jwt
 from quart import Response, jsonify, request
 
-from agent.canvas import Canvas
-from agent.component import LLM
-from agent.dsl_migration import normalize_chunker_dsl
 from api.apps import current_user, login_required
 from api.apps.services.canvas_replica_service import CanvasReplicaService
 from api.db import CanvasCategory
@@ -63,9 +60,42 @@ from common import settings
 from common.constants import RetCode
 from common.misc_utils import get_uuid, thread_pool_exec
 from peewee import MySQLDatabase, PostgresqlDatabase
-from rag.flow.pipeline import Pipeline
-from rag.nlp import search
-from rag.utils.redis_conn import REDIS_CONN
+
+
+def _canvas_cls():
+    from agent.canvas import Canvas
+
+    return Canvas
+
+
+def _llm_cls():
+    from agent.component import LLM
+
+    return LLM
+
+
+def _normalize_chunker_dsl(dsl):
+    from agent.dsl_migration import normalize_chunker_dsl
+
+    return normalize_chunker_dsl(dsl)
+
+
+def _pipeline_cls():
+    from rag.flow.pipeline import Pipeline
+
+    return Pipeline
+
+
+def _search():
+    from rag.nlp import search
+
+    return search
+
+
+def _redis_conn():
+    from rag.utils.redis_conn import REDIS_CONN
+
+    return REDIS_CONN
 
 
 def _require_canvas_access_sync(func):
@@ -194,6 +224,7 @@ def list_agent_sessions(agent_id, tenant_id):
 @add_tenant_id_to_kwargs
 @_require_canvas_access_async
 async def create_agent_session(agent_id, tenant_id):
+    Canvas = _canvas_cls()
     req = await get_request_json()
     user_id = req.get("user_id") or request.args.get("user_id", tenant_id)
     release_mode = bool(req.get("release", request.args.get("release", False)))
@@ -521,6 +552,7 @@ async def upload_agent_file(agent_id, tenant_id):
 @_require_canvas_access_sync
 def get_agent_component_input_form(agent_id, component_id, tenant_id):
     try:
+        Canvas = _canvas_cls()
         exists, user_canvas = UserCanvasService.get_by_id(agent_id)
         if not exists:
             return get_data_error_result(message="canvas not found.")
@@ -538,6 +570,8 @@ def get_agent_component_input_form(agent_id, component_id, tenant_id):
 async def debug_agent_component(agent_id, component_id, tenant_id):
     req = await get_request_json()
     try:
+        Canvas = _canvas_cls()
+        LLM = _llm_cls()
         _, user_canvas = UserCanvasService.get_by_id(agent_id)
         canvas = Canvas(json.dumps(user_canvas.dsl), tenant_id, canvas_id=user_canvas.id)
         canvas.reset()
@@ -596,7 +630,7 @@ def get_agent(agent_id, tenant_id):
             released_versions.sort(key=lambda version: version.update_time, reverse=True)
             last_publish_time = released_versions[0].update_time
 
-    canvas["dsl"] = normalize_chunker_dsl(canvas.get("dsl", {}))
+    canvas["dsl"] = _normalize_chunker_dsl(canvas.get("dsl", {}))
     canvas["last_publish_time"] = last_publish_time
 
     if canvas.get("canvas_category") == CanvasCategory.DataFlow:
@@ -641,6 +675,7 @@ def get_agent_version(agent_id, version_id, tenant_id):
 @_require_canvas_access_async
 async def get_agent_logs(agent_id, message_id, tenant_id):
     try:
+        REDIS_CONN = _redis_conn()
         binary = await thread_pool_exec(REDIS_CONN.get, f"{agent_id}-{message_id}-logs")
         if not binary:
             return get_json_result(data={})
@@ -718,6 +753,7 @@ async def update_agent(agent_id, tenant_id):
 @_require_canvas_access_async
 async def reset_agent(agent_id, tenant_id):
     try:
+        Canvas = _canvas_cls()
         exists, user_canvas = UserCanvasService.get_by_id(agent_id)
         if not exists:
             return get_data_error_result(message="canvas not found.")
@@ -746,6 +782,7 @@ async def reset_agent(agent_id, tenant_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def rerun_agent(tenant_id):
+    search = _search()
     req = await get_request_json()
     doc = PipelineOperationLogService.get_documents_info(req["id"])
     if not doc:
@@ -1026,6 +1063,7 @@ async def agent_chat_completion(tenant_id, agent_id=None):
         dsl_str = json.dumps(replica_dsl, ensure_ascii=False)
 
         if cvs.canvas_category == CanvasCategory.DataFlow:
+            Pipeline = _pipeline_cls()
             task_id = get_uuid()
             Pipeline(
                 dsl_str,
@@ -1048,6 +1086,7 @@ async def agent_chat_completion(tenant_id, agent_id=None):
             return get_json_result(data={"message_id": task_id})
 
         try:
+            Canvas = _canvas_cls()
             canvas = Canvas(dsl_str, str(tenant_id), canvas_id=agent_id, custom_header=custom_header)
         except Exception as exc:
             return server_error_response(exc)
@@ -1333,6 +1372,7 @@ async def webhook(agent_id: str):
         now = time.time()
 
         try:
+            REDIS_CONN = _redis_conn()
             res = REDIS_CONN.lua_token_bucket(
                 keys=[key],
                 args=[capacity, rate, now, cost],
@@ -1440,6 +1480,7 @@ async def webhook(agent_id: str):
     if not isinstance(cvs.dsl, str):
         dsl = json.dumps(cvs.dsl, ensure_ascii=False)
     try:
+        Canvas = _canvas_cls()
         canvas = Canvas(dsl, cvs.user_id, agent_id, canvas_id=agent_id)
     except Exception as e:
         resp=get_data_error_result(code=RetCode.BAD_REQUEST,message=str(e))
@@ -1693,6 +1734,7 @@ async def webhook(agent_id: str):
     response_cfg = webhook_cfg.get("response", {})
 
     def append_webhook_trace(agent_id: str, start_ts: float,event: dict, ttl=600):
+        REDIS_CONN = _redis_conn()
         key = f"webhook-trace-{agent_id}-logs"
 
         raw = REDIS_CONN.get(key)
@@ -1892,6 +1934,7 @@ async def webhook_trace(agent_id: str):
     webhook_id = request.args.get("webhook_id")
 
     key = f"webhook-trace-{agent_id}-logs"
+    REDIS_CONN = _redis_conn()
     raw = REDIS_CONN.get(key)
 
     if since_ts is None:

--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -43,8 +43,24 @@ from common.constants import LLMType, ParserType, RetCode
 from common.misc_utils import thread_pool_exec
 from common.string_utils import is_content_empty, remove_redundant_spaces
 from common.tag_feature_utils import validate_tag_features
-from rag.app.qa import beAdoc, rmPrefix
-from rag.nlp import rag_tokenizer, search
+
+
+def _search():
+    from rag.nlp import search
+
+    return search
+
+
+def _rag_tokenizer():
+    from rag.nlp import rag_tokenizer
+
+    return rag_tokenizer
+
+
+def _qa_helpers():
+    from rag.app.qa import beAdoc, rmPrefix
+
+    return beAdoc, rmPrefix
 
 
 class Chunk(BaseModel):
@@ -107,6 +123,7 @@ def _get_dataset_tenant_id(dataset_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def list_chunks(tenant_id, dataset_id, document_id):
+    search = _search()
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -191,6 +208,7 @@ async def list_chunks(tenant_id, dataset_id, document_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def get_chunk(tenant_id, dataset_id, document_id, chunk_id):
+    search = _search()
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -214,6 +232,8 @@ async def get_chunk(tenant_id, dataset_id, document_id, chunk_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def add_chunk(tenant_id, dataset_id, document_id):
+    search = _search()
+    rag_tokenizer = _rag_tokenizer()
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -303,6 +323,7 @@ async def add_chunk(tenant_id, dataset_id, document_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def rm_chunk(tenant_id, dataset_id, document_id):
+    search = _search()
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -350,6 +371,9 @@ async def rm_chunk(tenant_id, dataset_id, document_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def update_chunk(tenant_id, dataset_id, document_id, chunk_id):
+    search = _search()
+    rag_tokenizer = _rag_tokenizer()
+    beAdoc, rmPrefix = _qa_helpers()
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -436,6 +460,7 @@ async def update_chunk(tenant_id, dataset_id, document_id, chunk_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def switch_chunks(tenant_id, dataset_id, document_id):
+    search = _search()
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)

--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -45,24 +45,6 @@ from common.string_utils import is_content_empty, remove_redundant_spaces
 from common.tag_feature_utils import validate_tag_features
 
 
-def _search():
-    from rag.nlp import search
-
-    return search
-
-
-def _rag_tokenizer():
-    from rag.nlp import rag_tokenizer
-
-    return rag_tokenizer
-
-
-def _qa_helpers():
-    from rag.app.qa import beAdoc, rmPrefix
-
-    return beAdoc, rmPrefix
-
-
 class Chunk(BaseModel):
     id: str = ""
     content: str = ""
@@ -123,7 +105,8 @@ def _get_dataset_tenant_id(dataset_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def list_chunks(tenant_id, dataset_id, document_id):
-    search = _search()
+    from rag.nlp import search
+
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -208,7 +191,8 @@ async def list_chunks(tenant_id, dataset_id, document_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def get_chunk(tenant_id, dataset_id, document_id, chunk_id):
-    search = _search()
+    from rag.nlp import search
+
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -232,8 +216,8 @@ async def get_chunk(tenant_id, dataset_id, document_id, chunk_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def add_chunk(tenant_id, dataset_id, document_id):
-    search = _search()
-    rag_tokenizer = _rag_tokenizer()
+    from rag.nlp import rag_tokenizer, search
+
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -323,7 +307,8 @@ async def add_chunk(tenant_id, dataset_id, document_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def rm_chunk(tenant_id, dataset_id, document_id):
-    search = _search()
+    from rag.nlp import search
+
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -371,9 +356,9 @@ async def rm_chunk(tenant_id, dataset_id, document_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def update_chunk(tenant_id, dataset_id, document_id, chunk_id):
-    search = _search()
-    rag_tokenizer = _rag_tokenizer()
-    beAdoc, rmPrefix = _qa_helpers()
+    from rag.app.qa import beAdoc, rmPrefix
+    from rag.nlp import rag_tokenizer, search
+
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
@@ -460,7 +445,8 @@ async def update_chunk(tenant_id, dataset_id, document_id, chunk_id):
 @login_required
 @add_tenant_id_to_kwargs
 async def switch_chunks(tenant_id, dataset_id, document_id):
-    search = _search()
+    from rag.nlp import search
+
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)

--- a/api/db/services/tenant_llm_service.py
+++ b/api/db/services/tenant_llm_service.py
@@ -26,15 +26,6 @@ from api.db.services.langfuse_service import TenantLangfuseService
 from api.db.services.user_service import TenantService
 
 
-def _llm_registries():
-    # Importing rag.llm loads optional provider SDKs and native ML libraries.
-    # Keep that cost out of API startup; instantiate registries only when a
-    # model is actually used.
-    from rag.llm import ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel
-
-    return ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel
-
-
 class LLMFactoriesService(CommonService):
     model = LLMFactories
 
@@ -191,7 +182,8 @@ class TenantLLMService(CommonService):
     def model_instance(cls, model_config: dict, lang="Chinese", **kwargs):
         if not model_config:
             raise LookupError("Model config is required")
-        ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel = _llm_registries()
+        from rag.llm import ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel
+
         kwargs.update({"provider": model_config["llm_factory"]})
         api_key = model_config.get("api_key_payload", model_config["api_key"])
         if model_config["model_type"] == LLMType.EMBEDDING.value:

--- a/api/db/services/tenant_llm_service.py
+++ b/api/db/services/tenant_llm_service.py
@@ -24,7 +24,15 @@ from api.db.db_models import DB, LLMFactories, TenantLLM
 from api.db.services.common_service import CommonService
 from api.db.services.langfuse_service import TenantLangfuseService
 from api.db.services.user_service import TenantService
-from rag.llm import ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel
+
+
+def _llm_registries():
+    # Importing rag.llm loads optional provider SDKs and native ML libraries.
+    # Keep that cost out of API startup; instantiate registries only when a
+    # model is actually used.
+    from rag.llm import ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel
+
+    return ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel
 
 
 class LLMFactoriesService(CommonService):
@@ -183,6 +191,7 @@ class TenantLLMService(CommonService):
     def model_instance(cls, model_config: dict, lang="Chinese", **kwargs):
         if not model_config:
             raise LookupError("Model config is required")
+        ChatModel, CvModel, EmbeddingModel, OcrModel, RerankModel, Seq2txtModel, TTSModel = _llm_registries()
         kwargs.update({"provider": model_config["llm_factory"]})
         api_key = model_config.get("api_key_payload", model_config["api_key"])
         if model_config["model_type"] == LLMType.EMBEDDING.value:


### PR DESCRIPTION
### What problem does this PR solve?

Refactor: speed up ragflow server, save startup memory, saved 200MiB, and 5-9 seconds start time.

##### Before
1241292  |   |           \_ python3 api/ragflow_server.py
RAGFlow server is ready after 25.61845850944519s initialization.

##### After
1019968  |   |           \_ python3 api/ragflow_server.py
RAGFlow server is ready after 16.205134391784668s initialization.

### Type of change

- [x] Refactoring
