### PR TITLE
Chat completions: honor runtime kb_ids / dataset_ids override

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -322,6 +322,10 @@ async def _validate_rerank_id(rerank_id, tenant_id):
 
 
 async def _validate_dataset_ids(dataset_ids, tenant_id):
+    """Validate dataset_ids for chat create/update requests.
+
+    Returns a normalized id list on success, or an error message string.
+    """
     if dataset_ids is None:
         return []
     result = await thread_pool_exec(validate_runtime_kb_ids, dataset_ids, tenant_id)
@@ -334,6 +338,10 @@ _RUNTIME_KB_IDS_NOT_PROVIDED = object()
 
 
 def _pop_runtime_kb_ids(req):
+    """Extract a runtime dataset override from the completion request body.
+
+    Returns kb_ids or dataset_ids when present, otherwise _RUNTIME_KB_IDS_NOT_PROVIDED.
+    """
     if "kb_ids" in req:
         return req.pop("kb_ids")
     if "dataset_ids" in req:
@@ -342,6 +350,10 @@ def _pop_runtime_kb_ids(req):
 
 
 async def _apply_runtime_kb_ids(req, dia, user_id):
+    """Validate and apply a runtime kb_ids override to the completion dialog.
+
+    Returns an error message string on failure, or None when no override was sent.
+    """
     runtime_kb_ids = _pop_runtime_kb_ids(req)
     if runtime_kb_ids is _RUNTIME_KB_IDS_NOT_PROVIDED:
         return None

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -32,7 +32,7 @@ from api.db.joint_services.tenant_model_service import (
 )
 from api.db.services.chunk_feedback_service import ChunkFeedbackService
 from api.db.services.conversation_service import ConversationService, structure_answer
-from api.db.services.dialog_service import DialogService, async_chat, gen_mindmap
+from api.db.services.dialog_service import DialogService, async_chat, gen_mindmap, validate_runtime_kb_ids
 from api.db.services.knowledgebase_service import KnowledgebaseService
 from api.db.services.llm_service import LLMBundle
 from api.db.services.search_service import SearchService
@@ -324,27 +324,33 @@ async def _validate_rerank_id(rerank_id, tenant_id):
 async def _validate_dataset_ids(dataset_ids, tenant_id):
     if dataset_ids is None:
         return []
-    if not isinstance(dataset_ids, list):
-        return "`dataset_ids` should be a list."
+    result = await thread_pool_exec(validate_runtime_kb_ids, dataset_ids, tenant_id)
+    if isinstance(result, str):
+        return result.replace("`kb_ids`", "`dataset_ids`")
+    return result
 
-    normalized_ids = [dataset_id for dataset_id in dataset_ids if dataset_id]
-    kbs = []
-    for dataset_id in normalized_ids:
-        if not await thread_pool_exec(KnowledgebaseService.accessible, kb_id=dataset_id, user_id=tenant_id):
-            return f"You don't own the dataset {dataset_id}"
-        matches = await thread_pool_exec(KnowledgebaseService.query, id=dataset_id)
-        if not matches:
-            return f"You don't own the dataset {dataset_id}"
-        kb = matches[0]
-        if kb.chunk_num == 0:
-            return f"The dataset {dataset_id} doesn't own parsed file"
-        kbs.append(kb)
 
-    embd_ids = [split_model_name(kb.embd_id)[0] for kb in kbs]
-    if len(set(embd_ids)) > 1:
-        return f'Datasets use different embedding models: {[kb.embd_id for kb in kbs]}'
+_RUNTIME_KB_IDS_NOT_PROVIDED = object()
 
-    return normalized_ids
+
+def _pop_runtime_kb_ids(req):
+    if "kb_ids" in req:
+        return req.pop("kb_ids")
+    if "dataset_ids" in req:
+        return req.pop("dataset_ids")
+    return _RUNTIME_KB_IDS_NOT_PROVIDED
+
+
+async def _apply_runtime_kb_ids(req, dia, user_id):
+    runtime_kb_ids = _pop_runtime_kb_ids(req)
+    if runtime_kb_ids is _RUNTIME_KB_IDS_NOT_PROVIDED:
+        return None
+
+    validated = await thread_pool_exec(validate_runtime_kb_ids, runtime_kb_ids, user_id)
+    if isinstance(validated, str):
+        return validated
+    dia.kb_ids = validated
+    return None
 
 
 def _apply_prompt_defaults(req):
