### PR TITLE
Feature: propagate session user_id to Langfuse observations

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -165,6 +165,11 @@ class Graph:
     def get_tenant_id(self):
         return self._tenant_id
 
+    def get_langfuse_user_id(self):
+        from api.db.services.langfuse_service import resolve_langfuse_user_id
+
+        return resolve_langfuse_user_id(self.globals.get("sys.user_id"), self._tenant_id)
+
     def get_value_with_variable(self,value: str) -> Any:
         pat = re.compile(r"\{* *\{([a-zA-Z:0-9]+@[A-Za-z0-9_.-]+|sys\.[A-Za-z0-9_.]+|env\.[A-Za-z0-9_.]+)\} *\}*")
         out_parts = []
@@ -402,11 +407,19 @@ class Canvas(Graph):
                 break
 
         for k in kwargs.keys():
-            if k in ["query", "user_id", "files"] and kwargs[k]:
-                if k == "files":
-                    self.globals[f"sys.{k}"] = await self.get_files_async(kwargs[k], layout_recognize)
-                else:
-                    self.globals[f"sys.{k}"] = kwargs[k]
+            if k not in ["query", "user_id", "files"]:
+                continue
+            if k == "files":
+                if kwargs[k]:
+                    self.globals["sys.files"] = await self.get_files_async(kwargs[k], layout_recognize)
+                continue
+            if k == "user_id":
+                from api.db.services.langfuse_service import resolve_langfuse_user_id
+
+                self.globals["sys.user_id"] = resolve_langfuse_user_id(kwargs[k], self._tenant_id)
+                continue
+            if kwargs[k]:
+                self.globals[f"sys.{k}"] = kwargs[k]
         if not self.globals["sys.conversation_turns"] :
             self.globals["sys.conversation_turns"] = 0
         self.globals["sys.conversation_turns"] += 1
@@ -518,7 +531,11 @@ class Canvas(Graph):
                 if cpn_obj.component_name.lower() == "message":
                     if cpn_obj.get_param("auto_play"):
                         tts_model_config = get_tenant_default_model_by_type(self._tenant_id, LLMType.TTS)
-                        tts_mdl = LLMBundle(self._tenant_id, tts_model_config)
+                        tts_mdl = LLMBundle(
+                            self._tenant_id,
+                            tts_model_config,
+                            langfuse_user_id=self.get_langfuse_user_id(),
+                        )
                     if isinstance(cpn_obj.output("content"), partial):
                         _m = ""
                         buff_m = ""

--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -165,11 +165,6 @@ class Graph:
     def get_tenant_id(self):
         return self._tenant_id
 
-    def get_langfuse_user_id(self):
-        from api.db.services.langfuse_service import resolve_langfuse_user_id
-
-        return resolve_langfuse_user_id(self.globals.get("sys.user_id"), self._tenant_id)
-
     def get_value_with_variable(self,value: str) -> Any:
         pat = re.compile(r"\{* *\{([a-zA-Z:0-9]+@[A-Za-z0-9_.-]+|sys\.[A-Za-z0-9_.]+|env\.[A-Za-z0-9_.]+)\} *\}*")
         out_parts = []
@@ -407,19 +402,11 @@ class Canvas(Graph):
                 break
 
         for k in kwargs.keys():
-            if k not in ["query", "user_id", "files"]:
-                continue
-            if k == "files":
-                if kwargs[k]:
-                    self.globals["sys.files"] = await self.get_files_async(kwargs[k], layout_recognize)
-                continue
-            if k == "user_id":
-                from api.db.services.langfuse_service import resolve_langfuse_user_id
-
-                self.globals["sys.user_id"] = resolve_langfuse_user_id(kwargs[k], self._tenant_id)
-                continue
-            if kwargs[k]:
-                self.globals[f"sys.{k}"] = kwargs[k]
+            if k in ["query", "user_id", "files"] and kwargs[k]:
+                if k == "files":
+                    self.globals[f"sys.{k}"] = await self.get_files_async(kwargs[k], layout_recognize)
+                else:
+                    self.globals[f"sys.{k}"] = kwargs[k]
         if not self.globals["sys.conversation_turns"] :
             self.globals["sys.conversation_turns"] = 0
         self.globals["sys.conversation_turns"] += 1
@@ -534,7 +521,7 @@ class Canvas(Graph):
                         tts_mdl = LLMBundle(
                             self._tenant_id,
                             tts_model_config,
-                            langfuse_user_id=self.get_langfuse_user_id(),
+                            user_id=self.globals.get("sys.user_id"),
                         )
                     if isinstance(cpn_obj.output("content"), partial):
                         _m = ""

--- a/agent/component/agent_with_tools.py
+++ b/agent/component/agent_with_tools.py
@@ -89,7 +89,7 @@ class Agent(LLM, ToolBase):
             retry_interval=self._param.delay_after_error,
             max_rounds=self._param.max_rounds,
             verbose_tool_use=False,
-            langfuse_user_id=self._canvas.get_langfuse_user_id(),
+            user_id=self._canvas.globals.get("sys.user_id"),
         )
         self.tool_meta = []
         for indexed_name, tool_obj in self.tools.items():
@@ -193,8 +193,6 @@ class Agent(LLM, ToolBase):
     async def _invoke_async(self, **kwargs):
         if self.check_if_canceled("Agent processing"):
             return
-
-        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
 
         if kwargs.get("user_prompt"):
             usr_pmt = ""

--- a/agent/component/agent_with_tools.py
+++ b/agent/component/agent_with_tools.py
@@ -89,6 +89,7 @@ class Agent(LLM, ToolBase):
             retry_interval=self._param.delay_after_error,
             max_rounds=self._param.max_rounds,
             verbose_tool_use=False,
+            langfuse_user_id=self._canvas.get_langfuse_user_id(),
         )
         self.tool_meta = []
         for indexed_name, tool_obj in self.tools.items():
@@ -192,6 +193,8 @@ class Agent(LLM, ToolBase):
     async def _invoke_async(self, **kwargs):
         if self.check_if_canceled("Agent processing"):
             return
+
+        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
 
         if kwargs.get("user_prompt"):
             usr_pmt = ""

