### PR TITLE
fix: reclaim crashed-worker tasks and harden Redis pending-message replay

### DIFF
--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -1797,6 +1797,9 @@ async def report_status():
 
         # Report heartbeat to Redis
         try:
+            # Re-assert membership each cycle so a transient eviction from TASKEXE
+            # self-heals and our in-flight messages aren't reclaimed as orphans.
+            REDIS_CONN.sadd("TASKEXE", CONSUMER_NAME)
             REDIS_CONN.zadd(CONSUMER_NAME, heartbeat, now_ts)
         except Exception as e:
             logging.warning(f"Failed to report heartbeat: {e}")
@@ -1819,6 +1822,7 @@ async def report_status():
         if lock_acquired:
             try:
                 task_executors = REDIS_CONN.smembers("TASKEXE") or set()
+                live_workers = {CONSUMER_NAME}
                 for worker_name in task_executors:
                     if worker_name == CONSUMER_NAME:
                         continue
@@ -1832,6 +1836,23 @@ async def report_status():
                         logging.info(f"{worker_name} expired, removed")
                         REDIS_CONN.srem("TASKEXE", worker_name)
                         REDIS_CONN.delete(worker_name)
+                    else:
+                        live_workers.add(worker_name)
+
+                # Reclaim in-flight messages orphaned by dead consumers, which would
+                # otherwise sit in the PEL forever (e.g. on scale-down/rescheduling).
+                # Live workers are skipped and min_idle_ms avoids stealing fresh work.
+                try:
+                    reclaimed = REDIS_CONN.reclaim_pending_msg(
+                        settings.get_svr_queue_names(TASK_TYPE),
+                        SVR_CONSUMER_GROUP_NAME,
+                        live_workers,
+                        min_idle_ms=WORKER_HEARTBEAT_TIMEOUT * 1000,
+                    )
+                    if reclaimed:
+                        logging.info(f"Reclaimed {reclaimed} orphaned pending message(s) from dead consumers")
+                except Exception as e:
+                    logging.warning(f"Failed to reclaim orphaned pending messages: {e}")
             except Exception as e:
                 logging.warning(f"Failed to clean other executors: {e}")
             finally:

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -1821,15 +1821,20 @@ async def report_status():
             logging.warning(f"Failed to acquire Redis lock: {e}")
         if lock_acquired:
             try:
-                task_executors = REDIS_CONN.smembers("TASKEXE") or set()
+                # smembers returns None on a Redis error; without a known member
+                # list every peer would look dead, so skip reclaim in that case.
+                task_executors = REDIS_CONN.smembers("TASKEXE")
+                membership_known = task_executors is not None
                 live_workers = {CONSUMER_NAME}
-                for worker_name in task_executors:
+                for worker_name in task_executors or set():
                     if worker_name == CONSUMER_NAME:
                         continue
                     try:
                         last_heartbeat = REDIS_CONN.REDIS.zrevrange(worker_name, 0, 0, withscores=True)
                     except Exception as e:
                         logging.warning(f"Failed to read zset for {worker_name}: {e}")
+                        # Liveness unknown: treat as live so we don't reclaim it.
+                        live_workers.add(worker_name)
                         continue
 
                     if not last_heartbeat or now_ts - last_heartbeat[0][1] > WORKER_HEARTBEAT_TIMEOUT:
@@ -1842,17 +1847,20 @@ async def report_status():
                 # Reclaim in-flight messages orphaned by dead consumers, which would
                 # otherwise sit in the PEL forever (e.g. on scale-down/rescheduling).
                 # Live workers are skipped and min_idle_ms avoids stealing fresh work.
