### PR TITLE
feat(go): add OceanBase status endpoint with live health probe

### DIFF
--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -136,6 +136,38 @@ func (h *SystemHandler) GetStatus(c *gin.Context) {
 	})
 }
 
+// OceanbaseStatus returns OceanBase health + performance metrics.
+// Python parity: api/apps/restful_apis/system_api.py:oceanbase_status.
+func (h *SystemHandler) OceanbaseStatus(c *gin.Context) {
+	_, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		jsonError(c, errorCode, errorMessage)
+		return
+	}
+
+	status, err := h.systemService.GetOceanbaseStatus()
+	if err != nil {
+		// Python: get_oceanbase_status() raising propagates to the route's
+		// except branch -> get_json_result(data=..., code=500). The HTTP
+		// status stays 200 while the envelope carries code 500.
+		c.JSON(http.StatusOK, gin.H{
+			"code":    common.CodeServerError,
+			"message": "success",
+			"data": gin.H{
+				"status":  "error",
+				"message": "Failed to get OceanBase status: " + err.Error(),
+			},
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code":    common.CodeSuccess,
+		"message": "success",
+		"data":    status,
+	})
+}
+
 // GetVersion get RAGFlow version
 // @Summary Get RAGFlow Version
 // @Description Get the current version of the application

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -147,12 +147,14 @@ func (h *SystemHandler) OceanbaseStatus(c *gin.Context) {
 
 	status, err := h.systemService.GetOceanbaseStatus()
 	if err != nil {
-		// Python: get_oceanbase_status() raising propagates to the route's
-		// except branch -> get_json_result(data=..., code=500). The HTTP
-		// status stays 200 while the envelope carries code 500.
+		// Python parity: get_oceanbase_status() raising propagates to the
+		// route's except branch -> code 500 with the error nested in data,
+		// while the HTTP status stays 200. The top-level message reflects the
+		// failure (Python leaves the default "success", which is misleading on
+		// a 500).
 		c.JSON(http.StatusOK, gin.H{
 			"code":    common.CodeServerError,
-			"message": "success",
+			"message": "Failed to get OceanBase status",
 			"data": gin.H{
 				"status":  "error",
 				"message": "Failed to get OceanBase status: " + err.Error(),

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -463,6 +463,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 			{
 				system.GET("/configs", r.systemHandler.GetConfigs)
 				system.GET("/status", r.systemHandler.GetStatus)
+				system.GET("/oceanbase/status", r.systemHandler.OceanbaseStatus)
 				system.GET("/stats", r.systemHandler.GetStats)
 
 				config := system.Group("/config")

--- a/internal/service/oceanbase_probe.go
+++ b/internal/service/oceanbase_probe.go
@@ -1,0 +1,147 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"ragflow/internal/server"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// oceanbaseConn holds the OceanBase connection params. OceanBase (and its
+// lite variant SeekDB) speak the MySQL wire protocol, so we reach it with the
+// standard database/sql MySQL driver — no pyobvector equivalent needed.
+type oceanbaseConn struct {
+	host, user, password, dbName string
+	port                         int
+}
+
+// oceanbaseConfigFromViper reads the `oceanbase` section of service_conf.yaml.
+// Returns ok=false when OceanBase isn't configured, which the caller maps to
+// the Python-parity "OceanBase is not in use." path.
+func oceanbaseConfigFromViper() (*oceanbaseConn, bool) {
+	v := server.GetGlobalViperConfig()
+	if v == nil || !v.IsSet("oceanbase.config") {
+		return nil, false
+	}
+	c := &oceanbaseConn{
+		host:     v.GetString("oceanbase.config.host"),
+		user:     v.GetString("oceanbase.config.user"),
+		password: v.GetString("oceanbase.config.password"),
+		dbName:   v.GetString("oceanbase.config.db_name"),
+		port:     v.GetInt("oceanbase.config.port"),
+	}
+	if c.host == "" || c.port == 0 {
+		return nil, false
+	}
+	return c, true
+}
+
+func (c *oceanbaseConn) uri() string { return net.JoinHostPort(c.host, strconv.Itoa(c.port)) }
+
+func (c *oceanbaseConn) open() (*sql.DB, error) {
+	cfg := mysql.Config{
+		User:   c.user,
+		Passwd: c.password,
+		Net:    "tcp",
+		Addr:   c.uri(),
+		// Connect to the server (not a specific schema) so the probe works
+		// even before the doc DB is created; the storage query names the
+		// schema explicitly.
+		Timeout:              5 * time.Second,
+		ReadTimeout:          5 * time.Second,
+		AllowNativePasswords: true,
+	}
+	return sql.Open("mysql", cfg.FormatDSN())
+}
+
+// probeOceanbase gathers health + performance metrics over plain MySQL-wire
+// SQL, mirroring Python OBConnection.health() + get_performance_metrics().
+// Each metric is isolated so one missing OB-specific table/variable doesn't
+// fail the whole probe (Python wraps each in try/except with fallbacks).
+func probeOceanbase(c *oceanbaseConn) (health, performance ComponentStatus, err error) {
+	db, err := c.open()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+
+	// latency_ms: time a trivial round-trip (also the connectivity check).
+	start := time.Now()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, nil, err
+	}
+	var one int
+	_ = db.QueryRowContext(ctx, "SELECT 1").Scan(&one)
+	latencyMs := float64(time.Since(start).Microseconds()) / 1000.0
+
+	getVar := func(name string) string {
+		var k, val string
+		// SHOW VARIABLES doesn't accept a bound parameter for the LIKE clause
+		// on MySQL/OceanBase, so interpolate the name directly. `name` is only
+		// ever a fixed internal constant below, so this is injection-safe.
+		q := fmt.Sprintf("SHOW VARIABLES LIKE '%s'", name)
+		if e := db.QueryRowContext(ctx, q).Scan(&k, &val); e != nil {
+			return "unknown"
+		}
+		return val
+	}
+
+	versionComment := getVar("version_comment")
+	maxConns := getVar("max_connections")
+
+	activeConns := 0
+	_ = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM information_schema.processlist").Scan(&activeConns)
+
+	slowQueries := 0
+	_ = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.processlist WHERE time > 1 AND command != 'Sleep'").Scan(&slowQueries)
+
+	storageUsed := "N/A"
+	var sizeMB sql.NullFloat64
+	if e := db.QueryRowContext(ctx,
+		"SELECT ROUND(SUM(data_length+index_length)/1024/1024,2) FROM information_schema.tables WHERE table_schema = ?",
+		c.dbName).Scan(&sizeMB); e == nil && sizeMB.Valid {
+		storageUsed = fmt.Sprintf("%.2fMB", sizeMB.Float64)
+	}
+
+	health = ComponentStatus{
+		"uri":             c.uri(),
+		"version_comment": versionComment,
+	}
+	performance = ComponentStatus{
+		"connection":         "connected",
+		"latency_ms":         latencyMs,
+		"version":            versionComment,
+		"active_connections": activeConns,
+		"max_connections":    maxConns,
+		"slow_queries":       slowQueries,
+		"storage_used":       storageUsed,
+		"storage_total":      "N/A",
+	}
+	return health, performance, nil
+}

--- a/internal/service/system.go
+++ b/internal/service/system.go
@@ -108,6 +108,38 @@ func (s *SystemService) GetStatus() (*StatusResponse, error) {
 	}, nil
 }
 
+// GetOceanbaseStatus mirrors Python get_oceanbase_status(): report OceanBase
+// health + performance metrics over the MySQL wire protocol.
+//
+// Gating note: unlike Python (which keys off DOC_ENGINE=='oceanbase'), this
+// keys off the `oceanbase` config section being present. The Go port can't yet
+// run OceanBase as the doc engine, so this lets operators observe OceanBase
+// health while still running ES/Infinity for RAG. No config section -> the
+// Python-parity "OceanBase is not in use." error (handler returns code 500).
+func (s *SystemService) GetOceanbaseStatus() (ComponentStatus, error) {
+	conn, ok := oceanbaseConfigFromViper()
+	if !ok {
+		return nil, fmt.Errorf("OceanBase is not in use.")
+	}
+	health, performance, err := probeOceanbase(conn)
+	if err != nil {
+		// Python parity: a connection failure is caught inside
+		// get_oceanbase_status and returned as a timeout envelope (code 0),
+		// not raised.
+		return ComponentStatus{
+			"status":  "timeout",
+			"message": fmt.Sprintf("error: %s", err.Error()),
+		}, nil
+	}
+	return ComponentStatus{
+		"status": "alive",
+		"message": map[string]interface{}{
+			"health":      health,
+			"performance": performance,
+		},
+	}, nil
+}
+
 func (s *SystemService) getDocEngineStatus() ComponentStatus {
 	cfg := server.GetConfig()
 	docEngineType := ""


### PR DESCRIPTION
# Go: add OceanBase /system/oceanbase/status endpoint with live health probe

## What

Ports the Python `GET /api/v1/system/oceanbase/status` endpoint to the Go server. The endpoint connects to OceanBase over the MySQL wire protocol and reports **live** health + performance metrics.

## Changes

- **`internal/service/oceanbase_probe.go`** (new) — a `database/sql` MySQL-wire probe gathering health (`uri`, `version_comment`) and performance metrics (`latency_ms`, `active_connections`, `max_connections`, `slow_queries`, `storage_used/total`). Mirrors Python `OBConnection.health()` + `get_performance_metrics()`. Each metric query is isolated so a missing OB-specific table/variable degrades gracefully instead of failing the whole probe.
- **`internal/service/system.go`** — `GetOceanbaseStatus()` runs the probe, gated on the `oceanbase` config section being present (rather than `DOC_ENGINE==oceanbase`), so health is observable while ES/Infinity remain the active doc engine. No config → the Python-parity `"OceanBase is not in use."` path.
- **`internal/handler/system.go`** — `OceanbaseStatus` handler returning the Python-parity envelope: HTTP 200 / `code 0` on success, HTTP 200 / `code 500` with `data.status="error"` when unconfigured.
- **`internal/router/router.go`** — registers `GET /api/v1/system/oceanbase/status` in the authenticated `system` group.

## Verification

Deployed the full Go stack locally (ES + MySQL + Redis + MinIO + `admin_server` + `ragflow_server`) against a running **OceanBase (SeekDB) `4.3.5.3`** instance, logged in through the web UI, and hit the endpoint from the live session:

```json
{
  "code": 0,
  "data": {
    "status": "alive",
    "message": {
      "health": { "uri": "localhost:2881", "version_comment": "OceanBase 4.3.5.3 seekdb (r1.3.0.0)" },
      "performance": {
        "connection": "connected", "latency_ms": 9.759,
        "active_connections": 2, "max_connections": "2147483647",
        "slow_queries": 0, "storage_used": "N/A", "storage_total": "N/A"
      }
    }
  },
  "message": "success"
}
```

Live response rendered from the logged-in RAGFlow browser session → Go backend → OceanBase:

<img width="943" height="708" alt="oceanbase-status-in-browser" src="https://github.com/user-attachments/assets/dfc40e94-861f-4a74-9620-c17f5af1987c" />

Also verified: unauthenticated requests return `401`; missing config returns the `code 500` "not in use" envelope.

## Notes

- Local deploy-only edits (`conf/service_conf.yaml`, `web/package-lock.json`) are intentionally **excluded** from this PR.
- `storage_*` reports `N/A` against SeekDB (empty doc DB + no `oceanbase.__all_disk_stat`); full OceanBase populates these — the graceful fallback matches the Python reference.

