### PR TITLE
fix(connector): verify kb_id ownership in /connectors/<id>/rebuild (#15268)

### DIFF
--- a/api/apps/restful_apis/connector_api.py
+++ b/api/apps/restful_apis/connector_api.py
@@ -25,7 +25,8 @@ from quart import request, make_response
 from google_auth_oauthlib.flow import Flow
 
 from api.db import InputType
-from api.db.services.connector_service import ConnectorService, SyncLogsService
+from api.db.services.connector_service import Connector2KbService, ConnectorService, SyncLogsService
+from api.db.services.knowledgebase_service import KnowledgebaseService
 from api.utils.api_utils import get_data_error_result, get_json_result, get_request_json, validate_request
 from api.utils.pagination_utils import validate_rest_api_page_size
 from common.constants import RetCode, TaskStatus
@@ -160,7 +161,26 @@ async def rebuild(connector_id):
     if "kb_id" not in req:
         return get_json_result(code=RetCode.ARGUMENT_ERROR, message="required argument is missing: kb_id")
 
-    err = ConnectorService.rebuild(req["kb_id"], connector_id, current_user.id)
+    kb_id = req["kb_id"]
+    # Bind the caller-supplied kb_id to the caller's authorization context
+    # (fixes the CWE-284 class reported in #15268): the route already checked
+    # that the connector belongs to the caller, but rebuild() proceeds to
+    # delete docs and schedule sync tasks against `kb_id` — without these
+    # checks an authenticated user could target a kb they do not own.
+    if not KnowledgebaseService.accessible(kb_id, current_user.id):
+        LOGGER.warning(
+            "rebuild denied: kb not accessible connector_id=%s kb_id=%s user_id=%s",
+            connector_id, kb_id, current_user.id,
+        )
+        return get_json_result(data=False, message="No authorization.", code=RetCode.AUTHENTICATION_ERROR)
+    if not Connector2KbService.query(connector_id=connector_id, kb_id=kb_id):
+        LOGGER.warning(
+            "rebuild denied: connector not bound to kb connector_id=%s kb_id=%s user_id=%s",
+            connector_id, kb_id, current_user.id,
+        )
+        return get_json_result(data=False, message="Connector is not bound to this knowledge base.", code=RetCode.AUTHENTICATION_ERROR)
+
+    err = ConnectorService.rebuild(kb_id, connector_id, current_user.id)
     if err:
         return get_json_result(data=False, message=err, code=RetCode.SERVER_ERROR)
     return get_json_result(data=True)

--- a/test/testcases/restful_api/test_connector_routes_unit.py
+++ b/test/testcases/restful_api/test_connector_routes_unit.py
@@ -221,9 +221,37 @@ def _load_connector_app(monkeypatch):
         def list_sync_tasks(*_args, **_kwargs):
             return [], 0
 
+    class _StubConnector2KbService:
+        # The production rebuild route now verifies that the connector
+        # is bound to the caller-supplied kb_id via
+        # Connector2KbService.query(connector_id=, kb_id=) — fixes
+        # the access-control gap addressed by PR #15272. Default to a
+        # truthy result so existing pass-through tests do not need to
+        # know about this binding check; tests that exercise the deny
+        # branch monkeypatch this to return an empty list.
+        @staticmethod
+        def query(*_args, **_kwargs):
+            return [object()]
+
     connector_service_mod.ConnectorService = _StubConnectorService
     connector_service_mod.SyncLogsService = _StubSyncLogsService
+    connector_service_mod.Connector2KbService = _StubConnector2KbService
     monkeypatch.setitem(sys.modules, "api.db.services.connector_service", connector_service_mod)
+
+    # KnowledgebaseService.accessible() gates the same rebuild route on
+    # tenant ownership of the kb. Default to True for the same reason
+    # as Connector2KbService above.
+    knowledgebase_service_mod = ModuleType("api.db.services.knowledgebase_service")
+
+    class _StubKnowledgebaseService:
+        @staticmethod
+        def accessible(*_args, **_kwargs):
+            return True
+
+    knowledgebase_service_mod.KnowledgebaseService = _StubKnowledgebaseService
+    monkeypatch.setitem(
+        sys.modules, "api.db.services.knowledgebase_service", knowledgebase_service_mod
+    )
 
     api_utils_mod = ModuleType("api.utils.api_utils")
 

--- a/test/testcases/restful_api/test_connector_routes_unit.py
+++ b/test/testcases/restful_api/test_connector_routes_unit.py
@@ -486,6 +486,62 @@ def test_connector_by_id_routes_reject_cross_tenant_access(monkeypatch):
 
 
 @pytest.mark.p2
+def test_connector_rebuild_rejects_cross_tenant_kb_and_unbound_kb(monkeypatch):
+    """PR #15272 (issue #15268) — the rebuild route must verify the
+    caller-supplied kb_id, not just the connector_id, before reaching
+    ConnectorService.rebuild() (which deletes documents and schedules
+    sync tasks).
+
+    Three branches:
+      1. caller cannot access the kb → "No authorization." / no rebuild
+      2. caller can access the kb but the connector is not bound to it
+         → "Connector is not bound to this knowledge base." / no rebuild
+      3. caller can access the kb AND the connector is bound to it
+         → rebuild() runs and the route returns success
+    """
+    module = _load_connector_app(monkeypatch)
+
+    # The connector_id check passes; we're isolating the two new kb
+    # guards added in #15272.
+    monkeypatch.setattr(module.ConnectorService, "accessible", lambda cid, uid: True)
+    monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"kb_id": "kb-1"}))
+
+    rebuild_calls: list[tuple] = []
+
+    def _record_rebuild(*args):
+        rebuild_calls.append(args)
+        return None  # success
+
+    monkeypatch.setattr(module.ConnectorService, "rebuild", _record_rebuild)
+
+    # --- branch 1: KnowledgebaseService.accessible() denies -----------
+    monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda kb_id, uid: False)
+    monkeypatch.setattr(module.Connector2KbService, "query", lambda **_kwargs: [object()])
+    res = _run(module.rebuild("conn-victim"))
+    assert res["code"] == module.RetCode.AUTHENTICATION_ERROR
+    assert res["message"] == "No authorization."
+    assert res["data"] is False
+    assert rebuild_calls == [], "rebuild must NOT run when kb is not accessible"
+
+    # --- branch 2: kb accessible, but connector is not bound ----------
+    monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda kb_id, uid: True)
+    monkeypatch.setattr(module.Connector2KbService, "query", lambda **_kwargs: [])
+    res = _run(module.rebuild("conn-victim"))
+    assert res["code"] == module.RetCode.AUTHENTICATION_ERROR
+    assert res["message"] == "Connector is not bound to this knowledge base."
+    assert res["data"] is False
+    assert rebuild_calls == [], "rebuild must NOT run when connector is not bound to kb"
+
+    # --- branch 3: both gates pass → rebuild runs ---------------------
+    monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda kb_id, uid: True)
+    monkeypatch.setattr(module.Connector2KbService, "query", lambda **_kwargs: [object()])
+    res = _run(module.rebuild("conn-victim"))
+    assert res["data"] is True
+    assert len(rebuild_calls) == 1
+    assert rebuild_calls[0] == ("kb-1", "conn-victim", "tenant-1")
+
+
+@pytest.mark.p2
 def test_connector_oauth_helper_functions(monkeypatch):
     module = _load_connector_app(monkeypatch)
 


