### PR TITLE
fix(api): await asyncio.wait_for in verify_api_key embedding branch

### DIFF
--- a/api/apps/services/provider_api_service.py
+++ b/api/apps/services/provider_api_service.py
@@ -362,7 +362,7 @@ async def verify_api_key(provider_name: str, api_key: str, base_url: str=None, r
             assert provider_name in EmbeddingModel, f"Embedding model from {provider_name} is not supported yet."
             mdl = EmbeddingModel[provider_name](api_key, llm["llm_name"], base_url=base_url)
             try:
-                arr, tc = asyncio.wait_for(
+                arr, tc = await asyncio.wait_for(
                     asyncio.to_thread(mdl.encode, ["Test if the api key is available"]),
                     timeout=timeout_seconds,
                 )


### PR DESCRIPTION
## Summary
The embedding branch of `verify_api_key` was missing `await` on `asyncio.wait_for(...)`, so valid embedding-only providers always failed API-key verification.

## Root cause
`arr, tc = asyncio.wait_for(...)` (no `await`) returns a coroutine; unpacking it raises `TypeError: cannot unpack non-iterable coroutine`, which the `except` swallows as a failure. The chat branch (`await asyncio.wait_for(check_streamly())`) and rerank branch (`arr, tc = await asyncio.wait_for(...)`) already `await` correctly.

## Fix
```diff
-                arr, tc = asyncio.wait_for(
+                arr, tc = await asyncio.wait_for(
                     asyncio.to_thread(mdl.encode, ["Test if the api key is available"]),
                     timeout=timeout_seconds,
                 )
```

## Files changed
- `api/apps/services/provider_api_service.py`

## Verification
- `ruff check` — clean
- Fix mirrors the already-correct chat/rerank branches in the same function. Local full pytest not run (heavy RAG deps); CI validates.

## Note
Implemented with LLM assistance (model: claude-opus-4-8).

Closes #15619
