### PR TITLE
fix(deps): exclude litellm 1.82.6 (internal ImportError) — #15916

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,11 @@ dependencies = [
     #    "xxhash>=3.5.0,<4.0.0",
     #    "trio>=0.17.0,<0.29.0",
     #    "click>=8.1.8",
-    "litellm~=1.82.0,!=1.82.7,!=1.82.8",
+    # 1.82.6 has an internal ImportError loading add_system_prompt_to_messages
+    # from litellm_core_utils.prompt_templates.common_utils, which breaks
+    # `import litellm` at module load and tanks the whole server (#15916).
+    # 1.82.7 / 1.82.8 were already excluded for security in #13768.
+    "litellm~=1.82.0,!=1.82.6,!=1.82.7,!=1.82.8",
     #    "pip>=25.2",
     #    "imageio-ffmpeg>=0.6.0",
     #    "cryptography==46.0.3",


### PR DESCRIPTION
## Summary

Fixes #15916.

A fresh `docker compose -f docker-compose-macos.yml up -d` against v0.25.6 errors out on container start with:

```
ImportError: cannot import name 'add_system_prompt_to_messages'
from 'litellm.litellm_core_utils.prompt_templates.common_utils'
```

The error chain — straight from the user's traceback:

```
rag/llm/chat_model.py:29  →  import litellm
                            ↳ litellm/__init__.py
                              ↳ litellm.litellm_core_utils.prompt_templates.common_utils
                                ↳ ImportError: add_system_prompt_to_messages not found
```

Every module that transitively pulls `chat_model.py` then fails to load: `code_exec`, `begin`, `browser`, `categorize`, `excel_processor`, `fillup`, the LLM bundle, agent registration, canvas service, file service. Container starts, blueprint discovery sees the failures, server exits.

### Root cause

The bug is **internal to litellm 1.82.6**, not in ragflow. 1.82.6 ships a code path that calls `add_system_prompt_to_messages` but no longer re-exports it from `litellm_core_utils.prompt_templates.common_utils`. Any `import litellm` against 1.82.6 fails at module-load time.

[uv.lock:3727-3728](uv.lock#L3727-L3728) pins `litellm==1.82.6`, so `uv sync --python 3.13 --frozen` inside the Dockerfile always installs 1.82.6. Every macOS user who follows the README's "build from source" path (the `docker-compose-macos.yml` recipe uses `build:`, not `image:`) hits this.

### Fix

One line in [pyproject.toml](pyproject.toml#L162):

```diff
- "litellm~=1.82.0,!=1.82.7,!=1.82.8",
+ # 1.82.6 has an internal ImportError loading add_system_prompt_to_messages
+ # from litellm_core_utils.prompt_templates.common_utils, which breaks
+ # `import litellm` at module load and tanks the whole server (#15916).
+ # 1.82.7 / 1.82.8 were already excluded for security in #13768.
+ "litellm~=1.82.0,!=1.82.6,!=1.82.7,!=1.82.8",
```

`~=1.82.0,!=1.82.6,!=1.82.7,!=1.82.8` resolves to the highest published 1.82.x that isn't one of those three — 1.82.9 or later, which post-dates the .7/.8 security exclusions and won't re-introduce them.

The comment block above the line documents *both* #15916 and #13768 so the exclusion list doesn't read as mysterious to future maintainers — same reason the older exclusions existed without context was a debugging hazard.

### ⚠️ `uv.lock` regeneration required

I deliberately did **not** hand-edit `uv.lock`. Each pinned wheel and sdist entry carries a SHA-256 hash and a registry-derived URL specific to that exact version; without `uv` available in my sandbox there's no way to author a syntactically valid `1.82.9` entry. **The Docker build will not succeed under `uv sync --frozen` until the lock is regenerated** with:

```bash
uv lock --upgrade-package litellm
```

I'll push the regenerated `uv.lock` as a follow-up commit on this same PR once it lands on a machine with `uv` installed. **Please don't merge until that follow-up is in** — merging this PR alone would mean every CI build fails on the lock-vs-pyproject mismatch.

If the maintainer prefers to regenerate the lock locally before merging, the changeset is `pyproject.toml` (this PR) + `uv.lock` (uv-generated), with no other touched files.

### What this PR does NOT do

- **Bump litellm beyond `~=1.82`** (e.g. to `~=1.83`). Out of scope. A major-line bump risks unrelated API surface changes — this PR's job is to land on a working 1.82.x patch, not to retrofit a new minor.
- **Catch `ImportError` around `import litellm`** with a friendlier message. That's palliative — half the modules still fail to register and the server still doesn't start. The bug needs a version fix, not a politer crash.
- **Pre-pull a working litellm wheel inside `Dockerfile`** as a workaround. Fragile and leaks build-format details into the runtime image.
- **Patch the litellm package in-tree.** Outside our maintenance surface, and creates a long-term divergence that would silently rot.
- **Modify `rag/llm/chat_model.py` or any caller.** The import statement and call sites are correct; only the installed version of the third-party library is broken.

## Test plan

After the maintainer (or me, in the follow-up commit) regenerates `uv.lock`:

- [ ] `uv lock --upgrade-package litellm` produces a lock that pins litellm to `1.82.9` or later — not `1.82.6`, `1.82.7`, or `1.82.8`. Confirm with `grep -A1 '^name = "litellm"' uv.lock`.
- [ ] `docker compose -f docker/docker-compose-macos.yml up -d --build` on a fresh checkout (no Docker layer cache: `docker compose ... build --no-cache`). Container starts past blueprint discovery without `ImportError`.
- [ ] `docker logs ragflow-server` shows no `add_system_prompt_to_messages` traceback during boot.
- [ ] Hit `GET /api/v1/system/ping` against the running server — returns 200. (Smoke check that the Quart app actually came up.)
- [ ] Submit a basic chat request through any configured provider — confirms litellm is wired through `chat_model.LLMBundle` and round-trips successfully (i.e., the bumped patch version didn't break the API ragflow uses).
- [ ] Re-run the full backend test suite via `uv run pytest` — confirms no regression from the version bump.
- [ ] Confirm the existing `docker-compose.yml` (Linux path) still builds and starts identically. The constraint change is platform-agnostic, but worth verifying.

## Related

- [#13768](https://github.com/infiniflow/ragflow/pull/13768) — added the original `!=1.82.7,!=1.82.8` security exclusions. This PR extends that list with `!=1.82.6` for the same purpose (block a specific broken patch) for a different reason (load-time regression rather than CVE).

## Files changed

- [pyproject.toml](pyproject.toml#L162) — one-line constraint change + 4-line context comment.
- `uv.lock` — to be regenerated by `uv lock --upgrade-package litellm` in a follow-up commit on this PR; no manual edit.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
