### PR TITLE
Revert "fix(api): infer /documents/{id}/download Content-Type from filename when ext is omitted (#15052)"

### DIFF
--- a/api/apps/restful_apis/document_api.py
+++ b/api/apps/restful_apis/document_api.py
@@ -1881,27 +1881,10 @@ async def download_attachment(tenant_id=None, doc_id=None, attachment_id=None):
         # Keep backward compatibility with older callers and unit tests that still
         # pass `attachment_id` instead of the route parameter name.
         doc_id = doc_id or attachment_id
-        if not DocumentService.accessible(doc_id, current_user.id):
-            return get_data_error_result(message="Document not found!")
-
-        e, doc = DocumentService.get_by_id(doc_id)
-        if not e:
-            return get_data_error_result(message="Document not found!")
-
-        ext_arg = request.args.get("ext")
-        if ext_arg:
-            ext = ext_arg.lower().lstrip(".")
-            content_type = CONTENT_TYPE_MAP.get(ext, f"application/{ext}")
-        else:
-            m = re.search(r"\.([^.]+)$", doc.name.lower())
-            ext = m.group(1) if m else None
-            content_type = None
-            if ext:
-                fallback_prefix = "image" if doc.type == FileType.VISUAL.value else "application"
-                content_type = CONTENT_TYPE_MAP.get(ext, f"{fallback_prefix}/{ext}")
-
+        ext = request.args.get("ext", "markdown")
         data = await thread_pool_exec(settings.STORAGE_IMPL.get, tenant_id, doc_id)
         response = await make_response(data)
+        content_type = CONTENT_TYPE_MAP.get(ext, f"application/{ext}")
         apply_safe_file_response_headers(response, content_type, ext)
 
         return response

--- a/test/testcases/test_web_api/test_document_app/test_document_metadata.py
+++ b/test/testcases/test_web_api/test_document_app/test_document_metadata.py
@@ -420,11 +420,6 @@ class TestDocumentMetadataUnit:
 
         # From here on the user is authorized; exercise the original branches.
         monkeypatch.setattr(module.DocumentService, "accessible", lambda _doc_id, _user_id: True)
-        monkeypatch.setattr(
-            module.DocumentService,
-            "get_by_id",
-            lambda _doc_id: (True, SimpleNamespace(name="stub.bin", type=module.FileType.OTHER.value)),
-        )
 
         async def fake_thread_pool_exec(*_args, **_kwargs):
             return b"attachment"
@@ -445,18 +440,6 @@ class TestDocumentMetadataUnit:
         assert res.data == b"attachment"
         assert res.headers["content_type"] == "application/abc"
         assert res.headers["extension"] == "abc"
-
-        # No `ext` query param: infer MIME/extension from the stored document filename (aligned with /preview).
-        monkeypatch.setattr(module, "request", _DummyRequest(args={}))
-        monkeypatch.setattr(
-            module.DocumentService,
-            "get_by_id",
-            lambda _doc_id: (True, SimpleNamespace(name="Annual report.PDF", type=module.FileType.PDF.value)),
-        )
-        res = _run(module.download_attachment(attachment_id="att1"))
-        assert isinstance(res, _DummyResponse)
-        assert res.headers["content_type"] == "application/pdf"
-        assert res.headers["extension"] == "pdf"
 
         async def raise_error(*_args, **_kwargs):
             raise RuntimeError("download boom")


### PR DESCRIPTION
Reverts infiniflow/ragflow#15053