### PR TITLE
fix(graphrag): make set_graph write-then-delete for graph rows

### DIFF
--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -639,19 +639,22 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
 
     stale_graph_subgraph_ids = [chunk_id for chunk_id in old_graph_subgraph_ids if chunk_id not in new_graph_subgraph_ids]
     if stale_graph_subgraph_ids:
-        try:
-            await thread_pool_exec(
-                settings.docStoreConn.delete,
-                {"knowledge_graph_kwd": ["graph", "subgraph"], "id": stale_graph_subgraph_ids},
-                search.index_name(tenant_id),
-                kb_id,
-            )
-        except Exception:
-            logging.exception(
-                "Failed to prune %d stale graph/subgraph chunks for kb %s",
-                len(stale_graph_subgraph_ids),
-                kb_id,
-            )
+        prune_batch_size = 100
+        for i in range(0, len(stale_graph_subgraph_ids), prune_batch_size):
+            batch = stale_graph_subgraph_ids[i:i + prune_batch_size]
+            try:
+                await thread_pool_exec(
+                    settings.docStoreConn.delete,
+                    {"knowledge_graph_kwd": ["graph", "subgraph"], "id": batch},
+                    search.index_name(tenant_id),
+                    kb_id,
+                )
+            except Exception:
+                logging.exception(
+                    "Failed to prune stale graph/subgraph chunks for kb %s (batch offset %d)",
+                    kb_id,
+                    i,
+                )
 
     insert_now = asyncio.get_running_loop().time()
     if callback:

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -489,6 +489,30 @@ async def get_graph_doc_ids(tenant_id, kb_id) -> list[str]:
     return doc_ids
 
 
+async def _enumerate_graph_subgraph_chunk_ids(tenant_id: str, kb_id: str) -> list[str]:
+    """Return all doc-store ids for graph/subgraph rows in a KB."""
+    old_ids: list[str] = []
+    page_size = 256
+    for offset in range(0, 1024 * page_size, page_size):
+        res = await thread_pool_exec(
+            settings.docStoreConn.search,
+            ["id"],
+            [],
+            {"kb_id": kb_id, "knowledge_graph_kwd": ["graph", "subgraph"]},
+            [],
+            OrderByExpr(),
+            offset,
+            page_size,
+            search.index_name(tenant_id),
+            [kb_id],
+        )
+        fields = settings.docStoreConn.get_fields(res, ["id"])
+        if not fields:
+            break
+        old_ids.extend(fields.keys())
+    return old_ids
+
+
 async def get_graph(tenant_id, kb_id, exclude_rebuild=None):
     conds = {"fields": ["content_with_weight", "removed_kwd", "source_id"], "size": 1, "knowledge_graph_kwd": ["graph"]}
     res = await settings.retriever.search(conds, search.index_name(tenant_id), [kb_id])
@@ -587,15 +611,57 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
         callback(msg=f"set_graph converted graph change to {len(chunks)} chunks in {now - start:.2f}s.")
     start = now
 
-    # All new chunks are ready.  Now delete old data and insert the new data.
-    # Deleting only after chunks are built ensures that a crash during embedding
-    # generation above does not destroy the old graph/subgraph checkpoints.
-    await thread_pool_exec(
-        settings.docStoreConn.delete,
-        {"knowledge_graph_kwd": ["graph", "subgraph"]},
-        search.index_name(tenant_id),
-        kb_id
-    )
+    new_graph_subgraph_ids = {
+        chunk["id"]
+        for chunk in chunks
+        if chunk.get("knowledge_graph_kwd") in ("graph", "subgraph")
+    }
+
+    # Snapshot existing graph/subgraph ids before insert so a timeout during write
+    # cannot leave the KB with all graph rows deleted and only a partial rewrite.
+    old_graph_subgraph_ids: list[str] = []
+    try:
+        old_graph_subgraph_ids = await _enumerate_graph_subgraph_chunk_ids(tenant_id, kb_id)
+    except Exception:
+        logging.exception(
+            "Failed to enumerate existing graph/subgraph chunks for kb %s; falling back to delete-then-insert.",
+            kb_id,
+        )
+        await thread_pool_exec(
+            settings.docStoreConn.delete,
+            {"knowledge_graph_kwd": ["graph", "subgraph"]},
+            search.index_name(tenant_id),
+            kb_id,
+        )
+        old_graph_subgraph_ids = []
+
+    await insert_chunks_bounded(chunks, tenant_id, kb_id, callback=callback, label="Insert chunks")
+
+    stale_graph_subgraph_ids = [chunk_id for chunk_id in old_graph_subgraph_ids if chunk_id not in new_graph_subgraph_ids]
+    if stale_graph_subgraph_ids:
+        try:
+            await thread_pool_exec(
+                settings.docStoreConn.delete,
+                {"knowledge_graph_kwd": ["graph", "subgraph"], "id": stale_graph_subgraph_ids},
+                search.index_name(tenant_id),
+                kb_id,
+            )
+        except Exception:
+            logging.exception(
+                "Failed to prune %d stale graph/subgraph chunks for kb %s",
+                len(stale_graph_subgraph_ids),
+                kb_id,
+            )
+
+    insert_now = asyncio.get_running_loop().time()
+    if callback:
+        callback(
+            msg=(
+                f"set_graph inserted {len(chunks)} chunks and pruned {len(stale_graph_subgraph_ids)} "
+                f"stale graph/subgraph rows in {insert_now - start:.2f}s."
+            )
+        )
+    start = insert_now
 
     if change.removed_nodes:
         BATCH_SIZE = 100
