### PR TITLE
Fix MCP dataset page size configuration

### DIFF
--- a/docs/develop/mcp/launch_mcp_server.md
+++ b/docs/develop/mcp/launch_mcp_server.md
@@ -64,6 +64,10 @@ Where:
 
 The RAGFlow MCP server supports two transports: the legacy SSE transport (served at `/sse`), introduced on November 5, 2024, and deprecated on March 26, 2025, and the streamable-HTTP transport (served at `/mcp`). The legacy SSE transport and the streamable HTTP transport with JSON responses are enabled by default. To disable either transport, use the flags `--no-transport-sse-enabled` or `--no-transport-streamable-http-enabled`. To disable JSON responses for the streamable HTTP transport,  use the `--no-json-response` flag.
 
+### Dataset list page size
+
+The MCP server fetches datasets with a default page size of `100`. To use a smaller page size, set `RAGFLOW_MCP_DATASET_PAGE_SIZE` to an integer between `1` and `100`.
+
 ### Launch from Docker
 
 #### 1. Enable MCP server

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -63,6 +63,13 @@ class RAGFlowConnector:
     _dataset_metadata_cache: OrderedDict[str, tuple[dict, float | int]] = OrderedDict()  # "dataset_id" -> (metadata, expiry_ts)
     _document_metadata_cache: OrderedDict[str, tuple[list[tuple[str, dict]], float | int]] = OrderedDict()  # "dataset_id" -> ([(document_id, doc_metadata)], expiry_ts)
 
+    @staticmethod
+    def _validate_dataset_page_size(page_size: int) -> int:
+        """Validate dataset list page size against the backend API limit."""
+        if page_size < 1 or page_size > 100:
+            raise ValueError("page_size must be between 1 and 100.")
+        return page_size
+
     def __init__(self, base_url: str, version="v1"):
         self.base_url = base_url
         self.version = version
@@ -166,6 +173,7 @@ class RAGFlowConnector:
         """Return accessible datasets as newline-delimited JSON for MCP tool descriptions."""
         if page_size is None:
             page_size = self._DATASET_PAGE_SIZE
+        page_size = self._validate_dataset_page_size(page_size)
         res_json = await self._fetch_datasets_page(api_key=api_key, page=page, page_size=page_size, orderby=orderby, desc=desc, id=id, name=name)
         result_list = []
         for data in res_json["data"]:
@@ -690,6 +698,7 @@ def create_starlette_app():
     help="Enable or disable JSON response mode for streamable-http (default: enabled)",
 )
 def main(base_url, host, port, mode, api_key, transport_sse_enabled, transport_streamable_http_enabled, json_response):
+    """Launch the RAGFlow MCP server."""
     import os
 
     import uvicorn
