### PR TITLE
[Bug]: Variable Assigner rejects valid parameter 0 and parameterless operators

### DIFF
--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -38,6 +38,9 @@ class VariableAssignerParam(ComponentParamBase):
             }
         }
 
+_OPERATORS_WITHOUT_PARAMETER = {"clear", "remove_first", "remove_last"}
+
+
 class VariableAssigner(ComponentBase,ABC):
     component_name = "VariableAssigner"
 
@@ -47,7 +50,10 @@ class VariableAssigner(ComponentBase,ABC):
             return
         else:
             for item in self._param.variables:
-                if any([not item.get("variable"), not item.get("operator"), not item.get("parameter")]):
+                if not item.get("variable") or not item.get("operator"):
+                    raise ValueError("Variable is not complete.")
+                operator = item.get("operator")
+                if operator not in _OPERATORS_WITHOUT_PARAMETER and item.get("parameter") is None:
                     raise ValueError("Variable is not complete.")
                 variable=item["variable"]
                 operator=item["operator"]

--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -57,7 +57,7 @@ class VariableAssigner(ComponentBase,ABC):
                     raise ValueError("Variable is not complete.")
                 variable=item["variable"]
                 operator=item["operator"]
-                parameter=item["parameter"]
+                parameter=item.get("parameter")
                 variable_value=self._canvas.get_variable_value(variable)
                 new_variable=self._operate(variable_value,operator,parameter)
                 self._canvas.set_variable_value(variable, new_variable)

--- a/test/unit_test/agent/component/test_variable_assigner.py
+++ b/test/unit_test/agent/component/test_variable_assigner.py
@@ -1,3 +1,5 @@
+import pytest
+
 from agent.component.variable_assigner import VariableAssigner, VariableAssignerParam
 
 
@@ -20,13 +22,15 @@ def _make_component(variables, initial=None):
     return comp
 
 
+@pytest.mark.p1
 def test_set_number_zero_succeeds():
     comp = _make_component([{"variable": "counter", "operator": "set", "parameter": 0}])
     comp._invoke()
     assert comp._canvas._values["counter"] == 0
 
 
+@pytest.mark.p1
 def test_clear_without_parameter_succeeds():
-    comp = _make_component([{"variable": "items", "operator": "clear", "parameter": ""}])
+    comp = _make_component([{"variable": "items", "operator": "clear"}])
     comp._invoke()
     assert comp._canvas._values["items"] == []

--- a/test/unit_test/agent/component/test_variable_assigner.py
+++ b/test/unit_test/agent/component/test_variable_assigner.py
@@ -1,0 +1,32 @@
+from agent.component.variable_assigner import VariableAssigner, VariableAssignerParam
+
+
+class _FakeCanvas:
+    def __init__(self, values=None):
+        self._values = values or {}
+
+    def get_variable_value(self, key):
+        return self._values.get(key)
+
+    def set_variable_value(self, key, value):
+        self._values[key] = value
+
+
+def _make_component(variables, initial=None):
+    comp = VariableAssigner.__new__(VariableAssigner)
+    comp._canvas = _FakeCanvas(initial or {"counter": 5, "items": [1, 2, 3]})
+    comp._param = VariableAssignerParam()
+    comp._param.variables = variables
+    return comp
+
+
+def test_set_number_zero_succeeds():
+    comp = _make_component([{"variable": "counter", "operator": "set", "parameter": 0}])
+    comp._invoke()
+    assert comp._canvas._values["counter"] == 0
+
+
+def test_clear_without_parameter_succeeds():
+    comp = _make_component([{"variable": "items", "operator": "clear", "parameter": ""}])
+    comp._invoke()
+    assert comp._canvas._values["items"] == []


### PR DESCRIPTION
## Summary

Closes #15458.

Fix Variable Assigner validation so `parameter: 0` is valid and `clear` / `remove_*` do not require a parameter.

## Changes

- `agent/component/variable_assigner.py`: explicit `None` check and operator allowlist.
- `test/unit_test/agent/component/test_variable_assigner.py`: regression tests.

## Test plan

- [ ] `pytest test/unit_test/agent/component/test_variable_assigner.py -q`
