### PR TITLE
fix: prevent duplicated post-think text

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -1478,6 +1478,7 @@ def _next_think_delta(state: _ThinkStreamState) -> str:
         remainder = delta_ans[len("</think>") :]
         if remainder:
             state.post_think_text = remainder
+        state.last_idx = len(full_text)
         return "</think>"
 
     state.last_idx = len(full_text)


### PR DESCRIPTION
### What problem does this PR solve?
This fixes duplicated post-think text in streamed chat responses. When the model emits text immediately after `</think>`, the stream state now advances its cursor correctly so the same visible prefix is not emitted twice.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)
