### PR TITLE
feat[Go]: implement GET /dify/retrieval/health (issue #15240)

### DIFF
--- a/cmd/server_main.go
+++ b/cmd/server_main.go
@@ -217,9 +217,10 @@ func startServer(config *server.Config) {
 		tenantService,
 		&handler.SearchbotRealLLM{Svc: modelProviderService},
 	)
+	difyHandler := handler.NewDifyHandler()
 
 	// Initialize router
-	r := router.NewRouter(authHandler, userHandler, tenantHandler, documentHandler, datasetsHandler, systemHandler, knowledgebaseHandler, chunkHandler, llmHandler, chatHandler, chatSessionHandler, connectorHandler, searchHandler, fileHandler, memoryHandler, mcpHandler, skillSearchHandler, providerHandler, agentHandler, relatedQuestionsHandler)
+	r := router.NewRouter(authHandler, userHandler, tenantHandler, documentHandler, datasetsHandler, systemHandler, knowledgebaseHandler, chunkHandler, llmHandler, chatHandler, chatSessionHandler, connectorHandler, searchHandler, fileHandler, memoryHandler, mcpHandler, skillSearchHandler, providerHandler, agentHandler, relatedQuestionsHandler, difyHandler)
 
 	// Create Gin engine
 	ginEngine := gin.New()

--- a/internal/handler/dify.go
+++ b/internal/handler/dify.go
@@ -33,7 +33,7 @@ func NewDifyHandler() *DifyHandler {
 	return &DifyHandler{}
 }
 
-// RetrievalHealth handles GET /v1/dify/retrieval/health.
+// RetrievalHealth handles GET /api/v1/dify/retrieval/health.
 //
 // Returns a constant success envelope. Dify probes this endpoint to check
 // whether the RAGFlow external-knowledge connector is reachable, so it must
@@ -43,7 +43,7 @@ func NewDifyHandler() *DifyHandler {
 // @Tags     dify
 // @Produce  json
 // @Success  200 {object} map[string]interface{}
-// @Router   /v1/dify/retrieval/health [get]
+// @Router   /api/v1/dify/retrieval/health [get]
 func (h *DifyHandler) RetrievalHealth(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"code":    common.CodeSuccess,

--- a/internal/handler/dify.go
+++ b/internal/handler/dify.go
@@ -1,0 +1,53 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"ragflow/internal/common"
+)
+
+// DifyHandler serves the /dify/* HTTP routes used by Dify external
+// knowledge base connectors. Mirrors api/apps/restful_apis/dify_retrieval_api.py.
+type DifyHandler struct{}
+
+// NewDifyHandler creates a Dify handler.
+func NewDifyHandler() *DifyHandler {
+	return &DifyHandler{}
+}
+
+// RetrievalHealth handles GET /v1/dify/retrieval/health.
+//
+// Returns a constant success envelope. Dify probes this endpoint to check
+// whether the RAGFlow external-knowledge connector is reachable, so it must
+// not gate on auth or dependent infrastructure.
+//
+// @Summary  Dify retrieval health check
+// @Tags     dify
+// @Produce  json
+// @Success  200 {object} map[string]interface{}
+// @Router   /v1/dify/retrieval/health [get]
+func (h *DifyHandler) RetrievalHealth(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"code":    common.CodeSuccess,
+		"message": "success",
+		"data":    true,
+	})
+}

--- a/internal/handler/dify_test.go
+++ b/internal/handler/dify_test.go
@@ -56,8 +56,11 @@ func TestDifyRetrievalHealthReturnsTrueEnvelope(t *testing.T) {
 	}
 }
 
-func TestDifyRetrievalHealthDoesNotRequireAuth(t *testing.T) {
-	// Public probe: must succeed even with no user attached to the context.
+func TestDifyRetrievalHealthHandlerDoesNotReadUser(t *testing.T) {
+	// Handler-scope contract: the handler itself must not call GetUser or
+	// otherwise depend on an authenticated context, so that mounting it on
+	// the public apiNoAuth group succeeds without middleware. Router-level
+	// no-auth placement is verified by the router setup, not here.
 	gin.SetMode(gin.TestMode)
 
 	r := gin.New()
@@ -72,8 +75,10 @@ func TestDifyRetrievalHealthDoesNotRequireAuth(t *testing.T) {
 	}
 
 	var body map[string]interface{}
-	_ = json.Unmarshal(resp.Body.Bytes(), &body)
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, resp.Body.String())
+	}
 	if code, _ := body["code"].(float64); int(code) != int(common.CodeSuccess) {
-		t.Errorf("unauthenticated probe should succeed, got code=%v", body["code"])
+		t.Errorf("handler returned non-success without user context: code=%v", body["code"])
 	}
 }

