### PR TITLE
Go: implement provider: TokenPony

### DIFF
--- a/conf/models/tokenpony.json
+++ b/conf/models/tokenpony.json
@@ -1,0 +1,93 @@
+{
+  "name": "TokenPony",
+  "url": {
+    "default": "https://ragflow.vip-api.tokenpony.cn/v1"
+  },
+  "url_suffix": {
+    "chat": "chat/completions",
+    "models": "models"
+  },
+  "class": "tokenpony",
+  "models": [
+    {
+      "name": "qwen3-8b",
+      "max_tokens": 128000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "deepseek-v3-0324",
+      "max_tokens": 128000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "qwen3-32b",
+      "max_tokens": 128000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "kimi-k2-instruct-0905",
+      "max_tokens": 256000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "deepseek-r1-0528",
+      "max_tokens": 164000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "qwen3-coder-480b",
+      "max_tokens": 1024000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "hunyuan-a13b-instruct",
+      "max_tokens": 256000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "qwen3-next-80b-a3b-instruct",
+      "max_tokens": 1024000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "deepseek-v3.2-exp",
+      "max_tokens": 128000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "deepseek-v3.1-terminus",
+      "max_tokens": 128000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "qwen3-vl-235b-a22b-instruct",
+      "max_tokens": 262000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "qwen3-vl-30b-a3b-instruct",
+      "max_tokens": 262000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "deepseek-ocr",
+      "max_tokens": 8000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "qwen3-235b-a22b-instruct-2507",
+      "max_tokens": 256000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "glm-4.6",
+      "max_tokens": 200000,
+      "model_types": ["chat"]
+    },
+    {
+      "name": "minimax-m2",
+      "max_tokens": 200000,
+      "model_types": ["chat"]
+    }
+  ]
+}

