### PR TITLE
feat(i18n): complete French translation — add ~1400 missing keys

### DIFF
--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -1,31 +1,51 @@
 export default {
   translation: {
     common: {
+      confirm: 'Confirmer',
+      back: 'Retour',
+      noResults: 'Aucun résultat trouvé',
+      selectPlaceholder: 'Sélectionner une valeur',
+      selectAll: 'Tout sélectionner',
       delete: 'Supprimer',
       deleteModalTitle: 'Êtes-vous sûr de vouloir supprimer cet élément ?',
+      deleteThem: 'Êtes-vous sûr de vouloir les supprimer ?',
       ok: 'Oui',
       cancel: 'Non',
+      yes: 'Oui',
+      no: 'Non',
       total: 'Total',
       rename: 'Renommer',
       name: 'Nom',
       save: 'Enregistrer',
       namePlaceholder: 'Veuillez saisir le nom',
+      descriptionPlaceholder: 'Saisir une description',
       next: 'Suivant',
       create: 'Créer',
       edit: 'Modifier',
       upload: 'Télécharger',
       english: 'Anglais',
-      french: 'Français',
       portugueseBr: 'Portugais (Brésil)',
       chinese: 'Chinois simplifié',
       traditionalChinese: 'Chinois traditionnel',
+      russian: 'Russe',
+      indonesian: 'Indonésien',
+      indonesia: 'Indonésien',
+      spanish: 'Espagnol',
+      vietnamese: 'Vietnamien',
+      japanese: 'Japonais',
+      german: 'Allemand',
+      french: 'Français',
+      italian: 'Italien',
       bulgarian: 'Bulgare',
       arabic: 'Arabe',
+      turkish: 'Turc',
       language: 'Langue',
-      languageMessage: 'Veuillez saisir votre langue !',
+      languageMessage: 'Veuillez choisir votre langue',
       languagePlaceholder: 'Sélectionnez votre langue',
       copy: 'Copier',
       copied: 'Copié',
+      viewMore: 'Voir plus',
+      viewLess: 'Voir moins',
       comingSoon: 'Bientôt disponible',
       download: 'Télécharger',
       close: 'Fermer',
@@ -37,17 +57,35 @@ export default {
       pleaseSelect: 'Veuillez sélectionner',
       pleaseInput: 'Veuillez saisir',
       submit: 'Soumettre',
+      clear: 'Effacer',
       embedIntoSite: 'Intégrer dans la page web',
       openInNewTab: 'Chat dans un nouvel onglet',
       previousPage: 'Précédent',
       nextPage: 'Suivant',
+      previous: 'Précédent',
       add: 'Ajouter',
+      remove: 'Retirer',
+      search: 'Rechercher',
+      noDataFound: 'Aucune donnée trouvée.',
+      noData: 'Aucune donnée disponible',
       promptPlaceholder:
         'Veuillez saisir ou utilisez / pour insérer rapidement des variables.',
+      mcp: {
+        namePlaceholder: 'Mon serveur MCP',
+        nameRequired:
+          'Doit comporter entre 1 et 64 caractères et ne contenir que des lettres, chiffres, tirets et underscores.',
+        urlPlaceholder: 'https://api.example.com/v1/mcp',
+        tokenPlaceholder: 'ex. eyJhbGciOiJIUzI1Ni...',
+      },
+      selected: 'Sélectionné',
+      seeAll: 'Voir tout',
+      bulkOperate: 'Opération en masse',
     },
     login: {
+      loginTitle: 'Connexion à votre compte',
+      signUpTitle: 'Créer un compte',
       login: 'Se connecter',
-      signUp: 'S’inscrire',
+      signUp: "S'inscrire",
       loginDescription: 'Nous sommes ravis de vous revoir !',
       registerDescription: 'Ravi de vous accueillir !',
       emailLabel: 'Email',
@@ -65,6 +103,8 @@ export default {
       description:
         'Inscrivez-vous gratuitement pour explorer la technologie RAG. Créez des bases de connaissances et des IA pour booster votre activité.',
       review: 'sur plus de 500 avis',
+      start: 'Commençons',
+      seeAll: 'Voir tout',
     },
     header: {
       knowledgeBase: 'Base de connaissances',
@@ -75,20 +115,251 @@ export default {
       setting: 'Paramètres utilisateur',
       logout: 'Déconnexion',
       fileManager: 'Gestion des fichiers',
+      skills: 'Compétences',
       flow: 'Agent',
       search: 'Recherche',
       welcome: 'Bienvenue sur',
+      dataset: 'Base de connaissances',
+      memories: 'Mémoire',
+    },
+    skills: {
+      title: 'Compétences',
+      selectSpace: 'Sélectionnez un espace de compétences pour commencer',
+      spacePlaceholder: "Entrez un nom d'espace",
+      createSpace: 'Créer un espace de compétences',
+      createSpaceTitle: 'Créer un nouvel espace de compétences',
+      createSpaceDescription:
+        'Créez un nouvel espace pour organiser et gérer vos compétences.',
+      spaceName: "Nom de l'espace",
+      spaceNamePlaceholder: 'ex. : mon-espace',
+      spaceNameRequired: "Veuillez entrer un nom d'espace",
+      noSpaces: 'Aucun espace de compétences. Créez le premier !',
+      enterSpace: 'Entrer',
+      spaceCreated: 'Espace de compétences créé avec succès',
+      spaceDeleted: 'Espace de compétences supprimé avec succès',
+      fetchError: 'Impossible de récupérer les compétences',
+      deleteSpaceTitle: "Supprimer l'espace de compétences",
+      deleteSpaceDescription:
+        'Êtes-vous sûr de vouloir supprimer cet espace de compétences ? Cette action est irréversible et toutes les compétences de cet espace seront définitivement supprimées.',
+      deleteSpaceName: "Nom de l'espace",
+      uploadSuccess: 'Compétence téléversée avec succès',
+      uploadError: 'Échec du téléversement de la compétence',
+      deleteSuccess: 'Compétence supprimée avec succès',
+      deleteError: 'Échec de la suppression de la compétence',
+      skillExists:
+        'Une compétence portant ce nom existe déjà. Veuillez la supprimer ou utiliser un nom différent.',
+      uploadSkill: 'Téléverser une compétence',
+      searchPlaceholder: 'Rechercher des compétences...',
+      noSkills: "Aucune compétence pour l'instant. Téléversez la première.",
+      noSearchResults: 'Aucune compétence ne correspond à votre recherche',
+      filesCount: '{{count}} fichiers',
+      foldersCount: '{{count}} dossiers',
+      pageInfo: 'Page {{current}} sur {{total}}',
+      totalSkills: '{{total}} compétences au total',
+      backToSkills: 'Retour aux compétences',
+      selectFileToView: 'Sélectionnez un fichier à afficher',
+      skillName: 'Nom de la compétence',
+      skillNamePlaceholder: 'ex. : ma-super-competence',
+      skillNameHelp:
+        'Seuls les lettres, chiffres, tirets et underscores sont autorisés',
+      source: 'Source',
+      version: 'Version',
+      skillVersion: 'Version',
+      skillVersionPlaceholder: 'ex. : 1.0.0',
+      versionFormatHelp: 'La version doit être au format semver (ex. : 1.0.0)',
+      versionRequired: 'La version est requise',
+      selectFilesOrFolder: 'Sélectionner des fichiers ou un dossier',
+      uploadDescription:
+        'Téléversez des fichiers de compétence. Vous pouvez glisser-déposer des fichiers ou sélectionner un dossier.',
+      selectFolder: 'Sélectionner un dossier',
+      dragFilesHint: 'ou glissez les fichiers ci-dessous',
+      dragFilesTitle: 'Glissez le dossier de compétence ici',
+      dragFilesDescription:
+        'Glissez-déposez un dossier de compétence ici, ou utilisez le bouton « Sélectionner un dossier » ci-dessous.',
+      filesSelected: '{{count}} fichiers sélectionnés',
+      uploading: 'Téléversement en cours...',
+      files: 'Fichiers',
+      noFiles: 'Aucun fichier',
+      versionHistory: 'Historique des versions',
+      selectVersion: 'Sélectionner une version à prévisualiser',
+      latest: 'Dernière',
+      metadata: {
+        basic: 'Informations de base',
+        emoji: 'Emoji',
+        skillKey: 'Clé de compétence',
+        always: 'Toujours actif',
+        primaryEnv: "Variable d'environnement principale",
+        requires: 'Prérequis',
+        requiredBins: 'Binaires requis',
+        requiredEnv: "Variables d'environnement requises",
+        anyBins: 'Au moins un requis',
+        install: 'Dépendances',
+        links: 'Liens',
+        homepage: "Page d'accueil",
+        repository: 'Dépôt',
+        documentation: 'Documentation',
+      },
+      validation: {
+        missing_skill_md:
+          'Compétence invalide : SKILL.md introuvable. Assurez-vous que votre répertoire de compétences contient un fichier SKILL.md valide.',
+        invalid_frontmatter:
+          'Compétence invalide : SKILL.md doit avoir un frontmatter valide (commencer et finir par ---).',
+        missing_name:
+          'Compétence invalide : le frontmatter de SKILL.md doit inclure un champ "name".',
+        invalid_name_format:
+          'Compétence invalide : "name" doit être en minuscules et compatible URL (lettres, chiffres, tirets uniquement).',
+        invalid_version:
+          'Compétence invalide : "version" doit être un semver valide (ex. : 1.0.0).',
+        invalid_metadata:
+          'Compétence invalide : les métadonnées contiennent des champs invalides.',
+        invalid_file_type:
+          'Compétence invalide : seuls les fichiers texte sont autorisés.',
+        invalid_path:
+          'Compétence invalide : le chemin du fichier contient des caractères invalides.',
+        file_too_large:
+          'Compétence invalide : la taille du fichier dépasse la limite de 5 Mo.',
+        total_size_exceeded:
+          'Compétence invalide : la taille totale du bundle dépasse la limite de 50 Mo.',
+        no_files:
+          'Aucun fichier sélectionné. Veuillez sélectionner un dossier de compétence.',
+        noValidFiles:
+          'Aucun fichier valide trouvé. Veuillez vérifier votre sélection.',
+        junkFilesFound:
+          'Fichiers temporaires détectés (ex. : .DS_Store). Veuillez les supprimer avant de téléverser.',
+        read_failed:
+          'Compétence invalide : impossible de lire le fichier SKILL.md.',
+        invalid: 'Format de compétence invalide.',
+        valid: 'Format de compétence valide. Prêt à téléverser.',
+        versionExists:
+          'Cette version existe déjà. Veuillez utiliser un numéro de version différent.',
+        error: 'Validation échouée',
+      },
+      parsedMetadata: 'Extrait depuis SKILL.md :',
+      addSkill: 'Ajouter une compétence',
+      upload: 'Téléverser',
+      importFromGit: 'Importer depuis Git',
+      gitPlatform: 'Plateforme',
+      repoUrl: 'URL du dépôt',
+      repoUrlHelp: "Prend en charge l'URL du dépôt avec un chemin optionnel",
+      accessToken: "Jeton d'accès",
+      githubTokenHelp:
+        'Pour les dépôts privés ou des limites de taux plus élevées (5000 req/heure)',
+      giteeTokenHelp:
+        'Pour les dépôts privés ou des limites de taux plus élevées (2000 req/heure)',
+      rateLimitInfo: 'Informations sur les limites de taux',
+      githubRateLimit:
+        'Dépôts publics : 60 requêtes/heure par IP. Utilisez un jeton pour 5000 req/heure.',
+      giteeRateLimit:
+        'Dépôts publics : 1000 requêtes/heure par IP. Utilisez un jeton pour 2000 req/heure.',
+      import: 'Importer',
+      importing: 'Importation en cours...',
+      configureSearch: 'Configurer la recherche',
+    },
+    skillSearch: {
+      configTitle: 'Configuration de la recherche de compétences',
+      configDesc:
+        'Configurez la façon dont les compétences sont indexées et recherchées',
+      embeddingModel: "Modèle d'embedding",
+      embeddingModelPlaceholder: "Sélectionnez un modèle d'embedding",
+      vectorSimilarityWeight: 'Poids de la similarité vectorielle',
+      similarityThreshold: 'Seuil de similarité',
+      topK: 'Top K résultats',
+      indexFields: "Champs d'index",
+      indexFieldsDesc:
+        "Sélectionnez les champs à inclure dans l'index de recherche",
+      fieldName: 'Nom',
+      fieldNameDesc: 'Nom de la compétence',
+      fieldTags: 'Étiquettes',
+      fieldTagsDesc: 'Étiquettes de la compétence',
+      fieldDescription: 'Description',
+      fieldDescriptionDesc: 'Description de la compétence',
+      fieldContent: 'Contenu',
+      fieldContentDesc: 'Contenu de la compétence (ex. : README)',
+      weight: 'Poids',
+      pureVector: 'Vectoriel uniquement',
+      hybrid: 'Hybride',
+      keyword: 'Mot-clé',
+      vector: 'Vectoriel',
+      keywordOnly: 'Mots-clés uniquement',
+      balanced: 'Équilibré',
+      vectorOnly: 'Vectoriel uniquement',
+      reindex: 'Tout réindexer',
+      reindexing: 'Réindexation en cours...',
+      reindexSuccess: 'Réindexation réussie',
+      pleaseSelectEmbeddingModel: "Veuillez sélectionner un modèle d'embedding",
+      saveSuccess: 'Enregistré avec succès',
+      saveError: "Échec de l'enregistrement",
+      semanticSearchPlaceholder: 'Rechercher des compétences par sens...',
+      switchToSemantic: 'Passer à la recherche sémantique',
+      switchToLocal: 'Passer à la recherche locale',
+    },
+    memory: {
+      taskLogDialog: {
+        title: 'Journal des tâches',
+        startTime: 'Heure de début',
+        status: 'Statut',
+        details: 'Détails',
+        success: 'Succès',
+        running: 'En cours',
+        failed: 'Échoué',
+      },
+      messages: {
+        forget: 'Oublier',
+        forgetMessageTip: 'Êtes-vous sûr de vouloir oublier ?',
+        messageDescription:
+          "L'extraction de mémoire est configurée avec les invites et la température des paramètres avancés.",
+        copied: 'Copié !',
+        contentEmbed: 'Contenu intégré',
+        content: 'Contenu',
+        delMessageWarn:
+          'Après avoir oublié, ce message ne sera plus récupéré par les agents.',
+        forgetMessage: 'Oublier le message',
+        sessionId: 'ID de session',
+        agent: 'Agent',
+        type: 'Type',
+        validDate: 'Date de validité',
+        forgetAt: 'Oublier le',
+        source: 'Source',
+        enable: 'Activer',
+        action: 'Action',
+      },
+      config: {
+        descriptionPlaceholder: 'Décrivez votre mémoire',
+        memorySizeTooltip:
+          "Tient compte du contenu de chaque message + son vecteur d'embedding (≈ Contenu + Dimensions × 8 octets).\nExemple : un message de 1 Ko avec un embedding de 1024 dimensions utilise ~9 Ko. La limite par défaut de 5 Mo contient ~500 messages de ce type.",
+        avatar: 'Avatar',
+        description: 'Description',
+        memorySize: 'Taille de la mémoire',
+        advancedSettings: 'Paramètres avancés',
+        permission: 'Permission',
+        onlyMe: 'Moi uniquement',
+        team: 'Équipe',
+        storageType: 'Type de stockage',
+        storageTypePlaceholder: 'Veuillez sélectionner le type de stockage',
+        forgetPolicy: "Politique d'oubli",
+        temperature: 'Température',
+        systemPrompt: 'Invite système',
+        systemPromptPlaceholder: "Veuillez entrer l'invite système",
+        userPrompt: 'Invite utilisateur',
+        userPromptPlaceholder: "Veuillez entrer l'invite utilisateur",
+      },
+      sideBar: {
+        messages: 'Messages',
+        configuration: 'Configuration',
+      },
     },
     knowledgeList: {
       welcome: 'Bon retour',
       description:
-        'Quelles bases de connaissances allez-vous utiliser aujourd’hui ?',
+        "Quelles bases de connaissances allez-vous utiliser aujourd'hui ?",
       createKnowledgeBase: 'Créer une base de connaissances',
       name: 'Nom',
       namePlaceholder: 'Veuillez saisir un nom !',
       doc: 'Documents',
       searchKnowledgePlaceholder: 'Rechercher',
-      noMoreData: 'C’est tout. Rien de plus.',
+      noMoreData: "C'est tout. Rien de plus.",
+      parserRequired: 'La méthode de segmentation est requise',
+      dataFlowRequired: 'Le flux de données est requis',
     },
     knowledgeDetails: {
       dataset: 'Ensemble de données',
@@ -100,7 +371,7 @@ export default {
       namePlaceholder: 'Veuillez saisir un nom !',
       doc: 'Documents',
       datasetDescription:
-        '😉 Veuillez attendre la fin de l’analyse de vos fichiers avant de démarrer une discussion avec l’IA.',
+        "😉 Veuillez attendre la fin de l'analyse de vos fichiers avant de démarrer une discussion avec l'IA.",
       addFile: 'Ajouter un fichier',
       searchFiles: 'Rechercher vos fichiers',
       localFiles: 'Fichiers locaux',
@@ -112,9 +383,9 @@ export default {
       enabled: 'Activé',
       disabled: 'Désactivé',
       action: 'Action',
-      parsingStatus: 'Statut d’analyse',
+      parsingStatus: "Statut d'analyse",
       parsingStatusTip:
-        'Le temps d’analyse dépend de plusieurs facteurs. L’activation de fonctions comme le Graphe de connaissances, RAPTOR, l’extraction automatique de mots-clés ou de questions peut considérablement augmenter ce temps. Si la barre de progression reste bloquée, veuillez consulter ces deux FAQ : https: //ragflow.io/docs/dev/faq#why-does-my-document-parsing-stall-at-under-one-percent.',
+        "Le temps d'analyse dépend de plusieurs facteurs. L'activation de fonctions comme le Graphe de connaissances, RAPTOR, l'extraction automatique de mots-clés ou de questions peut considérablement augmenter ce temps. Si la barre de progression reste bloquée, veuillez consulter ces deux FAQ : https: //ragflow.io/docs/dev/faq#why-does-my-document-parsing-stall-at-under-one-percent.",
       processBeginAt: 'Commencé à',
       processDuration: 'Durée',
       progressMsg: 'Progression',
@@ -125,7 +396,7 @@ export default {
         'RAGFlow utilise une combinaison de similarité par mots-clés pondérée et de similarité cosinus vectorielle, ou bien un score de réordonnancement pondéré. Ce paramètre fixe le seuil en dessous duquel un segment est exclu. Par défaut, le seuil est 0.2 (soit 20%).',
       vectorSimilarityWeight: 'Poids de similarité des mots-clés',
       vectorSimilarityWeightTip:
-        'Définit l’importance de la similarité par mots-clés dans le score global. Le total des poids doit être de 1.0.',
+        "Définit l'importance de la similarité par mots-clés dans le score global. Le total des poids doit être de 1.0.",
       testText: 'Texte de test',
       testTextPlaceholder: 'Saisissez votre question ici !',
       testingLabel: 'Test',
@@ -151,7 +422,7 @@ export default {
       toMessage: 'Numéro de page de fin manquant (exclu)',
       layoutRecognize: 'Analyseur PDF',
       layoutRecognizeTip:
-        'Utilise un modèle visuel pour détecter les titres, blocs de texte, images et tableaux dans les PDF. Si l’option naïve est choisie, seul le texte brut est extrait. Ne fonctionne que sur les fichiers PDF.',
+        "Utilise un modèle visuel pour détecter les titres, blocs de texte, images et tableaux dans les PDF. Si l'option naïve est choisie, seul le texte brut est extrait. Ne fonctionne que sur les fichiers PDF.",
       taskPageSize: 'Taille de page par tâche',
       taskPageSizeMessage: 'Veuillez saisir une taille de page pour la tâche !',
       taskPageSizeTip:
@@ -164,7 +435,7 @@ export default {
       changeSpecificCategory: 'Changer de catégorie spécifique',
       uploadTitle: 'Glissez-déposez votre fichier ici pour le téléverser',
       uploadDescription:
-        'Prise en charge du téléversement unique ou en lot. Pour RAGFlow en local : 1 Go max par téléversement, jusqu’à 32 fichiers. Pour cloud.ragflow.io : 10 Mo max par fichier uploadDescription128 fichiers au total.',
+        "Prise en charge du téléversement unique ou en lot. Pour RAGFlow en local : 1 Go max par téléversement, jusqu'à 32 fichiers. Pour cloud.ragflow.io : 10 Mo max par fichier uploadDescription128 fichiers au total.",
       chunk: 'Segment',
       bulk: 'En masse',
       cancel: 'Annuler',
@@ -184,15 +455,131 @@ export default {
         'Extrait automatiquement N mots-clés par segment. Consomme des tokens. Voir la documentation : https: //ragflow.io/docs/dev/autokeyword_autoquestion.',
       autoQuestions: 'Questions automatiques',
       autoQuestionsTip:
-        'Extrait automatiquement N questions par segment. N’interrompt pas l’analyse si une erreur survient. Consomme aussi des tokens. Voir la documentation.',
+        "Extrait automatiquement N questions par segment. N'interrompt pas l'analyse si une erreur survient. Consomme aussi des tokens. Voir la documentation.",
       redo: 'Voulez-vous supprimer les {{chunkNum}} segments existants ?',
       setMetaData: 'Définir les métadonnées',
       pleaseInputJson: 'Veuillez saisir du JSON',
       documentMetaTips: `<p>Les métadonnées sont au format JSON (non recherchables) et seront ajoutées au prompt du LLM si des segments du document sont utilisés.</p>`,
       metaData: 'Métadonnées',
       deleteDocumentConfirmContent:
-        'Ce document est lié au graphe de connaissances. Sa suppression supprime aussi les nœuds associés. Le graphe ne sera mis à jour qu’à la prochaine analyse.',
+        "Ce document est lié au graphe de connaissances. Sa suppression supprime aussi les nœuds associés. Le graphe ne sera mis à jour qu'à la prochaine analyse.",
       plainText: 'Naïf',
+      metadata: {
+        fields: 'Champs',
+        selectFiles: '{{count}} fichiers sélectionnés',
+        type: 'Type',
+        fieldNameInvalid:
+          'Le nom du champ ne peut contenir que des lettres ou des underscores.',
+        builtIn: 'Intégré',
+        generation: 'Génération',
+        toMetadataSetting: 'Paramètres de génération',
+        toMetadataSettingTip:
+          'Définir les métadonnées automatiques dans Configuration.',
+        descriptionTip:
+          "Fournissez des descriptions ou des exemples pour guider le LLM dans l'extraction des valeurs de ce champ. Si vide, il se basera sur le nom du champ.",
+        restrictDefinedValuesTip:
+          "Mode énumération : limite l'extraction du LLM aux valeurs prédéfinies uniquement. Définissez les valeurs ci-dessous.",
+        valueExists:
+          'La valeur existe déjà. Confirmez pour fusionner les doublons et regrouper tous les fichiers associés.',
+        fieldNameExists:
+          'Le nom de champ existe déjà. Confirmez pour fusionner les doublons et regrouper tous les fichiers associés.',
+        valueSingleExists:
+          'La valeur existe déjà. Confirmez pour fusionner les doublons.',
+        fieldSingleNameExists:
+          'Le nom de champ existe déjà. Confirmez pour fusionner les doublons.',
+        fieldExists: 'Le champ existe déjà.',
+        fieldSetting: 'Paramètres du champ',
+        changesAffectNewParses:
+          "Les modifications ne s'appliquent qu'aux nouvelles analyses.",
+        restrictDefinedValues: 'Restreindre aux valeurs définies',
+        metadataGenerationSettings: 'Paramètres de génération des métadonnées',
+        manageMetadata: 'Gérer les métadonnées',
+        metadata: 'Métadonnées',
+        values: 'Valeurs',
+        value: 'Valeur',
+        action: 'Action',
+        field: 'Champ',
+        description: 'Description',
+        fieldName: 'Nom du champ',
+        editMetadata: 'Modifier les métadonnées',
+        addMetadata: 'Ajouter des métadonnées',
+        deleteWarn: 'Ce {{field}} sera supprimé de tous les fichiers associés',
+        deleteManageFieldAllWarn:
+          'Ce champ et toutes ses valeurs seront supprimés de tous les fichiers associés.',
+        deleteManageValueAllWarn:
+          'Cette valeur sera supprimée de tous les fichiers associés.',
+        deleteManageFieldSingleWarn:
+          'Ce champ et toutes ses valeurs seront supprimés de ce fichier.',
+        deleteManageValueSingleWarn:
+          'Cette valeur sera supprimée de ce fichier.',
+        deleteSettingFieldWarn:
+          'Ce champ sera supprimé ; les métadonnées existantes ne seront pas affectées.',
+        deleteSettingValueWarn:
+          'Cette valeur sera supprimée ; les métadonnées existantes ne seront pas affectées.',
+      },
+      redoAll: 'Supprimer les segments existants',
+      applyAutoMetadataSettings:
+        'Appliquer les paramètres globaux de métadonnées automatiques',
+      parseFileTip: 'Êtes-vous sûr de vouloir analyser ?',
+      parseFile: 'Analyser le fichier',
+      emptyMetadata: 'Aucune métadonnée',
+      metadataField: 'Champ de métadonnée',
+      systemAttribute: 'Attribut système',
+      localUpload: 'Téléversement local',
+      fileSize: 'Taille du fichier',
+      fileType: 'Type de fichier',
+      uploadedBy: 'Téléversé par',
+      notGenerated: 'Non généré',
+      generatedOn: 'Généré le ',
+      subbarFiles: 'Fichiers',
+      generateKnowledgeGraph:
+        'Cela extraira les entités et relations de tous vos documents dans cette base. Le traitement peut prendre un certain temps.',
+      generateRaptor:
+        'Effectue un regroupement récursif et une résumé des segments de document pour construire une structure arborescente hiérarchique, permettant une récupération plus contextuelle des longs documents.',
+      generate: 'Générer',
+      raptor: 'RAPTOR',
+      processingType: 'Type de traitement',
+      dataPipeline: "Changer ou configurer le pipeline d'ingestion.",
+      dataPipelineTitle: "Pipeline d'ingestion",
+      operations: 'Opérations',
+      taskId: 'ID de tâche',
+      duration: 'Durée',
+      details: 'Détails',
+      status: 'Statut',
+      task: 'Tâche',
+      startDate: 'Date de début',
+      source: 'Source',
+      fileName: 'Nom du fichier',
+      datasetLogs: 'Base de connaissances',
+      fileLogs: 'Fichier',
+      overview: 'Journaux',
+      success: 'Succès',
+      failed: 'Échec',
+      completed: 'Terminé',
+      datasetLog: 'Journal de la base',
+      created: 'Créé',
+      learnMore: 'Introduction au pipeline intégré',
+      general: 'Général',
+      chunkMethodTab: 'Méthode de segmentation',
+      testResults: 'Résultats',
+      testSetting: 'Paramètres',
+      retrievalTesting: 'Test de récupération',
+      retrievalTestingDescription:
+        'Effectuez un test de récupération pour vérifier si RAGFlow peut retrouver le contenu pertinent pour le LLM.',
+      Parse: 'Analyser',
+      noTestResultsForRuned:
+        "Aucun résultat pertinent trouvé. Essayez d'ajuster votre requête ou les paramètres.",
+      noTestResultsForNotRuned:
+        "Aucun test n'a encore été lancé. Les résultats apparaîtront ici.",
+      keywordSimilarityWeight: 'Poids de similarité par mots-clés',
+      keywordSimilarityWeightTip:
+        'Définit le poids de la similarité par mots-clés dans le score global, combiné avec la similarité vectorielle ou le score de réordonnancement. Le total des deux poids doit être égal à 1.0.',
+      close: 'Fermer',
+      enableChildrenDelimiter:
+        'Utiliser les segments enfants pour la récupération',
+      childrenDelimiter: 'Délimiteur de texte',
+      childrenDelimiterTip:
+        'Un délimiteur peut être un ou plusieurs caractères spéciaux. Pour plusieurs caractères, encadrez-les de backticks (``). Ex : \\n`##`;',
       reRankModelWaring:
         'Le modèle de réordonnancement est très consommateur de temps.',
     },
@@ -204,28 +591,28 @@ export default {
         "Capture N jetons de texte au-dessus et au-dessous de l'image et du tableau pour fournir un contexte plus riche.",
       name: 'Nom de la base de connaissances',
       photo: 'Photo de la base de connaissances',
-      photoTip: 'Vous pouvez télécharger une image jusqu’à 4 Mo.',
+      photoTip: "Vous pouvez télécharger une image jusqu'à 4 Mo.",
       description: 'Description',
       language: 'Langue du document',
-      languageMessage: 'Veuillez saisir votre langue !',
+      languageMessage: 'Veuillez choisir votre langue',
       languagePlaceholder: 'Veuillez saisir votre langue !',
       permissions: 'Autorisations',
-      embeddingModel: 'Modèle d’embedding',
+      embeddingModel: "Modèle d'embedding",
       chunkTokenNumber: 'Taille de segment recommandée',
       chunkTokenNumberMessage: 'Le nombre de tokens par segment est requis',
       embeddingModelTip:
-        'Modèle d’embedding par défaut de la base de connaissances. Une fois que la base de connaissances contient des segments, lors du changement de modèle d’embedding, le système prélève aléatoirement quelques segments pour un contrôle de compatibilité, les ré-encode avec le nouveau modèle d’embedding et calcule la similarité cosinus entre les nouveaux et anciens vecteurs. Le basculement est autorisé uniquement si la similarité moyenne de l’échantillon est ≥ 0.9. Sinon, vous devez supprimer tous les segments de la base de connaissances avant de pouvoir le modifier.',
+        "Modèle d'embedding par défaut de la base de connaissances. Une fois que la base de connaissances contient des segments, lors du changement de modèle d'embedding, le système prélève aléatoirement quelques segments pour un contrôle de compatibilité, les ré-encode avec le nouveau modèle d'embedding et calcule la similarité cosinus entre les nouveaux et anciens vecteurs. Le basculement est autorisé uniquement si la similarité moyenne de l'échantillon est ≥ 0.9. Sinon, vous devez supprimer tous les segments de la base de connaissances avant de pouvoir le modifier.",
       permissionsTip:
         "Si défini sur 'Équipe', tous les membres de votre équipe pourront gérer cette base.",
       chunkTokenNumberTip:
-        'Définit un seuil de tokens pour créer un segment. Les textes courts sont regroupés jusqu’à dépasser ce seuil, sauf si un délimiteur est détecté.',
+        "Définit un seuil de tokens pour créer un segment. Les textes courts sont regroupés jusqu'à dépasser ce seuil, sauf si un délimiteur est détecté.",
       chunkMethod: 'Méthode de découpage',
       chunkMethodTip: 'Voir les conseils à droite.',
       upload: 'Téléverser',
       english: 'Anglais',
       chinese: 'Chinois',
       portugueseBr: 'Portugais (Brésil)',
-      embeddingModelPlaceholder: 'Veuillez sélectionner un modèle d’embedding.',
+      embeddingModelPlaceholder: "Veuillez sélectionner un modèle d'embedding.",
       chunkMethodPlaceholder: 'Veuillez sélectionner une méthode de découpage.',
       save: 'Enregistrer',
       me: 'Moi uniquement',
@@ -234,14 +621,14 @@ export default {
       methodTitle: 'Description de la méthode de découpage',
       methodExamples: 'Exemples',
       methodExamplesDescription:
-        'Les captures d’écran suivantes sont fournies à titre explicatif.',
+        "Les captures d'écran suivantes sont fournies à titre explicatif.",
       dialogueExamplesTitle: 'voir',
       methodEmpty:
         'Affichera une explication visuelle des catégories de base de connaissances',
-      // Les contenus HTML comme "book", "laws", etc. sont laissés en l’état pour ne pas altérer leur structure technique.
+      // Les contenus HTML comme "book", "laws", etc. sont laissés en l'état pour ne pas altérer leur structure technique.
       useRaptor: 'Utiliser RAPTOR pour améliorer la récupération',
       useRaptorTip:
-        'Activez RAPTOR pour les questions nécessitant plusieurs étapes. Voir https: //ragflow.io/docs/dev/enable_raptor pour plus d’informations.',
+        "Activez RAPTOR pour les questions nécessitant plusieurs étapes. Voir https: //ragflow.io/docs/dev/enable_raptor pour plus d'informations.",
       prompt: 'Prompt',
       promptTip:
         'Décrivez la tâche attendue du LLM, ses réponses, ses exigences, etc. Utilisez `/` pour afficher les variables disponibles.',
@@ -260,7 +647,7 @@ export default {
       maxClusterMessage: 'Le nombre de groupes est requis',
       randomSeed: 'Graine aléatoire',
       randomSeedMessage: 'La graine est requise',
-      entityTypes: 'Types d’entités',
+      entityTypes: "Types d'entités",
       vietnamese: 'Vietnamien',
       pageRank: 'Rang de page',
       pageRankTip:
@@ -270,13 +657,13 @@ export default {
       searchTags: 'Rechercher des étiquettes',
       tagCloud: 'Nuage',
       tagTable: 'Tableau',
-      tagSet: 'Jeux d’étiquettes',
+      tagSet: "Jeux d'étiquettes",
       tagSetTip: `
     <p>Sélectionnez une ou plusieurs bases pour taguer automatiquement les segments. Voir documentation.</p>
     <p>Les questions utilisateurs seront aussi taguées.</p>
     <p>Différences avec les mots-clés automatiques :</p>
     <ul>
-      <li>Les tags viennent d’un ensemble fermé ; les mots-clés sont extraits librement par le LLM.</li>
+      <li>Les tags viennent d'un ensemble fermé ; les mots-clés sont extraits librement par le LLM.</li>
       <li>Vous devez téléverser les sets de tags au préalable.</li>
       <li>Les mots-clés consomment plus de tokens.</li>
     </ul>`,
@@ -290,28 +677,221 @@ export default {
       graphRagMethodTip: `Light : (Par défaut) utilise les prompts de github.com/HKUDS/LightRAG. Moins de consommation.
     General : utilise ceux de github.com/microsoft/graphrag.
     NER : utilise spaCy NER et l'extraction de mots-clés basée sur des règles pour extraire les entités et les relations. Aucun LLM n'est requis pour l'extraction, ce qui la rend rapide et économe en ressources.`,
-      resolution: 'Résolution d’entités',
+      resolution: "Résolution d'entités",
       resolutionTip:
-        'Fusionne des entités similaires comme "2025" et "l’année 2025".',
+        'Fusionne des entités similaires comme "2025" et "l\'année 2025".',
       community: 'Génération de rapports communautaires',
-      communityTip: `Un "community" est un groupe d’entités liées. Le LLM peut générer un résumé pour chaque groupe. Voir plus ici : https: //www.microsoft.com/en-us/research/blog/graphrag-improving-global-search-via-dynamic-community-selection/`,
+      communityTip: `Un "community" est un groupe d'entités liées. Le LLM peut générer un résumé pour chaque groupe. Voir plus ici : https: //www.microsoft.com/en-us/research/blog/graphrag-improving-global-search-via-dynamic-community-selection/`,
       theDocumentBeingParsedCannotBeDeleted:
-        'Le document en cours d’analyse ne peut pas être supprimé',
+        "Le document en cours d'analyse ne peut pas être supprimé",
+      lastWeek: 'de la semaine dernière',
       paddleocrOptions: 'Options PaddleOCR',
-      paddleocrApiUrl: 'URL de l’API PaddleOCR',
+      paddleocrApiUrl: "URL de l'API PaddleOCR",
       paddleocrApiUrlTip:
-        'URL du point de terminaison de l’API du service PaddleOCR',
+        "URL du point de terminaison de l'API du service PaddleOCR",
       paddleocrApiUrlPlaceholder:
         'Par exemple : https://paddleocr-server.com/layout-parsing',
-      paddleocrAccessToken: 'Jeton d’accès AI Studio',
-      paddleocrAccessTokenTip: 'Jeton d’accès à l’API PaddleOCR (optionnel)',
+      paddleocrAccessToken: "Jeton d'accès AI Studio",
+      paddleocrAccessTokenTip: "Jeton d'accès à l'API PaddleOCR (optionnel)",
       paddleocrAccessTokenPlaceholder: 'Votre jeton AI Studio (optionnel)',
       paddleocrAlgorithm: 'Algorithme PaddleOCR',
-      paddleocrAlgorithmTip: 'Algorithme utilisé pour l’analyse PaddleOCR',
+      paddleocrAlgorithmTip: "Algorithme utilisé pour l'analyse PaddleOCR",
       paddleocrSelectAlgorithm: 'Sélectionner un algorithme',
       paddleocrModelNamePlaceholder: 'Par exemple : paddleocr-environnement-1',
+      randomSeedTip:
+        "La graine est le point de départ d'un algorithme pseudo-aléatoire qui assure la reproductibilité des résultats.",
+      datasetDescription: 'Décrivez votre base de connaissances',
+      overlappedPercentTip:
+        'Le pourcentage de chevauchement entre deux segments adjacents',
+      globalIndexModelTip:
+        'Utilisé pour générer les graphes de connaissances, RAPTOR, les métadonnées automatiques, les mots-clés et questions automatiques. Les performances du modèle affectent la qualité de la génération.',
+      globalIndexModel: "Modèle d'indexation",
+      settings: 'Paramètres',
+      autoMetadataTip:
+        "Génère automatiquement des métadonnées. S'applique aux nouveaux fichiers lors de l'analyse. Les fichiers existants nécessitent une ré-analyse pour être mis à jour (les segments sont conservés). Des tokens supplémentaires seront consommés par le modèle d'indexation spécifié dans 'Configuration'.",
+      autoMetadata: 'Métadonnées automatiques',
+      mineruOptions: 'Options MinerU',
+      mineruParseMethod: "Méthode d'analyse",
+      mineruParseMethodTip:
+        "Méthode d'analyse des PDF : auto (détection automatique), txt (extraction de texte), ocr (reconnaissance optique de caractères)",
+      mineruFormulaEnable: 'Reconnaissance de formules',
+      mineruFormulaEnableTip:
+        'Activer la reconnaissance de formules. Note : peut ne pas fonctionner correctement pour les documents en cyrillique.',
+      mineruTableEnable: 'Reconnaissance de tableaux',
+      mineruTableEnableTip:
+        "Activer la reconnaissance et l'extraction de tableaux.",
+      overlappedPercent: 'Pourcentage de chevauchement (%)',
+      generationScopeTip:
+        "Détermine si RAPTOR est généré pour l'ensemble de la base ou pour un seul fichier.",
+      scopeDataset: 'Base de connaissances',
+      generationScope: 'Portée de génération',
+      scopeSingleFile: 'Fichier unique',
+      autoParse: 'Analyse automatique',
+      rebuildTip:
+        'Re-télécharge les fichiers depuis la source de données liée et les analyse à nouveau.',
+      baseInfo: 'Informations de base',
+      globalIndex: 'Index global',
+      dataSource: 'Source de données',
+      linkSourceSetTip: 'Gérer la liaison de source de données avec cette base',
+      linkDataSource: 'Lier une source de données',
+      tocExtraction: 'IndexPage',
+      tocExtractionTip:
+        "Pour les segments existants, génère une table des matières hiérarchique (un répertoire par fichier). Lors des requêtes, avec la Mise en valeur des répertoires activée, le système utilise un grand modèle pour déterminer quels éléments du répertoire sont pertinents à la question de l'utilisateur.",
+      deleteGenerateModalContent: `
+  <p>La suppression des résultats générés <strong class='text-text-primary'>{{type}}</strong>
+  supprimera toutes les entités et relations dérivées de cette base de connaissances.
+  Vos fichiers originaux resteront intacts.<p>
+  <br/>
+  Voulez-vous continuer ?
+`,
+      extractRaptor: 'Extraire Raptor',
+      extractKnowledgeGraph: 'Extraire le graphe de connaissances',
+      filterPlaceholder: 'saisir un filtre',
+      fileFilterTip: '',
+      fileFilter: 'Filtre de fichiers',
+      setDefaultTip: '',
+      setDefault: 'Définir comme défaut',
+      editLinkDataPipeline: "Modifier le pipeline d'ingestion",
+      linkPipelineSetTip:
+        "Gérer la liaison du pipeline d'ingestion avec cette base",
+      default: 'Par défaut',
+      dataPipeline: "Changer ou configurer le pipeline d'ingestion.",
+      linkDataPipeline: "Lier un pipeline d'ingestion",
+      enableAutoGenerate: 'Activer la génération automatique',
+      teamPlaceholder: 'Veuillez sélectionner une équipe.',
+      dataFlowPlaceholder: 'Veuillez sélectionner un pipeline.',
+      buildItFromScratch: 'Créer depuis zéro',
+      dataFlow: 'Pipeline',
+      parseType: "Type d'analyse",
+      manualSetup: 'Pipeline',
+      builtIn: 'Intégré',
+      tableColumnMode: 'Mode colonne',
+      tableColumnModeAuto: 'Auto',
+      tableColumnModeManual: 'Manuel',
+      tableColumnModeAutoDescription:
+        'Toutes les colonnes sont incluses dans le texte du segment et stockées comme métadonnées (par défaut RAGFlow).',
+      tableColumnRoles: 'Rôles des colonnes',
+      tableColumnRolesTip:
+        "Choisissez quelles colonnes inclure dans le texte du segment (indexé pour la recherche vectorielle et plein texte), dans les métadonnées uniquement (filtrable), ou les deux. Les modifications s'appliquent aux nouvelles analyses ; ré-analysez les documents existants pour appliquer les rôles.",
+      tableColumnRoleIndexing: 'Indexation',
+      tableColumnRoleMetadata: 'Métadonnées',
+      tableColumnRoleBoth: 'Les deux',
+      tableColumnRolesEmpty:
+        'Téléversez et analysez un fichier CSV ou Excel pour commencer à configurer les rôles des colonnes.',
+      tableColumnRolesReparseTip:
+        'Ré-analysez les documents existants pour appliquer les nouveaux rôles des colonnes.',
+      parserLabel: {
+        naive: 'Général',
+        qa: 'Q&R',
+        resume: 'CV',
+        manual: 'Manuel',
+        table: 'Tableau',
+        paper: 'Article',
+        book: 'Livre',
+        laws: 'Lois',
+        presentation: 'Présentation',
+        picture: 'Image',
+        one: 'Document entier',
+        audio: 'Audio',
+        email: 'E-mail',
+        tag: 'Étiquette',
+      },
+      book: `<p>Les formats de fichiers pris en charge sont <b>DOCX</b>, <b>PDF</b>, <b>TXT</b>.</p><p>
+Pour chaque livre au format PDF, veuillez définir les <i>plages de pages</i> afin de supprimer les informations non souhaitées et de réduire le temps d'analyse.</p>`,
+      laws: `<p>Les formats de fichiers pris en charge sont <b>DOCX</b>, <b>PDF</b>, <b>TXT</b>.</p><p>
+Les documents juridiques suivent généralement un format de rédaction rigoureux. Nous utilisons les caractéristiques du texte pour identifier les points de découpage.
+</p><p>
+La granularité du segment est cohérente avec 'ARTICLE', ce qui garantit que tout le texte de niveau supérieur est inclus dans le segment.
+</p>`,
+      manual: `<p>Seul le format <b>PDF</b> est pris en charge.</p><p>
+Nous supposons que le manuel a une structure de sections hiérarchique, utilisant les titres de section les plus bas comme unité de base pour le découpage des documents. Les figures et tableaux d'une même section ne seront pas séparés, ce qui peut entraîner des segments de plus grande taille.
+</p>`,
+      naive: `<p>Les formats de fichiers pris en charge sont <b>MD, MDX, DOCX, XLSX, XLS, PPTX, PDF, TXT, JPEG, JPG, PNG, TIF, GIF, CSV, JSON, EML, HTML</b>.</p>
+<p>Cette méthode découpe les fichiers de façon 'naïve' :</p>
+<p>
+<ul>
+<li>Utilise un modèle de détection visuelle pour diviser les textes en segments plus petits.</li>
+<li>Combine ensuite les segments adjacents jusqu'à ce que le nombre de tokens dépasse le seuil spécifié, moment auquel un segment est créé.</li></ul></p>`,
+      paper: `<p>Seul le format <b>PDF</b> est pris en charge.</p><p>
+Les articles seront divisés par section, comme <i>résumé, 1.1, 1.2</i>. </p><p>
+Cette approche permet au LLM de résumer l'article plus efficacement et de fournir des réponses plus complètes.
+Cependant, elle augmente également le contexte pour les conversations IA et le coût de calcul du LLM.</p>`,
+      presentation: `<p>Les formats de fichiers pris en charge sont <b>PDF</b>, <b>PPTX</b>.</p><p>
+Chaque page du diaporama est traitée comme un segment, avec son image miniature stockée.</p><p>
+<i>Cette méthode de découpage est automatiquement appliquée à tous les fichiers PPT téléversés.</i></p>`,
+      qa: `
+<p>
+Cette méthode de découpage prend en charge les formats <b>XLSX</b> et <b>CSV/TXT</b>.
+</p>
+<ul>
+<li>
+Pour les fichiers <b>XLSX</b> : deux colonnes sans en-têtes, questions puis réponses. Plusieurs feuilles sont acceptées.
+</li>
+<li>
+Pour les fichiers <b>CSV/TXT</b> : encodage UTF-8 avec TAB comme séparateur.
+</li>
+</ul>
+<p>
+<i>
+Les lignes ne respectant pas ces règles seront ignorées.
+Chaque paire Q&R est considérée comme un segment distinct.
+</i>
+</p>
+`,
+      resume: `<p>Les formats de fichiers pris en charge sont <b>DOCX</b>, <b>PDF</b>, <b>TXT</b>.
+</p><p>
+Les CV de différentes formes sont analysés et organisés en données structurées pour faciliter la recherche de candidats.
+</p>
+`,
+      table: `<p>Les formats de fichiers pris en charge sont <b>XLSX</b> et <b>CSV/TXT</b>.</p><p>
+Prérequis et conseils :
+<ul>
+<li>Pour CSV ou TXT, le délimiteur entre colonnes doit être <em><b>TAB</b></em>.</li>
+<li>La première ligne doit être les en-têtes de colonnes.</li>
+<li>Les en-têtes doivent être des termes significatifs pour aider le LLM.</li>
+<li>Chaque ligne du tableau sera traitée comme un segment.</li>
+</ul>`,
+      picture: `
+<p>Les fichiers image sont pris en charge, la vidéo sera disponible prochainement.</p><p>
+Cette méthode utilise un modèle OCR pour extraire le texte des images.
+</p><p>
+Si le texte extrait est insuffisant, un LLM visuel sera utilisé pour décrire l'image.
+</p>`,
+      one: `
+<p>Les formats de fichiers pris en charge sont <b>DOCX, XLSX, XLS, PDF, TXT</b>.
+</p><p>
+Cette méthode traite chaque document dans son intégralité comme un seul segment.
+</p><p>
+Applicable lorsque vous avez besoin que le LLM résume le document entier.
+</p>`,
+      knowledgeGraph: `<p>Les formats de fichiers pris en charge sont <b>DOCX, EXCEL, PPT, IMAGE, PDF, TXT, MD, JSON, EML</b>
+
+<p>Cette approche découpe les fichiers selon la méthode 'naïve'/'Général'. Elle divise un document en segments puis les combine jusqu'au seuil de tokens.</p>
+<p>Les segments sont ensuite transmis au LLM pour extraire les entités et relations d'un graphe de connaissances.</p>
+<p>Assurez-vous de définir les <b>Types d'entités</b>.</p>`,
+      tag: `<p>Une base utilisant la méthode de découpage 'Étiquette' fonctionne comme un jeu d'étiquettes. D'autres bases l'utilisent pour étiqueter leurs segments.</p>
+<p>Un jeu d'étiquettes ne sera <b>PAS</b> directement impliqué dans un processus RAG.</p>
+<p>Chaque segment est une paire description-étiquette indépendante.</p>
+<p>Formats supportés : <b>XLSX</b> et <b>CSV/TXT</b>.</p>
+`,
+      clusteringMethod: 'Méthode de regroupement',
+      clusteringMethodTip:
+        'Sélectionnez la méthode de regroupement RAPTOR. AHC peut utiliser une valeur de cluster maximum plus grande, mais peut nécessiter plus de mémoire pour de grandes entrées.',
+      clusteringMethodGmm: 'GMM',
+      clusteringMethodAhc: 'AHC',
+      graphRagBatchChunkTokenSize: 'Taille de lot de tokens par segment',
+      graphRagBatchChunkTokenSizeTip:
+        "La limite de tokens pour chaque lot de segments envoyés au LLM pour l'extraction d'entités et de relations du graphe de connaissances. Non applicable à NER.",
     },
     chunk: {
+      type: 'Type',
+      docType: {
+        image: 'Image',
+        table: 'Tableau',
+        text: 'Texte',
+      },
+      size: 'Taille',
+      uploadedTime: 'Date de téléversement',
       chunk: 'Segment',
       bulk: 'En masse',
       selectAll: 'Tout sélectionner',
@@ -323,6 +903,9 @@ export default {
       enabled: 'Activé',
       disabled: 'Désactivé',
       keyword: 'Mot-clé',
+      image: 'Image',
+      imageUploaderTitle:
+        "Téléverser une nouvelle image pour mettre à jour ce segment d'image",
       function: 'Fonction',
       chunkMessage: 'Veuillez saisir une valeur !',
       full: 'Texte complet',
@@ -330,7 +913,7 @@ export default {
       graph: 'Graphe de connaissances',
       mind: 'Carte mentale',
       question: 'Question',
-      questionTip: `S’il y a des questions fournies, l'embedding du segment se basera sur celles-ci.`,
+      questionTip: `S'il y a des questions fournies, l'embedding du segment se basera sur celles-ci.`,
       chunkResult: 'Résultat du segment',
       chunkResultTip: `Affiche les segments utilisés pour l'embedding et la récupération.`,
       enable: 'Activer',
@@ -343,33 +926,33 @@ export default {
       typeYourMessage: 'Tapez votre message...',
       newConversation: 'Nouvelle conversation',
       createAssistant: 'Créer un assistant',
-      assistantSetting: 'Paramètres de l’assistant',
+      assistantSetting: "Paramètres de l'assistant",
       promptEngine: 'Moteur de prompt',
       modelSetting: 'Paramètres du modèle',
       chat: 'Discussion',
       newChat: 'Nouvelle discussion',
       send: 'Envoyer',
-      sendPlaceholder: 'Envoyez un message à l’assistant...',
+      sendPlaceholder: "Envoyez un message à l'assistant...",
       chatConfiguration: 'Configuration de la discussion',
       chatConfigurationDescription:
         ' Configurez un assistant de chat pour vos ensembles de données sélectionnés (bases de connaissances) ici ! 💕',
-      assistantName: 'Nom de l’assistant',
-      assistantNameMessage: 'Le nom de l’assistant est requis',
+      assistantName: "Nom de l'assistant",
+      assistantNameMessage: "Le nom de l'assistant est requis",
       namePlaceholder: 'ex. Resume Jarvis',
-      assistantAvatar: 'Avatar de l’assistant',
+      assistantAvatar: "Avatar de l'assistant",
       language: 'Langue',
       emptyResponse: 'Réponse vide',
-      emptyResponseTip: `Définissez ceci comme réponse si aucun résultat n’est récupéré des bases de connaissances pour votre requête, ou laissez ce champ vide pour permettre au LLM d’improviser lorsqu’aucune information n’est trouvée.`,
-      emptyResponseMessage: `La réponse vide sera déclenchée lorsqu’aucune information pertinente n’est récupérée des bases de connaissances. Vous devez vider le champ 'Réponse vide' si aucune base de connaissances n’est sélectionnée.`,
-      setAnOpener: 'Message d’accueil',
+      emptyResponseTip: `Définissez ceci comme réponse si aucun résultat n'est récupéré des bases de connaissances pour votre requête, ou laissez ce champ vide pour permettre au LLM d'improviser lorsqu'aucune information n'est trouvée.`,
+      emptyResponseMessage: `La réponse vide sera déclenchée lorsqu'aucune information pertinente n'est récupérée des bases de connaissances. Vous devez vider le champ 'Réponse vide' si aucune base de connaissances n'est sélectionnée.`,
+      setAnOpener: "Message d'accueil",
       setAnOpenerInitial: `Bonjour ! Je suis votre assistant, que puis-je faire pour vous ?`,
-      setAnOpenerTip: 'Définissez un message d’accueil pour les utilisateurs.',
+      setAnOpenerTip: "Définissez un message d'accueil pour les utilisateurs.",
       knowledgeBases: 'Bases de connaissances',
       knowledgeBasesMessage: 'Veuillez sélectionner',
       knowledgeBasesTip:
-        'Sélectionnez les bases de connaissances à associer à cet assistant de chat. Une base de connaissances vide n’apparaîtra pas dans la liste déroulante.',
+        "Sélectionnez les bases de connaissances à associer à cet assistant de chat. Une base de connaissances vide n'apparaîtra pas dans la liste déroulante.",
       system: 'Prompt système',
-      systemInitialValue: `Vous êtes un assistant intelligent. Veuillez résumer le contenu de la base de connaissances pour répondre à la question. Veuillez lister les données de la base de connaissances et répondre en détail. Lorsque tout le contenu de la base de connaissances est sans rapport avec la question, votre réponse doit inclure la phrase "La réponse que vous cherchez ne se trouve pas dans la base de connaissances !" Les réponses doivent prendre en compte l’historique de la discussion.
+      systemInitialValue: `Vous êtes un assistant intelligent. Veuillez résumer le contenu de la base de connaissances pour répondre à la question. Veuillez lister les données de la base de connaissances et répondre en détail. Lorsque tout le contenu de la base de connaissances est sans rapport avec la question, votre réponse doit inclure la phrase "La réponse que vous cherchez ne se trouve pas dans la base de connaissances !" Les réponses doivent prendre en compte l'historique de la discussion.
       Voici la base de connaissances : {knowledge}
       Ce qui précède est la base de connaissances.`,
       systemMessage: 'Veuillez saisir !',
@@ -378,8 +961,8 @@ export default {
       topN: 'Top N',
       topNTip: `Tous les segments avec un score de similarité supérieur au 'seuil de similarité' ne seront pas forcément envoyés au LLM. Cela sélectionne les 'Top N' segments parmi ceux récupérés.`,
       variable: 'Variable',
-      variableTip: `Utilisé avec les API de gestion d’assistant de chat de RAGFlow, les variables aident à développer des stratégies de prompt système plus flexibles. Les variables définies seront utilisées dans le 'Prompt système' comme partie des prompts pour le LLM. {knowledge
-      } est une variable spéciale réservée représentant les segments récupérés des bases de connaissances spécifiées. Toutes les variables doivent être entourées d’accolades {} dans le 'Prompt système'. Voir https: //ragflow.io/docs/dev/set_chat_variables pour plus de détails.`,
+      variableTip: `Utilisé avec les API de gestion d'assistant de chat de RAGFlow, les variables aident à développer des stratégies de prompt système plus flexibles. Les variables définies seront utilisées dans le 'Prompt système' comme partie des prompts pour le LLM. {knowledge
+      } est une variable spéciale réservée représentant les segments récupérés des bases de connaissances spécifiées. Toutes les variables doivent être entourées d'accolades {} dans le 'Prompt système'. Voir https: //ragflow.io/docs/dev/set_chat_variables pour plus de détails.`,
       add: 'Ajouter',
       key: 'Clé',
       optional: 'Optionnel',
@@ -389,7 +972,7 @@ export default {
       modelMessage: 'Veuillez sélectionner !',
       modelEnabledTools: 'Outils activés',
       modelEnabledToolsTip:
-        'Veuillez sélectionner un ou plusieurs outils que le modèle de chat peut utiliser. N’a aucun effet pour les modèles ne supportant pas l’appel d’outil.',
+        "Veuillez sélectionner un ou plusieurs outils que le modèle de chat peut utiliser. N'a aucun effet pour les modèles ne supportant pas l'appel d'outil.",
       freedom: 'Liberté',
       improvise: 'Improviser',
       precise: 'Précis',
@@ -397,7 +980,7 @@ export default {
       freedomTip: `Un raccourci vers les paramètres 'Température', 'Top P', 'Pénalité de présence' et 'Pénalité de fréquence', indiquant le niveau de liberté du modèle. Ce paramètre a trois options : choisissez 'Improviser' pour des réponses plus créatives ; 'Précis' (par défaut) pour des réponses plus conservatrices ; 'Équilibre' est un compromis entre 'Improviser' et 'Précis'.`,
       temperature: 'Température',
       temperatureMessage: 'La température est requise',
-      temperatureTip: `Ce paramètre contrôle l’aléa des prédictions du modèle. Une température basse donne des réponses plus conservatrices, une température élevée des réponses plus créatives et variées.`,
+      temperatureTip: `Ce paramètre contrôle l'aléa des prédictions du modèle. Une température basse donne des réponses plus conservatrices, une température élevée des réponses plus créatives et variées.`,
       topP: 'Top P',
       topPMessage: 'Top P est requis',
       topPTip: `Aussi appelé "échantillonnage par noyau", ce paramètre fixe un seuil pour sélectionner un ensemble plus restreint de mots les plus probables à échantillonner, en éliminant les moins probables.`,
@@ -409,7 +992,7 @@ export default {
       frequencyPenaltyTip: `Similaire à la pénalité de présence, cela réduit la tendance du modèle à répéter fréquemment les mêmes mots.`,
       maxTokens: 'Nombre max de tokens',
       maxTokensMessage: 'Le nombre max de tokens est requis',
-      maxTokensTip: `La taille maximale de contexte de l’modèle ; une valeur invalide ou incorrecte provoquera une erreur. Valeur par défaut : 512.`,
+      maxTokensTip: `La taille maximale de contexte de l'modèle ; une valeur invalide ou incorrecte provoquera une erreur. Valeur par défaut : 512.`,
       maxTokensInvalidMessage:
         'Veuillez saisir un nombre valide pour le nombre max de tokens.',
       maxTokensMinMessage:
@@ -421,14 +1004,14 @@ export default {
         'Veuillez vous référer à : https: //huggingface.co/papers/2310.11511',
       overview: 'ID de discussion',
       pv: 'Nombre de messages',
-      uv: 'Nombre d’utilisateurs actifs',
+      uv: "Nombre d'utilisateurs actifs",
       speed: 'Vitesse de sortie des tokens',
       tokens: 'Nombre de tokens consommés',
-      round: 'Nombre d’interactions de session',
+      round: "Nombre d'interactions de session",
       thumbUp: 'Satisfaction client',
       preview: 'Aperçu',
       embedded: 'Intégré',
-      serviceApiEndpoint: 'Point d’API du service',
+      serviceApiEndpoint: "Point d'API du service",
       apiKey: 'Clé API',
       apiReference: 'Documents API',
       dateRange: 'Plage de dates :',
@@ -440,12 +1023,12 @@ export default {
       comingSoon: 'Bientôt disponible',
       fullScreenTitle: 'Intégration complète',
       fullScreenDescription:
-        'Intégrez l’iframe suivant dans votre site web à l’emplacement désiré',
+        "Intégrez l'iframe suivant dans votre site web à l'emplacement désiré",
       partialTitle: 'Intégration partielle',
       extensionTitle: 'Extension Chrome',
-      tokenError: 'Veuillez d’abord créer une clé API.',
+      tokenError: "Veuillez d'abord créer une clé API.",
       betaError:
-        'Veuillez d’abord obtenir une clé API RAGFlow depuis la page Paramètres système.',
+        "Veuillez d'abord obtenir une clé API RAGFlow depuis la page Paramètres système.",
       searching: 'Recherche en cours...',
       parsing: 'Analyse en cours',
       uploading: 'Téléversement en cours',
@@ -454,14 +1037,14 @@ export default {
       read: 'Lire le contenu',
       tts: 'Texte en parole',
       ttsTip:
-        'Assurez-vous de sélectionner un modèle TTS dans la page Paramètres avant d’activer cette option pour jouer le texte en audio.',
+        "Assurez-vous de sélectionner un modèle TTS dans la page Paramètres avant d'activer cette option pour jouer le texte en audio.",
       relatedQuestion: 'Question associée',
       answerTitle: 'R',
       multiTurn: 'Optimisation multi-tours',
       multiTurnTip:
-        'Optimise les requêtes utilisateur en utilisant le contexte d’une conversation multi-tours. Lorsqu’activé, cela consomme des tokens LLM supplémentaires.',
-      howUseId: 'Comment utiliser l’ID de discussion ?',
-      description: 'Description de l’assistant',
+        "Optimise les requêtes utilisateur en utilisant le contexte d'une conversation multi-tours. Lorsqu'activé, cela consomme des tokens LLM supplémentaires.",
+      howUseId: "Comment utiliser l'ID de discussion ?",
+      description: "Description de l'assistant",
       descriptionPlaceholder: 'ex. Un assistant de chat pour CV.',
       useKnowledgeGraph: 'Utiliser le graphe de connaissances',
       useKnowledgeGraphTip:
@@ -470,21 +1053,76 @@ export default {
       keywordTip: `Utiliser le LLM pour analyser les questions utilisateur, extraire des mots-clés qui seront mis en avant lors du calcul de pertinence. Fonctionne bien avec les requêtes longues mais augmente le temps de réponse.`,
       languageTip:
         'Permet la réécriture de phrases dans la langue spécifiée ou utilise la dernière question si aucune sélection.',
-      avatarHidden: 'Cacher l’avatar',
+      avatarHidden: "Cacher l'avatar",
       locale: 'Paramètres régionaux',
       selectLanguage: 'Sélectionner une langue',
       reasoning: 'Raisonnement',
-      reasoningTip: `Activer un flux de raisonnement lors de la réponse aux questions, comme dans les modèles Deepseek-R1 ou OpenAI o1. Cela permet au modèle d’accéder à des connaissances externes et de traiter des questions complexes étape par étape, en utilisant des techniques comme le chain-of-thought. Cette méthode améliore la précision des réponses en décomposant les problèmes en étapes gérables, augmentant les performances sur les tâches nécessitant un raisonnement logique et multi-étapes.`,
+      reasoningTip: `Activer un flux de raisonnement lors de la réponse aux questions, comme dans les modèles Deepseek-R1 ou OpenAI o1. Cela permet au modèle d'accéder à des connaissances externes et de traiter des questions complexes étape par étape, en utilisant des techniques comme le chain-of-thought. Cette méthode améliore la précision des réponses en décomposant les problèmes en étapes gérables, augmentant les performances sur les tâches nécessitant un raisonnement logique et multi-étapes.`,
       tavilyApiKeyTip:
         'Si une clé API est correctement configurée ici, les recherches web basées sur Tavily seront utilisées pour compléter la récupération des bases de connaissances.',
       tavilyApiKeyMessage: 'Veuillez saisir votre clé API Tavily',
-      tavilyApiKeyHelp: 'Comment l’obtenir ?',
+      tavilyApiKeyHelp: "Comment l'obtenir ?",
       crossLanguage: 'Recherche inter-langues',
-      crossLanguageTip: `Sélectionnez une ou plusieurs langues pour la recherche inter-langues. Si aucune langue n’est sélectionnée, le système recherche avec la requête originale.`,
+      crossLanguagePlaceholder: 'Sélectionner une valeur',
+      crossLanguageTip: `Sélectionnez une ou plusieurs langues pour la recherche inter-langues. Si aucune langue n'est sélectionnée, le système recherche avec la requête originale.`,
+      messagePlaceholder: 'Saisissez votre message ici...',
+      exit: 'Quitter',
+      multipleModels: 'Plusieurs modèles',
+      applyModelConfigs: 'Appliquer la configuration du modèle',
+      conversations: 'Conversations',
+      chatApps: 'Applications de chat',
+      emptyResponsePlaceholder:
+        'La réponse que vous cherchez ne se trouve pas dans la base de connaissances !',
+      knowledgeBasesPlaceholder: 'Sélectionner une valeur',
+      systemPlaceholder: `Vous êtes un assistant intelligent. Votre fonction principale est de répondre aux questions en vous basant strictement sur la base de connaissances fournie.
+
+**Règles essentielles :**
+  - Votre réponse doit être dérivée **uniquement** de cet ensemble de données : {knowledge}.
+  - **Lorsque l'information est disponible** : Résumez le contenu pour donner une réponse détaillée.
+  - **Lorsque l'information est indisponible** : Votre réponse doit contenir exactement cette phrase : "La réponse que vous cherchez ne se trouve pas dans la base de connaissances !"
+  - **Tenez toujours compte** de l'historique complet de la conversation.`,
+      custom: 'Personnalisé',
+      published: 'Publié',
+      publishedTooltip:
+        "Utiliser la version publiée pour cette intégration. Lorsqu'activé, l'URL générée inclut release=true.",
+      embedType: "Type d'intégration",
+      fullscreenChat: 'Chat plein écran (iframe traditionnel)',
+      floatingWidget: 'Widget flottant (style Intercom)',
+      theme: 'Thème',
+      light: 'Clair',
+      dark: 'Sombre',
+      enableStreaming: 'Activer les réponses en streaming',
+      muteWidget: 'Désactiver les sons du widget',
+      createChat: 'Créer un chat',
+      metadata: 'Métadonnées',
+      metadataTip:
+        "Le filtrage par métadonnées consiste à utiliser des attributs (tags, catégories, permissions d'accès…) pour affiner la récupération d'informations pertinentes.",
+      conditions: 'Conditions',
+      metadataKeys: 'Éléments filtrables',
+      addCondition: 'Ajouter une condition',
+      meta: {
+        disabled: 'Désactivé',
+        auto: 'Automatique',
+        manual: 'Manuel',
+        semi_auto: 'Semi-automatique',
+      },
+      cancel: 'Annuler',
+      chatSetting: 'Paramètres du chat',
+      tocEnhance: 'IndexPage',
+      tocEnhanceTip: `Lors de l'analyse du document, des informations de table des matières ont été générées (voir l'option 'Activer l'extraction de la table des matières' dans la méthode Général). Cela permet au grand modèle de retourner les éléments de table des matières pertinents à la requête de l'utilisateur, d'utiliser ces éléments pour récupérer les segments associés et d'appliquer une pondération lors du tri.`,
+      batchDeleteSessions: 'Suppression en masse',
+      deleteSelectedConfirm:
+        'Supprimer les {{count}} session(s) sélectionnée(s) ?',
     },
     language: {
       english: 'Anglais',
       chinese: 'Chinois',
+      spanish: 'Espagnol',
+      french: 'Français',
+      german: 'Allemand',
+      japanese: 'Japonais',
+      korean: 'Coréen',
+      vietnamese: 'Vietnamien',
       russian: 'Russe',
       bulgarian: 'Bulgare',
       arabic: 'Arabe',
@@ -498,7 +1136,7 @@ export default {
         'Mettez à jour votre photo et vos informations personnelles ici.',
       maxTokens: 'Nombre maximum de tokens',
       maxTokensMessage: 'Le nombre maximum de tokens est requis',
-      maxTokensTip: `La taille maximale de contexte de l’modèle ; une valeur invalide ou incorrecte provoquera une erreur. Valeur par défaut : 512.`,
+      maxTokensTip: `La taille maximale de contexte de l'modèle ; une valeur invalide ou incorrecte provoquera une erreur. Valeur par défaut : 512.`,
       maxTokensInvalidMessage:
         'Veuillez saisir un nombre valide pour le nombre maximum de tokens.',
       maxTokensMinMessage:
@@ -597,16 +1235,16 @@ export default {
       addLlmBaseUrl: 'URL de base',
       baseUrlNameMessage: 'Veuillez saisir votre URL de base !',
       paddleocr: {
-        apiUrl: 'URL de l’API PaddleOCR',
+        apiUrl: "URL de l'API PaddleOCR",
         apiUrlPlaceholder:
           'Par exemple : https://paddleocr-server.com/layout-parsing',
-        accessToken: 'Jeton d’accès AI Studio',
+        accessToken: "Jeton d'accès AI Studio",
         accessTokenPlaceholder: 'Votre jeton AI Studio (optionnel)',
         algorithm: 'Algorithme PaddleOCR',
         selectAlgorithm: 'Sélectionner un algorithme',
         modelNamePlaceholder: 'Par exemple : paddleocr-from-env-1',
         modelNameRequired: 'Le nom du modèle est obligatoire',
-        apiUrlRequired: 'L’URL de l’API PaddleOCR est obligatoire',
+        apiUrlRequired: "L'URL de l'API PaddleOCR est obligatoire",
       },
       vision: 'Supporte-t-il la vision ?',
       ollamaLink: 'Comment intégrer {{name}}',
@@ -691,10 +1329,319 @@ export default {
       viewLangfuseSDocumentation: 'Voir la documentation de Langfuse',
       view: 'Voir',
       modelsToBeAddedTooltip:
-        'Si votre fournisseur de modèle n\'est pas listé mais prétend être "compatible OpenAI", sélectionnez la carte compatible OpenAI-API pour ajouter le(s) modèle(s) pertinent(s).',
+        'Si votre fournisseur de modèle n\\\'est pas listé mais prétend être "compatible OpenAI", sélectionnez la carte compatible OpenAI-API pour ajouter le(s) modèle(s) pertinent(s).',
       mcp: 'MCP',
       dingtalkAITableDescription:
         "Connectez-vous à Dingtalk AI Table et synchronisez les enregistrements d'une table spécifiée.",
+      Verify: 'Vérifier',
+      keyValid: 'Votre clé API est valide.',
+      keyInvalid: 'Votre clé API est invalide.',
+      enableToolCall: "Activer l'appel d'outils",
+      enableToolCallTip:
+        "Autoriser ce modèle à appeler des outils lorsque le type de modèle sélectionné prend en charge l'appel d'outils.",
+      deleteModel: 'Supprimer le modèle',
+      bedrockCredentialsHint:
+        "Astuce : laissez la clé d'accès / clé secrète vides pour utiliser l'authentification AWS IAM.",
+      awsAuthModeAccessKeySecret: "Clé d'accès",
+      awsAuthModeIamRole: 'IAM Role',
+      awsAuthModeAssumeRole: 'Assume Role',
+      awsAuthModeProfile: 'Profil AWS',
+      awsAuthModeKey: 'Clé AWS',
+      awsAccessKeyId: "ID de clé d'accès AWS",
+      awsSecretAccessKey: 'Clé secrète AWS',
+      awsRoleArn: 'AWS Role ARN',
+      awsRoleArnMessage: 'Veuillez saisir le AWS Role ARN',
+      awsAssumeRoleTip:
+        "Si vous sélectionnez ce mode, l'instance Amazon EC2 utilisera son rôle existant pour accéder aux services AWS. Aucune information d'identification supplémentaire n'est requise.",
+      modelEmptyTip:
+        'Aucun modèle disponible. <br>Veuillez ajouter des modèles depuis le panneau de droite.',
+      sourceEmptyTip:
+        'Aucune source de données ajoutée. Sélectionnez-en une ci-dessous pour vous connecter.',
+      seconds: 'secondes',
+      minutes: 'minutes',
+      edit: 'Modifier',
+      cropTip:
+        "Faites glisser la zone de sélection pour choisir la position de recadrage de l'image, et faites défiler pour zoomer/dézoomer",
+      cropImage: "Recadrer l'image",
+      selectModelPlaceholder: 'Sélectionner un modèle',
+      configureModelTitle: 'Configurer le modèle',
+      connectorNameTip: 'Un nom descriptif pour le connecteur',
+      syncDeletedFiles: 'Synchroniser les fichiers supprimés',
+      confluenceIsCloudTip:
+        'Cochez si cette instance est Confluence Cloud, décochez pour Confluence Server/Data Center',
+      confluenceWikiBaseUrlTip:
+        "L'URL de base de votre instance Confluence (ex. : https://votre-domaine.atlassian.net/wiki)",
+      confluenceSpaceKeyTip:
+        "Optionnel : spécifiez une clé d'espace pour limiter la synchronisation à un espace spécifique. Laissez vide pour synchroniser tous les espaces accessibles. Pour plusieurs espaces, séparez par des virgules (ex. : DEV,DOCS,HR)",
+      s3PrefixTip: `Spécifiez le chemin du dossier dans votre bucket S3 depuis lequel récupérer les fichiers.
+Exemple : general/v2/`,
+      S3CompatibleEndpointUrlTip: `Requis pour un Storage Box compatible S3. Spécifiez l'URL du point de terminaison compatible S3.
+Exemple : https://fsn1.your-objectstorage.com`,
+      S3CompatibleAddressingStyleTip: `Requis pour un Storage Box compatible S3. Spécifiez le style d'adressage compatible S3.
+Exemple : Virtual Hosted Style`,
+      addDataSourceModalTitle: 'Créer votre connecteur {{name}}',
+      deleteSourceModalTitle: 'Supprimer la source de données',
+      deleteSourceModalContent: `
+      <p>Êtes-vous sûr de vouloir supprimer ce lien vers la source de données ?</p>`,
+      deleteSourceModalConfirmText: 'Confirmer',
+      errorMsg: "Message d'erreur",
+      newDocs: 'Nouveaux documents',
+      timeStarted: 'Heure de démarrage',
+      log: 'Journal',
+      rssDescription:
+        'Connectez-vous à un flux RSS ou Atom public et synchronisez les entrées dans votre base de connaissances.',
+      confluenceDescription:
+        'Intégrez votre espace Confluence pour rechercher dans la documentation.',
+      s3Description:
+        'Connectez-vous à votre bucket AWS S3 pour importer et synchroniser les fichiers stockés.',
+      google_cloud_storageDescription:
+        'Connectez votre bucket Google Cloud Storage pour importer et synchroniser des fichiers.',
+      r2Description:
+        'Connectez votre bucket Cloudflare R2 pour importer et synchroniser des fichiers.',
+      oci_storageDescription:
+        'Connectez votre bucket Oracle Cloud Object Storage pour importer et synchroniser des fichiers.',
+      discordDescription:
+        'Liez votre serveur Discord pour accéder et analyser les données de chat.',
+      notionDescription:
+        'Synchronisez des pages et bases de données Notion pour la recherche de connaissances.',
+      google_driveDescription:
+        'Connectez votre Google Drive via OAuth et synchronisez des dossiers ou lecteurs spécifiques.',
+      gmailDescription:
+        'Connectez votre Gmail via OAuth pour synchroniser les e-mails.',
+      webdavDescription:
+        'Connectez-vous à des serveurs WebDAV pour synchroniser des fichiers.',
+      webdavRemotePathTip:
+        'Optionnel : spécifiez un chemin de dossier sur le serveur WebDAV (ex. : /Documents). Laissez vide pour synchroniser depuis la racine.',
+      google_driveTokenTip:
+        'Téléversez le JSON de jeton OAuth généré depuis l\'assistant OAuth ou Google Cloud Console. Vous pouvez également téléverser un JSON client_secret depuis une application "installed" ou "web". Si c\'est votre première synchronisation, une fenêtre de navigateur s\'ouvrira pour finaliser le consentement OAuth. Si le JSON contient déjà un jeton de rafraîchissement, il sera réutilisé automatiquement.',
+      google_drivePrimaryAdminTip:
+        "Adresse e-mail disposant d'un accès au contenu Drive à synchroniser",
+      zendeskDescription:
+        'Connectez votre Zendesk pour synchroniser les tickets, articles et autres contenus.',
+      google_driveMyDriveEmailsTip:
+        'E-mails séparés par des virgules dont le contenu "Mon Drive" doit être indexé (inclure l\'administrateur principal).',
+      google_driveSharedFoldersTip:
+        'Liens de dossiers Google Drive séparés par des virgules à parcourir.',
+      gmailPrimaryAdminTip:
+        "E-mail de l'administrateur principal avec accès Gmail / Workspace, utilisé pour énumérer les utilisateurs du domaine et comme compte de synchronisation par défaut.",
+      gmailTokenTip:
+        "Téléversez le JSON OAuth généré depuis Google Console. S'il ne contient que des identifiants client, exécutez une fois la vérification en navigateur pour créer des jetons de rafraîchissement à longue durée de vie.",
+      dropboxDescription:
+        'Connectez votre Dropbox pour synchroniser les fichiers et dossiers depuis un compte choisi.',
+      bitbucketDescription:
+        'Connectez Bitbucket pour synchroniser le contenu des PR.',
+      bitbucketTopWorkspaceTip:
+        'Le workspace Bitbucket à indexer (ex. : "atlassian" depuis https://bitbucket.org/atlassian/workspace).',
+      bitbucketRepositorySlugsTip:
+        'Slugs de dépôts séparés par des virgules. Ex. : repo-one,repo-two',
+      bitbucketProjectsTip:
+        'Clés de projets séparées par des virgules. Ex. : PROJ1,PROJ2',
+      bitbucketWorkspaceTip:
+        'Ce connecteur indexera tous les dépôts dans le workspace.',
+      boxDescription:
+        'Connectez votre Box drive pour synchroniser les fichiers et dossiers.',
+      githubDescription:
+        'Connectez GitHub pour synchroniser les pull requests et issues pour la recherche.',
+      airtableDescription:
+        "Connectez-vous à Airtable et synchronisez les fichiers d'une table spécifiée dans un espace de travail désigné.",
+      gitlabDescription:
+        'Connectez GitLab pour synchroniser les dépôts, issues, merge requests et la documentation associée.',
+      asanaDescription:
+        "Connectez-vous à Asana et synchronisez les fichiers d'un espace de travail spécifié.",
+      imapDescription:
+        'Connectez-vous à votre boîte mail IMAP pour synchroniser les e-mails et les rendre accessibles dans votre base de connaissances.',
+      dropboxAccessTokenTip:
+        "Générez un jeton d'accès longue durée dans la console d'application Dropbox avec les portées files.metadata.read, files.content.read et sharing.read.",
+      moodleDescription:
+        'Connectez-vous à votre LMS Moodle pour synchroniser le contenu des cours, forums et ressources.',
+      moodleUrlTip:
+        "L'URL de base de votre instance Moodle (ex. : https://moodle.university.edu). N'incluez pas /webservice ou /login.",
+      moodleTokenTip:
+        "Générez un jeton de service web dans Moodle : allez dans Administration du site → Serveur → Services web → Gérer les jetons. L'utilisateur doit être inscrit aux cours que vous souhaitez synchroniser.",
+      seafileDescription:
+        'Connectez-vous à votre serveur SeaFile pour synchroniser les fichiers et documents de vos bibliothèques.',
+      seafileUrlTip:
+        "L'URL complète de votre serveur SeaFile incluant le protocole. Exemple : https://seafile.example.com — N'incluez pas de barre oblique finale ni de chemin après le domaine.",
+      seafileAccountScopeTip:
+        'Synchronise toutes les bibliothèques visibles par le jeton API de compte ci-dessous.',
+      seafileTokenPanelHeading:
+        "Fournissez l'une de ces méthodes d'authentification :",
+      seafileTokenPanelAccountBullet:
+        '- donne accès à toutes vos bibliothèques.',
+      seafileTokenPanelLibraryBullet:
+        '— limité à une seule bibliothèque (plus sécurisé).',
+      seafileValidationAccountTokenRequired:
+        'Le jeton API de compte est requis pour la portée Compte entier',
+      seafileValidationTokenRequired:
+        'Fournissez soit un jeton API de compte, soit un jeton de bibliothèque',
+      seafileValidationLibraryIdRequired: "L'ID de bibliothèque est requis",
+      seafileValidationDirectoryPathRequired:
+        'Le chemin du répertoire est requis',
+      seafileSyncScopeTip:
+        'Contrôle ce qui est synchronisé : ' +
+        '(1) Compte entier — synchronise toutes les bibliothèques accessibles par votre jeton. Nécessite un jeton API de compte. ' +
+        "(2) Bibliothèque unique — synchronise tous les fichiers d'une bibliothèque spécifique. Nécessite l'ID de bibliothèque et soit un jeton API de compte, soit un jeton API de bibliothèque. " +
+        "(3) Répertoire spécifique — synchronise uniquement les fichiers d'un dossier spécifique dans une bibliothèque. Nécessite l'ID de bibliothèque, le chemin du dossier dans cette bibliothèque, et soit un jeton API de compte, soit un jeton API de bibliothèque.",
+      seafileTokenTip:
+        'Votre jeton API SeaFile au niveau du compte. ' +
+        'Donne accès à toutes les bibliothèques visibles par votre compte. ' +
+        'Requis lorsque la portée de synchronisation est "Compte entier". ' +
+        'Pour "Bibliothèque unique" ou "Répertoire spécifique", vous pouvez utiliser ce jeton ou un jeton API de bibliothèque.',
+      seafileRepoTokenTip:
+        "Un jeton API limité à une bibliothèque qui ne donne accès qu'à une seule bibliothèque spécifique. " +
+        'Peut être utilisé à la place du jeton API de compte pour les portées "Bibliothèque unique" et "Répertoire spécifique".',
+      seafileRepoIdTip:
+        "L'identifiant unique (UUID) de la bibliothèque SeaFile à synchroniser. " +
+        "Vous pouvez le trouver dans la barre d'adresse de votre navigateur lorsque vous ouvrez la bibliothèque dans l'interface web SeaFile. " +
+        'Exemple : 7a9e1b3c-4d5f-6a7b-8c9d-0e1f2a3b4c5d. ' +
+        'Requis lorsque la portée de synchronisation est "Bibliothèque unique" ou "Répertoire spécifique".',
+      seafileSyncPathTip:
+        "Le chemin absolu du dossier à synchroniser dans la bibliothèque spécifiée par l'ID de bibliothèque ci-dessus. " +
+        'Doit commencer par une barre oblique. ' +
+        'Tous les fichiers et sous-dossiers sous ce chemin seront inclus récursivement. ' +
+        'Exemple : /Documents/Rapports. ' +
+        'Important : le dossier doit exister dans la bibliothèque spécifiée. ' +
+        'Les chemins en dehors de la bibliothèque ne sont pas pris en charge. ' +
+        'Utilisé uniquement lorsque la portée de synchronisation est "Répertoire spécifique".',
+      seafileIncludeSharedTip:
+        "Lorsqu'activé, les bibliothèques partagées par d'autres utilisateurs sont incluses dans la synchronisation. " +
+        'Lorsque désactivé, seules les bibliothèques appartenant à votre compte sont synchronisées. ' +
+        'S\'applique uniquement lorsque la portée de synchronisation est "Compte entier".',
+      seafileBatchSizeTip:
+        'Le nombre de documents traités et renvoyés par lot lors de la synchronisation. ' +
+        'Une valeur plus petite utilise moins de mémoire mais peut être plus lente. ' +
+        'Par défaut : 100.',
+      jiraDescription:
+        'Connectez votre espace Jira pour synchroniser les issues, commentaires et pièces jointes.',
+      jiraBaseUrlTip:
+        'URL de base de votre site Jira (ex. : https://votre-domaine.atlassian.net).',
+      jiraProjectKeyTip:
+        'Optionnel : limitez la synchronisation à une seule clé de projet (ex. : ENG).',
+      jiraJqlTip:
+        'Filtre JQL optionnel. Laissez vide pour utiliser les filtres de projet/temps.',
+      jiraBatchSizeTip: "Nombre maximum d'issues demandées à Jira par lot.",
+      jiraCommentsTip:
+        'Inclure les commentaires Jira dans le document markdown généré.',
+      jiraAttachmentsTip:
+        'Télécharger les pièces jointes comme documents séparés lors de la synchronisation.',
+      jiraAttachmentSizeTip:
+        "Les pièces jointes dont la taille dépasse ce nombre d'octets seront ignorées.",
+      jiraLabelsTip:
+        "Labels à ignorer lors de l'indexation (séparés par des virgules).",
+      jiraBlacklistTip:
+        "Les commentaires dont l'e-mail de l'auteur correspond à ces entrées seront ignorés.",
+      jiraScopedTokenTip:
+        'Activez ceci lorsque vous utilisez des jetons Atlassian à portée limitée (api.atlassian.com).',
+      jiraEmailTip: 'E-mail associé au compte Jira / jeton API.',
+      jiraTokenTip:
+        'Jeton API généré depuis https://id.atlassian.com/manage-profile/security/api-tokens.',
+      jiraPasswordTip:
+        'Mot de passe optionnel pour les environnements Jira Server/Data Center.',
+      mysqlDescription:
+        'Connectez-vous à une base de données MySQL pour synchroniser des données de tables via des requêtes SQL.',
+      mysqlQueryTip:
+        'Requête SQL pour extraire des données de votre base de données (ex. : SELECT * FROM products WHERE status = "active").',
+      mysqlContentColumnsTip:
+        'Noms de colonnes séparés par des virgules dont les valeurs seront combinées comme contenu du document pour la vectorisation.',
+      mysqlMetadataColumnsTip:
+        'Noms de colonnes séparés par des virgules à stocker comme métadonnées du document (non vectorisées, mais consultables).',
+      mysqlIdColumnTip:
+        'Colonne à utiliser comme identifiant unique du document. Si non spécifié, un hash du contenu sera utilisé.',
+      mysqlTimestampColumnTip:
+        'Colonne datetime/timestamp pour la synchronisation incrémentale. Seules les lignes modifiées après la dernière synchronisation seront récupérées.',
+      postgresqlDescription:
+        'Connectez-vous à une base de données PostgreSQL pour synchroniser des données de tables via des requêtes SQL.',
+      postgresqlQueryTip:
+        "Requête SQL pour extraire des données de votre base de données (ex. : SELECT * FROM products WHERE status = 'active').",
+      postgresqlContentColumnsTip:
+        'Noms de colonnes séparés par des virgules dont les valeurs seront combinées comme contenu du document pour la vectorisation.',
+      postgresqlMetadataColumnsTip:
+        'Noms de colonnes séparés par des virgules à stocker comme métadonnées du document (non vectorisées, mais consultables).',
+      postgresqlIdColumnTip:
+        'Colonne à utiliser comme identifiant unique du document. Si non spécifié, un hash du contenu sera utilisé.',
+      postgresqlTimestampColumnTip:
+        'Colonne datetime/timestamp pour la synchronisation incrémentale. Seules les lignes modifiées après la dernière synchronisation seront récupérées.',
+      rest_apiDescription:
+        "Connectez n'importe quel point de terminaison REST API comme source de données via un connecteur flexible et configurable.",
+      restApiQueryParamsTip:
+        "Paires clé=valeur (une par ligne) envoyées comme paramètres de requête URL. Utilisez ceci plutôt qu'intégrer les paramètres dans l'URL.",
+      restApiHeadersTip:
+        "Objet JSON optionnel d'en-têtes HTTP supplémentaires à envoyer avec chaque requête.",
+      restApiItemsPathTip:
+        'Nom du champ ou JSONPath vers le tableau d\'éléments dans la réponse. Laissez vide pour la détection automatique (essaie "items", "results", "data", etc.).',
+      restApiIdFieldTip:
+        "Chemin de champ dans chaque élément utilisé pour construire un ID de document stable. Laissez vide pour générer automatiquement à partir d'un hash de contenu.",
+      restApiContentFieldsTip:
+        'Liste de champs séparés par des virgules à concaténer comme contenu du document.',
+      restApiMetadataFieldsTip:
+        'Liste de champs séparés par des virgules à stocker comme métadonnées.',
+      restApiNextCursorPathTip:
+        'Expression JSONPath qui résout le curseur de la page suivante dans la réponse API.',
+      restApiPollTimestampFieldTip:
+        'Chemin de champ dans chaque élément représentant la dernière heure de mise à jour, utilisé pour la synchronisation incrémentale.',
+      restApiRequestBodyTip:
+        'Corps JSON optionnel à envoyer pour les requêtes POST. Utilisé avec les paramètres de requête et la pagination.',
+      restApiRequestDelayTip:
+        "Délai en secondes entre les requêtes de pages consécutives. Aide à éviter la limitation de débit de l'API. Définissez à 0 pour désactiver.",
+      restApiValidationApiKeyRequired:
+        "La clé API est requise lorsque le type d'authentification est API Key (Header).",
+      restApiValidationApiKeyHeaderNameRequired:
+        "Le nom d'en-tête de la clé API est requis lorsque le type d'authentification est API Key (Header).",
+      restApiValidationBearerTokenRequired:
+        "Le jeton Bearer est requis lorsque le type d'authentification est Bearer Token.",
+      restApiValidationBasicUsernameRequired:
+        "Le nom d'utilisateur est requis lorsque le type d'authentification est Basic Auth.",
+      restApiValidationBasicPasswordRequired:
+        "Le mot de passe est requis lorsque le type d'authentification est Basic Auth.",
+      restApiTestConnection: 'Tester la connexion',
+      restApiTestSuccess: 'Le connecteur REST API a été validé avec succès.',
+      restApiTestFailed:
+        'La validation du connecteur REST API a échoué. Veuillez vérifier votre configuration et les journaux.',
+      availableSourcesDescription:
+        'Sélectionner une source de données à ajouter',
+      availableSources: 'Sources disponibles',
+      datasourceDescription: 'Gérez vos sources de données et connexions',
+      save: 'Enregistrer',
+      search: 'Rechercher',
+      availableModels: 'Modèles disponibles',
+      systemModelDescription:
+        'Veuillez compléter ces paramètres avant de commencer',
+      dataSources: 'Sources de données',
+      mineru: {
+        modelNameRequired: 'Le nom du modèle est obligatoire',
+        apiServerRequired:
+          'La configuration du serveur API MinerU est obligatoire',
+        serverUrlBackendLimit:
+          "L'adresse URL du serveur MinerU est uniquement disponible pour le backend client HTTP",
+        apiserver: 'Configuration du serveur API MinerU',
+        outputDir: 'Chemin du répertoire de sortie MinerU',
+        backend: 'Type de backend de traitement MinerU',
+        serverUrl: 'Adresse URL du serveur MinerU',
+        deleteOutput: 'Supprimer les fichiers de sortie après traitement',
+        selectBackend: 'Sélectionner le backend de traitement',
+        backendOptions: {
+          pipeline: 'Traitement par pipeline standard',
+          vlmTransformers: 'Modèle de langage visuel avec Transformers',
+          vlmVllmEngine: 'Modèle de langage visuel avec moteur vLLM',
+          vlmHttpClient: 'Modèle de langage visuel via client HTTP',
+          vlmMlxEngine: 'Modèle de langage visuel avec moteur MLX',
+          vlmVllmAsyncEngine:
+            'Modèle de langage visuel avec moteur vLLM asynchrone (Expérimental)',
+          vlmLmdeployEngine:
+            'Modèle de langage visuel avec moteur LMDeploy (Expérimental)',
+        },
+      },
+      modelTypes: {
+        chat: 'Chat',
+        embedding: 'Embedding',
+        rerank: 'Rerank',
+        sequence2text: 'sequence2text',
+        tts: 'TTS',
+        image2text: 'OCR',
+        speech2text: 'ASR',
+      },
+      showToc: 'Afficher le contenu',
+      hideToc: 'Masquer le contenu',
     },
     message: {
       registered: 'Enregistré !',
@@ -711,20 +1658,20 @@ export default {
       uploaded: 'Téléversé',
       200: 'Le serveur a renvoyé les données demandées avec succès.',
       201: 'Création ou modification des données réussie.',
-      202: 'La requête a été mise en file d’attente en arrière-plan (tâche asynchrone).',
+      202: "La requête a été mise en file d'attente en arrière-plan (tâche asynchrone).",
       204: 'Données supprimées avec succès.',
-      400: 'Erreur dans la requête émise, le serveur n’a pas créé ou modifié les données.',
+      400: "Erreur dans la requête émise, le serveur n'a pas créé ou modifié les données.",
       401: 'Veuillez vous reconnecter.',
       403: "L'utilisateur est autorisé, mais l'accès est interdit.",
       404: "La requête concernait un enregistrement inexistant, le serveur n'a pas effectué l'opération.",
-      406: 'Le format demandé n’est pas disponible.',
+      406: "Le format demandé n'est pas disponible.",
       410: 'La ressource demandée a été définitivement supprimée et ne sera plus disponible.',
-      413: 'La taille totale des fichiers téléversés d’un coup est trop grande.',
+      413: "La taille totale des fichiers téléversés d'un coup est trop grande.",
       422: "Une erreur de validation s'est produite lors de la création de l'objet.",
       500: 'Erreur serveur, veuillez vérifier le serveur.',
       502: 'Erreur de passerelle.',
       503: 'Service indisponible, le serveur est temporairement surchargé ou en maintenance.',
-      504: 'Délai d’attente de la passerelle dépassé.',
+      504: "Délai d'attente de la passerelle dépassé.",
       requestError: 'Erreur de requête',
       networkAnomalyDescription:
         'Il y a une anomalie sur votre réseau et vous ne pouvez pas vous connecter au serveur.',
@@ -732,6 +1679,9 @@ export default {
       hint: 'Astuce',
     },
     fileManager: {
+      uploadFolderTitle: 'Téléverser un dossier',
+      folder: 'Dossier',
+      files: 'Fichiers',
       name: 'Nom',
       uploadDate: 'Date de téléversement',
       knowledgeBase: 'Base de connaissances',
@@ -746,7 +1696,7 @@ export default {
       directory: 'Répertoire',
       uploadTitle: 'Glissez-déposez votre fichier ici pour téléverser',
       uploadDescription:
-        'Prise en charge du téléversement de fichiers uniques ou en lot. Pour un déploiement local de RAGFlow : la taille totale des fichiers par téléversement est limitée à 1 Go, avec un maximum de 32 fichiers par lot. Il n’y a pas de limite sur le nombre total de fichiers par compte. Pour cloud.ragflow.io, la taille totale des fichiers par téléversement est limitée à 10 Mo, chaque fichier ne devant pas dépasser 10 Mo, avec un maximum de 128 fichiers par compte.',
+        "Prise en charge du téléversement de fichiers uniques ou en lot. Pour un déploiement local de RAGFlow : la taille totale des fichiers par téléversement est limitée à 1 Go, avec un maximum de 32 fichiers par lot. Il n'y a pas de limite sur le nombre total de fichiers par compte. Pour cloud.ragflow.io, la taille totale des fichiers par téléversement est limitée à 10 Mo, chaque fichier ne devant pas dépasser 10 Mo, avec un maximum de 128 fichiers par compte.",
       local: 'Téléversements locaux',
       s3: 'Téléversements S3',
       preview: 'Aperçu',
@@ -754,6 +1704,7 @@ export default {
       uploadLimit:
         'Chaque fichier ne doit pas dépasser 10 Mo, et le nombre total de fichiers ne doit pas dépasser 128.',
       destinationFolder: 'Dossier de destination',
+      pleaseUploadAtLeastOneFile: 'Veuillez téléverser au moins un fichier',
     },
     flow: {
       cite: 'Citation',
@@ -996,7 +1947,7 @@ export default {
       qWeatherTypeOptions: {
         weather: 'Prévisions météo',
         indices: 'Indices météo-vie',
-        airquality: 'Qualité de l’air',
+        airquality: "Qualité de l'air",
       },
       qWeatherUserTypeOptions: {
         free: 'Abonné gratuit',
@@ -1016,7 +1967,7 @@ export default {
         'Un composant qui exécute des requêtes SQL sur une base de données relationnelle, supportant MySQL, PostgreSQL ou MariaDB.',
       dbType: 'Type de base de données',
       database: 'Base de données',
-      username: 'Nom d’utilisateur',
+      username: "Nom d'utilisateur",
       host: 'Hôte',
       port: 'Port',
       password: 'Mot de passe',
@@ -1034,7 +1985,11 @@ export default {
         startWith: 'Commence par',
         endWith: 'Se termine par',
         empty: 'Est vide',
-        notEmpty: 'N’est pas vide',
+        notEmpty: "N'est pas vide",
+        in: 'Dans',
+        notIn: 'Pas dans',
+        is: 'Est',
+        isNot: "N'est pas",
       },
       switchLogicOperatorOptions: {
         and: 'ET',
@@ -1046,7 +2001,7 @@ export default {
       wenCai: 'WenCai',
       queryType: 'Type de requête',
       wenCaiDescription:
-        'Un composant qui obtient des informations financières, y compris les cours des actions et les actualités de financement, à partir d’un large éventail de sites financiers.',
+        "Un composant qui obtient des informations financières, y compris les cours des actions et les actualités de financement, à partir d'un large éventail de sites financiers.",
       wenCaiQueryTypeOptions: {
         stock: 'action',
         zhishu: 'indice',
@@ -1066,16 +2021,16 @@ export default {
       yahooFinance: 'YahooFinance',
       yahooFinanceDescription:
         'Un composant qui interroge des informations sur une société cotée en bourse à partir de son symbole boursier.',
-      crawler: 'Robot d’exploration',
+      crawler: "Robot d'exploration",
       crawlerDescription:
-        'Un composant qui récupère le code source HTML d’une URL spécifiée.',
+        "Un composant qui récupère le code source HTML d'une URL spécifiée.",
       proxy: 'Proxy',
       crawlerResultOptions: {
         html: 'Html',
         markdown: 'Markdown',
         content: 'Contenu',
       },
-      extractType: 'Type d’extraction',
+      extractType: "Type d'extraction",
       info: 'Infos',
       history: 'Historique',
       financials: 'Informations financières',
@@ -1130,7 +2085,7 @@ export default {
         'Un composant qui reçoit la sortie du composant en amont et la transmet en entrée aux composants en aval.',
       tuShare: 'TuShare',
       tuShareDescription:
-        'Un composant qui obtient des brèves d’actualités financières depuis des sites financiers grand public, aidant la recherche sectorielle et quantitative.',
+        "Un composant qui obtient des brèves d'actualités financières depuis des sites financiers grand public, aidant la recherche sectorielle et quantitative.",
       tuShareSrcOptions: {
         sina: 'Sina',
         wallstreetcn: 'wallstreetcn',
@@ -1149,10 +2104,10 @@ export default {
       noteDescription: 'Note',
       notePlaceholder: 'Veuillez entrer une note',
       invoke: 'Requête HTTP',
-      invokeDescription: `Un composant capable d’appeler des services distants, utilisant les sorties d’autres composants ou des constantes en entrée.`,
+      invokeDescription: `Un composant capable d'appeler des services distants, utilisant les sorties d'autres composants ou des constantes en entrée.`,
       url: 'URL',
       method: 'Méthode',
-      timeout: 'Délai d’attente',
+      timeout: "Délai d'attente",
       headers: 'En-têtes',
       cleanHtml: 'Nettoyer le HTML',
       cleanHtmlTip:
@@ -1163,48 +2118,48 @@ export default {
       input: 'Entrée',
       output: 'Sortie',
       parameter: 'Paramètre',
-      howUseId: 'Comment utiliser l’ID agent ?',
+      howUseId: "Comment utiliser l'ID agent ?",
       content: 'Contenu',
-      operationResults: 'Résultats de l’opération',
+      operationResults: "Résultats de l'opération",
       autosaved: 'Sauvegardé automatiquement',
       optional: 'Optionnel',
       pasteFileLink: 'Coller le lien du fichier',
       testRun: 'Test',
       template: 'Modèle',
       templateDescription:
-        'Un composant qui formate la sortie des autres composants. 1. Supporte les templates Jinja2, convertit d’abord l’entrée en objet puis rend le template, 2. Conserve en parallèle la méthode originale de remplacement de chaîne {parameter}',
+        "Un composant qui formate la sortie des autres composants. 1. Supporte les templates Jinja2, convertit d'abord l'entrée en objet puis rend le template, 2. Conserve en parallèle la méthode originale de remplacement de chaîne {parameter}",
       emailComponent: 'Email',
       emailDescription: 'Envoyer un email à une adresse spécifiée.',
       smtpServer: 'Hôte SMTP',
       smtpPort: 'Port SMTP',
-      senderEmail: 'Adresse d’expéditeur (From)',
-      smtpUsername: 'Nom d’utilisateur SMTP',
-      authCode: 'Mot de passe SMTP / mot de passe d’application',
-      senderName: 'Nom d’affichage de l’expéditeur',
+      senderEmail: "Adresse d'expéditeur (From)",
+      smtpUsername: "Nom d'utilisateur SMTP",
+      authCode: "Mot de passe SMTP / mot de passe d'application",
+      senderName: "Nom d'affichage de l'expéditeur",
       toEmail: 'Email du destinataire',
       ccEmail: 'Email en copie',
       emailSubject: 'Sujet',
       emailContent: 'Contenu',
-      smtpServerRequired: 'Veuillez saisir l’adresse du serveur SMTP',
-      senderEmailRequired: 'Veuillez saisir l’email de l’expéditeur',
-      authCodeRequired: 'Veuillez saisir le code d’autorisation',
-      toEmailRequired: 'Veuillez saisir l’email du destinataire',
-      emailContentRequired: 'Veuillez saisir le contenu de l’email',
+      smtpServerRequired: "Veuillez saisir l'adresse du serveur SMTP",
+      senderEmailRequired: "Veuillez saisir l'email de l'expéditeur",
+      authCodeRequired: "Veuillez saisir le code d'autorisation",
+      toEmailRequired: "Veuillez saisir l'email du destinataire",
+      emailContentRequired: "Veuillez saisir le contenu de l'email",
       emailSentSuccess: 'Email envoyé avec succès',
-      emailSentFailed: 'Échec de l’envoi de l’email',
+      emailSentFailed: "Échec de l'envoi de l'email",
       dynamicParameters: 'Paramètres dynamiques',
       jsonFormatTip:
         'Le composant en amont doit fournir une chaîne JSON au format suivant :',
       toEmailTip: 'to_email : Email du destinataire (Obligatoire)',
       ccEmailTip: 'cc_email : Email en copie (Optionnel)',
-      subjectTip: 'subject : Sujet de l’email (Optionnel)',
-      contentTip: 'content : Contenu de l’email (Optionnel)',
+      subjectTip: "subject : Sujet de l'email (Optionnel)",
+      contentTip: "content : Contenu de l'email (Optionnel)",
       jsonUploadTypeErrorMessage: 'Veuillez uploader un fichier JSON',
       jsonUploadContentErrorMessage: 'Erreur dans le fichier JSON',
       iteration: 'Itération',
-      iterationDescription: `Un composant de boucle qui itère sur un tableau d’entrée et exécute une logique définie pour chaque élément.`,
+      iterationDescription: `Un composant de boucle qui itère sur un tableau d'entrée et exécute une logique définie pour chaque élément.`,
       delimiterTip: `
-      Ce délimiteur est utilisé pour découper le texte d’entrée en plusieurs morceaux, chacun sera traité comme un élément d’entrée pour chaque itération.`,
+      Ce délimiteur est utilisé pour découper le texte d'entrée en plusieurs morceaux, chacun sera traité comme un élément d'entrée pour chaque itération.`,
       delimiterOptions: {
         comma: 'Virgule',
         lineBreak: 'Saut de ligne',
@@ -1241,14 +2196,14 @@ export default {
       },
       setting: 'Paramètres',
       settings: {
-        agentSetting: 'Paramètres de l’agent',
+        agentSetting: "Paramètres de l'agent",
         title: 'Titre',
         description: 'Description',
         upload: 'Téléverser',
         photo: 'Photo',
         permissions: 'Autorisations',
         permissionsTip:
-          'Vous pouvez définir ici les autorisations des membres de l’équipe.',
+          "Vous pouvez définir ici les autorisations des membres de l'équipe.",
         me: 'Moi',
         team: 'Équipe',
       },
@@ -1264,29 +2219,29 @@ export default {
       },
       prompt: 'Invite',
       promptTip:
-        'Utilisez l’invite système pour décrire la tâche pour le LLM, préciser comment il doit répondre et indiquer d’autres exigences diverses. L’invite système est souvent utilisée avec des clés (variables), qui servent d’entrées de données pour le LLM. Utilisez une barre oblique `/` ou le bouton (x) pour afficher les clés disponibles.',
-      promptMessage: 'L’invite est obligatoire',
-      infor: 'Informations d’exécution',
+        "Utilisez l'invite système pour décrire la tâche pour le LLM, préciser comment il doit répondre et indiquer d'autres exigences diverses. L'invite système est souvent utilisée avec des clés (variables), qui servent d'entrées de données pour le LLM. Utilisez une barre oblique `/` ou le bouton (x) pour afficher les clés disponibles.",
+      promptMessage: "L'invite est obligatoire",
+      infor: "Informations d'exécution",
       knowledgeBasesTip:
         'Sélectionnez les bases de connaissances à associer à cet assistant de chat, ou choisissez ci-dessous les variables contenant les IDs des bases de connaissances.',
       knowledgeBaseVars: 'Variables des bases de connaissances',
       code: 'Code',
       codeDescription:
-        'Permet aux développeurs d’écrire une logique Python personnalisée.',
-      inputVariables: 'Variables d’entrée',
-      runningHintText: 'en cours d’exécution...🕞',
-      openingSwitch: 'Activation de l’accueil',
+        "Permet aux développeurs d'écrire une logique Python personnalisée.",
+      inputVariables: "Variables d'entrée",
+      runningHintText: "en cours d'exécution...🕞",
+      openingSwitch: "Activation de l'accueil",
       openingCopy: 'Message de bienvenue',
       openingSwitchTip:
-        'Vos utilisateurs verront ce message d’accueil au début.',
+        "Vos utilisateurs verront ce message d'accueil au début.",
       modeTip: 'Le mode définit comment le workflow est initié.',
       beginInputTip:
-        'Les paramètres d’entrée définis ici peuvent être accessibles par les composants du workflow en aval.',
+        "Les paramètres d'entrée définis ici peuvent être accessibles par les composants du workflow en aval.",
       query: 'Variables de requête',
       agent: 'Agent',
       agentDescription:
-        'Construit des composants agents équipés de raisonnement, d’utilisation d’outils, et de collaboration multi-agent.',
-      maxRecords: 'Nombre maximum d’enregistrements',
+        "Construit des composants agents équipés de raisonnement, d'utilisation d'outils, et de collaboration multi-agent.",
+      maxRecords: "Nombre maximum d'enregistrements",
       createAgent: 'Créer un agent',
       stringTransform: 'Traitement du texte',
       userFillUp: 'En attente de réponse',
@@ -1301,6 +2256,470 @@ export default {
       export: 'Exporter',
       seconds: 'Secondes',
       subject: 'Sujet',
+      // --- clés manquantes ajoutées ---
+      preprocess: {
+        preprocess: 'Prétraitement',
+        mainContent: 'Contenu principal',
+        abstract: 'Résumé',
+        author: 'Auteur',
+        sectionTitle: 'Titre de section',
+      },
+      editTags: 'Modifier les étiquettes',
+      editTagsDescription:
+        'Ajoutez des étiquettes pour organiser et filtrer vos agents. Appuyez sur Entrée ou virgule pour ajouter.',
+      tagsPlaceholder: 'Ajouter une étiquette et appuyer sur Entrée',
+      tagSuggestionsLabel: 'Étiquettes existantes',
+      removeTagAriaLabel: 'Supprimer {{tag}}',
+      includeHeadingContent: 'Séparer le contenu du titre parent',
+      includeHeadingContentTip:
+        'Lorsque cette option est activée, les blocs incluent uniquement leur chemin de titre et leur contenu ; le contenu suivant immédiatement un titre parent est conservé comme bloc séparé.',
+      rootAsHeading: 'Définir le premier bloc comme contexte global',
+      rootAsHeadingTip:
+        'Traite le premier découpage comme un titre global pour maintenir un contexte cohérent dans la hiérarchie du document. Idéal pour les CV où la première section identifie le sujet.',
+      hierarchyTip: `Construit un arbre de titres et produit des blocs autonomes, chacun portant son chemin ancestral complet (ex. : Partie 1 › Chapitre 3 › Section 2 + corps du texte).\n
+Idéal pour : les textes très structurés — tels que les statuts juridiques, règlements, contrats et spécifications techniques — où chaque bloc doit être identifiable par sa position dans la hiérarchie.`,
+      groupTip: `Découpe le document à plat à un niveau de titre choisi, en fusionnant les petites sections adjacentes pour assurer la cohérence sémantique. Les blocs n'incluent pas le chemin ancestral.\n
+Idéal pour : les documents avec un contenu fluide et contextuellement lié — tels que les livres, manuels, rapports et articles — où la cohérence narrative dépend du maintien de paragraphes adjacents ensemble.`,
+      enableMultiColumn: 'Détecter la mise en page multi-colonnes',
+      enableMultiColumnTip:
+        "Détecte et analyse les mises en page à plusieurs colonnes pour préserver l'ordre de lecture correct. Activez cette option pour les PDF ou documents avec des dispositions à deux colonnes ou en style journal.",
+      removeToc: "Supprimer la table des matières d'origine",
+      removeTocTip:
+        "Supprime la table des matières incluse dans le PDF d'origine, afin qu'elle ne soit pas analysée comme contenu ordinaire ou découpée pour la récupération.",
+      removeHeaderFooter: 'Supprimer en-tête et pied de page',
+      autoPlay: 'Lecture automatique audio',
+      downloadFileTypeTip: 'Le type de fichier à télécharger',
+      downloadFileType: 'Type de fichier à télécharger',
+      formatTypeError: 'Erreur de format ou de type',
+      variableNameMessage:
+        'Le nom de variable ne peut contenir que des lettres, underscores et chiffres',
+      variableDescription: 'Description de la variable',
+      defaultValue: 'Valeur par défaut',
+      conversationVariable: 'Variable de conversation',
+      recommended: 'Recommandé',
+      customerSupport: 'Support client',
+      marketing: 'Marketing',
+      consumerApp: 'Application grand public',
+      other: 'Autre',
+      ingestionPipeline: "Pipeline d'ingestion",
+      agents: 'Agents',
+      publishedAt: 'Publié le',
+      days: 'Jours',
+      beginInput: 'Entrée de départ',
+      ref: 'Variable',
+      stockCode: 'Code action',
+      apiKeyPlaceholder:
+        'YOUR_API_KEY (obtenu depuis https://serpapi.com/manage-api-key)',
+      flowStart: 'Démarrer',
+      flowNum: 'N',
+      test: 'Test',
+      extractDepth: "Profondeur d'extraction",
+      format: 'Format',
+      basic: 'basique',
+      advanced: 'avancé',
+      general: 'général',
+      searchDepth: 'Profondeur de recherche',
+      tavilyTopic: 'Sujet Tavily',
+      maxResults: 'Nombre maximum de résultats',
+      includeAnswer: 'Inclure la réponse',
+      includeRawContent: 'Inclure le contenu brut',
+      includeImages: 'Inclure les images',
+      includeImageDescriptions: 'Inclure les descriptions des images',
+      includeDomains: 'Inclure les domaines',
+      ExcludeDomains: 'Exclure les domaines',
+      Days: 'Jours',
+      comma: 'Virgule',
+      semicolon: 'Point-virgule',
+      period: 'Point',
+      lineBreak: 'Saut de ligne',
+      tab: 'Tabulation',
+      space: 'Espace',
+      delimiters: 'Délimiteurs',
+      one: 'Un',
+      oneChunkTitle: 'Note',
+      oneChunkDescription:
+        'Toutes les sections analysées seront fusionnées dans un seul bloc.',
+      flattenMediaToText: 'Désactiver le modèle de vision',
+      flattenMediaToTextTip:
+        "Traite les sections d'images et de tableaux comme du texte brut et ignore l'amélioration par vision.",
+      enableChildrenDelimiters:
+        'Les blocs enfants sont utilisés pour la récupération',
+      merge: 'Fusionner',
+      split: 'Diviser',
+      script: 'Script',
+      iterationItemDescription:
+        "Représente l'élément courant dans l'itération, qui peut être référencé et manipulé dans les étapes suivantes.",
+      guidingQuestion: 'Question directrice',
+      onFailure: "En cas d'échec",
+      userPromptDefaultValue:
+        "Voici la commande que vous devez envoyer à l'agent.",
+      search: 'Rechercher',
+      communication: 'Communication',
+      developer: 'Développeur',
+      typeCommandORsearch: 'Tapez une commande ou recherchez...',
+      builtIn: 'Intégré',
+      ExceptionDefaultValue: "Valeur par défaut de l'exception",
+      exceptionMethod: "Méthode d'exception",
+      maxRounds: 'Nombre maximum de cycles de réflexion',
+      delayAfterError: 'Délai après une erreur',
+      maxRetries: 'Nombre maximum de tentatives',
+      maxSteps: "Nombre maximum d'étapes",
+      headless: 'Mode sans interface',
+      enableDefaultExtensions: 'Activer les extensions par défaut',
+      enableDefaultExtensionsTip:
+        "Active les extensions par défaut de browser-use (uBlock, gestion des cookies, ClearURLs). Désactivez cette option pour éviter les téléchargements d'extensions au moment de l'exécution.",
+      chromiumSandbox: 'Bac à sable Chromium',
+      chromiumSandboxTip:
+        "Indique si le bac à sable Chromium doit être activé. Dans les environnements Docker root, il est généralement désactivé ; sur les hôtes normaux, il est recommandé de l'activer.",
+      persistSession: 'Conserver la session',
+      persistSessionTip:
+        'Lorsque cette option est activée, ce nœud Browser réutilise sa session de navigateur pour éviter les connexions répétées.',
+      uploadSources: 'Sources de téléversement',
+      uploadSourcesTip:
+        'Prend en charge les IDs de fichiers, les URLs de fichiers ou des variables. Vous pouvez séparer plusieurs valeurs par des virgules ou utiliser un tableau JSON (par exemple ["id1","https://example.com/a.pdf"]).',
+      advancedSettings: 'Paramètres avancés',
+      addTools: 'Ajouter des outils',
+      sysPromptDefaultValue: `
+      <role>
+        Vous êtes un assistant utile, un assistant IA spécialisé dans la résolution de problèmes pour l'utilisateur.
+        Si un domaine spécifique est fourni, adaptez votre expertise à ce domaine ; sinon, agissez en tant que généraliste.
+      </role>
+      <instructions>
+        1. Comprenez la demande de l'utilisateur.
+        2. Décomposez-la en sous-tâches logiques.
+        3. Exécutez chaque sous-tâche étape par étape, en raisonnant de façon transparente.
+        4. Validez l'exactitude et la cohérence.
+        5. Résumez clairement le résultat final.
+      </instructions>`,
+      singleLineText: 'Texte sur une ligne',
+      multimodalModels: 'Modèles multimodaux',
+      textOnlyModels: 'Modèles texte uniquement',
+      allModels: 'Tous les modèles',
+      codeExecDescription:
+        'Rédigez votre logique Python ou Javascript personnalisée.',
+      stringTransformDescription:
+        'Modifie le contenu textuel. Prend actuellement en charge : la division ou la concaténation de texte.',
+      foundation: 'Fondation',
+      tools: 'Outils',
+      dataManipulation: 'Manipulation des données',
+      flow: 'Flux',
+      dialog: 'Dialogue',
+      lastSavedAt: 'Dernière sauvegarde à',
+      descriptionMessage: 'Ceci est un agent pour une tâche spécifique.',
+      loopDescription:
+        "La boucle est la limite supérieure du nombre de répétitions du composant actuel. Lorsque le nombre de boucles dépasse cette valeur, cela signifie que le composant ne peut pas terminer la tâche actuelle, veuillez réoptimiser l'agent.",
+      exitLoop: 'Quitter la boucle',
+      exitLoopDescription: `Équivalent à "break". Ce nœud n'a pas d'éléments de configuration. Lorsque le corps de la boucle atteint ce nœud, la boucle se termine.`,
+      loopVariables: 'Variables de boucle',
+      maximumLoopCount: 'Nombre maximum de boucles',
+      loopTerminationCondition: 'Condition de terminaison de la boucle',
+      userPrompt: 'Invite utilisateur',
+      tocDataSource: 'Source de données',
+      mergePath: 'Fusionner le chemin',
+      mergePathTip:
+        'Lorsque activé, un suffixe point immédiatement après une variable est fusionné dans une requête de chemin, comme {node@result.name}.',
+      addAgent: 'Ajouter un agent',
+      createFromBlank: 'Créer depuis un blanc',
+      createFromTemplate: 'Créer depuis un modèle',
+      importJsonFile: 'Importer un fichier JSON',
+      ceateAgent: 'Workflow',
+      createPipeline: "Pipeline d'ingestion",
+      chooseAgentType: "Choisir le type d'agent",
+      parser: 'Analyseur',
+      parserDescription:
+        'Extrait le texte brut et la structure des fichiers pour le traitement en aval.',
+      tokenizer: 'Indexeur',
+      tokenizerRequired: "Veuillez d'abord ajouter le nœud Indexeur",
+      tokenizerDescription:
+        "Transforme le texte en structure de données requise (ex. : vecteurs d'embedding pour la recherche vectorielle) selon la méthode de recherche choisie.",
+      tokenChunker: 'Découpeur par tokens',
+      tokenChunkerDescription:
+        'Divise le texte en blocs par longueur de token avec des délimiteurs optionnels et un chevauchement.',
+      titleChunkerDescription:
+        'Divise les documents en sections par hiérarchie de titres. Définissez les niveaux de titre avec des règles regex, puis choisissez le mode Hiérarchie ou Groupe pour contrôler la structure des blocs.',
+      titleChunker: 'Découpeur par titres',
+      extractor: 'Transformateur',
+      extractorDescription:
+        'Utilise un LLM pour extraire des informations structurées des blocs de document — telles que des résumés, classifications, etc.',
+      outputFormat: 'Format de sortie',
+      fileFormats: 'Type de fichier',
+      fileFormatOptions: {
+        pdf: 'PDF',
+        spreadsheet: 'Tableur',
+        image: 'Image',
+        email: 'Email',
+        markdown: 'Markdown',
+        'text&code': 'Texte & Code',
+        html: 'HTML',
+        doc: 'DOC',
+        docx: 'DOCX',
+        slides: 'PPTX',
+        audio: 'Audio',
+        video: 'Vidéo',
+      },
+      fields: 'Champ',
+      addParser: 'Ajouter un analyseur',
+      rule: 'Règle',
+      addRule: 'Ajouter une règle',
+      group: 'Groupe',
+      hierarchy: 'Hiérarchie',
+      addRegularExpressions: 'Ajouter des expressions régulières',
+      regularExpressions: 'Expressions régulières',
+      overlappedPercent: 'Pourcentage de chevauchement (%)',
+      searchMethod: 'Méthode de recherche',
+      searchMethodTip: `Définit comment le contenu peut être recherché — par texte intégral, embedding, ou les deux.
+L'indexeur stockera le contenu dans les structures de données correspondantes pour les méthodes sélectionnées.`,
+      parserMethod: 'Analyseur PDF',
+      tableResultType: 'Type de résultat du tableau',
+      markdownImageResponseType: "Type de réponse d'image Markdown",
+      systemPromptPlaceholder:
+        "Saisissez l'invite système pour l'analyse d'image ; si vide, la valeur système par défaut sera utilisée",
+      exportJson: 'Exporter JSON',
+      viewResult: 'Voir le résultat',
+      running: 'En cours',
+      summary: 'Résumé',
+      keywords: 'Mots-clés',
+      questions: 'Questions',
+      metadata: 'Métadonnées',
+      toc: 'Index de page',
+      fieldName: 'Destination du résultat',
+      prompts: {
+        system: {
+          keywords: `Rôle
+Vous êtes un analyseur de texte.
+
+Tâche
+Extrayez les mots-clés/phrases les plus importants d'un texte donné.
+
+Exigences
+- Résumez le contenu du texte et donnez les 5 mots-clés/phrases les plus importants.
+- Les mots-clés DOIVENT être dans la même langue que le texte donné.
+- Les mots-clés sont séparés par une VIRGULE ANGLAISE.
+- Sortie des mots-clés UNIQUEMENT.`,
+          questions: `Rôle
+Vous êtes un analyseur de texte.
+
+Tâche
+Proposez 3 questions sur un texte donné.
+
+Exigences
+- Comprenez et résumez le contenu du texte, et proposez les 3 questions les plus importantes.
+- Les questions NE DOIVENT PAS avoir de significations se chevauchant.
+- Les questions DOIVENT couvrir le contenu principal du texte autant que possible.
+- Les questions DOIVENT être dans la même langue que le texte donné.
+- Une question par ligne.
+- Sortie des questions UNIQUEMENT.`,
+          summary: `Agissez en tant que résumeur précis. Votre tâche est de créer un résumé du contenu fourni qui soit à la fois concis et fidèle à l'original.
+
+Instructions clés :
+1. Exactitude : Basez strictement le résumé sur les informations données. N'introduisez aucun nouveau fait, conclusion ou interprétation non explicitement mentionné.
+2. Langue : Rédigez le résumé dans la même langue que le texte source.
+3. Objectivité : Présentez les points clés sans parti pris, en préservant l'intention et le ton originaux du contenu.
+4. Concision : Concentrez-vous sur les idées les plus importantes, en omettant les détails mineurs.`,
+          metadata: `Extrayez les informations structurées importantes du contenu donné. Sortez UNIQUEMENT une chaîne JSON valide sans texte supplémentaire. Si aucune information structurée importante n'est trouvée, sortez un objet JSON vide : {}.
+
+Les informations structurées importantes peuvent inclure : noms, dates, lieux, événements, faits clés, données numériques ou autres entités extractibles.`,
+          toc: '',
+        },
+        user: {
+          keywords: `Contenu du texte
+[Insérer le texte ici]`,
+          questions: `Contenu du texte
+[Insérer le texte ici]`,
+          summary: `Texte à résumer :
+[Insérer le texte ici]`,
+          metadata: `Contenu : [INSÉRER LE CONTENU ICI]`,
+          toc: '[Insérer le texte ici]',
+        },
+      },
+      cancel: 'Annuler',
+      swicthPromptMessage:
+        "Les mots d'invite vont changer. Veuillez confirmer si vous souhaitez abandonner les mots d'invite existants ?",
+      switchPromptMessage:
+        "Les mots d'invite vont changer. Veuillez confirmer si vous souhaitez abandonner les mots d'invite existants ?",
+      tokenizerSearchMethodOptions: {
+        full_text: 'Texte intégral',
+        embedding: 'Embedding',
+      },
+      filenameEmbeddingWeight: "Poids d'embedding du nom de fichier",
+      tokenizerFieldsOptions: {
+        text: 'Texte traité',
+        keywords: 'Mots-clés',
+        questions: 'Questions',
+        summary: 'Contexte augmenté',
+      },
+      imageParseMethodOptions: {
+        ocr: 'OCR',
+      },
+      structuredOutput: {
+        configuration: 'Configuration',
+        structuredOutput: 'Sortie structurée',
+      },
+      operations: 'Opérations',
+      operationsOptions: {
+        selectKeys: 'Sélectionner les clés',
+        literalEval: 'Évaluation littérale',
+        combine: 'Combiner',
+        filterValues: 'Filtrer les valeurs',
+        appendOrUpdate: 'Ajouter ou mettre à jour',
+        removeKeys: 'Supprimer les clés',
+        renameKeys: 'Renommer les clés',
+      },
+      ListOperationsOptions: {
+        nth: 'N-ième',
+        head: 'Tête',
+        tail: 'Queue',
+        sort: 'Trier',
+        filter: 'Filtrer',
+        dropDuplicates: 'Supprimer les doublons',
+      },
+      sortMethod: 'Méthode de tri',
+      strictMode: 'Mode strict',
+      strictModeTip:
+        'Désactivé utilise un comportement souple et retourne un résultat vide pour n invalide. Activé utilise un comportement strict et génère une erreur pour n hors limites.',
+      SortMethodOptions: {
+        asc: 'Croissant',
+        desc: 'Décroissant',
+      },
+      variableAssignerLogicalOperatorOptions: {
+        overwrite: 'Remplacé par',
+        clear: 'Effacer',
+        set: 'Définir',
+        add: 'Ajouter',
+        subtract: 'Soustraire',
+        multiply: 'Multiplier',
+        divide: 'Diviser',
+        append: 'Annexer',
+        extend: 'Étendre',
+        removeFirst: 'Supprimer le premier',
+        removeLast: 'Supprimer le dernier',
+      },
+      webhook: {
+        name: 'Webhook',
+        methods: 'Méthodes',
+        contentTypes: 'Types de contenu',
+        security: 'Sécurité',
+        schema: 'Schéma',
+        response: 'Réponse',
+        executionMode: "Mode d'exécution",
+        executionModeTip:
+          "Réponse acceptée : le système renvoie un accusé de réception immédiatement après validation de la requête, tandis que le workflow continue à s'exécuter en arrière-plan. / Réponse finale : le système renvoie une réponse uniquement après la fin de l'exécution du workflow.",
+        authMethods: "Méthodes d'authentification",
+        authType: "Type d'authentification",
+        limit: 'Limite de fréquence des requêtes',
+        per: 'Période',
+        maxBodySize: 'Taille maximale du corps',
+        ipWhitelist: 'Liste blanche IP',
+        tokenHeader: 'En-tête de token',
+        tokenValue: 'Valeur du token',
+        username: "Nom d'utilisateur",
+        password: 'Mot de passe',
+        algorithm: 'Algorithme',
+        secret: 'Secret',
+        issuer: 'Émetteur',
+        audience: 'Audience',
+        requiredClaims: 'Claims requis',
+        header: 'En-tête',
+        status: 'Statut',
+        headersTemplate: "Modèle d'en-têtes",
+        bodyTemplate: 'Modèle de corps',
+        basic: 'Basique',
+        bearer: 'Bearer',
+        apiKey: 'Clé API',
+        queryParameters: 'Paramètres de requête',
+        headerParameters: "Paramètres d'en-tête",
+        requestBodyParameters: 'Paramètres du corps de la requête',
+        immediately: 'Réponse acceptée',
+        streaming: 'Réponse finale',
+        overview: "Vue d'ensemble",
+        logs: 'Journaux',
+        agentStatus: "Statut de l'agent :",
+      },
+      saveToMemory: 'Enregistrer en mémoire',
+      retrievalFrom: 'Récupération depuis',
+      id: 'ID',
+      state: 'État',
+      number: 'Nombre',
+      latestDate: 'Date la plus récente',
+      createDate: 'Date de création',
+      noDataToExport: 'Aucune donnée à exporter',
+      success: 'Succès',
+      failed: 'Échec',
+      logTitle: 'Titre',
+      tag: 'Étiquette',
+      tagPlaceholder: 'Veuillez saisir une étiquette',
+      descriptionPlaceholder: 'Veuillez saisir une description',
+      line: 'Texte sur une ligne',
+      paragraph: 'Texte en paragraphe',
+      options: 'Options déroulantes',
+      file: 'Téléversement de fichier',
+      integer: 'Nombre',
+      boolean: 'Booléen',
+      logTimeline: {
+        begin: 'Prêt à commencer',
+        agent: "L'agent réfléchit",
+        userFillUp: 'En attente de votre réponse',
+        retrieval: 'Recherche dans la base de connaissances',
+        message: "L'agent répond",
+        awaitResponse: 'En attente de votre réponse',
+        switch: 'Choix du meilleur chemin',
+        iteration: 'Traitement par lots',
+        categorize: 'Catégorisation des informations',
+        code: 'Exécution du script',
+        textProcessing: 'Traitement du texte',
+        tavilySearch: 'Recherche sur le web',
+        tavilyExtract: 'Lecture de la page',
+        exeSQL: 'Interrogation de la base de données',
+        google: 'Recherche sur le web',
+        wikipedia: 'Recherche sur Wikipedia',
+        googleScholar: 'Recherche académique',
+        gitHub: 'Recherche sur GitHub',
+        email: "Envoi d'email",
+        httpRequest: "Appel d'une API",
+        wenCai: 'Interrogation de données financières',
+      },
+      goto: "Branche d'échec",
+      comment: 'Valeur par défaut',
+      sqlStatement: 'Instruction SQL',
+      sqlStatementTip:
+        'Rédigez votre requête SQL ici. Vous pouvez utiliser des variables, du SQL brut, ou les deux en utilisant la syntaxe de variables.',
+      frameworkPrompts: 'Cadre',
+      release: 'Publier',
+      production: 'Production',
+      productionTooltip:
+        "Cette version est publiée en production. Accédez-y via l'API ou la page intégrée.",
+      confirmPublish: 'Confirmer la publication',
+      publishIngestionPipeline:
+        "Vous êtes sur le point de publier ce pipeline d'ingestion.",
+      publishAgent: 'Vous êtes sur le point de publier cet agent',
+      linkedDataset: 'Base de connaissances liée :',
+      lastPublished: 'Dernière publication',
+      mode: 'Mode',
+      conversational: 'Conversationnel',
+      task: 'Tâche',
+      queryRequired: 'La requête est obligatoire',
+      queryTip: 'Sélectionnez la variable que vous souhaitez utiliser',
+      dataOperations: 'Opérations sur les données',
+      dataOperationsDescription:
+        'Effectuer diverses opérations sur un objet Data.',
+      listOperations: 'Opérations sur les listes',
+      listOperationsDescription: 'Effectuer des opérations sur une liste.',
+      variableAssigner: 'Assignateur de variables',
+      variableAssignerDescription:
+        "Ce composant effectue des opérations sur des objets Data, incluant l'extraction, le filtrage, et la modification de clés et valeurs dans les données.",
+      variableAggregator: 'Agrégateur de variables',
+      variableAggregatorDescription: `
+Ce processus agrège des variables de plusieurs branches en une seule variable pour obtenir une configuration unifiée pour les nœuds en aval.`,
+      userFillUpDescription: `Met en pause le workflow et attend le message de l'utilisateur avant de continuer.`,
+      browser: 'Navigateur',
+      browserDescription:
+        'Automatise les tâches de navigation. Prend en charge la configuration du modèle et les actions pilotées par invite. Les sources de téléversement acceptent les IDs de fichiers et les URLs, et les fichiers téléchargés peuvent être enregistrés dans un dossier cible.',
+      channel: 'Canal',
+      channelTip:
+        "Effectuer une recherche textuelle ou une recherche d'actualités sur l'entrée du composant",
+      news: 'Actualités',
+      text: 'Texte',
+      userId: 'ID utilisateur',
     },
     llmTools: {
       bad_calculator: {
@@ -1324,6 +2743,345 @@ export default {
       serverType: 'Type de serveur',
       addMCP: 'Ajouter MCP',
       editMCP: 'Modifier MCP',
+      toolsAvailable: 'outils disponibles',
+      mcpServers: 'Serveurs MCP',
+      mcpServer: 'Serveur MCP',
+      customizeTheListOfMcpServers: 'Personnaliser la liste des serveurs MCP',
+      cachedTools: 'outils en cache',
+      bulkManage: 'Gestion en masse',
+      exitBulkManage: 'Quitter la gestion en masse',
+      selected: 'Sélectionné',
+    },
+    memories: {
+      llmTooltip:
+        'Analyse le contenu des conversations, extrait les informations clés et génère des résumés de mémoire structurés.',
+      embeddingModelTooltip:
+        'Convertit le texte en vecteurs numériques pour la recherche de similarité sémantique et la récupération de mémoire.',
+      embeddingModelError:
+        'Le type de mémoire est requis et "raw" ne peut pas être supprimé.',
+      memoryTypeTooltip: `Brut : le contenu brut du dialogue entre l'utilisateur et l'agent (requis par défaut).
+Mémoire sémantique : connaissances générales et faits sur l'utilisateur et le monde.
+Mémoire épisodique : enregistrements horodatés d'événements et d'expériences spécifiques.
+Mémoire procédurale : compétences acquises, habitudes et procédures automatisées.`,
+      raw: 'brut',
+      semantic: 'sémantique',
+      episodic: 'épisodique',
+      procedural: 'procédural',
+      editName: 'Modifier le nom',
+      memory: 'Mémoire',
+      createMemory: 'Créer une mémoire',
+      name: 'Nom',
+      memoryNamePlaceholder: 'nom de la mémoire',
+      memoryType: 'Type de mémoire',
+      embeddingModel: "Modèle d'embedding",
+      selectModel: 'Sélectionner un modèle',
+      llm: 'LLM',
+      delMemoryWarn:
+        'Après suppression, tous les messages de cette mémoire seront supprimés et ne pourront plus être récupérés par les agents.',
+    },
+    search: {
+      searchApps: 'Applications de recherche',
+      createSearch: 'Créer une recherche',
+      searchGreeting: 'Comment puis-je vous aider ?',
+      profile: 'Masquer le profil',
+      locale: 'Paramètres régionaux',
+      embedCode: "Code d'intégration",
+      id: 'ID',
+      copySuccess: 'Copié avec succès',
+      welcomeBack: 'Bon retour',
+      searchSettings: 'Paramètres de recherche',
+      name: 'Nom',
+      avatar: 'Avatar',
+      description: 'Description',
+      datasets: 'Bases de connaissances',
+      rerankModel: 'Modèle de réordonnancement',
+      AISummary: 'Résumé IA',
+      enableWebSearch: 'Activer la recherche web',
+      enableRelatedSearch: 'Activer la recherche connexe',
+      showQueryMindmap: 'Afficher la carte mentale de la requête',
+      embedApp: "Intégrer l'application",
+      relatedSearch: 'Recherche connexe',
+      descriptionValue: 'Vous êtes un assistant intelligent.',
+      okText: 'Enregistrer',
+      cancelText: 'Annuler',
+      chooseDataset:
+        'Veuillez sélectionner une base de connaissances en premier',
+    },
+    pagination: {
+      total: 'Total {{total}}',
+      page: '{{page}} / Page',
+    },
+    dataflowParser: {
+      result: 'Résultat',
+      parseSummary: "Résumé de l'analyse",
+      parseSummaryTip: 'Analyseur : DeepDoc',
+      parserMethod: "Méthode d'analyse",
+      outputFormat: 'Format de sortie',
+      rerunFromCurrentStep: 'Relancer depuis cette étape',
+      rerunFromCurrentStepTip:
+        'Modifications détectées. Cliquez pour relancer.',
+      confirmRerun: 'Confirmer le relancement',
+      confirmRerunModalContent: `
+      <p class="text-sm text-text-disabled font-medium mb-2">
+        Vous êtes sur le point de relancer le traitement à partir de l'étape <span class="text-text-secondary">{{step}}</span>.
+      </p>
+      <p class="text-sm mb-3 text-text-disabled">Cela va :</p><br />
+      <ul class="list-disc list-inside space-y-1 text-sm text-text-secondary">
+        <li>• Écraser les résultats existants à partir de cette étape</li>
+        <li>• Créer une nouvelle entrée de journal de suivi</li>
+        <li>• Les étapes précédentes resteront inchangées</li>
+      </ul>`,
+      changeStepModalTitle: "Avertissement de changement d'étape",
+      changeStepModalContent: `
+      <p>Vous êtes en train de modifier les résultats de cette étape.</p>
+      <p>Si vous passez à une étape ultérieure, vos modifications seront perdues.</p>
+      <p>Pour les conserver, cliquez sur Relancer pour réexécuter l'étape en cours.</p> `,
+      changeStepModalConfirmText: 'Changer quand même',
+      changeStepModalCancelText: 'Annuler',
+      unlinkPipelineModalTitle: "Dissocier le pipeline d'ingestion",
+      unlinkPipelineModalConfirmText: 'Dissocier',
+      unlinkPipelineModalContent: `
+      <p>Une fois dissocié, ce Dataset ne sera plus connecté au pipeline d'ingestion actuel.</p>
+      <p>Les fichiers en cours d'analyse continueront jusqu'à leur fin.</p>
+      <p>Les fichiers non encore analysés ne seront plus traités.</p> <br/>
+      <p>Êtes-vous sûr de vouloir continuer ?</p> `,
+      unlinkSourceModalTitle: 'Dissocier la source de données',
+      unlinkSourceModalContent: `
+      <p>Êtes-vous sûr de vouloir dissocier cette source de données ?</p>`,
+      unlinkSourceModalConfirmText: 'Dissocier',
+    },
+    datasetOverview: {
+      downloadTip:
+        'Fichiers en cours de téléchargement depuis les sources de données.',
+      processingTip:
+        "Fichiers en cours de traitement par le pipeline d'ingestion.",
+      totalFiles: 'Fichiers totaux',
+      downloading: 'Téléchargement',
+      downloadSuccessTip: 'Total des téléchargements réussis',
+      downloadFailedTip: 'Total des téléchargements échoués',
+      processingSuccessTip: 'Total des fichiers traités avec succès',
+      processingFailedTip: 'Total des traitements échoués',
+      processing: 'Traitement',
+      noData: 'Aucun journal disponible',
+    },
+    deleteModal: {
+      delAgent: "Supprimer l'agent",
+      delDataset: 'Supprimer la base de connaissances',
+      delSearch: 'Supprimer la recherche',
+      delFile: 'Supprimer le fichier',
+      delFiles: 'Supprimer les fichiers',
+      delFilesContent: '{{count}} fichiers sélectionnés',
+      delChat: 'Supprimer le chat',
+      delMember: 'Supprimer le membre',
+      delMemory: 'Supprimer la mémoire',
+    },
+    empty: {
+      noMCP: 'Aucun serveur MCP disponible',
+      agentTitle: 'Aucun agent créé pour le moment',
+      notFoundAgent: 'Agent introuvable',
+      datasetTitle: 'Aucune base de connaissances créée pour le moment',
+      notFoundDataset: 'Base de connaissances introuvable',
+      chatTitle: 'Aucun chat créé pour le moment',
+      notFoundChat: 'Chat introuvable',
+      searchTitle: 'Aucune recherche créée pour le moment',
+      notFoundSearch: 'Recherche introuvable',
+      memoryTitle: 'Aucune mémoire créée pour le moment',
+      notFoundMemory: 'Mémoire introuvable',
+      skillsTitle: 'Aucun espace de compétences créé pour le moment',
+      notFoundSkills: 'Espace de compétences introuvable',
+      addNow: 'Ajouter maintenant',
+    },
+    admin: {
+      loginTitle: "Console d'administration",
+      title: 'RAGFlow',
+      confirm: 'Confirmer',
+      close: 'Fermer',
+      yes: 'Oui',
+      no: 'Non',
+      delete: 'Supprimer',
+      cancel: 'Annuler',
+      reset: 'Réinitialiser',
+      import: 'Importer',
+      description: 'Description',
+      noDescription: 'Aucune description',
+      none: 'Aucun',
+
+      resourceType: {
+        dataset: 'Dataset',
+        chat: 'Chat',
+        agent: 'Agent',
+        search: 'Recherche',
+        file: 'Fichier',
+        team: 'Équipe',
+        memory: 'Mémoire',
+      },
+
+      permissionType: {
+        enable: 'Activer',
+        read: 'Lecture',
+        write: 'Écriture',
+        share: 'Partage',
+      },
+
+      serviceStatus: 'État des services',
+      userManagement: 'Gestion des utilisateurs',
+      sandboxSettings: 'Paramètres du bac à sable',
+      registrationWhitelist: "Liste blanche d'inscription",
+      roles: 'Rôles',
+      monitoring: 'Surveillance',
+
+      sandboxSettingsPage: {
+        description:
+          "Configurez le fournisseur de bac à sable pour l'exécution de code. Le bac à sable est utilisé par le composant Code dans les agents.",
+        providerSelection: 'Sélection du fournisseur',
+        providerSelectionDescription:
+          "Choisissez un fournisseur de bac à sable pour l'exécution de code",
+
+        namedProviderConfiguration: 'Configuration {{name}}',
+        namedProviderConfigurationDescription:
+          'Configurez les paramètres de connexion pour {{name}}.',
+
+        saveConfiguration: 'Enregistrer la configuration',
+        saving: 'Enregistrement…',
+
+        testConnectionResultModal: {
+          title: 'Résultat du test de connexion',
+          testing: 'Test de connexion au fournisseur de bac à sable…',
+          success: 'Connexion au fournisseur de bac à sable réussie',
+          failed: 'Échec de la connexion au fournisseur de bac à sable',
+
+          exitCode: 'Code de sortie',
+          executionTime: "Temps d'exécution",
+          stdout: 'Sortie standard',
+          stderr: "Sortie d'erreur / trace",
+        },
+
+        testConnection: 'Tester la connexion',
+        testing: 'Test en cours…',
+      },
+
+      selectFile: 'Sélectionner un fichier',
+      noFileSelected: 'Aucun fichier sélectionné',
+
+      back: 'Retour',
+      active: 'Actif',
+      inactive: 'Inactif',
+      enable: 'Activer',
+      disable: 'Désactiver',
+      all: 'Tous',
+      actions: 'Actions',
+      newUser: 'Nouvel utilisateur',
+      email: 'E-mail',
+      name: 'Nom',
+      nickname: 'Pseudo',
+      status: 'Statut',
+      id: 'ID',
+      serviceType: 'Type de service',
+      host: 'Hôte',
+      port: 'Port',
+
+      role: 'Rôle',
+      user: 'Utilisateur',
+      userType: "Type d'utilisateur",
+      superuser: 'Superutilisateur',
+      normalUser: 'Normal',
+
+      createTime: 'Date de création',
+      lastLoginTime: 'Dernière connexion',
+      lastUpdateTime: 'Dernière modification',
+
+      isAnonymous: 'Anonyme',
+      isSuperuser: 'Superutilisateur',
+
+      deleteUser: "Supprimer l'utilisateur",
+      deleteUserConfirmation:
+        'Êtes-vous sûr de vouloir supprimer cet utilisateur ?',
+
+      createNewUser: 'Créer un utilisateur',
+      changePassword: 'Changer le mot de passe',
+      newPassword: 'Nouveau mot de passe',
+      confirmNewPassword: 'Confirmer le nouveau mot de passe',
+      password: 'Mot de passe',
+      confirmPassword: 'Confirmer le mot de passe',
+
+      invalidEmail: 'Veuillez saisir une adresse e-mail valide !',
+      passwordRequired: 'Veuillez saisir votre mot de passe !',
+      passwordMinLength:
+        'Le mot de passe doit comporter au moins 8 caractères.',
+      confirmPasswordRequired: 'Veuillez confirmer votre mot de passe !',
+      confirmPasswordDoNotMatch:
+        'Les mots de passe saisis ne correspondent pas !',
+
+      read: 'Lecture',
+      write: 'Écriture',
+      share: 'Partage',
+      create: 'Création',
+
+      extraInfo: 'Informations supplémentaires',
+      serviceDetail: 'Détail du service {{name}}',
+      taskExecutorDetail: "Détail de l'exécuteur de tâches",
+
+      whitelistManagement: 'Gestion de la liste blanche',
+      exportAsExcel: 'Exporter Excel',
+      importFromExcel: 'Importer Excel',
+      createEmail: 'Créer un e-mail',
+      deleteEmail: "Supprimer l'e-mail",
+      editEmail: "Modifier l'e-mail",
+      deleteWhitelistEmailConfirmation:
+        'Êtes-vous sûr de vouloir supprimer cet e-mail de la liste blanche ? Cette action est irréversible.',
+
+      importWhitelist: 'Importer la liste blanche (Excel)',
+      importSelectExcelFile: 'Fichier Excel (.xlsx)',
+      importOverwriteExistingEmails: 'Écraser les e-mails existants',
+      importInvalidExcelFile: 'Veuillez sélectionner un fichier Excel valide',
+      importFileRequired: 'Veuillez sélectionner un fichier à importer',
+      importFileTips:
+        "Le fichier doit contenir une seule colonne d'en-tête nommée <code>email</code>.",
+
+      chunkNum: 'Fragments',
+      docNum: 'Documents',
+      tokenNum: 'Tokens utilisés',
+      language: 'Langue',
+      createDate: 'Date de création',
+      updateDate: 'Date de modification',
+      permission: 'Permission',
+
+      agentTitle: "Titre de l'agent",
+      canvasCategory: 'Catégorie du canvas',
+
+      newRole: 'Nouveau rôle',
+      addNewRole: 'Ajouter un rôle',
+      roleName: 'Nom du rôle',
+      roleNameRequired: 'Le nom du rôle est requis',
+      resources: 'Ressources',
+
+      editRoleDescription: 'Modifier la description du rôle',
+      deleteRole: 'Supprimer le rôle',
+      deleteRoleConfirmation:
+        'Êtes-vous sûr de vouloir supprimer ce rôle ? Cette action est irréversible.',
+
+      alive: 'Actif',
+      timeout: 'Délai expiré',
+      fail: 'Échec',
+    },
+    explore: {
+      title: 'Lancer',
+      canvasList: 'Liste des canvas',
+      sessions: 'Sessions',
+      newSession: 'Nouvelle session',
+      newSessionLabel: 'Démarrer une nouvelle conversation',
+      deleteSession: 'Supprimer la session',
+      searchCanvas: 'Rechercher un canvas...',
+      searchSessions: 'Rechercher des sessions...',
+      noCanvasSelected: 'Veuillez sélectionner un canvas',
+      noSessionSelected:
+        'Veuillez sélectionner une session ou en créer une nouvelle',
+      noSessionsFound: 'Aucune session trouvée',
+      createFirstSession: 'Créez votre première session',
+      noCanvasFound: 'Aucun canvas trouvé',
+      deleteSelectedConfirm:
+        'Êtes-vous sûr de vouloir supprimer {{count}} session(s) ?',
+      batchDeleteSessions: 'Supprimer les sessions',
     },
   },
 };


### PR DESCRIPTION
## Summary

- Brings the French locale (`web/src/locales/fr.ts`) to full parity with the English reference
- Adds ~1400 missing translation keys across **all sections**: `common`, `chat`, `header`, `login`, `admin`, `setting`, `flow`, `knowledgeDetails`, `knowledgeConfiguration`, `memory`, `skills`, `skillSearch`, `chunk`, `mcp`, `fileManager`, `search`, `dataflowParser`, `datasetOverview`, `deleteModal`, `empty`, `explore`, `memories`, `pagination`, `language`, `knowledgeList`
- All strings containing French apostrophes use double-quote delimiters (prevents JS syntax errors)

## Test plan

- [ ] `npx esbuild src/locales/fr.ts --bundle=false` — no errors
- [ ] `npx eslint src/locales/fr.ts` — no errors
- [ ] Switch UI language to French and verify key sections render correctly (chat, knowledge base, admin panel, agent flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)