--- a/agent/component/categorize.py
+++ b/agent/component/categorize.py
@@ -127,7 +127,7 @@ class Categorize(LLM, ABC):
         chat_mdl = LLMBundle(
             self._canvas.get_tenant_id(),
             chat_model_config,
-            langfuse_user_id=self._canvas.get_langfuse_user_id(),
+            user_id=self._canvas.globals.get("sys.user_id"),
         )
 
         user_prompt = """

--- a/agent/component/categorize.py
+++ b/agent/component/categorize.py
@@ -124,7 +124,11 @@ class Categorize(LLM, ABC):
         self.set_input_value(query_key, msg[-1]["content"])
         self._param.update_prompt()
         chat_model_config = get_model_config_by_type_and_name(self._canvas.get_tenant_id(), LLMType.CHAT, self._param.llm_id)
-        chat_mdl = LLMBundle(self._canvas.get_tenant_id(), chat_model_config)
+        chat_mdl = LLMBundle(
+            self._canvas.get_tenant_id(),
+            chat_model_config,
+            langfuse_user_id=self._canvas.get_langfuse_user_id(),
+        )
 
         user_prompt = """
 ---- Real Data ----

--- a/agent/component/llm.py
+++ b/agent/component/llm.py
@@ -86,9 +86,13 @@ class LLM(ComponentBase):
     def __init__(self, canvas, component_id, param: ComponentParamBase):
         super().__init__(canvas, component_id, param)
         chat_model_config = get_model_config_by_type_and_name(self._canvas.get_tenant_id(), TenantLLMService.llm_id2llm_type(self._param.llm_id), self._param.llm_id)
-        self.chat_mdl = LLMBundle(self._canvas.get_tenant_id(), chat_model_config,
-                                  max_retries=self._param.max_retries,
-                                  retry_interval=self._param.delay_after_error)
+        self.chat_mdl = LLMBundle(
+            self._canvas.get_tenant_id(),
+            chat_model_config,
+            max_retries=self._param.max_retries,
+            retry_interval=self._param.delay_after_error,
+            langfuse_user_id=self._canvas.get_langfuse_user_id(),
+        )
         self.imgs = []
 
     def get_input_form(self) -> dict[str, dict]:
@@ -248,10 +252,14 @@ class LLM(ComponentBase):
 
         self.imgs = self._uniq_images(self.imgs + extracted_imgs)
         if self.imgs and TenantLLMService.llm_id2llm_type(self._param.llm_id) == LLMType.CHAT.value:
-            self.chat_mdl = LLMBundle(self._canvas.get_tenant_id(), LLMType.IMAGE2TEXT.value,
-                                      self._param.llm_id, max_retries=self._param.max_retries,
-                                      retry_interval=self._param.delay_after_error
-                                      )
+            self.chat_mdl = LLMBundle(
+                self._canvas.get_tenant_id(),
+                LLMType.IMAGE2TEXT.value,
+                self._param.llm_id,
+                max_retries=self._param.max_retries,
+                retry_interval=self._param.delay_after_error,
+                langfuse_user_id=self._canvas.get_langfuse_user_id(),
+            )
 
         msg, sys_prompt = self._sys_prompt_and_msg(self._canvas.get_history(self._param.message_history_window_size)[:-1], args)
         user_defined_prompt, sys_prompt = self._extract_prompts(sys_prompt)
@@ -271,11 +279,13 @@ class LLM(ComponentBase):
         return pts, sys_prompt
 
     async def _generate_async(self, msg: list[dict], **kwargs) -> str:
+        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
         if not self.imgs:
             return await self.chat_mdl.async_chat(msg[0]["content"], msg[1:], self._param.gen_conf(), **kwargs)
         return await self.chat_mdl.async_chat(msg[0]["content"], msg[1:], self._param.gen_conf(), images=self.imgs, **kwargs)
 
     async def _generate_streamly(self, msg: list[dict], **kwargs) -> AsyncGenerator[str, None]:
+        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
         async def delta_wrapper(txt_iter):
             ans = ""
             last_idx = 0
@@ -316,6 +326,7 @@ class LLM(ComponentBase):
             yield t
 
     async def _stream_output_async(self, prompt, msg):
+        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
         _, msg = message_fit_in([{"role": "system", "content": prompt}, *msg], int(self.chat_mdl.max_length * 0.97))
         answer = ""
         last_idx = 0

--- a/agent/component/llm.py
+++ b/agent/component/llm.py
@@ -91,7 +91,7 @@ class LLM(ComponentBase):
             chat_model_config,
             max_retries=self._param.max_retries,
             retry_interval=self._param.delay_after_error,
-            langfuse_user_id=self._canvas.get_langfuse_user_id(),
+            user_id=self._canvas.globals.get("sys.user_id"),
         )
         self.imgs = []
 
@@ -258,7 +258,7 @@ class LLM(ComponentBase):
                 self._param.llm_id,
                 max_retries=self._param.max_retries,
                 retry_interval=self._param.delay_after_error,
-                langfuse_user_id=self._canvas.get_langfuse_user_id(),
+                user_id=self._canvas.globals.get("sys.user_id"),
             )
 
         msg, sys_prompt = self._sys_prompt_and_msg(self._canvas.get_history(self._param.message_history_window_size)[:-1], args)
@@ -279,13 +279,11 @@ class LLM(ComponentBase):
         return pts, sys_prompt
 
     async def _generate_async(self, msg: list[dict], **kwargs) -> str:
-        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
         if not self.imgs:
             return await self.chat_mdl.async_chat(msg[0]["content"], msg[1:], self._param.gen_conf(), **kwargs)
         return await self.chat_mdl.async_chat(msg[0]["content"], msg[1:], self._param.gen_conf(), images=self.imgs, **kwargs)
 
     async def _generate_streamly(self, msg: list[dict], **kwargs) -> AsyncGenerator[str, None]:
-        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
         async def delta_wrapper(txt_iter):
             ans = ""
             last_idx = 0
@@ -326,7 +324,6 @@ class LLM(ComponentBase):
             yield t
 
     async def _stream_output_async(self, prompt, msg):
-        self.chat_mdl.set_langfuse_user_id(self._canvas.get_langfuse_user_id())
         _, msg = message_fit_in([{"role": "system", "content": prompt}, *msg], int(self.chat_mdl.max_length * 0.97))
         answer = ""
         last_idx = 0

--- a/agent/tools/retrieval.py
+++ b/agent/tools/retrieval.py
@@ -251,7 +251,11 @@ class Retrieval(ToolBase, ABC):
                                                      [kb.tenant_id for kb in kbs],
                                                      kb_ids,
                                                      embd_mdl,