### PR DESCRIPTION
## Summary

Addresses the access-control class reported in #15268. The exact
endpoint cited there (`POST /v1/kb/update_metadata_setting`,
`api/apps/kb_app.py:190` in v0.24.0) no longer exists on current
`main` — it was refactored into
`PUT /api/v1/datasets/<dataset_id>/metadata/config`, and the
service-layer `update_auto_metadata` already scopes by tenant via
`KnowledgebaseService.get_or_none(id=..., tenant_id=...)`
(`api/apps/services/dataset_api_service.py:651`). So the literal
v0.24.0 vector is fixed.

This PR closes the **same vulnerability class** on the one
remaining route that still trusted a caller-supplied `kb_id`
without verifying ownership:
`POST /api/v1/connectors/<connector_id>/rebuild`.

## Audit findings

I grep'd every `req.get("kb_id")` / `req["kb_id"]` call site
under `api/apps/`. Results:

| Site | Status | Notes |
|---|---|---|
| `dataset_api.py` (all routes) | ✅ Safe | All routes scope by `dataset_id` via `KnowledgebaseService.accessible(...)` or `.get_or_none(id=, tenant_id=)` |
| `chat_api.py` `kb_ids` usage | ✅ Safe | Validated through `_validate_dataset_ids(req.get("dataset_ids"), current_user.id)` |
| `bot_api.py:423` `kb_ids = req["kb_id"]` | ✅ Safe | Used inside a `searchbots` ask flow that already validated tenant-bound dialog membership |
| `search_api.py` `kb_ids` usage | ✅ Safe | Validated through search config / tenant context |
| `connector_api.py:147` `rebuild` | ❌ **Vulnerable** | Only `ConnectorService.accessible(connector_id, ...)`; `kb_id` passed through unchecked |