--- a/internal/handler/dify_test.go
+++ b/internal/handler/dify_test.go
@@ -1,0 +1,79 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"ragflow/internal/common"
+)
+
+func TestDifyRetrievalHealthReturnsTrueEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.GET("/api/v1/dify/retrieval/health", NewDifyHandler().RetrievalHealth)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dify/retrieval/health", nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, resp.Body.String())
+	}
+	if code, _ := body["code"].(float64); int(code) != int(common.CodeSuccess) {
+		t.Errorf("code=%v want=%d body=%v", body["code"], common.CodeSuccess, body)
+	}
+	if msg, _ := body["message"].(string); msg != "success" {
+		t.Errorf("message=%q want=%q", msg, "success")
+	}
+	if got, ok := body["data"].(bool); !ok || got != true {
+		t.Errorf("data=%v want=true body=%v", body["data"], body)
+	}
+}
+
+func TestDifyRetrievalHealthDoesNotRequireAuth(t *testing.T) {
+	// Public probe: must succeed even with no user attached to the context.
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.GET("/api/v1/dify/retrieval/health", NewDifyHandler().RetrievalHealth)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dify/retrieval/health", nil)
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var body map[string]interface{}
+	_ = json.Unmarshal(resp.Body.Bytes(), &body)
+	if code, _ := body["code"].(float64); int(code) != int(common.CodeSuccess) {
+		t.Errorf("unauthenticated probe should succeed, got code=%v", body["code"])
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -43,6 +43,7 @@ type Router struct {
 	providerHandler         *handler.ProviderHandler
 	agentHandler            *handler.AgentHandler
 	relatedQuestionsHandler *handler.SearchbotHandler
+	difyHandler             *handler.DifyHandler
 }
 
 // NewRouter create router
@@ -67,6 +68,7 @@ func NewRouter(
 	providerHandler *handler.ProviderHandler,
 	agentHandler *handler.AgentHandler,
 	relatedQuestionsHandler *handler.SearchbotHandler,
+	difyHandler *handler.DifyHandler,
 ) *Router {
 	return &Router{
 		authHandler:             authHandler,
@@ -89,6 +91,7 @@ func NewRouter(
 		providerHandler:         providerHandler,
 		agentHandler:            agentHandler,
 		relatedQuestionsHandler: relatedQuestionsHandler,
+		difyHandler:             difyHandler,
 	}
 }
 
@@ -147,6 +150,11 @@ func (r *Router) Setup(engine *gin.Engine) {
 		// Google redirects here after Gmail / Google Drive web OAuth completes.
 		apiNoAuth.GET("/connectors/gmail/oauth/web/callback", r.connectorHandler.GmailWebOAuthCallback)
 		apiNoAuth.GET("/connectors/google-drive/oauth/web/callback", r.connectorHandler.GoogleDriveWebOAuthCallback)
+
+		// Dify external knowledge base reachability probe. Public by design:
+		// Dify must be able to test the connector before any credentials are
+		// configured.
+		apiNoAuth.GET("/dify/retrieval/health", r.difyHandler.RetrievalHealth)
 	}
 
 	// Protected routes


### PR DESCRIPTION
## Summary

Port the Dify external-knowledge-base reachability probe to the Go API server. Listed in the Go-API port checklist of #15240.

Dify calls this endpoint to verify that the RAGFlow external-knowledge connector is reachable before the user configures any credentials, so it returns a constant success envelope and stays on the public route group.

## What

- `internal/handler/dify.go` — new `DifyHandler.RetrievalHealth` returning the same `{"code":0, "message":"success", "data":true}` envelope the Python endpoint emits.
- `internal/router/router.go` — wire `apiNoAuth.GET("/dify/retrieval/health", ...)`. Public by design, matching the undecorated Python route.
- `cmd/server_main.go` — instantiate and inject `DifyHandler`.
- `internal/handler/dify_test.go` — unit tests for the envelope shape and confirmation that the probe succeeds without an authenticated user.

## Python source

`api/apps/restful_apis/dify_retrieval_api.py`:

```python
@manager.route('/dify/retrieval/health', methods=['GET'])
async def retrieval_health_check():
    """Health check endpoint for Dify external knowledge base connectivity verification."""
    return get_json_result(data=True)
```

## Test plan

- [x] `go vet ./internal/handler ./internal/router` clean
- [x] Unit tests cover the response envelope and the no-auth contract
- [ ] CI runs `go test ./internal/handler` with cgo binding linked

## Related

- Tracker: #15240