-                                                     LLMBundle(tenant_id, chat_model_config))
+                                                     LLMBundle(
+                                                         tenant_id,
+                                                         chat_model_config,
+                                                         user_id=self._canvas.globals.get("sys.user_id"),
+                                                     ))
                 if self.check_if_canceled("Retrieval processing"):
                     return
                 if ck["content_with_weight"]:
@@ -261,8 +265,17 @@ class Retrieval(ToolBase, ABC):
 
         if self._param.use_kg and kbs:
             chat_model_config = get_tenant_default_model_by_type(kbs[0].tenant_id, LLMType.CHAT)
-            ck = await settings.kg_retriever.retrieval(query, [kb.tenant_id for kb in kbs], filtered_kb_ids, embd_mdl,
-                                                 LLMBundle(kbs[0].tenant_id, chat_model_config))
+            ck = await settings.kg_retriever.retrieval(
+                query,
+                [kb.tenant_id for kb in kbs],
+                filtered_kb_ids,
+                embd_mdl,
+                LLMBundle(
+                    kbs[0].tenant_id,
+                    chat_model_config,
+                    user_id=self._canvas.globals.get("sys.user_id"),
+                ),
+            )
             if self.check_if_canceled("Retrieval processing"):
                 return
             if ck["content_with_weight"]:

--- a/agent/tools/retrieval.py
+++ b/agent/tools/retrieval.py
@@ -122,12 +122,20 @@ class Retrieval(ToolBase, ABC):
         if embd_nms:
             tenant_id = self._canvas.get_tenant_id()
             embd_model_config = get_model_config_by_type_and_name(tenant_id, LLMType.EMBEDDING, embd_nms[0])
-            embd_mdl = LLMBundle(tenant_id, embd_model_config)
+            embd_mdl = LLMBundle(
+                tenant_id,
+                embd_model_config,
+                langfuse_user_id=self._canvas.get_langfuse_user_id(),
+            )
 
         rerank_mdl = None
         if self._param.rerank_id:
             rerank_model_config = get_model_config_by_type_and_name(kbs[0].tenant_id, LLMType.RERANK, self._param.rerank_id)
-            rerank_mdl = LLMBundle(kbs[0].tenant_id, rerank_model_config)
+            rerank_mdl = LLMBundle(
+                kbs[0].tenant_id,
+                rerank_model_config,
+                langfuse_user_id=self._canvas.get_langfuse_user_id(),
+            )
 
         vars = self.get_input_elements_from_text(query_text)
         vars = {k: o["value"] for k, o in vars.items()}
@@ -180,7 +188,11 @@ class Retrieval(ToolBase, ABC):
             if self._param.meta_data_filter.get("method") in ["auto", "semi_auto"]:
                 tenant_id = self._canvas.get_tenant_id()
                 chat_model_config = get_tenant_default_model_by_type(tenant_id, LLMType.CHAT)
