### PR TITLE
Go: add more file parser

### DIFF
--- a/internal/ingestion/parser/doc_parser.go
+++ b/internal/ingestion/parser/doc_parser.go
@@ -16,7 +16,11 @@
 
 package parser
 
-import "fmt"
+import (
+	"fmt"
+
+	officeOxide "github.com/yfedoseev/office_oxide/go"
+)
 
 type DOCParser struct {
 }
@@ -27,6 +31,30 @@ func NewDOCParser() *DOCParser {
 
 func (p *DOCParser) Parse(filename string, data []byte) error {
 	fmt.Printf("Parsing DOC file: %s\n", filename)
+	doc, err := officeOxide.OpenFromBytes(data, "doc")
+	if err != nil {
+		return err
+	}
+	defer doc.Close()
+
+	docFormat, err := doc.Format()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Document format:", docFormat)
+
+	docContext, err := doc.PlainText()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document context:", docContext)
+
+	md, err := doc.ToMarkdown()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document Markdown:", md)
 	return nil
 }
 

--- a/internal/ingestion/parser/ppt_parser.go
+++ b/internal/ingestion/parser/ppt_parser.go
@@ -16,7 +16,11 @@
 
 package parser
 
-import "fmt"
+import (
+	"fmt"
+
+	officeOxide "github.com/yfedoseev/office_oxide/go"
+)
 
 type PPTParser struct {
 }
@@ -27,6 +31,30 @@ func NewPPTParser() *PPTParser {
 
 func (p *PPTParser) Parse(filename string, data []byte) error {
 	fmt.Printf("Parsing PPT file: %s\n", filename)
+	doc, err := officeOxide.OpenFromBytes(data, "ppt")
+	if err != nil {
+		return err
+	}
+	defer doc.Close()
+
+	docFormat, err := doc.Format()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Document format:", docFormat)
+
+	docContext, err := doc.PlainText()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document context:", docContext)
+
+	md, err := doc.ToMarkdown()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document Markdown:", md)
 	return nil
 }
 

--- a/internal/ingestion/parser/pptx_parser.go
+++ b/internal/ingestion/parser/pptx_parser.go
@@ -16,7 +16,11 @@
 
 package parser
 
-import "fmt"
+import (
+	"fmt"
+
+	officeOxide "github.com/yfedoseev/office_oxide/go"
+)
 
 type PPTXParser struct {
 }
@@ -27,6 +31,30 @@ func NewPPTXParser() *PPTXParser {
 
 func (p *PPTXParser) Parse(filename string, data []byte) error {
 	fmt.Printf("Parsing PPTX file: %s\n", filename)
+	doc, err := officeOxide.OpenFromBytes(data, "pptx")
+	if err != nil {
+		return err
+	}
+	defer doc.Close()
+
+	docFormat, err := doc.Format()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Document format:", docFormat)
+
+	docContext, err := doc.PlainText()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document context:", docContext)
+
+	md, err := doc.ToMarkdown()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document Markdown:", md)
 	return nil
 }
 

--- a/internal/ingestion/parser/xls_parser.go
+++ b/internal/ingestion/parser/xls_parser.go
@@ -16,7 +16,11 @@
 
 package parser
 
-import "fmt"
+import (
+	"fmt"
+
+	officeOxide "github.com/yfedoseev/office_oxide/go"
+)
 
 type XLSParser struct {
 }
@@ -27,6 +31,30 @@ func NewXLSParser() *XLSParser {
 
 func (p *XLSParser) Parse(filename string, data []byte) error {
 	fmt.Printf("Parsing XLS file: %s\n", filename)
+	doc, err := officeOxide.OpenFromBytes(data, "xls")
+	if err != nil {
+		return err
+	}
+	defer doc.Close()
+
+	docFormat, err := doc.Format()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Document format:", docFormat)
+
+	docContext, err := doc.PlainText()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document context:", docContext)
+
+	md, err := doc.ToMarkdown()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document Markdown:", md)
 	return nil
 }
 

--- a/internal/ingestion/parser/xlsx_parser.go
+++ b/internal/ingestion/parser/xlsx_parser.go
@@ -16,7 +16,11 @@
 
 package parser
 
-import "fmt"
+import (
+	"fmt"
+
+	officeOxide "github.com/yfedoseev/office_oxide/go"
+)
 
 type XLSXParser struct {
 }
@@ -27,6 +31,30 @@ func NewXLSXParser() *XLSXParser {
 
 func (p *XLSXParser) Parse(filename string, data []byte) error {
 	fmt.Printf("Parsing XLSX file: %s\n", filename)
+	doc, err := officeOxide.OpenFromBytes(data, "xlsx")
+	if err != nil {
+		return err
+	}
+	defer doc.Close()
+
+	docFormat, err := doc.Format()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Document format:", docFormat)
+
+	docContext, err := doc.PlainText()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document context:", docContext)
+
+	md, err := doc.ToMarkdown()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Document Markdown:", md)
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Now we can parse 'pptx', 'ppt', 'doc', 'xls', 'xlsx'

```
RAGFlow(api/default)> parse file 'test.pptx';
Parsing PPTX file: test.pptx
Document format: pptx
```

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
