### PR TITLE
fix: handle qwen rerank error response

### DIFF
--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -432,8 +432,11 @@ class QWenRerank(Base):
                 log_exception(_e, resp)
             return rank, total_token_count_from_response(resp)
         else:
-            error_body = getattr(resp, "text", None)
-            if error_body is None:
+            try:
+                error_body = resp["text"] if isinstance(resp, dict) and "text" in resp else None
+            except Exception:
+                error_body = None
+            if not error_body:
                 try:
                     error_body = json.dumps(dict(resp), ensure_ascii=False)
                 except Exception:

--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -432,7 +432,13 @@ class QWenRerank(Base):
                 log_exception(_e, resp)
             return rank, total_token_count_from_response(resp)
         else:
-            raise ValueError(f"Error calling QWenRerank model {self.model_name}: {resp.status_code} - {resp.text}")
+            error_body = getattr(resp, "text", None)
+            if error_body is None:
+                try:
+                    error_body = json.dumps(dict(resp), ensure_ascii=False)
+                except Exception:
+                    error_body = str(resp)
+            raise ValueError(f"Error calling QWenRerank model {self.model_name}: {resp.status_code} - {error_body}")
 
 
 class HuggingfaceRerank(Base):


### PR DESCRIPTION
### What problem does this PR solve?
Fix QWen rerank error handling so DashScope error responses without a text attribute do not raise a secondary KeyError and hide the real provider error.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)