### PR TITLE
fix: preserve <think> tags in streaming and prevent duplicate final answer

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -52,6 +52,28 @@ from common.misc_utils import get_uuid, thread_pool_exec
 from rag.prompts.generator import chunks_format
 from rag.prompts.template import load_prompt
 
+
+async def _inject_think_tags(stream):
+    """Restore legacy <think> tag format by converting marker events to text deltas.
+
+    When include_think_tags=True, start_to_think/end_to_think marker events are
+    replaced with ``<think>`` / ``</think>`` text chunks in the ``answer`` field,
+    matching the pre-0.24 streaming format while preserving incremental delta
+    semantics.  Marker flags are removed from all chunks so downstream consumers
+    receive a clean text stream.
+    """
+    async for ans in stream:
+        if ans.get("start_to_think"):
+            yield {"answer": "<think>", "reference": ans.get("reference", {}), "audio_binary": ans.get("audio_binary"), "final": False}
+            continue
+        if ans.get("end_to_think"):
+            yield {"answer": "</think>", "reference": ans.get("reference", {}), "audio_binary": ans.get("audio_binary"), "final": False}
+            continue
+        ans.pop("start_to_think", None)
+        ans.pop("end_to_think", None)
+        yield ans
+
+
 def _sanitize_json_floats(obj):
     """Replace NaN/Infinity floats with None so the result is RFC 8259 JSON.
 
@@ -1230,6 +1252,7 @@ async def session_completion(chat_id_in_arg=""):
             merge_generation_config(dia, chat_model_config)
 
         stream_mode = req.pop("stream", True)
+        include_think_tags = req.pop("include_think_tags", False)
 
         def _format_answer(ans):
             """Wrap a raw answer dict with session and chat identifiers."""
@@ -1242,7 +1265,10 @@ async def session_completion(chat_id_in_arg=""):
             """Yield SSE-formatted chunks from the async chat generator."""
             nonlocal dia, msg, req, conv
             try:
-                async for ans in async_chat(dia, msg, True, **req):
+                chat_stream = async_chat(dia, msg, True, **req)
+                if include_think_tags:
+                    chat_stream = _inject_think_tags(chat_stream)
+                async for ans in chat_stream:
                     ans = _format_answer(ans)
                     payload = _sanitize_json_floats({"code": 0, "message": "", "data": ans})
                     yield "data:" + json.dumps(payload, ensure_ascii=False) + "\n\n"

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -286,7 +286,7 @@ class DialogService(CommonService):
         return list(objs)
 
 
-async def async_chat_solo(dialog, messages, stream=True, include_think_tags: bool = False):
+async def async_chat_solo(dialog, messages, stream=True):
     llm_types = get_model_type_by_name(dialog.tenant_id, dialog.llm_id)
     attachments = ""
     image_attachments = []
@@ -321,7 +321,7 @@ async def async_chat_solo(dialog, messages, stream=True, include_think_tags: boo
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting)
         else:
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
-        async for kind, value, state in _stream_with_think_delta(stream_iter, include_think_tags=include_think_tags):
+        async for kind, value, state in _stream_with_think_delta(stream_iter):
             if kind == "marker":
                 flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}
                 yield {"answer": "", "reference": {}, "audio_binary": None, "prompt": "", "created_at": time.time(), "final": False, **flags}
@@ -543,9 +543,8 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
     assert messages[-1]["role"] == "user", "The last content of this conversation is not from user."
     use_web_search = _should_use_web_search(dialog.prompt_config, kwargs.get("internet"))
     logging.debug("web_search kb=%s tavily=%s internet=%r enabled=%s", bool(dialog.kb_ids), bool(dialog.prompt_config.get("tavily_api_key")), kwargs.get("internet"), use_web_search)
-    include_think_tags = kwargs.pop("include_think_tags", False)
     if not dialog.kb_ids and not use_web_search:
-        async for ans in async_chat_solo(dialog, messages, stream, include_think_tags=include_think_tags):
+        async for ans in async_chat_solo(dialog, messages, stream):
             yield ans
         return
 
@@ -885,7 +884,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         else:
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt + prompt4citation, msg[1:], gen_conf, images=image_files)
         last_state = None
-        async for kind, value, state in _stream_with_think_delta(stream_iter, include_think_tags=include_think_tags):
+        async for kind, value, state in _stream_with_think_delta(stream_iter):
             last_state = state
             if kind == "marker":
                 flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}
@@ -1444,7 +1443,6 @@ class _ThinkStreamState:
         self.pending_after_close = ""
         self.think_buffer = ""
         self.answer_buffer = ""
-        self.think_tag_started = False
 
 
 def _extract_visible_answer(text: str) -> str:
@@ -1460,20 +1458,14 @@ def _extract_visible_answer(text: str) -> str:
     return f"<think>{thought}</think>{answer}"
 
 
-async def _stream_with_think_delta(stream_iter, min_tokens: int = 16, include_think_tags: bool = False):
+async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
     state = _ThinkStreamState()
 
     def _emit_text(section: str, text: str):
         if not text:
             return None
         if section == "think":
-            if include_think_tags:
-                prefix = "<think>" if not state.think_tag_started else ""
-                state.think_tag_started = True
-                return prefix + text
             return text
-        if include_think_tags:
-            state.think_tag_started = False
         state.answer_buffer += text
         if num_tokens_from_string(state.answer_buffer) >= min_tokens:
             out = state.answer_buffer
@@ -1514,9 +1506,6 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16, include_th
             think_piece = _flush_think_buffer()
             if think_piece is not None:
                 yield ("text", think_piece, state)
-            if include_think_tags and state.think_tag_started:
-                state.think_tag_started = False
-                yield ("text", "</think>", state)
             state.in_think = False
             yield ("marker", "</think>", state)
             if state.pending_after_close:
@@ -1578,9 +1567,6 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16, include_th
                 think_piece = _flush_think_buffer()
                 if think_piece is not None:
                     yield ("text", think_piece, state)
-                if include_think_tags and state.think_tag_started:
-                    state.think_tag_started = False
-                    yield ("text", "</think>", state)
                 state.in_think = False
                 yield ("marker", "</think>", state)
                 pending = after_visible
@@ -1595,9 +1581,6 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16, include_th
         yield ("text", state.think_buffer, state)
         state.think_buffer = ""
     if state.close_pending:
-        if include_think_tags and state.think_tag_started:
-            state.think_tag_started = False
-            yield ("text", "</think>", state)
         state.in_think = False
         yield ("marker", "</think>", state)
     if state.answer_buffer:
@@ -1709,10 +1692,9 @@ async def async_ask(question, kb_ids, tenant_id, chat_llm_name=None, search_conf
         refs["chunks"] = chunks_format(refs)
         return {"answer": answer, "reference": refs}
 
-    include_think_tags = search_config.get("include_think_tags", False)
     stream_iter = chat_mdl.async_chat_streamly_delta(sys_prompt, msg, {"temperature": 0.1})
     last_state = None
-    async for kind, value, state in _stream_with_think_delta(stream_iter, include_think_tags=include_think_tags):
+    async for kind, value, state in _stream_with_think_delta(stream_iter):
         last_state = state
         if kind == "marker":
             flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -286,7 +286,7 @@ class DialogService(CommonService):
         return list(objs)
 
 
-async def async_chat_solo(dialog, messages, stream=True):
+async def async_chat_solo(dialog, messages, stream=True, include_think_tags: bool = False):
     llm_types = get_model_type_by_name(dialog.tenant_id, dialog.llm_id)
     attachments = ""
     image_attachments = []
@@ -321,7 +321,7 @@ async def async_chat_solo(dialog, messages, stream=True):
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting)
         else:
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
-        async for kind, value, state in _stream_with_think_delta(stream_iter):
+        async for kind, value, state in _stream_with_think_delta(stream_iter, include_think_tags=include_think_tags):
             if kind == "marker":
                 flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}
                 yield {"answer": "", "reference": {}, "audio_binary": None, "prompt": "", "created_at": time.time(), "final": False, **flags}
@@ -543,8 +543,9 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
     assert messages[-1]["role"] == "user", "The last content of this conversation is not from user."
     use_web_search = _should_use_web_search(dialog.prompt_config, kwargs.get("internet"))
     logging.debug("web_search kb=%s tavily=%s internet=%r enabled=%s", bool(dialog.kb_ids), bool(dialog.prompt_config.get("tavily_api_key")), kwargs.get("internet"), use_web_search)
+    include_think_tags = kwargs.pop("include_think_tags", False)
     if not dialog.kb_ids and not use_web_search:
-        async for ans in async_chat_solo(dialog, messages, stream):
+        async for ans in async_chat_solo(dialog, messages, stream, include_think_tags=include_think_tags):
             yield ans
         return
 
@@ -884,7 +885,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         else:
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt + prompt4citation, msg[1:], gen_conf, images=image_files)
         last_state = None
-        async for kind, value, state in _stream_with_think_delta(stream_iter):
+        async for kind, value, state in _stream_with_think_delta(stream_iter, include_think_tags=include_think_tags):
             last_state = state
             if kind == "marker":
                 flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}
@@ -1459,17 +1460,20 @@ def _extract_visible_answer(text: str) -> str:
     return f"<think>{thought}</think>{answer}"
 
 
-async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
+async def _stream_with_think_delta(stream_iter, min_tokens: int = 16, include_think_tags: bool = False):
     state = _ThinkStreamState()
 
     def _emit_text(section: str, text: str):
         if not text:
             return None
         if section == "think":
-            prefix = "<think>" if not state.think_tag_started else ""
-            state.think_tag_started = True
-            return prefix + text
-        state.think_tag_started = False
+            if include_think_tags:
+                prefix = "<think>" if not state.think_tag_started else ""
+                state.think_tag_started = True
+                return prefix + text
+            return text
+        if include_think_tags:
+            state.think_tag_started = False
         state.answer_buffer += text
         if num_tokens_from_string(state.answer_buffer) >= min_tokens:
             out = state.answer_buffer
@@ -1510,7 +1514,7 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
             think_piece = _flush_think_buffer()
             if think_piece is not None:
                 yield ("text", think_piece, state)
-            if state.think_tag_started:
+            if include_think_tags and state.think_tag_started:
                 state.think_tag_started = False
                 yield ("text", "</think>", state)
             state.in_think = False
@@ -1574,7 +1578,7 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
                 think_piece = _flush_think_buffer()
                 if think_piece is not None:
                     yield ("text", think_piece, state)
-                if state.think_tag_started:
+                if include_think_tags and state.think_tag_started:
                     state.think_tag_started = False
                     yield ("text", "</think>", state)
                 state.in_think = False
@@ -1591,7 +1595,7 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
         yield ("text", state.think_buffer, state)
         state.think_buffer = ""
     if state.close_pending:
-        if state.think_tag_started:
+        if include_think_tags and state.think_tag_started:
             state.think_tag_started = False
             yield ("text", "</think>", state)
         state.in_think = False
@@ -1705,9 +1709,10 @@ async def async_ask(question, kb_ids, tenant_id, chat_llm_name=None, search_conf
         refs["chunks"] = chunks_format(refs)
         return {"answer": answer, "reference": refs}
 
+    include_think_tags = search_config.get("include_think_tags", False)
     stream_iter = chat_mdl.async_chat_streamly_delta(sys_prompt, msg, {"temperature": 0.1})
     last_state = None
-    async for kind, value, state in _stream_with_think_delta(stream_iter):
+    async for kind, value, state in _stream_with_think_delta(stream_iter, include_think_tags=include_think_tags):
         last_state = state
         if kind == "marker":
             flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -896,6 +896,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             final = await decorate_answer(_extract_visible_answer(thought + full_answer))
             final["final"] = True
             final["audio_binary"] = None
+            final["answer"] = ""
             yield final
     else:
         if llm_model_config["model_type"] == "chat":
@@ -1442,6 +1443,7 @@ class _ThinkStreamState:
         self.pending_after_close = ""
         self.think_buffer = ""
         self.answer_buffer = ""
+        self.think_tag_started = False
 
 
 def _extract_visible_answer(text: str) -> str:
@@ -1464,7 +1466,10 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
         if not text:
             return None
         if section == "think":
-            return text
+            prefix = "<think>" if not state.think_tag_started else ""
+            state.think_tag_started = True
+            return prefix + text
+        state.think_tag_started = False
         state.answer_buffer += text
         if num_tokens_from_string(state.answer_buffer) >= min_tokens:
             out = state.answer_buffer
@@ -1505,6 +1510,9 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
             think_piece = _flush_think_buffer()
             if think_piece is not None:
                 yield ("text", think_piece, state)
+            if state.think_tag_started:
+                state.think_tag_started = False
+                yield ("text", "</think>", state)
             state.in_think = False
             yield ("marker", "</think>", state)
             if state.pending_after_close:
@@ -1566,6 +1574,9 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
                 think_piece = _flush_think_buffer()
                 if think_piece is not None:
                     yield ("text", think_piece, state)
+                if state.think_tag_started:
+                    state.think_tag_started = False
+                    yield ("text", "</think>", state)
                 state.in_think = False
                 yield ("marker", "</think>", state)
                 pending = after_visible
@@ -1580,6 +1591,9 @@ async def _stream_with_think_delta(stream_iter, min_tokens: int = 16):
         yield ("text", state.think_buffer, state)
         state.think_buffer = ""
     if state.close_pending:
+        if state.think_tag_started:
+            state.think_tag_started = False
+            yield ("text", "</think>", state)
         state.in_think = False
         yield ("marker", "</think>", state)
     if state.answer_buffer:
@@ -1703,6 +1717,7 @@ async def async_ask(question, kb_ids, tenant_id, chat_llm_name=None, search_conf
     full_answer = last_state.full_text if last_state else ""
     final = await decorate_answer(_extract_visible_answer(full_answer))
     final["final"] = True
+    final["answer"] = ""
     yield final
 
 


### PR DESCRIPTION
## 问题

PR #12453 引入了 think/answer 流式分离，将 `<think>` 标签拆成 marker 事件（`start_to_think`/`end_to_think`），文本内容走 `answer` 字段，标签本身被 `re.sub` 洗掉。这对 RAGFlow 前端有效，但破坏了与标准客户端（DeepSeek/openai_api 等）的兼容性，且最后导致了两重 bug：

### Bug 1：流式 think 文本丢失标签

`_stream_with_think_delta` 中多处 `re.sub(r"</?think>", "", ...)` 把标签全部清除，流式回答里看不到 `<think>` 标签。依赖标签解析的客户端无法区分思考区和回答区。

### Bug 2：final 帧重复完整回答

`async_chat` 和 `async_chat_solo` 流结束后 output 最后一帧，调用 `decorate_answer(_extract_visible_answer(...))` 重新包装标签并发送完整回答。但流式阶段已经发过全量文本，导致客户端收到**两份回答**。

这在 `openai_api.py` 不受影响（146-155 行 `continue` 跳过了 `final` 事件），但 `chat_api.py` 无此过滤。

## 修复

### 1. think 文本携带标签

在 `_emit_text` 和 think 关闭点，将 `<think>` / `</think>` 以文本形式注入到 `answer` 字段的流式内容中：

- `_emit_text("think", ...)`：首个 think chunk 自动前补 `<think>`
- 3 个 think 关闭路径：emit `</think>` 文本后 emit marker
- 进入 answer 文本时重置状态

### 2. final 帧清空 answer

在 `async_chat` 和 `async_chat_solo` 的 final yield 前加 `final["answer"] = ""`，恢复 #12453 原始行为。流式已发全量内容，final 帧只需提供 reference 元数据。

## 兼容性

修复后 stream 对两类客户端均正常工作：

- **RAGFlow 前端**：marker 事件用于折叠面板 UI，文本内标签不影响渲染
- **标准客户端**：`answer` 字段内包含完整 `<think>...</think>` 标签，可按 DeepSeek 风格解析