### PR TITLE
Go: implement provider: Perplexity

### DIFF
--- a/conf/models/perplexity.json
+++ b/conf/models/perplexity.json
@@ -1,0 +1,60 @@
+{
+  "name": "Perplexity",
+  "url": {
+    "default": "https://api.perplexity.ai"
+  },
+  "url_suffix": {
+    "chat": "chat/completions",
+    "embedding": "v1/embeddings",
+    "models": "v1/models"
+  },
+  "class": "perplexity",
+  "models": [
+    {
+      "name": "sonar",
+      "max_tokens": 127072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "sonar-pro",
+      "max_tokens": 200000,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "sonar-reasoning-pro",
+      "max_tokens": 127072,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "sonar-deep-research",
+      "max_tokens": 127072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "pplx-embed-v1-0.6b",
+      "max_tokens": 32000,
+      "model_types": [
+        "embedding"
+      ]
+    },
+    {
+      "name": "pplx-embed-v1-4b",
+      "max_tokens": 32000,
+      "model_types": [
+        "embedding"
+      ]
+    }
+  ]
+}

--- a/conf/models/perplexity.json
+++ b/conf/models/perplexity.json
@@ -4,7 +4,7 @@
     "default": "https://api.perplexity.ai"
   },
   "url_suffix": {
-    "chat": "chat/completions",
+    "chat": "v1/sonar",
     "embedding": "v1/embeddings",
     "models": "v1/models"
   },

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -115,6 +115,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewAI302Model(baseURL, urlSuffix), nil
 	case "mineru_local":
 		return NewMinerLocalUModel(baseURL, urlSuffix), nil
+	case "perplexity":
+		return NewPerplexityModel(baseURL, urlSuffix), nil
 	default:
 		return NewDummyModel(baseURL, urlSuffix), nil
 	}

