### PR TITLE
feat(connector): implement Tableau data source

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -156,6 +156,7 @@ class FileSource(StrEnum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    TABLEAU = "tableau"
 
 
 class PipelineTaskType(StrEnum):

--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -36,6 +36,7 @@ from .jira.connector import JiraConnector
 from .sharepoint_connector import SharePointConnector
 from .onedrive_connector import OneDriveConnector
 from .outlook_connector import OutlookConnector
+from .tableau_connector import TableauConnector
 from .teams_connector import TeamsConnector
 from .moodle_connector import MoodleConnector
 from .airtable_connector import AirtableConnector
@@ -71,6 +72,7 @@ __all__ = [
     "SharePointConnector",
     "OneDriveConnector",
     "OutlookConnector",
+    "TableauConnector",
     "TeamsConnector",
     "MoodleConnector",
     "BlobType",

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -71,6 +71,7 @@ class DocumentSource(str, Enum):
     DINGTALK_AI_TABLE = "dingtalk_ai_table"
     ONEDRIVE = "onedrive"
     OUTLOOK = "outlook"
+    TABLEAU = "tableau"
 
 
 class FileOrigin(str, Enum):

--- a/common/data_source/tableau_connector.py
+++ b/common/data_source/tableau_connector.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Generator, Iterator
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+
+from common.data_source.config import DocumentSource, INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
+from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
+from common.data_source.models import Document, SecondsSinceUnixEpoch, SlimDocument
+
+
+class TableauConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    def __init__(
+        self,
+        server_url: str,
+        site_content_url: str = "",
+        api_version: str = "3.24",
+        project_names: str = "",
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.server_url = server_url.rstrip("/")
+        self.site_content_url = site_content_url
+        self.api_version = api_version or "3.24"
+        self.project_names = {p.strip() for p in project_names.split(",") if p.strip()}
+        self.batch_size = batch_size or INDEX_BATCH_SIZE
+        self.session = requests.Session()
+        self._credentials: dict[str, Any] = {}
+        self._site_id = ""
+        self._signed_in = False
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._credentials = credentials or {}
+        return None
+
+    def validate_connector_settings(self) -> None:
+        if not self.server_url:
+            raise ValueError("Tableau connector requires server_url")
+        if not self._credentials.get("tableau_pat_name") or not self._credentials.get("tableau_pat_secret"):
+            raise ValueError("Tableau connector requires personal access token credentials")
+
+    def load_from_state(self) -> Generator[list[Document], None, None]:
+        yield from self._batch_documents(self._iter_documents())
+
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> Generator[list[Document], None, None]:
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        docs = (
+            doc
+            for doc in self._iter_documents()
+            if start_dt <= doc.doc_updated_at <= end_dt
+        )
+        yield from self._batch_documents(docs)
+
+    def retrieve_all_slim_docs_perm_sync(self, callback: Any = None) -> Generator[list[SlimDocument], None, None]:
+        del callback
+        batch: list[SlimDocument] = []
+        for doc in self._iter_documents():
+            batch.append(SlimDocument(id=doc.id))
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    def _iter_documents(self) -> Iterator[Document]:
+        self._ensure_signed_in()
+        for workbook in self._list_workbooks():
+            project_name = (workbook.get("project") or {}).get("name") or workbook.get("projectName") or ""
+            if self.project_names and project_name not in self.project_names:
+                continue
+            views = list(self._list_workbook_views(str(workbook.get("id"))))
+            if not views:
+                yield self._document_from_item("workbook", workbook, workbook)
+                continue
+            for view in views:
+                yield self._document_from_item("view", view, workbook)
+
+    def _ensure_signed_in(self) -> None:
+        if self._signed_in:
+            return
+        payload = {
+            "credentials": {
+                "personalAccessTokenName": self._credentials.get("tableau_pat_name"),
+                "personalAccessTokenSecret": self._credentials.get("tableau_pat_secret"),
+                "site": {"contentUrl": self.site_content_url},
+            }
+        }
+        response = self.session.post(
+            self._api_url("auth/signin"),
+            json=payload,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        credentials = response.json().get("credentials", {})
+        token = credentials.get("token")
+        site_id = (credentials.get("site") or {}).get("id")
+        if not token or not site_id:
+            raise ValueError("Tableau sign-in response did not include token and site id")
+        self._site_id = site_id
+        self.session.headers.update({"X-Tableau-Auth": token})
+        self._signed_in = True
+
+    def _list_workbooks(self) -> Iterator[dict[str, Any]]:
+        yield from self._paged_items(
+            f"sites/{self._site_id}/workbooks",
+            container="workbooks",
+            item_key="workbook",
+        )
+
+    def _list_workbook_views(self, workbook_id: str) -> Iterator[dict[str, Any]]:
+        yield from self._paged_items(
+            f"sites/{self._site_id}/workbooks/{workbook_id}/views",
+            container="views",
+            item_key="view",
+        )
+
+    def _paged_items(self, path: str, container: str, item_key: str) -> Iterator[dict[str, Any]]:
+        page_number = 1
+        page_size = 100
+        while True:
+            response = self.session.get(
+                self._api_url(path),
+                params={"pageSize": page_size, "pageNumber": page_number},
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            items = self._items_from_payload(payload, container, item_key)
+            yield from items
+            pagination = payload.get("pagination") or {}
+            total_available = int(pagination.get("totalAvailable") or len(items))
+            if page_number * page_size >= total_available or not items:
+                break
+            page_number += 1
+
+    def _api_url(self, path: str) -> str:
+        return urljoin(f"{self.server_url}/", f"api/{self.api_version}/{path.lstrip('/')}")
+
+    @staticmethod
+    def _items_from_payload(payload: dict[str, Any], container: str, item_key: str) -> list[dict[str, Any]]:
+        value = (payload.get(container) or {}).get(item_key)
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [value]
+        return []
+
+    def _document_from_item(self, item_type: str, item: dict[str, Any], workbook: dict[str, Any]) -> Document:
+        item_id = str(item.get("id"))
+        name = str(item.get("name") or item_id)
+        workbook_name = str(workbook.get("name") or "")
+        project_name = (workbook.get("project") or {}).get("name") or workbook.get("projectName") or ""
+        link = str(item.get("webpageUrl") or item.get("contentUrl") or workbook.get("webpageUrl") or "")
+        updated_at = self._parse_datetime(item.get("updatedAt") or workbook.get("updatedAt") or item.get("createdAt"))
+        text = "\n".join(
+            [
+                f"Type: Tableau {item_type}",
+                f"Name: {name}",
+                f"Workbook: {workbook_name}",
+                f"Project: {project_name}",
+                f"URL: {link}",
+            ]
+        )
+        blob = text.encode("utf-8")
+        return Document(
+            id=f"tableau:{item_type}:{item_id}",
+            source=DocumentSource.TABLEAU,
+            semantic_identifier=name,
+            extension="txt",
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            metadata={
+                "item_type": item_type,
+                "item_id": item_id,
+                "workbook_id": workbook.get("id"),
+                "workbook_name": workbook_name,
+                "project_name": project_name,
+                "url": link,
+            },
+            fingerprint=hashlib.sha256(blob).hexdigest(),
+        )
+
+    @staticmethod
+    def _parse_datetime(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str) and value:
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+            except ValueError:
+                pass
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+    def _batch_documents(self, docs: Iterator[Document]) -> Generator[list[Document], None, None]:
+        batch: list[Document] = []
+        for doc in docs:
+            batch.append(doc)
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -63,6 +63,7 @@ from common.data_source import (
     RestAPIConnector,
     OneDriveConnector,
     OutlookConnector,
+    TableauConnector,
     TeamsConnector,
     SlackConnector,
     SharePointConnector,
@@ -1975,6 +1976,33 @@ class REST_API(SyncBase):
         return document_generator
 
 
+class Tableau(SyncBase):
+    SOURCE_NAME: str = FileSource.TABLEAU
+
+    async def _generate(self, task: dict):
+        self.connector = TableauConnector(
+            server_url=self.conf.get("server_url", ""),
+            site_content_url=self.conf.get("site_content_url", ""),
+            api_version=self.conf.get("api_version", "3.24"),
+            project_names=self.conf.get("project_names", ""),
+            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+        )
+        self.connector.load_credentials(self.conf.get("credentials") or {})
+        self.connector.validate_connector_settings()
+
+        poll_start = task.get("poll_range_start")
+        if task.get("reindex") == "1" or poll_start is None:
+            document_generator = self.connector.load_from_state()
+        else:
+            document_generator = self.connector.poll_source(
+                poll_start.timestamp(),
+                datetime.now(timezone.utc).timestamp(),
+            )
+
+        self.log_connection("Tableau", self.conf.get("server_url", ""), task)
+        return document_generator
+
+
 func_factory = {
     FileSource.RSS: RSS,
     FileSource.S3: S3,
@@ -2008,6 +2036,7 @@ func_factory = {
     FileSource.POSTGRESQL: PostgreSQL,
     FileSource.DINGTALK_AI_TABLE: DingTalkAITable,
     FileSource.REST_API: REST_API,
+    FileSource.TABLEAU: Tableau,
 }
 
 

--- a/test/unit_test/data_source/test_tableau_connector_unit.py
+++ b/test/unit_test/data_source/test_tableau_connector_unit.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from common.data_source.tableau_connector import TableauConnector
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+        self.calls: list[str] = []
+
+    def post(self, url: str, json: dict[str, Any], timeout: int) -> FakeResponse:
+        del json, timeout
+        self.calls.append(url.split("https://tableau.test/", 1)[1])
+        return FakeResponse({"credentials": {"token": "token", "site": {"id": "site1"}}})
+
+    def get(self, url: str, params: dict[str, Any], timeout: int) -> FakeResponse:
+        del params, timeout
+        path = url.split("https://tableau.test/", 1)[1]
+        self.calls.append(path)
+        payloads = {
+            "api/3.24/sites/site1/workbooks": {
+                "pagination": {"totalAvailable": "1"},
+                "workbooks": {
+                    "workbook": [
+                        {
+                            "id": "wb1",
+                            "name": "Revenue",
+                            "updatedAt": "2026-06-01T10:00:00Z",
+                            "webpageUrl": "https://tableau.test/#/workbooks/wb1",
+                            "project": {"name": "Finance"},
+                        }
+                    ]
+                },
+            },
+            "api/3.24/sites/site1/workbooks/wb1/views": {
+                "pagination": {"totalAvailable": "1"},
+                "views": {
+                    "view": [
+                        {
+                            "id": "view1",
+                            "name": "Revenue Summary",
+                            "updatedAt": "2026-06-01T11:00:00Z",
+                            "webpageUrl": "https://tableau.test/#/views/view1",
+                        }
+                    ]
+                },
+            },
+        }
+        return FakeResponse(payloads[path])
+
+
+def make_connector() -> TableauConnector:
+    connector = TableauConnector("https://tableau.test", project_names="Finance")
+    connector.session = FakeSession()
+    connector.load_credentials({"tableau_pat_name": "name", "tableau_pat_secret": "secret"})
+    return connector
+
+
+@pytest.mark.p1
+def test_tableau_connector_builds_view_documents() -> None:
+    connector = make_connector()
+
+    batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    doc = batches[0][0]
+    text = doc.blob.decode("utf-8")
+    assert doc.id == "tableau:view:view1"
+    assert doc.source == "tableau"
+    assert doc.semantic_identifier == "Revenue Summary"
+    assert "Workbook: Revenue" in text
+    assert doc.metadata["project_name"] == "Finance"
+    assert doc.fingerprint
+
+
+@pytest.mark.p1
+def test_tableau_connector_poll_source_filters_by_date() -> None:
+    connector = make_connector()
+    start = datetime(2026, 5, 30, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc).timestamp()
+
+    batches = list(connector.poll_source(start, end))
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["tableau:view:view1"]]
+
+
+@pytest.mark.p1
+def test_tableau_connector_retrieves_slim_docs() -> None:
+    connector = make_connector()
+
+    batches = list(connector.retrieve_all_slim_docs_perm_sync())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["tableau:view:view1"]]
+
+
+@pytest.mark.p1
+def test_tableau_connector_requires_pat_credentials() -> None:
+    connector = TableauConnector("https://tableau.test")
+    connector.load_credentials({})
+
+    with pytest.raises(ValueError, match="personal access token"):
+        connector.validate_connector_settings()

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1204,6 +1204,14 @@ Example: Virtual Hosted Style`,
         'Connect to a public RSS or Atom feed and sync feed entries into your knowledge base.',
       confluenceDescription:
         'Integrate your Confluence workspace to search documentation.',
+      tableauDescription:
+        'Connect Tableau to sync workbook and view metadata into your knowledge base.',
+      tableauServerUrlTip:
+        'The Tableau Cloud or Tableau Server URL, e.g. https://prod-useast-a.online.tableau.com.',
+      tableauSiteContentUrlTip:
+        'The Tableau site content URL. Leave empty for the default site.',
+      tableauProjectNamesTip:
+        'Optional comma-separated project names to sync. Leave empty to sync all accessible projects.',
       s3Description:
         'Connect to your AWS S3 bucket to import and sync stored files.',
       google_cloud_storageDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1077,6 +1077,14 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       rssDescription:
         '连接公开的 RSS 或 Atom feed，并将 feed 条目同步到知识库。',
       confluenceDescription: '连接你的 Confluence 工作区以搜索文档内容。',
+      tableauDescription:
+        '连接 Tableau，将工作簿和视图元数据同步到知识库。',
+      tableauServerUrlTip:
+        'Tableau Cloud 或 Tableau Server URL，例如 https://prod-useast-a.online.tableau.com。',
+      tableauSiteContentUrlTip:
+        'Tableau 站点 content URL。默认站点可留空。',
+      tableauProjectNamesTip:
+        '可选：要同步的项目名称，多个用逗号分隔。留空则同步所有可访问项目。',
       s3Description: ' 连接你的 AWS S3 存储桶以导入和同步文件。',
       google_cloud_storageDescription:
         '连接你的 Google Cloud Storage 存储桶以导入和同步文件。',

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -2,7 +2,7 @@ import { FormFieldConfig, FormFieldType } from '@/components/dynamic-form';
 import { IconFontFill } from '@/components/icon-font';
 import SvgIcon from '@/components/svg-icon';
 import { t, TFunction } from 'i18next';
-import { Mail, Rss } from 'lucide-react';
+import { BarChart3, Mail, Rss } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BoxTokenField from '../component/box-token-field';
@@ -48,6 +48,7 @@ export enum DataSourceKey {
   TEAMS = 'teams',
   SLACK = 'slack',
   SHAREPOINT = 'sharepoint',
+  TABLEAU = 'tableau',
 }
 
 type DataSourceFeatureVisibility = {
@@ -146,6 +147,9 @@ export const DataSourceFeatureVisibilityMap: Partial<
   [DataSourceKey.SHAREPOINT]: {
     syncDeletedFiles: true,
   },
+  [DataSourceKey.TABLEAU]: {
+    syncDeletedFiles: true,
+  },
   [DataSourceKey.MYSQL]: {
     syncDeletedFiles: true,
   },
@@ -208,6 +212,11 @@ export const generateDataSourceInfo = (t: TFunction) => {
       name: 'Confluence',
       description: t(`setting.${DataSourceKey.CONFLUENCE}Description`),
       icon: <SvgIcon name={'data-source/confluence'} width={38} />,
+    },
+    [DataSourceKey.TABLEAU]: {
+      name: 'Tableau',
+      description: t(`setting.${DataSourceKey.TABLEAU}Description`),
+      icon: <BarChart3 className="text-text-primary" size={22} />,
     },
     [DataSourceKey.GOOGLE_DRIVE]: {
       name: 'Google Drive',
@@ -1568,6 +1577,51 @@ export const DataSourceFormFields = {
         !!values?.config?.show_advanced && values?.config?.method === 'POST',
     },
   ],
+  [DataSourceKey.TABLEAU]: [
+    {
+      label: 'Server URL',
+      name: 'config.server_url',
+      type: FormFieldType.Text,
+      required: true,
+      placeholder: 'https://prod-useast-a.online.tableau.com',
+      tooltip: t('setting.tableauServerUrlTip'),
+    },
+    {
+      label: 'Site Content URL',
+      name: 'config.site_content_url',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'my-site',
+      tooltip: t('setting.tableauSiteContentUrlTip'),
+    },
+    {
+      label: 'API Version',
+      name: 'config.api_version',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: '3.24',
+    },
+    {
+      label: 'Project Names',
+      name: 'config.project_names',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'Finance,Sales',
+      tooltip: t('setting.tableauProjectNamesTip'),
+    },
+    {
+      label: 'PAT Name',
+      name: 'config.credentials.tableau_pat_name',
+      type: FormFieldType.Text,
+      required: true,
+    },
+    {
+      label: 'PAT Secret',
+      name: 'config.credentials.tableau_pat_secret',
+      type: FormFieldType.Password,
+      required: true,
+    },
+  ],
 };
 
 export const DataSourceFormDefaultValues = {
@@ -1643,6 +1697,21 @@ export const DataSourceFormDefaultValues = {
         confluence_access_token: '',
       },
       index_mode: 'everything',
+    },
+  },
+  [DataSourceKey.TABLEAU]: {
+    name: '',
+    source: DataSourceKey.TABLEAU,
+    config: {
+      server_url: '',
+      site_content_url: '',
+      api_version: '3.24',
+      project_names: '',
+      batch_size: 2,
+      credentials: {
+        tableau_pat_name: '',
+        tableau_pat_secret: '',
+      },
     },
   },
   [DataSourceKey.GOOGLE_DRIVE]: {


### PR DESCRIPTION
### What problem does this PR solve?

Adds a Tableau data-source connector so RAGFlow can sync workbook and view metadata from Tableau Cloud or Tableau Server.

Fixes #15595

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

### Verification

- `python3 -m py_compile common/data_source/tableau_connector.py test/unit_test/data_source/test_tableau_connector_unit.py rag/svr/sync_data_source.py common/constants.py common/data_source/config.py common/data_source/__init__.py`
- `uv run --python 3.13 --with pytest --with pytest-asyncio pytest test/unit_test/data_source/test_tableau_connector_unit.py -q`
- `git diff --check`