### PR TITLE
fix(go-models): raise SSE scanner buffer so large stream chunks are not dropped

### DIFF
--- a/internal/entity/models/302ai.go
+++ b/internal/entity/models/302ai.go
@@ -338,6 +338,7 @@ func (a *AI302Model) ChatStreamlyWithSender(modelName string, messages []Message
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 

--- a/internal/entity/models/aliyun.go
+++ b/internal/entity/models/aliyun.go
@@ -294,6 +294,7 @@ func (z *AliyunModel) ChatStreamlyWithSender(modelName string, messages []Messag
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/baichuan.go
+++ b/internal/entity/models/baichuan.go
@@ -245,6 +245,7 @@ func (b *BaichuanModel) ChatStreamlyWithSender(modelName string, messages []Mess
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/baidu.go
+++ b/internal/entity/models/baidu.go
@@ -347,6 +347,7 @@ func (b *BaiduModel) ChatStreamlyWithSender(modelName string, messages []Message
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/cohere.go
+++ b/internal/entity/models/cohere.go
@@ -271,6 +271,7 @@ func (c *CoHereModel) ChatStreamlyWithSender(modelName string, messages []Messag
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		data := strings.TrimSpace(line)

--- a/internal/entity/models/deepinfra.go
+++ b/internal/entity/models/deepinfra.go
@@ -282,6 +282,7 @@ func (d *DeepInfraModel) ChatStreamlyWithSender(modelName string, messages []Mes
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/deepseek.go
+++ b/internal/entity/models/deepseek.go
@@ -348,6 +348,7 @@ func (z *DeepSeekModel) ChatStreamlyWithSender(modelName string, messages []Mess
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/gitee.go
+++ b/internal/entity/models/gitee.go
@@ -309,6 +309,7 @@ func (g *GiteeModel) ChatStreamlyWithSender(modelName string, messages []Message
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/huggingface.go
+++ b/internal/entity/models/huggingface.go
@@ -272,6 +272,7 @@ func (h *HuggingFaceModel) ChatStreamlyWithSender(modelName string, messages []M
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/lmstudio.go
+++ b/internal/entity/models/lmstudio.go
@@ -295,6 +295,7 @@ func (l *LmStudioModel) ChatStreamlyWithSender(modelName string, messages []Mess
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/longcat_test.go
+++ b/internal/entity/models/longcat_test.go
@@ -9,12 +9,6 @@ import (
 	"testing"
 )
 
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
-	return f(r)
-}
-
 func newLongCatServer(t *testing.T, expectedPath string, handler func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/entity/models/minimax.go
+++ b/internal/entity/models/minimax.go
@@ -278,6 +278,7 @@ func (z *MinimaxModel) ChatStreamlyWithSender(modelName string, messages []Messa
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/modelscope_test.go
+++ b/internal/entity/models/modelscope_test.go
@@ -26,12 +26,6 @@ import (
 	"time"
 )
 
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
-	return f(r)
-}
-
 func newModelScopeForTest(baseURL string) *ModelScopeModel {
 	return NewModelScopeModel(
 		map[string]string{"default": baseURL},

--- a/internal/entity/models/moonshot.go
+++ b/internal/entity/models/moonshot.go
@@ -292,6 +292,7 @@ func (k *MoonshotModel) ChatStreamlyWithSender(modelName string, messages []Mess
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/nvidia.go
+++ b/internal/entity/models/nvidia.go
@@ -270,6 +270,7 @@ func (n *NvidiaModel) ChatStreamlyWithSender(modelName string, messages []Messag
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 

--- a/internal/entity/models/ollama.go
+++ b/internal/entity/models/ollama.go
@@ -282,6 +282,7 @@ func (o *OllamaModel) ChatStreamlyWithSender(modelName string, messages []Messag
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 

--- a/internal/entity/models/openrouter.go
+++ b/internal/entity/models/openrouter.go
@@ -289,6 +289,7 @@ func (o *OpenRouterModel) ChatStreamlyWithSender(modelName string, messages []Me
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/orcarouter.go
+++ b/internal/entity/models/orcarouter.go
@@ -236,6 +236,7 @@ func (o *OrcaRouterModel) ChatStreamlyWithSender(modelName string, messages []Me
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/paddleocr.go
+++ b/internal/entity/models/paddleocr.go
@@ -248,6 +248,7 @@ func (p *PaddleOCRModel) OCRFile(modelName *string, content []byte, fileURL *str
 
 	var fullMarkdown strings.Builder
 	scanner := bufio.NewScanner(resResp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/internal/entity/models/ppio_test.go
+++ b/internal/entity/models/ppio_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 )
 
+// roundTripperFunc is the package-wide test helper for stubbing
+// http.RoundTripper. It lives here (the first provider test to need it) and is
+// shared by the other provider tests in this package; do not redeclare it.
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/internal/entity/models/siliconflow.go
+++ b/internal/entity/models/siliconflow.go
@@ -304,6 +304,7 @@ func (z *SiliconflowModel) ChatStreamlyWithSender(modelName string, messages []M
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/sse_scanner_buffer_test.go
+++ b/internal/entity/models/sse_scanner_buffer_test.go
@@ -1,0 +1,99 @@
+package models
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// chatStreamer is the streaming entrypoint shared by every OpenAI-compatible
+// provider. The buffer regression below exercises it through a table so a new
+// provider only needs one row.
+type chatStreamer interface {
+	ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, modelConfig *ChatConfig, sender func(*string, *string) error) error
+}
+
+// largeSSEStreamServer streams a single SSE "data:" line whose content delta is
+// larger than the default 64KB bufio.Scanner token size, followed by a
+// finish_reason chunk and the [DONE] sentinel. Without scanner.Buffer(...) the
+// oversized line makes scanner.Scan() return false with bufio.ErrTooLong and the
+// stream is truncated; with the raised buffer the full content is delivered.
+func largeSSEStreamServer(t *testing.T, content string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			`data: {"choices":[{"delta":{"content":"`+content+`"}}]}`+"\n"+
+				`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`+"\n"+
+				`data: [DONE]`+"\n",
+		)
+	}))
+}
+
+func TestChatStreamLargeChunkNotTruncated(t *testing.T) {
+	// 128KB content delta: comfortably past the 64KB default so the bare
+	// scanner would fail, well under the 1MB raised cap so the fix succeeds.
+	const big = 128 * 1024
+	content := strings.Repeat("a", big)
+
+	suffix := URLSuffix{Chat: "chat/completions", Models: "models"}
+	build := func(c func(map[string]string, URLSuffix) chatStreamer) func(string) chatStreamer {
+		return func(baseURL string) chatStreamer {
+			return c(map[string]string{"default": baseURL}, suffix)
+		}
+	}
+
+	cases := []struct {
+		name  string
+		build func(string) chatStreamer
+	}{
+		{"deepinfra", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewDeepInfraModel(b, s) })},
+		{"vllm", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewVllmModel(b, s) })},
+		{"openrouter", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewOpenRouterModel(b, s) })},
+		{"siliconflow", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewSiliconflowModel(b, s) })},
+		{"moonshot", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewMoonshotModel(b, s) })},
+		{"deepseek", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewDeepSeekModel(b, s) })},
+		{"nvidia", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewNvidiaModel(b, s) })},
+		{"lmstudio", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewLmStudioModel(b, s) })},
+		{"gitee", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewGiteeModel(b, s) })},
+		{"tokenhub", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewTokenHubModel(b, s) })},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			srv := largeSSEStreamServer(t, content)
+			defer srv.Close()
+
+			apiKey := "test-key"
+			var got strings.Builder
+			err := tc.build(srv.URL).ChatStreamlyWithSender(
+				"test-model",
+				[]Message{{Role: "user", Content: "hi"}},
+				&APIConfig{ApiKey: &apiKey},
+				// Empty (non-nil) config: providers default stream=true and
+				// only override when Stream != nil, so this streams for all of
+				// them while avoiding a nil-config deref in providers that read
+				// modelConfig unconditionally.
+				&ChatConfig{},
+				func(c *string, _ *string) error {
+					if c != nil && *c != "[DONE]" {
+						got.WriteString(*c)
+					}
+					return nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("ChatStreamlyWithSender returned error (large chunk truncated?): %v", err)
+			}
+			if got.Len() != big {
+				t.Fatalf("delivered %d bytes, want %d (content was truncated)", got.Len(), big)
+			}
+			if got.String() != content {
+				t.Fatalf("delivered content does not match streamed content")
+			}
+		})
+	}
+}

