### PR TITLE
fix(api): move dify retrieval health check to /dify/retrieval/health

### DIFF
--- a/api/apps/restful_apis/dify_retrieval_api.py
+++ b/api/apps/restful_apis/dify_retrieval_api.py
@@ -326,7 +326,7 @@ async def retrieval(tenant_id):
         return build_error_result(message=str(e), code=RetCode.SERVER_ERROR)
    
   
-@manager.route('/dify/retrieval', methods=['GET'])  # noqa: F821
+@manager.route('/dify/retrieval/health', methods=['GET'])  # noqa: F821
 async def retrieval_health_check():
     """Health check endpoint for Dify external knowledge base connectivity verification."""
     return get_json_result(data=True)


### PR DESCRIPTION
### Related issues
Closes #15310

### What problem does this PR solve?

`/api/v1/dify/retrieval` had duplicate `GET` route registrations in `dify_retrieval_api.py`: one for authenticated retrieval and another for unauthenticated health checks. Sharing the same path and method created ambiguous routing behavior and an unstable API contract for Dify external knowledge base integration.

This PR separates concerns by moving the health-check endpoint to `GET /api/v1/dify/retrieval/health`, while keeping retrieval on `/api/v1/dify/retrieval`. This makes auth behavior deterministic and prevents route shadowing/conflicts.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)