### PR TITLE
Fix/exesql workflow error handling

### DIFF
--- a/agent/tools/base.py
+++ b/agent/tools/base.py
@@ -161,6 +161,7 @@ class ToolBase(ComponentBase):
         except Exception as e:
             logging.exception(e)
             if self.get_exception_default_value():
+                self.set_output("_EXCEPTION", str(e))
                 self.set_exception_default_value()
                 res = self.get_exception_default_value()
             else:
@@ -192,6 +193,7 @@ class ToolBase(ComponentBase):
         except Exception as e:
             logging.exception(e)
             if self.get_exception_default_value():
+                self.set_output("_EXCEPTION", str(e))
                 self.set_exception_default_value()
                 res = self.get_exception_default_value()
             else:

--- a/agent/tools/base.py
+++ b/agent/tools/base.py
@@ -159,9 +159,13 @@ class ToolBase(ComponentBase):
         try:
             res = self._invoke(**kwargs)
         except Exception as e:
-            self._param.outputs["_ERROR"] = {"value": str(e)}
             logging.exception(e)
-            res = str(e)
+            if self.get_exception_default_value():
+                self.set_exception_default_value()
+                res = self.get_exception_default_value()
+            else:
+                self.set_output("_ERROR", str(e))
+                res = str(e)
         self._param.debug_inputs = []
 
         self.set_output("_elapsed_time", time.perf_counter() - self.output("_created_time"))
@@ -186,9 +190,13 @@ class ToolBase(ComponentBase):
             else:
                 res = await thread_pool_exec(self._invoke, **kwargs)
         except Exception as e:
-            self._param.outputs["_ERROR"] = {"value": str(e)}
             logging.exception(e)
-            res = str(e)
+            if self.get_exception_default_value():
+                self.set_exception_default_value()
+                res = self.get_exception_default_value()
+            else:
+                self.set_output("_ERROR", str(e))
+                res = str(e)
         self._param.debug_inputs = []
 
         self.set_output("_elapsed_time", time.perf_counter() - self.output("_created_time"))

--- a/agent/tools/exesql.py
+++ b/agent/tools/exesql.py
@@ -288,5 +288,9 @@ class ExeSQL(ToolBase, ABC):
         self.set_output("formalized_content", "\n\n".join(formalized_content))
         return self.output("formalized_content")
 
+    def set_exception_default_value(self):
+        self.set_output("formalized_content", self.get_exception_default_value())
+        self.set_output("json", [])
+
     def thoughts(self) -> str:
         return "Query sent—waiting for the data."

--- a/test/unit_test/agent/tools/test_tool_exception_defaults.py
+++ b/test/unit_test/agent/tools/test_tool_exception_defaults.py
@@ -1,0 +1,80 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from types import SimpleNamespace
+
+from agent.tools.base import ToolBase
+from agent.tools.exesql import ExeSQL
+
+
+class _FakeCanvas:
+    def is_canceled(self):
+        return False
+
+
+class _FailingTool(ToolBase):
+    component_name = "FailingTool"
+
+    def _invoke(self, **kwargs):
+        raise RuntimeError("boom")
+
+
+def _build_tool(tool_cls, outputs=None):
+    tool = tool_cls.__new__(tool_cls)
+    tool._canvas = _FakeCanvas()
+    tool._id = "tool:0"
+    tool._param = SimpleNamespace(
+        outputs=outputs or {},
+        inputs={},
+        debug_inputs={},
+        exception_method="comment",
+        exception_default_value="SQL failed, continue with fallback.",
+        exception_goto=None,
+    )
+    return tool
+
+
+def test_toolbase_comment_exception_sets_default_without_error():
+    tool = _build_tool(_FailingTool)
+
+    result = tool.invoke()
+
+    assert result == "SQL failed, continue with fallback."
+    assert tool.error() in ("", None)
+    assert tool.output("result") == "SQL failed, continue with fallback."
+
+
+def test_exesql_comment_exception_sets_sql_outputs(monkeypatch):
+    tool = _build_tool(
+        ExeSQL,
+        {
+            "formalized_content": {"value": "", "type": "string"},
+            "json": {"value": [], "type": "Array<Object>"},
+        },
+    )
+    tool._param.exception_default_value = "Database query failed."
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("bad sql")
+
+    monkeypatch.setattr(tool, "_invoke", fail)
+
+    result = tool.invoke(sql="select * from missing_table")
+
+    assert result == "Database query failed."
+    assert tool.error() in ("", None)
+    assert tool.output("formalized_content") == "Database query failed."
+    assert tool.output("json") == []