@@ -1228,6 +1234,10 @@ async def session_completion(chat_id_in_arg=""):
                 raise LookupError("No default chat model for tenant.")
             dia.llm_id = tenant_info.llm_id
             merge_generation_config(dia, chat_model_config)
+
+        kb_ids_error = await _apply_runtime_kb_ids(req, dia, current_user.id)
+        if kb_ids_error:
+            return get_data_error_result(message=kb_ids_error)
 
         stream_mode = req.pop("stream", True)
 

--- a/api/apps/restful_apis/openai_api.py
+++ b/api/apps/restful_apis/openai_api.py
@@ -282,15 +282,13 @@ async def openai_chat_completions(chat_id):
             return get_error_data_result(message=f"Cannot use specified model {requested_model}.")
     merge_generation_config(dia, extract_generation_config(req))
 
-    runtime_kb_ids = None
-    if "kb_ids" in req:
-        runtime_kb_ids = req.pop("kb_ids")
-    elif "dataset_ids" in req:
-        runtime_kb_ids = req.pop("dataset_ids")
-    elif "kb_ids" in extra_body:
-        runtime_kb_ids = extra_body.pop("kb_ids")
-    elif "dataset_ids" in extra_body:
-        runtime_kb_ids = extra_body.pop("dataset_ids")
+    runtime_kb_ids = req.pop("kb_ids", None)
+    if runtime_kb_ids is None:
+        runtime_kb_ids = req.pop("dataset_ids", None)
+    if runtime_kb_ids is None:
+        runtime_kb_ids = extra_body.pop("kb_ids", None)
+    if runtime_kb_ids is None:
+        runtime_kb_ids = extra_body.pop("dataset_ids", None)
     if runtime_kb_ids is not None:
         validated = validate_runtime_kb_ids(runtime_kb_ids, current_user.id)
         if isinstance(validated, str):

--- a/api/apps/restful_apis/openai_api.py
+++ b/api/apps/restful_apis/openai_api.py
@@ -236,6 +236,11 @@ def _normalize_openai_messages(messages):
 @login_required
 @validate_request("model", "messages")
 async def openai_chat_completions(chat_id):
+    """Handle OpenAI-compatible chat completions for a saved chat assistant.
+
+    Request body may include kb_ids or dataset_ids to override the assistant's
+    saved datasets for this completion only.
+    """
     req = await get_request_json()
 
     extra_body = req.get("extra_body") or {}

--- a/api/apps/restful_apis/openai_api.py
+++ b/api/apps/restful_apis/openai_api.py
@@ -21,7 +21,7 @@ from quart import Response, jsonify
 
 from api.apps import current_user, login_required
 from api.apps.restful_apis._generation_params import extract_generation_config, merge_generation_config
-from api.db.services.dialog_service import DialogService, async_chat
+from api.db.services.dialog_service import DialogService, async_chat, validate_runtime_kb_ids
 from api.db.services.doc_metadata_service import DocMetadataService
 from api.db.joint_services.tenant_model_service import get_model_config_from_provider_instance, get_api_key
 from api.utils.api_utils import get_error_data_result, get_request_json, validate_request
@@ -281,6 +281,21 @@ async def openai_chat_completions(chat_id):
         if not get_api_key(tenant_id=dia.tenant_id, model_name=requested_model):
             return get_error_data_result(message=f"Cannot use specified model {requested_model}.")
     merge_generation_config(dia, extract_generation_config(req))
+
+    runtime_kb_ids = None
+    if "kb_ids" in req:
+        runtime_kb_ids = req.pop("kb_ids")
+    elif "dataset_ids" in req:
+        runtime_kb_ids = req.pop("dataset_ids")
+    elif "kb_ids" in extra_body:
+        runtime_kb_ids = extra_body.pop("kb_ids")
+    elif "dataset_ids" in extra_body:
+        runtime_kb_ids = extra_body.pop("dataset_ids")
+    if runtime_kb_ids is not None:
+        validated = validate_runtime_kb_ids(runtime_kb_ids, current_user.id)
+        if isinstance(validated, str):
+            return get_error_data_result(message=validated, code=RetCode.ARGUMENT_ERROR)
+        dia.kb_ids = validated
 
     metadata_condition = extra_body.get("metadata_condition") or {}
     if metadata_condition and not isinstance(metadata_condition, dict):

