### PR TITLE
refactor(go): replace GenerateUUID1 with GenerateToken for entity IDs

### DIFF
--- a/internal/service/dataset.go
+++ b/internal/service/dataset.go
@@ -529,7 +529,6 @@ func (s *DatasetService) SearchDatasets(req *SearchDatasetsRequest, userID strin
 	}, nil
 }
 
-
 // AutoMetadataField mirrors the REST dataset auto metadata field schema.
 type AutoMetadataField struct {
 	Name           string      `json:"name"`
@@ -857,10 +856,7 @@ func (s *DatasetService) CreateDataset(req *CreateDatasetRequest, tenantID strin
 		embdID = embeddingModel
 	}
 
-	kbID, err := utility.GenerateUUID1()
-	if err != nil {
-		return nil, common.CodeServerError, errors.New("Internal server error")
-	}
+	kbID := utility.GenerateToken()
 
 	status := string(entity.StatusValid)
 	// Deduplicate name within tenant

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -119,10 +119,7 @@ func (m *ModelProviderService) AddModelProvider(providerName, userID string) (co
 
 	tenantID := tenants[0].TenantID
 
-	providerID, err := utility.GenerateUUID1()
-	if err != nil {
-		return common.CodeServerError, errors.New("fail to get UUID")
-	}
+	providerID := utility.GenerateToken()
 
 	tenantModelProvider := &entity.TenantModelProvider{
 		ID:           providerID,
@@ -312,10 +309,7 @@ func (m *ModelProviderService) CreateProviderInstance(providerName, instanceName
 		return common.CodeServerError, err
 	}
 
-	instanceID, err := utility.GenerateUUID1()
-	if err != nil {
-		return common.CodeServerError, errors.New("fail to get UUID")
-	}
+	instanceID := utility.GenerateToken()
 
 	extra := make(map[string]string)
 	extra["region"] = region
@@ -1106,10 +1100,7 @@ func (m *ModelProviderService) UpdateModelStatus(providerName, instanceName, mod
 	model, err := m.modelDAO.GetModelByProviderIDAndInstanceIDAndModelName(provider.ID, instance.ID, modelName)
 	if err != nil {
 		var modelID string
-		modelID, err = utility.GenerateUUID1()
-		if err != nil {
-			return common.CodeServerError, errors.New("fail to get UUID")
-		}
+		modelID = utility.GenerateToken()
 
 		var modelSchema *modelModule.Model
 		modelSchema, err = dao.GetModelProviderManager().GetModelByName(providerName, modelName)
@@ -2070,11 +2061,7 @@ func (m *ModelProviderService) AddModel(request *AddModelRequest, userID string)
 			return common.CodeServerError, err
 		}
 
-		var modelID string
-		modelID, err = utility.GenerateUUID1()
-		if err != nil {
-			return common.CodeServerError, errors.New("fail to get UUID")
-		}
+		modelID := utility.GenerateToken()
 
 		extra := map[string]interface{}{
 			"max_tokens":  model.MaxTokens,

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -136,14 +136,8 @@ func (s *UserService) Register(req *RegisterRequest) (*entity.User, common.Error
 		return nil, common.CodeServerError, fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	userID, err := utility.GenerateUUID1()
-	if err != nil {
-		return nil, common.CodeServerError, fmt.Errorf("failed to generate user id: %w", err)
-	}
-	accessToken, err := utility.GenerateUUID1()
-	if err != nil {
-		return nil, common.CodeServerError, fmt.Errorf("failed to generate access token: %w", err)
-	}
+	userID := utility.GenerateToken()
+	accessToken := utility.GenerateToken()
 	status := "1"
 	loginChannel := "password"
 	isSuperuser := false
@@ -204,10 +198,7 @@ func (s *UserService) Register(req *RegisterRequest) (*entity.User, common.Error
 		ParserIDs: "naive:General,Q&A:Q&A,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
 		Status:    &status,
 	}
-	userTenantID, err := utility.GenerateUUID1()
-	if err != nil {
-		return nil, common.CodeServerError, fmt.Errorf("failed to generate user tenant id: %w", err)
-	}
+	userTenantID := utility.GenerateToken()
 	userTenant := &entity.UserTenant{
 		ID:        userTenantID,
 		UserID:    userID,
@@ -216,10 +207,7 @@ func (s *UserService) Register(req *RegisterRequest) (*entity.User, common.Error
 		InvitedBy: userID,
 		Status:    &status,
 	}
-	fileID, err := utility.GenerateUUID1()
-	if err != nil {
-		return nil, common.CodeServerError, fmt.Errorf("failed to generate file id: %w", err)
-	}
+	fileID := utility.GenerateToken()
 	file__ := ""
 	rootFile := &entity.File{
 		ID:        fileID,

--- a/internal/utility/token.go
+++ b/internal/utility/token.go
@@ -142,14 +142,6 @@ func GenerateToken() string {
 	return strings.ReplaceAll(uuid.New().String(), "-", "")
 }
 
-func GenerateUUID1() (string, error) {
-	id, err := uuid.NewUUID()
-	if err != nil {
-		return "", err
-	}
-	return strings.ReplaceAll(id.String(), "-", ""), nil
-}
-
 // GenerateAPIToken generates a secure random access key
 // Equivalent to Python's generate_confirmation_token():
 // return "ragflow-" + secrets.token_urlsafe(32)


### PR DESCRIPTION
### Description
- **Refactor**: Replaced `utility.GenerateUUID1` (UUID v1) with `utility.GenerateToken` (UUID v4) for generating entity IDs (`userID`, `kbID`, `modelID`, etc.).

- **Cleanup**: Removed the unused `GenerateUUID1` function from `utility` package.

- **Improvement**: Simplified ID generation logic and eliminated unnecessary error handling boilerplate since `GenerateToken` cannot fail.