### PR TITLE
feat: add Feishu/Lark Drive data source connector

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -158,6 +158,7 @@ class FileSource(StrEnum):
     OUTLOOK = "outlook"
     SALESFORCE = "salesforce"
     AZURE_BLOB = "azure_blob"
+    FEISHU_DRIVE = "feishu_drive"
 
 
 class PipelineTaskType(StrEnum):

--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -42,6 +42,7 @@ from .teams_connector import TeamsConnector
 from .moodle_connector import MoodleConnector
 from .airtable_connector import AirtableConnector
 from .dingtalk_ai_table_connector import DingTalkAITableConnector
+from .feishu_drive_connector import FeishuDriveConnector
 from .asana_connector import AsanaConnector
 from .imap_connector import ImapConnector
 from .zendesk_connector import ZendeskConnector
@@ -96,5 +97,6 @@ __all__ = [
     "RDBMSConnector",
     "WebDAVConnector",
     "DingTalkAITableConnector",
+    "FeishuDriveConnector",
     "RestAPIConnector",
 ]

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -73,6 +73,7 @@ class DocumentSource(str, Enum):
     OUTLOOK = "outlook"
     SALESFORCE = "salesforce"
     AZURE_BLOB = "azure_blob"
+    FEISHU_DRIVE = "feishu_drive"
 
 
 class FileOrigin(str, Enum):

