### PR TITLE
feat[Go]: implement Langfuse API key management endpoints

### DIFF
--- a/internal/dao/langfuse.go
+++ b/internal/dao/langfuse.go
@@ -1,0 +1,73 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package dao
+
+import (
+	"gorm.io/gorm/clause"
+
+	"ragflow/internal/entity"
+)
+
+// LangfuseDAO data access for tenant_langfuse table.
+type LangfuseDAO struct{}
+
+// NewLangfuseDAO creates a LangfuseDAO.
+func NewLangfuseDAO() *LangfuseDAO {
+	return &LangfuseDAO{}
+}
+
+// GetByTenantID returns the Langfuse credential record for a tenant, or nil
+// when none exists.
+func (d *LangfuseDAO) GetByTenantID(tenantID string) (*entity.TenantLangfuse, error) {
+	var entry entity.TenantLangfuse
+	err := DB.Where("tenant_id = ?", tenantID).First(&entry).Error
+	if err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+// Create inserts a new TenantLangfuse record.
+func (d *LangfuseDAO) Create(entry *entity.TenantLangfuse) error {
+	return DB.Create(entry).Error
+}
+
+// UpdateByTenantID applies updates to the record for a tenant.
+func (d *LangfuseDAO) UpdateByTenantID(tenantID string, updates map[string]interface{}) error {
+	return DB.Model(&entity.TenantLangfuse{}).
+		Where("tenant_id = ?", tenantID).
+		Updates(updates).Error
+}
+
+// UpsertByTenantID atomically inserts the record or, when a row already exists
+// for the same tenant_id (unique index), updates its credentials in a single
+// statement. This removes the read-then-write race between concurrent callers.
+func (d *LangfuseDAO) UpsertByTenantID(entry *entity.TenantLangfuse) error {
+	return DB.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "tenant_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"secret_key", "public_key", "host", "update_time", "update_date",
+		}),
+	}).Create(entry).Error
+}
+
+// DeleteByTenantID hard-deletes the record for a tenant.
+func (d *LangfuseDAO) DeleteByTenantID(tenantID string) error {
+	return DB.Unscoped().
+		Where("tenant_id = ?", tenantID).
+		Delete(&entity.TenantLangfuse{}).Error
+}

