### PR TITLE
fix(llm): clearer error when embedding model returns no vectors (#15343)

### DIFF
--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -136,6 +136,19 @@ class LLMBundle(LLM4Tenant):
                 safe_texts.append(text)
 
         embeddings, used_tokens = self.mdl.encode(safe_texts)
+        # Surface a clear failure when the embedding model is unavailable or
+        # returns no vectors. Without this guard, downstream call sites do
+        # `len(vts[0])` and the error surfaces as the unhelpful
+        # `'NoneType' object is not subscriptable` (fixes #15343).
+        if embeddings is None or len(embeddings) == 0:
+            raise RuntimeError(
+                "Embedding model '{name}' (factory '{factory}') returned no vectors. "
+                "Check that the model service is reachable, the API key is valid, "
+                "and the model supports the requested input.".format(
+                    name=self.model_config.get("llm_name", "<unknown>"),
+                    factory=self.model_config.get("llm_factory", "<unknown>"),
+                )
+            )
         if self.model_config["llm_factory"] == "Builtin":
             logging.debug("LLMBundle.encode query: {}, emd len: {}, used_tokens: {}. Builtin model don't need to update token usage".format(texts, len(embeddings), used_tokens))
         else:
@@ -160,6 +173,18 @@ class LLMBundle(LLM4Tenant):
             )
             query = "None"
         emd, used_tokens = self.mdl.encode_queries(query)
+        # Mirror the encode() guard so a missing/refusing embedding model
+        # surfaces as a clear RuntimeError instead of a subscript crash
+        # downstream (fixes #15343).
+        if emd is None or len(emd) == 0:
+            raise RuntimeError(
+                "Embedding model '{name}' (factory '{factory}') returned no vector "
+                "for the query. Check that the model service is reachable, the API "
+                "key is valid, and the model supports the requested input.".format(
+                    name=self.model_config.get("llm_name", "<unknown>"),
+                    factory=self.model_config.get("llm_factory", "<unknown>"),
+                )
+            )
         if self.model_config["llm_factory"] == "Builtin":
             logging.info("LLMBundle.encode_queries query: {}, emd len: {}, used_tokens: {}. Builtin model don't need to update token usage".format(query, len(emd), used_tokens))
         else:

--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -141,11 +141,13 @@ class LLMBundle(LLM4Tenant):
         # `len(vts[0])` and the error surfaces as the unhelpful
         # `'NoneType' object is not subscriptable` (fixes #15343).
         if embeddings is None or len(embeddings) == 0:
