### PR TITLE
fix: Remove trailing comma in CREATE TABLE tenant_model SQL (#15832)

### DIFF
--- a/tools/scripts/mysql_migration.py
+++ b/tools/scripts/mysql_migration.py
@@ -834,7 +834,7 @@ class TenantModelStage(MigrationStage):
             create_date DATETIME,
             update_time BIGINT,
             update_date DATETIME,
-            INDEX idx_instance_id (instance_id),
+            INDEX idx_instance_id (instance_id)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
         """
         self.db.execute_sql(create_sql)


### PR DESCRIPTION
### What problem does this PR solve?
The last column definition `INDEX idx_instance_id (instance_id),` in the
`CREATE TABLE tenant_model` statement has a trailing comma, which causes
a MySQL syntax error during deployment.

Closes #15832

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)

### How was this tested?
- [x] Visual inspection: the trailing comma on line 837 has been removed
