### PR TITLE
Fix: retry transient ES 503 / NoShardAvailable errors in search and i…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ The project uses **uv** for dependency management.
 
 1. **Setup Environment**:
    ```bash
-   uv sync --python 3.12 --all-extras
+   uv sync --python 3.13 --all-extras
    uv run python3 download_deps.py
    ```
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_ar.md
+++ b/README_ar.md
@@ -328,7 +328,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_fr.md
+++ b/README_fr.md
@@ -319,7 +319,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_id.md
+++ b/README_id.md
@@ -302,7 +302,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -302,7 +302,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_ko.md
+++ b/README_ko.md
@@ -297,7 +297,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -319,7 +319,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # instala os módulos Python dependentes do RAGFlow
+   uv sync --python 3.13 # instala os módulos Python dependentes do RAGFlow
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_tr.md
+++ b/README_tr.md
@@ -323,7 +323,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # RAGFlow'un bağımlı Python modüllerini yükler
+   uv sync --python 3.13 # RAGFlow'un bağımlı Python modüllerini yükler
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_tzh.md
+++ b/README_tzh.md
@@ -329,7 +329,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -329,7 +329,7 @@ docker build --platform linux/amd64 \
    ```bash
    git clone https://github.com/infiniflow/ragflow.git
    cd ragflow/
-   uv sync --python 3.12 # install RAGFlow dependent python modules
+   uv sync --python 3.13 # install RAGFlow dependent python modules
    uv run python3 download_deps.py
    pre-commit install
    ```

--- a/admin/client/user.py
+++ b/admin/client/user.py
@@ -41,7 +41,7 @@ def encrypt_password(password_plain: str) -> str:
             return base64.b64encode(encrypted_password).decode('utf-8')
     except Exception as exc:
         raise AuthException(
-            "Password encryption unavailable; install pycryptodomex (uv sync --python 3.12 --group test)."
+            "Password encryption unavailable; install pycryptodomex (uv sync --python 3.13 --group test)."
         ) from exc
     return crypt(password_plain)
 

--- a/common/asyncio_utils.py
+++ b/common/asyncio_utils.py
@@ -1,0 +1,56 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import asyncio
+import weakref
+
+
+class LoopLocalSemaphore:
+    """
+    Asyncio synchronization primitives bind to the event loop that waits on them.
+    Keep one semaphore per running loop for module-level concurrency limiters.
+    """
+
+    def __init__(self, value: int):
+        self._value = int(value)
+        self._semaphores: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Semaphore]" = (
+            weakref.WeakKeyDictionary()
+        )
+
+    def _get(self) -> asyncio.Semaphore:
+        loop = asyncio.get_running_loop()
+        for cached_loop in list(self._semaphores):
+            if cached_loop.is_closed():
+                self._semaphores.pop(cached_loop, None)
+        sem = self._semaphores.get(loop)
+        if sem is None:
+            sem = asyncio.Semaphore(self._value)
+            self._semaphores[loop] = sem
+        return sem
+
+    async def acquire(self) -> bool:
+        return await self._get().acquire()
+
+    def release(self) -> None:
+        self._get().release()
+
+    async def __aenter__(self):
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.release()
+        return False

--- a/conf/models/novita.json
+++ b/conf/models/novita.json
@@ -7,6 +7,7 @@
     "chat": "openai/v1/chat/completions",
     "models": "openai/v1/models",
     "embedding": "openai/v1/embeddings",
+    "balance": "openapi/v1/billing/balance/detail",
     "rerank": "openai/v1/rerank"
   },
   "class": "novita",

--- a/conf/models/togetherai.json
+++ b/conf/models/togetherai.json
@@ -6,7 +6,10 @@
   "url_suffix": {
     "chat": "chat/completions",
     "models": "models",
-    "embedding": "embeddings"
+    "embedding": "embeddings",
+    "rerank": "rerank",
+    "asr": "audio/transcriptions",
+    "tts": "audio/speech"
   },
   "class": "together",
   "models": [
@@ -50,6 +53,25 @@
       "max_tokens": 512,
       "model_types": [
         "embedding"
+      ]
+    },
+    {
+      "name": "mixedbread-ai/mxbai-rerank-large-v2",
+      "max_tokens": "16384",
+      "model_types": [
+        "rerank"
+      ]
+    },
+    {
+      "name": "openai/whisper-large-v3",
+      "model_types": [
+        "asr"
+      ]
+    },
+    {
+      "name": "canopylabs/orpheus-3b-0.1-ft",
+      "model_types": [
+        "tts"
       ]
     }
   ]

--- a/docs/develop/launch_ragflow_from_source.md
+++ b/docs/develop/launch_ragflow_from_source.md
@@ -46,14 +46,14 @@ cd ragflow/
 2. Install RAGFlow service's Python dependencies:
 
    ```bash
-   uv sync --python 3.12 --frozen
+   uv sync --python 3.13 --frozen
    ```
    *A virtual environment named `.venv` is created, and all Python dependencies are installed into the new environment.*
 
    If you need to run tests against the RAGFlow service, install the test dependencies:
 
    ```bash
-   uv sync --python 3.12 --group test --frozen && uv pip install sdk/python --group test
+   uv sync --python 3.13 --group test --frozen && uv pip install sdk/python --group test
    ```
 
 ### Launch third-party services

