### PR TITLE
feat(connector): add SitemapConnector for sitemap.xml-based web ingestion

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -125,6 +125,7 @@ class FileSource(StrEnum):
     LOCAL = ""
     KNOWLEDGEBASE = "knowledgebase"
     RSS = "rss"
+    SITEMAP = "sitemap"
     S3 = "s3"
     NOTION = "notion"
     REST_API = "rest_api"

--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -25,6 +25,7 @@ SOFTWARE.
 
 from .blob_connector import BlobStorageConnector
 from .rss_connector import RSSConnector
+from .sitemap_connector import SitemapConnector
 from .slack_connector import SlackConnector
 from .gmail_connector import GmailConnector
 from .notion_connector import NotionConnector
@@ -62,6 +63,7 @@ from .exceptions import (
 __all__ = [
     "BlobStorageConnector",
     "RSSConnector",
+    "SitemapConnector",
     "SlackConnector",
     "GmailConnector",
     "NotionConnector",

--- a/common/data_source/config.py
+++ b/common/data_source/config.py
@@ -41,6 +41,7 @@ class BlobType(str, Enum):
 class DocumentSource(str, Enum):
     """Document sources"""
     RSS = "rss"
+    SITEMAP = "sitemap"
     S3 = "s3"
     NOTION = "notion"
     REST_API = "rest_api"

--- a/common/data_source/sitemap_connector.py
+++ b/common/data_source/sitemap_connector.py
@@ -1,0 +1,365 @@
+import hashlib
+import logging
+import re
+from datetime import datetime, timezone
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import urljoin, urlparse
+from xml.etree import ElementTree as ET
+
+import requests
+
+from common.data_source.config import (
+    REQUEST_TIMEOUT_SECONDS,
+    DocumentSource,
+)
+
+from common.data_source.interfaces import LoadConnector, PollConnector, SlimConnectorWithPermSync
+from common.data_source.models import (
+    Document,
+    GenerateDocumentsOutput,
+    GenerateSlimDocumentOutput,
+    SecondsSinceUnixEpoch,
+    SlimDocument,
+)
+from common.ssrf_guard import assert_url_is_safe
+
+_SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+_MAX_REDIRECTS = 10
+_MAX_SITEMAP_DEPTH = 5
+
+logger = logging.getLogger(__name__)
+
+
+class SitemapConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
+    """Connector that ingests web pages listed in a sitemap.xml.
+
+    Supports:
+    - Standard urlset sitemaps
+    - Sitemap index files (recursive, up to _MAX_SITEMAP_DEPTH levels)
+    - Incremental polling via <lastmod>
+    """
+
+    def __init__(
+        self,
+        sitemap_url: str,
+        batch_size: int = 10,
+        user_agent: str = "RAGFlow-SitemapConnector/1.0",
+        url_filter: str | None = None,
+        follow_pdf_links: bool = False,
+        restrict_pdf_to_domain: bool = True,
+    ) -> None:
+        self.sitemap_url = sitemap_url.strip()
+        self.batch_size = batch_size
+        self.user_agent = user_agent
+        try:
+            self._url_filter: re.Pattern | None = (
+                re.compile(url_filter) if url_filter else None
+            )
+        except re.error as exc:
+            raise ValueError(f"url_filter is not a valid regex: {exc}") from exc
+        self.follow_pdf_links = follow_pdf_links
+        self.restrict_pdf_to_domain = restrict_pdf_to_domain
+        self.credentials: dict[str, Any] = {}
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self.credentials = credentials or {}
+        return None
+
+    def validate_connector_settings(self) -> None:
+        self._validate_url(self.sitemap_url)
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be greater than 0")
+        if not any(self._url_matches(u[0]) for u in self._iter_sitemap_urls(self.sitemap_url, depth=0)):
+            raise ValueError("Sitemap contains no URLs matching the filter")
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        yield from self._load_urls()
+
+    def poll_source(
+        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
+    ) -> GenerateDocumentsOutput:
+        yield from self._load_urls(start=start, end=end)
+
+    def retrieve_all_slim_docs_perm_sync(
+        self, callback: Any = None
+    ) -> GenerateSlimDocumentOutput:
+        del callback
+        batch: list[SlimDocument] = []
+        for url, _lastmod in self._iter_sitemap_urls(self.sitemap_url, depth=0):
+            if not self._url_matches(url):
+                continue
+            batch.append(SlimDocument(id=self._build_document_id(url)))
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_urls(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+    ) -> GenerateDocumentsOutput:
+        seen: set[str] = set()
+        pending_pdfs: list[tuple[str, str]] = []  # (pdf_url, parent_url)
+        sitemap_domain = urlparse(self.sitemap_url).netloc
+
+        # --- Pass 1: sitemap URLs ---
+        batch: list[Document] = []
+        for url, lastmod in self._iter_sitemap_urls(self.sitemap_url, depth=0):
+            if url in seen or not self._url_matches(url):
+                continue
+            seen.add(url)
+
+            if start is not None or end is not None:
+                if lastmod is None:
+                    if start is not None:
+                        continue
+                else:
+                    ts = lastmod.timestamp()
+                    if start is not None and ts <= start:
+                        continue
+                    if end is not None and ts > end:
+                        continue
+
+            doc = self._fetch_and_build_document(
+                url, lastmod, seen, pending_pdfs, sitemap_domain
+            )
+            if doc is None:
+                continue
+
+            batch.append(doc)
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+
+        if batch:
+            yield batch
+
+        # --- Pass 2: PDF links discovered from HTML pages ---
+        if not self.follow_pdf_links or not pending_pdfs:
+            return
+
+        batch = []
+        for pdf_url, parent_url in pending_pdfs:
+            doc = self._fetch_and_build_document(pdf_url, None, seen, [], sitemap_domain, parent_url)
+            if doc is None:
+                continue
+            batch.append(doc)
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+
+        if batch:
+            yield batch
+
+    def _iter_sitemap_urls(
+        self, sitemap_url: str, depth: int
+    ) -> Iterator[tuple[str, datetime | None]]:
+        """Recursively yield (url, lastmod) pairs from a sitemap or sitemap index."""
+        if depth > _MAX_SITEMAP_DEPTH:
+            logger.warning("Max sitemap depth reached, stopping at %s", sitemap_url)
+            return
+
+        try:
+            self._validate_url(sitemap_url)
+            content, _ = self._fetch_raw(sitemap_url)
+        except Exception as exc:
+            logger.warning("Failed to fetch sitemap %s: %s", sitemap_url, exc)
+            return
+
+        try:
+            root = ET.fromstring(content)
+        except ET.ParseError as exc:
+            raise ValueError(f"Failed to parse sitemap XML from {sitemap_url!r}: {exc}") from exc
+
+        tag = root.tag.lower()
+
+        # Sitemap index → recurse into child sitemaps
+        if "sitemapindex" in tag:
+            for sitemap_el in root.iter(f"{{{_SITEMAP_NS}}}sitemap"):
+                loc_el = sitemap_el.find(f"{{{_SITEMAP_NS}}}loc")
+                if loc_el is None or not (loc_el.text or "").strip():
+                    continue
+                child_url = loc_el.text.strip()
+                yield from self._iter_sitemap_urls(child_url, depth + 1)
+            return
+
+        # Standard urlset
+        for url_el in root.iter(f"{{{_SITEMAP_NS}}}url"):
+            loc_el = url_el.find(f"{{{_SITEMAP_NS}}}loc")
+            if loc_el is None or not (loc_el.text or "").strip():
+                continue
+            loc = loc_el.text.strip()
+
+            lastmod: datetime | None = None
+            lastmod_el = url_el.find(f"{{{_SITEMAP_NS}}}lastmod")
+            if lastmod_el is not None and (lastmod_el.text or "").strip():
+                lastmod = self._parse_lastmod(lastmod_el.text.strip())
+
+            yield loc, lastmod
+
+    def _fetch_and_build_document(
+        self,
+        url: str,
+        lastmod: datetime | None,
+        seen: set[str] | None = None,
+        pending_pdfs: list[tuple[str, str]] | None = None,
+        sitemap_domain: str | None = None,
+        parent_url: str | None = None,
+    ) -> Document | None:
+        try:
+            self._validate_url(url)
+            raw, content_type = self._fetch_raw(url)
+        except Exception as exc:
+            logger.warning("Failed to fetch page %s: %s", url, exc)
+            return None
+
+        updated_at = lastmod or datetime.now(timezone.utc)
+
+        if "application/pdf" in content_type:
+            if not raw:
+                logger.debug("Empty PDF for %s, skipping", url)
+                return None
+            blob = raw
+            extension = ".pdf"
+        else:
+            if self.follow_pdf_links and seen is not None and pending_pdfs is not None:
+                for pdf_url in self._extract_pdf_links(raw, url):
+                    if pdf_url not in seen:
+                        if not self.restrict_pdf_to_domain or urlparse(pdf_url).netloc == sitemap_domain:
+                            pending_pdfs.append((pdf_url, url))
+                            seen.add(pdf_url)
+
+            try:
+                import trafilatura
+                text = trafilatura.extract(
+                    raw.decode("utf-8", errors="replace"),
+                    output_format="markdown",
+                    include_links=True,
+                    include_tables=True,
+                    include_images=False,
+                    favor_recall=True,
+                )
+            except Exception as exc:
+                logger.warning("Failed to parse page %s: %s", url, exc)
+                return None
+
+            if not text or not text.strip():
+                logger.debug("Empty content for %s, skipping", url)
+                return None
+
+            blob = text.encode("utf-8")
+            extension = ".md"
+
+        return Document(
+            id=self._build_document_id(url),
+            source=DocumentSource.SITEMAP,
+            semantic_identifier=self._url_to_identifier(url),
+            extension=extension,
+            blob=blob,
+            doc_updated_at=updated_at,
+            size_bytes=len(blob),
+            metadata={
+                "sitemap_url": self.sitemap_url,
+                "url": url,
+                **({"parent_url": parent_url} if parent_url else {}),
+            },
+        )
+
+    @staticmethod
+    def _extract_pdf_links(html_bytes: bytes, base_url: str) -> list[str]:
+        """Extract absolute PDF href links from an HTML page."""
+        from html.parser import HTMLParser
+
+        class _Extractor(HTMLParser):
+            def __init__(self):
+                super().__init__()
+                self.links: list[str] = []
+
+            def handle_starttag(self, tag, attrs):
+                if tag == "a":
+                    href = dict(attrs).get("href", "") or ""
+                    if href.lower().endswith(".pdf"):
+                        self.links.append(href)
+
+        ex = _Extractor()
+        ex.feed(html_bytes.decode("utf-8", errors="replace"))
+        return [urljoin(base_url, lnk) for lnk in ex.links]
+
+    def _fetch_raw(self, url: str) -> tuple[bytes, str]:
+        """Fetch a URL with redirect following and SSRF protection.
+
+        Returns (content, content_type).
+        """
+        current_url = url
+        current_hostname, current_ip = assert_url_is_safe(current_url)
+
+        response: requests.Response | None = None
+        for _ in range(_MAX_REDIRECTS + 1):
+            response = requests.get(
+                current_url,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+                allow_redirects=False,
+                headers={"User-Agent": self.user_agent},
+            )
+            if response.status_code not in (301, 302, 303, 307, 308):
+                break
+            location = response.headers.get("Location")
+            if not location:
+                break
+            redirect_url = urljoin(current_url, location)
+            current_hostname, current_ip = assert_url_is_safe(redirect_url)
+            current_url = redirect_url
+        else:
+            raise ValueError(f"Exceeded {_MAX_REDIRECTS} redirects fetching {url!r}")
+
+        response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "").lower()
+        return response.content, content_type
+
+    @staticmethod
+    def _validate_url(url: str) -> tuple[str, str]:
+        if not url:
+            raise ValueError("URL is required")
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"URL must be a valid http or https URL: {url!r}")
+        return assert_url_is_safe(url)
+
+    def _url_matches(self, url: str) -> bool:
+        if self._url_filter is None:
+            return True
+        return bool(self._url_filter.search(url))
+
+    @staticmethod
+    def _url_to_identifier(url: str) -> str:
+        parsed = urlparse(url)
+        identifier = f"{parsed.netloc}{parsed.path}"
+        if parsed.query:
+            identifier += f"?{parsed.query}"
+        if parsed.fragment:
+            identifier += f"#{parsed.fragment}"
+        return identifier.strip("/") or url
+
+    @staticmethod
+    def _build_document_id(url: str) -> str:
+        return f"sitemap:{hashlib.md5(url.encode('utf-8')).hexdigest()}"
+
+    @staticmethod
+    def _parse_lastmod(value: str) -> datetime | None:
+        for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d"):
+            try:
+                dt = datetime.strptime(value, fmt)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.astimezone(timezone.utc)
+            except ValueError:
+                continue
+        logger.debug("Unrecognised lastmod format: %r", value)
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "elasticsearch-dsl==8.12.0",
     "exceptiongroup>=1.3.0,<2.0.0",
     "feedparser>=6.0.11,<7.0.0",
