### PR TITLE
fix(service): tenant_rerank_id is an integer, not a string

### DIFF
--- a/internal/handler/searchbot.go
+++ b/internal/handler/searchbot.go
@@ -120,7 +120,7 @@ type SearchBotRetrievalTestRequest struct {
 	CrossLanguages         []string               `json:"cross_languages,omitempty"`
 	SearchID               *string                `json:"search_id,omitempty"`
 	MetaDataFilter         map[string]interface{} `json:"meta_data_filter,omitempty"`
-	TenantRerankID         *string                `json:"tenant_rerank_id,omitempty"`
+	TenantRerankID         *int                   `json:"tenant_rerank_id,omitempty"`
 	RerankID               *string                `json:"rerank_id,omitempty"`
 	Keyword                *bool                  `json:"keyword,omitempty"`
 	SimilarityThreshold    *float64               `json:"similarity_threshold,omitempty"`

--- a/internal/service/chunk/chunk.go
+++ b/internal/service/chunk/chunk.go
@@ -358,12 +358,8 @@ func (s *ChunkService) RetrievalTest(req *service.RetrievalTestRequest, userID s
 	// Get rerank model if RerankID is specified
 	var rerankModel *models.RerankModel
 	var rerankCompositeName string
-	if req.TenantRerankID != nil && *req.TenantRerankID != "" {
-		tenantRerankIDInt, parseErr := strconv.ParseInt(*req.TenantRerankID, 10, 64)
-		if parseErr != nil {
-			return nil, fmt.Errorf("invalid tenant_rerank_id: %w", parseErr)
-		}
-		_, rerankCompositeName, err = dao.LookupTenantLLMByID(dao.NewTenantLLMDAO(), tenantRerankIDInt)
+	if req.TenantRerankID != nil {
+		_, rerankCompositeName, err = dao.LookupTenantLLMByID(dao.NewTenantLLMDAO(), int64(*req.TenantRerankID))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get rerank model by tenant_rerank_id: %w", err)
 		}

--- a/internal/service/chunk_rerank_test.go
+++ b/internal/service/chunk_rerank_test.go
@@ -1,0 +1,47 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Issue #15714: tenant_rerank_id is a tenant-LLM id (an integer), matching the
+// *int64 column on the entity structs — not a string. The request struct must
+// accept a JSON integer and reject a JSON string (so the old strconv.ParseInt
+// compensation is no longer needed).
+func TestRetrievalTestRequestTenantRerankIDIsInt(t *testing.T) {
+	var r RetrievalTestRequest
+	if err := json.Unmarshal([]byte(`{"tenant_rerank_id": 5}`), &r); err != nil {
+		t.Fatalf("integer tenant_rerank_id should unmarshal, got error: %v", err)
+	}
+	if r.TenantRerankID == nil || *r.TenantRerankID != 5 {
+		t.Fatalf("want TenantRerankID=5, got %v", r.TenantRerankID)
+	}
+
+	var r2 RetrievalTestRequest
+	if err := json.Unmarshal([]byte(`{"tenant_rerank_id": "5"}`), &r2); err == nil {
+		t.Fatalf("a string tenant_rerank_id must be rejected now that the field is *int")
+	}
+
+	// omitted field stays nil (optional)
+	var r3 RetrievalTestRequest
+	if err := json.Unmarshal([]byte(`{}`), &r3); err != nil || r3.TenantRerankID != nil {
+		t.Fatalf("absent tenant_rerank_id should be nil, got %v (err %v)", r3.TenantRerankID, err)
+	}
+}

--- a/internal/service/chunk_types.go
+++ b/internal/service/chunk_types.go
@@ -54,7 +54,7 @@ type RetrievalTestRequest struct {
 	CrossLanguages         []string               `json:"cross_languages,omitempty"`
 	SearchID               *string                `json:"search_id,omitempty"`
 	Filter                 map[string]interface{} `json:"meta_data_filter,omitempty"`
-	TenantRerankID         *string                `json:"tenant_rerank_id,omitempty"`
+	TenantRerankID         *int                   `json:"tenant_rerank_id,omitempty"`
 	RerankID               *string                `json:"rerank_id,omitempty"`
 	Keyword                *bool                  `json:"keyword,omitempty"`
 	SimilarityThreshold    *float64               `json:"similarity_threshold,omitempty"`


### PR DESCRIPTION
service.RetrievalTestRequest.TenantRerankID was *string while Python defines
tenant_rerank_id as int | None (Pydantic) backed by an IntegerField, so the
canonical integer payload {"tenant_rerank_id": 123} failed binding with a 400
and only a non-canonical quoted form worked. Change the field to *int and drop
the strconv.ParseInt compensation; add a JSON contract regression test.

Note: the issue also lists internal/handler/searchbot.go, but no
SearchBotRetrievalTestRequest / TenantRerankID field exists on current main —
nothing to change there.

Closes #15714