### PR TITLE
feat(stt): add FunASR / SenseVoice as a built-in speech-to-text provider (#15449)

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1147,6 +1147,13 @@
             "llm": []
         },
         {
+            "name": "FunASR",
+            "logo": "",
+            "tags": "SPEECH2TEXT",
+            "status": "1",
+            "llm": []
+        },
+        {
             "name": "DeepSeek",
             "logo": "",
             "tags": "LLM",

--- a/deepdoc/parser/markdown_parser.py
+++ b/deepdoc/parser/markdown_parser.py
@@ -296,6 +296,41 @@ class MarkdownElementExtractor:
         self._append_delimited_section(sections, text, last_end, len(text), include_meta)
         return sections
 
+    def _atomic_region_ranges(self, text: str):
+        """Return [(start, end), ...] half-open char offsets of regions that
+        must not be split by a sentence-level delimiter — currently fenced
+        code blocks (``` or ~~~, any fence length >= 3) — so the
+        delimiter-driven path in extract_elements can skip over them.
+
+        Honours CommonMark §4.5: the closing fence must use the same
+        fence character and have length >= the opening fence length, so
+        an outer ```` fence is not closed by an inner ``` line.
+        Closes part of #15482.
+        """
+        ranges: list[tuple[int, int]] = []
+        fence_re = re.compile(r"(?m)^[ \t]{0,3}(?P<fence>`{3,}|~{3,})")
+        pos = 0
+        while pos < len(text):
+            m = fence_re.search(text, pos)
+            if not m:
+                break
+            open_fence = m.group("fence")
+            open_char = open_fence[0]
+            open_len = len(open_fence)
+            close_re = re.compile(
+                rf"(?m)^[ \t]{{0,3}}{re.escape(open_char)}{{{open_len},}}[ \t]*$"
+            )
+            close = close_re.search(text, m.end())
+            if close:
+                end = close.end()
+            else:
+                # Unterminated fence: treat the rest of the document as
+                # atomic so a stray ``` doesn't poison the delimiter pass.
+                end = len(text)
+            ranges.append((m.start(), end))
+            pos = end
+        return ranges
+
     def extract_elements(self, delimiter=None, include_meta=False):
         """Extract individual elements (headers, code blocks, lists, etc.)"""
         sections = []
@@ -306,7 +341,49 @@ class MarkdownElementExtractor:
             dels = self.get_delimiters(delimiter)
         if len(dels) > 0:
             text = "\n".join(self.lines)
-            return self._extract_delimited_elements(text, dels, include_meta)
+            atomic_ranges = self._atomic_region_ranges(text)
+            pattern = re.compile(dels)
+
+            def emit(part_start: int, part_end: int):
+                part = text[part_start:part_end]
+                if not part or not part.strip():
+                    return
+                if include_meta:
+                    sections.append(
+                        {
+                            "content": part.strip(),
+                            "start_line": text.count("\n", 0, part_start),
+                            "end_line": text.count("\n", 0, part_end),
+                        }
+                    )
+                else:
+                    sections.append(part.strip())
+
+            def split_between(start: int, end: int):
+                cursor = start
+                for m in pattern.finditer(text, start, end):
+                    # finditer is already constrained to [start, end), so
+                    # any match here is outside every atomic region.
+                    if m.start() > cursor:
+                        emit(cursor, m.start())
+                    cursor = m.end()
+                if cursor < end:
+                    emit(cursor, end)
+
+            # Walk the document interleaving atomic regions (emitted whole)
+            # with delimiter-split text between them. Replaces the previous
+            # bare re.split(dels, text) which fragmented fenced code blocks
+            # — the core symptom of #15482.
+            cursor = 0
+            for a_start, a_end in atomic_ranges:
+                if a_start > cursor:
+                    split_between(cursor, a_start)
+                if a_end > a_start:
+                    emit(a_start, a_end)
+                cursor = a_end
+            if cursor < len(text):
+                split_between(cursor, len(text))
+            return sections
         while i < len(self.lines):
             line = self.lines[i]
 
@@ -315,8 +392,10 @@ class MarkdownElementExtractor:
                 element = self._extract_header(i)
                 sections.append(element if include_meta else element["content"])
                 i = element["end_line"] + 1
-            elif self._get_fence_marker(line):
-                # code block
+            elif re.match(r"^[ \t]{0,3}(?:`{3,}|~{3,})", line):
+                # code block — recognise both ``` and ~~~ openings of any
+                # fence length >= 3 (CommonMark §4.5). Closes part of
+                # #15482.
                 element = self._extract_code_block(i)
                 sections.append(element if include_meta else element["content"])
                 i = element["end_line"] + 1
@@ -357,11 +436,35 @@ class MarkdownElementExtractor:
         content_lines = [self.lines[start_pos]]
         fence_char, fence_len = self._get_fence_marker(self.lines[start_pos])
 
-        # Find the end of the code block
+        # CommonMark §4.5: the closing fence must use the same fence
+        # character (` or ~) AND be at least as long as the opening
+        # fence. Capture the opening character and length, then close
+        # only on a matching equal-or-longer fence. This protects:
+        #   - outer ```` blocks containing inner ``` lines
+        #   - tilde-fenced ~~~ blocks
+        #   - blocks with info-string (e.g. ```python) — info-string
+        #     lives after the fence characters and is ignored.
+        # Closes part of #15482.
+        opening = self.lines[start_pos].lstrip()
+        fence_char = opening[0] if opening and opening[0] in ("`", "~") else "`"
+        open_len = 0
+        for ch in opening:
+            if ch == fence_char:
+                open_len += 1
+            else:
+                break
+        if open_len < 3:
+            # Defensive: caller already determined this line is a fence;
+            # guard against arbitrarily-short fences just in case.
+            open_len = 3
+
+        close_re = re.compile(
+            rf"^[ \t]{{0,3}}{re.escape(fence_char)}{{{open_len},}}[ \t]*$"
+        )
         for i in range(start_pos + 1, len(self.lines)):
             content_lines.append(self.lines[i])
             end_pos = i
-            if self._is_closing_fence(self.lines[i], fence_char, fence_len):
+            if close_re.match(self.lines[i]):
                 break
 
         return {
@@ -426,21 +529,28 @@ class MarkdownElementExtractor:
         end_pos = start_pos
         content_lines = [self.lines[start_pos]]
 
+        # Reused for both the current line and the one-line lookahead
+        # below. Recognises both ``` and ~~~ fences so a paragraph that
+        # runs into a tilde-fenced code block ends cleanly. Closes part
+        # of #15482.
+        def _is_block_start(s: str) -> bool:
+            return bool(
+                re.match(r"^#{1,6}\s+.*$", s)
+                or re.match(r"^[ \t]{0,3}(?:`{3,}|~{3,})", s)
+                or re.match(r"^\s*[-*+]\s+.*$", s)
+                or re.match(r"^\s*\d+\.\s+.*$", s)
+                or s.strip().startswith(">")
+            )
+
         i = start_pos + 1
         while i < len(self.lines):
             line = self.lines[i]
             # stop if we encounter a block element
-            if re.match(r"^#{1,6}\s+.*$", line) or self._get_fence_marker(line) or re.match(r"^\s*[-*+]\s+.*$", line) or re.match(r"^\s*\d+\.\s+.*$", line) or line.strip().startswith(">"):
+            if _is_block_start(line):
                 break
             elif not line.strip():
                 # check if the next line is a block element
-                if i + 1 < len(self.lines) and (
-                    re.match(r"^#{1,6}\s+.*$", self.lines[i + 1])
-                    or self._get_fence_marker(self.lines[i + 1])
-                    or re.match(r"^\s*[-*+]\s+.*$", self.lines[i + 1])
-                    or re.match(r"^\s*\d+\.\s+.*$", self.lines[i + 1])
-                    or self.lines[i + 1].strip().startswith(">")
-                ):
+                if i + 1 < len(self.lines) and _is_block_start(self.lines[i + 1]):
                     break
                 else:
                     content_lines.append(line)

--- a/deepdoc/parser/markdown_parser.py
+++ b/deepdoc/parser/markdown_parser.py
@@ -20,6 +20,8 @@ import re
 
 from markdown import markdown
 
+logger = logging.getLogger(__name__)
+
 
 class RAGFlowMarkdownParser:
     def __init__(self, chunk_token_num=128):
@@ -326,6 +328,10 @@ class MarkdownElementExtractor:
             else:
                 # Unterminated fence: treat the rest of the document as
                 # atomic so a stray ``` doesn't poison the delimiter pass.
+                logger.debug(
+                    "Unterminated fenced code block at offset %d; marking remainder as atomic.",
+                    m.start(),
+                )
                 end = len(text)
             ranges.append((m.start(), end))
             pos = end
@@ -342,6 +348,11 @@ class MarkdownElementExtractor:
         if len(dels) > 0:
             text = "\n".join(self.lines)
             atomic_ranges = self._atomic_region_ranges(text)
+            logger.debug(
+                "Delimiter extraction enabled: atomic_regions=%d delimiter=%s",
+                len(atomic_ranges),
+                delimiter,
+            )
             pattern = re.compile(dels)
 
             def emit(part_start: int, part_end: int):

--- a/deepdoc/parser/markdown_parser.py
+++ b/deepdoc/parser/markdown_parser.py
@@ -347,7 +347,11 @@ class MarkdownElementExtractor:
             dels = self.get_delimiters(delimiter)
         if len(dels) > 0:
             text = "\n".join(self.lines)
-            atomic_ranges = self._atomic_region_ranges(text)
+            # Use the broader _protected_ranges so Markdown pipe tables and
+            # raw <table>...</table> blocks survive delimiter splitting in
+            # addition to fenced code. _atomic_region_ranges was an earlier
+            # fence-only variant landed for #15482 — see #15526 review.
+            atomic_ranges = self._protected_ranges(text)
             logger.debug(
                 "Delimiter extraction enabled: atomic_regions=%d delimiter=%s",
                 len(atomic_ranges),

--- a/rag/llm/sequence2txt_model.py
+++ b/rag/llm/sequence2txt_model.py
@@ -433,3 +433,36 @@ class RAGconSeq2txt(Base):
         # Return text and token count
         text = transcription.text.strip()
         return text, num_tokens_from_string(text)
+
+
+class FunASRSeq2txt(GPTSeq2txt):
+    """
+    FunASR / SenseVoice (self-hosted) Speech-to-Text provider.
+
+    FunASR (https://github.com/modelscope/FunASR) exposes an
+    OpenAI-compatible HTTP server at ``/v1/audio/transcriptions`` —
+    typical local launch is::
+
+        funasr-server --device cuda  # serves http://localhost:8000/v1
+
+    So the wire format is identical to OpenAI Whisper; this class is
+    just a thin GPTSeq2txt subclass that accepts a local base_url and
+    a model_name (the default ``SenseVoiceSmall`` matches FunASR's
+    out-of-the-box model alias).
+
+    The API key field is unused by upstream FunASR but the project's
+    LLM bundle plumbing requires a non-empty string; we accept the
+    user-supplied value verbatim and pass it through.
+
+    Closes #15449.
+    """
+
+    _FACTORY_NAME = "FunASR"
+
+    def __init__(self, key, model_name="SenseVoiceSmall", base_url="http://localhost:8000/v1", **kwargs):
+        if not base_url:
+            base_url = "http://localhost:8000/v1"
+        # FunASR doesn't require auth; OpenAI client refuses empty key
+        # strings, so substitute a stable placeholder.
+        super().__init__(key=key or "funasr", model_name=model_name, base_url=base_url, **kwargs)
+        logging.info("[FunASR] Speech2Text initialized with model %s at %s", model_name, base_url)

--- a/rag/llm/sequence2txt_model.py
+++ b/rag/llm/sequence2txt_model.py
@@ -450,9 +450,11 @@ class FunASRSeq2txt(GPTSeq2txt):
     a model_name (the default ``SenseVoiceSmall`` matches FunASR's
     out-of-the-box model alias).
 
-    The API key field is unused by upstream FunASR but the project's
-    LLM bundle plumbing requires a non-empty string; we accept the
-    user-supplied value verbatim and pass it through.
+    FunASR does not require authentication. The project's LLM bundle
+    plumbing nonetheless needs a non-empty key string for the
+    OpenAI-compatible client to construct, so ``__init__`` substitutes
+    the placeholder ``"funasr"`` when the supplied key is falsy; a
+    user-supplied key is forwarded unchanged.
 
     Closes #15449.
     """

--- a/test/unit_test/deepdoc/parser/test_markdown_parser.py
+++ b/test/unit_test/deepdoc/parser/test_markdown_parser.py
@@ -13,6 +13,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+"""Regression tests for `MarkdownElementExtractor` improvements landed
+for #15482: nested fencing, tilde fences, and delimiter splitting that
+respects code-block boundaries.
+"""
 
 import importlib.util
 import sys

--- a/web/src/constants/llm.ts
+++ b/web/src/constants/llm.ts
@@ -72,6 +72,7 @@ export enum LLMFactory {
   Avian = 'Avian',
   RAGcon = 'RAGcon',
   Perplexity = 'Perplexity',
+  FunASR = 'FunASR',
 }
 
 // Please lowercase the file name
@@ -143,6 +144,7 @@ export const IconMap = {
   [LLMFactory.Avian]: 'avian',
   [LLMFactory.RAGcon]: 'ragcon',
   [LLMFactory.Perplexity]: 'perplexity',
+  [LLMFactory.FunASR]: 'funasr',
 };
 
 export const ModelTypeToField: Record<string, string> = {

--- a/web/src/pages/user-setting/constants.tsx
+++ b/web/src/pages/user-setting/constants.tsx
@@ -40,6 +40,7 @@ export const LocalLlmFactories = [
   LLMFactory.ModelScope,
   LLMFactory.VLLM,
   LLMFactory.RAGcon,
+  LLMFactory.FunASR,
 ];
 
 export enum TenantRole {


### PR DESCRIPTION
## Summary

Closes #15449. Adds FunASR / SenseVoice as a **built-in
speech-to-text provider** so RAGFlow can transcribe audio/video
documents fully self-hosted without setting up a separate
transcription service.

FunASR exposes an OpenAI-compatible HTTP server at
`/v1/audio/transcriptions` — typical launch is:

```bash
pip install funasr
funasr-server --device cuda
# serves http://localhost:8000/v1
```

…so this is the same one-class subclass pattern the other
self-hosted OpenAI-compat providers (GiteeAI, DeepInfra, CometAPI,
FuturMix, RAGcon) already use.

## Why FunASR

(from the issue)

- **Self-hosted** — aligns with RAGFlow's self-hosted philosophy
- **OpenAI-compatible API** — no custom HTTP code on our side
- **Fast** — SenseVoice is ~5× faster than Whisper
  (non-autoregressive, 234M params)
- **50+ languages** with automatic language detection
- **One toolkit** — VAD + ASR + punctuation + speaker diarization

## Files changed

| File | Change |
|---|---|
| `rag/llm/sequence2txt_model.py` | New `FunASRSeq2txt(GPTSeq2txt)` class. `_FACTORY_NAME = "FunASR"`. Defaults `base_url="http://localhost:8000/v1"` and `model_name="SenseVoiceSmall"`. Empty `key` is replaced with `"funasr"` so the OpenAI client constructs. `transcription()` is inherited from `Base`. |
| `conf/llm_factories.json` | New factory entry `{"name": "FunASR", "tags": "SPEECH2TEXT", "status": "1", "llm": []}`. `rag/llm/__init__.py` auto-discovers it by `_FACTORY_NAME`. |
| `web/src/constants/llm.ts` | `LLMFactory.FunASR = 'FunASR'` + `IconMap[FunASR] = 'funasr'`. |
| `web/src/pages/user-setting/constants.tsx` | Added to `LocalLlmFactories` so the local-server config modal handles it. |
| `web/src/pages/user-setting/setting-model/modal/ollama-modal/index.tsx` | `optionsMap[FunASR] = ['speech2text']` (single allowed model type) + docs URL to the FunASR GitHub repo. |

## What's intentionally **not** in this PR

- **Custom asset.** `IconMap[FunASR] = 'funasr'` references
  `funasr.svg` (or `.png`); follow the project's usual icon-asset
  PR pattern to drop it in.
- **Local server bundling.** RAGFlow remains a *remote client* of
  FunASR, mirroring the MinerU / Docling / OpenDataLoader story.
  Users run `funasr-server` themselves.
- **i18n strings.** No new copy added; the existing model-type
  labels carry the UX.

## Validation done in the sandbox

- `python -c "import ast; ast.parse('rag/llm/sequence2txt_model.py')"` ✓
- `python -c "import json; json.load(open('conf/llm_factories.json'))"` ✓
- Runtime smoke-load of the new class via `importlib.util` with
  project-internal deps stubbed: confirmed
  - `_FACTORY_NAME == "FunASR"` (matches JSON entry and FE enum)
  - MRO is `FunASRSeq2txt → GPTSeq2txt → Base → ABC → object` so
    `transcription()` is inherited correctly
  - constructs with both default and custom `base_url`
  - empty `key` is replaced with `"funasr"` before reaching the
    OpenAI client (verified `client.kw = {'api_key': 'funasr',
    'base_url': '…/v1'}`)
- `grep -c "FunASR"` confirms wiring touches all 5 files.

## Validation **not** done in the sandbox

The local venv isn't `uv sync`'d (project deps missing) and the
sandbox blocked the `pip install` of `pytest`. Please run in CI:

- [ ] `uv run pytest` — the changes are purely additive (no
      existing fixture or service touched), so this should be a
      no-op for existing tests.
- [ ] `cd web && npm run build` — frontend changes are data-only
      (enum member, Record entries, array push) so are type-safe by
      construction, but a full TS check confirms.

## Test plan

- [ ] Start FunASR locally:
      `funasr-server --device cuda` (defaults to
      `http://localhost:8000/v1`).
- [ ] In **Model providers**, FunASR appears in the list with the
      `SPEECH2TEXT` tag.
- [ ] Click **Add the model** on FunASR; the modal shows
      `speech2text` as the only model type (not `chat` / `embedding`
      / `rerank`). Default `base_url` shows
      `http://localhost:8000/v1`, default `llm_name` is
      `SenseVoiceSmall`. The "Verify" button hits the live server
      and returns a green check.
- [ ] Set FunASR as the tenant **Sequence2Text** model. Ingest an
      audio file (e.g. `.mp3` / `.wav` / `.m4a`). Transcript appears
      in the parsed document with correct text.
- [ ] Repeat with a video file (the existing audio-extract path)
      and confirm transcript ingestion.
- [ ] Custom remote endpoint:
      `base_url=http://gpu-host:9090/v1`, model
      `paraformer-zh`. Same flow works against a non-default host
      and a non-default model.
- [ ] Empty API-key field — the modal still saves and verification
      succeeds (the placeholder `funasr` is substituted server-side
      so the OpenAI client constructs).

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