+    "trafilatura>=2.0.0",
     "extract-msg>=0.39.0",
     "ffmpeg-python>=0.2.0",
     "flasgger>=0.9.7.1,<0.10.0",

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -47,6 +47,7 @@ from common.data_source.config import INDEX_BATCH_SIZE
 from common.data_source import (
     BlobStorageConnector,
     RSSConnector,
+    SitemapConnector,
     NotionConnector,
     DiscordConnector,
     GoogleDriveConnector,
@@ -525,6 +526,52 @@ class RSS(SyncBase):
             end_time,
         )
         return document_generator
+
+
+class Sitemap(SyncBase):
+    SOURCE_NAME: str = FileSource.SITEMAP
+
+    @staticmethod
+    def _sanitize_docs(gen):
+        """Strip URL scheme from semantic_identifier so object storage accepts it as a key."""
+        from urllib.parse import urlparse
+        for batch in gen:
+            sanitized = []
+            for doc in batch:
+                si = doc.semantic_identifier
+                if si.startswith(("http://", "https://")):
+                    parsed = urlparse(si)
+                    si = f"{parsed.netloc}{parsed.path}"
+                    if parsed.query:
+                        si += f"?{parsed.query}"
+                    if parsed.fragment:
+                        si += f"#{parsed.fragment}"
+                    si = si.strip("/")
+                    doc = doc.model_copy(update={"semantic_identifier": si})
+                sanitized.append(doc)
+            yield sanitized
+
+    async def _generate(self, task: dict):
+        self.connector = SitemapConnector(
+            sitemap_url=self.conf["sitemap_url"],
+            batch_size=self.conf.get("batch_size", INDEX_BATCH_SIZE),
+            user_agent=self.conf.get("user_agent", "RAGFlow-SitemapConnector/1.0"),
+            url_filter=self.conf.get("url_filter"),
+            follow_pdf_links=self.conf.get("follow_pdf_links", False),
+            restrict_pdf_to_domain=self.conf.get("restrict_pdf_to_domain", True),
+        )
+        self.connector.load_credentials(self.conf.get("credentials", {}))
+        self.connector.validate_connector_settings()
+        self.log_connection("Sitemap", self.conf["sitemap_url"], task)
+
+        if task["reindex"] == "1" or not task["poll_range_start"]:
+            return self._sanitize_docs(self.connector.load_from_state())
+
+        end_time = datetime.now(timezone.utc).timestamp()
+        return self._sanitize_docs(self.connector.poll_source(
+            task["poll_range_start"].timestamp(),
+            end_time,
+        ))
 
 
 class Confluence(SyncBase):