-                chat_mdl = LLMBundle(tenant_id, chat_model_config)
+                chat_mdl = LLMBundle(
+                    tenant_id,
+                    chat_model_config,
+                    langfuse_user_id=self._canvas.get_langfuse_user_id(),
+                )
 
             doc_ids = await apply_meta_data_filter(
                 self._param.meta_data_filter,
@@ -219,7 +231,11 @@ class Retrieval(ToolBase, ABC):
             if self._param.toc_enhance:
                 tenant_id = self._canvas._tenant_id
                 chat_model_config = get_tenant_default_model_by_type(tenant_id, LLMType.CHAT)
-                chat_mdl = LLMBundle(tenant_id, chat_model_config)
+                chat_mdl = LLMBundle(
+                    tenant_id,
+                    chat_model_config,
+                    langfuse_user_id=self._canvas.get_langfuse_user_id(),
+                )
                 cks = await settings.retriever.retrieval_by_toc(query, kbinfos["chunks"], [kb.tenant_id for kb in kbs],
                                                           chat_mdl, self._param.top_n)
                 if self.check_if_canceled("Retrieval processing"):

--- a/agent/tools/retrieval.py
+++ b/agent/tools/retrieval.py
@@ -125,7 +125,7 @@ class Retrieval(ToolBase, ABC):
             embd_mdl = LLMBundle(
                 tenant_id,
                 embd_model_config,
-                langfuse_user_id=self._canvas.get_langfuse_user_id(),
+                user_id=self._canvas.globals.get("sys.user_id"),
             )
 
         rerank_mdl = None
@@ -134,7 +134,7 @@ class Retrieval(ToolBase, ABC):
             rerank_mdl = LLMBundle(
                 kbs[0].tenant_id,
                 rerank_model_config,
-                langfuse_user_id=self._canvas.get_langfuse_user_id(),
+                user_id=self._canvas.globals.get("sys.user_id"),
             )
 
         vars = self.get_input_elements_from_text(query_text)
@@ -191,7 +191,7 @@ class Retrieval(ToolBase, ABC):
                 chat_mdl = LLMBundle(
                     tenant_id,
                     chat_model_config,
-                    langfuse_user_id=self._canvas.get_langfuse_user_id(),
+                    user_id=self._canvas.globals.get("sys.user_id"),
                 )
 
             doc_ids = await apply_meta_data_filter(
@@ -234,7 +234,7 @@ class Retrieval(ToolBase, ABC):
                 chat_mdl = LLMBundle(
                     tenant_id,
                     chat_model_config,
-                    langfuse_user_id=self._canvas.get_langfuse_user_id(),
+                    user_id=self._canvas.globals.get("sys.user_id"),
                 )
                 cks = await settings.retriever.retrieval_by_toc(query, kbinfos["chunks"], [kb.tenant_id for kb in kbs],
                                                           chat_mdl, self._param.top_n)

--- a/api/apps/restful_apis/agent_api.py
+++ b/api/apps/restful_apis/agent_api.py
@@ -1355,8 +1355,6 @@ async def agent_chat_completion(tenant_id, agent_id=None):
             return get_json_result(data={"message_id": task_id, "session_id": session_id})
 
         try:
-            from agent.canvas import Canvas
-
             canvas = Canvas(dsl_str, str(tenant_id), canvas_id=agent_id, custom_header=custom_header)
         except Exception as exc:
             return server_error_response(exc)

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -32,7 +32,12 @@ from api.db.db_models import DB, Dialog
 from api.db.services.common_service import CommonService
 from api.db.services.doc_metadata_service import DocMetadataService
 from api.db.services.knowledgebase_service import KnowledgebaseService
-from api.db.services.langfuse_service import TenantLangfuseService
+from api.db.services.langfuse_service import (
+    TenantLangfuseService,
+    end_langfuse_observation,
+    resolve_langfuse_user_id,
+    start_langfuse_observation,
+)
 from api.db.services.llm_service import LLMBundle
 from common.metadata_utils import apply_meta_data_filter
 from api.utils.reference_metadata_utils import (
@@ -573,7 +578,9 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
 
     langfuse_tracer = None
     langfuse_generation = None
+    langfuse_ctx = None
     trace_context = {}
+    langfuse_user_id = resolve_langfuse_user_id(kwargs.get("user_id"), dialog.tenant_id)
     langfuse_keys = TenantLangfuseService.filter_by_tenant(tenant_id=dialog.tenant_id)
     if langfuse_keys:
         langfuse = Langfuse(public_key=langfuse_keys.public_key, secret_key=langfuse_keys.secret_key, host=langfuse_keys.host)
@@ -588,6 +595,9 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
 
     check_langfuse_tracer_ts = timer()
     kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
+    for mdl in (embd_mdl, rerank_mdl, chat_mdl, tts_mdl):
+        if mdl is not None:
+            mdl.set_langfuse_user_id(langfuse_user_id)
     toolcall_session, tools = kwargs.get("toolcall_session"), kwargs.get("tools")
     if toolcall_session and tools:
         chat_mdl.bind_tools(toolcall_session, tools)
@@ -784,7 +794,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         gen_conf["max_tokens"] = min(gen_conf["max_tokens"], max_tokens - used_token_count)
 
     async def decorate_answer(answer):
-        nonlocal embd_mdl, prompt_config, knowledges, kwargs, kbinfos, prompt, retrieval_ts, questions, langfuse_generation
+        nonlocal embd_mdl, prompt_config, knowledges, kwargs, kbinfos, prompt, retrieval_ts, questions, langfuse_generation, langfuse_ctx
 
         refs = []
         ans = answer.split("</think>")
@@ -868,13 +878,16 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
                     "total": used_token_count + tk_num,
                 },
             )
-            langfuse_generation.end()
+            end_langfuse_observation(langfuse_generation, langfuse_ctx)
 
         return {"answer": think + answer, "reference": refs, "prompt": re.sub(r"\n", "  \n", prompt), "created_at": time.time()}
 
     if langfuse_tracer:
         try:
-            langfuse_generation = langfuse_tracer.start_observation(
+            langfuse_generation, langfuse_ctx = start_langfuse_observation(
+                langfuse_tracer,
+                langfuse_user_id,
+                dialog.tenant_id,
                 as_type="generation",
                 trace_context=trace_context,
                 name="chat",
@@ -885,6 +898,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             logger.warning("Langfuse start_observation failed; continuing without tracing: %s", e)
             langfuse_tracer = None
             langfuse_generation = None
+            langfuse_ctx = None
 
     if stream:
         if llm_type == "chat":

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 from datetime import datetime
 from functools import partial
 from timeit import default_timer as timer
-from langfuse import Langfuse
+from langfuse import Langfuse, propagate_attributes
 from peewee import fn
 from api.db.services.file_service import FileService
 from common.constants import LLMType, ParserType, StatusEnum
@@ -32,12 +32,7 @@ from api.db.db_models import DB, Dialog
 from api.db.services.common_service import CommonService
 from api.db.services.doc_metadata_service import DocMetadataService
 from api.db.services.knowledgebase_service import KnowledgebaseService
-from api.db.services.langfuse_service import (
-    TenantLangfuseService,
-    end_langfuse_observation,
-    resolve_langfuse_user_id,
-    start_langfuse_observation,
-)
+from api.db.services.langfuse_service import TenantLangfuseService
 from api.db.services.llm_service import LLMBundle
 from common.metadata_utils import apply_meta_data_filter
 from api.utils.reference_metadata_utils import (
@@ -351,8 +346,9 @@ async def async_chat_solo(dialog, messages, stream=True):
         yield {"answer": answer, "reference": {}, "audio_binary": tts(tts_mdl, answer), "prompt": "", "created_at": time.time()}
 
 
-def get_models(dialog):
+def get_models(dialog, user_id=None):
     embd_mdl, chat_mdl, rerank_mdl, tts_mdl = None, None, None, None
+    user_kw = {"user_id": str(user_id)} if user_id else {}
     kbs = KnowledgebaseService.get_by_ids(dialog.kb_ids)
     embedding_list = list(set([kb.embd_id for kb in kbs]))
     if len(embedding_list) > 1:
@@ -361,7 +357,7 @@ def get_models(dialog):
     if embedding_list:
         embd_owner_tenant_id = kbs[0].tenant_id
         embd_model_config = get_model_config_by_type_and_name(embd_owner_tenant_id, LLMType.EMBEDDING, embedding_list[0])
-        embd_mdl = LLMBundle(embd_owner_tenant_id, embd_model_config)
+        embd_mdl = LLMBundle(embd_owner_tenant_id, embd_model_config, **user_kw)
         if not embd_mdl:
             raise LookupError("Embedding model(%s) not found" % embedding_list[0])
 
@@ -372,15 +368,15 @@ def get_models(dialog):
     else:
         chat_model_config = get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
 
-    chat_mdl = LLMBundle(dialog.tenant_id, chat_model_config)
+    chat_mdl = LLMBundle(dialog.tenant_id, chat_model_config, **user_kw)
 
     if dialog.rerank_id:
         rerank_model_config = get_model_config_by_type_and_name(dialog.tenant_id, LLMType.RERANK, dialog.rerank_id)
-        rerank_mdl = LLMBundle(dialog.tenant_id, rerank_model_config)
+        rerank_mdl = LLMBundle(dialog.tenant_id, rerank_model_config, **user_kw)
 
     if dialog.prompt_config.get("tts"):
         default_tts_model_config = get_tenant_default_model_by_type(dialog.tenant_id, LLMType.TTS)
-        tts_mdl = LLMBundle(dialog.tenant_id, default_tts_model_config)
+        tts_mdl = LLMBundle(dialog.tenant_id, default_tts_model_config, **user_kw)
     return kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl
 
 
@@ -580,7 +576,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
     langfuse_generation = None
     langfuse_ctx = None
     trace_context = {}
-    langfuse_user_id = resolve_langfuse_user_id(kwargs.get("user_id"), dialog.tenant_id)
+    user_id = kwargs.get("user_id")
     langfuse_keys = TenantLangfuseService.filter_by_tenant(tenant_id=dialog.tenant_id)
     if langfuse_keys:
         langfuse = Langfuse(public_key=langfuse_keys.public_key, secret_key=langfuse_keys.secret_key, host=langfuse_keys.host)
@@ -594,10 +590,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             pass
 
     check_langfuse_tracer_ts = timer()
-    kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
-    for mdl in (embd_mdl, rerank_mdl, chat_mdl, tts_mdl):
-        if mdl is not None:
-            mdl.set_langfuse_user_id(langfuse_user_id)
+    kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog, user_id=user_id)
     toolcall_session, tools = kwargs.get("toolcall_session"), kwargs.get("tools")
     if toolcall_session and tools:
         chat_mdl.bind_tools(toolcall_session, tools)
@@ -878,16 +871,18 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
                     "total": used_token_count + tk_num,
                 },
             )
-            end_langfuse_observation(langfuse_generation, langfuse_ctx)
+            langfuse_generation.end()
+            if langfuse_ctx is not None:
+                langfuse_ctx.__exit__(None, None, None)
 
         return {"answer": think + answer, "reference": refs, "prompt": re.sub(r"\n", "  \n", prompt), "created_at": time.time()}
 
     if langfuse_tracer:
         try:
-            langfuse_generation, langfuse_ctx = start_langfuse_observation(
-                langfuse_tracer,
-                langfuse_user_id,
-                dialog.tenant_id,
+            if user_id:
+                langfuse_ctx = propagate_attributes(user_id=str(user_id))
+                langfuse_ctx.__enter__()
+            langfuse_generation = langfuse_tracer.start_observation(
                 as_type="generation",
                 trace_context=trace_context,
                 name="chat",
@@ -895,10 +890,12 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
                 input={"prompt": prompt, "prompt4citation": prompt4citation, "messages": msg},
             )
         except Exception as e:  # noqa: BLE001 - tracing must not break chat flow
+            if langfuse_ctx is not None:
+                langfuse_ctx.__exit__(None, None, None)
+                langfuse_ctx = None
             logger.warning("Langfuse start_observation failed; continuing without tracing: %s", e)
             langfuse_tracer = None
             langfuse_generation = None
-            langfuse_ctx = None
 
     if stream:
         if llm_type == "chat":

--- a/api/db/services/langfuse_service.py
+++ b/api/db/services/langfuse_service.py
@@ -15,42 +15,12 @@
 #
 
 from datetime import datetime
-from typing import Any, Optional, Tuple
 
 import peewee
-from langfuse import propagate_attributes
 
 from api.db.db_models import DB, TenantLangfuse
 from api.db.services.common_service import CommonService
 from common.time_utils import current_timestamp, datetime_format
-
-
-def resolve_langfuse_user_id(user_id: Any, tenant_id: Any) -> str:
-    """Use request user_id for Langfuse traces; fall back to tenant_id when empty."""
-    if user_id is None:
-        return str(tenant_id)
-    user_id_str = str(user_id).strip()
-    if not user_id_str:
-        return str(tenant_id)
-    return user_id_str
-
-
-def start_langfuse_observation(langfuse_client, user_id: Any, tenant_id: Any, **kwargs) -> Tuple[Any, Any]:
-    """Start a Langfuse observation with trace-level user_id propagated."""
-    ctx = propagate_attributes(user_id=resolve_langfuse_user_id(user_id, tenant_id))
-    ctx.__enter__()
-    try:
-        return langfuse_client.start_observation(**kwargs), ctx
-    except Exception:
-        ctx.__exit__(None, None, None)
-        raise
-
-
-def end_langfuse_observation(generation: Optional[Any], ctx: Optional[Any]) -> None:
-    if generation is not None:
-        generation.end()
-    if ctx is not None:
-        ctx.__exit__(None, None, None)
 
 
 class TenantLangfuseService(CommonService):

--- a/api/db/services/langfuse_service.py
+++ b/api/db/services/langfuse_service.py
@@ -15,12 +15,42 @@
 #
 
 from datetime import datetime
+from typing import Any, Optional, Tuple
 
 import peewee
+from langfuse import propagate_attributes
 
 from api.db.db_models import DB, TenantLangfuse
 from api.db.services.common_service import CommonService
 from common.time_utils import current_timestamp, datetime_format
+
+
+def resolve_langfuse_user_id(user_id: Any, tenant_id: Any) -> str:
+    """Use request user_id for Langfuse traces; fall back to tenant_id when empty."""
+    if user_id is None:
+        return str(tenant_id)
+    user_id_str = str(user_id).strip()
+    if not user_id_str:
+        return str(tenant_id)
+    return user_id_str
+
+
+def start_langfuse_observation(langfuse_client, user_id: Any, tenant_id: Any, **kwargs) -> Tuple[Any, Any]:
+    """Start a Langfuse observation with trace-level user_id propagated."""
+    ctx = propagate_attributes(user_id=resolve_langfuse_user_id(user_id, tenant_id))
+    ctx.__enter__()
+    try:
+        return langfuse_client.start_observation(**kwargs), ctx
+    except Exception:
+        ctx.__exit__(None, None, None)
+        raise
+
+
+def end_langfuse_observation(generation: Optional[Any], ctx: Optional[Any]) -> None:
+    if generation is not None:
+        generation.end()
+    if ctx is not None:
+        ctx.__exit__(None, None, None)
 
 
 class TenantLangfuseService(CommonService):

--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -283,14 +283,15 @@ class LLMBundle(LLM4Tenant):
     def tts(self, text: str) -> Generator[bytes, None, None]:
         generation, langfuse_ctx = self._start_langfuse_observation(as_type="generation", name="tts", input={"text": text})
 
-        for chunk in self.mdl.tts(text):
-            if isinstance(chunk, int):
-                if not TenantLLMService.increase_usage_by_id(self.model_config["id"], chunk):
-                    logging.error("LLMBundle.tts can't update token usage for {}/TTS".format(self.tenant_id))
-                return
-            yield chunk
-
-        self._end_langfuse_observation(generation, langfuse_ctx)
+        try:
+            for chunk in self.mdl.tts(text):
+                if isinstance(chunk, int):
+                    if not TenantLLMService.increase_usage_by_id(self.model_config["id"], chunk):
+                        logging.error("LLMBundle.tts can't update token usage for {}/TTS".format(self.tenant_id))
+                    return
+                yield chunk
+        finally:
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
     def _remove_reasoning_content(self, txt: str) -> str:
         if txt is None:

--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -93,8 +93,9 @@ class LLMBundle(LLM4Tenant):
         self.mdl.bind_tools(toolcall_session, tools)
 
     def encode(self, texts: list):
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="encode", model=self.model_config["llm_name"], input={"texts": texts})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="encode", model=self.model_config["llm_name"], input={"texts": texts}
+        )
 
         safe_texts = []
         for idx, text in enumerate(texts):
