### PR TITLE
feat[Go]: implement DELETE /agents/:agent_id (issue #15240)

### DIFF
--- a/internal/dao/user_canvas.go
+++ b/internal/dao/user_canvas.go
@@ -53,6 +53,17 @@ func (dao *UserCanvasDAO) Delete(id string) error {
 	return DB.Delete(&entity.UserCanvas{}, id).Error
 }
 
+// DeleteByIDOwnedBy deletes the canvas in a single SQL statement that gates
+// on user_id, so a non-owner can never delete someone else's row. Returns the
+// number of rows affected (0 = no matching owned canvas) and any DB error.
+//
+// Mirrors the Python `_require_canvas_owner_sync` decorator + delete_by_id
+// flow, but collapses the check and the delete into one atomic statement.
+func (dao *UserCanvasDAO) DeleteByIDOwnedBy(canvasID, userID string) (int64, error) {
+	result := DB.Where("id = ? AND user_id = ?", canvasID, userID).Delete(&entity.UserCanvas{})
+	return result.RowsAffected, result.Error
+}
+
 // GetList get canvases list with pagination and filtering
 // Similar to Python UserCanvasService.get_list
 func (dao *UserCanvasDAO) GetList(tenantID string, pageNumber, itemsPerPage int, orderby string, desc bool, id, title string, canvasCategory string) ([]*entity.UserCanvas, error) {

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -390,6 +390,42 @@ func (h *AgentHandler) ListTemplates(c *gin.Context) {
 	})
 }
 
+// DeleteAgent removes the canvas owned by the calling user.
+// @Summary Delete Agent
+// @Tags agents
+// @Produce json
+// @Security ApiKeyAuth
+// @Param agent_id path string true "Agent canvas ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/agents/{agent_id} [delete]
+func (h *AgentHandler) DeleteAgent(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		jsonError(c, errorCode, errorMessage)
+		return
+	}
+	agentID := c.Param("agent_id")
+	if agentID == "" {
+		jsonError(c, common.CodeArgumentError, "agent_id is required")
+		return
+	}
+
+	code, err := h.agentService.DeleteAgent(agentID, user.ID)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"code":    code,
+			"data":    false,
+			"message": err.Error(),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"code":    common.CodeSuccess,
+		"data":    true,
+		"message": "success",
+	})
+}
+
 // UploadAgentFile uploads one or more files associated with an agent.
 // @Summary Upload Agent File
 // @Description Upload one or more files for an agent canvas.

--- a/internal/handler/agent_test.go
+++ b/internal/handler/agent_test.go
@@ -592,12 +592,18 @@ type fakeAgentService struct {
 	err          error
 	templates    []*entity.CanvasTemplate
 	templatesErr error
+
+	deleteCode common.ErrorCode
+	deleteErr  error
+	deletedID  string
+	deletedBy  string
 }
 
 // agentServiceIface is the minimum interface the handler depends on.
 type agentServiceIface interface {
 	ListAgents(userID, keywords string, page, pageSize int, orderby string, desc bool, ownerIDs []string, canvasCategory string) (*service.ListAgentsResponse, common.ErrorCode, error)
 	ListTemplates() ([]*entity.CanvasTemplate, error)
+	DeleteAgent(agentID, tenantID string) (common.ErrorCode, error)
 }
 
 // agentHandlerTestable is a version of AgentHandler that accepts the interface.
@@ -635,12 +641,33 @@ func (h *agentHandlerTestable) listTemplates(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": templates, "message": "success"})
 }
 
