### PR TITLE
fix(api): preserve canvas_type on agent update when omitted

### DIFF
--- a/api/apps/restful_apis/agent_api.py
+++ b/api/apps/restful_apis/agent_api.py
@@ -872,8 +872,10 @@ def delete_agent(agent_id, tenant_id):
 @add_tenant_id_to_kwargs
 @_require_canvas_access_async
 async def update_agent(agent_id, tenant_id):
-    req = {k: v for k, v in (await get_request_json()).items() if v is not None}
-    req["canvas_type"] = req.get("canvas_type","")
+    body = await get_request_json()
+    req = {k: v for k, v in body.items() if v is not None}
+    if "canvas_type" in body:
+        req["canvas_type"] = body["canvas_type"]
     req["release"] = bool(req.get("release", ""))
 
     if req.get("dsl") is not None:


### PR DESCRIPTION
### What problem does this PR solve?

Only set canvas_type on the update payload when the client includes it in the request body, so partial updates do not overwrite the stored value with an empty string.


### Type of change

- [√] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