@@ -647,12 +713,14 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
     del_now = asyncio.get_running_loop().time()
     if callback:
         callback(msg=f"set_graph removed {len(change.removed_nodes)} nodes and {len(change.removed_edges)} edges from index in {del_now - start:.2f}s.")
-    start = del_now
-
-    await insert_chunks_bounded(chunks, tenant_id, kb_id, callback=callback, label="Insert chunks")
-    now = asyncio.get_running_loop().time()
+    now = del_now
     if callback:
-        callback(msg=f"set_graph added/updated {len(change.added_updated_nodes)} nodes and {len(change.added_updated_edges)} edges from index in {now - start:.2f}s.")
+        callback(
+            msg=(
+                f"set_graph added/updated {len(change.added_updated_nodes)} nodes and "
+                f"{len(change.added_updated_edges)} edges from index in {now - start:.2f}s."
+            )
+        )
 
 
 def is_continuous_subsequence(subseq, seq):

--- a/test/unit_test/rag/graphrag/test_set_graph_persistence.py
+++ b/test/unit_test/rag/graphrag/test_set_graph_persistence.py
@@ -1,0 +1,73 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import networkx as nx
+import pytest
+
+from common import settings
+from rag.graphrag.utils import GraphChange, set_graph
+
+
+@pytest.mark.asyncio
+async def test_set_graph_inserts_before_pruning_stale_graph_rows():
+    graph = nx.Graph()
+    graph.graph["source_id"] = ["doc-1"]
+    graph.add_node("A", description="node", source_id=["doc-1"], entity_type="ORG")
+
+    calls: list[str] = []
+
+    async def fake_insert_chunks_bounded(chunks, tenant_id, kb_id, *, callback=None, label="Insert chunks"):
+        calls.append("insert")
+
+    async def fake_enumerate(_tenant_id, _kb_id):
+        return ["old-graph", "old-subgraph"]
+
+    async def fake_thread_pool_exec(func, *args, **_kwargs):
+        if func is settings.docStoreConn.delete:
+            calls.append(f"delete:{args[0]}")
+        return None
+
+    with (
+        patch("rag.graphrag.utils.insert_chunks_bounded", fake_insert_chunks_bounded),
+        patch("rag.graphrag.utils._enumerate_graph_subgraph_chunk_ids", fake_enumerate),
+        patch("rag.graphrag.utils.thread_pool_exec", fake_thread_pool_exec),
+        patch("rag.graphrag.utils.graph_node_to_chunk", AsyncMock()),
+        patch("rag.graphrag.utils.graph_edge_to_chunk", AsyncMock()),
+    ):
+        await set_graph("tenant-1", "kb-1", MagicMock(), graph, GraphChange(), callback=None)
+
+    assert calls[0] == "insert"
+    assert any(call.startswith("delete:") for call in calls[1:])
+    stale_delete = next(call for call in calls if call.startswith("delete:"))
+    assert "'id'" in stale_delete
+    assert "old-graph" in stale_delete
+
+
+@pytest.mark.asyncio
+async def test_set_graph_skips_broad_delete_when_enumeration_succeeds():
+    graph = nx.Graph()
+    graph.graph["source_id"] = ["doc-1"]
+
+    delete_conditions: list[dict] = []
+
+    async def fake_thread_pool_exec(func, *args, **_kwargs):
+        if func is settings.docStoreConn.delete:
+            delete_conditions.append(args[0])
+        return None
+
+    with (
+        patch("rag.graphrag.utils.insert_chunks_bounded", AsyncMock()),
+        patch("rag.graphrag.utils._enumerate_graph_subgraph_chunk_ids", AsyncMock(return_value=["old-1"])),
+        patch("rag.graphrag.utils.thread_pool_exec", fake_thread_pool_exec),
+        patch("rag.graphrag.utils.graph_node_to_chunk", AsyncMock()),
+        patch("rag.graphrag.utils.graph_edge_to_chunk", AsyncMock()),
+    ):
+        await set_graph("tenant-1", "kb-1", MagicMock(), graph, GraphChange(), callback=None)
+
+    assert not any(
+        cond.get("knowledge_graph_kwd") == ["graph", "subgraph"] and "id" not in cond
+        for cond in delete_conditions
+    )

