### PR TITLE
Add HuaweiCloud model provider

### DIFF
--- a/conf/models/huaweicloud.json
+++ b/conf/models/huaweicloud.json
@@ -1,0 +1,218 @@
+{
+  "name": "HuaweiCloud",
+  "url": {
+    "default": "https://api.modelarts-maas.com",
+    "cn-southwest-2": "https://api.modelarts-maas.com",
+    "ap-southeast-1": "https://api-ap-southeast-1.modelarts-maas.com"
+  },
+  "url_suffix": {
+    "chat": "v2/chat/completions",
+    "async_chat": "v1/chat/completions",
+    "models": "v2/models",
+    "embedding": "v1/embeddings",
+    "rerank": "v1/rerank"
+  },
+  "class": "huaweicloud",
+  "models": [
+    {
+      "name": "deepseek-v4-pro",
+      "max_tokens": 1048576,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "deepseek-v4-flash",
+      "max_tokens": 1048576,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "deepseek-v3.2",
+      "max_tokens": 163840,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": false,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "deepseek-v3.1-terminus",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": false,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "DeepSeek-V3",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "deepseek-r1-250528",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen3-235b-a22b",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen3-32b",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen3-30b-a3b",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "kimi-k2.6",
+      "max_tokens": 262144,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "longcat-flash-chat",
+      "max_tokens": 131072,
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "glm-5",
+      "max_tokens": 202752,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "glm-5.1",
+      "max_tokens": 202752,
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen2.5-vl-72b",
+      "max_tokens": 49152,
+      "model_types": [
+        "chat",
+        "vision"
+      ]
+    },
+    {
+      "name": "bge-m3",
+      "max_tokens": 8000,
+      "model_types": [
+        "embedding"
+      ]
+    },
+    {
+      "name": "bge-reranker-v2-m3",
+      "max_tokens": 8000,
+      "model_types": [
+        "rerank"
+      ]
+    }
+  ],
+  "features": {
+    "thinking": {
+      "default_value": true,
+      "supported_models": [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v3.2",
+        "deepseek-v3.1-terminus",
+        "deepseek-r1-250528",
+        "qwen3-235b-a22b",
+        "qwen3-32b",
+        "qwen3-30b-a3b",
+        "kimi-k2.6",
+        "glm-5",
+        "glm-5.1"
+      ]
+    },
+    "clear_thinking": {
+      "default_value": true,
+      "supported_models": [
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v3.2",
+        "deepseek-v3.1-terminus",
+        "deepseek-r1-250528",
+        "qwen3-235b-a22b",
+        "qwen3-32b",
+        "qwen3-30b-a3b",
+        "kimi-k2.6",
+        "glm-5",
+        "glm-5.1"
+      ]
+    },
+    "reasoning": {
+      "type": "effort",
+      "enabled": true,
+      "default": "high",
+      "options": [
+        "high",
+        "max"
+      ]
+    }
+  }
+}

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -139,6 +139,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewN1NModel(baseURL, urlSuffix), nil
 	case "paddleocr_local":
 		return NewPaddleOCRLocalModel(baseURL, urlSuffix), nil
+	case "huaweicloud":
+		return NewHuaweiCloudModel(baseURL, urlSuffix), nil
 	default:
 		return NewDummyModel(baseURL, urlSuffix), nil
 	}

