### PR TITLE
Test: 🚨 [Expected CI Failure] Add unit tests for Agent EMPTY_RESULT handling (Depends on #14305)

### DIFF
--- a/test/unit_test/agent/sandbox/test_agent_false_action.py
+++ b/test/unit_test/agent/sandbox/test_agent_false_action.py
@@ -1,0 +1,126 @@
+"""Unit tests for Agent tool execution trapdoors."""
+import logging
+from unittest.mock import MagicMock, patch
+import pytest
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture
+def agent_setup():
+    """Sets up a barebones Agent."""
+    logger.debug("Setting up agent_setup fixture: Initializing barebones Agent.")
+    from agent.component.agent_with_tools import Agent, ToolExecutionState
+    from agent.canvas import Canvas
+
+    canvas_mock = MagicMock(spec=Canvas)
+    canvas_mock.get_tenant_id.return_value = "test_tenant"
+    canvas_mock.is_canceled.return_value = False
+    
+    param_mock = MagicMock()
+    param_mock.llm_id = "test_llm"
+    param_mock.max_retries = 0
+    param_mock.outputs = {} 
+    param_mock.tools = []
+    param_mock.mcp = []
+    param_mock.prompt = ""
+    
+    with patch('agent.component.llm.get_model_config_by_type_and_name', return_value={}), \
+         patch('agent.component.agent_with_tools.get_model_config_by_type_and_name', return_value={}), \
+         patch('agent.component.llm.LLMBundle'), \
+         patch('agent.component.agent_with_tools.LLMBundle'), \
+         patch('api.db.services.tenant_llm_service.TenantLLMService.llm_id2llm_type', return_value='chat'):
+        
+        agent = Agent(canvas=canvas_mock, id="test_agent", param=param_mock)
+        agent.tools = {"dummy_tool": MagicMock()}
+        
+        async def mock_generate_async(*args, **kwargs):
+            return "Mocked LLM Response"
+        agent._generate_async = mock_generate_async
+        
+        async def mock_stream(*args, **kwargs):
+            for _ in []:
+                yield ""
+            
+        agent._generate_streamly = mock_stream
+        agent._prepare_prompt_variables = MagicMock(return_value=("System Prompt", [{"role": "user", "content": "Test"}], {}))
+
+        canvas_mock.get_component.return_value = {"downstream": []}
+        
+        logger.debug("Agent setup complete. Yielding Agent and ToolExecutionState.")
+        yield agent, ToolExecutionState
+
+
+@pytest.mark.asyncio
+@pytest.mark.p1
+async def test_invoke_async_empty_result_trapdoor(agent_setup):
+    """CASE 1: Proves the trapdoor overrides the LLM output and returns safe structured data on EMPTY_RESULT."""
+    logger.info("Executing test_invoke_async_empty_result_trapdoor")
+    mock_agent, ToolExecutionState = agent_setup
+    mock_agent._param.outputs["structured"] = {"properties": {"summary": {"type": "string"}}}
+ 
+    with patch.object(mock_agent, '_get_tool_execution_state', return_value=ToolExecutionState.EMPTY_RESULT) as mock_get_state:
+        result = await mock_agent._invoke_async(user_prompt="Test query")
+        
+        logger.debug("Evaluating trapdoor assertions for EMPTY_RESULT state.")
+        mock_get_state.assert_called_once()
+        assert result == {}
+        assert mock_agent.output("structured") == {}
+        assert mock_agent.output("content") == "ACTION_NOT_PERFORMED"
+        assert mock_agent.error() is None
+    logger.info("test_invoke_async_empty_result_trapdoor passed successfully.")
+
+@pytest.mark.asyncio
+@pytest.mark.p1
+async def test_stream_output_empty_result_trapdoor(agent_setup):
+    """CASE 2: Proves the streaming generator intercepts EMPTY_RESULT and yields the sentinel string."""
+    logger.info("Executing test_stream_output_empty_result_trapdoor")
+    mock_agent, ToolExecutionState = agent_setup
+    with patch.object(mock_agent, '_get_tool_execution_state', return_value=ToolExecutionState.EMPTY_RESULT) as mock_get_state:
+        
+        stream_generator = mock_agent.stream_output_with_tools_async(
+            prompt="system prompt", 
+            msg=[{"role": "user", "content": "Test"}]
+        )
+        
+        chunks = [chunk async for chunk in stream_generator]
+        
+        logger.debug("Evaluating trapdoor assertions for streaming EMPTY_RESULT state.")
+        mock_get_state.assert_called_once()
+        assert chunks == ["ACTION_NOT_PERFORMED"]
+        assert mock_agent.output("content") == "ACTION_NOT_PERFORMED"
+    logger.info("test_stream_output_empty_result_trapdoor passed successfully.")
+
+@pytest.mark.asyncio
+@pytest.mark.p1
+async def test_invoke_async_real_error_bypasses_trapdoor(agent_setup):
+    """CASE 3: Proves that real tool crashes bypass the trapdoor and trigger the native error channel."""
+    logger.info("Executing test_invoke_async_real_error_bypasses_trapdoor")
+    mock_agent, ToolExecutionState = agent_setup
+    
+    async def mock_error_generate(*args, **kwargs):
+        return "**ERROR** Database Timeout"
+    mock_agent._generate_async = mock_error_generate
+    
+    with patch.object(mock_agent, '_get_tool_execution_state', return_value=ToolExecutionState.ERROR) as mock_get_state:
+        await mock_agent._invoke_async(user_prompt="Test query")
+        
+        logger.debug("Evaluating assertions for ERROR bypass state.")
+        mock_get_state.assert_called_once()
+        assert mock_agent.output("content") != "ACTION_NOT_PERFORMED"
+        assert mock_agent.error() == "**ERROR** Database Timeout"
+    logger.info("test_invoke_async_real_error_bypasses_trapdoor passed successfully.")
+
+@pytest.mark.asyncio
+@pytest.mark.p1
+async def test_invoke_async_baseline_success(agent_setup):
+    """CASE 4: Proves valid tool executions flow normally without triggering trapdoors."""
+    logger.info("Executing test_invoke_async_baseline_success")
+    mock_agent, ToolExecutionState = agent_setup
+    with patch.object(mock_agent, '_get_tool_execution_state', return_value=ToolExecutionState.SUCCESS) as mock_get_state:
+        await mock_agent._invoke_async(user_prompt="Test query")
+        
+        logger.debug("Evaluating assertions for baseline SUCCESS state.")
+        mock_get_state.assert_called_once()
+        assert mock_agent.output("content") == "Mocked LLM Response"
+        assert mock_agent.error() is None
+    logger.info("test_invoke_async_baseline_success passed successfully.")

--- a/test/unit_test/agent/sandbox/test_agent_false_action.py
+++ b/test/unit_test/agent/sandbox/test_agent_false_action.py
@@ -9,7 +9,10 @@ logger = logging.getLogger(__name__)
 def agent_setup():
     """Sets up a barebones Agent."""
     logger.debug("Setting up agent_setup fixture: Initializing barebones Agent.")
-    from agent.component.agent_with_tools import Agent, ToolExecutionState
+    try:
+        from agent.component.agent_with_tools import Agent, ToolExecutionState
+    except ImportError:
+        pytest.skip("Skipping test: Requires PR #14305 (ToolExecutionState) to be merged first.")
     from agent.canvas import Canvas
 
     canvas_mock = MagicMock(spec=Canvas)

--- a/test/unit_test/agent/sandbox/test_agent_false_action.py
+++ b/test/unit_test/agent/sandbox/test_agent_false_action.py
@@ -127,3 +127,23 @@ async def test_invoke_async_baseline_success(agent_setup):
         assert mock_agent.output("content") == "Mocked LLM Response"
         assert mock_agent.error() is None
     logger.info("test_invoke_async_baseline_success passed successfully.")
+
+@pytest.mark.asyncio
+@pytest.mark.p1
+async def test_invoke_async_normal_greeting_bypasses_trapdoor(agent_setup):
+    """CASE 5: Proves normal conversational responses are allowed when tools are not called."""
+    logger.info("Executing test_invoke_async_normal_greeting_bypasses_trapdoor")
+    mock_agent, ToolExecutionState = agent_setup
+    
+    # Override the LLM to output a standard, non-action greeting
+    async def mock_greeting_generate(*args, **kwargs):
+        return "Hello! I am ready to assist you today."
+    mock_agent._generate_async = mock_greeting_generate
+
+    with patch.object(mock_agent, '_get_tool_execution_state', return_value=ToolExecutionState.NOT_CALLED) as mock_get_state:
+        await mock_agent._invoke_async(user_prompt="Hi")
+        
+        logger.debug("Evaluating assertions for normal greeting state.")
+        mock_get_state.assert_called_once()
+        assert mock_agent.output("content") == "Hello! I am ready to assist you today."
+        assert mock_agent.error() is None


### PR DESCRIPTION
### ⚠️ **NOTE TO REVIEWERS: Expected CI Failure** ⚠️

### What problem does this PR solve?

This PR introduces the comprehensive unit test suite for the `EMPTY_RESULT` Agent trapdoor logic implemented in PR #14305.

**Context on PR Isolation & CI Status:**
These tests have been deliberately separated from the core implementation PR to isolate an environmental teardown anomaly in the CI pipeline without blocking the main feature review. 

To prevent this stacked test file from causing a hard setup failure on unmerged branches, the `ToolExecutionState` import has been gated inside a `try...except` block. If PR #14305 is not yet present, the new tests will gracefully **skip** rather than crash. This allows the rest of the repository's test suite to complete running, directly exposing the resource warnings during the session teardown phase.

The resulting CI logs pass the test suite (`972 passed, 30 skipped`) but surface the underlying loop cleanup warnings at the very end:
* `ResourceWarning: unclosed <socket.socket fd=15, family=1, type=1, proto=0>`
* `ResourceWarning: unclosed <socket.socket fd=14, family=1, type=1, proto=0>`
* `ResourceWarning: unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>`

*Note: This PR is strictly dependent on the structural changes introduced in #14305 and will automatically activate with 100% local pass coverage once that PR is merged.*


### Type of change

- [x] Other (please describe): Unit Tests & CI Diagnostic Profile