@@ -128,15 +129,16 @@ class LLMBundle(LLM4Tenant):
         elif not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error("LLMBundle.encode can't update token usage for <tenant redacted>/EMBEDDING used_tokens: {}".format(used_tokens))
 
-        if self.langfuse:
+        if generation is not None:
             generation.update(usage_details={"total_tokens": used_tokens})
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         return embeddings, used_tokens
 
     def encode_queries(self, query: str):
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="encode_queries", model=self.model_config["llm_name"], input={"query": query})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="encode_queries", model=self.model_config["llm_name"], input={"query": query}
+        )
 
         if query is None or not str(query).strip():
             marker = "None" if query is None else "whitespace-only"
@@ -152,65 +154,69 @@ class LLMBundle(LLM4Tenant):
         elif not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error("LLMBundle.encode_queries can't update token usage for <tenant redacted>/EMBEDDING used_tokens: {}".format(used_tokens))
 
-        if self.langfuse:
+        if generation is not None:
             generation.update(usage_details={"total_tokens": used_tokens})
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         return emd, used_tokens
 
     def similarity(self, query: str, texts: list):
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="similarity", model=self.model_config["llm_name"], input={"query": query, "texts": texts})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="similarity", model=self.model_config["llm_name"], input={"query": query, "texts": texts}
+        )
 
         sim, used_tokens = self.mdl.similarity(query, texts)
         if not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error("LLMBundle.similarity can't update token usage for {}/RERANK used_tokens: {}".format(self.tenant_id, used_tokens))
 
