### PR TITLE
fix(docker): mount tmpfs on es01 /tmp for entrypoint permissions

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -5,6 +5,10 @@ services:
     image: elasticsearch:${STACK_VERSION}
     volumes:
       - esdata01:/usr/share/elasticsearch/data
+    # Official ES image ACL on /tmp denies writes for user elasticsearch (r-x only).
+    # entrypoint.sh needs a writable temp dir for bash here-documents.
+    tmpfs:
+      - /tmp:mode=1777,size=512m
     ports:
       - ${ES_PORT}:9200
     env_file: .env


### PR DESCRIPTION
### What problem does this PR solve?

On some Linux hosts (e.g. x86_64 with enforced POSIX ACL on overlay storage), the official `elasticsearch` Docker image cannot start because `docker-entrypoint.sh` needs to create temporary files under `/tmp` for bash here-documents, while the image ACL grants `user:elasticsearch` only `r-x` on `/tmp`:

```
/usr/local/bin/docker-entrypoint.sh: line 73/84: cannot create temp file for here-document: Permission denied
```

RAGFlow users hit this when running `docker compose` with the default `es01` service. See also Refs #284.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## Summary

Mount a writable `tmpfs` at `/tmp` for the `es01` service so Elasticsearch entrypoint scripts can run on ACL-enforced environments. Closes the startup failure described in #284 for non-ARM deployments.

## Changes

- Add `tmpfs: /tmp:mode=1777,size=512m` to `es01` in `docker/docker-compose-base.yml`
- Document why the mount is required (ES image `/tmp` ACL vs entrypoint here-documents)

## Test plan

- [x] Verified on Linux (x86_64): `docker run --rm elasticsearch:8.11.3 bash -c 'mktemp'` fails without tmpfs and succeeds with `--tmpfs /tmp:mode=1777,size=512m`
- [x] Verified `es01` becomes healthy after `docker compose up -d es01` with this change
- [ ] Upstream maintainers: `docker compose -f docker/docker-compose-base.yml --profile elasticsearch up -d es01` on a host where ACL is enforced


Made with [Cursor](https://cursor.com)