--- a/internal/entity/models/tokenhub.go
+++ b/internal/entity/models/tokenhub.go
@@ -259,6 +259,7 @@ func (t *TokenHubModel) ChatStreamlyWithSender(modelName string, messages []Mess
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 

--- a/internal/entity/models/vllm.go
+++ b/internal/entity/models/vllm.go
@@ -311,6 +311,7 @@ func (z *VllmModel) ChatStreamlyWithSender(modelName string, messages []Message,
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/volcengine.go
+++ b/internal/entity/models/volcengine.go
@@ -339,6 +339,7 @@ func (z *VolcEngine) ChatStreamlyWithSender(modelName string, messages []Message
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/voyage_test.go
+++ b/internal/entity/models/voyage_test.go
@@ -9,12 +9,6 @@ import (
 	"testing"
 )
 
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
-	return f(r)
-}
-
 func newVoyageServer(t *testing.T, expectedPath string, handler func(t *testing.T, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/entity/models/xunfei.go
+++ b/internal/entity/models/xunfei.go
@@ -268,6 +268,7 @@ func (x *XunFeiModel) ChatStreamlyWithSender(modelName string, messages []Messag
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)

--- a/internal/entity/models/zhipu-ai.go
+++ b/internal/entity/models/zhipu-ai.go
@@ -299,6 +299,7 @@ func (z *ZhipuAIModel) ChatStreamlyWithSender(modelName string, messages []Messa
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		common.Info(line)


### PR DESCRIPTION
### Summary

Closes #15381 

Every provider in `internal/entity/models/` reads its streaming response with `bufio.NewScanner(resp.Body)` and iterates over `scanner.Scan()`. The default `bufio.Scanner` maximum token size is 64KB, so when an upstream sends a single SSE `data:` line larger than 64KB (long content deltas, large tool or function call argument blobs, bundled `reasoning_content`, or providers that emit a whole message in one event) `scanner.Scan()` returns `false` and `scanner.Err()` returns `bufio.ErrTooLong`. Streaming chat then ends with an error partway through the response.

This change adds `scanner.Buffer(make([]byte, 64*1024), 1024*1024)` immediately after every SSE scanner that was still bare, raising the cap to 1MB. 1MB is the value already used for streaming chat in `openai.go`, `modelscope.go`, `groq.go`, `mistral.go`, `xai.go` and the other already patched providers (the 8MB cap in the repo is reserved for TTS and embedding paths), so this simply converges the remaining providers onto the established pattern. Nothing else changes: line parsing, `data:` prefix handling, `[DONE]` detection, JSON unmarshalling, error handling, and the existing `scanner.Err()` checks all stay the same.

Providers covered (23 scanners across 22 files): 302ai, aliyun, baichuan, baidu, cohere, deepinfra, deepseek, gitee, huggingface, lmstudio, minimax (the chat scanner, whose TTS scanner was already bumped), moonshot, nvidia, ollama, openrouter, orcarouter, paddleocr, siliconflow, tokenhub, vllm, volcengine, xunfei, zhipu-ai. `jiekouai.go` is excluded because it is covered by the in flight #15337.

A table driven regression test (`sse_scanner_buffer_test.go`) streams a single 128KB `data:` content delta followed by `data: [DONE]` through an `httptest` server and asserts that `ChatStreamlyWithSender` delivers the full content with no error across a representative subset of providers. Without the buffer fix the test fails with `bufio.Scanner: token too long`.

This PR also removes three duplicate declarations of the package level `roundTripperFunc` test helper that several recently merged provider PRs each added independently, which had left the `internal/entity/models` test package unable to compile. The helper now lives in a single place and is shared.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
