### PR TITLE
Fix: allow multimodal models as chat LLMs and route through ChatModel

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -178,15 +178,20 @@ async def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
     if model_type not in {"chat", "image2text"}:
         model_type = "chat"
 
-    if not await thread_pool_exec(
-        TenantLLMService.query,
-        tenant_id=tenant_id,
-        llm_name=llm_name,
-        llm_factory=llm_factory,
-        model_type=model_type,
-    ):
-        return f"`llm_id` {llm_id} doesn't exist"
-    return None
+    # Try the requested model_type first, then fall back to the compatible type.
+    # image2text (multimodal) models are valid as chat models per tenant_model_service.
+    for mt in ((model_type, "image2text") if model_type == "chat"
+               else ("image2text", model_type) if model_type == "image2text"
+               else (model_type,)):
+        if await thread_pool_exec(
+            TenantLLMService.query,
+            tenant_id=tenant_id,
+            llm_name=llm_name,
+            llm_factory=llm_factory,
+            model_type=mt,
+        ):
+            return None
+    return f"`llm_id` {llm_id} doesn't exist"
 
 
 async def _validate_rerank_id(rerank_id, tenant_id):

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -181,7 +181,7 @@ async def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
     # Try the requested model_type first, then fall back to the compatible type.
     # image2text (multimodal) models are valid as chat models per tenant_model_service.
     for mt in ((model_type, "image2text") if model_type == "chat"
-               else ("image2text", model_type) if model_type == "image2text"
+               else ("image2text", "chat") if model_type == "image2text"
                else (model_type,)):
         if await thread_pool_exec(
             TenantLLMService.query,

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -180,9 +180,8 @@ async def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
 
     # Try the requested model_type first, then fall back to the compatible type.
     # image2text (multimodal) models are valid as chat models per tenant_model_service.
-    for mt in ((model_type, "image2text") if model_type == "chat"
-               else ("image2text", "chat") if model_type == "image2text"
-               else (model_type,)):
+    fallbacks = {"chat": ("chat", "image2text"), "image2text": ("image2text", "chat")}
+    for mt in fallbacks[model_type]:
         if await thread_pool_exec(
             TenantLLMService.query,
             tenant_id=tenant_id,

--- a/api/apps/restful_apis/openai_api.py
+++ b/api/apps/restful_apis/openai_api.py
@@ -41,7 +41,7 @@ def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
     # Try the requested model_type first, then fall back to the compatible type.
     # image2text (multimodal) models are valid as chat models per tenant_model_service.
     for mt in ((model_type, "image2text") if model_type == "chat"
-               else ("image2text", model_type) if model_type == "image2text"
+               else ("image2text", "chat") if model_type == "image2text"
                else (model_type,)):
         if TenantLLMService.query(
             tenant_id=tenant_id,

--- a/api/apps/restful_apis/openai_api.py
+++ b/api/apps/restful_apis/openai_api.py
@@ -38,14 +38,19 @@ def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
     if model_type not in {"chat", "image2text"}:
         model_type = "chat"
 
-    if not TenantLLMService.query(
-        tenant_id=tenant_id,
-        llm_name=llm_name,
-        llm_factory=llm_factory,
-        model_type=model_type,
-    ):
-        return f"`llm_id` {llm_id} doesn't exist"
-    return None
+    # Try the requested model_type first, then fall back to the compatible type.
+    # image2text (multimodal) models are valid as chat models per tenant_model_service.
+    for mt in ((model_type, "image2text") if model_type == "chat"
+               else ("image2text", model_type) if model_type == "image2text"
+               else (model_type,)):
+        if TenantLLMService.query(
+            tenant_id=tenant_id,
+            llm_name=llm_name,
+            llm_factory=llm_factory,
+            model_type=mt,
+        ):
+            return None
+    return f"`llm_id` {llm_id} doesn't exist"
 
 
 import logging

--- a/api/apps/restful_apis/openai_api.py
+++ b/api/apps/restful_apis/openai_api.py
@@ -40,9 +40,8 @@ def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
 
     # Try the requested model_type first, then fall back to the compatible type.
     # image2text (multimodal) models are valid as chat models per tenant_model_service.
-    for mt in ((model_type, "image2text") if model_type == "chat"
-               else ("image2text", "chat") if model_type == "image2text"
-               else (model_type,)):
+    fallbacks = {"chat": ("chat", "image2text"), "image2text": ("image2text", "chat")}
+    for mt in fallbacks[model_type]:
         if TenantLLMService.query(
             tenant_id=tenant_id,
             llm_name=llm_name,

--- a/api/db/joint_services/tenant_model_service.py
+++ b/api/db/joint_services/tenant_model_service.py
@@ -93,7 +93,7 @@ def get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_nam
             if not model_config:
                 raise LookupError(f"Tenant Model with name {model_name} and type {model_type_val} not found")
             config_dict = model_config.to_dict()
-            config_dict["model_type"] = LLMType.CHAT.value
+            config_dict["model_type"] = LLMType.CHAT.value  # normalize so model_instance creates ChatModel
         elif model_type_val == LLMType.IMAGE2TEXT.value:
             model_config = TenantLLMService.get_api_key(tenant_id, pure_model_name, LLMType.IMAGE2TEXT.value)
             if not model_config:

--- a/api/db/joint_services/tenant_model_service.py
+++ b/api/db/joint_services/tenant_model_service.py
@@ -93,6 +93,7 @@ def get_model_config_by_type_and_name(tenant_id: str, model_type: str, model_nam
             if not model_config:
                 raise LookupError(f"Tenant Model with name {model_name} and type {model_type_val} not found")
             config_dict = model_config.to_dict()
+            config_dict["model_type"] = LLMType.CHAT.value
         elif model_type_val == LLMType.IMAGE2TEXT.value:
             model_config = TenantLLMService.get_api_key(tenant_id, pure_model_name, LLMType.IMAGE2TEXT.value)
             if not model_config:

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -561,10 +561,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
 
     chat_start_ts = timer()
     llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
-    if llm_type == "image2text":
-        llm_model_config = TenantLLMService.get_model_config(dialog.tenant_id, LLMType.IMAGE2TEXT, dialog.llm_id)
-    else:
-        llm_model_config = TenantLLMService.get_model_config(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
+    llm_model_config = get_model_config_by_type_and_name(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
 
     factory = llm_model_config.get("llm_factory", "") if llm_model_config else ""
     max_tokens = llm_model_config.get("max_tokens", 8192)

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -561,7 +561,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
 
     chat_start_ts = timer()
     llm_type = TenantLLMService.llm_id2llm_type(dialog.llm_id)
-    llm_model_config = get_model_config_by_type_and_name(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)
+    llm_model_config = get_model_config_by_type_and_name(dialog.tenant_id, LLMType.CHAT, dialog.llm_id)  # unified lookup with CHAT↔IMAGE2TEXT fallback
 
     factory = llm_model_config.get("llm_factory", "") if llm_model_config else ""
     max_tokens = llm_model_config.get("max_tokens", 8192)


### PR DESCRIPTION
### What problem does this PR solve?

 Models stored with model_type="image2text" (via OpenAI-API-Compatible providers) cannot be set as chat LLMs — Chat Settings returns "llm_id doesn't exist". When forced, they route
  through CvModel, losing reasoning, tool-calling, and crashing on total_tokens.

model_type="image2text" conflates two categories — pure OCR/CV models and multimodal chat LLMs. Three code paths treated all image2text models as "OCR-only":

  1. _validate_llm_id() in chat_api.py/openai_api.py queried with model_type="chat" only, rejecting image2text models at validation
  2. dialog_service.py routed image2text → TenantLLMService.get_model_config(..., IMAGE2TEXT) → CvModel
  3. tenant_model_service.py found image2text models via CHAT↔IMAGE2TEXT fallback but left config_dict["model_type"]="image2text", so model_instance() still created CvModel

  The CHAT↔IMAGE2TEXT fallback already existed in tenant_model_service.py, but only for runtime config lookup — not for API validation or model instance creation. This PR extends the pattern
   consistently across all three paths.

### Changes
- Validation fallback: _validate_llm_id() tries requested model_type first, then compatible type. Only chat↔image2text are compatible — other types unaffected 
- Model type normalization: When IMAGE2TEXT model is found as CHAT fallback, config_dict["model_type"] set to "chat" → model_instance() creates ChatModel
- Consistent config source: async_chat() uses get_model_config_by_type_and_name() instead of TenantLLMService.get_model_config(). llm_type via llm_id2llm_type() unchanged to preserve image-file routing

### Limitations
- No way to distinguish a multimodal chat model from a pure OCR/CV model at the model_type level. If a pure vision-only model were ever registered as image2text and assigned to a chat dialog, it would  incorrectly instantiate ChatModel and likely fail at runtime.
- llm_type in async_chat() still reflects the raw DB type ("image2text"). Image-file handling (images=image_files) triggers on the else branch, passing images= to a ChatModel that ignores them via _clean_param(). It works, but the signal is semantically wrong.
- is_tools flag exists in llm_factories.json and db_models.py but is not used for routing. It already correctly marks multimodal chat models (is_tools=true) vs pure OCR (is_tools absent/false) and could drive the decision.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)

### Related issue
#15074 