-                try:
-                    reclaimed = REDIS_CONN.reclaim_pending_msg(
-                        settings.get_svr_queue_names(TASK_TYPE),
-                        SVR_CONSUMER_GROUP_NAME,
-                        live_workers,
-                        min_idle_ms=WORKER_HEARTBEAT_TIMEOUT * 1000,
-                    )
-                    if reclaimed:
-                        logging.info(f"Reclaimed {reclaimed} orphaned pending message(s) from dead consumers")
-                except Exception as e:
-                    logging.warning(f"Failed to reclaim orphaned pending messages: {e}")
+                if membership_known:
+                    try:
+                        reclaimed = REDIS_CONN.reclaim_pending_msg(
+                            settings.get_svr_queue_names(TASK_TYPE),
+                            SVR_CONSUMER_GROUP_NAME,
+                            live_workers,
+                            min_idle_ms=WORKER_HEARTBEAT_TIMEOUT * 1000,
+                        )
+                        if reclaimed:
+                            logging.info(f"Reclaimed {reclaimed} orphaned pending message(s) from dead consumers")
+                    except Exception as e:
+                        logging.warning(f"Failed to reclaim orphaned pending messages: {e}")
+                else:
+                    logging.warning("Skipping pending-message reclaim: TASKEXE membership could not be read")
             except Exception as e:
                 logging.warning(f"Failed to clean other executors: {e}")
             finally:

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -61,6 +61,26 @@ class RedisMsg:
 class RedisDB:
     lua_delete_if_equal = None
     lua_token_bucket = None
+    lua_requeue_msg = None
+    LUA_REQUEUE_MSG_SCRIPT = """
+        -- KEYS[1] = stream/queue
+        -- KEYS[2] = dedupe marker key
+        -- ARGV[1] = group name
+        -- ARGV[2] = message id
+        -- ARGV[3] = marker ttl seconds
+
+        -- Re-add + ack atomically; the NX marker makes retries skip the re-add,
+        -- so neither a partial failure nor a retry can duplicate the payload.
+        if redis.call('SET', KEYS[2], '1', 'NX', 'EX', tonumber(ARGV[3])) then
+            local entries = redis.call('XRANGE', KEYS[1], ARGV[2], ARGV[2])
+            if #entries > 0 then
+                redis.call('XADD', KEYS[1], '*', unpack(entries[1][2]))
+            end
+        end
+        redis.call('XACK', KEYS[1], ARGV[1], ARGV[2])
+        return 1
+    """
+
     LUA_DELETE_IF_EQUAL_SCRIPT = """
         local current_value = redis.call('get', KEYS[1])
         if current_value and current_value == ARGV[1] then
@@ -121,6 +141,7 @@ class RedisDB:
         client = self.REDIS
         cls.lua_delete_if_equal = client.register_script(cls.LUA_DELETE_IF_EQUAL_SCRIPT)
         cls.lua_token_bucket = client.register_script(cls.LUA_TOKEN_BUCKET_SCRIPT)
+        cls.lua_requeue_msg = client.register_script(cls.LUA_REQUEUE_MSG_SCRIPT)
 
     def __open__(self):
         try:
@@ -455,7 +476,10 @@ class RedisDB:
         return None
 
     def get_unacked_iterator(self, queue_names: list[str], group_name, consumer_name):
-        # Isolate each queue so one queue's failure can't skip the others' replay.
+        """Yield this consumer's own pending (delivered-but-unacked) messages so a
+        restarted worker can finish what it had in flight. Each queue is isolated:
+        a failure inspecting or draining one queue cannot skip the others' replay.
+        """
         for queue_name in queue_names:
             try:
                 try:
@@ -528,16 +552,14 @@ class RedisDB:
 
     def requeue_msg(self, queue: str, group_name: str, msg_id: str) -> bool:
         """Re-deliver a pending message: copy it to the stream tail for a fresh
