### PR TITLE
fix(llm): strip model_type from gen_conf in LiteLLMBase._clean_conf

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -1395,6 +1395,7 @@ class LiteLLMBase(ABC):
         )
 
         gen_conf.pop("max_tokens", None)
+        gen_conf.pop("model_type", None)  # RAGFlow-internal field, not a valid LiteLLM/API param
         return gen_conf
 
     def _need_reasoning_content_back(self) -> bool:


### PR DESCRIPTION
### What problem does this PR solve?

Since #15141 added `model_type` to `llm_setting` from the frontend, this field leaks into `gen_conf` (because `gen_conf = dialog.llm_setting` in `dialog_service.py`) and is forwarded verbatim to litellm/provider APIs.

Providers that validate their request body reject it with a 400 error. Bedrock in particular returns:
```
BedrockException - {"message": "Malformed input request: #: extraneous key [model_type] is not permitted"}
```

### Root cause

`Base._clean_conf` already handles this implicitly — it filters `gen_conf` to an **allowlist** of known API params, so `model_type` is dropped automatically.

`LiteLLMBase._clean_conf` uses a **denylist** approach instead (only pops `max_tokens`), so `model_type` slips through to the API call.

### Fix

Add `model_type` to the denylist in `LiteLLMBase._clean_conf`, consistent with how `max_tokens` is already handled.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)