--- a/conf/models/tokenpony.json
+++ b/conf/models/tokenpony.json
@@ -1,7 +1,7 @@
 {
   "name": "TokenPony",
   "url": {
-    "default": "https://ragflow.vip-api.tokenpony.cn/v1"
+    "default": "https://api.tokenpony.cn/v1"
   },
   "url_suffix": {
     "chat": "chat/completions",

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -93,6 +93,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewXinferenceModel(baseURL, urlSuffix), nil
 	case "longcat":
 		return NewLongCatModel(baseURL, urlSuffix), nil
+	case "tokenpony":
+		return NewTokenPonyModel(baseURL, urlSuffix), nil
 	case "novita":
 		return NewNovitaModel(baseURL, urlSuffix), nil
 	case "replicate":

--- a/internal/entity/models/tokenpony.go
+++ b/internal/entity/models/tokenpony.go
@@ -1,0 +1,493 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// TokenPonyModel implements ModelDriver for TokenPony. TokenPony is a
+// SaaS, OpenAI-compatible inference gateway hosting Qwen, DeepSeek,
+// Kimi, GLM, MiniMax, and Hunyuan families behind a single Bearer-token
+// API at https://ragflow.vip-api.tokenpony.cn/v1.
+//
+// Wire shape matches the OpenAI convention exactly:
+//   - POST /v1/chat/completions with {model, messages, stream, ...}
+//   - GET  /v1/models for the catalog
+//   - Authorization: Bearer <api-key> on every call
+//   - SSE response with `data:` lines and a [DONE] terminator
+//
+// Reasoning models surface chain-of-thought in `reasoning_content`
+// (OpenAI o-series shape), so the same handling as LongCat /
+// DeepSeek-R1 applies and there's no need for an inline <think>...
+// extractor like Novita's.
+type TokenPonyModel struct {
+	BaseURL    map[string]string
+	URLSuffix  URLSuffix
+	httpClient *http.Client
+}
+
+// NewTokenPonyModel creates a new TokenPony model instance.
+//
+// Same transport convention as the other Go drivers in this package:
+// clone http.DefaultTransport to keep ProxyFromEnvironment, DialContext,
+// HTTP/2, and TLS defaults, and only override the connection-pool
+// fields. No client-level Timeout so SSE streams aren't capped mid-flight.
+func NewTokenPonyModel(baseURL map[string]string, urlSuffix URLSuffix) *TokenPonyModel {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.DisableCompression = false
+	transport.ResponseHeaderTimeout = 60 * time.Second
+
+	return &TokenPonyModel{
+		BaseURL:   baseURL,
+		URLSuffix: urlSuffix,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+}
+
+func (a *TokenPonyModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewTokenPonyModel(baseURL, a.URLSuffix)
+}
+
+func (a *TokenPonyModel) Name() string {
+	return "tokenpony"
+}
+
+func (a *TokenPonyModel) baseURLForRegion(region string) (string, error) {
+	base, ok := a.BaseURL[region]
+	if !ok || base == "" {
+		return "", fmt.Errorf("tokenpony: no base URL configured for region %q", region)
+	}
+	return strings.TrimSuffix(base, "/"), nil
+}
+
+// ChatWithMessages sends a non-streaming chat request and returns the
+// full response. Forwards documented OpenAI-shaped parameters when the
+// caller supplies them; reasoning_content is surfaced separately so the
+// visible Answer is never polluted by chain-of-thought.
+func (a *TokenPonyModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := a.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, a.URLSuffix.Chat)
+
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   false,
+	}
+
+	if chatModelConfig != nil {
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	firstChoice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid choice format")
+	}
+
+	messageMap, ok := firstChoice["message"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid message format")
+	}
+
+	content, ok := messageMap["content"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid content format")
+	}
+
+	// Reasoning models (deepseek-r1 / kimi / glm-thinking) put
+	// chain-of-thought in a separate `reasoning_content` field with
+	// `content` already cleaned. Absent or non-string means no reasoning
+	// was emitted; leave it empty rather than synthesizing one.
+	reasonContent := ""
+	if r, ok := messageMap["reasoning_content"].(string); ok {
+		reasonContent = r
+	}
+
+	return &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+	}, nil
+}
+
+// ChatStreamlyWithSender opens the SSE chat-completions endpoint and
+// forwards each delta through the supplied sender. Reasoning chunks go
+// to the sender's second argument, content chunks to the first; the
+// stream is terminated by either `[DONE]` or a delta with finish_reason.
+func (a *TokenPonyModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := a.baseURLForRegion(region)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, a.URLSuffix.Chat)
+
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   true,
+	}
+
+	if chatModelConfig != nil {
+		// Guard against the caller asking for stream=false on a code path
+		// that only knows how to read SSE. Without this, a non-SSE JSON
+		// body would parse as zero chunks and look like a silent timeout.
+		if chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+			return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+		}
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// SSE is long-lived; rely on the transport's ResponseHeaderTimeout
+	// to cap connection-establishment instead of a hard deadline.
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	sawTerminal := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(line[5:])
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event map[string]interface{}
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			// A malformed frame usually means a truncated event or an
+			// upstream incident. Surface it instead of silently producing
+			// partial output.
+			return fmt.Errorf("tokenpony: invalid SSE event: %w", err)
+		}
+
+		// TokenPony can emit a terminal `{"error": ...}` frame when the
+		// upstream model rejects mid-stream (rate limit, content policy).
+		// Surface it verbatim instead of falling through to "no choices".
+		if apiErr, ok := event["error"]; ok {
+			return fmt.Errorf("tokenpony: upstream stream error: %v", apiErr)
+		}
+
+		choices, ok := event["choices"].([]interface{})
+		if !ok || len(choices) == 0 {
+			continue
+		}
+		firstChoice, ok := choices[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Reasoning first, content second — matches the wire ordering
+		// for reasoning models and lets UIs render the chain-of-thought
+		// before the visible token. A terminal frame may carry
+		// finish_reason without a delta, so don't skip when delta is absent.
+		if delta, ok := firstChoice["delta"].(map[string]interface{}); ok {
+			if r, ok := delta["reasoning_content"].(string); ok && r != "" {
+				rr := r
+				if err := sender(nil, &rr); err != nil {
+					return err
+				}
+			}
+			if c, ok := delta["content"].(string); ok && c != "" {
+				cc := c
+				if err := sender(&cc, nil); err != nil {
+					return err
+				}
+			}
+		}
+		if finish, ok := firstChoice["finish_reason"].(string); ok && finish != "" {
+			sawTerminal = true
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("tokenpony: stream ended before [DONE] or finish_reason")
+	}
+
+	endOfStream := "[DONE]"
+	if err := sender(&endOfStream, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ListModels returns the model ids visible to the API key by calling
+// /v1/models. Used by Add-Provider's connection check and by the UI's
+// model picker.
+func (a *TokenPonyModel) ListModels(apiConfig *APIConfig) ([]string, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := a.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, a.URLSuffix.Models)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	data, ok := result["data"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid models list format")
+	}
+
+	models := make([]string, 0, len(data))
+	for _, m := range data {
+		modelMap, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, ok := modelMap["id"].(string)
+		if !ok {
+			continue
+		}
+		models = append(models, id)
+	}
+	return models, nil
+}
+
+// CheckConnection verifies the API key by calling ListModels. The /v1/models
+// endpoint is the documented lightweight way to validate credentials on
+// OpenAI-compatible gateways without burning chat-completion quota.
+func (a *TokenPonyModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := a.ListModels(apiConfig)
+	return err
+}
+
+// Embed is not implemented for TokenPony in this initial driver; the
+// factory entry only registers chat models. Mirrors how LongCat /
+// Astraflow landed chat-only.
+func (a *TokenPonyModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}
+
+func (a *TokenPonyModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", a.Name())
+}

--- a/internal/entity/models/tokenpony_test.go
+++ b/internal/entity/models/tokenpony_test.go
@@ -1,0 +1,447 @@
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTokenPonyServer(t *testing.T, expectedPath string, handler func(t *testing.T, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		if r.Method == http.MethodPost {
+			if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+				t.Errorf("expected Content-Type to start with application/json, got %q", got)
+				return
+			}
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read error", http.StatusBadRequest)
+				return
+			}
+			var body map[string]interface{}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Errorf("unmarshal: %v\nraw=%s", err, string(raw))
+				http.Error(w, "unmarshal error", http.StatusBadRequest)
+				return
+			}
+			handler(t, body, w)
+			return
+		}
+		handler(t, nil, w)
+	}))
+}
+
+func newTokenPonySSEServer(t *testing.T, expectedPath, ssePayload string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			return
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path=%s, got %s", expectedPath, r.URL.Path)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+			t.Errorf("expected Content-Type to start with application/json, got %q", got)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ssePayload)
+	}))
+}
+
+func newTokenPonyForTest(baseURL string) *TokenPonyModel {
+	return NewTokenPonyModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{Chat: "chat/completions", Models: "models"},
+	)
+}
+
+func TestTokenPonyName(t *testing.T) {
+	if got := newTokenPonyForTest("http://unused").Name(); got != "tokenpony" {
+		t.Errorf("Name()=%q, want %q", got, "tokenpony")
+	}
+}
+
+func TestTokenPonyFactory(t *testing.T) {
+	driver, err := NewModelFactory().CreateModelDriver("TokenPony", map[string]string{"default": "http://unused"}, URLSuffix{})
+	if err != nil {
+		t.Fatalf("CreateModelDriver: %v", err)
+	}
+	if _, ok := driver.(*TokenPonyModel); !ok {
+		t.Fatalf("driver type=%T, want *TokenPonyModel", driver)
+	}
+}
+
+func TestTokenPonyChatHappyPath(t *testing.T) {
+	srv := newTokenPonyServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "qwen3-32b" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if body["stream"] != false {
+			t.Errorf("stream=%v, want false", body["stream"])
+		}
+		if body["max_tokens"] != float64(64) {
+			t.Errorf("max_tokens=%v, want 64", body["max_tokens"])
+		}
+		if body["temperature"] != 0.3 {
+			t.Errorf("temperature=%v, want 0.3", body["temperature"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content":           "pong",
+					"reasoning_content": "thought about it",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	mt := 64
+	temp := 0.3
+	resp, err := newTokenPonyForTest(srv.URL).ChatWithMessages(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{MaxTokens: &mt, Temperature: &temp},
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if resp.Answer == nil || *resp.Answer != "pong" {
+		t.Errorf("Answer=%v, want pong", resp.Answer)
+	}
+	if resp.ReasonContent == nil || *resp.ReasonContent != "thought about it" {
+		t.Errorf("ReasonContent=%v, want 'thought about it'", resp.ReasonContent)
+	}
+}
+
+func TestTokenPonyChatNoReasoning(t *testing.T) {
+	srv := newTokenPonyServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "hi"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	resp, err := newTokenPonyForTest(srv.URL).ChatWithMessages(
+		"qwen3-8b",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Answer == nil || *resp.Answer != "hi" {
+		t.Errorf("Answer=%v, want 'hi'", resp.Answer)
+	}
+	if resp.ReasonContent == nil || *resp.ReasonContent != "" {
+		t.Errorf("ReasonContent=%v, want empty", resp.ReasonContent)
+	}
+}
+
+func TestTokenPonyChatRequiresAPIKey(t *testing.T) {
+	_, err := newTokenPonyForTest("http://unused").ChatWithMessages(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestTokenPonyChatRequiresMessages(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newTokenPonyForTest("http://unused").ChatWithMessages(
+		"qwen3-32b", nil, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "messages is empty") {
+		t.Errorf("expected messages-empty error, got %v", err)
+	}
+}
+
+func TestTokenPonyChatPropagatesHTTPError(t *testing.T) {
+	srv := newTokenPonyServer(t, "/chat/completions", func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	_, err := newTokenPonyForTest(srv.URL).ChatWithMessages(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 propagated, got %v", err)
+	}
+}
+
+func TestTokenPonyStreamHappyPath(t *testing.T) {
+	srv := newTokenPonySSEServer(t, "/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var chunks []string
+	var sawDone bool
+	err := newTokenPonyForTest(srv.URL).ChatStreamlyWithSender(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, _ *string) error {
+			if c == nil {
+				return nil
+			}
+			if *c == "[DONE]" {
+				sawDone = true
+				return nil
+			}
+			chunks = append(chunks, *c)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if strings.Join(chunks, "") != "Hello world" {
+		t.Errorf("content=%v", chunks)
+	}
+	if !sawDone {
+		t.Error("expected [DONE] sentinel")
+	}
+}
+
+func TestTokenPonyStreamSplitsReasoning(t *testing.T) {
+	srv := newTokenPonySSEServer(t, "/chat/completions",
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 1. "}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":"step 2."}}]}`+"\n"+
+			`data: {"choices":[{"index":0,"delta":{"content":"final"},"finish_reason":"stop"}]}`+"\n"+
+			`data: [DONE]`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var content, reasoning []string
+	err := newTokenPonyForTest(srv.URL).ChatStreamlyWithSender(
+		"deepseek-r1-0528",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(c *string, r *string) error {
+			if c != nil && r != nil {
+				t.Errorf("sender called with both args non-nil")
+			}
+			if r != nil && *r != "" {
+				reasoning = append(reasoning, *r)
+			}
+			if c != nil && *c != "" && *c != "[DONE]" {
+				content = append(content, *c)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if got := strings.Join(reasoning, ""); got != "step 1. step 2." {
+		t.Errorf("reasoning=%q", got)
+	}
+	if got := strings.Join(content, ""); got != "final" {
+		t.Errorf("content=%q", got)
+	}
+}
+
+func TestTokenPonyStreamRejectsExplicitFalse(t *testing.T) {
+	apiKey := "test-key"
+	stream := false
+	err := newTokenPonyForTest("http://unused").ChatStreamlyWithSender(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Stream: &stream},
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream must be true") {
+		t.Errorf("expected stream-true guard, got %v", err)
+	}
+}
+
+func TestTokenPonyStreamRequiresSender(t *testing.T) {
+	apiKey := "test-key"
+	err := newTokenPonyForTest("http://unused").ChatStreamlyWithSender(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "sender is required") {
+		t.Errorf("expected sender-required error, got %v", err)
+	}
+}
+
+func TestTokenPonyStreamFailsWithoutTerminal(t *testing.T) {
+	srv := newTokenPonySSEServer(t, "/chat/completions",
+		`data: {"choices":[{"delta":{"content":"half"}}]}`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newTokenPonyForTest(srv.URL).ChatStreamlyWithSender(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "stream ended before") {
+		t.Errorf("expected truncation error, got %v", err)
+	}
+}
+
+func TestTokenPonyStreamRejectsMalformedFrame(t *testing.T) {
+	srv := newTokenPonySSEServer(t, "/chat/completions",
+		`data: {"choices":[{"delta":{"content":"ok"}}]}`+"\n"+
+			`data: {oops not json}`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newTokenPonyForTest(srv.URL).ChatStreamlyWithSender(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "invalid SSE event") {
+		t.Errorf("expected invalid-SSE error, got %v", err)
+	}
+}
+
+func TestTokenPonyStreamSurfacesUpstreamError(t *testing.T) {
+	srv := newTokenPonySSEServer(t, "/chat/completions",
+		`data: {"choices":[{"delta":{"content":"partial "}}]}`+"\n"+
+			`data: {"error":{"message":"rate limit","type":"rate_limit_error"}}`+"\n",
+	)
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newTokenPonyForTest(srv.URL).ChatStreamlyWithSender(
+		"qwen3-32b",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey}, nil,
+		func(*string, *string) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "upstream stream error") {
+		t.Errorf("expected upstream-error surfacing, got %v", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("expected upstream message included, got %v", err)
+	}
+}
+
+func TestTokenPonyListModelsHappyPath(t *testing.T) {
+	srv := newTokenPonyServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "qwen3-32b"},
+				{"id": "deepseek-v3-0324"},
+				{"id": "qwen3-coder-480b"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	models, err := newTokenPonyForTest(srv.URL).ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	want := []string{"qwen3-32b", "deepseek-v3-0324", "qwen3-coder-480b"}
+	if strings.Join(models, ",") != strings.Join(want, ",") {
+		t.Errorf("models=%v, want %v", models, want)
+	}
+}
+
+func TestTokenPonyListModelsRequiresAPIKey(t *testing.T) {
+	_, err := newTokenPonyForTest("http://unused").ListModels(&APIConfig{})
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestTokenPonyCheckConnectionDelegatesToListModels(t *testing.T) {
+	srv := newTokenPonyServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{{"id": "qwen3-32b"}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	if err := newTokenPonyForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
+		t.Errorf("CheckConnection: %v", err)
+	}
+}
+
+func TestTokenPonyCheckConnectionPropagatesError(t *testing.T) {
+	srv := newTokenPonyServer(t, "/models", func(t *testing.T, _ map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	err := newTokenPonyForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey})
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 propagated, got %v", err)
+	}
+}
+
+func TestTokenPonyBaseURLForRegionUnknown(t *testing.T) {
+	m := newTokenPonyForTest("http://unused")
+	apiKey := "test-key"
+	region := "missing"
+	_, err := m.ListModels(&APIConfig{ApiKey: &apiKey, Region: &region})
+	if err == nil || !strings.Contains(err.Error(), "no base URL configured") {
+		t.Errorf("expected base-URL error, got %v", err)
+	}
+}
+
+func TestTokenPonyEmbedReturnsNoSuchMethod(t *testing.T) {
+	model := "x"
+	_, err := newTokenPonyForTest("http://unused").Embed(&model, []string{"a"}, &APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Embed: want 'no such method', got %v", err)
+	}
+}
+
+func TestTokenPonyAudioOCRReturnNoSuchMethod(t *testing.T) {
+	m := newTokenPonyForTest("http://unused")
+	model := "x"
+	if _, err := m.TranscribeAudio(&model, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("TranscribeAudio: %v", err)
+	}
+	if _, err := m.AudioSpeech(&model, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("AudioSpeech: %v", err)
+	}
+	if _, err := m.OCRFile(&model, nil, &model, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("OCRFile: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `TokenPony` Go driver so the new API server can route TokenPony chat instances, matching the existing Python `TokenPonyChat` (`rag/llm/chat_model.py:1210`). Follows the same SaaS-driver shape used for Astraflow, Avian, Novita, TogetherAI, Replicate, DeepInfra, Upstage, and LongCat.

## Root Cause
`conf/llm_factories.json:282` already registers the `TokenPony` factory with 16 chat models and the default base URL `https://ragflow.vip-api.tokenpony.cn/v1`, but `internal/entity/models/` had no `tokenpony.go` driver and `conf/models/` had no `tokenpony.json`, so the Go API server fell back to the dummy driver for TokenPony instances.

## Fix
- `internal/entity/models/tokenpony.go` — OpenAI-compatible driver implementing `ChatWithMessages`, `ChatStreamlyWithSender`, `ListModels`, and `CheckConnection` (delegates to `ListModels`). Forwards documented fields only (`model`, `messages`, `stream`, `max_tokens`, `temperature`, `top_p`, `stop`). Reasoning models surface `reasoning_content` separately from `content`. SSE handling rejects malformed frames, surfaces upstream `{"error": …}` frames, and requires a `[DONE]`/`finish_reason` terminator.
- `conf/models/tokenpony.json` — base URL `https://ragflow.vip-api.tokenpony.cn/v1` + the 16 chat models from the factory entry (qwen3-8b/-32b/-coder-480b/-next-80b/-235b/-vl-*, deepseek-v3-0324/-r1-0528/-v3.2-exp/-v3.1-terminus/-ocr, kimi-k2-instruct-0905, hunyuan-a13b-instruct, glm-4.6, minimax-m2).
- `internal/entity/models/factory.go` — registers the `tokenpony` case.
- `internal/entity/models/tokenpony_test.go` — 21 hermetic tests using `httptest.Server` (no network).

## Test Plan
- [x] Regression tests added: `internal/entity/models/tokenpony_test.go`
- [x] All tests pass: `go test ./internal/entity/models/ -run TokenPony -count=1 -vet=off`
- [x] Output: 21/21 PASS.

Closes #15086
