### PR TITLE
feat(connector): implement OpenText data source

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -156,6 +156,7 @@ class FileSource(StrEnum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    OPENTEXT = "opentext"
 
 
 class PipelineTaskType(StrEnum):

--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -36,6 +36,7 @@ from .jira.connector import JiraConnector
 from .sharepoint_connector import SharePointConnector
 from .onedrive_connector import OneDriveConnector
 from .outlook_connector import OutlookConnector
+from .opentext_connector import OpenTextConnector
 from .teams_connector import TeamsConnector
 from .moodle_connector import MoodleConnector
 from .airtable_connector import AirtableConnector
@@ -71,6 +72,7 @@ __all__ = [
     "SharePointConnector",
     "OneDriveConnector",
     "OutlookConnector",
+    "OpenTextConnector",
     "TeamsConnector",
     "MoodleConnector",
     "BlobType",

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -71,6 +71,7 @@ class DocumentSource(str, Enum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    OPENTEXT = "opentext"
 
 
 class FileOrigin(str, Enum):

--- a/common/data_source/opentext_connector.py
+++ b/common/data_source/opentext_connector.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Generator, Iterator
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+
+from common.data_source.config import DocumentSource, INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
+from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
+from common.data_source.models import Document, SecondsSinceUnixEpoch, SlimDocument
+
+
+class OpenTextConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    def __init__(
+        self,
+        base_url: str,
+        root_node_ids: str,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.root_node_ids = [node.strip() for node in root_node_ids.split(",") if node.strip()]
+        self.batch_size = batch_size or INDEX_BATCH_SIZE
+        self.session = requests.Session()
+        self._credentials: dict[str, Any] = {}
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._credentials = credentials or {}
+        ticket = self._credentials.get("opentext_ticket")
+        token = self._credentials.get("opentext_api_token")
+        username = self._credentials.get("opentext_username")
+        password = self._credentials.get("opentext_password")
+        if ticket:
+            self.session.headers.update({"OTCSTicket": ticket})
+        elif token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+        elif username and password:
+            self.session.auth = (username, password)
+        return None
+
+    def validate_connector_settings(self) -> None:
+        if not self.base_url:
+            raise ValueError("OpenText connector requires base_url")
+        if not self.root_node_ids:
+            raise ValueError("OpenText connector requires at least one root_node_id")
+
+    def load_from_state(self) -> Generator[list[Document], None, None]:
+        yield from self._batch_documents(self._iter_documents())
+
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> Generator[list[Document], None, None]:
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        docs = (
+            doc
+            for doc in self._iter_documents()
+            if start_dt <= doc.doc_updated_at <= end_dt
+        )
+        yield from self._batch_documents(docs)
+
+    def retrieve_all_slim_docs_perm_sync(self, callback: Any = None) -> Generator[list[SlimDocument], None, None]:
+        del callback
+        batch: list[SlimDocument] = []
+        for doc in self._iter_documents():
+            batch.append(SlimDocument(id=doc.id))
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    def _iter_documents(self) -> Iterator[Document]:
+        for root_node_id in self.root_node_ids:
+            for node in self._walk_node(root_node_id):
+                if self._is_folder(node):
+                    continue
+                detail = self._node_detail(str(node.get("id")))
+                content = self._node_content(str(node.get("id")))
+                yield self._document_from_node({**node, **detail}, content)
+
+    def _walk_node(self, node_id: str) -> Iterator[dict[str, Any]]:
+        node = self._node_detail(node_id)
+        if not self._is_folder(node):
+            yield node
+            return
+        for child in self._child_nodes(node_id):
+            yield child
+            if self._is_folder(child):
+                yield from self._walk_node(str(child.get("id")))
+
+    def _node_detail(self, node_id: str) -> dict[str, Any]:
+        return self._data_from_payload(self._get_json(f"api/v1/nodes/{node_id}"))
+
+    def _child_nodes(self, node_id: str) -> Iterator[dict[str, Any]]:
+        payload = self._get_json(f"api/v1/nodes/{node_id}/nodes")
+        for item in self._items_from_payload(payload):
+            data = self._data_from_payload(item)
+            if isinstance(data, dict):
+                yield data
+
+    def _node_content(self, node_id: str) -> bytes:
+        response = self.session.get(
+            urljoin(f"{self.base_url}/", f"api/v1/nodes/{node_id}/content"),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        return response.content
+
+    def _get_json(self, path: str) -> dict[str, Any]:
+        response = self.session.get(urljoin(f"{self.base_url}/", path), timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _data_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        data = payload.get("data")
+        if isinstance(data, dict) and isinstance(data.get("properties"), dict):
+            return data["properties"]
+        if isinstance(data, dict):
+            return data
+        return payload
+
+    @staticmethod
+    def _items_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for key in ("items", "children", "nodes"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    return value
+        for key in ("items", "children", "nodes", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+        return []
+
+    @staticmethod
+    def _is_folder(node: dict[str, Any]) -> bool:
+        type_name = str(node.get("type_name") or node.get("container") or "").lower()
+        return bool(node.get("container")) or type_name in {"folder", "container"} or node.get("type") in (0, 1)
+
+    def _document_from_node(self, node: dict[str, Any], blob: bytes) -> Document:
+        node_id = str(node.get("id"))
+        name = str(node.get("name") or node.get("title") or node_id)
+        updated_at = self._parse_datetime(node.get("modify_date") or node.get("modified") or node.get("create_date"))
+        link = str(node.get("url") or node.get("web_url") or urljoin(f"{self.base_url}/", f"app/nodes/{node_id}"))
+        metadata = {
+            "node_id": node_id,
+            "name": name,
+            "mime_type": node.get("mime_type") or node.get("mimeType") or "",
+            "url": link,
+        }
+        return Document(
+            id=f"opentext:{node_id}",
+            source=DocumentSource.OPENTEXT,
+            semantic_identifier=name,
+            extension=self._extension(name, metadata["mime_type"]),
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            metadata=metadata,
+            fingerprint=hashlib.sha256(blob).hexdigest(),
+        )
+
+    @staticmethod
+    def _extension(name: str, mime_type: str) -> str:
+        if "." in name.rsplit("/", 1)[-1]:
+            return name.rsplit(".", 1)[-1].lower()
+        if mime_type == "application/pdf":
+            return "pdf"
+        if mime_type.startswith("text/"):
+            return "txt"
+        return "bin"
+
+    @staticmethod
+    def _parse_datetime(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str) and value:
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+            except ValueError:
+                pass
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+    def _batch_documents(self, docs: Iterator[Document]) -> Generator[list[Document], None, None]:
+        batch: list[Document] = []
+        for doc in docs:
+            batch.append(doc)
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -63,6 +63,7 @@ from common.data_source import (
     RestAPIConnector,
     OneDriveConnector,
     OutlookConnector,
+    OpenTextConnector,
     TeamsConnector,
     SlackConnector,
     SharePointConnector,
@@ -1975,6 +1976,31 @@ class REST_API(SyncBase):
         return document_generator
 
 
+class OpenText(SyncBase):
+    SOURCE_NAME: str = FileSource.OPENTEXT
+
+    async def _generate(self, task: dict):
+        self.connector = OpenTextConnector(
+            base_url=self.conf.get("base_url", ""),
+            root_node_ids=self.conf.get("root_node_ids", ""),
+            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+        )
+        self.connector.load_credentials(self.conf.get("credentials") or {})
+        self.connector.validate_connector_settings()
+
+        poll_start = task.get("poll_range_start")
+        if task.get("reindex") == "1" or poll_start is None:
+            document_generator = self.connector.load_from_state()
+        else:
+            document_generator = self.connector.poll_source(
+                poll_start.timestamp(),
+                datetime.now(timezone.utc).timestamp(),
+            )
+
+        self.log_connection("OpenText", self.conf.get("base_url", ""), task)
+        return document_generator
+
+
 func_factory = {
     FileSource.RSS: RSS,
     FileSource.S3: S3,
@@ -2008,6 +2034,7 @@ func_factory = {
     FileSource.POSTGRESQL: PostgreSQL,
     FileSource.DINGTALK_AI_TABLE: DingTalkAITable,
     FileSource.REST_API: REST_API,
+    FileSource.OPENTEXT: OpenText,
 }
 
 

--- a/test/unit_test/data_source/test_opentext_connector_unit.py
+++ b/test/unit_test/data_source/test_opentext_connector_unit.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from common.data_source.opentext_connector import OpenTextConnector
+
+
+class FakeResponse:
+    def __init__(self, payload: Any = None, content: bytes = b"") -> None:
+        self.payload = payload if payload is not None else {}
+        self.content = content
+
+    def json(self) -> Any:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.auth: tuple[str, str] | None = None
+        self.headers: dict[str, str] = {}
+        self.calls: list[str] = []
+
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        del timeout
+        path = url.split("https://otcs.test/", 1)[1]
+        self.calls.append(path)
+        if path == "api/v1/nodes/2000/content":
+            return FakeResponse(content=b"Quarterly policy text")
+        payloads = {
+            "api/v1/nodes/1000": {
+                "data": {"properties": {"id": 1000, "name": "Policies", "container": True, "type_name": "Folder"}}
+            },
+            "api/v1/nodes/1000/nodes": {
+                "data": [
+                    {
+                        "data": {
+                            "properties": {
+                                "id": 2000,
+                                "name": "policy.txt",
+                                "type_name": "Document",
+                                "mime_type": "text/plain",
+                                "modify_date": "2026-06-01T10:00:00Z",
+                            }
+                        }
+                    }
+                ]
+            },
+            "api/v1/nodes/2000": {
+                "data": {
+                    "properties": {
+                        "id": 2000,
+                        "name": "policy.txt",
+                        "type_name": "Document",
+                        "mime_type": "text/plain",
+                        "modify_date": "2026-06-01T10:00:00Z",
+                    }
+                }
+            },
+        }
+        return FakeResponse(payloads[path])
+
+
+def make_connector() -> OpenTextConnector:
+    connector = OpenTextConnector("https://otcs.test", "1000")
+    connector.session = FakeSession()
+    connector.load_credentials({"opentext_ticket": "ticket"})
+    return connector
+
+
+@pytest.mark.p1
+def test_opentext_connector_builds_document_nodes() -> None:
+    connector = make_connector()
+
+    batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    doc = batches[0][0]
+    assert doc.id == "opentext:2000"
+    assert doc.source == "opentext"
+    assert doc.semantic_identifier == "policy.txt"
+    assert doc.blob == b"Quarterly policy text"
+    assert doc.extension == "txt"
+    assert doc.metadata["node_id"] == "2000"
+    assert doc.fingerprint
+
+
+@pytest.mark.p1
+def test_opentext_connector_poll_source_filters_by_date() -> None:
+    connector = make_connector()
+    start = datetime(2026, 5, 30, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc).timestamp()
+
+    batches = list(connector.poll_source(start, end))
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["opentext:2000"]]
+
+
+@pytest.mark.p1
+def test_opentext_connector_retrieves_slim_docs() -> None:
+    connector = make_connector()
+
+    batches = list(connector.retrieve_all_slim_docs_perm_sync())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["opentext:2000"]]
+
+
+@pytest.mark.p1
+def test_opentext_connector_requires_root_node_ids() -> None:
+    connector = OpenTextConnector("https://otcs.test", "")
+
+    with pytest.raises(ValueError, match="root_node_id"):
+        connector.validate_connector_settings()

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1204,6 +1204,12 @@ Example: Virtual Hosted Style`,
         'Connect to a public RSS or Atom feed and sync feed entries into your knowledge base.',
       confluenceDescription:
         'Integrate your Confluence workspace to search documentation.',
+      opentextDescription:
+        'Connect OpenText Content Server to sync managed documents into your knowledge base.',
+      opentextBaseUrlTip:
+        'The base URL of your OpenText Content Server instance, e.g. https://content.example.com.',
+      opentextRootNodeIdsTip:
+        'Comma-separated root folder or document node IDs to sync.',
       s3Description:
         'Connect to your AWS S3 bucket to import and sync stored files.',
       google_cloud_storageDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1077,6 +1077,12 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       rssDescription:
         '连接公开的 RSS 或 Atom feed，并将 feed 条目同步到知识库。',
       confluenceDescription: '连接你的 Confluence 工作区以搜索文档内容。',
+      opentextDescription:
+        '连接 OpenText Content Server，将托管文档同步到知识库。',
+      opentextBaseUrlTip:
+        'OpenText Content Server 实例的基础 URL，例如 https://content.example.com。',
+      opentextRootNodeIdsTip:
+        '要同步的根文件夹或文档节点 ID，多个用逗号分隔。',
       s3Description: ' 连接你的 AWS S3 存储桶以导入和同步文件。',
       google_cloud_storageDescription:
         '连接你的 Google Cloud Storage 存储桶以导入和同步文件。',

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -2,7 +2,7 @@ import { FormFieldConfig, FormFieldType } from '@/components/dynamic-form';
 import { IconFontFill } from '@/components/icon-font';
 import SvgIcon from '@/components/svg-icon';
 import { t, TFunction } from 'i18next';
-import { Mail, Rss } from 'lucide-react';
+import { FolderArchive, Mail, Rss } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BoxTokenField from '../component/box-token-field';
@@ -48,6 +48,7 @@ export enum DataSourceKey {
   TEAMS = 'teams',
   SLACK = 'slack',
   SHAREPOINT = 'sharepoint',
+  OPENTEXT = 'opentext',
 }
 
 type DataSourceFeatureVisibility = {
@@ -146,6 +147,9 @@ export const DataSourceFeatureVisibilityMap: Partial<
   [DataSourceKey.SHAREPOINT]: {
     syncDeletedFiles: true,
   },
+  [DataSourceKey.OPENTEXT]: {
+    syncDeletedFiles: true,
+  },
   [DataSourceKey.MYSQL]: {
     syncDeletedFiles: true,
   },
@@ -208,6 +212,11 @@ export const generateDataSourceInfo = (t: TFunction) => {
       name: 'Confluence',
       description: t(`setting.${DataSourceKey.CONFLUENCE}Description`),
       icon: <SvgIcon name={'data-source/confluence'} width={38} />,
+    },
+    [DataSourceKey.OPENTEXT]: {
+      name: 'OpenText',
+      description: t(`setting.${DataSourceKey.OPENTEXT}Description`),
+      icon: <FolderArchive className="text-text-primary" size={22} />,
     },
     [DataSourceKey.GOOGLE_DRIVE]: {
       name: 'Google Drive',
@@ -1568,6 +1577,48 @@ export const DataSourceFormFields = {
         !!values?.config?.show_advanced && values?.config?.method === 'POST',
     },
   ],
+  [DataSourceKey.OPENTEXT]: [
+    {
+      label: 'Base URL',
+      name: 'config.base_url',
+      type: FormFieldType.Text,
+      required: true,
+      placeholder: 'https://content.example.com',
+      tooltip: t('setting.opentextBaseUrlTip'),
+    },
+    {
+      label: 'Root Node IDs',
+      name: 'config.root_node_ids',
+      type: FormFieldType.Text,
+      required: true,
+      placeholder: '2000,3456',
+      tooltip: t('setting.opentextRootNodeIdsTip'),
+    },
+    {
+      label: 'OTCS Ticket',
+      name: 'config.credentials.opentext_ticket',
+      type: FormFieldType.Password,
+      required: false,
+    },
+    {
+      label: 'API Token',
+      name: 'config.credentials.opentext_api_token',
+      type: FormFieldType.Password,
+      required: false,
+    },
+    {
+      label: 'Username',
+      name: 'config.credentials.opentext_username',
+      type: FormFieldType.Text,
+      required: false,
+    },
+    {
+      label: 'Password',
+      name: 'config.credentials.opentext_password',
+      type: FormFieldType.Password,
+      required: false,
+    },
+  ],
 };
 
 export const DataSourceFormDefaultValues = {
@@ -1643,6 +1694,21 @@ export const DataSourceFormDefaultValues = {
         confluence_access_token: '',
       },
       index_mode: 'everything',
+    },
+  },
+  [DataSourceKey.OPENTEXT]: {
+    name: '',
+    source: DataSourceKey.OPENTEXT,
+    config: {
+      base_url: '',
+      root_node_ids: '',
+      batch_size: 2,
+      credentials: {
+        opentext_ticket: '',
+        opentext_api_token: '',
+        opentext_username: '',
+        opentext_password: '',
+      },
     },
   },
   [DataSourceKey.GOOGLE_DRIVE]: {


### PR DESCRIPTION
### What problem does this PR solve?

Adds an OpenText Content Server data-source connector so RAGFlow can sync managed documents from configured root nodes.

Fixes #15596

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

### Verification

- `python3 -m py_compile common/data_source/opentext_connector.py test/unit_test/data_source/test_opentext_connector_unit.py rag/svr/sync_data_source.py common/constants.py common/data_source/config.py common/data_source/__init__.py`
- `uv run --python 3.13 --with pytest --with pytest-asyncio pytest test/unit_test/data_source/test_opentext_connector_unit.py -q`
- `git diff --check`