-        if self.langfuse:
+        if generation is not None:
             generation.update(usage_details={"total_tokens": used_tokens})
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         return sim, used_tokens
 
     def describe(self, image, max_tokens=300):
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="describe", metadata={"model": self.model_config["llm_name"]})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="describe", metadata={"model": self.model_config["llm_name"]}
+        )
 
         txt, used_tokens = self.mdl.describe(image)
         if not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error("LLMBundle.describe can't update token usage for {}/IMAGE2TEXT used_tokens: {}".format(self.tenant_id, used_tokens))
 
-        if self.langfuse:
+        if generation is not None:
             generation.update(output={"output": txt}, usage_details={"total_tokens": used_tokens})
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         return txt
 
     def describe_with_prompt(self, image, prompt):
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="describe_with_prompt", metadata={"model": self.model_config["llm_name"], "prompt": prompt})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="describe_with_prompt", metadata={"model": self.model_config["llm_name"], "prompt": prompt}
+        )
 
         txt, used_tokens = self.mdl.describe_with_prompt(image, prompt)
         if not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error("LLMBundle.describe can't update token usage for {}/IMAGE2TEXT used_tokens: {}".format(self.tenant_id, used_tokens))
 
-        if self.langfuse:
+        if generation is not None:
             generation.update(output={"output": txt}, usage_details={"total_tokens": used_tokens})
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         return txt
 
     def transcription(self, audio):
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="transcription", metadata={"model": self.model_config["llm_name"]})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="transcription", metadata={"model": self.model_config["llm_name"]}
+        )
 
         txt, used_tokens = self.mdl.transcription(audio)
         if not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error("LLMBundle.transcription can't update token usage for {}/SEQUENCE2TXT used_tokens: {}".format(self.tenant_id, used_tokens))
 
-        if self.langfuse:
+        if generation is not None:
             generation.update(output={"output": txt}, usage_details={"total_tokens": used_tokens})
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         return txt
 
@@ -218,12 +224,11 @@ class LLMBundle(LLM4Tenant):
         mdl = self.mdl
         supports_stream = hasattr(mdl, "stream_transcription") and callable(getattr(mdl, "stream_transcription"))
         if supports_stream:
-            if self.langfuse:
-                generation = self.langfuse.start_observation(as_type="generation",
-                    trace_context=self.trace_context,
-                    name="stream_transcription",
-                    metadata={"model": self.model_config["llm_name"]},
-                )
+            generation, langfuse_ctx = self._start_langfuse_observation(
+                as_type="generation",
+                name="stream_transcription",
+                metadata={"model": self.model_config["llm_name"]},
+            )
             final_text = ""
             used_tokens = 0
 
@@ -243,32 +248,31 @@ class LLMBundle(LLM4Tenant):
                     used_tokens = num_tokens_from_string(final_text)
                     TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens)
 
-                if self.langfuse:
+                if generation is not None:
                     generation.update(
                         output={"output": final_text},
                         usage_details={"total_tokens": used_tokens},
                     )
-                    generation.end()
+                    self._end_langfuse_observation(generation, langfuse_ctx)
 
             return
 
-        if self.langfuse:
-            generation = self.langfuse.start_observation(as_type="generation",
-                trace_context=self.trace_context,
-                name="stream_transcription",
-                metadata={"model": self.model_config["llm_name"]},
-            )
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation",
+            name="stream_transcription",
+            metadata={"model": self.model_config["llm_name"]},
+        )
 
         full_text, used_tokens = mdl.transcription(audio)
         if not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error(f"LLMBundle.stream_transcription can't update token usage for {self.tenant_id}/SEQUENCE2TXT used_tokens: {used_tokens}")
 
-        if self.langfuse:
+        if generation is not None:
             generation.update(
                 output={"output": full_text},
                 usage_details={"total_tokens": used_tokens},
             )
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         yield {
             "event": "final",
@@ -277,8 +281,7 @@ class LLMBundle(LLM4Tenant):
         }
 
     def tts(self, text: str) -> Generator[bytes, None, None]:
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="tts", input={"text": text})
+        generation, langfuse_ctx = self._start_langfuse_observation(as_type="generation", name="tts", input={"text": text})
 
         for chunk in self.mdl.tts(text):
             if isinstance(chunk, int):
@@ -287,8 +290,7 @@ class LLMBundle(LLM4Tenant):
                 return
             yield chunk
 