+func (h *agentHandlerTestable) deleteAgent(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		jsonError(c, errorCode, errorMessage)
+		return
+	}
+	agentID := c.Param("agent_id")
+	code, err := h.svc.DeleteAgent(agentID, user.ID)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"code": code, "data": false, "message": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": true, "message": "success"})
+}
+
 func (f *fakeAgentService) ListAgents(userID, keywords string, page, pageSize int, orderby string, desc bool, ownerIDs []string, canvasCategory string) (*service.ListAgentsResponse, common.ErrorCode, error) {
 	return f.result, f.code, f.err
 }
 
 func (f *fakeAgentService) ListTemplates() ([]*entity.CanvasTemplate, error) {
 	return f.templates, f.templatesErr
+}
+
+func (f *fakeAgentService) DeleteAgent(agentID, tenantID string) (common.ErrorCode, error) {
+	f.deletedID = agentID
+	f.deletedBy = tenantID
+	return f.deleteCode, f.deleteErr
 }
 
 func setupAgentRouter(svc agentServiceIface) *gin.Engine {
@@ -658,6 +685,14 @@ func setupAgentRouter(svc agentServiceIface) *gin.Engine {
 	r.GET("/api/v1/agents/templates_anon", func(c *gin.Context) {
 		// no user set → unauthenticated probe
 		h.listTemplates(c)
+	})
+	r.DELETE("/api/v1/agents/:agent_id", func(c *gin.Context) {
+		c.Set("user", &entity.User{ID: "user-abc"})
+		h.deleteAgent(c)
+	})
+	r.DELETE("/api/v1/agents_anon/:agent_id", func(c *gin.Context) {
+		// no user set → unauthenticated
+		h.deleteAgent(c)
 	})
 	return r
 }
@@ -769,3 +804,80 @@ func TestListAgentTemplates_RequiresAuth(t *testing.T) {
 		t.Errorf("expected non-success without auth, got body=%v", body)
 	}
 }
+
+func TestDeleteAgent_Success(t *testing.T) {
+	svc := &fakeAgentService{deleteCode: common.CodeSuccess}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/agents/canvas-7", nil)
+	setupAgentRouter(svc).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+	if body["code"] != float64(common.CodeSuccess) {
+		t.Errorf("code=%v want %d", body["code"], common.CodeSuccess)
+	}
+	if body["data"] != true {
+		t.Errorf("data=%v want true", body["data"])
+	}
+	if svc.deletedID != "canvas-7" {
+		t.Errorf("service was passed agentID=%q want %q", svc.deletedID, "canvas-7")
+	}
+	if svc.deletedBy != "user-abc" {
+		t.Errorf("service was passed tenantID=%q want %q", svc.deletedBy, "user-abc")
+	}
+}
+
+func TestDeleteAgent_NotOwner(t *testing.T) {
+	// Service returns CodeOperatingError when the caller does not own the
+	// agent (or it does not exist) - mirrors the Python decorator.
+	svc := &fakeAgentService{
+		deleteCode: common.CodeOperatingError,
+		deleteErr:  errNotOwner,
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/agents/canvas-7", nil)
+	setupAgentRouter(svc).ServeHTTP(w, req)
+
+	var body map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body["code"] != float64(common.CodeOperatingError) {
+		t.Errorf("code=%v want %d", body["code"], common.CodeOperatingError)
+	}
+	if body["data"] != false {
+		t.Errorf("data=%v want false", body["data"])
+	}
+	msg, _ := body["message"].(string)
+	if msg == "" {
+		t.Errorf("message must be non-empty, got body=%v", body)
+	}
+}
+
+func TestDeleteAgent_RequiresAuth(t *testing.T) {
+	svc := &fakeAgentService{deleteCode: common.CodeSuccess}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/agents_anon/canvas-7", nil)
+	setupAgentRouter(svc).ServeHTTP(w, req)
+
+	var body map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if code, _ := body["code"].(float64); int(code) == int(common.CodeSuccess) {
+		t.Errorf("expected non-success without auth, got body=%v", body)
+	}
+	if svc.deletedID != "" {
+		t.Errorf("service should not be called without auth, but was called with %q", svc.deletedID)
+	}
+}
+
+var errNotOwner = sErr("Only the owner of the agent is authorized for this operation.")
+
+type sErr string
+
+func (e sErr) Error() string { return string(e) }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -392,6 +392,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 				agents.GET("/:agent_id/sessions", r.agentHandler.ListAgentSessions)
 				agents.GET("/:agent_id/sessions/:session_id", r.agentHandler.GetAgentSession)
 				agents.DELETE("/:agent_id/sessions/:session_id", r.agentHandler.DeleteAgentSessionItem)
+				agents.DELETE("/:agent_id", r.agentHandler.DeleteAgent)
 			}
 
 			// Plugin routes

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -35,6 +35,13 @@ const (
 	agentTagMaxLen    = 64
 )
 
