### PR TITLE
feat(go-models): add RAGcon model driver

### DIFF
--- a/conf/models/ragcon.json
+++ b/conf/models/ragcon.json
@@ -1,0 +1,12 @@
+{
+  "name": "RAGcon",
+  "url": {
+    "default": "https://connect.ragcon.com/v1"
+  },
+  "url_suffix": {
+    "chat": "chat/completions",
+    "models": "models",
+    "embedding": "embeddings"
+  },
+  "class": "ragcon"
+}

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -115,6 +115,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewAI302Model(baseURL, urlSuffix), nil
 	case "mineru_local":
 		return NewMinerLocalUModel(baseURL, urlSuffix), nil
+	case "ragcon":
+		return NewRAGconModel(baseURL, urlSuffix), nil
 	default:
 		return NewDummyModel(baseURL, urlSuffix), nil
 	}

--- a/internal/entity/models/ragcon.go
+++ b/internal/entity/models/ragcon.go
@@ -1,0 +1,564 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RAGconModel implements ModelDriver for RAGcon (https://www.ragcon.ai).
+//
+// RAGcon is a SaaS inference platform that exposes an OpenAI-compatible
+// REST API through a LiteLLM proxy (default base URL
+// https://connect.ragcon.com/v1). Because the wire shape — request body,
+// SSE stream, /models listing, and Bearer-token auth — is plain OpenAI,
+// this driver mirrors the OpenAI driver rather than introducing any
+// RAGcon-specific protocol handling. The provider differs from OpenAI
+// only in its default base URL, which ships in conf/models/ragcon.json.
+type RAGconModel struct {
+	BaseURL    map[string]string
+	URLSuffix  URLSuffix
+	httpClient *http.Client
+}
+
+// NewRAGconModel creates a new RAGcon model instance.
+//
+// Same transport convention as the other Go drivers in this package:
+// clone http.DefaultTransport, override the connection-pool fields, and
+// keep no client-level Timeout so SSE streams in ChatStreamlyWithSender
+// are not cut off. ResponseHeaderTimeout caps the connection-setup phase;
+// non-streaming calls wrap each request with context.WithTimeout.
+func NewRAGconModel(baseURL map[string]string, urlSuffix URLSuffix) *RAGconModel {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.DisableCompression = false
+	transport.ResponseHeaderTimeout = 60 * time.Second
+
+	return &RAGconModel{
+		BaseURL:   baseURL,
+		URLSuffix: urlSuffix,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+}
+
+func (r *RAGconModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewRAGconModel(baseURL, r.URLSuffix)
+}
+
+func (r *RAGconModel) Name() string {
+	return "ragcon"
+}
+
+// baseURLForRegion returns the base URL for the given region, trimming a
+// trailing "/" so callers can build URLs with fmt.Sprintf("%s/%s", base,
+// suffix) without producing a "//" in the path. A tenant may override the
+// shipped base URL per-instance and add a trailing slash.
+func (r *RAGconModel) baseURLForRegion(region string) (string, error) {
+	base, ok := r.BaseURL[region]
+	if !ok || base == "" {
+		return "", fmt.Errorf("ragcon: no base URL configured for region %q", region)
+	}
+	return strings.TrimSuffix(base, "/"), nil
+}
+
+func (r *RAGconModel) chatPayload(modelName string, messages []Message, stream bool, chatModelConfig *ChatConfig) map[string]interface{} {
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   stream,
+	}
+
+	if chatModelConfig != nil {
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+	}
+
+	return reqBody
+}
+
+// ChatWithMessages sends multiple messages with roles and returns a
+// single non-streaming response.
+func (r *RAGconModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := r.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, r.URLSuffix.Chat)
+
+	jsonData, err := json.Marshal(r.chatPayload(modelName, messages, false, chatModelConfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	firstChoice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid choice format")
+	}
+
+	messageMap, ok := firstChoice["message"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid message format")
+	}
+
+	content, ok := messageMap["content"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid content format")
+	}
+
+	// Reasoning models routed through the proxy may return chain-of-thought
+	// in a separate reasoning_content field. Pass it through when present.
+	var reasonContent string
+	if rc, ok := messageMap["reasoning_content"].(string); ok {
+		reasonContent = rc
+		if reasonContent != "" && reasonContent[0] == '\n' {
+			reasonContent = reasonContent[1:]
+		}
+	}
+
+	return &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+	}, nil
+}
+
+const ragconStreamTimeout = 10 * time.Minute
+
+// ChatStreamlyWithSender sends messages and streams the response via the
+// sender function over SSE.
+func (r *RAGconModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+	if chatModelConfig != nil && chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+		return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := r.baseURLForRegion(region)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, r.URLSuffix.Chat)
+
+	jsonData, err := json.Marshal(r.chatPayload(modelName, messages, true, chatModelConfig))
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// ResponseHeaderTimeout caps the initial header wait. This context also
+	// caps the body-read phase so a stalled SSE stream cannot hold the
+	// caller's goroutine and connection indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), ragconStreamTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Bump the scanner buffer to 1MB so a long SSE data: line is never
+	// silently truncated (default is 64KB).
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	// sawTerminal flips to true only when the upstream actually signalled
+	// end-of-stream ("[DONE]" or a non-empty finish_reason). If the body
+	// closes before either, we must not emit a synthetic "[DONE]" — doing
+	// so would hide a truncated response from the caller.
+	sawTerminal := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimSpace(line[5:])
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event map[string]interface{}
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+
+		choices, ok := event["choices"].([]interface{})
+		if !ok || len(choices) == 0 {
+			continue
+		}
+
+		firstChoice, ok := choices[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		delta, ok := firstChoice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if reasoningContent, ok := delta["reasoning_content"].(string); ok && reasoningContent != "" {
+			if err := sender(nil, &reasoningContent); err != nil {
+				return err
+			}
+		}
+
+		if content, ok := delta["content"].(string); ok && content != "" {
+			if err := sender(&content, nil); err != nil {
+				return err
+			}
+		}
+
+		if finishReason, ok := firstChoice["finish_reason"].(string); ok && finishReason != "" {
+			sawTerminal = true
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("ragcon: stream ended before [DONE] or finish_reason")
+	}
+
+	endOfStream := "[DONE]"
+	return sender(&endOfStream, nil)
+}
+
+// ListModels returns the list of model ids visible to the API key.
+func (r *RAGconModel) ListModels(apiConfig *APIConfig) ([]string, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := r.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, r.URLSuffix.Models)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	data, ok := result["data"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid models list format")
+	}
+
+	models := make([]string, 0, len(data))
+	for _, model := range data {
+		modelMap, ok := model.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, ok := modelMap["id"].(string)
+		if !ok {
+			continue
+		}
+		models = append(models, id)
+	}
+	return models, nil
+}
+
+// CheckConnection runs a lightweight ListModels call to verify the API key.
+func (r *RAGconModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := r.ListModels(apiConfig)
+	return err
+}
+
+type ragconEmbeddingData struct {
+	Embedding []float64 `json:"embedding"`
+	Object    string    `json:"object"`
+	Index     int       `json:"index"`
+}
+
+type ragconEmbeddingResponse struct {
+	Data   []ragconEmbeddingData `json:"data"`
+	Model  string                `json:"model"`
+	Object string                `json:"object"`
+}
+
+// Embed turns a list of texts into embedding vectors using the
+// OpenAI-compatible /embeddings endpoint. The output has one vector per
+// input, placed back in the order the inputs were given.
+func (r *RAGconModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	if len(texts) == 0 {
+		return []EmbeddingData{}, nil
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if modelName == nil || *modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := r.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, r.URLSuffix.Embedding)
+
+	reqBody := map[string]interface{}{
+		"model": *modelName,
+		"input": texts,
+	}
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+		reqBody["dimensions"] = embeddingConfig.Dimension
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RAGcon embeddings API error: %s, body: %s", resp.Status, string(body))
+	}
+
+	var parsed ragconEmbeddingResponse
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	embeddings := make([]EmbeddingData, len(texts))
+	filled := make([]bool, len(texts))
+	for _, item := range parsed.Data {
+		if item.Index < 0 || item.Index >= len(texts) {
+			return nil, fmt.Errorf("ragcon: response index %d out of range for %d inputs", item.Index, len(texts))
+		}
+		if filled[item.Index] {
+			return nil, fmt.Errorf("ragcon: duplicate embedding index %d in response", item.Index)
+		}
+		embeddings[item.Index] = EmbeddingData{
+			Embedding: item.Embedding,
+			Index:     item.Index,
+		}
+		filled[item.Index] = true
+	}
+	for i, ok := range filled {
+		if !ok {
+			return nil, fmt.Errorf("ragcon: missing embedding for input index %d", i)
+		}
+	}
+
+	return embeddings, nil
+}
+
+// Rerank is not implemented for the RAGcon Go driver.
+func (r *RAGconModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+// Balance is not exposed by the RAGcon API.
+func (r *RAGconModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}

--- a/internal/entity/models/ragcon_test.go
+++ b/internal/entity/models/ragcon_test.go
@@ -1,0 +1,432 @@
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newRAGconServer asserts the JSON wire contract (path, Authorization,
+// Content-Type) shared by the POST chat/embed paths and the GET
+// ListModels path, then delegates the response to handler.
+func newRAGconServer(t *testing.T, expectedPath string, handler func(t *testing.T, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+			t.Errorf("expected Content-Type to start with application/json, got %q", got)
+			return
+		}
+		if r.Method == http.MethodPost {
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+				return
+			}
+			var body map[string]interface{}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Errorf("unmarshal: %v\nraw=%s", err, string(raw))
+				return
+			}
+			handler(t, body, w)
+			return
+		}
+		handler(t, nil, w)
+	}))
+}
+
+// newRAGconSSEServer asserts the SSE-chat request shape, then writes the
+// supplied SSE payload.
+func newRAGconSSEServer(t *testing.T, expectedPath, ssePayload string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			return
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ssePayload)
+	}))
+}
+
+func newRAGconForTest(baseURL string) *RAGconModel {
+	return NewRAGconModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{Chat: "chat/completions", Models: "models", Embedding: "embeddings"},
+	)
+}
+
+func TestRAGconName(t *testing.T) {
+	if got := newRAGconForTest("http://unused").Name(); got != "ragcon" {
+		t.Errorf("Name()=%q", got)
+	}
+}
+
+func TestRAGconChatHappyPath(t *testing.T) {
+	srv := newRAGconServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "gpt-4o-mini" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if body["stream"] != false {
+			t.Errorf("stream=%v, want false", body["stream"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "pong"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	resp, err := newRAGconForTest(srv.URL).ChatWithMessages(
+		"gpt-4o-mini",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if *resp.Answer != "pong" || *resp.ReasonContent != "" {
+		t.Errorf("(%q,%q)", *resp.Answer, *resp.ReasonContent)
+	}
+}
+
+func TestRAGconChatExtractsReasoningContent(t *testing.T) {
+	srv := newRAGconServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"role":              "assistant",
+					"content":           "4",
+					"reasoning_content": "2+2 is 4.",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	resp, err := newRAGconForTest(srv.URL).ChatWithMessages(
+		"deepseek-r1",
+		[]Message{{Role: "user", Content: "2+2?"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if *resp.Answer != "4" {
+		t.Errorf("Answer=%q", *resp.Answer)
+	}
+	if *resp.ReasonContent != "2+2 is 4." {
+		t.Errorf("ReasonContent=%q", *resp.ReasonContent)
+	}
+}
+
+func TestRAGconChatRequiresAPIKey(t *testing.T) {
+	_, err := newRAGconForTest("http://unused").ChatWithMessages("m",
+		[]Message{{Role: "user", Content: "x"}}, &APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconChatRequiresModelName(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newRAGconForTest("http://unused").ChatWithMessages("  ",
+		[]Message{{Role: "user", Content: "x"}}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "model name is required") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconChatRequiresMessages(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newRAGconForTest("http://unused").ChatWithMessages("m", nil,
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "messages is empty") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconChatRejectsHTTPError(t *testing.T) {
+	srv := newRAGconServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	_, err := newRAGconForTest(srv.URL).ChatWithMessages("m",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconStreamHappyPath(t *testing.T) {
+	srv := newRAGconSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"Hello "}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"world"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var chunks []string
+	var sawDone bool
+	err := newRAGconForTest(srv.URL).ChatStreamlyWithSender("gpt-4o-mini",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, _ *string) error {
+			if c == nil {
+				return nil
+			}
+			if *c == "[DONE]" {
+				sawDone = true
+				return nil
+			}
+			chunks = append(chunks, *c)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if strings.Join(chunks, "") != "Hello world" {
+		t.Errorf("content=%v", chunks)
+	}
+	if !sawDone {
+		t.Error("expected [DONE] sentinel")
+	}
+}
+
+func TestRAGconStreamForwardsReasoningContent(t *testing.T) {
+	srv := newRAGconSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 1. "}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 2."}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var content, reasoning []string
+	err := newRAGconForTest(srv.URL).ChatStreamlyWithSender("deepseek-r1",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, rc *string) error {
+			if c != nil && rc != nil {
+				t.Errorf("sender called with both args non-nil")
+			}
+			if rc != nil && *rc != "" {
+				reasoning = append(reasoning, *rc)
+			}
+			if c != nil && *c != "" && *c != "[DONE]" {
+				content = append(content, *c)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if got := strings.Join(reasoning, ""); got != "step 1. step 2." {
+		t.Errorf("reasoning=%q", got)
+	}
+	if got := strings.Join(content, ""); got != "answer" {
+		t.Errorf("content=%q", got)
+	}
+}
+
+func TestRAGconStreamRequiresSender(t *testing.T) {
+	apiKey := "test-key"
+	err := newRAGconForTest("http://unused").ChatStreamlyWithSender("m",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "sender is required") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconStreamRejectsExplicitFalse(t *testing.T) {
+	apiKey := "test-key"
+	stream := false
+	err := newRAGconForTest("http://unused").ChatStreamlyWithSender("m",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Stream: &stream},
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream must be true") {
+		t.Errorf("got %v", err)
+	}
+}
+
+// A stream that closes without [DONE] or a finish_reason is a truncated
+// response; the driver must surface an error rather than emit a synthetic
+// terminal marker.
+func TestRAGconStreamErrorsOnTruncation(t *testing.T) {
+	srv := newRAGconSSEServer(t, "/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"content":"partial"}}]}`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newRAGconForTest(srv.URL).ChatStreamlyWithSender("m",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream ended before") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconListModelsHappyPath(t *testing.T) {
+	srv := newRAGconServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "gpt-4o-mini"},
+				{"id": "text-embedding-3-small"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	ids, err := newRAGconForTest(srv.URL).ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Errorf("ids=%v", ids)
+	}
+}
+
+func TestRAGconCheckConnection(t *testing.T) {
+	srv := newRAGconServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []map[string]interface{}{{"id": "x"}}})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	if err := newRAGconForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
+		t.Errorf("CheckConnection: %v", err)
+	}
+}
+
+func TestRAGconEmbedHappyPath(t *testing.T) {
+	srv := newRAGconServer(t, "/embeddings", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "text-embedding-3-small" {
+			t.Errorf("model=%v", body["model"])
+		}
+		// Return out of order to verify the driver re-orders by index.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"index": 1, "embedding": []float64{0.3, 0.4}},
+				{"index": 0, "embedding": []float64{0.1, 0.2}},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	model := "text-embedding-3-small"
+	out, err := newRAGconForTest(srv.URL).Embed(&model, []string{"a", "b"},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len=%d", len(out))
+	}
+	if out[0].Embedding[0] != 0.1 || out[1].Embedding[0] != 0.3 {
+		t.Errorf("out of order: %v", out)
+	}
+}
+
+func TestRAGconEmbedEmptyTexts(t *testing.T) {
+	model := "text-embedding-3-small"
+	out, err := newRAGconForTest("http://unused").Embed(&model, nil, &APIConfig{}, nil)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty, got %v", out)
+	}
+}
+
+func TestRAGconEmbedRequiresAPIKey(t *testing.T) {
+	model := "m"
+	_, err := newRAGconForTest("http://unused").Embed(&model, []string{"a"}, &APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconRerankReturnsNoSuchMethod(t *testing.T) {
+	m := "x"
+	_, err := newRAGconForTest("http://unused").Rerank(&m, "q", []string{"a"}, &APIConfig{}, &RerankConfig{TopN: 1})
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconBalanceReturnsNoSuchMethod(t *testing.T) {
+	if _, err := newRAGconForTest("http://unused").Balance(&APIConfig{}); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("got %v", err)
+	}
+}
+
+func TestRAGconAudioOCRReturnNoSuchMethod(t *testing.T) {
+	m := "x"
+	v := newRAGconForTest("http://unused")
+	if _, err := v.TranscribeAudio(&m, &m, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("TranscribeAudio: %v", err)
+	}
+	if _, err := v.AudioSpeech(&m, &m, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("AudioSpeech: %v", err)
+	}
+	if _, err := v.OCRFile(&m, nil, &m, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("OCRFile: %v", err)
+	}
+}
+
+// TestRAGconBaseURLTrimsTrailingSlash pins that a base URL configured
+// with a trailing "/" still produces clean single-slash paths.
+func TestRAGconBaseURLTrimsTrailingSlash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path=%q want /chat/completions (double-slash bug?)", r.URL.Path)
+			return
+		}
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}]}`)
+	}))
+	defer srv.Close()
+
+	m := NewRAGconModel(
+		map[string]string{"default": srv.URL + "/"},
+		URLSuffix{Chat: "chat/completions"},
+	)
+	apiKey := "test-key"
+	if _, err := m.ChatWithMessages("gpt-4o-mini",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

Closes #15065.

RAGcon is registered in `conf/llm_factories.json` and fully supported on the Python side (`RAGconChat`, `RAGconEmbed`,  RAGconRerank`, `RAGconSeq2txt`, `RAGconTTS`, `RAGconCV`) plus the frontend, but had **no Go driver** — so the Go model factory fell through to the no-op `DummyModel` and RAGcon was non-functional in the Go API server.

## What is changed and how it works?

Adds a RAGcon driver, registers it in the model factory, and ships a provider config.

| File | Change |
| --- | --- |
| `internal/entity/models/ragcon.go` | New `RAGconModel` implementing the `ModelDriver` interface |
| `internal/entity/models/ragcon_test.go` | `httptest`-based tests for the wire contract |
| `internal/entity/models/factory.go` | Register the `ragcon` provider in `CreateModelDriver` |
| `conf/models/ragcon.json` | Provider config (default base URL + url suffixes) |

### Why it mirrors the OpenAI driver

RAGcon is a SaaS inference platform exposing an **OpenAI-compatible** REST API through a LiteLLM proxy (default `https://connect.ragcon.com/v1`): Bearer-token auth, standard `/chat/completions`, `/models`, and `/embeddings`. The wire shape is plain OpenAI, so the driver follows the existing OpenAI/Novita drivers rather than adding any RAGcon-specific protocol handling. It differs from OpenAI **only in its default base URL**, which ships in `conf/models/ragcon.json`.

### Implemented methods

- `ChatWithMessages` — non-streaming chat (single JSON response), passes through `reasoning_content` when present
- `ChatStreamlyWithSender` — streaming chat over SSE, with a 1 MB scanner buffer and a guard that won't emit a synthetic `[DONE]` on a truncated stream - `Embed` — OpenAI-compatible `/embeddings`, re-orders results by `index` and
  supports `dimensions`
- `ListModels` / `CheckConnection` — connectivity + key validation via `/models`

All other interface methods (`Rerank`, `Balance`, audio, OCR, file parse, tasks) return `"no such method"`, matching the OpenAI driver.

The HTTP transport mirrors the OpenAI driver: cloned `http.DefaultTransport` with a tuned connection pool, no client-wide timeout (to avoid cutting off SSE streams), `ResponseHeaderTimeout` to cap connection setup, and a `context.WithTimeout` on every non-streaming call.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How was this patch tested?

- Added `ragcon_test.go` with `httptest`-backed tests: chat (happy path, reasoning_content, validation, HTTP error), streaming (content, reasoning, truncation guard, sender/stream validation), `ListModels`, `CheckConnection`, `Embed` (order preservation, empty input, key validation), `no such method` coverage, and a trailing-slash base-URL test.
- Manual review against the `ModelDriver` interface — all 17 methods implemented, imports all used, no symbol conflicts in the `models` package.
- Provider-name mapping verified: JSON `name: "RAGcon"` → `strings.ToLower` → `ragcon`, which matches the new factory case.

## Checklist

- [x] Driver implements the full `ModelDriver` interface
- [x] Factory registration added
- [x] Provider config added
- [x] Unit tests added (`ragcon_test.go`)
- [x] CI green (`go build`, `go vet`, `go test`)