--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -21,7 +21,7 @@ from common.constants import StatusEnum
 from api.db.db_models import Conversation, DB
 from api.db.services.api_service import API4ConversationService
 from api.db.services.common_service import CommonService
-from api.db.services.dialog_service import DialogService, async_chat
+from api.db.services.dialog_service import DialogService, async_chat, validate_runtime_kb_ids
 from common.misc_utils import get_uuid
 import json
 
@@ -202,8 +202,11 @@ async def async_completion(tenant_id, chat_id, question, name="New session", ses
     message_id = msg[-1].get("id")
     e, dia = DialogService.get_by_id(conv.dialog_id)
 
-    kb_ids = kwargs.get("kb_ids",[])
-    dia.kb_ids = list(set(dia.kb_ids + kb_ids))
+    if "kb_ids" in kwargs:
+        validated = validate_runtime_kb_ids(kwargs.pop("kb_ids"), tenant_id)
+        if isinstance(validated, str):
+            raise ValueError(validated)
+        dia.kb_ids = validated
     if not conv.reference:
         conv.reference = []
     conv.message.append({"role": "assistant", "content": "", "id": message_id})
@@ -296,6 +299,13 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
     if not conv.reference:
         conv.reference = []
     conv.reference.append({"chunks": [], "doc_aggs": []})
+
+    if "kb_ids" in kwargs:
+        user_id = kwargs.get("user_id") or dia.tenant_id
+        validated = validate_runtime_kb_ids(kwargs.pop("kb_ids"), user_id)
+        if isinstance(validated, str):
+            raise ValueError(validated)
+        dia.kb_ids = validated
 
     if stream:
         try:

--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -139,6 +139,10 @@ def structure_answer(conv, ans, message_id, session_id):
 
 
 async def async_completion(tenant_id, chat_id, question, name="New session", session_id=None, stream=True, **kwargs):
+    """Run a tenant-scoped chat completion, creating the session when session_id is omitted.
+
+    Optional kwargs may include kb_ids to override the dialog's datasets for this request.
+    """
     assert name, "`name` can not be empty."
     dia = DialogService.query(id=chat_id, tenant_id=tenant_id, status=StatusEnum.VALID.value)
     assert dia, "You do not own the chat."
@@ -233,6 +237,10 @@ async def async_completion(tenant_id, chat_id, question, name="New session", ses
         yield answer
 
 async def async_iframe_completion(dialog_id, question, session_id=None, stream=True, tenant_id=None, **kwargs):
+    """Run an iframe/embed chat completion, optionally scoped to a tenant.
+
+    Optional kwargs may include kb_ids to override the dialog's datasets for this request.
+    """
     if tenant_id:
         exists, dia = DialogService.get_by_id(dialog_id)
         if (not exists

--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -301,8 +301,8 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
     conv.reference.append({"chunks": [], "doc_aggs": []})
 
     if "kb_ids" in kwargs:
-        user_id = kwargs.get("user_id") or dia.tenant_id
-        validated = validate_runtime_kb_ids(kwargs.pop("kb_ids"), user_id)
+        owner_id = tenant_id or dia.tenant_id
+        validated = validate_runtime_kb_ids(kwargs.pop("kb_ids"), owner_id)
         if isinstance(validated, str):
             raise ValueError(validated)
         dia.kb_ids = validated

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -363,7 +363,7 @@ def validate_runtime_kb_ids(kb_ids, user_id):
             return f"The dataset {dataset_id} doesn't own parsed file"
         kbs.append(kb)
 
-    embd_ids = [split_model_name(kb.embd_id)[0] for kb in kbs]
+    embd_ids = [kb.embd_id for kb in kbs]
     if len(set(embd_ids)) > 1:
         return f"Datasets use different embedding models: {[kb.embd_id for kb in kbs]}"
 

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -39,7 +39,12 @@ from api.utils.reference_metadata_utils import (
     enrich_chunks_with_document_metadata,
     resolve_reference_metadata_preferences,
 )
-from api.db.joint_services.tenant_model_service import get_tenant_default_model_by_type, get_model_config_from_provider_instance, get_model_type_by_name
+from api.db.joint_services.tenant_model_service import (
+    get_model_config_from_provider_instance,
+    get_model_type_by_name,
+    get_tenant_default_model_by_type,
+    split_model_name,
+)
 from common.time_utils import current_timestamp, datetime_format
 from common.text_utils import normalize_arabic_digits
 from rag.graphrag.general.mind_map_extractor import MindMapExtractor
@@ -335,6 +340,34 @@ async def async_chat_solo(dialog, messages, stream=True, session_id=None):
         user_content = msg[-1].get("content", "[content not available]")
         logging.debug("User: {}|Assistant: {}".format(user_content, answer))
         yield {"answer": answer, "reference": {}, "audio_binary": tts(tts_mdl, answer), "prompt": "", "created_at": time.time()}
+
+
+def validate_runtime_kb_ids(kb_ids, user_id):
+    """Validate runtime kb_ids override for chat completions.
+
+    Returns a normalized kb id list on success, or an error message string.
+    """
+    if not isinstance(kb_ids, list):
+        return "`kb_ids` should be a list."
+
+    normalized_ids = [dataset_id for dataset_id in kb_ids if dataset_id]
+    kbs = []
+    for dataset_id in normalized_ids:
+        if not KnowledgebaseService.accessible(kb_id=dataset_id, user_id=user_id):
+            return f"You don't own the dataset {dataset_id}"
+        matches = KnowledgebaseService.query(id=dataset_id)
+        if not matches:
+            return f"You don't own the dataset {dataset_id}"
+        kb = matches[0]
+        if kb.chunk_num == 0:
+            return f"The dataset {dataset_id} doesn't own parsed file"
+        kbs.append(kb)
+
+    embd_ids = [split_model_name(kb.embd_id)[0] for kb in kbs]
+    if len(set(embd_ids)) > 1:
+        return f"Datasets use different embedding models: {[kb.embd_id for kb in kbs]}"
+
+    return normalized_ids
 
 
 def get_models(dialog, trace_context=None, langfuse_session_id=None):

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -602,6 +602,8 @@ class Base(ABC):
         assert False, "Shouldn't be here."
 
     async def _async_chat(self, history, gen_conf, **kwargs):
+        kwargs.pop("images", None)
+        kwargs.pop("chat_template_kwargs", None)
         logging.info("[HISTORY]" + json.dumps(history, ensure_ascii=False, indent=2))
         if self.model_name.lower().find("qwq") >= 0:
             logging.info(f"[INFO] {self.model_name} detected as reasoning model, using async_chat_streamly")
@@ -1498,6 +1500,8 @@ class LiteLLMBase(ABC):
         return self.provider == SupportedLiteLLMProvider.DeepSeek
 
     async def async_chat(self, system, history, gen_conf, **kwargs):
+        kwargs.pop("images", None)
+        kwargs.pop("chat_template_kwargs", None)
         hist = list(history) if history else []
         if system:
             if not hist or hist[0].get("role") != "system":

--- a/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
@@ -2759,8 +2759,22 @@ def test_session_completion_overrides_runtime_kb_ids(monkeypatch):
 
 @pytest.mark.p2
 def test_session_completion_rejects_invalid_runtime_kb_ids(monkeypatch):
+    """Invalid runtime kb_ids should be rejected before any completion side effects."""
     module = _load_chat_api_module(monkeypatch)
 
+    create_session_called = []
+    save_called = []
+
+    async def _spy_create_session(*_args, **_kwargs):
+        create_session_called.append(True)
+        raise RuntimeError("session creation should not run for invalid kb_ids")
+
+    def _spy_save(**_kwargs):
+        save_called.append(True)
+        raise RuntimeError("ConversationService.save should not run for invalid kb_ids")
+
+    monkeypatch.setattr(module, "_create_session_for_completion", _spy_create_session)
+    monkeypatch.setattr(module.ConversationService, "save", _spy_save)
     monkeypatch.setattr(
         module,
         "validate_runtime_kb_ids",
@@ -2771,7 +2785,6 @@ def test_session_completion_rejects_invalid_runtime_kb_ids(monkeypatch):
         "get_request_json",
         lambda: _AwaitableValue({
             "chat_id": "chat-1",
-            "session_id": "session-1",
             "stream": False,
             "messages": [{"role": "user", "content": "latest question"}],
             "kb_ids": ["runtime-kb-1"],
@@ -2782,3 +2795,5 @@ def test_session_completion_rejects_invalid_runtime_kb_ids(monkeypatch):
 
     assert res["code"] == module.RetCode.DATA_ERROR, res
     assert "You don't own the dataset runtime-kb-1" in res["message"]
+    assert create_session_called == []
+    assert save_called == []

--- a/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
+++ b/test/testcases/test_http_api/test_session_management/test_session_sdk_routes_unit.py
@@ -2319,6 +2319,9 @@ def _load_chat_api_module(monkeypatch):
     )
     dialog_svc_mod.async_chat = lambda *_a, **_k: None
     dialog_svc_mod.gen_mindmap = lambda *_a, **_k: None
+    dialog_svc_mod.validate_runtime_kb_ids = lambda kb_ids, _user_id: (
+        kb_ids if isinstance(kb_ids, list) else "`kb_ids` should be a list."
+    )
     monkeypatch.setitem(sys.modules, "api.db.services.dialog_service", dialog_svc_mod)
 
     kb_svc_mod = ModuleType("api.db.services.knowledgebase_service")
@@ -2719,3 +2722,63 @@ def test_session_completion_accepts_question_payload(monkeypatch):
     assert res["code"] == 0, res
     assert [message["content"] for message in captured_messages[0]] == ["latest question"]
     assert conv.message[-1]["content"] == "latest question"
+
+
+@pytest.mark.p2
+def test_session_completion_overrides_runtime_kb_ids(monkeypatch):
+    """Runtime kb_ids in the request should override the chat assistant's saved datasets."""
+    module = _load_chat_api_module(monkeypatch)
+
+    captured = {}
+
+    async def _fake_async_chat(dia, _messages, stream=True, **_kwargs):
+        captured["kb_ids"] = list(dia.kb_ids)
+        captured["kwargs"] = dict(_kwargs)
+        yield {"answer": "ok", "reference": {}}
+
+    monkeypatch.setattr(module, "async_chat", _fake_async_chat)
+    monkeypatch.setattr(module, "structure_answer", lambda _conv, ans, _message_id, _session_id: ans)
+    monkeypatch.setattr(
+        module,
+        "get_request_json",
+        lambda: _AwaitableValue({
+            "chat_id": "chat-1",
+            "session_id": "session-1",
+            "stream": False,
+            "messages": [{"role": "user", "content": "latest question"}],
+            "kb_ids": ["runtime-kb-1", "runtime-kb-2"],
+        }),
+    )
+
+    res = _run(inspect.unwrap(module.session_completion)())
+
+    assert res["code"] == 0, res
+    assert captured["kb_ids"] == ["runtime-kb-1", "runtime-kb-2"]
+    assert "kb_ids" not in captured["kwargs"]
+
+
+@pytest.mark.p2
+def test_session_completion_rejects_invalid_runtime_kb_ids(monkeypatch):
+    module = _load_chat_api_module(monkeypatch)
+
+    monkeypatch.setattr(
+        module,
+        "validate_runtime_kb_ids",
+        lambda _kb_ids, _user_id: "You don't own the dataset runtime-kb-1",
+    )
+    monkeypatch.setattr(
+        module,
+        "get_request_json",
+        lambda: _AwaitableValue({
+            "chat_id": "chat-1",
+            "session_id": "session-1",
+            "stream": False,
+            "messages": [{"role": "user", "content": "latest question"}],
+            "kb_ids": ["runtime-kb-1"],
+        }),
+    )
+
+    res = _run(inspect.unwrap(module.session_completion)())
+
+    assert res["code"] == module.RetCode.DATA_ERROR, res
+    assert "You don't own the dataset runtime-kb-1" in res["message"]


### PR DESCRIPTION

### What problem does this PR solve?

Chat completion endpoints (POST /api/v1/chat/completions, deprecated POST /api/v1/chats/{chat_id}/completions, and OpenAI-compatible POST /api/v1/openai/{chat_id}/chat/completions) ignored kb_ids (and dataset_ids) in the request body. Retrieval always used the chat assistant’s saved datasets from dialog.kb_ids, so clients could not scope a single completion to different knowledge bases at runtime.

This change validates request-supplied dataset IDs (ownership, parsed content, consistent embedding model) and uses them for that completion only, without changing the persisted chat assistant configuration. If neither field is sent, behavior is unchanged and saved datasets are used.



### Type of change

- [X ] Bug Fix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
