### PR TITLE
Custom the file extension when saving DB fields, and Parse HTML fragments not just full HTML doc

### DIFF
--- a/common/data_source/rdbms_connector.py
+++ b/common/data_source/rdbms_connector.py
@@ -53,6 +53,7 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         id_column: Optional[str] = None,
         timestamp_column: Optional[str] = None,
         batch_size: int = INDEX_BATCH_SIZE,
+        file_extension=None,
     ) -> None:
         """
         Initialize the RDBMS connector.
@@ -68,6 +69,7 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             id_column: Column to use as unique document ID (optional, will generate hash if not provided)
             timestamp_column: Column to use for incremental sync (optional, must be datetime/timestamp type)
             batch_size: Number of documents per batch
+            file_extension: File Extension to save content column into
         """
         self.db_type = DatabaseType(db_type.lower())
         self.host = host.strip()
@@ -79,6 +81,7 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.id_column = id_column.strip() if id_column else None
         self.timestamp_column = timestamp_column.strip() if timestamp_column else None
         self.batch_size = batch_size
+        self.file_extension = file_extension if file_extension else '.txt'
         
         self._connection = None
         self._credentials: Dict[str, Any] = {}
@@ -334,7 +337,7 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             blob=blob,
             source=DocumentSource(self.db_type.value),
             semantic_identifier=semantic_id,
-            extension=".txt",
+            extension=self.file_extension,
             doc_updated_at=doc_updated_at,
             size_bytes=len(blob),
             metadata=metadata if metadata else None,

--- a/common/data_source/rdbms_connector.py
+++ b/common/data_source/rdbms_connector.py
@@ -87,8 +87,8 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.id_column = id_column.strip() if id_column else None
         self.timestamp_column = timestamp_column.strip() if timestamp_column else None
         self.batch_size = batch_size
-        self.file_extension = file_extension if file_extension else '.txt'
-        
+        self.file_extension = file_extension if file_extension else ".txt"
+
         self._connection = None
         self._credentials: Dict[str, Any] = {}
         self._sync_connector_id: str | None = None

--- a/common/data_source/rdbms_connector.py
+++ b/common/data_source/rdbms_connector.py
@@ -57,6 +57,7 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         id_column: Optional[str] = None,
         timestamp_column: Optional[str] = None,
         batch_size: int = INDEX_BATCH_SIZE,
+        file_extension=None,
     ) -> None:
         """
         Initialize the RDBMS connector.
@@ -72,6 +73,7 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             id_column: Column to use as unique document ID (optional, will generate hash if not provided)
             timestamp_column: Column to use for incremental sync (optional, must be datetime/timestamp type)
             batch_size: Number of documents per batch
+            file_extension: File Extension to save content column into
         """
         self.db_type = DatabaseType(db_type.lower())
         self.host = host.strip()
@@ -85,7 +87,8 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         self.id_column = id_column.strip() if id_column else None
         self.timestamp_column = timestamp_column.strip() if timestamp_column else None
         self.batch_size = batch_size
-
+        self.file_extension = file_extension if file_extension else '.txt'
+        
         self._connection = None
         self._credentials: Dict[str, Any] = {}
         self._sync_connector_id: str | None = None
@@ -450,7 +453,7 @@ class RDBMSConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
             blob=blob,
             source=DocumentSource(self.db_type.value),
             semantic_identifier=semantic_id,
-            extension=".txt",
+            extension=self.file_extension,
             doc_updated_at=doc_updated_at,
             size_bytes=len(blob),
             metadata=metadata if metadata else None,

--- a/deepdoc/parser/html_parser.py
+++ b/deepdoc/parser/html_parser.py
@@ -68,7 +68,7 @@ class RAGFlowHtmlParser:
         for comment in soup.find_all(string=lambda text: isinstance(text, Comment)):
             comment.extract()
 
-        cls.read_text_recursively(soup.body, temp_sections, chunk_token_num=chunk_token_num)
+        cls.read_text_recursively(soup if soup.body is None else soup.body, temp_sections, chunk_token_num=chunk_token_num)
         block_txt_list, table_list = cls.merge_block_text(temp_sections)
         sections = cls.chunk_block(block_txt_list, chunk_token_num=chunk_token_num)
         for table in table_list:

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -1602,6 +1602,7 @@ class _RDBMSBase(SyncBase):
             id_column=self.conf.get("id_column") or None,
             timestamp_column=self.conf.get("timestamp_column") or None,
             batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+            file_extension=self.conf.get("file_extension", ".txt"),
         )
 
         credentials = self.conf.get("credentials")

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -2151,6 +2151,7 @@ class _RDBMSBase(_CursorPersistingSyncBase):
             id_column=self.conf.get("id_column") or None,
             timestamp_column=self.conf.get("timestamp_column") or None,
             batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+            file_extension=self.conf.get("file_extension", ".txt"),
         )
 
         credentials = self.conf.get("credentials")

--- a/test/unit_test/rag/test_sync_data_source.py
+++ b/test/unit_test/rag/test_sync_data_source.py
@@ -276,6 +276,7 @@ class _FakeRDBMSConnector:
         id_column=None,
         timestamp_column=None,
         batch_size=2,
+        file_extension=None,
     ):
         self.db_type = db_type
         self.host = host
@@ -287,6 +288,7 @@ class _FakeRDBMSConnector:
         self.id_column = id_column
         self.timestamp_column = timestamp_column
         self.batch_size = batch_size
