### PR TITLE
fix(api): guard legacy DELETE /chunks stop when doc store index is missing

### DIFF
--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -189,7 +189,9 @@ async def parse(tenant_id, dataset_id):
             == 0
         ):
             return get_error_data_result("Can't parse document that is currently being processed")
-        settings.docStoreConn.delete({"doc_id": id}, search.index_name(tenant_id), dataset_id)
+        index_name = search.index_name(tenant_id)
+        if settings.docStoreConn.index_exist(index_name, doc[0].kb_id):
+            settings.docStoreConn.delete({"doc_id": id}, index_name, doc[0].kb_id)
         TaskService.filter_delete([Task.doc_id == id])
         e, doc = DocumentService.get_by_id(id)
         doc = doc.to_dict()
@@ -239,7 +241,9 @@ async def stop_parsing(tenant_id, dataset_id):
         cancel_all_task_of(id)
         info = {"run": "2", "progress": 0, "chunk_num": 0}
         DocumentService.update_by_id(id, info)
-        settings.docStoreConn.delete({"doc_id": doc[0].id}, search.index_name(tenant_id), dataset_id)
+        index_name = search.index_name(tenant_id)
+        if settings.docStoreConn.index_exist(index_name, doc[0].kb_id):
+            settings.docStoreConn.delete({"doc_id": doc[0].id}, index_name, doc[0].kb_id)
         success_count += 1
     if duplicate_messages:
         if success_count > 0:

--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -161,6 +161,9 @@ def _enrich_chunks_with_document_metadata(chunks: list[dict], metadata_fields=No
 async def parse(tenant_id, dataset_id):
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
+    dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
+    if not dataset_tenant_id:
+        return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     req = await get_request_json()
     if not req.get("document_ids"):
         return get_error_data_result("`document_ids` is required")
@@ -189,7 +192,7 @@ async def parse(tenant_id, dataset_id):
             == 0
         ):
             return get_error_data_result("Can't parse document that is currently being processed")
-        index_name = search.index_name(tenant_id)
+        index_name = search.index_name(dataset_tenant_id)
         if settings.docStoreConn.index_exist(index_name, doc[0].kb_id):
             settings.docStoreConn.delete({"doc_id": id}, index_name, doc[0].kb_id)
         TaskService.filter_delete([Task.doc_id == id])
@@ -219,6 +222,9 @@ async def parse(tenant_id, dataset_id):
 async def stop_parsing(tenant_id, dataset_id):
     if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=tenant_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
+    dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
+    if not dataset_tenant_id:
+        return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     req = await get_request_json()
 
     if not req.get("document_ids"):
@@ -241,7 +247,7 @@ async def stop_parsing(tenant_id, dataset_id):
         cancel_all_task_of(id)
         info = {"run": "2", "progress": 0, "chunk_num": 0}
         DocumentService.update_by_id(id, info)
-        index_name = search.index_name(tenant_id)
+        index_name = search.index_name(dataset_tenant_id)
         if settings.docStoreConn.index_exist(index_name, doc[0].kb_id):
             settings.docStoreConn.delete({"doc_id": doc[0].id}, index_name, doc[0].kb_id)
         success_count += 1

