### PR TITLE
fix(go-models): guard nil pointers in DeepSeek and VolcEngine streaming

### DIFF
--- a/internal/entity/models/deepseek.go
+++ b/internal/entity/models/deepseek.go
@@ -293,7 +293,11 @@ func (d *DeepSeekModel) ChatStreamlyWithSender(modelName string, messages []Mess
 		if chatModelConfig.Thinking != nil {
 			if *chatModelConfig.Thinking {
 				var thinkingFlag string
-				switch *chatModelConfig.Effort {
+				effort := "high"
+				if chatModelConfig.Effort != nil {
+					effort = *chatModelConfig.Effort
+				}
+				switch effort {
 				case "none":
 					thinkingFlag = "disabled"
 					break

--- a/internal/entity/models/volcengine.go
+++ b/internal/entity/models/volcengine.go
@@ -257,6 +257,10 @@ func (v *VolcEngine) ChatStreamlyWithSender(modelName string, messages []Message
 		"temperature": 1,
 	}
 
+	if modelConfig == nil {
+		modelConfig = &ChatConfig{}
+	}
+
 	if modelConfig.Stream != nil {
 		reqBody["stream"] = *modelConfig.Stream
 	}
@@ -285,7 +289,11 @@ func (v *VolcEngine) ChatStreamlyWithSender(modelName string, messages []Message
 	if modelConfig.Thinking != nil {
 		if *modelConfig.Thinking {
 			var thinkingFlag string
-			switch *modelConfig.Effort {
+			effort := "medium"
+			if modelConfig.Effort != nil {
+				effort = *modelConfig.Effort
+			}
+			switch effort {
 			case "none", "minimal":
 				thinkingFlag = "disabled"
 				reqBody["reasoning_effort"] = "minimal"


### PR DESCRIPTION
### What problem does this PR solve?

`ChatStreamlyWithSender` in two Go model drivers could panic on nil pointer dereferences when a caller passes a nil model config or omits the reasoning `Effort`:

- **deepseek.go** - `switch *chatModelConfig.Effort` dereferenced `Effort` without a nil check. It now defaults to `"high"` when nil.
- **volcengine.go** - the `modelConfig` pointer itself was dereferenced (`Stream`, `MaxTokens`, `Temperature`, .) with no guard, and `Effort` was dereferenced unchecked. `modelConfig` now defaults to an empty `&ChatConfig{}` when nil so the optional-field accesses are safe, and `Effort` defaults to `"medium"` when nil.

Addresses the CodeRabbit review on `volcengine.go` `ChatStreamlyWithSender`. Per maintainer feedback ("one PR do one thing"), the unrelated `handler/auth.go` and `service/heartbeat_sender.go` changes were removed so this PR is scoped to the model-provider fixes.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