+            state = "embeddings is None" if embeddings is None else "len(embeddings)==0"
             logging.error(
-                "LLMBundle.encode: Embedding model '%s' (factory '%s') returned no vectors for %d input texts",
+                "LLMBundle.encode: Embedding model '%s' (factory '%s') returned no vectors for %d input texts (%s)",
                 self.model_config.get("llm_name", "<unknown>"),
                 self.model_config.get("llm_factory", "<unknown>"),
                 len(safe_texts),
+                state,
             )
             raise RuntimeError(
                 "Embedding model '{name}' (factory '{factory}') returned no vectors. "
@@ -183,10 +185,12 @@ class LLMBundle(LLM4Tenant):
         # surfaces as a clear RuntimeError instead of a subscript crash
         # downstream (fixes #15343).
         if emd is None or len(emd) == 0:
+            state = "emd is None" if emd is None else "len(emd)==0"
             logging.error(
-                "LLMBundle.encode_queries: Embedding model '%s' (factory '%s') returned no vector for query",
+                "LLMBundle.encode_queries: Embedding model '%s' (factory '%s') returned no vector for query (%s)",
                 self.model_config.get("llm_name", "<unknown>"),
                 self.model_config.get("llm_factory", "<unknown>"),
+                state,
             )
             raise RuntimeError(
                 "Embedding model '{name}' (factory '{factory}') returned no vector "

--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -141,6 +141,12 @@ class LLMBundle(LLM4Tenant):
         # `len(vts[0])` and the error surfaces as the unhelpful
         # `'NoneType' object is not subscriptable` (fixes #15343).
         if embeddings is None or len(embeddings) == 0:
+            logging.error(
+                "LLMBundle.encode: Embedding model '%s' (factory '%s') returned no vectors for %d input texts",
+                self.model_config.get("llm_name", "<unknown>"),
+                self.model_config.get("llm_factory", "<unknown>"),
+                len(safe_texts),
+            )
             raise RuntimeError(
                 "Embedding model '{name}' (factory '{factory}') returned no vectors. "
                 "Check that the model service is reachable, the API key is valid, "
@@ -177,6 +183,11 @@ class LLMBundle(LLM4Tenant):
         # surfaces as a clear RuntimeError instead of a subscript crash
         # downstream (fixes #15343).
         if emd is None or len(emd) == 0:
+            logging.error(
+                "LLMBundle.encode_queries: Embedding model '%s' (factory '%s') returned no vector for query",
+                self.model_config.get("llm_name", "<unknown>"),
+                self.model_config.get("llm_factory", "<unknown>"),
+            )
             raise RuntimeError(
                 "Embedding model '{name}' (factory '{factory}') returned no vector "
                 "for the query. Check that the model service is reachable, the API "


### PR DESCRIPTION
## Summary

Fixes #15343. When the embedding model is unavailable, RAGFlow
currently shows:

```
Fail to bind embedding model: 'NoneType' object is not subscriptable
```

— which is uninformative. After this PR the same condition surfaces
as:

```
Fail to bind embedding model: Embedding model 'bge-m3' (factory 'Ollama')
returned no vectors. Check that the model service is reachable, the API
key is valid, and the model supports the requested input.
```

## Root cause

`LLMBundle.encode(...)` / `encode_queries(...)` (in
`api/db/services/llm_service.py`) returns whatever the underlying
driver returns. When the driver answers with `None` or `[]`
(connection refused, model service down, refused payload, etc.),
three downstream sites subscript the result:

| Site | Snippet |
|---|---|
| `rag/svr/task_executor.py:1411-1412` | `vts, _ = embedding_model.encode(["ok"]); vector_size = len(vts[0])` — bind-time probe |
| `rag/svr/task_executor_refactor/task_handler.py:172-173` | identical probe in `_get_vector_size` |
| `rag/flow/tokenizer/tokenizer.py:91-93` | `vts, c = embedding_model.encode([name]); tts = np.tile(vts[0], ...)` |

Each site raises `'NoneType' object is not subscriptable`. The
bind-site catch then prepends `Fail to bind embedding model:` and
the operator is left guessing.

## Fix

One change, one place. Add a guard immediately after
`self.mdl.encode(safe_texts)` and `self.mdl.encode_queries(query)`
inside `LLMBundle`:

```python
if embeddings is None or len(embeddings) == 0:
    raise RuntimeError(
        "Embedding model '{name}' (factory '{factory}') returned no vectors. "
        "Check that the model service is reachable, the API key is valid, "
        "and the model supports the requested input.".format(
            name=self.model_config.get("llm_name", "<unknown>"),
            factory=self.model_config.get("llm_factory", "<unknown>"),
        )
    )
```

(`encode_queries` raises with a slightly different message for
the single-query case.)

Because all three offending subscript sites already wrap their
calls in `try/except Exception`, the new `RuntimeError` flows
through the existing error path and the user sees the actionable
message in the progress log or API response with no further
plumbing changes.

## What's intentionally **not** in this PR

- No changes at the three subscript sites. They're already wrapped
  in `try/except Exception` and pick up the new message for free.
  Touching them adds churn and risks divergence.
- No change to the per-driver `encode`/`encode_queries` methods in
  `rag/llm/embedding_model.py`. Those raise their own specific
  exceptions when an HTTP call fails; the new guard only fires
  when a driver returns successfully with an empty result (which
  happens when, e.g., a misconfigured Ollama returns `{"embeddings": []}`).
- No retry / fallback logic. Out of scope and a behavioral change.

## Test plan

- [ ] Point `EMBEDDING` to an unreachable Ollama (`http://nowhere:11434`)
      and parse a document. Progress log should show the new
      "Embedding model '<name>' (factory '<factory>') returned no
      vectors." message, not `'NoneType' object is not subscriptable`.
- [ ] Configure an embedding model whose API responds with HTTP 200
      and an empty `data: []`. Same expected message.
- [ ] Healthy embedding model — parse a normal document. Behaviour
      unchanged, vectors stored, no extra latency.
- [ ] Query a chat with retrieval enabled while the embedding model
      is down — `encode_queries` should now raise the second
      (query-flavoured) message instead of crashing on
      `embds[0]` inside `encode_queries` callers.
- [ ] `uv run pytest` to make sure no existing tests regress.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
