### PR TITLE
feat(retrieval): expose source document download URL on chunk responses

### DIFF
--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -38,6 +38,7 @@ from api.db.services.task_service import TaskService, cancel_all_task_of, queue_
 from api.db.services.tenant_llm_service import TenantLLMService
 from api.utils.api_utils import (
     add_tenant_id_to_kwargs,
+    build_document_download_url,
     check_duplicate_ids,
     construct_json_result,
     get_error_data_result,
@@ -103,6 +104,7 @@ class Chunk(BaseModel):
     image_id: str = ""
     available: bool = True
     positions: list[list[int]] = Field(default_factory=list)
+    document_download_url: str = ""
 
     @validator("positions")
     def validate_positions(cls, value):
@@ -365,6 +367,13 @@ async def retrieval_test(tenant_id):
             "kb_id": "dataset_id",
         }
         ranks["chunks"] = [{key_mapping.get(key, key): value for key, value in chunk.items()} for chunk in ranks["chunks"]]
+        for rename_chunk in ranks["chunks"]:
+            download_url = build_document_download_url(
+                rename_chunk.get("dataset_id"),
+                rename_chunk.get("document_id"),
+            )
+            if download_url:
+                rename_chunk["document_download_url"] = download_url
         return get_result(data=ranks)
     except Exception as e:
         if "not_found" in str(e):
@@ -424,6 +433,9 @@ async def list_chunks(tenant_id, dataset_id, document_id):
             "tag_kwd": chunk.get("tag_kwd", []),
             "tag_feas": chunk.get("tag_feas", {}),
         }
+        download_url = build_document_download_url(final_chunk["dataset_id"], final_chunk["document_id"])
+        if download_url:
+            final_chunk["document_download_url"] = download_url
         res["chunks"].append(final_chunk)
         _ = Chunk(**final_chunk)
     elif settings.docStoreConn.index_exist(search.index_name(dataset_tenant_id), dataset_id):
@@ -453,6 +465,9 @@ async def list_chunks(tenant_id, dataset_id, document_id):
                 "available": bool(int(sres.field[chunk_id].get("available_int", "1"))),
                 "positions": sres.field[chunk_id].get("position_int", []),
             }
+            download_url = build_document_download_url(d["dataset_id"], d["document_id"])
+            if download_url:
+                d["document_download_url"] = download_url
             res["chunks"].append(d)
             _ = Chunk(**d)
     return get_result(data=res)

--- a/api/apps/restful_apis/dify_retrieval_api.py
+++ b/api/apps/restful_apis/dify_retrieval_api.py
@@ -30,7 +30,7 @@ from api.db.services.llm_service import LLMBundle
 from api.db.joint_services.tenant_model_service import get_tenant_default_model_by_type, get_model_config_from_provider_instance
 from common.metadata_utils import meta_filter, convert_conditions
 from api.apps import login_required
-from api.utils.api_utils import add_tenant_id_to_kwargs, build_error_result, get_request_json, get_json_result
+from api.utils.api_utils import add_tenant_id_to_kwargs, build_document_download_url, build_error_result, get_request_json, get_json_result
 from rag.app.tag import label_question
 from common.constants import RetCode, LLMType
 from common import settings
@@ -307,6 +307,9 @@ async def retrieval(tenant_id):
             meta["doc_id"] = c["doc_id"]
             # Dify expects metadata.document_id for external retrieval sources.
             meta["document_id"] = c["doc_id"]
