### PR TITLE
Fix: agent template description not displayed for unsupported languages

### DIFF
--- a/web/src/pages/agents/template-card.tsx
+++ b/web/src/pages/agents/template-card.tsx
@@ -19,12 +19,15 @@ export function TemplateCard({ data, showModal }: IProps) {
     showModal(data);
   }, [data, showModal]);
 
-  const language = useMemo(() => {
+  const language = useMemo((): 'en' | 'zh' | 'de' => {
     if (i18n.language === LanguageAbbreviation.Zh) {
       return 'zh';
     }
-    return i18n.language || 'en';
-  }, []) as 'en' | 'zh' | 'de';
+    if (i18n.language === 'de') {
+      return 'de';
+    }
+    return 'en';
+  }, []);
 
   return (
     <Card className="border-colors-outline-neutral-standard group relative min-h-40">
@@ -42,7 +45,7 @@ export function TemplateCard({ data, showModal }: IProps) {
             {data?.title[language]}
           </div>
         </div>
-        <p className="break-words hypens-auto" lang={language}>
+        <p className="break-words hyphens-auto" lang={language}>
           {data?.description[language]}
         </p>
         <div className="group-hover:bg-gradient-to-t from-black/70 from-10% via-black/0 via-50% to-black/0 w-full h-full group-hover:block absolute top-0 left-0 hidden rounded-xl">

--- a/web/src/pages/agents/template-card.tsx
+++ b/web/src/pages/agents/template-card.tsx
@@ -27,7 +27,7 @@ export function TemplateCard({ data, showModal }: IProps) {
       return 'de';
     }
     return 'en';
-  }, []);
+  }, [i18n.language]);
 
   return (
     <Card className="border-colors-outline-neutral-standard group relative min-h-40">


### PR DESCRIPTION
### What problem does this PR solve?

When the UI language is set to a locale not covered by the template data (e.g. French, Spanish, etc.), `data.description[language]` resolves to `undefined` and the template description is not displayed on the `/agent-templates` page.

Additionally, the CSS class `hypens-auto` was a typo and had no effect.

### Root cause

The `language` computation in `TemplateCard` only handled the Chinese case explicitly, then fell back to `i18n.language` directly — without checking whether that language key exists in the template data (`en`, `zh`, `de` only).

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Changes

- `web/src/pages/agents/template-card.tsx`: fall back to `'en'` for any language that is not `zh` or `de`
- Fix typo `hypens-auto` → `hyphens-auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)