--- a/test/unit_test/agent/tools/test_tool_exception_defaults.py
+++ b/test/unit_test/agent/tools/test_tool_exception_defaults.py
@@ -54,6 +54,7 @@ def test_toolbase_comment_exception_sets_default_without_error():
 
     assert result == "SQL failed, continue with fallback."
     assert tool.error() in ("", None)
+    assert tool.output("_EXCEPTION") == "boom"
     assert tool.output("result") == "SQL failed, continue with fallback."
 
 
@@ -76,5 +77,6 @@ def test_exesql_comment_exception_sets_sql_outputs(monkeypatch):
 
     assert result == "Database query failed."
     assert tool.error() in ("", None)
+    assert tool.output("_EXCEPTION") == "bad sql"
     assert tool.output("formalized_content") == "Database query failed."
     assert tool.output("json") == []

--- a/web/src/pages/agent/constant/index.tsx
+++ b/web/src/pages/agent/constant/index.tsx
@@ -300,6 +300,9 @@ export const initialExeSqlValues = {
   port: 3306,
   password: '',
   max_records: 1024,
+  exception_method: '',
+  exception_goto: [],
+  exception_default_value: '',
   outputs: {
     formalized_content: {
       value: '',

--- a/web/src/pages/agent/form/exesql-form/index.tsx
+++ b/web/src/pages/agent/form/exesql-form/index.tsx
@@ -14,10 +14,10 @@ import { Input } from '@/components/ui/input';
 import { useTranslate } from '@/hooks/common-hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { memo } from 'react';
-import { useForm, useFormContext } from 'react-hook-form';
+import { useForm, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
-import { initialExeSqlValues } from '../../constant';
+import { AgentExceptionMethod, initialExeSqlValues } from '../../constant';
 import { useFormValues } from '../../hooks/use-form-values';
 import { useWatchFormChange } from '../../hooks/use-watch-form-change';
 import { INextOperatorForm } from '../../interface';
@@ -147,9 +147,19 @@ function ExeSQLForm({ node }: INextOperatorForm) {
 
   const { onSubmit, loading } = useSubmitForm();
 
+  const ExceptionMethodOptions = [AgentExceptionMethod.Comment].map((x) => ({
+    label: t(`flow.${x}`),
+    value: x,
+  }));
+
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues,
+  });
+
+  const exceptionMethod = useWatch({
+    control: form.control,
+    name: 'exception_method',
   });
 
   useWatchFormChange(node?.id, form);
@@ -165,6 +175,36 @@ function ExeSQLForm({ node }: INextOperatorForm) {
           <PromptEditor></PromptEditor>
         </RAGFlowFormItem>
         <ExeSQLFormWidgets loading={loading}></ExeSQLFormWidgets>
+        <FormField
+          control={form.control}
+          name="exception_method"
+          render={({ field }) => (
+            <FormItem className="flex-1">
+              <FormLabel>{t('flow.exceptionMethod')}</FormLabel>
+              <FormControl>
+                <SelectWithSearch
+                  {...field}
+                  options={ExceptionMethodOptions}
+                  allowClear
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        {exceptionMethod === AgentExceptionMethod.Comment && (
+          <FormField
+            control={form.control}
+            name="exception_default_value"
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                <FormLabel>{t('flow.ExceptionDefaultValue')}</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        )}
       </FormWrapper>
       <div className="p-5">
         <Output list={outputList}></Output>

--- a/web/src/pages/agent/form/exesql-form/use-submit-form.ts
+++ b/web/src/pages/agent/form/exesql-form/use-submit-form.ts
@@ -1,4 +1,5 @@
 import { useTestDbConnect } from '@/hooks/use-agent-request';
+import { omit } from 'lodash';
 import { useCallback } from 'react';
 import { z } from 'zod';
 
@@ -16,6 +17,9 @@ export const FormSchema = z
   .object({
     sql: z.string().optional(),
     ...ExeSQLFormSchema,
+    exception_method: z.string().optional(),
+    exception_goto: z.array(z.string()).optional(),
+    exception_default_value: z.string().optional(),
   })
   .superRefine((v, ctx) => {
     if (
@@ -35,7 +39,13 @@ export function useSubmitForm() {
 
   const onSubmit = useCallback(
     async (data: z.infer<typeof FormSchema>) => {
-      testDbConnect(data);
+      testDbConnect(
+        omit(data, [
+          'exception_method',
+          'exception_goto',
+          'exception_default_value',
+        ]),
+      );
     },
     [testDbConnect],
   );


### PR DESCRIPTION
### What problem does this PR solve?

This PR is related to #14737.

ExeSQL can be used both as an Agent tool and as a workflow node. When used as a workflow node, failures outside normal query-result generation are recorded as `_ERROR` by `ToolBase`. The workflow runner then treats the node as failed and stops downstream execution.

RAGFlow already has an exception fallback mechanism through `exception_method = comment`, but `ToolBase` did not respect it. ExeSQL also did not expose fallback configuration in the workflow form, so users could not configure a default failure output for the ExeSQL node.

This PR adds **configurable fallback handling** for ExeSQL workflow nodes:
- `ToolBase.invoke()` and `invoke_async()` now respect the existing `comment` fallback mechanism.
- When fallback is used, **the original exception is preserved in `_EXCEPTION`** for debugging while `_ERROR` remains unset so the workflow can continue.
- ExeSQL writes configured fallback text to `formalized_content` and sets `json` to an empty array.
- The ExeSQL workflow form now exposes fallback configuration.
- Database connection test submissions omit workflow-only exception fields.
- Existing fail-fast behavior is preserved when no fallback value is configured.

This allows downstream workflow nodes to continue when the user explicitly configures a fallback value for ExeSQL failures, while still preserving the original exception for diagnostics. 

when using the **streaming** API, a handled ExeSQL failure now looks like this:
```json
{
  "event": "node_finished",
  "data": {
    "inputs": {
      "sql": "select * from <missing_table> limit 10;"
    },
    "outputs": {
      "formalized_content": "sql execution error show up",
      "json": [],
      "_created_time": 535360.748029885,
      "_EXCEPTION": "(1146, \"Table '<database>.<table>' doesn't exist\")",
      "_elapsed_time": 0.2532709779916331
    },
    "component_id": "ExeSQL:<node_id>",
    "component_name": "SQL",
    "component_type": "ExeSQL",
    "error": null,
    "elapsed_time": 0.25361144496127963,
    "created_at": 535360.748029885
  },
  "session_id": "<session_id>"
}
```
Before, it is like:
```json
{
  "event": "node_finished",
  "message_id": "<message_id>",
  "created_at": 1779794334,
  "task_id": "<task_id>",
  "data": {
    "inputs": {
      "sql": "select * from <missing_table> limit 10;"
    },
    "outputs": {
      "formalized_content": "",
      "json": [],
      "_created_time": 534147.265439174,
      "_ERROR": "(1146, \"Table '<database>.<table>' doesn't exist\")",
      "_elapsed_time": 0.2447614719858393
    },
    "component_id": "ExeSQL:<node_id>",
    "component_name": "SQL",
    "component_type": "ExeSQL",
    "error": "(1146, \"Table '<database>.<table>' doesn't exist\")",
    "elapsed_time": 0.24520841799676418,
    "created_at": 534147.265439174
  },
  "session_id": "<session_id>"
}
```
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

### Test Plan

- [x] `uv run python -m pytest test/unit_test/agent/tools/test_tool_exception_defaults.py -q`
- [x] Manually verified on a Linux source deployment that an ExeSQL workflow node with invalid SQL can return the configured fallback value, preserve the original exception in `_EXCEPTION`, and allow downstream nodes to continue.