@@ -698,19 +707,26 @@ def main(base_url, host, port, mode, api_key, transport_sse_enabled, transport_s
     load_dotenv()
 
     def parse_bool_flag(key: str, default: bool) -> bool:
+        """Parse a boolean MCP launch option from the environment."""
         val = os.environ.get(key, str(default))
         return str(val).strip().lower() in ("1", "true", "yes", "on")
 
-    def parse_int_flag(key: str, default: int) -> int:
+    def parse_dataset_page_size(default: int) -> int:
+        """Parse the dataset list page size from the environment."""
+        key = "RAGFLOW_MCP_DATASET_PAGE_SIZE"
         val = os.environ.get(key)
         if val is None:
+            logging.info("%s is not set; using default value %s.", key, default)
             return default
         try:
             parsed = int(val)
         except ValueError as e:
             raise click.UsageError(f"{key} must be an integer.") from e
-        if parsed < 1 or parsed > 100:
-            raise click.UsageError(f"{key} must be between 1 and 100.")
+        try:
+            parsed = RAGFlowConnector._validate_dataset_page_size(parsed)
+        except ValueError as e:
+            raise click.UsageError(f"{key} must be between 1 and 100.") from e
+        logging.info("%s is set; using value %s.", key, parsed)
         return parsed
 
     global BASE_URL, HOST, PORT, MODE, HOST_API_KEY, TRANSPORT_SSE_ENABLED, TRANSPORT_STREAMABLE_HTTP_ENABLED, JSON_RESPONSE
@@ -722,7 +738,7 @@ def main(base_url, host, port, mode, api_key, transport_sse_enabled, transport_s
     TRANSPORT_SSE_ENABLED = parse_bool_flag("RAGFLOW_MCP_TRANSPORT_SSE_ENABLED", transport_sse_enabled)
     TRANSPORT_STREAMABLE_HTTP_ENABLED = parse_bool_flag("RAGFLOW_MCP_TRANSPORT_STREAMABLE_ENABLED", transport_streamable_http_enabled)
     JSON_RESPONSE = parse_bool_flag("RAGFLOW_MCP_JSON_RESPONSE", json_response)
-    RAGFlowConnector._DATASET_PAGE_SIZE = parse_int_flag("RAGFLOW_MCP_DATASET_PAGE_SIZE", RAGFlowConnector._DATASET_PAGE_SIZE)
+    RAGFlowConnector._DATASET_PAGE_SIZE = parse_dataset_page_size(RAGFlowConnector._DATASET_PAGE_SIZE)
 
     if MODE == LaunchMode.SELF_HOST and not HOST_API_KEY:
         raise click.UsageError("--api-key is required when --mode is 'self-host'")

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -58,7 +58,7 @@ JSON_RESPONSE = True
 class RAGFlowConnector:
     _MAX_DATASET_CACHE = 32
     _CACHE_TTL = 300
-    _DATASET_PAGE_SIZE = 1000
+    _DATASET_PAGE_SIZE = 100
 
     _dataset_metadata_cache: OrderedDict[str, tuple[dict, float | int]] = OrderedDict()  # "dataset_id" -> (metadata, expiry_ts)
     _document_metadata_cache: OrderedDict[str, tuple[list[tuple[str, dict]], float | int]] = OrderedDict()  # "dataset_id" -> ([(document_id, doc_metadata)], expiry_ts)
@@ -162,8 +162,10 @@ class RAGFlowConnector:
 
         return res_json
 
-    async def list_datasets(self, *, api_key: str, page: int = 1, page_size: int = 1000, orderby: str = "create_time", desc: bool = True, id: str | None = None, name: str | None = None):
+    async def list_datasets(self, *, api_key: str, page: int = 1, page_size: int | None = None, orderby: str = "create_time", desc: bool = True, id: str | None = None, name: str | None = None):
         """Return accessible datasets as newline-delimited JSON for MCP tool descriptions."""
+        if page_size is None:
+            page_size = self._DATASET_PAGE_SIZE
         res_json = await self._fetch_datasets_page(api_key=api_key, page=page, page_size=page_size, orderby=orderby, desc=desc, id=id, name=name)
         result_list = []
         for data in res_json["data"]:
@@ -699,6 +701,18 @@ def main(base_url, host, port, mode, api_key, transport_sse_enabled, transport_s
         val = os.environ.get(key, str(default))
         return str(val).strip().lower() in ("1", "true", "yes", "on")
 
+    def parse_int_flag(key: str, default: int) -> int:
+        val = os.environ.get(key)
+        if val is None:
+            return default
+        try:
+            parsed = int(val)
+        except ValueError as e:
+            raise click.UsageError(f"{key} must be an integer.") from e
+        if parsed < 1 or parsed > 100:
+            raise click.UsageError(f"{key} must be between 1 and 100.")
+        return parsed
+
     global BASE_URL, HOST, PORT, MODE, HOST_API_KEY, TRANSPORT_SSE_ENABLED, TRANSPORT_STREAMABLE_HTTP_ENABLED, JSON_RESPONSE
     BASE_URL = os.environ.get("RAGFLOW_MCP_BASE_URL", base_url)
     HOST = os.environ.get("RAGFLOW_MCP_HOST", host)
@@ -708,6 +722,7 @@ def main(base_url, host, port, mode, api_key, transport_sse_enabled, transport_s
     TRANSPORT_SSE_ENABLED = parse_bool_flag("RAGFLOW_MCP_TRANSPORT_SSE_ENABLED", transport_sse_enabled)
     TRANSPORT_STREAMABLE_HTTP_ENABLED = parse_bool_flag("RAGFLOW_MCP_TRANSPORT_STREAMABLE_ENABLED", transport_streamable_http_enabled)
     JSON_RESPONSE = parse_bool_flag("RAGFLOW_MCP_JSON_RESPONSE", json_response)
+    RAGFlowConnector._DATASET_PAGE_SIZE = parse_int_flag("RAGFLOW_MCP_DATASET_PAGE_SIZE", RAGFlowConnector._DATASET_PAGE_SIZE)
 
     if MODE == LaunchMode.SELF_HOST and not HOST_API_KEY:
         raise click.UsageError("--api-key is required when --mode is 'self-host'")


### PR DESCRIPTION
### What problem does this PR solve?

The MCP server uses `page_size=1000` when listing datasets, but the backend datasets API validates `page_size` with an upper bound of `100`. This can make MCP tool listing fail with a validation error.

This PR changes the default MCP dataset list page size to `100`, adds `RAGFLOW_MCP_DATASET_PAGE_SIZE` for configuration within the backend limit, and documents the new environment variable.

Validation:
- `python -m py_compile mcp/server/server.py`
- `git diff --check`

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update
