### PR TITLE
Fix: Correct the API path

### DIFF
--- a/api/apps/backward_compat.py
+++ b/api/apps/backward_compat.py
@@ -37,8 +37,8 @@ Deprecated APIs and their replacements:
 - GET /api/v1/file/* -> GET /api/v1/files*
 - POST /api/v1/file/* -> POST /api/v1/files*
 - GET /api/v1/document/get/{doc_id} -> GET /api/v1/documents/{doc_id}/preview
-- GET /api/v1/document/download/{doc_id} -> GET /api/v1/agents/{doc_id}/download
-- GET /v1/document/download/{attachment_id} -> GET /api/v1/agents/{attachment_id}/download
+- GET /api/v1/document/download/{doc_id} -> GET /api/v1/agents/attachments/{doc_id}/download
+- GET /v1/document/download/{attachment_id} -> GET /api/v1/agents/attachments/{attachment_id}/download
 - GET /v1/system/healthz -> GET /api/v1/system/healthz
 - POST /api/v1/sessions/related_questions -> POST /api/v1/chat/recommandation
 - PUT (chunk update) -> PATCH (chunk update)
@@ -606,14 +606,14 @@ async def deprecated_document_get(doc_id):
 @login_required
 async def deprecated_document_download(doc_id):
     """
-    Deprecated: Use GET /api/v1/agents/{attachment_id}/download instead.
+    Deprecated: Use GET /api/v1/agents/attachments/{attachment_id}/download instead.
 
     Old path: GET /api/v1/document/download/{doc_id}
-    New path: GET /api/v1/agents/{doc_id}/download
+    New path: GET /api/v1/agents/attachments/{doc_id}/download
     """
     logging.warning(
         "API endpoint /api/v1/document/download/%s is deprecated. "
-        "Please use /api/v1/agents/%s/download instead.",
+        "Please use /api/v1/agents/attachments/%s/download instead.",
         doc_id, doc_id,
     )
     return await agent_api.download_attachment(attachment_id=doc_id)
@@ -626,11 +626,11 @@ async def document_download_v1(attachment_id):
     Compatibility alias for document download under /v1.
 
     Old path: GET /v1/document/download/{attachment_id}
-    New path: GET /api/v1/agents/{attachment_id}/download
+    New path: GET /api/v1/agents/attachments/{attachment_id}/download
     """
     logging.warning(
         "API endpoint /v1/document/download/%s is deprecated. "
-        "Please use /api/v1/agents/%s/download instead.",
+        "Please use /api/v1/agents/attachments/%s/download instead.",
         attachment_id, attachment_id,
     )
     return await agent_api.download_attachment(attachment_id=attachment_id)

--- a/api/apps/backward_compat.py
+++ b/api/apps/backward_compat.py
@@ -37,8 +37,8 @@ Deprecated APIs and their replacements:
 - GET /api/v1/file/* -> GET /api/v1/files*
 - POST /api/v1/file/* -> POST /api/v1/files*
 - GET /api/v1/document/get/{doc_id} -> GET /api/v1/documents/{doc_id}/preview
-- GET /api/v1/document/download/{doc_id} -> GET /api/v1/documents/{doc_id}/download
-- GET /v1/document/download/{attachment_id} -> GET /api/v1/documents/{attachment_id}/download
+- GET /api/v1/document/download/{doc_id} -> GET /api/v1/agents/{doc_id}/download
+- GET /v1/document/download/{attachment_id} -> GET /api/v1/agents/{attachment_id}/download
 - GET /v1/system/healthz -> GET /api/v1/system/healthz
 - POST /api/v1/sessions/related_questions -> POST /api/v1/chat/recommandation
 - PUT (chunk update) -> PATCH (chunk update)
@@ -606,17 +606,17 @@ async def deprecated_document_get(doc_id):
 @login_required
 async def deprecated_document_download(doc_id):
     """
-    Deprecated: Use GET /api/v1/documents/{doc_id}/download instead.
+    Deprecated: Use GET /api/v1/agents/{attachment_id}/download instead.
 
     Old path: GET /api/v1/document/download/{doc_id}
-    New path: GET /api/v1/documents/{doc_id}/download
+    New path: GET /api/v1/agents/{doc_id}/download
     """
     logging.warning(
         "API endpoint /api/v1/document/download/%s is deprecated. "
-        "Please use /api/v1/documents/%s/download instead.",
+        "Please use /api/v1/agents/%s/download instead.",
         doc_id, doc_id,
     )
-    return await document_api.download_attachment(doc_id=doc_id)
+    return await agent_api.download_attachment(attachment_id=doc_id)
 
 
 @legacy_v1_manager.route("/document/download/<attachment_id>", methods=["GET"])
@@ -626,14 +626,14 @@ async def document_download_v1(attachment_id):
     Compatibility alias for document download under /v1.
 
     Old path: GET /v1/document/download/{attachment_id}
-    New path: GET /api/v1/documents/{attachment_id}/download
+    New path: GET /api/v1/agents/{attachment_id}/download
     """
     logging.warning(
         "API endpoint /v1/document/download/%s is deprecated. "
-        "Please use /api/v1/documents/%s/download instead.",
+        "Please use /api/v1/agents/%s/download instead.",
         attachment_id, attachment_id,
     )
-    return await document_api.download_attachment(attachment_id=attachment_id)
+    return await agent_api.download_attachment(attachment_id=attachment_id)
 
 # =============================================================================
 # Agent Chat API

--- a/api/apps/restful_apis/agent_api.py
+++ b/api/apps/restful_apis/agent_api.py
@@ -2269,7 +2269,7 @@ async def webhook_trace(agent_id: str):
         }
     )
 
-@manager.route("/agents/<attachment_id>/download", methods=["GET"])  # noqa: F821
+@manager.route("/agents/attachments/<attachment_id>/download", methods=["GET"])  # noqa: F821
 @login_required
 @add_tenant_id_to_kwargs
 async def download_attachment(tenant_id=None, attachment_id=None):

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -6905,18 +6905,18 @@ Failure:
 
 ### Download attachment
 
-**GET** `/api/v1/documents/{doc_id}/download`
+**GET** `/api/v1/agents/{attachment_id}/download`
 
 :::caution DEPRECATED
-The previous endpoint `GET /v1/document/download/{doc_id}` is deprecated. Please use this endpoint instead.
+The previous endpoints `GET /v1/document/download/{doc_id}` and `GET /api/v1/document/download/{doc_id}` are deprecated. Please use this endpoint instead.
 :::
 
-Downloads a runtime attachment previously uploaded via the [Upload document](#upload-document) method.
+Downloads a runtime attachment previously uploaded for use in the agent system.
 
 #### Request
 
 - Method: GET
-- URL: `/api/v1/documents/{doc_id}/download`
+- URL: `/api/v1/agents/{attachment_id}/download`
 - Headers:
   - `'Authorization: Bearer <YOUR_API_KEY>'`
 - Query parameter:
@@ -6926,15 +6926,15 @@ Downloads a runtime attachment previously uploaded via the [Upload document](#up
 
 ```bash
 curl --request GET \
-     --url 'http://{address}/api/v1/documents/{doc_id}/download?ext=pdf' \
+     --url 'http://{address}/api/v1/agents/{attachment_id}/download?ext=pdf' \
      --header 'Authorization: Bearer <YOUR_API_KEY>' \
      --output ./downloaded_attachment.pdf
 ```
 
 ##### Request parameters
 
-- `doc_id`: (*Path parameter*), `string`, *Required*
-  The document ID whose attachment should be downloaded.
+- `attachment_id`: (*Path parameter*), `string`, *Required*
+  The attachment ID whose file should be downloaded.
 - `ext`: (*Query parameter*), `string`, *Optional*
   A file extension hint specifying the response's Content-Type. Defaults to `"markdown"`. Available values:
   - `"markdown"`

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -6905,7 +6905,7 @@ Failure:
 
 ### Download attachment
 
-**GET** `/api/v1/agents/{attachment_id}/download`
+**GET** `/api/v1/agents/attachments/{attachment_id}/download`
 
 :::caution DEPRECATED
 The previous endpoints `GET /v1/document/download/{doc_id}` and `GET /api/v1/document/download/{doc_id}` are deprecated. Please use this endpoint instead.
@@ -6916,7 +6916,7 @@ Downloads a runtime attachment previously uploaded for use in the agent system.
 #### Request
 
 - Method: GET
-- URL: `/api/v1/agents/{attachment_id}/download`
+- URL: `/api/v1/agents/attachments/{attachment_id}/download`
 - Headers:
   - `'Authorization: Bearer <YOUR_API_KEY>'`
 - Query parameter:
@@ -6926,7 +6926,7 @@ Downloads a runtime attachment previously uploaded for use in the agent system.
 
 ```bash
 curl --request GET \
-     --url 'http://{address}/api/v1/agents/{attachment_id}/download?ext=pdf' \
+     --url 'http://{address}/api/v1/agents/attachments/{attachment_id}/download?ext=pdf' \
      --header 'Authorization: Bearer <YOUR_API_KEY>' \
      --output ./downloaded_attachment.pdf
 ```

--- a/test/testcases/test_web_api/test_common.py
+++ b/test/testcases/test_web_api/test_common.py
@@ -421,7 +421,7 @@ def document_get(auth, document_id, *, headers=HEADERS, data=None):
 
 def document_download(auth, attachment_id, *, ext="markdown", headers=HEADERS, data=None):
     res = requests.get(
-        url=f"{HOST_ADDRESS}/api/{VERSION}/documents/{attachment_id}/download",
+        url=f"{HOST_ADDRESS}/api/{VERSION}/agents/attachments/{attachment_id}/download",
         headers=headers,
         auth=auth,
         params={"ext": ext},

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -222,7 +222,7 @@ export default {
   prompt: `${restAPIv1}/agents/prompts`,
   cancelDataflow: (id: string) => `${restAPIv1}/tasks/${id}/cancel`,
   getAttachmentFileDownload: (docId: string) =>
-    `${restAPIv1}/agents/${docId}/download`,
+    `${restAPIv1}/agents/attachments/${docId}/download`,
   downloadFile: `${restAPIv1}/agents/download`,
   testWebhook: (id: string) => `${restAPIv1}/agents/${id}/webhook/test`,
   fetchWebhookTrace: (id: string) => `${restAPIv1}/agents/${id}/webhook/logs`,


### PR DESCRIPTION
Follow on PR #15146 to reslove the backwad compatability issue.

1. /agents/<attachment_id>/download -> /agents/attachments/<attachment_id>/download

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