--- a/common/data_source/feishu_drive_connector.py
+++ b/common/data_source/feishu_drive_connector.py
@@ -1,0 +1,292 @@
+"""Feishu (Lark) Drive connector.
+
+Scope: this connector treats Feishu Drive as a cloud file store. It walks a
+Drive folder tree and downloads *uploaded files* (``type == "file"``), handing
+the raw bytes to RAGFlow's parser. Feishu-native documents (docx/sheet/bitable)
+are NOT downloadable binaries and are intentionally skipped here; reading their
+content requires the docx ``raw_content`` API and is tracked as a follow-up.
+
+Auth: an internal (self-built) app's ``app_id`` + ``app_secret``. The lark-oapi
+client manages the ``tenant_access_token`` automatically. Note that a tenant
+token can only see files explicitly shared with the app, so the target folder
+must be shared with the app for it to appear.
+
+API references (open.feishu.cn):
+- List files:  GET /open-apis/drive/v1/files
+- Download:    GET /open-apis/drive/v1/files/{file_token}/download
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import lark_oapi as lark
+from lark_oapi.api.drive.v1 import DownloadFileRequest, ListFileRequest
+
+from common.data_source.config import INDEX_BATCH_SIZE, DocumentSource
+from common.data_source.exceptions import (
+    ConnectorMissingCredentialError,
+    ConnectorValidationError,
+    InsufficientPermissionsError,
+)
+from common.data_source.interfaces import LoadConnector, PollConnector, SecondsSinceUnixEpoch, SlimConnectorWithPermSync
+from common.data_source.models import Document, GenerateDocumentsOutput, GenerateSlimDocumentOutput, SlimDocument
+from common.data_source.utils import get_file_ext
+
+logger = logging.getLogger(__name__)
+
+# Feishu Drive entry types. Only FILE is a downloadable binary; the rest are
+# native cloud documents handled by other APIs.
+_FEISHU_FILE_TYPE = "file"
+_FEISHU_FOLDER_TYPE = "folder"
+# Permission errors surface as these Feishu server codes.
+_FEISHU_FORBIDDEN_CODES = {1061002, 1062002, 1061004}
+
+
+class FeishuDriveConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    """Feishu Drive connector for downloading uploaded files from a folder tree.
+
+    Scoped to Drive *files* only (hence ``FEISHU_DRIVE``, not ``FEISHU``); native
+    docs/wiki are separate surfaces that would warrant their own connectors.
+    """
+
+    def __init__(self, folder_token: str = "", batch_size: int = INDEX_BATCH_SIZE) -> None:
+        # Empty folder_token lists the app's Drive root.
+        self.folder_token = folder_token or ""
+        self.batch_size = batch_size
+        self.client: lark.Client | None = None
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        """Build a lark-oapi client from app_id / app_secret.
+
+        ``feishu_domain`` selects the API host: "feishu" (open.feishu.cn,
+        default) for Feishu/China apps, or "lark" (open.larksuite.com) for Lark
+        international apps. A full URL is also accepted.
+        """
+        app_id = credentials.get("feishu_app_id")
+        app_secret = credentials.get("feishu_app_secret")
+        if not app_id or not app_secret:
+            raise ConnectorMissingCredentialError("Feishu app_id and app_secret are required")
+
+        # A per-connector folder scope may also arrive via credentials.
+        folder_token = credentials.get("feishu_folder_token")
+        if folder_token:
+            self.folder_token = folder_token
+
+        # "feishu" / "lark" map to the known hosts; anything else is treated as a full URL.
+        domain = (credentials.get("feishu_domain") or "feishu").strip()
+        domain_url = {"feishu": lark.FEISHU_DOMAIN, "lark": lark.LARK_DOMAIN}.get(domain.lower(), domain)
+
+        self.client = lark.Client.builder().app_id(app_id).app_secret(app_secret).domain(domain_url).build()
+        return None
+
+    def validate_connector_settings(self) -> None:
+        """Validate credentials by listing the configured folder once."""
+        if self.client is None:
+            raise ConnectorMissingCredentialError("Feishu")
+
+        try:
+            self._list_folder_page(self.folder_token, page_token=None, page_size=1)
+        except InsufficientPermissionsError:
+            raise
+        except ConnectorValidationError:
+            raise
+        except Exception as e:
+            raise ConnectorValidationError(f"Unexpected error during Feishu settings validation: {e}")
+
+    def _list_folder_page(self, folder_token: str, page_token: str | None, page_size: int = 200):
+        """Call drive.v1.file.list for a single page and return its response data."""
+        if self.client is None:
+            raise ConnectorMissingCredentialError("Feishu")
+
+        builder = (
+            ListFileRequest.builder()
+            .page_size(page_size)
+            .order_by("EditedTime")
+            .direction("DESC")
+        )
+        if folder_token:
+            builder = builder.folder_token(folder_token)
+        if page_token:
+            builder = builder.page_token(page_token)
+
+        resp = self.client.drive.v1.file.list(builder.build())
+        if not resp.success():
+            if resp.code in _FEISHU_FORBIDDEN_CODES:
+                raise InsufficientPermissionsError(
+                    f"Feishu app lacks permission for folder '{folder_token or 'root'}': "
+                    f"{resp.code} {resp.msg}. Share the folder with the app and grant drive:drive:readonly."
+                )
+            raise ConnectorValidationError(f"Feishu list files failed: {resp.code} {resp.msg} log_id={resp.get_log_id()}")
+        return resp.data
+
+    def _download_file(self, file_token: str) -> bytes:
+        """Download a single uploaded file's bytes."""
+        if self.client is None:
+            raise ConnectorMissingCredentialError("Feishu")
+
+        resp = self.client.drive.v1.file.download(DownloadFileRequest.builder().file_token(file_token).build())
+        if not resp.success():
+            raise ConnectorValidationError(
+                f"Feishu download failed for {file_token}: {resp.code} {resp.msg} log_id={resp.get_log_id()}"
+            )
+        return resp.file.read()
+
+    def _collect_file_entries_recursive(
+        self,
+        folder_token: str,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,
+        all_files: list[dict[str, Any]],
+    ) -> None:
+        """Recursively collect downloadable files matching the time window."""
+        page_token: str | None = None
+        while True:
+            data = self._list_folder_page(folder_token, page_token=page_token)
+            for entry in getattr(data, "files", None) or []:
+                entry_type = getattr(entry, "type", None)
+                if entry_type == _FEISHU_FILE_TYPE:
+                    modified = self._normalize_modified_time(getattr(entry, "modified_time", None))
+                    time_as_seconds = modified.timestamp()
+                    if start is not None and time_as_seconds <= start:
+                        continue
+                    if end is not None and time_as_seconds > end:
+                        continue
+                    all_files.append(
+                        {
+                            "token": getattr(entry, "token", None),
+                            "name": getattr(entry, "name", "") or "",
+                            "modified": modified,
+                            "url": getattr(entry, "url", "") or "",
+                            "parent": getattr(entry, "parent_token", "") or "",
+                        }
+                    )
+                elif entry_type == _FEISHU_FOLDER_TYPE:
+                    child_token = getattr(entry, "token", None)
+                    if child_token:
+                        self._collect_file_entries_recursive(child_token, start, end, all_files)
+                # native docs (docx/sheet/bitable/...) are skipped on purpose.
+
+            if not getattr(data, "has_more", False):
+                break
+            page_token = getattr(data, "next_page_token", None)
+            if not page_token:
+                break
+
+    def _yield_files_recursive(
+        self,
+        folder_token: str,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,
+    ) -> GenerateDocumentsOutput:
+        """Yield downloaded files in batches from the folder tree."""
+        if self.client is None:
+            raise ConnectorMissingCredentialError("Feishu")
+
+        all_files: list[dict[str, Any]] = []
+        self._collect_file_entries_recursive(folder_token, start, end, all_files)
+
+        filename_counts: dict[str, int] = {}
+        for entry in all_files:
+            filename_counts[entry["name"]] = filename_counts.get(entry["name"], 0) + 1
+
+        batch: list[Document] = []
+        for entry in all_files:
+            token = entry["token"]
+            if not token:
+                continue
+            try:
+                downloaded_file = self._download_file(token)
+            except Exception:
+                logger.exception(f"[Feishu]: Error downloading file {entry['name']} ({token})")
+                continue
+
+            batch.append(
+                Document(
+                    id=f"feishu_drive:{token}",
+                    blob=downloaded_file,
+                    source=DocumentSource.FEISHU_DRIVE,
+                    semantic_identifier=self._get_semantic_identifier(entry, filename_counts),
+                    extension=get_file_ext(entry["name"]),
+                    doc_updated_at=entry["modified"],
+                    size_bytes=len(downloaded_file),
+                )
+            )
+
+            if len(batch) == self.batch_size:
+                yield batch
+                batch = []
+
+        if batch:
+            yield batch
+
+    def _normalize_modified_time(self, modified_time: Any) -> datetime:
+        """Feishu returns modified_time as seconds-since-epoch (str or int)."""
+        if modified_time is None:
+            return datetime.now(timezone.utc)
+        try:
+            return datetime.fromtimestamp(int(modified_time), tz=timezone.utc)
+        except (ValueError, TypeError):
+            return datetime.now(timezone.utc)
+
+    def _get_semantic_identifier(self, entry: dict[str, Any], filename_counts: dict[str, int]) -> str:
+        name = entry["name"]
+        if filename_counts.get(name, 0) <= 1:
+            return name
+        # Disambiguate duplicate filenames by appending the parent folder token.
+        parent = entry.get("parent", "")
+        return f"{parent} / {name}" if parent else name
+
+    def retrieve_all_slim_docs_perm_sync(self, callback: Any = None) -> GenerateSlimDocumentOutput:
+        del callback
+        if self.client is None:
+            raise ConnectorMissingCredentialError("Feishu")
+
+        all_files: list[dict[str, Any]] = []
+        self._collect_file_entries_recursive(self.folder_token, None, None, all_files)
+
+        batch: list[SlimDocument] = []
+        for entry in all_files:
+            if not entry["token"]:
+                continue
+            batch.append(SlimDocument(id=f"feishu_drive:{entry['token']}"))
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+
+        if batch:
+            yield batch
+
+    def poll_source(self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch) -> GenerateDocumentsOutput:
+        """Poll Feishu Drive for files changed within the window."""
+        if self.client is None:
+            raise ConnectorMissingCredentialError("Feishu")
+        for batch in self._yield_files_recursive(self.folder_token, start, end):
+            yield batch
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        """Load all downloadable files from the configured folder tree."""
+        return self._yield_files_recursive(self.folder_token, None, None)
+
+
+if __name__ == "__main__":
+    import os
+
+    logging.basicConfig(level=logging.DEBUG)
+    connector = FeishuDriveConnector(folder_token=os.environ.get("FEISHU_FOLDER_TOKEN", ""))
+    connector.load_credentials(
+        {
+            "feishu_app_id": os.environ.get("FEISHU_APP_ID"),
+            "feishu_app_secret": os.environ.get("FEISHU_APP_SECRET"),
+            "feishu_domain": os.environ.get("FEISHU_DOMAIN", "feishu"),
+        }
+    )
+    connector.validate_connector_settings()
+    document_batches = connector.load_from_state()
+    try:
+        first_batch = next(document_batches)
+        print(f"Loaded {len(first_batch)} documents in first batch.")
+        for doc in first_batch:
+            print(f"- {doc.semantic_identifier} ({doc.size_bytes} bytes)")
+    except StopIteration:
+        print("No downloadable files available in Feishu Drive.")

