### PR TITLE
Support alternate OAuth user email fields

### DIFF
--- a/api/apps/auth/oauth.py
+++ b/api/apps/auth/oauth.py
@@ -142,10 +142,16 @@ class OAuthClient:
 
 
     def normalize_user_info(self, user_info):
-        email = user_info.get("email")
-        username = user_info.get("username", str(email).split("@")[0])
-        nickname = user_info.get("nickname", username)
-        avatar_url = user_info.get("avatar_url", None)
+        profile = user_info.get("data") if isinstance(user_info.get("data"), dict) else user_info
+        email = (
+            profile.get("email")
+            or profile.get("enterprise_email")
+            or profile.get("mail")
+            or profile.get("email_address")
+        )
+        username = profile.get("username", str(email).split("@")[0] if email else "")
+        nickname = profile.get("nickname", profile.get("name", username))
+        avatar_url = profile.get("avatar_url", None)
         if avatar_url is None:
-            avatar_url = user_info.get("picture", "")
+            avatar_url = profile.get("picture", "")
         return UserInfo(email=email, username=username, nickname=nickname, avatar_url=avatar_url)

--- a/test/testcases/test_web_api/test_auth_app/test_oauth_client_unit.py
+++ b/test/testcases/test_web_api/test_auth_app/test_oauth_client_unit.py
@@ -158,6 +158,22 @@ def test_oauth_client_sync_matrix_unit(monkeypatch):
     )
     assert normalized.to_dict()["avatar_url"] == "direct-avatar"
 
+    enterprise_email = client.normalize_user_info({"enterprise_email": "enterprise@example.com", "name": "Enterprise User"})
+    assert enterprise_email.to_dict() == {
+        "email": "enterprise@example.com",
+        "username": "enterprise",
+        "nickname": "Enterprise User",
+        "avatar_url": "",
+    }
+
+    nested_enterprise_email = client.normalize_user_info({"data": {"enterprise_email": "nested@example.com", "name": "Nested User"}})
+    assert nested_enterprise_email.to_dict() == {
+        "email": "nested@example.com",
+        "username": "nested",
+        "nickname": "Nested User",
+        "avatar_url": "",
+    }
+
     monkeypatch.setattr(oauth_module, "sync_request", lambda *_args, **_kwargs: _FakeResponse(err=RuntimeError("status boom")))
     with pytest.raises(ValueError, match="Failed to exchange authorization code for token: status boom"):
         client.exchange_code_for_token("code-2")


### PR DESCRIPTION
## What

This updates the default OAuth user info normalization to accept common alternate email claim names in addition to the standard `email` field. It also supports providers that wrap the user profile in a top-level `data` object.

Supported fallback fields now include:

- `enterprise_email`
- `mail`
- `email_address`

## Why

Some OAuth/OIDC identity providers do not expose a top-level `email` claim from their userinfo endpoint, even when email scope is enabled. In those cases RAGFlow redirects with `error=email_missing` despite a usable email address being present under another common field name.

## Tests

- `python3 -m py_compile api/apps/auth/oauth.py test/testcases/test_web_api/test_auth_app/test_oauth_client_unit.py`
- Added unit coverage for top-level and nested `enterprise_email` normalization.

Note: targeted pytest was not run locally because this machine does not have pytest installed in the active Python environment.
