### PR TITLE
fix: improve remember me checkbox UX in login form

### DIFF
--- a/web/src/pages/login-next/index.tsx
+++ b/web/src/pages/login-next/index.tsx
@@ -149,8 +149,8 @@ function LoginFormContent({
                   name="remember"
                   render={({ field }) => (
                     <FormItem>
-                      <FormControl>
-                        <div className="flex gap-2 group">
+                      <div className="flex gap-2 group">
+                        <FormControl>
                           <Checkbox
                             checked={field.value}
                             onCheckedChange={(checked) => {
@@ -158,17 +158,16 @@ function LoginFormContent({
                             }}
                             className="group-hover:border-border-default group-hover:bg-border-button"
                           />
-                          <FormLabel
-                            className={cn('cursor-pointer', {
-                              'text-text-disabled': !field.value,
-                              'text-text-primary': field.value,
-                            })}
-                            onClick={() => field.onChange(!field.value)}
-                          >
-                            {t('rememberMe')}
-                          </FormLabel>
-                        </div>
-                      </FormControl>
+                        </FormControl>
+                        <FormLabel
+                          className={cn('cursor-pointer', {
+                            'text-text-disabled': !field.value,
+                            'text-text-primary': field.value,
+                          })}
+                        >
+                          {t('rememberMe')}
+                        </FormLabel>
+                      </div>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/web/src/pages/login-next/index.tsx
+++ b/web/src/pages/login-next/index.tsx
@@ -150,18 +150,20 @@ function LoginFormContent({
                   render={({ field }) => (
                     <FormItem>
                       <FormControl>
-                        <div className="flex gap-2">
+                        <div className="flex gap-2 group">
                           <Checkbox
                             checked={field.value}
                             onCheckedChange={(checked) => {
                               field.onChange(checked);
                             }}
+                            className="group-hover:border-border-default group-hover:bg-border-button"
                           />
                           <FormLabel
-                            className={cn(' hover:text-text-primary', {
+                            className={cn('cursor-pointer', {
                               'text-text-disabled': !field.value,
                               'text-text-primary': field.value,
                             })}
+                            onClick={() => field.onChange(!field.value)}
                           >
                             {t('rememberMe')}
                           </FormLabel>


### PR DESCRIPTION
### What problem does this PR solve?

## What
- Add `group` class to wrapper div to enable hover state coordination
- Apply hover styles to checkbox via group-hover
- Make FormLabel clickable via onClick toggle + cursor-pointer
- Fix label color logic: disabled vs primary state

## Why
The "Remember me" label was not clickable and had no hover feedback,
making the UX inconsistent with standard checkbox behavior.

## How to test
0. Go to the demo video before/after attached below
1. Go to the login page
2. Click directly on the "Remember me" label → should toggle the checkbox
3. Hover over the checkbox area → should show hover styles

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## Before

https://github.com/user-attachments/assets/bd47d45c-09ea-437f-bd98-3397ce040c1e

## After

https://github.com/user-attachments/assets/45c65d1a-bec7-4ad6-8f1c-d149f7296f8f




