### PR TITLE
Feat: add owner filter to Chats list (#15061)

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -415,7 +415,7 @@ async def list_chat_owners():
         else:
             effective_owner_ids = list(authorized_owner_ids)
 
-        owners = DialogService.get_owner_summaries_by_tenant_ids(effective_owner_ids)
+        owners = await thread_pool_exec(DialogService.get_owner_summaries_by_tenant_ids, effective_owner_ids)
         return get_json_result(data={"owners": owners})
     except Exception as ex:
         return server_error_response(ex)

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -388,6 +388,39 @@ async def list_chats():
         return server_error_response(ex)
 
 
+@manager.route("/chats/owners", methods=["GET"])  # noqa: F821
+@login_required
+async def list_chat_owners():
+    owner_ids = request.args.getlist("owner_ids")
+    try:
+        tenants = TenantService.get_joined_tenants_by_user_id(current_user.id)
+        authorized_owner_ids = {member["tenant_id"] for member in tenants}
+        authorized_owner_ids.add(current_user.id)
+
+        if owner_ids:
+            requested_owner_ids = set(owner_ids)
+            unauthorized_owner_ids = requested_owner_ids - authorized_owner_ids
+            if unauthorized_owner_ids:
+                logging.warning(
+                    "Rejected list_chat_owners request: user=%s attempted unauthorized owner_ids=%s",
+                    current_user.id,
+                    sorted(unauthorized_owner_ids),
+                )
+                return get_json_result(
+                    data=False,
+                    message="Only authorized owner_ids can be queried.",
+                    code=RetCode.OPERATING_ERROR,
+                )
+            effective_owner_ids = list(requested_owner_ids)
+        else:
+            effective_owner_ids = list(authorized_owner_ids)
+
+        owners = DialogService.get_owner_summaries_by_tenant_ids(effective_owner_ids)
+        return get_json_result(data={"owners": owners})
+    except Exception as ex:
+        return server_error_response(ex)
+
+
 @manager.route("/chats/<chat_id>", methods=["GET"])  # noqa: F821
 @login_required
 async def get_chat(chat_id):

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -263,6 +263,27 @@ class DialogService(CommonService):
 
     @classmethod
     @DB.connection_context()
+    def get_owner_summaries_by_tenant_ids(cls, tenant_ids):
+        from api.db.db_models import User
+
+        owners = (
+            cls.model.select(
+                cls.model.tenant_id,
+                User.nickname,
+                User.avatar.alias('tenant_avatar'),
+            )
+            .join(User, on=(cls.model.tenant_id == User.id))
+            .where(
+                cls.model.tenant_id.in_(tenant_ids),
+                cls.model.status == StatusEnum.VALID.value,
+            )
+            .distinct()
+            .order_by(User.nickname.asc())
+        )
+        return list(owners.dicts())
+
+    @classmethod
+    @DB.connection_context()
     def get_all_dialogs_by_tenant_id(cls, tenant_id):
         fields = [cls.model.id]
         dialogs = cls.model.select(*fields).where(cls.model.tenant_id == tenant_id)

--- a/web/src/hooks/use-chat-request.ts
+++ b/web/src/hooks/use-chat-request.ts
@@ -1,4 +1,5 @@
 import { FileUploadProps } from '@/components/file-upload';
+import { useHandleFilterSubmit } from '@/components/list-filter-bar/use-handle-filter-submit';
 import message from '@/components/ui/message';
 import { ChatSearchParams } from '@/constants/chat';
 import {
@@ -30,6 +31,8 @@ import { useHandleSearchStrChange } from './logic-hooks/use-change-search';
 
 export const enum ChatApiAction {
   FetchChatList = 'fetchChatList',
+  FetchAllChatList = 'fetchAllChatList',
+  FetchOwnerList = 'fetchOwnerList',
   DeleteChat = 'deleteChat',
   CreateChat = 'createChat',
   UpdateChat = 'updateChat',
@@ -50,6 +53,12 @@ export const enum ChatApiAction {
   CreateSharedConversation = 'createSharedConversation',
 }
 
+export interface IChatOwnerSummary {
+  tenant_id: string;
+  nickname?: string;
+  tenant_avatar?: string;
+}
+
 export const useGetChatSearchParams = () => {
   const [currentQueryParameters] = useSearchParams();
 
@@ -65,6 +74,8 @@ export const useFetchChatList = () => {
   const { searchString, handleInputChange } = useHandleSearchChange();
   const { pagination, setPagination } = useGetPaginationWithRouter();
   const debouncedSearchString = useDebounce(searchString, { wait: 500 });
+  const { filterValue, handleFilterSubmit } = useHandleFilterSubmit();
+  const ownerIds = (filterValue.owner as string[] | undefined) ?? [];
 
   const {
     data,
@@ -76,6 +87,7 @@ export const useFetchChatList = () => {
       {
         debouncedSearchString,
         ...pagination,
+        ownerIds,
       },
     ],
     initialData: { chats: [], total: 0 },
@@ -88,7 +100,9 @@ export const useFetchChatList = () => {
             keywords: debouncedSearchString,
             page_size: pagination.pageSize,
             page: pagination.current,
+            ...(ownerIds.length ? { owner_ids: ownerIds } : {}),
           },
+          paramsSerializer: { indexes: null },
           data: {},
         },
         true,
@@ -113,7 +127,34 @@ export const useFetchChatList = () => {
     handleInputChange: onInputChange,
     pagination: { ...pagination, total: data?.total },
     setPagination,
+    filterValue,
+    handleFilterSubmit,
   };
+};
+
+export const useFetchAllChatList = (): {
+  list: IChatOwnerSummary[];
+  loading: boolean;
+} => {
+  const { data, isFetching: loading } = useQuery<IChatOwnerSummary[]>({
+    queryKey: [ChatApiAction.FetchOwnerList],
+    initialData: [],
+    gcTime: 0,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const { data } = await chatService.listChatOwners(
+        {
+          params: {},
+          data: {},
+        },
+        true,
+      );
+
+      return data?.data?.owners ?? [];
+    },
+  });
+
+  return { list: data, loading };
 };
 
 export const useDeleteChat = () => {
@@ -131,6 +172,9 @@ export const useDeleteChat = () => {
       if (data.code === 0) {
         queryClient.invalidateQueries({
           queryKey: [ChatApiAction.FetchChatList],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [ChatApiAction.FetchOwnerList],
         });
         message.success(t('message.deleted'));
       }
@@ -157,6 +201,9 @@ export const useCreateChat = () => {
         queryClient.invalidateQueries({
           exact: false,
           queryKey: [ChatApiAction.FetchChatList],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [ChatApiAction.FetchOwnerList],
         });
         message.success(t('message.created'));
       }

--- a/web/src/interfaces/database/chat.ts
+++ b/web/src/interfaces/database/chat.ts
@@ -69,6 +69,8 @@ export interface IDialog {
   prompt_type: string;
   status: string;
   tenant_id: string;
+  tenant_avatar?: string;
+  nickname?: string;
   update_date: string;
   update_time: number;
   vector_similarity_weight: number;

--- a/web/src/pages/next-chats/index.tsx
+++ b/web/src/pages/next-chats/index.tsx
@@ -13,10 +13,19 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router';
 import { ChatCard } from './chat-card';
 import { useRenameChat } from './hooks/use-rename-chat';
+import { useSelectOwners } from './use-select-owners';
 
 export default function ChatList() {
-  const { data, setPagination, pagination, handleInputChange, searchString } =
-    useFetchChatList();
+  const {
+    data,
+    setPagination,
+    pagination,
+    handleInputChange,
+    searchString,
+    filterValue,
+    handleFilterSubmit,
+  } = useFetchChatList();
+  const owners = useSelectOwners();
   const { t } = useTranslation();
   const {
     initialChatName,
@@ -58,6 +67,9 @@ export default function ChatList() {
               icon="chats"
               onSearchChange={handleInputChange}
               searchString={searchString}
+              value={filterValue}
+              filters={owners}
+              onChange={handleFilterSubmit}
             >
               <Button data-testid="create-chat" onClick={handleShowCreateModal}>
                 <Plus className="size-[1em]" />

--- a/web/src/pages/next-chats/use-select-owners.ts
+++ b/web/src/pages/next-chats/use-select-owners.ts
@@ -1,0 +1,11 @@
+import { FilterCollection } from '@/components/list-filter-bar/interface';
+import { useFetchAllChatList } from '@/hooks/use-chat-request';
+import { buildOwnersFilter } from '@/utils/list-filter-util';
+
+export function useSelectOwners() {
+  const { list } = useFetchAllChatList();
+
+  const filters: FilterCollection[] = [buildOwnersFilter(list)];
+
+  return filters;
+}

--- a/web/src/services/next-chat-service.ts
+++ b/web/src/services/next-chat-service.ts
@@ -4,6 +4,7 @@ import { registerNextServer } from '@/utils/register-server';
 const {
   createChat,
   listChats,
+  listChatOwners,
   getChat,
   updateChat,
   patchChat,
@@ -30,6 +31,10 @@ const methods = {
   },
   listChats: {
     url: listChats,
+    method: 'get',
+  },
+  listChatOwners: {
+    url: listChatOwners,
     method: 'get',
   },
   getChat: {

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -143,6 +143,7 @@ export default {
   // chat
   createChat: `${restAPIv1}/chats`,
   listChats: `${restAPIv1}/chats`,
+  listChatOwners: `${restAPIv1}/chats/owners`,
   getChat: (chatId: string) => `${restAPIv1}/chats/${chatId}`,
   updateChat: (chatId: string) => `${restAPIv1}/chats/${chatId}`,
   patchChat: (chatId: string) => `${restAPIv1}/chats/${chatId}`,


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #15061.

In team deployments, the Chats page shows every assistant created by every
teammate, but users can only edit/delete their own — attempting to modify
someone else's returns "No authorization." The backend `GET /api/v1/chats`
already accepts an `owner_ids` filter; this PR exposes it in the UI.

- Adds an **Owner** filter to the Chats page's `ListFilterBar`, mirroring
  the existing pattern on the Knowledge Base page
  ([datasets/use-select-owners.ts](web/src/pages/datasets/use-select-owners.ts)).
- New `useFetchAllChatList` hook fetches the unpaginated chat list used to
  populate the owner options; `useCreateChat` / `useDeleteChat` invalidate
  it so newly added/removed owners show up immediately.
- `useFetchChatList` sends `owner_ids` as repeat query params via
  `paramsSerializer: { indexes: null }` so Flask's
  `request.args.getlist("owner_ids")` reads them correctly.
- Added optional `nickname` / `tenant_avatar` to `IDialog` to reflect
  what the backend already returns.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
