### PR TITLE
fix(go-models): increase JieKouAI SSE scanner buffer

### DIFF
--- a/internal/entity/models/jiekouai.go
+++ b/internal/entity/models/jiekouai.go
@@ -292,6 +292,7 @@ func (j *JieKouAIModel) ChatStreamlyWithSender(modelName string, messages []Mess
 
 	// SSE parsing: read line by line
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 

--- a/internal/entity/models/sse_scanner_buffer_test.go
+++ b/internal/entity/models/sse_scanner_buffer_test.go
@@ -59,6 +59,7 @@ func TestChatStreamLargeChunkNotTruncated(t *testing.T) {
 		{"lmstudio", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewLmStudioModel(b, s) })},
 		{"gitee", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewGiteeModel(b, s) })},
 		{"tokenhub", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewTokenHubModel(b, s) })},
+		{"jiekouai", build(func(b map[string]string, s URLSuffix) chatStreamer { return NewJieKouAIModel(b, s) })},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- Raise the JieKouAI streaming SSE scanner buffer to handle larger data chunks without truncation.

## What changed
- Configure `bufio.Scanner` with a 1 MB maximum token size in `ChatStreamlyWithSender` for JieKouAI.
- Add JieKouAI to the existing large-SSE-chunk regression coverage shared by OpenAI-compatible providers.

## Why
- The default scanner token limit is 64 KB, so a single large SSE `data:` event can stop scanning and truncate streamed content.

## Validation
- `codex review --base upstream/main` completed with no actionable findings.
- `coderabbit review --agent --type committed --base upstream/main` completed with 0 findings.
- `go test ./internal/entity/models -run 'TestChatStreamLargeChunkNotTruncated/jiekouai|TestJieKouAIStreamForcesStreaming' -count=1`
- `go vet ./internal/entity/models`
- `git diff --check`

## Notes
- Package-wide `go test ./internal/entity/models -count=1` was also attempted, but this checkout currently has unrelated existing provider API-key expectation failures outside this change.
