### PR TITLE
Fix IMAP From headers with multiple addresses

### DIFF
--- a/common/data_source/imap_connector.py
+++ b/common/data_source/imap_connector.py
@@ -40,6 +40,8 @@ _PAGE_SIZE = 100
 _USERNAME_KEY = "imap_username"
 _PASSWORD_KEY = "imap_password"
 
+logger = logging.getLogger(__name__)
+
 class Header(str, Enum):
     SUBJECT_HEADER = "subject"
     FROM_HEADER = "from"
@@ -752,10 +754,9 @@ def _parse_singular_addr(raw_header: str) -> tuple[str, str]:
     if not addrs:
         return ("Unknown", "unknown@example.com")
     elif len(addrs) >= 2:
-        logging.warning(
-            "Expected a singular address, but instead got multiple; raw_header=%r addrs=%r",
-            raw_header,
-            addrs,
+        logger.warning(
+            "Expected a singular address, but parsed %d addresses; using first parsed address",
+            len(addrs),
         )
 
     return addrs[0]

--- a/common/data_source/imap_connector.py
+++ b/common/data_source/imap_connector.py
@@ -752,8 +752,10 @@ def _parse_singular_addr(raw_header: str) -> tuple[str, str]:
     if not addrs:
         return ("Unknown", "unknown@example.com")
     elif len(addrs) >= 2:
-        raise RuntimeError(
-            f"Expected a singular address, but instead got multiple; {raw_header=} {addrs=}"
+        logging.warning(
+            "Expected a singular address, but instead got multiple; raw_header=%r addrs=%r",
+            raw_header,
+            addrs,
         )
 
     return addrs[0]

--- a/test/unit_test/data_source/test_imap_connector.py
+++ b/test/unit_test/data_source/test_imap_connector.py
@@ -14,25 +14,39 @@
 #  limitations under the License.
 #
 
-import logging
+import importlib
 import sys
 import types
 
+import pytest
 from pydantic import BaseModel
 
-sys.modules.setdefault("anthropic", types.SimpleNamespace(BaseModel=BaseModel))
-from common.data_source.imap_connector import _parse_singular_addr
+
+@pytest.fixture
+def parse_singular_addr(monkeypatch):
+    monkeypatch.setitem(sys.modules, "anthropic", types.SimpleNamespace(BaseModel=BaseModel))
+    module = importlib.import_module("common.data_source.imap_connector")
+    return module._parse_singular_addr
 
 
-def test_parse_singular_addr_returns_unknown_when_no_addresses_parse():
-    assert _parse_singular_addr("") == ("Unknown", "unknown@example.com")
+def test_parse_singular_addr_returns_unknown_when_no_addresses_parse(
+    parse_singular_addr,
+):
+    assert parse_singular_addr("") == ("Unknown", "unknown@example.com")
 
 
-def test_parse_singular_addr_returns_first_address_and_warns_for_multiple(caplog):
+def test_parse_singular_addr_returns_first_address_and_warns_for_multiple(
+    caplog,
+    parse_singular_addr,
+):
     raw_header = "Alice <alice@example.com>, Bob <bob@example.com>"
 
-    with caplog.at_level(logging.WARNING):
-        parsed_addr = _parse_singular_addr(raw_header)
+    with caplog.at_level("WARNING", logger="common.data_source.imap_connector"):
+        parsed_addr = parse_singular_addr(raw_header)
 
     assert parsed_addr == ("Alice", "alice@example.com")
-    assert "Expected a singular address, but instead got multiple" in caplog.text
+    assert "Expected a singular address, but parsed 2 addresses; using first parsed address" in caplog.text
+    assert "Alice" not in caplog.text
+    assert "alice@example.com" not in caplog.text
+    assert "Bob" not in caplog.text
+    assert "bob@example.com" not in caplog.text

--- a/test/unit_test/data_source/test_imap_connector.py
+++ b/test/unit_test/data_source/test_imap_connector.py
@@ -1,0 +1,38 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import logging
+import sys
+import types
+
+from pydantic import BaseModel
+
+sys.modules.setdefault("anthropic", types.SimpleNamespace(BaseModel=BaseModel))
+from common.data_source.imap_connector import _parse_singular_addr
+
+
+def test_parse_singular_addr_returns_unknown_when_no_addresses_parse():
+    assert _parse_singular_addr("") == ("Unknown", "unknown@example.com")
+
+
+def test_parse_singular_addr_returns_first_address_and_warns_for_multiple(caplog):
+    raw_header = "Alice <alice@example.com>, Bob <bob@example.com>"
+
+    with caplog.at_level(logging.WARNING):
+        parsed_addr = _parse_singular_addr(raw_header)
+
+    assert parsed_addr == ("Alice", "alice@example.com")
+    assert "Expected a singular address, but instead got multiple" in caplog.text


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #14964.

IMAP sync currently raises from _parse_singular_addr when a From header parses to multiple addresses. That exception can fail the whole sync for a single message.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### What is changed and how it works?

- Logs a warning when a From header has multiple parsed addresses
- Uses the first parsed address as the sender instead of raising
- Keeps the existing unknown-sender fallback when no address parses
- Adds focused unit coverage for empty and multi-address From headers

### Check List

- [x] Self-test passed

Verification run:

- pytest -q test/unit_test/data_source/test_imap_connector.py
- ruff check common/data_source/imap_connector.py test/unit_test/data_source/test_imap_connector.py
- ruff format --check test/unit_test/data_source/test_imap_connector.py
- git diff --check

Note: the targeted pytest was run through the local available pytest path because the full uv test environment was blocked by dependency resolution/fetch issues unrelated to this parser change.