-        pickup, then ack the original to drain the PEL. The ack is unconditional
-        so already-trimmed entries still leave the PEL. Idempotent; returns True
-        once the original is acked.
+        pickup and ack the original, in one atomic Lua script guarded by an NX
+        dedupe marker so it can't be enqueued twice. Returns True once acked.
         """
+        # Hash-tag the marker to the queue's slot so both keys stay co-located.
+        marker = f"reclaim:{{{queue}}}:{group_name}:{msg_id}"
         for _ in range(3):
             try:
-                messages = self.REDIS.xrange(queue, msg_id, msg_id)
-                if messages:
-                    self.REDIS.xadd(queue, messages[0][1])
-                self.REDIS.xack(queue, group_name, msg_id)
+                self.lua_requeue_msg(keys=[queue, marker], args=[group_name, msg_id, 300], client=self.REDIS)
                 return True
             except Exception as e:
                 logging.warning(

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -455,14 +455,17 @@ class RedisDB:
         return None
 
     def get_unacked_iterator(self, queue_names: list[str], group_name, consumer_name):
-        try:
-            for queue_name in queue_names:
+        # Isolate each queue so one queue's failure can't skip the others' replay.
+        for queue_name in queue_names:
+            try:
                 try:
                     group_info = self.REDIS.xinfo_groups(queue_name)
-                except Exception as e:
-                    if str(e) == 'no such key':
+                except redis.exceptions.ResponseError as e:
+                    if "no such key" in str(e).lower():
                         logging.warning(f"RedisDB.get_unacked_iterator queue {queue_name} doesn't exist")
-                        continue
+                    else:
+                        logging.exception(f"RedisDB.get_unacked_iterator queue {queue_name} xinfo_groups failed")
+                    continue
                 if not any(gi["name"] == group_name for gi in group_info):
                     logging.warning(f"RedisDB.get_unacked_iterator queue {queue_name} group {group_name} doesn't exist")
                     continue
@@ -474,35 +477,96 @@ class RedisDB:
                     current_min = payload.get_msg_id()
                     logging.info(f"RedisDB.get_unacked_iterator {queue_name} {consumer_name} {current_min}")
                     yield payload
-        except Exception:
-            logging.exception(
-                "RedisDB.get_unacked_iterator got exception: "
-            )
-            self.__open__()
+            except Exception:
+                logging.exception(f"RedisDB.get_unacked_iterator queue {queue_name} got exception")
+                self.__open__()
+                continue
 
-    def get_pending_msg(self, queue, group_name):
+    def get_pending_msg(self, queue, group_name, consumer_name=None, min_idle_ms=None, count=256):
+        """List a group's pending (delivered-but-unacked) messages, paging through
+        the whole PEL. Optionally filter by ``consumer_name`` and/or ``min_idle_ms``.
+        Returns dicts with keys ``message_id``/``consumer``/``time_since_delivered``/
+        ``times_delivered`` (empty on error or missing stream/group).
+        """
+        pending = []
+        start = "-"
+        last_id = None
         try:
-            messages = self.REDIS.xpending_range(queue, group_name, '-', '+', 10)
-            return messages
-        except Exception as e:
-            if 'No such key' not in (str(e) or ''):
+            while True:
+                batch = self.REDIS.xpending_range(
+                    queue,
+                    group_name,
+                    min=start,
+                    max="+",
+                    count=count,
+                    consumername=consumer_name,
+                    idle=min_idle_ms,
+                )
+                if not batch:
+                    break
+                pending.extend(batch)
+                if len(batch) < count:
+                    break
+                batch_last_id = str(batch[-1]["message_id"])
+                if batch_last_id == last_id:  # boundary didn't advance: stop, don't spin
+                    break
+                last_id = batch_last_id
+                start = "(" + batch_last_id  # exclusive: page strictly past the last id
+        except redis.exceptions.ResponseError as e:
+            # Missing stream/group means no PEL; anything else is worth logging.
+            err = str(e).lower()
+            if "no such key" not in err and "nogroup" not in err:
                 logging.warning(
                     "RedisDB.get_pending_msg " + str(queue) + " got exception: " + str(e)
                 )
-        return []
+        except Exception as e:
+            logging.warning(
+                "RedisDB.get_pending_msg " + str(queue) + " got exception: " + str(e)
+            )
+            self.__open__()
+        return pending
 
-    def requeue_msg(self, queue: str, group_name: str, msg_id: str):
+    def requeue_msg(self, queue: str, group_name: str, msg_id: str) -> bool:
+        """Re-deliver a pending message: copy it to the stream tail for a fresh
+        pickup, then ack the original to drain the PEL. The ack is unconditional
+        so already-trimmed entries still leave the PEL. Idempotent; returns True
+        once the original is acked.
+        """
         for _ in range(3):
             try:
                 messages = self.REDIS.xrange(queue, msg_id, msg_id)
                 if messages:
                     self.REDIS.xadd(queue, messages[0][1])
-                    self.REDIS.xack(queue, group_name, msg_id)
+                self.REDIS.xack(queue, group_name, msg_id)
+                return True
             except Exception as e:
                 logging.warning(
-                    "RedisDB.get_pending_msg " + str(queue) + " got exception: " + str(e)
+                    "RedisDB.requeue_msg " + str(queue) + " got exception: " + str(e)
                 )
                 self.__open__()
+        return False
+
+    def reclaim_pending_msg(self, queue_names: list[str], group_name: str, live_consumers, min_idle_ms: int = 0) -> int:
+        """Requeue pending messages owned by consumers not in ``live_consumers``,
+        rescuing in-flight work from crashed workers that would otherwise sit in
+        the PEL forever. ``min_idle_ms`` skips just-delivered entries. Idempotent
+        (requeue_msg acks the original). Returns the count reclaimed.
+        """
+        reclaimed = 0
+        live = set(live_consumers or [])
+        for queue_name in queue_names:
+            for msg in self.get_pending_msg(queue_name, group_name, min_idle_ms=min_idle_ms or None):
+                consumer = msg.get("consumer")
+                if consumer in live:
+                    continue
+                msg_id = msg["message_id"]
+                if self.requeue_msg(queue_name, group_name, msg_id):
+                    reclaimed += 1
+                    logging.info(
+                        f"RedisDB.reclaim_pending_msg requeued {queue_name} {msg_id} "
+                        f"orphaned by dead consumer {consumer}"
+                    )
+        return reclaimed
 
     def queue_info(self, queue, group_name) -> dict | None:
         for _ in range(3):

--- a/test/unit_test/rag/utils/test_redis_conn_reclaim.py
+++ b/test/unit_test/rag/utils/test_redis_conn_reclaim.py
@@ -36,16 +36,21 @@ import valkey
 from rag.utils.redis_conn import RedisDB
 
 
-def _make_db():
-    """A RedisDB whose connection is replaced by a mock (no live server).
-
-    __open__ is stubbed so a simulated connection error in a method under test
-    does not reconnect and replace the mock with a real (dead) client.
+@pytest.fixture
+def db():
+    """RedisDB (a @singleton) with its connection mocked. The shared instance is
+    restored on teardown to keep tests order-independent, and __open__ is stubbed
+    so a simulated connection error doesn't reconnect over the mock.
     """
