### PR TITLE
Fix: If the filename is too long, it overflows the confirmation box for deleting the file.

### DIFF
--- a/web/src/pages/files/action-cell.tsx
+++ b/web/src/pages/files/action-cell.tsx
@@ -177,7 +177,7 @@ export function ActionCell({
                     <FileIcon name={name} type={type}></FileIcon>
                   </span>
                   <span
-                    className={cn('truncate text-xs', {
+                    className={cn('truncate text-xs text-wrap', {
                       ['cursor-pointer']: isFolder,
                     })}
                   >


### PR DESCRIPTION


### What problem does this PR solve?

Fix: If the filename is too long, it overflows the confirmation box for deleting the file.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
