### PR TITLE
feat(connector): implement Linear data source

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -156,6 +156,7 @@ class FileSource(StrEnum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    LINEAR = "linear"
 
 
 class PipelineTaskType(StrEnum):

--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -36,6 +36,7 @@ from .jira.connector import JiraConnector
 from .sharepoint_connector import SharePointConnector
 from .onedrive_connector import OneDriveConnector
 from .outlook_connector import OutlookConnector
+from .linear_connector import LinearConnector
 from .teams_connector import TeamsConnector
 from .moodle_connector import MoodleConnector
 from .airtable_connector import AirtableConnector
@@ -71,6 +72,7 @@ __all__ = [
     "SharePointConnector",
     "OneDriveConnector",
     "OutlookConnector",
+    "LinearConnector",
     "TeamsConnector",
     "MoodleConnector",
     "BlobType",

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -71,6 +71,7 @@ class DocumentSource(str, Enum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    LINEAR = "linear"
 
 
 class FileOrigin(str, Enum):

--- a/common/data_source/linear_connector.py
+++ b/common/data_source/linear_connector.py
@@ -1,0 +1,510 @@
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+from common.data_source.config import INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS, DocumentSource
+from common.data_source.exceptions import ConnectorMissingCredentialError, ConnectorValidationError
+from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
+from common.data_source.models import (
+    BasicExpertInfo,
+    Document,
+    GenerateDocumentsOutput,
+    GenerateSlimDocumentOutput,
+    SecondsSinceUnixEpoch,
+    SlimDocument,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LINEAR_API_URL = "https://api.linear.app/graphql"
+_USER_AGENT = "RAGFlow"
+
+_ISSUES_QUERY = """
+query LinearIssues($first: Int!, $after: String, $includeArchived: Boolean!) {
+  issues(first: $first, after: $after, includeArchived: $includeArchived, orderBy: updatedAt) {
+    nodes {
+      id
+      identifier
+      title
+      description
+      url
+      createdAt
+      updatedAt
+      archivedAt
+      priority
+      priorityLabel
+      state { id name type }
+      assignee { id name displayName email }
+      creator { id name displayName email }
+      team { id name key }
+      project { id name description url state updatedAt }
+      cycle { id name number startsAt endsAt }
+      labels { nodes { id name } }
+      comments(first: 50) {
+        nodes {
+          id
+          body
+          createdAt
+          updatedAt
+          url
+          user { id name displayName email }
+        }
+      }
+      attachments(first: 50) {
+        nodes {
+          id
+          title
+          subtitle
+          url
+          createdAt
+          updatedAt
+          creator { id name displayName email }
+        }
+      }
+    }
+    pageInfo { endCursor hasNextPage }
+  }
+}
+"""
+
+_PROJECTS_QUERY = """
+query LinearProjects($first: Int!, $after: String, $includeArchived: Boolean!) {
+  projects(first: $first, after: $after, includeArchived: $includeArchived, orderBy: updatedAt) {
+    nodes {
+      id
+      name
+      description
+      url
+      state
+      startDate
+      targetDate
+      createdAt
+      updatedAt
+      archivedAt
+      creator { id name displayName email }
+      lead { id name displayName email }
+      teams { nodes { id name key } }
+    }
+    pageInfo { endCursor hasNextPage }
+  }
+}
+"""
+
+_VIEWER_QUERY = "query LinearViewer { viewer { id name displayName email } }"
+
+
+class LinearConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    def __init__(
+        self,
+        team_ids: list[str] | str | None = None,
+        project_ids: list[str] | str | None = None,
+        include_archived: bool = False,
+        include_comments: bool = True,
+        include_attachments: bool = True,
+        include_projects: bool = True,
+        batch_size: int = INDEX_BATCH_SIZE,
+        api_url: str = _DEFAULT_LINEAR_API_URL,
+    ) -> None:
+        self.team_ids = self._normalize_id_list(team_ids)
+        self.project_ids = self._normalize_id_list(project_ids)
+        self.include_archived = include_archived
+        self.include_comments = include_comments
+        self.include_attachments = include_attachments
+        self.include_projects = include_projects
+        self.batch_size = batch_size
+        self.api_url = api_url
+        self.credentials: dict[str, Any] = {}
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": _USER_AGENT})
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self.credentials = credentials or {}
+        return None
+
+    def validate_connector_settings(self) -> None:
+        self._require_credentials()
+        if self.batch_size < 1:
+            raise ConnectorValidationError("batch_size must be at least 1")
+        self._graphql(_VIEWER_QUERY)
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        yield from self._load_documents()
+
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> GenerateDocumentsOutput:
+        yield from self._load_documents(start=start, end=end)
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        callback: Any = None,
+    ) -> GenerateSlimDocumentOutput:
+        del callback
+
+        batch: list[SlimDocument] = []
+        for issue in self._iter_issues():
+            batch.append(SlimDocument(id=self._issue_document_id(issue)))
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+
+        if self.include_projects:
+            for project in self._iter_projects():
+                batch.append(SlimDocument(id=self._project_document_id(project)))
+                if len(batch) >= self.batch_size:
+                    yield batch
+                    batch = []
+
+        if batch:
+            yield batch
+
+    def _load_documents(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+    ) -> GenerateDocumentsOutput:
+        batch: list[Document] = []
+        for issue in self._iter_issues():
+            updated_at = self._parse_linear_datetime(issue.get("updatedAt"))
+            if not self._is_in_poll_range(updated_at, start, end):
+                continue
+            batch.append(self._build_issue_document(issue, updated_at))
+            if len(batch) >= self.batch_size:
+                logger.debug("Emitting Linear issue document batch size=%s", len(batch))
+                yield batch
+                batch = []
+
+        if self.include_projects:
+            for project in self._iter_projects():
+                updated_at = self._parse_linear_datetime(project.get("updatedAt"))
+                if not self._is_in_poll_range(updated_at, start, end):
+                    continue
+                batch.append(self._build_project_document(project, updated_at))
+                if len(batch) >= self.batch_size:
+                    logger.debug("Emitting Linear document batch size=%s", len(batch))
+                    yield batch
+                    batch = []
+
+        if batch:
+            logger.debug("Emitting final Linear document batch size=%s", len(batch))
+            yield batch
+
+    def _iter_issues(self) -> list[dict[str, Any]]:
+        issues: list[dict[str, Any]] = []
+        after = None
+        while True:
+            payload = self._graphql(
+                _ISSUES_QUERY,
+                {
+                    "first": min(max(self.batch_size, 1), 100),
+                    "after": after,
+                    "includeArchived": self.include_archived,
+                },
+            )
+            connection = payload.get("issues") or {}
+            page_issues = [
+                issue
+                for issue in connection.get("nodes") or []
+                if self._matches_issue_scope(issue)
+            ]
+            issues.extend(page_issues)
+            page_info = connection.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            after = page_info.get("endCursor")
+        logger.info("Loaded %s Linear issue(s)", len(issues))
+        return issues
+
+    def _iter_projects(self) -> list[dict[str, Any]]:
+        projects: list[dict[str, Any]] = []
+        after = None
+        while True:
+            payload = self._graphql(
+                _PROJECTS_QUERY,
+                {
+                    "first": min(max(self.batch_size, 1), 100),
+                    "after": after,
+                    "includeArchived": self.include_archived,
+                },
+            )
+            connection = payload.get("projects") or {}
+            page_projects = [
+                project
+                for project in connection.get("nodes") or []
+                if self._matches_project_scope(project)
+            ]
+            projects.extend(page_projects)
+            page_info = connection.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            after = page_info.get("endCursor")
+        logger.info("Loaded %s Linear project(s)", len(projects))
+        return projects
+
+    def _build_issue_document(
+        self,
+        issue: dict[str, Any],
+        updated_at: datetime,
+    ) -> Document:
+        content = self._build_issue_content(issue)
+        blob = content.encode("utf-8")
+        labels = self._connection_nodes(issue.get("labels"))
+        metadata = {
+            "type": "issue",
+            "issue_id": issue.get("id"),
+            "identifier": issue.get("identifier"),
+            "url": issue.get("url"),
+            "state": (issue.get("state") or {}).get("name"),
+            "priority": issue.get("priority"),
+            "priority_label": issue.get("priorityLabel"),
+            "team_id": (issue.get("team") or {}).get("id"),
+            "team_key": (issue.get("team") or {}).get("key"),
+            "project_id": (issue.get("project") or {}).get("id"),
+            "project_name": (issue.get("project") or {}).get("name"),
+            "labels": [label.get("name") for label in labels if label.get("name")],
+            "archived_at": issue.get("archivedAt"),
+        }
+        return Document(
+            id=self._issue_document_id(issue),
+            source=DocumentSource.LINEAR,
+            semantic_identifier=issue.get("identifier")
+            or issue.get("title")
+            or issue.get("id"),
+            extension=".md",
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            primary_owners=[
+                self._user_to_expert(issue.get("assignee") or issue.get("creator"))
+            ],
+            metadata=metadata,
+            fingerprint=hashlib.md5(blob).hexdigest(),
+        )
+
+    def _build_project_document(
+        self,
+        project: dict[str, Any],
+        updated_at: datetime,
+    ) -> Document:
+        content = self._build_project_content(project)
+        blob = content.encode("utf-8")
+        teams = self._connection_nodes(project.get("teams"))
+        metadata = {
+            "type": "project",
+            "project_id": project.get("id"),
+            "url": project.get("url"),
+            "state": project.get("state"),
+            "team_ids": [team.get("id") for team in teams if team.get("id")],
+            "team_keys": [team.get("key") for team in teams if team.get("key")],
+            "archived_at": project.get("archivedAt"),
+        }
+        return Document(
+            id=self._project_document_id(project),
+            source=DocumentSource.LINEAR,
+            semantic_identifier=project.get("name") or project.get("id"),
+            extension=".md",
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            primary_owners=[
+                self._user_to_expert(project.get("lead") or project.get("creator"))
+            ],
+            metadata=metadata,
+            fingerprint=hashlib.md5(blob).hexdigest(),
+        )
+
+    def _build_issue_content(self, issue: dict[str, Any]) -> str:
+        parts = [
+            f"Issue: {issue.get('identifier', '')} {issue.get('title', '')}".strip(),
+            f"URL: {issue.get('url', '')}",
+            f"State: {(issue.get('state') or {}).get('name', '')}",
+            f"Team: {(issue.get('team') or {}).get('name', '')}",
+        ]
+        project = issue.get("project") or {}
+        if project:
+            parts.append(f"Project: {project.get('name', '')}")
+        if issue.get("priorityLabel"):
+            parts.append(f"Priority: {issue.get('priorityLabel')}")
+        if issue.get("description"):
+            parts.append("Description:\n" + issue["description"].strip())
+
+        comments = (
+            self._connection_nodes(issue.get("comments"))
+            if self.include_comments
+            else []
+        )
+        if comments:
+            parts.append("Comments:")
+            for comment in comments:
+                user = comment.get("user") or {}
+                author = user.get("displayName") or user.get("name") or "Unknown"
+                parts.append(
+                    f"- {author} ({comment.get('updatedAt') or comment.get('createdAt', '')}): "
+                    f"{comment.get('body', '')}"
+                )
+
+        attachments = (
+            self._connection_nodes(issue.get("attachments"))
+            if self.include_attachments
+            else []
+        )
+        if attachments:
+            parts.append("Attachments:")
+            for attachment in attachments:
+                title = (
+                    attachment.get("title")
+                    or attachment.get("subtitle")
+                    or attachment.get("id")
+                )
+                parts.append(f"- {title}: {attachment.get('url', '')}".strip())
+
+        return "\n\n".join(part for part in parts if part).strip()
+
+    def _build_project_content(self, project: dict[str, Any]) -> str:
+        teams = self._connection_nodes(project.get("teams"))
+        parts = [
+            f"Project: {project.get('name', '')}",
+            f"URL: {project.get('url', '')}",
+            f"State: {project.get('state', '')}",
+        ]
+        if teams:
+            parts.append(
+                "Teams: "
+                + ", ".join(
+                    team.get("name") or team.get("key") or team.get("id")
+                    for team in teams
+                )
+            )
+        if project.get("targetDate"):
+            parts.append(f"Target date: {project.get('targetDate')}")
+        if project.get("description"):
+            parts.append("Description:\n" + project["description"].strip())
+        return "\n\n".join(part for part in parts if part).strip()
+
+    def _graphql(
+        self,
+        query: str,
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self._require_credentials()
+        headers = {
+            "Authorization": self.credentials["linear_api_key"],
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        try:
+            response = self.session.post(
+                self.api_url,
+                json={"query": query, "variables": variables or {}},
+                headers=headers,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException:
+            logger.exception("Linear GraphQL request failed before response")
+            raise
+
+        if response.status_code < 200 or response.status_code >= 300:
+            logger.warning(
+                "Linear GraphQL request failed status_code=%s",
+                response.status_code,
+            )
+            raise requests.exceptions.HTTPError(
+                f"{response.status_code} Error for url: {self.api_url}",
+                response=response,
+            )
+
+        payload = response.json()
+        if payload.get("errors"):
+            messages = ", ".join(
+                str(error.get("message", error)) for error in payload["errors"]
+            )
+            raise ConnectorValidationError(f"Linear GraphQL error: {messages}")
+        return payload.get("data") or {}
+
+    def _require_credentials(self) -> None:
+        if not self.credentials.get("linear_api_key"):
+            raise ConnectorMissingCredentialError("Linear")
+
+    def _matches_issue_scope(self, issue: dict[str, Any]) -> bool:
+        team_id = (issue.get("team") or {}).get("id")
+        project_id = (issue.get("project") or {}).get("id")
+        if self.team_ids and team_id not in self.team_ids:
+            return False
+        if self.project_ids and project_id not in self.project_ids:
+            return False
+        return True
+
+    def _matches_project_scope(self, project: dict[str, Any]) -> bool:
+        if self.project_ids and project.get("id") not in self.project_ids:
+            return False
+        if not self.team_ids:
+            return True
+        teams = self._connection_nodes(project.get("teams"))
+        return any(team.get("id") in self.team_ids for team in teams)
+
+    @staticmethod
+    def _connection_nodes(connection: Any) -> list[dict[str, Any]]:
+        if not isinstance(connection, dict):
+            return []
+        nodes = connection.get("nodes")
+        if isinstance(nodes, list):
+            return [node for node in nodes if isinstance(node, dict)]
+        return []
+
+    @staticmethod
+    def _is_in_poll_range(
+        value: datetime,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,
+    ) -> bool:
+        timestamp = value.timestamp()
+        if start is not None and timestamp <= start:
+            return False
+        if end is not None and timestamp > end:
+            return False
+        return True
+
+    @staticmethod
+    def _parse_linear_datetime(value: Any) -> datetime:
+        if not isinstance(value, str) or not value.strip():
+            return datetime.fromtimestamp(0, tz=timezone.utc)
+        normalized = value.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            logger.warning("Invalid Linear timestamp value: %r", value)
+            return datetime.fromtimestamp(0, tz=timezone.utc)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _normalize_id_list(value: list[str] | str | None) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            raw_items = value.split(",")
+        else:
+            raw_items = value
+        return [str(item).strip() for item in raw_items if str(item).strip()]
+
+    @staticmethod
+    def _user_to_expert(user: Any) -> BasicExpertInfo:
+        user = user or {}
+        return BasicExpertInfo(
+            display_name=user.get("displayName") or user.get("name"),
+            email=user.get("email"),
+        )
+
+    @staticmethod
+    def _issue_document_id(issue: dict[str, Any]) -> str:
+        return f"linear:issue:{issue['id']}"
+
+    @staticmethod
+    def _project_document_id(project: dict[str, Any]) -> str:
+        return f"linear:project:{project['id']}"

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -63,6 +63,7 @@ from common.data_source import (
     RestAPIConnector,
     OneDriveConnector,
     OutlookConnector,
+    LinearConnector,
     TeamsConnector,
     SlackConnector,
     SharePointConnector,
@@ -1444,6 +1445,61 @@ class Asana(SyncBase):
 
         return document_generator
 
+
+class Linear(SyncBase):
+    SOURCE_NAME: str = FileSource.LINEAR
+
+    async def _generate(self, task: dict):
+        raw_batch_size = self.conf.get("batch_size", INDEX_BATCH_SIZE)
+        try:
+            batch_size = int(raw_batch_size)
+        except (TypeError, ValueError):
+            batch_size = INDEX_BATCH_SIZE
+        if batch_size <= 0:
+            batch_size = INDEX_BATCH_SIZE
+
+        self.connector = LinearConnector(
+            team_ids=self.conf.get("team_ids"),
+            project_ids=self.conf.get("project_ids"),
+            include_archived=self._as_bool(self.conf.get("include_archived", False)),
+            include_comments=self._as_bool(self.conf.get("include_comments", True)),
+            include_attachments=self._as_bool(self.conf.get("include_attachments", True)),
+            include_projects=self._as_bool(self.conf.get("include_projects", True)),
+            batch_size=batch_size,
+        )
+
+        credentials = self.conf.get("credentials", {})
+        self.connector.load_credentials(
+            {"linear_api_key": credentials.get("linear_api_key")}
+        )
+        self.connector.validate_connector_settings()
+
+        poll_start = task.get("poll_range_start")
+        if task.get("reindex") == "1" or not poll_start:
+            document_generator = self.connector.load_from_state()
+        else:
+            document_generator = self.connector.poll_source(
+                poll_start.timestamp(),
+                datetime.now(timezone.utc).timestamp(),
+            )
+
+        self.log_connection(
+            "Linear",
+            f"team_ids({self.conf.get('team_ids') or '<all-teams>'}), "
+            f"project_ids({self.conf.get('project_ids') or '<all-projects>'})",
+            task,
+        )
+        return document_generator
+
+    @staticmethod
+    def _as_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() not in {"false", "0", "no", "off", ""}
+        return bool(value)
+
+
 class Github(SyncBase):
     SOURCE_NAME: str = FileSource.GITHUB
 
@@ -1998,6 +2054,7 @@ func_factory = {
     FileSource.BOX: BOX,
     FileSource.AIRTABLE: Airtable,
     FileSource.ASANA: Asana,
+    FileSource.LINEAR: Linear,
     FileSource.IMAP: IMAP,
     FileSource.ZENDESK: Zendesk,
     FileSource.GITHUB: Github,

--- a/test/unit_test/data_source/test_linear_connector_unit.py
+++ b/test/unit_test/data_source/test_linear_connector_unit.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from common.data_source.exceptions import (
+    ConnectorMissingCredentialError,
+    ConnectorValidationError,
+)
+from common.data_source.linear_connector import LinearConnector
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    def post(
+        self,
+        url: str,
+        json: dict[str, Any],
+        headers: dict[str, str],
+        timeout: int,
+    ) -> FakeResponse:
+        del url, timeout
+        self.calls.append({"json": json, "headers": headers})
+        query = json["query"]
+        if "viewer" in query:
+            return FakeResponse({"data": {"viewer": {"id": "u1", "name": "Alice"}}})
+        if "issues" in query:
+            return FakeResponse({"data": {"issues": self._issues_connection()}})
+        if "projects" in query:
+            return FakeResponse({"data": {"projects": self._projects_connection()}})
+        return FakeResponse(self.payload or {"data": {}})
+
+    @staticmethod
+    def _issues_connection() -> dict[str, Any]:
+        return {
+            "nodes": [
+                {
+                    "id": "issue-1",
+                    "identifier": "ENG-1",
+                    "title": "Ship Linear connector",
+                    "description": "Implement Linear sync.",
+                    "url": "https://linear.app/acme/issue/ENG-1",
+                    "createdAt": "2026-06-01T10:00:00.000Z",
+                    "updatedAt": "2026-06-01T12:00:00.000Z",
+                    "archivedAt": None,
+                    "priority": 1,
+                    "priorityLabel": "Urgent",
+                    "state": {"id": "state-1", "name": "In Progress", "type": "started"},
+                    "assignee": {
+                        "id": "u1",
+                        "displayName": "Alice",
+                        "email": "alice@example.com",
+                    },
+                    "creator": {
+                        "id": "u2",
+                        "displayName": "Bob",
+                        "email": "bob@example.com",
+                    },
+                    "team": {"id": "team-1", "name": "Engineering", "key": "ENG"},
+                    "project": {
+                        "id": "project-1",
+                        "name": "Connectors",
+                        "description": "Data source connectors",
+                        "url": "https://linear.app/acme/project/connectors",
+                        "state": "started",
+                        "updatedAt": "2026-06-01T12:00:00.000Z",
+                    },
+                    "cycle": {"id": "cycle-1", "name": "Cycle 1", "number": 1},
+                    "labels": {"nodes": [{"id": "label-1", "name": "Backend"}]},
+                    "comments": {
+                        "nodes": [
+                            {
+                                "id": "comment-1",
+                                "body": "Looks good.",
+                                "createdAt": "2026-06-01T13:00:00.000Z",
+                                "updatedAt": "2026-06-01T13:00:00.000Z",
+                                "url": "https://linear.app/acme/issue/ENG-1#comment-comment-1",
+                                "user": {"id": "u3", "displayName": "Carol"},
+                            }
+                        ]
+                    },
+                    "attachments": {
+                        "nodes": [
+                            {
+                                "id": "attachment-1",
+                                "title": "Design",
+                                "url": "https://example.com/design",
+                                "createdAt": "2026-06-01T14:00:00.000Z",
+                                "updatedAt": "2026-06-01T14:00:00.000Z",
+                            }
+                        ]
+                    },
+                },
+                {
+                    "id": "issue-2",
+                    "identifier": "OPS-1",
+                    "title": "Other team issue",
+                    "description": "",
+                    "url": "https://linear.app/acme/issue/OPS-1",
+                    "updatedAt": "2026-05-01T12:00:00.000Z",
+                    "team": {"id": "team-2", "name": "Operations", "key": "OPS"},
+                    "project": None,
+                    "labels": {"nodes": []},
+                    "comments": {"nodes": []},
+                    "attachments": {"nodes": []},
+                },
+            ],
+            "pageInfo": {"endCursor": None, "hasNextPage": False},
+        }
+
+    @staticmethod
+    def _projects_connection() -> dict[str, Any]:
+        return {
+            "nodes": [
+                {
+                    "id": "project-1",
+                    "name": "Connectors",
+                    "description": "Data source connectors",
+                    "url": "https://linear.app/acme/project/connectors",
+                    "state": "started",
+                    "startDate": "2026-06-01",
+                    "targetDate": "2026-06-30",
+                    "createdAt": "2026-06-01T09:00:00.000Z",
+                    "updatedAt": "2026-06-02T12:00:00.000Z",
+                    "archivedAt": None,
+                    "creator": {"id": "u2", "displayName": "Bob"},
+                    "lead": {"id": "u1", "displayName": "Alice"},
+                    "teams": {
+                        "nodes": [{"id": "team-1", "name": "Engineering", "key": "ENG"}]
+                    },
+                }
+            ],
+            "pageInfo": {"endCursor": None, "hasNextPage": False},
+        }
+
+
+def make_connector(**kwargs: Any) -> LinearConnector:
+    connector = LinearConnector(api_url="https://linear.test/graphql", **kwargs)
+    connector.session = FakeSession()
+    connector.load_credentials({"linear_api_key": "linear-key"})
+    return connector
+
+
+@pytest.mark.p1
+def test_linear_connector_builds_issue_and_project_documents() -> None:
+    connector = make_connector(team_ids=["team-1"])
+
+    batches = list(connector.load_from_state())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [
+        ["linear:issue:issue-1", "linear:project:project-1"]
+    ]
+    issue_doc = batches[0][0]
+    issue_text = issue_doc.blob.decode("utf-8")
+    assert issue_doc.source == "linear"
+    assert issue_doc.semantic_identifier == "ENG-1"
+    assert issue_doc.metadata["team_key"] == "ENG"
+    assert issue_doc.metadata["project_name"] == "Connectors"
+    assert "Implement Linear sync." in issue_text
+    assert "Looks good." in issue_text
+    assert "Design" in issue_text
+    assert issue_doc.fingerprint
+
+
+@pytest.mark.p1
+def test_linear_connector_poll_source_filters_by_updated_at() -> None:
+    connector = make_connector(team_ids=["team-1"], include_projects=False)
+    start = datetime(2026, 6, 1, 11, 0, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc).timestamp()
+
+    batches = list(connector.poll_source(start, end))
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["linear:issue:issue-1"]]
+
+
+@pytest.mark.p1
+def test_linear_connector_retrieves_slim_docs() -> None:
+    connector = make_connector(team_ids=["team-1"])
+
+    batches = list(connector.retrieve_all_slim_docs_perm_sync())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [
+        ["linear:issue:issue-1", "linear:project:project-1"]
+    ]
+
+
+@pytest.mark.p1
+def test_linear_connector_requires_credentials() -> None:
+    connector = LinearConnector()
+
+    with pytest.raises(ConnectorMissingCredentialError):
+        connector.validate_connector_settings()
+
+
+@pytest.mark.p1
+def test_linear_connector_raises_graphql_errors() -> None:
+    connector = LinearConnector(api_url="https://linear.test/graphql")
+    connector.session = FakeSession({"errors": [{"message": "Invalid API key"}]})
+    connector.load_credentials({"linear_api_key": "linear-key"})
+
+    with pytest.raises(ConnectorValidationError, match="Invalid API key"):
+        connector._graphql("query Something { something }")

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1270,6 +1270,14 @@ Example: Virtual Hosted Style`,
         'Connect to Dingtalk AI Table and synchronize records from a specified table.',
       gitlabDescription:
         'Connect GitLab to sync repositories, issues, merge requests, and related documentation.',
+      linearDescription:
+        'Connect Linear to sync issues, comments, projects, and attachment metadata.',
+      linearApiKeyTip:
+        'Create a Linear personal API key from Linear workspace API settings.',
+      linearTeamIdsTip:
+        'Optional: Linear team IDs to sync. Leave empty to sync all teams visible to the API key.',
+      linearProjectIdsTip:
+        'Optional: Linear project IDs to sync. Leave empty to sync all projects visible to the API key.',
       asanaDescription:
         'Connect to Asana and synchronize files from a specified workspace.',
       imapDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1148,6 +1148,13 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       dingtalkAITableDescription: '连接钉钉AI表格，同步指定表格中的记录。',
       gitlabDescription:
         '连接 GitLab，同步仓库、Issue、合并请求（MR）及相关文档内容。',
+      linearDescription:
+        '连接 Linear，同步 Issue、评论、项目和附件元数据。',
+      linearApiKeyTip: '请从 Linear 工作区 API 设置中创建个人 API Key。',
+      linearTeamIdsTip:
+        '可选：要同步的 Linear Team ID。留空则同步该 API Key 可见的所有团队。',
+      linearProjectIdsTip:
+        '可选：要同步的 Linear Project ID。留空则同步该 API Key 可见的所有项目。',
       asanaDescription: '连接 Asana，同步工作区中的文件。',
       imapDescription:
         '连接你的 IMAP 邮箱，同步指定mailboxes中的邮件，用于知识检索与分析',

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -2,7 +2,7 @@ import { FormFieldConfig, FormFieldType } from '@/components/dynamic-form';
 import { IconFontFill } from '@/components/icon-font';
 import SvgIcon from '@/components/svg-icon';
 import { t, TFunction } from 'i18next';
-import { Mail, Rss } from 'lucide-react';
+import { ListTodo, Mail, Rss } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BoxTokenField from '../component/box-token-field';
@@ -48,6 +48,7 @@ export enum DataSourceKey {
   TEAMS = 'teams',
   SLACK = 'slack',
   SHAREPOINT = 'sharepoint',
+  LINEAR = 'linear',
 }
 
 type DataSourceFeatureVisibility = {
@@ -144,6 +145,9 @@ export const DataSourceFeatureVisibilityMap: Partial<
     syncDeletedFiles: true,
   },
   [DataSourceKey.SHAREPOINT]: {
+    syncDeletedFiles: true,
+  },
+  [DataSourceKey.LINEAR]: {
     syncDeletedFiles: true,
   },
   [DataSourceKey.MYSQL]: {
@@ -334,6 +338,11 @@ export const generateDataSourceInfo = (t: TFunction) => {
       name: 'Outlook',
       description: t(`setting.${DataSourceKey.OUTLOOK}Description`),
       icon: <Mail className="text-text-primary" size={22} />,
+    },
+    [DataSourceKey.LINEAR]: {
+      name: 'Linear',
+      description: t(`setting.${DataSourceKey.LINEAR}Description`),
+      icon: <ListTodo className="text-text-primary" size={22} />,
     },
   };
 };
@@ -1034,6 +1043,67 @@ export const DataSourceFormFields = {
       name: 'config.asana_team_id',
       type: FormFieldType.Text,
       required: false,
+    },
+  ],
+  [DataSourceKey.LINEAR]: [
+    {
+      label: 'Linear API Key',
+      name: 'config.credentials.linear_api_key',
+      type: FormFieldType.Password,
+      required: true,
+      tooltip: t('setting.linearApiKeyTip'),
+    },
+    {
+      label: 'Team IDs',
+      name: 'config.team_ids',
+      type: FormFieldType.Tag,
+      required: false,
+      tooltip: t('setting.linearTeamIdsTip'),
+    },
+    {
+      label: 'Project IDs',
+      name: 'config.project_ids',
+      type: FormFieldType.Tag,
+      required: false,
+      tooltip: t('setting.linearProjectIdsTip'),
+    },
+    {
+      label: 'Include Comments',
+      name: 'config.include_comments',
+      type: FormFieldType.Checkbox,
+      required: false,
+      defaultValue: true,
+    },
+    {
+      label: 'Include Attachments',
+      name: 'config.include_attachments',
+      type: FormFieldType.Checkbox,
+      required: false,
+      defaultValue: true,
+    },
+    {
+      label: 'Include Projects',
+      name: 'config.include_projects',
+      type: FormFieldType.Checkbox,
+      required: false,
+      defaultValue: true,
+    },
+    {
+      label: 'Include Archived',
+      name: 'config.include_archived',
+      type: FormFieldType.Checkbox,
+      required: false,
+      defaultValue: false,
+    },
+    {
+      label: 'Batch Size',
+      name: 'config.batch_size',
+      type: FormFieldType.Number,
+      required: false,
+      validation: {
+        min: 1,
+        message: 'Batch Size must be at least 1',
+      },
     },
   ],
   [DataSourceKey.GITHUB]: [
@@ -1846,6 +1916,22 @@ export const DataSourceFormDefaultValues = {
       asana_team_id: '',
       credentials: {
         asana_api_token_secret: '',
+      },
+    },
+  },
+  [DataSourceKey.LINEAR]: {
+    name: '',
+    source: DataSourceKey.LINEAR,
+    config: {
+      team_ids: [],
+      project_ids: [],
+      include_comments: true,
+      include_attachments: true,
+      include_projects: true,
+      include_archived: false,
+      batch_size: 2,
+      credentials: {
+        linear_api_key: '',
       },
     },
   },


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #15547.

Adds Linear as a native data-source connector so RAGFlow can sync Linear issues, comments, projects, and attachment metadata into knowledge bases.

Implementation references Linear's official docs:

- GraphQL API: https://linear.app/developers/graphql
- API and webhooks: https://linear.app/docs/api-and-webhooks
- Attachments: https://linear.app/developers/attachments

### What is changed and how it works?

- Adds `LinearConnector` with Linear GraphQL API-key auth, pagination, issue/project document generation, incremental polling by `updatedAt`, slim-doc sync, and GraphQL error handling.
- Registers `linear` in backend data-source enums, connector exports, and sync dispatch.
- Adds Linear data-source UI settings for API key, optional team/project filters, comments, attachments, projects, archived resources, and batch size.
- Adds English and Chinese locale strings.
- Adds mocked unit tests for document generation, polling, slim docs, missing credentials, and GraphQL errors.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] `git diff --cached --check`
- [x] `python3 -m py_compile common/data_source/linear_connector.py test/unit_test/data_source/test_linear_connector_unit.py rag/svr/sync_data_source.py common/constants.py common/data_source/config.py common/data_source/__init__.py`
- [x] `uv run --python 3.13 --with pytest --with pytest-asyncio pytest test/unit_test/data_source/test_linear_connector_unit.py -q`

Note: frontend type-check was not run locally because `web/node_modules` is not installed in this checkout.
