### PR TITLE
 Fix: Sync parser_id and parser_config to existing documents when dataset settings change

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -329,7 +329,16 @@ async def update_dataset(tenant_id: str, dataset_id: str, req: dict):
 
     if not KnowledgebaseService.update_by_id(kb.id, req):
         return False, "Update dataset error.(Database error)"
-
+    # Sync parser_id and parser_config to all existing documents when they change
+    if chunk_method and chunk_method != kb.parser_id:
+        DocumentService.model.update(parser_id=chunk_method).where(
+            DocumentService.model.kb_id == kb.id
+        ).execute()
+    if req.get("parser_config"):
+        DocumentService.model.update(parser_config=req["parser_config"]).where(
+            DocumentService.model.kb_id == kb.id
+        ).execute()
+        
     ok, k = KnowledgebaseService.get_by_id(kb.id)
     if not ok:
         return False, "Dataset updated failed"


### PR DESCRIPTION
## Problem
  When a user changes the dataset's **chunk method** (`parser_id`) or **parser configuration** (e.g. `layout_recognize`, `chunk_token_num`, `auto_keywords`,
   etc.) via the knowledge base settings page, the changes only affect newly uploaded documents. Existing documents continue to use the old `parser_id` and
  `parser_config`, so re-parsing them produces identical results regardless of the new settings.

  This has been reported in:
  - #10803 (closed without fix)
  - #13173

  ## Reproduction Steps
  1. Create a dataset with chunk method `naive` and `layout_recognize: "DeepDOC"`.
  2. Upload a PDF and wait for parsing to complete.
  3. Go to dataset settings, change chunk method to another parser (e.g. `paper`) or change `layout_recognize` to `mineru-remote@MinerU`.
  4. Save settings.
  5. Re-run parsing on the existing document.
  6. **Expected**: The document is parsed with the new settings.
  7. **Actual**: The document is still parsed with the old `parser_id` and `parser_config`.

  ## Root Cause
  In `dataset_api_service.update_dataset()`, only the knowledge base record is updated:

  ```python
  KnowledgebaseService.update_by_id(kb.id, req)

  However, the task executor (task_service.get_task()) reads parser_id and parser_config from the Document model, not the Knowledgebase model. Since
  existing documents were never updated, they retain the old values.

  Solution

  After updating the knowledge base, sync the new parser_id and parser_config to all existing documents in that dataset:

  # Sync parser_id and parser_config to all existing documents when they change
  if chunk_method and chunk_method != kb.parser_id:
      DocumentService.model.update(parser_id=chunk_method).where(
          DocumentService.model.kb_id == kb.id
      ).execute()
  if req.get("parser_config"):
      DocumentService.model.update(parser_config=req["parser_config"]).where(
          DocumentService.model.kb_id == kb.id
      ).execute()

  Changes

  - api/apps/services/dataset_api_service.py: Added two conditional sync blocks after KnowledgebaseService.update_by_id().

  Testing

  - Manually verified: Changed dataset layout_recognize from DeepDOC to mineru-remote@MinerU, re-parsed an existing document, and confirmed the task
  executor received the new parser_config.
  - Confirmed parser_id sync by switching chunk method and re-parsing existing documents.

  Closes #13173
  ``` 