-    db = RedisDB()
-    db.__open__ = MagicMock()
-    db.REDIS = MagicMock()
-    return db
+    inst = RedisDB()
+    saved = dict(inst.__dict__)
+    inst.__open__ = MagicMock()
+    inst.REDIS = MagicMock()
+    try:
+        yield inst
+    finally:
+        inst.__dict__.clear()
+        inst.__dict__.update(saved)
 
 
 def _msg(msg_id):
@@ -56,14 +61,12 @@ def _msg(msg_id):
 
 @pytest.mark.p1
 class TestGetUnackedIterator:
-    def test_non_missing_key_error_does_not_skip_remaining_queues(self):
+    def test_non_missing_key_error_does_not_skip_remaining_queues(self, db):
         """A transient error on the first queue must not abort the second."""
-        db = _make_db()
 
         def xinfo_groups(queue_name):
+            # A non "no such key" error used to abort the whole replay.
             if queue_name == "te.1.common":
-                # Anything other than an exact "no such key" used to leave
-                # group_info unbound -> UnboundLocalError -> whole loop aborts.
                 raise valkey.exceptions.ConnectionError("connection reset by peer")
             return [{"name": "grp"}]
 
@@ -77,8 +80,7 @@ class TestGetUnackedIterator:
 
         assert [m.get_msg_id() for m in out] == ["5-0"]
 
-    def test_missing_stream_is_skipped(self):
-        db = _make_db()
+    def test_missing_stream_is_skipped(self, db):
         db.REDIS.xinfo_groups.side_effect = valkey.exceptions.ResponseError("no such key")
         db.queue_consumer = MagicMock()
 
@@ -87,8 +89,7 @@ class TestGetUnackedIterator:
         assert out == []
         db.queue_consumer.assert_not_called()
 
-    def test_missing_group_is_skipped(self):
-        db = _make_db()
+    def test_missing_group_is_skipped(self, db):
         db.REDIS.xinfo_groups.return_value = [{"name": "other-group"}]
         db.queue_consumer = MagicMock()
 
@@ -100,36 +101,35 @@ class TestGetUnackedIterator:
 
 @pytest.mark.p1
 class TestRequeueMsg:
-    def test_requeues_exactly_once(self):
-        """The retry loop must stop on success instead of re-adding 3x."""
-        db = _make_db()
-        db.REDIS.xrange.return_value = [("9-0", {"message": "{}"})]
+    def test_requeues_via_atomic_script_once(self, db):
+        """A successful handoff runs the script once and stops retrying."""
+        db.lua_requeue_msg = MagicMock(return_value=1)
 
         assert db.requeue_msg("te.0.common", "grp", "9-0") is True
