### PR TITLE
Guard missing storage blobs on preview and image endpoints

### DIFF
--- a/api/apps/restful_apis/document_api.py
+++ b/api/apps/restful_apis/document_api.py
@@ -1924,6 +1924,8 @@ async def get(doc_id):
 
         b, n = File2DocumentService.get_storage_address(doc_id=doc_id)
         data = await thread_pool_exec(settings.STORAGE_IMPL.get, b, n)
+        if not data:
+            return get_data_error_result(message="This file is empty.")
         response = await make_response(data)
 
         ext = re.search(r"\.([^.]+)$", doc.name.lower())

--- a/test/testcases/test_web_api/test_document_app/test_document_metadata.py
+++ b/test/testcases/test_web_api/test_document_app/test_document_metadata.py
@@ -533,6 +533,7 @@ class TestDocumentMetadataUnit:
         async def fake_thread_pool_exec(*_args, **_kwargs):
             return None
 
+        monkeypatch.setattr(module.DocumentService, "accessible", lambda _doc_id, _user_id: True)
         monkeypatch.setattr(
             module.DocumentService,
             "get_by_id",

--- a/test/testcases/test_web_api/test_document_app/test_document_metadata.py
+++ b/test/testcases/test_web_api/test_document_app/test_document_metadata.py
@@ -526,6 +526,23 @@ class TestDocumentMetadataUnit:
         assert res["code"] == RetCode.DATA_ERROR
         assert res["message"] == "Image not found."
 
+    @pytest.mark.p2
+    def test_get_preview_missing_blob_unit(self, document_app_module, monkeypatch):
+        module = document_app_module
+
+        async def fake_thread_pool_exec(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(
+            module.DocumentService,
+            "get_by_id",
+            lambda _doc_id: (True, SimpleNamespace(name="report.pdf", type=module.FileType.OTHER.value)),
+        )
+        monkeypatch.setattr(module.File2DocumentService, "get_storage_address", lambda **_kwargs: ("bucket", "name"))
+        monkeypatch.setattr(module, "thread_pool_exec", fake_thread_pool_exec)
+        res = _run(module.get("doc1"))
+        assert res["code"] == RetCode.DATA_ERROR
+        assert res["message"] == "This file is empty."
 
     @pytest.mark.skip(reason="Moved to /api/v1/documents/images/<image_id>")
     def test_get_image_success_and_exception_unit(self, document_app_module, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes [#15365](https://github.com/infiniflow/ragflow/issues/15365) — `get_document_image()` and document preview call `make_response(None)` when storage returns no bytes, causing HTTP 500.

## Related Issue

Fixes #15365

## Change Type

- [x] Bug fix
- [x] Regression tests
- [ ] New feature
- [ ] Refactor

## What Changed

- **`get_document_image()`** — return `get_data_error_result("Image not found.")` when storage blob is missing (mirrors `get_artifact()`).
- **Preview `get()`** — return `get_data_error_result("This file is empty.")` when storage blob is missing (matches document REST download wording).

## Files Changed

| File | Change |
|------|--------|
| `api/apps/restful_apis/document_api.py` | Empty-blob guards before `make_response()` |
| `test/testcases/test_web_api/test_document_app/test_document_metadata.py` | 2 unit tests |

## Validation

```bash
cd /root/gittensor/ragflow
pytest test/testcases/test_web_api/test_document_app/test_document_metadata.py::TestDocumentMetadataUnit::test_get_document_image_missing_blob_unit -v
pytest test/testcases/test_web_api/test_document_app/test_document_metadata.py::TestDocumentMetadataUnit::test_get_preview_missing_blob_unit -v
```

## Test Plan

- [x] Missing image blob → 4xx `"Image not found."`, not HTTP 500
- [x] Missing preview blob → 4xx `"This file is empty."`, not HTTP 500
- [ ] CI green