### PR TITLE
feat(go-models): implement provider RAGcon (issue #15065)

### DIFF
--- a/conf/models/ragcon.json
+++ b/conf/models/ragcon.json
@@ -1,0 +1,12 @@
+{
+  "name": "ragcon",
+  "url": {
+    "default": "https://connect.ragcon.com"
+  },
+  "url_suffix": {
+    "chat": "v1/chat/completions",
+    "models": "v1/models"
+  },
+  "class": "ragcon",
+  "models": []
+}

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -109,6 +109,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewTokenHubModel(baseURL, urlSuffix), nil
 	case "novita":
 		return NewNovitaModel(baseURL, urlSuffix), nil
+	case "ragcon":
+		return NewRAGconModel(baseURL, urlSuffix), nil
 	case "avian":
 		return NewAvianModel(baseURL, urlSuffix), nil
 	case "replicate":

--- a/internal/entity/models/ragcon.go
+++ b/internal/entity/models/ragcon.go
@@ -1,0 +1,458 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RAGconModel implements ModelDriver for RAGcon (https://connect.ragcon.com).
+//
+// RAGcon is a SaaS inference platform fronting a LiteLLM proxy with an
+// OpenAI-compatible REST surface (chat completions at /v1/chat/completions,
+// list models at /v1/models). The Python side already supports the chat
+// path at rag/llm/chat_model.py::RAGconChat with the same default base URL,
+// so this driver brings the new Go API server to parity for the LLM tag.
+//
+// The default base URL is https://connect.ragcon.com; the tenant may
+// override per-instance. Authentication is always required: every call
+// sets Authorization: Bearer <api_key>. Reasoning models surface their
+// thinking in either `reasoning_content` (preferred) or `reasoning`; the
+// driver extracts whichever is non-empty and routes it to
+// ChatResponse.ReasonContent (non-stream) or the sender's second argument
+// (stream).
+type RAGconModel struct {
+	BaseURL    map[string]string
+	URLSuffix  URLSuffix
+	httpClient *http.Client
+}
+
+// NewRAGconModel creates a new RAGcon model instance.
+//
+// Same transport convention as other Go SaaS drivers in this package:
+// clone http.DefaultTransport, override the connection-pool fields, no
+// client-level Timeout so SSE streams are not capped at the client layer
+// (per-request contexts handle that).
+func NewRAGconModel(baseURL map[string]string, urlSuffix URLSuffix) *RAGconModel {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+	transport.DisableCompression = false
+	transport.ResponseHeaderTimeout = 60 * time.Second
+
+	return &RAGconModel{
+		BaseURL:   baseURL,
+		URLSuffix: urlSuffix,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+}
+
+func (r *RAGconModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewRAGconModel(baseURL, r.URLSuffix)
+}
+
+func (r *RAGconModel) Name() string {
+	return "ragcon"
+}
+
+func (r *RAGconModel) baseURLForRegion(region string) (string, error) {
+	base, ok := r.BaseURL[region]
+	if !ok || base == "" {
+		return "", fmt.Errorf("ragcon: no base URL configured for region %q", region)
+	}
+	// Tenants may paste in a base URL that already includes the API
+	// version (".../v1" or ".../v1/"); callers append "v1/..." so we
+	// strip those plus any trailing "/" to avoid "/v1/v1/..." paths.
+	base = strings.TrimSuffix(base, "/")
+	base = strings.TrimSuffix(base, "/v1")
+	return strings.TrimSuffix(base, "/"), nil
+}
+
+func (r *RAGconModel) chatPayload(modelName string, messages []Message, stream bool, chatModelConfig *ChatConfig) map[string]interface{} {
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMessages[i] = map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+	}
+
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": apiMessages,
+		"stream":   stream,
+	}
+
+	if chatModelConfig != nil {
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+	}
+
+	return reqBody
+}
+
+func (r *RAGconModel) chatURL(apiConfig *APIConfig) (string, error) {
+	region := "default"
+	if apiConfig != nil && apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := r.baseURLForRegion(region)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%s", baseURL, r.URLSuffix.Chat), nil
+}
+
+type ragconChatMessage struct {
+	Content          string `json:"content"`
+	ReasoningContent string `json:"reasoning_content"`
+	Reasoning        string `json:"reasoning"`
+}
+
+type ragconChatChoice struct {
+	Message      ragconChatMessage `json:"message"`
+	Delta        ragconChatMessage `json:"delta"`
+	FinishReason string            `json:"finish_reason"`
+}
+
+type ragconChatResponse struct {
+	Choices      []ragconChatChoice `json:"choices"`
+	Error        interface{}        `json:"error"`
+	FinishReason string             `json:"finish_reason"`
+}
+
+func (r *RAGconModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	url, err := r.chatURL(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(r.chatPayload(modelName, messages, false, chatModelConfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result ragconChatResponse
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("ragcon: upstream error: %v", result.Error)
+	}
+	if len(result.Choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	content := result.Choices[0].Message.Content
+	reasonContent := result.Choices[0].Message.ReasoningContent
+	if reasonContent == "" {
+		reasonContent = result.Choices[0].Message.Reasoning
+	}
+	return &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+	}, nil
+}
+
+func (r *RAGconModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+	if chatModelConfig != nil && chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+		return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+	}
+
+	url, err := r.chatURL(apiConfig)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err := json.Marshal(r.chatPayload(modelName, messages, true, chatModelConfig))
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// ResponseHeaderTimeout caps the initial header wait. This context
+	// also caps the body-read phase so a stalled SSE stream cannot hold
+	// the caller's goroutine and connection indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), streamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	sawTerminal := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimSpace(line[5:])
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event ragconChatResponse
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			return fmt.Errorf("ragcon: invalid SSE event: %w", err)
+		}
+		if event.Error != nil {
+			return fmt.Errorf("ragcon: upstream stream error: %v", event.Error)
+		}
+		if len(event.Choices) == 0 {
+			continue
+		}
+
+		choice := event.Choices[0]
+		if reasoning := choice.Delta.ReasoningContent; reasoning != "" {
+			if err := sender(nil, &reasoning); err != nil {
+				return err
+			}
+		} else if reasoning := choice.Delta.Reasoning; reasoning != "" {
+			if err := sender(nil, &reasoning); err != nil {
+				return err
+			}
+		}
+		if choice.Delta.Content != "" {
+			if err := sender(&choice.Delta.Content, nil); err != nil {
+				return err
+			}
+		}
+		if choice.FinishReason != "" || event.FinishReason != "" {
+			sawTerminal = true
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("ragcon: stream ended before [DONE] or finish_reason")
+	}
+
+	endOfStream := "[DONE]"
+	return sender(&endOfStream, nil)
+}
+
+type ragconModelInfo struct {
+	ID string `json:"id"`
+}
+
+type ragconModelsEnvelope struct {
+	Data []ragconModelInfo `json:"data"`
+}
+
+func (r *RAGconModel) ListModels(apiConfig *APIConfig) ([]string, error) {
+	if apiConfig == nil || apiConfig.ApiKey == nil || *apiConfig.ApiKey == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	region := "default"
+	if apiConfig.Region != nil && *apiConfig.Region != "" {
+		region = *apiConfig.Region
+	}
+
+	baseURL, err := r.baseURLForRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, r.URLSuffix.Models)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// LiteLLM proxies (which back RAGcon) emit the OpenAI envelope
+	// {"data":[{"id":"..."}]} rather than a bare list, so try the
+	// envelope first and fall back to the legacy bare-list shape.
+	var envelope ragconModelsEnvelope
+	if err = json.Unmarshal(body, &envelope); err == nil && envelope.Data != nil {
+		models := make([]string, 0, len(envelope.Data))
+		for _, m := range envelope.Data {
+			if m.ID != "" {
+				models = append(models, m.ID)
+			}
+		}
+		return models, nil
+	}
+
+	var bare []ragconModelInfo
+	if err = json.Unmarshal(body, &bare); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	models := make([]string, 0, len(bare))
+	for _, m := range bare {
+		if m.ID != "" {
+			models = append(models, m.ID)
+		}
+	}
+	return models, nil
+}
+
+func (r *RAGconModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := r.ListModels(apiConfig)
+	return err
+}
+
+func (r *RAGconModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	return fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}