+        self.file_extension = file_extension if file_extension else ".txt"
         self.load_from_state_called = False
         self.retrieve_all_slim_docs_perm_sync_called = False
         self.prepare_sync_state_called = False

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1357,6 +1357,8 @@ Example: Virtual Hosted Style`,
         'Column to use as unique document ID. If not specified, a hash of the content will be used.',
       mysqlTimestampColumnTip:
         'Datetime/timestamp column for incremental sync. Only rows modified after the last sync will be fetched.',
+      mysqlFileExtensionTip:
+        'The file extension to save the content column into files. default: .txt',
       postgresqlDescription:
         'Connect to PostgreSQL database to sync data from tables using SQL queries.',
       postgresqlQueryTip:
@@ -1369,6 +1371,8 @@ Example: Virtual Hosted Style`,
         'Column to use as unique document ID. If not specified, a hash of the content will be used.',
       postgresqlTimestampColumnTip:
         'Datetime/timestamp column for incremental sync. Only rows modified after the last sync will be fetched.',
+      postgresqlFileExtensionTip:
+        'The file extension to save the content column into files. default: .txt',
       rest_apiDescription:
         'Connect any REST API endpoint as a data source using a flexible, configuration-driven connector.',
       restApiQueryParamsTip:

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1749,7 +1749,7 @@ Example: Virtual Hosted Style`,
       mysqlTimestampColumnTip:
         'Datetime/timestamp column for incremental sync. Only rows modified after the last sync will be fetched.',
       mysqlFileExtensionTip:
-        'The file extension to save the content column into files. default: .txt',
+        'The extension used for documents synced from this source (default: .txt). Since each row is saved as one file, when set to .html or .md, select only content columns that are purely HTML or Markdown.',
       postgresqlDescription:
         'Connect to PostgreSQL database to sync data from tables using SQL queries.',
       postgresqlQueryTip:
@@ -1763,7 +1763,7 @@ Example: Virtual Hosted Style`,
       postgresqlTimestampColumnTip:
         'Datetime/timestamp column for incremental sync. Only rows modified after the last sync will be fetched.',
       postgresqlFileExtensionTip:
-        'The file extension to save the content column into files. default: .txt',
+        'The extension used for documents synced from this source (default: .txt). Since each row is saved as one file, when set to .html or .md, select only content columns that are purely HTML or Markdown.',
       bigqueryDescription:
         'Connect to Google BigQuery to sync rows from a table or a custom GoogleSQL query.',
       bigqueryProjectIdTip:

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1748,6 +1748,8 @@ Example: Virtual Hosted Style`,
         'Column to use as unique document ID. If not specified, a hash of the content will be used.',
       mysqlTimestampColumnTip:
         'Datetime/timestamp column for incremental sync. Only rows modified after the last sync will be fetched.',
+      mysqlFileExtensionTip:
+        'The file extension to save the content column into files. default: .txt',
       postgresqlDescription:
         'Connect to PostgreSQL database to sync data from tables using SQL queries.',
       postgresqlQueryTip:
@@ -1760,6 +1762,8 @@ Example: Virtual Hosted Style`,
         'Column to use as unique document ID. If not specified, a hash of the content will be used.',
       postgresqlTimestampColumnTip:
         'Datetime/timestamp column for incremental sync. Only rows modified after the last sync will be fetched.',
+      postgresqlFileExtensionTip:
+        'The file extension to save the content column into files. default: .txt',
       bigqueryDescription:
         'Connect to Google BigQuery to sync rows from a table or a custom GoogleSQL query.',
       bigqueryProjectIdTip:

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -1013,6 +1013,14 @@ export const DataSourceFormFields = {
       placeholder: 'updated_at',
       tooltip: t('setting.mysqlTimestampColumnTip'),
     },
+    {
+      label: 'File Extension',
+      name: 'config.file_extension',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: '.txt',
+      tooltip: t('setting.mysqlFileExtensionTip'),
+    },
   ],
   [DataSourceKey.POSTGRESQL]: [
     {
@@ -1086,6 +1094,14 @@ export const DataSourceFormFields = {
       required: false,
       placeholder: 'updated_at',
       tooltip: t('setting.postgresqlTimestampColumnTip'),
+    },
+    {
+      label: 'File Extension',
+      name: 'config.file_extension',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: '.txt',
+      tooltip: t('setting.postgresqlFileExtensionTip'),
     },
   ],
   [DataSourceKey.REST_API]: [

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -1549,6 +1549,14 @@ const generateDataSourceFormFields = (t: TFunction) => ({
       placeholder: 'updated_at',
       tooltip: t('setting.mysqlTimestampColumnTip'),
     },
+    {
+      label: 'File Extension',
+      name: 'config.file_extension',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: '.txt',
+      tooltip: t('setting.mysqlFileExtensionTip'),
+    },
   ],
   [DataSourceKey.POSTGRESQL]: [
     {
@@ -1622,6 +1630,14 @@ const generateDataSourceFormFields = (t: TFunction) => ({
       required: false,
       placeholder: 'updated_at',
       tooltip: t('setting.postgresqlTimestampColumnTip'),
+    },
+    {
+      label: 'File Extension',
+      name: 'config.file_extension',
+      type: FormFieldType.Text,
+      required: false,
+      placeholder: '.txt',
+      tooltip: t('setting.postgresqlFileExtensionTip'),
     },
   ],
   [DataSourceKey.BIGQUERY]: [


### PR DESCRIPTION
### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

Since the database fields often store HTML fragments or Markdown fragments, a custom file name suffix field was added in the database datasource. Also, when parsing HTML, it should be compatible with parsing HTML fragments (without a body tag), not just full HTML documents (with a body tag).

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ √] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