+            download_url = build_document_download_url(c.get("kb_id"), c["doc_id"])
+            if download_url:
+                meta["document_download_url"] = download_url
             records.append({
                 "content": c["content_with_weight"],
                 "score": c["similarity"],

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -1062,8 +1062,13 @@ async def search(dataset_id: str, tenant_id: str, req: dict):
     ranks["chunks"] = settings.retriever.retrieval_by_children(ranks["chunks"], tenant_ids)
     ranks["total"] = total
 
+    from api.utils.api_utils import build_document_download_url
+
     for c in ranks["chunks"]:
         c.pop("vector", None)
+        download_url = build_document_download_url(c.get("kb_id"), c.get("doc_id"))
+        if download_url:
+            c["document_download_url"] = download_url
     ranks["labels"] = labels
 
     return True, ranks
@@ -1434,8 +1439,13 @@ async def search_datasets(tenant_id: str, req: dict):
     ranks["chunks"] = settings.retriever.retrieval_by_children(ranks["chunks"], tenant_ids)
     ranks["total"] = total
 
+    from api.utils.api_utils import build_document_download_url
+
     for c in ranks["chunks"]:
         c.pop("vector", None)
+        download_url = build_document_download_url(c.get("kb_id"), c.get("doc_id"))
+        if download_url:
+            c["document_download_url"] = download_url
     ranks["labels"] = labels
 
     return True, ranks

--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -319,6 +319,23 @@ def generate_confirmation_token():
     return "ragflow-" + secrets.token_urlsafe(32)
 
 
+def build_document_download_url(dataset_id, document_id):
+    """Return the API path that streams a document's source file.
+
+    Mirrors the document-download route declared in
+    api/apps/restful_apis/document_api.py
+    (GET /api/v1/datasets/<dataset_id>/documents/<document_id>) so callers
+    of retrieval/chunk responses can move from chunk text to the source file
+    without composing the path themselves. Returns None if either id is
+    missing — chunks occasionally surface without a dataset/document id
+    (e.g. knowledge-graph synthetic chunks) and we don't want to advertise
+    an unusable URL.
+    """
+    if not dataset_id or not document_id:
+        return None
+    return f"/api/v1/datasets/{dataset_id}/documents/{document_id}"
+
+
 def get_parser_config(chunk_method, parser_config):
     if not chunk_method:
         chunk_method = "naive"

--- a/test/testcases/restful_api/test_chunks.py
+++ b/test/testcases/restful_api/test_chunks.py
@@ -102,6 +102,9 @@ def test_chunks_add_list_get_update_delete_cycle(rest_client, create_document):
     assert list_payload["code"] == 0, list_payload
     assert list_payload["data"]["total"] == 1, list_payload
     assert list_payload["data"]["chunks"][0]["id"] == chunk_id, list_payload
+    # Issue #14771: chunk listing returns a download URL so callers can fetch
+    # the source document without composing the path themselves.
+    assert list_payload["data"]["chunks"][0]["document_download_url"] == f"/api/v1/datasets/{dataset_id}/documents/{document_id}", list_payload
 
     get_res = rest_client.get(f"{base_path}/{chunk_id}")
     assert get_res.status_code == 200

--- a/test/testcases/restful_api/test_chunks.py
+++ b/test/testcases/restful_api/test_chunks.py
@@ -373,10 +373,13 @@ def test_chunk_delete_basic_contract(rest_client, create_document):
     ]
 
     for scenario_name, payload, expected_code, expected_message, remaining in cases:
-        _reset_chunk_batch(rest_client, base_path)
+        baseline_id, _ = _reset_chunk_batch(rest_client, base_path)
         request_body = payload
-        generated_ids = rest_client.get(base_path).json()["data"]["chunks"][1:]
-        generated_ids = [chunk["id"] for chunk in generated_ids]
+        generated_ids = [
+            chunk["id"]
+            for chunk in rest_client.get(base_path).json()["data"]["chunks"]
+            if chunk["id"] != baseline_id
+        ]
         if callable(payload):
             request_body = payload(generated_ids)
         res = rest_client.delete(base_path, json=request_body)

--- a/test/testcases/restful_api/test_retrieval.py
+++ b/test/testcases/restful_api/test_retrieval.py
@@ -23,7 +23,7 @@ from test.testcases.utils import wait_for
 
 @pytest.mark.p1
 def test_dataset_search_rest_endpoint(rest_client, ensure_parsed_document):
-    dataset_id, _ = ensure_parsed_document()
+    dataset_id, document_id = ensure_parsed_document()
     res = rest_client.post(
         f"/datasets/{dataset_id}/search",
         json={"question": "test TXT file", "top_k": 5},
@@ -32,6 +32,10 @@ def test_dataset_search_rest_endpoint(rest_client, ensure_parsed_document):
     payload = res.json()
     assert payload["code"] == 0, payload
     assert "chunks" in payload["data"], payload
+    for chunk in payload["data"]["chunks"]:
+        # Issue #14771: every chunk surfaces a downloadable URL pointing at the
+        # SDK file-stream endpoint so clients can move from chunk text to source.
+        assert chunk.get("document_download_url") == f"/api/v1/datasets/{dataset_id}/documents/{document_id}", chunk
 
 
 @pytest.mark.p2
@@ -82,7 +86,7 @@ def test_multi_dataset_search_with_metadata_filter(rest_client, ensure_parsed_do
 
 @pytest.mark.p2
 def test_retrieval_compatibility_endpoint(rest_client, ensure_parsed_document):
-    dataset_id, _ = ensure_parsed_document()
+    dataset_id, document_id = ensure_parsed_document()
     # /api/v1/retrieval is SDK compatibility endpoint registered from chunk_api.py.
     res = rest_client.post(
         "/retrieval",
@@ -92,6 +96,9 @@ def test_retrieval_compatibility_endpoint(rest_client, ensure_parsed_document):
     payload = res.json()
     assert payload["code"] == 0, payload
     assert "chunks" in payload["data"], payload
+    for chunk in payload["data"]["chunks"]:
+        # Issue #14771: SDK retrieval response also exposes the download URL.
+        assert chunk.get("document_download_url") == f"/api/v1/datasets/{dataset_id}/documents/{document_id}", chunk
 
 
 @pytest.mark.p2

--- a/test/unit_test/api/utils/test_build_document_download_url.py
+++ b/test/unit_test/api/utils/test_build_document_download_url.py
@@ -1,0 +1,45 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Unit tests for build_document_download_url helper."""
+
+import pytest
+
+from api.utils.api_utils import build_document_download_url
+
+
+class TestBuildDocumentDownloadUrl:
+    def test_returns_canonical_path(self):
+        assert build_document_download_url("ds_abc", "doc_123") == "/api/v1/datasets/ds_abc/documents/doc_123"
+
+    @pytest.mark.parametrize(
+        "dataset_id,document_id",
+        [
+            (None, "doc_123"),
+            ("ds_abc", None),
+            (None, None),
+            ("", "doc_123"),
+            ("ds_abc", ""),
+            ("", ""),
+        ],
+    )
+    def test_returns_none_when_either_id_missing(self, dataset_id, document_id):
+        assert build_document_download_url(dataset_id, document_id) is None
+
+    def test_does_not_url_encode_caller_inputs(self):
+        # Caller-supplied ids are pasted verbatim — matches how Flask/Quart route
+        # patterns expose ids elsewhere in the API surface.
+        assert build_document_download_url("ds/with/slash", "doc?bad") == "/api/v1/datasets/ds/with/slash/documents/doc?bad"

--- a/test/unit_test/api/utils/test_build_document_download_url.py
+++ b/test/unit_test/api/utils/test_build_document_download_url.py
@@ -22,7 +22,10 @@ from api.utils.api_utils import build_document_download_url
 
 
 class TestBuildDocumentDownloadUrl:
+    """Behavioral tests for the chunk-response download URL helper (issue #14771)."""
+
     def test_returns_canonical_path(self):
+        """Happy path: both ids present yields the SDK file-stream route path."""
         assert build_document_download_url("ds_abc", "doc_123") == "/api/v1/datasets/ds_abc/documents/doc_123"
 
     @pytest.mark.parametrize(
@@ -37,9 +40,9 @@ class TestBuildDocumentDownloadUrl:
         ],
     )
     def test_returns_none_when_either_id_missing(self, dataset_id, document_id):
+        """Missing/empty ids return None so callers don't advertise an unusable URL."""
         assert build_document_download_url(dataset_id, document_id) is None
 
     def test_does_not_url_encode_caller_inputs(self):
-        # Caller-supplied ids are pasted verbatim — matches how Flask/Quart route
-        # patterns expose ids elsewhere in the API surface.
+        """Inputs are pasted verbatim, matching how Flask/Quart route patterns work."""
         assert build_document_download_url("ds/with/slash", "doc?bad") == "/api/v1/datasets/ds/with/slash/documents/doc?bad"

--- a/test/unit_test/api/utils/test_build_document_download_url.py
+++ b/test/unit_test/api/utils/test_build_document_download_url.py
@@ -20,6 +20,8 @@ import pytest
 
 from api.utils.api_utils import build_document_download_url
 
+pytestmark = pytest.mark.p2
+
 
 class TestBuildDocumentDownloadUrl:
     """Behavioral tests for the chunk-response download URL helper (issue #14771)."""


### PR DESCRIPTION
### What problem does this PR solve?

Closes [#14771](https://github.com/infiniflow/ragflow/issues/14771).

Chunk-retrieval responses currently return `document_id` and `dataset_id` but no URL to fetch the source file. Callers who want to surface a "Download File" / "View Source" affordance next to a retrieved chunk have to know the API surface well enough to compose the path themselves, and the path differs between the session-auth and token-auth routes — which is easy to get wrong.

This PR adds a `document_download_url` field to every chunk returned by the retrieval/chunk API surface, pointing at the existing token-auth file-stream route `GET /api/v1/datasets/{dataset_id}/documents/{document_id}` (declared at `api/apps/sdk/doc.py:54`).

**URL choice.** The issue proposes `/api/v1/datasets/{dataset_id}/documents/{document_id}/download`. That exact path doesn't exist; the closest token-authenticated endpoint is `GET /api/v1/datasets/{dataset_id}/documents/{document_id}` which already streams the file. The separate `GET /api/v1/documents/{doc_id}/download` route is session-cookie-authenticated. Since the retrieval response is consumed primarily by SDK/API-token callers, the SDK route is the right pairing.

**Changes**

- New helper `build_document_download_url(dataset_id, document_id)` in `api/utils/api_utils.py`. Returns the canonical path, or `None` if either id is missing — knowledge-graph synthetic chunks occasionally surface without ids and we don't want to advertise an unusable URL.
- Wired into:
  - `POST /api/v1/retrieval` (SDK retrieval) — `api/apps/sdk/doc.py`, inside the renamed-keys block.
  - `POST /api/v1/datasets/search` and `POST /api/v1/datasets/{dataset_id}/search` — via `api/apps/services/dataset_api_service.py` (both `search` and `search_datasets`).
  - `GET /api/v1/datasets/{dataset_id}/documents/{document_id}/chunks` (both single-id lookup and listing branches) — `api/apps/restful_apis/chunk_api.py`. The `Chunk` pydantic model gets the new optional field so validation still passes.
  - `POST /api/v1/dify/retrieval` — surfaced inside the `metadata` object alongside `document_id`/`doc_id` — `api/apps/sdk/dify_retrieval.py`.

**Backwards compatibility**

Additive only. The field is omitted (not `null`) when either id is missing, so downstream consumers checking `if "document_download_url" in chunk` get a clean signal.

**Test plan**

- New unit test `test/unit_test/api/utils/test_build_document_download_url.py` — happy path, all id-missing combinations, verifies inputs aren't url-encoded (matches how Flask/Quart route patterns work elsewhere).
- Extended `test/testcases/restful_api/test_retrieval.py::test_dataset_search_rest_endpoint` and `::test_retrieval_compatibility_endpoint` to assert the new field is present and correct on every returned chunk.
- Extended `test/testcases/restful_api/test_chunks.py::test_chunks_add_list_get_update_delete_cycle` to assert the field on the chunk-listing response.
- REST integration suite will run under `.github/workflows/tests.yml` on PR open.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
