### PR TITLE
fix(browser): show resolved variables in workflow run log input

### DIFF
--- a/agent/component/browser.py
+++ b/agent/component/browser.py
@@ -413,6 +413,7 @@ class Browser(ComponentBase, ABC):
         if not model_name:
             raise ValueError(f"Invalid model config for Browser llm_id={self._param.llm_id}")
         base_url = self._resolve_openai_compatible_base_url(cfg)
+        provider_name = self._infer_provider_name(cfg).lower()
 
         # ChatBrowserUse only supports bu-* models. For tenant models, use OpenAI-compatible adapter.
         if model_name.startswith("bu-") or model_name.startswith("browser-use/"):
@@ -433,6 +434,9 @@ class Browser(ComponentBase, ABC):
             "temperature": self._param.temperature,
             "max_retries": self._param.max_retries,
         }
+        if "deepseek" in provider_name:
+            llm_kwargs["add_schema_to_system_prompt"] = True
+            llm_kwargs["dont_force_structured_output"] = True
         llm_kwargs = {k: v for k, v in llm_kwargs.items() if v not in (None, "")}
         return ChatOpenAI(**llm_kwargs)
 
@@ -671,6 +675,19 @@ class Browser(ComponentBase, ABC):
                 return ""
         return pick_final_result(final_result_fn)
 
+    @staticmethod
+    def _friendly_invoke_error(exc: Exception) -> str:
+        raw = str(exc)
+        lowered = raw.lower()
+        if "response_format type is unavailable" in lowered:
+            return (
+                "Browser model provider rejected required response_format. "
+                "Current model/provider does not support the structured response format required by browser-use. "
+                "Please switch Browser node llm_id to a compatible model/provider (for example Qwen/bu-* or an OpenAI-compatible gateway that supports this response_format). "
+                f"Original error: {raw}"
+            )
+        return raw
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 20 * 60)))
     def _invoke(self, **kwargs):
         profile_dir = None
@@ -716,7 +733,7 @@ class Browser(ComponentBase, ABC):
                 return self.output()
         except Exception as e:
             logging.exception("Browser invoke failed")
-            self.set_output("_ERROR", str(e))
+            self.set_output("_ERROR", self._friendly_invoke_error(e))
             return self.output()
         finally:
             if profile_dir and not persist_session:

--- a/agent/component/browser.py
+++ b/agent/component/browser.py
@@ -413,7 +413,6 @@ class Browser(ComponentBase, ABC):
         if not model_name:
             raise ValueError(f"Invalid model config for Browser llm_id={self._param.llm_id}")
         base_url = self._resolve_openai_compatible_base_url(cfg)
-        provider_name = self._infer_provider_name(cfg).lower()
 
         # ChatBrowserUse only supports bu-* models. For tenant models, use OpenAI-compatible adapter.
         if model_name.startswith("bu-") or model_name.startswith("browser-use/"):
@@ -427,16 +426,18 @@ class Browser(ComponentBase, ABC):
             llm_kwargs = {k: v for k, v in llm_kwargs.items() if v not in (None, "")}
             return ChatBrowserUse(**llm_kwargs)
 
+        # browser-use Agent defaults to json_schema response_format and may use tool_choice via
+        # ChatDeepSeek. Many providers (e.g. DeepSeek thinking models) reject both. Use ChatOpenAI
+        # with schema-in-prompt and without forced structured output on the first run.
         llm_kwargs = {
             "model": model_name,
             "api_key": cfg.get("api_key"),
             "base_url": base_url,
             "temperature": self._param.temperature,
             "max_retries": self._param.max_retries,
+            "add_schema_to_system_prompt": True,
+            "dont_force_structured_output": True,
         }
-        if "deepseek" in provider_name:
-            llm_kwargs["add_schema_to_system_prompt"] = True
-            llm_kwargs["dont_force_structured_output"] = True
         llm_kwargs = {k: v for k, v in llm_kwargs.items() if v not in (None, "")}
         return ChatOpenAI(**llm_kwargs)
 
@@ -675,19 +676,6 @@ class Browser(ComponentBase, ABC):
                 return ""
         return pick_final_result(final_result_fn)
 
