### PR TITLE
fix: restore TitleChunker output for json/chunks upstream formats

### DIFF
--- a/rag/flow/chunker/title_chunker/common.py
+++ b/rag/flow/chunker/title_chunker/common.py
@@ -120,13 +120,9 @@ class BaseTitleChunker(ABC):
                 }
                 for line in clean_lines
             ]
-        # Return empty array directly for null payload to block invalid branch fallthrough
-        return []
-
         items = self.from_upstream.chunks if self.from_upstream.output_format == "chunks" else self.from_upstream.json_result
         return [
             {
-                # Serialization fix: avoid None value being converted into literal "None" string
                 "text": item.get("text") or "",
                 "doc_type_kwd": str(item.get("doc_type_kwd") or "text"),
                 "img_id": item.get("img_id"),
@@ -281,25 +277,25 @@ class BaseTitleChunker(ABC):
                 for records in record_groups
                 if records
             ]
-
-        chunks = [
-            (
-                {
-                    "text": RAGFlowPdfParser.remove_tag("".join(record["text"] + "\n" for record in records)),
-                    "doc_type_kwd": "text",
-                    PDF_POSITIONS_KEY: merge_pdf_positions(records),
-                }
-                if records[0]["doc_type_kwd"] == "text"
-                else {
-                    "text": records[0]["text"],
-                    "doc_type_kwd": records[0]["doc_type_kwd"],
-                    "img_id": records[0]["img_id"],
-                    PDF_POSITIONS_KEY: records[0][PDF_POSITIONS_KEY],
-                }
-            )
-            for records in record_groups
-            if records
-        ]
+        else:
+            chunks = [
+                (
+                    {
+                        "text": RAGFlowPdfParser.remove_tag("".join(record["text"] + "\n" for record in records)),
+                        "doc_type_kwd": "text",
+                        PDF_POSITIONS_KEY: merge_pdf_positions(records),
+                    }
+                    if records[0]["doc_type_kwd"] == "text"
+                    else {
+                        "text": records[0]["text"],
+                        "doc_type_kwd": records[0]["doc_type_kwd"],
+                        "img_id": records[0]["img_id"],
+                        PDF_POSITIONS_KEY: records[0][PDF_POSITIONS_KEY],
+                    }
+                )
+                for records in record_groups
+                if records
+            ]
         
         if self.param.root_chunk_as_heading and len(chunks) > 1:
             root_chunk = chunks[0]


### PR DESCRIPTION
fix: restore TitleChunker output for json/chunks upstream formats

## Summary

The refactor commit e194027b (#14247) introduced two regressions that caused `TitleChunker` to produce zero chunks when the upstream Parser node outputs `json` or `chunks` format (e.g. PDF parsing).

## Root Cause

### 1. Dead code in `extract_line_records` (critical)

After refactor, when `payload` is `None` (which is the case for `json` and `chunks` output formats), the method returns an empty list immediately via `return []`, so no records are ever extracted from structured upstream output. The original `json`/`chunks` handling code became unreachable dead code.

### 2. Unconditional overwrite in `build_chunks_from_record_groups`

The `chunks` variable assigned in the `if` branch for markdown/text/html formats was unconditionally overwritten by the statement below it, due to a missing `else` keyword.

## Fix

- Remove the premature `return []` so the `json`/`chunks` branch is reachable again.
- Add `else` branch in `build_chunks_from_record_groups` so the two format families are handled independently.

## Test Plan

- [x] Verified no lint errors on the changed file
- [ ] Tested with a PDF document parsed via DeepDOC → TitleChunker pipeline
- [ ] Tested with markdown input through TitleChunker
- [ ] Tested hierarchy and group chunking modes

## Impact

- Fixes the regression where documents parsed with `json`/`chunks` output format produced no chunks from `TitleChunker`.
- No API or configuration changes. Fully backward compatible.
