### PR TITLE
fix: return Dify retrieval metadata

### DIFF
--- a/api/apps/sdk/dify_retrieval.py
+++ b/api/apps/sdk/dify_retrieval.py
@@ -297,6 +297,7 @@ async def retrieval(tenant_id):
         doc_ids = list(set([c["doc_id"] for c in ranks["chunks"]]))
         docs = DocumentService.get_by_ids(doc_ids)
         doc_map = {doc.id: doc for doc in docs}
+        metadata_map = DocMetadataService.get_metadata_for_documents(doc_ids, kb_id) if doc_ids else {}
 
         records = []
         for c in ranks["chunks"]:
@@ -304,7 +305,7 @@ async def retrieval(tenant_id):
             if not doc:
                 continue
             c.pop("vector", None)
-            meta = getattr(doc, 'meta_fields', {})
+            meta = dict(metadata_map.get(c["doc_id"], {}))
             meta["doc_id"] = c["doc_id"]
             # Dify expects metadata.document_id for external retrieval sources.
             meta["document_id"] = c["doc_id"]

--- a/test/testcases/restful_api/test_dify_retrieval_routes_unit.py
+++ b/test/testcases/restful_api/test_dify_retrieval_routes_unit.py
@@ -272,6 +272,11 @@ def test_retrieval_success_with_metadata_and_kg(monkeypatch):
 
     monkeypatch.setattr(module, "jsonify", lambda payload: payload)
     monkeypatch.setattr(module.DocMetadataService, "get_flatted_meta_by_kbs", lambda _kbs: [{"doc_id": "doc-1"}])
+    monkeypatch.setattr(
+        module.DocMetadataService,
+        "get_metadata_for_documents",
+        lambda doc_ids, kb_id: {doc_id: {"origin": f"metadata-{doc_id}", "kb_id": kb_id} for doc_id in doc_ids},
+    )
     monkeypatch.setattr(module.KnowledgebaseService, "get_by_id", lambda _kb_id: (True, _DummyKB()))
     monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda _kb_id, _tenant_id: True)
     monkeypatch.setattr(module, "convert_conditions", lambda cond: cond.get("conditions", []))
@@ -303,6 +308,9 @@ def test_retrieval_success_with_metadata_and_kg(monkeypatch):
     top = res["records"][0]
     assert top["title"] == "kg-title", res
     assert top["metadata"]["doc_id"] == "doc-2", res
+    assert top["metadata"]["document_id"] == "doc-2", res
+    assert top["metadata"]["origin"] == "metadata-doc-2", res
+    assert top["metadata"]["kb_id"] == "kb-1", res
     assert "score" in top, res
 
 

--- a/test/unit_test/api/apps/sdk/test_dify_retrieval.py
+++ b/test/unit_test/api/apps/sdk/test_dify_retrieval.py
@@ -83,7 +83,7 @@ class _FakeKGRetriever:
         return {"content_with_weight": ""}
 
 
-def _load_dify_retrieval(monkeypatch, *, kb, accessible, request_body, chunks=None):
+def _load_dify_retrieval(monkeypatch, *, kb, accessible, request_body, chunks=None, metadata_by_doc=None):
     """Load dify_retrieval.py with minimum stubs to exercise the retrieval handler."""
     _stub(
         monkeypatch,
@@ -105,7 +105,12 @@ def _load_dify_retrieval(monkeypatch, *, kb, accessible, request_body, chunks=No
     _stub(
         monkeypatch,
         "api.db.services.doc_metadata_service",
-        DocMetadataService=SimpleNamespace(get_flatted_meta_by_kbs=lambda _ids: {}),
+        DocMetadataService=SimpleNamespace(
+            get_flatted_meta_by_kbs=lambda _ids: {},
+            get_metadata_for_documents=lambda doc_ids, _kb_id: {
+                doc_id: dict(metadata_by_doc.get(doc_id, {})) for doc_id in doc_ids
+            } if metadata_by_doc else {},
+        ),
     )
 
     acc_fn = accessible if callable(accessible) else (lambda *_a, **_k: accessible)
@@ -229,6 +234,34 @@ class TestDifyRetrievalTenantCheck:
         assert len(result["records"]) == 1
         assert result["records"][0]["content"] == "hello world"
         assert module._fake_retriever.retrieval_calls, "retriever was not called on legitimate request"
+
+    @pytest.mark.p1
+    def test_retrieval_returns_metadata_from_doc_metadata_service(self, monkeypatch):
+        """Dify metadata comes from the document metadata index, not Document.meta_fields."""
+        owner_kb = SimpleNamespace(id="kb-owner", tenant_id="tenant-owner", tenant_embd_id="", embd_id="bge")
+        request_body = {
+            "knowledge_id": "kb-owner",
+            "query": "hello",
+            "retrieval_setting": {"top_k": 5, "score_threshold": 0.0},
+        }
+
+        module = _load_dify_retrieval(
+            monkeypatch,
+            kb=(True, owner_kb),
+            accessible=lambda _id, _u: True,
+            request_body=request_body,
+            chunks=[{"doc_id": "d1", "content_with_weight": "hello world", "similarity": 0.8, "docnm_kwd": "doc.txt"}],
+            metadata_by_doc={"d1": {"author": "alice", "source": "metadata-index"}},
+        )
+
+        result = asyncio.run(module.retrieval(tenant_id="tenant-owner"))
+
+        assert len(result["records"]) == 1
+        metadata = result["records"][0]["metadata"]
+        assert metadata["author"] == "alice"
+        assert metadata["source"] == "metadata-index"
+        assert metadata["doc_id"] == "d1"
+        assert metadata["document_id"] == "d1"
 
     @pytest.mark.p1
     def test_missing_knowledge_base_returns_not_found(self, monkeypatch):


### PR DESCRIPTION
## Summary
- load Dify retrieval response metadata from DocMetadataService.get_metadata_for_documents() instead of the deprecated document row field
- keep Dify-compatible doc_id and document_id fields in each record
- add regression coverage for metadata returned by /api/v1/dify/retrieval

Fixes #15105

## Testing
- ZHIPU_AI_API_KEY=dummy .venv-pr-test/bin/python -m pytest --confcutdir=test/unit_test test/unit_test/api/apps/sdk/test_dify_retrieval.py
- python3 -m ruff check api/apps/sdk/dify_retrieval.py test/unit_test/api/apps/sdk/test_dify_retrieval.py test/testcases/restful_api/test_dify_retrieval_routes_unit.py
- /opt/homebrew/bin/python3.13 -m py_compile api/apps/sdk/dify_retrieval.py test/unit_test/api/apps/sdk/test_dify_retrieval.py test/testcases/restful_api/test_dify_retrieval_routes_unit.py
- git diff --check
