### PR TITLE
feat(connector): implement Trino data source

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -158,6 +158,7 @@ class FileSource(StrEnum):
     OUTLOOK = "outlook"
     SALESFORCE = "salesforce"
     AZURE_BLOB = "azure_blob"
+    TRINO = "trino"
 
 
 class PipelineTaskType(StrEnum):

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -73,6 +73,7 @@ class DocumentSource(str, Enum):
     OUTLOOK = "outlook"
     SALESFORCE = "salesforce"
     AZURE_BLOB = "azure_blob"
+    TRINO = "trino"
 
 
 class FileOrigin(str, Enum):

--- a/common/data_source/trino_connector.py
+++ b/common/data_source/trino_connector.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Generator, Iterator
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+
+from common.data_source.config import DocumentSource, INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
+from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
+from common.data_source.models import Document, SecondsSinceUnixEpoch, SlimDocument
+
+
+class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    def __init__(
+        self,
+        server_url: str,
+        catalog: str,
+        schema: str,
+        query: str,
+        content_columns: str,
+        metadata_columns: str = "",
+        id_column: str = "",
+        timestamp_column: str = "",
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.server_url = server_url.rstrip("/")
+        self.catalog = catalog.strip()
+        self.schema = schema.strip()
+        self.query = query.strip().rstrip(";")
+        self.content_columns = [c.strip() for c in content_columns.split(",") if c.strip()]
+        self.metadata_columns = [c.strip() for c in metadata_columns.split(",") if c.strip()]
+        self.id_column = id_column.strip()
+        self.timestamp_column = timestamp_column.strip()
+        self.batch_size = batch_size or INDEX_BATCH_SIZE
+        self.session = requests.Session()
+        self._credentials: dict[str, Any] = {}
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._credentials = credentials or {}
+        username = self._credentials.get("trino_username")
+        password = self._credentials.get("trino_password")
+        token = self._credentials.get("trino_bearer_token")
+        if username:
+            self.session.headers.update({"X-Trino-User": username})
+        if token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+        elif username and password:
+            self.session.auth = (username, password)
+        return None
+
+    def validate_connector_settings(self) -> None:
+        if not self.server_url:
+            raise ValueError("Trino connector requires server_url")
+        if not self.query:
+            raise ValueError("Trino connector requires query")
+        if not self.content_columns:
+            raise ValueError("Trino connector requires content_columns")
+        if not self._credentials.get("trino_username"):
+            raise ValueError("Trino connector requires trino_username")
+
+    def load_from_state(self) -> Generator[list[Document], None, None]:
+        yield from self._batch_documents(self._iter_documents())
+
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> Generator[list[Document], None, None]:
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        docs = (
+            doc
+            for doc in self._iter_documents()
+            if start_dt <= doc.doc_updated_at <= end_dt
+        )
+        yield from self._batch_documents(docs)
+
+    def retrieve_all_slim_docs_perm_sync(self, callback: Any = None) -> Generator[list[SlimDocument], None, None]:
+        del callback
+        batch: list[SlimDocument] = []
+        for doc in self._iter_documents():
+            batch.append(SlimDocument(id=doc.id))
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    def _iter_documents(self) -> Iterator[Document]:
+        for row in self._query_rows():
+            yield self._document_from_row(row)
+
+    def _query_rows(self) -> Iterator[dict[str, Any]]:
+        response = self.session.post(
+            urljoin(f"{self.server_url}/", "v1/statement"),
+            data=self.query,
+            headers=self._statement_headers(),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        while True:
+            yield from self._rows_from_payload(payload)
+            next_uri = payload.get("nextUri")
+            if not next_uri:
+                break
+            response = self.session.get(next_uri, timeout=REQUEST_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            payload = response.json()
+
+    def _statement_headers(self) -> dict[str, str]:
+        headers = {"X-Trino-Source": "ragflow"}
+        if self.catalog:
+            headers["X-Trino-Catalog"] = self.catalog
+        if self.schema:
+            headers["X-Trino-Schema"] = self.schema
+        return headers
+
+    @staticmethod
+    def _rows_from_payload(payload: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        columns = [column["name"] for column in payload.get("columns") or []]
+        for row in payload.get("data") or []:
+            yield dict(zip(columns, row))
+
+    def _document_from_row(self, row: dict[str, Any]) -> Document:
+        content_lines = [f"{column}: {row.get(column, '')}" for column in self.content_columns]
+        metadata = {column: row.get(column) for column in self.metadata_columns}
+        row_id = str(row.get(self.id_column) if self.id_column else self._row_hash(row))
+        updated_at = self._parse_datetime(row.get(self.timestamp_column)) if self.timestamp_column else datetime.now(timezone.utc)
+        text = "\n".join(content_lines)
+        blob = text.encode("utf-8")
+        metadata.update(
+            {
+                "catalog": self.catalog,
+                "schema": self.schema,
+                "row_id": row_id,
+            }
+        )
+        return Document(
+            id=f"trino:{row_id}",
+            source=DocumentSource.TRINO,
+            semantic_identifier=row_id,
+            extension="txt",
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            metadata=metadata,
+            fingerprint=hashlib.sha256(blob).hexdigest(),
+        )
+
+    @staticmethod
+    def _row_hash(row: dict[str, Any]) -> str:
+        return hashlib.sha256(repr(sorted(row.items())).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _parse_datetime(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        if isinstance(value, str) and value:
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+            except ValueError:
+                pass
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+    def _batch_documents(self, docs: Iterator[Document]) -> Generator[list[Document], None, None]:
+        batch: list[Document] = []
+        for doc in docs:
+            batch.append(doc)
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch

--- a/common/data_source/trino_connector.py
+++ b/common/data_source/trino_connector.py
@@ -103,6 +103,7 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         response.raise_for_status()
         payload = response.json()
         while True:
+            self._raise_for_trino_error(payload)
             yield from self._rows_from_payload(payload)
             next_uri = payload.get("nextUri")
             if not next_uri:
@@ -118,6 +119,17 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         if self.schema:
             headers["X-Trino-Schema"] = self.schema
         return headers
+
+    @staticmethod
+    def _raise_for_trino_error(payload: dict[str, Any]) -> None:
+        error = payload.get("error")
+        if not error:
+            return
+        message = error.get("message") or "Trino query failed"
+        name = error.get("errorName")
+        if name:
+            message = f"{name}: {message}"
+        raise ValueError(message)
 
     @staticmethod
     def _rows_from_payload(payload: dict[str, Any]) -> Iterator[dict[str, Any]]:

--- a/common/data_source/trino_connector.py
+++ b/common/data_source/trino_connector.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import hashlib
+import logging
+import time
 from collections.abc import Generator, Iterator
 from datetime import datetime, timezone
 from typing import Any
@@ -11,6 +13,9 @@ import requests
 from common.data_source.config import DocumentSource, INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
 from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
 from common.data_source.models import Document, SecondsSinceUnixEpoch, SlimDocument
+
+
+logger = logging.getLogger(__name__)
 
 
 class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
@@ -37,6 +42,17 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.batch_size = batch_size or INDEX_BATCH_SIZE
         self.session = requests.Session()
         self._credentials: dict[str, Any] = {}
+        logger.info(
+            "Initialized Trino connector server_url=%s catalog=%s schema=%s batch_size=%s content_columns=%s metadata_columns=%s has_id_column=%s has_timestamp_column=%s",
+            self.server_url,
+            self.catalog,
+            self.schema,
+            self.batch_size,
+            len(self.content_columns),
+            len(self.metadata_columns),
+            bool(self.id_column),
+            bool(self.timestamp_column),
+        )
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self._credentials = credentials or {}
@@ -47,8 +63,12 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             self.session.headers.update({"X-Trino-User": username})
         if token:
             self.session.headers.update({"Authorization": f"Bearer {token}"})
+            logger.info("Loaded Trino connector credentials auth_mode=bearer has_username=%s", bool(username))
         elif username and password:
             self.session.auth = (username, password)
+            logger.info("Loaded Trino connector credentials auth_mode=basic has_username=%s", bool(username))
+        else:
+            logger.info("Loaded Trino connector credentials auth_mode=none has_username=%s", bool(username))
         return None
 
     def validate_connector_settings(self) -> None:
@@ -94,23 +114,41 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             yield self._document_from_row(row)
 
     def _query_rows(self) -> Iterator[dict[str, Any]]:
-        response = self.session.post(
-            urljoin(f"{self.server_url}/", "v1/statement"),
-            data=self.query,
-            headers=self._statement_headers(),
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-        payload = response.json()
-        while True:
-            self._raise_for_trino_error(payload)
-            yield from self._rows_from_payload(payload)
-            next_uri = payload.get("nextUri")
-            if not next_uri:
-                break
-            response = self.session.get(next_uri, timeout=REQUEST_TIMEOUT_SECONDS)
+        started_at = time.perf_counter()
+        row_count = 0
+        logger.info("Starting Trino query catalog=%s schema=%s", self.catalog, self.schema)
+        try:
+            response = self.session.post(
+                urljoin(f"{self.server_url}/", "v1/statement"),
+                data=self.query,
+                headers=self._statement_headers(),
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
             response.raise_for_status()
             payload = response.json()
+            while True:
+                self._raise_for_trino_error(payload)
+                for row in self._rows_from_payload(payload):
+                    row_count += 1
+                    yield row
+                next_uri = payload.get("nextUri")
+                if not next_uri:
+                    break
+                response = self.session.get(next_uri, timeout=REQUEST_TIMEOUT_SECONDS)
+                response.raise_for_status()
+                payload = response.json()
+            logger.info(
+                "Finished Trino query rows=%s elapsed_seconds=%.3f",
+                row_count,
+                time.perf_counter() - started_at,
+            )
+        except Exception:
+            logger.exception(
+                "Trino query failed rows=%s elapsed_seconds=%.3f",
+                row_count,
+                time.perf_counter() - started_at,
+            )
+            raise
 
     def _statement_headers(self) -> dict[str, str]:
         headers = {"X-Trino-Source": "ragflow"}
@@ -120,8 +158,7 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             headers["X-Trino-Schema"] = self.schema
         return headers
 
-    @staticmethod
-    def _raise_for_trino_error(payload: dict[str, Any]) -> None:
+    def _raise_for_trino_error(self, payload: dict[str, Any]) -> None:
         error = payload.get("error")
         if not error:
             return
@@ -129,6 +166,7 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         name = error.get("errorName")
         if name:
             message = f"{name}: {message}"
+        logger.error("Trino returned query error error_name=%s message=%s", name, message)
         raise ValueError(message)
 
     @staticmethod
@@ -141,7 +179,7 @@ class TrinoConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         content_lines = [f"{column}: {row.get(column, '')}" for column in self.content_columns]
         metadata = {column: row.get(column) for column in self.metadata_columns}
         row_id = str(row.get(self.id_column) if self.id_column else self._row_hash(row))
-        updated_at = self._parse_datetime(row.get(self.timestamp_column)) if self.timestamp_column else datetime.now(timezone.utc)
+        updated_at = self._parse_datetime(row.get(self.timestamp_column)) if self.timestamp_column else self._parse_datetime(None)
         text = "\n".join(content_lines)
         blob = text.encode("utf-8")
         metadata.update(

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -79,6 +79,7 @@ from common.data_source.gitlab_connector import GitlabConnector
 from common.data_source.bitbucket.connector import BitbucketConnector
 from common.data_source.interfaces import CheckpointOutputWrapper
 from common.data_source.exceptions import ConnectorValidationError
+from common.data_source.trino_connector import TrinoConnector
 from common.log_utils import init_root_logger
 from common.signal_utils import start_tracemalloc_and_snapshot, stop_tracemalloc
 from common.versions import get_ragflow_version
@@ -2090,6 +2091,37 @@ class REST_API(SyncBase):
         return document_generator
 
 
+class Trino(SyncBase):
+    SOURCE_NAME: str = FileSource.TRINO
+
+    async def _generate(self, task: dict):
+        self.connector = TrinoConnector(
+            server_url=self.conf.get("server_url", ""),
+            catalog=self.conf.get("catalog", ""),
+            schema=self.conf.get("schema", ""),
+            query=self.conf.get("query", ""),
+            content_columns=self.conf.get("content_columns", ""),
+            metadata_columns=self.conf.get("metadata_columns", ""),
+            id_column=self.conf.get("id_column", ""),
+            timestamp_column=self.conf.get("timestamp_column", ""),
+            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+        )
+        self.connector.load_credentials(self.conf.get("credentials") or {})
+        self.connector.validate_connector_settings()
+
+        poll_start = task.get("poll_range_start")
+        if task.get("reindex") == "1" or poll_start is None:
+            document_generator = self.connector.load_from_state()
+        else:
+            document_generator = self.connector.poll_source(
+                poll_start.timestamp(),
+                datetime.now(timezone.utc).timestamp(),
+            )
+
+        self.log_connection("Trino", self.conf.get("server_url", ""), task)
+        return document_generator
+
+
 func_factory = {
     FileSource.RSS: RSS,
     FileSource.S3: S3,
@@ -2125,6 +2157,7 @@ func_factory = {
     FileSource.POSTGRESQL: PostgreSQL,
     FileSource.DINGTALK_AI_TABLE: DingTalkAITable,
     FileSource.REST_API: REST_API,
+    FileSource.TRINO: Trino,
 }
 
 

--- a/test/unit_test/data_source/test_trino_connector_unit.py
+++ b/test/unit_test/data_source/test_trino_connector_unit.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from common.data_source.trino_connector import TrinoConnector
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+        self.auth: tuple[str, str] | None = None
+        self.calls: list[str] = []
+
+    def post(self, url: str, data: str, headers: dict[str, str], timeout: int) -> FakeResponse:
+        del timeout
+        self.calls.append(f"POST {url} {data} {headers.get('X-Trino-Catalog')}")
+        return FakeResponse(
+            {
+                "columns": [
+                    {"name": "id"},
+                    {"name": "title"},
+                    {"name": "body"},
+                    {"name": "updated_at"},
+                ],
+                "data": [["1", "Policy", "Quarterly policy text", "2026-06-01T10:00:00Z"]],
+            }
+        )
+
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        del url, timeout
+        return FakeResponse({})
+
+
+def make_connector() -> TrinoConnector:
+    connector = TrinoConnector(
+        server_url="https://trino.test",
+        catalog="hive",
+        schema="default",
+        query="SELECT id, title, body, updated_at FROM docs",
+        content_columns="title,body",
+        metadata_columns="updated_at",
+        id_column="id",
+        timestamp_column="updated_at",
+    )
+    connector.session = FakeSession()
+    connector.load_credentials({"trino_username": "user", "trino_password": "pass"})
+    return connector
+
+
+@pytest.mark.p1
+def test_trino_connector_builds_row_documents() -> None:
+    connector = make_connector()
+
+    batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    doc = batches[0][0]
+    text = doc.blob.decode("utf-8")
+    assert doc.id == "trino:1"
+    assert doc.source == "trino"
+    assert doc.semantic_identifier == "1"
+    assert "title: Policy" in text
+    assert "body: Quarterly policy text" in text
+    assert doc.metadata["catalog"] == "hive"
+    assert doc.fingerprint
+
+
+@pytest.mark.p1
+def test_trino_connector_poll_source_filters_by_date() -> None:
+    connector = make_connector()
+    start = datetime(2026, 5, 30, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc).timestamp()
+
+    batches = list(connector.poll_source(start, end))
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["trino:1"]]
+
+
+@pytest.mark.p1
+def test_trino_connector_retrieves_slim_docs() -> None:
+    connector = make_connector()
+
+    batches = list(connector.retrieve_all_slim_docs_perm_sync())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["trino:1"]]
+
+
+@pytest.mark.p1
+def test_trino_connector_requires_query() -> None:
+    connector = TrinoConnector("https://trino.test", "hive", "default", "", "title")
+    connector.load_credentials({"trino_username": "user"})
+
+    with pytest.raises(ValueError, match="query"):
+        connector.validate_connector_settings()

--- a/test/unit_test/data_source/test_trino_connector_unit.py
+++ b/test/unit_test/data_source/test_trino_connector_unit.py
@@ -45,6 +45,12 @@ class FakeSession:
         return FakeResponse({})
 
 
+class ErrorSession(FakeSession):
+    def post(self, url: str, data: str, headers: dict[str, str], timeout: int) -> FakeResponse:
+        del url, data, headers, timeout
+        return FakeResponse({"error": {"errorName": "USER_ERROR", "message": "bad query"}})
+
+
 def make_connector() -> TrinoConnector:
     connector = TrinoConnector(
         server_url="https://trino.test",
@@ -106,3 +112,12 @@ def test_trino_connector_requires_query() -> None:
 
     with pytest.raises(ValueError, match="query"):
         connector.validate_connector_settings()
+
+
+@pytest.mark.p1
+def test_trino_connector_raises_trino_errors() -> None:
+    connector = make_connector()
+    connector.session = ErrorSession()
+
+    with pytest.raises(ValueError, match="USER_ERROR: bad query"):
+        list(connector.load_from_state())

--- a/test/unit_test/data_source/test_trino_connector_unit.py
+++ b/test/unit_test/data_source/test_trino_connector_unit.py
@@ -51,6 +51,39 @@ class ErrorSession(FakeSession):
         return FakeResponse({"error": {"errorName": "USER_ERROR", "message": "bad query"}})
 
 
+class PaginatedSession(FakeSession):
+    def post(self, url: str, data: str, headers: dict[str, str], timeout: int) -> FakeResponse:
+        del timeout
+        self.calls.append(f"POST {url} {data} {headers.get('X-Trino-Catalog')}")
+        return FakeResponse(
+            {
+                "columns": [
+                    {"name": "id"},
+                    {"name": "title"},
+                    {"name": "body"},
+                    {"name": "updated_at"},
+                ],
+                "data": [["1", "Policy", "Quarterly policy text", "2026-06-01T10:00:00Z"]],
+                "nextUri": "https://trino.test/v1/statement/queued/2",
+            }
+        )
+
+    def get(self, url: str, timeout: int) -> FakeResponse:
+        del timeout
+        self.calls.append(f"GET {url}")
+        return FakeResponse(
+            {
+                "columns": [
+                    {"name": "id"},
+                    {"name": "title"},
+                    {"name": "body"},
+                    {"name": "updated_at"},
+                ],
+                "data": [["2", "Runbook", "Incident response steps", "2026-06-01T11:00:00Z"]],
+            }
+        )
+
+
 def make_connector() -> TrinoConnector:
     connector = TrinoConnector(
         server_url="https://trino.test",
@@ -103,6 +136,18 @@ def test_trino_connector_retrieves_slim_docs() -> None:
     batches = list(connector.retrieve_all_slim_docs_perm_sync())
 
     assert [[doc.id for doc in batch] for batch in batches] == [["trino:1"]]
+
+
+@pytest.mark.p1
+def test_trino_connector_follows_next_uri_pages() -> None:
+    connector = make_connector()
+    session = PaginatedSession()
+    connector.session = session
+
+    batches = list(connector.load_from_state())
+
+    assert [[doc.id for doc in batch] for batch in batches] == [["trino:1", "trino:2"]]
+    assert "GET https://trino.test/v1/statement/queued/2" in session.calls
 
 
 @pytest.mark.p1

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1204,6 +1204,16 @@ Example: Virtual Hosted Style`,
         'Connect to a public RSS or Atom feed and sync feed entries into your knowledge base.',
       confluenceDescription:
         'Integrate your Confluence workspace to search documentation.',
+      trinoDescription:
+        'Connect Trino to sync federated SQL query results into your knowledge base.',
+      trinoServerUrlTip:
+        'The base URL of your Trino coordinator, e.g. https://trino.example.com.',
+      trinoQueryTip:
+        'SQL query used to extract rows from Trino. The selected columns are mapped into documents.',
+      trinoContentColumnsTip:
+        'Comma-separated column names whose values will be combined as document content.',
+      trinoTimestampColumnTip:
+        'Optional timestamp column used to filter incremental sync windows.',
       s3Description:
         'Connect to your AWS S3 bucket to import and sync stored files.',
       google_cloud_storageDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1077,6 +1077,16 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       rssDescription:
         '连接公开的 RSS 或 Atom feed，并将 feed 条目同步到知识库。',
       confluenceDescription: '连接你的 Confluence 工作区以搜索文档内容。',
+      trinoDescription:
+        '连接 Trino，将联邦 SQL 查询结果同步到知识库。',
+      trinoServerUrlTip:
+        'Trino coordinator 的基础 URL，例如 https://trino.example.com。',
+      trinoQueryTip:
+        '用于从 Trino 提取行数据的 SQL 查询。选定列会映射为文档。',
+      trinoContentColumnsTip:
+        '作为文档内容合并的列名，多个用逗号分隔。',
+      trinoTimestampColumnTip:
+        '可选：用于过滤增量同步窗口的时间戳列。',
       s3Description: ' 连接你的 AWS S3 存储桶以导入和同步文件。',
       google_cloud_storageDescription:
         '连接你的 Google Cloud Storage 存储桶以导入和同步文件。',

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -2,7 +2,7 @@ import { FormFieldConfig, FormFieldType } from '@/components/dynamic-form';
 import { IconFontFill } from '@/components/icon-font';
 import SvgIcon from '@/components/svg-icon';
 import { t, TFunction } from 'i18next';
-import { Mail, Rss } from 'lucide-react';
+import { Database, Mail, Rss } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BoxTokenField from '../component/box-token-field';
@@ -50,6 +50,7 @@ export enum DataSourceKey {
   TEAMS = 'teams',
   SLACK = 'slack',
   SHAREPOINT = 'sharepoint',
+  TRINO = 'trino',
 }
 
 type DataSourceFeatureVisibility = {
@@ -158,6 +159,9 @@ export const DataSourceFeatureVisibilityMap: Partial<
     syncDeletedFiles: true,
   },
   [DataSourceKey.POSTGRESQL]: {
+    syncDeletedFiles: true,
+  },
+  [DataSourceKey.TRINO]: {
     syncDeletedFiles: true,
   },
 };
@@ -332,6 +336,11 @@ export const generateDataSourceInfo = (t: TFunction) => {
       name: 'PostgreSQL',
       description: t(`setting.${DataSourceKey.POSTGRESQL}Description`),
       icon: <SvgIcon name={'data-source/postgresql'} width={38} />,
+    },
+    [DataSourceKey.TRINO]: {
+      name: 'Trino',
+      description: t(`setting.${DataSourceKey.TRINO}Description`),
+      icon: <Database className="text-text-primary" size={22} />,
     },
     [DataSourceKey.ONEDRIVE]: {
       name: 'OneDrive',
@@ -1483,6 +1492,86 @@ export const DataSourceFormFields = {
       tooltip: t('setting.postgresqlTimestampColumnTip'),
     },
   ],
+  [DataSourceKey.TRINO]: [
+    {
+      label: 'Server URL',
+      name: 'config.server_url',
+      type: FormFieldType.Text,
+      required: true,
+      placeholder: 'https://trino.example.com',
+      tooltip: t('setting.trinoServerUrlTip'),
+    },
+    {
+      label: 'Catalog',
+      name: 'config.catalog',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'hive',
+    },
+    {
+      label: 'Schema',
+      name: 'config.schema',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'default',
+    },
+    {
+      label: 'SQL Query',
+      name: 'config.query',
+      type: FormFieldType.Textarea,
+      required: true,
+      placeholder: 'SELECT id, title, body, updated_at FROM docs',
+      tooltip: t('setting.trinoQueryTip'),
+    },
+    {
+      label: 'Content Columns',
+      name: 'config.content_columns',
+      type: FormFieldType.Text,
+      required: true,
+      placeholder: 'title,body',
+      tooltip: t('setting.trinoContentColumnsTip'),
+    },
+    {
+      label: 'Metadata Columns',
+      name: 'config.metadata_columns',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'updated_at,category',
+    },
+    {
+      label: 'ID Column',
+      name: 'config.id_column',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'id',
+    },
+    {
+      label: 'Timestamp Column',
+      name: 'config.timestamp_column',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'updated_at',
+      tooltip: t('setting.trinoTimestampColumnTip'),
+    },
+    {
+      label: 'Username',
+      name: 'config.credentials.trino_username',
+      type: FormFieldType.Text,
+      required: true,
+    },
+    {
+      label: 'Password',
+      name: 'config.credentials.trino_password',
+      type: FormFieldType.Password,
+      required: false,
+    },
+    {
+      label: 'Bearer Token',
+      name: 'config.credentials.trino_bearer_token',
+      type: FormFieldType.Password,
+      required: false,
+    },
+  ],
   [DataSourceKey.REST_API]: [
     // ── Essential fields ──────────────────────────────────────────────
     {
@@ -2147,6 +2236,26 @@ export const DataSourceFormDefaultValues = {
       credentials: {
         username: '',
         password: '',
+      },
+    },
+  },
+  [DataSourceKey.TRINO]: {
+    name: '',
+    source: DataSourceKey.TRINO,
+    config: {
+      server_url: '',
+      catalog: '',
+      schema: '',
+      query: '',
+      content_columns: '',
+      metadata_columns: '',
+      id_column: '',
+      timestamp_column: '',
+      batch_size: 2,
+      credentials: {
+        trino_username: '',
+        trino_password: '',
+        trino_bearer_token: '',
       },
     },
   },


### PR DESCRIPTION
### What problem does this PR solve?

Adds a Trino data-source connector so RAGFlow can sync federated SQL query results through Trino's statement REST protocol.

Fixes #13220

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

### Verification

- `python3 -m py_compile common/data_source/trino_connector.py test/unit_test/data_source/test_trino_connector_unit.py rag/svr/sync_data_source.py common/constants.py common/data_source/config.py common/data_source/__init__.py`
- `uv run --python 3.13 --with pytest --with pytest-asyncio pytest test/unit_test/data_source/test_trino_connector_unit.py -q`
- `git diff --check`