`backward_compat.py` was clean — no legacy metadata route maps
through it.

## The connector rebuild gap

```python
@manager.route("/connectors/<connector_id>/rebuild", methods=["POST"])
@login_required
async def rebuild(connector_id):
    if not ConnectorService.accessible(connector_id, current_user.id):
        return _connector_auth_error(connector_id, current_user.id)

    req = await get_request_json()
    if "kb_id" not in req:
        return get_json_result(
            code=RetCode.ARGUMENT_ERROR,
            message="required argument is missing: kb_id",
        )

    err = ConnectorService.rebuild(req["kb_id"], connector_id, current_user.id)
```

`ConnectorService.rebuild()` then runs:

- `SyncLogsService.filter_delete(connector_id=, kb_id=)` on the
  caller-supplied kb.
- `DocumentService.query(..., kb_id=)` + `FileService.delete_docs(...)`.
- `SyncLogsService.schedule(connector_id, kb_id, reindex=True, ...)`.

The sibling function `cleanup_stale_documents_for_task` already
validates the connector↔kb binding via
`Connector2KbService.query(connector_id=connector_id, kb_id=kb_id)`
(`api/db/services/connector_service.py:166`). The same pattern
just wasn't applied to `rebuild`.

## Fix

`api/apps/restful_apis/connector_api.py`:

- Add `Connector2KbService` and `KnowledgebaseService` to imports.
- Before calling `ConnectorService.rebuild(...)`, run two binding
  checks against the caller-supplied `kb_id`:
  1. `KnowledgebaseService.accessible(kb_id, current_user.id)` —
     caller can access the kb (owner or team-shared, matching
     `accessible()` semantics used elsewhere).
  2. `Connector2KbService.query(connector_id=, kb_id=)` — this
     specific connector is bound to this kb (mirrors the sibling
     cleanup function).
- Both failures log to the existing `LOGGER` with
  `connector_id`, `kb_id`, `user_id` and return
  `AUTHENTICATION_ERROR` / `No authorization.` — matches
  `_connector_auth_error`'s convention.

No service-layer changes; no other endpoints touched.

## Test plan

- [ ] As tenant A, create a connector and bind it to a dataset
      that A owns. `POST /api/v1/connectors/<id>/rebuild` with the
      bound `kb_id` — request succeeds, sync task scheduled.
- [ ] As tenant B (no shared membership), authenticate and call
      `POST /api/v1/connectors/<A's connector_id>/rebuild` with
      A's `kb_id`. Request should fail with `AUTHENTICATION_ERROR`
      at the `ConnectorService.accessible(...)` check (existing
      behavior, sanity).
- [ ] As tenant A, call `POST /api/v1/connectors/<A's connector_id>/rebuild`
      with **B's** `kb_id`. Before this PR: `rebuild()` runs
      anyway. After this PR: rejected with
      `"No authorization."` at the new
      `KnowledgebaseService.accessible(kb_id, ...)` check, and a
      structured log line is emitted.
- [ ] As tenant A, call `POST /api/v1/connectors/<A's connector_id>/rebuild`
      with a `kb_id` A owns but that this connector is **not** bound
      to. After this PR: rejected with
      `"Connector is not bound to this knowledge base."` at the
      new `Connector2KbService.query(...)` check.
- [ ] Verify the `update_auto_metadata` endpoint
      (`PUT /api/v1/datasets/<id>/metadata/config`) still rejects
      cross-tenant requests — unchanged behavior, sanity check
      the headline scenario from the issue.
- [ ] Run `uv run pytest` to make sure no existing tests regress.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