--- a/docs/develop/mcp/launch_mcp_server.md
+++ b/docs/develop/mcp/launch_mcp_server.md
@@ -178,7 +178,7 @@ This section is contributed by our community contributor [yiminghub2024](https:/
    iii. Copy [docker/entrypoint.sh](https://github.com/infiniflow/ragflow/blob/main/docker/entrypoint.sh) locally.  
    iv. Install the required dependencies using `uv`:  
        - Run `uv add mcp` or
-       - Copy [pyproject.toml](https://github.com/infiniflow/ragflow/blob/main/pyproject.toml) locally and run `uv sync --python 3.12`.
+       - Copy [pyproject.toml](https://github.com/infiniflow/ragflow/blob/main/pyproject.toml) locally and run `uv sync --python 3.13`.
 2. Edit **docker-compose.yml** to enable MCP (disabled by default).
 3. Launch the MCP server:
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -15,32 +15,31 @@ Released on May 20, 2026.
 
 ### New features
 
-- Adds local & SSH providers in admin panel. [#15039](https://github.com/infiniflow/ragflow/pull/15039)
+- Introduces local and SSH provider options for sandbox environment settings within the admin interface, allowing administrators to configure execution environments without editing environment variables. [#15039](https://github.com/infiniflow/ragflow/pull/15039)
 
 ### Improvements
 
-- Accelerated dataset search path, reducing latency by 50–100% by removing expensive vector fetch and rerank similarity computation steps. [#14970](https://github.com/infiniflow/ragflow/pull/14970)
-- Pushes metadata filters down to Infinity, significantly speeding up metadata filtering. [#14974](https://github.com/infiniflow/ragflow/pull/14974)
-- added Redis caching for TTS. [#14851](https://github.com/infiniflow/ragflow/pull/14851)
-- atomic document counter updates [#14867](https://github.com/infiniflow/ragflow/pull/14974)
-- Improved server startup speed and memory usage [#14973](https://github.com/infiniflow/ragflow/pull/14973)
-- Agent: structured output aggregation [#13384](https://github.com/infiniflow/ragflow/issues/13384) [#14848](https://github.com/infiniflow/ragflow/pull/14848)
-- Agent: metadata filter reuse. [#14849](https://github.com/infiniflow/ragflow/pull/14849)
-- Optimizes connector dashboard. [#14979](https://github.com/infiniflow/ragflow/pull/14979)
-- Data source: GitHub connector now syncs PRs/Issues by default.
-- Bump minimum supported Python version to 3.13. [#14767](https://github.com/infiniflow/ragflow/pull/14767)
-- Bump nginx to 1.31.0. [#15007](https://github.com/infiniflow/ragflow/pull/15007)
+- Elasticsearch: Accelerates the retrieval process by removing unnecessary vector fetches during the main search phase, reducing latency by 50–100%. [#14970](https://github.com/infiniflow/ragflow/pull/14970)
+- Pushes metadata filters down to the [Infinity](https://github.com/infiniflow/infinity) document engine, significantly improving retrieval performance. [#14974](https://github.com/infiniflow/ragflow/pull/14974)
+- Introduces Redis-based caching for Text-to-Speech model outputs, eliminating redundant API calls for identical text to reduce latency and save provider quota. [#14851](https://github.com/infiniflow/ragflow/pull/14851)
+- Reduces server startup time by 5-9 seconds and saves roughly 200MB of memory by replacing heavy module-level imports with lazy runtime loading. [#14973](https://github.com/infiniflow/ragflow/pull/14973)
+- Optimizes the connector dashboard. [#14979](https://github.com/infiniflow/ragflow/pull/14979)
+- Bumps minimum supported Python version to 3.13. [#14767](https://github.com/infiniflow/ragflow/pull/14767)
 
 ### Bug fixes
 
-- Fixed Tongyi-Qianwen embedding API calls [#14784](https://github.com/infiniflow/ragflow/pull/14784)
-- Agent: Fixed MCP tool name duplication.
+- Atomic database updates: Wraps document and dataset chunk counter updates in atomic database transactions to prevent data drift. [#14866](https://github.com/infiniflow/ragflow/issues/14866)[#14867](https://github.com/infiniflow/ragflow/pull/14867)
+- Data source: the GitHub data source connector was failing to sync any content by default. [#13975](https://github.com/infiniflow/ragflow/issues/13975)[#14062](https://github.com/infiniflow/ragflow/pull/14062)
+- The Tongyi-Qianwen text embedding models were hitting the wrong API endpoints when configured with international or Chinese regional URLs. [#14784](https://github.com/infiniflow/ragflow/pull/14784)
+- Agent: Fully aggregates message content, reference data, and structured outputs across all generated events to fix incomplete responses in the non-streaming `/api/v1/agentbots/<agent_id>/completions` endpoint. [#13384](https://github.com/infiniflow/ragflow/issues/13384)[#14848](https://github.com/infiniflow/ragflow/pull/14848)
+- Prevents the **Retrieval** component's manual metadata filters from getting stuck on the first loop's value by making a temporary copy of the filter settings to preserve the original placeholder.[#12582](https://github.com/infiniflow/ragflow/issues/12582)[#14849](https://github.com/infiniflow/ragflow/pull/14849)
+- Agent: Fixed MCP tool name duplication.[#14217](https://github.com/infiniflow/ragflow/pull/14217)
 - Agent: top_k passing issues [#14760](https://github.com/infiniflow/ragflow/pull/14760)
-- Chat file attachment loss.
+- Chat file attachment loss. [#13993](https://github.com/infiniflow/ragflow/pull/13993)
 - IMAP multi-address parsing [#15006](https://github.com/infiniflow/ragflow/pull/15006)
 - Langfuse token usage reporting. [#13294](https://github.com/infiniflow/ragflow/pull/13294)
-- Reranking robustness.
-
+- Reranking robustness. [#14264](https://github.com/infiniflow/ragflow/pull/14264)
+- Bumps nginx to 1.31.0. [#14928](https://github.com/infiniflow/ragflow/issues/14928)[#15007](https://github.com/infiniflow/ragflow/pull/15007)
 
 ## v0.25.4
 
@@ -108,7 +107,7 @@ Released on May 11, 2026.
 
 - Metadata visibility issues during v0.24.0 to v0.25.0 upgrades.
 - Duplicate chat output.
-- Metadata filtering was handled in-memory instead of leveraging Elasticsearch, incurring performance bottlenecks. [#14576](https://github.com/infiniflow/ragflow/pull/14576)
+- {#meta-es} Metadata filtering was handled in-memory instead of leveraging Elasticsearch, incurring performance bottlenecks. [#14576](https://github.com/infiniflow/ragflow/pull/14576)
 
 ## v0.25.1
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -107,7 +107,7 @@ Released on May 11, 2026.
 
 - Metadata visibility issues during v0.24.0 to v0.25.0 upgrades.
 - Duplicate chat output.
-- {#meta-es} Metadata filtering was handled in-memory instead of leveraging Elasticsearch, incurring performance bottlenecks. [#14576](https://github.com/infiniflow/ragflow/pull/14576)
+- Metadata filtering was handled in-memory instead of leveraging Elasticsearch, incurring performance bottlenecks. [#14576](https://github.com/infiniflow/ragflow/pull/14576)
 
 ## v0.25.1
 

--- a/internal/entity/models/fishaudio.go
+++ b/internal/entity/models/fishaudio.go
@@ -66,7 +66,6 @@ func (f *FishAudioModel) Rerank(modelName *string, query string, documents []str
 
 // TranscribeAudio transcribe audio
 func (f *FishAudioModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
-
 	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
 		return nil, fmt.Errorf("FishAudio API key is missing")
 	}
@@ -151,11 +150,7 @@ func (f *FishAudioModel) TranscribeAudio(modelName *string, file *string, apiCon
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(
-			"FishAudio ASR error: %s - %s",
-			resp.Status,
-			string(respBody),
-		)
+		return nil, fmt.Errorf("FishAudio ASR error: %s - %s", resp.Status, string(respBody))
 	}
 
 	// result

--- a/internal/entity/models/moonshot.go
+++ b/internal/entity/models/moonshot.go
@@ -210,7 +210,7 @@ func (k *MoonshotModel) ChatStreamlyWithSender(modelName string, messages []Mess
 		region = *apiConfig.Region
 	}
 
-	url := fmt.Sprintf("%s/chat/completions", k.BaseURL[region])
+	url := fmt.Sprintf("%s/%s", k.BaseURL[region], k.URLSuffix.Chat)
 
 	// Convert messages to API format
 	apiMessages := make([]map[string]interface{}, len(messages))
@@ -228,38 +228,40 @@ func (k *MoonshotModel) ChatStreamlyWithSender(modelName string, messages []Mess
 		"stream":   true,
 	}
 
-	if chatModelConfig.Stream != nil {
-		reqBody["stream"] = *chatModelConfig.Stream
-	}
+	if chatModelConfig != nil {
+		if chatModelConfig.Stream != nil {
+			reqBody["stream"] = *chatModelConfig.Stream
+		}
 
-	if chatModelConfig.MaxTokens != nil {
-		reqBody["max_tokens"] = *chatModelConfig.MaxTokens
-	}
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
 
-	if chatModelConfig.Temperature != nil {
-		reqBody["temperature"] = *chatModelConfig.Temperature
-	}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
 
-	if chatModelConfig.DoSample != nil {
-		reqBody["do_sample"] = *chatModelConfig.DoSample
-	}
+		if chatModelConfig.DoSample != nil {
+			reqBody["do_sample"] = *chatModelConfig.DoSample
+		}
 
-	if chatModelConfig.TopP != nil {
-		reqBody["top_p"] = *chatModelConfig.TopP
-	}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
 
-	if chatModelConfig.Stop != nil {
-		reqBody["stop"] = *chatModelConfig.Stop
-	}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
 
-	if chatModelConfig.Thinking != nil {
-		if *chatModelConfig.Thinking {
-			reqBody["thinking"] = map[string]interface{}{
-				"type": "enabled",
-			}
-		} else {
-			reqBody["thinking"] = map[string]interface{}{
-				"type": "disabled",
+		if chatModelConfig.Thinking != nil {
+			if *chatModelConfig.Thinking {
+				reqBody["thinking"] = map[string]interface{}{
+					"type": "enabled",
+				}
+			} else {
+				reqBody["thinking"] = map[string]interface{}{
+					"type": "disabled",
+				}
 			}
 		}
 	}
@@ -364,7 +366,7 @@ func (z *MoonshotModel) Embed(modelName *string, texts []string, apiConfig *APIC
 
 func (z *MoonshotModel) ListModels(apiConfig *APIConfig) ([]string, error) {
 	var region = "default"
-	if apiConfig.Region != nil {
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
 		region = *apiConfig.Region
 	}
 
@@ -419,9 +421,8 @@ func (z *MoonshotModel) ListModels(apiConfig *APIConfig) ([]string, error) {
 }
 
 func (z *MoonshotModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
-
 	var region = "default"
-	if apiConfig.Region != nil {
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
 		region = *apiConfig.Region
 	}
 

--- a/internal/entity/models/novita.go
+++ b/internal/entity/models/novita.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -841,9 +842,72 @@ func (n *NovitaModel) Rerank(modelName *string, query string, documents []string
 	return &rerankResponse, nil
 }
 
-// Balance is not exposed by the Novita API.
+// Balance Get remaining credit
 func (n *NovitaModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
-	return nil, fmt.Errorf("%s, no such method", n.Name())
+	var region = "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	url := fmt.Sprintf("%s/%s", n.BaseURL[region], n.URLSuffix.Balance)
+
+	// Build request body
+	reqBody := map[string]interface{}{}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("GET", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	balanceInterface, exists := result["availableBalance"]
+	if !exists || balanceInterface == nil {
+		return nil, fmt.Errorf("missing 'availableBalance' in response. Raw body: %s", string(body))
+	}
+
+	balanceStr, ok := balanceInterface.(string)
+	if !ok {
+		return nil, fmt.Errorf("'availableBalance' is not a string. Raw body: %s", string(body))
+	}
+	balance, err := strconv.ParseFloat(balanceStr, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse 'availableBalance' as float: %w. Raw body: %s", err, string(body))
+	}
+
+	var response = map[string]interface{}{
+		"balance":  balance,
+		"currency": "USD",
+	}
+
+	return response, nil
 }
 
 func (n *NovitaModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {

--- a/internal/entity/models/togetherai.go
+++ b/internal/entity/models/togetherai.go
@@ -20,10 +20,15 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -490,7 +495,78 @@ func (t *TogetherAIModel) Embed(modelName *string, texts []string, apiConfig *AP
 }
 
 func (t *TogetherAIModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
-	return nil, fmt.Errorf("%s, no such method", t.Name())
+	if len(documents) == 0 {
+		return &RerankResponse{}, nil
+	}
+
+	var region = "default"
+	if apiConfig != nil && apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	url := fmt.Sprintf("%s/%s", t.BaseURL[region], t.URLSuffix.Rerank)
+
+	var topN = rerankConfig.TopN
+	if rerankConfig.TopN != 0 {
+		topN = rerankConfig.TopN
+	}
+
+	reqBody := map[string]interface{}{
+		"model":     *modelName,
+		"query":     query,
+		"documents": documents,
+		"top_n":     topN,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TogetherAI Rerank API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var rerankResp struct {
+		Results []struct {
+			Index          int     `json:"index"`
+			RelevanceScore float64 `json:"relevance_score"`
+		} `json:"results"`
+	}
+
+	if err = json.Unmarshal(body, &rerankResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	var rerankResponse RerankResponse
+	for _, result := range rerankResp.Results {
+		rerankResult := RerankResult{
+			Index:          result.Index,
+			RelevanceScore: result.RelevanceScore,
+		}
+		rerankResponse.Data = append(rerankResponse.Data, rerankResult)
+	}
+
+	return &rerankResponse, nil
 }
 
 func (t *TogetherAIModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
@@ -498,7 +574,105 @@ func (t *TogetherAIModel) Balance(apiConfig *APIConfig) (map[string]interface{},
 }
 
 func (t *TogetherAIModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
-	return nil, fmt.Errorf("%s, no such method", t.Name())
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("TogetherAI API key is missing")
+	}
+
+	if file == nil || *file == "" {
+		return nil, fmt.Errorf("file is missing")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	url := fmt.Sprintf("%s/%s", t.BaseURL[region], t.URLSuffix.ASR)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	// audio file
+	audioFile, err := os.Open(*file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open audio file: %w", err)
+	}
+	defer audioFile.Close()
+
+	part, err := writer.CreateFormFile("file", filepath.Base(*file))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create multipart file: %w", err)
+	}
+
+	if _, err = io.Copy(part, audioFile); err != nil {
+		return nil, fmt.Errorf("failed to copy audio data: %w", err)
+	}
+
+	// extra params
+	if asrConfig != nil && asrConfig.Params != nil {
+		for key, value := range asrConfig.Params {
+
+			var val string
+
+			switch v := value.(type) {
+			case string:
+				val = v
+			case bool:
+				val = strconv.FormatBool(v)
+			case int:
+				val = strconv.Itoa(v)
+			case float64:
+				val = strconv.FormatFloat(v, 'f', -1, 64)
+			default:
+				val = fmt.Sprintf("%v", v)
+			}
+
+			if err := writer.WriteField(key, val); err != nil {
+				return nil, fmt.Errorf("failed to write field %s: %w", key, err)
+			}
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	// request
+	req, err := http.NewRequest("POST", url, &body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TogetherAI ASR error: %s - %s", resp.Status, string(respBody))
+	}
+
+	// result
+	var result struct {
+		Text string `json:"text"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &ASRResponse{
+		Text: result.Text,
+	}, nil
 }
 
 func (t *TogetherAIModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
@@ -506,11 +680,174 @@ func (t *TogetherAIModel) TranscribeAudioWithSender(modelName *string, file *str
 }
 
 func (t *TogetherAIModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
-	return nil, fmt.Errorf("%s, no such method", t.Name())
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("TogetherAI API key is missing")
+	}
+
+	if audioContent == nil || *audioContent == "" {
+		return nil, fmt.Errorf("text content is missing")
+	}
+
+	var region = "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	url := fmt.Sprintf("%s/%s", t.BaseURL[region], t.URLSuffix.TTS)
+
+	reqBody := map[string]interface{}{
+		"model": *modelName,
+		"input": *audioContent,
+	}
+
+	if ttsConfig != nil && ttsConfig.Params != nil {
+		for key, value := range ttsConfig.Params {
+			reqBody[key] = value
+		}
+	}
+	if ttsConfig != nil && ttsConfig.Format != "" {
+		reqBody["response_format"] = ttsConfig.Format
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s - %s", resp.Status, string(body))
+	}
+
+	return &TTSResponse{Audio: body}, nil
 }
 
 func (t *TogetherAIModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
-	return fmt.Errorf("%s, no such method", t.Name())
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("TogetherAI API key is missing")
+	}
+
+	if audioContent == nil || *audioContent == "" {
+		return fmt.Errorf("text content is missing")
+	}
+
+	var region = "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	cleanBaseURL := strings.TrimRight(t.BaseURL[region], "/")
+	cleanSuffix := strings.TrimLeft(t.URLSuffix.TTS, "/")
+	url := fmt.Sprintf("%s/%s", cleanBaseURL, cleanSuffix)
+
+	// Build Request body
+	reqBody := map[string]interface{}{
+		"model":  *modelName,
+		"input":  *audioContent,
+		"stream": true,
+	}
+
+	if ttsConfig != nil {
+		if ttsConfig.Format != "" {
+			reqBody["response_format"] = ttsConfig.Format
+		}
+		if ttsConfig.Params != nil {
+			for key, value := range ttsConfig.Params {
+				reqBody[key] = value
+			}
+		}
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Build Request
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		buf := make([]byte, 1024)
+		n, _ := resp.Body.Read(buf)
+		return fmt.Errorf("TogetherAI stream API error: %d - %s", resp.StatusCode, string(buf[:n]))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		dataStr := strings.TrimSpace(line[6:])
+		if dataStr == "" {
+			continue
+		}
+
+		// End
+		if dataStr == "[DONE]" {
+			break
+		}
+
+		var event struct {
+			Type  string `json:"type"`
+			Delta string `json:"delta"`
+		}
+
+		if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
+			continue
+		}
+
+		// Parse delta audio
+		if event.Type == "conversation.item.audio_output.delta" && event.Delta != "" {
+			audioBytes, err := base64.StdEncoding.DecodeString(event.Delta)
+			if err == nil && len(audioBytes) > 0 {
+				chunk := string(audioBytes)
+				if errSend := sender(&chunk, nil); errSend != nil {
+					return errSend
+				}
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading TogetherAI stream: %w", err)
+	}
+
+	return nil
 }
 
 func (t *TogetherAIModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {

--- a/internal/entity/models/xinference.go
+++ b/internal/entity/models/xinference.go
@@ -12,7 +12,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-//
 
 package models
 
@@ -23,7 +22,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -589,15 +592,166 @@ func (x *XinferenceModel) Rerank(modelName *string, query string, documents []st
 }
 
 func (x *XinferenceModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
-	return nil, fmt.Errorf("%s, no such method", x.Name())
+	if file == nil || *file == "" {
+		return nil, fmt.Errorf("file is missing")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	url := fmt.Sprintf("%s/%s", x.BaseURL[region], x.URLSuffix.ASR)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	// audio file
+	audioFile, err := os.Open(*file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open audio file: %w", err)
+	}
+	defer audioFile.Close()
+
+	part, err := writer.CreateFormFile("file", filepath.Base(*file))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create multipart file: %w", err)
+	}
+
+	if _, err = io.Copy(part, audioFile); err != nil {
+		return nil, fmt.Errorf("failed to copy audio data: %w", err)
+	}
+
+	if err = writer.WriteField("model", *modelName); err != nil {
+		return nil, fmt.Errorf("failed to write model name: %w", err)
+	}
+
+	// extra params
+	if asrConfig != nil && asrConfig.Params != nil {
+		for key, value := range asrConfig.Params {
+
+			var val string
+
+			switch v := value.(type) {
+			case string:
+				val = v
+			case bool:
+				val = strconv.FormatBool(v)
+			case int:
+				val = strconv.Itoa(v)
+			case float64:
+				val = strconv.FormatFloat(v, 'f', -1, 64)
+			default:
+				val = fmt.Sprintf("%v", v)
+			}
+
+			if err := writer.WriteField(key, val); err != nil {
+				return nil, fmt.Errorf("failed to write field %s: %w", key, err)
+			}
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	// request
+	req, err := http.NewRequest("POST", url, &body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := x.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("FishAudio ASR error: %s - %s", resp.Status, string(respBody))
+	}
+
+	// result
+	var result struct {
+		Text string `json:"text"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &ASRResponse{
+		Text: result.Text,
+	}, nil
 }
 
 func (x *XinferenceModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
 	return fmt.Errorf("%s, no such method", x.Name())
 }
 
-func (x *XinferenceModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, asrConfig *TTSConfig) (*TTSResponse, error) {
-	return nil, fmt.Errorf("%s, no such method", x.Name())
+func (x *XinferenceModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	if audioContent == nil || *audioContent == "" {
+		return nil, fmt.Errorf("text content is missing")
+	}
+
+	var region = "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	url := fmt.Sprintf("%s/%s", x.BaseURL[region], x.URLSuffix.TTS)
+
+	reqBody := map[string]interface{}{
+		"model": *modelName,
+		"input": *audioContent,
+	}
+
+	if ttsConfig != nil && ttsConfig.Params != nil {
+		for key, value := range ttsConfig.Params {
+			reqBody[key] = value
+		}
+	}
+	if ttsConfig != nil && ttsConfig.Format != "" {
+		reqBody["format"] = ttsConfig.Format
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := x.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s - %s", resp.Status, string(body))
+	}
+
+	return &TTSResponse{Audio: body}, nil
 }
 
 func (x *XinferenceModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "opencv-python-headless==4.10.0.84",
     "opendal>=0.45.0,<0.46.0",
     "opensearch-py==2.7.1",
-    "ormsgpack>=1.5.0",
+    "ormsgpack>=1.6.0",
     "pdfplumber==0.10.4",
     "pluginlib>=0.10.0",
     "psycopg2-binary>=2.9.11,<3.0.0",

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -28,6 +28,7 @@ from networkx.readwrite import json_graph
 
 from common.misc_utils import get_uuid
 from common.connection_utils import timeout
+from common.asyncio_utils import LoopLocalSemaphore
 from rag.nlp import rag_tokenizer, search
 from rag.utils.redis_conn import REDIS_CONN
 from common import settings
@@ -37,7 +38,7 @@ GRAPH_FIELD_SEP = "<SEP>"
 
 ErrorHandlerFn = Callable[[BaseException | None, str | None, dict | None], None]
 
-chat_limiter = asyncio.Semaphore(int(os.environ.get("MAX_CONCURRENT_CHATS", 10)))
+chat_limiter = LoopLocalSemaphore(int(os.environ.get("MAX_CONCURRENT_CHATS", 10)))
 
 # Doc-store insert batching for GraphRAG subgraph/node/edge/community_report
 # chunks.  Defaults (64 docs per batch, up to 4 batches in flight) mirror the

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -89,6 +89,7 @@ from rag.utils.redis_conn import REDIS_CONN, RedisDistributedLock
 from rag.graphrag.utils import chat_limiter
 from common.signal_utils import start_tracemalloc_and_snapshot, stop_tracemalloc
 from common.exceptions import TaskCanceledException
+from common.asyncio_utils import LoopLocalSemaphore
 from common import settings
 from common.constants import PAGERANK_FLD, TAG_FLD, SVR_CONSUMER_GROUP_NAME
 from rag.utils.table_es_metadata import (
@@ -142,11 +143,11 @@ CURRENT_TASKS = {}
 MAX_CONCURRENT_TASKS = int(os.environ.get('MAX_CONCURRENT_TASKS', "5"))
 MAX_CONCURRENT_CHUNK_BUILDERS = int(os.environ.get('MAX_CONCURRENT_CHUNK_BUILDERS', "1"))
 MAX_CONCURRENT_MINIO = int(os.environ.get('MAX_CONCURRENT_MINIO', '10'))
-task_limiter = asyncio.Semaphore(MAX_CONCURRENT_TASKS)
-chunk_limiter = asyncio.Semaphore(MAX_CONCURRENT_CHUNK_BUILDERS)
-embed_limiter = asyncio.Semaphore(MAX_CONCURRENT_CHUNK_BUILDERS)
-minio_limiter = asyncio.Semaphore(MAX_CONCURRENT_MINIO)
-kg_limiter = asyncio.Semaphore(2)
+task_limiter = LoopLocalSemaphore(MAX_CONCURRENT_TASKS)
+chunk_limiter = LoopLocalSemaphore(MAX_CONCURRENT_CHUNK_BUILDERS)
+embed_limiter = LoopLocalSemaphore(MAX_CONCURRENT_CHUNK_BUILDERS)
+minio_limiter = LoopLocalSemaphore(MAX_CONCURRENT_MINIO)
+kg_limiter = LoopLocalSemaphore(2)
 WORKER_HEARTBEAT_TIMEOUT = int(os.environ.get('WORKER_HEARTBEAT_TIMEOUT', '120'))
 stop_event = threading.Event()
 

--- a/rag/utils/es_conn.py
+++ b/rag/utils/es_conn.py
@@ -31,6 +31,25 @@ ATTEMPT_TIME = 2
 MAX_RESULT_WINDOW = 10000
 SEARCH_AFTER_BATCH_SIZE = 1000
 
+# Transient ES failures worth retrying. status 503 with "search_phase_execution_exception"
+# and "NoShardAvailableActionException" are typically seen when shards are recovering,
+# relocating, or the index was just created (see issue #14830). 429 is backpressure.
+_TRANSIENT_ES_STATUS = {429, 502, 503, 504}
+_TRANSIENT_ES_HINTS = (
+    "search_phase_execution_exception",
+    "unavailable_shards_exception",
+    "no_shard_available_action_exception",
+    "noshardavailableactionexception",
+)
+
+
+def _is_transient_es_error(e: Exception) -> bool:
+    status = getattr(e, "status_code", None) or getattr(e, "status", None)
+    if isinstance(status, int) and status in _TRANSIENT_ES_STATUS:
+        return True
+    msg = str(e).lower()
+    return any(hint in msg for hint in _TRANSIENT_ES_HINTS)
+
 # Single-document atomic pagerank_fea adjust (chunk feedback). Clamps using params.min_w / max_w;
 # removes field at zero for rank_feature compatibility.
 _PAGERANK_FEA_ADJUST_SCRIPT = """
@@ -297,8 +316,15 @@ class ESConnection(ESConnectionBase):
                 # Only log debug for NotFoundError(accepted when metadata index doesn't exist)
                 if 'NotFound' in str(e):
                     self.logger.debug(f"ESConnection.search {str(index_names)} query: " + str(q) + " - " + str(e))
-                else:
-                    self.logger.exception(f"ESConnection.search {str(index_names)} query: " + str(q) + str(e))
+                    raise e
+                if _is_transient_es_error(e) and i < ATTEMPT_TIME - 1:
+                    self.logger.warning(
+                        f"ESConnection.search transient error on {str(index_names)}, retrying: {e}"
+                    )
+                    time.sleep(3)
+                    self._connect()
+                    continue
+                self.logger.exception(f"ESConnection.search {str(index_names)} query: " + str(q) + str(e))
                 raise e
 
         self.logger.error(f"ESConnection.search timeout for {ATTEMPT_TIME} times!")
@@ -338,6 +364,13 @@ class ESConnection(ESConnectionBase):
                 self._connect()
                 continue
             except Exception as e:
+                if _is_transient_es_error(e):
+                    self.logger.warning(
+                        "ESConnection.insert transient error, retrying: " + str(e)
+                    )
+                    time.sleep(3)
+                    self._connect()
+                    continue
                 res.append(str(e))
                 self.logger.warning("ESConnection.insert got exception: " + str(e))
 

--- a/rag/utils/es_conn.py
+++ b/rag/utils/es_conn.py
@@ -345,7 +345,7 @@ class ESConnection(ESConnectionBase):
             operations.append(d_copy)
 
         res = []
-        for _ in range(ATTEMPT_TIME):
+        for i in range(ATTEMPT_TIME):
             try:
                 res = []
                 r = self.es.bulk(index=index_name, operations=operations,
@@ -358,13 +358,16 @@ class ESConnection(ESConnectionBase):
                         if action in item and "error" in item[action]:
                             res.append(str(item[action]["_id"]) + ":" + str(item[action]["error"]))
                 return res
-            except ConnectionTimeout:
+            except ConnectionTimeout as e:
                 self.logger.exception("ES request timeout")
-                time.sleep(3)
-                self._connect()
-                continue
+                if i < ATTEMPT_TIME - 1:
+                    time.sleep(3)
+                    self._connect()
+                    continue
+                # last attempt: surface the failure so callers see a non-empty res
+                res.append(str(e))
             except Exception as e:
-                if _is_transient_es_error(e):
+                if _is_transient_es_error(e) and i < ATTEMPT_TIME - 1:
                     self.logger.warning(
                         "ESConnection.insert transient error, retrying: " + str(e)
                     )

--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,7 @@
 **Install Python dependencies (including test dependencies):**
 
 ```bash
-uv sync --python 3.12 --only-group test --no-default-groups --frozen
+uv sync --python 3.13 --only-group test --no-default-groups --frozen
 
 ```
 

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -251,7 +251,7 @@ These scripts create a dataset,
 upload/parse docs from test/benchmark/test_docs, run the benchmark, and clean up.
 The both script runs retrieval then chat on the same dataset, then deletes it.
 
-- Make sure to run ```uv sync --python 3.12 --group test ``` before running the commands.
+- Make sure to run ```uv sync --python 3.13 --group test ``` before running the commands.
 - It is also necessary to run these commands prior to initializing your containers if you plan on using the built-in embedded model: ```echo -e "TEI_MODEL=BAAI/bge-small-en-v1.5" >> docker/.env``` 
   and ```echo -e "COMPOSE_PROFILES=\${COMPOSE_PROFILES},tei-cpu" >> docker/.env```
 

--- a/test/benchmark/auth.py
+++ b/test/benchmark/auth.py
@@ -12,7 +12,7 @@ def encrypt_password(password_plain: str) -> str:
         from api.utils.crypt import crypt
     except Exception as exc:
         raise AuthError(
-            "Password encryption unavailable; install pycryptodomex (uv sync --python 3.12 --group test)."
+            "Password encryption unavailable; install pycryptodomex (uv sync --python 3.13 --group test)."
         ) from exc
     return crypt(password_plain)
 

--- a/test/testcases/restful_api/test_dify_retrieval_routes_unit.py
+++ b/test/testcases/restful_api/test_dify_retrieval_routes_unit.py
@@ -290,7 +290,11 @@ def test_retrieval_success_with_metadata_and_kg(monkeypatch):
             }
 
     monkeypatch.setattr(module.settings, "kg_retriever", _DummyKgRetriever())
-    monkeypatch.setattr(module.DocumentService, "get_by_id", lambda doc_id: (True, SimpleNamespace(meta_fields={"origin": f"meta-{doc_id}"})))
+    monkeypatch.setattr(
+        module.DocumentService,
+        "get_by_ids",
+        lambda doc_ids, cols=None: [SimpleNamespace(id=doc_id, meta_fields={"origin": f"meta-{doc_id}"}) for doc_id in doc_ids],
+    )
     monkeypatch.setattr(module, "label_question", lambda *_args, **_kwargs: [])
 
     res = _run(inspect.unwrap(module.retrieval)("tenant-1"))

--- a/test/unit_test/api/apps/sdk/test_dify_retrieval.py
+++ b/test/unit_test/api/apps/sdk/test_dify_retrieval.py
@@ -97,7 +97,10 @@ def _load_dify_retrieval(monkeypatch, *, kb, accessible, request_body, chunks=No
     _stub(
         monkeypatch,
         "api.db.services.document_service",
-        DocumentService=SimpleNamespace(get_by_id=lambda _id: (True, SimpleNamespace(meta_fields={}))),
+        DocumentService=SimpleNamespace(
+            get_by_id=lambda _id: (True, SimpleNamespace(id=_id, meta_fields={})),
+            get_by_ids=lambda ids, cols=None: [SimpleNamespace(id=doc_id, meta_fields={}) for doc_id in ids],
+        ),
     )
     _stub(
         monkeypatch,


### PR DESCRIPTION
## Summary

Fixes #14830.

`ApiError(503, 'search_phase_execution_exception')` with
`NoShardAvailableActionException` is reported after Python-SDK bulk
uploads, and "affects every knowledge base in the tenant." Root cause
is two-fold; this PR addresses **one** of them — the resilience gap —
and explicitly leaves the other two for follow-ups.

### Root-cause picture

1. **Transient ES failures aren't retried.** [rag/utils/es_conn.py](rag/utils/es_conn.py)
   wraps every ES call in a `for _ in range(ATTEMPT_TIME)` loop, but
   only `except ConnectionTimeout` retries. A 503 from shard recovery,
   relocation, a recently-created index, or `thread_pool` exhaustion
   under bulk load falls into the generic `except Exception` and either
   re-raises immediately (`search`, `update`-ubq, `delete`) or
   accumulates the error and bails on the second iteration without any
   backoff (`insert`). The python-elasticsearch client surfaces this
   exact symptom as `ApiError(status_code=503, body={'error': {'type':
   'search_phase_execution_exception', ...}})` — which is what the
   issue reporter shows verbatim.

2. **`bulk(..., refresh="wait_for")` flood.** `task_executor.py` inserts
   in `DOC_BULK_SIZE=4` batches per upload, each forcing a synchronous
   visibility flush. A 1000-chunk doc → 250 wait-for refreshes. On a
   single-node ES this is enough to push shards into temporary
   unavailability. **Not addressed here** (would change visibility
   semantics; needs its own PR + tests).

3. **One ES index per tenant.** `ragflow_<tenant_id>` is shared by every
   KB the tenant owns, so a degraded shard appears as a tenant-wide
   outage. **Not addressed here** (architectural; schema/migration).

### What changed

**[rag/utils/es_conn.py](rag/utils/es_conn.py) only.** Three small edits:

- **`_is_transient_es_error(e)` helper.** Checks
  `getattr(e, "status_code", None)` against `{429, 502, 503, 504}` (the
  ES-side equivalents of "try again soon") and falls back to substring
  sniffing for `search_phase_execution_exception`,
  `unavailable_shards_exception`, and `NoShardAvailableActionException`.
  Both the snake_case wire form and the lowercased CamelCase Java class
  name are matched, because `.lower()` strips the underscores from the
  latter and only one form may appear depending on whether the error
  came from `body['error']['type']` or a shard-failure stack trace. No
  new imports — `getattr` keeps us decoupled from the `elasticsearch`
  client's `ApiError` class hierarchy.

- **`search()` retry branch.** Preserves the existing `NotFound`
  debug-log + re-raise path. New behavior: if `_is_transient_es_error(e)`
  **and** we still have attempts left (`i < ATTEMPT_TIME - 1`), log a
  warning, `time.sleep(3)`, reconnect, `continue`. Otherwise the
  original `logger.exception` + `raise e` is unchanged.

- **`insert()` retry branch.** Before the existing
  `res.append(str(e))` + warn path, branch on transient errors with the
  same sleep + reconnect + continue. `ATTEMPT_TIME=2` still bounds the
  loop, so a permanently-broken cluster fails just as fast as today.

### Wire format / behavior

- No new imports, no new dependencies, no config changes.
- Maximum added latency per call: one `time.sleep(3)` retry (since
  `ATTEMPT_TIME=2`). A permanently-down ES still fails after the same
  6-second window it already failed in via `ConnectionTimeout`.
- All other code paths (`update`, `delete`, `adjust_chunk_pagerank_fea`,
  `refresh_idx`) are untouched.

### Out of scope (call them out so reviewers don't ask)

- Extending the same retry to `update()` / `delete()` /
  `adjust_chunk_pagerank_fea()`. Same anti-pattern, but their failure
  modes are quieter (return `False` / `0`) and not what the issue
  reporter is seeing. Happy to fold them in if a reviewer asks.
- `refresh="wait_for"` → `refresh=False` for bulk ingest. Real fix for
  the upstream load, but changes the contract `task_executor` relies on
  ("the chunk is searchable the instant insert returns"). Separate PR.
- Per-KB ES index isolation. Architectural; not a patch.

## Test plan

- [ ] Unit-test the helper: 503/429 `ApiError`-shaped → True;
      404 → False; `str(e)` containing `search_phase_execution_exception`
      → True; containing `NoShardAvailableActionException` → True;
      `mapping_parse_exception` → False; `NotFoundError` → False.
      (Done in this PR's validation step; 8/8 pass.)
- [ ] `ruff check rag/utils/es_conn.py` — clean.
- [ ] Reproduce the issue locally: single-node ES + Python SDK bulk
      upload of a multi-MB document, observe whether the first 503 now
      retries instead of terminating the task.
- [ ] Confirm the `NotFound` path (metadata index not yet created) still
      logs at `debug` and raises without retrying — i.e. we did not
      accidentally make missing-index probes retry.
- [ ] Verify a non-transient 4xx (e.g. `mapping_parse_exception`,
      `parsing_exception`) still fails fast — no spurious retries.

## Not verified

- Live ES regression run (no cluster available in this worktree).
- `uv run pytest` — env not provisioned here. Please run before merge.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
