### PR TITLE
fix: use /api/tags endpoint for Ollama model listing (#16000)

### DIFF
--- a/conf/models/ollama.json
+++ b/conf/models/ollama.json
@@ -2,7 +2,7 @@
   "name": "ollama",
   "url_suffix": {
     "chat": "api/chat",
-    "models": "api/ps",
+    "models": "api/tags",
     "embedding": "api/embed"
   },
   "class": "local"


### PR DESCRIPTION
### What problem does this PR solve?

After upgrading to v0.26.0, the Ollama provider returns an empty model list because the Go rewrite uses `/api/ps` (only running models) instead of `/api/tags` (all installed models). This PR changes the endpoint to `/api/tags`, restoring the ability to list and add Ollama models.

### Type of change

- [x] Bug Fix

### How has this been tested?

- Edited `conf/models/ollama.json` and verified that the model list populates correctly in the UI.
- The change is minimal and matches the previous Python implementation's endpoint.

### Related Issue

Closes #16000