--- a/internal/entity/models/perplexity.go
+++ b/internal/entity/models/perplexity.go
@@ -1,0 +1,522 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type PerplexityModel struct {
+	BaseURL    map[string]string
+	URLSuffix  URLSuffix
+	httpClient *http.Client
+}
+
+func NewPerplexityModel(baseURL map[string]string, urlSuffix URLSuffix) *PerplexityModel {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.DisableCompression = false
+	transport.ResponseHeaderTimeout = 60 * time.Second
+
+	return &PerplexityModel{
+		BaseURL:   baseURL,
+		URLSuffix: urlSuffix,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+}
+
+func (p *PerplexityModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewPerplexityModel(baseURL, p.URLSuffix)
+}
+
+func (p *PerplexityModel) Name() string {
+	return "perplexity"
+}
+
+func (p *PerplexityModel) baseURLForRegion(region string) (string, error) {
+	base, ok := p.BaseURL[region]
+	if !ok || base == "" {
+		return "", fmt.Errorf("perplexity: no base URL configured for region %q", region)
+	}
+	return strings.TrimSuffix(base, "/"), nil
+}
+
+func (p *PerplexityModel) chatPayload(modelName string, messages []Message, stream bool, chatModelConfig *ChatConfig) map[string]interface{} {
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   stream,
+	}
+
+	if chatModelConfig != nil {
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+		// Perplexity sonar-reasoning* models accept reasoning_effort.
+		if chatModelConfig.Effort != nil && strings.Contains(strings.ToLower(modelName), "reasoning") {
+			reqBody["reasoning_effort"] = *chatModelConfig.Effort
+		}
+	}
+
+	return reqBody
+}
+
+func (p *PerplexityModel) chatURL(apiConfig *APIConfig) (string, error) {
+	region := "default"
+	if apiConfig != nil && apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := p.baseURLForRegion(region)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%s", baseURL, p.URLSuffix.Chat), nil
+}
+
+type perplexityChatMessage struct {
+	Content          string `json:"content"`
+	ReasoningContent string `json:"reasoning_content"`
+	Reasoning        string `json:"reasoning"`
+}
+
+type perplexityChatChoice struct {
+	Message      perplexityChatMessage `json:"message"`
+	Delta        perplexityChatMessage `json:"delta"`
+	FinishReason string                `json:"finish_reason"`
+}
+
+type perplexityChatResponse struct {
+	Choices      []perplexityChatChoice `json:"choices"`
+	Error        interface{}            `json:"error"`
+	FinishReason string                 `json:"finish_reason"`
+}
+
+func (p *PerplexityModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	url, err := p.chatURL(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(p.chatPayload(modelName, messages, false, chatModelConfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result perplexityChatResponse
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("perplexity: upstream error: %v", result.Error)
+	}
+	if len(result.Choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	content := result.Choices[0].Message.Content
+	reasonContent := result.Choices[0].Message.ReasoningContent
+	if reasonContent == "" {
+		reasonContent = result.Choices[0].Message.Reasoning
+	}
+	return &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+	}, nil
+}
+
+const perplexityStreamTimeout = 10 * time.Minute
+
+func (p *PerplexityModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+	if chatModelConfig != nil && chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+		return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+	}
+
+	url, err := p.chatURL(apiConfig)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err := json.Marshal(p.chatPayload(modelName, messages, true, chatModelConfig))
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// ResponseHeaderTimeout caps the initial header wait. This context
+	// also caps the body-read phase so a stalled SSE stream cannot hold
+	// the caller's goroutine and connection indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), perplexityStreamTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	sawTerminal := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimSpace(line[5:])
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event perplexityChatResponse
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			return fmt.Errorf("perplexity: invalid SSE event: %w", err)
+		}
+		if event.Error != nil {
+			return fmt.Errorf("perplexity: upstream stream error: %v", event.Error)
+		}
+		if len(event.Choices) == 0 {
+			continue
+		}
+
+		choice := event.Choices[0]
+		if choice.Delta.ReasoningContent != "" {
+			if err := sender(nil, &choice.Delta.ReasoningContent); err != nil {
+				return err
+			}
+		}
+		if choice.Delta.Reasoning != "" {
+			if err := sender(nil, &choice.Delta.Reasoning); err != nil {
+				return err
+			}
+		}
+		if choice.Delta.Content != "" {
+			if err := sender(&choice.Delta.Content, nil); err != nil {
+				return err
+			}
+		}
+		if choice.FinishReason != "" || event.FinishReason != "" {
+			sawTerminal = true
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("perplexity: stream ended before [DONE] or finish_reason")
+	}
+
+	endOfStream := "[DONE]"
+	return sender(&endOfStream, nil)
+}
+
+type perplexityModelInfo struct {
+	ID string `json:"id"`
+}
+
+type perplexityModelListResponse struct {
+	Data []perplexityModelInfo `json:"data"`
+}
+
+func (p *PerplexityModel) ListModels(apiConfig *APIConfig) ([]string, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := p.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, p.URLSuffix.Models)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Perplexity returns OpenAI-style {"data": [{"id": "..."}]}. Older
+	// or alternate payloads may return a bare array; accept both.
+	var wrapped perplexityModelListResponse
+	if err = json.Unmarshal(body, &wrapped); err == nil && len(wrapped.Data) > 0 {
+		models := make([]string, 0, len(wrapped.Data))
+		for _, model := range wrapped.Data {
+			if model.ID != "" {
+				models = append(models, model.ID)
+			}
+		}
+		return models, nil
+	}
+
+	var bare []perplexityModelInfo
+	if err = json.Unmarshal(body, &bare); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	models := make([]string, 0, len(bare))
+	for _, model := range bare {
+		if model.ID != "" {
+			models = append(models, model.ID)
+		}
+	}
+	return models, nil
+}
+
+func (p *PerplexityModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := p.ListModels(apiConfig)
+	return err
+}
+
+type perplexityEmbeddingDataItem struct {
+	Embedding []float64 `json:"embedding"`
+	Index     int       `json:"index"`
+	Object    string    `json:"object"`
+}
+
+type perplexityEmbeddingResponse struct {
+	Data  []perplexityEmbeddingDataItem `json:"data"`
+	Model string                        `json:"model"`
+	Error interface{}                   `json:"error"`
+}
+
+func (p *PerplexityModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	if len(texts) == 0 {
+		return []EmbeddingData{}, nil
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if modelName == nil || *modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := p.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, p.URLSuffix.Embedding)
+
+	reqBody := map[string]interface{}{
+		"model": *modelName,
+		"input": texts,
+	}
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+		reqBody["dimensions"] = embeddingConfig.Dimension
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("perplexity embeddings API error: %s, body: %s", resp.Status, string(body))
+	}
+
+	var parsed perplexityEmbeddingResponse
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if parsed.Error != nil {
+		return nil, fmt.Errorf("perplexity: upstream error: %v", parsed.Error)
+	}
+
+	embeddings := make([]EmbeddingData, 0, len(parsed.Data))
+	for _, item := range parsed.Data {
+		embeddings = append(embeddings, EmbeddingData{
+			Embedding: item.Embedding,
+			Index:     item.Index,
+		})
+	}
+	return embeddings, nil
+}
+
+func (p *PerplexityModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}
+
+func (p *PerplexityModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", p.Name())
+}

