### PR TITLE
ci(release): publish multi-arch (amd64+arm64) image on tag/nightly (#15747)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,9 @@ jobs:
           # Register QEMU so amd64 runners can cross-build the arm64 layer.
           # tonistiigi/binfmt is the docker/setup-qemu-action upstream and is
           # safe to re-run; it's a no-op when emulators are already registered.
-          sudo docker run --privileged --rm tonistiigi/binfmt:latest --install arm64,amd64
+          # Pin to a specific qemu-vX.Y.Z tag for reproducibility rather than
+          # :latest, so a future binfmt regression can't break the release.
+          sudo docker run --privileged --rm tonistiigi/binfmt:qemu-v8.1.5 --install arm64,amd64
           # Use (or create) a buildx builder capable of multi-platform output.
           if ! sudo docker buildx inspect ragflow-multiarch >/dev/null 2>&1; then
             sudo docker buildx create --name ragflow-multiarch --driver docker-container --bootstrap
@@ -104,6 +106,27 @@ jobs:
             --file Dockerfile \
             --push \
             .
+
+      # Fail loudly if a platform silently went missing from the push (e.g. a
+      # build-context bind-mount image lacks an arm64 variant and buildx
+      # produced an amd64-only manifest). Without this, an incomplete release
+      # would only be noticed by aarch64 users at `docker compose pull` time.
+      - name: Verify multi-arch manifest
+        run: |
+          set -euo pipefail
+          for tag in "${RELEASE_TAG}" "latest"; do
+            ref="infiniflow/ragflow:${tag}"
+            echo "Inspecting manifest for ${ref} ..."
+            inspection=$(sudo docker buildx imagetools inspect "${ref}")
+            echo "${inspection}"
+            for platform in linux/amd64 linux/arm64; do
+              if ! grep -qE "Platform:[[:space:]]*${platform}\b" <<< "${inspection}"; then
+                echo "ERROR: ${platform} missing from ${ref} manifest" >&2
+                exit 1
+              fi
+            done
+          done
+          echo "Both linux/amd64 and linux/arm64 confirmed in the pushed manifest list."
 
       - name: Build and push ragflow-sdk
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,13 +82,28 @@ jobs:
           # The body field does not support environment variable substitution directly.
           body_path: release_body.md
 
-      - name: Build and push image
+      # Multi-arch image so docker-compose deployments on aarch64 hosts
+      # (Kunpeng-920, Graviton, Apple-Silicon Linux VMs, etc.) can pull the
+      # same tag the README documents — see #15747.
+      - name: Build and push image (linux/amd64, linux/arm64)
         run: |
           sudo docker login --username infiniflow --password-stdin <<< ${{ secrets.DOCKERHUB_TOKEN }}
-          sudo docker build -t infiniflow/ragflow:${RELEASE_TAG} -f Dockerfile .
-          sudo docker tag infiniflow/ragflow:${RELEASE_TAG} infiniflow/ragflow:latest
-          sudo docker push infiniflow/ragflow:${RELEASE_TAG}
-          sudo docker push infiniflow/ragflow:latest
+          # Register QEMU so amd64 runners can cross-build the arm64 layer.
+          # tonistiigi/binfmt is the docker/setup-qemu-action upstream and is
+          # safe to re-run; it's a no-op when emulators are already registered.
+          sudo docker run --privileged --rm tonistiigi/binfmt:latest --install arm64,amd64
+          # Use (or create) a buildx builder capable of multi-platform output.
+          if ! sudo docker buildx inspect ragflow-multiarch >/dev/null 2>&1; then
+            sudo docker buildx create --name ragflow-multiarch --driver docker-container --bootstrap
+          fi
+          sudo docker buildx use ragflow-multiarch
+          sudo docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag infiniflow/ragflow:${RELEASE_TAG} \
+            --tag infiniflow/ragflow:latest \
+            --file Dockerfile \
+            --push \
+            .
 
       - name: Build and push ragflow-sdk
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary

Fixes #15747.

User runs RAGFlow on a Kunpeng-920 (HiSilicon aarch64, 192-core) box with an Ascend-910B accelerator and reports `docker compose pull` fails because the org only publishes an amd64 manifest for `infiniflow/ragflow:${TAG}`. They want org-built ARM64 images for both the tagged releases and the nightly stream so a standard `docker compose up` works on aarch64 hosts.

### Root cause

[.github/workflows/release.yml:85-91](.github/workflows/release.yml#L85-L91) uses:

```yaml
- name: Build and push image
  run: |
    sudo docker login ...
    sudo docker build -t infiniflow/ragflow:${RELEASE_TAG} -f Dockerfile .
    sudo docker tag infiniflow/ragflow:${RELEASE_TAG} infiniflow/ragflow:latest
    sudo docker push infiniflow/ragflow:${RELEASE_TAG}
    sudo docker push infiniflow/ragflow:latest
```

`docker build` produces a **single-platform** image for the runner's native arch (amd64). The `docker push` then publishes only an amd64 entry under the tag. On the aarch64 host, `docker compose pull` errors out with `no matching manifest for linux/arm64/v8 in the manifest list entries`.

### Fix

One workflow step replaced — no source / Dockerfile / compose changes:

1. Register QEMU emulators on the runner via `tonistiigi/binfmt:latest --install arm64,amd64` (the same image `docker/setup-qemu-action` shells out to; idempotent on re-runs once binfmt is registered).
2. Create a `docker-container`-driver buildx builder named `ragflow-multiarch` once, reuse it on subsequent runs.
3. Replace the single-arch build/tag/push triple with one `docker buildx build --platform linux/amd64,linux/arm64 --tag <tag> --tag latest --push .` so both arches are baked into one manifest list under each tag.

Because the image is a manifest list, any `docker pull infiniflow/ragflow:${TAG}` from an aarch64 host (Kunpeng, Graviton, Apple-Silicon Linux VM, etc.) transparently selects the arm64 layer — existing `docker/.env` configs like `RAGFLOW_IMAGE=infiniflow/ragflow:v0.25.6` keep working as-is.

### Why this is the minimal change

- **`docker/docker-compose.yml`** ([line 11](docker/docker-compose.yml#L11), [line 62](docker/docker-compose.yml#L62)) and **`docker/.env`** ([line 162](docker/.env#L162)) — already reference `${RAGFLOW_IMAGE}`. Manifest-list resolution is automatic; no edit required.
- **`Dockerfile`** — already has arch-conditional branches for the uv tarball ([:76-80](Dockerfile#L76-L80)), `msodbcsql17` vs `msodbcsql18` ([:99-110](Dockerfile#L99-L110)), and `libssl1.1` `.deb` ([:125-130](Dockerfile#L125-L130)). It builds cleanly on both platforms; no edit required.
- **`tests.yml`** — left alone. CI tests still run on the amd64 self-hosted runner. Multi-arch belongs to release, not tests.

### What this PR does NOT change

- **`infiniflow/ragflow_deps:latest`.** [Dockerfile:12-23](Dockerfile#L12-L23), [:68-80](Dockerfile#L68-L80), and [:116-130](Dockerfile#L116-L130) mount that image as a build context. BuildKit will fetch the platform-matching variant per build; **if `infiniflow/ragflow_deps:latest` does not yet have an arm64 manifest, the arm64 layer here will fail.** Re-building and re-pushing the deps image multi-arch is a prerequisite ops step that's deliberately *not* part of this PR — call it out in the merge checklist.
- **GPU runtime.** The user mentioned Ascend-910B; this PR only delivers a CPU-arch-correct image. Vendor-specific GPU support (`HCCL`, `CANN`, etc.) is a separate, much larger effort.
- **Native aarch64 runner.** Build wall-clock will roughly double or worse because the arm64 layer runs under QEMU emulation on the amd64 release runner. The clean follow-up is a matrix job on a real aarch64 runner; QEMU is the safest first step that doesn't introduce a new fleet dependency.

## Test plan

- [ ] **Pre-flight (prerequisite):** verify `docker buildx imagetools inspect infiniflow/ragflow_deps:latest` shows both `linux/amd64` and `linux/arm64`. If not, re-publish multi-arch deps first.
- [ ] Trigger the release workflow on a throwaway tag (`v0.0.0-arm-smoke`) or the nightly cron.
- [ ] After the workflow completes, run `docker buildx imagetools inspect infiniflow/ragflow:v0.0.0-arm-smoke` and confirm both `linux/amd64` and `linux/arm64` entries appear in the manifest list.
- [ ] On an aarch64 host, run `RAGFLOW_IMAGE=infiniflow/ragflow:v0.0.0-arm-smoke docker compose -f docker/docker-compose.yml pull` — should pull without `no matching manifest` errors.
- [ ] On the same aarch64 host, `docker compose up -d` and hit `/api/v1/system/ping` to confirm the container boots.
- [ ] On the amd64 host, repeat the same compose pull/up — confirm no regression for existing amd64 users.

## Files changed

- [.github/workflows/release.yml](.github/workflows/release.yml) — `Build and push image` step replaced with a multi-arch `docker buildx build --push` flow plus QEMU + buildx-builder setup. No other files touched.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

