### PR TITLE
fix(api): allow canvas_type in agent create and update APIs

### DIFF
--- a/api/apps/restful_apis/agent_api.py
+++ b/api/apps/restful_apis/agent_api.py
@@ -612,6 +612,7 @@ async def update_agent_tags(tenant_id, canvas_id):
 @add_tenant_id_to_kwargs
 async def create_agent(tenant_id):
     req = {k: v for k, v in (await get_request_json()).items() if v is not None}
+    req["canvas_type"] = req.get("canvas_type","")
     req["user_id"] = tenant_id
     req["canvas_category"] = req.get("canvas_category") or CanvasCategory.Agent
     req["release"] = bool(req.get("release", ""))
@@ -868,6 +869,7 @@ def delete_agent(agent_id, tenant_id):
 @_require_canvas_access_async
 async def update_agent(agent_id, tenant_id):
     req = {k: v for k, v in (await get_request_json()).items() if v is not None}
+    req["canvas_type"] = req.get("canvas_type","")
     req["release"] = bool(req.get("release", ""))
 
     if req.get("dsl") is not None:

--- a/sdk/python/ragflow_sdk/ragflow.py
+++ b/sdk/python/ragflow_sdk/ragflow.py
@@ -257,11 +257,20 @@ class RAGFlow:
             return Agent(self, res["data"])
         raise Exception(res["message"])
 
-    def create_agent(self, title: str, dsl: dict, description: str | None = None) -> None:
+    def create_agent(
+        self,
+        title: str,
+        dsl: dict,
+        description: str | None = None,
+        canvas_type: str | None = None,
+    ) -> None:
         req = {"title": title, "dsl": dsl}
 
         if description is not None:
             req["description"] = description
+
+        if canvas_type is not None:
+            req["canvas_type"] = canvas_type
 
         res = self.post("/agents", req)
         res = res.json()
@@ -269,7 +278,14 @@ class RAGFlow:
         if res.get("code") != 0:
             raise Exception(res["message"])
 
-    def update_agent(self, agent_id: str, title: str | None = None, description: str | None = None, dsl: dict | None = None) -> None:
+    def update_agent(
+        self,
+        agent_id: str,
+        title: str | None = None,
+        description: str | None = None,
+        dsl: dict | None = None,
+        canvas_type: str | None = None,
+    ) -> None:
         req = {}
 
         if title is not None:
@@ -280,6 +296,9 @@ class RAGFlow:
 
         if dsl is not None:
             req["dsl"] = dsl
+
+        if canvas_type is not None:
+            req["canvas_type"] = canvas_type
 
         res = self.put(f"/agents/{agent_id}", req)
         res = res.json()

--- a/test/testcases/test_sdk_api/test_agent_management/test_agent_crud_unit.py
+++ b/test/testcases/test_sdk_api/test_agent_management/test_agent_crud_unit.py
@@ -80,6 +80,9 @@ def test_create_agent_payload_and_error(monkeypatch):
     client.create_agent("agent-title", {"graph": {}}, description="desc")
     assert calls[-1][1] == {"title": "agent-title", "dsl": {"graph": {}}, "description": "desc"}
 
+    client.create_agent("agent-title", {"graph": {}}, canvas_type="Marketing")
+    assert calls[-1][1] == {"title": "agent-title", "dsl": {"graph": {}}, "canvas_type": "Marketing"}
+
     monkeypatch.setattr(client, "post", lambda *_args, **_kwargs: _DummyResponse({"code": 1, "message": "create boom"}))
     with pytest.raises(Exception) as exception_info:
         client.create_agent("agent-title", {"graph": {}})
@@ -104,6 +107,7 @@ def test_update_agent_payload_matrix_and_error(monkeypatch):
             {"title": "new-title", "description": "new-description", "dsl": {"nodes": []}},
             {"title": "new-title", "description": "new-description", "dsl": {"nodes": []}},
         ),
+        ({"canvas_type": "Agent"}, {"canvas_type": "Agent"}),
     ]
     for kwargs, expected_payload in cases:
         client.update_agent("agent-1", **kwargs)


### PR DESCRIPTION
### What problem does this PR solve?

Creating or updating an agent via `POST /api/v1/agents` and `PUT /api/v1/agents/{agent_id}` did not persist `canvas_type` because the handler `req` dict never assigned the field before `UserCanvasService.save` / `update_by_id`.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