@@ -2139,6 +2186,7 @@ class REST_API(SyncBase):
 
 func_factory = {
     FileSource.RSS: RSS,
+    FileSource.SITEMAP: Sitemap,
     FileSource.S3: S3,
     FileSource.R2: R2,
     FileSource.OCI_STORAGE: OCI_STORAGE,

--- a/test/unit_test/data_source/test_sitemap_connector_unit.py
+++ b/test/unit_test/data_source/test_sitemap_connector_unit.py
@@ -1,0 +1,403 @@
+"""Unit tests for SitemapConnector — no network, no external dependencies."""
+import importlib
+import sys
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+_sitemap_mod = importlib.import_module("common.data_source.sitemap_connector")
+SitemapConnector = _sitemap_mod.SitemapConnector
+DocumentSource = importlib.import_module("common.data_source.config").DocumentSource
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+
+_SITEMAP_XML = f"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="{_NS}">
+  <url>
+    <loc>https://example.com/page-1</loc>
+    <lastmod>2024-03-15</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/page-2</loc>
+  </url>
+</urlset>""".encode()
+
+_SITEMAP_INDEX_XML = f"""<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="{_NS}">
+  <sitemap>
+    <loc>https://example.com/sitemap-en.xml</loc>
+  </sitemap>
+</sitemapindex>""".encode()
+
+_CHILD_SITEMAP_XML = f"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="{_NS}">
+  <url>
+    <loc>https://example.com/en/page-1</loc>
+    <lastmod>2024-06-01</lastmod>
+  </url>
+</urlset>""".encode()
+
+_SITEMAP_TWO_PAGES = f"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="{_NS}">
+  <url><loc>https://example.com/page-1</loc></url>
+  <url><loc>https://example.com/page-2</loc></url>
+</urlset>""".encode()
+
+_HTML_WITH_PDF = b"""<html><body>
+  <a href="/docs/report.pdf">Report</a>
+  <a href="https://other.com/external.pdf">External PDF</a>
+  <p>Some content about the report.</p>
+</body></html>"""
+
+_HTML_SAME_PDF = b'<html><body><a href="/shared.pdf">Shared</a></html>'
+
+_PDF_BYTES = b"%PDF-1.4 fake pdf content"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_response(content: bytes, content_type: str = "text/html; charset=utf-8"):
+    resp = MagicMock()
+    resp.content = content
+    resp.status_code = 200
+    resp.headers.get.side_effect = lambda key, default="": {
+        "Content-Type": content_type,
+    }.get(key, default)
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_get(url_map: dict):
+    def _get(url, **kwargs):
+        if url in url_map:
+            return url_map[url]
+        raise AssertionError(f"Unexpected URL requested in test: {url!r}")
+    return _get
+
+
+def _patch_ssrf(monkeypatch):
+    monkeypatch.setattr(_sitemap_mod, "assert_url_is_safe", lambda url: ("example.com", "1.2.3.4"))
+
+
+def _patch_requests(monkeypatch, url_map: dict):
+    monkeypatch.setattr(_sitemap_mod.requests, "get", _make_get(url_map))
+
+
+def _patch_trafilatura(monkeypatch, text="# Title\n\nBody text."):
+    mock = MagicMock()
+    mock.extract.return_value = text
+    monkeypatch.setitem(sys.modules, "trafilatura", mock)
+    return mock
+
+
+def _connector(**kwargs):
+    return SitemapConnector(sitemap_url="https://example.com/sitemap.xml", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# validate_connector_settings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_validate_rejects_non_http_scheme():
+    connector = SitemapConnector(sitemap_url="ftp://example.com/sitemap.xml")
+    with pytest.raises(ValueError, match="valid http or https URL"):
+        connector.validate_connector_settings()
+
+
+@pytest.mark.p2
+def test_validate_rejects_batch_size_below_one(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    connector = _connector(batch_size=0)
+    with pytest.raises(ValueError, match="batch_size"):
+        connector.validate_connector_settings()
+
+
+@pytest.mark.p2
+def test_validate_rejects_sitemap_with_no_matching_urls(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_requests(monkeypatch, {"https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML)})
+    connector = _connector(url_filter=r"/blog/.*")
+    with pytest.raises(ValueError, match="no URLs matching"):
+        connector.validate_connector_settings()
+
+
+@pytest.mark.p2
+def test_validate_accepts_valid_sitemap(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_requests(monkeypatch, {"https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML)})
+    _connector().validate_connector_settings()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _iter_sitemap_urls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_iter_sitemap_urls_parses_standard_urlset(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_requests(monkeypatch, {"https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML)})
+    results = list(_connector()._iter_sitemap_urls("https://example.com/sitemap.xml", depth=0))
+
+    assert len(results) == 2
+    assert results[0] == ("https://example.com/page-1", datetime(2024, 3, 15, tzinfo=timezone.utc))
+    assert results[1] == ("https://example.com/page-2", None)
+
+
+@pytest.mark.p2
+def test_iter_sitemap_urls_recurses_into_index(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_INDEX_XML),
+        "https://example.com/sitemap-en.xml": _fake_response(_CHILD_SITEMAP_XML),
+    })
+    results = list(_connector()._iter_sitemap_urls("https://example.com/sitemap.xml", depth=0))
+
+    assert len(results) == 1
+    assert results[0][0] == "https://example.com/en/page-1"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_and_build_document
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_fetch_builds_markdown_doc_for_html(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch, text="# Title\n\nHello world.")
+    _patch_requests(monkeypatch, {"https://example.com/page-1": _fake_response(b"<html>page</html>")})
+    lastmod = datetime(2024, 3, 15, tzinfo=timezone.utc)
+    doc = _connector()._fetch_and_build_document("https://example.com/page-1", lastmod)
+
+    assert doc is not None
+    assert doc.source == DocumentSource.SITEMAP
+    assert doc.extension == ".md"
+    assert doc.semantic_identifier == "example.com/page-1"
+    assert b"Hello world" in doc.blob
+    assert doc.doc_updated_at == lastmod
+    assert "parent_url" not in doc.metadata
+
+
+@pytest.mark.p2
+def test_fetch_builds_pdf_doc_for_pdf_content_type(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/doc.pdf": _fake_response(_PDF_BYTES, content_type="application/pdf"),
+    })
+    doc = _connector()._fetch_and_build_document("https://example.com/doc.pdf", None)
+
+    assert doc is not None
+    assert doc.extension == ".pdf"
+    assert doc.blob == _PDF_BYTES
+    assert doc.semantic_identifier == "example.com/doc.pdf"
+
+
+@pytest.mark.p2
+def test_fetch_skips_empty_html_content(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch, text="")
+    _patch_requests(monkeypatch, {"https://example.com/page": _fake_response(b"<html></html>")})
+    doc = _connector()._fetch_and_build_document("https://example.com/page", None)
+    assert doc is None
+
+
+# ---------------------------------------------------------------------------
+# load_from_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_load_from_state_yields_all_documents(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML),
+        "https://example.com/page-1": _fake_response(b"<html>p1</html>"),
+        "https://example.com/page-2": _fake_response(b"<html>p2</html>"),
+    })
+    batches = list(_connector(batch_size=10).load_from_state())
+    assert sum(len(b) for b in batches) == 2
+
+
+@pytest.mark.p2
+def test_load_from_state_respects_batch_size(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML),
+        "https://example.com/page-1": _fake_response(b"<html>p1</html>"),
+        "https://example.com/page-2": _fake_response(b"<html>p2</html>"),
+    })
+    batches = list(_connector(batch_size=1).load_from_state())
+    assert len(batches) == 2
+    assert all(len(b) == 1 for b in batches)
+
+
+# ---------------------------------------------------------------------------
+# poll_source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_poll_source_includes_url_within_range(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML),
+        "https://example.com/page-1": _fake_response(b"<html>p1</html>"),
+    })
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp()
+    end = datetime(2024, 12, 31, tzinfo=timezone.utc).timestamp()
+    docs = [doc for batch in _connector().poll_source(start, end) for doc in batch]
+
+    # page-1 has lastmod 2024-03-15 (in range); page-2 has no lastmod (skipped)
+    assert [doc.semantic_identifier for doc in docs] == ["example.com/page-1"]
+
+
+@pytest.mark.p2
+def test_poll_source_excludes_url_before_start(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_requests(monkeypatch, {"https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML)})
+    # start after 2024-03-15 → page-1 excluded; page-2 has no lastmod → excluded too
+    start = datetime(2024, 6, 1, tzinfo=timezone.utc).timestamp()
+    end = datetime(2024, 12, 31, tzinfo=timezone.utc).timestamp()
+    batches = list(_connector().poll_source(start, end))
+    assert batches == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_pdf_links
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_extract_pdf_links_returns_absolute_urls():
+    links = SitemapConnector._extract_pdf_links(_HTML_WITH_PDF, "https://example.com/page")
+    assert "https://example.com/docs/report.pdf" in links
+    assert "https://other.com/external.pdf" in links
+
+
+@pytest.mark.p2
+def test_extract_pdf_links_empty_when_no_pdf_hrefs():
+    links = SitemapConnector._extract_pdf_links(b"<html><a href='/page'>link</a></html>", "https://example.com/")
+    assert links == []
+
+
+# ---------------------------------------------------------------------------
+# follow_pdf_links
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_follow_pdf_links_yields_pdf_documents(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML),
+        "https://example.com/page-1": _fake_response(_HTML_WITH_PDF),
+        "https://example.com/page-2": _fake_response(b"<html>no pdfs</html>"),
+        "https://example.com/docs/report.pdf": _fake_response(_PDF_BYTES, content_type="application/pdf"),
+    })
+    connector = _connector(follow_pdf_links=True, restrict_pdf_to_domain=True)
+    docs = [doc for batch in connector.load_from_state() for doc in batch]
+
+    assert any(doc.extension == ".pdf" for doc in docs)
+    assert any(doc.extension == ".md" for doc in docs)
+
+
+@pytest.mark.p2
+def test_follow_pdf_links_sets_parent_url_in_metadata(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML),
+        "https://example.com/page-1": _fake_response(_HTML_WITH_PDF),
+        "https://example.com/page-2": _fake_response(b"<html>no pdfs</html>"),
+        "https://example.com/docs/report.pdf": _fake_response(_PDF_BYTES, content_type="application/pdf"),
+    })
+    connector = _connector(follow_pdf_links=True, restrict_pdf_to_domain=True)
+    docs = [doc for batch in connector.load_from_state() for doc in batch]
+    pdf_docs = [doc for doc in docs if doc.extension == ".pdf"]
+
+    assert len(pdf_docs) == 1
+    assert pdf_docs[0].metadata["parent_url"] == "https://example.com/page-1"
+
+
+@pytest.mark.p2
+def test_follow_pdf_links_restricts_to_domain(monkeypatch):
+    """External PDF (other.com) must not be fetched when restrict_pdf_to_domain=True."""
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    # https://other.com/external.pdf is intentionally NOT in the map
+    # _make_get raises AssertionError if it is called
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML),
+        "https://example.com/page-1": _fake_response(_HTML_WITH_PDF),
+        "https://example.com/page-2": _fake_response(b"<html>no pdfs</html>"),
+        "https://example.com/docs/report.pdf": _fake_response(_PDF_BYTES, content_type="application/pdf"),
+    })
+    connector = _connector(follow_pdf_links=True, restrict_pdf_to_domain=True)
+    docs = [doc for batch in connector.load_from_state() for doc in batch]
+    pdf_identifiers = [doc.semantic_identifier for doc in docs if doc.extension == ".pdf"]
+
+    assert any("report.pdf" in s for s in pdf_identifiers)
+    assert not any("external.pdf" in s for s in pdf_identifiers)
+
+
+@pytest.mark.p2
+def test_follow_pdf_links_allows_external_when_unrestricted(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML),
+        "https://example.com/page-1": _fake_response(_HTML_WITH_PDF),
+        "https://example.com/page-2": _fake_response(b"<html>no pdfs</html>"),
+        "https://example.com/docs/report.pdf": _fake_response(_PDF_BYTES, content_type="application/pdf"),
+        "https://other.com/external.pdf": _fake_response(_PDF_BYTES, content_type="application/pdf"),
+    })
+    connector = _connector(follow_pdf_links=True, restrict_pdf_to_domain=False)
+    docs = [doc for batch in connector.load_from_state() for doc in batch]
+    pdf_count = sum(1 for doc in docs if doc.extension == ".pdf")
+    assert pdf_count == 2
+
+
+@pytest.mark.p2
+def test_pdf_deduplicated_when_linked_from_multiple_pages(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_trafilatura(monkeypatch)
+    _patch_requests(monkeypatch, {
+        "https://example.com/sitemap.xml": _fake_response(_SITEMAP_TWO_PAGES),
+        "https://example.com/page-1": _fake_response(_HTML_SAME_PDF),
+        "https://example.com/page-2": _fake_response(_HTML_SAME_PDF),
+        # shared.pdf must be fetched exactly once
+        "https://example.com/shared.pdf": _fake_response(_PDF_BYTES, content_type="application/pdf"),
+    })
+    connector = _connector(follow_pdf_links=True, restrict_pdf_to_domain=True)
+    docs = [doc for batch in connector.load_from_state() for doc in batch]
+    pdf_docs = [doc for doc in docs if doc.extension == ".pdf"]
+    assert len(pdf_docs) == 1
+
+
+# ---------------------------------------------------------------------------
+# retrieve_all_slim_docs_perm_sync
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.p2
+def test_retrieve_all_slim_docs_yields_one_per_url(monkeypatch):
+    _patch_ssrf(monkeypatch)
+    _patch_requests(monkeypatch, {"https://example.com/sitemap.xml": _fake_response(_SITEMAP_XML)})
+    slim_docs = [doc for batch in _connector().retrieve_all_slim_docs_perm_sync() for doc in batch]
+
+    assert len(slim_docs) == 2
+    assert all(doc.id.startswith("sitemap:") for doc in slim_docs)


### PR DESCRIPTION
## Summary

Closes #12328

Adds a `SitemapConnector` that ingests web pages listed in a `sitemap.xml` into a RAGFlow knowledge base, with incremental sync support.

- Supports standard `urlset` sitemaps and `sitemapindex` files (recursive, up to 5 levels)
- Incremental polling via `<lastmod>` timestamps — only pages modified since the last sync are re-fetched
- HTML → Markdown extraction via **trafilatura** (removes nav/footer noise, preserves links and tables)
- **PDF support**: URLs with `Content-Type: application/pdf` are stored as raw `.pdf` blobs and processed by the existing RAGFlow PDF pipeline
- Optional PDF link discovery from HTML pages (`follow_pdf_links`), with domain restriction and global deduplication
- `url_filter` regex to restrict which URLs are indexed
- SSRF protection via `assert_url_is_safe` on every HTTP request
- Configurable `user_agent` and `batch_size`

## Files changed

| File | Change |
|---|---|
| `common/data_source/sitemap_connector.py` | New connector (LoadConnector + PollConnector + SlimConnectorWithPermSync) |
| `common/constants.py` | `FileSource.SITEMAP = "sitemap"` |
| `common/data_source/config.py` | `DocumentSource.SITEMAP = "sitemap"` |
| `common/data_source/__init__.py` | Export `SitemapConnector` |
| `rag/svr/sync_data_source.py` | `Sitemap(SyncBase)` class + `func_factory` entry |
| `pyproject.toml` | Add `trafilatura>=2.0.0` dependency |
| `test/unit_test/data_source/test_sitemap_connector_unit.py` | 21 unit tests (no network) |

## Test plan

- [x] 21 unit tests pass (`pytest test/unit_test/data_source/test_sitemap_connector_unit.py`)
- [x] Tests cover: URL validation, sitemap index recursion, HTML→Markdown, PDF Content-Type, lastmod filtering, PDF link scanning, domain restriction, deduplication, slim docs sync

🤖 Generated with [Claude Code](https://claude.ai/claude-code)