-        if self.langfuse:
-            generation.end()
+        self._end_langfuse_observation(generation, langfuse_ctx)
 
     def _remove_reasoning_content(self, txt: str) -> str:
         if txt is None:
@@ -399,9 +401,9 @@ class LLMBundle(LLM4Tenant):
         else:
             raise RuntimeError(f"Model {self.mdl} does not implement async_chat or async_chat_with_tools")
 
-        generation = None
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="chat", model=self.model_config["llm_name"], input={"system": system, "history": history})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="chat", model=self.model_config["llm_name"], input={"system": system, "history": history}
+        )
 
         chat_partial = partial(base_fn, system, history, gen_conf)
         use_kwargs = self._clean_param(chat_partial, **kwargs)
@@ -409,9 +411,9 @@ class LLMBundle(LLM4Tenant):
         try:
             txt, used_tokens = await chat_partial(**use_kwargs)
         except Exception as e:
-            if generation:
+            if generation is not None:
                 generation.update(output={"error": str(e)})
-                generation.end()
+                self._end_langfuse_observation(generation, langfuse_ctx)
             raise
 
         txt = self._remove_reasoning_content(txt)
@@ -421,9 +423,9 @@ class LLMBundle(LLM4Tenant):
         if used_tokens and not TenantLLMService.increase_usage_by_id(self.model_config["id"], used_tokens):
             logging.error("LLMBundle.async_chat can't update token usage for {}/CHAT llm_name: {}, used_tokens: {}".format(self.tenant_id, self.model_config["llm_name"], used_tokens))
 
-        if generation:
+        if generation is not None:
             generation.update(output={"output": txt}, usage_details={"total_tokens": used_tokens})
-            generation.end()
+            self._end_langfuse_observation(generation, langfuse_ctx)
 
         return txt
 
@@ -440,9 +442,9 @@ class LLMBundle(LLM4Tenant):
         else:
             raise RuntimeError(f"Model {self.mdl} does not implement async_chat or async_chat_with_tools")
 
-        generation = None
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="chat_streamly", model=self.model_config["llm_name"], input={"system": system, "history": history})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="chat_streamly", model=self.model_config["llm_name"], input={"system": system, "history": history}
+        )
 
         if stream_fn:
             chat_partial = partial(stream_fn, system, history, gen_conf)
@@ -462,15 +464,15 @@ class LLMBundle(LLM4Tenant):
                     ans += txt
                     yield ans
             except Exception as e:
-                if generation:
+                if generation is not None:
                     generation.update(output={"error": str(e)})
-                    generation.end()
+                    self._end_langfuse_observation(generation, langfuse_ctx)
                 raise
             if total_tokens and not TenantLLMService.increase_usage_by_id(self.model_config["id"], total_tokens):
                 logging.error("LLMBundle.async_chat_streamly can't update token usage for {}/CHAT llm_name: {}, used_tokens: {}".format(self.tenant_id, self.model_config["llm_name"], total_tokens))
-            if generation:
+            if generation is not None:
                 generation.update(output={"output": ans}, usage_details={"total_tokens": total_tokens})
-                generation.end()
+                self._end_langfuse_observation(generation, langfuse_ctx)
             return
 
     async def async_chat_streamly_delta(self, system: str, history: list, gen_conf: dict = {}, **kwargs):
@@ -483,9 +485,9 @@ class LLMBundle(LLM4Tenant):
         else:
             raise RuntimeError(f"Model {self.mdl} does not implement async_chat or async_chat_with_tools")
 
-        generation = None
-        if self.langfuse:
-            generation = self.langfuse.start_observation(trace_context=self.trace_context, as_type="generation", name="chat_streamly", model=self.model_config["llm_name"], input={"system": system, "history": history})
+        generation, langfuse_ctx = self._start_langfuse_observation(
+            as_type="generation", name="chat_streamly", model=self.model_config["llm_name"], input={"system": system, "history": history}
+        )
 
         if stream_fn:
             chat_partial = partial(stream_fn, system, history, gen_conf)
@@ -505,13 +507,13 @@ class LLMBundle(LLM4Tenant):
                     ans += txt
                     yield txt
             except Exception as e:
-                if generation:
+                if generation is not None:
                     generation.update(output={"error": str(e)})
-                    generation.end()
+                    self._end_langfuse_observation(generation, langfuse_ctx)
                 raise
             if total_tokens and not TenantLLMService.increase_usage_by_id(self.model_config["id"], total_tokens):
                 logging.error("LLMBundle.async_chat_streamly can't update token usage for {}/CHAT llm_name: {}, used_tokens: {}".format(self.tenant_id, self.model_config["llm_name"], total_tokens))
-            if generation:
+            if generation is not None:
                 generation.update(output={"output": ans}, usage_details={"total_tokens": total_tokens})
-                generation.end()
+                self._end_langfuse_observation(generation, langfuse_ctx)
             return

--- a/api/db/services/tenant_llm_service.py
+++ b/api/db/services/tenant_llm_service.py
@@ -17,17 +17,12 @@ import os
 import json
 import logging
 from peewee import IntegrityError
-from langfuse import Langfuse
+from langfuse import Langfuse, propagate_attributes
 from common import settings
 from common.constants import MINERU_DEFAULT_CONFIG, MINERU_ENV_KEYS, OPENDATALOADER_DEFAULT_CONFIG, OPENDATALOADER_ENV_KEYS, PADDLEOCR_DEFAULT_CONFIG, PADDLEOCR_ENV_KEYS, LLMType
 from api.db.db_models import DB, LLMFactories, TenantLLM
 from api.db.services.common_service import CommonService
-from api.db.services.langfuse_service import (
-    TenantLangfuseService,
-    end_langfuse_observation,
-    resolve_langfuse_user_id,
-    start_langfuse_observation,
-)
+from api.db.services.langfuse_service import TenantLangfuseService
 from api.db.services.user_service import TenantService
 
 
@@ -512,10 +507,8 @@ class LLM4Tenant:
 
         self.is_tools = model_config.get("is_tools", False)
         self.verbose_tool_use = kwargs.get("verbose_tool_use")
-        self.langfuse_user_id = resolve_langfuse_user_id(
-            kwargs.get("langfuse_user_id") or kwargs.get("user_id"),
-            tenant_id,
-        )
+        user_id = kwargs.get("user_id")
+        self.user_id = str(user_id) if user_id else tenant_id
 
         langfuse_keys = TenantLangfuseService.filter_by_tenant(tenant_id=tenant_id)
         self.langfuse = None