--- a/internal/handler/langfuse.go
+++ b/internal/handler/langfuse.go
@@ -27,7 +27,7 @@ import (
 
 // langfuseServiceIface defines the LangfuseService methods used by LangfuseHandler.
 type langfuseServiceIface interface {
-	SetAPIKey(tenantID string, req *service.SetAPIKeyRequest) (map[string]interface{}, error)
+	SetAPIKey(tenantID string, req *service.SetLangfuseAPIKeyRequest) (map[string]interface{}, error)
 	GetAPIKey(tenantID string) (map[string]interface{}, error)
 	DeleteAPIKey(tenantID string) (bool, error)
 }
@@ -50,7 +50,7 @@ func NewLangfuseHandler() *LangfuseHandler {
 // @Tags langfuse
 // @Accept json
 // @Produce json
-// @Param request body service.SetAPIKeyRequest true "Langfuse credentials"
+// @Param request body service.SetLangfuseAPIKeyRequest true "Langfuse credentials"
 // @Success 200 {object} map[string]interface{}
 // @Router /api/v1/langfuse/api-key [post]
 func (h *LangfuseHandler) SetAPIKey(c *gin.Context) {
@@ -60,7 +60,7 @@ func (h *LangfuseHandler) SetAPIKey(c *gin.Context) {
 		return
 	}
 
-	var req service.SetAPIKeyRequest
+	var req service.SetLangfuseAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusOK, gin.H{"code": common.CodeDataError, "data": false, "message": err.Error()})
 		return

--- a/internal/handler/langfuse.go
+++ b/internal/handler/langfuse.go
@@ -25,9 +25,16 @@ import (
 	"ragflow/internal/service"
 )
 
+// langfuseServiceIface defines the LangfuseService methods used by LangfuseHandler.
+type langfuseServiceIface interface {
+	SetAPIKey(tenantID string, req *service.SetAPIKeyRequest) (map[string]interface{}, error)
+	GetAPIKey(tenantID string) (map[string]interface{}, error)
+	DeleteAPIKey(tenantID string) (bool, error)
+}
+
 // LangfuseHandler manages Langfuse credential endpoints.
 type LangfuseHandler struct {
-	langfuseService *service.LangfuseService
+	langfuseService langfuseServiceIface
 }
 
 // NewLangfuseHandler creates a LangfuseHandler.

--- a/internal/handler/langfuse.go
+++ b/internal/handler/langfuse.go
@@ -1,0 +1,125 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"ragflow/internal/common"
+	"ragflow/internal/service"
+)
+
+// LangfuseHandler manages Langfuse credential endpoints.
+type LangfuseHandler struct {
+	langfuseService *service.LangfuseService
+}
+
+// NewLangfuseHandler creates a LangfuseHandler.
+func NewLangfuseHandler() *LangfuseHandler {
+	return &LangfuseHandler{langfuseService: service.NewLangfuseService()}
+}
+
+// SetAPIKey handles POST/PUT /api/v1/langfuse/api-key.
+// Validates the supplied keys against Langfuse, then upserts the record.
+// Secret key is stored but not echoed back to the caller.
+// @Summary Set Langfuse API key
+// @Description Create or update the Langfuse credentials for the current tenant.
+// @Tags langfuse
+// @Accept json
+// @Produce json
+// @Param request body service.SetAPIKeyRequest true "Langfuse credentials"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/langfuse/api-key [post]
+func (h *LangfuseHandler) SetAPIKey(c *gin.Context) {
+	user, code, msg := GetUser(c)
+	if code != common.CodeSuccess {
+		jsonError(c, code, msg)
+		return
+	}
+
+	var req service.SetAPIKeyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusOK, gin.H{"code": common.CodeDataError, "data": false, "message": err.Error()})
+		return
+	}
+
+	data, err := h.langfuseService.SetAPIKey(user.ID, &req)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"code": common.CodeDataError, "data": false, "message": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": data, "message": "success"})
+}
+
+// GetAPIKey handles GET /api/v1/langfuse/api-key.
+// Returns stored metadata and Langfuse project info; secret_key is never returned.
+// @Summary Get Langfuse API key info
+// @Description Retrieve the stored Langfuse credentials (without secret_key) and project info.
+// @Tags langfuse
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/langfuse/api-key [get]
+func (h *LangfuseHandler) GetAPIKey(c *gin.Context) {
+	user, code, msg := GetUser(c)
+	if code != common.CodeSuccess {
+		jsonError(c, code, msg)
+		return
+	}
+
+	data, err := h.langfuseService.GetAPIKey(user.ID)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"code": common.CodeDataError, "data": false, "message": err.Error()})
+		return
+	}
+	if data == nil {
+		c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": nil, "message": "Have not record any Langfuse keys."})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": data, "message": "success"})
+}
+
+// DeleteAPIKey handles DELETE /api/v1/langfuse/api-key.
+// Removes the stored Langfuse credentials for the current tenant.
+// @Summary Delete Langfuse API key
+// @Description Remove the stored Langfuse credentials for the current tenant.
+// @Tags langfuse
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/langfuse/api-key [delete]
+func (h *LangfuseHandler) DeleteAPIKey(c *gin.Context) {
+	user, code, msg := GetUser(c)
+	if code != common.CodeSuccess {
+		jsonError(c, code, msg)
+		return
+	}
+
+	deleted, err := h.langfuseService.DeleteAPIKey(user.ID)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"code": common.CodeDataError, "data": false, "message": err.Error()})
+		return
+	}
+	if !deleted {
+		c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": nil, "message": "Have not record any Langfuse keys."})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": true, "message": "success"})
+}

--- a/internal/handler/langfuse_test.go
+++ b/internal/handler/langfuse_test.go
@@ -42,7 +42,7 @@ type fakeLangfuseService struct {
 	deleteErr  error
 }
 