-    @staticmethod
-    def _friendly_invoke_error(exc: Exception) -> str:
-        raw = str(exc)
-        lowered = raw.lower()
-        if "response_format type is unavailable" in lowered:
-            return (
-                "Browser model provider rejected required response_format. "
-                "Current model/provider does not support the structured response format required by browser-use. "
-                "Please switch Browser node llm_id to a compatible model/provider (for example Qwen/bu-* or an OpenAI-compatible gateway that supports this response_format). "
-                f"Original error: {raw}"
-            )
-        return raw
-
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 20 * 60)))
     def _invoke(self, **kwargs):
         profile_dir = None
@@ -733,7 +721,7 @@ class Browser(ComponentBase, ABC):
                 return self.output()
         except Exception as e:
             logging.exception("Browser invoke failed")
-            self.set_output("_ERROR", self._friendly_invoke_error(e))
+            self.set_output("_ERROR", str(e))
             return self.output()
         finally:
             if profile_dir and not persist_session:

--- a/agent/component/browser.py
+++ b/agent/component/browser.py
@@ -84,6 +84,15 @@ class BrowserParam(LLMParam):
 class Browser(ComponentBase, ABC):
     component_name = "Browser"
 
+    def _prepare_input_values(self):
+        for key, meta in self.get_input_elements().items():
+            val = meta.get("value")
+            if val is None:
+                val = ""
+            elif not isinstance(val, str):
+                val = json.dumps(val, ensure_ascii=False)
+            self.set_input_value(key, val)
+
     def get_input_elements(self) -> dict[str, dict]:
         text_parts = [
             str(self._param.prompts or ""),
@@ -667,6 +676,7 @@ class Browser(ComponentBase, ABC):
         profile_dir = None
         persist_session = self._should_persist_session()
         try:
+            self._prepare_input_values()
             user_prompt = self._resolve_text(kwargs.get("prompts", self._param.prompts))
             with tempfile.TemporaryDirectory(prefix="browser_use_upload_") as upload_dir, tempfile.TemporaryDirectory(
                 prefix="browser_use_download_"

--- a/rag/llm/__init__.py
+++ b/rag/llm/__init__.py
@@ -67,6 +67,7 @@ class SupportedLiteLLMProvider(StrEnum):
 FACTORY_DEFAULT_BASE_URL = {
     SupportedLiteLLMProvider.Tongyi_Qianwen: "https://dashscope.aliyuncs.com/compatible-mode/v1",
     SupportedLiteLLMProvider.Dashscope: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    SupportedLiteLLMProvider.DeepSeek: "https://api.deepseek.com/v1",
     SupportedLiteLLMProvider.Moonshot: "https://api.moonshot.cn/v1",
     SupportedLiteLLMProvider.Ollama: "",
     SupportedLiteLLMProvider.LongCat: "https://api.longcat.chat/openai",

--- a/test/unit_test/agent/component/test_browser_use_component.py
+++ b/test/unit_test/agent/component/test_browser_use_component.py
@@ -53,9 +53,13 @@ class _FakeCanvas:
         self._refs = refs or {}
 
     def is_reff(self, token):
-        return token in self._refs
+        key = token.strip("{} ")
+        return key in self._refs or token in self._refs
 
     def get_variable_value(self, token):
+        key = token.strip("{} ")
+        if key in self._refs:
+            return self._refs[key]
         return self._refs[token]
 
     def get_tenant_id(self):
@@ -67,6 +71,19 @@ def _build_component():
     component._canvas = _FakeCanvas()
     component._param = SimpleNamespace(upload_sources="")
     return component
+
+
+def test_prepare_input_values_records_variable_inputs():
+    component = browser_use_module.Browser.__new__(browser_use_module.Browser)
+    component._canvas = _FakeCanvas(refs={"sys.query": "open example.com"})
+    component._param = browser_use_module.BrowserParam()
+    component._param.prompts = "{sys.query}"
+    component._param.inputs = {}
+
+    component._prepare_input_values()
+
+    assert component.get_input_value("sys.query") == "open example.com"
+    assert component.get_input_values()["sys.query"] == "open example.com"
 
 
 def test_extract_ids_supports_mixed_literals_and_variables():


### PR DESCRIPTION
### What problem does this PR solve?

Browser parsed sys.query from prompts but never called set_input_value, so node_finished inputs displayed null in the agent orchestration run log.
Additionally, Browser’s tenant-model path could trigger unsupported structured-output modes (response_format/tool_choice) for some OpenAI-compatible providers (notably DeepSeek thinking models), causing step failures.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
