### PR TITLE
feat(go-api): implement GET /datasets/<dataset_id>/metadata/summary (issue #15240)

### DIFF
--- a/internal/handler/document.go
+++ b/internal/handler/document.go
@@ -683,6 +683,63 @@ func (h *DocumentHandler) MetadataSummary(c *gin.Context) {
 	})
 }
 
+// parseDocIDsQuery parses a comma-separated doc_ids query string into a slice.
+// Empty / whitespace-only entries are dropped. An empty or absent value
+// returns nil (meaning "no filter — summarize over every document").
+func parseDocIDsQuery(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// MetadataSummaryByDataset handles GET /api/v1/datasets/:dataset_id/metadata/summary,
+// the public dataset-scoped contract from api/apps/restful_apis/document_api.py::metadata_summary.
+//
+// The optional doc_ids query parameter is a comma-separated list of document
+// IDs to filter the summary by; when absent or empty the summary covers every
+// document in the dataset. The legacy POST /v1/document/metadata/summary
+// endpoint (kb_id in body) is left untouched.
+func (h *DocumentHandler) MetadataSummaryByDataset(c *gin.Context) {
+	datasetID := c.Param("dataset_id")
+	userID := c.GetString("user_id")
+
+	if !h.datasetService.Accessible(datasetID, userID) {
+		jsonError(c, common.CodeAuthenticationError, "No authorization.")
+		return
+	}
+
+	docIDs := parseDocIDsQuery(c.Query("doc_ids"))
+
+	summary, err := h.documentService.GetMetadataSummary(datasetID, docIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"code":    1,
+			"message": "Failed to get metadata summary: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code":    0,
+		"message": "success",
+		"data": gin.H{
+			"summary": summary,
+		},
+	})
+}
+
 // SetMetaRequest represents the request for setting document metadata
 type SetMetaRequest struct {
 	DocID string `json:"doc_id" binding:"required"`

--- a/internal/handler/document_test.go
+++ b/internal/handler/document_test.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/glebarez/sqlite"
 	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
 	"ragflow/internal/common"
@@ -368,7 +369,7 @@ func setupHandlerAccessDB(t *testing.T) *gorm.DB {
 	db.Create(&entity.Knowledgebase{
 		ID: "ds-1", TenantID: "tenant-1", Name: "test-kb", EmbdID: "embd-1",
 		CreatedBy: "user-1", Permission: string(entity.TenantPermissionTeam),
-		Status:    sptr(string(entity.StatusValid)),
+		Status: sptr(string(entity.StatusValid)),
 	})
 
 	return db
@@ -617,5 +618,31 @@ func TestDownloadDocument_NotFound(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["code"] != float64(common.CodeDataError) {
 		t.Fatalf("expected code %d, got %v", common.CodeDataError, resp["code"])
+	}
+}
+
+func TestParseDocIDsQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty string returns nil so the summary covers every document", in: "", want: nil},
+		{name: "whitespace-only string returns nil", in: "   ", want: nil},
+		{name: "only commas and whitespace returns nil rather than empty strings", in: " , , ,", want: nil},
+		{name: "single id is returned as a one-element slice", in: "doc-1", want: []string{"doc-1"}},
+		{name: "comma-separated ids are split in order", in: "doc-1,doc-2,doc-3", want: []string{"doc-1", "doc-2", "doc-3"}},
+		{name: "surrounding whitespace on each id is trimmed", in: " doc-1 , doc-2 ,doc-3 ", want: []string{"doc-1", "doc-2", "doc-3"}},
+		{name: "empty segments between commas are dropped", in: "doc-1,,doc-2, ,doc-3", want: []string{"doc-1", "doc-2", "doc-3"}},
+		{name: "trailing comma does not produce an empty trailing id", in: "doc-1,doc-2,", want: []string{"doc-1", "doc-2"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDocIDsQuery(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseDocIDsQuery(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -253,6 +253,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 				// Metadata Config
 				datasets.GET("/:dataset_id/metadata/config", r.datasetsHandler.GetMetadataConfig)
 				datasets.PUT("/:dataset_id/metadata/config", r.datasetsHandler.UpdateMetadataConfig)
+				datasets.GET("/:dataset_id/metadata/summary", r.documentHandler.MetadataSummaryByDataset)
 
 				// Dataset documents
 				datasets.GET("/:dataset_id/documents", r.documentHandler.ListDocuments)


### PR DESCRIPTION
## Summary
- Ports the dataset-scoped metadata-summary endpoint from `api/apps/restful_apis/document_api.py::metadata_summary` to the Go API server. The path is unchecked in tracker #15240, and the Go server had no handler wired under the `datasets` group, so MCP / Web Client / SDK calls to `GET /api/v1/datasets/<dataset_id>/metadata/summary` returned 404 against the Go API.

## Python Contract
- **path:**  `GET /api/v1/datasets/<dataset_id>/metadata/summary`
- **auth:**  `login_required` + `add_tenant_id_to_kwargs`
- **query:** `doc_ids` (optional, comma-separated; absent = summarize every document)
- **check:** `KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id)`
- **result:** `{"code":0,"data":{"summary":<service summary>}}`

## Implementation
Three files, +138 lines, mirroring the existing `ListDocuments` authorization pattern + the legacy `MetadataSummary` response shape:

- **`internal/handler/document.go`** -- new `parseDocIDsQuery` helper (factored out so its edge cases can be unit-tested without wiring the full handler) plus `DocumentHandler.MetadataSummaryByDataset` -- reads `dataset_id` from path, `doc_ids` from query, calls `h.datasetService.Accessible(datasetID, userID)` for ownership, then delegates to the existing `h.documentService.GetMetadataSummary(datasetID, docIDs)`.
- **`internal/router/router.go`** -- registers `datasets.GET("/:dataset_id/metadata/summary", r.documentHandler.MetadataSummaryByDataset)` next to the existing `metadata/config` routes.
- **`internal/handler/document_test.go`** -- table-driven coverage for `parseDocIDsQuery` (8 cases: empty input, whitespace-only, only-commas, single id, basic CSV, surrounding whitespace per id, empty mid-segments, trailing comma).

The legacy `POST /v1/document/metadata/summary` (`kb_id` in JSON body) is untouched.

## Test Plan
- [x] `gofmt -l internal/handler/document.go internal/handler/document_test.go internal/router/router.go` -- empty (formatted).
- [x] `go vet ./internal/handler/ ./internal/router/` -- clean.
- [x] `go build ./internal/handler/ ./internal/router/` -- exit 0.
- [x] `parseDocIDsQuery` table-driven cases verified (the local environment lacks the pre-built `internal/cpp/cmake-build-release/librag_tokenizer_c_api.a` that the handler-package cgo binary needs to link, so a standalone runner with the identical helper logic was used to drive the same 8 cases; CI builds the C library and runs the real `TestParseDocIDsQuery`):

```
  PASS parseDocIDsQuery("") = []string(nil) want []string(nil)
  PASS parseDocIDsQuery("   ") = []string(nil) want []string(nil)
  PASS parseDocIDsQuery(" , , ,") = []string(nil) want []string(nil)
  PASS parseDocIDsQuery("doc-1") = []string{"doc-1"} want []string{"doc-1"}
  PASS parseDocIDsQuery("doc-1,doc-2,doc-3") = []string{"doc-1","doc-2","doc-3"} want []string{"doc-1","doc-2","doc-3"}
  PASS parseDocIDsQuery(" doc-1 , doc-2 ,doc-3 ") = []string{"doc-1","doc-2","doc-3"} want []string{"doc-1","doc-2","doc-3"}
  PASS parseDocIDsQuery("doc-1,,doc-2, ,doc-3") = []string{"doc-1","doc-2","doc-3"} want []string{"doc-1","doc-2","doc-3"}
  PASS parseDocIDsQuery("doc-1,doc-2,") = []string{"doc-1","doc-2"} want []string{"doc-1","doc-2"}
ALL PASS
```

Refs #15240
