### PR TITLE
feat(connector): implement Trello data-source connector

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -156,6 +156,7 @@ class FileSource(StrEnum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    TRELLO = "trello"
 
 
 class PipelineTaskType(StrEnum):

--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -36,6 +36,7 @@ from .jira.connector import JiraConnector
 from .sharepoint_connector import SharePointConnector
 from .onedrive_connector import OneDriveConnector
 from .outlook_connector import OutlookConnector
+from .trello_connector import TrelloConnector
 from .teams_connector import TeamsConnector
 from .moodle_connector import MoodleConnector
 from .airtable_connector import AirtableConnector
@@ -71,6 +72,7 @@ __all__ = [
     "SharePointConnector",
     "OneDriveConnector",
     "OutlookConnector",
+    "TrelloConnector",
     "TeamsConnector",
     "MoodleConnector",
     "BlobType",

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -71,6 +71,7 @@ class DocumentSource(str, Enum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    TRELLO = "trello"
 
 
 class FileOrigin(str, Enum):

--- a/common/data_source/trello_connector.py
+++ b/common/data_source/trello_connector.py
@@ -14,6 +14,8 @@ from common.data_source.models import (
     SlimDocument,
 )
 
+_USER_AGENT = "RAGFlow"
+
 
 class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
     def __init__(
@@ -31,6 +33,7 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.api_base = api_base.rstrip("/")
         self.credentials: dict[str, Any] = {}
         self.session = requests.Session()
+        self.session.headers.update({"User-Agent": _USER_AGENT})
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self.credentials = credentials or {}
@@ -82,7 +85,7 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         for board in self._iter_boards():
             lists_by_id = self._lists_by_id(board["id"])
             for card in self._iter_cards(board["id"]):
-                updated_at = self._parse_trello_datetime(card.get("dateLastActivity"))
+                updated_at = self._resolve_card_updated_at(card)
                 ts = updated_at.timestamp()
                 if start is not None and ts <= start:
                     continue
@@ -250,14 +253,33 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         return f"trello:{card['id']}"
 
     @staticmethod
-    def _parse_trello_datetime(value: Any) -> datetime:
+    def _parse_trello_datetime(value: Any) -> datetime | None:
         if not isinstance(value, str) or not value.strip():
-            return datetime.now(timezone.utc)
+            return None
         normalized = value.replace("Z", "+00:00")
-        parsed = datetime.fromisoformat(normalized)
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed.astimezone(timezone.utc)
+
+    def _resolve_card_updated_at(self, card: dict[str, Any]) -> datetime:
+        parsed = self._parse_trello_datetime(card.get("dateLastActivity"))
+        if parsed is not None:
+            return parsed
+        return self._datetime_from_card_id(card.get("id")) or datetime.now(timezone.utc)
+
+    @staticmethod
+    def _datetime_from_card_id(card_id: Any) -> datetime | None:
+        if not isinstance(card_id, str) or len(card_id) < 8:
+            return None
+        try:
+            timestamp = int(card_id[:8], 16)
+        except ValueError:
+            return None
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
     @staticmethod
     def _normalize_id_list(value: list[str] | str | None) -> list[str]:

--- a/common/data_source/trello_connector.py
+++ b/common/data_source/trello_connector.py
@@ -1,0 +1,270 @@
+import hashlib
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+from common.data_source.config import INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS, DocumentSource
+from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
+from common.data_source.models import (
+    Document,
+    GenerateDocumentsOutput,
+    GenerateSlimDocumentOutput,
+    SecondsSinceUnixEpoch,
+    SlimDocument,
+)
+
+
+class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    def __init__(
+        self,
+        board_ids: list[str] | str | None = None,
+        include_comments: bool = True,
+        include_attachments: bool = True,
+        batch_size: int = INDEX_BATCH_SIZE,
+        api_base: str = "https://api.trello.com/1",
+    ) -> None:
+        self.board_ids = self._normalize_id_list(board_ids)
+        self.include_comments = include_comments
+        self.include_attachments = include_attachments
+        self.batch_size = batch_size
+        self.api_base = api_base.rstrip("/")
+        self.credentials: dict[str, Any] = {}
+        self.session = requests.Session()
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self.credentials = credentials or {}
+        return None
+
+    def validate_connector_settings(self) -> None:
+        self._require_credentials()
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be greater than 0")
+        if self.board_ids:
+            for board_id in self.board_ids:
+                self._get(f"boards/{board_id}", {"fields": "id,name"})
+            return
+        self._get("members/me/boards", {"fields": "id,name", "filter": "open"})
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        yield from self._load_cards()
+
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> GenerateDocumentsOutput:
+        yield from self._load_cards(start=start, end=end)
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        callback: Any = None,
+    ) -> GenerateSlimDocumentOutput:
+        del callback
+
+        batch: list[SlimDocument] = []
+        for board in self._iter_boards():
+            for card in self._iter_cards(board["id"]):
+                batch.append(SlimDocument(id=self._build_document_id(card)))
+                if len(batch) >= self.batch_size:
+                    yield batch
+                    batch = []
+
+        if batch:
+            yield batch
+
+    def _load_cards(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+    ) -> GenerateDocumentsOutput:
+        batch: list[Document] = []
+        for board in self._iter_boards():
+            lists_by_id = self._lists_by_id(board["id"])
+            for card in self._iter_cards(board["id"]):
+                updated_at = self._parse_trello_datetime(card.get("dateLastActivity"))
+                ts = updated_at.timestamp()
+                if start is not None and ts <= start:
+                    continue
+                if end is not None and ts > end:
+                    continue
+
+                comments = self._comments_for_card(card["id"]) if self.include_comments else []
+                attachments = self._attachments_for_card(card["id"]) if self.include_attachments else []
+                batch.append(self._build_document(board, lists_by_id, card, comments, attachments, updated_at))
+
+                if len(batch) >= self.batch_size:
+                    yield batch
+                    batch = []
+
+        if batch:
+            yield batch
+
+    def _iter_boards(self) -> list[dict[str, Any]]:
+        params = {"fields": "id,name,url,dateLastActivity", "filter": "open"}
+        if not self.board_ids:
+            boards = self._get("members/me/boards", params)
+            return [board for board in boards if board.get("id")]
+
+        boards: list[dict[str, Any]] = []
+        for board_id in self.board_ids:
+            board = self._get(f"boards/{board_id}", params)
+            if board.get("id"):
+                boards.append(board)
+        return boards
+
+    def _lists_by_id(self, board_id: str) -> dict[str, str]:
+        lists = self._get(f"boards/{board_id}/lists", {"fields": "id,name", "filter": "open"})
+        return {item["id"]: item.get("name", "") for item in lists if item.get("id")}
+
+    def _iter_cards(self, board_id: str) -> list[dict[str, Any]]:
+        fields = ",".join(
+            [
+                "id",
+                "name",
+                "desc",
+                "url",
+                "shortUrl",
+                "dateLastActivity",
+                "due",
+                "dueComplete",
+                "idList",
+                "labels",
+                "closed",
+            ]
+        )
+        cards = self._get(f"boards/{board_id}/cards", {"fields": fields, "filter": "open"})
+        return [card for card in cards if card.get("id") and not card.get("closed")]
+
+    def _comments_for_card(self, card_id: str) -> list[dict[str, Any]]:
+        actions = self._get(
+            f"cards/{card_id}/actions",
+            {
+                "filter": "commentCard",
+                "fields": "data,date,memberCreator",
+                "limit": "1000",
+            },
+        )
+        return [action for action in actions if action.get("data", {}).get("text")]
+
+    def _attachments_for_card(self, card_id: str) -> list[dict[str, Any]]:
+        attachments = self._get(
+            f"cards/{card_id}/attachments",
+            {"fields": "id,name,url,mimeType,bytes,date"},
+        )
+        return [attachment for attachment in attachments if attachment.get("id")]
+
+    def _build_document(
+        self,
+        board: dict[str, Any],
+        lists_by_id: dict[str, str],
+        card: dict[str, Any],
+        comments: list[dict[str, Any]],
+        attachments: list[dict[str, Any]],
+        updated_at: datetime,
+    ) -> Document:
+        content = self._build_content(board, lists_by_id, card, comments, attachments)
+        blob = content.encode("utf-8")
+        labels = [label.get("name") or label.get("color") for label in card.get("labels", []) if label.get("name") or label.get("color")]
+        metadata = {
+            "board_id": board.get("id"),
+            "board_name": board.get("name"),
+            "list_id": card.get("idList"),
+            "list_name": lists_by_id.get(card.get("idList", ""), ""),
+            "card_id": card.get("id"),
+            "card_url": card.get("url") or card.get("shortUrl"),
+            "labels": labels,
+            "due": card.get("due"),
+            "due_complete": card.get("dueComplete"),
+        }
+        return Document(
+            id=self._build_document_id(card),
+            source=DocumentSource.TRELLO,
+            semantic_identifier=card.get("name") or card.get("id"),
+            extension=".txt",
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            metadata=metadata,
+            fingerprint=hashlib.md5(blob).hexdigest(),
+        )
+
+    def _build_content(
+        self,
+        board: dict[str, Any],
+        lists_by_id: dict[str, str],
+        card: dict[str, Any],
+        comments: list[dict[str, Any]],
+        attachments: list[dict[str, Any]],
+    ) -> str:
+        labels = [label.get("name") or label.get("color") for label in card.get("labels", []) if label.get("name") or label.get("color")]
+        parts = [
+            f"Card: {card.get('name', '')}",
+            f"Board: {board.get('name', '')}",
+            f"List: {lists_by_id.get(card.get('idList', ''), '')}",
+        ]
+        if card.get("url") or card.get("shortUrl"):
+            parts.append(f"URL: {card.get('url') or card.get('shortUrl')}")
+        if card.get("due"):
+            parts.append(f"Due: {card.get('due')}")
+        if labels:
+            parts.append("Labels: " + ", ".join(labels))
+        if card.get("desc"):
+            parts.append("Description:\n" + card["desc"].strip())
+        if comments:
+            parts.append("Comments:")
+            for comment in comments:
+                author = (comment.get("memberCreator") or {}).get("fullName") or "Unknown"
+                text = (comment.get("data") or {}).get("text", "")
+                date = comment.get("date", "")
+                parts.append(f"- {author} ({date}): {text}")
+        if attachments:
+            parts.append("Attachments:")
+            for attachment in attachments:
+                name = attachment.get("name") or attachment.get("url") or attachment.get("id")
+                url = attachment.get("url", "")
+                parts.append(f"- {name}: {url}".strip())
+        return "\n\n".join(part for part in parts if part).strip()
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        self._require_credentials()
+        request_params = dict(params or {})
+        request_params["key"] = self.credentials["trello_api_key"]
+        request_params["token"] = self.credentials["trello_api_token"]
+        response = self.session.get(
+            f"{self.api_base}/{path.lstrip('/')}",
+            params=request_params,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _require_credentials(self) -> None:
+        if not self.credentials.get("trello_api_key"):
+            raise ValueError("Missing trello_api_key in credentials")
+        if not self.credentials.get("trello_api_token"):
+            raise ValueError("Missing trello_api_token in credentials")
+
+    @staticmethod
+    def _build_document_id(card: dict[str, Any]) -> str:
+        return f"trello:{card['id']}"
+
+    @staticmethod
+    def _parse_trello_datetime(value: Any) -> datetime:
+        if not isinstance(value, str) or not value.strip():
+            return datetime.now(timezone.utc)
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _normalize_id_list(value: list[str] | str | None) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            raw_items = value.split(",")
+        else:
+            raw_items = value
+        return [str(item).strip() for item in raw_items if str(item).strip()]

--- a/common/data_source/trello_connector.py
+++ b/common/data_source/trello_connector.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import requests
 
@@ -37,6 +38,11 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.credentials: dict[str, Any] = {}
         self.session = requests.Session()
         self.session.headers.update({"User-Agent": _USER_AGENT})
+        self.logger = logger
+        self.logger.debug(
+            "Initialized Trello connector for board_ids=%s",
+            self.board_ids or "<all-accessible-boards>",
+        )
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self.credentials = credentials or {}
@@ -100,28 +106,35 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
                 batch.append(self._build_document(board, lists_by_id, card, comments, attachments, updated_at))
 
                 if len(batch) >= self.batch_size:
+                    self.logger.debug("Emitting Trello document batch size=%s", len(batch))
                     yield batch
                     batch = []
 
         if batch:
+            self.logger.debug("Emitting final Trello document batch size=%s", len(batch))
             yield batch
 
     def _iter_boards(self) -> list[dict[str, Any]]:
         params = {"fields": "id,name,url,dateLastActivity", "filter": "open"}
         if not self.board_ids:
             boards = self._get("members/me/boards", params)
-            return [board for board in boards if board.get("id")]
+            board_list = [board for board in boards if board.get("id")]
+            self.logger.info("Discovered %s Trello board(s)", len(board_list))
+            return board_list
 
         boards: list[dict[str, Any]] = []
         for board_id in self.board_ids:
             board = self._get(f"boards/{board_id}", params)
             if board.get("id"):
                 boards.append(board)
+        self.logger.info("Loaded %s configured Trello board(s)", len(boards))
         return boards
 
     def _lists_by_id(self, board_id: str) -> dict[str, str]:
         lists = self._get(f"boards/{board_id}/lists", {"fields": "id,name", "filter": "open"})
-        return {item["id"]: item.get("name", "") for item in lists if item.get("id")}
+        lists_by_id = {item["id"]: item.get("name", "") for item in lists if item.get("id")}
+        self.logger.debug("Loaded %s Trello list(s) for board_id=%s", len(lists_by_id), board_id)
+        return lists_by_id
 
     def _iter_cards(self, board_id: str) -> list[dict[str, Any]]:
         fields = ",".join(
@@ -140,7 +153,9 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             ]
         )
         cards = self._get(f"boards/{board_id}/cards", {"fields": fields, "filter": "open"})
-        return [card for card in cards if card.get("id") and not card.get("closed")]
+        card_list = [card for card in cards if card.get("id") and not card.get("closed")]
+        self.logger.debug("Loaded %s Trello card(s) for board_id=%s", len(card_list), board_id)
+        return card_list
 
     def _comments_for_card(self, card_id: str) -> list[dict[str, Any]]:
         actions = self._get(
@@ -151,14 +166,18 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
                 "limit": "1000",
             },
         )
-        return [action for action in actions if action.get("data", {}).get("text")]
+        comments = [action for action in actions if action.get("data", {}).get("text")]
+        self.logger.debug("Loaded %s Trello comment(s) for card_id=%s", len(comments), card_id)
+        return comments
 
     def _attachments_for_card(self, card_id: str) -> list[dict[str, Any]]:
         attachments = self._get(
             f"cards/{card_id}/attachments",
             {"fields": "id,name,url,mimeType,bytes,date"},
         )
-        return [attachment for attachment in attachments if attachment.get("id")]
+        attachment_list = [attachment for attachment in attachments if attachment.get("id")]
+        self.logger.debug("Loaded %s Trello attachment(s) for card_id=%s", len(attachment_list), card_id)
+        return attachment_list
 
     def _build_document(
         self,
@@ -237,12 +256,30 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         request_params = dict(params or {})
         request_params["key"] = self.credentials["trello_api_key"]
         request_params["token"] = self.credentials["trello_api_token"]
-        response = self.session.get(
-            f"{self.api_base}/{path.lstrip('/')}",
-            params=request_params,
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
+        url = f"{self.api_base}/{path.lstrip('/')}"
+        try:
+            response = self.session.get(
+                url,
+                params=request_params,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException:
+            self.logger.exception("Trello request failed before response path=%s", path)
+            raise
+        if response.status_code < 200 or response.status_code >= 300:
+            request_url = getattr(getattr(response, "request", None), "url", url)
+            sanitized_url = self._sanitize_url(request_url)
+            self.logger.warning(
+                "Trello request failed path=%s status_code=%s url=%s",
+                path,
+                response.status_code,
+                sanitized_url,
+            )
+            raise requests.exceptions.HTTPError(
+                f"{response.status_code} Error for url: {sanitized_url}",
+                response=response,
+            )
+        self.logger.debug("Trello request succeeded path=%s status_code=%s", path, response.status_code)
         return response.json()
 
     def _require_credentials(self) -> None:
@@ -274,7 +311,13 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         parsed = self._parse_trello_datetime(card.get("dateLastActivity"))
         if parsed is not None:
             return parsed
-        return self._datetime_from_card_id(card.get("id")) or _FALLBACK_UPDATED_AT
+        card_id = card.get("id")
+        fallback = self._datetime_from_card_id(card_id)
+        if fallback is not None:
+            self.logger.warning("Using Trello card id timestamp fallback for card_id=%s", card_id)
+            return fallback
+        self.logger.warning("Using epoch timestamp fallback for Trello card_id=%s", card_id)
+        return _FALLBACK_UPDATED_AT
 
     @staticmethod
     def _datetime_from_card_id(card_id: Any) -> datetime | None:
@@ -285,6 +328,20 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         except ValueError:
             return None
         return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+    @staticmethod
+    def _sanitize_url(url: str) -> str:
+        split_url = urlsplit(url)
+        query = urlencode(
+            [
+                (key, value)
+                for key, value in parse_qsl(split_url.query, keep_blank_values=True)
+                if key not in {"key", "token"}
+            ]
+        )
+        return urlunsplit(
+            (split_url.scheme, split_url.netloc, split_url.path, query, split_url.fragment)
+        )
 
     @staticmethod
     def _normalize_id_list(value: list[str] | str | None) -> list[str]:

--- a/common/data_source/trello_connector.py
+++ b/common/data_source/trello_connector.py
@@ -158,15 +158,35 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         return card_list
 
     def _comments_for_card(self, card_id: str) -> list[dict[str, Any]]:
-        actions = self._get(
-            f"cards/{card_id}/actions",
-            {
+        comments: list[dict[str, Any]] = []
+        before = None
+
+        while True:
+            params = {
                 "filter": "commentCard",
-                "fields": "data,date,memberCreator",
+                "fields": "id,data,date,memberCreator",
                 "limit": "1000",
-            },
-        )
-        comments = [action for action in actions if action.get("data", {}).get("text")]
+            }
+            if before:
+                params["before"] = before
+
+            actions = self._get(f"cards/{card_id}/actions", params)
+            comments.extend(
+                action for action in actions if action.get("data", {}).get("text")
+            )
+
+            if len(actions) < 1000:
+                break
+
+            next_before = actions[-1].get("id") or actions[-1].get("date")
+            if not next_before or next_before == before:
+                self.logger.warning(
+                    "Stopping Trello comment pagination for card_id=%s: missing cursor",
+                    card_id,
+                )
+                break
+            before = next_before
+
         self.logger.debug("Loaded %s Trello comment(s) for card_id=%s", len(comments), card_id)
         return comments
 

--- a/common/data_source/trello_connector.py
+++ b/common/data_source/trello_connector.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from datetime import datetime, timezone
 from typing import Any
 
@@ -15,6 +16,8 @@ from common.data_source.models import (
 )
 
 _USER_AGENT = "RAGFlow"
+_FALLBACK_UPDATED_AT = datetime.fromtimestamp(0, tz=timezone.utc)
+logger = logging.getLogger(__name__)
 
 
 class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
@@ -42,7 +45,7 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
     def validate_connector_settings(self) -> None:
         self._require_credentials()
         if self.batch_size < 1:
-            raise ValueError("batch_size must be greater than 0")
+            raise ValueError("batch_size must be at least 1")
         if self.board_ids:
             for board_id in self.board_ids:
                 self._get(f"boards/{board_id}", {"fields": "id,name"})
@@ -255,11 +258,13 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
     @staticmethod
     def _parse_trello_datetime(value: Any) -> datetime | None:
         if not isinstance(value, str) or not value.strip():
+            logger.warning("Missing Trello dateLastActivity value: %r", value)
             return None
         normalized = value.replace("Z", "+00:00")
         try:
             parsed = datetime.fromisoformat(normalized)
-        except ValueError:
+        except ValueError as exc:
+            logger.warning("Invalid Trello dateLastActivity value %r: %s", value, exc)
             return None
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
@@ -269,7 +274,7 @@ class TrelloConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         parsed = self._parse_trello_datetime(card.get("dateLastActivity"))
         if parsed is not None:
             return parsed
-        return self._datetime_from_card_id(card.get("id")) or datetime.now(timezone.utc)
+        return self._datetime_from_card_id(card.get("id")) or _FALLBACK_UPDATED_AT
 
     @staticmethod
     def _datetime_from_card_id(card_id: Any) -> datetime | None:

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -1143,11 +1143,11 @@ class Trello(SyncBase):
 
         self.connector = TrelloConnector(
             board_ids=self.conf.get("board_ids"),
-            include_comments=bool(self.conf.get("include_comments", True)),
-            include_attachments=bool(self.conf.get("include_attachments", True)),
+            include_comments=self._as_bool(self.conf.get("include_comments", True)),
+            include_attachments=self._as_bool(self.conf.get("include_attachments", True)),
             batch_size=batch_size,
         )
-        self.connector.load_credentials(self.conf["credentials"])
+        self.connector.load_credentials(self.conf.get("credentials", {}))
         self.connector.validate_connector_settings()
 
         poll_start = task.get("poll_range_start")
@@ -1162,6 +1162,14 @@ class Trello(SyncBase):
         board_ids = self.conf.get("board_ids") or "<all-accessible-boards>"
         self.log_connection("Trello", f"board_ids({board_ids})", task)
         return document_generator
+
+    @staticmethod
+    def _as_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() not in {"false", "0", "no", "off", ""}
+        return bool(value)
 
 
 class Slack(SyncBase):

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -63,6 +63,7 @@ from common.data_source import (
     RestAPIConnector,
     OneDriveConnector,
     OutlookConnector,
+    TrelloConnector,
     TeamsConnector,
     SlackConnector,
     SharePointConnector,
@@ -1128,6 +1129,41 @@ class Outlook(SyncBase):
         return wrapper()
 
 
+class Trello(SyncBase):
+    SOURCE_NAME: str = FileSource.TRELLO
+
+    async def _generate(self, task: dict):
+        raw_batch_size = self.conf.get("batch_size", INDEX_BATCH_SIZE)
+        try:
+            batch_size = int(raw_batch_size)
+        except (TypeError, ValueError):
+            batch_size = INDEX_BATCH_SIZE
+        if batch_size <= 0:
+            batch_size = INDEX_BATCH_SIZE
+
+        self.connector = TrelloConnector(
+            board_ids=self.conf.get("board_ids"),
+            include_comments=bool(self.conf.get("include_comments", True)),
+            include_attachments=bool(self.conf.get("include_attachments", True)),
+            batch_size=batch_size,
+        )
+        self.connector.load_credentials(self.conf["credentials"])
+        self.connector.validate_connector_settings()
+
+        poll_start = task.get("poll_range_start")
+        if task.get("reindex") == "1" or not poll_start:
+            document_generator = self.connector.load_from_state()
+        else:
+            document_generator = self.connector.poll_source(
+                poll_start.timestamp(),
+                datetime.now(timezone.utc).timestamp(),
+            )
+
+        board_ids = self.conf.get("board_ids") or "<all-accessible-boards>"
+        self.log_connection("Trello", f"board_ids({board_ids})", task)
+        return document_generator
+
+
 class Slack(SyncBase):
     SOURCE_NAME: str = FileSource.SLACK
 
@@ -1990,6 +2026,7 @@ func_factory = {
     FileSource.SHAREPOINT: SharePoint,
     FileSource.ONEDRIVE: OneDrive,
     FileSource.OUTLOOK: Outlook,
+    FileSource.TRELLO: Trello,
     FileSource.SLACK: Slack,
     FileSource.TEAMS: Teams,
     FileSource.MOODLE: Moodle,

--- a/test/unit_test/data_source/test_trello_connector_unit.py
+++ b/test/unit_test/data_source/test_trello_connector_unit.py
@@ -145,6 +145,15 @@ def test_trello_connector_retrieves_slim_docs() -> None:
     assert [[doc.id for doc in batch] for batch in batches] == [["trello:c1", "trello:c2"]]
 
 
+def test_trello_connector_falls_back_to_card_id_timestamp() -> None:
+    connector = make_connector()
+    expected = datetime(2026, 6, 1, 11, 0, tzinfo=timezone.utc)
+    card_id = f"{int(expected.timestamp()):08x}0000000000000000"
+
+    assert connector._parse_trello_datetime("not-a-date") is None
+    assert connector._resolve_card_updated_at({"id": card_id, "dateLastActivity": "not-a-date"}) == expected
+
+
 def test_trello_connector_requires_credentials() -> None:
     connector = TrelloConnector(api_base="https://trello.test/1")
 

--- a/test/unit_test/data_source/test_trello_connector_unit.py
+++ b/test/unit_test/data_source/test_trello_connector_unit.py
@@ -107,6 +107,40 @@ class FailingSession:
         return response
 
 
+class PaginatedCommentsSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, params: dict[str, Any], timeout: int) -> FakeResponse:
+        del timeout
+        path = url.split("/1/", 1)[1]
+        self.calls.append((path, params))
+        if path != "cards/c1/actions":
+            return FakeResponse([])
+
+        if not params.get("before"):
+            return FakeResponse(
+                [
+                    {
+                        "id": f"a{index}",
+                        "date": f"2026-06-01T12:{index % 60:02d}:00.000Z",
+                        "data": {"text": f"Comment {index}"},
+                    }
+                    for index in range(1000)
+                ]
+            )
+
+        return FakeResponse(
+            [
+                {
+                    "id": "older",
+                    "date": "2026-05-31T12:00:00.000Z",
+                    "data": {"text": "Older comment"},
+                }
+            ]
+        )
+
+
 def make_connector() -> TrelloConnector:
     connector = TrelloConnector(api_base="https://trello.test/1")
     connector.session = FakeSession()
@@ -158,6 +192,19 @@ def test_trello_connector_retrieves_slim_docs() -> None:
     batches = list(connector.retrieve_all_slim_docs_perm_sync())
 
     assert [[doc.id for doc in batch] for batch in batches] == [["trello:c1", "trello:c2"]]
+
+
+@pytest.mark.p1
+def test_trello_connector_paginates_card_comments() -> None:
+    connector = make_connector()
+    connector.session = PaginatedCommentsSession()
+
+    comments = connector._comments_for_card("c1")
+
+    assert len(comments) == 1001
+    assert comments[-1]["data"]["text"] == "Older comment"
+    assert connector.session.calls[0][1]["limit"] == "1000"
+    assert connector.session.calls[1][1]["before"] == "a999"
 
 
 @pytest.mark.p1

--- a/test/unit_test/data_source/test_trello_connector_unit.py
+++ b/test/unit_test/data_source/test_trello_connector_unit.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from common.data_source.trello_connector import TrelloConnector
+
+
+class FakeResponse:
+    def __init__(self, payload: Any, status_code: int = 200) -> None:
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self) -> Any:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, params: dict[str, Any], timeout: int) -> FakeResponse:
+        del timeout
+        path = url.split("/1/", 1)[1]
+        self.calls.append((path, params))
+        payloads: dict[str, Any] = {
+            "members/me/boards": [
+                {
+                    "id": "b1",
+                    "name": "Roadmap",
+                    "url": "https://trello.com/b/b1/roadmap",
+                    "dateLastActivity": "2026-06-01T10:00:00.000Z",
+                }
+            ],
+            "boards/b1": {
+                "id": "b1",
+                "name": "Roadmap",
+                "url": "https://trello.com/b/b1/roadmap",
+                "dateLastActivity": "2026-06-01T10:00:00.000Z",
+            },
+            "boards/b1/lists": [
+                {"id": "l1", "name": "Doing"},
+            ],
+            "boards/b1/cards": [
+                {
+                    "id": "c1",
+                    "name": "Ship Trello connector",
+                    "desc": "Implement card sync.",
+                    "url": "https://trello.com/c/c1",
+                    "shortUrl": "https://trello.com/c/c1",
+                    "dateLastActivity": "2026-06-01T11:00:00.000Z",
+                    "due": "2026-06-10T00:00:00.000Z",
+                    "dueComplete": False,
+                    "idList": "l1",
+                    "labels": [{"name": "Backend", "color": "blue"}],
+                    "closed": False,
+                },
+                {
+                    "id": "c2",
+                    "name": "Old card",
+                    "desc": "",
+                    "url": "https://trello.com/c/c2",
+                    "dateLastActivity": "2026-05-01T11:00:00.000Z",
+                    "idList": "l1",
+                    "labels": [],
+                    "closed": False,
+                },
+            ],
+            "cards/c1/actions": [
+                {
+                    "date": "2026-06-01T12:00:00.000Z",
+                    "data": {"text": "Looks good."},
+                    "memberCreator": {"fullName": "Alice"},
+                }
+            ],
+            "cards/c2/actions": [],
+            "cards/c1/attachments": [
+                {
+                    "id": "a1",
+                    "name": "spec.pdf",
+                    "url": "https://trello.com/1/cards/c1/attachments/a1/download/spec.pdf",
+                    "mimeType": "application/pdf",
+                    "bytes": 1024,
+                    "date": "2026-06-01T12:30:00.000Z",
+                }
+            ],
+            "cards/c2/attachments": [],
+        }
+        return FakeResponse(payloads[path])
+
+
+def make_connector() -> TrelloConnector:
+    connector = TrelloConnector(api_base="https://trello.test/1")
+    connector.session = FakeSession()
+    connector.load_credentials(
+        {
+            "trello_api_key": "key",
+            "trello_api_token": "token",
+        }
+    )
+    return connector
+
+
+def test_trello_connector_builds_card_documents() -> None:
+    connector = make_connector()
+
+    batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    assert len(batches[0]) == 2
+    doc = batches[0][0]
+    text = doc.blob.decode("utf-8")
+    assert doc.id == "trello:c1"
+    assert doc.source == "trello"
+    assert doc.semantic_identifier == "Ship Trello connector"
+    assert doc.metadata["board_name"] == "Roadmap"
+    assert doc.metadata["list_name"] == "Doing"
+    assert "Description:\nImplement card sync." in text
+    assert "Alice" in text
+    assert "spec.pdf" in text
+    assert doc.fingerprint
+
+
+def test_trello_connector_poll_source_filters_by_date() -> None:
+    connector = make_connector()
+    start = datetime(2026, 5, 15, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc).timestamp()
+
+    batches = list(connector.poll_source(start, end))
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["trello:c1"]]
+
+
+def test_trello_connector_retrieves_slim_docs() -> None:
+    connector = make_connector()
+
+    batches = list(connector.retrieve_all_slim_docs_perm_sync())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["trello:c1", "trello:c2"]]
+
+
+def test_trello_connector_requires_credentials() -> None:
+    connector = TrelloConnector(api_base="https://trello.test/1")
+
+    with pytest.raises(ValueError, match="trello_api_key"):
+        connector.validate_connector_settings()

--- a/test/unit_test/data_source/test_trello_connector_unit.py
+++ b/test/unit_test/data_source/test_trello_connector_unit.py
@@ -107,6 +107,7 @@ def make_connector() -> TrelloConnector:
     return connector
 
 
+@pytest.mark.p1
 def test_trello_connector_builds_card_documents() -> None:
     connector = make_connector()
 
@@ -127,6 +128,7 @@ def test_trello_connector_builds_card_documents() -> None:
     assert doc.fingerprint
 
 
+@pytest.mark.p1
 def test_trello_connector_poll_source_filters_by_date() -> None:
     connector = make_connector()
     start = datetime(2026, 5, 15, tzinfo=timezone.utc).timestamp()
@@ -137,6 +139,7 @@ def test_trello_connector_poll_source_filters_by_date() -> None:
     assert [[doc.id for doc in batch] for batch in batches] == [["trello:c1"]]
 
 
+@pytest.mark.p1
 def test_trello_connector_retrieves_slim_docs() -> None:
     connector = make_connector()
 
@@ -145,6 +148,7 @@ def test_trello_connector_retrieves_slim_docs() -> None:
     assert [[doc.id for doc in batch] for batch in batches] == [["trello:c1", "trello:c2"]]
 
 
+@pytest.mark.p1
 def test_trello_connector_falls_back_to_card_id_timestamp() -> None:
     connector = make_connector()
     expected = datetime(2026, 6, 1, 11, 0, tzinfo=timezone.utc)
@@ -152,8 +156,12 @@ def test_trello_connector_falls_back_to_card_id_timestamp() -> None:
 
     assert connector._parse_trello_datetime("not-a-date") is None
     assert connector._resolve_card_updated_at({"id": card_id, "dateLastActivity": "not-a-date"}) == expected
+    assert connector._resolve_card_updated_at({"id": "nothex", "dateLastActivity": ""}) == datetime.fromtimestamp(
+        0, tz=timezone.utc
+    )
 
 
+@pytest.mark.p1
 def test_trello_connector_requires_credentials() -> None:
     connector = TrelloConnector(api_base="https://trello.test/1")
 

--- a/test/unit_test/data_source/test_trello_connector_unit.py
+++ b/test/unit_test/data_source/test_trello_connector_unit.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import requests
 
 from common.data_source.trello_connector import TrelloConnector
 
@@ -95,6 +97,16 @@ class FakeSession:
         return FakeResponse(payloads[path])
 
 
+class FailingSession:
+    def get(self, url: str, params: dict[str, Any], timeout: int) -> FakeResponse:
+        del timeout
+        response = FakeResponse({"error": "unauthorized"}, status_code=401)
+        response.request = SimpleNamespace(
+            url=f"{url}?key={params['key']}&token={params['token']}&fields=id,name"
+        )
+        return response
+
+
 def make_connector() -> TrelloConnector:
     connector = TrelloConnector(api_base="https://trello.test/1")
     connector.session = FakeSession()
@@ -167,3 +179,23 @@ def test_trello_connector_requires_credentials() -> None:
 
     with pytest.raises(ValueError, match="trello_api_key"):
         connector.validate_connector_settings()
+
+
+@pytest.mark.p1
+def test_trello_connector_redacts_credentials_from_http_errors() -> None:
+    connector = TrelloConnector(api_base="https://trello.test/1")
+    connector.session = FailingSession()
+    connector.load_credentials(
+        {
+            "trello_api_key": "secret-key",
+            "trello_api_token": "secret-token",
+        }
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        connector.validate_connector_settings()
+
+    message = str(exc_info.value)
+    assert "secret-key" not in message
+    assert "secret-token" not in message
+    assert "fields=id%2Cname" in message

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1270,6 +1270,14 @@ Example: Virtual Hosted Style`,
         'Connect to Dingtalk AI Table and synchronize records from a specified table.',
       gitlabDescription:
         'Connect GitLab to sync repositories, issues, merge requests, and related documentation.',
+      trelloDescription:
+        'Connect Trello to sync boards, lists, cards, comments, and attachment metadata.',
+      trelloApiKeyTip:
+        'Generate an API key from the Trello developer portal or a Trello Power-Up.',
+      trelloApiTokenTip:
+        'Generate a Trello API token for the account that can access the boards to sync.',
+      trelloBoardIdsTip:
+        'Optional: Trello board IDs to sync. Leave empty to sync all open boards visible to the token.',
       asanaDescription:
         'Connect to Asana and synchronize files from a specified workspace.',
       imapDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1148,6 +1148,14 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       dingtalkAITableDescription: '连接钉钉AI表格，同步指定表格中的记录。',
       gitlabDescription:
         '连接 GitLab，同步仓库、Issue、合并请求（MR）及相关文档内容。',
+      trelloDescription:
+        '连接 Trello，同步看板、列表、卡片、评论和附件元数据。',
+      trelloApiKeyTip:
+        '请从 Trello 开发者门户或 Trello Power-Up 生成 API Key。',
+      trelloApiTokenTip:
+        '请生成可访问目标看板的 Trello API Token。',
+      trelloBoardIdsTip:
+        '可选：要同步的 Trello Board ID。留空则同步该 Token 可见的所有打开看板。',
       asanaDescription: '连接 Asana，同步工作区中的文件。',
       imapDescription:
         '连接你的 IMAP 邮箱，同步指定mailboxes中的邮件，用于知识检索与分析',

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -2,7 +2,7 @@ import { FormFieldConfig, FormFieldType } from '@/components/dynamic-form';
 import { IconFontFill } from '@/components/icon-font';
 import SvgIcon from '@/components/svg-icon';
 import { t, TFunction } from 'i18next';
-import { Mail, Rss } from 'lucide-react';
+import { Kanban, Mail, Rss } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BoxTokenField from '../component/box-token-field';
@@ -48,6 +48,7 @@ export enum DataSourceKey {
   TEAMS = 'teams',
   SLACK = 'slack',
   SHAREPOINT = 'sharepoint',
+  TRELLO = 'trello',
 }
 
 type DataSourceFeatureVisibility = {
@@ -144,6 +145,9 @@ export const DataSourceFeatureVisibilityMap: Partial<
     syncDeletedFiles: true,
   },
   [DataSourceKey.SHAREPOINT]: {
+    syncDeletedFiles: true,
+  },
+  [DataSourceKey.TRELLO]: {
     syncDeletedFiles: true,
   },
   [DataSourceKey.MYSQL]: {
@@ -335,6 +339,11 @@ export const generateDataSourceInfo = (t: TFunction) => {
       description: t(`setting.${DataSourceKey.OUTLOOK}Description`),
       icon: <Mail className="text-text-primary" size={22} />,
     },
+    [DataSourceKey.TRELLO]: {
+      name: 'Trello',
+      description: t(`setting.${DataSourceKey.TRELLO}Description`),
+      icon: <Kanban className="text-text-primary" size={22} />,
+    },
   };
 };
 
@@ -503,6 +512,53 @@ export const DataSourceFormFields = {
       required: false,
       placeholder: 'support@example.com, sales@example.com',
       tooltip: t('setting.outlookUserIdsTip'),
+    },
+    {
+      label: 'Batch Size',
+      name: 'config.batch_size',
+      type: FormFieldType.Number,
+      required: false,
+      validation: {
+        min: 1,
+        message: 'Batch Size must be at least 1',
+      },
+    },
+  ],
+  [DataSourceKey.TRELLO]: [
+    {
+      label: 'Trello API Key',
+      name: 'config.credentials.trello_api_key',
+      type: FormFieldType.Text,
+      required: true,
+      tooltip: t('setting.trelloApiKeyTip'),
+    },
+    {
+      label: 'Trello API Token',
+      name: 'config.credentials.trello_api_token',
+      type: FormFieldType.Password,
+      required: true,
+      tooltip: t('setting.trelloApiTokenTip'),
+    },
+    {
+      label: 'Board IDs',
+      name: 'config.board_ids',
+      type: FormFieldType.Tag,
+      required: false,
+      tooltip: t('setting.trelloBoardIdsTip'),
+    },
+    {
+      label: 'Include Comments',
+      name: 'config.include_comments',
+      type: FormFieldType.Checkbox,
+      required: false,
+      defaultValue: true,
+    },
+    {
+      label: 'Include Attachment Metadata',
+      name: 'config.include_attachments',
+      type: FormFieldType.Checkbox,
+      required: false,
+      defaultValue: true,
     },
     {
       label: 'Batch Size',
@@ -1627,6 +1683,20 @@ export const DataSourceFormDefaultValues = {
       channels: [],
       credentials: {
         discord_bot_token: '',
+      },
+    },
+  },
+  [DataSourceKey.TRELLO]: {
+    name: '',
+    source: DataSourceKey.TRELLO,
+    config: {
+      board_ids: [],
+      include_comments: true,
+      include_attachments: true,
+      batch_size: 2,
+      credentials: {
+        trello_api_key: '',
+        trello_api_token: '',
       },
     },
   },


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #15545.

Replaces the previous OAuth login/callback implementation on this branch with a Trello data-source connector. This adds Trello as a first-class data source so users can sync boards, lists, cards, comments, and attachment metadata into knowledge bases.

### What is changed and how it works?

- Adds `common/data_source/trello_connector.py` with API key/token authentication, board discovery, board/list/card loading, comment loading, attachment metadata loading, polling by `dateLastActivity`, and permission-sync slim document retrieval.
- Registers Trello in common data-source constants/config, connector exports, and `rag/svr/sync_data_source.py`.
- Adds the Trello data-source settings form in the web UI with API key, API token, optional board IDs, comment/attachment toggles, and batch size.
- Adds English and Chinese locale strings for the Trello connector settings.
- Adds unit tests for document building, polling date filters, slim document sync, and credential validation.

### Type of change

- [x] New Feature

### How Has This Been Tested?

- [x] `git diff --cached --check`
- [x] `python3 -m py_compile common/data_source/trello_connector.py test/unit_test/data_source/test_trello_connector_unit.py rag/svr/sync_data_source.py common/constants.py common/data_source/config.py common/data_source/__init__.py`
- [x] `uv run --python 3.13 --with pytest --with pytest-asyncio pytest test/unit_test/data_source/test_trello_connector_unit.py -q`

Note: `npm run type-check` could not be completed locally because `web/node_modules` is not installed in this checkout (`tsc: not found`).