--- a/test/unit_test/rag/graphrag/test_set_graph_persistence.py
+++ b/test/unit_test/rag/graphrag/test_set_graph_persistence.py
@@ -11,6 +11,7 @@ from common import settings
 from rag.graphrag.utils import GraphChange, set_graph
 
 
+@pytest.mark.p2
 @pytest.mark.asyncio
 async def test_set_graph_inserts_before_pruning_stale_graph_rows():
     graph = nx.Graph()
@@ -46,6 +47,7 @@ async def test_set_graph_inserts_before_pruning_stale_graph_rows():
     assert "old-graph" in stale_delete
 
 
+@pytest.mark.p2
 @pytest.mark.asyncio
 async def test_set_graph_skips_broad_delete_when_enumeration_succeeds():
     graph = nx.Graph()
@@ -71,3 +73,33 @@ async def test_set_graph_skips_broad_delete_when_enumeration_succeeds():
         cond.get("knowledge_graph_kwd") == ["graph", "subgraph"] and "id" not in cond
         for cond in delete_conditions
     )
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_set_graph_prunes_stale_graph_rows_in_batches():
+    graph = nx.Graph()
+    graph.graph["source_id"] = ["doc-1"]
+
+    delete_batches: list[list[str]] = []
+
+    async def fake_thread_pool_exec(func, *args, **_kwargs):
+        if func is settings.docStoreConn.delete and isinstance(args[0], dict) and "id" in args[0]:
+            delete_batches.append(list(args[0]["id"]))
+        return None
+
+    stale_ids = [f"old-{i}" for i in range(250)]
+
+    with (
+        patch("rag.graphrag.utils.insert_chunks_bounded", AsyncMock()),
+        patch("rag.graphrag.utils._enumerate_graph_subgraph_chunk_ids", AsyncMock(return_value=stale_ids)),
+        patch("rag.graphrag.utils.thread_pool_exec", fake_thread_pool_exec),
+        patch("rag.graphrag.utils.graph_node_to_chunk", AsyncMock()),
+        patch("rag.graphrag.utils.graph_edge_to_chunk", AsyncMock()),
+    ):
+        await set_graph("tenant-1", "kb-1", MagicMock(), graph, GraphChange(), callback=None)
+
+    assert len(delete_batches) == 3
+    assert len(delete_batches[0]) == 100
+    assert len(delete_batches[1]) == 100
+    assert len(delete_batches[2]) == 50


### PR DESCRIPTION
## Summary
`set_graph()` previously deleted all `graph`/`subgraph` chunks for a KB before inserting replacements. A timeout between those steps could permanently delete thousands of subgraph checkpoints and force expensive LLM re-extraction.

This change follows the same write-then-delete pattern already used for community reports:
1. Enumerate existing graph/subgraph chunk ids
2. Insert all new chunks
3. Prune stale graph/subgraph rows by id in batches of 100

If enumeration fails, the code falls back to the prior delete-then-insert behavior.

Fixes #15400

## Test plan
- [x] `pytest test/unit_test/rag/graphrag/test_set_graph_persistence.py` (3/3)
- [x] `pytest test/unit_test/rag/graphrag/test_graphrag_utils.py` (87/87)