-func (f *fakeLangfuseService) SetAPIKey(_ string, _ *service.SetAPIKeyRequest) (map[string]interface{}, error) {
+func (f *fakeLangfuseService) SetAPIKey(_ string, _ *service.SetLangfuseAPIKeyRequest) (map[string]interface{}, error) {
 	return f.setData, f.setErr
 }
 

--- a/internal/handler/langfuse_test.go
+++ b/internal/handler/langfuse_test.go
@@ -1,0 +1,251 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"ragflow/internal/common"
+	"ragflow/internal/entity"
+	"ragflow/internal/service"
+)
+
+// ── fake service ─────────────────────────────────────────────────────────────
+
+type fakeLangfuseService struct {
+	setData    map[string]interface{}
+	setErr     error
+	getData    map[string]interface{}
+	getErr     error
+	deleted    bool
+	deleteErr  error
+}
+
+func (f *fakeLangfuseService) SetAPIKey(_ string, _ *service.SetAPIKeyRequest) (map[string]interface{}, error) {
+	return f.setData, f.setErr
+}
+
+func (f *fakeLangfuseService) GetAPIKey(_ string) (map[string]interface{}, error) {
+	return f.getData, f.getErr
+}
+
+func (f *fakeLangfuseService) DeleteAPIKey(_ string) (bool, error) {
+	return f.deleted, f.deleteErr
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newLangfuseCtx(method, path, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	c.Request = req
+	c.Set("user", &entity.User{ID: "user-1"})
+	c.Set("user_id", "user-1")
+	return c, w
+}
+
+func newLangfuseHandler(fake langfuseServiceIface) *LangfuseHandler {
+	return &LangfuseHandler{langfuseService: fake}
+}
+
+func decodeLangfuseResp(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var out map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("failed to decode response: %v\nbody: %s", err, w.Body.String())
+	}
+	return out
+}
+
+// ── SetAPIKey tests ───────────────────────────────────────────────────────────
+
+func TestLangfuseSetAPIKey_BadJSON(t *testing.T) {
+	h := newLangfuseHandler(&fakeLangfuseService{})
+	c, w := newLangfuseCtx(http.MethodPost, "/api/v1/langfuse/api-key", "{bad json")
+
+	h.SetAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeDataError {
+		t.Errorf("expected CodeDataError (%d), got %d", common.CodeDataError, code)
+	}
+}
+
+func TestLangfuseSetAPIKey_MissingRequiredFields(t *testing.T) {
+	h := newLangfuseHandler(&fakeLangfuseService{})
+	// Omit all required fields — ShouldBindJSON will fail.
+	c, w := newLangfuseCtx(http.MethodPost, "/api/v1/langfuse/api-key", "{}")
+
+	h.SetAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeDataError {
+		t.Errorf("expected CodeDataError (%d), got %d", common.CodeDataError, code)
+	}
+}
+
+func TestLangfuseSetAPIKey_ServiceError(t *testing.T) {
+	fake := &fakeLangfuseService{setErr: errors.New("invalid keys")}
+	h := newLangfuseHandler(fake)
+	body := `{"secret_key":"sk","public_key":"pk","host":"https://h.example.com"}`
+	c, w := newLangfuseCtx(http.MethodPost, "/api/v1/langfuse/api-key", body)
+
+	h.SetAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeDataError {
+		t.Errorf("expected CodeDataError (%d), got %d", common.CodeDataError, code)
+	}
+}
+
+func TestLangfuseSetAPIKey_Success(t *testing.T) {
+	returnData := map[string]interface{}{"tenant_id": "user-1", "public_key": "pk", "host": "https://h.example.com"}
+	fake := &fakeLangfuseService{setData: returnData}
+	h := newLangfuseHandler(fake)
+	body := `{"secret_key":"sk","public_key":"pk","host":"https://h.example.com"}`
+	c, w := newLangfuseCtx(http.MethodPost, "/api/v1/langfuse/api-key", body)
+
+	h.SetAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeSuccess {
+		t.Errorf("expected CodeSuccess (%d), got %d", common.CodeSuccess, code)
+	}
+	if resp["data"] == nil {
+		t.Error("expected non-nil data in success response")
+	}
+}
+
+// ── GetAPIKey tests ───────────────────────────────────────────────────────────
+
+func TestLangfuseGetAPIKey_NotFound(t *testing.T) {
+	// Service returns (nil, nil) → "Have not record" message.
+	fake := &fakeLangfuseService{getData: nil, getErr: nil}
+	h := newLangfuseHandler(fake)
+	c, w := newLangfuseCtx(http.MethodGet, "/api/v1/langfuse/api-key", "")
+
+	h.GetAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeSuccess {
+		t.Errorf("expected CodeSuccess (%d), got %d", common.CodeSuccess, code)
+	}
+	msg, _ := resp["message"].(string)
+	if !strings.Contains(msg, "Have not record") {
+		t.Errorf("expected 'Have not record' in message, got %q", msg)
+	}
+}
+
+func TestLangfuseGetAPIKey_ServiceError(t *testing.T) {
+	fake := &fakeLangfuseService{getErr: errors.New("db error")}
+	h := newLangfuseHandler(fake)
+	c, w := newLangfuseCtx(http.MethodGet, "/api/v1/langfuse/api-key", "")
+
+	h.GetAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeDataError {
+		t.Errorf("expected CodeDataError (%d), got %d", common.CodeDataError, code)
+	}
+}
+
+func TestLangfuseGetAPIKey_Success(t *testing.T) {
+	returnData := map[string]interface{}{
+		"tenant_id":    "user-1",
+		"public_key":   "pk",
+		"host":         "https://h.example.com",
+		"project_name": "my-project",
+	}
+	fake := &fakeLangfuseService{getData: returnData}
+	h := newLangfuseHandler(fake)
+	c, w := newLangfuseCtx(http.MethodGet, "/api/v1/langfuse/api-key", "")
+
+	h.GetAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeSuccess {
+		t.Errorf("expected CodeSuccess (%d), got %d", common.CodeSuccess, code)
+	}
+	if resp["data"] == nil {
+		t.Error("expected non-nil data in success response")
+	}
+}
+
+// ── DeleteAPIKey tests ────────────────────────────────────────────────────────
+
+func TestLangfuseDeleteAPIKey_NotFound(t *testing.T) {
+	// Service returns (false, nil) → "Have not record" message.
+	fake := &fakeLangfuseService{deleted: false, deleteErr: nil}
+	h := newLangfuseHandler(fake)
+	c, w := newLangfuseCtx(http.MethodDelete, "/api/v1/langfuse/api-key", "")
+
+	h.DeleteAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeSuccess {
+		t.Errorf("expected CodeSuccess (%d), got %d", common.CodeSuccess, code)
+	}
+	msg, _ := resp["message"].(string)
+	if !strings.Contains(msg, "Have not record") {
+		t.Errorf("expected 'Have not record' in message, got %q", msg)
+	}
+}
+
+func TestLangfuseDeleteAPIKey_ServiceError(t *testing.T) {
+	fake := &fakeLangfuseService{deleteErr: errors.New("db error")}
+	h := newLangfuseHandler(fake)
+	c, w := newLangfuseCtx(http.MethodDelete, "/api/v1/langfuse/api-key", "")
+
+	h.DeleteAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeDataError {
+		t.Errorf("expected CodeDataError (%d), got %d", common.CodeDataError, code)
+	}
+}
+
+func TestLangfuseDeleteAPIKey_Success(t *testing.T) {
+	fake := &fakeLangfuseService{deleted: true, deleteErr: nil}
+	h := newLangfuseHandler(fake)
+	c, w := newLangfuseCtx(http.MethodDelete, "/api/v1/langfuse/api-key", "")
+
+	h.DeleteAPIKey(c)
+
+	resp := decodeLangfuseResp(t, w)
+	if code := int(resp["code"].(float64)); code != common.CodeSuccess {
+		t.Errorf("expected CodeSuccess (%d), got %d", common.CodeSuccess, code)
+	}
+	data, ok := resp["data"].(bool)
+	if !ok || !data {
+		t.Errorf("expected data=true in success response, got %v", resp["data"])
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -46,6 +46,7 @@ type Router struct {
 	difyRetrievalHandler *handler.DifyRetrievalHandler
 	pluginHandler        *handler.PluginHandler
 	modelHandler         *handler.ModelHandler
+	langfuseHandler      *handler.LangfuseHandler
 }
 
 // NewRouter create router
@@ -98,6 +99,7 @@ func NewRouter(
 		difyRetrievalHandler: difyRetrievalHandler,
 		pluginHandler:        pluginHandler,
 		modelHandler:         modelHandler,
+		langfuseHandler:      handler.NewLangfuseHandler(),
 	}
 }
 
@@ -398,6 +400,15 @@ func (r *Router) Setup(engine *gin.Engine) {
 			plugin := v1.Group("/plugin")
 			{
 				plugin.GET("/tools", r.pluginHandler.ListLLMTools)
+			}
+
+			// Langfuse credential management routes.
+			langfuse := v1.Group("/langfuse")
+			{
+				langfuse.POST("/api-key", r.langfuseHandler.SetAPIKey)
+				langfuse.PUT("/api-key", r.langfuseHandler.SetAPIKey)
+				langfuse.GET("/api-key", r.langfuseHandler.GetAPIKey)
+				langfuse.DELETE("/api-key", r.langfuseHandler.DeleteAPIKey)
 			}
 
 			connector := v1.Group("/connectors")

--- a/internal/service/langfuse.go
+++ b/internal/service/langfuse.go
@@ -50,8 +50,8 @@ func NewLangfuseService() *LangfuseService {
 	return &LangfuseService{langfuseDAO: dao.NewLangfuseDAO()}
 }
 
-// SetAPIKeyRequest is the body for POST/PUT /langfuse/api-key.
-type SetAPIKeyRequest struct {
+// SetLangfuseAPIKeyRequest is the body for POST/PUT /langfuse/api-key.
+type SetLangfuseAPIKeyRequest struct {
 	SecretKey string `json:"secret_key" binding:"required"`
 	PublicKey string `json:"public_key" binding:"required"`
 	Host      string `json:"host"       binding:"required"`
@@ -65,7 +65,7 @@ type LangfuseProject struct {
 
 // SetAPIKey validates credentials against Langfuse, then upserts the record.
 // Mirrors Python set_api_key.
-func (s *LangfuseService) SetAPIKey(tenantID string, req *SetAPIKeyRequest) (map[string]interface{}, error) {
+func (s *LangfuseService) SetAPIKey(tenantID string, req *SetLangfuseAPIKeyRequest) (map[string]interface{}, error) {
 	if strings.TrimSpace(req.SecretKey) == "" ||
 		strings.TrimSpace(req.PublicKey) == "" ||
 		strings.TrimSpace(req.Host) == "" {

--- a/internal/service/langfuse.go
+++ b/internal/service/langfuse.go
@@ -1,0 +1,297 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"ragflow/internal/dao"
+	"ragflow/internal/entity"
+)
+
+const (
+	langfuseAuthCheckTimeout = 7 * time.Second
+	// projectsPath is the Langfuse endpoint used for auth_check.
+	langfuseProjectsPath = "/api/public/projects"
+)
+
+// LangfuseService manages per-tenant Langfuse credentials.
+type LangfuseService struct {
+	langfuseDAO *dao.LangfuseDAO
+}
+
+// NewLangfuseService creates a LangfuseService.
+func NewLangfuseService() *LangfuseService {
+	return &LangfuseService{langfuseDAO: dao.NewLangfuseDAO()}
+}
+
+// SetAPIKeyRequest is the body for POST/PUT /langfuse/api-key.
+type SetAPIKeyRequest struct {
+	SecretKey string `json:"secret_key" binding:"required"`
+	PublicKey string `json:"public_key" binding:"required"`
+	Host      string `json:"host"       binding:"required"`
+}
+
+// LangfuseProject is one project entry returned by the Langfuse projects API.
+type LangfuseProject struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// SetAPIKey validates credentials against Langfuse, then upserts the record.
+// Mirrors Python set_api_key.
+func (s *LangfuseService) SetAPIKey(tenantID string, req *SetAPIKeyRequest) (map[string]interface{}, error) {
+	if strings.TrimSpace(req.SecretKey) == "" ||
+		strings.TrimSpace(req.PublicKey) == "" ||
+		strings.TrimSpace(req.Host) == "" {
+		return nil, fmt.Errorf("Missing required fields")
+	}
+
+	if err := langfuseAuthCheck(req.PublicKey, req.SecretKey, req.Host); err != nil {
+		return nil, fmt.Errorf("Invalid Langfuse keys")
+	}
+
+	// Atomic upsert: insert the credentials, or update them in place when a row
+	// already exists for this tenant. Avoids the read-then-write race between
+	// concurrent SetAPIKey calls for the same tenant.
+	record := &entity.TenantLangfuse{
+		TenantID:  tenantID,
+		SecretKey: req.SecretKey,
+		PublicKey: req.PublicKey,
+		Host:      req.Host,
+	}
+	if err := s.langfuseDAO.UpsertByTenantID(record); err != nil {
+		return nil, fmt.Errorf("failed to save Langfuse keys: %w", err)
+	}
+
+	return map[string]interface{}{
+		"tenant_id":  tenantID,
+		"public_key": req.PublicKey,
+		"host":       req.Host,
+	}, nil
+}
+
+// GetAPIKey retrieves the stored credentials and validates them.
+// The secret_key is intentionally omitted from the response.
+// Mirrors Python get_api_key.
+func (s *LangfuseService) GetAPIKey(tenantID string) (map[string]interface{}, error) {
+	entry, err := s.langfuseDAO.GetByTenantID(tenantID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil // caller interprets nil as "no keys stored"
+		}
+		return nil, fmt.Errorf("database error: %w", err)
+	}
+
+	if err := langfuseAuthCheck(entry.PublicKey, entry.SecretKey, entry.Host); err != nil {
+		return nil, fmt.Errorf("Invalid Langfuse keys loaded")
+	}
+
+	projects, err := langfuseGetProjects(entry.PublicKey, entry.SecretKey, entry.Host)
+	if err != nil {
+		return nil, fmt.Errorf("Error from Langfuse: %w", err)
+	}
+
+	result := map[string]interface{}{
+		"tenant_id":  entry.TenantID,
+		"public_key": entry.PublicKey,
+		"host":       entry.Host,
+		// secret_key is intentionally excluded.
+	}
+	if len(projects) > 0 {
+		result["project_id"] = projects[0].ID
+		result["project_name"] = projects[0].Name
+	}
+	return result, nil
+}
+
+// DeleteAPIKey removes the stored Langfuse credentials for a tenant.
+// Mirrors Python delete_api_key.
+func (s *LangfuseService) DeleteAPIKey(tenantID string) (bool, error) {
+	_, err := s.langfuseDAO.GetByTenantID(tenantID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil // caller interprets false as "no keys stored"
+		}
+		return false, fmt.Errorf("database error: %w", err)
+	}
+
+	if err := s.langfuseDAO.DeleteByTenantID(tenantID); err != nil {
+		return false, fmt.Errorf("failed to delete Langfuse keys: %w", err)
+	}
+	return true, nil
+}
+
+// ── Langfuse API helpers ──────────────────────────────────────────────────────
+
+// maxLangfuseResponseBytes bounds how much of a Langfuse response we read or
+// drain, guarding against resource exhaustion from a hostile endpoint.
+const maxLangfuseResponseBytes = 1 << 20 // 1 MB
+
+// langfuseAuthCheck calls GET {host}/api/public/projects with Basic Auth.
+// Returns nil on HTTP 2xx, error otherwise — mirrors Python langfuse.auth_check().
+func langfuseAuthCheck(publicKey, secretKey, host string) error {
+	if err := validateLangfuseHost(host); err != nil {
+		return err
+	}
+	reqURL := strings.TrimRight(host, "/") + langfuseProjectsPath
+
+	ctx, cancel := context.WithTimeout(context.Background(), langfuseAuthCheckTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(publicKey, secretKey)
+
+	resp, err := langfuseHTTPClient(langfuseAuthCheckTimeout).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Bound the drain so a hostile endpoint cannot stream an unbounded body.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxLangfuseResponseBytes))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("Langfuse auth failed: HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// langfuseGetProjects fetches the project list for the tenant.
+func langfuseGetProjects(publicKey, secretKey, host string) ([]LangfuseProject, error) {
+	if err := validateLangfuseHost(host); err != nil {
+		return nil, err
+	}
+	reqURL := strings.TrimRight(host, "/") + langfuseProjectsPath
+
+	ctx, cancel := context.WithTimeout(context.Background(), langfuseAuthCheckTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(publicKey, secretKey)
+
+	resp, err := langfuseHTTPClient(langfuseAuthCheckTimeout).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLangfuseResponseBytes))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Langfuse projects API returned HTTP %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Data []LangfuseProject `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	return payload.Data, nil
+}
+
+// validateLangfuseHost ensures the configured host is a well-formed http(s) URL.
+// The user supplies this host and the server then issues requests to it, so it
+// must be validated before use.
+func validateLangfuseHost(host string) error {
+	u, err := url.Parse(strings.TrimRight(strings.TrimSpace(host), "/"))
+	if err != nil {
+		return fmt.Errorf("invalid Langfuse host")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("Langfuse host must use http or https")
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("Langfuse host is missing a hostname")
+	}
+	return nil
+}
+
+// langfuseHTTPClient returns an HTTP client whose dialer resolves the target
+// host, rejects any non-globally-routable IP, and pins the validated address —
+// an SSRF guard (with DNS-rebinding protection) for the user-supplied Langfuse
+// host. The IP check runs on every connection, so redirect hops are covered too.
+func langfuseHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				host, port, err := net.SplitHostPort(addr)
+				if err != nil {
+					return nil, err
+				}
+				ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+				if err != nil {
+					return nil, fmt.Errorf("could not resolve host %q: %w", host, err)
+				}
+				var pinned net.IP
+				for _, ip := range ips {
+					if !isGloballyRoutableIP(ip) {
+						return nil, fmt.Errorf("Langfuse host resolves to a non-public address (%s)", ip)
+					}
+					if pinned == nil {
+						pinned = ip
+					}
+				}
+				if pinned == nil {
+					return nil, fmt.Errorf("host %q resolved to no addresses", host)
+				}
+				return dialer.DialContext(ctx, network, net.JoinHostPort(pinned.String(), port))
+			},
+		},
+	}
+}
+
+// isGloballyRoutableIP reports whether ip is a public, routable address. It
+// rejects loopback, private, link-local, multicast, unspecified, and
+// carrier-grade-NAT ranges. IPv4-mapped IPv6 addresses are handled by the
+// stdlib predicates.
+func isGloballyRoutableIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+	// Carrier-grade NAT 100.64.0.0/10 (RFC 6598) — not covered by IsPrivate.
+	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1]&0xc0 == 0x40 {
+		return false
+	}
+	return true
+}

--- a/internal/service/langfuse_test.go
+++ b/internal/service/langfuse_test.go
@@ -122,12 +122,12 @@ func TestLangfuseService_SetAPIKey_EmptyFields(t *testing.T) {
 
 	cases := []struct {
 		name string
-		req  SetAPIKeyRequest
+		req  SetLangfuseAPIKeyRequest
 	}{
-		{"empty secret_key", SetAPIKeyRequest{SecretKey: "", PublicKey: "pk", Host: "https://h.example.com"}},
-		{"empty public_key", SetAPIKeyRequest{SecretKey: "sk", PublicKey: "", Host: "https://h.example.com"}},
-		{"empty host", SetAPIKeyRequest{SecretKey: "sk", PublicKey: "pk", Host: ""}},
-		{"whitespace secret_key", SetAPIKeyRequest{SecretKey: "   ", PublicKey: "pk", Host: "https://h.example.com"}},
+		{"empty secret_key", SetLangfuseAPIKeyRequest{SecretKey: "", PublicKey: "pk", Host: "https://h.example.com"}},
+		{"empty public_key", SetLangfuseAPIKeyRequest{SecretKey: "sk", PublicKey: "", Host: "https://h.example.com"}},
+		{"empty host", SetLangfuseAPIKeyRequest{SecretKey: "sk", PublicKey: "pk", Host: ""}},
+		{"whitespace secret_key", SetLangfuseAPIKeyRequest{SecretKey: "   ", PublicKey: "pk", Host: "https://h.example.com"}},
 	}
 
 	for _, tc := range cases {

--- a/internal/service/langfuse_test.go
+++ b/internal/service/langfuse_test.go
@@ -1,0 +1,209 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"net"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"ragflow/internal/dao"
+	"ragflow/internal/entity"
+)
+
+// setupLangfuseTestDB opens an in-memory SQLite database and migrates
+// TenantLangfuse.
+func setupLangfuseTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&entity.TenantLangfuse{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	return db
+}
+
+// swapLangfuseDB replaces dao.DB with db and restores the original in Cleanup.
+func swapLangfuseDB(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	orig := dao.DB
+	dao.DB = db
+	t.Cleanup(func() { dao.DB = orig })
+}
+
+// ── validateLangfuseHost ──────────────────────────────────────────────────────
+
+func TestValidateLangfuseHost(t *testing.T) {
+	cases := []struct {
+		host    string
+		wantErr bool
+	}{
+		{"https://langfuse.example.com", false},
+		{"http://localhost:3000", false},
+		{"http://langfuse.internal/", false},
+		{"", true},
+		{"ftp://langfuse.example.com", true},
+		{"//langfuse.example.com", true},
+		{"not-a-url", true},
+		{"https://", true},
+	}
+
+	for _, tc := range cases {
+		err := validateLangfuseHost(tc.host)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("validateLangfuseHost(%q) error=%v, wantErr=%v", tc.host, err, tc.wantErr)
+		}
+	}
+}
+
+// ── isGloballyRoutableIP ─────────────────────────────────────────────────────
+
+func TestIsGloballyRoutableIP(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		// public addresses
+		{"8.8.8.8", true},
+		{"1.1.1.1", true},
+		{"203.0.113.1", true},
+		// loopback
+		{"127.0.0.1", false},
+		{"::1", false},
+		// private RFC1918
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+		{"192.168.1.1", false},
+		// link-local
+		{"169.254.0.1", false},
+		// CG-NAT (RFC 6598)
+		{"100.64.0.1", false},
+		{"100.127.255.255", false},
+		// multicast
+		{"224.0.0.1", false},
+		// unspecified
+		{"0.0.0.0", false},
+	}
+
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("invalid test IP: %s", tc.ip)
+		}
+		got := isGloballyRoutableIP(ip)
+		if got != tc.want {
+			t.Errorf("isGloballyRoutableIP(%s) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+}
+
+// ── SetAPIKey (no HTTP) ───────────────────────────────────────────────────────
+
+func TestLangfuseService_SetAPIKey_EmptyFields(t *testing.T) {
+	svc := NewLangfuseService()
+
+	cases := []struct {
+		name string
+		req  SetAPIKeyRequest
+	}{
+		{"empty secret_key", SetAPIKeyRequest{SecretKey: "", PublicKey: "pk", Host: "https://h.example.com"}},
+		{"empty public_key", SetAPIKeyRequest{SecretKey: "sk", PublicKey: "", Host: "https://h.example.com"}},
+		{"empty host", SetAPIKeyRequest{SecretKey: "sk", PublicKey: "pk", Host: ""}},
+		{"whitespace secret_key", SetAPIKeyRequest{SecretKey: "   ", PublicKey: "pk", Host: "https://h.example.com"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := svc.SetAPIKey("t-1", &tc.req)
+			if err == nil {
+				t.Errorf("expected error for %q, got data=%v", tc.name, data)
+			}
+			if data != nil {
+				t.Errorf("expected nil data, got %v", data)
+			}
+		})
+	}
+}
+
+// ── GetAPIKey — not found ─────────────────────────────────────────────────────
+
+func TestLangfuseService_GetAPIKey_NotFound(t *testing.T) {
+	db := setupLangfuseTestDB(t)
+	swapLangfuseDB(t, db)
+
+	svc := NewLangfuseService()
+	data, err := svc.GetAPIKey("nonexistent-tenant")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data != nil {
+		t.Errorf("expected nil data for missing record, got %v", data)
+	}
+}
+
+// ── DeleteAPIKey — not found ──────────────────────────────────────────────────
+
+func TestLangfuseService_DeleteAPIKey_NotFound(t *testing.T) {
+	db := setupLangfuseTestDB(t)
+	swapLangfuseDB(t, db)
+
+	svc := NewLangfuseService()
+	deleted, err := svc.DeleteAPIKey("nonexistent-tenant")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted {
+		t.Error("expected deleted=false for missing record, got true")
+	}
+}
+
+// ── DeleteAPIKey — success ────────────────────────────────────────────────────
+
+func TestLangfuseService_DeleteAPIKey_Success(t *testing.T) {
+	db := setupLangfuseTestDB(t)
+	swapLangfuseDB(t, db)
+
+	// Seed a record directly.
+	if err := db.Create(&entity.TenantLangfuse{
+		TenantID:  "tenant-del-1",
+		SecretKey: "sk-test",
+		PublicKey: "pk-test",
+		Host:      "https://langfuse.example.com",
+	}).Error; err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+
+	svc := NewLangfuseService()
+	deleted, err := svc.DeleteAPIKey("tenant-del-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deleted {
+		t.Error("expected deleted=true, got false")
+	}
+
+	// Verify the row is gone.
+	var count int64
+	db.Model(&entity.TenantLangfuse{}).Where("tenant_id = ?", "tenant-del-1").Count(&count)
+	if count != 0 {
+		t.Errorf("expected 0 rows after delete, got %d", count)
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Closes #15675 — ports three Langfuse credential-management endpoints from Python (`api/apps/restful_apis/langfuse_api.py`) to Go, following the layered architecture specified in the issue.

| Method | Path | Handler |
|--------|------|---------|
| POST / PUT | `/api/v1/langfuse/api-key` | `LangfuseHandler.SetAPIKey` |
| GET | `/api/v1/langfuse/api-key` | `LangfuseHandler.GetAPIKey` |
| DELETE | `/api/v1/langfuse/api-key` | `LangfuseHandler.DeleteAPIKey` |

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

---

#### Implementation notes

**Files created (per the architecture in the issue):**

```
internal/entity/langfuse.go   – TenantLangfuse (→ tenant_langfuse table)
internal/dao/langfuse.go      – LangfuseDAO CRUD
internal/service/langfuse.go  – LangfuseService + Langfuse HTTP helpers
internal/handler/langfuse.go  – Three HTTP handlers
internal/router/router.go     – Router wiring + four routes
```

**Functional parity table:**

| Concern | Go behaviour |
|---------|-------------|
| Required fields | `secret_key`, `public_key`, `host` all checked; missing any → `"Missing required fields"` — mirrors Python `@validate_request` + explicit check |
| Auth check | `langfuseAuthCheck`: `GET {host}/api/public/projects` with Basic Auth (`public_key:secret_key`), 7 s timeout — mirrors `langfuse.auth_check()` |
| Upsert | `LangfuseDAO.GetByTenantID` → Create or UpdateByTenantID — mirrors Python `filter_by_tenant` + `save` / `update_by_tenant` |
| Secret not leaked on set | Response includes only `tenant_id`, `public_key`, `host` — secret never echoed |
| Secret not leaked on get | GET response includes `public_key`, `host`, `project_id`, `project_name`; `secret_key` intentionally excluded — satisfies issue requirement |
| Project info | `langfuseGetProjects`: same `GET /api/public/projects` call, parses `data[0].id` and `data[0].name` — mirrors Python `langfuse.api.projects.get()` |
| No keys stored | GET / DELETE return `"Have not record any Langfuse keys."` — exact Python message |
| Delete | Hard-delete via `LangfuseDAO.DeleteByTenantID` — mirrors `TenantLangfuseService.delete_model` |
| Auth middleware | All three routes sit inside the `authorized` group (same as all other v1 routes) |
