### PR TITLE
feat(go): implement provider Astraflow (#15062)

### DIFF
--- a/conf/models/astraflow.json
+++ b/conf/models/astraflow.json
@@ -1,0 +1,103 @@
+{
+  "name": "Astraflow",
+  "url": {
+    "default": "https://api-us-ca.umodelverse.ai/v1"
+  },
+  "url_suffix": {
+    "chat": "chat/completions",
+    "models": "models"
+  },
+  "class": "astraflow",
+  "models": [
+    {
+      "name": "claude-opus-4-7",
+      "max_tokens": 200000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "claude-opus-4-6",
+      "max_tokens": 200000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "claude-sonnet-4-5-20250929",
+      "max_tokens": 200000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "claude-haiku-4-5-20251001",
+      "max_tokens": 200000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "gpt-5.4",
+      "max_tokens": 400000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "gpt-5.4-mini",
+      "max_tokens": 400000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "gpt-5.4-nano",
+      "max_tokens": 400000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "gpt-4o-mini",
+      "max_tokens": 128000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "Qwen/Qwen3-Max",
+      "max_tokens": 131072,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "Qwen/Qwen3-Coder",
+      "max_tokens": 131072,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "Qwen/Qwen3-32B",
+      "max_tokens": 131072,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+      "max_tokens": 131072,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "kimi-k2.6",
+      "max_tokens": 200000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "glm-5.1",
+      "max_tokens": 128000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "MiniMax-M2.7",
+      "max_tokens": 1000000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "MiniMax-M2",
+      "max_tokens": 1000000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "gemini-2.5-pro",
+      "max_tokens": 1000000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "gemini-2.5-flash",
+      "max_tokens": 1000000,
+      "model_types": ["chat"]
+    }
+  ]
+}

--- a/internal/entity/models/astraflow.go
+++ b/internal/entity/models/astraflow.go
@@ -1,0 +1,498 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// AstraflowModel implements ModelDriver for Astraflow (UCloud
+// ModelVerse). Astraflow is a SaaS, OpenAI-compatible inference
+// gateway hosting Anthropic, OpenAI, Qwen, DeepSeek, Kimi, GLM,
+// MiniMax, and Gemini families behind a single Bearer-token API at
+// https://api-us-ca.umodelverse.ai/v1. Reference docs:
+// https://astraflow.ucloud.cn/reference/modelverse.
+//
+// Wire shape matches the OpenAI convention exactly:
+//   - POST /v1/chat/completions with {model, messages, stream, ...}
+//   - GET  /v1/models for the catalog
+//   - Authorization: Bearer <api-key> on every call
+//   - SSE response with `data:` lines and a [DONE] terminator
+//
+// Reasoning models surface chain-of-thought in `reasoning_content`
+// (OpenAI o-series shape), so the same handling as LongCat /
+// DeepSeek-R1 applies and there's no need for an inline <think>...
+// extractor like Novita's.
+type AstraflowModel struct {
+	BaseURL    map[string]string
+	URLSuffix  URLSuffix
+	httpClient *http.Client
+}
+
+// NewAstraflowModel creates a new Astraflow model instance.
+//
+// Same transport convention as the other Go drivers in this package:
+// clone http.DefaultTransport to keep ProxyFromEnvironment, DialContext,
+// HTTP/2, and TLS defaults, and only override the connection-pool
+// fields. No client-level Timeout so SSE streams aren't capped mid-flight.
+func NewAstraflowModel(baseURL map[string]string, urlSuffix URLSuffix) *AstraflowModel {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.DisableCompression = false
+	transport.ResponseHeaderTimeout = 60 * time.Second
+
+	return &AstraflowModel{
+		BaseURL:   baseURL,
+		URLSuffix: urlSuffix,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+}
+
+func (a *AstraflowModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewAstraflowModel(baseURL, a.URLSuffix)
+}
+
+func (a *AstraflowModel) Name() string {
+	return "astraflow"
+}
+
+func (a *AstraflowModel) baseURLForRegion(region string) (string, error) {
+	base, ok := a.BaseURL[region]
+	if !ok || base == "" {
+		return "", fmt.Errorf("astraflow: no base URL configured for region %q", region)
+	}
+	return strings.TrimSuffix(base, "/"), nil
+}
+
+// ChatWithMessages sends a non-streaming chat request and returns the
+// full response. Forwards documented OpenAI-shaped parameters when the
+// caller supplies them; reasoning_content is surfaced separately so the
+// visible Answer is never polluted by chain-of-thought.
+func (a *AstraflowModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := a.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, a.URLSuffix.Chat)
+
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   false,
+	}
+
+	if chatModelConfig != nil {
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	firstChoice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid choice format")
+	}
+
+	messageMap, ok := firstChoice["message"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid message format")
+	}
+
+	content, ok := messageMap["content"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid content format")
+	}
+
+	// Reasoning models (deepseek-r1 / kimi / glm-thinking) put
+	// chain-of-thought in a separate `reasoning_content` field with
+	// `content` already cleaned. Absent or non-string means no reasoning
+	// was emitted; leave it empty rather than synthesizing one.
+	reasonContent := ""
+	if r, ok := messageMap["reasoning_content"].(string); ok {
+		reasonContent = r
+	}
+
+	return &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+	}, nil
+}
+
+// ChatStreamlyWithSender opens the SSE chat-completions endpoint and
+// forwards each delta through the supplied sender. Reasoning chunks go
+// to the sender's second argument, content chunks to the first; the
+// stream is terminated by either `[DONE]` or a delta with finish_reason.
+func (a *AstraflowModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := a.baseURLForRegion(region)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, a.URLSuffix.Chat)
+
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   true,
+	}
+
+	if chatModelConfig != nil {
+		// Guard against the caller asking for stream=false on a code path
+		// that only knows how to read SSE. Without this, a non-SSE JSON
+		// body would parse as zero chunks and look like a silent timeout.
+		if chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+			return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+		}
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// SSE is long-lived; rely on the transport's ResponseHeaderTimeout
+	// to cap connection-establishment instead of a hard deadline.
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	sawTerminal := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(line[5:])
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event map[string]interface{}
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			// A malformed frame usually means a truncated event or an
+			// upstream incident. Surface it instead of silently producing
+			// partial output.
+			return fmt.Errorf("astraflow: invalid SSE event: %w", err)
+		}
+
+		// Astraflow can emit a terminal `{"error": ...}` frame when the
+		// upstream model rejects mid-stream (rate limit, content policy).
+		// Surface it verbatim instead of falling through to "no choices".
+		if apiErr, ok := event["error"]; ok {
+			return fmt.Errorf("astraflow: upstream stream error: %v", apiErr)
+		}
+
+		choices, ok := event["choices"].([]interface{})
+		if !ok || len(choices) == 0 {
+			continue
+		}
+		firstChoice, ok := choices[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		delta, ok := firstChoice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Reasoning first, content second — matches the wire ordering
+		// for reasoning models and lets UIs render the chain-of-thought
+		// before the visible token.
+		if r, ok := delta["reasoning_content"].(string); ok && r != "" {
+			rr := r
+			if err := sender(nil, &rr); err != nil {
+				return err
+			}
+		}
+		if c, ok := delta["content"].(string); ok && c != "" {
+			cc := c
+			if err := sender(&cc, nil); err != nil {
+				return err
+			}
+		}
+		if finish, ok := firstChoice["finish_reason"].(string); ok && finish != "" {
+			sawTerminal = true
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("astraflow: stream ended before [DONE] or finish_reason")
+	}
+
+	endOfStream := "[DONE]"
+	if err := sender(&endOfStream, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ListModels returns the model ids visible to the API key by calling
+// /v1/models. Used by Add-Provider's connection check and by the UI's
+// model picker.
+func (a *AstraflowModel) ListModels(apiConfig *APIConfig) ([]string, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := a.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, a.URLSuffix.Models)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	data, ok := result["data"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid models list format")
+	}
+
+	models := make([]string, 0, len(data))
+	for _, m := range data {
+		modelMap, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, ok := modelMap["id"].(string)
+		if !ok {
+			continue
+		}
+		models = append(models, id)
+	}
+	return models, nil
+}
+
+// CheckConnection verifies the API key by calling ListModels. The /v1/models
+// endpoint is the documented lightweight way to validate credentials on
+// OpenAI-compatible gateways without burning chat-completion quota.
+func (a *AstraflowModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := a.ListModels(apiConfig)
+	return err
+}
+
+// Embed is reserved for a follow-up issue; the Astraflow factory tag
+// includes "TEXT EMBEDDING" but this initial driver only implements
+// chat, mirroring how Novita / TogetherAI / DeepInfra landed
+// method-by-method.
+func (a *AstraflowModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *AstraflowModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}

--- a/internal/entity/models/astraflow.go
+++ b/internal/entity/models/astraflow.go
@@ -334,24 +334,22 @@ func (a *AstraflowModel) ChatStreamlyWithSender(modelName string, messages []Mes
 		if !ok {
 			continue
 		}
-		delta, ok := firstChoice["delta"].(map[string]interface{})
-		if !ok {
-			continue
-		}
-
 		// Reasoning first, content second — matches the wire ordering
 		// for reasoning models and lets UIs render the chain-of-thought
-		// before the visible token.
-		if r, ok := delta["reasoning_content"].(string); ok && r != "" {
-			rr := r
-			if err := sender(nil, &rr); err != nil {
-				return err
+		// before the visible token. A terminal frame may carry
+		// finish_reason without a delta, so don't skip when delta is absent.
+		if delta, ok := firstChoice["delta"].(map[string]interface{}); ok {
+			if r, ok := delta["reasoning_content"].(string); ok && r != "" {
+				rr := r
+				if err := sender(nil, &rr); err != nil {
+					return err
+				}
 			}
-		}
-		if c, ok := delta["content"].(string); ok && c != "" {
-			cc := c
-			if err := sender(&cc, nil); err != nil {
-				return err
+			if c, ok := delta["content"].(string); ok && c != "" {
+				cc := c
+				if err := sender(&cc, nil); err != nil {
+					return err
+				}
 			}
 		}
 		if finish, ok := firstChoice["finish_reason"].(string); ok && finish != "" {

--- a/internal/entity/models/astraflow_test.go
+++ b/internal/entity/models/astraflow_test.go
@@ -1,0 +1,447 @@
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newAstraflowServer(t *testing.T, expectedPath string, handler func(t *testing.T, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		if r.Method == http.MethodPost {
+			if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+				t.Errorf("expected Content-Type to start with application/json, got %q", got)
+				return
+			}
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read error", http.StatusBadRequest)
+				return
+			}
+			var body map[string]interface{}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Errorf("unmarshal: %v\nraw=%s", err, string(raw))
+				http.Error(w, "unmarshal error", http.StatusBadRequest)
+				return
+			}
+			handler(t, body, w)
+			return
+		}
+		handler(t, nil, w)
+	}))
+}
+
+func newAstraflowSSEServer(t *testing.T, expectedPath, ssePayload string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			return
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+			t.Errorf("expected Content-Type to start with application/json, got %q", got)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ssePayload)
+	}))
+}
+
+func newAstraflowForTest(baseURL string) *AstraflowModel {
+	return NewAstraflowModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{Chat: "chat/completions", Models: "models"},
+	)
+}
+
+func TestAstraflowName(t *testing.T) {
+	if got := newAstraflowForTest("http://unused").Name(); got != "astraflow" {
+		t.Errorf("Name()=%q, want %q", got, "astraflow")
+	}
+}
+
+func TestAstraflowFactory(t *testing.T) {
+	driver, err := NewModelFactory().CreateModelDriver("Astraflow", map[string]string{"default": "http://unused"}, URLSuffix{})
+	if err != nil {
+		t.Fatalf("CreateModelDriver: %v", err)
+	}
+	if _, ok := driver.(*AstraflowModel); !ok {
+		t.Fatalf("driver type=%T, want *AstraflowModel", driver)
+	}
+}
+
+func TestAstraflowChatHappyPath(t *testing.T) {
+	srv := newAstraflowServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "claude-opus-4-7" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if body["stream"] != false {
+			t.Errorf("stream=%v, want false", body["stream"])
+		}
+		if body["max_tokens"] != float64(64) {
+			t.Errorf("max_tokens=%v, want 64", body["max_tokens"])
+		}
+		if body["temperature"] != 0.3 {
+			t.Errorf("temperature=%v, want 0.3", body["temperature"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content":           "pong",
+					"reasoning_content": "thought about it",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	mt := 64
+	temp := 0.3
+	resp, err := newAstraflowForTest(srv.URL).ChatWithMessages(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{MaxTokens: &mt, Temperature: &temp},
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if resp.Answer == nil || *resp.Answer != "pong" {
+		t.Errorf("Answer=%v, want pong", resp.Answer)
+	}
+	if resp.ReasonContent == nil || *resp.ReasonContent != "thought about it" {
+		t.Errorf("ReasonContent=%v, want 'thought about it'", resp.ReasonContent)
+	}
+}
+
+func TestAstraflowChatNoReasoning(t *testing.T) {
+	srv := newAstraflowServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "hi"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	resp, err := newAstraflowForTest(srv.URL).ChatWithMessages(
+		"gpt-4o-mini",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Answer == nil || *resp.Answer != "hi" {
+		t.Errorf("Answer=%v, want 'hi'", resp.Answer)
+	}
+	if resp.ReasonContent == nil || *resp.ReasonContent != "" {
+		t.Errorf("ReasonContent=%v, want empty", resp.ReasonContent)
+	}
+}
+
+func TestAstraflowChatRequiresAPIKey(t *testing.T) {
+	_, err := newAstraflowForTest("http://unused").ChatWithMessages(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestAstraflowChatRequiresMessages(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newAstraflowForTest("http://unused").ChatWithMessages(
+		"claude-opus-4-7", nil, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "messages is empty") {
+		t.Errorf("expected messages-empty error, got %v", err)
+	}
+}
+
+func TestAstraflowChatPropagatesHTTPError(t *testing.T) {
+	srv := newAstraflowServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	_, err := newAstraflowForTest(srv.URL).ChatWithMessages(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 propagated, got %v", err)
+	}
+}
+
+func TestAstraflowStreamHappyPath(t *testing.T) {
+	srv := newAstraflowSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var chunks []string
+	var sawDone bool
+	err := newAstraflowForTest(srv.URL).ChatStreamlyWithSender(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, _ *string) error {
+			if c == nil {
+				return nil
+			}
+			if *c == "[DONE]" {
+				sawDone = true
+				return nil
+			}
+			chunks = append(chunks, *c)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if strings.Join(chunks, "") != "Hello world" {
+		t.Errorf("content=%v", chunks)
+	}
+	if !sawDone {
+		t.Error("expected [DONE] sentinel")
+	}
+}
+
+func TestAstraflowStreamSplitsReasoning(t *testing.T) {
+	srv := newAstraflowSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 1. "}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 2."}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"final"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var content, reasoning []string
+	err := newAstraflowForTest(srv.URL).ChatStreamlyWithSender(
+		"kimi-k2.6",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, r *string) error {
+			if c != nil && r != nil {
+				t.Errorf("sender called with both args non-nil")
+			}
+			if r != nil && *r != "" {
+				reasoning = append(reasoning, *r)
+			}
+			if c != nil && *c != "" && *c != "[DONE]" {
+				content = append(content, *c)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if got := strings.Join(reasoning, ""); got != "step 1. step 2." {
+		t.Errorf("reasoning=%q", got)
+	}
+	if got := strings.Join(content, ""); got != "final" {
+		t.Errorf("content=%q", got)
+	}
+}
+
+func TestAstraflowStreamRejectsExplicitFalse(t *testing.T) {
+	apiKey := "test-key"
+	stream := false
+	err := newAstraflowForTest("http://unused").ChatStreamlyWithSender(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Stream: &stream},
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream must be true") {
+		t.Errorf("expected stream-true guard, got %v", err)
+	}
+}
+
+func TestAstraflowStreamRequiresSender(t *testing.T) {
+	apiKey := "test-key"
+	err := newAstraflowForTest("http://unused").ChatStreamlyWithSender(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "sender is required") {
+		t.Errorf("expected sender-required error, got %v", err)
+	}
+}
+
+func TestAstraflowStreamFailsWithoutTerminal(t *testing.T) {
+	srv := newAstraflowSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"delta":{"content":"half"}}]}`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newAstraflowForTest(srv.URL).ChatStreamlyWithSender(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream ended before") {
+		t.Errorf("expected truncation error, got %v", err)
+	}
+}
+
+func TestAstraflowStreamRejectsMalformedFrame(t *testing.T) {
+	srv := newAstraflowSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"delta":{"content":"ok"}}]}`+"\n"+
+			`data: {oops not json}`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newAstraflowForTest(srv.URL).ChatStreamlyWithSender(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "invalid SSE event") {
+		t.Errorf("expected invalid-SSE error, got %v", err)
+	}
+}
+
+func TestAstraflowStreamSurfacesUpstreamError(t *testing.T) {
+	srv := newAstraflowSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"delta":{"content":"partial "}}]}`+"\n"+
+			`data: {"error":{"message":"rate limit","type":"rate_limit_error"}}`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newAstraflowForTest(srv.URL).ChatStreamlyWithSender(
+		"claude-opus-4-7",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "upstream stream error") {
+		t.Errorf("expected upstream-error surfacing, got %v", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("expected upstream message included, got %v", err)
+	}
+}
+
+func TestAstraflowListModelsHappyPath(t *testing.T) {
+	srv := newAstraflowServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "claude-opus-4-7"},
+				{"id": "gpt-5.4"},
+				{"id": "Qwen/Qwen3-Max"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	models, err := newAstraflowForTest(srv.URL).ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	want := []string{"claude-opus-4-7", "gpt-5.4", "Qwen/Qwen3-Max"}
+	if strings.Join(models, ",") != strings.Join(want, ",") {
+		t.Errorf("models=%v, want %v", models, want)
+	}
+}
+
+func TestAstraflowListModelsRequiresAPIKey(t *testing.T) {
+	_, err := newAstraflowForTest("http://unused").ListModels(&APIConfig{})
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestAstraflowCheckConnectionDelegatesToListModels(t *testing.T) {
+	srv := newAstraflowServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{{"id": "claude-opus-4-7"}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	if err := newAstraflowForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
+		t.Errorf("CheckConnection: %v", err)
+	}
+}
+
+func TestAstraflowCheckConnectionPropagatesError(t *testing.T) {
+	srv := newAstraflowServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newAstraflowForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey})
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 propagated, got %v", err)
+	}
+}
+
+func TestAstraflowBaseURLForRegionUnknown(t *testing.T) {
+	m := newAstraflowForTest("http://unused")
+	apiKey := "test-key"
+	region := "missing"
+	_, err := m.ListModels(&APIConfig{ApiKey: &apiKey, Region: &region})
+	if err == nil || !strings.Contains(err.Error(), "no base URL configured") {
+		t.Errorf("expected base-URL error, got %v", err)
+	}
+}
+
+func TestAstraflowEmbedReturnsNoSuchMethod(t *testing.T) {
+	model := "x"
+	_, err := newAstraflowForTest("http://unused").Embed(&model, []string{"a"}, &APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Embed: want 'no such method', got %v", err)
+	}
+}
+
+func TestAstraflowAudioOCRReturnNoSuchMethod(t *testing.T) {
+	m := newAstraflowForTest("http://unused")
+	model := "x"
+	if _, err := m.TranscribeAudio(&model, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("TranscribeAudio: %v", err)
+	}
+	if _, err := m.AudioSpeech(&model, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("AudioSpeech: %v", err)
+	}
+	if _, err := m.OCRFile(&model, nil, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("OCRFile: %v", err)
+	}
+}

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -91,6 +91,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewLocalAIModel(baseURL, urlSuffix), nil
 	case "xinference":
 		return NewXinferenceModel(baseURL, urlSuffix), nil
+	case "astraflow":
+		return NewAstraflowModel(baseURL, urlSuffix), nil
 	case "longcat":
 		return NewLongCatModel(baseURL, urlSuffix), nil
 	case "novita":


### PR DESCRIPTION
- Adds an `Astraflow` Go driver so the new API server can route Astraflow (UCloud ModelVerse) chat instances, matching the existing Python `AstraflowChat` (`rag/llm/chat_model.py:1237`). Follows the same SaaS-driver shape used for Avian, Novita, TogetherAI, Replicate, DeepInfra, Upstage, and LongCat.

## Root Cause
`conf/llm_factories.json:6234` already registers the `Astraflow` factory with 18 chat models and the default base URL `https://api-us-ca.umodelverse.ai/v1`, but `internal/entity/models/` had no `astraflow.go` driver and `conf/models/` had no `astraflow.json`, so the Go API server fell back to the dummy driver for Astraflow instances.

## Fix
- `internal/entity/models/astraflow.go` — OpenAI-compatible driver implementing `ChatWithMessages`, `ChatStreamlyWithSender`, `ListModels`, and `CheckConnection` (delegates to `ListModels`). Forwards documented fields only (`model`, `messages`, `stream`, `max_tokens`, `temperature`, `top_p`, `stop`). Reasoning models surface `reasoning_content` separately from `content`. SSE handling rejects malformed frames, surfaces upstream `{"error": …}` frames, and requires a `[DONE]`/`finish_reason` terminator.
- `conf/models/astraflow.json` — base URL `https://api-us-ca.umodelverse.ai/v1` + the 18 chat models from the factory entry (claude-opus-4-7/4-6, claude-sonnet-4-5, claude-haiku-4-5, gpt-5.4/-mini/-nano, gpt-4o-mini, Qwen3-Max/-Coder/-32B/-VL, kimi-k2.6, glm-5.1, MiniMax-M2.7/M2, gemini-2.5-pro/-flash).
- `internal/entity/models/factory.go` — registers the `astraflow` case.
- `internal/entity/models/astraflow_test.go` — 21 hermetic tests using `httptest.Server` (no network).

Follow-on issues will add Embed (factory tags include `TEXT EMBEDDING`) and the China-region sibling `Astraflow-CN` (Python `chat_model.py:1246`, base `https://api.modelverse.cn/v1`), in line with how Novita / NVIDIA / TogetherAI landed method-by-method.

## Test Plan
- [x] Regression tests added: `internal/entity/models/astraflow_test.go`
- [x] All tests pass: `go test ./internal/entity/models/ -run Astraflow -count=1 -vet=off`
- [x] Output:

Closes #15062 