### PR TITLE
fix: return 404 when file blob missing from storage

### DIFF
--- a/api/apps/restful_apis/file_api.py
+++ b/api/apps/restful_apis/file_api.py
@@ -22,6 +22,7 @@ from api.db import FileType
 from api.db.services.file2document_service import File2DocumentService
 from api.utils.api_utils import (
     add_tenant_id_to_kwargs,
+    construct_json_result,
     get_error_argument_result,
     get_error_data_result,
     get_json_result,
@@ -301,7 +302,8 @@ async def download(tenant_id: str = None, file_id: str = None):
             blob = await thread_pool_exec(settings.STORAGE_IMPL.get, b, n)
 
         if not blob:
-            return get_error_data_result(message="File content not found in storage.")
+            logging.error("File content not found in storage for file_id=%s", file_id)
+            return construct_json_result(message="File content not found in storage.", code=RetCode.DATA_ERROR)
 
         response = await make_response(blob)
         ext = re.search(r"\.([^.]+)$", file.name.lower())

--- a/api/apps/restful_apis/file_api.py
+++ b/api/apps/restful_apis/file_api.py
@@ -300,6 +300,9 @@ async def download(tenant_id: str = None, file_id: str = None):
             b, n = File2DocumentService.get_storage_address(file_id=file_id)
             blob = await thread_pool_exec(settings.STORAGE_IMPL.get, b, n)
 
+        if not blob:
+            return get_error_data_result(message="File content not found in storage.")
+
         response = await make_response(blob)
         ext = re.search(r"\.([^.]+)$", file.name.lower())
         ext = ext.group(1) if ext else None


### PR DESCRIPTION
## Summary

Fixes #15369

When both primary and fallback storage lookups return `None`, the file download endpoint calls `make_response(None)`, which Quart converts to an HTTP **500** `TypeError`.

This PR adds a null check after the fallback lookup and returns a structured JSON error response instead.

## Changes

- `api/apps/restful_apis/file_api.py`: Add `if not blob` check after `File2DocumentService.get_storage_address` fallback, returning `get_error_data_result(message="File content not found in storage.")`

## How to verify

1. Upload a file to a knowledge base
2. Delete the blob from storage (MinIO/S3) while keeping the DB record
3. Call `GET /api/v1/files/<file_id>`
4. **Before**: HTTP 500 (TypeError: response value cannot be None)
5. **After**: HTTP 200 with `{"code": 500, "message": "File content not found in storage."}`

## Related

- Pattern matches existing error handling in `document_api.py` (lines 1938-1939)