-        assert db.REDIS.xadd.call_count == 1
-        db.REDIS.xack.assert_called_once_with("te.0.common", "grp", "9-0")
 
-    def test_acks_even_when_entry_trimmed(self):
-        """A PEL entry whose stream payload was trimmed is still drained."""
-        db = _make_db()
-        db.REDIS.xrange.return_value = []
+        db.lua_requeue_msg.assert_called_once()
+        kwargs = db.lua_requeue_msg.call_args.kwargs
+        assert kwargs["keys"][0] == "te.0.common"
+        # Marker is hash-tagged to the queue's slot so both keys co-locate.
+        assert kwargs["keys"][1] == "reclaim:{te.0.common}:grp:9-0"
+        assert kwargs["args"][:2] == ["grp", "9-0"]
 
-        assert db.requeue_msg("te.0.common", "grp", "9-0") is True
-        db.REDIS.xadd.assert_not_called()
-        db.REDIS.xack.assert_called_once_with("te.0.common", "grp", "9-0")
+    def test_returns_false_after_exhausting_retries(self, db):
+        db.lua_requeue_msg = MagicMock(side_effect=valkey.exceptions.ConnectionError("boom"))
+
+        assert db.requeue_msg("te.0.common", "grp", "9-0") is False
+        assert db.lua_requeue_msg.call_count == 3
 
 
 @pytest.mark.p1
 class TestGetPendingMsg:
-    def test_returns_empty_on_nogroup(self):
-        db = _make_db()
+    def test_returns_empty_on_nogroup(self, db):
         db.REDIS.xpending_range.side_effect = valkey.exceptions.ResponseError(
             "NOGROUP No such key 'te.0.common' or consumer group 'grp'"
         )
         assert db.get_pending_msg("te.0.common", "grp") == []
 
-    def test_paginates_through_full_pel(self):
-        db = _make_db()
+    def test_paginates_through_full_pel(self, db):
         page1 = [{"message_id": f"{i}-0", "consumer": "c"} for i in range(256)]
         page2 = [{"message_id": "256-0", "consumer": "c"}]
         db.REDIS.xpending_range.side_effect = [page1, page2]
@@ -142,32 +142,32 @@ class TestGetPendingMsg:
 
 @pytest.mark.p1
 class TestReclaimPendingMsg:
-    def test_reclaims_only_dead_consumer_entries(self):
-        db = _make_db()
+    def test_reclaims_only_dead_consumer_entries(self, db):
         db.REDIS.xpending_range.return_value = [
             {"message_id": "1-0", "consumer": "dead_worker"},
             {"message_id": "2-0", "consumer": "live_worker"},
         ]
-        db.REDIS.xrange.side_effect = lambda q, a, b: [(a, {"message": "{}"})]
+        db.lua_requeue_msg = MagicMock(return_value=1)
 
         reclaimed = db.reclaim_pending_msg(
             ["te.0.common"], "grp", live_consumers={"live_worker"}
         )
 
         assert reclaimed == 1
-        # Only the dead worker's entry is acked/requeued.
-        db.REDIS.xack.assert_called_once_with("te.0.common", "grp", "1-0")
+        # Only the dead worker's entry is requeued.
+        db.lua_requeue_msg.assert_called_once()
+        assert db.lua_requeue_msg.call_args.kwargs["args"][:2] == ["grp", "1-0"]
 
-    def test_noop_when_all_consumers_live(self):
-        db = _make_db()
+    def test_noop_when_all_consumers_live(self, db):
         db.REDIS.xpending_range.return_value = [
             {"message_id": "1-0", "consumer": "live_a"},
             {"message_id": "2-0", "consumer": "live_b"},
         ]
+        db.lua_requeue_msg = MagicMock(return_value=1)
 
         reclaimed = db.reclaim_pending_msg(
             ["te.0.common"], "grp", live_consumers={"live_a", "live_b"}
         )
 
         assert reclaimed == 0
-        db.REDIS.xack.assert_not_called()
+        db.lua_requeue_msg.assert_not_called()

