### PR TITLE
fix: correct dataset overview status counts (#15304)

### DIFF
--- a/web/src/pages/dataset/dataset-overview/hook.ts
+++ b/web/src/pages/dataset/dataset-overview/hook.ts
@@ -12,18 +12,19 @@ import { useCallback, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import { LogTabs } from './dataset-common';
 import { IFileLogList, IOverviewTotal } from './interface';
+import { mapOverviewTotal } from './utils';
 
 const useFetchOverviewTotal = () => {
   const [searchParams] = useSearchParams();
   const { id } = useParams();
   const knowledgeBaseId = searchParams.get('id') || id;
   const { data } = useQuery<IOverviewTotal>({
-    queryKey: ['overviewTotal'],
+    queryKey: ['overviewTotal', knowledgeBaseId],
     queryFn: async () => {
       const { data: res = {} } = await getKnowledgeBasicInfo(
         knowledgeBaseId || '',
       );
-      return res.data || [];
+      return mapOverviewTotal(res.data);
     },
   });
   return { data };

--- a/web/src/pages/dataset/dataset-overview/utils.test.ts
+++ b/web/src/pages/dataset/dataset-overview/utils.test.ts
@@ -1,0 +1,54 @@
+import { mapOverviewTotal } from './utils';
+
+describe('mapOverviewTotal', () => {
+  it('maps nested status counts to the flat overview fields', () => {
+    const result = mapOverviewTotal({
+      doc_num: 2576,
+      status: {
+        cancel_count: 0,
+        done_count: 937,
+        fail_count: 18,
+        running_count: 767,
+        unstart_count: 854,
+      },
+    });
+
+    expect(result).toEqual({
+      cancelled: 0,
+      failed: 18,
+      finished: 937,
+      processing: 767,
+      downloaded: 854,
+    });
+  });
+
+  it('defaults every field to 0 when status is missing', () => {
+    expect(mapOverviewTotal({ doc_num: 0 })).toEqual({
+      cancelled: 0,
+      failed: 0,
+      finished: 0,
+      processing: 0,
+      downloaded: 0,
+    });
+  });
+
+  it('defaults every field to 0 when data is undefined', () => {
+    expect(mapOverviewTotal(undefined)).toEqual({
+      cancelled: 0,
+      failed: 0,
+      finished: 0,
+      processing: 0,
+      downloaded: 0,
+    });
+  });
+
+  it('fills only the counts present in a partial status', () => {
+    expect(mapOverviewTotal({ status: { done_count: 5 } })).toEqual({
+      cancelled: 0,
+      failed: 0,
+      finished: 5,
+      processing: 0,
+      downloaded: 0,
+    });
+  });
+});

--- a/web/src/pages/dataset/dataset-overview/utils.ts
+++ b/web/src/pages/dataset/dataset-overview/utils.ts
@@ -1,0 +1,30 @@
+import { IOverviewTotal } from './interface';
+
+export interface IIngestionStatus {
+  cancel_count?: number;
+  done_count?: number;
+  fail_count?: number;
+  running_count?: number;
+  unstart_count?: number;
+}
+
+export interface IIngestionSummary {
+  doc_num?: number;
+  chunk_num?: number;
+  token_num?: number;
+  status?: IIngestionStatus;
+}
+
+// The `ingestions/summary` API nests the counts under `status` with
+// `*_count` keys. The overview UI reads flat fields, so translate here
+// to keep the two sides decoupled.
+export function mapOverviewTotal(data?: IIngestionSummary): IOverviewTotal {
+  const status = data?.status ?? {};
+  return {
+    cancelled: status.cancel_count ?? 0,
+    failed: status.fail_count ?? 0,
+    finished: status.done_count ?? 0,
+    processing: status.running_count ?? 0,
+    downloaded: status.unstart_count ?? 0,
+  };
+}


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #15304.

On the dataset overview page, all status counts (Downloading, Processing, Success, Failed) always showed `0`, even though the database held valid data and the `ingestions/summary` API returned correct counts.

The cause is a frontend/backend data-structure mismatch. The API returns the counts nested under `status` with `*_count` keys:

```json
{ "data": { "doc_num": 2576, "status": { "cancel_count": 0, "done_count": 937, "fail_count": 18, "running_count": 767, "unstart_count": 854 } } }
```

but the overview hook read flat top-level fields (`downloaded`, `processing`, `finished`, `failed`, `cancelled`), which were all `undefined`.

This keeps the backend contract unchanged and translates the response into the flat shape the UI expects via a new `mapOverviewTotal` helper. The React Query cache key is also scoped by dataset id so counts no longer leak between datasets. Unit tests cover the full mapping, missing/undefined data, and partial status payloads.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):