### PR TITLE
fix: No models found for self-deployed providers (e.g. Xinference) in verify_api_key

### DIFF
--- a/api/apps/services/provider_api_service.py
+++ b/api/apps/services/provider_api_service.py
@@ -380,11 +380,22 @@ async def verify_api_key(provider_name: str, api_key: str|dict, base_url: str=No
     factory_llms = factory_info[0]["llm"]
     if not factory_llms:
         if not model_info:
-            return False, f"No models found for provider '{provider_name}'"
-        factory_llms = [{
-            "model_type": _type,
-            "llm_name": model.get("model_name", ""),
-        } for model in model_info if model for _type in model.get("model_type", []) ]
+            # Try to fetch models dynamically for self-deployed providers (e.g. Xinference)
+            if provider_name in ModelMeta:
+                model_base_url = base_url or factory_info[0].get("url", "")
+                remote_models = await ModelMeta[provider_name](api_key_str if isinstance(api_key, str) else (json.dumps(api_key) if isinstance(api_key, dict) else ""), model_base_url).get_model_list()
+                if remote_models:
+                    factory_llms = [{
+                        "model_type": m.get("model_types", [LLMType.CHAT.value])[0] if m.get("model_types") else LLMType.CHAT.value,
+                        "llm_name": m.get("name", ""),
+                    } for m in remote_models if m.get("name")]
+            if not factory_llms:
+                return False, f"No models found for provider '{provider_name}'"
+        else:
+            factory_llms = [{
+                "model_type": _type,
+                "llm_name": model.get("model_name", ""),
+            } for model in model_info if model for _type in model.get("model_type", []) ]
 
     # test if api key works
     chat_passed, embd_passed, rerank_passed = False, False, False


### PR DESCRIPTION
### What problem does this PR solve?

When verifying the API key for self-deployed providers like Xinference in the new provider API (`POST /providers/<name>/connection`), the error `No models found for provider 'Xinference'` is returned immediately, even when the Xinference server has models available.

**Root cause:**

`verify_api_key()` in `provider_api_service.py` only checks the static `FACTORY_LLM_INFOS` for models. Self-deployed providers like Xinference have `"llm": []` (empty static model list) because their models are discovered dynamically at runtime via API endpoints (e.g. Xinference `/v1/models`). The existing `list_provider_models()` already handles this by calling `ModelMeta[provider_name]`, but `verify_api_key()` did not.

**Fix:**

When `factory_llms` is empty and no `model_info` is provided, dynamically fetch models from the provider via `ModelMeta[provider_name].get_model_list()` before returning the "No models found" error. This matches the pattern already used in `list_provider_models()`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
