### PR TITLE
perf(graphrag): batch entity/relation embeddings in set_graph

### DIFF
--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -460,7 +460,6 @@ async def embed_graph_chunks(embd_mdl, pending, callback=None, label="", batch_s
     so a batch-capable backend makes one ``encode`` call per group instead of one
     per node/edge. Mutates the chunk dicts in place.
     """
-    global chat_limiter
     enable_timeout_assertion = os.environ.get("ENABLE_TIMEOUT_ASSERTION")
 
     misses = []

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -41,6 +41,11 @@ ErrorHandlerFn = Callable[[BaseException | None, str | None, dict | None], None]
 
 chat_limiter = LoopLocalSemaphore(int(os.environ.get("MAX_CONCURRENT_CHATS", 10)))
 
+# GraphRAG entity/relation embeddings are filled in batches of this size so a
+# batch-capable embedding backend makes one encode() call per group instead of
+# one call per node/edge. Override with GRAPH_EMBED_BATCH_SIZE.
+GRAPH_EMBED_BATCH_SIZE = int(os.environ.get("GRAPH_EMBED_BATCH_SIZE", 16))
+
 # Doc-store insert batching for GraphRAG subgraph/node/edge/community_report
 # chunks.  Defaults (64 docs per batch, up to 4 batches in flight) mirror the
 # regular ingest pipeline in document_service.py while still keeping the total
@@ -371,9 +376,13 @@ def chunk_id(chunk):
     return xxhash.xxh64((chunk["content_with_weight"] + chunk["kb_id"]).encode("utf-8")).hexdigest()
 
 
-async def graph_node_to_chunk(kb_id, embd_mdl, ent_name, meta, chunks, nhop_neighbors=None):
-    global chat_limiter
-    enable_timeout_assertion = os.environ.get("ENABLE_TIMEOUT_ASSERTION")
+def build_node_chunk(kb_id, ent_name, meta, nhop_neighbors=None):
+    """Build an entity chunk without its embedding vector.
+
+    Returns ``(chunk, cache_key, embed_text)``. The caller batch-fills the
+    ``q_<dim>_vec`` field via :func:`embed_graph_chunks`, so a graph update with
+    many entities issues a few batched ``encode`` calls instead of one per node.
+    """
     chunk = {
         "id": get_uuid(),
         "important_kwd": [ent_name],
@@ -393,19 +402,7 @@ async def graph_node_to_chunk(kb_id, embd_mdl, ent_name, meta, chunks, nhop_neig
         "available_int": 0,
     }
     chunk["content_sm_ltks"] = rag_tokenizer.fine_grained_tokenize(chunk["content_ltks"])
-    ebd = get_embed_cache(embd_mdl.llm_name, ent_name)
-    if ebd is None:
-        async with chat_limiter:
-            timeout = 3 if enable_timeout_assertion else 30000000
-            ebd, _ = await asyncio.wait_for(
-                thread_pool_exec(embd_mdl.encode, [ent_name]),
-                timeout=timeout
-            )
-        ebd = ebd[0]
-        set_embed_cache(embd_mdl.llm_name, ent_name, ebd)
-    assert ebd is not None
-    chunk["q_%d_vec" % len(ebd)] = ebd
-    chunks.append(chunk)
+    return chunk, ent_name, ent_name
 
 
 @timeout(3, 3)
@@ -430,8 +427,12 @@ async def get_relation(tenant_id, kb_id, from_ent_name, to_ent_name, size=1):
     return res
 
 
-async def graph_edge_to_chunk(kb_id, embd_mdl, from_ent_name, to_ent_name, meta, chunks):
-    enable_timeout_assertion = os.environ.get("ENABLE_TIMEOUT_ASSERTION")
+def build_edge_chunk(kb_id, from_ent_name, to_ent_name, meta):
+    """Build a relation chunk without its embedding vector.
+
+    Returns ``(chunk, cache_key, embed_text)`` for batched embedding by
+    :func:`embed_graph_chunks`.
+    """
     chunk = {
         "id": get_uuid(),
         "from_entity_kwd": from_ent_name,
@@ -447,22 +448,45 @@ async def graph_edge_to_chunk(kb_id, embd_mdl, from_ent_name, to_ent_name, meta,
     }
     chunk["content_sm_ltks"] = rag_tokenizer.fine_grained_tokenize(chunk["content_ltks"])
     txt = f"{from_ent_name}->{to_ent_name}"
-    ebd = get_embed_cache(embd_mdl.llm_name, txt)
-    if ebd is None:
+    return chunk, txt, f"{txt}: {meta['description']}"
+
+
+async def embed_graph_chunks(embd_mdl, pending, callback=None, label="", batch_size=GRAPH_EMBED_BATCH_SIZE):
+    """Fill ``q_<dim>_vec`` on graph chunks, batching embedding-model calls.
+
+    ``pending`` is a list of ``(chunk, cache_key, embed_text)`` produced by
+    :func:`build_node_chunk` / :func:`build_edge_chunk`. Cached vectors are
+    applied directly; the remaining texts are encoded in groups of ``batch_size``
+    so a batch-capable backend makes one ``encode`` call per group instead of one
+    per node/edge. Mutates the chunk dicts in place.
+    """
+    global chat_limiter
+    enable_timeout_assertion = os.environ.get("ENABLE_TIMEOUT_ASSERTION")
+
+    misses = []
+    for chunk, cache_key, embed_text in pending:
+        ebd = get_embed_cache(embd_mdl.llm_name, cache_key)
+        if ebd is not None:
+            chunk["q_%d_vec" % len(ebd)] = ebd
+        else:
+            misses.append((chunk, cache_key, embed_text))
+
+    for start in range(0, len(misses), batch_size):
+        batch = misses[start:start + batch_size]
+        texts = [embed_text for _, _, embed_text in batch]
         async with chat_limiter:
-            timeout = 3 if enable_timeout_assertion else 300000000
-            ebd, _ = await asyncio.wait_for(
-                thread_pool_exec(
-                    embd_mdl.encode,
-                    [txt + f": {meta['description']}"]
-                ),
-                timeout=timeout
+            timeout = 3 if enable_timeout_assertion else 30000000
+            embeddings, _ = await asyncio.wait_for(
+                thread_pool_exec(embd_mdl.encode, texts),
+                timeout=timeout,
             )
-        ebd = ebd[0]
-        set_embed_cache(embd_mdl.llm_name, txt, ebd)
-    assert ebd is not None
-    chunk["q_%d_vec" % len(ebd)] = ebd
-    chunks.append(chunk)
+        for (chunk, cache_key, _), ebd in zip(batch, embeddings):
+            assert ebd is not None
+            set_embed_cache(embd_mdl.llm_name, cache_key, ebd)
+            chunk["q_%d_vec" % len(ebd)] = ebd
+        if callback:
+            done = min(start + batch_size, len(misses))
+            callback(msg=f"Get embedding of {label}: {done}/{len(misses)}")
 
 
 async def does_graph_contains(tenant_id, kb_id, doc_id):
@@ -552,42 +576,27 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
             }
         )
 
-    tasks = []
-    for ii, node in enumerate(change.added_updated_nodes):
+    # Two-phase: build all entity/relation chunks (no vectors) first, then fill
+    # embeddings in bounded batches. This replaces one asyncio task + one encode()
+    # call per node/edge, which scaled poorly on large graphs.
+    node_pending = []
+    for node in change.added_updated_nodes:
         node_attrs = graph.nodes[node]
         nhop_neighbors = n_neighbor(graph, node)
-        tasks.append(asyncio.create_task(
-            graph_node_to_chunk(kb_id, embd_mdl, node, node_attrs, chunks, nhop_neighbors)
-        ))
-        if ii % 100 == 9 and callback:
-            callback(msg=f"Get embedding of nodes: {ii}/{len(change.added_updated_nodes)}")
-    try:
-        await asyncio.gather(*tasks, return_exceptions=False)
-    except Exception as e:
-        logging.error(f"Error in get_embedding_of_nodes: {e}")
-        for t in tasks:
-            t.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        raise
+        chunk, cache_key, embed_text = build_node_chunk(kb_id, node, node_attrs, nhop_neighbors)
+        chunks.append(chunk)
+        node_pending.append((chunk, cache_key, embed_text))
+    await embed_graph_chunks(embd_mdl, node_pending, callback, "nodes")
 
-    tasks = []
-    for ii, (from_node, to_node) in enumerate(change.added_updated_edges):
+    edge_pending = []
+    for from_node, to_node in change.added_updated_edges:
         edge_attrs = graph.get_edge_data(from_node, to_node)
         if not edge_attrs:
             continue
-        tasks.append(asyncio.create_task(
-            graph_edge_to_chunk(kb_id, embd_mdl, from_node, to_node, edge_attrs, chunks)
-        ))
-        if ii % 100 == 9 and callback:
-            callback(msg=f"Get embedding of edges: {ii}/{len(change.added_updated_edges)}")
-    try:
-        await asyncio.gather(*tasks, return_exceptions=False)
-    except Exception as e:
-        logging.error(f"Error in get_embedding_of_edges: {e}")
-        for t in tasks:
-            t.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        raise
+        chunk, cache_key, embed_text = build_edge_chunk(kb_id, from_node, to_node, edge_attrs)
+        chunks.append(chunk)
+        edge_pending.append((chunk, cache_key, embed_text))
+    await embed_graph_chunks(embd_mdl, edge_pending, callback, "edges")
 
     now = asyncio.get_running_loop().time()
     if callback:

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -474,12 +474,19 @@ async def embed_graph_chunks(embd_mdl, pending, callback=None, label="", batch_s
     for start in range(0, len(misses), batch_size):
         batch = misses[start:start + batch_size]
         texts = [embed_text for _, _, embed_text in batch]
-        async with chat_limiter:
-            timeout = 3 if enable_timeout_assertion else 30000000
-            embeddings, _ = await asyncio.wait_for(
-                thread_pool_exec(embd_mdl.encode, texts),
-                timeout=timeout,
+        try:
+            async with chat_limiter:
+                timeout = 3 if enable_timeout_assertion else 30000000
+                embeddings, _ = await asyncio.wait_for(
+                    thread_pool_exec(embd_mdl.encode, texts),
+                    timeout=timeout,
+                )
+        except Exception:
+            logging.exception(
+                "embed_graph_chunks(%s): failed encoding batch %d-%d of %d misses",
+                label, start, start + len(batch), len(misses),
             )
+            raise
         for (chunk, cache_key, _), ebd in zip(batch, embeddings):
             assert ebd is not None
             set_embed_cache(embd_mdl.llm_name, cache_key, ebd)

--- a/test/unit_test/rag/graphrag/test_graphrag_utils.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_utils.py
@@ -15,7 +15,6 @@
 #
 
 import json
-from types import SimpleNamespace
 
 import networkx as nx
 import numpy as np
@@ -573,49 +572,92 @@ class TestNNeighbor:
 
 @pytest.mark.p1
 class TestGraphNodeToChunk:
-    """Tests for graph_node_to_chunk field population.
+    """Tests for build_node_chunk field population.
 
     Regression coverage for the dropped ranking fields: the entity chunk must
     carry ``rank_flt`` (pagerank) and ``n_hop_with_weight`` so KGSearch's
     ``pagerank * sim`` ranking and n-hop enrichment are not permanently dead.
+    The vector is filled separately by embed_graph_chunks, so the builder must
+    not embed.
     """
 
-    @pytest.fixture
-    def fake_embd(self, monkeypatch):
-        # Skip the real encode/Redis path by returning a cached embedding.
-        monkeypatch.setattr(graphrag_utils, "get_embed_cache", lambda *_a, **_k: np.array([0.1, 0.2, 0.3]))
-        return graphrag_utils
-
-    @pytest.mark.asyncio
-    async def test_writes_rank_flt_from_pagerank(self, fake_embd):
-        chunks = []
+    def test_writes_rank_flt_from_pagerank(self):
         meta = {"entity_type": "PERSON", "description": "desc", "source_id": ["s1"], "pagerank": 0.42}
-        await fake_embd.graph_node_to_chunk("kb1", SimpleNamespace(llm_name="m"), "ALICE", meta, chunks)
-        assert len(chunks) == 1
-        assert chunks[0]["rank_flt"] == pytest.approx(0.42)
+        chunk, cache_key, embed_text = graphrag_utils.build_node_chunk("kb1", "ALICE", meta)
+        assert chunk["rank_flt"] == pytest.approx(0.42)
+        assert cache_key == "ALICE"
+        assert embed_text == "ALICE"
 
-    @pytest.mark.asyncio
-    async def test_rank_flt_defaults_to_zero_without_pagerank(self, fake_embd):
-        chunks = []
+    def test_rank_flt_defaults_to_zero_without_pagerank(self):
         meta = {"entity_type": "PERSON", "description": "desc", "source_id": ["s1"]}
-        await fake_embd.graph_node_to_chunk("kb1", SimpleNamespace(llm_name="m"), "ALICE", meta, chunks)
-        assert chunks[0]["rank_flt"] == 0.0
+        chunk, _, _ = graphrag_utils.build_node_chunk("kb1", "ALICE", meta)
+        assert chunk["rank_flt"] == 0.0
 
-    @pytest.mark.asyncio
-    async def test_writes_n_hop_with_weight(self, fake_embd):
-        chunks = []
+    def test_writes_n_hop_with_weight(self):
         meta = {"entity_type": "PERSON", "description": "desc", "source_id": ["s1"], "pagerank": 0.1}
         nhop = [{"path": ("ALICE", "BOB"), "weights": [3]}]
-        await fake_embd.graph_node_to_chunk("kb1", SimpleNamespace(llm_name="m"), "ALICE", meta, chunks, nhop)
-        stored = json.loads(chunks[0]["n_hop_with_weight"])
+        chunk, _, _ = graphrag_utils.build_node_chunk("kb1", "ALICE", meta, nhop)
+        stored = json.loads(chunk["n_hop_with_weight"])
         assert stored == [{"path": ["ALICE", "BOB"], "weights": [3]}]
 
-    @pytest.mark.asyncio
-    async def test_n_hop_defaults_to_empty_list(self, fake_embd):
-        chunks = []
+    def test_n_hop_defaults_to_empty_list(self):
         meta = {"entity_type": "PERSON", "description": "desc", "source_id": ["s1"]}
-        await fake_embd.graph_node_to_chunk("kb1", SimpleNamespace(llm_name="m"), "ALICE", meta, chunks)
-        assert json.loads(chunks[0]["n_hop_with_weight"]) == []
+        chunk, _, _ = graphrag_utils.build_node_chunk("kb1", "ALICE", meta)
+        assert json.loads(chunk["n_hop_with_weight"]) == []
+
+    def test_builder_does_not_embed(self):
+        meta = {"entity_type": "PERSON", "description": "desc", "source_id": ["s1"]}
+        chunk, _, _ = graphrag_utils.build_node_chunk("kb1", "ALICE", meta)
+        assert not any(k.startswith("q_") and k.endswith("_vec") for k in chunk)
+
+
+@pytest.mark.p1
+class TestEmbedGraphChunks:
+    """embed_graph_chunks must batch encode() calls (one per group, not one per
+    item), honor the embedding cache, and map each vector back to its own chunk
+    (issue #15921)."""
+
+    class _FakeEmbd:
+        llm_name = "m"
+
+        def __init__(self):
+            self.calls = []
+
+        def encode(self, texts):
+            self.calls.append(list(texts))
+            # 2-dim vector per text; first component encodes the text length so
+            # we can assert each vector lands on the right chunk.
+            return np.array([[float(len(t)), 0.0] for t in texts]), len(texts)
+
+    @pytest.mark.asyncio
+    async def test_batches_encode_calls(self, monkeypatch):
+        monkeypatch.setattr(graphrag_utils, "get_embed_cache", lambda *_a, **_k: None)
+        monkeypatch.setattr(graphrag_utils, "set_embed_cache", lambda *_a, **_k: None)
+        embd = self._FakeEmbd()
+
+        chunks = [{"id": str(i)} for i in range(5)]
+        pending = [(chunks[i], f"k{i}", f"text{i}") for i in range(5)]
+        await graphrag_utils.embed_graph_chunks(embd, pending, batch_size=2)
+
+        # 5 misses at batch_size 2 -> 3 encode calls (2, 2, 1), not 5.
+        assert [len(c) for c in embd.calls] == [2, 2, 1]
+        for i, ch in enumerate(chunks):
+            assert ch["q_2_vec"][0] == pytest.approx(float(len(f"text{i}")))
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_encode(self, monkeypatch):
+        cached = {"k0": np.array([9.0, 9.0])}
+        monkeypatch.setattr(graphrag_utils, "get_embed_cache", lambda _n, key: cached.get(key))
+        monkeypatch.setattr(graphrag_utils, "set_embed_cache", lambda *_a, **_k: None)
+        embd = self._FakeEmbd()
+
+        chunks = [{"id": "0"}, {"id": "1"}]
+        pending = [(chunks[0], "k0", "text0"), (chunks[1], "k1", "text1")]
+        await graphrag_utils.embed_graph_chunks(embd, pending, batch_size=8)
+
+        assert embd.calls == [["text1"]]  # only the cache miss is encoded
+        assert chunks[0]["q_2_vec"][0] == pytest.approx(9.0)  # from cache
+        assert chunks[1]["q_2_vec"][0] == pytest.approx(float(len("text1")))  # from encode
 
 
 class TestFlatUniqList:


### PR DESCRIPTION
### What problem does this PR solve?

`set_graph()` converts each changed entity and relation into a chunk by creating one `asyncio` task per item, and each task calls `embd_mdl.encode([single_text])`. So embedding-model calls grow linearly with the number of changed nodes/edges, batch-capable embedding backends can't be used, and every chunk + task is materialized up front before any insert. On large graph updates this makes the write side of GraphRAG indexing a bottleneck even after extraction is done.

Split chunk building from embedding (the direction suggested in the issue):

- `build_node_chunk` / `build_edge_chunk` build the chunk and return `(chunk, cache_key, embed_text)` without a vector.
- `embed_graph_chunks` fills `q_<dim>_vec` in bounded batches (`GRAPH_EMBED_BATCH_SIZE`, default 16) — it checks the embed cache first and issues one `encode()` per group of cache misses instead of one per item.
- `set_graph` builds all node/edge chunks, then batch-embeds, replacing the per-item `asyncio.create_task` fan-out.

Chunk content, cache keys, and the build-before-delete ordering are unchanged, so a failure during embedding still leaves the old graph/subgraph checkpoints intact. Unit tests updated to the new builder API, with added coverage that `encode()` is batched and the cache short-circuits misses.

Closes #15921

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):
