### PR TITLE
Fix: remove duplicate function definitions

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -54,12 +54,6 @@ from rag.utils.tts_cache import synthesize_with_cache
 from common.string_utils import remove_redundant_spaces
 from common import settings
 
-def _resolve_reference_metadata(request_payload=None, config=None):
-    return resolve_reference_metadata_preferences(request_payload or {}, config)
-
-def _enrich_chunks_with_document_metadata(chunks, metadata_fields=None):
-    enrich_chunks_with_document_metadata(chunks, metadata_fields)
-
 def _chunk_kb_id_for_doc(row_dict, kb_ids, doc_id):
     if len(kb_ids or []) == 1:
         return kb_ids[0]


### PR DESCRIPTION
### What problem does this PR solve?

Remove duplicate function definitions in `api/db/services/dialog_service.py`.

**Problem:** Two helper functions were defined twice in the same file, but with different parameter orders:

- First definition (line 57): `_resolve_reference_metadata(request_payload=None, config=None)`
- Second definition (line 136): `_resolve_reference_metadata(config, request_payload=None)`

**Solution:** Keep the second definition (which is actually used by other modules) and remove the first one to avoid confusion.

Additionally, remove duplicate `_enrich_chunks_with_document_metadata` definition (keep line 140 version).
<img width="1584" height="313" alt="image" src="https://github.com/user-attachments/assets/7daee832-244f-4bb2-8488-e3b65012a3f9" />
<img width="1672" height="359" alt="image" src="https://github.com/user-attachments/assets/4fd2f523-273c-4b20-a7c9-ab35740b7834" />


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