@@ -530,19 +523,23 @@ class LLM4Tenant:
                 # Skip langfuse tracing if connection fails
                 pass
 
-    def set_langfuse_user_id(self, user_id=None) -> None:
-        self.langfuse_user_id = resolve_langfuse_user_id(user_id, self.tenant_id)
-
     def _start_langfuse_observation(self, **kwargs):
         if not self.langfuse:
             return None, None
         kwargs.setdefault("trace_context", self.trace_context)
-        return start_langfuse_observation(
-            self.langfuse,
-            self.langfuse_user_id,
-            self.tenant_id,
-            **kwargs,
-        )
+        ctx = None
+        if self.user_id:
+            ctx = propagate_attributes(user_id=self.user_id)
+            ctx.__enter__()
+        try:
+            return self.langfuse.start_observation(**kwargs), ctx
+        except Exception:
+            if ctx is not None:
+                ctx.__exit__(None, None, None)
+            raise
 
     def _end_langfuse_observation(self, generation, ctx) -> None:
-        end_langfuse_observation(generation, ctx)
+        if generation is not None:
+            generation.end()
+        if ctx is not None:
+            ctx.__exit__(None, None, None)

--- a/api/db/services/tenant_llm_service.py
+++ b/api/db/services/tenant_llm_service.py
@@ -22,7 +22,12 @@ from common import settings
 from common.constants import MINERU_DEFAULT_CONFIG, MINERU_ENV_KEYS, OPENDATALOADER_DEFAULT_CONFIG, OPENDATALOADER_ENV_KEYS, PADDLEOCR_DEFAULT_CONFIG, PADDLEOCR_ENV_KEYS, LLMType
 from api.db.db_models import DB, LLMFactories, TenantLLM
 from api.db.services.common_service import CommonService
-from api.db.services.langfuse_service import TenantLangfuseService
+from api.db.services.langfuse_service import (
+    TenantLangfuseService,
+    end_langfuse_observation,
+    resolve_langfuse_user_id,
+    start_langfuse_observation,
+)
 from api.db.services.user_service import TenantService
 
 
@@ -507,6 +512,10 @@ class LLM4Tenant:
 
         self.is_tools = model_config.get("is_tools", False)
         self.verbose_tool_use = kwargs.get("verbose_tool_use")
+        self.langfuse_user_id = resolve_langfuse_user_id(
+            kwargs.get("langfuse_user_id") or kwargs.get("user_id"),
+            tenant_id,
+        )
 
         langfuse_keys = TenantLangfuseService.filter_by_tenant(tenant_id=tenant_id)
         self.langfuse = None
@@ -520,3 +529,20 @@ class LLM4Tenant:
             except Exception:
                 # Skip langfuse tracing if connection fails
                 pass
+
+    def set_langfuse_user_id(self, user_id=None) -> None:
+        self.langfuse_user_id = resolve_langfuse_user_id(user_id, self.tenant_id)
+
+    def _start_langfuse_observation(self, **kwargs):
+        if not self.langfuse:
+            return None, None
+        kwargs.setdefault("trace_context", self.trace_context)
+        return start_langfuse_observation(
+            self.langfuse,
+            self.langfuse_user_id,
+            self.tenant_id,
+            **kwargs,
+        )
+
+    def _end_langfuse_observation(self, generation, ctx) -> None:
+        end_langfuse_observation(generation, ctx)

--- a/test/unit_test/api/db/services/test_dialog_service_final_answer.py
+++ b/test/unit_test/api/db/services/test_dialog_service_final_answer.py
@@ -358,7 +358,7 @@ def test_async_chat_final_event_carries_decorated_answer(monkeypatch):
     # get_models returns (kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl)
     monkeypatch.setattr(
         dialog_service, "get_models",
-        lambda _dialog: ([_KB], chat_mdl, None, chat_mdl, None),
+        lambda _dialog, user_id=None: ([_KB], chat_mdl, None, chat_mdl, None),
     )
     monkeypatch.setattr(
         dialog_service.KnowledgebaseService, "get_field_map", lambda _kb_ids: {}
@@ -424,7 +424,7 @@ def test_async_chat_langfuse_uses_start_observation(monkeypatch):
     monkeypatch.setattr(
         dialog_service,
         "get_models",
-        lambda _dialog: ([_KB], chat_mdl, None, chat_mdl, None),
+        lambda _dialog, user_id=None: ([_KB], chat_mdl, None, chat_mdl, None),
     )
     monkeypatch.setattr(
         dialog_service.KnowledgebaseService, "get_field_map", lambda _kb_ids: {}
@@ -493,7 +493,7 @@ def test_async_chat_continues_when_langfuse_observation_start_fails(monkeypatch)
     monkeypatch.setattr(
         dialog_service,
         "get_models",
-        lambda _dialog: ([_KB], chat_mdl, None, chat_mdl, None),
+        lambda _dialog, user_id=None: ([_KB], chat_mdl, None, chat_mdl, None),
     )
     monkeypatch.setattr(
         dialog_service.KnowledgebaseService, "get_field_map", lambda _kb_ids: {}

--- a/test/unit_test/api/db/services/test_dialog_service_use_sql_source_columns.py
+++ b/test/unit_test/api/db/services/test_dialog_service_use_sql_source_columns.py
@@ -292,7 +292,7 @@ def test_async_chat_uses_all_docs_when_no_doc_ids_selected(monkeypatch):
     monkeypatch.setattr(
         dialog_service,
         "get_models",
-        lambda _dialog: ([SimpleNamespace(tenant_id="tenant-id")], object(), None, chat_model, None),
+        lambda _dialog, user_id=None: ([SimpleNamespace(tenant_id="tenant-id")], object(), None, chat_model, None),
     )
     monkeypatch.setattr(dialog_service.KnowledgebaseService, "get_field_map", lambda _kb_ids: {})
     monkeypatch.setattr(dialog_service, "label_question", lambda _question, _kbs: None)


### PR DESCRIPTION
### What problem does this PR solve?

RAGFlow integrates with [Langfuse](https://langfuse.com/) for LLM observability, but traces and generations created via LLMBundle did not include the business user ID from chat sessions or agent runs. Operators could not filter or aggregate Langfuse data (for example, cost and usage) by the actual end user.

This change wires the existing user_id passed through chat/agent request flows into Langfuse using the Python SDK v4 propagate_attributes(user_id=...) API, which is the recommended way to set trace-level user attributes for observations created with start_observation().

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
