### PR TITLE
Fix: default OpenAI chat completions to non-stream

### DIFF
--- a/api/apps/restful_apis/openai_api.py
+++ b/api/apps/restful_apis/openai_api.py
@@ -162,7 +162,7 @@ async def openai_chat_completions(chat_id):
 
     tools = None
     toolcall_session = None
-    stream_mode = req.get("stream", True)
+    stream_mode = bool(req.get("stream", False))
 
     if stream_mode:
         async def streamed_response_generator():

--- a/test/testcases/restful_api/test_openai_compatible.py
+++ b/test/testcases/restful_api/test_openai_compatible.py
@@ -141,6 +141,26 @@ def test_openai_compatible_nonstream_shape(rest_client, create_chat):
 
 
 @pytest.mark.p2
+def test_openai_compatible_defaults_to_nonstream_when_stream_is_missing(rest_client, create_chat):
+    chat_id = create_chat("restful_openai_default_nonstream_chat")
+    res = rest_client.post(
+        f"/openai/{chat_id}/chat/completions",
+        json={
+            "model": "model",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        timeout=60,
+    )
+    assert res.status_code == 200
+    assert "application/json" in res.headers.get("Content-Type", ""), res.headers.get("Content-Type", "")
+
+    payload = res.json()
+    assert payload["object"] == "chat.completion", payload
+    assert isinstance(payload["choices"], list) and payload["choices"], payload
+    assert payload["choices"][0].get("finish_reason") == "stop", payload
+
+
+@pytest.mark.p2
 def test_openai_compatible_nonstream_with_reference_output_shape(rest_client, create_chat):
     chat_id = create_chat("restful_openai_reference_chat")
     res = rest_client.post(


### PR DESCRIPTION
### What problem does this PR solve?

default OpenAI chat completions to non-stream when `stream` is omitted
https://github.com/infiniflow/ragflow/issues/15356
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)