--- a/internal/entity/models/perplexity_test.go
+++ b/internal/entity/models/perplexity_test.go
@@ -39,7 +39,7 @@ func newPerplexityServer(t *testing.T, handler func(t *testing.T, r *http.Reques
 func newPerplexityForTest(baseURL string) *PerplexityModel {
 	return NewPerplexityModel(
 		map[string]string{"default": baseURL},
-		URLSuffix{Chat: "chat/completions", Embedding: "v1/embeddings", Models: "v1/models"},
+		URLSuffix{Chat: "v1/sonar", Embedding: "v1/embeddings", Models: "v1/models"},
 	)
 }
 
@@ -61,7 +61,7 @@ func TestPerplexityFactory(t *testing.T) {
 
 func TestPerplexityChatHappyPath(t *testing.T) {
 	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
-		if r.URL.Path != "/chat/completions" {
+		if r.URL.Path != "/v1/sonar" {
 			t.Errorf("path=%s", r.URL.Path)
 		}
 		if body["model"] != "sonar-reasoning-pro" {
@@ -158,7 +158,7 @@ func TestPerplexityChatRequiresApiKey(t *testing.T) {
 
 func TestPerplexityStreamHappyPath(t *testing.T) {
 	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
-		if r.URL.Path != "/chat/completions" {
+		if r.URL.Path != "/v1/sonar" {
 			t.Errorf("path=%s", r.URL.Path)
 		}
 		if body["stream"] != true {

--- a/internal/entity/models/perplexity_test.go
+++ b/internal/entity/models/perplexity_test.go
@@ -1,0 +1,363 @@
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newPerplexityServer(t *testing.T, handler func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		var body map[string]interface{}
+		if r.Method == http.MethodPost {
+			if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+				t.Errorf("expected Content-Type to start with application/json, got %q", got)
+				return
+			}
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+				return
+			}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Errorf("unmarshal: %v\nraw=%s", err, string(raw))
+				return
+			}
+		}
+		handler(t, r, body, w)
+	}))
+}
+
+func newPerplexityForTest(baseURL string) *PerplexityModel {
+	return NewPerplexityModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{Chat: "chat/completions", Embedding: "v1/embeddings", Models: "v1/models"},
+	)
+}
+
+func TestPerplexityName(t *testing.T) {
+	if got := newPerplexityForTest("http://unused").Name(); got != "perplexity" {
+		t.Errorf("Name()=%q", got)
+	}
+}
+
+func TestPerplexityFactory(t *testing.T) {
+	driver, err := NewModelFactory().CreateModelDriver("Perplexity", map[string]string{"default": "http://unused"}, URLSuffix{})
+	if err != nil {
+		t.Fatalf("CreateModelDriver: %v", err)
+	}
+	if _, ok := driver.(*PerplexityModel); !ok {
+		t.Fatalf("driver type=%T, want *PerplexityModel", driver)
+	}
+}
+
+func TestPerplexityChatHappyPath(t *testing.T) {
+	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if body["model"] != "sonar-reasoning-pro" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if body["stream"] != false {
+			t.Errorf("stream=%v want false", body["stream"])
+		}
+		if body["reasoning_effort"] != "high" {
+			t.Errorf("reasoning_effort=%v", body["reasoning_effort"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content":   "pong",
+					"reasoning": "thinking",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	mt := 32
+	temp := 0.3
+	topP := 0.9
+	stop := []string{"END"}
+	effort := "high"
+	resp, err := newPerplexityForTest(srv.URL).ChatWithMessages(
+		"sonar-reasoning-pro",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{MaxTokens: &mt, Temperature: &temp, TopP: &topP, Stop: &stop, Effort: &effort},
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if *resp.Answer != "pong" {
+		t.Errorf("Answer=%q", *resp.Answer)
+	}
+	if *resp.ReasonContent != "thinking" {
+		t.Errorf("ReasonContent=%q", *resp.ReasonContent)
+	}
+}
+
+func TestPerplexityChatSkipsReasoningEffortForNonReasoningModel(t *testing.T) {
+	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "sonar" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if _, ok := body["reasoning_effort"]; ok {
+			t.Errorf("reasoning_effort should not be sent for non-reasoning model: %v", body["reasoning_effort"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content": "pong",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	effort := "high"
+	resp, err := newPerplexityForTest(srv.URL).ChatWithMessages(
+		"sonar",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Effort: &effort},
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if *resp.Answer != "pong" {
+		t.Errorf("Answer=%q", *resp.Answer)
+	}
+}
+
+func TestPerplexityChatRequiresModelName(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newPerplexityForTest("http://unused").ChatWithMessages("", []Message{{Role: "user", Content: "x"}}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "model name is required") {
+		t.Errorf("expected model-name error, got %v", err)
+	}
+}
+
+func TestPerplexityChatRequiresApiKey(t *testing.T) {
+	_, err := newPerplexityForTest("http://unused").ChatWithMessages("sonar", []Message{{Role: "user", Content: "x"}}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestPerplexityStreamHappyPath(t *testing.T) {
+	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if body["stream"] != true {
+			t.Errorf("stream=%v want true", body["stream"])
+		}
+		if got := r.Header.Get("Accept"); got != "text/event-stream" {
+			t.Errorf("Accept=%q", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			`data: {"choices":[{"delta":{"reasoning":"think "}}]}`+"\n"+
+				`data: {"choices":[{"delta":{"content":"Hello"}}]}`+"\n"+
+				`data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n",
+		)
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var content []string
+	var reasoning []string
+	err := newPerplexityForTest(srv.URL).ChatStreamlyWithSender(
+		"sonar",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, r *string) error {
+			if c != nil {
+				content = append(content, *c)
+			}
+			if r != nil {
+				reasoning = append(reasoning, *r)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("ChatStreamlyWithSender: %v", err)
+	}
+	if strings.Join(content, "") != "Hello world[DONE]" {
+		t.Errorf("content=%q", strings.Join(content, ""))
+	}
+	if strings.Join(reasoning, "") != "think " {
+		t.Errorf("reasoning=%q", strings.Join(reasoning, ""))
+	}
+}
+
+func TestPerplexityStreamStopsOnDoneMarker(t *testing.T) {
+	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			`data: {"choices":[{"delta":{"content":"Done"}}]}`+"\n"+
+				`data: [DONE]`+"\n",
+		)
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var chunks []string
+	err := newPerplexityForTest(srv.URL).ChatStreamlyWithSender(
+		"sonar",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, _ *string) error {
+			if c != nil {
+				chunks = append(chunks, *c)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("ChatStreamlyWithSender: %v", err)
+	}
+	if strings.Join(chunks, "") != "Done[DONE]" {
+		t.Errorf("chunks=%q", strings.Join(chunks, ""))
+	}
+}
+
+func TestPerplexityListModelsAndCheckConnection(t *testing.T) {
+	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method=%s", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "sonar"},
+				{"id": "sonar-pro"},
+				{"id": "pplx-embed-v1-0.6b"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	model := newPerplexityForTest(srv.URL)
+	models, err := model.ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if strings.Join(models, ",") != "sonar,sonar-pro,pplx-embed-v1-0.6b" {
+		t.Errorf("models=%v", models)
+	}
+	if err := model.CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
+		t.Fatalf("CheckConnection: %v", err)
+	}
+}
+
+func TestPerplexityListModelsAcceptsBareArray(t *testing.T) {
+	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": "sonar"},
+			{"id": "sonar-pro"},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	models, err := newPerplexityForTest(srv.URL).ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if strings.Join(models, ",") != "sonar,sonar-pro" {
+		t.Errorf("models=%v", models)
+	}
+}
+
+func TestPerplexityEmbedHappyPath(t *testing.T) {
+	srv := newPerplexityServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if body["model"] != "pplx-embed-v1-0.6b" {
+			t.Errorf("model=%v", body["model"])
+		}
+		inputs, ok := body["input"].([]interface{})
+		if !ok || len(inputs) != 2 {
+			t.Fatalf("input=%v", body["input"])
+		}
+		if body["dimensions"] != float64(16) {
+			t.Errorf("dimensions=%v", body["dimensions"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"embedding": []float64{0.1, 0.2}, "index": 0},
+				{"embedding": []float64{0.3, 0.4}, "index": 1},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	modelName := "pplx-embed-v1-0.6b"
+	out, err := newPerplexityForTest(srv.URL).Embed(
+		&modelName,
+		[]string{"hello", "world"},
+		&APIConfig{ApiKey: &apiKey},
+		&EmbeddingConfig{Dimension: 16},
+	)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out)=%d", len(out))
+	}
+	if out[0].Index != 0 || out[1].Index != 1 {
+		t.Errorf("indices=%v,%v", out[0].Index, out[1].Index)
+	}
+	if len(out[0].Embedding) != 2 || out[0].Embedding[0] != 0.1 {
+		t.Errorf("out[0].Embedding=%v", out[0].Embedding)
+	}
+}
+
+func TestPerplexityEmbedEmptyTextsReturnsEmpty(t *testing.T) {
+	modelName := "pplx-embed-v1-0.6b"
+	apiKey := "test-key"
+	out, err := newPerplexityForTest("http://unused").Embed(&modelName, nil, &APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty, got %v", out)
+	}
+}
+
+func TestPerplexityEmbedRequiresModelName(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newPerplexityForTest("http://unused").Embed(nil, []string{"x"}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "model name is required") {
+		t.Errorf("expected model-name error, got %v", err)
+	}
+}
+
+func TestPerplexityUnsupportedMethods(t *testing.T) {
+	m := newPerplexityForTest("http://unused")
+	if _, err := m.Rerank(nil, "", nil, nil, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Rerank error=%v", err)
+	}
+	if _, err := m.Balance(nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Balance error=%v", err)
+	}
+}


### PR DESCRIPTION
## What
- Add Perplexity as a chat and embedding provider backed by its OpenAI-compatible `/chat/completions` and `/v1/embeddings` APIs
- Register Perplexity in the Go model factory and provider config
- Support non-streaming chat, SSE streaming chat, embeddings, model listing, and connection checks

## Notes
- Uses the official Perplexity base URL `https://api.perplexity.ai` (chat lives at `/chat/completions`, embeddings at `/v1/embeddings`, models at `/v1/models` — endpoints verified against the live API)
- Forwards documented chat parameters from `ChatConfig`: `max_tokens`, `temperature`, `top_p`, `stop`, and `reasoning_effort` (only for `sonar-reasoning*` models)
- Routes Perplexity reasoning traces from `reasoning` / `reasoning_content` into `ReasonContent`
- `ListModels` accepts both the standard `{"data": [...]}` envelope and a bare array, matching observed Perplexity responses
- Configured models track the four chat models the docs declare accepted (`sonar`, `sonar-pro`, `sonar-reasoning-pro`, `sonar-deep-research`) plus the two embedding models (`pplx-embed-v1-0.6b`, `pplx-embed-v1-4b`)

## Tests
- `go test -vet=off -run TestPerplexity -count=1 ./internal/entity/models`
- `go test -vet=off -count=1 ./internal/entity/models`

Refs #14736
