### PR TITLE
fix: preserve source position page numbers

### DIFF
--- a/rag/nlp/__init__.py
+++ b/rag/nlp/__init__.py
@@ -845,6 +845,7 @@ def add_positions(d, poss):
 
 
 def add_source_positions(d, poss):
+    """Copy source coordinates that already use public one-based page numbers."""
     if not poss:
         return
     page_num_int = []

--- a/rag/nlp/__init__.py
+++ b/rag/nlp/__init__.py
@@ -851,7 +851,14 @@ def add_source_positions(d, poss):
     position_int = []
     top_int = []
     for pn, left, right, top, bottom in poss:
-        page_no = max(1, int(pn))
+        page_no = int(pn)
+        if page_no <= 0:
+            logging.warning(
+                "Clamping non-positive source page number %s to 1 for source position %s",
+                pn,
+                (pn, left, right, top, bottom),
+            )
+            page_no = 1
         page_num_int.append(page_no)
         top_int.append(int(top))
         position_int.append((page_no, int(left), int(right), int(top), int(bottom)))

--- a/rag/nlp/__init__.py
+++ b/rag/nlp/__init__.py
@@ -844,6 +844,22 @@ def add_positions(d, poss):
     d["top_int"] = top_int
 
 
+def add_source_positions(d, poss):
+    if not poss:
+        return
+    page_num_int = []
+    position_int = []
+    top_int = []
+    for pn, left, right, top, bottom in poss:
+        page_no = max(1, int(pn))
+        page_num_int.append(page_no)
+        top_int.append(int(top))
+        position_int.append((page_no, int(left), int(right), int(top), int(bottom)))
+    d["page_num_int"] = page_num_int
+    d["position_int"] = position_int
+    d["top_int"] = top_int
+
+
 def remove_contents_table(sections, eng=False):
     i = 0
     while i < len(sections):

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -83,7 +83,7 @@ from api.db.joint_services.tenant_model_service import get_tenant_default_model_
 from common.versions import get_ragflow_version
 from api.db.db_models import close_connection
 from rag.app import laws, paper, presentation, manual, qa, table, book, resume, picture, naive, one, audio, email, tag
-from rag.nlp import search, rag_tokenizer, add_positions
+from rag.nlp import search, rag_tokenizer, add_source_positions
 from rag.raptor import (
     RAPTOR_TREE_BUILDER,
 )
@@ -866,7 +866,7 @@ async def run_dataflow(task: dict):
             ck["content_with_weight"] = ck["text"]
         del ck["text"]
         if "positions" in ck:
-            add_positions(ck, ck["positions"])
+            add_source_positions(ck, ck["positions"])
             del ck["positions"]
 
     if metadata:

--- a/rag/svr/task_executor_refactor/dataflow_service.py
+++ b/rag/svr/task_executor_refactor/dataflow_service.py
@@ -43,7 +43,7 @@ from common.connection_utils import timeout
 from common.constants import LLMType, PipelineTaskType
 from common.metadata_utils import update_metadata_to
 from common.misc_utils import thread_pool_exec
-from rag.nlp import rag_tokenizer, add_positions
+from rag.nlp import rag_tokenizer, add_source_positions
 from rag.svr.task_executor_refactor.constants import CANVAS_DEBUG_DOC_ID
 from rag.svr.task_executor_refactor.task_context import TaskContext
 
@@ -342,7 +342,7 @@ class DataflowService:
             del ck["text"]
 
             if "positions" in ck:
-                add_positions(ck, ck["positions"])
+                add_source_positions(ck, ck["positions"])
                 del ck["positions"]
 
         return metadata

--- a/test/unit_test/rag/test_source_positions.py
+++ b/test/unit_test/rag/test_source_positions.py
@@ -13,7 +13,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
+
+import pytest
+
 from rag.nlp import add_positions, add_source_positions
+
+pytestmark = pytest.mark.p2
 
 
 def test_add_source_positions_keeps_public_one_based_page_numbers():
@@ -26,14 +32,16 @@ def test_add_source_positions_keeps_public_one_based_page_numbers():
     assert chunk["top_int"] == [30]
 
 
