### PR TITLE
Go: add dimensions for list models and fix some embed-bug in providers

### DIFF
--- a/internal/entity/models/astraflow.go
+++ b/internal/entity/models/astraflow.go
@@ -399,6 +399,9 @@ func (a *AstraflowModel) Embed(modelName *string, texts []string, apiConfig *API
 		"model": *modelName,
 		"input": texts,
 	}
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+		reqBody["dimensions"] = embeddingConfig.Dimension
+	}
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/entity/models/base_model.go
+++ b/internal/entity/models/base_model.go
@@ -100,6 +100,7 @@ func ParseListModel(modelList ModelList) []ListModelResponse {
 			modelResponse.MaxTokens = modelEntity.MaxTokens
 			modelResponse.ModelTypes = modelEntity.ModelTypes
 			modelResponse.Thinking = modelEntity.Thinking
+			modelResponse.Dimensions = modelEntity.Dimensions
 		}
 
 		models = append(models, modelResponse)

--- a/internal/entity/models/cohere.go
+++ b/internal/entity/models/cohere.go
@@ -372,6 +372,10 @@ func (c *CoHereModel) Embed(modelName *string, texts []string, apiConfig *APICon
 		"input_type":      "search_document",
 		"embedding_types": []string{"float"},
 	}
+	// This is only available for embed-v4 and newer models. Possible values are 256, 512, 1024, and 1536. The default is 1536.
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+		reqBody["output_dimension"] = embeddingConfig.Dimension
+	}
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/entity/models/mistral.go
+++ b/internal/entity/models/mistral.go
@@ -399,6 +399,9 @@ func (m *MistralModel) Embed(modelName *string, texts []string, apiConfig *APICo
 		"model": *modelName,
 		"input": texts,
 	}
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+		reqBody["output_dimension"] = embeddingConfig.Dimension
+	}
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/entity/models/model.go
+++ b/internal/entity/models/model.go
@@ -387,12 +387,6 @@ func (pm *ProviderManager) ListAllModels() ([]map[string]interface{}, error) {
 		if model.MaxTokens != nil {
 			modelData["max_tokens"] = *model.MaxTokens
 		}
-		if model.MaxDimension != nil {
-			modelData["max_dimension"] = *model.MaxDimension
-		}
-		if len(model.Dimensions) > 0 {
-			modelData["dimensions"] = model.Dimensions
-		}
 		modelList = append(modelList, modelData)
 	}
 

--- a/internal/entity/models/model.go
+++ b/internal/entity/models/model.go
@@ -387,6 +387,12 @@ func (pm *ProviderManager) ListAllModels() ([]map[string]interface{}, error) {
 		if model.MaxTokens != nil {
 			modelData["max_tokens"] = *model.MaxTokens
 		}
+		if model.MaxDimension != nil {
+			modelData["max_dimension"] = *model.MaxDimension
+		}
+		if len(model.Dimensions) > 0 {
+			modelData["dimensions"] = model.Dimensions
+		}
 		modelList = append(modelList, modelData)
 	}
 

--- a/internal/entity/models/replicate.go
+++ b/internal/entity/models/replicate.go
@@ -76,16 +76,19 @@ type replicatePrediction struct {
 	URLs   replicatePredictionURLs `json:"urls"`
 }
 