--- a/internal/entity/models/huaweicloud.go
+++ b/internal/entity/models/huaweicloud.go
@@ -575,32 +575,26 @@ func (h *HuaweiCloudModel) Rerank(modelName *string, query string, documents []s
 
 func (h *HuaweiCloudModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
 	return nil, fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
 	return fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
 	return nil, fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
 	return fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
 	return nil, fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
 	return nil, fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) ListModels(apiConfig *APIConfig) ([]string, error) {
@@ -660,7 +654,6 @@ func (h *HuaweiCloudModel) ListModels(apiConfig *APIConfig) ([]string, error) {
 
 func (h *HuaweiCloudModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
 	return nil, fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) CheckConnection(apiConfig *APIConfig) error {
@@ -670,10 +663,8 @@ func (h *HuaweiCloudModel) CheckConnection(apiConfig *APIConfig) error {
 
 func (h *HuaweiCloudModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
 	return nil, fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }
 
 func (h *HuaweiCloudModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
 	return nil, fmt.Errorf("%s, no such method", h.Name())
-	panic("implement me")
 }

--- a/internal/entity/models/huaweicloud.go
+++ b/internal/entity/models/huaweicloud.go
@@ -1,0 +1,679 @@
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-json"
+)
+
+type HuaweiCloudModel struct {
+	BaseURL    map[string]string
+	URLSuffix  URLSuffix
+	httpClient *http.Client
+}
+
+func NewHuaweiCloudModel(baseURL map[string]string, urlSuffix URLSuffix) *HuaweiCloudModel {
+	return &HuaweiCloudModel{
+		BaseURL:   baseURL,
+		URLSuffix: urlSuffix,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        10,
+				MaxIdleConnsPerHost: 100,
+				IdleConnTimeout:     90 * time.Second,
+				DisableCompression:  false,
+			},
+		},
+	}
+}
+
+func (h *HuaweiCloudModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewHuaweiCloudModel(baseURL, h.URLSuffix)
+}
+
+func (h *HuaweiCloudModel) Name() string {
+	return "huaweicloud"
+}
+
+func (h *HuaweiCloudModel) baseURLForRegion(region string) (string, error) {
+	base, ok := h.BaseURL[region]
+	if !ok || base == "" {
+		return "", fmt.Errorf("huaweicloud: no base URL configured for region %q", region)
+	}
+	return strings.TrimSuffix(base, "/"), nil
+}
+
+func huaweiCloudRegion(api *APIConfig) string {
+	region := "default"
+	if api != nil && api.Region != nil && *api.Region != "" {
+		region = *api.Region
+	}
+	return region
+}
+
+func huaweiCloudRegionForModel(api *APIConfig, modelName string) string {
+	region := huaweiCloudRegion(api)
+	return region
+}
+
+func huaweiCloudMessages(messages []Message) []map[string]interface{} {
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+	return apiMessages
+}
+
+func huaweiCloudIsDeepSeekV4(modelName string) bool {
+	model := strings.ToLower(modelName)
+	return strings.Contains(model, "deepseek-v4-pro") || strings.Contains(model, "deepseek-v4-flash")
+}
+
+func huaweiCloudSupportsThinkingToggle(modelName string) bool {
+	model := strings.ToLower(modelName)
+	switch {
+	case strings.Contains(model, "deepseek-v4-pro"),
+		strings.Contains(model, "deepseek-v4-flash"),
+		strings.Contains(model, "deepseek-v3.1"),
+		strings.Contains(model, "deepseek-v3.2"),
+		strings.Contains(model, "qwen3-235b-a22b"),
+		strings.Contains(model, "qwen3-32b"),
+		strings.Contains(model, "qwen3-30b-a3b"),
+		strings.Contains(model, "glm-5.1"),
+		strings.Contains(model, "glm-5"),
+		strings.Contains(model, "kimi-k2.6"):
+		return true
+	default:
+		return false
+	}
+}
+
+func huaweiCloudUsesV1Chat(modelName string) bool {
+	model := strings.ToLower(modelName)
+	return model == "deepseek-v3"
+}
+
+func huaweiCloudChatModelName(modelName string) string {
+	if huaweiCloudUsesV1Chat(modelName) {
+		return strings.ToLower(modelName)
+	}
+	return modelName
+}
+
+func huaweiCloudAuthorization(apiKey string) string {
+	key := strings.TrimSpace(apiKey)
+	if strings.HasPrefix(strings.ToLower(key), "bearer ") {
+		key = strings.TrimSpace(key[len("bearer "):])
+	}
+	return fmt.Sprintf("Bearer %s", key)
+}
+
+func (h *HuaweiCloudModel) chatURL(baseURL, modelName string) string {
+	suffix := h.URLSuffix.Chat
+	if huaweiCloudUsesV1Chat(modelName) {
+		if h.URLSuffix.AsyncChat != "" {
+			suffix = h.URLSuffix.AsyncChat
+		} else {
+			suffix = "v1/chat/completions"
+		}
+	}
+	return baseURL + "/" + strings.TrimPrefix(suffix, "/")
+}
+
+func huaweiCloudApplyChatConfig(req map[string]any, modelName string, chatModelConfig *ChatConfig) {
+	if chatModelConfig == nil {
+		return
+	}
+	if chatModelConfig.MaxTokens != nil {
+		req["max_tokens"] = *chatModelConfig.MaxTokens
+	}
+	if chatModelConfig.Temperature != nil {
+		req["temperature"] = *chatModelConfig.Temperature
+	}
+	if chatModelConfig.TopP != nil {
+		req["top_p"] = *chatModelConfig.TopP
+	}
+	if chatModelConfig.Stop != nil && len(*chatModelConfig.Stop) > 0 {
+		req["stop"] = *chatModelConfig.Stop
+	}
+	if chatModelConfig.Thinking == nil || !huaweiCloudSupportsThinkingToggle(modelName) {
+		return
+	}
+
+	thinkingType := "disabled"
+	if *chatModelConfig.Thinking {
+		thinkingType = "enabled"
+		if huaweiCloudIsDeepSeekV4(modelName) {
+			effort := "high"
+			if chatModelConfig.Effort != nil && *chatModelConfig.Effort != "" {
+				effort = *chatModelConfig.Effort
+			}
+			switch strings.ToLower(effort) {
+			case "none", "low", "medium":
+				thinkingType = "disabled"
+			case "max":
+				req["reasoning_effort"] = "max"
+			default:
+				req["reasoning_effort"] = "high"
+			}
+		}
+	}
+
+	req["thinking"] = map[string]interface{}{
+		"type": thinkingType,
+	}
+}
+
+func (h *HuaweiCloudModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	baseURL, err := h.baseURLForRegion(huaweiCloudRegionForModel(apiConfig, modelName))
+	if err != nil {
+		return nil, err
+	}
+
+	url := h.chatURL(baseURL, modelName)
+
+	reqb := map[string]interface{}{
+		"model":    huaweiCloudChatModelName(modelName),
+		"messages": huaweiCloudMessages(messages),
+		"stream":   false,
+	}
+	huaweiCloudApplyChatConfig(reqb, modelName, chatModelConfig)
+
+	jsonData, err := json.Marshal(reqb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", huaweiCloudAuthorization(*apiConfig.ApiKey))
+
+	rep, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer rep.Body.Close()
+
+	body, err := io.ReadAll(rep.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if rep.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Huawei Cloud chat API error: status %d, body: %s", rep.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	firstChoice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid choice format")
+	}
+
+	messageMap, ok := firstChoice["message"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid message format")
+	}
+	content, ok := messageMap["content"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid content format")
+	}
+
+	reasonContent := ""
+	if r, ok := messageMap["reasoning_content"].(string); ok {
+		reasonContent = r
+		if reasonContent != "" && reasonContent[0] == '\n' {
+			reasonContent = reasonContent[1:]
+		}
+	}
+
+	return &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+	}, nil
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+	if modelName == "" {
+		return fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+
+	baseURL, err := h.baseURLForRegion(huaweiCloudRegionForModel(apiConfig, modelName))
+	if err != nil {
+		return err
+	}
+	url := h.chatURL(baseURL, modelName)
+
+	reqBody := map[string]interface{}{
+		"model":    huaweiCloudChatModelName(modelName),
+		"messages": huaweiCloudMessages(messages),
+		"stream":   true,
+	}
+	if chatModelConfig != nil && chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+		return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+	}
+	huaweiCloudApplyChatConfig(reqBody, modelName, chatModelConfig)
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", huaweiCloudAuthorization(*apiConfig.ApiKey))
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Huawei Cloud stream API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	sawTerminal := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimSpace(line[5:])
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event map[string]interface{}
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			return fmt.Errorf("huaweicloud: invalid SSE event: %w", err)
+		}
+		if apiErr, ok := event["error"]; ok {
+			return fmt.Errorf("huaweicloud: upstream stream error: %v", apiErr)
+		}
+
+		choices, ok := event["choices"].([]interface{})
+		if !ok || len(choices) == 0 {
+			continue
+		}
+		firstChoice, ok := choices[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		delta, ok := firstChoice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if r, ok := delta["reasoning_content"].(string); ok && r != "" {
+			if err := sender(nil, &r); err != nil {
+				return err
+			}
+		}
+		if content, ok := delta["content"].(string); ok && content != "" {
+			if err := sender(&content, nil); err != nil {
+				return err
+			}
+		}
+		if finishReason, ok := firstChoice["finish_reason"].(string); ok && finishReason != "" {
+			sawTerminal = true
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("huaweicloud: stream ended before [DONE] or finish_reason")
+	}
+
+	endOfStream := "[DONE]"
+	if err := sender(&endOfStream, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+type huaweiCloudEmbeddingResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+		Index     *int      `json:"index"`
+	} `json:"data"`
+}
+
+func (h *HuaweiCloudModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if modelName == nil || *modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(texts) == 0 {
+		return []EmbeddingData{}, nil
+	}
+
+	baseURL, err := h.baseURLForRegion(huaweiCloudRegion(apiConfig))
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, strings.TrimPrefix(h.URLSuffix.Embedding, "/"))
+
+	reqBody := map[string]interface{}{
+		"model":           *modelName,
+		"input":           texts,
+		"encoding_format": "float",
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", huaweiCloudAuthorization(*apiConfig.ApiKey))
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Huawei Cloud embedding API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed huaweiCloudEmbeddingResponse
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	if len(parsed.Data) != len(texts) {
+		return nil, fmt.Errorf("expected %d embeddings, got %d", len(texts), len(parsed.Data))
+	}
+
+	embeddings := make([]EmbeddingData, len(texts))
+	seen := make([]bool, len(texts))
+	for _, item := range parsed.Data {
+		if item.Index == nil {
+			return nil, fmt.Errorf("missing index field in embedding item")
+		}
+		idx := *item.Index
+		if idx < 0 || idx >= len(texts) {
+			return nil, fmt.Errorf("embedding index %d out of range", idx)
+		}
+		if seen[idx] {
+			return nil, fmt.Errorf("duplicate embedding index %d", idx)
+		}
+		if len(item.Embedding) == 0 {
+			return nil, fmt.Errorf("empty embedding at index %d", idx)
+		}
+		seen[idx] = true
+		embeddings[idx] = EmbeddingData{
+			Embedding: item.Embedding,
+			Index:     idx,
+		}
+	}
+
+	for i, ok := range seen {
+		if !ok {
+			return nil, fmt.Errorf("missing embedding index %d", i)
+		}
+	}
+
+	return embeddings, nil
+}
+
+func (h *HuaweiCloudModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if modelName == nil || *modelName == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if query == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+	if len(documents) == 0 {
+		return &RerankResponse{}, nil
+	}
+
+	baseURL, err := h.baseURLForRegion(huaweiCloudRegion(apiConfig))
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, strings.TrimPrefix(h.URLSuffix.Rerank, "/"))
+
+	reqBody := map[string]interface{}{
+		"model":     *modelName,
+		"query":     query,
+		"documents": documents,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", huaweiCloudAuthorization(*apiConfig.ApiKey))
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Huawei Cloud rerank API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		Results []struct {
+			Index          int     `json:"index"`
+			RelevanceScore float64 `json:"relevance_score"`
+		} `json:"results"`
+	}
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	limit := len(parsed.Results)
+	if rerankConfig != nil && rerankConfig.TopN > 0 && rerankConfig.TopN < limit {
+		limit = rerankConfig.TopN
+	}
+
+	result := &RerankResponse{
+		Data: make([]RerankResult, 0, limit),
+	}
+	for i := 0; i < limit; i++ {
+		item := parsed.Results[i]
+		if item.Index < 0 || item.Index >= len(documents) {
+			return nil, fmt.Errorf("rerank index %d out of range", item.Index)
+		}
+		result.Data = append(result.Data, RerankResult{
+			Index:          item.Index,
+			RelevanceScore: item.RelevanceScore,
+		})
+	}
+
+	return result, nil
+}
+
+func (h *HuaweiCloudModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) ListModels(apiConfig *APIConfig) ([]string, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	baseURL, err := h.baseURLForRegion(huaweiCloudRegion(apiConfig))
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, strings.TrimPrefix(h.URLSuffix.Models, "/"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", huaweiCloudAuthorization(*apiConfig.ApiKey))
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Huawei Cloud models API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	models := make([]string, 0, len(parsed.Data))
+	for _, item := range parsed.Data {
+		if item.ID != "" {
+			models = append(models, item.ID)
+		}
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("no models in response")
+	}
+	return models, nil
+}
+
+func (h *HuaweiCloudModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := h.ListModels(apiConfig)
+	return err
+}
+
+func (h *HuaweiCloudModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
+	return nil, fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}
+
+func (h *HuaweiCloudModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", h.Name())
+	panic("implement me")
+}


### PR DESCRIPTION
### What problem does this PR solve?

Related to #14736

  This PR adds HuaweiCloud provider integration in RAGFlow.

  Supported capabilities:

  - [x] Chat / Think Chat / Stream Chat / Stream Think Chat
  - [x] Embedding
  - [x] Rerank
  - [x] Model listing
  - [x] Provider connection checking

  Verified examples from the CLI:

  ```
  check instance 'test' from 'HuaweiCloud';

  chat with 'deepseek-v4-flash@test@HuaweiCloud' message 'hello';

  think chat with 'deepseek-v4-flash@test@HuaweiCloud' message 'hello';

  stream chat with 'deepseek-v4-flash@test@HuaweiCloud' message 'hello';

  stream think chat with 'deepseek-v4-flash@test@HuaweiCloud' message 'hello';

  embed text 'what is rag' 'who are you' with 'bge-m3@test@HuaweiCloud' dimension 1024;

  rerank query 'what is rag' document 'rag is retrieval augmented generation' 'rag need llm' 'famous rag
  project includes ragflow' with 'bge-reranker-v2-m3@test@HuaweiCloud' top 3;

  list supported models from 'HuaweiCloud' 'test';

  LIST MODELS FROM 'HuaweiCloud' 'test';
```
  ### Type of change

  - [x] New Feature
  - [x] Provider integration