+// errAgentNotOwner is the not-owner sentinel returned by DeleteAgent. The
+// wire message must match the Python decorator byte-for-byte because
+// conformance tests (test/testcases/restful_api/test_agents.py,
+// test/testcases/test_http_api/test_session_management/test_agent_sessions.py)
+// substring-match on this exact text.
+var errAgentNotOwner = errors.New("Only the owner of the agent is authorized for this operation.") //nolint:staticcheck // ST1005: matches Python wire contract
+
 // AgentService agent service
 type AgentService struct {
 	canvasDAO            *dao.UserCanvasDAO
@@ -625,8 +632,7 @@ func (s *AgentService) DeleteAgent(agentID, tenantID string) (common.ErrorCode, 
 		return common.CodeServerError, fmt.Errorf("failed to delete agent: %w", err)
 	}
 	if rows == 0 {
-		return common.CodeOperatingError,
-			fmt.Errorf("only the owner of the agent is authorized for this operation")
+		return common.CodeOperatingError, errAgentNotOwner
 	}
 	return common.CodeSuccess, nil
 }

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -611,3 +611,22 @@ func (s *AgentService) GetVersion(canvasID, versionID string) (*entity.UserCanva
 	}
 	return version, nil
 }
+
+// DeleteAgent removes the agent canvas identified by agentID, but only if it
+// is owned by tenantID. Mirrors the Python `_require_canvas_owner_sync`
+// decorator + `UserCanvasService.delete_by_id` flow.
+//
+// Returns CodeOperatingError with no DB error when the caller does not own
+// the agent (or the agent does not exist) — same response shape and code
+// Python returns from the decorator.
+func (s *AgentService) DeleteAgent(agentID, tenantID string) (common.ErrorCode, error) {
+	rows, err := s.canvasDAO.DeleteByIDOwnedBy(agentID, tenantID)
+	if err != nil {
+		return common.CodeServerError, fmt.Errorf("failed to delete agent: %w", err)
+	}
+	if rows == 0 {
+		return common.CodeOperatingError,
+			fmt.Errorf("only the owner of the agent is authorized for this operation")
+	}
+	return common.CodeSuccess, nil
+}


### PR DESCRIPTION
## Summary

Port the agent-canvas delete endpoint to the Go API server. Listed in the Go-API port checklist of #15240.

Mirrors the Python handler in `api/apps/restful_apis/agent_api.py`:

```python
@manager.route("/agents/<agent_id>", methods=["DELETE"])
@login_required
@add_tenant_id_to_kwargs
@_require_canvas_owner_sync   # only the owner may delete
def delete_agent(agent_id, tenant_id):
    UserCanvasService.delete_by_id(agent_id)
    return get_json_result(data=True)
```

## Implementation note: atomic check + delete

Python checks ownership with `UserCanvasService.query(user_id=tenant_id, id=agent_id)` and then calls `delete_by_id` — two separate statements with a small race window. The Go port collapses this into one atomic `DELETE … WHERE id = ? AND user_id = ?`, then inspects `rows_affected`. Zero matches → `CodeOperatingError` with the same authorization message Python returns; the resulting JSON response is byte-shape compatible.

## What

- `internal/dao/user_canvas.go` — new `DeleteByIDOwnedBy(canvasID, userID string)` that returns `(rowsAffected, error)`.
- `internal/service/agent.go` — `AgentService.DeleteAgent(agentID, tenantID)` returns `CodeOperatingError` if the owner check fails.
- `internal/handler/agent.go` — new `AgentHandler.DeleteAgent` mounted at `agents.DELETE("/:agent_id", ...)`.
- `internal/router/router.go` — route registration.
- `internal/handler/agent_test.go` — three new tests cover happy path, not-owner rejection, and the auth gate.

## Test plan

- [x] `go vet ./internal/handler ./internal/service ./internal/dao ./internal/router` clean
- [x] Three handler unit tests added; existing `TestListAgents_Success` untouched
- [ ] CI runs `go test ./internal/handler` with cgo binding linked

## Related

- Tracker: #15240