### PR TITLE
fix: pass search id to searchbots ask

### DIFF
--- a/web/src/pages/next-search/hooks.ts
+++ b/web/src/pages/next-search/hooks.ts
@@ -344,6 +344,7 @@ export const useSendQuestion = (
           kb_ids: kbIds,
           question: q,
           tenantId,
+          search_id: searchId,
         });
       }
       testChunk({


### PR DESCRIPTION
### What problem does this PR solve?
This change ensures `/searchbots/ask` receives `search_id` from the frontend, so the backend can load the matching search configuration when the shared search flow invokes the endpoint.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)
