### PR TITLE
fix: take max PageRank across paths in AnalyzeNHopPaths

### DIFF
--- a/internal/service/kg_scoring_funcs.go
+++ b/internal/service/kg_scoring_funcs.go
@@ -38,7 +38,11 @@ func AnalyzeNHopPaths(entsFromQuery map[string]*KGEntity) map[Edge]EdgeScore {
 				edge := Edge{From: f, To: t}
 				es := nhopPathes[edge]
 				es.Sim += ent.Similarity / (2.0 + float64(i))
-				if i < len(weights) {
+				// Take the max across paths that contribute the same edge.
+				// Plain assignment was last-write-wins, which is non-deterministic
+				// under Go's randomized map iteration and can clobber a stronger
+				// weight with a weaker one. See infiniflow/ragflow#15695.
+				if i < len(weights) && weights[i] > es.PageRank {
 					es.PageRank = weights[i]
 				}
 				nhopPathes[edge] = es

--- a/internal/service/kg_scoring_funcs_test.go
+++ b/internal/service/kg_scoring_funcs_test.go
@@ -79,6 +79,35 @@ func TestAnalyzeNHopPaths_Empty(t *testing.T) {
 	}
 }
 
+// Regression: when two paths from different query entities contribute the
+// same edge, PageRank must keep the *max* weight rather than whichever
+// arrives last. The previous last-write-wins behaviour was non-deterministic
+// under Go's randomized map iteration. See infiniflow/ragflow#15695.
+func TestAnalyzeNHopPaths_PageRankTakesMaxAcrossPaths(t *testing.T) {
+	ents := map[string]*KGEntity{
+		"A": {
+			Similarity: 0.8,
+			NhopEnts: []NhopEntity{
+				{Path: []string{"A", "B"}, Weights: []float64{0.3}}, // weak
+			},
+		},
+		"X": {
+			Similarity: 0.6,
+			NhopEnts: []NhopEntity{
+				{Path: []string{"X", "B"}, Weights: []float64{0.5}},
+				{Path: []string{"A", "B"}, Weights: []float64{0.9}}, // strong, same edge as A→B
+			},
+		},
+	}
+	result := AnalyzeNHopPaths(ents)
+	if got := result[Edge{"A", "B"}].PageRank; got != 0.9 {
+		t.Errorf("expected A→B PageRank=0.9 (max), got %f", got)
+	}
+	if got := result[Edge{"X", "B"}].PageRank; got != 0.5 {
+		t.Errorf("expected X→B PageRank=0.5, got %f", got)
+	}
+}
+
 // --- DoubleHitBoost ---
 
 func TestDoubleHitBoost(t *testing.T) {

--- a/rag/graphrag/search.py
+++ b/rag/graphrag/search.py
@@ -184,7 +184,12 @@ class KGSearch(Dealer):
                         nhop_pathes[(f, t)]["sim"] += ent["sim"] / (2 + i)
                     else:
                         nhop_pathes[(f, t)]["sim"] = ent["sim"] / (2 + i)
-                    nhop_pathes[(f, t)]["pagerank"] = wts[i]
+                    # Take the max across paths that contribute the same edge —
+                    # plain assignment was last-write-wins and could clobber a
+                    # stronger weight with a weaker one. See infiniflow/ragflow#15695.
+                    nhop_pathes[(f, t)]["pagerank"] = max(
+                        nhop_pathes[(f, t)].get("pagerank", 0.0), wts[i]
+                    )
 
         logging.info("Retrieved entities: {}".format(list(ents_from_query.keys())))
         logging.info("Retrieved relations: {}".format(list(rels_from_txt.keys())))


### PR DESCRIPTION
### What problem does this PR solve?

When two N-hop paths contribute the same edge, `PageRank` was assigned with plain `=`, so it kept whichever value was written last. In Go that's non-deterministic (randomized map iteration), and in both languages it can clobber a stronger weight with a weaker one. `Sim` already accumulates correctly; only `PageRank` had this bug.

Fix takes the max across contributing paths:

- `internal/service/kg_scoring_funcs.go` — guarded `if i < len(weights) && weights[i] > es.PageRank`
- `rag/graphrag/search.py` — `max(existing_or_0, wts[i])`

Closes #15695.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Tests

Added `TestAnalyzeNHopPaths_PageRankTakesMaxAcrossPaths` covering the multi-path case both orderings of the outer `range` map produce the same result.