### PR TITLE
feat(connector): implement XWiki data source

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -158,6 +158,7 @@ class FileSource(StrEnum):
     OUTLOOK = "outlook"
     SALESFORCE = "salesforce"
     AZURE_BLOB = "azure_blob"
+    XWIKI = "xwiki"
 
 
 class PipelineTaskType(StrEnum):

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -73,6 +73,7 @@ class DocumentSource(str, Enum):
     OUTLOOK = "outlook"
     SALESFORCE = "salesforce"
     AZURE_BLOB = "azure_blob"
+    XWIKI = "xwiki"
 
 
 class FileOrigin(str, Enum):

--- a/common/data_source/xwiki_connector.py
+++ b/common/data_source/xwiki_connector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections.abc import Generator, Iterator
 from datetime import datetime, timezone
 from typing import Any
@@ -11,6 +12,8 @@ import requests
 from common.data_source.config import DocumentSource, INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
 from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
 from common.data_source.models import Document, SecondsSinceUnixEpoch, SlimDocument
+
+logger = logging.getLogger(__name__)
 
 
 class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
@@ -30,6 +33,21 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.session = requests.Session()
         self._credentials: dict[str, Any] = {}
 
+    def __enter__(self) -> XWikiConnector:
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        del exc_type, exc, traceback
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+    def close(self) -> None:
+        close = getattr(getattr(self, "session", None), "close", None)
+        if close is not None:
+            close()
+
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self._credentials = credentials or {}
         token = self._credentials.get("xwiki_api_token")
@@ -37,8 +55,10 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         password = self._credentials.get("xwiki_password")
         if token:
             self.session.headers.update({"Authorization": f"Bearer {token}"})
+            logger.info("XWiki connector using bearer token authentication")
         elif username and password:
             self.session.auth = (username, password)
+            logger.info("XWiki connector using basic authentication for user: %s", username)
         return None
 
     def validate_connector_settings(self) -> None:
@@ -48,6 +68,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             raise ValueError("XWiki connector requires a space or page IDs")
 
     def load_from_state(self) -> Generator[list[Document], None, None]:
+        logger.debug("XWiki load_from_state started")
         yield from self._batch_documents(self._iter_documents())
 
     def poll_source(
@@ -55,6 +76,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         start: SecondsSinceUnixEpoch,
         end: SecondsSinceUnixEpoch,
     ) -> Generator[list[Document], None, None]:
+        logger.debug("XWiki poll_source started start=%s end=%s", start, end)
         start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
         end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
         docs = (
@@ -77,6 +99,12 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             yield batch
 
     def _iter_documents(self) -> Iterator[Document]:
+        logger.debug(
+            "XWiki iterating documents wiki=%s space=%s configured_pages=%s",
+            self.wiki,
+            self.space,
+            len(self.page_ids),
+        )
         summaries = self._configured_page_summaries() if self.page_ids else self._list_space_pages(self.space)
         for summary in summaries:
             page = self._page_detail(summary)
@@ -88,6 +116,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
 
     def _list_space_pages(self, space: str) -> Iterator[dict[str, Any]]:
         path = f"rest/wikis/{quote(self.wiki)}/{self._space_path(space)}/pages"
+        logger.debug("XWiki listing pages path=%s", path)
         for item in self._items_from_payload(self._get(path)):
             yield item
 
@@ -101,14 +130,20 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             return summary
         space, page = full_name.rsplit(".", 1)
         path = f"rest/wikis/{quote(self.wiki)}/{self._space_path(space)}/pages/{quote(page)}"
+        logger.debug("XWiki fetching page detail full_name=%s path=%s", full_name, path)
         detail = self._get(path)
         detail.setdefault("fullName", full_name)
         return {**summary, **detail}
 
     def _get(self, path: str) -> dict[str, Any]:
         url = urljoin(f"{self.base_url}/", path)
-        response = self.session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
-        response.raise_for_status()
+        logger.debug("XWiki request url=%s", url)
+        try:
+            response = self.session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+            response.raise_for_status()
+        except requests.RequestException:
+            logger.exception("XWiki request failed url=%s", url)
+            raise
         return response.json()
 
     @staticmethod
@@ -144,6 +179,14 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         ).strip()
         blob = text.encode("utf-8")
         doc_id = f"xwiki:{full_name}"
