### PR TITLE
fix(go-models): remove duplicate roundTripperFunc from novita_test.go

### DIFF
--- a/internal/entity/models/novita_test.go
+++ b/internal/entity/models/novita_test.go
@@ -9,12 +9,6 @@ import (
 	"testing"
 )
 
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
-	return f(r)
-}
-
 func newNovitaServer(t *testing.T, expectedPath string, handler func(t *testing.T, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- `internal/entity/models/novita_test.go` redeclares the package-wide
  `roundTripperFunc` helper that already lives in `ppio_test.go`, breaking the
  whole model-driver test package build.
- Drop the duplicate so `go vet ./internal/entity/models/` is clean and the
  test suite compiles again.

## Root Cause
`ppio_test.go:12` carries the canonical stub helper with an explicit
"do not redeclare" comment:

```go
// roundTripperFunc is the package-wide test helper for stubbing
// http.RoundTripper. It lives here (the first provider test to need it) and is
// shared by the other provider tests in this package; do not redeclare it.
```

`novita_test.go` (added in #15350) included an identical `type roundTripperFunc`
plus `RoundTrip` method, so the package failed to build under `go vet`:

```
vet: internal/entity/models/novita_test.go:12:6: roundTripperFunc redeclared in this block
        internal/entity/models/ppio_test.go:15:6: other declaration of roundTripperFunc
```

This blocked every test under `./internal/entity/models/` from running.

## Fix
Removed the six-line duplicate (`type` + `RoundTrip` method + trailing blank)
from `novita_test.go`. The existing Novita tests already call
`roundTripperFunc(...)` and now resolve to the canonical declaration in
`ppio_test.go`. One file, six deletions.

## Test Plan
- [x] `go vet ./internal/entity/models/`
  - **Before:** `vet: internal/entity/models/novita_test.go:12:6: roundTripperFunc redeclared in this block`
  - **After:** clean of the redeclaration (the pre-existing `huaweicloud.go:268: unreachable code` warning is untouched by this PR).
- [x] `gofmt -l internal/entity/models/novita_test.go` → empty (formatted).
- [x] Novita tests compile and pass:
  ```
  $ go test ./internal/entity/models/ -vet=off -count=1 -run '^TestNovita' \
      -skip '.*ReturnsNoSuchMethod.*' -v
  --- PASS: TestNovitaRerankHappyPathReordersByIndex (0.00s)
  --- PASS: TestNovitaRerankRespectsTopNConfig (0.02s)
  --- PASS: TestNovitaRerankEmptyDocumentsShortCircuits (0.00s)
  --- PASS: TestNovitaRerankRequiresApiKey (0.00s)
  --- PASS: TestNovitaRerankRequiresModelName (0.00s)
  --- PASS: TestNovitaRerankRejectsOutOfRangeIndex (0.00s)
  --- PASS: TestNovitaRerankRejectsDuplicateIndex (0.00s)
  --- PASS: TestNovitaRerankSurfacesHTTPError (0.00s)
  --- PASS: TestNovitaRerankRejectsMissingRerankSuffix (0.00s)
  --- PASS: TestNovitaAudioOCRReturnNoSuchMethod (0.00s)
  --- PASS: TestNovitaBaseURLTrimsTrailingSlash (0.01s)
  --- PASS: TestNovitaBaseURLTrimsTrailingSlash/Chat (0.00s)
  --- PASS: TestNovitaBaseURLTrimsTrailingSlash/ListModels (0.00s)
  --- PASS: TestNovitaBaseURLTrimsTrailingSlash/Stream (0.01s)
  PASS
  ok  	ragflow/internal/entity/models	0.114s
  ```
  (The `-skip` excludes a pre-existing nil-deref in `Novita.Balance` that
  panics on missing API key — a separate stale-test issue unrelated to this
  dedup.)