--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -163,6 +163,11 @@ async def parse(tenant_id, dataset_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
     if not dataset_tenant_id:
+        logging.warning(
+            "legacy.chunks.parse dataset tenant unresolved dataset_id=%s requester_tenant_id=%s",
+            dataset_id,
+            tenant_id,
+        )
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     req = await get_request_json()
     if not req.get("document_ids"):
@@ -195,6 +200,13 @@ async def parse(tenant_id, dataset_id):
         index_name = search.index_name(dataset_tenant_id)
         if settings.docStoreConn.index_exist(index_name, doc[0].kb_id):
             settings.docStoreConn.delete({"doc_id": id}, index_name, doc[0].kb_id)
+        else:
+            logging.info(
+                "legacy.chunks.parse skip docstore delete: index missing index_name=%s kb_id=%s doc_id=%s",
+                index_name,
+                doc[0].kb_id,
+                id,
+            )
         TaskService.filter_delete([Task.doc_id == id])
         e, doc = DocumentService.get_by_id(id)
         doc = doc.to_dict()
@@ -224,6 +236,11 @@ async def stop_parsing(tenant_id, dataset_id):
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     dataset_tenant_id = _get_dataset_tenant_id(dataset_id)
     if not dataset_tenant_id:
+        logging.warning(
+            "legacy.chunks.stop dataset tenant unresolved dataset_id=%s requester_tenant_id=%s",
+            dataset_id,
+            tenant_id,
+        )
         return get_error_data_result(message=f"You don't own the dataset {dataset_id}.")
     req = await get_request_json()
 
@@ -250,6 +267,13 @@ async def stop_parsing(tenant_id, dataset_id):
         index_name = search.index_name(dataset_tenant_id)
         if settings.docStoreConn.index_exist(index_name, doc[0].kb_id):
             settings.docStoreConn.delete({"doc_id": doc[0].id}, index_name, doc[0].kb_id)
+        else:
+            logging.info(
+                "legacy.chunks.stop skip docstore delete: index missing index_name=%s kb_id=%s doc_id=%s",
+                index_name,
+                doc[0].kb_id,
+                doc[0].id,
+            )
         success_count += 1
     if duplicate_messages:
         if success_count > 0:

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
@@ -731,6 +731,72 @@ class TestDocRoutesUnit:
         res = _run(module.stop_parsing.__wrapped__("tenant-1", "ds-1"))
         assert res["code"] == 0
 
+    def test_legacy_chunks_stop_skips_delete_when_index_missing(self, monkeypatch):
+        module = _load_doc_module(monkeypatch)
+        deleted = []
+
+        monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda **_kwargs: True)
+        monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"document_ids": ["doc-1"]}))
+        monkeypatch.setattr(module, "check_duplicate_ids", lambda ids, _kind: (ids, []))
+        monkeypatch.setattr(
+            module.DocumentService,
+            "query",
+            lambda **_kwargs: [_DummyDoc(doc_id="doc-1", run=module.TaskStatus.RUNNING.value)],
+        )
+        monkeypatch.setattr(module, "cancel_all_task_of", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(module.DocumentService, "update_by_id", lambda *_args, **_kwargs: True)
+        _patch_docstore(
+            monkeypatch,
+            module,
+            index_exist=lambda *_args, **_kwargs: False,
+            delete=lambda condition, index, kb_id: deleted.append((condition, index, kb_id)),
+        )
+
+        res = _run(module.stop_parsing.__wrapped__("tenant-1", "ds-1"))
+
+        assert res["code"] == 0
+        assert deleted == []
+
+        deleted.clear()
+        _patch_docstore(
+            monkeypatch,
+            module,
+            index_exist=lambda *_args, **_kwargs: True,
+            delete=lambda condition, index, kb_id: deleted.append((condition, index, kb_id)),
+        )
+        res = _run(module.stop_parsing.__wrapped__("tenant-1", "ds-1"))
+        assert res["code"] == 0
+        assert deleted == [({"doc_id": "doc-1"}, module.search.index_name("tenant-1"), "kb-1")]
+
+    def test_legacy_chunks_parse_skips_delete_when_index_missing(self, monkeypatch):
+        module = _load_doc_module(monkeypatch)
+        deleted = []
+
+        monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda **_kwargs: True)
+        monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"document_ids": ["doc-1"]}))
+        monkeypatch.setattr(module, "check_duplicate_ids", lambda ids, _kind: (ids, []))
+        monkeypatch.setattr(
+            module.DocumentService,
+            "query",
+            lambda **_kwargs: [_DummyDoc(doc_id="doc-1", run=module.TaskStatus.UNSTART.value)],
+        )
+        monkeypatch.setattr(module.DocumentService, "filter_update", lambda *_args, **_kwargs: 1)
+        monkeypatch.setattr(module.DocumentService, "get_by_id", lambda _id: (True, _DummyDoc(doc_id="doc-1")))
+        monkeypatch.setattr(module.File2DocumentService, "get_storage_address", lambda **_kwargs: ("b", "n"))
+        monkeypatch.setattr(module.TaskService, "filter_delete", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(module, "queue_tasks", lambda *_args, **_kwargs: None)
+        _patch_docstore(
+            monkeypatch,
+            module,
+            index_exist=lambda *_args, **_kwargs: False,
+            delete=lambda condition, index, kb_id: deleted.append((condition, index, kb_id)),
+        )
+
+        res = _run(module.parse.__wrapped__("tenant-1", "ds-1"))
+
+        assert res["code"] == 0
+        assert deleted == []
+
     def test_list_chunks_branches(self, monkeypatch):
         module = _load_restful_chunk_module(monkeypatch)
         monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda **_kwargs: False)

