### PR TITLE
[Fix] set_graph: write-then-delete to prevent data loss on timeout

### DIFF
--- a/rag/graphrag/general/index.py
+++ b/rag/graphrag/general/index.py
@@ -716,7 +716,8 @@ async def generate_subgraph(
     return subgraph
 
 
-@timeout(60 * 3)
+# @timeout(60 * 3)  # REMOVED: ineffective in production (ENABLE_TIMEOUT_ASSERTION not set)
+                   # Real timeout control is in _run_with_retry() (L501~505)
 async def merge_subgraph(
     tenant_id: str,
     kb_id: str,

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -587,16 +587,40 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
         callback(msg=f"set_graph converted graph change to {len(chunks)} chunks in {now - start:.2f}s.")
     start = now
 
-    # All new chunks are ready.  Now delete old data and insert the new data.
-    # Deleting only after chunks are built ensures that a crash during embedding
-    # generation above does not destroy the old graph/subgraph checkpoints.
-    await thread_pool_exec(
-        settings.docStoreConn.delete,
-        {"knowledge_graph_kwd": ["graph", "subgraph"]},
-        search.index_name(tenant_id),
-        kb_id
-    )
+    # CRITICAL FIX: Write new chunks FIRST, then delete old chunks.
+    # This prevents data loss if timeout occurs between delete and write.
+    # See: https://github.com/infiniflow/ragflow/issues/<issue_number>
+    
+    # Step 1: Query OLD chunk IDs (before deleting anything)
+    old_chunk_ids = []
+    try:
+        old_chunks_result = await thread_pool_exec(
+            settings.docStoreConn.search,
+            ["id"],
+            {"knowledge_graph_kwd": ["graph", "subgraph"], "kb_id": kb_id},
+            [],
+            OrderByExpr(),
+            0,
+            10000,
+            search.index_name(tenant_id),
+            [kb_id]
+        )
+        if old_chunks_result:
+            old_chunk_ids = [c.get("id") for c in old_chunks_result if c.get("id")]
+        if callback:
+            callback(msg=f"set_graph: found {len(old_chunk_ids)} old chunks to replace.")
+    except Exception as e:
+        logging.warning(f"set_graph: failed to query old chunks (non-fatal): {e}")
+        old_chunk_ids = []
 
+    # Step 2: WRITE NEW CHUNKS FIRST (safe: old data still exists if this fails)
+    await insert_chunks_bounded(chunks, tenant_id, kb_id, callback=callback, label="Insert chunks")
+    now = asyncio.get_running_loop().time()
+    if callback:
+        callback(msg=f"set_graph added/updated {len(change.added_updated_nodes)} nodes and {len(change.added_updated_edges)} edges in {now - start:.2f}s.")
+    start = now
+
+    # Step 3: Delete removed nodes/edges (precise, safe)
     if change.removed_nodes:
         BATCH_SIZE = 100
         sorted_nodes = sorted(change.removed_nodes)
@@ -649,10 +673,22 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
         callback(msg=f"set_graph removed {len(change.removed_nodes)} nodes and {len(change.removed_edges)} edges from index in {del_now - start:.2f}s.")
     start = del_now
 
-    await insert_chunks_bounded(chunks, tenant_id, kb_id, callback=callback, label="Insert chunks")
-    now = asyncio.get_running_loop().time()
-    if callback:
-        callback(msg=f"set_graph added/updated {len(change.added_updated_nodes)} nodes and {len(change.added_updated_edges)} edges from index in {now - start:.2f}s.")
+    # Step 4: DELETE OLD CHUNKS BY ID (safe: new data already written)
+    if old_chunk_ids:
+        deleted_count = 0
+        for chunk_id in old_chunk_ids:
+            try:
+                await thread_pool_exec(
+                    settings.docStoreConn.delete,
+                    {"id": chunk_id},
+                    search.index_name(tenant_id),
+                    kb_id
+                )
+                deleted_count += 1
+            except Exception as e:
+                logging.warning(f"set_graph: failed to delete old chunk {chunk_id} (non-fatal): {e}")
+        if callback:
+            callback(msg=f"set_graph: cleaned up {deleted_count} old chunks.")
 
 
 def is_continuous_subsequence(subseq, seq):


### PR DESCRIPTION
## Summary

This PR fixes a **data loss bug** in `set_graph()` function where the "delete-then-write" pattern can cause irreversible data loss when a timeout occurs between the delete and write operations.

Fixes #15400

---

## Problem

In `rag/graphrag/utils.py`, `set_graph()` deletes ALL `graph`/`subgraph` chunks for the entire KB (L593~598), then writes new chunks (L652). If `asyncio.wait_for()` (in `_run_with_retry`) times out after the delete but before the write:
1. All `graph` and `subgraph` chunks are **permanently deleted**
2. Only a few subgraph chunks (for already-merged docs) are rewritten
3. All other docs' `build_subgraph` results (LLM extraction) are **lost**
4. Resuming the task requires **re-running LLM extraction** for all lost docs (expensive!)

---

## Solution

Changed from **"delete-then-write"** to **"write-then-delete"**:

1. **Query old chunk IDs** before deleting anything
2. **Write NEW chunks FIRST** (safe: old data intact if write fails)
3. **Delete old chunks by ID AFTER write** (safe: new data already written)

### Code Changes

#### `rag/graphrag/utils.py`
- Modified `set_graph()` to query existing chunk IDs before deletion
- Insert new chunks BEFORE deleting old chunks
- Delete old chunks by ID after successful write
- Added error handling for query/delete failures (non-fatal, logged as warnings)

#### `rag/graphrag/general/index.py`
- Removed ineffective `@timeout(60 * 3)` decorator from `merge_subgraph()`
- Added comment explaining that real timeout control is in `_run_with_retry()`

---

## Testing

- [x] Python syntax check passed (`python -m py_compile`)
- [ ] Tested with timeout simulation (to be done)
- [ ] Tested with large KB (2000+ docs) (to be done)

---

## Impact

- **Before**: Timeout during `set_graph` → **data loss** (all subgraph chunks deleted, only few rewritten)
- **After**: Timeout during `set_graph` → **no data loss** (old chunks still exist until new chunks are successfully written)

---

## Related Issues

- Fixes #15400
- Related: #7957 (GraphRAG will not finish - multiple failures)
- Related: #9647 (GraphRAG is still failing to process knowledgegraph well)

---

## Checklist

- [x] Code follows RAGFlow coding style
- [x] Comments added explaining the atomicity guarantee
- [x] No sensitive information exposed
- [ ] Add unit tests (suggest: mock timeout during `set_graph`)
- [ ] Update documentation if needed