### PR TITLE
fix: early return from KGSearch._community_retrieval_ when entities empty (#15923)

### DIFF
--- a/rag/graphrag/search.py
+++ b/rag/graphrag/search.py
@@ -299,6 +299,8 @@ class KGSearch(Dealer):
             }
 
     def _community_retrieval_(self, entities, condition, kb_ids, idxnms, topn, max_token):
+        if not entities:
+            return ""
         ## Community retrieval
         fields = ["docnm_kwd", "content_with_weight"]
         odr = OrderByExpr()


### PR DESCRIPTION
### What problem does this PR solve?

`KGSearch._community_retrieval_` does not guard against an empty entity list, leading to a community report query that may return irrelevant results. This PR adds an early return when `entities` is empty.

### Type of change

- [x] Bug Fix

### How has this been tested?

Manually verified that `_community_retrieval_` returns `""` when `entities=[]`.

### Related Issue

Closes #15923