--- a/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py
@@ -734,8 +734,14 @@ class TestDocRoutesUnit:
     def test_legacy_chunks_stop_skips_delete_when_index_missing(self, monkeypatch):
         module = _load_doc_module(monkeypatch)
         deleted = []
+        dataset_owner_tenant = "owner-tenant"
 
         monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda **_kwargs: True)
+        monkeypatch.setattr(
+            module.KnowledgebaseService,
+            "get_by_id",
+            lambda _id: (True, SimpleNamespace(tenant_id=dataset_owner_tenant)),
+        )
         monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"document_ids": ["doc-1"]}))
         monkeypatch.setattr(module, "check_duplicate_ids", lambda ids, _kind: (ids, []))
         monkeypatch.setattr(
@@ -766,13 +772,19 @@ class TestDocRoutesUnit:
         )
         res = _run(module.stop_parsing.__wrapped__("tenant-1", "ds-1"))
         assert res["code"] == 0
-        assert deleted == [({"doc_id": "doc-1"}, module.search.index_name("tenant-1"), "kb-1")]
+        assert deleted == [({"doc_id": "doc-1"}, module.search.index_name(dataset_owner_tenant), "kb-1")]
 
     def test_legacy_chunks_parse_skips_delete_when_index_missing(self, monkeypatch):
         module = _load_doc_module(monkeypatch)
         deleted = []
+        dataset_owner_tenant = "owner-tenant"
 
         monkeypatch.setattr(module.KnowledgebaseService, "accessible", lambda **_kwargs: True)
+        monkeypatch.setattr(
+            module.KnowledgebaseService,
+            "get_by_id",
+            lambda _id: (True, SimpleNamespace(tenant_id=dataset_owner_tenant)),
+        )
         monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"document_ids": ["doc-1"]}))
         monkeypatch.setattr(module, "check_duplicate_ids", lambda ids, _kind: (ids, []))
         monkeypatch.setattr(
@@ -796,6 +808,17 @@ class TestDocRoutesUnit:
 
         assert res["code"] == 0
         assert deleted == []
+
+        deleted.clear()
+        _patch_docstore(
+            monkeypatch,
+            module,
+            index_exist=lambda *_args, **_kwargs: True,
+            delete=lambda condition, index, kb_id: deleted.append((condition, index, kb_id)),
+        )
+        res = _run(module.parse.__wrapped__("tenant-1", "ds-1"))
+        assert res["code"] == 0
+        assert deleted == [({"doc_id": "doc-1"}, module.search.index_name(dataset_owner_tenant), "kb-1")]
 
     def test_list_chunks_branches(self, monkeypatch):
         module = _load_restful_chunk_module(monkeypatch)


### PR DESCRIPTION
### What problem does this PR solve?

Fixes [#15874](https://github.com/infiniflow/ragflow/issues/15874). Legacy `DELETE /api/v1/datasets/{dataset_id}/chunks` (`stop_parsing`) and `POST /chunks` (`parse`) call `docStoreConn.delete` unconditionally. When the tenant/dataset index has not been created yet, the delete can throw and the API returns HTTP 500 **after** the document was already marked `CANCEL` with zeroed counters.

The newer `POST /documents/parse` route already guards with `index_exist`; this PR aligns the legacy `/chunks` routes with that pattern.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

### Changes

- Wrap `docStoreConn.delete` in `stop_parsing` and legacy `parse` with `index_exist` check.
- Add unit tests asserting delete is skipped when index is missing and invoked when index exists.

### Test plan

- [x] `pytest test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py::TestDocRoutesUnit::test_legacy_chunks_stop_skips_delete_when_index_missing -v`
- [x] `pytest test/testcases/test_http_api/test_file_management_within_dataset/test_doc_sdk_routes_unit.py::TestDocRoutesUnit::test_legacy_chunks_parse_skips_delete_when_index_missing -v`
- [ ] Manual: start parse on fresh dataset, stop via `DELETE .../chunks` before index exists — expect success, not HTTP 500