### PR TITLE
fix: persist logout access token invalidation

### DIFF
--- a/api/apps/restful_apis/user_api.py
+++ b/api/apps/restful_apis/user_api.py
@@ -289,9 +289,13 @@ async def log_out():
         schema:
           type: object
     """
-    user_id = current_user.id
-    current_user.access_token = f"INVALID_{secrets.token_hex(16)}"
-    current_user.save()
+    user = current_user._get_current_object() if hasattr(current_user, "_get_current_object") else current_user
+    user_id = user.id
+    user.access_token = f"INVALID_{secrets.token_hex(16)}"
+    saved = user.save()
+    if saved == 0:
+        logging.error("Logout failed to persist access token update: user_id=%s", user_id)
+        return get_json_result(code=RetCode.SERVER_ERROR, data=False, message="Failed to update access token")
     logout_user()
     logging.info("Logout: user_id=%s, access_token invalidated", user_id)
     return get_json_result(data=True)


### PR DESCRIPTION
  ### What this PR fixes

  This PR fixes an issue in the Python backend where user logout did not reliably persist the invalidated access_token to the database.
  Although the logout endpoint returned success and logged that the token had been invalidated, the user.access_token value could remain
  unchanged in the database, which meant the previous login token could stay valid longer than expected.

  ### What changed

  - Resolve the real user object before updating the token
  - Persist the invalidated access_token before calling logout_user()
  - Return a server error if the token update is not written successfully

  ### Impact

  - Logging out now correctly replaces the stored access_token with an INVALID_... value
  - The previous login session is properly invalidated
  - The change is limited to the logout flow and is intentionally small in scope