--- a/internal/entity/models/ragcon_test.go
+++ b/internal/entity/models/ragcon_test.go
@@ -1,0 +1,324 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newRAGconServer(t *testing.T, handler func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		// The RAGcon client sets Content-Type: application/json on every
+		// request, including the GET to /v1/models (see ragcon.go ListModels),
+		// so this assertion intentionally applies even when there's no body.
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+			t.Errorf("expected Content-Type to start with application/json, got %q", got)
+			return
+		}
+		var body map[string]interface{}
+		if r.Method == http.MethodPost {
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+				return
+			}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Errorf("unmarshal: %v\nraw=%s", err, string(raw))
+				return
+			}
+		}
+		handler(t, r, body, w)
+	}))
+}
+
+func newRAGconForTest(baseURL string) *RAGconModel {
+	return NewRAGconModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{Chat: "v1/chat/completions", Models: "v1/models"},
+	)
+}
+
+func TestRAGconName(t *testing.T) {
+	if got := newRAGconForTest("http://unused").Name(); got != "ragcon" {
+		t.Errorf("Name()=%q want %q", got, "ragcon")
+	}
+}
+
+func TestRAGconFactory(t *testing.T) {
+	driver, err := NewModelFactory().CreateModelDriver("RAGcon", map[string]string{"default": "http://unused"}, URLSuffix{})
+	if err != nil {
+		t.Fatalf("CreateModelDriver: %v", err)
+	}
+	if _, ok := driver.(*RAGconModel); !ok {
+		t.Fatalf("driver type=%T, want *RAGconModel", driver)
+	}
+}
+
+func TestRAGconChatHappyPath(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if body["model"] != "gpt-4o" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if body["stream"] != false {
+			t.Errorf("stream=%v want false", body["stream"])
+		}
+		if body["max_tokens"] != float64(32) {
+			t.Errorf("max_tokens=%v", body["max_tokens"])
+		}
+		messages, ok := body["messages"].([]interface{})
+		if !ok || len(messages) != 1 {
+			t.Fatalf("messages=%#v", body["messages"])
+		}
+		first, _ := messages[0].(map[string]interface{})
+		if first["role"] != "user" || first["content"] != "ping" {
+			t.Errorf("message=%#v", first)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content":           "pong",
+					"reasoning_content": "thinking",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	mt := 32
+	resp, err := newRAGconForTest(srv.URL).ChatWithMessages(
+		"gpt-4o",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{MaxTokens: &mt},
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if *resp.Answer != "pong" {
+		t.Errorf("Answer=%q", *resp.Answer)
+	}
+	if *resp.ReasonContent != "thinking" {
+		t.Errorf("ReasonContent=%q", *resp.ReasonContent)
+	}
+}
+
+func TestRAGconChatRequiresApiKey(t *testing.T) {
+	_, err := newRAGconForTest("http://unused").ChatWithMessages("gpt-4o", []Message{{Role: "user", Content: "x"}}, &APIConfig{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key error, got %v", err)
+	}
+}
+
+func TestRAGconChatRequiresModelName(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newRAGconForTest("http://unused").ChatWithMessages("", []Message{{Role: "user", Content: "x"}}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "model name is required") {
+		t.Errorf("expected model-name error, got %v", err)
+	}
+}
+
+func TestRAGconChatRequiresMessages(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newRAGconForTest("http://unused").ChatWithMessages("gpt-4o", nil, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "messages is empty") {
+		t.Errorf("expected messages error, got %v", err)
+	}
+}
+
+func TestRAGconChatSurfacesHTTPError(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		http.Error(w, "bad key", http.StatusUnauthorized)
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	_, err := newRAGconForTest(srv.URL).ChatWithMessages("gpt-4o", []Message{{Role: "user", Content: "x"}}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "status 401") {
+		t.Errorf("expected HTTP status error, got %v", err)
+	}
+}
+
+func TestRAGconChatRejectsProviderError(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{"message": "invalid model"},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	_, err := newRAGconForTest(srv.URL).ChatWithMessages("gpt-4o", []Message{{Role: "user", Content: "x"}}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err == nil || !strings.Contains(err.Error(), "upstream error") {
+		t.Errorf("expected upstream error, got %v", err)
+	}
+}
+
+func TestRAGconStreamHappyPath(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if body["stream"] != true {
+			t.Errorf("stream=%v want true", body["stream"])
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			`data: {"choices":[{"delta":{"reasoning_content":"think"}}]}`+"\n\n"+
+				`data: {"choices":[{"delta":{"content":"pong"}}]}`+"\n\n"+
+				`data: [DONE]`+"\n\n",
+		)
+	})
+	defer srv.Close()
+
+	var contentParts []string
+	var reasonParts []string
+	apiKey := "test-key"
+	err := newRAGconForTest(srv.URL).ChatStreamlyWithSender(
+		"gpt-4o",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		nil,
+		func(content *string, reason *string) error {
+			if content != nil {
+				contentParts = append(contentParts, *content)
+			}
+			if reason != nil {
+				reasonParts = append(reasonParts, *reason)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("ChatStreamlyWithSender: %v", err)
+	}
+	if strings.Join(reasonParts, "") != "think" {
+		t.Errorf("reasonParts=%v", reasonParts)
+	}
+	if contentParts[0] != "pong" {
+		t.Errorf("contentParts[0]=%q", contentParts[0])
+	}
+	if contentParts[len(contentParts)-1] != "[DONE]" {
+		t.Errorf("missing trailing [DONE] sentinel, got %v", contentParts)
+	}
+}
+
+func TestRAGconStreamRejectsNilSender(t *testing.T) {
+	apiKey := "test-key"
+	err := newRAGconForTest("http://unused").ChatStreamlyWithSender("gpt-4o", []Message{{Role: "user", Content: "x"}}, &APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "sender is required") {
+		t.Errorf("expected sender error, got %v", err)
+	}
+}
+
+func TestRAGconListModelsEnvelope(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Errorf("method/path=%s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "gpt-4o"},
+				{"id": "claude-3-7-sonnet"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	models, err := newRAGconForTest(srv.URL).ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	want := []string{"gpt-4o", "claude-3-7-sonnet"}
+	if strings.Join(models, ",") != strings.Join(want, ",") {
+		t.Errorf("models=%v want %v", models, want)
+	}
+}
+
+func TestRAGconListModelsBareList(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": "llama-3.1-8b"},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	models, err := newRAGconForTest(srv.URL).ListModels(&APIConfig{ApiKey: &apiKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) != 1 || models[0] != "llama-3.1-8b" {
+		t.Errorf("models=%v", models)
+	}
+}
+
+func TestRAGconCheckConnection(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []map[string]interface{}{}})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	if err := newRAGconForTest(srv.URL).CheckConnection(&APIConfig{ApiKey: &apiKey}); err != nil {
+		t.Errorf("CheckConnection: %v", err)
+	}
+}
+
+func TestRAGconUnsupportedMethodsReturnNoSuchMethod(t *testing.T) {
+	m := newRAGconForTest("http://unused")
+	apiKey := "test-key"
+	cfg := &APIConfig{ApiKey: &apiKey}
+	if _, err := m.Embed(nil, nil, cfg, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Embed=%v", err)
+	}
+	if _, err := m.Rerank(nil, "", nil, cfg, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Rerank=%v", err)
+	}
+	if _, err := m.Balance(cfg); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Balance=%v", err)
+	}
+	if _, err := m.AudioSpeech(nil, nil, cfg, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("AudioSpeech=%v", err)
+	}
+	if _, err := m.OCRFile(nil, nil, nil, cfg, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("OCRFile=%v", err)
+	}
+	if _, err := m.ParseFile(nil, nil, nil, cfg, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("ParseFile=%v", err)
+	}
+	if _, err := m.ListTasks(cfg); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("ListTasks=%v", err)
+	}
+	if _, err := m.ShowTask("", cfg); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("ShowTask=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `conf/llm_factories.json` registers a `RAGcon` factory but `internal/entity/models/` had no driver, so the new Go API server could not route RAGcon instances.
- Add the Go chat-scope driver (mirroring Astraflow / Avian / Novita / TogetherAI / etc.) plus its `conf/models/ragcon.json` and factory wiring, so `Add Provider -> RAGcon` works through the Go server the same way it already does for the other SaaS OpenAI-compatible providers.

## Root Cause
RAGcon is a SaaS inference platform fronting a LiteLLM proxy with an OpenAI-compatible REST surface at `https://connect.ragcon.com/v1`. The Python side already supports the chat path at `rag/llm/chat_model.py::RAGconChat` (added in PR #13425). The Go side had `case "ragcon":` missing from `internal/entity/models/factory.go` and no `ragcon.go` / `conf/models/ragcon.json`, so the factory entry was non-routable on the Go API server tracked under #14736.

## Implementation
Four new/edited files, ~796 added lines:

- **`internal/entity/models/ragcon.go`** -- `RAGconModel` with `ChatWithMessages`, `ChatStreamlyWithSender` (SSE with `[DONE]` sentinel + `reasoning_content` / `reasoning` fallback), `ListModels`, and `CheckConnection`. `ListModels` accepts both the OpenAI envelope (`{"data":[...]}`) emitted by the LiteLLM proxy fronting RAGcon and the legacy bare-list shape. Same connection-pool transport convention as the other SaaS drivers (no client-level `Timeout` so SSE streams are not capped at the client layer). Unsupported method types (`Embed`, `Rerank`, `Balance`, `TranscribeAudio`/`WithSender`, `AudioSpeech`/`WithSender`, `OCRFile`, `ParseFile`, `ListTasks`, `ShowTask`) return the shared `"<name>, no such method"` sentinel -- follow-on issues will fill in `Embed` / `Rerank` / `TTS` / `ASR` / `Image2Text` method-by-method (cf. how Novita / NVIDIA / TogetherAI landed those).
- **`conf/models/ragcon.json`** -- default base URL `https://connect.ragcon.com`, `url_suffix {chat: v1/chat/completions, models: v1/models}`, empty `models` list. RAGcon's LiteLLM proxy accepts any model name the user adds at instance-creation time, matching how Ollama / vLLM / Xinference handle their server-side model catalogs.
- **`internal/entity/models/factory.go`** -- `case "ragcon": return NewRAGconModel(baseURL, urlSuffix), nil` registered alongside Novita / Avian.
- **`internal/entity/models/ragcon_test.go`** -- 14 focused tests (see Test Plan below).

## Test Plan
- [x] `go vet ./internal/entity/models/` -- clean of new errors (only the pre-existing `huaweicloud.go:267 unreachable code` warning remains, untouched by this PR and tracked under #15430).
- [x] `gofmt -l` -- empty for all three changed Go files.
- [x] `go test ./internal/entity/models/ -vet=off -count=1 -run '^TestRAGcon' -v` -- all 14 tests PASS:

```
=== RUN   TestRAGconName
--- PASS: TestRAGconName (0.00s)
=== RUN   TestRAGconFactory
--- PASS: TestRAGconFactory (0.00s)
=== RUN   TestRAGconChatHappyPath
--- PASS: TestRAGconChatHappyPath (0.00s)
=== RUN   TestRAGconChatRequiresApiKey
--- PASS: TestRAGconChatRequiresApiKey (0.00s)
=== RUN   TestRAGconChatRequiresModelName
--- PASS: TestRAGconChatRequiresModelName (0.00s)
=== RUN   TestRAGconChatRequiresMessages
--- PASS: TestRAGconChatRequiresMessages (0.00s)
=== RUN   TestRAGconChatSurfacesHTTPError
--- PASS: TestRAGconChatSurfacesHTTPError (0.00s)
=== RUN   TestRAGconChatRejectsProviderError
--- PASS: TestRAGconChatRejectsProviderError (0.00s)
=== RUN   TestRAGconStreamHappyPath
--- PASS: TestRAGconStreamHappyPath (0.00s)
=== RUN   TestRAGconStreamRejectsNilSender
--- PASS: TestRAGconStreamRejectsNilSender (0.00s)
=== RUN   TestRAGconListModelsEnvelope
--- PASS: TestRAGconListModelsEnvelope (0.00s)
=== RUN   TestRAGconListModelsBareList
--- PASS: TestRAGconListModelsBareList (0.00s)
=== RUN   TestRAGconCheckConnection
--- PASS: TestRAGconCheckConnection (0.00s)
=== RUN   TestRAGconUnsupportedMethodsReturnNoSuchMethod
--- PASS: TestRAGconUnsupportedMethodsReturnNoSuchMethod (0.00s)
PASS
ok  	ragflow/internal/entity/models	0.018s
```

Closes #15065