--- a/docs/guides/dataset/add_data_source/add_feishu_drive.md
+++ b/docs/guides/dataset/add_data_source/add_feishu_drive.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 17
+slug: /add_feishu_drive
+sidebar_custom_props: {
+  categoryIcon: SiGoogledrive
+}
+---
+
+# Add Feishu/Lark Drive
+
+Integrate Feishu/Lark Drive as a data source.
+
+---
+
+This guide outlines the integration of Feishu (Lark) Drive as a data source for RAGFlow.
+
+The connector syncs **uploaded files** (PDF, Word, Excel, images, and other binaries) from a Feishu/Lark Drive folder, including its subfolders. Feishu-native online documents (Docs, Sheets, Bitable) are not downloadable files and are **not** synced by this connector.
+
+## Prerequisites
+
+Create a self-built app in the Feishu/Lark developer console and obtain the following:
+
+- **App ID** and **App Secret**: From your app's **Credentials & Basic Info** page.
+  - Feishu (China): [open.feishu.cn](https://open.feishu.cn)
+  - Lark (International): [open.larksuite.com](https://open.larksuite.com)
+- **Permission scope**: Add `drive:drive:readonly` (View, comment, and download all files in cloud docs) under **Permissions & Scopes**, then publish a version of the app so the scope takes effect.
+- **Folder access**: A tenant-token app can only see content shared with it. Share the target folder with the app, either:
+  - directly, by adding the app as a collaborator with read access, or
+  - by adding the app's bot to a group and sharing the folder with that group.
+- **Folder Token** (optional): Open the target folder and copy the token at the end of its URL: `https://<your-domain>/drive/folder/<folder_token>`.
+
+## Configuration steps
+
+### Define Feishu/Lark Drive as an external data source
+
+Navigate to the **Data sources** section in the RAGFlow user settings and select **Feishu/Lark Drive**. Enter the following in the popup window:
+
+- **Name**: *Required* A unique identifier for this connector (e.g., `Tender-Documents`).
+- **App ID**: *Required* Your self-built app's App ID (starts with `cli_`).
+- **App Secret**: *Required* Your self-built app's App Secret.
+- **Domain**: *Required* The API host that matches your account.
+  - `Feishu (open.feishu.cn)` (default): for Feishu/China apps.
+  - `Lark (open.larksuite.com)`: for Lark international apps.
+- **Folder Token**: *Optional* The folder to sync. Leave empty to use the app's Drive root. The folder must be shared with the app.
+- **Batch Size**: *Optional* Number of documents indexed per batch. Defaults to `2`.
+
+Once configuration is complete, click **Confirm** to save your changes.
+
+*RAGFlow validates the connection immediately. A `1061004` permission error means the folder has not been shared with the app, or the `drive:drive:readonly` scope has not been published.*
+
+### Link to a dataset
+
+Credentials alone do not trigger indexing. You must link the data source to a specific dataset:
+
+1. Navigate to the **Dataset** tab.
+2. Select or create the target Dataset.
+3. Navigate to the Dataset's **Configuration** page and select **Link data source**.
+4. Choose the previously created Feishu/Lark Drive connector in the popup window.
+
+Files are pulled in on the connector's refresh schedule; subsequent changes in the folder are synced incrementally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "elasticsearch-dsl==8.12.0",
     "exceptiongroup>=1.3.0,<2.0.0",
     "feedparser>=6.0.11,<7.0.0",
+    "lark-oapi>=1.4.0,<2.0.0",
     "extract-msg>=0.39.0",
     "ffmpeg-python>=0.2.0",
     "flasgger>=0.9.7.1,<0.10.0",

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -60,6 +60,7 @@ from common.data_source import (
     SeaFileConnector,
     RDBMSConnector,
     DingTalkAITableConnector,
+    FeishuDriveConnector,
     RestAPIConnector,
     OneDriveConnector,
     OutlookConnector,
@@ -746,6 +747,28 @@ class Dropbox(SyncBase):
             _begin_info = f"from {poll_start}"
 
         self.log_connection("Dropbox", "workspace", task)
+        return document_generator
+
+
+class FeishuDrive(SyncBase):
+    SOURCE_NAME: str = FileSource.FEISHU_DRIVE
+
+    async def _generate(self, task: dict):
+        self.connector = FeishuDriveConnector(
+            folder_token=self.conf.get("folder_token", ""),
+            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+        )
+        self.connector.load_credentials(self.conf["credentials"])
+        poll_start = task["poll_range_start"]
+        if task["reindex"] == "1" or not poll_start:
+            document_generator = self.connector.load_from_state()
+            _begin_info = "totally"
+        else:
+            end_time = datetime.now(timezone.utc).timestamp()
+            document_generator = self.connector.poll_source(poll_start.timestamp(), end_time)
+            _begin_info = f"from {poll_start}"
+
+        self.log_connection("FeishuDrive", self.conf.get("folder_token", "") or "workspace", task)
         return document_generator
 
 
@@ -2124,6 +2147,7 @@ func_factory = {
     FileSource.MYSQL: MySQL,
     FileSource.POSTGRESQL: PostgreSQL,
     FileSource.DINGTALK_AI_TABLE: DingTalkAITable,
+    FileSource.FEISHU_DRIVE: FeishuDrive,
     FileSource.REST_API: REST_API,
 }
 

--- a/test/unit_test/data_source/test_feishu_drive_connector_unit.py
+++ b/test/unit_test/data_source/test_feishu_drive_connector_unit.py
@@ -1,0 +1,224 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import warnings
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from common.data_source.config import DocumentSource
+from common.data_source.exceptions import (
+    ConnectorMissingCredentialError,
+    ConnectorValidationError,
+    InsufficientPermissionsError,
+)
+
+# lark_oapi emits a pkg_resources UserWarning at import time; scope the
+# suppression to just this import so the repo-wide ``filterwarnings = error``
+# pytest setting does not fail collection (and no warnings are hidden elsewhere).
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message=r"pkg_resources is deprecated.*")
+    import lark_oapi as lark  # noqa: E402
+    from common.data_source.feishu_drive_connector import FeishuDriveConnector  # noqa: E402
+
+pytestmark = [pytest.mark.p2]
+
+
+# ---------------------------------------------------------------------------
+# Fake Feishu/Lark Drive client
+# ---------------------------------------------------------------------------
+
+T_OLD = 1_700_000_000
+T_NEW = 1_800_000_000
+
+
+def _entry(token, name, typ, mtime, parent="root"):
+    return SimpleNamespace(
+        token=token, name=name, type=typ, modified_time=str(mtime), parent_token=parent, url=f"https://feishu/{token}"
+    )
+
+
+# A root folder with two files, one subfolder, and one native doc (must be skipped).
+_ROOT = [
+    _entry("f1", "spec.pdf", "file", T_NEW),
+    _entry("f2", "budget.xlsx", "file", T_OLD),
+    _entry("sub", "2024", "folder", T_NEW),
+    _entry("d1", "plan.docx", "docx", T_NEW),
+]
+_SUB = [_entry("f3", "minutes.pdf", "file", T_NEW, parent="sub")]
+
+
+class _FakeResp:
+    def __init__(self, data=None, file_bytes=None, code=0, msg="ok"):
+        self.data = data
+        self._file = file_bytes
+        self.code = code
+        self.msg = msg
+
+    def success(self):
+        return self.code == 0
+
+    def get_log_id(self):
+        return "log123"
+
+    @property
+    def file(self):
+        return SimpleNamespace(read=lambda: self._file)
+
+
+class _FakeFileApi:
+    def __init__(self, list_error_code=None):
+        self._list_error_code = list_error_code
+
+    def list(self, req):
+        if self._list_error_code is not None:
+            return _FakeResp(code=self._list_error_code, msg="forbidden")
+        folder = getattr(req, "folder_token", "") or "root"
+        files = _ROOT if folder == "root" else (_SUB if folder == "sub" else [])
+        return _FakeResp(data=SimpleNamespace(files=files, has_more=False, next_page_token=None))
+
+    def download(self, req):
+        return _FakeResp(file_bytes=f"BYTES_OF_{req.file_token}".encode())
+
+
+def _fake_client(list_error_code=None):
+    return SimpleNamespace(drive=SimpleNamespace(v1=SimpleNamespace(file=_FakeFileApi(list_error_code))))
+
+
+def _connector(folder_token="", list_error_code=None):
+    c = FeishuDriveConnector(folder_token=folder_token)
+    c.client = _fake_client(list_error_code)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# load_credentials
+# ---------------------------------------------------------------------------
+
+
+def test_load_credentials_requires_app_id_and_secret():
+    c = FeishuDriveConnector()
+    with pytest.raises(ConnectorMissingCredentialError):
+        c.load_credentials({"feishu_app_id": "cli_x"})
+    with pytest.raises(ConnectorMissingCredentialError):
+        c.load_credentials({"feishu_app_secret": "secret"})
+
+
+@patch("common.data_source.feishu_drive_connector.lark.Client")
+def test_load_credentials_selects_feishu_domain_by_default(mock_client):
+    builder = mock_client.builder.return_value
+    builder.app_id.return_value = builder
+    builder.app_secret.return_value = builder
+    builder.domain.return_value = builder
+
+    FeishuDriveConnector().load_credentials({"feishu_app_id": "cli_x", "feishu_app_secret": "s"})
+    builder.domain.assert_called_once_with(lark.FEISHU_DOMAIN)
+
+
+@patch("common.data_source.feishu_drive_connector.lark.Client")
+def test_load_credentials_selects_lark_domain(mock_client):
+    builder = mock_client.builder.return_value
+    builder.app_id.return_value = builder
+    builder.app_secret.return_value = builder
+    builder.domain.return_value = builder
+
+    c = FeishuDriveConnector()
+    c.load_credentials({"feishu_app_id": "cli_x", "feishu_app_secret": "s", "feishu_domain": "lark"})
+    builder.domain.assert_called_once_with(lark.LARK_DOMAIN)
+
+
+@patch("common.data_source.feishu_drive_connector.lark.Client")
+def test_load_credentials_picks_up_folder_token(mock_client):
+    builder = mock_client.builder.return_value
+    builder.app_id.return_value = builder
+    builder.app_secret.return_value = builder
+    builder.domain.return_value = builder
+
+    c = FeishuDriveConnector()
+    c.load_credentials({"feishu_app_id": "cli_x", "feishu_app_secret": "s", "feishu_folder_token": "FLDabc"})
+    assert c.folder_token == "FLDabc"
+
+
+# ---------------------------------------------------------------------------
+# load_from_state — recursion, type filtering, download
+# ---------------------------------------------------------------------------
+
+
+def test_load_from_state_downloads_files_and_skips_native_docs():
+    docs = [d for batch in _connector().load_from_state() for d in batch]
+    ids = {d.id for d in docs}
+
+    # f1, f2 in root + f3 in subfolder; native docx d1 skipped.
+    assert ids == {"feishu_drive:f1", "feishu_drive:f2", "feishu_drive:f3"}
+    assert "feishu_drive:d1" not in ids
+    assert all(d.source == DocumentSource.FEISHU_DRIVE for d in docs)
+    # blob bytes come from the download call
+    assert all(d.blob == f"BYTES_OF_{d.id.split(':')[1]}".encode() for d in docs)
+    # extension is derived from the filename
+    by_id = {d.id: d for d in docs}
+    assert by_id["feishu_drive:f1"].extension == ".pdf"
+    assert by_id["feishu_drive:f2"].extension == ".xlsx"
+
+
+def test_documents_carry_modified_time():
+    docs = {d.id: d for batch in _connector().load_from_state() for d in batch}
+    assert docs["feishu_drive:f1"].doc_updated_at.timestamp() == T_NEW
+    assert docs["feishu_drive:f2"].doc_updated_at.timestamp() == T_OLD
+
+
+# ---------------------------------------------------------------------------
+# poll_source — incremental filtering
+# ---------------------------------------------------------------------------
+
+
+def test_poll_source_excludes_files_not_in_window():
+    ids = {d.id for batch in _connector().poll_source(start=T_OLD, end=T_NEW + 1) for d in batch}
+    # f2 (modified at T_OLD) is excluded because time <= start; f1/f3 (T_NEW) kept.
+    assert ids == {"feishu_drive:f1", "feishu_drive:f3"}
+
+
+# ---------------------------------------------------------------------------
+# slim docs
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_all_slim_docs():
+    ids = {s.id for batch in _connector().retrieve_all_slim_docs_perm_sync() for s in batch}
+    assert ids == {"feishu_drive:f1", "feishu_drive:f2", "feishu_drive:f3"}
+
+
+# ---------------------------------------------------------------------------
+# error handling
+# ---------------------------------------------------------------------------
+
+
+def test_permission_error_is_mapped():
+    c = _connector(list_error_code=1061004)
+    with pytest.raises(InsufficientPermissionsError):
+        c.validate_connector_settings()
+
+
+def test_generic_list_error_raises_validation_error():
+    c = _connector(list_error_code=1663)
+    with pytest.raises(ConnectorValidationError):
+        c.validate_connector_settings()
+
+
+def test_operations_without_client_raise():
+    c = FeishuDriveConnector()  # no client loaded
+    with pytest.raises(ConnectorMissingCredentialError):
+        list(c.load_from_state())

--- a/web/src/assets/svg/data-source/feishu.svg
+++ b/web/src/assets/svg/data-source/feishu.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="feishu_g" x1="3" y1="4" x2="21" y2="20" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00D6B9"/>
+      <stop offset="0.5" stop-color="#3370FF"/>
+      <stop offset="1" stop-color="#133C9A"/>
+    </linearGradient>
+  </defs>
+  <path d="M12.6 3.2c-.5-.3-1.2-.2-1.6.3L4.3 11c-1 1.1-.5 2.9.9 3.4l3.6 1.2c1.3.4 2.7 0 3.6-1l5.9-6.7c.5-.6.4-1.5-.3-1.9L12.6 3.2z" fill="url(#feishu_g)"/>
+  <path d="M3.5 13.4c2.9 3.2 6.7 5.1 11 5.6 2.1.2 4.2 0 6.2-.7.4-.1.5-.7.1-1-2.3-1.7-4.9-3-7.7-3.8-.9-.3-1.9-.1-2.6.5l-1.6 1.3c-.5.4-1.2.5-1.8.2l-3.3-1.6c-.3-.2-.7.2-.5.5l.2.8z" fill="#3370FF"/>
+</svg>

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1268,6 +1268,14 @@ Example: Virtual Hosted Style`,
         'Connect to Airtable and synchronize files from a specified table within a designated workspace.',
       dingtalkAITableDescription:
         'Connect to Dingtalk AI Table and synchronize records from a specified table.',
+      feishu_driveDescription:
+        'Connect to Feishu/Lark Drive and sync uploaded files from a shared folder.',
+      feishuAppIdTip:
+        'The App ID of your Feishu/Lark custom app, found under Credentials & Basic Info in the developer console.',
+      feishuDomainTip:
+        'Choose Feishu (open.feishu.cn) for China apps or Lark (open.larksuite.com) for international apps.',
+      feishuFolderTokenTip:
+        'The token at the end of the folder URL (.../drive/folder/<token>). Leave empty to use the app root. The folder must be shared with the app.',
       gitlabDescription:
         'Connect GitLab to sync repositories, issues, merge requests, and related documentation.',
       asanaDescription:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1176,6 +1176,14 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
         '连接 GitHub，可同步 Pull Request 与 Issue 内容用于检索。',
       airtableDescription: '连接 Airtable，同步指定工作区下指定表格中的文件。',
       dingtalkAITableDescription: '连接钉钉AI表格，同步指定表格中的记录。',
+      feishu_driveDescription:
+        '连接飞书/Lark 云空间，同步共享文件夹中上传的文件。',
+      feishuAppIdTip:
+        '飞书/Lark 自建应用的 App ID，在开发者后台「凭证与基础信息」中获取。',
+      feishuDomainTip:
+        '国内飞书应用选 Feishu（open.feishu.cn），国际版 Lark 应用选 Lark（open.larksuite.com）。',
+      feishuFolderTokenTip:
+        '文件夹 URL 末尾的 token（.../drive/folder/<token>）。留空则使用应用根目录。该文件夹需分享给应用。',
       gitlabDescription:
         '连接 GitLab，同步仓库、Issue、合并请求（MR）及相关文档内容。',
       asanaDescription: '连接 Asana，同步工作区中的文件。',

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -38,6 +38,7 @@ export enum DataSourceKey {
   ASANA = 'asana',
   IMAP = 'imap',
   DINGTALK_AI_TABLE = 'dingtalk_ai_table',
+  FEISHU_DRIVE = 'feishu_drive',
   SEAFILE = 'seafile',
   MYSQL = 'mysql',
   POSTGRESQL = 'postgresql',
@@ -113,6 +114,9 @@ export const DataSourceFeatureVisibilityMap: Partial<
     syncDeletedFiles: true,
   },
   [DataSourceKey.DINGTALK_AI_TABLE]: {
+    syncDeletedFiles: true,
+  },
+  [DataSourceKey.FEISHU_DRIVE]: {
     syncDeletedFiles: true,
   },
   [DataSourceKey.WEBDAV]: {
@@ -281,6 +285,11 @@ export const generateDataSourceInfo = (t: TFunction) => {
       name: 'Dingtalk AI Table',
       description: t(`setting.dingtalkAITableDescription`),
       icon: <SvgIcon name={'data-source/dingtalk-ai-table'} width={38} />,
+    },
+    [DataSourceKey.FEISHU_DRIVE]: {
+      name: 'Feishu/Lark Drive',
+      description: t(`setting.feishu_driveDescription`),
+      icon: <SvgIcon name={'data-source/feishu'} width={38} />,
     },
     [DataSourceKey.GITLAB]: {
       name: 'GitLab',
@@ -1157,6 +1166,49 @@ export const DataSourceFormFields = {
       required: true,
     },
   ],
+  [DataSourceKey.FEISHU_DRIVE]: [
+    {
+      label: 'App ID',
+      name: 'config.credentials.feishu_app_id',
+      type: FormFieldType.Text,
+      required: true,
+      placeholder: 'cli_xxxxxxxxxxxx',
+      tooltip: t('setting.feishuAppIdTip'),
+    },
+    {
+      label: 'App Secret',
+      name: 'config.credentials.feishu_app_secret',
+      type: FormFieldType.Password,
+      required: true,
+    },
+    {
+      label: 'Domain',
+      name: 'config.credentials.feishu_domain',
+      type: FormFieldType.Select,
+      required: true,
+      defaultValue: 'feishu',
+      options: [
+        { label: 'Feishu (open.feishu.cn)', value: 'feishu' },
+        { label: 'Lark (open.larksuite.com)', value: 'lark' },
+      ],
+      tooltip: t('setting.feishuDomainTip'),
+    },
+    {
+      label: 'Folder Token',
+      name: 'config.folder_token',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: 'Defaults to app root',
+      tooltip: t('setting.feishuFolderTokenTip'),
+    },
+    {
+      label: 'Batch Size',
+      name: 'config.batch_size',
+      type: FormFieldType.Number,
+      required: false,
+      placeholder: 'Defaults to 2',
+    },
+  ],
   [DataSourceKey.GITLAB]: [
     {
       label: 'Project Owner',
@@ -2013,6 +2065,19 @@ export const DataSourceFormDefaultValues = {
       operator_id: '',
       credentials: {
         access_token: '',
+      },
+    },
+  },
+  [DataSourceKey.FEISHU_DRIVE]: {
+    name: '',
+    source: DataSourceKey.FEISHU_DRIVE,
+    config: {
+      folder_token: '',
+      batch_size: 2,
+      credentials: {
+        feishu_app_id: '',
+        feishu_app_secret: '',
+        feishu_domain: 'feishu',
       },
     },
   },


### PR DESCRIPTION
### What problem does this PR solve?

Adds a **Feishu/Lark Drive** data source connector. It syncs **uploaded files** (PDF/Word/Excel/images/…) from a Feishu/Lark Drive folder tree into a knowledge base, mirroring the existing cloud-storage connectors (Dropbox/Box).

Scope is intentionally narrow: it walks a Drive folder, downloads `type == "file"` entries, and hands the raw bytes to RAGFlow's parser. Feishu-native online docs (`docx`/`sheet`/`bitable`) are **not** downloadable binaries and are skipped on purpose — they require a different API and are left as a follow-up (hence the `FEISHU_DRIVE` naming, leaving room for a future `FEISHU_WIKI`/`FEISHU_DOCX`).

### What is changed

**Backend**

- `common/data_source/feishu_drive_connector.py` (new) — `FeishuDriveConnector` implementing `LoadConnector` / `PollConnector` / `SlimConnectorWithPermSync`:
  - Auth via a self-built app's `app_id` + `app_secret`; lark-oapi manages the `tenant_access_token`.
  - **Feishu vs Lark domain switch** (`feishu_domain`: `feishu` → `open.feishu.cn`, `lark` → `open.larksuite.com`, or a full URL) — a Lark international app cannot authenticate against the Feishu host.
  - Recursive folder traversal, incremental sync by `modified_time`, batched `Document` output, slim-doc enumeration, and permission-error mapping (`1061002/1061004/...` → `InsufficientPermissionsError`).
- `common/constants.py`, `common/data_source/config.py` — `FEISHU_DRIVE` source enum.
- `common/data_source/__init__.py` — export `FeishuDriveConnector`.
- `rag/svr/sync_data_source.py` — `FeishuDrive` sync wrapper + `func_factory` registration.
- `pyproject.toml` — add `lark-oapi>=1.4.0,<2.0.0`.

**Frontend (`web/`)**

- Added the `FEISHU_DRIVE` data source: form fields (App ID, App Secret, Domain selector, Folder Token, Batch Size), default values, list-card entry, icon, and en/zh i18n.

**Docs**

- `docs/guides/dataset/add_data_source/add_feishu_drive.md` (new) — setup guide.

**Tests**

- `test/unit_test/data_source/test_feishu_drive_connector_unit.py` (new) — 11 unit tests covering credential validation, the Feishu/Lark domain switch, recursive traversal, native-doc filtering, byte download, incremental `poll_source` windowing, slim docs, and permission/error mapping.

### Notes for reviewers

- The Feishu `tenant_access_token` can only see folders shared with the app, so the target folder must be shared with the app (directly or via a group the app belongs to). This is documented in the field tooltips and the setup guide.
- The connector does not populate `external_access` (per-document permission sync), consistent with the existing cloud-storage connectors and the current retrieval path.

### How was this PR tested?

- **Unit tests**: `11 passed`; `ruff check` clean; frontend `eslint` clean.
- **End-to-end against real Lark**: configured a Feishu/Lark Drive data source in the UI, linked it to a dataset, the sync worker pulled the files from a shared Drive folder, documents were created and parsed, and retrieval returned cited chunks.
