### PR TITLE
perf: add persist_subgraphs flag to skip per-doc subgraph writes

### DIFF
--- a/rag/graphrag/general/index.py
+++ b/rag/graphrag/general/index.py
@@ -748,7 +748,7 @@ async def merge_subgraph(
     for node_name, pagerank in pr.items():
         new_graph.nodes[node_name]["pagerank"] = pagerank
 
-    await set_graph(tenant_id, kb_id, embedding_model, new_graph, change, callback)
+    await set_graph(tenant_id, kb_id, embedding_model, new_graph, change, callback, persist_subgraphs=False)
     now = asyncio.get_running_loop().time()
     callback(msg=f"merging subgraph for doc {doc_id} into the global graph done in {now - start:.2f} seconds.")
     return new_graph

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -514,7 +514,7 @@ async def get_graph(tenant_id, kb_id, exclude_rebuild=None):
     return result
 
 
-async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, change: GraphChange, callback):
+async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, change: GraphChange, callback, persist_subgraphs: bool = True):
     global chat_limiter
     start = asyncio.get_running_loop().time()
 
@@ -535,22 +535,23 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
     ]
 
     # generate updated subgraphs
-    for source in graph.graph["source_id"]:
-        subgraph = graph.subgraph([n for n in graph.nodes if source in graph.nodes[n]["source_id"]]).copy()
-        subgraph.graph["source_id"] = [source]
-        for n in subgraph.nodes:
-            subgraph.nodes[n]["source_id"] = [source]
-        chunks.append(
-            {
-                "id": get_uuid(),
-                "content_with_weight": json.dumps(nx.node_link_data(subgraph, edges="edges"), ensure_ascii=False),
-                "knowledge_graph_kwd": "subgraph",
-                "kb_id": kb_id,
-                "source_id": [source],
-                "available_int": 0,
-                "removed_kwd": "N",
-            }
-        )
+    if persist_subgraphs:
+        for source in graph.graph["source_id"]:
+            subgraph = graph.subgraph([n for n in graph.nodes if source in graph.nodes[n]["source_id"]]).copy()
+            subgraph.graph["source_id"] = [source]
+            for n in subgraph.nodes:
+                subgraph.nodes[n]["source_id"] = [source]
+            chunks.append(
+                {
+                    "id": get_uuid(),
+                    "content_with_weight": json.dumps(nx.node_link_data(subgraph, edges="edges"), ensure_ascii=False),
+                    "knowledge_graph_kwd": "subgraph",
+                    "kb_id": kb_id,
+                    "source_id": [source],
+                    "available_int": 0,
+                    "removed_kwd": "N",
+                }
+            )
 
     tasks = []
     for ii, node in enumerate(change.added_updated_nodes):


### PR DESCRIPTION
### What problem does this PR solve?

Currently, `set_graph()` always regenerates **all per-document subgraph chunks** even for global graph updates like entity resolution. This causes unnecessary write amplification proportional to the number of source documents.

This PR adds an optional `persist_subgraphs` parameter (default `True` for backward compatibility). When set to `False`, the function skips rewriting the per-document subgraph chunks, which are not needed for retrieval (retrieval only uses entity, relation, and community_report chunks).

### Type of change

- [ ] Bug Fix
- [x] Performance Improvement

### How has this been tested?

- Verified that existing behavior (default `persist_subgraphs=True`) remains unchanged.
- Updated `resolve_entities` in `general/index.py` to call `set_graph(..., persist_subgraphs=False)`, which now updates the global graph without regenerating subgraphs.
- GraphRAG retrieval still works correctly (uses entity/relation/community_report chunks as before).

### Related Issue

Closes #15922