### PR TITLE
fix: backfill missing api token beta values

### DIFF
--- a/internal/service/api_token.go
+++ b/internal/service/api_token.go
@@ -43,12 +43,26 @@ func (s *SystemService) ListAPITokens(tenantID string) ([]*TokenResponse, error)
 
 	responses := make([]*TokenResponse, len(tokens))
 	for i, token := range tokens {
+		beta := token.Beta
+		if beta == nil || *beta == "" {
+			generatedBeta := utility.GenerateBetaAPIToken(utility.GenerateAPIToken())
+			if err := dao.DB.Model(&entity.APIToken{}).
+				Where("tenant_id = ? AND token = ?", tenantID, token.Token).
+				Updates(map[string]interface{}{
+					"beta": generatedBeta,
+				}).Error; err != nil {
+				return nil, err
+			}
+			beta = &generatedBeta
+			token.Beta = beta
+		}
+
 		responses[i] = &TokenResponse{
 			TenantID:   token.TenantID,
 			Token:      token.Token,
 			DialogID:   token.DialogID,
 			Source:     token.Source,
-			Beta:       token.Beta,
+			Beta:       beta,
 			CreateTime: token.CreateTime,
 			UpdateTime: token.UpdateTime,
 		}


### PR DESCRIPTION
### What problem does this PR solve?

This PR updates `SystemService.ListAPITokens` to lazily backfill missing `beta` values for API tokens, matching the Python behavior of `/api/v1/system/tokens`.

### Type of change
  
  - When an API token has an empty `beta`, generate a new one.
  - Persist the generated `beta` back to the `api_token` table.
  - Keep the handler/routing unchanged.
  - `GET /api/v1/system/tokens` now returns tokens with `beta` filled in for older records that were missing it.
  - This aligns Go behavior with the Python implementation.