--- a/test/unit_test/rag/utils/test_redis_conn_reclaim.py
+++ b/test/unit_test/rag/utils/test_redis_conn_reclaim.py
@@ -1,0 +1,173 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Unit tests for the Redis consumer-group pending/reclaim helpers.
+
+Covers two regressions:
+  * get_unacked_iterator must not abort the replay of every remaining queue
+    when one queue raises a non-"no such key" error (was an UnboundLocalError).
+  * requeue_msg must re-add a message exactly once (the retry loop used to fall
+    through and xadd up to three times), and reclaim_pending_msg must requeue
+    only the entries owned by dead consumers.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# common.settings must be imported before rag.utils.redis_conn to resolve the
+# settings <-> redis_conn circular import the same way the app does.
+import common.settings  # noqa: F401
+import valkey
+
+from rag.utils.redis_conn import RedisDB
+
+
+def _make_db():
+    """A RedisDB whose connection is replaced by a mock (no live server).
+
+    __open__ is stubbed so a simulated connection error in a method under test
+    does not reconnect and replace the mock with a real (dead) client.
+    """
+    db = RedisDB()
+    db.__open__ = MagicMock()
+    db.REDIS = MagicMock()
+    return db
+
+
+def _msg(msg_id):
+    m = MagicMock()
+    m.get_msg_id.return_value = msg_id
+    return m
+
+
+@pytest.mark.p1
+class TestGetUnackedIterator:
+    def test_non_missing_key_error_does_not_skip_remaining_queues(self):
+        """A transient error on the first queue must not abort the second."""
+        db = _make_db()
+
+        def xinfo_groups(queue_name):
+            if queue_name == "te.1.common":
+                # Anything other than an exact "no such key" used to leave
+                # group_info unbound -> UnboundLocalError -> whole loop aborts.
+                raise valkey.exceptions.ConnectionError("connection reset by peer")
+            return [{"name": "grp"}]
+
+        db.REDIS.xinfo_groups.side_effect = xinfo_groups
+
+        # Second queue yields one pending message, then is drained.
+        payloads = iter([_msg("5-0"), None])
+        db.queue_consumer = MagicMock(side_effect=lambda *a, **k: next(payloads, None))
+
+        out = list(db.get_unacked_iterator(["te.1.common", "te.0.common"], "grp", "c0"))
+
+        assert [m.get_msg_id() for m in out] == ["5-0"]
+
+    def test_missing_stream_is_skipped(self):
+        db = _make_db()
+        db.REDIS.xinfo_groups.side_effect = valkey.exceptions.ResponseError("no such key")
+        db.queue_consumer = MagicMock()
+
+        out = list(db.get_unacked_iterator(["te.0.common"], "grp", "c0"))
+
+        assert out == []
+        db.queue_consumer.assert_not_called()
+
+    def test_missing_group_is_skipped(self):
+        db = _make_db()
+        db.REDIS.xinfo_groups.return_value = [{"name": "other-group"}]
+        db.queue_consumer = MagicMock()
+
+        out = list(db.get_unacked_iterator(["te.0.common"], "grp", "c0"))
+
+        assert out == []
+        db.queue_consumer.assert_not_called()
+
+
+@pytest.mark.p1
+class TestRequeueMsg:
+    def test_requeues_exactly_once(self):
+        """The retry loop must stop on success instead of re-adding 3x."""
+        db = _make_db()
+        db.REDIS.xrange.return_value = [("9-0", {"message": "{}"})]
+
+        assert db.requeue_msg("te.0.common", "grp", "9-0") is True
+        assert db.REDIS.xadd.call_count == 1
+        db.REDIS.xack.assert_called_once_with("te.0.common", "grp", "9-0")
+
+    def test_acks_even_when_entry_trimmed(self):
+        """A PEL entry whose stream payload was trimmed is still drained."""
+        db = _make_db()
+        db.REDIS.xrange.return_value = []
+
+        assert db.requeue_msg("te.0.common", "grp", "9-0") is True
+        db.REDIS.xadd.assert_not_called()
+        db.REDIS.xack.assert_called_once_with("te.0.common", "grp", "9-0")
+
+
+@pytest.mark.p1
+class TestGetPendingMsg:
+    def test_returns_empty_on_nogroup(self):
+        db = _make_db()
+        db.REDIS.xpending_range.side_effect = valkey.exceptions.ResponseError(
+            "NOGROUP No such key 'te.0.common' or consumer group 'grp'"
+        )
+        assert db.get_pending_msg("te.0.common", "grp") == []
+
+    def test_paginates_through_full_pel(self):
+        db = _make_db()
+        page1 = [{"message_id": f"{i}-0", "consumer": "c"} for i in range(256)]
+        page2 = [{"message_id": "256-0", "consumer": "c"}]
+        db.REDIS.xpending_range.side_effect = [page1, page2]
+
+        out = db.get_pending_msg("te.0.common", "grp")
+
+        assert len(out) == 257
+        assert db.REDIS.xpending_range.call_count == 2
+
+
+@pytest.mark.p1
+class TestReclaimPendingMsg:
+    def test_reclaims_only_dead_consumer_entries(self):
+        db = _make_db()
+        db.REDIS.xpending_range.return_value = [
+            {"message_id": "1-0", "consumer": "dead_worker"},
+            {"message_id": "2-0", "consumer": "live_worker"},
+        ]
+        db.REDIS.xrange.side_effect = lambda q, a, b: [(a, {"message": "{}"})]
+
+        reclaimed = db.reclaim_pending_msg(
+            ["te.0.common"], "grp", live_consumers={"live_worker"}
+        )
+
+        assert reclaimed == 1
+        # Only the dead worker's entry is acked/requeued.
+        db.REDIS.xack.assert_called_once_with("te.0.common", "grp", "1-0")
+
+    def test_noop_when_all_consumers_live(self):
+        db = _make_db()
+        db.REDIS.xpending_range.return_value = [
+            {"message_id": "1-0", "consumer": "live_a"},
+            {"message_id": "2-0", "consumer": "live_b"},
+        ]
+
+        reclaimed = db.reclaim_pending_msg(
+            ["te.0.common"], "grp", live_consumers={"live_a", "live_b"}
+        )
+
+        assert reclaimed == 0
+        db.REDIS.xack.assert_not_called()


