### PR TITLE
fix(rag): paragraph() splits a token string into characters

### DIFF
--- a/rag/nlp/query.py
+++ b/rag/nlp/query.py
@@ -223,7 +223,7 @@ class FulltextQueryer(QueryBase):
 
     def paragraph(self, content_tks: str, keywords: list = [], keywords_topn=30):
         if isinstance(content_tks, str):
-            content_tks = [c.strip() for c in content_tks.strip() if c.strip()]
+            content_tks = [c for c in content_tks.split() if c.strip()]
         tks_w = self.tw.weights(content_tks, preprocess=False)
 
         origin_keywords = keywords.copy()

--- a/test/unit_test/rag/test_paragraph_token_split.py
+++ b/test/unit_test/rag/test_paragraph_token_split.py
@@ -1,0 +1,48 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Unit test for ``FulltextQueryer.paragraph`` token handling.
+
+Regression: callers (e.g. ``Dealer.tag_content``) pass a *space-joined token
+string* such as ``title_tks + " " + content_ltks``. ``paragraph`` previously
+iterated that string character-by-character (``[c.strip() for c in
+content_tks.strip()]``), so ``self.tw.weights`` received single characters
+instead of whole tokens and the tag-feature query weights were meaningless.
+"""
+
+from unittest.mock import MagicMock
+
+from rag.nlp.query import FulltextQueryer
+
+
+def test_paragraph_splits_token_string_on_whitespace():
+    # Bypass the heavy __init__ (term-weight / synonym dictionary loading).
+    q = FulltextQueryer.__new__(FulltextQueryer)
+
+    captured = {}
+
+    def fake_weights(tks, preprocess=False):
+        captured["tks"] = tks
+        return []
+
+    q.tw = MagicMock()
+    q.tw.weights.side_effect = fake_weights
+    q.syn = MagicMock()
+
+    q.paragraph("foo bar baz")
+
+    # Whole tokens, not individual characters.
+    assert captured["tks"] == ["foo", "bar", "baz"]


### PR DESCRIPTION
## Summary
`FulltextQueryer.paragraph` split a space-joined token string into **characters** instead of tokens, so term weights (and the resulting tag-feature query) were computed over single characters.

## Root cause
`Dealer.tag_content` passes `title_tks + " " + content_ltks` (a token string). The `str` branch did `[c.strip() for c in content_tks.strip() if c.strip()]`, which iterates characters.

## Fix
```diff
-            content_tks = [c.strip() for c in content_tks.strip() if c.strip()]
+            content_tks = [c for c in content_tks.split() if c.strip()]
```
Splits on whitespace into whole tokens, matching how every other tokenized field is handled (`self.tw.weights(..., preprocess=False)` expects tokens).

## Files changed
- `rag/nlp/query.py`
- `test/unit_test/rag/test_paragraph_token_split.py` (new)

## Verification
- `ruff check` / `ruff format --check` — clean
- Added unit test: `paragraph("foo bar baz")` passes `["foo","bar","baz"]` to `tw.weights` (was characters). (Standalone-verified the split.)
- Local full pytest not run (heavy RAG deps); CI validates.

## Note
Implemented with LLM assistance (model: claude-opus-4-8).

Closes #15617
