### PR TITLE
fix(retrieval): remove debug prints in rerank_by_model that leak document content

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -513,9 +513,7 @@ class Dealer:
     def rerank_by_model(self, rerank_mdl, sres, query, tkweight=0.3,
                         vtweight=0.7, cfield="content_ltks",
                         rank_feature: dict | None = None):
-        print(f"[DEBUG rerank_by_model] query={query}, tkweight={tkweight}, vtweight={vtweight}")
         _, keywords = self.qryr.question(query)
-        print(f"[DEBUG rerank_by_model] keywords={keywords}")
 
         for i in sres.ids:
             if isinstance(sres.field[i].get("important_kwd", []), str):
@@ -527,29 +525,12 @@ class Dealer:
             important_kwd = sres.field[i].get("important_kwd", [])
             tks = content_ltks + title_tks + important_kwd
             ins_tw.append(tks)
-            print(f"[DEBUG rerank_by_model] chunk id={i}, content_ltks={len(content_ltks)}, title_tks={len(title_tks)}, important_kwd={len(important_kwd)}")
-            doc_text = remove_redundant_spaces(" ".join(tks))
-            if len(doc_text) > 100:
-                print(f"[DEBUG rerank_by_model] chunk id={i}, doc_text (first 100)={doc_text[:100]}...")
-            else:
-                print(f"[DEBUG rerank_by_model] chunk id={i}, doc_text={doc_text}")
 
         docs = [remove_redundant_spaces(" ".join(tks)) for tks in ins_tw]
-        print(f"[DEBUG rerank_by_model] docs sent to reranker: {len(docs)} docs")
-        for idx, doc in enumerate(docs[:2]):  # Print first 2
-            print(f"[DEBUG rerank_by_model] doc[{idx}] len={len(doc)}, full={doc}")
-            if len(doc) > 100:
-                print(f"[DEBUG rerank_by_model] doc[{idx}] (first 100)={doc[:100]}...")
-            else:
-                print(f"[DEBUG rerank_by_model] doc[{idx}]={doc}")
-
         tksim = self.qryr.token_similarity(keywords, ins_tw)
-        print(f"[DEBUG rerank_by_model] tksim={tksim}")
         vtsim, _ = rerank_mdl.similarity(query, docs)
-        print(f"[DEBUG rerank_by_model] vtsim from reranker={vtsim}")
         ## For rank feature(tag_fea) scores.
         rank_fea = self._rank_feature_scores(rank_feature, sres)
-        print(f"[DEBUG rerank_by_model] rank_fea={rank_fea}")
 
         return tkweight * np.array(tksim) + vtweight * vtsim + rank_fea, tksim, vtsim
 


### PR DESCRIPTION
## Summary
Closes #15716

Removes 12 leftover `print("[DEBUG rerank_by_model] ...")` statements in `Dealer.rerank_by_model` (`rag/nlp/search.py`), introduced in #14231. This method runs on the hot retrieval path — once per chat/search query whenever the dialog has a rerank model configured (`dialog_service.retrieval` → `rerank_by_model`).

Two problems on every reranked query:
- **Log noise / IO:** ~12 lines to stdout, bypassing the module `logging` logger (ignoring log level/formatting/routing).
- **Information disclosure:** `doc[{idx}] ... full={doc}` (line 540) writes the full reconstructed text of retrieved chunks — user document content — into container logs unconditionally.

## Changes
- `rag/nlp/search.py` — delete all 12 debug `print()` statements in `rerank_by_model`, plus the now-unused `doc_text` local (it existed only to feed two of the prints).

## Why it's safe (no behavior change)
The deleted lines are pure side-effecting I/O with no assignments and no control flow. The returned `(sim, tksim, vtsim)` is computed from `tksim`/`vtsim`/`rank_fea`, all unchanged. `docs` is independently rebuilt on the existing list-comprehension line, so removing `doc_text` is safe. Every other line in the module already logs via the module `logging` logger, so this restores consistency.

## Verification
- `grep "print(" rag/nlp/search.py` → 0 matches.
- `python -m py_compile rag/nlp/search.py` → OK.
- `ruff check rag/nlp/search.py` → clean.
- Diff is a pure deletion (19 lines).