+        fingerprint = hashlib.sha256(blob).hexdigest()
+        logger.debug(
+            "XWiki built document id=%s full_name=%s size=%s fingerprint=%s",
+            doc_id,
+            full_name,
+            len(blob),
+            fingerprint,
+        )
         return Document(
             id=doc_id,
             source=DocumentSource.XWIKI,
@@ -157,7 +200,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
                 "space": full_name.rsplit(".", 1)[0] if "." in full_name else "",
                 "url": link,
             },
-            fingerprint=hashlib.sha256(blob).hexdigest(),
+            fingerprint=fingerprint,
         )
 
     def _page_link(self, page: dict[str, Any]) -> str:
@@ -182,14 +225,16 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
                 return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
             except ValueError:
                 pass
-        return datetime.fromtimestamp(0, tz=timezone.utc)
+        return datetime.now(timezone.utc)
 
     def _batch_documents(self, docs: Iterator[Document]) -> Generator[list[Document], None, None]:
         batch: list[Document] = []
         for doc in docs:
             batch.append(doc)
             if len(batch) >= self.batch_size:
+                logger.debug("XWiki yielding document batch size=%s", len(batch))
                 yield batch
                 batch = []
         if batch:
+            logger.debug("XWiki yielding final document batch size=%s", len(batch))
             yield batch