### PR DESCRIPTION
### Summary

Closes #15805 

Task executors consume documents from Redis streams via a consumer group. Two issues in `rag/utils/redis_conn.py` keep in-flight work from recovering when a worker dies.

**1. Pending-message replay aborts on any non-exact error**

`get_unacked_iterator` replays each queue's pending entries on startup, but it only recognized a missing stream when the error string equaled `'no such key'` exactly. Any other error (a connection blip, or a differently worded message) fell through to a `group_info` check where `group_info` was never assigned, raising `UnboundLocalError`. The outer `except` swallowed it and ended the whole replay, silently skipping every remaining queue. `queue_consumer` already does the right thing with `"no such key" in str(e).lower()`, so the behavior was also inconsistent.

Each queue is now isolated in its own try block, `group_info` is always bound before use, and missing streams are matched case-insensitively.

**2. A crashed worker's in-flight messages are orphaned forever**

There was no `XCLAIM`/`XAUTOCLAIM` in the codebase, and `get_pending_msg`/`requeue_msg` had no callers. A worker could recover only its own pending entries, and only when restarted under the identical `CONSUMER_NAME`. On scale-down or rescheduling, a dead worker's messages stayed in the group's Pending Entries List forever, leaving documents stuck and the PEL growing without bound.

This completes that existing scaffolding. `report_status` already tracks worker liveness via heartbeats; it now also calls a new `reclaim_pending_msg`, under the existing `clean_task_executor` distributed lock, to requeue any pending message whose owning consumer is no longer alive. A `min_idle_ms` guard (set to the heartbeat timeout) prevents stealing recently delivered work, and live workers are skipped so an active task is never reclaimed.

Additional hardening found along the way:

- `requeue_msg` now stops on success. Its retry loop previously fell through and re-added the same message up to three times.
- Its ack is unconditional, so an entry whose payload was already trimmed still leaves the PEL.
- Workers re-assert `TASKEXE` membership on every heartbeat, so a transient eviction self-heals and an alive worker is never mistaken for a dead one.

### Safety

The primary guard is consumer liveness: a busy worker keeps heartbeating because heavy work runs through `asyncio.to_thread` and async limiters, so its messages are never reclaimed regardless of task length. The idle guard covers the startup window and any momentary gap. The worst remaining case is a single re-delivery, which the existing at-least-once task handling already tolerates, and which is strictly better than the previous orphaned-forever behavior.

### Tests

Added `test/unit_test/rag/utils/test_redis_conn_reclaim.py` covering replay isolation across queues, missing stream and group handling, single requeue, trimmed-entry ack, PEL paging, and dead-versus-live reclaim selection.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