-def test_add_source_positions_normalizes_legacy_zero_page_number():
+def test_add_source_positions_normalizes_legacy_zero_page_number(caplog):
     chunk = {}
 
-    add_source_positions(chunk, [[0, 10, 20, 30, 40]])
+    with caplog.at_level(logging.WARNING):
+        add_source_positions(chunk, [[0, 10, 20, 30, 40]])
 
     assert chunk["page_num_int"] == [1]
     assert chunk["position_int"] == [(1, 10, 20, 30, 40)]
     assert chunk["top_int"] == [30]
+    assert caplog.records[0].args == (0, (0, 10, 20, 30, 40))
 
 
 def test_add_positions_still_offsets_parser_zero_based_page_numbers():

--- a/test/unit_test/rag/test_source_positions.py
+++ b/test/unit_test/rag/test_source_positions.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.p2
 
 
 def test_add_source_positions_keeps_public_one_based_page_numbers():
+    """Verify source positions keep their public one-based page number."""
     chunk = {}
 
     add_source_positions(chunk, [[1, 10, 20, 30, 40]])
@@ -33,6 +34,7 @@ def test_add_source_positions_keeps_public_one_based_page_numbers():
 
 
 def test_add_source_positions_normalizes_legacy_zero_page_number(caplog):
+    """Verify legacy zero page numbers are clamped and logged."""
     chunk = {}
 
     with caplog.at_level(logging.WARNING):
@@ -45,6 +47,7 @@ def test_add_source_positions_normalizes_legacy_zero_page_number(caplog):
 
 
 def test_add_positions_still_offsets_parser_zero_based_page_numbers():
+    """Verify parser-local positions still receive the legacy page offset."""
     chunk = {}
 
     add_positions(chunk, [[1, 10, 20, 30, 40]])

--- a/test/unit_test/rag/test_source_positions.py
+++ b/test/unit_test/rag/test_source_positions.py
@@ -1,0 +1,46 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from rag.nlp import add_positions, add_source_positions
+
+
+def test_add_source_positions_keeps_public_one_based_page_numbers():
+    chunk = {}
+
+    add_source_positions(chunk, [[1, 10, 20, 30, 40]])
+
+    assert chunk["page_num_int"] == [1]
+    assert chunk["position_int"] == [(1, 10, 20, 30, 40)]
+    assert chunk["top_int"] == [30]
+
+
+def test_add_source_positions_normalizes_legacy_zero_page_number():
+    chunk = {}
+
+    add_source_positions(chunk, [[0, 10, 20, 30, 40]])
+
+    assert chunk["page_num_int"] == [1]
+    assert chunk["position_int"] == [(1, 10, 20, 30, 40)]
+    assert chunk["top_int"] == [30]
+
+
+def test_add_positions_still_offsets_parser_zero_based_page_numbers():
+    chunk = {}
+
+    add_positions(chunk, [[1, 10, 20, 30, 40]])
+
+    assert chunk["page_num_int"] == [2]
+    assert chunk["position_int"] == [(2, 10, 20, 30, 40)]
+    assert chunk["top_int"] == [30]


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #8819.

Dataflow chunks can already carry 1-based source positions from the parser pipeline. The legacy dataflow executor converted those positions with `add_positions`, which is intended for parser-local zero-based page indexes. That can shift a single-page reference from page 1 to page 2.

This PR adds a source-position conversion helper and uses it in both dataflow executor paths so public/source positions keep their page numbers. The existing `add_positions` behavior is kept for parser-local zero-based positions.

Validation run locally:

- `python -m py_compile rag\nlp\__init__.py rag\svr\task_executor.py rag\svr\task_executor_refactor\dataflow_service.py test\unit_test\rag\test_source_positions.py`
- `python -m pytest test\unit_test\rag\test_source_positions.py -q`
- `python -m ruff check rag\nlp\__init__.py rag\svr\task_executor.py rag\svr\task_executor_refactor\dataflow_service.py test\unit_test\rag\test_source_positions.py`
- `git diff --check`

Note: the local environment used Python 3.11.9, while the project requires Python 3.13 for the full test environment.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):