-type replicateModelsResponse struct {
-	Results []struct {
-		Owner string `json:"owner"`
-		Name  string `json:"name"`
-	} `json:"results"`
-}
-
 type replicateSSEEvent struct {
 	event string
 	data  string
+}
+
+type replicateModelList struct {
+	Results []replicateModelSummary `json:"results"`
+}
+
+type replicateModelSummary struct {
+	ID    string `json:"id"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
 }
 
 func (r *ReplicateModel) endpoint(apiConfig *APIConfig, suffix string) (string, error) {
@@ -538,35 +541,38 @@ func (r *ReplicateModel) ListModels(apiConfig *APIConfig) ([]ListModelResponse, 
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var result replicateModelsResponse
-	if err = json.Unmarshal(body, &result); err != nil {
+	var modelList ModelList
+	if err = json.Unmarshal(body, &modelList); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
-
-	models := make([]ListModelResponse, 0, len(result.Results))
-	pm := GetProviderManager()
-	for _, model := range result.Results {
-		modelName := model.Name
-		var modelResponse ListModelResponse
-		var modelEntity *Model
-		if pm != nil {
-			modelEntity = pm.GetModelByNameOrAlias(modelName)
-		}
-		if model.Owner != "" {
-			modelName = model.Name + "@" + model.Owner
-		}
-		modelResponse.Name = modelName
-		if modelEntity != nil {
-			modelResponse.MaxDimension = modelEntity.MaxDimension
-			modelResponse.Dimensions = modelEntity.Dimensions
-			modelResponse.MaxTokens = modelEntity.MaxTokens
-			modelResponse.ModelTypes = modelEntity.ModelTypes
-			modelResponse.Thinking = modelEntity.Thinking
-		}
-
-		models = append(models, modelResponse)
+	if modelList.Models != nil {
+		return ParseListModel(modelList), nil
 	}
-	return models, nil
+
+	var replicateList replicateModelList
+	if err = json.Unmarshal(body, &replicateList); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if replicateList.Results == nil {
+		return nil, fmt.Errorf("invalid models list format")
+	}
+	for _, model := range replicateList.Results {
+		modelName := strings.TrimSpace(model.ID)
+		if modelName == "" && model.Owner != "" && model.Name != "" {
+			modelName = fmt.Sprintf("%s/%s", model.Owner, model.Name)
+		}
+		if modelName == "" {
+			modelName = strings.TrimSpace(model.Name)
+		}
+		if modelName == "" {
+			continue
+		}
+		modelList.Models = append(modelList.Models, DSModel{
+			ID: modelName,
+		})
+	}
+
+	return ParseListModel(modelList), nil
 }
 
 func (r *ReplicateModel) CheckConnection(apiConfig *APIConfig) error {

--- a/internal/entity/models/siliconflow.go
+++ b/internal/entity/models/siliconflow.go
@@ -444,6 +444,9 @@ func (s *SiliconflowModel) Embed(modelName *string, texts []string, apiConfig *A
 		"model": modelName,
 		"input": texts,
 	}
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+		reqBody["dimensions"] = embeddingConfig.Dimension
+	}
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/entity/models/volcengine.go
+++ b/internal/entity/models/volcengine.go
@@ -479,6 +479,9 @@ func (v *VolcEngine) Embed(modelName *string, texts []string, apiConfig *APIConf
 				},
 			},
 		}
+		if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+			reqBody["dimensions"] = embeddingConfig.Dimension
+		}
 
 		jsonData, err := json.Marshal(reqBody)
 		if err != nil {

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -254,6 +254,17 @@ func (m *ModelProviderService) ListSupportedModels(providerName, instanceName, u
 			"model_types":   model.ModelTypes,
 			"thinking":      model.Thinking,
 		})
+		modelData := map[string]interface{}{
+			"name":        model.Name,
+			"dimension":   model.Dimension,
+			"max_tokens":  model.MaxTokens,
+			"model_types": model.ModelTypes,
+			"thinking":    model.Thinking,
+		}
+		if len(model.Dimensions) > 0 {
+			modelData["dimensions"] = model.Dimensions
+		}
+		result = append(result, modelData)
 	}
 	return result, nil
 }

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -256,7 +256,7 @@ func (m *ModelProviderService) ListSupportedModels(providerName, instanceName, u
 		})
 		modelData := map[string]interface{}{
 			"name":        model.Name,
-			"dimension":   model.Dimension,
+			"dimension":   model.MaxDimension,
 			"max_tokens":  model.MaxTokens,
 			"model_types": model.ModelTypes,
 			"thinking":    model.Thinking,


### PR DESCRIPTION
### What problem does this PR solve?

As title

**From RAGFlow CLI**
```
RAGFlow(api/default)> list models
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-------------------------+------------+--------------------------------------------------------------------------------------------------+------------------------------------------------+---------------------------------------------+
| alias                                                                                                                                                                                                          | dimension | dimensions              | max_tokens | model_types                                                                                      | name                                           | thinking                                    |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+-------------------------+------------+--------------------------------------------------------------------------------------------------+------------------------------------------------+---------------------------------------------+
| [deepseek-v4-flash deepseek-chat deepseek-ai/DeepSeek-V4-Flash deepseek-ai/deepseek-v4-flash deepseek/deepseek-v4-flash deepseek-v4-flash-260425]                                                              |           |                         | 1048576    | [chat]                                                                                           | deepseek-v4-flash                              | map[clear_thinking:true default_value:true] |
| [deepseek-v4-flash-base deepseek/deepseek-v4-flash-base deepseek-ai/DeepSeek-V4-Flash-Base deepseek-ai/deepseek-v4-flash-base]                                                                                 |           |                         | 1048576    | [chat]                                                                                           | deepseek-v4-flash-base                         |                                             |
| [deepseek-v4-pro deepseek-ai/DeepSeek-V4-Pro deepseek-ai/deepseek-v4-pro deepseek/deepseek-v4-pro deepseek-v4-pro-260425]                                                                                      |           |                         | 1048576    | [chat]                                                                                           | deepseek-v4-pro                                | map[clear_thinking:true default_value:true] |
| [deepseek-v4-pro-base deepseek/deepseek-v4-pro-base deepseek-ai/DeepSeek-V4-Pro-Base deepseek-ai/deepseek-v4-pro-base]                                                                                         |           |                         | 1048576    | [chat]                                                                                           | deepseek-v4-pro-base                           |                                             |
| [deepseek-ocr-2 deepseek-ai/DeepSeek-OCR-2 deepseek-ai/deepseek-ocr-2]                                                                                                                                         |           |                         | 8192       | [ocr]                                                                                            | deepseek-ocr-2                                 |                                             |
| [deepseek-v3.2 deepseek-ai/DeepSeek-V3.2 deepseek-ai/deepseek-v3.2 deepseek/deepseek-v3.2 Pro/deepseek-ai/DeepSeek-V3.2 deepseek/deepseek-v3.2-251201 deepseek-v3-2-251201]                                    |           |                         | 163840     | [chat]                                                                                           | deepseek-v3.2                                  |                                             |
| [deepseek-v3.2-speciale deepseek-ai/DeepSeek-V3.2-Speciale deepseek-ai/deepseek-v3.2-speciale]                                                                                                                 |           |                         | 163840     | [chat]                                                                                           | deepseek-v3.2-speciale                         |                                             |
| [qwen/qwen3-embedding-0.6b-gguf Qwen/Qwen3-Embedding-0.6B-GGUF qwen3-embedding-0.6b-gguf]                                                                                                                      | 1024      |                         | 32768      | [embedding]                                                                                      | qwen/qwen3-embedding-0.6b-gguf                 |                                             |
| [qwen/qwen3-embedding-4b-gguf Qwen/Qwen3-Embedding-4B-GGUF qwen3-embedding-4b-gguf]                                                                                                                            | 2560      | [128 256 512 1024 2048] | 32768      | [embedding]                                                                                      | qwen/qwen3-embedding-4b-gguf                   |                                             |
| [qwen/qwen3-embedding-8b-gguf Qwen/Qwen3-Embedding-8B-GGUF qwen3-embedding-8b-gguf]                                                                                                                            | 4096      |                         | 32768      | [embedding]                                                                                      | qwen/qwen3-embedding-8b-gguf                   |                                             |
| [qwen/qwen3-reranker-4b Qwen/Qwen3-Reranker-4B qwen3-reranker-4b Qwen3-Reranker-4B]                                                                                                                            |           |                         | 32768      | [rerank]                                                                                         | qwen/qwen3-reranker-4b                         |                                             |
| [qwen/qwen3-embedding-8b Qwen/Qwen3-Embedding-8B qwen3-embedding-8b Qwen3-Embedding-8B]                                                                                                                        | 4096      |                         | 32768      | [embedding]                                                                                      | qwen/qwen3-embedding-8b                        |                                             |
| [qwen/qwen3-embedding-4b Qwen/Qwen3-Embedding-4B qwen3-embedding-4b Qwen3-Embedding-4B]                                                                                                                        | 2560      |                         | 32768      | [embedding]                                                                                      | qwen/qwen3-embedding-4b                        |                                             |
| [qwen/qwen3-embedding-0.6b Qwen/Qwen3-Embedding-0.6B qwen3-embedding-0.6b Qwen3-Embedding-0.6B]                                                                                                                | 1024      | [1 3 5 76 8]            | 32768      | [embedding]                                                                                      | qwen/qwen3-embedding-0.6b                      |                                             |
| [qwen/qwen3-reranker-0.6b Qwen/Qwen3-Reranker-0.6B qwen3-reranker-0.6b Qwen3-Reranker-0.6B]                                                                                                                    |           |                         | 32768      | [rerank]                                                                                         | qwen/qwen3-reranker-0.6b                       |                                             |


RAGFlow(api/default)> list supported models from 'baidu' 'test'
+-----------+--------------+------------+-----------------------------------------------------------------+-------------------------------------------+---------------------------------------------+
| dimension | dimensions   | max_tokens | model_types                                                     | name                                      | thinking                                    |
+-----------+--------------+------------+-----------------------------------------------------------------+-------------------------------------------+---------------------------------------------+
|           |              |            |                                                                 | tao-8k@其他                                   |                                             |
|           |              |            |                                                                 | qianfan-vl-70b@Baidu                      |                                             |
|           |              | 262144     | [chat]                                                          | qwen3-vl-8b-thinking@Tongyi Lab           | map[clear_thinking:true default_value:true] |
|           |              | 131072     | [chat]                                                          | deepseek-r1-distill-qwen-14b@DeepSeek     |                                             |
|           |              |            |                                                                 | qianfan-vl-8b@Baidu                       |                                             |
|           |              | 262144     | [chat]                                                          | qwen3-vl-235b-a22b-thinking@Tongyi Lab    | map[clear_thinking:true default_value:true] |
|           |              | 262144     | [chat]                                                          | qwen3-vl-235b-a22b-instruct@Tongyi Lab    |                                             |
|           |              | 262144     | [chat]                                                          | qwen3-vl-32b-thinking@Tongyi Lab          | map[clear_thinking:true default_value:true] |
|           |              | 262144     | [chat]                                                          | qwen3-vl-32b-instruct@Tongyi Lab          |                                             |
|           |              | 262144     | [chat]                                                          | qwen3-coder-30b-a3b-instruct@Tongyi Lab   |                                             |
|           |              |            |                                                                 | kimi-k2.5@其他                                |                                             |
|           |              | 32768      | [chat]                                                          | qwen3-8b@Tongyi Lab                       |                                             |
| 1024      | [1 3 5 76 8] | 32768      | [embedding]                                                     | qwen3-embedding-0.6b@Tongyi Lab           |                                             |
|           |              | 1048576    | [chat]                                                          | deepseek-v4-pro@DeepSeek                  | map[clear_thinking:true default_value:true] |
|           |              |            |                                                                 | embedding@Baidu                           |                                             |
|           |              | 262144     | [chat]                                                          | qwen3-coder-480b-a35b-instruct@Tongyi Lab |                                             |
|           |              |            |                                                                 | paddleocr-vl-0.9b@Baidu                   |                                             |
|           |              | 163840     | [chat]                                                          | deepseek-v3@DeepSeek                      |                                             |
|           |              |            |                                                                 | qianfan-ocr-fast@Baidu                    |                                             |

```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Refactoring
