### PR TITLE
Go: implement Embed (embeddings) in Replicate driver

### DIFF
--- a/conf/models/replicate.json
+++ b/conf/models/replicate.json
@@ -22,6 +22,13 @@
       "model_types": [
         "chat"
       ]
+    },
+    {
+      "name": "replicate/all-mpnet-base-v2:b6b7585c9640cd7a9572c6e129c9549d79c9c31f0d3fdce7baac7c67ca38f305",
+      "max_tokens": 384,
+      "model_types": [
+        "embedding"
+      ]
     }
   ]
 }

--- a/internal/entity/models/replicate.go
+++ b/internal/entity/models/replicate.go
@@ -566,8 +566,154 @@ func (r *ReplicateModel) CheckConnection(apiConfig *APIConfig) error {
 	return err
 }
 
+// replicateEmbedInput shapes the request body for Replicate's standard
+// embedding models (e.g. replicate/all-mpnet-base-v2). Per the
+// canonical Replicate embedding schema published in the model's
+// openapi_schema, the two input fields are:
+//
+//	text       — single string to encode (used when len(texts) == 1)
+//	text_batch — JSON-formatted list of strings (used when len > 1)
+//
+// `text_batch` is `type: string` in the schema, so the JSON-encoded
+// list itself is sent as a string value, NOT as a JSON array. Models
+// that use different field names (e.g. nateraw/bge-large-en-v1.5's
+// `texts`) are not currently supported by this driver; tenants on
+// those should consult Replicate's OpenAPI schema and configure a
+// compatible model in conf/models/replicate.json.
+func replicateEmbedInput(texts []string) (map[string]interface{}, error) {
+	switch len(texts) {
+	case 0:
+		return nil, fmt.Errorf("replicate: texts is empty")
+	case 1:
+		return map[string]interface{}{"text": texts[0]}, nil
+	default:
+		encoded, err := json.Marshal(texts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode text_batch: %w", err)
+		}
+		return map[string]interface{}{"text_batch": string(encoded)}, nil
+	}
+}
+
+// replicateEmbedOutputToVectors normalizes Replicate's two observed
+// embedding-output shapes into []EmbeddingData aligned with the
+// caller's input order:
+//
+//	[]{embedding: [floats]}   — the documented Embedding schema used
+//	                            by replicate/all-mpnet-base-v2
+//	[][floats]                — bare nested array used by some
+//	                            community models
+//
+// The driver rejects mismatched cardinality (output length != input
+// length) and non-numeric vector entries rather than silently
+// truncate or pad, matching the defensive posture the n1n / CometAPI
+// drivers already use.
+func replicateEmbedOutputToVectors(output interface{}, n int) ([]EmbeddingData, error) {
+	outputs, ok := output.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("replicate: expected output to be an array, got %T", output)
+	}
+	if len(outputs) != n {
+		return nil, fmt.Errorf("replicate: expected %d embeddings, got %d", n, len(outputs))
+	}
+
+	vectors := make([]EmbeddingData, n)
+	for i, item := range outputs {
+		vec, err := replicateExtractEmbeddingVector(item)
+		if err != nil {
+			return nil, fmt.Errorf("replicate: output[%d]: %w", i, err)
+		}
+		vectors[i] = EmbeddingData{Embedding: vec, Index: i}
+	}
+	return vectors, nil
+}
+
+func replicateExtractEmbeddingVector(item interface{}) ([]float64, error) {
+	switch v := item.(type) {
+	case []interface{}:
+		return replicateFloatsFromInterface(v)
+	case map[string]interface{}:
+		raw, ok := v["embedding"]
+		if !ok {
+			return nil, fmt.Errorf("missing 'embedding' field; got keys %v", replicateKeys(v))
+		}
+		arr, ok := raw.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("embedding field is %T, expected array", raw)
+		}
+		return replicateFloatsFromInterface(arr)
+	default:
+		return nil, fmt.Errorf("unsupported item type %T", item)
+	}
+}
+
+func replicateFloatsFromInterface(arr []interface{}) ([]float64, error) {
+	floats := make([]float64, len(arr))
+	for i, v := range arr {
+		f, ok := v.(float64)
+		if !ok {
+			return nil, fmt.Errorf("element %d is %T, expected number", i, v)
+		}
+		floats[i] = f
+	}
+	return floats, nil
+}
+
+func replicateKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Embed turns a list of texts into embedding vectors via Replicate's
+// prediction API. Replicate's embedding surface is the same async
+// /v1/predictions or /v1/models/{owner}/{name}/predictions endpoint
+// the chat path already uses: create a prediction with `Prefer: wait`
+// to skip the polling round-trip when possible, fall back to
+// waitForPrediction for predictions that don't finish in the wait
+// window. The driver targets the canonical Replicate embedding
+// schema (input.text / input.text_batch, output is an array of
+// {embedding: [floats]} objects); see replicateEmbedInput and
+// replicateEmbedOutputToVectors for details.
 func (r *ReplicateModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
-	return nil, fmt.Errorf("%s, no such method", r.Name())
+	if len(texts) == 0 {
+		return []EmbeddingData{}, nil
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if modelName == nil || strings.TrimSpace(*modelName) == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	url, version, err := r.predictionEndpoint(apiConfig, *modelName)
+	if err != nil {
+		return nil, err
+	}
+
+	input, err := replicateEmbedInput(texts)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	prediction, err := r.createPrediction(ctx, url, version, input, false, *apiConfig.ApiKey, true)
+	if err != nil {
+		return nil, err
+	}
+	prediction, err = r.waitForPrediction(ctx, prediction, *apiConfig.ApiKey)
+	if err != nil {
+		return nil, err
+	}
+	if !replicatePredictionSucceeded(prediction.Status) {
+		return nil, fmt.Errorf("replicate: prediction ended with status %q", prediction.Status)
+	}
+
+	return replicateEmbedOutputToVectors(prediction.Output, len(texts))
 }
 
 func (r *ReplicateModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {


### PR DESCRIPTION
### What problem does this PR solve?

`ReplicateModel.Embed` in `internal/entity/models/replicate.go` was a `"replicate, no such method"` stub. Tracking issue #14736 lists Replicate's embedding surface as not implemented. This PR wires it up against Replicate's documented embedding schema.

Until this PR, a tenant who selected a Replicate embedding model got the sentinel error on every embed call.

### What this PR includes

- `internal/entity/models/replicate.go` — real `Embed` method backed by Replicate's `/v1/predictions` async API, reusing the existing `createPrediction` + `waitForPrediction` plumbing the chat path already validates.
- `conf/models/replicate.json` — adds `replicate/all-mpnet-base-v2` at version `b6b7585c...` (`model_types: ["embedding"]`).

### Wire shape (verified against Replicate's openapi_schema)

Input (per the canonical `replicate/all-mpnet-base-v2` schema):
- `text` (string) — single text to encode, used when `len(texts) == 1`
- `text_batch` (string) — JSON-encoded list of strings to encode, used when `len(texts) > 1`. Note that the schema declares `text_batch` as `type: string`, so the JSON-encoded list is sent **as a string**, not as a JSON array.

Output: array of `{embedding: [number]}` objects, one per input in order. The driver also tolerates the alternative bare-nested-array shape `[[number]]` some community models emit.

### Live test transcripts (api.replicate.com)

The Replicate account on the provided key has no billing credit, so I could not run a full embedding inference end-to-end. Everything **up to** the billing gate works:

**T1 — Auth check**
```
GET /v1/account
→ HTTP 200
→ username: tmimmanuel
```

**T2 — Model metadata for replicate/all-mpnet-base-v2**
```
GET /v1/models/replicate/all-mpnet-base-v2
→ HTTP 200
→ owner/name:  replicate/all-mpnet-base-v2
→ visibility:  public
→ version id:  b6b7585c9640cd7a...
→ Input properties:
    - text         (type=string)  "A single string to encode."
    - text_batch   (type=string)  "A JSON-formatted list of strings to encode."
→ Output:
    type: array
    items: $ref=#/components/schemas/Embedding
    Embedding shape: {embedding: array<number>} (required)
```
Confirms the input field names and output shape the driver targets.

**T3 — Driver's request reaches the prediction endpoint (route ✓, payload ✓, version ✓)**
```
POST /v1/predictions   (Prefer: wait=60)
body: {"version":"b6b7585c…","input":{"text":"hello world"}}
→ HTTP 402  "Insufficient credit"
→ "You have insufficient credit to run this model.…"
```
Replicate accepts the request — URL, headers, version, and `input.text` field shape all pass validation. Only the billing gate stops execution.

**T4 — Invalid version (control, proves Replicate validates the version field)**
```
POST /v1/predictions
body: {"version":"deadbeef…","input":{"text":"x"}}
→ HTTP 422  "Invalid version or not permitted"
→ "The specified version does not exist (or perhaps you don't have permission to use it?)"
```
This rules out a false-positive on T3: Replicate does validate the version up-front. T3's 402 means the version is real and the request shape is correct.

**T5 — Bare owner/name path on a community model (background)**
```
POST /v1/models/replicate/all-mpnet-base-v2/predictions
→ HTTP 404
```
Confirms that `replicate/all-mpnet-base-v2` is not on Replicate's official-models list, so the catalog uses the `owner/name:version` notation which the existing `predictionEndpoint` in `replicate.go` routes through `/v1/predictions` with the `version` field — the format that returned 402 in T3.

### Why owner/name:version in the catalog

`replicate.go:111` already implements:
```go
func replicateUsesVersionEndpoint(modelName string) bool {
    name := strings.TrimSpace(modelName)
    return !strings.Contains(name, "/") || strings.Contains(name, ":")
}
```
Names containing `":"` go through `/v1/predictions` with `version`. Community embedding models (which is most of them on Replicate) need this form because they aren't on the official-models list and 404 on the owner/name endpoint (T5). The pinned version in the catalog can be overridden per-tenant if a newer version ships.

### What I deliberately did NOT do

- **No unit tests** — per user direction. The chat path already exercises `createPrediction` + `waitForPrediction` in production, and the new `Embed` reuses those same code paths; the only new logic is input/output shaping (`replicateEmbedInput`, `replicateEmbedOutputToVectors`).
- **No full end-to-end embedding inference** — the test account hit Replicate's billing gate (HTTP 402) on every prediction. The 402/422 differential above is the closest verification available without funding the account.
- **No support for the `nateraw/bge-large-en-v1.5` schema** — that model uses `input.texts` (different field name) and returns either inline arrays or a `.npy` file URI. Implementing that alternative input/output shape belongs in a follow-up; the canonical `text`/`text_batch` + `[{embedding:[…]}]` schema (replicate/all-mpnet-base-v2) is implemented here.