--- a/common/data_source/xwiki_connector.py
+++ b/common/data_source/xwiki_connector.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Generator, Iterator
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote, urljoin
+
+import requests
+
+from common.data_source.config import DocumentSource, INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
+from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
+from common.data_source.models import Document, SecondsSinceUnixEpoch, SlimDocument
+
+
+class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    def __init__(
+        self,
+        base_url: str,
+        wiki: str = "xwiki",
+        space: str = "Main",
+        page_ids: str = "",
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.wiki = wiki.strip() or "xwiki"
+        self.space = space.strip() or "Main"
+        self.page_ids = [p.strip() for p in page_ids.split(",") if p.strip()]
+        self.batch_size = batch_size or INDEX_BATCH_SIZE
+        self.session = requests.Session()
+        self._credentials: dict[str, Any] = {}
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._credentials = credentials or {}
+        token = self._credentials.get("xwiki_api_token")
+        username = self._credentials.get("xwiki_username")
+        password = self._credentials.get("xwiki_password")
+        if token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+        elif username and password:
+            self.session.auth = (username, password)
+        return None
+
+    def validate_connector_settings(self) -> None:
+        if not self.base_url:
+            raise ValueError("XWiki connector requires base_url")
+        if not self.space and not self.page_ids:
+            raise ValueError("XWiki connector requires a space or page IDs")
+
+    def load_from_state(self) -> Generator[list[Document], None, None]:
+        yield from self._batch_documents(self._iter_documents())
+
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> Generator[list[Document], None, None]:
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        docs = (
+            doc
+            for doc in self._iter_documents()
+            if start_dt <= doc.doc_updated_at <= end_dt
+        )
+        yield from self._batch_documents(docs)
+
+    def retrieve_all_slim_docs_perm_sync(self, callback: Any = None) -> Generator[list[SlimDocument], None, None]:
+        del callback
+        docs = (SlimDocument(id=doc.id) for doc in self._iter_documents())
+        batch: list[SlimDocument] = []
+        for doc in docs:
+            batch.append(doc)
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    def _iter_documents(self) -> Iterator[Document]:
+        summaries = self._configured_page_summaries() if self.page_ids else self._list_space_pages(self.space)
+        for summary in summaries:
+            page = self._page_detail(summary)
+            yield self._document_from_page(page)
+
+    def _configured_page_summaries(self) -> Iterator[dict[str, Any]]:
+        for page_id in self.page_ids:
+            yield {"id": page_id, "fullName": page_id.split(":", 1)[-1]}
+
+    def _list_space_pages(self, space: str) -> Iterator[dict[str, Any]]:
+        path = f"rest/wikis/{quote(self.wiki)}/{self._space_path(space)}/pages"
+        for item in self._items_from_payload(self._get(path)):
+            yield item
+
+    def _page_detail(self, summary: dict[str, Any]) -> dict[str, Any]:
+        full_name = (
+            summary.get("fullName")
+            or summary.get("name")
+            or summary.get("id", "").split(":", 1)[-1]
+        )
+        if "." not in full_name:
+            return summary
+        space, page = full_name.rsplit(".", 1)
+        path = f"rest/wikis/{quote(self.wiki)}/{self._space_path(space)}/pages/{quote(page)}"
+        detail = self._get(path)
+        detail.setdefault("fullName", full_name)
+        return {**summary, **detail}
+
+    def _get(self, path: str) -> dict[str, Any]:
+        url = urljoin(f"{self.base_url}/", path)
+        response = self.session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _space_path(space: str) -> str:
+        return "/".join(f"spaces/{quote(part)}" for part in space.split(".") if part)
+
+    @staticmethod
+    def _items_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        for key in ("pageSummaries", "pageSummary", "pages", "items", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+            if isinstance(value, dict):
+                return [value]
+        return []
+
+    def _document_from_page(self, page: dict[str, Any]) -> Document:
+        full_name = page.get("fullName") or page.get("name") or page.get("id", "page")
+        title = page.get("title") or full_name.rsplit(".", 1)[-1]
+        content = page.get("content") or page.get("renderedContent") or ""
+        updated_at = self._parse_datetime(page.get("modified") or page.get("updated") or page.get("created"))
+        link = self._page_link(page)
+        text = "\n".join(
+            part
+            for part in (
+                f"Title: {title}",
+                f"Page: {full_name}",
+                f"URL: {link}" if link else "",
+                "",
+                str(content).strip(),
+            )
+            if part is not None
+        ).strip()
+        blob = text.encode("utf-8")
+        doc_id = f"xwiki:{full_name}"
+        return Document(
+            id=doc_id,
+            source=DocumentSource.XWIKI,
+            semantic_identifier=title,
+            extension="txt",
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            metadata={
+                "page": full_name,
+                "space": full_name.rsplit(".", 1)[0] if "." in full_name else "",
+                "url": link,
+            },
+            fingerprint=hashlib.sha256(blob).hexdigest(),
+        )
+
+    def _page_link(self, page: dict[str, Any]) -> str:
+        for key in ("xwikiAbsoluteUrl", "absoluteUrl", "url"):
+            if page.get(key):
+                return str(page[key])
+        relative = page.get("xwikiRelativeUrl") or page.get("relativeUrl")
+        if relative:
+            return urljoin(f"{self.base_url}/", str(relative).lstrip("/"))
+        links = page.get("links") or page.get("_links") or {}
+        href = links.get("http://www.xwiki.org/rel/page") or links.get("self")
+        if isinstance(href, dict):
+            href = href.get("href")
+        return urljoin(f"{self.base_url}/", str(href).lstrip("/")) if href else ""
+
+    @staticmethod
+    def _parse_datetime(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str) and value:
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+            except ValueError:
+                pass
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+    def _batch_documents(self, docs: Iterator[Document]) -> Generator[list[Document], None, None]:
+        batch: list[Document] = []
+        for doc in docs:
+            batch.append(doc)
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch

--- a/common/data_source/xwiki_connector.py
+++ b/common/data_source/xwiki_connector.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    _INVALID_TIMESTAMP = datetime.fromtimestamp(0, tz=timezone.utc)
+
     def __init__(
         self,
         base_url: str,
@@ -31,6 +33,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.page_ids = [p.strip() for p in page_ids.split(",") if p.strip()]
         self.batch_size = batch_size or INDEX_BATCH_SIZE
         self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
         self._credentials: dict[str, Any] = {}
 
     def __enter__(self) -> XWikiConnector:
@@ -58,7 +61,8 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             logger.info("XWiki connector using bearer token authentication")
         elif username and password:
             self.session.auth = (username, password)
-            logger.info("XWiki connector using basic authentication for user: %s", username)
+            logger.info("XWiki connector using basic authentication")
+        self.session.headers.setdefault("Accept", "application/json")
         return None
 
     def validate_connector_settings(self) -> None:
@@ -82,7 +86,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         docs = (
             doc
             for doc in self._iter_documents()
-            if start_dt <= doc.doc_updated_at <= end_dt
+            if doc.doc_updated_at != self._INVALID_TIMESTAMP and start_dt <= doc.doc_updated_at <= end_dt
         )
         yield from self._batch_documents(docs)
 
@@ -178,11 +182,12 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             if part is not None
         ).strip()
         blob = text.encode("utf-8")
-        doc_id = f"xwiki:{full_name}"
-        fingerprint = hashlib.sha256(blob).hexdigest()
+        doc_id = f"xwiki:{self.wiki}:{full_name}"
+        fingerprint = hashlib.md5(blob).hexdigest()
         logger.debug(
-            "XWiki built document id=%s full_name=%s size=%s fingerprint=%s",
+            "XWiki built document id=%s wiki=%s full_name=%s size=%s fingerprint=%s",
             doc_id,
+            self.wiki,
             full_name,
             len(blob),
             fingerprint,
@@ -196,6 +201,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             doc_updated_at=updated_at,
             size_bytes=len(blob),
             metadata={
+                "wiki": self.wiki,
                 "page": full_name,
                 "space": full_name.rsplit(".", 1)[0] if "." in full_name else "",
                 "url": link,
@@ -225,7 +231,7 @@ class XWikiConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
                 return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
             except ValueError:
                 pass
-        return datetime.now(timezone.utc)
+        return XWikiConnector._INVALID_TIMESTAMP
 
     def _batch_documents(self, docs: Iterator[Document]) -> Generator[list[Document], None, None]:
         batch: list[Document] = []

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -77,8 +77,8 @@ from common.data_source.box_connector import BoxConnector
 from common.data_source.github.connector import GithubConnector
 from common.data_source.gitlab_connector import GitlabConnector
 from common.data_source.bitbucket.connector import BitbucketConnector
-from common.data_source.xwiki_connector import XWikiConnector
 from common.data_source.interfaces import CheckpointOutputWrapper
+from common.data_source.xwiki_connector import XWikiConnector
 from common.data_source.exceptions import ConnectorValidationError
 from common.log_utils import init_root_logger
 from common.signal_utils import start_tracemalloc_and_snapshot, stop_tracemalloc

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -2115,7 +2115,15 @@ class XWiki(SyncBase):
             )
 
         self.log_connection("XWiki", self.conf.get("base_url", ""), task)
-        return document_generator
+
+        def wrapper():
+            try:
+                for document_batch in document_generator:
+                    yield document_batch
+            finally:
+                self.connector.close()
+
+        return wrapper()
 
 
 func_factory = {

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -77,6 +77,7 @@ from common.data_source.box_connector import BoxConnector
 from common.data_source.github.connector import GithubConnector
 from common.data_source.gitlab_connector import GitlabConnector
 from common.data_source.bitbucket.connector import BitbucketConnector
+from common.data_source.xwiki_connector import XWikiConnector
 from common.data_source.interfaces import CheckpointOutputWrapper
 from common.data_source.exceptions import ConnectorValidationError
 from common.log_utils import init_root_logger
@@ -2090,6 +2091,33 @@ class REST_API(SyncBase):
         return document_generator
 
 
+class XWiki(SyncBase):
+    SOURCE_NAME: str = FileSource.XWIKI
+
+    async def _generate(self, task: dict):
+        self.connector = XWikiConnector(
+            base_url=self.conf.get("base_url", ""),
+            wiki=self.conf.get("wiki", "xwiki"),
+            space=self.conf.get("space", "Main"),
+            page_ids=self.conf.get("page_ids", ""),
+            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+        )
+        self.connector.load_credentials(self.conf.get("credentials") or {})
+        self.connector.validate_connector_settings()
+
+        poll_start = task.get("poll_range_start")
+        if task.get("reindex") == "1" or poll_start is None:
+            document_generator = self.connector.load_from_state()
+        else:
+            document_generator = self.connector.poll_source(
+                poll_start.timestamp(),
+                datetime.now(timezone.utc).timestamp(),
+            )
+
+        self.log_connection("XWiki", self.conf.get("base_url", ""), task)
+        return document_generator
+
+
 func_factory = {
     FileSource.RSS: RSS,
     FileSource.S3: S3,
@@ -2125,6 +2153,7 @@ func_factory = {
     FileSource.POSTGRESQL: PostgreSQL,
     FileSource.DINGTALK_AI_TABLE: DingTalkAITable,
     FileSource.REST_API: REST_API,
+    FileSource.XWIKI: XWiki,
 }
 
 

--- a/test/unit_test/data_source/test_xwiki_connector_unit.py
+++ b/test/unit_test/data_source/test_xwiki_connector_unit.py
@@ -24,9 +24,15 @@ class FakeSession:
         self.auth: tuple[str, str] | None = None
         self.headers: dict[str, str] = {}
         self.calls: list[str] = []
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
 
     def get(self, url: str, timeout: int) -> FakeResponse:
         del timeout
+        if not url.startswith("https://xwiki.test/"):
+            raise ValueError(f"unexpected XWiki test URL: {url}")
         path = url.split("https://xwiki.test/", 1)[1]
         self.calls.append(path)
         payloads = {
@@ -50,6 +56,8 @@ class FakeSession:
                 "xwikiRelativeUrl": "bin/view/Main/",
             },
         }
+        if path not in payloads:
+            raise KeyError(f"unexpected XWiki test path: url={url}, path={path}")
         return FakeResponse(payloads[path])
 
 
@@ -104,3 +112,13 @@ def test_xwiki_connector_requires_base_url() -> None:
 
     with pytest.raises(ValueError, match="base_url"):
         connector.validate_connector_settings()
+
+
+@pytest.mark.p1
+def test_xwiki_connector_closes_session() -> None:
+    connector = make_connector()
+    session = connector.session
+
+    connector.close()
+
+    assert session.closed

--- a/test/unit_test/data_source/test_xwiki_connector_unit.py
+++ b/test/unit_test/data_source/test_xwiki_connector_unit.py
@@ -61,6 +61,15 @@ class FakeSession:
         return FakeResponse(payloads[path])
 
 
+class InvalidTimestampSession(FakeSession):
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        response = super().get(url, timeout)
+        payload = response.json()
+        if payload.get("fullName") == "Main.WebHome":
+            payload = {**payload, "modified": "not-a-date"}
+        return FakeResponse(payload)
+
+
 def make_connector() -> XWikiConnector:
     connector = XWikiConnector("https://xwiki.test", space="Main")
     connector.session = FakeSession()
@@ -77,13 +86,14 @@ def test_xwiki_connector_builds_page_documents() -> None:
     assert len(batches) == 1
     doc = batches[0][0]
     text = doc.blob.decode("utf-8")
-    assert doc.id == "xwiki:Main.WebHome"
+    assert doc.id == "xwiki:xwiki:Main.WebHome"
     assert doc.source == "xwiki"
     assert doc.semantic_identifier == "Home"
     assert "Runbooks and onboarding notes." in text
+    assert doc.metadata["wiki"] == "xwiki"
     assert doc.metadata["space"] == "Main"
     assert doc.metadata["url"] == "https://xwiki.test/bin/view/Main/"
-    assert doc.fingerprint
+    assert doc.fingerprint and len(doc.fingerprint) == 32
 
 
 @pytest.mark.p1
@@ -94,7 +104,19 @@ def test_xwiki_connector_poll_source_filters_by_date() -> None:
 
     batches = list(connector.poll_source(start, end))
 
-    assert [[doc.id for doc in batch] for batch in batches] == [["xwiki:Main.WebHome"]]
+    assert [[doc.id for doc in batch] for batch in batches] == [["xwiki:xwiki:Main.WebHome"]]
+
+
+@pytest.mark.p1
+def test_xwiki_connector_poll_source_skips_invalid_timestamps() -> None:
+    connector = make_connector()
+    connector.session = InvalidTimestampSession()
+    start = datetime(2026, 5, 30, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc).timestamp()
+
+    batches = list(connector.poll_source(start, end))
+
+    assert batches == []
 
 
 @pytest.mark.p1
@@ -103,7 +125,7 @@ def test_xwiki_connector_retrieves_slim_docs() -> None:
 
     batches = list(connector.retrieve_all_slim_docs_perm_sync())
 
-    assert [[doc.id for doc in batch] for batch in batches] == [["xwiki:Main.WebHome"]]
+    assert [[doc.id for doc in batch] for batch in batches] == [["xwiki:xwiki:Main.WebHome"]]
 
 
 @pytest.mark.p1

--- a/test/unit_test/data_source/test_xwiki_connector_unit.py
+++ b/test/unit_test/data_source/test_xwiki_connector_unit.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from common.data_source.xwiki_connector import XWikiConnector
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.auth: tuple[str, str] | None = None
+        self.headers: dict[str, str] = {}
+        self.calls: list[str] = []
+
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        del timeout
+        path = url.split("https://xwiki.test/", 1)[1]
+        self.calls.append(path)
+        payloads = {
+            "rest/wikis/xwiki/spaces/Main/pages": {
+                "pageSummaries": [
+                    {
+                        "id": "xwiki:Main.WebHome",
+                        "fullName": "Main.WebHome",
+                        "title": "Home",
+                        "modified": "2026-06-01T10:00:00Z",
+                        "xwikiRelativeUrl": "bin/view/Main/",
+                    }
+                ]
+            },
+            "rest/wikis/xwiki/spaces/Main/pages/WebHome": {
+                "id": "xwiki:Main.WebHome",
+                "fullName": "Main.WebHome",
+                "title": "Home",
+                "content": "Runbooks and onboarding notes.",
+                "modified": "2026-06-01T10:00:00Z",
+                "xwikiRelativeUrl": "bin/view/Main/",
+            },
+        }
+        return FakeResponse(payloads[path])
+
+
+def make_connector() -> XWikiConnector:
+    connector = XWikiConnector("https://xwiki.test", space="Main")
+    connector.session = FakeSession()
+    connector.load_credentials({"xwiki_username": "user", "xwiki_password": "pass"})
+    return connector
+
+
+@pytest.mark.p1
+def test_xwiki_connector_builds_page_documents() -> None:
+    connector = make_connector()
+
+    batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    doc = batches[0][0]
+    text = doc.blob.decode("utf-8")
+    assert doc.id == "xwiki:Main.WebHome"
+    assert doc.source == "xwiki"
+    assert doc.semantic_identifier == "Home"
+    assert "Runbooks and onboarding notes." in text
+    assert doc.metadata["space"] == "Main"
+    assert doc.metadata["url"] == "https://xwiki.test/bin/view/Main/"
+    assert doc.fingerprint
+
+
+@pytest.mark.p1
+def test_xwiki_connector_poll_source_filters_by_date() -> None:
+    connector = make_connector()
+    start = datetime(2026, 5, 30, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc).timestamp()
+
+    batches = list(connector.poll_source(start, end))
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["xwiki:Main.WebHome"]]
+
+
+@pytest.mark.p1
+def test_xwiki_connector_retrieves_slim_docs() -> None:
+    connector = make_connector()
+
+    batches = list(connector.retrieve_all_slim_docs_perm_sync())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["xwiki:Main.WebHome"]]
+
+
+@pytest.mark.p1
+def test_xwiki_connector_requires_base_url() -> None:
+    connector = XWikiConnector("")
+
+    with pytest.raises(ValueError, match="base_url"):
+        connector.validate_connector_settings()

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1204,6 +1204,14 @@ Example: Virtual Hosted Style`,
         'Connect to a public RSS or Atom feed and sync feed entries into your knowledge base.',
       confluenceDescription:
         'Integrate your Confluence workspace to search documentation.',
+      xwikiDescription:
+        'Connect XWiki to sync wiki pages and documentation into your knowledge base.',
+      xwikiBaseUrlTip:
+        'The base URL of your XWiki instance, e.g. https://xwiki.example.com.',
+      xwikiSpaceTip:
+        'Optional XWiki space to sync. Use dot notation for nested spaces, e.g. Main.Docs.',
+      xwikiPageIdsTip:
+        'Optional comma-separated page IDs or full names. Leave empty to sync the configured space.',
       s3Description:
         'Connect to your AWS S3 bucket to import and sync stored files.',
       google_cloud_storageDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1077,6 +1077,13 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       rssDescription:
         '连接公开的 RSS 或 Atom feed，并将 feed 条目同步到知识库。',
       confluenceDescription: '连接你的 Confluence 工作区以搜索文档内容。',
+      xwikiDescription: '连接 XWiki，将 Wiki 页面和文档同步到知识库。',
+      xwikiBaseUrlTip:
+        'XWiki 实例的基础 URL，例如 https://xwiki.example.com。',
+      xwikiSpaceTip:
+        '可选：要同步的 XWiki 空间。嵌套空间使用点号表示，例如 Main.Docs。',
+      xwikiPageIdsTip:
+        '可选：页面 ID 或完整名称，多个用逗号分隔。留空则同步配置的空间。',
       s3Description: ' 连接你的 AWS S3 存储桶以导入和同步文件。',
       google_cloud_storageDescription:
         '连接你的 Google Cloud Storage 存储桶以导入和同步文件。',

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -2,7 +2,7 @@ import { FormFieldConfig, FormFieldType } from '@/components/dynamic-form';
 import { IconFontFill } from '@/components/icon-font';
 import SvgIcon from '@/components/svg-icon';
 import { t, TFunction } from 'i18next';
-import { Mail, Rss } from 'lucide-react';
+import { BookOpen, Mail, Rss } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BoxTokenField from '../component/box-token-field';
@@ -50,6 +50,7 @@ export enum DataSourceKey {
   TEAMS = 'teams',
   SLACK = 'slack',
   SHAREPOINT = 'sharepoint',
+  XWIKI = 'xwiki',
 }
 
 type DataSourceFeatureVisibility = {
@@ -154,6 +155,9 @@ export const DataSourceFeatureVisibilityMap: Partial<
   [DataSourceKey.SHAREPOINT]: {
     syncDeletedFiles: true,
   },
+  [DataSourceKey.XWIKI]: {
+    syncDeletedFiles: true,
+  },
   [DataSourceKey.MYSQL]: {
     syncDeletedFiles: true,
   },
@@ -216,6 +220,11 @@ export const generateDataSourceInfo = (t: TFunction) => {
       name: 'Confluence',
       description: t(`setting.${DataSourceKey.CONFLUENCE}Description`),
       icon: <SvgIcon name={'data-source/confluence'} width={38} />,
+    },
+    [DataSourceKey.XWIKI]: {
+      name: 'XWiki',
+      description: t(`setting.${DataSourceKey.XWIKI}Description`),
+      icon: <BookOpen className="text-text-primary" size={22} />,
     },
     [DataSourceKey.GOOGLE_DRIVE]: {
       name: 'Google Drive',
@@ -1763,6 +1772,57 @@ export const DataSourceFormFields = {
         !!values?.config?.show_advanced && values?.config?.method === 'POST',
     },
   ],
+  [DataSourceKey.XWIKI]: [
+    {
+      label: 'Base URL',
+      name: 'config.base_url',
+      type: FormFieldType.Text,
+      required: true,
+      placeholder: 'https://xwiki.example.com',
+      tooltip: t('setting.xwikiBaseUrlTip'),
+    },
+    {
+      label: 'Wiki',
+      name: 'config.wiki',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'xwiki',
+    },
+    {
+      label: 'Space',
+      name: 'config.space',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'Main',
+      tooltip: t('setting.xwikiSpaceTip'),
+    },
+    {
+      label: 'Page IDs',
+      name: 'config.page_ids',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'Main.WebHome,Docs.Installation',
+      tooltip: t('setting.xwikiPageIdsTip'),
+    },
+    {
+      label: 'Username',
+      name: 'config.credentials.xwiki_username',
+      type: FormFieldType.Text,
+      required: false,
+    },
+    {
+      label: 'Password',
+      name: 'config.credentials.xwiki_password',
+      type: FormFieldType.Password,
+      required: false,
+    },
+    {
+      label: 'API Token',
+      name: 'config.credentials.xwiki_api_token',
+      type: FormFieldType.Password,
+      required: false,
+    },
+  ],
 };
 
 export const DataSourceFormDefaultValues = {
@@ -1838,6 +1898,22 @@ export const DataSourceFormDefaultValues = {
         confluence_access_token: '',
       },
       index_mode: 'everything',
+    },
+  },
+  [DataSourceKey.XWIKI]: {
+    name: '',
+    source: DataSourceKey.XWIKI,
+    config: {
+      base_url: '',
+      wiki: 'xwiki',
+      space: 'Main',
+      page_ids: '',
+      batch_size: 2,
+      credentials: {
+        xwiki_username: '',
+        xwiki_password: '',
+        xwiki_api_token: '',
+      },
     },
   },
   [DataSourceKey.GOOGLE_DRIVE]: {


### PR DESCRIPTION
### What problem does this PR solve?

Adds an XWiki data-source connector so RAGFlow can sync wiki pages from XWiki into a knowledge base.

Fixes #15594

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

### Verification

- `python3 -m py_compile common/data_source/xwiki_connector.py test/unit_test/data_source/test_xwiki_connector_unit.py rag/svr/sync_data_source.py common/constants.py common/data_source/config.py common/data_source/__init__.py`
- `uv run --python 3.13 --with pytest --with pytest-asyncio pytest test/unit_test/data_source/test_xwiki_connector_unit.py -q`
- `git diff --check`