### PR TITLE
fix(go): all_models.json

### DIFF
--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -278,7 +278,8 @@
     {
       "name": "amazon/nova-micro-v1",
       "alias": [
-        "amazon.nova-micro-v1:0"
+        "amazon.nova-micro-v1:0",
+        "us.amazon.nova-micro-v1:0"
       ],
       "model_types": [
         "chat"
@@ -365,7 +366,8 @@
     {
       "name": "anthropic/claude-fable-5",
       "alias": [
-        "anthropic.claude-fable-5"
+        "anthropic.claude-fable-5",
+        "claude-fable-5"
       ],
       "model_types": [
         "chat",
@@ -379,7 +381,9 @@
     },
     {
       "name": "anthropic/claude-mythos-5",
-      "alias": [],
+      "alias": [
+        "claude-mythos-5"
+      ],
       "model_types": [
         "chat",
         "vision"
@@ -663,7 +667,9 @@
       "name": "anthropic/claude-sonnet-4-5",
       "alias": [
         "anthropic.claude-sonnet-4-5",
-        "anthropic/claude-sonnet-4.5"
+        "anthropic/claude-sonnet-4.5",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4.5"
       ],
       "model_types": [
         "chat",
@@ -696,7 +702,8 @@
     {
       "name": "anthropic/claude-sonnet-4-7",
       "alias": [
-        "anthropic.claude-sonnet-4-7"
+        "anthropic.claude-sonnet-4-7",
+        "claude-sonnet-4-7"
       ],
       "model_types": [
         "chat",
@@ -882,16 +889,6 @@
       }
     },
     {
-      "name": "antigravity-preview-05-2026",
-      "alias": [
-        "models/antigravity-preview-05-2026"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "arcee-ai/coder-large",
       "alias": [],
       "model_types": [
@@ -996,7 +993,8 @@
     {
       "name": "azure/o1-preview",
       "alias": [
-        "azure/eu/o1-preview"
+        "azure/eu/o1-preview",
+        "openai/o1-preview"
       ],
       "max_tokens": 128000,
       "model_types": [
@@ -1029,7 +1027,10 @@
     },
     {
       "name": "BAAI/bge-reranker-v2-m3",
-      "alias": [],
+      "alias": [
+        "bge-reranker-v2-m3",
+        "Pro/BAAI/bge-reranker-v2-m3"
+      ],
       "model_types": [
         "rerank"
       ],
@@ -1074,7 +1075,9 @@
     },
     {
       "name": "BAAI/bge-m3",
-      "alias": [],
+      "alias": [
+        "bge-m3"
+      ],
       "model_types": [
         "embedding"
       ],
@@ -1999,25 +2002,6 @@
       ]
     },
     {
-      "name": "bge-m3",
-      "alias": [],
-      "max_tokens": 8192,
-      "model_types": [
-        "embedding"
-      ],
-      "max_dimension": 1024
-    },
-    {
-      "name": "bge-reranker-v2-m3",
-      "alias": [
-        "Pro/BAAI/bge-reranker-v2-m3"
-      ],
-      "max_tokens": 1024,
-      "model_types": [
-        "rerank"
-      ]
-    },
-    {
       "name": "bigcode/starcoder2-15b-instruct-v0.1",
       "alias": [
         "starcoder2-15b-instruct-v0.1"
@@ -2837,7 +2821,8 @@
     {
       "name": "bytedance-seed/doubao-seedance-1-5-pro",
       "alias": [
-        "doubao-seedance-1-5-pro"
+        "doubao-seedance-1-5-pro",
+        "doubao-seedance-1-5-pro-251215"
       ],
       "model_types": [
         "video_generation"
@@ -3221,19 +3206,6 @@
       ]
     },
     {
-      "name": "claude-fable-5",
-      "alias": [],
-      "max_tokens": 1000000,
-      "model_types": [
-        "chat",
-        "vision"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
       "name": "claude-haiku-4-5-20251001",
       "alias": [
         "anthropic/claude-haiku-4-5",
@@ -3256,18 +3228,6 @@
       "max_tokens": 200000,
       "model_types": [
         "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "claude-mythos-5",
-      "max_tokens": 1000000,
-      "model_types": [
-        "chat",
-        "vision"
       ],
       "thinking": {
         "default_value": true,
@@ -3415,21 +3375,6 @@
       }
     },
     {
-      "name": "claude-sonnet-4-5",
-      "alias": [
-        "claude-sonnet-4.5"
-      ],
-      "max_tokens": 1000000,
-      "model_types": [
-        "chat",
-        "vision"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
       "name": "claude-sonnet-4-5-20250929",
       "max_tokens": 200000,
       "model_types": [
@@ -3470,19 +3415,6 @@
       "max_tokens": 1000000,
       "model_types": [
         "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "claude-sonnet-4-7",
-      "alias": [],
-      "max_tokens": 1000000,
-      "model_types": [
-        "chat",
-        "vision"
       ],
       "thinking": {
         "default_value": true,
@@ -3917,26 +3849,6 @@
       ]
     },
     {
-      "name": "deep-research-max-preview-04-2026",
-      "alias": [
-        "models/deep-research-max-preview-04-2026"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deep-research-preview-04-2026",
-      "alias": [
-        "models/deep-research-preview-04-2026"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "deepcogito/cogito-v2.1-671b",
       "alias": [],
       "model_types": [
@@ -4225,7 +4137,9 @@
         "deepseek-chat",
         "deepseek/deepseek-v4-flash",
         "deepseek-v4-flash-260425",
-        "deepseek/deepseek-v4-flash-202605"
+        "deepseek/deepseek-v4-flash-202605",
+        "deepseek-v4-flash",
+        "Deepseek V4 Flash"
       ],
       "model_types": [
         "chat"
@@ -4239,7 +4153,8 @@
     {
       "name": "deepseek-ai/deepseek-v4-flash-base",
       "alias": [
-        "deepseek/deepseek-v4-flash-base"
+        "deepseek/deepseek-v4-flash-base",
+        "deepseek-v4-flash-base"
       ],
       "model_types": [
         "chat"
@@ -4251,7 +4166,9 @@
       "alias": [
         "deepseek/deepseek-v4-pro",
         "deepseek-v4-pro-260425",
-        "deepseek/deepseek-v4-pro-202606"
+        "deepseek/deepseek-v4-pro-202606",
+        "deepseek-v4-pro",
+        "Deepseek V4 Pro"
       ],
       "model_types": [
         "chat"
@@ -4265,7 +4182,8 @@
     {
       "name": "deepseek-ai/deepseek-v4-pro-base",
       "alias": [
-        "deepseek/deepseek-v4-pro-base"
+        "deepseek/deepseek-v4-pro-base",
+        "deepseek-v4-pro-base"
       ],
       "model_types": [
         "chat"
@@ -4306,7 +4224,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v3.2-exp-base",
-      "alias": [],
+      "alias": [
+        "deepseek-v3.2-exp-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4315,7 +4235,8 @@
     {
       "name": "deepseek-ai/deepseek-v3.2-speciale",
       "alias": [
-        "deepseek/deepseek-v3.2-speciale-or"
+        "deepseek/deepseek-v3.2-speciale-or",
+        "deepseek-v3.2-speciale"
       ],
       "model_types": [
         "chat"
@@ -4336,7 +4257,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v3.1-base",
-      "alias": [],
+      "alias": [
+        "deepseek-v3.1-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4380,7 +4303,13 @@
     {
       "name": "deepseek-ai/deepseek-v3",
       "alias": [
-        "deepseek/deepseek-chat"
+        "deepseek/deepseek-chat",
+        "deepseek-v3",
+        "deepseek/deepseek_v3",
+        "deepseek_v3",
+        "DeepSeek V3",
+        "deepseek/deepseek-v3",
+        "deepseek-v3-241226"
       ],
       "model_types": [
         "chat"
@@ -4389,7 +4318,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v3-base",
-      "alias": [],
+      "alias": [
+        "deepseek-v3-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4397,7 +4328,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2.5",
-      "alias": [],
+      "alias": [
+        "deepseek-v2.5"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4405,7 +4338,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2.5-1210",
-      "alias": [],
+      "alias": [
+        "deepseek-v2.5-1210"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4413,7 +4348,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-base",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-v2-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4421,7 +4358,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-instruct",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-v2-instruct"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4429,7 +4368,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-instruct-0724",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-v2-instruct-0724"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4437,7 +4378,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-lite-base",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-v2-lite-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4445,7 +4388,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-lite-instruct",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-v2-lite-instruct"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4454,7 +4399,8 @@
     {
       "name": "deepseek-ai/deepseek-math-v2",
       "alias": [
-        "deepseek/deepseek-math-v2"
+        "deepseek/deepseek-math-v2",
+        "deepseek-math-v2"
       ],
       "model_types": [
         "chat"
@@ -4463,7 +4409,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v2-671b",
-      "alias": [],
+      "alias": [
+        "deepseek-prover-v2-671b"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4471,7 +4419,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v2-7b",
-      "alias": [],
+      "alias": [
+        "deepseek-prover-v2-7b"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4479,7 +4429,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2",
-      "alias": [],
+      "alias": [
+        "deepseek-v2"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4487,7 +4439,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-chat",
-      "alias": [],
+      "alias": [
+        "deepseek-v2-chat"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4495,7 +4449,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-chat-0628",
-      "alias": [],
+      "alias": [
+        "deepseek-v2-chat-0628"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4503,7 +4459,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-lite",
-      "alias": [],
+      "alias": [
+        "deepseek-v2-lite"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4511,7 +4469,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-lite-chat",
-      "alias": [],
+      "alias": [
+        "deepseek-v2-lite-chat"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4519,7 +4479,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-7b-base-v1.5",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-7b-base-v1.5"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4527,7 +4489,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-7b-instruct-v1.5",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-7b-instruct-v1.5"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4535,7 +4499,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-base",
-      "alias": [],
+      "alias": [
+        "deepseek-prover-v1.5-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4543,7 +4509,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-rl",
-      "alias": [],
+      "alias": [
+        "deepseek-prover-v1.5-rl"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4551,7 +4519,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-sft",
-      "alias": [],
+      "alias": [
+        "deepseek-prover-v1.5-sft"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4559,7 +4529,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1",
-      "alias": [],
+      "alias": [
+        "deepseek-prover-v1"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4645,7 +4617,11 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-0528-qwen3-8b",
-      "alias": [],
+      "alias": [
+        "deepseek-r1-0528-qwen3-8b",
+        "deepseek/deepseek-r1-0528-qwen3-8b",
+        "DeepSeek R1 0528 Qwen3 8B"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4663,7 +4639,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-llama-8b",
-      "alias": [],
+      "alias": [
+        "deepseek-r1-distill-llama-8b"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4687,7 +4665,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-zero",
-      "alias": [],
+      "alias": [
+        "deepseek-r1-zero"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4695,7 +4675,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl2",
-      "alias": [],
+      "alias": [
+        "deepseek-vl2"
+      ],
       "model_types": [
         "image2text"
       ],
@@ -4703,7 +4685,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl2-small",
-      "alias": [],
+      "alias": [
+        "deepseek-vl2-small"
+      ],
       "model_types": [
         "image2text"
       ],
@@ -4711,7 +4695,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl2-tiny",
-      "alias": [],
+      "alias": [
+        "deepseek-vl2-tiny"
+      ],
       "model_types": [
         "image2text"
       ],
@@ -4719,7 +4705,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-1.3b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-1.3b-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4727,7 +4715,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-1.3b-instruct",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-1.3b-instruct"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4735,7 +4725,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-33b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-33b-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4743,7 +4735,10 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-33b-instruct",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-33b-instruct",
+        "Deepseek Coder 33B Instruct"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4751,7 +4746,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-5.7bmqa-base",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-5.7bmqa-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4759,7 +4756,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-6.7b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-6.7b-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4767,7 +4766,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-6.7b-instruct",
-      "alias": [],
+      "alias": [
+        "deepseek-coder-6.7b-instruct"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4775,7 +4776,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-67b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-llm-67b-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4783,7 +4786,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-67b-chat",
-      "alias": [],
+      "alias": [
+        "deepseek-llm-67b-chat"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4791,7 +4796,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-7b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-llm-7b-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4799,7 +4806,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-7b-chat",
-      "alias": [],
+      "alias": [
+        "deepseek-llm-7b-chat"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4807,7 +4816,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-math-7b-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4815,7 +4826,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-instruct",
-      "alias": [],
+      "alias": [
+        "deepseek-math-7b-instruct"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4823,7 +4836,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-rl",
-      "alias": [],
+      "alias": [
+        "deepseek-math-7b-rl"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4831,7 +4846,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-moe-16b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-moe-16b-base"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4839,7 +4856,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-moe-16b-chat",
-      "alias": [],
+      "alias": [
+        "deepseek-moe-16b-chat"
+      ],
       "model_types": [
         "chat"
       ],
@@ -4855,7 +4874,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-1.3b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-vl-1.3b-base"
+      ],
       "model_types": [
         "image2text"
       ],
@@ -4863,7 +4884,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-1.3b-chat",
-      "alias": [],
+      "alias": [
+        "deepseek-vl-1.3b-chat"
+      ],
       "model_types": [
         "image2text"
       ],
@@ -4871,7 +4894,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-7b-base",
-      "alias": [],
+      "alias": [
+        "deepseek-vl-7b-base"
+      ],
       "model_types": [
         "image2text"
       ],
@@ -4879,7 +4904,9 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-7b-chat",
-      "alias": [],
+      "alias": [
+        "deepseek-vl-7b-chat"
+      ],
       "model_types": [
         "image2text"
       ],
@@ -4903,200 +4930,6 @@
       "model_types": [
         "text-to-image",
         "image_generation"
-      ]
-    },
-    {
-      "name": "deepseek-coder-1.3b-base",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-1.3b-instruct",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-33b-base",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-33b-instruct",
-      "alias": [
-        "Deepseek Coder 33B Instruct"
-      ],
-      "max_tokens": 16384,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-5.7bmqa-base",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-6.7b-base",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-6.7b-instruct",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-7b-base-v1.5",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-7b-instruct-v1.5",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-v2-base",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-v2-instruct",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-v2-instruct-0724",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-v2-lite-base",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-coder-v2-lite-instruct",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-llm-67b-base",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-llm-67b-chat",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-llm-7b-base",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-llm-7b-chat",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-math-7b-base",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-math-7b-instruct",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-math-7b-rl",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-math-v2",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-moe-16b-base",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-moe-16b-chat",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
       ]
     },
     {
@@ -5124,54 +4957,6 @@
         "chat",
         "vision",
         "image2text"
-      ]
-    },
-    {
-      "name": "deepseek-prover-v1",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-prover-v1.5-base",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-prover-v1.5-rl",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-prover-v1.5-sft",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-prover-v2-671b",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-prover-v2-7b",
-      "alias": [],
-      "max_tokens": 32768,
-      "model_types": [
-        "chat"
       ]
     },
     {
@@ -5205,18 +4990,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "deepseek-r1-0528-qwen3-8b",
-      "alias": [
-        "deepseek/deepseek-r1-0528-qwen3-8b",
-        "DeepSeek R1 0528 Qwen3 8B"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat"
-      ],
-      "max_completion_tokens": 32000
     },
     {
       "name": "deepseek-r1-2025-01-20",
@@ -5260,14 +5033,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "deepseek-r1-distill-llama-8b",
-      "alias": [],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat"
-      ]
     },
     {
       "name": "deepseek-r1-distill-qwen-1.5b",
@@ -5352,14 +5117,6 @@
       }
     },
     {
-      "name": "deepseek-r1-zero",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "deepseek-reasoner",
       "alias": [
         "deepseek/deepseek-reasoner"
@@ -5372,77 +5129,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "deepseek-v2",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v2-chat",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v2-chat-0628",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v2-lite",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v2-lite-chat",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v2.5",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v2.5-1210",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v3",
-      "alias": [
-        "deepseek/deepseek_v3",
-        "deepseek_v3",
-        "DeepSeek V3",
-        "deepseek/deepseek-v3",
-        "deepseek-v3-241226"
-      ],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ],
-      "max_completion_tokens": 16000
     },
     {
       "name": "deepseek-v3-0324",
@@ -5478,14 +5164,6 @@
       ]
     },
     {
-      "name": "deepseek-v3-base",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "deepseek-v3-huoshan",
       "max_tokens": 64000,
       "model_types": [
@@ -5508,14 +5186,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "deepseek-v3.1-base",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
     },
     {
       "name": "deepseek-v3.1-huoshan",
@@ -5582,14 +5252,6 @@
       }
     },
     {
-      "name": "deepseek-v3.2-exp-base",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "deepseek-v3.2-exp-thinking",
       "max_tokens": 128000,
       "model_types": [
@@ -5601,14 +5263,6 @@
       }
     },
     {
-      "name": "deepseek-v3.2-speciale",
-      "alias": [],
-      "max_tokens": 163840,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "deepseek-v3.2-thinking",
       "max_tokens": 128000,
       "model_types": [
@@ -5618,108 +5272,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "deepseek-v4-flash",
-      "alias": [
-        "Deepseek V4 Flash"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "max_completion_tokens": 393216
-    },
-    {
-      "name": "deepseek-v4-flash-base",
-      "alias": [],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-v4-pro",
-      "alias": [
-        "Deepseek V4 Pro"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "max_completion_tokens": 393216
-    },
-    {
-      "name": "deepseek-v4-pro-base",
-      "alias": [],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "deepseek-vl-1.3b-base",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "image2text"
-      ]
-    },
-    {
-      "name": "deepseek-vl-1.3b-chat",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "image2text"
-      ]
-    },
-    {
-      "name": "deepseek-vl-7b-base",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "image2text"
-      ]
-    },
-    {
-      "name": "deepseek-vl-7b-chat",
-      "alias": [],
-      "max_tokens": 16384,
-      "model_types": [
-        "image2text"
-      ]
-    },
-    {
-      "name": "deepseek-vl2",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "image2text"
-      ]
-    },
-    {
-      "name": "deepseek-vl2-small",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "image2text"
-      ]
-    },
-    {
-      "name": "deepseek-vl2-tiny",
-      "alias": [],
-      "max_tokens": 4096,
-      "model_types": [
-        "image2text"
-      ]
     },
     {
       "name": "dev/glm46",
@@ -6449,13 +6001,6 @@
       ]
     },
     {
-      "name": "doubao-seedance-1-5-pro-251215",
-      "model_types": [
-        "video_generation"
-      ],
-      "alias": []
-    },
-    {
       "name": "doubao-seedance-2-0-260128",
       "model_types": [
         "video_generation"
@@ -6972,354 +6517,6 @@
       ]
     },
     {
-      "name": "gemini-2.0-flash",
-      "alias": [
-        "gemini-2.0-flash-001",
-        "gemini-2.0-flash-exp",
-        "models/gemini-2.0-flash"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ]
-    },
-    {
-      "name": "gemini-2.0-flash-lite",
-      "alias": [
-        "gemini-2.0-flash-lite-001",
-        "models/gemini-2.0-flash-lite"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ]
-    },
-    {
-      "name": "gemini-2.5-computer-use-preview-10-2025",
-      "alias": [
-        "models/gemini-2.5-computer-use-preview-10-2025"
-      ],
-      "max_tokens": 128000,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision"
-      ]
-    },
-    {
-      "name": "gemini-2.5-flash",
-      "alias": [
-        "gemini-2.5-flash-preview-09-2025",
-        "models/gemini-2.5-flash",
-        "google.gemini-2.5-flash"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-2.5-flash-image",
-      "alias": [
-        "gemini-2.5-flash-image-preview",
-        "models/gemini-2.5-flash-image"
-      ],
-      "max_tokens": 65536,
-      "model_types": [
-        "text-to-image",
-        "image_generation",
-        "image_edit",
-        "image_understanding"
-      ]
-    },
-    {
-      "name": "gemini-2.5-flash-lite",
-      "alias": [
-        "gemini-2.5-flash-lite-preview-09-2025",
-        "models/gemini-2.5-flash-lite",
-        "google.gemini-2.5-flash-lite"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-2.5-flash-native-audio-preview-12-2025",
-      "alias": [
-        "models/gemini-2.5-flash-native-audio-preview-12-2025"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat",
-        "omni",
-        "audio_understanding",
-        "audio2text",
-        "tts",
-        "video_understanding"
-      ]
-    },
-    {
-      "name": "gemini-2.5-flash-preview-tts",
-      "alias": [
-        "models/gemini-2.5-flash-preview-tts"
-      ],
-      "max_tokens": 8192,
-      "model_types": [
-        "tts",
-        "audio_generation"
-      ]
-    },
-    {
-      "name": "gemini-2.5-pro",
-      "alias": [
-        "models/gemini-2.5-pro",
-        "google/gemini-2.5-pro-preview",
-        "google/gemini-2.5-pro-preview-05-06",
-        "google.gemini-2.5-pro"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-2.5-pro-preview-tts",
-      "alias": [
-        "models/gemini-2.5-pro-preview-tts"
-      ],
-      "max_tokens": 8192,
-      "model_types": [
-        "tts",
-        "audio_generation"
-      ]
-    },
-    {
-      "name": "gemini-3-flash-preview",
-      "alias": [
-        "models/gemini-3-flash-preview"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-3-pro-image",
-      "alias": [
-        "models/gemini-3-pro-image",
-        "google/gemini-3-pro-image-preview"
-      ],
-      "max_tokens": 65536,
-      "model_types": [
-        "text-to-image",
-        "image_generation",
-        "image_edit",
-        "image_understanding"
-      ]
-    },
-    {
-      "name": "gemini-3-pro-preview",
-      "alias": [
-        "models/gemini-3-pro-preview"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-3.1-flash-image",
-      "alias": [
-        "models/gemini-3.1-flash-image",
-        "google/gemini-3.1-flash-image-preview"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "text-to-image",
-        "image_generation",
-        "image_edit",
-        "image_understanding"
-      ]
-    },
-    {
-      "name": "gemini-3.1-flash-lite",
-      "alias": [
-        "models/gemini-3.1-flash-lite"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-3.1-flash-lite-preview",
-      "alias": [
-        "models/gemini-3.1-flash-lite-preview"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-3.1-flash-live-preview",
-      "alias": [
-        "models/gemini-3.1-flash-live-preview"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat",
-        "omni",
-        "audio_understanding",
-        "audio2text",
-        "tts",
-        "video_understanding"
-      ]
-    },
-    {
-      "name": "gemini-3.1-flash-tts-preview",
-      "alias": [
-        "models/gemini-3.1-flash-tts-preview"
-      ],
-      "max_tokens": 8192,
-      "model_types": [
-        "tts",
-        "audio_generation"
-      ]
-    },
-    {
-      "name": "gemini-3.1-pro-preview",
-      "alias": [
-        "models/gemini-3.1-pro-preview",
-        "google/gemini-3.1-pro"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-3.1-pro-preview-customtools",
-      "alias": [
-        "models/gemini-3.1-pro-preview-customtools"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-3.5-flash",
-      "alias": [
-        "models/gemini-3.5-flash"
-      ],
-      "max_tokens": 1048576,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "video_understanding",
-        "audio_understanding"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gemini-3.5-live-translate-preview",
-      "alias": [
-        "models/gemini-3.5-live-translate-preview"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "speech_translation",
-        "audio2text",
-        "tts"
-      ]
-    },
-    {
       "name": "gemini-embedding-001",
       "alias": [
         "models/gemini-embedding-001"
@@ -7337,19 +6534,6 @@
       "max_dimension": 3072,
       "model_types": [
         "embedding"
-      ]
-    },
-    {
-      "name": "gemini-robotics-er-1.6-preview",
-      "alias": [
-        "models/gemini-robotics-er-1.6-preview"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat",
-        "image2text",
-        "vision",
-        "robotics"
       ]
     },
     {
@@ -7661,7 +6845,10 @@
     },
     {
       "name": "google/gemini-3.5-flash",
-      "alias": [],
+      "alias": [
+        "gemini-3.5-flash",
+        "models/gemini-3.5-flash"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7677,7 +6864,10 @@
     },
     {
       "name": "google/gemini-3.5-live-translate-preview",
-      "alias": [],
+      "alias": [
+        "gemini-3.5-live-translate-preview",
+        "models/gemini-3.5-live-translate-preview"
+      ],
       "model_types": [
         "speech_translation",
         "audio2text",
@@ -7708,7 +6898,10 @@
     {
       "name": "google/gemini-3.1-flash-image",
       "alias": [
-        "gemini-3.1-flash-image-preview"
+        "gemini-3.1-flash-image-preview",
+        "gemini-3.1-flash-image",
+        "models/gemini-3.1-flash-image",
+        "google/gemini-3.1-flash-image-preview"
       ],
       "model_types": [
         "text-to-image",
@@ -7720,7 +6913,10 @@
     },
     {
       "name": "google/gemini-3.1-flash-lite",
-      "alias": [],
+      "alias": [
+        "gemini-3.1-flash-lite",
+        "models/gemini-3.1-flash-lite"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7736,7 +6932,10 @@
     },
     {
       "name": "google/gemini-3.1-flash-lite-preview",
-      "alias": [],
+      "alias": [
+        "gemini-3.1-flash-lite-preview",
+        "models/gemini-3.1-flash-lite-preview"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7752,7 +6951,10 @@
     },
     {
       "name": "google/gemini-3.1-flash-live-preview",
-      "alias": [],
+      "alias": [
+        "gemini-3.1-flash-live-preview",
+        "models/gemini-3.1-flash-live-preview"
+      ],
       "model_types": [
         "chat",
         "omni",
@@ -7765,7 +6967,10 @@
     },
     {
       "name": "google/gemini-3.1-flash-tts-preview",
-      "alias": [],
+      "alias": [
+        "gemini-3.1-flash-tts-preview",
+        "models/gemini-3.1-flash-tts-preview"
+      ],
       "model_types": [
         "tts",
         "audio_generation"
@@ -7774,7 +6979,11 @@
     },
     {
       "name": "google/gemini-3.1-pro-preview",
-      "alias": [],
+      "alias": [
+        "gemini-3.1-pro-preview",
+        "models/gemini-3.1-pro-preview",
+        "google/gemini-3.1-pro"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7790,7 +6999,10 @@
     },
     {
       "name": "google/gemini-3.1-pro-preview-customtools",
-      "alias": [],
+      "alias": [
+        "gemini-3.1-pro-preview-customtools",
+        "models/gemini-3.1-pro-preview-customtools"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7819,7 +7031,10 @@
     },
     {
       "name": "google/gemini-3-flash-preview",
-      "alias": [],
+      "alias": [
+        "gemini-3-flash-preview",
+        "models/gemini-3-flash-preview"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7835,7 +7050,11 @@
     },
     {
       "name": "google/gemini-3-pro-image",
-      "alias": [],
+      "alias": [
+        "gemini-3-pro-image",
+        "models/gemini-3-pro-image",
+        "google/gemini-3-pro-image-preview"
+      ],
       "model_types": [
         "text-to-image",
         "image_generation",
@@ -7846,7 +7065,10 @@
     },
     {
       "name": "google/gemini-3-pro-preview",
-      "alias": [],
+      "alias": [
+        "gemini-3-pro-preview",
+        "models/gemini-3-pro-preview"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7862,7 +7084,10 @@
     },
     {
       "name": "google/gemini-2.5-computer-use-preview-10-2025",
-      "alias": [],
+      "alias": [
+        "gemini-2.5-computer-use-preview-10-2025",
+        "models/gemini-2.5-computer-use-preview-10-2025"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7872,7 +7097,12 @@
     },
     {
       "name": "google/gemini-2.5-flash",
-      "alias": [],
+      "alias": [
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-preview-09-2025",
+        "models/gemini-2.5-flash",
+        "google.gemini-2.5-flash"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -7888,7 +7118,11 @@
     },
     {
       "name": "google/gemini-2.5-flash-image",
-      "alias": [],
+      "alias": [
+        "gemini-2.5-flash-image",
+        "gemini-2.5-flash-image-preview",
+        "models/gemini-2.5-flash-image"
+      ],
       "model_types": [
         "text-to-image",
         "image_generation",
@@ -7900,7 +7134,11 @@
     {
       "name": "google/gemini-2.5-flash-lite",
       "alias": [
-        "google/gemini-2.5-flash-lite-preview-09-2025"
+        "google/gemini-2.5-flash-lite-preview-09-2025",
+        "gemini-2.5-flash-lite",
+        "gemini-2.5-flash-lite-preview-09-2025",
+        "models/gemini-2.5-flash-lite",
+        "google.gemini-2.5-flash-lite"
       ],
       "model_types": [
         "chat",
@@ -7935,7 +7173,10 @@
     },
     {
       "name": "google/gemini-2.5-flash-native-audio-preview-12-2025",
-      "alias": [],
+      "alias": [
+        "gemini-2.5-flash-native-audio-preview-12-2025",
+        "models/gemini-2.5-flash-native-audio-preview-12-2025"
+      ],
       "model_types": [
         "chat",
         "omni",
@@ -7966,7 +7207,10 @@
     },
     {
       "name": "google/gemini-2.5-flash-preview-tts",
-      "alias": [],
+      "alias": [
+        "gemini-2.5-flash-preview-tts",
+        "models/gemini-2.5-flash-preview-tts"
+      ],
       "model_types": [
         "tts",
         "audio_generation"
@@ -7975,7 +7219,13 @@
     },
     {
       "name": "google/gemini-2.5-pro",
-      "alias": [],
+      "alias": [
+        "gemini-2.5-pro",
+        "models/gemini-2.5-pro",
+        "google/gemini-2.5-pro-preview",
+        "google/gemini-2.5-pro-preview-05-06",
+        "google.gemini-2.5-pro"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -8009,7 +7259,10 @@
     },
     {
       "name": "google/gemini-2.5-pro-preview-tts",
-      "alias": [],
+      "alias": [
+        "gemini-2.5-pro-preview-tts",
+        "models/gemini-2.5-pro-preview-tts"
+      ],
       "model_types": [
         "tts",
         "audio_generation"
@@ -8039,7 +7292,12 @@
     },
     {
       "name": "google/gemini-2.0-flash",
-      "alias": [],
+      "alias": [
+        "gemini-2.0-flash",
+        "gemini-2.0-flash-001",
+        "gemini-2.0-flash-exp",
+        "models/gemini-2.0-flash"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -8051,7 +7309,11 @@
     },
     {
       "name": "google/gemini-2.0-flash-lite",
-      "alias": [],
+      "alias": [
+        "gemini-2.0-flash-lite",
+        "gemini-2.0-flash-lite-001",
+        "models/gemini-2.0-flash-lite"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -8318,7 +7580,10 @@
     },
     {
       "name": "google/gemini-robotics-er-1.6-preview",
-      "alias": [],
+      "alias": [
+        "gemini-robotics-er-1.6-preview",
+        "models/gemini-robotics-er-1.6-preview"
+      ],
       "model_types": [
         "chat",
         "image2text",
@@ -9248,7 +8513,8 @@
     {
       "name": "google/lyria-3-clip-preview",
       "alias": [
-        "models/lyria-3-clip-preview"
+        "models/lyria-3-clip-preview",
+        "lyria-3-clip-preview"
       ],
       "model_types": [
         "audio_generation"
@@ -9258,7 +8524,8 @@
     {
       "name": "google/lyria-3-pro-preview",
       "alias": [
-        "models/lyria-3-pro-preview"
+        "models/lyria-3-pro-preview",
+        "lyria-3-pro-preview"
       ],
       "model_types": [
         "audio_generation"
@@ -9268,7 +8535,8 @@
     {
       "name": "google/lyria-realtime-exp",
       "alias": [
-        "models/lyria-realtime-exp"
+        "models/lyria-realtime-exp",
+        "lyria-realtime-exp"
       ],
       "model_types": [
         "audio_generation"
@@ -10519,7 +9787,8 @@
     {
       "name": "google/veo-3.1-fast-generate-preview",
       "alias": [
-        "models/veo-3.1-fast-generate-preview"
+        "models/veo-3.1-fast-generate-preview",
+        "veo-3.1-fast-generate-preview"
       ],
       "model_types": [
         "video_generation"
@@ -10528,7 +9797,8 @@
     {
       "name": "google/veo-3.1-generate-preview",
       "alias": [
-        "models/veo-3.1-generate-preview"
+        "models/veo-3.1-generate-preview",
+        "veo-3.1-generate-preview"
       ],
       "model_types": [
         "video_generation"
@@ -10537,7 +9807,8 @@
     {
       "name": "google/veo-3.1-lite-generate-preview",
       "alias": [
-        "models/veo-3.1-lite-generate-preview"
+        "models/veo-3.1-lite-generate-preview",
+        "veo-3.1-lite-generate-preview"
       ],
       "model_types": [
         "video_generation"
@@ -10771,16 +10042,6 @@
       ]
     },
     {
-      "name": "gpt-4-turbo",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat",
-        "vision",
-        "image2text"
-      ],
-      "alias": []
-    },
-    {
       "name": "gpt-4-turbo-2024-04-09",
       "max_tokens": 128000,
       "model_types": [
@@ -10865,16 +10126,6 @@
       "alias": [
         "gpt-4o-all"
       ]
-    },
-    {
-      "name": "gpt-4o-2024-05-13",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat",
-        "vision",
-        "image2text"
-      ],
-      "alias": []
     },
     {
       "name": "gpt-4o-2024-08-06",
@@ -10978,14 +10229,6 @@
       ]
     },
     {
-      "name": "gpt-4o-mini-search-preview",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat"
-      ],
-      "alias": []
-    },
-    {
       "name": "gpt-4o-mini-transcribe",
       "max_tokens": 16000,
       "model_types": [
@@ -11045,14 +10288,6 @@
       ]
     },
     {
-      "name": "gpt-4o-search-preview",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat"
-      ],
-      "alias": []
-    },
-    {
       "name": "gpt-4o-transcribe",
       "max_tokens": 16000,
       "model_types": [
@@ -11066,20 +10301,6 @@
       "max_tokens": 16000,
       "model_types": [
         "chat"
-      ]
-    },
-    {
-      "name": "gpt-5",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": [
-        "gpt-5-all"
       ]
     },
     {
@@ -11131,18 +10352,6 @@
       "alias": []
     },
     {
-      "name": "gpt-5-codex",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": []
-    },
-    {
       "name": "gpt-5-codex-2025-09-15",
       "model_types": [
         "chat"
@@ -11174,16 +10383,6 @@
       ]
     },
     {
-      "name": "gpt-5-codex-mini",
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
       "name": "gpt-5-image",
       "model_types": [
         "chat",
@@ -11208,20 +10407,6 @@
       }
     },
     {
-      "name": "gpt-5-mini",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat",
-        "vision",
-        "image2text"
-      ],
-      "alias": [],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
       "name": "gpt-5-mini-2025-08-07",
       "max_tokens": 400000,
       "model_types": [
@@ -11230,20 +10415,6 @@
       "alias": [
         "openai/gpt-5-mini-2025-08-07"
       ]
-    },
-    {
-      "name": "gpt-5-nano",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat",
-        "vision",
-        "image2text"
-      ],
-      "alias": [],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
     },
     {
       "name": "gpt-5-nano-2025-08-07",
@@ -11292,21 +10463,6 @@
       ]
     },
     {
-      "name": "gpt-5.1",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": [
-        "gpt-5.1-thinking-all",
-        "gpt-5.1-all"
-      ]
-    },
-    {
       "name": "gpt-5.1-2025-11-13",
       "max_tokens": 400000,
       "model_types": [
@@ -11345,30 +10501,7 @@
       "alias": []
     },
     {
-      "name": "gpt-5.1-codex",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": []
-    },
-    {
       "name": "gpt-5.1-codex-2025-11-13",
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gpt-5.1-codex-max",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
@@ -11388,18 +10521,6 @@
       }
     },
     {
-      "name": "gpt-5.1-codex-mini",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": []
-    },
-    {
       "name": "gpt-5.1-plus",
       "max_tokens": 400000,
       "model_types": [
@@ -11416,20 +10537,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "gpt-5.2",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": [
-        "gpt-5.2-all"
-      ]
     },
     {
       "name": "gpt-5.2-2025-12-11",
@@ -11467,18 +10574,6 @@
       "model_types": [
         "chat"
       ],
-      "alias": []
-    },
-    {
-      "name": "gpt-5.2-codex",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
       "alias": []
     },
     {
@@ -11545,44 +10640,7 @@
       "alias": []
     },
     {
-      "name": "gpt-5.3-codex",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": []
-    },
-    {
       "name": "gpt-5.3-codex-2026-02-24",
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gpt-5.3-codex-spark",
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "gpt-5.4",
-      "alias": [
-        "gpt-5.4-2026-03-05",
-        "openai/gpt-5.4-2026-03-05"
-      ],
-      "max_tokens": 1050000,
       "model_types": [
         "chat"
       ],
@@ -11602,18 +10660,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "gpt-5.4-mini",
-      "max_tokens": 400000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": []
     },
     {
       "name": "gpt-5.4-mini-2026-03-17",
@@ -11669,18 +10715,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "gpt-5.5",
-      "max_tokens": 1050000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": []
     },
     {
       "name": "gpt-5.5-2026-04-24",
@@ -11946,56 +10980,6 @@
       ]
     },
     {
-      "name": "grok-4.3",
-      "max_tokens": 1000000,
-      "model_types": [
-        "chat",
-        "vision",
-        "image2text"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": [
-        "xai/grok-4.3",
-        "grok-4.3-latest",
-        "grok-latest",
-        "grok-3",
-        "grok-3-latest",
-        "grok-3-beta",
-        "grok-3-fast",
-        "grok-3-fast-latest",
-        "grok-3-fast-beta",
-        "grok-3-mini",
-        "grok-3-mini-latest",
-        "grok-3-mini-beta",
-        "grok-3-mini-fast",
-        "grok-3-mini-fast-latest",
-        "grok-3-mini-fast-beta",
-        "grok-3-mini-high",
-        "grok-3-mini-high-beta",
-        "grok-3-mini-fast-high",
-        "grok-3-mini-fast-high-beta",
-        "grok-4-0709",
-        "grok-4",
-        "grok-4-latest",
-        "grok-4-fast-reasoning",
-        "grok-4-fast",
-        "grok-4-fast-reasoning-latest",
-        "grok-4-fast-non-reasoning",
-        "grok-4-fast-non-reasoning-latest",
-        "grok-4-1-fast-reasoning",
-        "grok-4-1-fast",
-        "grok-4-1-fast-reasoning-latest",
-        "grok-4-1-fast-non-reasoning",
-        "grok-4-1-fast-non-reasoning-latest",
-        "grok-4.1-fast",
-        "grok-4.2",
-        "grok-4.2-fast"
-      ]
-    },
-    {
       "name": "grok-build-0.1",
       "max_tokens": 256000,
       "model_types": [
@@ -12034,15 +11018,6 @@
         "grok-imagine-image-quality-20260403",
         "grok-imagine-image-quality-latest",
         "grok-imagine-image-pro"
-      ]
-    },
-    {
-      "name": "grok-imagine-video",
-      "model_types": [
-        "video_generation"
-      ],
-      "alias": [
-        "xai/grok-imagine-video"
       ]
     },
     {
@@ -15562,29 +14537,6 @@
       ]
     },
     {
-      "name": "lyria-3-clip-preview",
-      "alias": [],
-      "max_tokens": 131072,
-      "model_types": [
-        "audio_generation"
-      ]
-    },
-    {
-      "name": "lyria-3-pro-preview",
-      "alias": [],
-      "max_tokens": 131072,
-      "model_types": [
-        "audio_generation"
-      ]
-    },
-    {
-      "name": "lyria-realtime-exp",
-      "alias": [],
-      "model_types": [
-        "audio_generation"
-      ]
-    },
-    {
       "name": "M2-her",
       "max_tokens": 1000000,
       "model_types": [
@@ -16356,7 +15308,10 @@
       "name": "meta-llama/llama-3-70b-instruct",
       "alias": [
         "llama-3-70b-instruct",
-        "Llama3 70B Instruct"
+        "Llama3 70B Instruct",
+        "meta-llama/Meta-Llama-3-70B-Instruct",
+        "Meta-Llama-3-70B-Instruct",
+        "meta/meta-llama-3-70b-instruct"
       ],
       "max_tokens": 8192,
       "max_completion_tokens": 8000,
@@ -16379,7 +15334,11 @@
       "name": "meta-llama/llama-3-8b-instruct",
       "alias": [
         "llama-3-8b-instruct",
-        "Llama 3 8B Instruct"
+        "Llama 3 8B Instruct",
+        "meta-llama/Meta-Llama-3-8B-Instruct",
+        "Meta-Llama-3-8B-Instruct",
+        "meta/meta-llama-3-8b-instruct",
+        "Meta Llama 3 8B Instruct"
       ],
       "max_tokens": 8192,
       "max_completion_tokens": 8192,
@@ -16738,17 +15697,6 @@
       "max_tokens": 8192
     },
     {
-      "name": "meta-llama/Meta-Llama-3-70B-Instruct",
-      "alias": [
-        "Meta-Llama-3-70B-Instruct",
-        "meta/meta-llama-3-70b-instruct"
-      ],
-      "model_types": [
-        "chat"
-      ],
-      "max_tokens": 8192
-    },
-    {
       "name": "meta-llama/Meta-Llama-3-70B-Instruct-Turbo",
       "alias": [
         "Meta-Llama-3-70B-Instruct-Turbo",
@@ -16763,18 +15711,6 @@
       "name": "meta-llama/Meta-Llama-3-8B",
       "alias": [
         "Meta-Llama-3-8B"
-      ],
-      "model_types": [
-        "chat"
-      ],
-      "max_tokens": 8192
-    },
-    {
-      "name": "meta-llama/Meta-Llama-3-8B-Instruct",
-      "alias": [
-        "Meta-Llama-3-8B-Instruct",
-        "meta/meta-llama-3-8b-instruct",
-        "Meta Llama 3 8B Instruct"
       ],
       "model_types": [
         "chat"
@@ -17404,12 +16340,6 @@
       "max_completion_tokens": 131072
     },
     {
-      "name": "mimo-v2-tts",
-      "model_types": [
-        "tts"
-      ]
-    },
-    {
       "name": "mimo-v2.5",
       "max_tokens": 1048576,
       "model_types": [
@@ -17448,15 +16378,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "mimo-v2.5-tts",
-      "model_types": [
-        "tts"
-      ],
-      "alias": [
-        "XiaomiMiMo/MiMo-V2.5-tts"
-      ]
     },
     {
       "name": "minimax/hailuo-02",
@@ -17515,7 +16436,10 @@
     },
     {
       "name": "minimax/minimax-m2.5-highspeed",
-      "alias": [],
+      "alias": [
+        "MiniMax-M2.5-highspeed",
+        "MiniMax M2.5-highspeed"
+      ],
       "model_types": [
         "chat"
       ],
@@ -17527,7 +16451,10 @@
     },
     {
       "name": "minimax/minimax-m2.7-highspeed",
-      "alias": [],
+      "alias": [
+        "MiniMax-M2.7-highspeed",
+        "MiniMax M2.7-highspeed"
+      ],
       "model_types": [
         "chat"
       ],
@@ -17634,36 +16561,6 @@
         "default_value": true,
         "clear_thinking": true
       }
-    },
-    {
-      "name": "MiniMax-M2.5-highspeed",
-      "max_tokens": 204800,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": [
-        "MiniMax M2.5-highspeed"
-      ],
-      "max_completion_tokens": 131100
-    },
-    {
-      "name": "MiniMax-M2.7-highspeed",
-      "max_tokens": 204800,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      },
-      "alias": [
-        "MiniMax M2.7-highspeed"
-      ],
-      "max_completion_tokens": 131072
     },
     {
       "name": "minimax-m3",
@@ -18102,7 +16999,9 @@
     },
     {
       "name": "mistral/mistral-large-latest",
-      "alias": [],
+      "alias": [
+        "mistral-large-latest"
+      ],
       "model_types": [
         "chat"
       ],
@@ -18110,7 +17009,9 @@
     },
     {
       "name": "mistral/mistral-medium-latest",
-      "alias": [],
+      "alias": [
+        "mistral-medium-latest"
+      ],
       "model_types": [
         "chat"
       ],
@@ -18118,7 +17019,9 @@
     },
     {
       "name": "mistral/mistral-small-latest",
-      "alias": [],
+      "alias": [
+        "mistral-small-latest"
+      ],
       "model_types": [
         "chat"
       ],
@@ -18195,28 +17098,7 @@
       ]
     },
     {
-      "name": "mistral-large-latest",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "mistral-medium-latest",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "mistral-small-2503",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "mistral-small-latest",
       "max_tokens": 128000,
       "model_types": [
         "chat"
@@ -22854,12 +21736,6 @@
       ]
     },
     {
-      "name": "omni-moderation-latest",
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "openai/gpt-6",
       "alias": [
         "gpt-6"
@@ -22901,7 +21777,8 @@
     {
       "name": "openai/gpt-5.5",
       "alias": [
-        "gpt-5.5-r"
+        "gpt-5.5-r",
+        "gpt-5.5"
       ],
       "model_types": [
         "chat"
@@ -22956,7 +21833,11 @@
     },
     {
       "name": "openai/gpt-5.4",
-      "alias": [],
+      "alias": [
+        "gpt-5.4",
+        "gpt-5.4-2026-03-05",
+        "openai/gpt-5.4-2026-03-05"
+      ],
       "model_types": [
         "chat"
       ],
@@ -22984,7 +21865,9 @@
     },
     {
       "name": "openai/gpt-5.4-mini",
-      "alias": [],
+      "alias": [
+        "gpt-5.4-mini"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23055,7 +21938,9 @@
     },
     {
       "name": "openai/gpt-5.3-codex",
-      "alias": [],
+      "alias": [
+        "gpt-5.3-codex"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23067,7 +21952,9 @@
     },
     {
       "name": "openai/gpt-5.3-codex-spark",
-      "alias": [],
+      "alias": [
+        "gpt-5.3-codex-spark"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23078,7 +21965,10 @@
     },
     {
       "name": "openai/gpt-5.2",
-      "alias": [],
+      "alias": [
+        "gpt-5.2",
+        "gpt-5.2-all"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23110,7 +22000,9 @@
     },
     {
       "name": "openai/gpt-5.2-codex",
-      "alias": [],
+      "alias": [
+        "gpt-5.2-codex"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23136,7 +22028,11 @@
     },
     {
       "name": "openai/gpt-5.1",
-      "alias": [],
+      "alias": [
+        "gpt-5.1",
+        "gpt-5.1-thinking-all",
+        "gpt-5.1-all"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23170,7 +22066,9 @@
     },
     {
       "name": "openai/gpt-5.1-codex",
-      "alias": [],
+      "alias": [
+        "gpt-5.1-codex"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23182,7 +22080,9 @@
     },
     {
       "name": "openai/gpt-5.1-codex-max",
-      "alias": [],
+      "alias": [
+        "gpt-5.1-codex-max"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23194,7 +22094,9 @@
     },
     {
       "name": "openai/gpt-5.1-codex-mini",
-      "alias": [],
+      "alias": [
+        "gpt-5.1-codex-mini"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23215,7 +22117,10 @@
     },
     {
       "name": "openai/gpt-5",
-      "alias": [],
+      "alias": [
+        "gpt-5",
+        "gpt-5-all"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23247,7 +22152,9 @@
     },
     {
       "name": "openai/gpt-5-codex",
-      "alias": [],
+      "alias": [
+        "gpt-5-codex"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23259,7 +22166,9 @@
     },
     {
       "name": "openai/gpt-5-codex-mini",
-      "alias": [],
+      "alias": [
+        "gpt-5-codex-mini"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23301,7 +22210,9 @@
     },
     {
       "name": "openai/gpt-5-mini",
-      "alias": [],
+      "alias": [
+        "gpt-5-mini"
+      ],
       "model_types": [
         "chat",
         "vision",
@@ -23315,7 +22226,9 @@
     },
     {
       "name": "openai/gpt-5-nano",
-      "alias": [],
+      "alias": [
+        "gpt-5-nano"
+      ],
       "model_types": [
         "chat",
         "vision",
@@ -23489,7 +22402,9 @@
     },
     {
       "name": "openai/gpt-4o-2024-05-13",
-      "alias": [],
+      "alias": [
+        "gpt-4o-2024-05-13"
+      ],
       "model_types": [
         "chat",
         "vision",
@@ -23507,7 +22422,9 @@
     },
     {
       "name": "openai/gpt-4-turbo",
-      "alias": [],
+      "alias": [
+        "gpt-4-turbo"
+      ],
       "model_types": [
         "chat",
         "vision",
@@ -23561,7 +22478,9 @@
     },
     {
       "name": "openai/gpt-4o-mini-search-preview",
-      "alias": [],
+      "alias": [
+        "gpt-4o-mini-search-preview"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23576,7 +22495,9 @@
     },
     {
       "name": "openai/gpt-4o-search-preview",
-      "alias": [],
+      "alias": [
+        "gpt-4o-search-preview"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23721,7 +22642,10 @@
     },
     {
       "name": "openai/antigravity-preview-05-2026",
-      "alias": [],
+      "alias": [
+        "antigravity-preview-05-2026",
+        "models/antigravity-preview-05-2026"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23813,7 +22737,10 @@
     },
     {
       "name": "openai/deep-research-max-preview-04-2026",
-      "alias": [],
+      "alias": [
+        "deep-research-max-preview-04-2026",
+        "models/deep-research-max-preview-04-2026"
+      ],
       "model_types": [
         "chat"
       ],
@@ -23821,7 +22748,10 @@
     },
     {
       "name": "openai/deep-research-preview-04-2026",
-      "alias": [],
+      "alias": [
+        "deep-research-preview-04-2026",
+        "models/deep-research-preview-04-2026"
+      ],
       "model_types": [
         "chat"
       ],
@@ -24202,18 +23132,6 @@
       }
     },
     {
-      "name": "openai/o1-preview",
-      "alias": [],
-      "model_types": [
-        "chat"
-      ],
-      "max_tokens": 128000,
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
       "name": "openai/o1-pro",
       "alias": [
         "o1-pro"
@@ -24343,7 +23261,9 @@
     },
     {
       "name": "openai/omni-moderation-latest",
-      "alias": [],
+      "alias": [
+        "omni-moderation-latest"
+      ],
       "model_types": [
         "chat"
       ]
@@ -34021,7 +32941,8 @@
     {
       "name": "shengshu-ai/viduq3",
       "alias": [
-        "vidu-q3"
+        "vidu-q3",
+        "viduq3"
       ],
       "model_types": [
         "video_generation"
@@ -34030,7 +32951,8 @@
     {
       "name": "shengshu-ai/viduq3-turbo",
       "alias": [
-        "vidu-q3-turbo"
+        "vidu-q3-turbo",
+        "viduq3-turbo"
       ],
       "model_types": [
         "video_generation"
@@ -34864,12 +33786,6 @@
       ]
     },
     {
-      "name": "step-audio-tts-3b",
-      "model_types": [
-        "tts"
-      ]
-    },
-    {
       "name": "step-image-edit-2",
       "model_types": [
         "image",
@@ -35206,7 +34122,9 @@
     },
     {
       "name": "stepfun-ai/step-audio-tts-3b",
-      "alias": [],
+      "alias": [
+        "step-audio-tts-3b"
+      ],
       "model_types": [
         "tts"
       ]
@@ -37123,14 +36041,6 @@
       ]
     },
     {
-      "name": "us.amazon.nova-micro-v1:0",
-      "alias": [],
-      "max_tokens": 300000,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
       "name": "us.amazon.nova-pro-v1:0",
       "alias": [],
       "max_tokens": 300000,
@@ -37179,27 +36089,6 @@
       "name": "vectorizer",
       "model_types": [
         "chat"
-      ]
-    },
-    {
-      "name": "veo-3.1-fast-generate-preview",
-      "alias": [],
-      "model_types": [
-        "video_generation"
-      ]
-    },
-    {
-      "name": "veo-3.1-generate-preview",
-      "alias": [],
-      "model_types": [
-        "video_generation"
-      ]
-    },
-    {
-      "name": "veo-3.1-lite-generate-preview",
-      "alias": [],
-      "model_types": [
-        "video_generation"
       ]
     },
     {
@@ -37292,12 +36181,6 @@
       ]
     },
     {
-      "name": "viduq3",
-      "model_types": [
-        "video_generation"
-      ]
-    },
-    {
       "name": "viduq3-mix",
       "model_types": [
         "video_generation"
@@ -37305,12 +36188,6 @@
     },
     {
       "name": "viduq3-pro",
-      "model_types": [
-        "video_generation"
-      ]
-    },
-    {
-      "name": "viduq3-turbo",
       "model_types": [
         "video_generation"
       ]
@@ -38036,7 +36913,44 @@
     },
     {
       "name": "x-ai/grok-4.3",
-      "alias": [],
+      "alias": [
+        "grok-4.3",
+        "xai/grok-4.3",
+        "grok-4.3-latest",
+        "grok-latest",
+        "grok-3",
+        "grok-3-latest",
+        "grok-3-beta",
+        "grok-3-fast",
+        "grok-3-fast-latest",
+        "grok-3-fast-beta",
+        "grok-3-mini",
+        "grok-3-mini-latest",
+        "grok-3-mini-beta",
+        "grok-3-mini-fast",
+        "grok-3-mini-fast-latest",
+        "grok-3-mini-fast-beta",
+        "grok-3-mini-high",
+        "grok-3-mini-high-beta",
+        "grok-3-mini-fast-high",
+        "grok-3-mini-fast-high-beta",
+        "grok-4-0709",
+        "grok-4",
+        "grok-4-latest",
+        "grok-4-fast-reasoning",
+        "grok-4-fast",
+        "grok-4-fast-reasoning-latest",
+        "grok-4-fast-non-reasoning",
+        "grok-4-fast-non-reasoning-latest",
+        "grok-4-1-fast-reasoning",
+        "grok-4-1-fast",
+        "grok-4-1-fast-reasoning-latest",
+        "grok-4-1-fast-non-reasoning",
+        "grok-4-1-fast-non-reasoning-latest",
+        "grok-4.1-fast",
+        "grok-4.2",
+        "grok-4.2-fast"
+      ],
       "model_types": [
         "chat",
         "vision",
@@ -38156,7 +37070,10 @@
     },
     {
       "name": "x-ai/grok-imagine-video",
-      "alias": [],
+      "alias": [
+        "grok-imagine-video",
+        "xai/grok-imagine-video"
+      ],
       "model_types": [
         "video_generation"
       ]
@@ -38222,7 +37139,10 @@
     },
     {
       "name": "xiaomi/mimo-v2.5-tts",
-      "alias": [],
+      "alias": [
+        "mimo-v2.5-tts",
+        "XiaomiMiMo/MiMo-V2.5-tts"
+      ],
       "model_types": [
         "tts"
       ]
@@ -38241,7 +37161,9 @@
     },
     {
       "name": "xiaomi/mimo-v2-tts",
-      "alias": [],
+      "alias": [
+        "mimo-v2-tts"
+      ],
       "model_types": [
         "tts"
       ]

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -265,7 +265,6 @@
     {
       "name": "amazon/nova-lite-v1",
       "alias": [
-        "us.amazon.nova-lite-v1:0",
         "amazon.nova-lite-v1:0",
         "apac.amazon.nova-lite-v1:0"
       ],
@@ -279,7 +278,6 @@
     {
       "name": "amazon/nova-micro-v1",
       "alias": [
-        "us.amazon.nova-micro-v1:0",
         "amazon.nova-micro-v1:0"
       ],
       "model_types": [
@@ -300,7 +298,6 @@
     {
       "name": "amazon/nova-pro-v1",
       "alias": [
-        "us.amazon.nova-pro-v1:0",
         "amazon.nova-pro-v1:0"
       ],
       "model_types": [
@@ -312,9 +309,7 @@
     },
     {
       "name": "amazon/titan-embed-text-v1",
-      "alias": [
-        "amazon.titan-embed-text-v1"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -370,7 +365,6 @@
     {
       "name": "anthropic/claude-fable-5",
       "alias": [
-        "claude-fable-5",
         "anthropic.claude-fable-5"
       ],
       "model_types": [
@@ -385,9 +379,7 @@
     },
     {
       "name": "anthropic/claude-mythos-5",
-      "alias": [
-        "claude-mythos-5"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision"
@@ -419,7 +411,6 @@
     {
       "name": "anthropic/claude-opus-4-5-20251101",
       "alias": [
-        "claude-opus-4-5-20251101",
         "claude-opus-4-5-20251101-dd"
       ],
       "model_types": [
@@ -432,7 +423,6 @@
     {
       "name": "anthropic/claude-haiku-4-5-20251001",
       "alias": [
-        "claude-haiku-4-5-20251001",
         "claude-haiku-4-5",
         "anthropic.claude-haiku-4-5-20251001-v1:0",
         "anthropic/claude-haiku-4.5",
@@ -452,7 +442,6 @@
     {
       "name": "anthropic/claude-sonnet-4-5-20250929",
       "alias": [
-        "claude-sonnet-4-5-20250929",
         "claude-sonnet-4-5-20250929-dd"
       ],
       "model_types": [
@@ -468,9 +457,7 @@
     },
     {
       "name": "anthropic/claude-opus-4-1-20250805",
-      "alias": [
-        "claude-opus-4-1-20250805"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -480,9 +467,7 @@
     },
     {
       "name": "anthropic/claude-opus-4-20250514",
-      "alias": [
-        "claude-opus-4-20250514"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -497,7 +482,6 @@
     {
       "name": "anthropic/claude-sonnet-4-20250514",
       "alias": [
-        "claude-sonnet-4-20250514",
         "claude-sonnet-4-20250514-dd"
       ],
       "model_types": [
@@ -526,8 +510,7 @@
     {
       "name": "anthropic/claude-opus-4-1",
       "alias": [
-        "claude-opus-4-1",
-        "anthropic/claude-opus-4.1"
+        "claude-opus-4-1"
       ],
       "model_types": [
         "chat",
@@ -560,7 +543,6 @@
     {
       "name": "anthropic/claude-opus-4-6",
       "alias": [
-        "claude-opus-4-6",
         "anthropic/claude-opus-4.6",
         "claude-opus-4-6-r",
         "claude-opus-4-6-dd"
@@ -596,7 +578,6 @@
     {
       "name": "anthropic/claude-opus-4-7",
       "alias": [
-        "claude-opus-4-7",
         "anthropic/claude-opus-4.7",
         "claude-opus-4-7-r"
       ],
@@ -631,7 +612,6 @@
     {
       "name": "anthropic/claude-opus-4-8",
       "alias": [
-        "claude-opus-4-8",
         "anthropic.claude-opus-4-8",
         "anthropic/claude-opus-4.8",
         "claude-opus-4-8-r"
@@ -682,7 +662,6 @@
     {
       "name": "anthropic/claude-sonnet-4-5",
       "alias": [
-        "claude-sonnet-4-5",
         "anthropic.claude-sonnet-4-5",
         "anthropic/claude-sonnet-4.5"
       ],
@@ -699,7 +678,6 @@
     {
       "name": "anthropic/claude-sonnet-4-6",
       "alias": [
-        "claude-sonnet-4-6",
         "anthropic.claude-sonnet-4-6",
         "anthropic/claude-sonnet-4.6",
         "claude-sonnet-4-6-r",
@@ -718,7 +696,6 @@
     {
       "name": "anthropic/claude-sonnet-4-7",
       "alias": [
-        "claude-sonnet-4-7",
         "anthropic.claude-sonnet-4-7"
       ],
       "model_types": [
@@ -733,9 +710,7 @@
     },
     {
       "name": "anthropic/claude-3-7-sonnet-20250219",
-      "alias": [
-        "claude-3-7-sonnet-20250219"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -746,8 +721,6 @@
     {
       "name": "anthropic/claude-3-5-haiku-20241022",
       "alias": [
-        "claude-3-5-haiku-20241022",
-        "us.anthropic.claude-3-5-haiku-20241022-v1:0",
         "anthropic.claude-3-5-haiku-20241022-v1:0"
       ],
       "model_types": [
@@ -760,8 +733,6 @@
     {
       "name": "anthropic/claude-3-5-sonnet-20241022",
       "alias": [
-        "claude-3-5-sonnet-20241022",
-        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
         "anthropic.claude-3-5-sonnet-20241022-v2:0",
         "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
       ],
@@ -774,9 +745,7 @@
     },
     {
       "name": "anthropic/claude-3-haiku-20240307",
-      "alias": [
-        "claude-3-haiku-20240307"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -797,7 +766,6 @@
     {
       "name": "anthropic/claude-3-5-haiku",
       "alias": [
-        "claude-3-5-haiku",
         "anthropic/claude-3.5-haiku"
       ],
       "model_types": [
@@ -916,7 +884,6 @@
     {
       "name": "antigravity-preview-05-2026",
       "alias": [
-        "antigravity-preview-05-2026",
         "models/antigravity-preview-05-2026"
       ],
       "max_tokens": 1048576,
@@ -1062,10 +1029,7 @@
     },
     {
       "name": "BAAI/bge-reranker-v2-m3",
-      "alias": [
-        "bge-reranker-v2-m3",
-        "baai/bge-reranker-v2-m3"
-      ],
+      "alias": [],
       "model_types": [
         "rerank"
       ],
@@ -1110,10 +1074,7 @@
     },
     {
       "name": "BAAI/bge-m3",
-      "alias": [
-        "bge-m3",
-        "baai/bge-m3"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -1141,9 +1102,7 @@
     {
       "name": "baichuan-inc/baichuanmed-ocr-72b",
       "alias": [
-        "baichuan-inc/BaichuanMed-OCR-72B",
-        "BaichuanMed-OCR-72B",
-        "baichuanmed-ocr-72b"
+        "BaichuanMed-OCR-72B"
       ],
       "model_types": [
         "ocr",
@@ -1155,9 +1114,7 @@
     {
       "name": "baichuan-inc/baichuanmed-ocr-7b",
       "alias": [
-        "baichuan-inc/BaichuanMed-OCR-7B",
-        "BaichuanMed-OCR-7B",
-        "baichuanmed-ocr-7b"
+        "BaichuanMed-OCR-7B"
       ],
       "model_types": [
         "ocr",
@@ -1169,9 +1126,7 @@
     {
       "name": "baichuan-inc/baichuan-13b-base",
       "alias": [
-        "baichuan-inc/Baichuan-13B-Base",
-        "Baichuan-13B-Base",
-        "baichuan-13b-base"
+        "Baichuan-13B-Base"
       ],
       "model_types": [
         "chat"
@@ -1181,9 +1136,7 @@
     {
       "name": "baichuan-inc/baichuan-13b-chat",
       "alias": [
-        "baichuan-inc/Baichuan-13B-Chat",
-        "Baichuan-13B-Chat",
-        "baichuan-13b-chat"
+        "Baichuan-13B-Chat"
       ],
       "model_types": [
         "chat"
@@ -1193,9 +1146,7 @@
     {
       "name": "baichuan-inc/baichuan-7b",
       "alias": [
-        "baichuan-inc/Baichuan-7B",
-        "Baichuan-7B",
-        "baichuan-7b"
+        "Baichuan-7B"
       ],
       "model_types": [
         "chat"
@@ -1205,9 +1156,7 @@
     {
       "name": "baichuan-inc/baichuan-audio-base",
       "alias": [
-        "baichuan-inc/Baichuan-Audio-Base",
-        "Baichuan-Audio-Base",
-        "baichuan-audio-base"
+        "Baichuan-Audio-Base"
       ],
       "model_types": [
         "audio",
@@ -1219,9 +1168,7 @@
     {
       "name": "baichuan-inc/baichuan-audio-instruct",
       "alias": [
-        "baichuan-inc/Baichuan-Audio-Instruct",
-        "Baichuan-Audio-Instruct",
-        "baichuan-audio-instruct"
+        "Baichuan-Audio-Instruct"
       ],
       "model_types": [
         "audio",
@@ -1234,9 +1181,7 @@
     {
       "name": "baichuan-inc/baichuan-m1-14b-base",
       "alias": [
-        "baichuan-inc/Baichuan-M1-14B-Base",
-        "Baichuan-M1-14B-Base",
-        "baichuan-m1-14b-base"
+        "Baichuan-M1-14B-Base"
       ],
       "model_types": [
         "chat"
@@ -1246,9 +1191,7 @@
     {
       "name": "baichuan-inc/baichuan-m1-14b-instruct",
       "alias": [
-        "baichuan-inc/Baichuan-M1-14B-Instruct",
-        "Baichuan-M1-14B-Instruct",
-        "baichuan-m1-14b-instruct"
+        "Baichuan-M1-14B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -1258,9 +1201,7 @@
     {
       "name": "baichuan-inc/baichuan-m2-32b",
       "alias": [
-        "baichuan-inc/Baichuan-M2-32B",
         "Baichuan-M2-32B",
-        "baichuan-m2-32b",
         "baichuan/baichuan-m2-32b",
         "BaiChuan M2 32B"
       ],
@@ -1277,9 +1218,7 @@
     {
       "name": "baichuan-inc/baichuan-m2-32b-gptq-int4",
       "alias": [
-        "baichuan-inc/Baichuan-M2-32B-GPTQ-Int4",
-        "Baichuan-M2-32B-GPTQ-Int4",
-        "baichuan-m2-32b-gptq-int4"
+        "Baichuan-M2-32B-GPTQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -1293,9 +1232,7 @@
     {
       "name": "baichuan-inc/baichuan-m2-32b-q4_k_m-gguf",
       "alias": [
-        "baichuan-inc/Baichuan-M2-32B-Q4_K_M-GGUF",
-        "Baichuan-M2-32B-Q4_K_M-GGUF",
-        "baichuan-m2-32b-q4_k_m-gguf"
+        "Baichuan-M2-32B-Q4_K_M-GGUF"
       ],
       "model_types": [
         "chat"
@@ -1309,9 +1246,7 @@
     {
       "name": "baichuan-inc/baichuan-m3-235b",
       "alias": [
-        "baichuan-inc/Baichuan-M3-235B",
-        "Baichuan-M3-235B",
-        "baichuan-m3-235b"
+        "Baichuan-M3-235B"
       ],
       "model_types": [
         "chat"
@@ -1325,9 +1260,7 @@
     {
       "name": "baichuan-inc/baichuan-m3-235b-fp8",
       "alias": [
-        "baichuan-inc/Baichuan-M3-235B-FP8",
-        "Baichuan-M3-235B-FP8",
-        "baichuan-m3-235b-fp8"
+        "Baichuan-M3-235B-FP8"
       ],
       "model_types": [
         "chat"
@@ -1341,9 +1274,7 @@
     {
       "name": "baichuan-inc/baichuan-m3-235b-gptq-int4",
       "alias": [
-        "baichuan-inc/Baichuan-M3-235B-GPTQ-INT4",
-        "Baichuan-M3-235B-GPTQ-INT4",
-        "baichuan-m3-235b-gptq-int4"
+        "Baichuan-M3-235B-GPTQ-INT4"
       ],
       "model_types": [
         "chat"
@@ -1357,9 +1288,7 @@
     {
       "name": "baichuan-inc/baichuan-m3-235b-q4_k_m-gguf",
       "alias": [
-        "baichuan-inc/Baichuan-M3-235B-Q4_K_M-GGUF",
-        "Baichuan-M3-235B-Q4_K_M-GGUF",
-        "baichuan-m3-235b-q4_k_m-gguf"
+        "Baichuan-M3-235B-Q4_K_M-GGUF"
       ],
       "model_types": [
         "chat"
@@ -1373,9 +1302,7 @@
     {
       "name": "baichuan-inc/baichuan-omni-1d5",
       "alias": [
-        "baichuan-inc/Baichuan-Omni-1d5",
         "Baichuan-Omni-1d5",
-        "baichuan-omni-1d5",
         "Baichuan-Omni-1.5"
       ],
       "model_types": [
@@ -1392,9 +1319,7 @@
     {
       "name": "baichuan-inc/baichuan-omni-1d5-base",
       "alias": [
-        "baichuan-inc/Baichuan-Omni-1d5-Base",
         "Baichuan-Omni-1d5-Base",
-        "baichuan-omni-1d5-base",
         "Baichuan-Omni-1.5-Base"
       ],
       "model_types": [
@@ -1411,9 +1336,7 @@
     {
       "name": "baichuan-inc/baichuan2-13b-base",
       "alias": [
-        "baichuan-inc/Baichuan2-13B-Base",
-        "Baichuan2-13B-Base",
-        "baichuan2-13b-base"
+        "Baichuan2-13B-Base"
       ],
       "model_types": [
         "chat"
@@ -1423,9 +1346,7 @@
     {
       "name": "baichuan-inc/baichuan2-13b-chat",
       "alias": [
-        "baichuan-inc/Baichuan2-13B-Chat",
-        "Baichuan2-13B-Chat",
-        "baichuan2-13b-chat"
+        "Baichuan2-13B-Chat"
       ],
       "model_types": [
         "chat"
@@ -1435,9 +1356,7 @@
     {
       "name": "baichuan-inc/baichuan2-13b-chat-4bits",
       "alias": [
-        "baichuan-inc/Baichuan2-13B-Chat-4bits",
-        "Baichuan2-13B-Chat-4bits",
-        "baichuan2-13b-chat-4bits"
+        "Baichuan2-13B-Chat-4bits"
       ],
       "model_types": [
         "chat"
@@ -1447,9 +1366,7 @@
     {
       "name": "baichuan-inc/baichuan2-7b-base",
       "alias": [
-        "baichuan-inc/Baichuan2-7B-Base",
-        "Baichuan2-7B-Base",
-        "baichuan2-7b-base"
+        "Baichuan2-7B-Base"
       ],
       "model_types": [
         "chat"
@@ -1459,9 +1376,7 @@
     {
       "name": "baichuan-inc/baichuan2-7b-chat",
       "alias": [
-        "baichuan-inc/Baichuan2-7B-Chat",
-        "Baichuan2-7B-Chat",
-        "baichuan2-7b-chat"
+        "Baichuan2-7B-Chat"
       ],
       "model_types": [
         "chat"
@@ -1471,9 +1386,7 @@
     {
       "name": "baichuan-inc/baichuan2-7b-chat-4bits",
       "alias": [
-        "baichuan-inc/Baichuan2-7B-Chat-4bits",
-        "Baichuan2-7B-Chat-4bits",
-        "baichuan2-7b-chat-4bits"
+        "Baichuan2-7B-Chat-4bits"
       ],
       "model_types": [
         "chat"
@@ -1483,9 +1396,7 @@
     {
       "name": "baichuan-inc/baichuan2-7b-intermediate-checkpoints",
       "alias": [
-        "baichuan-inc/Baichuan2-7B-Intermediate-Checkpoints",
-        "Baichuan2-7B-Intermediate-Checkpoints",
-        "baichuan2-7b-intermediate-checkpoints"
+        "Baichuan2-7B-Intermediate-Checkpoints"
       ],
       "model_types": [
         "chat"
@@ -1607,7 +1518,6 @@
     {
       "name": "baidu/ernie-4.5-0.3b-base-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-0.3B-Base-Paddle",
         "ernie-4.5-0.3b-base-paddle"
       ],
       "model_types": [
@@ -1618,7 +1528,6 @@
     {
       "name": "baidu/ernie-4.5-0.3b-base-pt",
       "alias": [
-        "baidu/ERNIE-4.5-0.3B-Base-PT",
         "ernie-4.5-0.3b-base-pt"
       ],
       "model_types": [
@@ -1629,7 +1538,6 @@
     {
       "name": "baidu/ernie-4.5-0.3b-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-0.3B-Paddle",
         "ernie-4.5-0.3b-paddle"
       ],
       "model_types": [
@@ -1640,7 +1548,6 @@
     {
       "name": "baidu/ernie-4.5-0.3b-pt",
       "alias": [
-        "baidu/ERNIE-4.5-0.3B-PT",
         "ernie-4.5-0.3b-pt"
       ],
       "model_types": [
@@ -1663,7 +1570,6 @@
     {
       "name": "baidu/ernie-4.5-21b-a3b-base-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-21B-A3B-Base-Paddle",
         "ernie-4.5-21b-a3b-base-paddle"
       ],
       "model_types": [
@@ -1674,7 +1580,6 @@
     {
       "name": "baidu/ernie-4.5-21b-a3b-base-pt",
       "alias": [
-        "baidu/ERNIE-4.5-21B-A3B-Base-PT",
         "ernie-4.5-21b-a3b-base-pt"
       ],
       "model_types": [
@@ -1685,7 +1590,6 @@
     {
       "name": "baidu/ernie-4.5-21b-a3b-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-21B-A3B-Paddle",
         "ernie-4.5-21b-a3b-paddle"
       ],
       "model_types": [
@@ -1696,7 +1600,6 @@
     {
       "name": "baidu/ernie-4.5-21b-a3b-pt",
       "alias": [
-        "baidu/ERNIE-4.5-21B-A3B-PT",
         "ernie-4.5-21b-a3b-pt"
       ],
       "model_types": [
@@ -1707,7 +1610,6 @@
     {
       "name": "baidu/ernie-4.5-21b-a3b-thinking",
       "alias": [
-        "baidu/ERNIE-4.5-21B-A3B-Thinking",
         "ernie-4.5-21b-a3b-thinking"
       ],
       "model_types": [
@@ -1730,7 +1632,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-2bits-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-2Bits-Paddle",
         "ernie-4.5-300b-a47b-2bits-paddle"
       ],
       "model_types": [
@@ -1741,7 +1642,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-2bits-tp2-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-2Bits-TP2-Paddle",
         "ernie-4.5-300b-a47b-2bits-tp2-paddle"
       ],
       "model_types": [
@@ -1752,7 +1652,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-2bits-tp4-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-2Bits-TP4-Paddle",
         "ernie-4.5-300b-a47b-2bits-tp4-paddle"
       ],
       "model_types": [
@@ -1763,7 +1662,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-base-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-Base-Paddle",
         "ernie-4.5-300b-a47b-base-paddle"
       ],
       "model_types": [
@@ -1774,7 +1672,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-base-pt",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-Base-PT",
         "ernie-4.5-300b-a47b-base-pt"
       ],
       "model_types": [
@@ -1785,7 +1682,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-fp8-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-FP8-Paddle",
         "ernie-4.5-300b-a47b-fp8-paddle"
       ],
       "model_types": [
@@ -1796,7 +1692,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-Paddle",
         "ernie-4.5-300b-a47b-paddle",
         "ERNIE 4.5 300B A47B"
       ],
@@ -1809,7 +1704,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-pt",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-PT",
         "ernie-4.5-300b-a47b-pt"
       ],
       "model_types": [
@@ -1820,7 +1714,6 @@
     {
       "name": "baidu/ernie-4.5-300b-a47b-w4a8c8-tp4-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-300B-A47B-W4A8C8-TP4-Paddle",
         "ernie-4.5-300b-a47b-w4a8c8-tp4-paddle"
       ],
       "model_types": [
@@ -1849,7 +1742,6 @@
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-base-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-VL-28B-A3B-Base-Paddle",
         "ernie-4.5-vl-28b-a3b-base-paddle"
       ],
       "model_types": [
@@ -1861,7 +1753,6 @@
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-base-pt",
       "alias": [
-        "baidu/ERNIE-4.5-VL-28B-A3B-Base-PT",
         "ernie-4.5-vl-28b-a3b-base-pt"
       ],
       "model_types": [
@@ -1873,7 +1764,6 @@
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-VL-28B-A3B-Paddle",
         "ernie-4.5-vl-28b-a3b-paddle"
       ],
       "model_types": [
@@ -1887,7 +1777,6 @@
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-pt",
       "alias": [
-        "baidu/ERNIE-4.5-VL-28B-A3B-PT",
         "ernie-4.5-vl-28b-a3b-pt"
       ],
       "model_types": [
@@ -1901,7 +1790,6 @@
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-thinking",
       "alias": [
-        "baidu/ERNIE-4.5-VL-28B-A3B-Thinking",
         "ernie-4.5-vl-28b-a3b-thinking"
       ],
       "model_types": [
@@ -1938,7 +1826,6 @@
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-base-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-VL-424B-A47B-Base-Paddle",
         "ernie-4.5-vl-424b-a47b-base-paddle"
       ],
       "model_types": [
@@ -1950,7 +1837,6 @@
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-base-pt",
       "alias": [
-        "baidu/ERNIE-4.5-VL-424B-A47B-Base-PT",
         "ernie-4.5-vl-424b-a47b-base-pt"
       ],
       "model_types": [
@@ -1962,7 +1848,6 @@
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-paddle",
       "alias": [
-        "baidu/ERNIE-4.5-VL-424B-A47B-Paddle",
         "ernie-4.5-vl-424b-a47b-paddle"
       ],
       "model_types": [
@@ -1976,9 +1861,7 @@
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-pt",
       "alias": [
-        "baidu/ERNIE-4.5-VL-424B-A47B-PT",
-        "ernie-4.5-vl-424b-a47b-pt",
-        "baidu/ernie-4.5-vl-424b-a47b"
+        "ernie-4.5-vl-424b-a47b-pt"
       ],
       "model_types": [
         "chat",
@@ -2006,7 +1889,6 @@
     {
       "name": "baidu/ernie-image",
       "alias": [
-        "baidu/ERNIE-Image",
         "ernie-image"
       ],
       "model_types": [
@@ -2016,7 +1898,6 @@
     {
       "name": "baidu/ernie-image-aes",
       "alias": [
-        "baidu/ERNIE-Image-Aes",
         "ernie-image-aes"
       ],
       "model_types": [
@@ -2027,7 +1908,6 @@
     {
       "name": "baidu/ernie-image-turbo",
       "alias": [
-        "baidu/ERNIE-Image-Turbo",
         "ernie-image-turbo"
       ],
       "model_types": [
@@ -2038,7 +1918,6 @@
     {
       "name": "baidu/nava",
       "alias": [
-        "baidu/NAVA",
         "nava"
       ],
       "model_types": [
@@ -2048,7 +1927,6 @@
     {
       "name": "baidu/qianfan-ocr",
       "alias": [
-        "baidu/Qianfan-OCR",
         "qianfan-ocr"
       ],
       "model_types": [
@@ -2061,7 +1939,6 @@
     {
       "name": "baidu/qianfan-vl-3b",
       "alias": [
-        "baidu/Qianfan-VL-3B",
         "qianfan-vl-3b"
       ],
       "model_types": [
@@ -2074,7 +1951,6 @@
     {
       "name": "baidu/qianfan-vl-70b",
       "alias": [
-        "baidu/Qianfan-VL-70B",
         "qianfan-vl-70b"
       ],
       "model_types": [
@@ -2091,7 +1967,6 @@
     {
       "name": "baidu/qianfan-vl-8b",
       "alias": [
-        "baidu/Qianfan-VL-8B",
         "qianfan-vl-8b"
       ],
       "model_types": [
@@ -2125,9 +2000,7 @@
     },
     {
       "name": "bge-m3",
-      "alias": [
-        "baai/bge-m3"
-      ],
+      "alias": [],
       "max_tokens": 8192,
       "model_types": [
         "embedding"
@@ -2137,7 +2010,6 @@
     {
       "name": "bge-reranker-v2-m3",
       "alias": [
-        "baai/bge-reranker-v2-m3",
         "Pro/BAAI/bge-reranker-v2-m3"
       ],
       "max_tokens": 1024,
@@ -2191,8 +2063,7 @@
       "name": "black-forest-labs/flux-1.1-pro",
       "alias": [
         "black-forest-labs/flux-1-1-pro",
-        "FLUX-1.1-pro",
-        "black-forest-labs/FLUX-1.1-pro"
+        "FLUX-1.1-pro"
       ],
       "model_types": [
         "image",
@@ -2216,8 +2087,7 @@
         "FLUX.2-dev",
         "FLUX-2-dev",
         "black-forest-labs/FLUX.2-dev",
-        "FLUX.2 [dev]",
-        "black-forest-labs/FLUX-2-dev"
+        "FLUX.2 [dev]"
       ],
       "model_types": [
         "image",
@@ -2260,11 +2130,9 @@
       "name": "black-forest-labs/flux-2-max",
       "alias": [
         "flux-2-max",
-        "FLUX-2-max",
         "black-forest-labs/FLUX.2-max",
         "FLUX.2-max",
-        "FLUX.2 [max]",
-        "black-forest-labs/FLUX-2-max"
+        "FLUX.2 [max]"
       ],
       "model_types": [
         "image",
@@ -2277,11 +2145,9 @@
       "name": "black-forest-labs/flux-2-pro",
       "alias": [
         "flux-2-pro",
-        "FLUX-2-pro",
         "black-forest-labs/FLUX.2-pro",
         "FLUX.2-pro",
-        "FLUX.2 [pro]",
-        "black-forest-labs/FLUX-2-pro"
+        "FLUX.2 [pro]"
       ],
       "model_types": [
         "image",
@@ -2335,9 +2201,7 @@
     {
       "name": "black-forest-labs/flux-pro",
       "alias": [
-        "flux-pro",
-        "FLUX-pro",
-        "black-forest-labs/FLUX-pro"
+        "flux-pro"
       ],
       "model_types": [
         "image",
@@ -2456,9 +2320,7 @@
     },
     {
       "name": "black-forest-labs/flux-schnell",
-      "alias": [
-        "flux-1-schnell"
-      ],
+      "alias": [],
       "model_types": [
         "image",
         "image_generation"
@@ -2948,7 +2810,6 @@
     {
       "name": "bytedance-seed/doubao-seed-2-0-mini-260215",
       "alias": [
-        "doubao-seed-2-0-mini-260215",
         "doubao-seed-2-0"
       ],
       "model_types": [
@@ -2958,7 +2819,6 @@
     {
       "name": "bytedance-seed/doubao-seedream-5-0-260128",
       "alias": [
-        "doubao-seedream-5-0-260128",
         "doubao-seedream-5"
       ],
       "model_types": [
@@ -2968,9 +2828,7 @@
     },
     {
       "name": "bytedance-seed/doubao-seed-1-8-251228",
-      "alias": [
-        "doubao-seed-1-8-251228"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -2979,8 +2837,7 @@
     {
       "name": "bytedance-seed/doubao-seedance-1-5-pro",
       "alias": [
-        "doubao-seedance-1-5-pro",
-        "doubao-seedance-1-5-pro-251215"
+        "doubao-seedance-1-5-pro"
       ],
       "model_types": [
         "video_generation"
@@ -2988,9 +2845,7 @@
     },
     {
       "name": "bytedance-seed/doubao-seedream-4-5-251128",
-      "alias": [
-        "doubao-seedream-4-5-251128"
-      ],
+      "alias": [],
       "model_types": [
         "image",
         "image_generation"
@@ -2998,9 +2853,7 @@
     },
     {
       "name": "bytedance-seed/doubao-seedream-4-0-250828",
-      "alias": [
-        "doubao-seedream-4-0-250828"
-      ],
+      "alias": [],
       "model_types": [
         "image",
         "image_generation"
@@ -3020,9 +2873,7 @@
     },
     {
       "name": "bytedance-seed/doubao-1-5-pro-32k-250115",
-      "alias": [
-        "doubao-1-5-pro-32k-250115"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -3363,9 +3214,7 @@
     },
     {
       "name": "claude-3-haiku-20240307",
-      "alias": [
-        "claude-3-haiku"
-      ],
+      "alias": [],
       "max_tokens": 200000,
       "model_types": [
         "chat"
@@ -3373,10 +3222,7 @@
     },
     {
       "name": "claude-fable-5",
-      "alias": [
-        "anthropic.claude-fable-5",
-        "anthropic/claude-fable-5"
-      ],
+      "alias": [],
       "max_tokens": 1000000,
       "model_types": [
         "chat",
@@ -3390,11 +3236,7 @@
     {
       "name": "claude-haiku-4-5-20251001",
       "alias": [
-        "claude-haiku-4-5",
-        "anthropic.claude-haiku-4-5-20251001-v1:0",
         "anthropic/claude-haiku-4-5",
-        "anthropic/claude-haiku-4-5-20251001",
-        "anthropic/claude-haiku-4.5",
         "claude-haiku-4.5"
       ],
       "max_tokens": 200000,
@@ -3438,9 +3280,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "anthropic/claude-opus-4-1-20250805"
-      ]
+      "alias": []
     },
     {
       "name": "claude-opus-4-1-20250805-thinking",
@@ -3478,10 +3318,6 @@
         "chat"
       ],
       "alias": [
-        "anthropic/claude-opus-4-5-20251101",
-        "anthropic/claude-opus-4-5",
-        "claude-opus-4-5",
-        "anthropic/claude-opus-4.5",
         "claude-opus-4.5"
       ]
     },
@@ -3501,8 +3337,6 @@
         "ocr"
       ],
       "alias": [
-        "anthropic/claude-opus-4-6",
-        "anthropic/claude-opus-4.6",
         "claude-opus-4.6"
       ],
       "max_tokens": 200000
@@ -3517,8 +3351,6 @@
         "ocr"
       ],
       "alias": [
-        "anthropic/claude-opus-4-7",
-        "anthropic/claude-opus-4.7",
         "claude-opus-4.7"
       ]
     },
@@ -3532,9 +3364,6 @@
     {
       "name": "claude-opus-4-8",
       "alias": [
-        "anthropic.claude-opus-4-8",
-        "anthropic/claude-opus-4-8",
-        "anthropic/claude-opus-4.8",
         "claude-opus-4.8"
       ],
       "max_tokens": 1000000,
@@ -3588,9 +3417,6 @@
     {
       "name": "claude-sonnet-4-5",
       "alias": [
-        "anthropic.claude-sonnet-4-5",
-        "anthropic/claude-sonnet-4-5",
-        "anthropic/claude-sonnet-4.5",
         "claude-sonnet-4.5"
       ],
       "max_tokens": 1000000,
@@ -3609,9 +3435,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "anthropic/claude-sonnet-4-5-20250929"
-      ]
+      "alias": []
     },
     {
       "name": "claude-sonnet-4-5-20250929-thinking",
@@ -3627,9 +3451,6 @@
     {
       "name": "claude-sonnet-4-6",
       "alias": [
-        "anthropic.claude-sonnet-4-6",
-        "anthropic/claude-sonnet-4-6",
-        "anthropic/claude-sonnet-4.6",
         "claude-sonnet-4.6"
       ],
       "max_tokens": 1000000,
@@ -3657,9 +3478,7 @@
     },
     {
       "name": "claude-sonnet-4-7",
-      "alias": [
-        "anthropic.claude-sonnet-4-7"
-      ],
+      "alias": [],
       "max_tokens": 1000000,
       "model_types": [
         "chat",
@@ -4100,7 +3919,6 @@
     {
       "name": "deep-research-max-preview-04-2026",
       "alias": [
-        "deep-research-max-preview-04-2026",
         "models/deep-research-max-preview-04-2026"
       ],
       "max_tokens": 1048576,
@@ -4111,7 +3929,6 @@
     {
       "name": "deep-research-preview-04-2026",
       "alias": [
-        "deep-research-preview-04-2026",
         "models/deep-research-preview-04-2026"
       ],
       "max_tokens": 1048576,
@@ -4405,9 +4222,7 @@
     {
       "name": "deepseek-ai/deepseek-v4-flash",
       "alias": [
-        "deepseek-v4-flash",
         "deepseek-chat",
-        "deepseek-ai/DeepSeek-V4-Flash",
         "deepseek/deepseek-v4-flash",
         "deepseek-v4-flash-260425",
         "deepseek/deepseek-v4-flash-202605"
@@ -4424,9 +4239,7 @@
     {
       "name": "deepseek-ai/deepseek-v4-flash-base",
       "alias": [
-        "deepseek-v4-flash-base",
-        "deepseek/deepseek-v4-flash-base",
-        "deepseek-ai/DeepSeek-V4-Flash-Base"
+        "deepseek/deepseek-v4-flash-base"
       ],
       "model_types": [
         "chat"
@@ -4436,8 +4249,6 @@
     {
       "name": "deepseek-ai/deepseek-v4-pro",
       "alias": [
-        "deepseek-v4-pro",
-        "deepseek-ai/DeepSeek-V4-Pro",
         "deepseek/deepseek-v4-pro",
         "deepseek-v4-pro-260425",
         "deepseek/deepseek-v4-pro-202606"
@@ -4454,9 +4265,7 @@
     {
       "name": "deepseek-ai/deepseek-v4-pro-base",
       "alias": [
-        "deepseek-v4-pro-base",
-        "deepseek/deepseek-v4-pro-base",
-        "deepseek-ai/DeepSeek-V4-Pro-Base"
+        "deepseek/deepseek-v4-pro-base"
       ],
       "model_types": [
         "chat"
@@ -4465,11 +4274,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-ocr-2",
-      "alias": [
-        "deepseek-ocr-2",
-        "deepseek-ai/DeepSeek-OCR-2",
-        "deepseek/deepseek-ocr-2"
-      ],
+      "alias": [],
       "model_types": [
         "ocr"
       ],
@@ -4478,8 +4283,6 @@
     {
       "name": "deepseek-ai/deepseek-v3.2",
       "alias": [
-        "deepseek-v3.2",
-        "deepseek-ai/DeepSeek-V3.2",
         "deepseek/deepseek-v3.2",
         "Pro/deepseek-ai/DeepSeek-V3.2",
         "deepseek/deepseek-v3.2-251201",
@@ -4493,8 +4296,6 @@
     {
       "name": "deepseek-ai/deepseek-v3.2-exp",
       "alias": [
-        "deepseek-v3.2-exp",
-        "deepseek-ai/DeepSeek-V3.2-Exp",
         "deepseek/deepseek-v3.2-exp",
         "deepseek/deepseek-v3.2-exp-thinking"
       ],
@@ -4505,10 +4306,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v3.2-exp-base",
-      "alias": [
-        "deepseek-v3.2-exp-base",
-        "deepseek-ai/DeepSeek-V3.2-Exp-Base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4517,8 +4315,6 @@
     {
       "name": "deepseek-ai/deepseek-v3.2-speciale",
       "alias": [
-        "deepseek-v3.2-speciale",
-        "deepseek-ai/DeepSeek-V3.2-Speciale",
         "deepseek/deepseek-v3.2-speciale-or"
       ],
       "model_types": [
@@ -4529,12 +4325,9 @@
     {
       "name": "deepseek-ai/deepseek-v3.1",
       "alias": [
-        "deepseek-v3.1",
-        "deepseek-ai/DeepSeek-V3.1",
         "deepseek/deepseek-chat-v3.1",
         "deepseek-v3-1-250821",
-        "DeepSeek-V3_1",
-        "deepseek/deepseek-v3.1"
+        "DeepSeek-V3_1"
       ],
       "model_types": [
         "chat"
@@ -4543,10 +4336,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v3.1-base",
-      "alias": [
-        "deepseek-v3.1-base",
-        "deepseek-ai/DeepSeek-V3.1-Base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4555,8 +4345,6 @@
     {
       "name": "deepseek-ai/deepseek-v3.1-terminus",
       "alias": [
-        "deepseek-v3.1-terminus",
-        "deepseek-ai/DeepSeek-V3.1-Terminus",
         "deepseek/deepseek-v3.1-terminus",
         "Pro/deepseek-ai/DeepSeek-V3.1-Terminus",
         "deepseek/deepseek-v3.1-terminus-thinking",
@@ -4570,12 +4358,9 @@
     {
       "name": "deepseek-ai/deepseek-v3-0324",
       "alias": [
-        "deepseek-v3-0324",
-        "deepseek-ai/DeepSeek-V3-0324",
         "deepseek/deepseek-chat-v3-0324",
         "deepseek-v3-250324",
-        "Pro/deepseek-ai/DeepSeek-V3",
-        "deepseek/deepseek-v3-0324"
+        "Pro/deepseek-ai/DeepSeek-V3"
       ],
       "model_types": [
         "chat"
@@ -4595,10 +4380,7 @@
     {
       "name": "deepseek-ai/deepseek-v3",
       "alias": [
-        "deepseek-v3",
-        "deepseek-ai/DeepSeek-V3",
-        "deepseek/deepseek-chat",
-        "DeepSeek-V3"
+        "deepseek/deepseek-chat"
       ],
       "model_types": [
         "chat"
@@ -4607,10 +4389,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v3-base",
-      "alias": [
-        "deepseek-v3-base",
-        "deepseek-ai/DeepSeek-V3-Base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4618,10 +4397,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2.5",
-      "alias": [
-        "deepseek-v2.5",
-        "deepseek-ai/DeepSeek-V2.5"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4629,10 +4405,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2.5-1210",
-      "alias": [
-        "deepseek-v2.5-1210",
-        "deepseek-ai/DeepSeek-V2.5-1210"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4640,10 +4413,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-base",
-      "alias": [
-        "deepseek-coder-v2-base",
-        "deepseek-ai/DeepSeek-Coder-V2-Base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4651,10 +4421,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-instruct",
-      "alias": [
-        "deepseek-coder-v2-instruct",
-        "deepseek-ai/DeepSeek-Coder-V2-Instruct"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4662,10 +4429,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-instruct-0724",
-      "alias": [
-        "deepseek-coder-v2-instruct-0724",
-        "deepseek-ai/DeepSeek-Coder-V2-Instruct-0724"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4673,10 +4437,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-lite-base",
-      "alias": [
-        "deepseek-coder-v2-lite-base",
-        "deepseek-ai/DeepSeek-Coder-V2-Lite-Base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4684,10 +4445,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-lite-instruct",
-      "alias": [
-        "deepseek-coder-v2-lite-instruct",
-        "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4696,8 +4454,6 @@
     {
       "name": "deepseek-ai/deepseek-math-v2",
       "alias": [
-        "deepseek-math-v2",
-        "deepseek-ai/DeepSeek-Math-V2",
         "deepseek/deepseek-math-v2"
       ],
       "model_types": [
@@ -4707,10 +4463,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v2-671b",
-      "alias": [
-        "deepseek-prover-v2-671b",
-        "deepseek-ai/DeepSeek-Prover-V2-671B"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4718,10 +4471,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v2-7b",
-      "alias": [
-        "deepseek-prover-v2-7b",
-        "deepseek-ai/DeepSeek-Prover-V2-7B"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4729,10 +4479,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2",
-      "alias": [
-        "deepseek-v2",
-        "deepseek-ai/DeepSeek-V2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4740,10 +4487,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-chat",
-      "alias": [
-        "deepseek-v2-chat",
-        "deepseek-ai/DeepSeek-V2-Chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4751,10 +4495,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-chat-0628",
-      "alias": [
-        "deepseek-v2-chat-0628",
-        "deepseek-ai/DeepSeek-V2-Chat-0628"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4762,10 +4503,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-lite",
-      "alias": [
-        "deepseek-v2-lite",
-        "deepseek-ai/DeepSeek-V2-Lite"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4773,10 +4511,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-v2-lite-chat",
-      "alias": [
-        "deepseek-v2-lite-chat",
-        "deepseek-ai/DeepSeek-V2-Lite-Chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4784,9 +4519,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-7b-base-v1.5",
-      "alias": [
-        "deepseek-coder-7b-base-v1.5"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4794,9 +4527,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-7b-instruct-v1.5",
-      "alias": [
-        "deepseek-coder-7b-instruct-v1.5"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4804,10 +4535,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-base",
-      "alias": [
-        "deepseek-prover-v1.5-base",
-        "deepseek-ai/DeepSeek-Prover-V1.5-Base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4815,10 +4543,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-rl",
-      "alias": [
-        "deepseek-prover-v1.5-rl",
-        "deepseek-ai/DeepSeek-Prover-V1.5-RL"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4826,10 +4551,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-sft",
-      "alias": [
-        "deepseek-prover-v1.5-sft",
-        "deepseek-ai/DeepSeek-Prover-V1.5-SFT"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4837,10 +4559,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1",
-      "alias": [
-        "deepseek-prover-v1",
-        "deepseek-ai/DeepSeek-Prover-V1"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4858,8 +4577,6 @@
     {
       "name": "deepseek-ai/deepseek-r1-0528",
       "alias": [
-        "deepseek-r1-0528",
-        "deepseek-ai/DeepSeek-R1-0528",
         "deepseek/deepseek-r1-0528",
         "deepseek-r1-250528",
         "Pro/deepseek-ai/DeepSeek-R1"
@@ -4886,10 +4603,7 @@
     {
       "name": "deepseek-ai/deepseek-r1",
       "alias": [
-        "deepseek-r1",
-        "deepseek-ai/DeepSeek-R1",
         "deepseek/deepseek-r1",
-        "DeepSeek-R1",
         "deepseek-r1-250120",
         "deepseek-r1_32k"
       ],
@@ -4901,8 +4615,6 @@
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-32b",
       "alias": [
-        "deepseek-r1-distill-qwen-32b",
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
         "deepseek/deepseek-r1-distill-qwen-32b",
         "deepseek-r1-distill-qwen-32b-250120"
       ],
@@ -4914,8 +4626,6 @@
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-7b",
       "alias": [
-        "deepseek-r1-distill-qwen-7b",
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
         "deepseek-r1-distill-qwen-7b-250120"
       ],
       "model_types": [
@@ -4935,10 +4645,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-0528-qwen3-8b",
-      "alias": [
-        "deepseek-r1-0528-qwen3-8b",
-        "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4947,8 +4654,6 @@
     {
       "name": "deepseek-ai/deepseek-r1-distill-llama-70b",
       "alias": [
-        "deepseek-r1-distill-llama-70b",
-        "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
         "deepseek/deepseek-r1-distill-llama-70b"
       ],
       "model_types": [
@@ -4958,10 +4663,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-llama-8b",
-      "alias": [
-        "deepseek-r1-distill-llama-8b",
-        "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4969,10 +4671,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-1.5b",
-      "alias": [
-        "deepseek-r1-distill-qwen-1.5b",
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4980,10 +4679,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-14b",
-      "alias": [
-        "deepseek-r1-distill-qwen-14b",
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -4991,10 +4687,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-r1-zero",
-      "alias": [
-        "deepseek-r1-zero",
-        "deepseek-ai/DeepSeek-R1-Zero"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5002,9 +4695,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl2",
-      "alias": [
-        "deepseek-vl2"
-      ],
+      "alias": [],
       "model_types": [
         "image2text"
       ],
@@ -5012,9 +4703,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl2-small",
-      "alias": [
-        "deepseek-vl2-small"
-      ],
+      "alias": [],
       "model_types": [
         "image2text"
       ],
@@ -5022,9 +4711,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl2-tiny",
-      "alias": [
-        "deepseek-vl2-tiny"
-      ],
+      "alias": [],
       "model_types": [
         "image2text"
       ],
@@ -5032,9 +4719,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-1.3b-base",
-      "alias": [
-        "deepseek-coder-1.3b-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5042,9 +4727,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-1.3b-instruct",
-      "alias": [
-        "deepseek-coder-1.3b-instruct"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5052,9 +4735,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-33b-base",
-      "alias": [
-        "deepseek-coder-33b-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5062,9 +4743,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-33b-instruct",
-      "alias": [
-        "deepseek-coder-33b-instruct"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5072,9 +4751,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-5.7bmqa-base",
-      "alias": [
-        "deepseek-coder-5.7bmqa-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5082,9 +4759,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-6.7b-base",
-      "alias": [
-        "deepseek-coder-6.7b-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5092,9 +4767,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-coder-6.7b-instruct",
-      "alias": [
-        "deepseek-coder-6.7b-instruct"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5102,9 +4775,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-67b-base",
-      "alias": [
-        "deepseek-llm-67b-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5112,9 +4783,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-67b-chat",
-      "alias": [
-        "deepseek-llm-67b-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5122,9 +4791,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-7b-base",
-      "alias": [
-        "deepseek-llm-7b-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5132,9 +4799,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-llm-7b-chat",
-      "alias": [
-        "deepseek-llm-7b-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5142,9 +4807,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-base",
-      "alias": [
-        "deepseek-math-7b-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5152,9 +4815,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-instruct",
-      "alias": [
-        "deepseek-math-7b-instruct"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5162,9 +4823,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-rl",
-      "alias": [
-        "deepseek-math-7b-rl"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5172,9 +4831,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-moe-16b-base",
-      "alias": [
-        "deepseek-moe-16b-base"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5182,9 +4839,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-moe-16b-chat",
-      "alias": [
-        "deepseek-moe-16b-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -5192,10 +4847,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-ocr",
-      "alias": [
-        "deepseek-ocr",
-        "deepseek-ai/DeepSeek-OCR"
-      ],
+      "alias": [],
       "model_types": [
         "ocr"
       ],
@@ -5203,9 +4855,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-1.3b-base",
-      "alias": [
-        "deepseek-vl-1.3b-base"
-      ],
+      "alias": [],
       "model_types": [
         "image2text"
       ],
@@ -5213,9 +4863,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-1.3b-chat",
-      "alias": [
-        "deepseek-vl-1.3b-chat"
-      ],
+      "alias": [],
       "model_types": [
         "image2text"
       ],
@@ -5223,9 +4871,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-7b-base",
-      "alias": [
-        "deepseek-vl-7b-base"
-      ],
+      "alias": [],
       "model_types": [
         "image2text"
       ],
@@ -5233,9 +4879,7 @@
     },
     {
       "name": "deepseek-ai/deepseek-vl-7b-chat",
-      "alias": [
-        "deepseek-vl-7b-chat"
-      ],
+      "alias": [],
       "model_types": [
         "image2text"
       ],
@@ -5263,9 +4907,7 @@
     },
     {
       "name": "deepseek-coder-1.3b-base",
-      "alias": [
-        "deepseek-ai/deepseek-coder-1.3b-base"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "chat"
@@ -5273,9 +4915,7 @@
     },
     {
       "name": "deepseek-coder-1.3b-instruct",
-      "alias": [
-        "deepseek-ai/deepseek-coder-1.3b-instruct"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "chat"
@@ -5283,9 +4923,7 @@
     },
     {
       "name": "deepseek-coder-33b-base",
-      "alias": [
-        "deepseek-ai/deepseek-coder-33b-base"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "chat"
@@ -5294,7 +4932,6 @@
     {
       "name": "deepseek-coder-33b-instruct",
       "alias": [
-        "deepseek-ai/deepseek-coder-33b-instruct",
         "Deepseek Coder 33B Instruct"
       ],
       "max_tokens": 16384,
@@ -5304,9 +4941,7 @@
     },
     {
       "name": "deepseek-coder-5.7bmqa-base",
-      "alias": [
-        "deepseek-ai/deepseek-coder-5.7bmqa-base"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "chat"
@@ -5314,9 +4949,7 @@
     },
     {
       "name": "deepseek-coder-6.7b-base",
-      "alias": [
-        "deepseek-ai/deepseek-coder-6.7b-base"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "chat"
@@ -5324,9 +4957,7 @@
     },
     {
       "name": "deepseek-coder-6.7b-instruct",
-      "alias": [
-        "deepseek-ai/deepseek-coder-6.7b-instruct"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "chat"
@@ -5334,9 +4965,7 @@
     },
     {
       "name": "deepseek-coder-7b-base-v1.5",
-      "alias": [
-        "deepseek-ai/deepseek-coder-7b-base-v1.5"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5344,9 +4973,7 @@
     },
     {
       "name": "deepseek-coder-7b-instruct-v1.5",
-      "alias": [
-        "deepseek-ai/deepseek-coder-7b-instruct-v1.5"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5354,9 +4981,7 @@
     },
     {
       "name": "deepseek-coder-v2-base",
-      "alias": [
-        "deepseek-ai/DeepSeek-Coder-V2-Base"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5364,9 +4989,7 @@
     },
     {
       "name": "deepseek-coder-v2-instruct",
-      "alias": [
-        "deepseek-ai/DeepSeek-Coder-V2-Instruct"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5374,9 +4997,7 @@
     },
     {
       "name": "deepseek-coder-v2-instruct-0724",
-      "alias": [
-        "deepseek-ai/DeepSeek-Coder-V2-Instruct-0724"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5384,9 +5005,7 @@
     },
     {
       "name": "deepseek-coder-v2-lite-base",
-      "alias": [
-        "deepseek-ai/DeepSeek-Coder-V2-Lite-Base"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5394,9 +5013,7 @@
     },
     {
       "name": "deepseek-coder-v2-lite-instruct",
-      "alias": [
-        "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5404,9 +5021,7 @@
     },
     {
       "name": "deepseek-llm-67b-base",
-      "alias": [
-        "deepseek-ai/deepseek-llm-67b-base"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5414,9 +5029,7 @@
     },
     {
       "name": "deepseek-llm-67b-chat",
-      "alias": [
-        "deepseek-ai/deepseek-llm-67b-chat"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5424,9 +5037,7 @@
     },
     {
       "name": "deepseek-llm-7b-base",
-      "alias": [
-        "deepseek-ai/deepseek-llm-7b-base"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5434,9 +5045,7 @@
     },
     {
       "name": "deepseek-llm-7b-chat",
-      "alias": [
-        "deepseek-ai/deepseek-llm-7b-chat"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5444,9 +5053,7 @@
     },
     {
       "name": "deepseek-math-7b-base",
-      "alias": [
-        "deepseek-ai/deepseek-math-7b-base"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5454,9 +5061,7 @@
     },
     {
       "name": "deepseek-math-7b-instruct",
-      "alias": [
-        "deepseek-ai/deepseek-math-7b-instruct"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5464,9 +5069,7 @@
     },
     {
       "name": "deepseek-math-7b-rl",
-      "alias": [
-        "deepseek-ai/deepseek-math-7b-rl"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5474,10 +5077,7 @@
     },
     {
       "name": "deepseek-math-v2",
-      "alias": [
-        "deepseek-ai/DeepSeek-Math-V2",
-        "deepseek/deepseek-math-v2"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5485,9 +5085,7 @@
     },
     {
       "name": "deepseek-moe-16b-base",
-      "alias": [
-        "deepseek-ai/deepseek-moe-16b-base"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5495,9 +5093,7 @@
     },
     {
       "name": "deepseek-moe-16b-chat",
-      "alias": [
-        "deepseek-ai/deepseek-moe-16b-chat"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5506,7 +5102,6 @@
     {
       "name": "deepseek-ocr",
       "alias": [
-        "deepseek-ai/DeepSeek-OCR",
         "deepseek/deepseek-ocr"
       ],
       "max_tokens": 8192,
@@ -5521,7 +5116,6 @@
     {
       "name": "deepseek-ocr-2",
       "alias": [
-        "deepseek-ai/DeepSeek-OCR-2",
         "Deepseek OCR 2"
       ],
       "max_tokens": 8192,
@@ -5534,9 +5128,7 @@
     },
     {
       "name": "deepseek-prover-v1",
-      "alias": [
-        "deepseek-ai/DeepSeek-Prover-V1"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5544,9 +5136,7 @@
     },
     {
       "name": "deepseek-prover-v1.5-base",
-      "alias": [
-        "deepseek-ai/DeepSeek-Prover-V1.5-Base"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5554,9 +5144,7 @@
     },
     {
       "name": "deepseek-prover-v1.5-rl",
-      "alias": [
-        "deepseek-ai/DeepSeek-Prover-V1.5-RL"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5564,9 +5152,7 @@
     },
     {
       "name": "deepseek-prover-v1.5-sft",
-      "alias": [
-        "deepseek-ai/DeepSeek-Prover-V1.5-SFT"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "chat"
@@ -5574,9 +5160,7 @@
     },
     {
       "name": "deepseek-prover-v2-671b",
-      "alias": [
-        "deepseek-ai/DeepSeek-Prover-V2-671B"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5584,9 +5168,7 @@
     },
     {
       "name": "deepseek-prover-v2-7b",
-      "alias": [
-        "deepseek-ai/DeepSeek-Prover-V2-7B"
-      ],
+      "alias": [],
       "max_tokens": 32768,
       "model_types": [
         "chat"
@@ -5595,10 +5177,6 @@
     {
       "name": "deepseek-r1",
       "alias": [
-        "deepseek-ai/DeepSeek-R1",
-        "deepseek/deepseek-r1",
-        "deepseek-r1-250120",
-        "deepseek-r1_32k",
         "deepseek-r1-searching",
         "DeepSeek R1"
       ],
@@ -5615,10 +5193,6 @@
     {
       "name": "deepseek-r1-0528",
       "alias": [
-        "deepseek-ai/DeepSeek-R1-0528",
-        "deepseek/deepseek-r1-0528",
-        "deepseek-r1-250528",
-        "Pro/deepseek-ai/DeepSeek-R1",
         "DeepSeek R1 0528",
         "DeepSeek R1 0528 NVFP4"
       ],
@@ -5635,7 +5209,6 @@
     {
       "name": "deepseek-r1-0528-qwen3-8b",
       "alias": [
-        "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
         "deepseek/deepseek-r1-0528-qwen3-8b",
         "DeepSeek R1 0528 Qwen3 8B"
       ],
@@ -5676,8 +5249,6 @@
     {
       "name": "deepseek-r1-distill-llama-70b",
       "alias": [
-        "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-        "deepseek/deepseek-r1-distill-llama-70b",
         "DeepSeek R1 Distill LLama 70B"
       ],
       "max_tokens": 131072,
@@ -5692,9 +5263,7 @@
     },
     {
       "name": "deepseek-r1-distill-llama-8b",
-      "alias": [
-        "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
-      ],
+      "alias": [],
       "max_tokens": 131072,
       "model_types": [
         "chat"
@@ -5703,7 +5272,6 @@
     {
       "name": "deepseek-r1-distill-qwen-1.5b",
       "alias": [
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
         "DeepSeek R1 Distill Qwen 1.5B"
       ],
       "max_tokens": 131072,
@@ -5718,7 +5286,6 @@
     {
       "name": "deepseek-r1-distill-qwen-14b",
       "alias": [
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
         "deepseek/deepseek-r1-distill-qwen-14b",
         "DeepSeek R1 Distill Qwen 14B"
       ],
@@ -5735,9 +5302,6 @@
     {
       "name": "deepseek-r1-distill-qwen-32b",
       "alias": [
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-        "deepseek/deepseek-r1-distill-qwen-32b",
-        "deepseek-r1-distill-qwen-32b-250120",
         "DeepSeek R1 Distill Qwen 32B"
       ],
       "max_tokens": 131072,
@@ -5753,8 +5317,6 @@
     {
       "name": "deepseek-r1-distill-qwen-7b",
       "alias": [
-        "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
-        "deepseek-r1-distill-qwen-7b-250120",
         "DeepSeek R1 Distill Qwen 7B"
       ],
       "max_tokens": 131072,
@@ -5791,9 +5353,7 @@
     },
     {
       "name": "deepseek-r1-zero",
-      "alias": [
-        "deepseek-ai/DeepSeek-R1-Zero"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5815,9 +5375,7 @@
     },
     {
       "name": "deepseek-v2",
-      "alias": [
-        "deepseek-ai/DeepSeek-V2"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5825,9 +5383,7 @@
     },
     {
       "name": "deepseek-v2-chat",
-      "alias": [
-        "deepseek-ai/DeepSeek-V2-Chat"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5835,9 +5391,7 @@
     },
     {
       "name": "deepseek-v2-chat-0628",
-      "alias": [
-        "deepseek-ai/DeepSeek-V2-Chat-0628"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5845,9 +5399,7 @@
     },
     {
       "name": "deepseek-v2-lite",
-      "alias": [
-        "deepseek-ai/DeepSeek-V2-Lite"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5855,9 +5407,7 @@
     },
     {
       "name": "deepseek-v2-lite-chat",
-      "alias": [
-        "deepseek-ai/DeepSeek-V2-Lite-Chat"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5865,9 +5415,7 @@
     },
     {
       "name": "deepseek-v2.5",
-      "alias": [
-        "deepseek-ai/DeepSeek-V2.5"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5875,9 +5423,7 @@
     },
     {
       "name": "deepseek-v2.5-1210",
-      "alias": [
-        "deepseek-ai/DeepSeek-V2.5-1210"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5886,8 +5432,6 @@
     {
       "name": "deepseek-v3",
       "alias": [
-        "deepseek-ai/DeepSeek-V3",
-        "deepseek/deepseek-chat",
         "deepseek/deepseek_v3",
         "deepseek_v3",
         "DeepSeek V3",
@@ -5902,12 +5446,7 @@
     },
     {
       "name": "deepseek-v3-0324",
-      "alias": [
-        "deepseek-ai/DeepSeek-V3-0324",
-        "deepseek/deepseek-chat-v3-0324",
-        "deepseek-v3-250324",
-        "Pro/deepseek-ai/DeepSeek-V3"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5940,9 +5479,7 @@
     },
     {
       "name": "deepseek-v3-base",
-      "alias": [
-        "deepseek-ai/DeepSeek-V3-Base"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5958,9 +5495,6 @@
     {
       "name": "deepseek-v3.1",
       "alias": [
-        "deepseek-ai/DeepSeek-V3.1",
-        "deepseek/deepseek-chat-v3.1",
-        "deepseek-v3-1-250821",
         "deepseek-v3-1-terminus",
         "deepseek-v3-1",
         "Deepseek V3.1 NVFP4"
@@ -5977,9 +5511,7 @@
     },
     {
       "name": "deepseek-v3.1-base",
-      "alias": [
-        "deepseek-ai/DeepSeek-V3.1-Base"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -5995,10 +5527,6 @@
     {
       "name": "deepseek-v3.1-terminus",
       "alias": [
-        "deepseek-ai/DeepSeek-V3.1-Terminus",
-        "deepseek/deepseek-v3.1-terminus",
-        "Pro/deepseek-ai/DeepSeek-V3.1-Terminus",
-        "deepseek/deepseek-v3.1-terminus-thinking",
         "Deepseek V3.1 Terminus"
       ],
       "max_tokens": 163840,
@@ -6025,11 +5553,6 @@
     {
       "name": "deepseek-v3.2",
       "alias": [
-        "deepseek-ai/DeepSeek-V3.2",
-        "deepseek/deepseek-v3.2",
-        "Pro/deepseek-ai/DeepSeek-V3.2",
-        "deepseek/deepseek-v3.2-251201",
-        "deepseek-v3-2-251201",
         "Deepseek V3.2",
         "deepseek-v3-2"
       ],
@@ -6046,9 +5569,6 @@
     {
       "name": "deepseek-v3.2-exp",
       "alias": [
-        "deepseek-ai/DeepSeek-V3.2-Exp",
-        "deepseek/deepseek-v3.2-exp",
-        "deepseek/deepseek-v3.2-exp-thinking",
         "Deepseek V3.2 Exp"
       ],
       "max_tokens": 163840,
@@ -6063,9 +5583,7 @@
     },
     {
       "name": "deepseek-v3.2-exp-base",
-      "alias": [
-        "deepseek-ai/DeepSeek-V3.2-Exp-Base"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -6084,9 +5602,7 @@
     },
     {
       "name": "deepseek-v3.2-speciale",
-      "alias": [
-        "deepseek-ai/DeepSeek-V3.2-Speciale"
-      ],
+      "alias": [],
       "max_tokens": 163840,
       "model_types": [
         "chat"
@@ -6106,10 +5622,6 @@
     {
       "name": "deepseek-v4-flash",
       "alias": [
-        "deepseek-chat",
-        "deepseek-ai/DeepSeek-V4-Flash",
-        "deepseek/deepseek-v4-flash",
-        "deepseek-v4-flash-260425",
         "Deepseek V4 Flash"
       ],
       "max_tokens": 1048576,
@@ -6124,10 +5636,7 @@
     },
     {
       "name": "deepseek-v4-flash-base",
-      "alias": [
-        "deepseek/deepseek-v4-flash-base",
-        "deepseek-ai/DeepSeek-V4-Flash-Base"
-      ],
+      "alias": [],
       "max_tokens": 1048576,
       "model_types": [
         "chat"
@@ -6136,9 +5645,6 @@
     {
       "name": "deepseek-v4-pro",
       "alias": [
-        "deepseek-ai/DeepSeek-V4-Pro",
-        "deepseek/deepseek-v4-pro",
-        "deepseek-v4-pro-260425",
         "Deepseek V4 Pro"
       ],
       "max_tokens": 1048576,
@@ -6153,10 +5659,7 @@
     },
     {
       "name": "deepseek-v4-pro-base",
-      "alias": [
-        "deepseek/deepseek-v4-pro-base",
-        "deepseek-ai/DeepSeek-V4-Pro-Base"
-      ],
+      "alias": [],
       "max_tokens": 1048576,
       "model_types": [
         "chat"
@@ -6164,9 +5667,7 @@
     },
     {
       "name": "deepseek-vl-1.3b-base",
-      "alias": [
-        "deepseek-ai/deepseek-vl-1.3b-base"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "image2text"
@@ -6174,9 +5675,7 @@
     },
     {
       "name": "deepseek-vl-1.3b-chat",
-      "alias": [
-        "deepseek-ai/deepseek-vl-1.3b-chat"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "image2text"
@@ -6184,9 +5683,7 @@
     },
     {
       "name": "deepseek-vl-7b-base",
-      "alias": [
-        "deepseek-ai/deepseek-vl-7b-base"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "image2text"
@@ -6194,9 +5691,7 @@
     },
     {
       "name": "deepseek-vl-7b-chat",
-      "alias": [
-        "deepseek-ai/deepseek-vl-7b-chat"
-      ],
+      "alias": [],
       "max_tokens": 16384,
       "model_types": [
         "image2text"
@@ -6204,9 +5699,7 @@
     },
     {
       "name": "deepseek-vl2",
-      "alias": [
-        "deepseek-ai/deepseek-vl2"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "image2text"
@@ -6214,9 +5707,7 @@
     },
     {
       "name": "deepseek-vl2-small",
-      "alias": [
-        "deepseek-ai/deepseek-vl2-small"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "image2text"
@@ -6224,9 +5715,7 @@
     },
     {
       "name": "deepseek-vl2-tiny",
-      "alias": [
-        "deepseek-ai/deepseek-vl2-tiny"
-      ],
+      "alias": [],
       "max_tokens": 4096,
       "model_types": [
         "image2text"
@@ -6964,18 +6453,14 @@
       "model_types": [
         "video_generation"
       ],
-      "alias": [
-        "doubao-seedance-1-5-pro"
-      ]
+      "alias": []
     },
     {
       "name": "doubao-seedance-2-0-260128",
       "model_types": [
         "video_generation"
       ],
-      "alias": [
-        "doubao-seedance-2-0"
-      ]
+      "alias": []
     },
     {
       "name": "doubao-seedance-2-0-fast-260128",
@@ -7489,7 +6974,6 @@
     {
       "name": "gemini-2.0-flash",
       "alias": [
-        "gemini-2.0-flash",
         "gemini-2.0-flash-001",
         "gemini-2.0-flash-exp",
         "models/gemini-2.0-flash"
@@ -7506,7 +6990,6 @@
     {
       "name": "gemini-2.0-flash-lite",
       "alias": [
-        "gemini-2.0-flash-lite",
         "gemini-2.0-flash-lite-001",
         "models/gemini-2.0-flash-lite"
       ],
@@ -7522,7 +7005,6 @@
     {
       "name": "gemini-2.5-computer-use-preview-10-2025",
       "alias": [
-        "gemini-2.5-computer-use-preview-10-2025",
         "models/gemini-2.5-computer-use-preview-10-2025"
       ],
       "max_tokens": 128000,
@@ -7535,10 +7017,8 @@
     {
       "name": "gemini-2.5-flash",
       "alias": [
-        "gemini-2.5-flash",
         "gemini-2.5-flash-preview-09-2025",
         "models/gemini-2.5-flash",
-        "google/gemini-2.5-flash",
         "google.gemini-2.5-flash"
       ],
       "max_tokens": 1048576,
@@ -7557,10 +7037,8 @@
     {
       "name": "gemini-2.5-flash-image",
       "alias": [
-        "gemini-2.5-flash-image",
         "gemini-2.5-flash-image-preview",
-        "models/gemini-2.5-flash-image",
-        "google/gemini-2.5-flash-image"
+        "models/gemini-2.5-flash-image"
       ],
       "max_tokens": 65536,
       "model_types": [
@@ -7573,10 +7051,8 @@
     {
       "name": "gemini-2.5-flash-lite",
       "alias": [
-        "gemini-2.5-flash-lite",
         "gemini-2.5-flash-lite-preview-09-2025",
         "models/gemini-2.5-flash-lite",
-        "google/gemini-2.5-flash-lite",
         "google.gemini-2.5-flash-lite"
       ],
       "max_tokens": 1048576,
@@ -7595,7 +7071,6 @@
     {
       "name": "gemini-2.5-flash-native-audio-preview-12-2025",
       "alias": [
-        "gemini-2.5-flash-native-audio-preview-12-2025",
         "models/gemini-2.5-flash-native-audio-preview-12-2025"
       ],
       "max_tokens": 131072,
@@ -7611,7 +7086,6 @@
     {
       "name": "gemini-2.5-flash-preview-tts",
       "alias": [
-        "gemini-2.5-flash-preview-tts",
         "models/gemini-2.5-flash-preview-tts"
       ],
       "max_tokens": 8192,
@@ -7623,9 +7097,7 @@
     {
       "name": "gemini-2.5-pro",
       "alias": [
-        "gemini-2.5-pro",
         "models/gemini-2.5-pro",
-        "google/gemini-2.5-pro",
         "google/gemini-2.5-pro-preview",
         "google/gemini-2.5-pro-preview-05-06",
         "google.gemini-2.5-pro"
@@ -7646,7 +7118,6 @@
     {
       "name": "gemini-2.5-pro-preview-tts",
       "alias": [
-        "gemini-2.5-pro-preview-tts",
         "models/gemini-2.5-pro-preview-tts"
       ],
       "max_tokens": 8192,
@@ -7658,9 +7129,7 @@
     {
       "name": "gemini-3-flash-preview",
       "alias": [
-        "gemini-3-flash-preview",
-        "models/gemini-3-flash-preview",
-        "google/gemini-3-flash-preview"
+        "models/gemini-3-flash-preview"
       ],
       "max_tokens": 1048576,
       "model_types": [
@@ -7678,9 +7147,7 @@
     {
       "name": "gemini-3-pro-image",
       "alias": [
-        "gemini-3-pro-image",
         "models/gemini-3-pro-image",
-        "google/gemini-3-pro-image",
         "google/gemini-3-pro-image-preview"
       ],
       "max_tokens": 65536,
@@ -7694,7 +7161,6 @@
     {
       "name": "gemini-3-pro-preview",
       "alias": [
-        "gemini-3-pro-preview",
         "models/gemini-3-pro-preview"
       ],
       "max_tokens": 1048576,
@@ -7713,7 +7179,6 @@
     {
       "name": "gemini-3.1-flash-image",
       "alias": [
-        "gemini-3.1-flash-image",
         "models/gemini-3.1-flash-image",
         "google/gemini-3.1-flash-image-preview"
       ],
@@ -7728,9 +7193,7 @@
     {
       "name": "gemini-3.1-flash-lite",
       "alias": [
-        "gemini-3.1-flash-lite",
-        "models/gemini-3.1-flash-lite",
-        "google/gemini-3.1-flash-lite"
+        "models/gemini-3.1-flash-lite"
       ],
       "max_tokens": 1048576,
       "model_types": [
@@ -7748,9 +7211,7 @@
     {
       "name": "gemini-3.1-flash-lite-preview",
       "alias": [
-        "gemini-3.1-flash-lite-preview",
-        "models/gemini-3.1-flash-lite-preview",
-        "google/gemini-3.1-flash-lite-preview"
+        "models/gemini-3.1-flash-lite-preview"
       ],
       "max_tokens": 1048576,
       "model_types": [
@@ -7768,7 +7229,6 @@
     {
       "name": "gemini-3.1-flash-live-preview",
       "alias": [
-        "gemini-3.1-flash-live-preview",
         "models/gemini-3.1-flash-live-preview"
       ],
       "max_tokens": 131072,
@@ -7784,7 +7244,6 @@
     {
       "name": "gemini-3.1-flash-tts-preview",
       "alias": [
-        "gemini-3.1-flash-tts-preview",
         "models/gemini-3.1-flash-tts-preview"
       ],
       "max_tokens": 8192,
@@ -7796,9 +7255,7 @@
     {
       "name": "gemini-3.1-pro-preview",
       "alias": [
-        "gemini-3.1-pro-preview",
         "models/gemini-3.1-pro-preview",
-        "google/gemini-3.1-pro-preview",
         "google/gemini-3.1-pro"
       ],
       "max_tokens": 1048576,
@@ -7817,9 +7274,7 @@
     {
       "name": "gemini-3.1-pro-preview-customtools",
       "alias": [
-        "gemini-3.1-pro-preview-customtools",
-        "models/gemini-3.1-pro-preview-customtools",
-        "google/gemini-3.1-pro-preview-customtools"
+        "models/gemini-3.1-pro-preview-customtools"
       ],
       "max_tokens": 1048576,
       "model_types": [
@@ -7837,9 +7292,7 @@
     {
       "name": "gemini-3.5-flash",
       "alias": [
-        "gemini-3.5-flash",
-        "models/gemini-3.5-flash",
-        "google/gemini-3.5-flash"
+        "models/gemini-3.5-flash"
       ],
       "max_tokens": 1048576,
       "model_types": [
@@ -7857,7 +7310,6 @@
     {
       "name": "gemini-3.5-live-translate-preview",
       "alias": [
-        "gemini-3.5-live-translate-preview",
         "models/gemini-3.5-live-translate-preview"
       ],
       "max_tokens": 131072,
@@ -7870,7 +7322,6 @@
     {
       "name": "gemini-embedding-001",
       "alias": [
-        "gemini-embedding-001",
         "models/gemini-embedding-001"
       ],
       "max_dimension": 3072,
@@ -7881,7 +7332,6 @@
     {
       "name": "gemini-embedding-2",
       "alias": [
-        "gemini-embedding-2",
         "models/gemini-embedding-2"
       ],
       "max_dimension": 3072,
@@ -7892,7 +7342,6 @@
     {
       "name": "gemini-robotics-er-1.6-preview",
       "alias": [
-        "gemini-robotics-er-1.6-preview",
         "models/gemini-robotics-er-1.6-preview"
       ],
       "max_tokens": 131072,
@@ -8151,9 +7600,7 @@
         "vision",
         "image2text"
       ],
-      "alias": [
-        "zai-org/glm-5v-turbo"
-      ],
+      "alias": [],
       "max_completion_tokens": 131072,
       "thinking": {
         "default_value": true,
@@ -8214,10 +7661,7 @@
     },
     {
       "name": "google/gemini-3.5-flash",
-      "alias": [
-        "gemini-3.5-flash",
-        "models/gemini-3.5-flash"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8233,10 +7677,7 @@
     },
     {
       "name": "google/gemini-3.5-live-translate-preview",
-      "alias": [
-        "gemini-3.5-live-translate-preview",
-        "models/gemini-3.5-live-translate-preview"
-      ],
+      "alias": [],
       "model_types": [
         "speech_translation",
         "audio2text",
@@ -8267,9 +7708,6 @@
     {
       "name": "google/gemini-3.1-flash-image",
       "alias": [
-        "gemini-3.1-flash-image",
-        "models/gemini-3.1-flash-image",
-        "google/gemini-3.1-flash-image-preview",
         "gemini-3.1-flash-image-preview"
       ],
       "model_types": [
@@ -8282,10 +7720,7 @@
     },
     {
       "name": "google/gemini-3.1-flash-lite",
-      "alias": [
-        "gemini-3.1-flash-lite",
-        "models/gemini-3.1-flash-lite"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8301,10 +7736,7 @@
     },
     {
       "name": "google/gemini-3.1-flash-lite-preview",
-      "alias": [
-        "gemini-3.1-flash-lite-preview",
-        "models/gemini-3.1-flash-lite-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8320,10 +7752,7 @@
     },
     {
       "name": "google/gemini-3.1-flash-live-preview",
-      "alias": [
-        "gemini-3.1-flash-live-preview",
-        "models/gemini-3.1-flash-live-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "omni",
@@ -8336,10 +7765,7 @@
     },
     {
       "name": "google/gemini-3.1-flash-tts-preview",
-      "alias": [
-        "gemini-3.1-flash-tts-preview",
-        "models/gemini-3.1-flash-tts-preview"
-      ],
+      "alias": [],
       "model_types": [
         "tts",
         "audio_generation"
@@ -8348,11 +7774,7 @@
     },
     {
       "name": "google/gemini-3.1-pro-preview",
-      "alias": [
-        "gemini-3.1-pro-preview",
-        "models/gemini-3.1-pro-preview",
-        "google/gemini-3.1-pro"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8368,10 +7790,7 @@
     },
     {
       "name": "google/gemini-3.1-pro-preview-customtools",
-      "alias": [
-        "gemini-3.1-pro-preview-customtools",
-        "models/gemini-3.1-pro-preview-customtools"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8400,10 +7819,7 @@
     },
     {
       "name": "google/gemini-3-flash-preview",
-      "alias": [
-        "gemini-3-flash-preview",
-        "models/gemini-3-flash-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8419,11 +7835,7 @@
     },
     {
       "name": "google/gemini-3-pro-image",
-      "alias": [
-        "gemini-3-pro-image",
-        "models/gemini-3-pro-image",
-        "google/gemini-3-pro-image-preview"
-      ],
+      "alias": [],
       "model_types": [
         "text-to-image",
         "image_generation",
@@ -8434,10 +7846,7 @@
     },
     {
       "name": "google/gemini-3-pro-preview",
-      "alias": [
-        "gemini-3-pro-preview",
-        "models/gemini-3-pro-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8453,10 +7862,7 @@
     },
     {
       "name": "google/gemini-2.5-computer-use-preview-10-2025",
-      "alias": [
-        "gemini-2.5-computer-use-preview-10-2025",
-        "models/gemini-2.5-computer-use-preview-10-2025"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8466,12 +7872,7 @@
     },
     {
       "name": "google/gemini-2.5-flash",
-      "alias": [
-        "gemini-2.5-flash",
-        "gemini-2.5-flash-preview-09-2025",
-        "models/gemini-2.5-flash",
-        "google.gemini-2.5-flash"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8487,11 +7888,7 @@
     },
     {
       "name": "google/gemini-2.5-flash-image",
-      "alias": [
-        "gemini-2.5-flash-image",
-        "gemini-2.5-flash-image-preview",
-        "models/gemini-2.5-flash-image"
-      ],
+      "alias": [],
       "model_types": [
         "text-to-image",
         "image_generation",
@@ -8503,10 +7900,6 @@
     {
       "name": "google/gemini-2.5-flash-lite",
       "alias": [
-        "gemini-2.5-flash-lite",
-        "gemini-2.5-flash-lite-preview-09-2025",
-        "models/gemini-2.5-flash-lite",
-        "google.gemini-2.5-flash-lite",
         "google/gemini-2.5-flash-lite-preview-09-2025"
       ],
       "model_types": [
@@ -8542,10 +7935,7 @@
     },
     {
       "name": "google/gemini-2.5-flash-native-audio-preview-12-2025",
-      "alias": [
-        "gemini-2.5-flash-native-audio-preview-12-2025",
-        "models/gemini-2.5-flash-native-audio-preview-12-2025"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "omni",
@@ -8576,10 +7966,7 @@
     },
     {
       "name": "google/gemini-2.5-flash-preview-tts",
-      "alias": [
-        "gemini-2.5-flash-preview-tts",
-        "models/gemini-2.5-flash-preview-tts"
-      ],
+      "alias": [],
       "model_types": [
         "tts",
         "audio_generation"
@@ -8588,13 +7975,7 @@
     },
     {
       "name": "google/gemini-2.5-pro",
-      "alias": [
-        "gemini-2.5-pro",
-        "models/gemini-2.5-pro",
-        "google/gemini-2.5-pro-preview",
-        "google/gemini-2.5-pro-preview-05-06",
-        "google.gemini-2.5-pro"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8628,10 +8009,7 @@
     },
     {
       "name": "google/gemini-2.5-pro-preview-tts",
-      "alias": [
-        "gemini-2.5-pro-preview-tts",
-        "models/gemini-2.5-pro-preview-tts"
-      ],
+      "alias": [],
       "model_types": [
         "tts",
         "audio_generation"
@@ -8654,22 +8032,14 @@
     },
     {
       "name": "google/DiarizationLM-8b-Fisher-v2",
-      "alias": [
-        "google/diarizationlm-8b-fisher-v2",
-        "google/DiarizationLM-8b-Fisher-v2"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemini-2.0-flash",
-      "alias": [
-        "gemini-2.0-flash",
-        "gemini-2.0-flash-001",
-        "gemini-2.0-flash-exp",
-        "models/gemini-2.0-flash"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8681,11 +8051,7 @@
     },
     {
       "name": "google/gemini-2.0-flash-lite",
-      "alias": [
-        "gemini-2.0-flash-lite",
-        "gemini-2.0-flash-lite-001",
-        "models/gemini-2.0-flash-lite"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8697,183 +8063,140 @@
     },
     {
       "name": "google/metricx-24-hybrid-large-v2p6",
-      "alias": [
-        "google/metricx-24-hybrid-large-v2p6"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/metricx-24-hybrid-large-v2p6-bfloat16",
-      "alias": [
-        "google/metricx-24-hybrid-large-v2p6-bfloat16"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/metricx-24-hybrid-xl-v2p6",
-      "alias": [
-        "google/metricx-24-hybrid-xl-v2p6"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/metricx-24-hybrid-xl-v2p6-bfloat16",
-      "alias": [
-        "google/metricx-24-hybrid-xl-v2p6-bfloat16"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/metricx-24-hybrid-xxl-v2p6",
-      "alias": [
-        "google/metricx-24-hybrid-xxl-v2p6"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/metricx-24-hybrid-xxl-v2p6-bfloat16",
-      "alias": [
-        "google/metricx-24-hybrid-xxl-v2p6-bfloat16"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/DiarizationLM-8b-Fisher-v1",
-      "alias": [
-        "google/diarizationlm-8b-fisher-v1",
-        "google/DiarizationLM-8b-Fisher-v1"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/alphagenome-all-folds",
-      "alias": [
-        "google/alphagenome-all-folds"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/alphagenome-fold-0",
-      "alias": [
-        "google/alphagenome-fold-0"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/alphagenome-fold-1",
-      "alias": [
-        "google/alphagenome-fold-1"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/alphagenome-fold-2",
-      "alias": [
-        "google/alphagenome-fold-2"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/alphagenome-fold-3",
-      "alias": [
-        "google/alphagenome-fold-3"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/CircularNet",
-      "alias": [
-        "google/circularnet",
-        "google/CircularNet"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/codegemma-1.1-2b-keras",
-      "alias": [
-        "google/codegemma-1.1-2b-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/codegemma-1.1-7b-it-keras",
-      "alias": [
-        "google/codegemma-1.1-7b-it-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/cxr-foundation",
-      "alias": [
-        "google/cxr-foundation"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/datagemma-rag-27b-it",
-      "alias": [
-        "google/datagemma-rag-27b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/datagemma-rig-27b-it",
-      "alias": [
-        "google/datagemma-rig-27b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/derm-foundation",
-      "alias": [
-        "google/derm-foundation"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/diffusiongemma-26B-A4B-it",
-      "alias": [
-        "google/diffusiongemma-26b-a4b-it",
-        "google/diffusiongemma-26B-A4B-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -8882,9 +8205,7 @@
     },
     {
       "name": "google/embeddinggemma-300m",
-      "alias": [
-        "google/embeddinggemma-300m"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -8898,9 +8219,7 @@
     },
     {
       "name": "google/embeddinggemma-300m-qat-q4_0-unquantized",
-      "alias": [
-        "google/embeddinggemma-300m-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -8914,9 +8233,7 @@
     },
     {
       "name": "google/embeddinggemma-300m-qat-q8_0-unquantized",
-      "alias": [
-        "google/embeddinggemma-300m-qat-q8_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -8930,19 +8247,14 @@
     },
     {
       "name": "google/functiongemma-270m-it",
-      "alias": [
-        "google/functiongemma-270m-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemini-embedding-001",
-      "alias": [
-        "gemini-embedding-001",
-        "models/gemini-embedding-001"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -8955,10 +8267,7 @@
     },
     {
       "name": "google/gemini-embedding-2",
-      "alias": [
-        "gemini-embedding-2",
-        "models/gemini-embedding-2"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -9009,10 +8318,7 @@
     },
     {
       "name": "google/gemini-robotics-er-1.6-preview",
-      "alias": [
-        "gemini-robotics-er-1.6-preview",
-        "models/gemini-robotics-er-1.6-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9031,138 +8337,105 @@
     },
     {
       "name": "google/gemma-2-2b",
-      "alias": [
-        "google/gemma-2-2b"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-2b-GGUF",
-      "alias": [
-        "google/gemma-2-2b-gguf",
-        "google/gemma-2-2b-GGUF"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-2-2b-it",
-      "alias": [
-        "google/gemma-2-2b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-2b-it-GGUF",
-      "alias": [
-        "google/gemma-2-2b-it-gguf",
-        "google/gemma-2-2b-it-GGUF"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-2-2b-it-pytorch",
-      "alias": [
-        "google/gemma-2-2b-it-pytorch"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-2b-jpn-it",
-      "alias": [
-        "google/gemma-2-2b-jpn-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-2b-jpn-it-flax",
-      "alias": [
-        "google/gemma-2-2b-jpn-it-flax"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-2b-jpn-it-pytorch",
-      "alias": [
-        "google/gemma-2-2b-jpn-it-pytorch"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-2b-pytorch",
-      "alias": [
-        "google/gemma-2-2b-pytorch"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-9b",
-      "alias": [
-        "google/gemma-2-9b"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-9b-it",
-      "alias": [
-        "google/gemma-2-9b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-9b-keras",
-      "alias": [
-        "google/gemma-2-9b-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2-instruct-9b-keras",
-      "alias": [
-        "google/gemma-2-instruct-9b-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2b-aps-it",
-      "alias": [
-        "google/gemma-2b-aps-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-2b-AWQ",
-      "alias": [
-        "google/gemma-2b-awq",
-        "google/gemma-2b-AWQ"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
@@ -9170,8 +8443,7 @@
     {
       "name": "google/gemma-3-12b-it",
       "alias": [
-        "google.gemma-3-12b-it",
-        "google/gemma-3-12b-it"
+        "google.gemma-3-12b-it"
       ],
       "model_types": [
         "chat",
@@ -9181,9 +8453,7 @@
     },
     {
       "name": "google/gemma-3-12b-it-qat-int4-unquantized",
-      "alias": [
-        "google/gemma-3-12b-it-qat-int4-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9192,9 +8462,7 @@
     },
     {
       "name": "google/gemma-3-12b-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-12b-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9203,9 +8471,7 @@
     },
     {
       "name": "google/gemma-3-12b-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-3-12b-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9214,9 +8480,7 @@
     },
     {
       "name": "google/gemma-3-12b-pt",
-      "alias": [
-        "google/gemma-3-12b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9225,9 +8489,7 @@
     },
     {
       "name": "google/gemma-3-12b-pt-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-12b-pt-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9236,90 +8498,70 @@
     },
     {
       "name": "google/gemma-3-1b-it",
-      "alias": [
-        "google/gemma-3-1b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-1b-it-qat-int4-unquantized",
-      "alias": [
-        "google/gemma-3-1b-it-qat-int4-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-1b-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-1b-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-1b-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-3-1b-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-1b-pt",
-      "alias": [
-        "google/gemma-3-1b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-1b-pt-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-1b-pt-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-270m",
-      "alias": [
-        "google/gemma-3-270m"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-270m-it",
-      "alias": [
-        "google/gemma-3-270m-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-270m-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-3-270m-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3-270m-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-3-270m-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
@@ -9328,8 +8570,7 @@
       "name": "google/gemma-3-27b-it",
       "alias": [
         "google.gemma-3-27b-it",
-        "gemma-3-27b-it",
-        "google/gemma-3-27b-it"
+        "gemma-3-27b-it"
       ],
       "model_types": [
         "chat",
@@ -9339,9 +8580,7 @@
     },
     {
       "name": "google/gemma-3-27b-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-27b-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9350,9 +8589,7 @@
     },
     {
       "name": "google/gemma-3-27b-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-3-27b-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9361,9 +8598,7 @@
     },
     {
       "name": "google/gemma-3-27b-pt",
-      "alias": [
-        "google/gemma-3-27b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9372,9 +8607,7 @@
     },
     {
       "name": "google/gemma-3-27b-pt-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-27b-pt-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9384,8 +8617,7 @@
     {
       "name": "google/gemma-3-4b-it",
       "alias": [
-        "google.gemma-3-4b-it",
-        "google/gemma-3-4b-it"
+        "google.gemma-3-4b-it"
       ],
       "model_types": [
         "chat",
@@ -9395,9 +8627,7 @@
     },
     {
       "name": "google/gemma-3-4b-it-qat-int4-unquantized",
-      "alias": [
-        "google/gemma-3-4b-it-qat-int4-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9406,9 +8636,7 @@
     },
     {
       "name": "google/gemma-3-4b-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-4b-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9417,9 +8645,7 @@
     },
     {
       "name": "google/gemma-3-4b-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-3-4b-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9428,9 +8654,7 @@
     },
     {
       "name": "google/gemma-3-4b-pt",
-      "alias": [
-        "google/gemma-3-4b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9439,9 +8663,7 @@
     },
     {
       "name": "google/gemma-3-4b-pt-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-3-4b-pt-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9450,10 +8672,7 @@
     },
     {
       "name": "google/gemma-3n-E2B",
-      "alias": [
-        "google/gemma-3n-e2b",
-        "google/gemma-3n-E2B"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9462,10 +8681,7 @@
     },
     {
       "name": "google/gemma-3n-E2B-it",
-      "alias": [
-        "google/gemma-3n-e2b-it",
-        "google/gemma-3n-E2B-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9474,20 +8690,14 @@
     },
     {
       "name": "google/gemma-3n-E2B-it-litert-lm",
-      "alias": [
-        "google/gemma-3n-e2b-it-litert-lm",
-        "google/gemma-3n-E2B-it-litert-lm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3n-E2B-it-litert-preview",
-      "alias": [
-        "google/gemma-3n-e2b-it-litert-preview",
-        "google/gemma-3n-E2B-it-litert-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9496,10 +8706,7 @@
     },
     {
       "name": "google/gemma-3n-E4B",
-      "alias": [
-        "google/gemma-3n-e4b",
-        "google/gemma-3n-E4B"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9508,10 +8715,7 @@
     },
     {
       "name": "google/gemma-3n-E4B-it",
-      "alias": [
-        "google/gemma-3n-e4b-it",
-        "google/gemma-3n-E4B-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9520,20 +8724,14 @@
     },
     {
       "name": "google/gemma-3n-E4B-it-litert-lm",
-      "alias": [
-        "google/gemma-3n-e4b-it-litert-lm",
-        "google/gemma-3n-E4B-it-litert-lm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-3n-E4B-it-litert-preview",
-      "alias": [
-        "google/gemma-3n-e4b-it-litert-preview",
-        "google/gemma-3n-E4B-it-litert-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9542,80 +8740,56 @@
     },
     {
       "name": "google/gemma-4-12B",
-      "alias": [
-        "google/gemma-4-12b",
-        "google/gemma-4-12B"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-12B-it",
-      "alias": [
-        "google/gemma-4-12b-it",
-        "google/gemma-4-12B-it"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-12B-it-assistant",
-      "alias": [
-        "google/gemma-4-12b-it-assistant",
-        "google/gemma-4-12B-it-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-12B-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-4-12b-it-qat-q4_0-gguf",
-        "google/gemma-4-12B-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-12B-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-4-12b-it-qat-q4_0-unquantized",
-        "google/gemma-4-12B-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-12B-it-qat-q4_0-unquantized-assistant",
-      "alias": [
-        "google/gemma-4-12b-it-qat-q4_0-unquantized-assistant",
-        "google/gemma-4-12B-it-qat-q4_0-unquantized-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-12B-it-qat-w4a16-ct",
-      "alias": [
-        "google/gemma-4-12b-it-qat-w4a16-ct",
-        "google/gemma-4-12B-it-qat-w4a16-ct"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-26B-A4B",
-      "alias": [
-        "google/gemma-4-26b-a4b",
-        "google/gemma-4-26B-A4B"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9625,11 +8799,9 @@
     {
       "name": "google/gemma-4-26B-A4B-it",
       "alias": [
-        "google/gemma-4-26b-a4b-it",
         "google/gemma-4-26b-a4b-it:free",
         "google.gemma-4-26b-a4b",
-        "gemma-4-26B-A4B-it",
-        "google/gemma-4-26B-A4B-it"
+        "gemma-4-26B-A4B-it"
       ],
       "model_types": [
         "chat",
@@ -9639,20 +8811,14 @@
     },
     {
       "name": "google/gemma-4-26B-A4B-it-assistant",
-      "alias": [
-        "google/gemma-4-26b-a4b-it-assistant",
-        "google/gemma-4-26B-A4B-it-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-26B-A4B-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-4-26b-a4b-it-qat-q4_0-gguf",
-        "google/gemma-4-26B-A4B-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9661,10 +8827,7 @@
     },
     {
       "name": "google/gemma-4-26B-A4B-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-4-26b-a4b-it-qat-q4_0-unquantized",
-        "google/gemma-4-26B-A4B-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9673,10 +8836,7 @@
     },
     {
       "name": "google/gemma-4-26B-A4B-it-qat-q4_0-unquantized-assistant",
-      "alias": [
-        "google/gemma-4-26b-a4b-it-qat-q4_0-unquantized-assistant",
-        "google/gemma-4-26B-A4B-it-qat-q4_0-unquantized-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9685,10 +8845,7 @@
     },
     {
       "name": "google/gemma-4-31B",
-      "alias": [
-        "google/gemma-4-31b",
-        "google/gemma-4-31B"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9698,11 +8855,9 @@
     {
       "name": "google/gemma-4-31B-it",
       "alias": [
-        "google/gemma-4-31b-it",
         "google/gemma-4-31b-it:free",
         "google/gemma-4-31B-it-turbo",
-        "google.gemma-4-31b",
-        "google/gemma-4-31B-it"
+        "google.gemma-4-31b"
       ],
       "model_types": [
         "chat",
@@ -9712,20 +8867,14 @@
     },
     {
       "name": "google/gemma-4-31B-it-assistant",
-      "alias": [
-        "google/gemma-4-31b-it-assistant",
-        "google/gemma-4-31B-it-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-31B-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-4-31b-it-qat-q4_0-gguf",
-        "google/gemma-4-31B-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9734,10 +8883,7 @@
     },
     {
       "name": "google/gemma-4-31B-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-4-31b-it-qat-q4_0-unquantized",
-        "google/gemma-4-31B-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9746,10 +8892,7 @@
     },
     {
       "name": "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant",
-      "alias": [
-        "google/gemma-4-31b-it-qat-q4_0-unquantized-assistant",
-        "google/gemma-4-31B-it-qat-q4_0-unquantized-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9758,10 +8901,7 @@
     },
     {
       "name": "google/gemma-4-31B-it-qat-w4a16-ct",
-      "alias": [
-        "google/gemma-4-31b-it-qat-w4a16-ct",
-        "google/gemma-4-31B-it-qat-w4a16-ct"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -9770,406 +8910,301 @@
     },
     {
       "name": "google/gemma-4-E2B",
-      "alias": [
-        "google/gemma-4-e2b",
-        "google/gemma-4-E2B"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it",
-      "alias": [
-        "google/gemma-4-e2b-it",
-        "google/gemma-4-E2B-it"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it-assistant",
-      "alias": [
-        "google/gemma-4-e2b-it-assistant",
-        "google/gemma-4-E2B-it-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it-qat-mobile-ct",
-      "alias": [
-        "google/gemma-4-e2b-it-qat-mobile-ct",
-        "google/gemma-4-E2B-it-qat-mobile-ct"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it-qat-mobile-transformers",
-      "alias": [
-        "google/gemma-4-e2b-it-qat-mobile-transformers",
-        "google/gemma-4-E2B-it-qat-mobile-transformers"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-4-e2b-it-qat-q4_0-gguf",
-        "google/gemma-4-E2B-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-4-e2b-it-qat-q4_0-unquantized",
-        "google/gemma-4-E2B-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant",
-      "alias": [
-        "google/gemma-4-e2b-it-qat-q4_0-unquantized-assistant",
-        "google/gemma-4-E2B-it-qat-q4_0-unquantized-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E2B-it-qat-w4a16-ct",
-      "alias": [
-        "google/gemma-4-e2b-it-qat-w4a16-ct",
-        "google/gemma-4-E2B-it-qat-w4a16-ct"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B",
-      "alias": [
-        "google/gemma-4-e4b",
-        "google/gemma-4-E4B"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it",
-      "alias": [
-        "google/gemma-4-e4b-it",
-        "google/gemma-4-E4B-it"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it-assistant",
-      "alias": [
-        "google/gemma-4-e4b-it-assistant",
-        "google/gemma-4-E4B-it-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it-qat-mobile-ct",
-      "alias": [
-        "google/gemma-4-e4b-it-qat-mobile-ct",
-        "google/gemma-4-E4B-it-qat-mobile-ct"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it-qat-mobile-transformers",
-      "alias": [
-        "google/gemma-4-e4b-it-qat-mobile-transformers",
-        "google/gemma-4-E4B-it-qat-mobile-transformers"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it-qat-q4_0-gguf",
-      "alias": [
-        "google/gemma-4-e4b-it-qat-q4_0-gguf",
-        "google/gemma-4-E4B-it-qat-q4_0-gguf"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it-qat-q4_0-unquantized",
-      "alias": [
-        "google/gemma-4-e4b-it-qat-q4_0-unquantized",
-        "google/gemma-4-E4B-it-qat-q4_0-unquantized"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant",
-      "alias": [
-        "google/gemma-4-e4b-it-qat-q4_0-unquantized-assistant",
-        "google/gemma-4-E4B-it-qat-q4_0-unquantized-assistant"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-4-E4B-it-qat-w4a16-ct",
-      "alias": [
-        "google/gemma-4-e4b-it-qat-w4a16-ct",
-        "google/gemma-4-E4B-it-qat-w4a16-ct"
-      ],
+      "alias": [],
       "model_types": [
         "omni"
       ]
     },
     {
       "name": "google/gemma-7b-aps-it",
-      "alias": [
-        "google/gemma-7b-aps-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-7b-AWQ",
-      "alias": [
-        "google/gemma-7b-awq",
-        "google/gemma-7b-AWQ"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-scope",
-      "alias": [
-        "google/gemma-scope"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2",
-      "alias": [
-        "google/gemma-scope-2"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-12b-it",
-      "alias": [
-        "google/gemma-scope-2-12b-it"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-12b-pt",
-      "alias": [
-        "google/gemma-scope-2-12b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-1b-it",
-      "alias": [
-        "google/gemma-scope-2-1b-it"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-1b-pt",
-      "alias": [
-        "google/gemma-scope-2-1b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-270m-it",
-      "alias": [
-        "google/gemma-scope-2-270m-it"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-270m-pt",
-      "alias": [
-        "google/gemma-scope-2-270m-pt"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-27b-it",
-      "alias": [
-        "google/gemma-scope-2-27b-it"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-27b-pt",
-      "alias": [
-        "google/gemma-scope-2-27b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-4b-it",
-      "alias": [
-        "google/gemma-scope-2-4b-it"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2-4b-pt",
-      "alias": [
-        "google/gemma-scope-2-4b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-27b-pt-res",
-      "alias": [
-        "google/gemma-scope-27b-pt-res"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2b-pt-att",
-      "alias": [
-        "google/gemma-scope-2b-pt-att"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2b-pt-mlp",
-      "alias": [
-        "google/gemma-scope-2b-pt-mlp"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2b-pt-res",
-      "alias": [
-        "google/gemma-scope-2b-pt-res"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-2b-pt-transcoders",
-      "alias": [
-        "google/gemma-scope-2b-pt-transcoders"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-9b-it-res",
-      "alias": [
-        "google/gemma-scope-9b-it-res"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-9b-pt-att",
-      "alias": [
-        "google/gemma-scope-9b-pt-att"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-9b-pt-mlp",
-      "alias": [
-        "google/gemma-scope-9b-pt-mlp"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/gemma-scope-9b-pt-res",
-      "alias": [
-        "google/gemma-scope-9b-pt-res"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/hear",
-      "alias": [
-        "google/hear"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/hear-pytorch",
-      "alias": [
-        "google/hear-pytorch"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
@@ -10177,7 +9212,6 @@
     {
       "name": "google/imagen-4.0-fast-generate-001",
       "alias": [
-        "imagen-4.0-fast-generate-001",
         "models/imagen-4.0-fast-generate-001"
       ],
       "model_types": [
@@ -10190,7 +9224,6 @@
     {
       "name": "google/imagen-4.0-generate-001",
       "alias": [
-        "imagen-4.0-generate-001",
         "models/imagen-4.0-generate-001"
       ],
       "model_types": [
@@ -10203,7 +9236,6 @@
     {
       "name": "google/imagen-4.0-ultra-generate-001",
       "alias": [
-        "imagen-4.0-ultra-generate-001",
         "models/imagen-4.0-ultra-generate-001"
       ],
       "model_types": [
@@ -10216,7 +9248,6 @@
     {
       "name": "google/lyria-3-clip-preview",
       "alias": [
-        "lyria-3-clip-preview",
         "models/lyria-3-clip-preview"
       ],
       "model_types": [
@@ -10227,7 +9258,6 @@
     {
       "name": "google/lyria-3-pro-preview",
       "alias": [
-        "lyria-3-pro-preview",
         "models/lyria-3-pro-preview"
       ],
       "model_types": [
@@ -10238,7 +9268,6 @@
     {
       "name": "google/lyria-realtime-exp",
       "alias": [
-        "lyria-realtime-exp",
         "models/lyria-realtime-exp"
       ],
       "model_types": [
@@ -10247,27 +9276,21 @@
     },
     {
       "name": "google/magenta-realtime",
-      "alias": [
-        "google/magenta-realtime"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/magenta-realtime-2",
-      "alias": [
-        "google/magenta-realtime-2"
-      ],
+      "alias": [],
       "model_types": [
         "audio_generation"
       ]
     },
     {
       "name": "google/medasr",
-      "alias": [
-        "google/medasr"
-      ],
+      "alias": [],
       "model_types": [
         "asr",
         "speech2text",
@@ -10276,9 +9299,7 @@
     },
     {
       "name": "google/medgemma-1.5-4b-it",
-      "alias": [
-        "google/medgemma-1.5-4b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10287,9 +9308,7 @@
     },
     {
       "name": "google/medgemma-27b-it",
-      "alias": [
-        "google/medgemma-27b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10298,9 +9317,7 @@
     },
     {
       "name": "google/medgemma-27b-text-it",
-      "alias": [
-        "google/medgemma-27b-text-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
@@ -10308,8 +9325,7 @@
     {
       "name": "google/medgemma-4b-it",
       "alias": [
-        "medgemma-4b-it",
-        "google/medgemma-4b-it"
+        "medgemma-4b-it"
       ],
       "model_types": [
         "chat",
@@ -10319,9 +9335,7 @@
     },
     {
       "name": "google/medgemma-4b-pt",
-      "alias": [
-        "google/medgemma-4b-pt"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10330,9 +9344,7 @@
     },
     {
       "name": "google/medsiglip-448",
-      "alias": [
-        "google/medsiglip-448"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
@@ -10349,9 +9361,7 @@
     },
     {
       "name": "google/paligemma-3b-mix-224-keras",
-      "alias": [
-        "google/paligemma-3b-mix-224-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10360,9 +9370,7 @@
     },
     {
       "name": "google/paligemma-3b-mix-448-keras",
-      "alias": [
-        "google/paligemma-3b-mix-448-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10371,9 +9379,7 @@
     },
     {
       "name": "google/paligemma-3b-pt-224-keras",
-      "alias": [
-        "google/paligemma-3b-pt-224-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10382,9 +9388,7 @@
     },
     {
       "name": "google/paligemma-3b-pt-448-keras",
-      "alias": [
-        "google/paligemma-3b-pt-448-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10393,9 +9397,7 @@
     },
     {
       "name": "google/paligemma-3b-pt-896-keras",
-      "alias": [
-        "google/paligemma-3b-pt-896-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10404,9 +9406,7 @@
     },
     {
       "name": "google/paligemma2-10b-ft-docci-448",
-      "alias": [
-        "google/paligemma2-10b-ft-docci-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10415,9 +9415,7 @@
     },
     {
       "name": "google/paligemma2-10b-ft-docci-448-jax",
-      "alias": [
-        "google/paligemma2-10b-ft-docci-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10426,9 +9424,7 @@
     },
     {
       "name": "google/paligemma2-10b-mix-224",
-      "alias": [
-        "google/paligemma2-10b-mix-224"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10437,9 +9433,7 @@
     },
     {
       "name": "google/paligemma2-10b-mix-224-jax",
-      "alias": [
-        "google/paligemma2-10b-mix-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10448,9 +9442,7 @@
     },
     {
       "name": "google/paligemma2-10b-mix-448",
-      "alias": [
-        "google/paligemma2-10b-mix-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10459,9 +9451,7 @@
     },
     {
       "name": "google/paligemma2-10b-mix-448-jax",
-      "alias": [
-        "google/paligemma2-10b-mix-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10470,9 +9460,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-224",
-      "alias": [
-        "google/paligemma2-10b-pt-224"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10481,9 +9469,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-224-jax",
-      "alias": [
-        "google/paligemma2-10b-pt-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10492,9 +9478,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-224-keras",
-      "alias": [
-        "google/paligemma2-10b-pt-224-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10503,9 +9487,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-448",
-      "alias": [
-        "google/paligemma2-10b-pt-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10514,9 +9496,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-448-jax",
-      "alias": [
-        "google/paligemma2-10b-pt-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10525,9 +9505,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-448-keras",
-      "alias": [
-        "google/paligemma2-10b-pt-448-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10536,9 +9514,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-896",
-      "alias": [
-        "google/paligemma2-10b-pt-896"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10547,9 +9523,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-896-jax",
-      "alias": [
-        "google/paligemma2-10b-pt-896-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10558,9 +9532,7 @@
     },
     {
       "name": "google/paligemma2-10b-pt-896-keras",
-      "alias": [
-        "google/paligemma2-10b-pt-896-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10569,9 +9541,7 @@
     },
     {
       "name": "google/paligemma2-28b-mix-224",
-      "alias": [
-        "google/paligemma2-28b-mix-224"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10580,9 +9550,7 @@
     },
     {
       "name": "google/paligemma2-28b-mix-224-jax",
-      "alias": [
-        "google/paligemma2-28b-mix-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10591,9 +9559,7 @@
     },
     {
       "name": "google/paligemma2-28b-mix-448",
-      "alias": [
-        "google/paligemma2-28b-mix-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10602,9 +9568,7 @@
     },
     {
       "name": "google/paligemma2-28b-mix-448-jax",
-      "alias": [
-        "google/paligemma2-28b-mix-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10613,9 +9577,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-224",
-      "alias": [
-        "google/paligemma2-28b-pt-224"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10624,9 +9586,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-224-jax",
-      "alias": [
-        "google/paligemma2-28b-pt-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10635,9 +9595,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-224-keras",
-      "alias": [
-        "google/paligemma2-28b-pt-224-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10646,9 +9604,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-448",
-      "alias": [
-        "google/paligemma2-28b-pt-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10657,9 +9613,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-448-jax",
-      "alias": [
-        "google/paligemma2-28b-pt-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10668,9 +9622,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-448-keras",
-      "alias": [
-        "google/paligemma2-28b-pt-448-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10679,9 +9631,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-896",
-      "alias": [
-        "google/paligemma2-28b-pt-896"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10690,9 +9640,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-896-jax",
-      "alias": [
-        "google/paligemma2-28b-pt-896-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10701,9 +9649,7 @@
     },
     {
       "name": "google/paligemma2-28b-pt-896-keras",
-      "alias": [
-        "google/paligemma2-28b-pt-896-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10712,9 +9658,7 @@
     },
     {
       "name": "google/paligemma2-3b-ft-docci-448",
-      "alias": [
-        "google/paligemma2-3b-ft-docci-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10723,9 +9667,7 @@
     },
     {
       "name": "google/paligemma2-3b-ft-docci-448-jax",
-      "alias": [
-        "google/paligemma2-3b-ft-docci-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10734,9 +9676,7 @@
     },
     {
       "name": "google/paligemma2-3b-mix-224",
-      "alias": [
-        "google/paligemma2-3b-mix-224"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10745,9 +9685,7 @@
     },
     {
       "name": "google/paligemma2-3b-mix-224-jax",
-      "alias": [
-        "google/paligemma2-3b-mix-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10756,9 +9694,7 @@
     },
     {
       "name": "google/paligemma2-3b-mix-448",
-      "alias": [
-        "google/paligemma2-3b-mix-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10767,9 +9703,7 @@
     },
     {
       "name": "google/paligemma2-3b-mix-448-jax",
-      "alias": [
-        "google/paligemma2-3b-mix-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10778,9 +9712,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-224",
-      "alias": [
-        "google/paligemma2-3b-pt-224"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10789,9 +9721,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-224-jax",
-      "alias": [
-        "google/paligemma2-3b-pt-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10800,9 +9730,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-224-keras",
-      "alias": [
-        "google/paligemma2-3b-pt-224-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10811,9 +9739,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-448",
-      "alias": [
-        "google/paligemma2-3b-pt-448"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10822,9 +9748,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-448-jax",
-      "alias": [
-        "google/paligemma2-3b-pt-448-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10833,9 +9757,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-448-keras",
-      "alias": [
-        "google/paligemma2-3b-pt-448-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10844,9 +9766,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-896",
-      "alias": [
-        "google/paligemma2-3b-pt-896"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10855,9 +9775,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-896-jax",
-      "alias": [
-        "google/paligemma2-3b-pt-896-jax"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10866,9 +9784,7 @@
     },
     {
       "name": "google/paligemma2-3b-pt-896-keras",
-      "alias": [
-        "google/paligemma2-3b-pt-896-keras"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10877,18 +9793,14 @@
     },
     {
       "name": "google/path-foundation",
-      "alias": [
-        "google/path-foundation"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/shieldgemma-2-4b-it",
-      "alias": [
-        "google/shieldgemma-2-4b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -10897,369 +9809,287 @@
     },
     {
       "name": "google/shieldgemma-27b",
-      "alias": [
-        "google/shieldgemma-27b"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/shieldgemma-2b",
-      "alias": [
-        "google/shieldgemma-2b"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/shieldgemma-9b",
-      "alias": [
-        "google/shieldgemma-9b"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/siglip-so400m-patch14-224",
-      "alias": [
-        "google/siglip-so400m-patch14-224"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip-so400m-patch16-256-i18n",
-      "alias": [
-        "google/siglip-so400m-patch16-256-i18n"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-224",
-      "alias": [
-        "google/siglip2-base-patch16-224"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-224-jax",
-      "alias": [
-        "google/siglip2-base-patch16-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-256",
-      "alias": [
-        "google/siglip2-base-patch16-256"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-256-jax",
-      "alias": [
-        "google/siglip2-base-patch16-256-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-384",
-      "alias": [
-        "google/siglip2-base-patch16-384"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-384-jax",
-      "alias": [
-        "google/siglip2-base-patch16-384-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-512",
-      "alias": [
-        "google/siglip2-base-patch16-512"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-512-jax",
-      "alias": [
-        "google/siglip2-base-patch16-512-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-naflex",
-      "alias": [
-        "google/siglip2-base-patch16-naflex"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch16-naflex-jax",
-      "alias": [
-        "google/siglip2-base-patch16-naflex-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch32-256",
-      "alias": [
-        "google/siglip2-base-patch32-256"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-base-patch32-256-jax",
-      "alias": [
-        "google/siglip2-base-patch32-256-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-giant-opt-patch16-256",
-      "alias": [
-        "google/siglip2-giant-opt-patch16-256"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-giant-opt-patch16-256-jax",
-      "alias": [
-        "google/siglip2-giant-opt-patch16-256-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-giant-opt-patch16-384",
-      "alias": [
-        "google/siglip2-giant-opt-patch16-384"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-giant-opt-patch16-384-jax",
-      "alias": [
-        "google/siglip2-giant-opt-patch16-384-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-large-patch16-256",
-      "alias": [
-        "google/siglip2-large-patch16-256"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-large-patch16-256-jax",
-      "alias": [
-        "google/siglip2-large-patch16-256-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-large-patch16-384",
-      "alias": [
-        "google/siglip2-large-patch16-384"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-large-patch16-384-jax",
-      "alias": [
-        "google/siglip2-large-patch16-384-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-large-patch16-512",
-      "alias": [
-        "google/siglip2-large-patch16-512"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-large-patch16-512-jax",
-      "alias": [
-        "google/siglip2-large-patch16-512-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch14-224",
-      "alias": [
-        "google/siglip2-so400m-patch14-224"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch14-224-jax",
-      "alias": [
-        "google/siglip2-so400m-patch14-224-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch14-384",
-      "alias": [
-        "google/siglip2-so400m-patch14-384"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch14-384-jax",
-      "alias": [
-        "google/siglip2-so400m-patch14-384-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-256",
-      "alias": [
-        "google/siglip2-so400m-patch16-256"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-256-jax",
-      "alias": [
-        "google/siglip2-so400m-patch16-256-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-384",
-      "alias": [
-        "google/siglip2-so400m-patch16-384"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-384-jax",
-      "alias": [
-        "google/siglip2-so400m-patch16-384-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-512",
-      "alias": [
-        "google/siglip2-so400m-patch16-512"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-512-jax",
-      "alias": [
-        "google/siglip2-so400m-patch16-512-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-naflex",
-      "alias": [
-        "google/siglip2-so400m-patch16-naflex"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/siglip2-so400m-patch16-naflex-jax",
-      "alias": [
-        "google/siglip2-so400m-patch16-naflex-jax"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/svq",
-      "alias": [
-        "google/svq"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/t5gemma-2-1b-1b",
-      "alias": [
-        "google/t5gemma-2-1b-1b"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -11268,9 +10098,7 @@
     },
     {
       "name": "google/t5gemma-2-270m-270m",
-      "alias": [
-        "google/t5gemma-2-270m-270m"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -11279,9 +10107,7 @@
     },
     {
       "name": "google/t5gemma-2-4b-4b",
-      "alias": [
-        "google/t5gemma-2-4b-4b"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -11290,369 +10116,287 @@
     },
     {
       "name": "google/t5gemma-2b-2b-prefixlm",
-      "alias": [
-        "google/t5gemma-2b-2b-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-2b-2b-prefixlm-it",
-      "alias": [
-        "google/t5gemma-2b-2b-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-2b-2b-ul2",
-      "alias": [
-        "google/t5gemma-2b-2b-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-2b-2b-ul2-it",
-      "alias": [
-        "google/t5gemma-2b-2b-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-2b-prefixlm",
-      "alias": [
-        "google/t5gemma-9b-2b-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-2b-prefixlm-it",
-      "alias": [
-        "google/t5gemma-9b-2b-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-2b-ul2",
-      "alias": [
-        "google/t5gemma-9b-2b-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-2b-ul2-it",
-      "alias": [
-        "google/t5gemma-9b-2b-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-9b-prefixlm",
-      "alias": [
-        "google/t5gemma-9b-9b-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-9b-prefixlm-it",
-      "alias": [
-        "google/t5gemma-9b-9b-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-9b-ul2",
-      "alias": [
-        "google/t5gemma-9b-9b-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-9b-9b-ul2-it",
-      "alias": [
-        "google/t5gemma-9b-9b-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-b-b-prefixlm",
-      "alias": [
-        "google/t5gemma-b-b-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-b-b-prefixlm-it",
-      "alias": [
-        "google/t5gemma-b-b-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-b-b-ul2",
-      "alias": [
-        "google/t5gemma-b-b-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-b-b-ul2-it",
-      "alias": [
-        "google/t5gemma-b-b-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-l-l-prefixlm",
-      "alias": [
-        "google/t5gemma-l-l-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-l-l-prefixlm-it",
-      "alias": [
-        "google/t5gemma-l-l-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-l-l-ul2",
-      "alias": [
-        "google/t5gemma-l-l-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-l-l-ul2-it",
-      "alias": [
-        "google/t5gemma-l-l-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-ml-ml-prefixlm",
-      "alias": [
-        "google/t5gemma-ml-ml-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-ml-ml-prefixlm-it",
-      "alias": [
-        "google/t5gemma-ml-ml-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-ml-ml-ul2",
-      "alias": [
-        "google/t5gemma-ml-ml-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-ml-ml-ul2-it",
-      "alias": [
-        "google/t5gemma-ml-ml-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-s-s-prefixlm",
-      "alias": [
-        "google/t5gemma-s-s-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-s-s-prefixlm-it",
-      "alias": [
-        "google/t5gemma-s-s-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-s-s-ul2",
-      "alias": [
-        "google/t5gemma-s-s-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-s-s-ul2-it",
-      "alias": [
-        "google/t5gemma-s-s-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-xl-xl-prefixlm",
-      "alias": [
-        "google/t5gemma-xl-xl-prefixlm"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-xl-xl-prefixlm-it",
-      "alias": [
-        "google/t5gemma-xl-xl-prefixlm-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-xl-xl-ul2",
-      "alias": [
-        "google/t5gemma-xl-xl-ul2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/t5gemma-xl-xl-ul2-it",
-      "alias": [
-        "google/t5gemma-xl-xl-ul2-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/tapnet",
-      "alias": [
-        "google/tapnet"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/timesfm-1.0-200m-pytorch",
-      "alias": [
-        "google/timesfm-1.0-200m-pytorch"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/timesfm-2.0-500m-jax",
-      "alias": [
-        "google/timesfm-2.0-500m-jax"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/timesfm-2.0-500m-pytorch",
-      "alias": [
-        "google/timesfm-2.0-500m-pytorch"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/timesfm-2.5-200m-flax",
-      "alias": [
-        "google/timesfm-2.5-200m-flax"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/timesfm-2.5-200m-pytorch",
-      "alias": [
-        "google/timesfm-2.5-200m-pytorch"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/timesfm-2.5-200m-transformers",
-      "alias": [
-        "google/timesfm-2.5-200m-transformers"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "google/tipsv2-b14",
-      "alias": [
-        "google/tipsv2-b14"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/tipsv2-b14-dpt",
-      "alias": [
-        "google/tipsv2-b14-dpt"
-      ],
+      "alias": [],
       "model_types": [
         "vision",
         "depth_estimation"
@@ -11660,18 +10404,14 @@
     },
     {
       "name": "google/tipsv2-g14",
-      "alias": [
-        "google/tipsv2-g14"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/tipsv2-g14-dpt",
-      "alias": [
-        "google/tipsv2-g14-dpt"
-      ],
+      "alias": [],
       "model_types": [
         "vision",
         "depth_estimation"
@@ -11679,18 +10419,14 @@
     },
     {
       "name": "google/tipsv2-l14",
-      "alias": [
-        "google/tipsv2-l14"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/tipsv2-l14-dpt",
-      "alias": [
-        "google/tipsv2-l14-dpt"
-      ],
+      "alias": [],
       "model_types": [
         "vision",
         "depth_estimation"
@@ -11698,18 +10434,14 @@
     },
     {
       "name": "google/tipsv2-so400m14",
-      "alias": [
-        "google/tipsv2-so400m14"
-      ],
+      "alias": [],
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "google/tipsv2-so400m14-dpt",
-      "alias": [
-        "google/tipsv2-so400m14-dpt"
-      ],
+      "alias": [],
       "model_types": [
         "vision",
         "depth_estimation"
@@ -11717,9 +10449,7 @@
     },
     {
       "name": "google/translategemma-12b-it",
-      "alias": [
-        "google/translategemma-12b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -11728,9 +10458,7 @@
     },
     {
       "name": "google/translategemma-27b-it",
-      "alias": [
-        "google/translategemma-27b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -11739,9 +10467,7 @@
     },
     {
       "name": "google/translategemma-4b-it",
-      "alias": [
-        "google/translategemma-4b-it"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image2text",
@@ -11750,54 +10476,42 @@
     },
     {
       "name": "google/txgemma-27b-chat",
-      "alias": [
-        "google/txgemma-27b-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/txgemma-27b-predict",
-      "alias": [
-        "google/txgemma-27b-predict"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/txgemma-2b-predict",
-      "alias": [
-        "google/txgemma-2b-predict"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/txgemma-9b-chat",
-      "alias": [
-        "google/txgemma-9b-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/txgemma-9b-predict",
-      "alias": [
-        "google/txgemma-9b-predict"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/vaultgemma-1b",
-      "alias": [
-        "google/vaultgemma-1b"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
@@ -11805,7 +10519,6 @@
     {
       "name": "google/veo-3.1-fast-generate-preview",
       "alias": [
-        "veo-3.1-fast-generate-preview",
         "models/veo-3.1-fast-generate-preview"
       ],
       "model_types": [
@@ -11815,7 +10528,6 @@
     {
       "name": "google/veo-3.1-generate-preview",
       "alias": [
-        "veo-3.1-generate-preview",
         "models/veo-3.1-generate-preview"
       ],
       "model_types": [
@@ -11825,7 +10537,6 @@
     {
       "name": "google/veo-3.1-lite-generate-preview",
       "alias": [
-        "veo-3.1-lite-generate-preview",
         "models/veo-3.1-lite-generate-preview"
       ],
       "model_types": [
@@ -11882,36 +10593,28 @@
     },
     {
       "name": "google/videoprism-base-f16r288",
-      "alias": [
-        "google/videoprism-base-f16r288"
-      ],
+      "alias": [],
       "model_types": [
         "video_understanding"
       ]
     },
     {
       "name": "google/videoprism-large-f8r288",
-      "alias": [
-        "google/videoprism-large-f8r288"
-      ],
+      "alias": [],
       "model_types": [
         "video_understanding"
       ]
     },
     {
       "name": "google/videoprism-lvt-base-f16r288",
-      "alias": [
-        "google/videoprism-lvt-base-f16r288"
-      ],
+      "alias": [],
       "model_types": [
         "video_understanding"
       ]
     },
     {
       "name": "google/videoprism-lvt-large-f8r288",
-      "alias": [
-        "google/videoprism-lvt-large-f8r288"
-      ],
+      "alias": [],
       "model_types": [
         "video_understanding"
       ]
@@ -11935,9 +10638,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-3.5-turbo"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-3.5-turbo-0125",
@@ -11965,9 +10666,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-3.5-turbo-16k"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-3.5-turbo-instruct",
@@ -11995,8 +10694,7 @@
         "image2text"
       ],
       "alias": [
-        "gpt-4-all",
-        "openai/gpt-4"
+        "gpt-4-all"
       ]
     },
     {
@@ -12080,9 +10778,7 @@
         "vision",
         "image2text"
       ],
-      "alias": [
-        "openai/gpt-4-turbo"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4-turbo-2024-04-09",
@@ -12116,9 +10812,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4.1"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4.1-2025-04-14",
@@ -12126,9 +10820,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4.1-2025-04-14"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4.1-mini",
@@ -12136,9 +10828,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4.1-mini"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4.1-mini-2025-04-14",
@@ -12146,9 +10836,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4.1-mini-2025-04-14"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4.1-nano",
@@ -12156,9 +10844,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4.1-nano"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4.1-nano-2025-04-14",
@@ -12166,9 +10852,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4.1-nano-2025-04-14"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o",
@@ -12179,8 +10863,7 @@
         "image2text"
       ],
       "alias": [
-        "gpt-4o-all",
-        "openai/gpt-4o"
+        "gpt-4o-all"
       ]
     },
     {
@@ -12191,9 +10874,7 @@
         "vision",
         "image2text"
       ],
-      "alias": [
-        "openai/gpt-4o-2024-05-13"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-2024-08-06",
@@ -12201,9 +10882,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4o-2024-08-06"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-2024-11-20",
@@ -12211,9 +10890,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4o-2024-11-20"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-audio-preview",
@@ -12266,9 +10943,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4o-mini"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-mini-2024-07-18",
@@ -12276,9 +10951,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4o-mini-2024-07-18"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-mini-audio-preview",
@@ -12310,9 +10983,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4o-mini-search-preview"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-mini-transcribe",
@@ -12329,9 +11000,7 @@
         "tts",
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4o-mini-tts"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-mini-tts-1",
@@ -12381,9 +11050,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-4o-search-preview"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-4o-transcribe",
@@ -12412,8 +11079,7 @@
         "clear_thinking": true
       },
       "alias": [
-        "gpt-5-all",
-        "openai/gpt-5"
+        "gpt-5-all"
       ]
     },
     {
@@ -12462,9 +11128,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-5-chat-latest"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5-codex",
@@ -12476,9 +11140,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5-codex"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5-codex-2025-09-15",
@@ -12553,9 +11215,7 @@
         "vision",
         "image2text"
       ],
-      "alias": [
-        "openai/gpt-5-mini"
-      ],
+      "alias": [],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -12579,9 +11239,7 @@
         "vision",
         "image2text"
       ],
-      "alias": [
-        "openai/gpt-5-nano"
-      ],
+      "alias": [],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -12603,9 +11261,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-5-pro"
-      ],
+      "alias": [],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -12647,8 +11303,7 @@
       },
       "alias": [
         "gpt-5.1-thinking-all",
-        "gpt-5.1-all",
-        "openai/gpt-5.1"
+        "gpt-5.1-all"
       ]
     },
     {
@@ -12687,9 +11342,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-5.1-chat-latest"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.1-codex",
@@ -12701,9 +11354,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5.1-codex"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.1-codex-2025-11-13",
@@ -12746,9 +11397,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5.1-codex-mini"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.1-plus",
@@ -12779,8 +11428,7 @@
         "clear_thinking": true
       },
       "alias": [
-        "gpt-5.2-all",
-        "openai/gpt-5.2"
+        "gpt-5.2-all"
       ]
     },
     {
@@ -12819,9 +11467,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-5.2-chat-latest"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.2-codex",
@@ -12833,9 +11479,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5.2-codex"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.2-codex-2026-01-14",
@@ -12853,9 +11497,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-5.2-pro"
-      ],
+      "alias": [],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -12900,9 +11542,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "openai/gpt-5.3-chat-latest"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.3-codex",
@@ -12914,9 +11554,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5.3-codex"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.3-codex-2026-02-24",
@@ -12942,7 +11580,6 @@
       "name": "gpt-5.4",
       "alias": [
         "gpt-5.4-2026-03-05",
-        "openai/gpt-5.4",
         "openai/gpt-5.4-2026-03-05"
       ],
       "max_tokens": 1050000,
@@ -12976,9 +11613,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5.4-mini"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.4-mini-2026-03-17",
@@ -13004,9 +11639,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5.4-nano"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.4-nano-2026-03-17",
@@ -13026,7 +11659,6 @@
       "name": "gpt-5.4-pro-2026-03-05",
       "alias": [
         "gpt-5.4-pro",
-        "openai/gpt-5.4-pro",
         "openai/gpt-5.4-pro-2026-03-05"
       ],
       "max_tokens": 1050000,
@@ -13048,9 +11680,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "openai/gpt-5.5"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-5.5-2026-04-24",
@@ -13085,8 +11715,7 @@
         "chat"
       ],
       "alias": [
-        "gpt-image-1-all",
-        "openai/gpt-image-1"
+        "gpt-image-1-all"
       ]
     },
     {
@@ -13105,9 +11734,7 @@
         "image_edit",
         "chat"
       ],
-      "alias": [
-        "openai/gpt-image-1-mini"
-      ]
+      "alias": []
     },
     {
       "name": "gpt-image-1.5",
@@ -13121,7 +11748,6 @@
       ],
       "alias": [
         "gpt-image-1.5-all",
-        "openai/gpt-image-1.5",
         "GPT Image 1.5"
       ]
     },
@@ -13135,7 +11761,6 @@
         "image_generation"
       ],
       "alias": [
-        "openai/gpt-image-2",
         "gpt-image-2-all",
         "GPT Image 2"
       ]
@@ -13478,8 +12103,7 @@
       "name": "gryphe/mythomax-l2-13b",
       "alias": [
         "MythoMax-L2-13b",
-        "Mythomax L2 13B",
-        "Gryphe/MythoMax-L2-13b"
+        "Mythomax L2 13B"
       ],
       "model_types": [
         "chat"
@@ -13858,10 +12482,7 @@
     },
     {
       "name": "imagen-4.0-fast-generate-001",
-      "alias": [
-        "imagen-4.0-fast-generate-001",
-        "models/imagen-4.0-fast-generate-001"
-      ],
+      "alias": [],
       "max_tokens": 480,
       "model_types": [
         "text-to-image",
@@ -13870,10 +12491,7 @@
     },
     {
       "name": "imagen-4.0-generate-001",
-      "alias": [
-        "imagen-4.0-generate-001",
-        "models/imagen-4.0-generate-001"
-      ],
+      "alias": [],
       "max_tokens": 480,
       "model_types": [
         "text-to-image",
@@ -13882,10 +12500,7 @@
     },
     {
       "name": "imagen-4.0-ultra-generate-001",
-      "alias": [
-        "imagen-4.0-ultra-generate-001",
-        "models/imagen-4.0-ultra-generate-001"
-      ],
+      "alias": [],
       "max_tokens": 480,
       "model_types": [
         "text-to-image",
@@ -14128,9 +12743,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-classification-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-nano-classification-gguf",
-        "jina-embeddings-v5-omni-nano-classification-GGUF",
-        "jina-embeddings-v5-omni-nano-classification-gguf"
+        "jina-embeddings-v5-omni-nano-classification-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14196,9 +12809,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-clustering-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-nano-clustering-gguf",
-        "jina-embeddings-v5-omni-nano-clustering-GGUF",
-        "jina-embeddings-v5-omni-nano-clustering-gguf"
+        "jina-embeddings-v5-omni-nano-clustering-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14286,9 +12897,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-retrieval-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-nano-retrieval-gguf",
-        "jina-embeddings-v5-omni-nano-retrieval-GGUF",
-        "jina-embeddings-v5-omni-nano-retrieval-gguf"
+        "jina-embeddings-v5-omni-nano-retrieval-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14354,9 +12963,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-text-matching-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-nano-text-matching-gguf",
-        "jina-embeddings-v5-omni-nano-text-matching-GGUF",
-        "jina-embeddings-v5-omni-nano-text-matching-gguf"
+        "jina-embeddings-v5-omni-nano-text-matching-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14444,9 +13051,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-classification-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-small-classification-gguf",
-        "jina-embeddings-v5-omni-small-classification-GGUF",
-        "jina-embeddings-v5-omni-small-classification-gguf"
+        "jina-embeddings-v5-omni-small-classification-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14512,9 +13117,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-clustering-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-small-clustering-gguf",
-        "jina-embeddings-v5-omni-small-clustering-GGUF",
-        "jina-embeddings-v5-omni-small-clustering-gguf"
+        "jina-embeddings-v5-omni-small-clustering-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14602,9 +13205,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-retrieval-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-small-retrieval-gguf",
-        "jina-embeddings-v5-omni-small-retrieval-GGUF",
-        "jina-embeddings-v5-omni-small-retrieval-gguf"
+        "jina-embeddings-v5-omni-small-retrieval-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14670,9 +13271,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-text-matching-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-omni-small-text-matching-gguf",
-        "jina-embeddings-v5-omni-small-text-matching-GGUF",
-        "jina-embeddings-v5-omni-small-text-matching-gguf"
+        "jina-embeddings-v5-omni-small-text-matching-GGUF"
       ],
       "model_types": [
         "embedding",
@@ -14756,9 +13355,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-classification-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-nano-classification-gguf",
-        "jina-embeddings-v5-text-nano-classification-GGUF",
-        "jina-embeddings-v5-text-nano-classification-gguf"
+        "jina-embeddings-v5-text-nano-classification-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -14818,9 +13415,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-clustering-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-nano-clustering-gguf",
-        "jina-embeddings-v5-text-nano-clustering-GGUF",
-        "jina-embeddings-v5-text-nano-clustering-gguf"
+        "jina-embeddings-v5-text-nano-clustering-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -14900,9 +13495,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-retrieval-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-nano-retrieval-gguf",
-        "jina-embeddings-v5-text-nano-retrieval-GGUF",
-        "jina-embeddings-v5-text-nano-retrieval-gguf"
+        "jina-embeddings-v5-text-nano-retrieval-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -14962,9 +13555,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-text-matching-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-nano-text-matching-gguf",
-        "jina-embeddings-v5-text-nano-text-matching-GGUF",
-        "jina-embeddings-v5-text-nano-text-matching-gguf"
+        "jina-embeddings-v5-text-nano-text-matching-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15044,9 +13635,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-small-classification-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-small-classification-gguf",
-        "jina-embeddings-v5-text-small-classification-GGUF",
-        "jina-embeddings-v5-text-small-classification-gguf"
+        "jina-embeddings-v5-text-small-classification-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15106,9 +13695,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-small-clustering-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-small-clustering-gguf",
-        "jina-embeddings-v5-text-small-clustering-GGUF",
-        "jina-embeddings-v5-text-small-clustering-gguf"
+        "jina-embeddings-v5-text-small-clustering-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15188,9 +13775,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-small-retrieval-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-small-retrieval-gguf",
-        "jina-embeddings-v5-text-small-retrieval-GGUF",
-        "jina-embeddings-v5-text-small-retrieval-gguf"
+        "jina-embeddings-v5-text-small-retrieval-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15250,9 +13835,7 @@
     {
       "name": "jinaai/jina-embeddings-v5-text-small-text-matching-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v5-text-small-text-matching-gguf",
-        "jina-embeddings-v5-text-small-text-matching-GGUF",
-        "jina-embeddings-v5-text-small-text-matching-gguf"
+        "jina-embeddings-v5-text-small-text-matching-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15330,9 +13913,7 @@
     {
       "name": "jinaai/jina-embeddings-v4-text-code-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v4-text-code-gguf",
-        "jina-embeddings-v4-text-code-GGUF",
-        "jina-embeddings-v4-text-code-gguf"
+        "jina-embeddings-v4-text-code-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15350,9 +13931,7 @@
     {
       "name": "jinaai/jina-embeddings-v4-text-matching-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v4-text-matching-gguf",
-        "jina-embeddings-v4-text-matching-GGUF",
-        "jina-embeddings-v4-text-matching-gguf"
+        "jina-embeddings-v4-text-matching-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15370,9 +13949,7 @@
     {
       "name": "jinaai/jina-embeddings-v4-text-retrieval-GGUF",
       "alias": [
-        "jinaai/jina-embeddings-v4-text-retrieval-gguf",
-        "jina-embeddings-v4-text-retrieval-GGUF",
-        "jina-embeddings-v4-text-retrieval-gguf"
+        "jina-embeddings-v4-text-retrieval-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15517,9 +14094,7 @@
     {
       "name": "jinaai/jina-reranker-v3-GGUF",
       "alias": [
-        "jinaai/jina-reranker-v3-gguf",
-        "jina-reranker-v3-GGUF",
-        "jina-reranker-v3-gguf"
+        "jina-reranker-v3-GGUF"
       ],
       "model_types": [
         "rerank"
@@ -15699,9 +14274,7 @@
     {
       "name": "jinaai/ReaderLM-v2",
       "alias": [
-        "jinaai/readerlm-v2",
-        "ReaderLM-v2",
-        "readerlm-v2"
+        "ReaderLM-v2"
       ],
       "model_types": [
         "chat"
@@ -15918,9 +14491,7 @@
     {
       "name": "jinaai/jina-code-embeddings-0.5b-GGUF",
       "alias": [
-        "jinaai/jina-code-embeddings-0.5b-gguf",
-        "jina-code-embeddings-0.5b-GGUF",
-        "jina-code-embeddings-0.5b-gguf"
+        "jina-code-embeddings-0.5b-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -15971,9 +14542,7 @@
     {
       "name": "jinaai/jina-code-embeddings-1.5b-GGUF",
       "alias": [
-        "jinaai/jina-code-embeddings-1.5b-gguf",
-        "jina-code-embeddings-1.5b-GGUF",
-        "jina-code-embeddings-1.5b-gguf"
+        "jina-code-embeddings-1.5b-GGUF"
       ],
       "model_types": [
         "embedding"
@@ -16027,9 +14596,7 @@
     {
       "name": "jinaai/jina-reranker-m0-GGUF",
       "alias": [
-        "jinaai/jina-reranker-m0-gguf",
-        "jina-reranker-m0-GGUF",
-        "jina-reranker-m0-gguf"
+        "jina-reranker-m0-GGUF"
       ],
       "model_types": [
         "rerank"
@@ -16063,9 +14630,7 @@
     {
       "name": "jinaai/Phi-3-tiny-untrained",
       "alias": [
-        "jinaai/phi-3-tiny-untrained",
-        "Phi-3-tiny-untrained",
-        "phi-3-tiny-untrained"
+        "Phi-3-tiny-untrained"
       ],
       "model_types": [
         "chat"
@@ -16287,7 +14852,6 @@
         "image2text"
       ],
       "alias": [
-        "moonshotai/kimi-k2.7-code",
         "Kimi K2.7 Code",
         "kimi/kimi-k2.7-code"
       ],
@@ -16591,8 +15155,7 @@
     {
       "name": "kuaishou/kling_avatar_image2video",
       "alias": [
-        "kling_avatar_image2video",
-        "kling-avatar-image2video"
+        "kling_avatar_image2video"
       ],
       "model_types": [
         "video_generation"
@@ -16649,8 +15212,7 @@
     {
       "name": "kuaishou/kling_image_recognize",
       "alias": [
-        "kling_image_recognize",
-        "kling-image-recognize"
+        "kling_image_recognize"
       ],
       "model_types": [
         "video_generation"
@@ -17001,11 +15563,7 @@
     },
     {
       "name": "lyria-3-clip-preview",
-      "alias": [
-        "lyria-3-clip-preview",
-        "models/lyria-3-clip-preview",
-        "google/lyria-3-clip-preview"
-      ],
+      "alias": [],
       "max_tokens": 131072,
       "model_types": [
         "audio_generation"
@@ -17013,11 +15571,7 @@
     },
     {
       "name": "lyria-3-pro-preview",
-      "alias": [
-        "lyria-3-pro-preview",
-        "models/lyria-3-pro-preview",
-        "google/lyria-3-pro-preview"
-      ],
+      "alias": [],
       "max_tokens": 131072,
       "model_types": [
         "audio_generation"
@@ -17025,10 +15579,7 @@
     },
     {
       "name": "lyria-realtime-exp",
-      "alias": [
-        "lyria-realtime-exp",
-        "models/lyria-realtime-exp"
-      ],
+      "alias": [],
       "model_types": [
         "audio_generation"
       ]
@@ -17079,9 +15630,7 @@
     {
       "name": "meituan-longcat/longcat-audio-codec",
       "alias": [
-        "meituan-longcat/LongCat-Audio-Codec",
-        "LongCat-Audio-Codec",
-        "longcat-audio-codec"
+        "LongCat-Audio-Codec"
       ],
       "model_types": [
         "audio_codec"
@@ -17090,9 +15639,7 @@
     {
       "name": "meituan-longcat/longcat-audiodit-1b",
       "alias": [
-        "meituan-longcat/LongCat-AudioDiT-1B",
-        "LongCat-AudioDiT-1B",
-        "longcat-audiodit-1b"
+        "LongCat-AudioDiT-1B"
       ],
       "model_types": [
         "audio_generation"
@@ -17101,9 +15648,7 @@
     {
       "name": "meituan-longcat/longcat-audiodit-3.5b",
       "alias": [
-        "meituan-longcat/LongCat-AudioDiT-3.5B",
-        "LongCat-AudioDiT-3.5B",
-        "longcat-audiodit-3.5b"
+        "LongCat-AudioDiT-3.5B"
       ],
       "model_types": [
         "audio_generation"
@@ -17112,9 +15657,7 @@
     {
       "name": "meituan-longcat/longcat-flash-chat",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Chat",
-        "LongCat-Flash-Chat",
-        "longcat-flash-chat"
+        "LongCat-Flash-Chat"
       ],
       "model_types": [
         "chat"
@@ -17124,9 +15667,7 @@
     {
       "name": "meituan-longcat/longcat-flash-chat-fp8",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Chat-FP8",
-        "LongCat-Flash-Chat-FP8",
-        "longcat-flash-chat-fp8"
+        "LongCat-Flash-Chat-FP8"
       ],
       "model_types": [
         "chat"
@@ -17136,9 +15677,7 @@
     {
       "name": "meituan-longcat/longcat-flash-lite",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Lite",
         "LongCat-Flash-Lite",
-        "longcat-flash-lite",
         "meituan/longcat-flash-lite"
       ],
       "model_types": [
@@ -17149,9 +15688,7 @@
     {
       "name": "meituan-longcat/longcat-flash-lite-fp8",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Lite-FP8",
-        "LongCat-Flash-Lite-FP8",
-        "longcat-flash-lite-fp8"
+        "LongCat-Flash-Lite-FP8"
       ],
       "model_types": [
         "chat"
@@ -17161,9 +15698,7 @@
     {
       "name": "meituan-longcat/longcat-flash-omni",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Omni",
-        "LongCat-Flash-Omni",
-        "longcat-flash-omni"
+        "LongCat-Flash-Omni"
       ],
       "model_types": [
         "chat",
@@ -17179,9 +15714,7 @@
     {
       "name": "meituan-longcat/longcat-flash-omni-fp8",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Omni-FP8",
-        "LongCat-Flash-Omni-FP8",
-        "longcat-flash-omni-fp8"
+        "LongCat-Flash-Omni-FP8"
       ],
       "model_types": [
         "chat",
@@ -17197,9 +15730,7 @@
     {
       "name": "meituan-longcat/longcat-flash-prover",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Prover",
-        "LongCat-Flash-Prover",
-        "longcat-flash-prover"
+        "LongCat-Flash-Prover"
       ],
       "model_types": [
         "chat"
@@ -17213,9 +15744,7 @@
     {
       "name": "meituan-longcat/longcat-flash-thinking",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Thinking",
-        "LongCat-Flash-Thinking",
-        "longcat-flash-thinking"
+        "LongCat-Flash-Thinking"
       ],
       "model_types": [
         "chat"
@@ -17229,9 +15758,7 @@
     {
       "name": "meituan-longcat/longcat-flash-thinking-2601",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Thinking-2601",
-        "LongCat-Flash-Thinking-2601",
-        "longcat-flash-thinking-2601"
+        "LongCat-Flash-Thinking-2601"
       ],
       "model_types": [
         "chat"
@@ -17245,9 +15772,7 @@
     {
       "name": "meituan-longcat/longcat-flash-thinking-2601-fp8",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Thinking-2601-FP8",
-        "LongCat-Flash-Thinking-2601-FP8",
-        "longcat-flash-thinking-2601-fp8"
+        "LongCat-Flash-Thinking-2601-FP8"
       ],
       "model_types": [
         "chat"
@@ -17261,9 +15786,7 @@
     {
       "name": "meituan-longcat/longcat-flash-thinking-fp8",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Thinking-FP8",
-        "LongCat-Flash-Thinking-FP8",
-        "longcat-flash-thinking-fp8"
+        "LongCat-Flash-Thinking-FP8"
       ],
       "model_types": [
         "chat"
@@ -17277,9 +15800,7 @@
     {
       "name": "meituan-longcat/longcat-flash-thinking-zigzag",
       "alias": [
-        "meituan-longcat/LongCat-Flash-Thinking-ZigZag",
-        "LongCat-Flash-Thinking-ZigZag",
-        "longcat-flash-thinking-zigzag"
+        "LongCat-Flash-Thinking-ZigZag"
       ],
       "model_types": [
         "chat"
@@ -17293,9 +15814,7 @@
     {
       "name": "meituan-longcat/longcat-heavymode-summary",
       "alias": [
-        "meituan-longcat/LongCat-HeavyMode-Summary",
-        "LongCat-HeavyMode-Summary",
-        "longcat-heavymode-summary"
+        "LongCat-HeavyMode-Summary"
       ],
       "model_types": [
         "chat"
@@ -17309,9 +15828,7 @@
     {
       "name": "meituan-longcat/longcat-image",
       "alias": [
-        "meituan-longcat/LongCat-Image",
-        "LongCat-Image",
-        "longcat-image"
+        "LongCat-Image"
       ],
       "model_types": [
         "image"
@@ -17320,9 +15837,7 @@
     {
       "name": "meituan-longcat/longcat-image-dev",
       "alias": [
-        "meituan-longcat/LongCat-Image-Dev",
-        "LongCat-Image-Dev",
-        "longcat-image-dev"
+        "LongCat-Image-Dev"
       ],
       "model_types": [
         "image",
@@ -17332,9 +15847,7 @@
     {
       "name": "meituan-longcat/longcat-image-edit",
       "alias": [
-        "meituan-longcat/LongCat-Image-Edit",
-        "LongCat-Image-Edit",
-        "longcat-image-edit"
+        "LongCat-Image-Edit"
       ],
       "model_types": [
         "image_edit",
@@ -17345,9 +15858,7 @@
     {
       "name": "meituan-longcat/longcat-image-edit-turbo",
       "alias": [
-        "meituan-longcat/LongCat-Image-Edit-Turbo",
-        "LongCat-Image-Edit-Turbo",
-        "longcat-image-edit-turbo"
+        "LongCat-Image-Edit-Turbo"
       ],
       "model_types": [
         "image_edit",
@@ -17358,9 +15869,7 @@
     {
       "name": "meituan-longcat/longcat-next",
       "alias": [
-        "meituan-longcat/LongCat-Next",
-        "LongCat-Next",
-        "longcat-next"
+        "LongCat-Next"
       ],
       "model_types": [
         "chat",
@@ -17375,9 +15884,7 @@
     {
       "name": "meituan-longcat/longcat-video",
       "alias": [
-        "meituan-longcat/LongCat-Video",
-        "LongCat-Video",
-        "longcat-video"
+        "LongCat-Video"
       ],
       "model_types": [
         "video_generation"
@@ -17386,9 +15893,7 @@
     {
       "name": "meituan-longcat/longcat-video-avatar",
       "alias": [
-        "meituan-longcat/LongCat-Video-Avatar",
-        "LongCat-Video-Avatar",
-        "longcat-video-avatar"
+        "LongCat-Video-Avatar"
       ],
       "model_types": [
         "video_generation"
@@ -17397,9 +15902,7 @@
     {
       "name": "meituan-longcat/longcat-video-avatar-1.5",
       "alias": [
-        "meituan-longcat/LongCat-Video-Avatar-1.5",
-        "LongCat-Video-Avatar-1.5",
-        "longcat-video-avatar-1.5"
+        "LongCat-Video-Avatar-1.5"
       ],
       "model_types": [
         "video_generation"
@@ -17408,9 +15911,7 @@
     {
       "name": "meituan-longcat/wbench-weights",
       "alias": [
-        "meituan-longcat/WBench-weights",
-        "WBench-weights",
-        "wbench-weights"
+        "WBench-weights"
       ],
       "model_types": [
         "other"
@@ -17425,9 +15926,7 @@
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E",
       "alias": [
-        "meta-llama/llama-4-maverick-17b-128e",
-        "Llama-4-Maverick-17B-128E",
-        "llama-4-maverick-17b-128e"
+        "Llama-4-Maverick-17B-128E"
       ],
       "model_types": [
         "chat",
@@ -17439,11 +15938,8 @@
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
       "alias": [
-        "meta-llama/llama-4-maverick-17b-128e-instruct",
         "Llama-4-Maverick-17B-128E-Instruct",
-        "llama-4-maverick-17b-128e-instruct",
-        "meta/llama-4-maverick-instruct",
-        "meta-llama/llama-4-maverick"
+        "meta/llama-4-maverick-instruct"
       ],
       "model_types": [
         "chat",
@@ -17468,9 +15964,7 @@
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
       "alias": [
-        "meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
         "Llama-4-Maverick-17B-128E-Instruct-FP8",
-        "llama-4-maverick-17b-128e-instruct-fp8",
         "Llama 4 Maverick Instruct"
       ],
       "model_types": [
@@ -17485,9 +15979,7 @@
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-Original",
       "alias": [
-        "meta-llama/llama-4-maverick-17b-128e-instruct-fp8-original",
-        "Llama-4-Maverick-17B-128E-Instruct-FP8-Original",
-        "llama-4-maverick-17b-128e-instruct-fp8-original"
+        "Llama-4-Maverick-17B-128E-Instruct-FP8-Original"
       ],
       "model_types": [
         "chat",
@@ -17499,9 +15991,7 @@
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-Original",
       "alias": [
-        "meta-llama/llama-4-maverick-17b-128e-instruct-original",
-        "Llama-4-Maverick-17B-128E-Instruct-Original",
-        "llama-4-maverick-17b-128e-instruct-original"
+        "Llama-4-Maverick-17B-128E-Instruct-Original"
       ],
       "model_types": [
         "chat",
@@ -17523,9 +16013,7 @@
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Original",
       "alias": [
-        "meta-llama/llama-4-maverick-17b-128e-original",
-        "Llama-4-Maverick-17B-128E-Original",
-        "llama-4-maverick-17b-128e-original"
+        "Llama-4-Maverick-17B-128E-Original"
       ],
       "model_types": [
         "chat",
@@ -17537,9 +16025,7 @@
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E",
       "alias": [
-        "meta-llama/llama-4-scout-17b-16e",
         "Llama-4-Scout-17B-16E",
-        "llama-4-scout-17b-16e",
         "Llama 4 Scout (17Bx16E)"
       ],
       "model_types": [
@@ -17552,11 +16038,8 @@
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
       "alias": [
-        "meta-llama/llama-4-scout-17b-16e-instruct",
         "Llama-4-Scout-17B-16E-Instruct",
-        "llama-4-scout-17b-16e-instruct",
         "meta/llama-4-scout-instruct",
-        "meta-llama/llama-4-scout",
         "Llama 4 Scout Instruct",
         "Llama 4 Scout Instruct (17Bx16E)"
       ],
@@ -17585,9 +16068,7 @@
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Instruct-Original",
       "alias": [
-        "meta-llama/llama-4-scout-17b-16e-instruct-original",
-        "Llama-4-Scout-17B-16E-Instruct-Original",
-        "llama-4-scout-17b-16e-instruct-original"
+        "Llama-4-Scout-17B-16E-Instruct-Original"
       ],
       "model_types": [
         "chat",
@@ -17599,9 +16080,7 @@
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Original",
       "alias": [
-        "meta-llama/llama-4-scout-17b-16e-original",
-        "Llama-4-Scout-17B-16E-Original",
-        "llama-4-scout-17b-16e-original"
+        "Llama-4-Scout-17B-16E-Original"
       ],
       "model_types": [
         "chat",
@@ -17613,9 +16092,7 @@
     {
       "name": "meta-llama/Llama-3.3-70B-Instruct",
       "alias": [
-        "meta-llama/llama-3.3-70b-instruct",
         "Llama-3.3-70B-Instruct",
-        "llama-3.3-70b-instruct",
         "meta-llama/llama-3.3-70b-instruct:free",
         "Llama 3.3 70B Instruct",
         "Meta Llama 3.3 70B Instruct",
@@ -17652,9 +16129,7 @@
     {
       "name": "meta-llama/Llama-3.2-11B-Vision",
       "alias": [
-        "meta-llama/llama-3.2-11b-vision",
-        "Llama-3.2-11B-Vision",
-        "llama-3.2-11b-vision"
+        "Llama-3.2-11B-Vision"
       ],
       "model_types": [
         "chat",
@@ -17666,9 +16141,7 @@
     {
       "name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
       "alias": [
-        "meta-llama/llama-3.2-11b-vision-instruct",
         "Llama-3.2-11B-Vision-Instruct",
-        "llama-3.2-11b-vision-instruct",
         "nim/meta/llama-3.2-11b-vision-instruct"
       ],
       "model_types": [
@@ -17682,9 +16155,7 @@
     {
       "name": "meta-llama/Llama-3.2-1B",
       "alias": [
-        "meta-llama/llama-3.2-1b",
         "Llama-3.2-1B",
-        "llama-3.2-1b",
         "Llama 3.2 1B"
       ],
       "model_types": [
@@ -17695,9 +16166,7 @@
     {
       "name": "meta-llama/Llama-3.2-1B-Instruct",
       "alias": [
-        "meta-llama/llama-3.2-1b-instruct",
         "Llama-3.2-1B-Instruct",
-        "llama-3.2-1b-instruct",
         "Llama 3.2 1B Instruct",
         "Meta Llama 3.2 1B Instruct"
       ],
@@ -17710,9 +16179,7 @@
     {
       "name": "meta-llama/Llama-3.2-1B-Instruct-QLORA_INT4_EO8",
       "alias": [
-        "meta-llama/llama-3.2-1b-instruct-qlora_int4_eo8",
-        "Llama-3.2-1B-Instruct-QLORA_INT4_EO8",
-        "llama-3.2-1b-instruct-qlora_int4_eo8"
+        "Llama-3.2-1B-Instruct-QLORA_INT4_EO8"
       ],
       "model_types": [
         "chat"
@@ -17722,9 +16189,7 @@
     {
       "name": "meta-llama/Llama-3.2-1B-Instruct-SpinQuant_INT4_EO8",
       "alias": [
-        "meta-llama/llama-3.2-1b-instruct-spinquant_int4_eo8",
-        "Llama-3.2-1B-Instruct-SpinQuant_INT4_EO8",
-        "llama-3.2-1b-instruct-spinquant_int4_eo8"
+        "Llama-3.2-1B-Instruct-SpinQuant_INT4_EO8"
       ],
       "model_types": [
         "chat"
@@ -17734,9 +16199,7 @@
     {
       "name": "meta-llama/Llama-3.2-3B",
       "alias": [
-        "meta-llama/llama-3.2-3b",
         "Llama-3.2-3B",
-        "llama-3.2-3b",
         "Meta Llama 3.2 3B"
       ],
       "model_types": [
@@ -17747,9 +16210,7 @@
     {
       "name": "meta-llama/Llama-3.2-3B-Instruct",
       "alias": [
-        "meta-llama/llama-3.2-3b-instruct",
         "Llama-3.2-3B-Instruct",
-        "llama-3.2-3b-instruct",
         "meta-llama/llama-3.2-3b-instruct:free",
         "Llama 3.2 3B Instruct",
         "Meta Llama 3.2 3B Instruct"
@@ -17763,9 +16224,7 @@
     {
       "name": "meta-llama/Llama-3.2-3B-Instruct-QLORA_INT4_EO8",
       "alias": [
-        "meta-llama/llama-3.2-3b-instruct-qlora_int4_eo8",
-        "Llama-3.2-3B-Instruct-QLORA_INT4_EO8",
-        "llama-3.2-3b-instruct-qlora_int4_eo8"
+        "Llama-3.2-3B-Instruct-QLORA_INT4_EO8"
       ],
       "model_types": [
         "chat"
@@ -17775,9 +16234,7 @@
     {
       "name": "meta-llama/Llama-3.2-3B-Instruct-SpinQuant_INT4_EO8",
       "alias": [
-        "meta-llama/llama-3.2-3b-instruct-spinquant_int4_eo8",
-        "Llama-3.2-3B-Instruct-SpinQuant_INT4_EO8",
-        "llama-3.2-3b-instruct-spinquant_int4_eo8"
+        "Llama-3.2-3B-Instruct-SpinQuant_INT4_EO8"
       ],
       "model_types": [
         "chat"
@@ -17787,9 +16244,7 @@
     {
       "name": "meta-llama/Llama-3.2-90B-Vision",
       "alias": [
-        "meta-llama/llama-3.2-90b-vision",
-        "Llama-3.2-90B-Vision",
-        "llama-3.2-90b-vision"
+        "Llama-3.2-90B-Vision"
       ],
       "model_types": [
         "chat",
@@ -17801,9 +16256,7 @@
     {
       "name": "meta-llama/Llama-3.2-90B-Vision-Instruct",
       "alias": [
-        "meta-llama/llama-3.2-90b-vision-instruct",
         "Llama-3.2-90B-Vision-Instruct",
-        "llama-3.2-90b-vision-instruct",
         "nim/meta/llama-3.2-90b-vision-instruct"
       ],
       "model_types": [
@@ -17816,9 +16269,7 @@
     {
       "name": "meta-llama/Llama-3.1-405B",
       "alias": [
-        "meta-llama/llama-3.1-405b",
         "Llama-3.1-405B",
-        "llama-3.1-405b",
         "Llama 3.1 405B"
       ],
       "model_types": [
@@ -17829,9 +16280,7 @@
     {
       "name": "meta-llama/Llama-3.1-405B-FP8",
       "alias": [
-        "meta-llama/llama-3.1-405b-fp8",
-        "Llama-3.1-405B-FP8",
-        "llama-3.1-405b-fp8"
+        "Llama-3.1-405B-FP8"
       ],
       "model_types": [
         "chat"
@@ -17841,9 +16290,7 @@
     {
       "name": "meta-llama/Llama-3.1-405B-Instruct",
       "alias": [
-        "meta-llama/llama-3.1-405b-instruct",
         "Llama-3.1-405B-Instruct",
-        "llama-3.1-405b-instruct",
         "Meta Llama 3.1 405B Instruct"
       ],
       "model_types": [
@@ -17854,9 +16301,7 @@
     {
       "name": "meta-llama/Llama-3.1-405B-Instruct-FP8",
       "alias": [
-        "meta-llama/llama-3.1-405b-instruct-fp8",
-        "Llama-3.1-405B-Instruct-FP8",
-        "llama-3.1-405b-instruct-fp8"
+        "Llama-3.1-405B-Instruct-FP8"
       ],
       "model_types": [
         "chat"
@@ -17866,9 +16311,7 @@
     {
       "name": "meta-llama/Llama-3.1-70B",
       "alias": [
-        "meta-llama/llama-3.1-70b",
-        "Llama-3.1-70B",
-        "llama-3.1-70b"
+        "Llama-3.1-70B"
       ],
       "model_types": [
         "chat"
@@ -17878,9 +16321,7 @@
     {
       "name": "meta-llama/Llama-3.1-70B-Instruct",
       "alias": [
-        "meta-llama/llama-3.1-70b-instruct",
         "Llama-3.1-70B-Instruct",
-        "llama-3.1-70b-instruct",
         "nim/meta/llama-3.1-70b-instruct"
       ],
       "model_types": [
@@ -17891,9 +16332,7 @@
     {
       "name": "meta-llama/Llama-3.1-8B",
       "alias": [
-        "meta-llama/llama-3.1-8b",
-        "Llama-3.1-8B",
-        "llama-3.1-8b"
+        "Llama-3.1-8B"
       ],
       "model_types": [
         "chat"
@@ -17903,9 +16342,7 @@
     {
       "name": "meta-llama/Llama-3.1-8B-Instruct",
       "alias": [
-        "meta-llama/llama-3.1-8b-instruct",
         "Llama-3.1-8B-Instruct",
-        "llama-3.1-8b-instruct",
         "Llama 3.1 8B Instruct",
         "nim/meta/llama-3.1-8b-instruct"
       ],
@@ -17953,9 +16390,7 @@
     {
       "name": "meta-llama/Llama-2-13b",
       "alias": [
-        "meta-llama/llama-2-13b",
-        "Llama-2-13b",
-        "llama-2-13b"
+        "Llama-2-13b"
       ],
       "model_types": [
         "chat"
@@ -17965,9 +16400,7 @@
     {
       "name": "meta-llama/Llama-2-13b-chat",
       "alias": [
-        "meta-llama/llama-2-13b-chat",
-        "Llama-2-13b-chat",
-        "llama-2-13b-chat"
+        "Llama-2-13b-chat"
       ],
       "model_types": [
         "chat"
@@ -17977,9 +16410,7 @@
     {
       "name": "meta-llama/Llama-2-13b-chat-hf",
       "alias": [
-        "meta-llama/llama-2-13b-chat-hf",
-        "Llama-2-13b-chat-hf",
-        "llama-2-13b-chat-hf"
+        "Llama-2-13b-chat-hf"
       ],
       "model_types": [
         "chat"
@@ -17989,9 +16420,7 @@
     {
       "name": "meta-llama/Llama-2-13b-hf",
       "alias": [
-        "meta-llama/llama-2-13b-hf",
-        "Llama-2-13b-hf",
-        "llama-2-13b-hf"
+        "Llama-2-13b-hf"
       ],
       "model_types": [
         "chat"
@@ -18001,9 +16430,7 @@
     {
       "name": "meta-llama/Llama-2-70b",
       "alias": [
-        "meta-llama/llama-2-70b",
-        "Llama-2-70b",
-        "llama-2-70b"
+        "Llama-2-70b"
       ],
       "model_types": [
         "chat"
@@ -18013,9 +16440,7 @@
     {
       "name": "meta-llama/Llama-2-70b-chat",
       "alias": [
-        "meta-llama/llama-2-70b-chat",
-        "Llama-2-70b-chat",
-        "llama-2-70b-chat"
+        "Llama-2-70b-chat"
       ],
       "model_types": [
         "chat"
@@ -18025,9 +16450,7 @@
     {
       "name": "meta-llama/Llama-2-70b-chat-hf",
       "alias": [
-        "meta-llama/llama-2-70b-chat-hf",
-        "Llama-2-70b-chat-hf",
-        "llama-2-70b-chat-hf"
+        "Llama-2-70b-chat-hf"
       ],
       "model_types": [
         "chat"
@@ -18037,9 +16460,7 @@
     {
       "name": "meta-llama/Llama-2-70b-hf",
       "alias": [
-        "meta-llama/llama-2-70b-hf",
-        "Llama-2-70b-hf",
-        "llama-2-70b-hf"
+        "Llama-2-70b-hf"
       ],
       "model_types": [
         "chat"
@@ -18049,9 +16470,7 @@
     {
       "name": "meta-llama/Llama-2-7b",
       "alias": [
-        "meta-llama/llama-2-7b",
-        "Llama-2-7b",
-        "llama-2-7b"
+        "Llama-2-7b"
       ],
       "model_types": [
         "chat"
@@ -18061,9 +16480,7 @@
     {
       "name": "meta-llama/Llama-2-7b-chat",
       "alias": [
-        "meta-llama/llama-2-7b-chat",
-        "Llama-2-7b-chat",
-        "llama-2-7b-chat"
+        "Llama-2-7b-chat"
       ],
       "model_types": [
         "chat"
@@ -18073,9 +16490,7 @@
     {
       "name": "meta-llama/Llama-2-7b-chat-hf",
       "alias": [
-        "meta-llama/llama-2-7b-chat-hf",
-        "Llama-2-7b-chat-hf",
-        "llama-2-7b-chat-hf"
+        "Llama-2-7b-chat-hf"
       ],
       "model_types": [
         "chat"
@@ -18085,9 +16500,7 @@
     {
       "name": "meta-llama/Llama-2-7b-hf",
       "alias": [
-        "meta-llama/llama-2-7b-hf",
-        "Llama-2-7b-hf",
-        "llama-2-7b-hf"
+        "Llama-2-7b-hf"
       ],
       "model_types": [
         "chat"
@@ -18097,9 +16510,7 @@
     {
       "name": "meta-llama/CodeLlama-13b-hf",
       "alias": [
-        "meta-llama/codellama-13b-hf",
-        "CodeLlama-13b-hf",
-        "codellama-13b-hf"
+        "CodeLlama-13b-hf"
       ],
       "model_types": [
         "chat"
@@ -18109,9 +16520,7 @@
     {
       "name": "meta-llama/CodeLlama-13b-Instruct-hf",
       "alias": [
-        "meta-llama/codellama-13b-instruct-hf",
-        "CodeLlama-13b-Instruct-hf",
-        "codellama-13b-instruct-hf"
+        "CodeLlama-13b-Instruct-hf"
       ],
       "model_types": [
         "chat"
@@ -18121,9 +16530,7 @@
     {
       "name": "meta-llama/CodeLlama-13b-Python-hf",
       "alias": [
-        "meta-llama/codellama-13b-python-hf",
-        "CodeLlama-13b-Python-hf",
-        "codellama-13b-python-hf"
+        "CodeLlama-13b-Python-hf"
       ],
       "model_types": [
         "chat"
@@ -18133,9 +16540,7 @@
     {
       "name": "meta-llama/CodeLlama-34b-hf",
       "alias": [
-        "meta-llama/codellama-34b-hf",
-        "CodeLlama-34b-hf",
-        "codellama-34b-hf"
+        "CodeLlama-34b-hf"
       ],
       "model_types": [
         "chat"
@@ -18145,9 +16550,7 @@
     {
       "name": "meta-llama/CodeLlama-34b-Instruct-hf",
       "alias": [
-        "meta-llama/codellama-34b-instruct-hf",
-        "CodeLlama-34b-Instruct-hf",
-        "codellama-34b-instruct-hf"
+        "CodeLlama-34b-Instruct-hf"
       ],
       "model_types": [
         "chat"
@@ -18157,9 +16560,7 @@
     {
       "name": "meta-llama/CodeLlama-34b-Python-hf",
       "alias": [
-        "meta-llama/codellama-34b-python-hf",
-        "CodeLlama-34b-Python-hf",
-        "codellama-34b-python-hf"
+        "CodeLlama-34b-Python-hf"
       ],
       "model_types": [
         "chat"
@@ -18169,9 +16570,7 @@
     {
       "name": "meta-llama/CodeLlama-70b-hf",
       "alias": [
-        "meta-llama/codellama-70b-hf",
-        "CodeLlama-70b-hf",
-        "codellama-70b-hf"
+        "CodeLlama-70b-hf"
       ],
       "model_types": [
         "chat"
@@ -18181,9 +16580,7 @@
     {
       "name": "meta-llama/CodeLlama-70b-Instruct-hf",
       "alias": [
-        "meta-llama/codellama-70b-instruct-hf",
-        "CodeLlama-70b-Instruct-hf",
-        "codellama-70b-instruct-hf"
+        "CodeLlama-70b-Instruct-hf"
       ],
       "model_types": [
         "chat"
@@ -18193,9 +16590,7 @@
     {
       "name": "meta-llama/CodeLlama-70b-Python-hf",
       "alias": [
-        "meta-llama/codellama-70b-python-hf",
-        "CodeLlama-70b-Python-hf",
-        "codellama-70b-python-hf"
+        "CodeLlama-70b-Python-hf"
       ],
       "model_types": [
         "chat"
@@ -18205,9 +16600,7 @@
     {
       "name": "meta-llama/CodeLlama-7b-hf",
       "alias": [
-        "meta-llama/codellama-7b-hf",
-        "CodeLlama-7b-hf",
-        "codellama-7b-hf"
+        "CodeLlama-7b-hf"
       ],
       "model_types": [
         "chat"
@@ -18217,9 +16610,7 @@
     {
       "name": "meta-llama/CodeLlama-7b-Instruct-hf",
       "alias": [
-        "meta-llama/codellama-7b-instruct-hf",
-        "CodeLlama-7b-Instruct-hf",
-        "codellama-7b-instruct-hf"
+        "CodeLlama-7b-Instruct-hf"
       ],
       "model_types": [
         "chat"
@@ -18229,9 +16620,7 @@
     {
       "name": "meta-llama/CodeLlama-7b-Python-hf",
       "alias": [
-        "meta-llama/codellama-7b-python-hf",
-        "CodeLlama-7b-Python-hf",
-        "codellama-7b-python-hf"
+        "CodeLlama-7b-Python-hf"
       ],
       "model_types": [
         "chat"
@@ -18241,9 +16630,7 @@
     {
       "name": "meta-llama/Llama-Guard-3-11B-Vision",
       "alias": [
-        "meta-llama/llama-guard-3-11b-vision",
-        "Llama-Guard-3-11B-Vision",
-        "llama-guard-3-11b-vision"
+        "Llama-Guard-3-11B-Vision"
       ],
       "model_types": [
         "moderation",
@@ -18255,9 +16642,7 @@
     {
       "name": "meta-llama/Llama-Guard-3-1B",
       "alias": [
-        "meta-llama/llama-guard-3-1b",
-        "Llama-Guard-3-1B",
-        "llama-guard-3-1b"
+        "Llama-Guard-3-1B"
       ],
       "model_types": [
         "moderation"
@@ -18267,9 +16652,7 @@
     {
       "name": "meta-llama/Llama-Guard-3-1B-INT4",
       "alias": [
-        "meta-llama/llama-guard-3-1b-int4",
-        "Llama-Guard-3-1B-INT4",
-        "llama-guard-3-1b-int4"
+        "Llama-Guard-3-1B-INT4"
       ],
       "model_types": [
         "moderation"
@@ -18279,9 +16662,7 @@
     {
       "name": "meta-llama/Llama-Guard-3-8B",
       "alias": [
-        "meta-llama/llama-guard-3-8b",
-        "Llama-Guard-3-8B",
-        "llama-guard-3-8b"
+        "Llama-Guard-3-8B"
       ],
       "model_types": [
         "moderation",
@@ -18292,9 +16673,7 @@
     {
       "name": "meta-llama/Llama-Guard-3-8B-INT8",
       "alias": [
-        "meta-llama/llama-guard-3-8b-int8",
-        "Llama-Guard-3-8B-INT8",
-        "llama-guard-3-8b-int8"
+        "Llama-Guard-3-8B-INT8"
       ],
       "model_types": [
         "moderation"
@@ -18304,9 +16683,7 @@
     {
       "name": "meta-llama/Llama-Guard-4-12B",
       "alias": [
-        "meta-llama/llama-guard-4-12b",
         "Llama-Guard-4-12B",
-        "llama-guard-4-12b",
         "Llama Guard 4 12B"
       ],
       "model_types": [
@@ -18321,9 +16698,7 @@
     {
       "name": "meta-llama/Llama-Prompt-Guard-2-22M",
       "alias": [
-        "meta-llama/llama-prompt-guard-2-22m",
-        "Llama-Prompt-Guard-2-22M",
-        "llama-prompt-guard-2-22m"
+        "Llama-Prompt-Guard-2-22M"
       ],
       "model_types": [
         "moderation"
@@ -18334,9 +16709,7 @@
     {
       "name": "meta-llama/Llama-Prompt-Guard-2-86M",
       "alias": [
-        "meta-llama/llama-prompt-guard-2-86m",
-        "Llama-Prompt-Guard-2-86M",
-        "llama-prompt-guard-2-86m"
+        "Llama-Prompt-Guard-2-86M"
       ],
       "model_types": [
         "moderation"
@@ -18347,9 +16720,7 @@
     {
       "name": "meta-llama/LlamaGuard-7b",
       "alias": [
-        "meta-llama/llamaguard-7b",
-        "LlamaGuard-7b",
-        "llamaguard-7b"
+        "LlamaGuard-7b"
       ],
       "model_types": [
         "moderation"
@@ -18359,9 +16730,7 @@
     {
       "name": "meta-llama/Meta-Llama-3-70B",
       "alias": [
-        "meta-llama/meta-llama-3-70b",
-        "Meta-Llama-3-70B",
-        "meta-llama-3-70b"
+        "Meta-Llama-3-70B"
       ],
       "model_types": [
         "chat"
@@ -18371,11 +16740,8 @@
     {
       "name": "meta-llama/Meta-Llama-3-70B-Instruct",
       "alias": [
-        "meta-llama/meta-llama-3-70b-instruct",
         "Meta-Llama-3-70B-Instruct",
-        "meta-llama-3-70b-instruct",
-        "meta/meta-llama-3-70b-instruct",
-        "meta-llama/llama-3-70b-instruct"
+        "meta/meta-llama-3-70b-instruct"
       ],
       "model_types": [
         "chat"
@@ -18396,9 +16762,7 @@
     {
       "name": "meta-llama/Meta-Llama-3-8B",
       "alias": [
-        "meta-llama/meta-llama-3-8b",
-        "Meta-Llama-3-8B",
-        "meta-llama-3-8b"
+        "Meta-Llama-3-8B"
       ],
       "model_types": [
         "chat"
@@ -18408,11 +16772,8 @@
     {
       "name": "meta-llama/Meta-Llama-3-8B-Instruct",
       "alias": [
-        "meta-llama/meta-llama-3-8b-instruct",
         "Meta-Llama-3-8B-Instruct",
-        "meta-llama-3-8b-instruct",
         "meta/meta-llama-3-8b-instruct",
-        "meta-llama/llama-3-8b-instruct",
         "Meta Llama 3 8B Instruct"
       ],
       "model_types": [
@@ -18508,9 +16869,7 @@
     {
       "name": "meta-llama/Meta-Llama-Guard-2-8B",
       "alias": [
-        "meta-llama/meta-llama-guard-2-8b",
-        "Meta-Llama-Guard-2-8B",
-        "meta-llama-guard-2-8b"
+        "Meta-Llama-Guard-2-8B"
       ],
       "model_types": [
         "moderation"
@@ -18520,9 +16879,7 @@
     {
       "name": "meta-llama/Prompt-Guard-86M",
       "alias": [
-        "meta-llama/prompt-guard-86m",
-        "Prompt-Guard-86M",
-        "prompt-guard-86m"
+        "Prompt-Guard-86M"
       ],
       "model_types": [
         "moderation"
@@ -18592,8 +16949,7 @@
       "name": "microsoft/wizardlm-2-8x22b",
       "alias": [
         "WizardLM-2-8x22B",
-        "Wizardlm 2 8x22B",
-        "microsoft/WizardLM-2-8x22B"
+        "Wizardlm 2 8x22B"
       ],
       "model_types": [
         "chat"
@@ -19044,9 +17400,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "alias": [
-        "xiaomimimo/mimo-v2-pro"
-      ],
+      "alias": [],
       "max_completion_tokens": 131072
     },
     {
@@ -19185,9 +17539,7 @@
     },
     {
       "name": "minimax/minimax-m3",
-      "alias": [
-        "minimax-m3"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -19294,7 +17646,6 @@
         "clear_thinking": true
       },
       "alias": [
-        "minimax/minimax-m2.5-highspeed",
         "MiniMax M2.5-highspeed"
       ],
       "max_completion_tokens": 131100
@@ -19310,7 +17661,6 @@
         "clear_thinking": true
       },
       "alias": [
-        "minimax/minimax-m2.7-highspeed",
         "MiniMax M2.7-highspeed"
       ],
       "max_completion_tokens": 131072
@@ -19328,7 +17678,6 @@
         "clear_thinking": true
       },
       "alias": [
-        "minimax/minimax-m3",
         "MiniMaxAI/MiniMax-M3",
         "MiniMax M3"
       ],
@@ -19364,7 +17713,6 @@
     {
       "name": "minimaxai/MiniMax-M1-40k",
       "alias": [
-        "minimaxai/minimax-m1-40k",
         "minimax-m1-40k",
         "Minimax M1 40K"
       ],
@@ -19380,7 +17728,6 @@
     {
       "name": "minimaxai/MiniMax-M1-40k-hf",
       "alias": [
-        "minimaxai/minimax-m1-40k-hf",
         "minimax-m1-40k-hf"
       ],
       "model_types": [
@@ -19395,7 +17742,6 @@
     {
       "name": "minimaxai/MiniMax-M1-80k",
       "alias": [
-        "minimaxai/minimax-m1-80k",
         "minimax-m1-80k",
         "MiniMax M1",
         "Minimax M1 80K"
@@ -19413,7 +17759,6 @@
     {
       "name": "minimaxai/MiniMax-M1-80k-hf",
       "alias": [
-        "minimaxai/minimax-m1-80k-hf",
         "minimax-m1-80k-hf"
       ],
       "model_types": [
@@ -19428,7 +17773,6 @@
     {
       "name": "minimaxai/MiniMax-M2",
       "alias": [
-        "minimaxai/minimax-m2",
         "minimax-m2",
         "minimax/minimax-m2",
         "MiniMax M2"
@@ -19446,7 +17790,6 @@
     {
       "name": "minimaxai/MiniMax-M2.1",
       "alias": [
-        "minimaxai/minimax-m2.1",
         "minimax-m2.1",
         "minimax/minimax-m2.1",
         "Minimax M2.1"
@@ -19464,7 +17807,6 @@
     {
       "name": "minimaxai/MiniMax-M2.5",
       "alias": [
-        "minimaxai/minimax-m2.5",
         "minimax-m2.5",
         "minimax/minimax-m2.5",
         "MiniMax M2.5"
@@ -19482,7 +17824,6 @@
     {
       "name": "minimaxai/MiniMax-M2.7",
       "alias": [
-        "minimaxai/minimax-m2.7",
         "minimax-m2.7",
         "minimax/minimax-m2.7",
         "MiniMax M2.7",
@@ -19501,7 +17842,6 @@
     {
       "name": "minimaxai/MiniMax-Text-01",
       "alias": [
-        "minimaxai/minimax-text-01",
         "minimax-text-01",
         "minimax/minimax-01"
       ],
@@ -19517,7 +17857,6 @@
     {
       "name": "minimaxai/MiniMax-Text-01-hf",
       "alias": [
-        "minimaxai/minimax-text-01-hf",
         "minimax-text-01-hf"
       ],
       "model_types": [
@@ -19532,7 +17871,6 @@
     {
       "name": "minimaxai/MiniMax-VL-01",
       "alias": [
-        "minimaxai/minimax-vl-01",
         "minimax-vl-01"
       ],
       "model_types": [
@@ -19549,7 +17887,6 @@
     {
       "name": "minimaxai/SynLogic-32B",
       "alias": [
-        "minimaxai/synlogic-32b",
         "synlogic-32b"
       ],
       "model_types": [
@@ -19564,7 +17901,6 @@
     {
       "name": "minimaxai/SynLogic-7B",
       "alias": [
-        "minimaxai/synlogic-7b",
         "synlogic-7b"
       ],
       "model_types": [
@@ -19579,7 +17915,6 @@
     {
       "name": "minimaxai/SynLogic-Mix-3-32B",
       "alias": [
-        "minimaxai/synlogic-mix-3-32b",
         "synlogic-mix-3-32b"
       ],
       "model_types": [
@@ -19594,7 +17929,6 @@
     {
       "name": "minimaxai/VTP-Base-f16d64",
       "alias": [
-        "minimaxai/vtp-base-f16d64",
         "vtp-base-f16d64"
       ],
       "model_types": [
@@ -19610,7 +17944,6 @@
     {
       "name": "minimaxai/VTP-Large-f16d64",
       "alias": [
-        "minimaxai/vtp-large-f16d64",
         "vtp-large-f16d64"
       ],
       "model_types": [
@@ -19626,7 +17959,6 @@
     {
       "name": "minimaxai/VTP-Small-f16d64",
       "alias": [
-        "minimaxai/vtp-small-f16d64",
         "vtp-small-f16d64"
       ],
       "model_types": [
@@ -19770,9 +18102,7 @@
     },
     {
       "name": "mistral/mistral-large-latest",
-      "alias": [
-        "mistral-large-latest"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -19780,9 +18110,7 @@
     },
     {
       "name": "mistral/mistral-medium-latest",
-      "alias": [
-        "mistral-medium-latest"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -19790,9 +18118,7 @@
     },
     {
       "name": "mistral/mistral-small-latest",
-      "alias": [
-        "mistral-small-latest"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -19840,9 +18166,7 @@
     },
     {
       "name": "mistral/pixtral-large-latest",
-      "alias": [
-        "pixtral-large-latest"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision"
@@ -20156,8 +18480,7 @@
       "name": "mistralai/mistral-small-24b-instruct-2501",
       "alias": [
         "Mistral-Small-24B-Instruct-2501",
-        "Mistral Small (24B) Instruct 25.01",
-        "mistralai/Mistral-Small-24B-Instruct-2501"
+        "Mistral Small (24B) Instruct 25.01"
       ],
       "model_types": [
         "chat"
@@ -20243,8 +18566,7 @@
     {
       "name": "mistralai/voxtral-small-24b-2507",
       "alias": [
-        "Voxtral-Small-24B-2507",
-        "mistralai/Voxtral-Small-24B-2507"
+        "Voxtral-Small-24B-2507"
       ],
       "model_types": [
         "chat",
@@ -20473,7 +18795,6 @@
     {
       "name": "moonshotai/Kimi-Audio-7B",
       "alias": [
-        "moonshotai/kimi-audio-7b",
         "kimi-audio-7b"
       ],
       "model_types": [
@@ -20485,7 +18806,6 @@
     {
       "name": "moonshotai/Kimi-Audio-7B-Instruct",
       "alias": [
-        "moonshotai/kimi-audio-7b-instruct",
         "kimi-audio-7b-instruct"
       ],
       "model_types": [
@@ -20497,7 +18817,6 @@
     {
       "name": "moonshotai/Kimi-Dev-72B",
       "alias": [
-        "moonshotai/kimi-dev-72b",
         "kimi-dev-72b"
       ],
       "model_types": [
@@ -20524,7 +18843,6 @@
     {
       "name": "moonshotai/Kimi-K2-Base",
       "alias": [
-        "moonshotai/kimi-k2-base",
         "kimi-k2-base"
       ],
       "model_types": [
@@ -20535,7 +18853,6 @@
     {
       "name": "moonshotai/Kimi-K2-Instruct",
       "alias": [
-        "moonshotai/kimi-k2-instruct",
         "kimi-k2-instruct",
         "moonshotai/kimi-k2",
         "Kimi K2 Instruct"
@@ -20553,9 +18870,7 @@
     {
       "name": "moonshotai/Kimi-K2-Instruct-0905",
       "alias": [
-        "moonshotai/kimi-k2-instruct-0905",
-        "kimi-k2-instruct-0905",
-        "moonshotai/kimi-k2-0905"
+        "kimi-k2-instruct-0905"
       ],
       "model_types": [
         "chat"
@@ -20584,7 +18899,6 @@
     {
       "name": "moonshotai/Kimi-K2.5",
       "alias": [
-        "moonshotai/kimi-k2.5",
         "kimi-k2.5",
         "Kimi K2.5",
         "kimi/kimi-k2.5"
@@ -20629,7 +18943,6 @@
     {
       "name": "moonshotai/Kimi-K2.6",
       "alias": [
-        "moonshotai/kimi-k2.6",
         "kimi-k2.6",
         "Kimi K2.6",
         "kimi/kimi-k2.6",
@@ -20681,7 +18994,6 @@
     {
       "name": "moonshotai/Kimi-Linear-48B-A3B-Base",
       "alias": [
-        "moonshotai/kimi-linear-48b-a3b-base",
         "kimi-linear-48b-a3b-base"
       ],
       "model_types": [
@@ -20692,7 +19004,6 @@
     {
       "name": "moonshotai/Kimi-Linear-48B-A3B-Instruct",
       "alias": [
-        "moonshotai/kimi-linear-48b-a3b-instruct",
         "kimi-linear-48b-a3b-instruct"
       ],
       "model_types": [
@@ -20707,7 +19018,6 @@
     {
       "name": "moonshotai/Kimi-VL-A3B-Instruct",
       "alias": [
-        "moonshotai/kimi-vl-a3b-instruct",
         "kimi-vl-a3b-instruct"
       ],
       "model_types": [
@@ -20720,7 +19030,6 @@
     {
       "name": "moonshotai/Kimi-VL-A3B-Thinking",
       "alias": [
-        "moonshotai/kimi-vl-a3b-thinking",
         "kimi-vl-a3b-thinking"
       ],
       "model_types": [
@@ -20737,7 +19046,6 @@
     {
       "name": "moonshotai/Kimi-VL-A3B-Thinking-2506",
       "alias": [
-        "moonshotai/kimi-vl-a3b-thinking-2506",
         "kimi-vl-a3b-thinking-2506"
       ],
       "model_types": [
@@ -20754,7 +19062,6 @@
     {
       "name": "moonshotai/Moonlight-16B-A3B",
       "alias": [
-        "moonshotai/moonlight-16b-a3b",
         "moonlight-16b-a3b"
       ],
       "model_types": [
@@ -20765,7 +19072,6 @@
     {
       "name": "moonshotai/Moonlight-16B-A3B-Instruct",
       "alias": [
-        "moonshotai/moonlight-16b-a3b-instruct",
         "moonlight-16b-a3b-instruct"
       ],
       "model_types": [
@@ -20780,7 +19086,6 @@
     {
       "name": "moonshotai/MoonViT-SO-400M",
       "alias": [
-        "moonshotai/moonvit-so-400m",
         "moonvit-so-400m"
       ],
       "model_types": [
@@ -20958,8 +19263,7 @@
     {
       "name": "nousresearch/hermes-3-llama-3.1-70b",
       "alias": [
-        "Hermes-3-Llama-3.1-70B",
-        "NousResearch/Hermes-3-Llama-3.1-70B"
+        "Hermes-3-Llama-3.1-70B"
       ],
       "model_types": [
         "chat"
@@ -21015,9 +19319,7 @@
     {
       "name": "nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0",
       "alias": [
-        "nvidia/qwen3-vl-235b-a22b-instruct-nvfp4-mlperf-inference-closed-v6.0",
-        "Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0",
-        "qwen3-vl-235b-a22b-instruct-nvfp4-mlperf-inference-closed-v6.0"
+        "Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0"
       ],
       "model_types": [
         "chat",
@@ -21029,9 +19331,7 @@
     {
       "name": "nvidia/GLM-5-NVFP4",
       "alias": [
-        "nvidia/glm-5-nvfp4",
-        "GLM-5-NVFP4",
-        "glm-5-nvfp4"
+        "GLM-5-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21041,9 +19341,7 @@
     {
       "name": "nvidia/DeepSeek-V4-Flash-NVFP4",
       "alias": [
-        "nvidia/deepseek-v4-flash-nvfp4",
-        "DeepSeek-V4-Flash-NVFP4",
-        "deepseek-v4-flash-nvfp4"
+        "DeepSeek-V4-Flash-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21057,9 +19355,7 @@
     {
       "name": "nvidia/DeepSeek-V4-Pro-NVFP4",
       "alias": [
-        "nvidia/deepseek-v4-pro-nvfp4",
-        "DeepSeek-V4-Pro-NVFP4",
-        "deepseek-v4-pro-nvfp4"
+        "DeepSeek-V4-Pro-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21093,9 +19389,7 @@
     {
       "name": "nvidia/Qwen3.5-122B-A10B-NVFP4",
       "alias": [
-        "nvidia/qwen3.5-122b-a10b-nvfp4",
-        "Qwen3.5-122B-A10B-NVFP4",
-        "qwen3.5-122b-a10b-nvfp4"
+        "Qwen3.5-122B-A10B-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21105,9 +19399,7 @@
     {
       "name": "nvidia/Llama-3.3-70B-Instruct-Eagle3",
       "alias": [
-        "nvidia/llama-3.3-70b-instruct-eagle3",
-        "Llama-3.3-70B-Instruct-Eagle3",
-        "llama-3.3-70b-instruct-eagle3"
+        "Llama-3.3-70B-Instruct-Eagle3"
       ],
       "model_types": [
         "other"
@@ -21126,8 +19418,7 @@
     {
       "name": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
       "alias": [
-        "Llama-3.3-Nemotron-Super-49B-v1.5",
-        "nvidia/Llama-3.3-Nemotron-Super-49B-v1.5"
+        "Llama-3.3-Nemotron-Super-49B-v1.5"
       ],
       "model_types": [
         "chat"
@@ -21141,9 +19432,7 @@
     {
       "name": "nvidia/DeepSeek-V3.2-NVFP4",
       "alias": [
-        "nvidia/deepseek-v3.2-nvfp4",
-        "DeepSeek-V3.2-NVFP4",
-        "deepseek-v3.2-nvfp4"
+        "DeepSeek-V3.2-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21157,9 +19446,7 @@
     {
       "name": "nvidia/DeepSeek-V3.1-NVFP4",
       "alias": [
-        "nvidia/deepseek-v3.1-nvfp4",
-        "DeepSeek-V3.1-NVFP4",
-        "deepseek-v3.1-nvfp4"
+        "DeepSeek-V3.1-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21216,9 +19503,7 @@
     {
       "name": "nvidia/Audio2Emotion-v3.0",
       "alias": [
-        "nvidia/audio2emotion-v3.0",
-        "Audio2Emotion-v3.0",
-        "audio2emotion-v3.0"
+        "Audio2Emotion-v3.0"
       ],
       "model_types": [
         "audio"
@@ -21227,9 +19512,7 @@
     {
       "name": "nvidia/gpt-oss-120b-Eagle3-v3",
       "alias": [
-        "nvidia/gpt-oss-120b-eagle3-v3",
-        "gpt-oss-120b-Eagle3-v3",
-        "gpt-oss-120b-eagle3-v3"
+        "gpt-oss-120b-Eagle3-v3"
       ],
       "model_types": [
         "chat"
@@ -21260,9 +19543,7 @@
     {
       "name": "nvidia/Qwen3-235B-A22B-Eagle3",
       "alias": [
-        "nvidia/qwen3-235b-a22b-eagle3",
-        "Qwen3-235B-A22B-Eagle3",
-        "qwen3-235b-a22b-eagle3"
+        "Qwen3-235B-A22B-Eagle3"
       ],
       "model_types": [
         "chat"
@@ -21272,9 +19553,7 @@
     {
       "name": "nvidia/Qwen3-235B-A22B-Instruct-2507-NVFP4",
       "alias": [
-        "nvidia/qwen3-235b-a22b-instruct-2507-nvfp4",
-        "Qwen3-235B-A22B-Instruct-2507-NVFP4",
-        "qwen3-235b-a22b-instruct-2507-nvfp4"
+        "Qwen3-235B-A22B-Instruct-2507-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21284,9 +19563,7 @@
     {
       "name": "nvidia/Qwen3-235B-A22B-Thinking-2507-Eagle3",
       "alias": [
-        "nvidia/qwen3-235b-a22b-thinking-2507-eagle3",
-        "Qwen3-235B-A22B-Thinking-2507-Eagle3",
-        "qwen3-235b-a22b-thinking-2507-eagle3"
+        "Qwen3-235B-A22B-Thinking-2507-Eagle3"
       ],
       "model_types": [
         "chat"
@@ -21300,9 +19577,7 @@
     {
       "name": "nvidia/Qwen3-235B-A22B-Thinking-2507-FP4-Eagle3",
       "alias": [
-        "nvidia/qwen3-235b-a22b-thinking-2507-fp4-eagle3",
-        "Qwen3-235B-A22B-Thinking-2507-FP4-Eagle3",
-        "qwen3-235b-a22b-thinking-2507-fp4-eagle3"
+        "Qwen3-235B-A22B-Thinking-2507-FP4-Eagle3"
       ],
       "model_types": [
         "chat"
@@ -21316,9 +19591,7 @@
     {
       "name": "nvidia/Qwen3-235B-A22B-Thinking-2507-NVFP4",
       "alias": [
-        "nvidia/qwen3-235b-a22b-thinking-2507-nvfp4",
-        "Qwen3-235B-A22B-Thinking-2507-NVFP4",
-        "qwen3-235b-a22b-thinking-2507-nvfp4"
+        "Qwen3-235B-A22B-Thinking-2507-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21332,9 +19605,7 @@
     {
       "name": "nvidia/Qwen3-30B-A3B-Thinking-2507-Eagle3",
       "alias": [
-        "nvidia/qwen3-30b-a3b-thinking-2507-eagle3",
-        "Qwen3-30B-A3B-Thinking-2507-Eagle3",
-        "qwen3-30b-a3b-thinking-2507-eagle3"
+        "Qwen3-30B-A3B-Thinking-2507-Eagle3"
       ],
       "model_types": [
         "chat"
@@ -21348,9 +19619,7 @@
     {
       "name": "nvidia/Qwen3-8B-DMS-8x",
       "alias": [
-        "nvidia/qwen3-8b-dms-8x",
-        "Qwen3-8B-DMS-8x",
-        "qwen3-8b-dms-8x"
+        "Qwen3-8B-DMS-8x"
       ],
       "model_types": [
         "chat"
@@ -21360,9 +19629,7 @@
     {
       "name": "nvidia/Qwen3-Coder-480B-A35B-Instruct-NVFP4",
       "alias": [
-        "nvidia/qwen3-coder-480b-a35b-instruct-nvfp4",
-        "Qwen3-Coder-480B-A35B-Instruct-NVFP4",
-        "qwen3-coder-480b-a35b-instruct-nvfp4"
+        "Qwen3-Coder-480B-A35B-Instruct-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21372,9 +19639,7 @@
     {
       "name": "nvidia/Qwen3-Nemotron-14B-BRRM",
       "alias": [
-        "nvidia/qwen3-nemotron-14b-brrm",
-        "Qwen3-Nemotron-14B-BRRM",
-        "qwen3-nemotron-14b-brrm"
+        "Qwen3-Nemotron-14B-BRRM"
       ],
       "model_types": [
         "chat"
@@ -21398,9 +19663,7 @@
     {
       "name": "nvidia/Qwen3-Nemotron-235B-A22B-GenRM-2603",
       "alias": [
-        "nvidia/qwen3-nemotron-235b-a22b-genrm-2603",
-        "Qwen3-Nemotron-235B-A22B-GenRM-2603",
-        "qwen3-nemotron-235b-a22b-genrm-2603"
+        "Qwen3-Nemotron-235B-A22B-GenRM-2603"
       ],
       "model_types": [
         "chat"
@@ -21438,9 +19701,7 @@
     {
       "name": "nvidia/Qwen3-Nemotron-8B-BRRM",
       "alias": [
-        "nvidia/qwen3-nemotron-8b-brrm",
-        "Qwen3-Nemotron-8B-BRRM",
-        "qwen3-nemotron-8b-brrm"
+        "Qwen3-Nemotron-8B-BRRM"
       ],
       "model_types": [
         "chat"
@@ -21450,9 +19711,7 @@
     {
       "name": "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
       "alias": [
-        "nvidia/qwen3-next-80b-a3b-instruct-nvfp4",
-        "Qwen3-Next-80B-A3B-Instruct-NVFP4",
-        "qwen3-next-80b-a3b-instruct-nvfp4"
+        "Qwen3-Next-80B-A3B-Instruct-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21462,9 +19721,7 @@
     {
       "name": "nvidia/Qwen3-Next-80B-A3B-Thinking-NVFP4",
       "alias": [
-        "nvidia/qwen3-next-80b-a3b-thinking-nvfp4",
-        "Qwen3-Next-80B-A3B-Thinking-NVFP4",
-        "qwen3-next-80b-a3b-thinking-nvfp4"
+        "Qwen3-Next-80B-A3B-Thinking-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21478,9 +19735,7 @@
     {
       "name": "nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4",
       "alias": [
-        "nvidia/qwen3-vl-235b-a22b-instruct-nvfp4",
-        "Qwen3-VL-235B-A22B-Instruct-NVFP4",
-        "qwen3-vl-235b-a22b-instruct-nvfp4"
+        "Qwen3-VL-235B-A22B-Instruct-NVFP4"
       ],
       "model_types": [
         "chat",
@@ -21492,9 +19747,7 @@
     {
       "name": "nvidia/Qwen2.5-CascadeRL-RM-72B",
       "alias": [
-        "nvidia/qwen2.5-cascaderl-rm-72b",
-        "Qwen2.5-CascadeRL-RM-72B",
-        "qwen2.5-cascaderl-rm-72b"
+        "Qwen2.5-CascadeRL-RM-72B"
       ],
       "model_types": [
         "chat"
@@ -21527,9 +19780,7 @@
     {
       "name": "nvidia/Qwen2.5-VL-7B-Surg-CholecT50",
       "alias": [
-        "nvidia/qwen2.5-vl-7b-surg-cholect50",
-        "Qwen2.5-VL-7B-Surg-CholecT50",
-        "qwen2.5-vl-7b-surg-cholect50"
+        "Qwen2.5-VL-7B-Surg-CholecT50"
       ],
       "model_types": [
         "chat",
@@ -21571,9 +19822,7 @@
     {
       "name": "nvidia/Audio2Emotion-v2.2",
       "alias": [
-        "nvidia/audio2emotion-v2.2",
-        "Audio2Emotion-v2.2",
-        "audio2emotion-v2.2"
+        "Audio2Emotion-v2.2"
       ],
       "model_types": [
         "audio"
@@ -21742,9 +19991,7 @@
     {
       "name": "nvidia/NV-KERMT-70M-v2",
       "alias": [
-        "nvidia/nv-kermt-70m-v2",
-        "NV-KERMT-70M-v2",
-        "nv-kermt-70m-v2"
+        "NV-KERMT-70M-v2"
       ],
       "model_types": [
         "other"
@@ -21753,9 +20000,7 @@
     {
       "name": "nvidia/NV-ReaSyn-AR-166M-v2",
       "alias": [
-        "nvidia/nv-reasyn-ar-166m-v2",
-        "NV-ReaSyn-AR-166M-v2",
-        "nv-reasyn-ar-166m-v2"
+        "NV-ReaSyn-AR-166M-v2"
       ],
       "model_types": [
         "other"
@@ -21764,9 +20009,7 @@
     {
       "name": "nvidia/NV-ReaSyn-EB-174M-v2",
       "alias": [
-        "nvidia/nv-reasyn-eb-174m-v2",
-        "NV-ReaSyn-EB-174M-v2",
-        "nv-reasyn-eb-174m-v2"
+        "NV-ReaSyn-EB-174M-v2"
       ],
       "model_types": [
         "other"
@@ -21837,9 +20080,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
       "alias": [
-        "nvidia/nvidia-nemotron-nano-9b-v2",
         "NVIDIA-Nemotron-Nano-9B-v2",
-        "nvidia-nemotron-nano-9b-v2",
         "nvidia/nemotron-nano-9b-v2:free",
         "Nvidia Nemotron Nano 9B V2"
       ],
@@ -21861,9 +20102,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8",
       "alias": [
-        "nvidia/nvidia-nemotron-nano-9b-v2-fp8",
-        "NVIDIA-Nemotron-Nano-9B-v2-FP8",
-        "nvidia-nemotron-nano-9b-v2-fp8"
+        "NVIDIA-Nemotron-Nano-9B-v2-FP8"
       ],
       "model_types": [
         "chat"
@@ -21873,9 +20112,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese",
       "alias": [
-        "nvidia/nvidia-nemotron-nano-9b-v2-japanese",
-        "NVIDIA-Nemotron-Nano-9B-v2-Japanese",
-        "nvidia-nemotron-nano-9b-v2-japanese"
+        "NVIDIA-Nemotron-Nano-9B-v2-Japanese"
       ],
       "model_types": [
         "chat"
@@ -21885,9 +20122,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4",
       "alias": [
-        "nvidia/nvidia-nemotron-nano-9b-v2-nvfp4",
-        "NVIDIA-Nemotron-Nano-9B-v2-NVFP4",
-        "nvidia-nemotron-nano-9b-v2-nvfp4"
+        "NVIDIA-Nemotron-Nano-9B-v2-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -21906,9 +20141,7 @@
     {
       "name": "nvidia/Kimodo-SOMA-RP-v1.1",
       "alias": [
-        "nvidia/kimodo-soma-rp-v1.1",
-        "Kimodo-SOMA-RP-v1.1",
-        "kimodo-soma-rp-v1.1"
+        "Kimodo-SOMA-RP-v1.1"
       ],
       "model_types": [
         "robotics"
@@ -21917,9 +20150,7 @@
     {
       "name": "nvidia/Kimodo-SOMA-SEED-v1.1",
       "alias": [
-        "nvidia/kimodo-soma-seed-v1.1",
-        "Kimodo-SOMA-SEED-v1.1",
-        "kimodo-soma-seed-v1.1"
+        "Kimodo-SOMA-SEED-v1.1"
       ],
       "model_types": [
         "robotics"
@@ -21928,9 +20159,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Parse-v1.1-TC",
       "alias": [
-        "nvidia/nvidia-nemotron-parse-v1.1-tc",
-        "NVIDIA-Nemotron-Parse-v1.1-TC",
-        "nvidia-nemotron-parse-v1.1-tc"
+        "NVIDIA-Nemotron-Parse-v1.1-TC"
       ],
       "model_types": [
         "chat",
@@ -21942,9 +20171,7 @@
     {
       "name": "nvidia/Riva-Translate-4B-Instruct-v1.1",
       "alias": [
-        "nvidia/riva-translate-4b-instruct-v1.1",
-        "Riva-Translate-4B-Instruct-v1.1",
-        "riva-translate-4b-instruct-v1.1"
+        "Riva-Translate-4B-Instruct-v1.1"
       ],
       "model_types": [
         "chat"
@@ -21980,9 +20207,7 @@
     {
       "name": "nvidia/Kimodo-G1-RP-v1",
       "alias": [
-        "nvidia/kimodo-g1-rp-v1",
-        "Kimodo-G1-RP-v1",
-        "kimodo-g1-rp-v1"
+        "Kimodo-G1-RP-v1"
       ],
       "model_types": [
         "robotics"
@@ -21991,9 +20216,7 @@
     {
       "name": "nvidia/Kimodo-G1-SEED-v1",
       "alias": [
-        "nvidia/kimodo-g1-seed-v1",
-        "Kimodo-G1-SEED-v1",
-        "kimodo-g1-seed-v1"
+        "Kimodo-G1-SEED-v1"
       ],
       "model_types": [
         "robotics"
@@ -22002,9 +20225,7 @@
     {
       "name": "nvidia/Kimodo-SMPLX-RP-v1",
       "alias": [
-        "nvidia/kimodo-smplx-rp-v1",
-        "Kimodo-SMPLX-RP-v1",
-        "kimodo-smplx-rp-v1"
+        "Kimodo-SMPLX-RP-v1"
       ],
       "model_types": [
         "robotics"
@@ -22013,9 +20234,7 @@
     {
       "name": "nvidia/Kimodo-SOMA-RP-v1",
       "alias": [
-        "nvidia/kimodo-soma-rp-v1",
-        "Kimodo-SOMA-RP-v1",
-        "kimodo-soma-rp-v1"
+        "Kimodo-SOMA-RP-v1"
       ],
       "model_types": [
         "robotics"
@@ -22024,9 +20243,7 @@
     {
       "name": "nvidia/Kimodo-SOMA-SEED-v1",
       "alias": [
-        "nvidia/kimodo-soma-seed-v1",
-        "Kimodo-SOMA-SEED-v1",
-        "kimodo-soma-seed-v1"
+        "Kimodo-SOMA-SEED-v1"
       ],
       "model_types": [
         "robotics"
@@ -22250,9 +20467,7 @@
     {
       "name": "nvidia/NV-Proteina-Complexa-AME-160M-v1",
       "alias": [
-        "nvidia/nv-proteina-complexa-ame-160m-v1",
-        "NV-Proteina-Complexa-AME-160M-v1",
-        "nv-proteina-complexa-ame-160m-v1"
+        "NV-Proteina-Complexa-AME-160M-v1"
       ],
       "model_types": [
         "other"
@@ -22261,9 +20476,7 @@
     {
       "name": "nvidia/NV-Proteina-Complexa-Ligand-Target-160M-v1",
       "alias": [
-        "nvidia/nv-proteina-complexa-ligand-target-160m-v1",
-        "NV-Proteina-Complexa-Ligand-Target-160M-v1",
-        "nv-proteina-complexa-ligand-target-160m-v1"
+        "NV-Proteina-Complexa-Ligand-Target-160M-v1"
       ],
       "model_types": [
         "other"
@@ -22272,9 +20485,7 @@
     {
       "name": "nvidia/NV-Proteina-Complexa-Protein-Target-160M-v1",
       "alias": [
-        "nvidia/nv-proteina-complexa-protein-target-160m-v1",
-        "NV-Proteina-Complexa-Protein-Target-160M-v1",
-        "nv-proteina-complexa-protein-target-160m-v1"
+        "NV-Proteina-Complexa-Protein-Target-160M-v1"
       ],
       "model_types": [
         "other"
@@ -22283,9 +20494,7 @@
     {
       "name": "nvidia/NV-ReaSyn-AR-166M-v1",
       "alias": [
-        "nvidia/nv-reasyn-ar-166m-v1",
-        "NV-ReaSyn-AR-166M-v1",
-        "nv-reasyn-ar-166m-v1"
+        "NV-ReaSyn-AR-166M-v1"
       ],
       "model_types": [
         "other"
@@ -22332,9 +20541,7 @@
     {
       "name": "nvidia/TMR-SOMA-RP-v1",
       "alias": [
-        "nvidia/tmr-soma-rp-v1",
-        "TMR-SOMA-RP-v1",
-        "tmr-soma-rp-v1"
+        "TMR-SOMA-RP-v1"
       ],
       "model_types": [
         "robotics"
@@ -22378,9 +20585,7 @@
     {
       "name": "nvidia/ArtiFixer",
       "alias": [
-        "nvidia/artifixer",
-        "ArtiFixer",
-        "artifixer"
+        "ArtiFixer"
       ],
       "model_types": [
         "other"
@@ -22462,9 +20667,7 @@
     {
       "name": "nvidia/AutoGaze",
       "alias": [
-        "nvidia/autogaze",
-        "AutoGaze",
-        "autogaze"
+        "AutoGaze"
       ],
       "model_types": [
         "vision"
@@ -22473,9 +20676,7 @@
     {
       "name": "nvidia/C-RADIOv2-B",
       "alias": [
-        "nvidia/c-radiov2-b",
-        "C-RADIOv2-B",
-        "c-radiov2-b"
+        "C-RADIOv2-B"
       ],
       "model_types": [
         "embedding",
@@ -22487,9 +20688,7 @@
     {
       "name": "nvidia/C-RADIOv2-H",
       "alias": [
-        "nvidia/c-radiov2-h",
-        "C-RADIOv2-H",
-        "c-radiov2-h"
+        "C-RADIOv2-H"
       ],
       "model_types": [
         "embedding",
@@ -22501,9 +20700,7 @@
     {
       "name": "nvidia/C-RADIOv2-L",
       "alias": [
-        "nvidia/c-radiov2-l",
-        "C-RADIOv2-L",
-        "c-radiov2-l"
+        "C-RADIOv2-L"
       ],
       "model_types": [
         "embedding",
@@ -22515,9 +20712,7 @@
     {
       "name": "nvidia/C-RADIOv3-B",
       "alias": [
-        "nvidia/c-radiov3-b",
-        "C-RADIOv3-B",
-        "c-radiov3-b"
+        "C-RADIOv3-B"
       ],
       "model_types": [
         "embedding",
@@ -22529,9 +20724,7 @@
     {
       "name": "nvidia/C-RADIOv3-g",
       "alias": [
-        "nvidia/c-radiov3-g",
-        "C-RADIOv3-g",
-        "c-radiov3-g"
+        "C-RADIOv3-g"
       ],
       "model_types": [
         "embedding",
@@ -22543,9 +20736,7 @@
     {
       "name": "nvidia/C-RADIOv3-H",
       "alias": [
-        "nvidia/c-radiov3-h",
-        "C-RADIOv3-H",
-        "c-radiov3-h"
+        "C-RADIOv3-H"
       ],
       "model_types": [
         "embedding",
@@ -22557,9 +20748,7 @@
     {
       "name": "nvidia/C-RADIOv3-L",
       "alias": [
-        "nvidia/c-radiov3-l",
-        "C-RADIOv3-L",
-        "c-radiov3-l"
+        "C-RADIOv3-L"
       ],
       "model_types": [
         "embedding",
@@ -22571,9 +20760,7 @@
     {
       "name": "nvidia/C-RADIOv4-H",
       "alias": [
-        "nvidia/c-radiov4-h",
-        "C-RADIOv4-H",
-        "c-radiov4-h"
+        "C-RADIOv4-H"
       ],
       "model_types": [
         "embedding",
@@ -22585,9 +20772,7 @@
     {
       "name": "nvidia/C-RADIOv4-SO400M",
       "alias": [
-        "nvidia/c-radiov4-so400m",
-        "C-RADIOv4-SO400M",
-        "c-radiov4-so400m"
+        "C-RADIOv4-SO400M"
       ],
       "model_types": [
         "embedding",
@@ -22653,9 +20838,7 @@
     {
       "name": "nvidia/Cosmos-Embed1-224p",
       "alias": [
-        "nvidia/cosmos-embed1-224p",
-        "Cosmos-Embed1-224p",
-        "cosmos-embed1-224p"
+        "Cosmos-Embed1-224p"
       ],
       "model_types": [
         "embedding",
@@ -22667,9 +20850,7 @@
     {
       "name": "nvidia/Cosmos-Embed1-336p",
       "alias": [
-        "nvidia/cosmos-embed1-336p",
-        "Cosmos-Embed1-336p",
-        "cosmos-embed1-336p"
+        "Cosmos-Embed1-336p"
       ],
       "model_types": [
         "embedding",
@@ -22681,9 +20862,7 @@
     {
       "name": "nvidia/Cosmos-Embed1-448p",
       "alias": [
-        "nvidia/cosmos-embed1-448p",
-        "Cosmos-Embed1-448p",
-        "cosmos-embed1-448p"
+        "Cosmos-Embed1-448p"
       ],
       "model_types": [
         "embedding",
@@ -22695,9 +20874,7 @@
     {
       "name": "nvidia/Cosmos-Embed1-448p-anomaly-detection",
       "alias": [
-        "nvidia/cosmos-embed1-448p-anomaly-detection",
-        "Cosmos-Embed1-448p-anomaly-detection",
-        "cosmos-embed1-448p-anomaly-detection"
+        "Cosmos-Embed1-448p-anomaly-detection"
       ],
       "model_types": [
         "embedding",
@@ -22709,9 +20886,7 @@
     {
       "name": "nvidia/Cosmos-H-Surgical",
       "alias": [
-        "nvidia/cosmos-h-surgical",
-        "Cosmos-H-Surgical",
-        "cosmos-h-surgical"
+        "Cosmos-H-Surgical"
       ],
       "model_types": [
         "other"
@@ -22720,9 +20895,7 @@
     {
       "name": "nvidia/Cosmos-H-Surgical-Simulator",
       "alias": [
-        "nvidia/cosmos-h-surgical-simulator",
-        "Cosmos-H-Surgical-Simulator",
-        "cosmos-h-surgical-simulator"
+        "Cosmos-H-Surgical-Simulator"
       ],
       "model_types": [
         "other"
@@ -22731,9 +20904,7 @@
     {
       "name": "nvidia/Cosmos-Policy-ALOHA-Planning-Model-Predict2-2B",
       "alias": [
-        "nvidia/cosmos-policy-aloha-planning-model-predict2-2b",
-        "Cosmos-Policy-ALOHA-Planning-Model-Predict2-2B",
-        "cosmos-policy-aloha-planning-model-predict2-2b"
+        "Cosmos-Policy-ALOHA-Planning-Model-Predict2-2B"
       ],
       "model_types": [
         "robotics"
@@ -22742,9 +20913,7 @@
     {
       "name": "nvidia/Cosmos-Policy-ALOHA-Predict2-2B",
       "alias": [
-        "nvidia/cosmos-policy-aloha-predict2-2b",
-        "Cosmos-Policy-ALOHA-Predict2-2B",
-        "cosmos-policy-aloha-predict2-2b"
+        "Cosmos-Policy-ALOHA-Predict2-2B"
       ],
       "model_types": [
         "robotics"
@@ -22753,9 +20922,7 @@
     {
       "name": "nvidia/Cosmos-Policy-LIBERO-Predict2-2B",
       "alias": [
-        "nvidia/cosmos-policy-libero-predict2-2b",
-        "Cosmos-Policy-LIBERO-Predict2-2B",
-        "cosmos-policy-libero-predict2-2b"
+        "Cosmos-Policy-LIBERO-Predict2-2B"
       ],
       "model_types": [
         "robotics"
@@ -22764,9 +20931,7 @@
     {
       "name": "nvidia/Cosmos-Policy-RoboCasa-Predict2-2B",
       "alias": [
-        "nvidia/cosmos-policy-robocasa-predict2-2b",
-        "Cosmos-Policy-RoboCasa-Predict2-2B",
-        "cosmos-policy-robocasa-predict2-2b"
+        "Cosmos-Policy-RoboCasa-Predict2-2B"
       ],
       "model_types": [
         "robotics"
@@ -22784,9 +20949,7 @@
     {
       "name": "nvidia/Cosmos-Predict2.5-2B",
       "alias": [
-        "nvidia/cosmos-predict2.5-2b",
-        "Cosmos-Predict2.5-2B",
-        "cosmos-predict2.5-2b"
+        "Cosmos-Predict2.5-2B"
       ],
       "model_types": [
         "video_generation"
@@ -22815,9 +20978,7 @@
     {
       "name": "nvidia/Cosmos-Tokenizer-Surg",
       "alias": [
-        "nvidia/cosmos-tokenizer-surg",
-        "Cosmos-Tokenizer-Surg",
-        "cosmos-tokenizer-surg"
+        "Cosmos-Tokenizer-Surg"
       ],
       "model_types": [
         "other"
@@ -22844,9 +21005,7 @@
     {
       "name": "nvidia/Cosmos-Transfer2.5-2B",
       "alias": [
-        "nvidia/cosmos-transfer2.5-2b",
-        "Cosmos-Transfer2.5-2B",
-        "cosmos-transfer2.5-2b"
+        "Cosmos-Transfer2.5-2B"
       ],
       "model_types": [
         "video_generation"
@@ -22864,9 +21023,7 @@
     {
       "name": "nvidia/Cosmos3-Super",
       "alias": [
-        "nvidia/cosmos3-super",
-        "Cosmos3-Super",
-        "cosmos3-super"
+        "Cosmos3-Super"
       ],
       "model_types": [
         "other",
@@ -22876,9 +21033,7 @@
     {
       "name": "nvidia/DiffiT",
       "alias": [
-        "nvidia/diffit",
-        "DiffiT",
-        "diffit"
+        "DiffiT"
       ],
       "model_types": [
         "image"
@@ -22887,9 +21042,7 @@
     {
       "name": "nvidia/diffusiongemma-26B-A4B-it-NVFP4",
       "alias": [
-        "nvidia/diffusiongemma-26b-a4b-it-nvfp4",
-        "diffusiongemma-26B-A4B-it-NVFP4",
-        "diffusiongemma-26b-a4b-it-nvfp4"
+        "diffusiongemma-26B-A4B-it-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -22918,9 +21071,7 @@
     {
       "name": "nvidia/DreamDojo",
       "alias": [
-        "nvidia/dreamdojo",
-        "DreamDojo",
-        "dreamdojo"
+        "DreamDojo"
       ],
       "model_types": [
         "video_generation"
@@ -22940,9 +21091,7 @@
     {
       "name": "nvidia/EGM-4B",
       "alias": [
-        "nvidia/egm-4b",
-        "EGM-4B",
-        "egm-4b"
+        "EGM-4B"
       ],
       "model_types": [
         "chat",
@@ -22953,9 +21102,7 @@
     {
       "name": "nvidia/EGM-4B-SFT",
       "alias": [
-        "nvidia/egm-4b-sft",
-        "EGM-4B-SFT",
-        "egm-4b-sft"
+        "EGM-4B-SFT"
       ],
       "model_types": [
         "chat",
@@ -22966,9 +21113,7 @@
     {
       "name": "nvidia/EGM-8B",
       "alias": [
-        "nvidia/egm-8b",
-        "EGM-8B",
-        "egm-8b"
+        "EGM-8B"
       ],
       "model_types": [
         "chat",
@@ -22979,9 +21124,7 @@
     {
       "name": "nvidia/EGM-8B-SFT",
       "alias": [
-        "nvidia/egm-8b-sft",
-        "EGM-8B-SFT",
-        "egm-8b-sft"
+        "EGM-8B-SFT"
       ],
       "model_types": [
         "chat",
@@ -22992,9 +21135,7 @@
     {
       "name": "nvidia/esm2_t33_650M_UR50D",
       "alias": [
-        "nvidia/esm2_t33_650m_ur50d",
-        "esm2_t33_650M_UR50D",
-        "esm2_t33_650m_ur50d"
+        "esm2_t33_650M_UR50D"
       ],
       "model_types": [
         "other"
@@ -23003,9 +21144,7 @@
     {
       "name": "nvidia/esm2_t36_3B_UR50D",
       "alias": [
-        "nvidia/esm2_t36_3b_ur50d",
-        "esm2_t36_3B_UR50D",
-        "esm2_t36_3b_ur50d"
+        "esm2_t36_3B_UR50D"
       ],
       "model_types": [
         "other"
@@ -23014,9 +21153,7 @@
     {
       "name": "nvidia/esm2_t48_15B_UR50D",
       "alias": [
-        "nvidia/esm2_t48_15b_ur50d",
-        "esm2_t48_15B_UR50D",
-        "esm2_t48_15b_ur50d"
+        "esm2_t48_15B_UR50D"
       ],
       "model_types": [
         "other"
@@ -23070,9 +21207,7 @@
     {
       "name": "nvidia/GEAR-SONIC",
       "alias": [
-        "nvidia/gear-sonic",
-        "GEAR-SONIC",
-        "gear-sonic"
+        "GEAR-SONIC"
       ],
       "model_types": [
         "robotics"
@@ -23081,9 +21216,7 @@
     {
       "name": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "alias": [
-        "nvidia/gemma-4-26b-a4b-nvfp4",
-        "Gemma-4-26B-A4B-NVFP4",
-        "gemma-4-26b-a4b-nvfp4"
+        "Gemma-4-26B-A4B-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -23093,9 +21226,7 @@
     {
       "name": "nvidia/Gemma-4-31B-IT-NVFP4",
       "alias": [
-        "nvidia/gemma-4-31b-it-nvfp4",
-        "Gemma-4-31B-IT-NVFP4",
-        "gemma-4-31b-it-nvfp4"
+        "Gemma-4-31B-IT-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -23123,9 +21254,7 @@
     {
       "name": "nvidia/GN1.6-Tuned-Arena-GR1-PlaceItemCloseDoor-Task",
       "alias": [
-        "nvidia/gn1.6-tuned-arena-gr1-placeitemclosedoor-task",
-        "GN1.6-Tuned-Arena-GR1-PlaceItemCloseDoor-Task",
-        "gn1.6-tuned-arena-gr1-placeitemclosedoor-task"
+        "GN1.6-Tuned-Arena-GR1-PlaceItemCloseDoor-Task"
       ],
       "model_types": [
         "robotics"
@@ -23134,9 +21263,7 @@
     {
       "name": "nvidia/GN16-Tuned-Arena-GR1-Manipulation",
       "alias": [
-        "nvidia/gn16-tuned-arena-gr1-manipulation",
-        "GN16-Tuned-Arena-GR1-Manipulation",
-        "gn16-tuned-arena-gr1-manipulation"
+        "GN16-Tuned-Arena-GR1-Manipulation"
       ],
       "model_types": [
         "robotics"
@@ -23145,9 +21272,7 @@
     {
       "name": "nvidia/GN1x-Tuned-Arena-G1-Loco-Manipulation",
       "alias": [
-        "nvidia/gn1x-tuned-arena-g1-loco-manipulation",
-        "GN1x-Tuned-Arena-G1-Loco-Manipulation",
-        "gn1x-tuned-arena-g1-loco-manipulation"
+        "GN1x-Tuned-Arena-G1-Loco-Manipulation"
       ],
       "model_types": [
         "robotics"
@@ -23156,9 +21281,7 @@
     {
       "name": "nvidia/GN1x-Tuned-Arena-GR1-Manipulation",
       "alias": [
-        "nvidia/gn1x-tuned-arena-gr1-manipulation",
-        "GN1x-Tuned-Arena-GR1-Manipulation",
-        "gn1x-tuned-arena-gr1-manipulation"
+        "GN1x-Tuned-Arena-GR1-Manipulation"
       ],
       "model_types": [
         "robotics"
@@ -23167,9 +21290,7 @@
     {
       "name": "nvidia/gpt-oss-120b-Eagle3-long-context",
       "alias": [
-        "nvidia/gpt-oss-120b-eagle3-long-context",
-        "gpt-oss-120b-Eagle3-long-context",
-        "gpt-oss-120b-eagle3-long-context"
+        "gpt-oss-120b-Eagle3-long-context"
       ],
       "model_types": [
         "chat"
@@ -23179,9 +21300,7 @@
     {
       "name": "nvidia/gpt-oss-120b-Eagle3-short-context",
       "alias": [
-        "nvidia/gpt-oss-120b-eagle3-short-context",
-        "gpt-oss-120b-Eagle3-short-context",
-        "gpt-oss-120b-eagle3-short-context"
+        "gpt-oss-120b-Eagle3-short-context"
       ],
       "model_types": [
         "chat"
@@ -23191,9 +21310,7 @@
     {
       "name": "nvidia/gpt-oss-120b-Eagle3-throughput",
       "alias": [
-        "nvidia/gpt-oss-120b-eagle3-throughput",
-        "gpt-oss-120b-Eagle3-throughput",
-        "gpt-oss-120b-eagle3-throughput"
+        "gpt-oss-120b-Eagle3-throughput"
       ],
       "model_types": [
         "chat"
@@ -23203,9 +21320,7 @@
     {
       "name": "nvidia/GR00T-H",
       "alias": [
-        "nvidia/gr00t-h",
-        "GR00T-H",
-        "gr00t-h"
+        "GR00T-H"
       ],
       "model_types": [
         "other"
@@ -23214,9 +21329,7 @@
     {
       "name": "nvidia/GR00T-N1.5-RL-Rheo-AssembleTrocar",
       "alias": [
-        "nvidia/gr00t-n1.5-rl-rheo-assembletrocar",
-        "GR00T-N1.5-RL-Rheo-AssembleTrocar",
-        "gr00t-n1.5-rl-rheo-assembletrocar"
+        "GR00T-N1.5-RL-Rheo-AssembleTrocar"
       ],
       "model_types": [
         "other"
@@ -23225,9 +21338,7 @@
     {
       "name": "nvidia/GR00T-N1.6-3B",
       "alias": [
-        "nvidia/gr00t-n1.6-3b",
-        "GR00T-N1.6-3B",
-        "gr00t-n1.6-3b"
+        "GR00T-N1.6-3B"
       ],
       "model_types": [
         "other"
@@ -23236,9 +21347,7 @@
     {
       "name": "nvidia/GR00T-N1.6-DROID",
       "alias": [
-        "nvidia/gr00t-n1.6-droid",
-        "GR00T-N1.6-DROID",
-        "gr00t-n1.6-droid"
+        "GR00T-N1.6-DROID"
       ],
       "model_types": [
         "other"
@@ -23247,9 +21356,7 @@
     {
       "name": "nvidia/GR00T-N1.6-Rheo-PickNPlaceTray",
       "alias": [
-        "nvidia/gr00t-n1.6-rheo-picknplacetray",
-        "GR00T-N1.6-Rheo-PickNPlaceTray",
-        "gr00t-n1.6-rheo-picknplacetray"
+        "GR00T-N1.6-Rheo-PickNPlaceTray"
       ],
       "model_types": [
         "other"
@@ -23258,9 +21365,7 @@
     {
       "name": "nvidia/GR00T-N1.6-Rheo-Sim-PushCart",
       "alias": [
-        "nvidia/gr00t-n1.6-rheo-sim-pushcart",
-        "GR00T-N1.6-Rheo-Sim-PushCart",
-        "gr00t-n1.6-rheo-sim-pushcart"
+        "GR00T-N1.6-Rheo-Sim-PushCart"
       ],
       "model_types": [
         "other"
@@ -23269,9 +21374,7 @@
     {
       "name": "nvidia/GR00T-N1.7-DROID",
       "alias": [
-        "nvidia/gr00t-n1.7-droid",
-        "GR00T-N1.7-DROID",
-        "gr00t-n1.7-droid"
+        "GR00T-N1.7-DROID"
       ],
       "model_types": [
         "other"
@@ -23280,9 +21383,7 @@
     {
       "name": "nvidia/GR00T-N1.7-LIBERO",
       "alias": [
-        "nvidia/gr00t-n1.7-libero",
-        "GR00T-N1.7-LIBERO",
-        "gr00t-n1.7-libero"
+        "GR00T-N1.7-LIBERO"
       ],
       "model_types": [
         "other"
@@ -23291,9 +21392,7 @@
     {
       "name": "nvidia/GR00T-N1.7-SimplerEnv-Bridge",
       "alias": [
-        "nvidia/gr00t-n1.7-simplerenv-bridge",
-        "GR00T-N1.7-SimplerEnv-Bridge",
-        "gr00t-n1.7-simplerenv-bridge"
+        "GR00T-N1.7-SimplerEnv-Bridge"
       ],
       "model_types": [
         "other"
@@ -23302,9 +21401,7 @@
     {
       "name": "nvidia/GR00T-N1.7-SimplerEnv-Fractal",
       "alias": [
-        "nvidia/gr00t-n1.7-simplerenv-fractal",
-        "GR00T-N1.7-SimplerEnv-Fractal",
-        "gr00t-n1.7-simplerenv-fractal"
+        "GR00T-N1.7-SimplerEnv-Fractal"
       ],
       "model_types": [
         "other"
@@ -23377,9 +21474,7 @@
     {
       "name": "nvidia/Ising-Calibration-1-35B-A3B",
       "alias": [
-        "nvidia/ising-calibration-1-35b-a3b",
-        "Ising-Calibration-1-35B-A3B",
-        "ising-calibration-1-35b-a3b"
+        "Ising-Calibration-1-35B-A3B"
       ],
       "model_types": [
         "other"
@@ -23388,9 +21483,7 @@
     {
       "name": "nvidia/Kimi-K2-Thinking-Eagle3",
       "alias": [
-        "nvidia/kimi-k2-thinking-eagle3",
-        "Kimi-K2-Thinking-Eagle3",
-        "kimi-k2-thinking-eagle3"
+        "Kimi-K2-Thinking-Eagle3"
       ],
       "model_types": [
         "chat"
@@ -23404,9 +21497,7 @@
     {
       "name": "nvidia/Kimi-K2-Thinking-NVFP4",
       "alias": [
-        "nvidia/kimi-k2-thinking-nvfp4",
-        "Kimi-K2-Thinking-NVFP4",
-        "kimi-k2-thinking-nvfp4"
+        "Kimi-K2-Thinking-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -23420,9 +21511,7 @@
     {
       "name": "nvidia/Kimi-K2.5-NVFP4",
       "alias": [
-        "nvidia/kimi-k2.5-nvfp4",
-        "Kimi-K2.5-NVFP4",
-        "kimi-k2.5-nvfp4"
+        "Kimi-K2.5-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -23432,9 +21521,7 @@
     {
       "name": "nvidia/Kimi-K2.5-Thinking-Eagle3",
       "alias": [
-        "nvidia/kimi-k2.5-thinking-eagle3",
-        "Kimi-K2.5-Thinking-Eagle3",
-        "kimi-k2.5-thinking-eagle3"
+        "Kimi-K2.5-Thinking-Eagle3"
       ],
       "model_types": [
         "chat"
@@ -23448,9 +21535,7 @@
     {
       "name": "nvidia/Kimi-K2.6-Eagle3",
       "alias": [
-        "nvidia/kimi-k2.6-eagle3",
-        "Kimi-K2.6-Eagle3",
-        "kimi-k2.6-eagle3"
+        "Kimi-K2.6-Eagle3"
       ],
       "model_types": [
         "chat"
@@ -23460,9 +21545,7 @@
     {
       "name": "nvidia/Kimi-K2.6-NVFP4",
       "alias": [
-        "nvidia/kimi-k2.6-nvfp4",
-        "Kimi-K2.6-NVFP4",
-        "kimi-k2.6-nvfp4"
+        "Kimi-K2.6-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -23472,9 +21555,7 @@
     {
       "name": "nvidia/KVzap-linear-Llama-3.1-8B-Instruct",
       "alias": [
-        "nvidia/kvzap-linear-llama-3.1-8b-instruct",
-        "KVzap-linear-Llama-3.1-8B-Instruct",
-        "kvzap-linear-llama-3.1-8b-instruct"
+        "KVzap-linear-Llama-3.1-8B-Instruct"
       ],
       "model_types": [
         "other"
@@ -23483,9 +21564,7 @@
     {
       "name": "nvidia/KVzap-linear-Qwen3-32B",
       "alias": [
-        "nvidia/kvzap-linear-qwen3-32b",
-        "KVzap-linear-Qwen3-32B",
-        "kvzap-linear-qwen3-32b"
+        "KVzap-linear-Qwen3-32B"
       ],
       "model_types": [
         "chat"
@@ -23495,9 +21574,7 @@
     {
       "name": "nvidia/KVzap-linear-Qwen3-8B",
       "alias": [
-        "nvidia/kvzap-linear-qwen3-8b",
-        "KVzap-linear-Qwen3-8B",
-        "kvzap-linear-qwen3-8b"
+        "KVzap-linear-Qwen3-8B"
       ],
       "model_types": [
         "chat"
@@ -23507,9 +21584,7 @@
     {
       "name": "nvidia/KVzap-mlp-Llama-3.1-8B-Instruct",
       "alias": [
-        "nvidia/kvzap-mlp-llama-3.1-8b-instruct",
-        "KVzap-mlp-Llama-3.1-8B-Instruct",
-        "kvzap-mlp-llama-3.1-8b-instruct"
+        "KVzap-mlp-Llama-3.1-8B-Instruct"
       ],
       "model_types": [
         "other"
@@ -23518,9 +21593,7 @@
     {
       "name": "nvidia/KVzap-mlp-Qwen3-32B",
       "alias": [
-        "nvidia/kvzap-mlp-qwen3-32b",
-        "KVzap-mlp-Qwen3-32B",
-        "kvzap-mlp-qwen3-32b"
+        "KVzap-mlp-Qwen3-32B"
       ],
       "model_types": [
         "chat"
@@ -23530,9 +21603,7 @@
     {
       "name": "nvidia/KVzap-mlp-Qwen3-8B",
       "alias": [
-        "nvidia/kvzap-mlp-qwen3-8b",
-        "KVzap-mlp-Qwen3-8B",
-        "kvzap-mlp-qwen3-8b"
+        "KVzap-mlp-Qwen3-8B"
       ],
       "model_types": [
         "chat"
@@ -23553,9 +21624,7 @@
     {
       "name": "nvidia/LocateAnything-3B",
       "alias": [
-        "nvidia/locateanything-3b",
-        "LocateAnything-3B",
-        "locateanything-3b"
+        "LocateAnything-3B"
       ],
       "model_types": [
         "chat",
@@ -23566,9 +21635,7 @@
     {
       "name": "nvidia/Lyra-2.0",
       "alias": [
-        "nvidia/lyra-2.0",
-        "Lyra-2.0",
-        "lyra-2.0"
+        "Lyra-2.0"
       ],
       "model_types": [
         "3d_generation"
@@ -23577,9 +21644,7 @@
     {
       "name": "nvidia/MiniMax-M2.5-NVFP4",
       "alias": [
-        "nvidia/minimax-m2.5-nvfp4",
-        "MiniMax-M2.5-NVFP4",
-        "minimax-m2.5-nvfp4"
+        "MiniMax-M2.5-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -23612,9 +21677,7 @@
     {
       "name": "nvidia/Nemotron-3-Content-Safety",
       "alias": [
-        "nvidia/nemotron-3-content-safety",
-        "Nemotron-3-Content-Safety",
-        "nemotron-3-content-safety"
+        "Nemotron-3-Content-Safety"
       ],
       "model_types": [
         "moderation",
@@ -23656,9 +21719,7 @@
     {
       "name": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
       "alias": [
-        "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-bf16",
-        "Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "nemotron-3-nano-omni-30b-a3b-reasoning-bf16"
+        "Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"
       ],
       "model_types": [
         "chat"
@@ -23757,9 +21818,7 @@
     {
       "name": "nvidia/Nemotron-3.5-Content-Safety",
       "alias": [
-        "nvidia/nemotron-3.5-content-safety",
         "Nemotron-3.5-Content-Safety",
-        "nemotron-3.5-content-safety",
         "nvidia/nemotron-3.5-content-safety:free"
       ],
       "model_types": [
@@ -23780,9 +21839,7 @@
     {
       "name": "nvidia/Nemotron-4-Mini-Hindi-4B-Base",
       "alias": [
-        "nvidia/nemotron-4-mini-hindi-4b-base",
-        "Nemotron-4-Mini-Hindi-4B-Base",
-        "nemotron-4-mini-hindi-4b-base"
+        "Nemotron-4-Mini-Hindi-4B-Base"
       ],
       "model_types": [
         "chat"
@@ -23792,9 +21849,7 @@
     {
       "name": "nvidia/Nemotron-Cascade-14B-Thinking",
       "alias": [
-        "nvidia/nemotron-cascade-14b-thinking",
-        "Nemotron-Cascade-14B-Thinking",
-        "nemotron-cascade-14b-thinking"
+        "Nemotron-Cascade-14B-Thinking"
       ],
       "model_types": [
         "chat"
@@ -23808,9 +21863,7 @@
     {
       "name": "nvidia/Nemotron-Cascade-8B",
       "alias": [
-        "nvidia/nemotron-cascade-8b",
-        "Nemotron-Cascade-8B",
-        "nemotron-cascade-8b"
+        "Nemotron-Cascade-8B"
       ],
       "model_types": [
         "chat"
@@ -23824,9 +21877,7 @@
     {
       "name": "nvidia/Nemotron-Cascade-8B-Intermediate-ckpts",
       "alias": [
-        "nvidia/nemotron-cascade-8b-intermediate-ckpts",
-        "Nemotron-Cascade-8B-Intermediate-ckpts",
-        "nemotron-cascade-8b-intermediate-ckpts"
+        "Nemotron-Cascade-8B-Intermediate-ckpts"
       ],
       "model_types": [
         "chat"
@@ -23840,9 +21891,7 @@
     {
       "name": "nvidia/Nemotron-Cascade-8B-Thinking",
       "alias": [
-        "nvidia/nemotron-cascade-8b-thinking",
-        "Nemotron-Cascade-8B-Thinking",
-        "nemotron-cascade-8b-thinking"
+        "Nemotron-Cascade-8B-Thinking"
       ],
       "model_types": [
         "chat"
@@ -23898,9 +21947,7 @@
     {
       "name": "nvidia/Nemotron-Elastic-12B",
       "alias": [
-        "nvidia/nemotron-elastic-12b",
-        "Nemotron-Elastic-12B",
-        "nemotron-elastic-12b"
+        "Nemotron-Elastic-12B"
       ],
       "model_types": [
         "chat"
@@ -23910,9 +21957,7 @@
     {
       "name": "nvidia/Nemotron-Flash-1B",
       "alias": [
-        "nvidia/nemotron-flash-1b",
-        "Nemotron-Flash-1B",
-        "nemotron-flash-1b"
+        "Nemotron-Flash-1B"
       ],
       "model_types": [
         "chat"
@@ -23922,9 +21967,7 @@
     {
       "name": "nvidia/Nemotron-Flash-3B",
       "alias": [
-        "nvidia/nemotron-flash-3b",
-        "Nemotron-Flash-3B",
-        "nemotron-flash-3b"
+        "Nemotron-Flash-3B"
       ],
       "model_types": [
         "chat"
@@ -23934,9 +21977,7 @@
     {
       "name": "nvidia/Nemotron-Flash-3B-Instruct",
       "alias": [
-        "nvidia/nemotron-flash-3b-instruct",
-        "Nemotron-Flash-3B-Instruct",
-        "nemotron-flash-3b-instruct"
+        "Nemotron-Flash-3B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -23966,9 +22007,7 @@
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-14B",
       "alias": [
-        "nvidia/nemotron-labs-diffusion-14b",
-        "Nemotron-Labs-Diffusion-14B",
-        "nemotron-labs-diffusion-14b"
+        "Nemotron-Labs-Diffusion-14B"
       ],
       "model_types": [
         "chat"
@@ -23978,9 +22017,7 @@
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-14B-Base",
       "alias": [
-        "nvidia/nemotron-labs-diffusion-14b-base",
-        "Nemotron-Labs-Diffusion-14B-Base",
-        "nemotron-labs-diffusion-14b-base"
+        "Nemotron-Labs-Diffusion-14B-Base"
       ],
       "model_types": [
         "chat"
@@ -23990,9 +22027,7 @@
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-3B",
       "alias": [
-        "nvidia/nemotron-labs-diffusion-3b",
-        "Nemotron-Labs-Diffusion-3B",
-        "nemotron-labs-diffusion-3b"
+        "Nemotron-Labs-Diffusion-3B"
       ],
       "model_types": [
         "chat"
@@ -24002,9 +22037,7 @@
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "alias": [
-        "nvidia/nemotron-labs-diffusion-3b-base",
-        "Nemotron-Labs-Diffusion-3B-Base",
-        "nemotron-labs-diffusion-3b-base"
+        "Nemotron-Labs-Diffusion-3B-Base"
       ],
       "model_types": [
         "chat"
@@ -24014,9 +22047,7 @@
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-8B",
       "alias": [
-        "nvidia/nemotron-labs-diffusion-8b",
-        "Nemotron-Labs-Diffusion-8B",
-        "nemotron-labs-diffusion-8b"
+        "Nemotron-Labs-Diffusion-8B"
       ],
       "model_types": [
         "chat"
@@ -24026,9 +22057,7 @@
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-8B-Base",
       "alias": [
-        "nvidia/nemotron-labs-diffusion-8b-base",
-        "Nemotron-Labs-Diffusion-8B-Base",
-        "nemotron-labs-diffusion-8b-base"
+        "Nemotron-Labs-Diffusion-8B-Base"
       ],
       "model_types": [
         "chat"
@@ -24038,9 +22067,7 @@
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "alias": [
-        "nvidia/nemotron-labs-diffusion-vlm-8b",
-        "Nemotron-Labs-Diffusion-VLM-8B",
-        "nemotron-labs-diffusion-vlm-8b"
+        "Nemotron-Labs-Diffusion-VLM-8B"
       ],
       "model_types": [
         "chat",
@@ -24066,9 +22093,7 @@
     {
       "name": "nvidia/Nemotron-Research-GooseReason-4B-Instruct",
       "alias": [
-        "nvidia/nemotron-research-goosereason-4b-instruct",
-        "Nemotron-Research-GooseReason-4B-Instruct",
-        "nemotron-research-goosereason-4b-instruct"
+        "Nemotron-Research-GooseReason-4B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -24106,9 +22131,7 @@
     {
       "name": "nvidia/Nemotron-Terminal-14B",
       "alias": [
-        "nvidia/nemotron-terminal-14b",
-        "Nemotron-Terminal-14B",
-        "nemotron-terminal-14b"
+        "Nemotron-Terminal-14B"
       ],
       "model_types": [
         "chat"
@@ -24122,9 +22145,7 @@
     {
       "name": "nvidia/Nemotron-Terminal-32B",
       "alias": [
-        "nvidia/nemotron-terminal-32b",
-        "Nemotron-Terminal-32B",
-        "nemotron-terminal-32b"
+        "Nemotron-Terminal-32B"
       ],
       "model_types": [
         "chat"
@@ -24138,9 +22159,7 @@
     {
       "name": "nvidia/Nemotron-Terminal-8B",
       "alias": [
-        "nvidia/nemotron-terminal-8b",
-        "Nemotron-Terminal-8B",
-        "nemotron-terminal-8b"
+        "Nemotron-Terminal-8B"
       ],
       "model_types": [
         "chat"
@@ -24154,9 +22173,7 @@
     {
       "name": "nvidia/NitroGen",
       "alias": [
-        "nvidia/nitrogen",
-        "NitroGen",
-        "nitrogen"
+        "NitroGen"
       ],
       "model_types": [
         "robotics"
@@ -24165,9 +22182,7 @@
     {
       "name": "nvidia/NV-Raw2insights-MRI",
       "alias": [
-        "nvidia/nv-raw2insights-mri",
-        "NV-Raw2insights-MRI",
-        "nv-raw2insights-mri"
+        "NV-Raw2insights-MRI"
       ],
       "model_types": [
         "other"
@@ -24196,9 +22211,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16",
       "alias": [
-        "nvidia/nvidia-nemotron-3-nano-30b-a3b-base-bf16",
-        "NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16",
-        "nvidia-nemotron-3-nano-30b-a3b-base-bf16"
+        "NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16"
       ],
       "model_types": [
         "chat"
@@ -24208,9 +22221,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "alias": [
-        "nvidia/nvidia-nemotron-3-nano-30b-a3b-bf16",
         "NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "nvidia-nemotron-3-nano-30b-a3b-bf16",
         "nvidia/nemotron-3-nano-30b-a3b:free",
         "Nvidia Nemotron 3 Nano 30B A3b Bf16"
       ],
@@ -24222,9 +22233,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
       "alias": [
-        "nvidia/nvidia-nemotron-3-nano-30b-a3b-fp8",
-        "NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
-        "nvidia-nemotron-3-nano-30b-a3b-fp8"
+        "NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
       ],
       "model_types": [
         "chat"
@@ -24234,9 +22243,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
       "alias": [
-        "nvidia/nvidia-nemotron-3-nano-30b-a3b-nvfp4",
-        "NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
-        "nvidia-nemotron-3-nano-30b-a3b-nvfp4"
+        "NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -24246,9 +22253,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
       "alias": [
-        "nvidia/nvidia-nemotron-3-nano-4b-bf16",
-        "NVIDIA-Nemotron-3-Nano-4B-BF16",
-        "nvidia-nemotron-3-nano-4b-bf16"
+        "NVIDIA-Nemotron-3-Nano-4B-BF16"
       ],
       "model_types": [
         "chat"
@@ -24258,9 +22263,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
       "alias": [
-        "nvidia/nvidia-nemotron-3-nano-4b-fp8",
-        "NVIDIA-Nemotron-3-Nano-4B-FP8",
-        "nvidia-nemotron-3-nano-4b-fp8"
+        "NVIDIA-Nemotron-3-Nano-4B-FP8"
       ],
       "model_types": [
         "chat"
@@ -24270,9 +22273,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "alias": [
-        "nvidia/nvidia-nemotron-3-nano-4b-gguf",
-        "NVIDIA-Nemotron-3-Nano-4B-GGUF",
-        "nvidia-nemotron-3-nano-4b-gguf"
+        "NVIDIA-Nemotron-3-Nano-4B-GGUF"
       ],
       "model_types": [
         "chat"
@@ -24296,9 +22297,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16",
       "alias": [
-        "nvidia/nvidia-nemotron-3-super-120b-a12b-base-bf16",
-        "NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16",
-        "nvidia-nemotron-3-super-120b-a12b-base-bf16"
+        "NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16"
       ],
       "model_types": [
         "chat"
@@ -24346,9 +22345,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-Base-BF16",
       "alias": [
-        "nvidia/nvidia-nemotron-3-ultra-550b-a55b-base-bf16",
-        "NVIDIA-Nemotron-3-Ultra-550B-A55B-Base-BF16",
-        "nvidia-nemotron-3-ultra-550b-a55b-base-bf16"
+        "NVIDIA-Nemotron-3-Ultra-550B-A55B-Base-BF16"
       ],
       "model_types": [
         "chat"
@@ -24358,9 +22355,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
       "alias": [
-        "nvidia/nvidia-nemotron-3-ultra-550b-a55b-bf16",
         "NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
-        "nvidia-nemotron-3-ultra-550b-a55b-bf16",
         "nvidia/nemotron-3-ultra-550b-a55b:free"
       ],
       "model_types": [
@@ -24373,9 +22368,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM",
       "alias": [
-        "nvidia/nvidia-nemotron-3-ultra-550b-a55b-genrm",
-        "NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM",
-        "nvidia-nemotron-3-ultra-550b-a55b-genrm"
+        "NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM"
       ],
       "model_types": [
         "chat"
@@ -24389,9 +22382,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
       "alias": [
-        "nvidia/nvidia-nemotron-3-ultra-550b-a55b-nvfp4",
-        "NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
-        "nvidia-nemotron-3-ultra-550b-a55b-nvfp4"
+        "NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -24401,9 +22392,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "alias": [
-        "nvidia/nvidia-nemotron-labs-3-elastic-30b-a3b-bf16",
-        "NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
-        "nvidia-nemotron-labs-3-elastic-30b-a3b-bf16"
+        "NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16"
       ],
       "model_types": [
         "chat"
@@ -24413,9 +22402,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "alias": [
-        "nvidia/nvidia-nemotron-labs-3-elastic-30b-a3b-fp8",
-        "NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
-        "nvidia-nemotron-labs-3-elastic-30b-a3b-fp8"
+        "NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8"
       ],
       "model_types": [
         "chat"
@@ -24425,9 +22412,7 @@
     {
       "name": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "alias": [
-        "nvidia/nvidia-nemotron-labs-3-elastic-30b-a3b-nvfp4",
-        "NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
-        "nvidia-nemotron-labs-3-elastic-30b-a3b-nvfp4"
+        "NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4"
       ],
       "model_types": [
         "chat"
@@ -24437,9 +22422,7 @@
     {
       "name": "nvidia/NVILA-8B-HD-Video",
       "alias": [
-        "nvidia/nvila-8b-hd-video",
-        "NVILA-8B-HD-Video",
-        "nvila-8b-hd-video"
+        "NVILA-8B-HD-Video"
       ],
       "model_types": [
         "video_generation"
@@ -24475,9 +22458,7 @@
     {
       "name": "nvidia/parakeet-ctc-0.6b-Vietnamese",
       "alias": [
-        "nvidia/parakeet-ctc-0.6b-vietnamese",
-        "parakeet-ctc-0.6b-Vietnamese",
-        "parakeet-ctc-0.6b-vietnamese"
+        "parakeet-ctc-0.6b-Vietnamese"
       ],
       "model_types": [
         "asr"
@@ -24531,9 +22512,7 @@
     {
       "name": "nvidia/PhysicalAI-Simulation-VoMP-Model",
       "alias": [
-        "nvidia/physicalai-simulation-vomp-model",
-        "PhysicalAI-Simulation-VoMP-Model",
-        "physicalai-simulation-vomp-model"
+        "PhysicalAI-Simulation-VoMP-Model"
       ],
       "model_types": [
         "other"
@@ -24551,9 +22530,7 @@
     {
       "name": "nvidia/PixelDiT-1300M-1024px",
       "alias": [
-        "nvidia/pixeldit-1300m-1024px",
-        "PixelDiT-1300M-1024px",
-        "pixeldit-1300m-1024px"
+        "PixelDiT-1300M-1024px"
       ],
       "model_types": [
         "image"
@@ -24562,9 +22539,7 @@
     {
       "name": "nvidia/PixelDiT-ImageNet",
       "alias": [
-        "nvidia/pixeldit-imagenet",
-        "PixelDiT-ImageNet",
-        "pixeldit-imagenet"
+        "PixelDiT-ImageNet"
       ],
       "model_types": [
         "image",
@@ -24574,9 +22549,7 @@
     {
       "name": "nvidia/PointWorld_models",
       "alias": [
-        "nvidia/pointworld_models",
-        "PointWorld_models",
-        "pointworld_models"
+        "PointWorld_models"
       ],
       "model_types": [
         "other"
@@ -24585,9 +22558,7 @@
     {
       "name": "nvidia/RE-USE",
       "alias": [
-        "nvidia/re-use",
-        "RE-USE",
-        "re-use"
+        "RE-USE"
       ],
       "model_types": [
         "audio",
@@ -24608,9 +22579,7 @@
     {
       "name": "nvidia/RNAPro-Private-Best-500M",
       "alias": [
-        "nvidia/rnapro-private-best-500m",
-        "RNAPro-Private-Best-500M",
-        "rnapro-private-best-500m"
+        "RNAPro-Private-Best-500M"
       ],
       "model_types": [
         "other"
@@ -24619,9 +22588,7 @@
     {
       "name": "nvidia/RNAPro-Public-Best-500M",
       "alias": [
-        "nvidia/rnapro-public-best-500m",
-        "RNAPro-Public-Best-500M",
-        "rnapro-public-best-500m"
+        "RNAPro-Public-Best-500M"
       ],
       "model_types": [
         "other"
@@ -24639,9 +22606,7 @@
     {
       "name": "nvidia/SOMA-X",
       "alias": [
-        "nvidia/soma-x",
-        "SOMA-X",
-        "soma-x"
+        "SOMA-X"
       ],
       "model_types": [
         "robotics"
@@ -24659,9 +22624,7 @@
     {
       "name": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "alias": [
-        "nvidia/wan2.2-t2v-a14b-diffusers-fp8",
-        "Wan2.2-T2V-A14B-Diffusers-FP8",
-        "wan2.2-t2v-a14b-diffusers-fp8"
+        "Wan2.2-T2V-A14B-Diffusers-FP8"
       ],
       "model_types": [
         "other"
@@ -24670,9 +22633,7 @@
     {
       "name": "nvidia/Wan2.2-T2V-A14B-Diffusers-NVFP4",
       "alias": [
-        "nvidia/wan2.2-t2v-a14b-diffusers-nvfp4",
-        "Wan2.2-T2V-A14B-Diffusers-NVFP4",
-        "wan2.2-t2v-a14b-diffusers-nvfp4"
+        "Wan2.2-T2V-A14B-Diffusers-NVFP4"
       ],
       "model_types": [
         "other"
@@ -24940,7 +22901,6 @@
     {
       "name": "openai/gpt-5.5",
       "alias": [
-        "gpt-5.5",
         "gpt-5.5-r"
       ],
       "model_types": [
@@ -24996,9 +22956,7 @@
     },
     {
       "name": "openai/gpt-5.4",
-      "alias": [
-        "gpt-5.4"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25010,9 +22968,7 @@
     },
     {
       "name": "openai/gpt-5.4-image-2",
-      "alias": [
-        "gpt-5.4-image-2"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25028,9 +22984,7 @@
     },
     {
       "name": "openai/gpt-5.4-mini",
-      "alias": [
-        "gpt-5.4-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25042,9 +22996,7 @@
     },
     {
       "name": "openai/gpt-5.4-nano",
-      "alias": [
-        "gpt-5.4-nano"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25058,9 +23010,7 @@
     },
     {
       "name": "openai/gpt-5.4-pro",
-      "alias": [
-        "gpt-5.4-pro"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25084,9 +23034,7 @@
     },
     {
       "name": "openai/gpt-5.3-chat",
-      "alias": [
-        "gpt-5.3-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25097,7 +23045,6 @@
     {
       "name": "openai/gpt-5.3-chat-latest",
       "alias": [
-        "gpt-5.3-chat-latest",
         "gpt-5-3-chat-latest"
       ],
       "model_types": [
@@ -25108,9 +23055,7 @@
     },
     {
       "name": "openai/gpt-5.3-codex",
-      "alias": [
-        "gpt-5.3-codex"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25122,9 +23067,7 @@
     },
     {
       "name": "openai/gpt-5.3-codex-spark",
-      "alias": [
-        "gpt-5.3-codex-spark"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25135,9 +23078,7 @@
     },
     {
       "name": "openai/gpt-5.2",
-      "alias": [
-        "gpt-5.2"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25149,9 +23090,7 @@
     },
     {
       "name": "openai/gpt-5.2-chat",
-      "alias": [
-        "gpt-5.2-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25161,9 +23100,7 @@
     },
     {
       "name": "openai/gpt-5.2-chat-latest",
-      "alias": [
-        "gpt-5.2-chat-latest"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25173,9 +23110,7 @@
     },
     {
       "name": "openai/gpt-5.2-codex",
-      "alias": [
-        "gpt-5.2-codex"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25187,9 +23122,7 @@
     },
     {
       "name": "openai/gpt-5.2-pro",
-      "alias": [
-        "gpt-5.2-pro"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25203,9 +23136,7 @@
     },
     {
       "name": "openai/gpt-5.1",
-      "alias": [
-        "gpt-5.1"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25217,9 +23148,7 @@
     },
     {
       "name": "openai/gpt-5.1-chat",
-      "alias": [
-        "gpt-5.1-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25230,7 +23159,6 @@
     {
       "name": "openai/gpt-5.1-chat-latest",
       "alias": [
-        "gpt-5.1-chat-latest",
         "gpt-5-1-chat-latest"
       ],
       "model_types": [
@@ -25242,9 +23170,7 @@
     },
     {
       "name": "openai/gpt-5.1-codex",
-      "alias": [
-        "gpt-5.1-codex"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25256,9 +23182,7 @@
     },
     {
       "name": "openai/gpt-5.1-codex-max",
-      "alias": [
-        "gpt-5.1-codex-max"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25270,9 +23194,7 @@
     },
     {
       "name": "openai/gpt-5.1-codex-mini",
-      "alias": [
-        "gpt-5.1-codex-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25293,9 +23215,7 @@
     },
     {
       "name": "openai/gpt-5",
-      "alias": [
-        "gpt-5"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25307,9 +23227,7 @@
     },
     {
       "name": "openai/gpt-5-chat",
-      "alias": [
-        "gpt-5-chat"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25319,9 +23237,7 @@
     },
     {
       "name": "openai/gpt-5-chat-latest",
-      "alias": [
-        "gpt-5-chat-latest"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25331,9 +23247,7 @@
     },
     {
       "name": "openai/gpt-5-codex",
-      "alias": [
-        "gpt-5-codex"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25345,9 +23259,7 @@
     },
     {
       "name": "openai/gpt-5-codex-mini",
-      "alias": [
-        "gpt-5-codex-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25358,9 +23270,7 @@
     },
     {
       "name": "openai/gpt-5-image",
-      "alias": [
-        "gpt-5-image"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25375,9 +23285,7 @@
     },
     {
       "name": "openai/gpt-5-image-mini",
-      "alias": [
-        "gpt-5-image-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25393,9 +23301,7 @@
     },
     {
       "name": "openai/gpt-5-mini",
-      "alias": [
-        "gpt-5-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25409,9 +23315,7 @@
     },
     {
       "name": "openai/gpt-5-nano",
-      "alias": [
-        "gpt-5-nano"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25425,9 +23329,7 @@
     },
     {
       "name": "openai/gpt-5-pro",
-      "alias": [
-        "gpt-5-pro"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25450,9 +23352,7 @@
     },
     {
       "name": "openai/gpt-4.1-2025-04-14",
-      "alias": [
-        "gpt-4.1-2025-04-14"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25462,9 +23362,7 @@
     },
     {
       "name": "openai/gpt-4.1-mini-2025-04-14",
-      "alias": [
-        "gpt-4.1-mini-2025-04-14"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25474,9 +23372,7 @@
     },
     {
       "name": "openai/gpt-4.1-nano-2025-04-14",
-      "alias": [
-        "gpt-4.1-nano-2025-04-14"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25486,9 +23382,7 @@
     },
     {
       "name": "openai/gpt-4.1",
-      "alias": [
-        "gpt-4.1"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25498,9 +23392,7 @@
     },
     {
       "name": "openai/gpt-4.1-mini",
-      "alias": [
-        "gpt-4.1-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25510,9 +23402,7 @@
     },
     {
       "name": "openai/gpt-4.1-nano",
-      "alias": [
-        "gpt-4.1-nano"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25550,7 +23440,6 @@
     {
       "name": "openai/gpt-4o-mini-audio-preview-2024-12-17",
       "alias": [
-        "gpt-4o-mini-audio-preview-2024-12-17",
         "gpt-4o-mini-audio"
       ],
       "model_types": [
@@ -25560,9 +23449,7 @@
     },
     {
       "name": "openai/gpt-4o-2024-11-20",
-      "alias": [
-        "gpt-4o-2024-11-20"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25572,12 +23459,7 @@
     },
     {
       "name": "openai/gpt-4o",
-      "alias": [
-        "gpt-4o",
-        "azure/gpt-4o",
-        "azure/global-standard/gpt-4o-2024-08-06",
-        "azure/eu/gpt-4o"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25587,9 +23469,7 @@
     },
     {
       "name": "openai/gpt-4o-2024-08-06",
-      "alias": [
-        "gpt-4o-2024-08-06"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25599,9 +23479,7 @@
     },
     {
       "name": "openai/gpt-4o-mini-2024-07-18",
-      "alias": [
-        "gpt-4o-mini-2024-07-18"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25611,9 +23489,7 @@
     },
     {
       "name": "openai/gpt-4o-2024-05-13",
-      "alias": [
-        "gpt-4o-2024-05-13"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25623,9 +23499,7 @@
     },
     {
       "name": "openai/gpt-4",
-      "alias": [
-        "gpt-4"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25633,9 +23507,7 @@
     },
     {
       "name": "openai/gpt-4-turbo",
-      "alias": [
-        "gpt-4-turbo"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25645,9 +23517,7 @@
     },
     {
       "name": "openai/gpt-4-turbo-preview",
-      "alias": [
-        "gpt-4-turbo-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25665,11 +23535,7 @@
     },
     {
       "name": "openai/gpt-4o-mini",
-      "alias": [
-        "gpt-4o-mini",
-        "azure/gpt-4o-mini",
-        "azure/global-standard/gpt-4o-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25679,9 +23545,7 @@
     },
     {
       "name": "openai/gpt-4o-mini-audio-preview",
-      "alias": [
-        "gpt-4o-mini-audio-preview"
-      ],
+      "alias": [],
       "model_types": [
         "tts",
         "speech2text"
@@ -25689,9 +23553,7 @@
     },
     {
       "name": "openai/gpt-4o-mini-realtime-preview",
-      "alias": [
-        "gpt-4o-mini-realtime-preview"
-      ],
+      "alias": [],
       "model_types": [
         "tts",
         "speech2text"
@@ -25699,9 +23561,7 @@
     },
     {
       "name": "openai/gpt-4o-mini-search-preview",
-      "alias": [
-        "gpt-4o-mini-search-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25709,18 +23569,14 @@
     },
     {
       "name": "openai/gpt-4o-mini-tts",
-      "alias": [
-        "gpt-4o-mini-tts"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
     },
     {
       "name": "openai/gpt-4o-search-preview",
-      "alias": [
-        "gpt-4o-search-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25728,9 +23584,7 @@
     },
     {
       "name": "openai/gpt-4o-transcribe",
-      "alias": [
-        "gpt-4o-transcribe"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "speech2text"
@@ -25738,9 +23592,7 @@
     },
     {
       "name": "openai/gpt-3.5-turbo",
-      "alias": [
-        "gpt-3.5-turbo"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25758,9 +23610,7 @@
     },
     {
       "name": "openai/gpt-3.5-turbo-16k",
-      "alias": [
-        "gpt-3.5-turbo-16k"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25768,9 +23618,7 @@
     },
     {
       "name": "openai/gpt-3.5-turbo-instruct",
-      "alias": [
-        "gpt-3.5-turbo-instruct"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25813,9 +23661,7 @@
     },
     {
       "name": "openai/o3-pro-2025-06-10",
-      "alias": [
-        "o3-pro-2025-06-10"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25825,9 +23671,7 @@
     },
     {
       "name": "openai/o3-2025-04-16",
-      "alias": [
-        "o3-2025-04-16"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25836,9 +23680,7 @@
     },
     {
       "name": "openai/o4-mini-2025-04-16",
-      "alias": [
-        "o4-mini-2025-04-16"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -25856,18 +23698,14 @@
     },
     {
       "name": "openai/o3-mini-2025-01-31",
-      "alias": [
-        "o3-mini-2025-01-31"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "openai/o1-2024-12-17",
-      "alias": [
-        "o1-2024-12-17"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
@@ -25883,10 +23721,7 @@
     },
     {
       "name": "openai/antigravity-preview-05-2026",
-      "alias": [
-        "antigravity-preview-05-2026",
-        "models/antigravity-preview-05-2026"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25970,9 +23805,7 @@
     },
     {
       "name": "openai/dall-e-3",
-      "alias": [
-        "dall-e-3"
-      ],
+      "alias": [],
       "model_types": [
         "image",
         "image_generation"
@@ -25980,10 +23813,7 @@
     },
     {
       "name": "openai/deep-research-max-preview-04-2026",
-      "alias": [
-        "deep-research-max-preview-04-2026",
-        "models/deep-research-max-preview-04-2026"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -25991,10 +23821,7 @@
     },
     {
       "name": "openai/deep-research-preview-04-2026",
-      "alias": [
-        "deep-research-preview-04-2026",
-        "models/deep-research-preview-04-2026"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -26086,9 +23913,7 @@
     },
     {
       "name": "openai/gpt-audio",
-      "alias": [
-        "gpt-audio"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "audio_understanding",
@@ -26132,9 +23957,7 @@
     },
     {
       "name": "openai/gpt-image-1",
-      "alias": [
-        "gpt-image-1"
-      ],
+      "alias": [],
       "model_types": [
         "image",
         "image_generation",
@@ -26143,9 +23966,7 @@
     },
     {
       "name": "openai/gpt-image-1-mini",
-      "alias": [
-        "gpt-image-1-mini"
-      ],
+      "alias": [],
       "model_types": [
         "image",
         "image_generation"
@@ -26155,7 +23976,6 @@
     {
       "name": "openai/gpt-image-1.5",
       "alias": [
-        "gpt-image-1.5",
         "gpt-image-1-5"
       ],
       "model_types": [
@@ -26165,9 +23985,7 @@
     },
     {
       "name": "openai/gpt-image-2",
-      "alias": [
-        "gpt-image-2"
-      ],
+      "alias": [],
       "model_types": [
         "image",
         "image_edit",
@@ -26176,9 +23994,7 @@
     },
     {
       "name": "openai/gpt-image-2-all",
-      "alias": [
-        "gpt-image-2-all"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "image",
@@ -26306,7 +24122,6 @@
     {
       "name": "openai/gpt-realtime-1.5",
       "alias": [
-        "gpt-realtime-1.5",
         "gpt-realtime-1-5"
       ],
       "model_types": [
@@ -26360,9 +24175,7 @@
     },
     {
       "name": "openai/o1",
-      "alias": [
-        "o1"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -26376,9 +24189,7 @@
     },
     {
       "name": "openai/o1-mini",
-      "alias": [
-        "o1-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -26392,10 +24203,7 @@
     },
     {
       "name": "openai/o1-preview",
-      "alias": [
-        "azure/o1-preview",
-        "azure/eu/o1-preview"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -26423,9 +24231,7 @@
     },
     {
       "name": "openai/o3",
-      "alias": [
-        "o3"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -26439,9 +24245,7 @@
     },
     {
       "name": "openai/o3-deep-research",
-      "alias": [
-        "o3-deep-research"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -26455,11 +24259,7 @@
     },
     {
       "name": "openai/o3-mini",
-      "alias": [
-        "o3-mini",
-        "azure/o3-mini",
-        "azure/eu/o3-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -26485,9 +24285,7 @@
     },
     {
       "name": "openai/o3-pro",
-      "alias": [
-        "o3-pro"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -26501,9 +24299,7 @@
     },
     {
       "name": "openai/o4-mini",
-      "alias": [
-        "o4-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -26517,9 +24313,7 @@
     },
     {
       "name": "openai/o4-mini-deep-research",
-      "alias": [
-        "o4-mini-deep-research"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -26549,9 +24343,7 @@
     },
     {
       "name": "openai/omni-moderation-latest",
-      "alias": [
-        "omni-moderation-latest"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ]
@@ -26587,9 +24379,7 @@
     },
     {
       "name": "openai/sora-2",
-      "alias": [
-        "sora-2"
-      ],
+      "alias": [],
       "model_types": [
         "video_generation"
       ]
@@ -26606,9 +24396,7 @@
     },
     {
       "name": "openai/text-embedding-3-large",
-      "alias": [
-        "text-embedding-3-large"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -26617,9 +24405,7 @@
     },
     {
       "name": "openai/text-embedding-3-small",
-      "alias": [
-        "text-embedding-3-small"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -26628,9 +24414,7 @@
     },
     {
       "name": "openai/text-embedding-ada-002",
-      "alias": [
-        "text-embedding-ada-002"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -26648,45 +24432,35 @@
     },
     {
       "name": "openai/tts-1",
-      "alias": [
-        "tts-1"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
     },
     {
       "name": "openai/tts-1-1106",
-      "alias": [
-        "tts-1-1106"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
     },
     {
       "name": "openai/tts-1-hd",
-      "alias": [
-        "tts-1-hd"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
     },
     {
       "name": "openai/tts-1-hd-1106",
-      "alias": [
-        "tts-1-hd-1106"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
     },
     {
       "name": "openai/whisper-1",
-      "alias": [
-        "whisper-1"
-      ],
+      "alias": [],
       "model_types": [
         "speech2text"
       ]
@@ -27296,7 +25070,6 @@
     {
       "name": "paddleocr/paddleocr-vl-0.9b",
       "alias": [
-        "paddleocr-vl-0.9b",
         "paddleocr-vl-1.5"
       ],
       "model_types": [
@@ -27326,7 +25099,6 @@
     {
       "name": "paddleocr-vl-0.9b",
       "alias": [
-        "paddleocr-vl-1.5",
         "PaddlePaddle/PaddleOCR-VL-0.9B"
       ],
       "model_types": [
@@ -28187,7 +25959,6 @@
     {
       "name": "qwen/qwen3.6-27b",
       "alias": [
-        "Qwen/Qwen3.6-27B",
         "qwen3.6-27b",
         "qwen/qwen3.6-27b-20260422"
       ],
@@ -28240,7 +26011,6 @@
     {
       "name": "qwen/qwen3.6-35b-a3b",
       "alias": [
-        "Qwen/Qwen3.6-35B-A3B",
         "qwen3.6-35b-a3b",
         "qwen/qwen3.6-35b-a3b-20260415"
       ],
@@ -28279,7 +26049,6 @@
     {
       "name": "qwen/qwen3.6-27b-fp8",
       "alias": [
-        "Qwen/Qwen3.6-27B-FP8",
         "qwen3.6-27b-fp8"
       ],
       "model_types": [
@@ -28297,7 +26066,6 @@
     {
       "name": "qwen/qwen3.6-35b-a3b-fp8",
       "alias": [
-        "Qwen/Qwen3.6-35B-A3B-FP8",
         "qwen3.6-35b-a3b-fp8",
         "Qwen3.6 35B A3b Fp8"
       ],
@@ -28408,7 +26176,6 @@
     {
       "name": "qwen/qwen3.5-9b",
       "alias": [
-        "Qwen/Qwen3.5-9B",
         "qwen3.5-9b",
         "qwen/qwen3.5-9b-20260310",
         "Qwen3.5 9B FP8"
@@ -28428,7 +26195,6 @@
     {
       "name": "qwen/qwen3.5-9b-base",
       "alias": [
-        "Qwen/Qwen3.5-9B-Base",
         "qwen3.5-9b-base"
       ],
       "model_types": [
@@ -28446,7 +26212,6 @@
     {
       "name": "qwen/qwen3.5-122b-a10b",
       "alias": [
-        "Qwen/Qwen3.5-122B-A10B",
         "qwen3.5-122b-a10b",
         "qwen/qwen3.5-122b-a10b-20260224"
       ],
@@ -28466,7 +26231,6 @@
     {
       "name": "qwen/qwen3.5-27b",
       "alias": [
-        "Qwen/Qwen3.5-27B",
         "qwen3.5-27b",
         "qwen/qwen3.5-27b-20260224"
       ],
@@ -28486,7 +26250,6 @@
     {
       "name": "qwen/qwen3.5-35b-a3b",
       "alias": [
-        "Qwen/Qwen3.5-35B-A3B",
         "qwen3.5-35b-a3b",
         "qwen/qwen3.5-35b-a3b-20260224",
         "Qwen3.5 35B A3b"
@@ -28507,7 +26270,6 @@
     {
       "name": "qwen/qwen3.5-35b-a3b-base",
       "alias": [
-        "Qwen/Qwen3.5-35B-A3B-Base",
         "qwen3.5-35b-a3b-base"
       ],
       "model_types": [
@@ -28544,7 +26306,6 @@
     {
       "name": "qwen/qwen3.5-397b-a17b",
       "alias": [
-        "Qwen/Qwen3.5-397B-A17B",
         "qwen3.5-397b-a17b",
         "qwen/qwen3.5-397b-a17b-20260216",
         "Qwen3.5 397B A17b"
@@ -28585,7 +26346,6 @@
     {
       "name": "qwen/qwen3.5-0.8b",
       "alias": [
-        "Qwen/Qwen3.5-0.8B",
         "qwen3.5-0.8b"
       ],
       "model_types": [
@@ -28603,7 +26363,6 @@
     {
       "name": "qwen/qwen3.5-0.8b-base",
       "alias": [
-        "Qwen/Qwen3.5-0.8B-Base",
         "qwen3.5-0.8b-base"
       ],
       "model_types": [
@@ -28621,7 +26380,6 @@
     {
       "name": "qwen/qwen3.5-122b-a10b-fp8",
       "alias": [
-        "Qwen/Qwen3.5-122B-A10B-FP8",
         "qwen3.5-122b-a10b-fp8",
         "Qwen3.5 122B A10b Fp8"
       ],
@@ -28640,7 +26398,6 @@
     {
       "name": "qwen/qwen3.5-122b-a10b-gptq-int4",
       "alias": [
-        "Qwen/Qwen3.5-122B-A10B-GPTQ-Int4",
         "qwen3.5-122b-a10b-gptq-int4"
       ],
       "model_types": [
@@ -28658,7 +26415,6 @@
     {
       "name": "qwen/qwen3.5-27b-fp8",
       "alias": [
-        "Qwen/Qwen3.5-27B-FP8",
         "qwen3.5-27b-fp8"
       ],
       "model_types": [
@@ -28676,7 +26432,6 @@
     {
       "name": "qwen/qwen3.5-27b-gptq-int4",
       "alias": [
-        "Qwen/Qwen3.5-27B-GPTQ-Int4",
         "qwen3.5-27b-gptq-int4"
       ],
       "model_types": [
@@ -28694,7 +26449,6 @@
     {
       "name": "qwen/qwen3.5-2b",
       "alias": [
-        "Qwen/Qwen3.5-2B",
         "qwen3.5-2b"
       ],
       "model_types": [
@@ -28712,7 +26466,6 @@
     {
       "name": "qwen/qwen3.5-2b-base",
       "alias": [
-        "Qwen/Qwen3.5-2B-Base",
         "qwen3.5-2b-base"
       ],
       "model_types": [
@@ -28730,7 +26483,6 @@
     {
       "name": "qwen/qwen3.5-35b-a3b-fp8",
       "alias": [
-        "Qwen/Qwen3.5-35B-A3B-FP8",
         "qwen3.5-35b-a3b-fp8"
       ],
       "model_types": [
@@ -28748,7 +26500,6 @@
     {
       "name": "qwen/qwen3.5-35b-a3b-gptq-int4",
       "alias": [
-        "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4",
         "qwen3.5-35b-a3b-gptq-int4"
       ],
       "model_types": [
@@ -28766,7 +26517,6 @@
     {
       "name": "qwen/qwen3.5-397b-a17b-fp8",
       "alias": [
-        "Qwen/Qwen3.5-397B-A17B-FP8",
         "qwen3.5-397b-a17b-fp8"
       ],
       "model_types": [
@@ -28784,7 +26534,6 @@
     {
       "name": "qwen/qwen3.5-397b-a17b-gptq-int4",
       "alias": [
-        "Qwen/Qwen3.5-397B-A17B-GPTQ-Int4",
         "qwen3.5-397b-a17b-gptq-int4"
       ],
       "model_types": [
@@ -28802,7 +26551,6 @@
     {
       "name": "qwen/qwen3.5-4b",
       "alias": [
-        "Qwen/Qwen3.5-4B",
         "qwen3.5-4b"
       ],
       "model_types": [
@@ -28820,7 +26568,6 @@
     {
       "name": "qwen/qwen3.5-4b-base",
       "alias": [
-        "Qwen/Qwen3.5-4B-Base",
         "qwen3.5-4b-base"
       ],
       "model_types": [
@@ -29343,9 +27090,7 @@
     {
       "name": "qwen/qwen3-14b",
       "alias": [
-        "Qwen/Qwen3-14B",
         "qwen3-14b",
-        "Qwen3-14B",
         "Qwen3 14B",
         "qwen3-14b-20250429"
       ],
@@ -29357,7 +27102,6 @@
     {
       "name": "qwen/qwen3-14b-base",
       "alias": [
-        "Qwen/Qwen3-14B-Base",
         "qwen3-14b-base",
         "Qwen3 14B Base"
       ],
@@ -29369,9 +27113,7 @@
     {
       "name": "qwen/qwen3-32b",
       "alias": [
-        "Qwen/Qwen3-32B",
         "qwen3-32b",
-        "Qwen3-32B",
         "qwen.qwen3-32b",
         "qwen.qwen3-32b-v1:0",
         "qwen3-32b-20250429"
@@ -29385,9 +27127,7 @@
     {
       "name": "qwen/qwen3-8b",
       "alias": [
-        "Qwen/Qwen3-8B",
         "qwen3-8b",
-        "Qwen3-8B",
         "qwen3-8b-20250429"
       ],
       "model_types": [
@@ -29398,7 +27138,6 @@
     {
       "name": "qwen/qwen3-8b-base",
       "alias": [
-        "Qwen/Qwen3-8B-Base",
         "qwen3-8b-base",
         "Qwen3 8B Base"
       ],
@@ -29410,7 +27149,6 @@
     {
       "name": "qwen/qwen3-coder-next",
       "alias": [
-        "Qwen/Qwen3-Coder-Next",
         "qwen3-coder-next",
         "qwen/qwen3-coder-next-2025-02-03",
         "Qwen3 Coder Next"
@@ -29424,7 +27162,6 @@
     {
       "name": "qwen/qwen3-coder-next-base",
       "alias": [
-        "Qwen/Qwen3-Coder-Next-Base",
         "qwen3-coder-next-base"
       ],
       "model_types": [
@@ -29435,9 +27172,7 @@
     {
       "name": "qwen/qwen3-0.6b",
       "alias": [
-        "Qwen/Qwen3-0.6B",
         "qwen3-0.6b",
-        "Qwen3-0.6B",
         "Qwen3 0.6B"
       ],
       "model_types": [
@@ -29448,7 +27183,6 @@
     {
       "name": "qwen/qwen3-0.6b-base",
       "alias": [
-        "Qwen/Qwen3-0.6B-Base",
         "qwen3-0.6b-base",
         "Qwen3 0.6B Base"
       ],
@@ -29460,7 +27194,6 @@
     {
       "name": "qwen/qwen3-0.6b-fp8",
       "alias": [
-        "Qwen/Qwen3-0.6B-FP8",
         "qwen3-0.6b-fp8"
       ],
       "model_types": [
@@ -29471,7 +27204,6 @@
     {
       "name": "qwen/qwen3-0.6b-gguf",
       "alias": [
-        "Qwen/Qwen3-0.6B-GGUF",
         "qwen3-0.6b-gguf"
       ],
       "model_types": [
@@ -29482,7 +27214,6 @@
     {
       "name": "qwen/qwen3-0.6b-gptq-int8",
       "alias": [
-        "Qwen/Qwen3-0.6B-GPTQ-Int8",
         "qwen3-0.6b-gptq-int8"
       ],
       "model_types": [
@@ -29493,7 +27224,6 @@
     {
       "name": "qwen/qwen3-0.6b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-0.6B-MLX-4bit",
         "qwen3-0.6b-mlx-4bit"
       ],
       "model_types": [
@@ -29504,7 +27234,6 @@
     {
       "name": "qwen/qwen3-0.6b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-0.6B-MLX-6bit",
         "qwen3-0.6b-mlx-6bit"
       ],
       "model_types": [
@@ -29515,7 +27244,6 @@
     {
       "name": "qwen/qwen3-0.6b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-0.6B-MLX-8bit",
         "qwen3-0.6b-mlx-8bit"
       ],
       "model_types": [
@@ -29526,7 +27254,6 @@
     {
       "name": "qwen/qwen3-0.6b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-0.6B-MLX-bf16",
         "qwen3-0.6b-mlx-bf16"
       ],
       "model_types": [
@@ -29537,7 +27264,6 @@
     {
       "name": "qwen/qwen3-1.7b",
       "alias": [
-        "Qwen/Qwen3-1.7B",
         "qwen3-1.7b",
         "Qwen3 1.7B"
       ],
@@ -29549,7 +27275,6 @@
     {
       "name": "qwen/qwen3-1.7b-base",
       "alias": [
-        "Qwen/Qwen3-1.7B-Base",
         "qwen3-1.7b-base",
         "Qwen3 1.7B Base"
       ],
@@ -29561,7 +27286,6 @@
     {
       "name": "qwen/qwen3-1.7b-fp8",
       "alias": [
-        "Qwen/Qwen3-1.7B-FP8",
         "qwen3-1.7b-fp8"
       ],
       "model_types": [
@@ -29572,7 +27296,6 @@
     {
       "name": "qwen/qwen3-1.7b-gguf",
       "alias": [
-        "Qwen/Qwen3-1.7B-GGUF",
         "qwen3-1.7b-gguf"
       ],
       "model_types": [
@@ -29583,7 +27306,6 @@
     {
       "name": "qwen/qwen3-1.7b-gptq-int8",
       "alias": [
-        "Qwen/Qwen3-1.7B-GPTQ-Int8",
         "qwen3-1.7b-gptq-int8"
       ],
       "model_types": [
@@ -29594,7 +27316,6 @@
     {
       "name": "qwen/qwen3-1.7b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-1.7B-MLX-4bit",
         "qwen3-1.7b-mlx-4bit"
       ],
       "model_types": [
@@ -29605,7 +27326,6 @@
     {
       "name": "qwen/qwen3-1.7b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-1.7B-MLX-6bit",
         "qwen3-1.7b-mlx-6bit"
       ],
       "model_types": [
@@ -29616,7 +27336,6 @@
     {
       "name": "qwen/qwen3-1.7b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-1.7B-MLX-8bit",
         "qwen3-1.7b-mlx-8bit"
       ],
       "model_types": [
@@ -29627,7 +27346,6 @@
     {
       "name": "qwen/qwen3-1.7b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-1.7B-MLX-bf16",
         "qwen3-1.7b-mlx-bf16"
       ],
       "model_types": [
@@ -29638,7 +27356,6 @@
     {
       "name": "qwen/qwen3-14b-awq",
       "alias": [
-        "Qwen/Qwen3-14B-AWQ",
         "qwen3-14b-awq"
       ],
       "model_types": [
@@ -29649,7 +27366,6 @@
     {
       "name": "qwen/qwen3-14b-fp8",
       "alias": [
-        "Qwen/Qwen3-14B-FP8",
         "qwen3-14b-fp8"
       ],
       "model_types": [
@@ -29660,7 +27376,6 @@
     {
       "name": "qwen/qwen3-14b-gguf",
       "alias": [
-        "Qwen/Qwen3-14B-GGUF",
         "qwen3-14b-gguf"
       ],
       "model_types": [
@@ -29671,7 +27386,6 @@
     {
       "name": "qwen/qwen3-14b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-14B-MLX-4bit",
         "qwen3-14b-mlx-4bit"
       ],
       "model_types": [
@@ -29682,7 +27396,6 @@
     {
       "name": "qwen/qwen3-14b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-14B-MLX-6bit",
         "qwen3-14b-mlx-6bit"
       ],
       "model_types": [
@@ -29693,7 +27406,6 @@
     {
       "name": "qwen/qwen3-14b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-14B-MLX-8bit",
         "qwen3-14b-mlx-8bit"
       ],
       "model_types": [
@@ -29704,7 +27416,6 @@
     {
       "name": "qwen/qwen3-14b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-14B-MLX-bf16",
         "qwen3-14b-mlx-bf16"
       ],
       "model_types": [
@@ -29715,9 +27426,7 @@
     {
       "name": "qwen/qwen3-235b-a22b",
       "alias": [
-        "Qwen/Qwen3-235B-A22B",
-        "qwen3-235b-a22b",
-        "Qwen3-235B-A22B"
+        "qwen3-235b-a22b"
       ],
       "model_types": [
         "chat"
@@ -29727,7 +27436,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-fp8",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-FP8",
         "qwen3-235b-a22b-fp8",
         "Qwen3 235B A22B"
       ],
@@ -29744,7 +27452,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-gguf",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-GGUF",
         "qwen3-235b-a22b-gguf"
       ],
       "model_types": [
@@ -29755,7 +27462,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-gptq-int4",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-GPTQ-Int4",
         "qwen3-235b-a22b-gptq-int4"
       ],
       "model_types": [
@@ -29766,7 +27472,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-instruct-2507",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-Instruct-2507",
         "qwen3-235b-a22b-instruct-2507",
         "qwen/qwen3-235b-a22b-07-25",
         "qwen/qwen3-235b-a22b-2507",
@@ -29783,7 +27488,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-instruct-2507-fp8",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
         "qwen3-235b-a22b-instruct-2507-fp8",
         "Qwen3 235B A22b Instruct 2507 Fp8"
       ],
@@ -29795,7 +27499,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-MLX-4bit",
         "qwen3-235b-a22b-mlx-4bit"
       ],
       "model_types": [
@@ -29806,7 +27509,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-MLX-6bit",
         "qwen3-235b-a22b-mlx-6bit"
       ],
       "model_types": [
@@ -29817,7 +27519,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-MLX-8bit",
         "qwen3-235b-a22b-mlx-8bit"
       ],
       "model_types": [
@@ -29828,7 +27529,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-MLX-bf16",
         "qwen3-235b-a22b-mlx-bf16"
       ],
       "model_types": [
@@ -29839,7 +27539,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-thinking-2507",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "qwen3-235b-a22b-thinking-2507",
         "Qwen3 235B A22b Thinking 2507"
       ],
@@ -29856,7 +27555,6 @@
     {
       "name": "qwen/qwen3-235b-a22b-thinking-2507-fp8",
       "alias": [
-        "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8",
         "qwen3-235b-a22b-thinking-2507-fp8"
       ],
       "model_types": [
@@ -29871,9 +27569,7 @@
     {
       "name": "qwen/qwen3-30b-a3b",
       "alias": [
-        "Qwen/Qwen3-30B-A3B",
-        "qwen3-30b-a3b",
-        "Qwen3-30B-A3B"
+        "qwen3-30b-a3b"
       ],
       "model_types": [
         "chat"
@@ -29883,7 +27579,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-base",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-Base",
         "qwen3-30b-a3b-base",
         "Qwen3 30B A3b Base"
       ],
@@ -29895,7 +27590,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-fp8",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-FP8",
         "qwen3-30b-a3b-fp8",
         "Qwen3 30B A3B"
       ],
@@ -29912,7 +27606,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-gguf",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-GGUF",
         "qwen3-30b-a3b-gguf"
       ],
       "model_types": [
@@ -29923,7 +27616,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-gptq-int4",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-GPTQ-Int4",
         "qwen3-30b-a3b-gptq-int4"
       ],
       "model_types": [
@@ -29934,7 +27626,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-instruct-2507",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-Instruct-2507",
         "qwen3-30b-a3b-instruct-2507"
       ],
       "model_types": [
@@ -29945,7 +27636,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-instruct-2507-fp8",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
         "qwen3-30b-a3b-instruct-2507-fp8"
       ],
       "model_types": [
@@ -29956,7 +27646,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-MLX-4bit",
         "qwen3-30b-a3b-mlx-4bit"
       ],
       "model_types": [
@@ -29967,7 +27656,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-MLX-6bit",
         "qwen3-30b-a3b-mlx-6bit"
       ],
       "model_types": [
@@ -29978,7 +27666,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-MLX-8bit",
         "qwen3-30b-a3b-mlx-8bit"
       ],
       "model_types": [
@@ -29989,7 +27676,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-MLX-bf16",
         "qwen3-30b-a3b-mlx-bf16"
       ],
       "model_types": [
@@ -30000,7 +27686,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-thinking-2507",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-Thinking-2507",
         "qwen3-30b-a3b-thinking-2507"
       ],
       "model_types": [
@@ -30015,7 +27700,6 @@
     {
       "name": "qwen/qwen3-30b-a3b-thinking-2507-fp8",
       "alias": [
-        "Qwen/Qwen3-30B-A3B-Thinking-2507-FP8",
         "qwen3-30b-a3b-thinking-2507-fp8"
       ],
       "model_types": [
@@ -30030,7 +27714,6 @@
     {
       "name": "qwen/qwen3-32b-awq",
       "alias": [
-        "Qwen/Qwen3-32B-AWQ",
         "qwen3-32b-awq"
       ],
       "model_types": [
@@ -30041,7 +27724,6 @@
     {
       "name": "qwen/qwen3-32b-fp8",
       "alias": [
-        "Qwen/Qwen3-32B-FP8",
         "qwen3-32b-fp8",
         "Qwen3 32B"
       ],
@@ -30058,7 +27740,6 @@
     {
       "name": "qwen/qwen3-32b-gguf",
       "alias": [
-        "Qwen/Qwen3-32B-GGUF",
         "qwen3-32b-gguf"
       ],
       "model_types": [
@@ -30069,7 +27750,6 @@
     {
       "name": "qwen/qwen3-32b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-32B-MLX-4bit",
         "qwen3-32b-mlx-4bit"
       ],
       "model_types": [
@@ -30080,7 +27760,6 @@
     {
       "name": "qwen/qwen3-32b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-32B-MLX-6bit",
         "qwen3-32b-mlx-6bit"
       ],
       "model_types": [
@@ -30091,7 +27770,6 @@
     {
       "name": "qwen/qwen3-32b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-32B-MLX-8bit",
         "qwen3-32b-mlx-8bit"
       ],
       "model_types": [
@@ -30102,7 +27780,6 @@
     {
       "name": "qwen/qwen3-32b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-32B-MLX-bf16",
         "qwen3-32b-mlx-bf16"
       ],
       "model_types": [
@@ -30113,9 +27790,7 @@
     {
       "name": "qwen/qwen3-4b",
       "alias": [
-        "Qwen/Qwen3-4B",
-        "qwen3-4b",
-        "Qwen3-4B"
+        "qwen3-4b"
       ],
       "model_types": [
         "chat"
@@ -30125,7 +27800,6 @@
     {
       "name": "qwen/qwen3-4b-awq",
       "alias": [
-        "Qwen/Qwen3-4B-AWQ",
         "qwen3-4b-awq"
       ],
       "model_types": [
@@ -30136,7 +27810,6 @@
     {
       "name": "qwen/qwen3-4b-base",
       "alias": [
-        "Qwen/Qwen3-4B-Base",
         "qwen3-4b-base",
         "Qwen3 4B Base"
       ],
@@ -30148,7 +27821,6 @@
     {
       "name": "qwen/qwen3-4b-fp8",
       "alias": [
-        "Qwen/Qwen3-4B-FP8",
         "qwen3-4b-fp8",
         "Qwen3 4B"
       ],
@@ -30165,7 +27837,6 @@
     {
       "name": "qwen/qwen3-4b-gguf",
       "alias": [
-        "Qwen/Qwen3-4B-GGUF",
         "qwen3-4b-gguf"
       ],
       "model_types": [
@@ -30176,7 +27847,6 @@
     {
       "name": "qwen/qwen3-4b-instruct-2507",
       "alias": [
-        "Qwen/Qwen3-4B-Instruct-2507",
         "qwen3-4b-instruct-2507",
         "Qwen3 4B Instruct 2507"
       ],
@@ -30188,7 +27858,6 @@
     {
       "name": "qwen/qwen3-4b-instruct-2507-fp8",
       "alias": [
-        "Qwen/Qwen3-4B-Instruct-2507-FP8",
         "qwen3-4b-instruct-2507-fp8"
       ],
       "model_types": [
@@ -30199,7 +27868,6 @@
     {
       "name": "qwen/qwen3-4b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-4B-MLX-4bit",
         "qwen3-4b-mlx-4bit"
       ],
       "model_types": [
@@ -30210,7 +27878,6 @@
     {
       "name": "qwen/qwen3-4b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-4B-MLX-6bit",
         "qwen3-4b-mlx-6bit"
       ],
       "model_types": [
@@ -30221,7 +27888,6 @@
     {
       "name": "qwen/qwen3-4b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-4B-MLX-8bit",
         "qwen3-4b-mlx-8bit"
       ],
       "model_types": [
@@ -30232,7 +27898,6 @@
     {
       "name": "qwen/qwen3-4b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-4B-MLX-bf16",
         "qwen3-4b-mlx-bf16"
       ],
       "model_types": [
@@ -30243,7 +27908,6 @@
     {
       "name": "qwen/qwen3-4b-saferl",
       "alias": [
-        "Qwen/Qwen3-4B-SafeRL",
         "qwen3-4b-saferl"
       ],
       "model_types": [
@@ -30254,7 +27918,6 @@
     {
       "name": "qwen/qwen3-4b-thinking-2507",
       "alias": [
-        "Qwen/Qwen3-4B-Thinking-2507",
         "qwen3-4b-thinking-2507"
       ],
       "model_types": [
@@ -30269,7 +27932,6 @@
     {
       "name": "qwen/qwen3-4b-thinking-2507-fp8",
       "alias": [
-        "Qwen/Qwen3-4B-Thinking-2507-FP8",
         "qwen3-4b-thinking-2507-fp8"
       ],
       "model_types": [
@@ -30284,7 +27946,6 @@
     {
       "name": "qwen/qwen3-8b-awq",
       "alias": [
-        "Qwen/Qwen3-8B-AWQ",
         "qwen3-8b-awq"
       ],
       "model_types": [
@@ -30295,7 +27956,6 @@
     {
       "name": "qwen/qwen3-8b-fp8",
       "alias": [
-        "Qwen/Qwen3-8B-FP8",
         "qwen3-8b-fp8",
         "Qwen3 8B"
       ],
@@ -30308,7 +27968,6 @@
     {
       "name": "qwen/qwen3-8b-gguf",
       "alias": [
-        "Qwen/Qwen3-8B-GGUF",
         "qwen3-8b-gguf"
       ],
       "model_types": [
@@ -30319,7 +27978,6 @@
     {
       "name": "qwen/qwen3-8b-mlx-4bit",
       "alias": [
-        "Qwen/Qwen3-8B-MLX-4bit",
         "qwen3-8b-mlx-4bit"
       ],
       "model_types": [
@@ -30330,7 +27988,6 @@
     {
       "name": "qwen/qwen3-8b-mlx-6bit",
       "alias": [
-        "Qwen/Qwen3-8B-MLX-6bit",
         "qwen3-8b-mlx-6bit"
       ],
       "model_types": [
@@ -30341,7 +27998,6 @@
     {
       "name": "qwen/qwen3-8b-mlx-8bit",
       "alias": [
-        "Qwen/Qwen3-8B-MLX-8bit",
         "qwen3-8b-mlx-8bit"
       ],
       "model_types": [
@@ -30352,7 +28008,6 @@
     {
       "name": "qwen/qwen3-8b-mlx-bf16",
       "alias": [
-        "Qwen/Qwen3-8B-MLX-bf16",
         "qwen3-8b-mlx-bf16"
       ],
       "model_types": [
@@ -30363,7 +28018,6 @@
     {
       "name": "qwen/qwen3-asr-0.6b",
       "alias": [
-        "Qwen/Qwen3-ASR-0.6B",
         "qwen3-asr-0.6b"
       ],
       "model_types": [
@@ -30375,7 +28029,6 @@
     {
       "name": "qwen/qwen3-asr-1.7b",
       "alias": [
-        "Qwen/Qwen3-ASR-1.7B",
         "qwen3-asr-1.7b"
       ],
       "model_types": [
@@ -30431,7 +28084,6 @@
     {
       "name": "qwen/qwen3-coder-30b-a3b-instruct",
       "alias": [
-        "Qwen/Qwen3-Coder-30B-A3B-Instruct",
         "qwen3-coder-30b-a3b-instruct",
         "Qwen3 Coder 30b A3B Instruct"
       ],
@@ -30444,7 +28096,6 @@
     {
       "name": "qwen/qwen3-coder-30b-a3b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8",
         "qwen3-coder-30b-a3b-instruct-fp8"
       ],
       "model_types": [
@@ -30455,7 +28106,6 @@
     {
       "name": "qwen/qwen3-coder-480b-a35b-instruct",
       "alias": [
-        "Qwen/Qwen3-Coder-480B-A35B-Instruct",
         "qwen3-coder-480b-a35b-instruct",
         "qwen3-coder-480b",
         "qwen/qwen3-coder",
@@ -30465,7 +28115,6 @@
         "qwen/qwen3-coder-480b-a35b-instruct-maas",
         "qwen.qwen3-coder-480b-a35b-instruct",
         "qwen.qwen3-coder-480b-a35b-v1:0",
-        "qwen3-coder",
         "Qwen3 Coder 480B A35B Instruct"
       ],
       "model_types": [
@@ -30477,7 +28126,6 @@
     {
       "name": "qwen/qwen3-coder-480b-a35b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
         "qwen3-coder-480b-a35b-instruct-fp8",
         "Qwen3 Coder 480B A35B Instruct Fp8"
       ],
@@ -30499,7 +28147,6 @@
     {
       "name": "qwen/qwen3-coder-next-fp8",
       "alias": [
-        "Qwen/Qwen3-Coder-Next-FP8",
         "qwen3-coder-next-fp8",
         "Qwen3 Coder Next Fp8"
       ],
@@ -30511,7 +28158,6 @@
     {
       "name": "qwen/qwen3-coder-next-gguf",
       "alias": [
-        "Qwen/Qwen3-Coder-Next-GGUF",
         "qwen3-coder-next-gguf"
       ],
       "model_types": [
@@ -30532,9 +28178,7 @@
     {
       "name": "qwen/qwen3-embedding-0.6b",
       "alias": [
-        "Qwen/Qwen3-Embedding-0.6B",
-        "qwen3-embedding-0.6b",
-        "Qwen3-Embedding-0.6B"
+        "qwen3-embedding-0.6b"
       ],
       "model_types": [
         "embedding"
@@ -30546,7 +28190,6 @@
     {
       "name": "qwen/qwen3-embedding-0.6b-gguf",
       "alias": [
-        "Qwen/Qwen3-Embedding-0.6B-GGUF",
         "qwen3-embedding-0.6b-gguf"
       ],
       "model_types": [
@@ -30559,9 +28202,7 @@
     {
       "name": "qwen/qwen3-embedding-4b",
       "alias": [
-        "Qwen/Qwen3-Embedding-4B",
-        "qwen3-embedding-4b",
-        "Qwen3-Embedding-4B"
+        "qwen3-embedding-4b"
       ],
       "model_types": [
         "embedding"
@@ -30573,7 +28214,6 @@
     {
       "name": "qwen/qwen3-embedding-4b-gguf",
       "alias": [
-        "Qwen/Qwen3-Embedding-4B-GGUF",
         "qwen3-embedding-4b-gguf"
       ],
       "model_types": [
@@ -30586,9 +28226,7 @@
     {
       "name": "qwen/qwen3-embedding-8b",
       "alias": [
-        "Qwen/Qwen3-Embedding-8B",
-        "qwen3-embedding-8b",
-        "Qwen3-Embedding-8B"
+        "qwen3-embedding-8b"
       ],
       "model_types": [
         "embedding"
@@ -30600,7 +28238,6 @@
     {
       "name": "qwen/qwen3-embedding-8b-gguf",
       "alias": [
-        "Qwen/Qwen3-Embedding-8B-GGUF",
         "qwen3-embedding-8b-gguf"
       ],
       "model_types": [
@@ -30613,7 +28250,6 @@
     {
       "name": "qwen/qwen3-forcedaligner-0.6b",
       "alias": [
-        "Qwen/Qwen3-ForcedAligner-0.6B",
         "qwen3-forcedaligner-0.6b"
       ],
       "model_types": [
@@ -30676,7 +28312,6 @@
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct",
       "alias": [
-        "Qwen/Qwen3-Next-80B-A3B-Instruct",
         "qwen3-next-80b-a3b-instruct",
         "qwen/qwen3-next-80b-a3b-instruct-2509",
         "qwen/qwen3-next-80b-a3b-instruct-2509:free",
@@ -30696,7 +28331,6 @@
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
         "qwen3-next-80b-a3b-instruct-fp8",
         "Qwen3 Next 80B A3b Instruct Fp8"
       ],
@@ -30708,7 +28342,6 @@
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen3-Next-80B-A3B-Instruct-GGUF",
         "qwen3-next-80b-a3b-instruct-gguf"
       ],
       "model_types": [
@@ -30718,7 +28351,6 @@
     {
       "name": "qwen/qwen3-next-80b-a3b-thinking",
       "alias": [
-        "Qwen/Qwen3-Next-80B-A3B-Thinking",
         "qwen3-next-80b-a3b-thinking",
         "qwen/qwen3-next-80b-a3b-thinking-2509",
         "Qwen3 Next 80B A3B Thinking"
@@ -30736,7 +28368,6 @@
     {
       "name": "qwen/qwen3-next-80b-a3b-thinking-fp8",
       "alias": [
-        "Qwen/Qwen3-Next-80B-A3B-Thinking-FP8",
         "qwen3-next-80b-a3b-thinking-fp8"
       ],
       "model_types": [
@@ -30751,7 +28382,6 @@
     {
       "name": "qwen/qwen3-next-80b-a3b-thinking-gguf",
       "alias": [
-        "Qwen/Qwen3-Next-80B-A3B-Thinking-GGUF",
         "qwen3-next-80b-a3b-thinking-gguf"
       ],
       "model_types": [
@@ -30765,7 +28395,6 @@
     {
       "name": "qwen/qwen3-omni-30b-a3b-captioner",
       "alias": [
-        "Qwen/Qwen3-Omni-30B-A3B-Captioner",
         "qwen3-omni-30b-a3b-captioner"
       ],
       "model_types": [
@@ -30780,7 +28409,6 @@
     {
       "name": "qwen/qwen3-omni-30b-a3b-instruct",
       "alias": [
-        "Qwen/Qwen3-Omni-30B-A3B-Instruct",
         "qwen3-omni-30b-a3b-instruct",
         "Qwen3 Omni 30B A3B Instruct"
       ],
@@ -30801,7 +28429,6 @@
     {
       "name": "qwen/qwen3-omni-30b-a3b-thinking",
       "alias": [
-        "Qwen/Qwen3-Omni-30B-A3B-Thinking",
         "qwen3-omni-30b-a3b-thinking",
         "Qwen3 Omni 30B A3B Thinking"
       ],
@@ -30869,9 +28496,7 @@
     {
       "name": "qwen/qwen3-reranker-0.6b",
       "alias": [
-        "Qwen/Qwen3-Reranker-0.6B",
-        "qwen3-reranker-0.6b",
-        "Qwen3-Reranker-0.6B"
+        "qwen3-reranker-0.6b"
       ],
       "model_types": [
         "rerank"
@@ -30881,9 +28506,7 @@
     {
       "name": "qwen/qwen3-reranker-4b",
       "alias": [
-        "Qwen/Qwen3-Reranker-4B",
-        "qwen3-reranker-4b",
-        "Qwen3-Reranker-4B"
+        "qwen3-reranker-4b"
       ],
       "model_types": [
         "rerank"
@@ -30893,9 +28516,7 @@
     {
       "name": "qwen/qwen3-reranker-8b",
       "alias": [
-        "Qwen/Qwen3-Reranker-8B",
-        "qwen3-reranker-8b",
-        "Qwen3-Reranker-8B"
+        "qwen3-reranker-8b"
       ],
       "model_types": [
         "rerank"
@@ -30905,7 +28526,6 @@
     {
       "name": "qwen/qwen3-tts-12hz-0.6b-base",
       "alias": [
-        "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
         "qwen3-tts-12hz-0.6b-base"
       ],
       "model_types": [
@@ -30916,7 +28536,6 @@
     {
       "name": "qwen/qwen3-tts-12hz-0.6b-customvoice",
       "alias": [
-        "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
         "qwen3-tts-12hz-0.6b-customvoice"
       ],
       "model_types": [
@@ -30927,7 +28546,6 @@
     {
       "name": "qwen/qwen3-tts-12hz-1.7b-base",
       "alias": [
-        "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
         "qwen3-tts-12hz-1.7b-base"
       ],
       "model_types": [
@@ -30938,7 +28556,6 @@
     {
       "name": "qwen/qwen3-tts-12hz-1.7b-customvoice",
       "alias": [
-        "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
         "qwen3-tts-12hz-1.7b-customvoice"
       ],
       "model_types": [
@@ -30949,7 +28566,6 @@
     {
       "name": "qwen/qwen3-tts-12hz-1.7b-voicedesign",
       "alias": [
-        "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
         "qwen3-tts-12hz-1.7b-voicedesign"
       ],
       "model_types": [
@@ -30996,7 +28612,6 @@
     {
       "name": "qwen/qwen3-tts-tokenizer-12hz",
       "alias": [
-        "Qwen/Qwen3-TTS-Tokenizer-12Hz",
         "qwen3-tts-tokenizer-12hz"
       ],
       "model_types": [
@@ -31017,7 +28632,6 @@
     {
       "name": "qwen/qwen3-vl-235b-a22b-instruct",
       "alias": [
-        "Qwen/Qwen3-VL-235B-A22B-Instruct",
         "qwen3-vl-235b-a22b-instruct",
         "Qwen3 VL 235B A22B Instruct"
       ],
@@ -31037,7 +28651,6 @@
     {
       "name": "qwen/qwen3-vl-235b-a22b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8",
         "qwen3-vl-235b-a22b-instruct-fp8"
       ],
       "model_types": [
@@ -31054,7 +28667,6 @@
     {
       "name": "qwen/qwen3-vl-235b-a22b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-235B-A22B-Instruct-GGUF",
         "qwen3-vl-235b-a22b-instruct-gguf"
       ],
       "model_types": [
@@ -31069,7 +28681,6 @@
     {
       "name": "qwen/qwen3-vl-235b-a22b-thinking",
       "alias": [
-        "Qwen/Qwen3-VL-235B-A22B-Thinking",
         "qwen3-vl-235b-a22b-thinking",
         "Qwen3 VL 235B A22B Thinking"
       ],
@@ -31088,7 +28699,6 @@
     {
       "name": "qwen/qwen3-vl-235b-a22b-thinking-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-235B-A22B-Thinking-FP8",
         "qwen3-vl-235b-a22b-thinking-fp8"
       ],
       "model_types": [
@@ -31103,7 +28713,6 @@
     {
       "name": "qwen/qwen3-vl-235b-a22b-thinking-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-235B-A22B-Thinking-GGUF",
         "qwen3-vl-235b-a22b-thinking-gguf"
       ],
       "model_types": [
@@ -31118,7 +28727,6 @@
     {
       "name": "qwen/qwen3-vl-2b-instruct",
       "alias": [
-        "Qwen/Qwen3-VL-2B-Instruct",
         "qwen3-vl-2b-instruct"
       ],
       "model_types": [
@@ -31133,7 +28741,6 @@
     {
       "name": "qwen/qwen3-vl-2b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-2B-Instruct-FP8",
         "qwen3-vl-2b-instruct-fp8"
       ],
       "model_types": [
@@ -31148,7 +28755,6 @@
     {
       "name": "qwen/qwen3-vl-2b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-2B-Instruct-GGUF",
         "qwen3-vl-2b-instruct-gguf"
       ],
       "model_types": [
@@ -31163,7 +28769,6 @@
     {
       "name": "qwen/qwen3-vl-2b-thinking",
       "alias": [
-        "Qwen/Qwen3-VL-2B-Thinking",
         "qwen3-vl-2b-thinking"
       ],
       "model_types": [
@@ -31178,7 +28783,6 @@
     {
       "name": "qwen/qwen3-vl-2b-thinking-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-2B-Thinking-FP8",
         "qwen3-vl-2b-thinking-fp8"
       ],
       "model_types": [
@@ -31193,7 +28797,6 @@
     {
       "name": "qwen/qwen3-vl-2b-thinking-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-2B-Thinking-GGUF",
         "qwen3-vl-2b-thinking-gguf"
       ],
       "model_types": [
@@ -31218,7 +28821,6 @@
     {
       "name": "qwen/qwen3-vl-30b-a3b-instruct",
       "alias": [
-        "Qwen/Qwen3-VL-30B-A3B-Instruct",
         "qwen3-vl-30b-a3b-instruct"
       ],
       "model_types": [
@@ -31238,7 +28840,6 @@
     {
       "name": "qwen/qwen3-vl-30b-a3b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8",
         "qwen3-vl-30b-a3b-instruct-fp8"
       ],
       "model_types": [
@@ -31253,7 +28854,6 @@
     {
       "name": "qwen/qwen3-vl-30b-a3b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-30B-A3B-Instruct-GGUF",
         "qwen3-vl-30b-a3b-instruct-gguf"
       ],
       "model_types": [
@@ -31268,7 +28868,6 @@
     {
       "name": "qwen/qwen3-vl-30b-a3b-thinking",
       "alias": [
-        "Qwen/Qwen3-VL-30B-A3B-Thinking",
         "qwen3-vl-30b-a3b-thinking"
       ],
       "model_types": [
@@ -31287,7 +28886,6 @@
     {
       "name": "qwen/qwen3-vl-30b-a3b-thinking-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-30B-A3B-Thinking-FP8",
         "qwen3-vl-30b-a3b-thinking-fp8"
       ],
       "model_types": [
@@ -31302,7 +28900,6 @@
     {
       "name": "qwen/qwen3-vl-30b-a3b-thinking-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-30B-A3B-Thinking-GGUF",
         "qwen3-vl-30b-a3b-thinking-gguf"
       ],
       "model_types": [
@@ -31326,7 +28923,6 @@
     {
       "name": "qwen/qwen3-vl-32b-instruct",
       "alias": [
-        "Qwen/Qwen3-VL-32B-Instruct",
         "qwen3-vl-32b-instruct"
       ],
       "model_types": [
@@ -31343,7 +28939,6 @@
     {
       "name": "qwen/qwen3-vl-32b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-32B-Instruct-FP8",
         "qwen3-vl-32b-instruct-fp8"
       ],
       "model_types": [
@@ -31358,7 +28953,6 @@
     {
       "name": "qwen/qwen3-vl-32b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-32B-Instruct-GGUF",
         "qwen3-vl-32b-instruct-gguf"
       ],
       "model_types": [
@@ -31373,7 +28967,6 @@
     {
       "name": "qwen/qwen3-vl-32b-thinking",
       "alias": [
-        "Qwen/Qwen3-VL-32B-Thinking",
         "qwen3-vl-32b-thinking"
       ],
       "model_types": [
@@ -31389,7 +28982,6 @@
     {
       "name": "qwen/qwen3-vl-32b-thinking-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-32B-Thinking-FP8",
         "qwen3-vl-32b-thinking-fp8"
       ],
       "model_types": [
@@ -31404,7 +28996,6 @@
     {
       "name": "qwen/qwen3-vl-32b-thinking-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-32B-Thinking-GGUF",
         "qwen3-vl-32b-thinking-gguf"
       ],
       "model_types": [
@@ -31419,7 +29010,6 @@
     {
       "name": "qwen/qwen3-vl-4b-instruct",
       "alias": [
-        "Qwen/Qwen3-VL-4B-Instruct",
         "qwen3-vl-4b-instruct"
       ],
       "model_types": [
@@ -31436,7 +29026,6 @@
     {
       "name": "qwen/qwen3-vl-4b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-4B-Instruct-FP8",
         "qwen3-vl-4b-instruct-fp8"
       ],
       "model_types": [
@@ -31451,7 +29040,6 @@
     {
       "name": "qwen/qwen3-vl-4b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-4B-Instruct-GGUF",
         "qwen3-vl-4b-instruct-gguf"
       ],
       "model_types": [
@@ -31466,7 +29054,6 @@
     {
       "name": "qwen/qwen3-vl-4b-thinking",
       "alias": [
-        "Qwen/Qwen3-VL-4B-Thinking",
         "qwen3-vl-4b-thinking"
       ],
       "model_types": [
@@ -31483,7 +29070,6 @@
     {
       "name": "qwen/qwen3-vl-4b-thinking-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-4B-Thinking-FP8",
         "qwen3-vl-4b-thinking-fp8"
       ],
       "model_types": [
@@ -31498,7 +29084,6 @@
     {
       "name": "qwen/qwen3-vl-4b-thinking-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-4B-Thinking-GGUF",
         "qwen3-vl-4b-thinking-gguf"
       ],
       "model_types": [
@@ -31513,7 +29098,6 @@
     {
       "name": "qwen/qwen3-vl-8b-instruct",
       "alias": [
-        "Qwen/Qwen3-VL-8B-Instruct",
         "qwen3-vl-8b-instruct"
       ],
       "model_types": [
@@ -31532,7 +29116,6 @@
     {
       "name": "qwen/qwen3-vl-8b-instruct-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-8B-Instruct-FP8",
         "qwen3-vl-8b-instruct-fp8"
       ],
       "model_types": [
@@ -31547,7 +29130,6 @@
     {
       "name": "qwen/qwen3-vl-8b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-8B-Instruct-GGUF",
         "qwen3-vl-8b-instruct-gguf"
       ],
       "model_types": [
@@ -31562,7 +29144,6 @@
     {
       "name": "qwen/qwen3-vl-8b-thinking",
       "alias": [
-        "Qwen/Qwen3-VL-8B-Thinking",
         "qwen3-vl-8b-thinking"
       ],
       "model_types": [
@@ -31580,7 +29161,6 @@
     {
       "name": "qwen/qwen3-vl-8b-thinking-fp8",
       "alias": [
-        "Qwen/Qwen3-VL-8B-Thinking-FP8",
         "qwen3-vl-8b-thinking-fp8"
       ],
       "model_types": [
@@ -31595,7 +29175,6 @@
     {
       "name": "qwen/qwen3-vl-8b-thinking-gguf",
       "alias": [
-        "Qwen/Qwen3-VL-8B-Thinking-GGUF",
         "qwen3-vl-8b-thinking-gguf"
       ],
       "model_types": [
@@ -31630,7 +29209,6 @@
     {
       "name": "qwen/qwen3-vl-embedding-2b",
       "alias": [
-        "Qwen/Qwen3-VL-Embedding-2B",
         "qwen3-vl-embedding-2b"
       ],
       "model_types": [
@@ -31643,7 +29221,6 @@
     {
       "name": "qwen/qwen3-vl-embedding-8b",
       "alias": [
-        "Qwen/Qwen3-VL-Embedding-8B",
         "qwen3-vl-embedding-8b"
       ],
       "model_types": [
@@ -31717,7 +29294,6 @@
     {
       "name": "qwen/qwen3-vl-reranker-2b",
       "alias": [
-        "Qwen/Qwen3-VL-Reranker-2B",
         "qwen3-vl-reranker-2b"
       ],
       "model_types": [
@@ -31728,7 +29304,6 @@
     {
       "name": "qwen/qwen3-vl-reranker-8b",
       "alias": [
-        "Qwen/Qwen3-VL-Reranker-8B",
         "qwen3-vl-reranker-8b"
       ],
       "model_types": [
@@ -31739,7 +29314,6 @@
     {
       "name": "qwen/qwen3guard-gen-0.6b",
       "alias": [
-        "Qwen/Qwen3Guard-Gen-0.6B",
         "qwen3guard-gen-0.6b"
       ],
       "model_types": [
@@ -31750,7 +29324,6 @@
     {
       "name": "qwen/qwen3guard-gen-4b",
       "alias": [
-        "Qwen/Qwen3Guard-Gen-4B",
         "qwen3guard-gen-4b"
       ],
       "model_types": [
@@ -31761,7 +29334,6 @@
     {
       "name": "qwen/qwen3guard-gen-8b",
       "alias": [
-        "Qwen/Qwen3Guard-Gen-8B",
         "qwen3guard-gen-8b"
       ],
       "model_types": [
@@ -31772,7 +29344,6 @@
     {
       "name": "qwen/qwen3guard-stream-0.6b",
       "alias": [
-        "Qwen/Qwen3Guard-Stream-0.6B",
         "qwen3guard-stream-0.6b"
       ],
       "model_types": [
@@ -31783,7 +29354,6 @@
     {
       "name": "qwen/qwen3guard-stream-4b",
       "alias": [
-        "Qwen/Qwen3Guard-Stream-4B",
         "qwen3guard-stream-4b"
       ],
       "model_types": [
@@ -31794,7 +29364,6 @@
     {
       "name": "qwen/qwen3guard-stream-8b",
       "alias": [
-        "Qwen/Qwen3Guard-Stream-8B",
         "qwen3guard-stream-8b"
       ],
       "model_types": [
@@ -31805,7 +29374,6 @@
     {
       "name": "qwen/qwen2.5-0.5b",
       "alias": [
-        "Qwen/Qwen2.5-0.5B",
         "qwen2.5-0.5b"
       ],
       "model_types": [
@@ -31816,7 +29384,6 @@
     {
       "name": "qwen/qwen2.5-0.5b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-0.5B-Instruct",
         "qwen2.5-0.5b-instruct"
       ],
       "model_types": [
@@ -31827,7 +29394,6 @@
     {
       "name": "qwen/qwen2.5-0.5b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-0.5B-Instruct-AWQ",
         "qwen2.5-0.5b-instruct-awq"
       ],
       "model_types": [
@@ -31838,7 +29404,6 @@
     {
       "name": "qwen/qwen2.5-0.5b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-0.5B-Instruct-GGUF",
         "qwen2.5-0.5b-instruct-gguf"
       ],
       "model_types": [
@@ -31848,7 +29413,6 @@
     {
       "name": "qwen/qwen2.5-0.5b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int4",
         "qwen2.5-0.5b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -31859,7 +29423,6 @@
     {
       "name": "qwen/qwen2.5-0.5b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int8",
         "qwen2.5-0.5b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -31870,7 +29433,6 @@
     {
       "name": "qwen/qwen2.5-1.5b",
       "alias": [
-        "Qwen/Qwen2.5-1.5B",
         "qwen2.5-1.5b",
         "Qwen2.5 1.5B"
       ],
@@ -31882,7 +29444,6 @@
     {
       "name": "qwen/qwen2.5-1.5b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-1.5B-Instruct",
         "qwen2.5-1.5b-instruct",
         "Qwen2.5 1.5B Instruct"
       ],
@@ -31894,7 +29455,6 @@
     {
       "name": "qwen/qwen2.5-1.5b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
         "qwen2.5-1.5b-instruct-awq"
       ],
       "model_types": [
@@ -31905,7 +29465,6 @@
     {
       "name": "qwen/qwen2.5-1.5b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
         "qwen2.5-1.5b-instruct-gguf"
       ],
       "model_types": [
@@ -31915,7 +29474,6 @@
     {
       "name": "qwen/qwen2.5-1.5b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-1.5B-Instruct-GPTQ-Int4",
         "qwen2.5-1.5b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -31926,7 +29484,6 @@
     {
       "name": "qwen/qwen2.5-1.5b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-1.5B-Instruct-GPTQ-Int8",
         "qwen2.5-1.5b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -31937,7 +29494,6 @@
     {
       "name": "qwen/qwen2.5-14b",
       "alias": [
-        "Qwen/Qwen2.5-14B",
         "qwen2.5-14b",
         "Qwen2.5 14B"
       ],
@@ -31949,9 +29505,7 @@
     {
       "name": "qwen/qwen2.5-14b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-14B-Instruct",
         "qwen2.5-14b-instruct",
-        "Qwen2.5-14B-Instruct",
         "Qwen 2.5 14B Instruct"
       ],
       "model_types": [
@@ -31962,7 +29516,6 @@
     {
       "name": "qwen/qwen2.5-14b-instruct-1m",
       "alias": [
-        "Qwen/Qwen2.5-14B-Instruct-1M",
         "qwen2.5-14b-instruct-1m"
       ],
       "model_types": [
@@ -31973,7 +29526,6 @@
     {
       "name": "qwen/qwen2.5-14b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-14B-Instruct-AWQ",
         "qwen2.5-14b-instruct-awq"
       ],
       "model_types": [
@@ -31984,7 +29536,6 @@
     {
       "name": "qwen/qwen2.5-14b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-14B-Instruct-GGUF",
         "qwen2.5-14b-instruct-gguf"
       ],
       "model_types": [
@@ -31995,7 +29546,6 @@
     {
       "name": "qwen/qwen2.5-14b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-14B-Instruct-GPTQ-Int4",
         "qwen2.5-14b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32006,7 +29556,6 @@
     {
       "name": "qwen/qwen2.5-14b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-14B-Instruct-GPTQ-Int8",
         "qwen2.5-14b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32017,7 +29566,6 @@
     {
       "name": "qwen/qwen2.5-32b",
       "alias": [
-        "Qwen/Qwen2.5-32B",
         "qwen2.5-32b",
         "Qwen2.5 32B"
       ],
@@ -32029,9 +29577,7 @@
     {
       "name": "qwen/qwen2.5-32b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-32B-Instruct",
         "qwen2.5-32b-instruct",
-        "Qwen2.5-32B-Instruct",
         "Qwen2.5 32B Instruct"
       ],
       "model_types": [
@@ -32043,7 +29589,6 @@
     {
       "name": "qwen/qwen2.5-32b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-32B-Instruct-AWQ",
         "qwen2.5-32b-instruct-awq"
       ],
       "model_types": [
@@ -32054,7 +29599,6 @@
     {
       "name": "qwen/qwen2.5-32b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-32B-Instruct-GGUF",
         "qwen2.5-32b-instruct-gguf"
       ],
       "model_types": [
@@ -32065,7 +29609,6 @@
     {
       "name": "qwen/qwen2.5-32b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-32B-Instruct-GPTQ-Int4",
         "qwen2.5-32b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32076,7 +29619,6 @@
     {
       "name": "qwen/qwen2.5-32b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8",
         "qwen2.5-32b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32087,7 +29629,6 @@
     {
       "name": "qwen/qwen2.5-3b",
       "alias": [
-        "Qwen/Qwen2.5-3B",
         "qwen2.5-3b"
       ],
       "model_types": [
@@ -32098,7 +29639,6 @@
     {
       "name": "qwen/qwen2.5-3b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-3B-Instruct",
         "qwen2.5-3b-instruct",
         "Qwen2.5 3B Instruct"
       ],
@@ -32110,7 +29650,6 @@
     {
       "name": "qwen/qwen2.5-3b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-3B-Instruct-AWQ",
         "qwen2.5-3b-instruct-awq"
       ],
       "model_types": [
@@ -32121,7 +29660,6 @@
     {
       "name": "qwen/qwen2.5-3b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-3B-Instruct-GGUF",
         "qwen2.5-3b-instruct-gguf"
       ],
       "model_types": [
@@ -32131,7 +29669,6 @@
     {
       "name": "qwen/qwen2.5-3b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-3B-Instruct-GPTQ-Int4",
         "qwen2.5-3b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32142,7 +29679,6 @@
     {
       "name": "qwen/qwen2.5-3b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-3B-Instruct-GPTQ-Int8",
         "qwen2.5-3b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32153,9 +29689,7 @@
     {
       "name": "qwen/qwen2.5-72b",
       "alias": [
-        "Qwen/Qwen2.5-72B",
         "qwen2.5-72b",
-        "Qwen2.5-72B",
         "Qwen2.5 72B"
       ],
       "model_types": [
@@ -32166,10 +29700,8 @@
     {
       "name": "qwen/qwen2.5-72b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-72B-Instruct",
         "qwen2.5-72b-instruct",
         "qwen/qwen-2.5-72b-instruct",
-        "Qwen2.5-72B-Instruct",
         "qwen-2.5-72b-instruct",
         "Qwen 2.5 72B Instruct",
         "Qwen2.5 72B Instruct"
@@ -32183,7 +29715,6 @@
     {
       "name": "qwen/qwen2.5-72b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-72B-Instruct-AWQ",
         "qwen2.5-72b-instruct-awq"
       ],
       "model_types": [
@@ -32194,7 +29725,6 @@
     {
       "name": "qwen/qwen2.5-72b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-72B-Instruct-GGUF",
         "qwen2.5-72b-instruct-gguf"
       ],
       "model_types": [
@@ -32205,7 +29735,6 @@
     {
       "name": "qwen/qwen2.5-72b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-72B-Instruct-GPTQ-Int4",
         "qwen2.5-72b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32216,7 +29745,6 @@
     {
       "name": "qwen/qwen2.5-72b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-72B-Instruct-GPTQ-Int8",
         "qwen2.5-72b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32227,7 +29755,6 @@
     {
       "name": "qwen/qwen2.5-7b",
       "alias": [
-        "Qwen/Qwen2.5-7B",
         "qwen2.5-7b",
         "Qwen2.5 7B"
       ],
@@ -32239,9 +29766,7 @@
     {
       "name": "qwen/qwen2.5-7b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-7B-Instruct",
         "qwen2.5-7b-instruct",
-        "Qwen2.5-7B-Instruct",
         "qwen/qwen-2.5-7b-instruct",
         "Qwen2.5 7B Instruct"
       ],
@@ -32254,7 +29779,6 @@
     {
       "name": "qwen/qwen2.5-7b-instruct-1m",
       "alias": [
-        "Qwen/Qwen2.5-7B-Instruct-1M",
         "qwen2.5-7b-instruct-1m"
       ],
       "model_types": [
@@ -32265,7 +29789,6 @@
     {
       "name": "qwen/qwen2.5-7b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-7B-Instruct-AWQ",
         "qwen2.5-7b-instruct-awq"
       ],
       "model_types": [
@@ -32276,7 +29799,6 @@
     {
       "name": "qwen/qwen2.5-7b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-7B-Instruct-GGUF",
         "qwen2.5-7b-instruct-gguf"
       ],
       "model_types": [
@@ -32287,7 +29809,6 @@
     {
       "name": "qwen/qwen2.5-7b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
         "qwen2.5-7b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32298,7 +29819,6 @@
     {
       "name": "qwen/qwen2.5-7b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int8",
         "qwen2.5-7b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32309,7 +29829,6 @@
     {
       "name": "qwen/qwen2.5-coder-0.5b",
       "alias": [
-        "Qwen/Qwen2.5-Coder-0.5B",
         "qwen2.5-coder-0.5b"
       ],
       "model_types": [
@@ -32320,7 +29839,6 @@
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Coder-0.5B-Instruct",
         "qwen2.5-coder-0.5b-instruct"
       ],
       "model_types": [
@@ -32331,7 +29849,6 @@
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-Coder-0.5B-Instruct-AWQ",
         "qwen2.5-coder-0.5b-instruct-awq"
       ],
       "model_types": [
@@ -32342,7 +29859,6 @@
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF",
         "qwen2.5-coder-0.5b-instruct-gguf"
       ],
       "model_types": [
@@ -32352,7 +29868,6 @@
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-Coder-0.5B-Instruct-GPTQ-Int4",
         "qwen2.5-coder-0.5b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32363,7 +29878,6 @@
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-Coder-0.5B-Instruct-GPTQ-Int8",
         "qwen2.5-coder-0.5b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32374,7 +29888,6 @@
     {
       "name": "qwen/qwen2.5-coder-1.5b",
       "alias": [
-        "Qwen/Qwen2.5-Coder-1.5B",
         "qwen2.5-coder-1.5b"
       ],
       "model_types": [
@@ -32385,7 +29898,6 @@
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Coder-1.5B-Instruct",
         "qwen2.5-coder-1.5b-instruct"
       ],
       "model_types": [
@@ -32396,7 +29908,6 @@
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-Coder-1.5B-Instruct-AWQ",
         "qwen2.5-coder-1.5b-instruct-awq"
       ],
       "model_types": [
@@ -32407,7 +29918,6 @@
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF",
         "qwen2.5-coder-1.5b-instruct-gguf"
       ],
       "model_types": [
@@ -32417,7 +29927,6 @@
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-Coder-1.5B-Instruct-GPTQ-Int4",
         "qwen2.5-coder-1.5b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32428,7 +29937,6 @@
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-Coder-1.5B-Instruct-GPTQ-Int8",
         "qwen2.5-coder-1.5b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32439,7 +29947,6 @@
     {
       "name": "qwen/qwen2.5-coder-14b",
       "alias": [
-        "Qwen/Qwen2.5-Coder-14B",
         "qwen2.5-coder-14b"
       ],
       "model_types": [
@@ -32450,7 +29957,6 @@
     {
       "name": "qwen/qwen2.5-coder-14b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Coder-14B-Instruct",
         "qwen2.5-coder-14b-instruct"
       ],
       "model_types": [
@@ -32461,7 +29967,6 @@
     {
       "name": "qwen/qwen2.5-coder-14b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-Coder-14B-Instruct-AWQ",
         "qwen2.5-coder-14b-instruct-awq"
       ],
       "model_types": [
@@ -32472,7 +29977,6 @@
     {
       "name": "qwen/qwen2.5-coder-14b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
         "qwen2.5-coder-14b-instruct-gguf"
       ],
       "model_types": [
@@ -32482,7 +29986,6 @@
     {
       "name": "qwen/qwen2.5-coder-14b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-Coder-14B-Instruct-GPTQ-Int4",
         "qwen2.5-coder-14b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32493,7 +29996,6 @@
     {
       "name": "qwen/qwen2.5-coder-14b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-Coder-14B-Instruct-GPTQ-Int8",
         "qwen2.5-coder-14b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32504,7 +30006,6 @@
     {
       "name": "qwen/qwen2.5-coder-32b",
       "alias": [
-        "Qwen/Qwen2.5-Coder-32B",
         "qwen2.5-coder-32b"
       ],
       "model_types": [
@@ -32515,7 +30016,6 @@
     {
       "name": "qwen/qwen2.5-coder-32b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Coder-32B-Instruct",
         "qwen2.5-coder-32b-instruct",
         "qwen/qwen-2.5-coder-32b-instruct",
         "Qwen 2.5 Coder 32B Instruct"
@@ -32528,7 +30028,6 @@
     {
       "name": "qwen/qwen2.5-coder-32b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-Coder-32B-Instruct-AWQ",
         "qwen2.5-coder-32b-instruct-awq"
       ],
       "model_types": [
@@ -32539,7 +30038,6 @@
     {
       "name": "qwen/qwen2.5-coder-32b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
         "qwen2.5-coder-32b-instruct-gguf"
       ],
       "model_types": [
@@ -32549,7 +30047,6 @@
     {
       "name": "qwen/qwen2.5-coder-32b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-Coder-32B-Instruct-GPTQ-Int4",
         "qwen2.5-coder-32b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32560,7 +30057,6 @@
     {
       "name": "qwen/qwen2.5-coder-32b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-Coder-32B-Instruct-GPTQ-Int8",
         "qwen2.5-coder-32b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32571,7 +30067,6 @@
     {
       "name": "qwen/qwen2.5-coder-3b",
       "alias": [
-        "Qwen/Qwen2.5-Coder-3B",
         "qwen2.5-coder-3b"
       ],
       "model_types": [
@@ -32582,7 +30077,6 @@
     {
       "name": "qwen/qwen2.5-coder-3b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Coder-3B-Instruct",
         "qwen2.5-coder-3b-instruct"
       ],
       "model_types": [
@@ -32593,7 +30087,6 @@
     {
       "name": "qwen/qwen2.5-coder-3b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-Coder-3B-Instruct-AWQ",
         "qwen2.5-coder-3b-instruct-awq"
       ],
       "model_types": [
@@ -32604,7 +30097,6 @@
     {
       "name": "qwen/qwen2.5-coder-3b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-Coder-3B-Instruct-GGUF",
         "qwen2.5-coder-3b-instruct-gguf"
       ],
       "model_types": [
@@ -32614,7 +30106,6 @@
     {
       "name": "qwen/qwen2.5-coder-3b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-Coder-3B-Instruct-GPTQ-Int4",
         "qwen2.5-coder-3b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32625,7 +30116,6 @@
     {
       "name": "qwen/qwen2.5-coder-3b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-Coder-3B-Instruct-GPTQ-Int8",
         "qwen2.5-coder-3b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32636,7 +30126,6 @@
     {
       "name": "qwen/qwen2.5-coder-7b",
       "alias": [
-        "Qwen/Qwen2.5-Coder-7B",
         "qwen2.5-coder-7b"
       ],
       "model_types": [
@@ -32647,7 +30136,6 @@
     {
       "name": "qwen/qwen2.5-coder-7b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Coder-7B-Instruct",
         "qwen2.5-coder-7b-instruct"
       ],
       "model_types": [
@@ -32658,7 +30146,6 @@
     {
       "name": "qwen/qwen2.5-coder-7b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-Coder-7B-Instruct-AWQ",
         "qwen2.5-coder-7b-instruct-awq"
       ],
       "model_types": [
@@ -32669,7 +30156,6 @@
     {
       "name": "qwen/qwen2.5-coder-7b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
         "qwen2.5-coder-7b-instruct-gguf"
       ],
       "model_types": [
@@ -32679,7 +30165,6 @@
     {
       "name": "qwen/qwen2.5-coder-7b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4",
         "qwen2.5-coder-7b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -32690,7 +30175,6 @@
     {
       "name": "qwen/qwen2.5-coder-7b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int8",
         "qwen2.5-coder-7b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -32701,7 +30185,6 @@
     {
       "name": "qwen/qwen2.5-math-1.5b",
       "alias": [
-        "Qwen/Qwen2.5-Math-1.5B",
         "qwen2.5-math-1.5b"
       ],
       "model_types": [
@@ -32712,7 +30195,6 @@
     {
       "name": "qwen/qwen2.5-math-1.5b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Math-1.5B-Instruct",
         "qwen2.5-math-1.5b-instruct"
       ],
       "model_types": [
@@ -32723,7 +30205,6 @@
     {
       "name": "qwen/qwen2.5-math-72b",
       "alias": [
-        "Qwen/Qwen2.5-Math-72B",
         "qwen2.5-math-72b"
       ],
       "model_types": [
@@ -32734,7 +30215,6 @@
     {
       "name": "qwen/qwen2.5-math-72b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Math-72B-Instruct",
         "qwen2.5-math-72b-instruct"
       ],
       "model_types": [
@@ -32745,7 +30225,6 @@
     {
       "name": "qwen/qwen2.5-math-7b",
       "alias": [
-        "Qwen/Qwen2.5-Math-7B",
         "qwen2.5-math-7b"
       ],
       "model_types": [
@@ -32756,7 +30235,6 @@
     {
       "name": "qwen/qwen2.5-math-7b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-Math-7B-Instruct",
         "qwen2.5-math-7b-instruct"
       ],
       "model_types": [
@@ -32767,7 +30245,6 @@
     {
       "name": "qwen/qwen2.5-math-7b-prm800k",
       "alias": [
-        "Qwen/Qwen2.5-Math-7B-PRM800K",
         "qwen2.5-math-7b-prm800k"
       ],
       "model_types": [
@@ -32778,7 +30255,6 @@
     {
       "name": "qwen/qwen2.5-math-prm-72b",
       "alias": [
-        "Qwen/Qwen2.5-Math-PRM-72B",
         "qwen2.5-math-prm-72b"
       ],
       "model_types": [
@@ -32789,7 +30265,6 @@
     {
       "name": "qwen/qwen2.5-math-prm-7b",
       "alias": [
-        "Qwen/Qwen2.5-Math-PRM-7B",
         "qwen2.5-math-prm-7b"
       ],
       "model_types": [
@@ -32800,7 +30275,6 @@
     {
       "name": "qwen/qwen2.5-math-rm-72b",
       "alias": [
-        "Qwen/Qwen2.5-Math-RM-72B",
         "qwen2.5-math-rm-72b"
       ],
       "model_types": [
@@ -32820,7 +30294,6 @@
     {
       "name": "qwen/qwen2.5-omni-3b",
       "alias": [
-        "Qwen/Qwen2.5-Omni-3B",
         "qwen2.5-omni-3b"
       ],
       "model_types": [
@@ -32839,7 +30312,6 @@
     {
       "name": "qwen/qwen2.5-omni-7b",
       "alias": [
-        "Qwen/Qwen2.5-Omni-7B",
         "qwen2.5-omni-7b"
       ],
       "model_types": [
@@ -32858,7 +30330,6 @@
     {
       "name": "qwen/qwen2.5-omni-7b-awq",
       "alias": [
-        "Qwen/Qwen2.5-Omni-7B-AWQ",
         "qwen2.5-omni-7b-awq"
       ],
       "model_types": [
@@ -32877,7 +30348,6 @@
     {
       "name": "qwen/qwen2.5-omni-7b-gptq-int4",
       "alias": [
-        "Qwen/Qwen2.5-Omni-7B-GPTQ-Int4",
         "qwen2.5-omni-7b-gptq-int4"
       ],
       "model_types": [
@@ -32896,10 +30366,8 @@
     {
       "name": "qwen/qwen2.5-vl-32b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-VL-32B-Instruct",
         "qwen2.5-vl-32b-instruct",
-        "Qwen2.5-VL-32B",
-        "Qwen2.5-VL-32B-Instruct"
+        "Qwen2.5-VL-32B"
       ],
       "model_types": [
         "chat",
@@ -32912,7 +30380,6 @@
     {
       "name": "qwen/qwen2.5-vl-32b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-VL-32B-Instruct-AWQ",
         "qwen2.5-vl-32b-instruct-awq"
       ],
       "model_types": [
@@ -32923,7 +30390,6 @@
     {
       "name": "qwen/qwen2.5-vl-3b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-VL-3B-Instruct",
         "qwen2.5-vl-3b-instruct",
         "Qwen2.5-VL-3b"
       ],
@@ -32935,7 +30401,6 @@
     {
       "name": "qwen/qwen2.5-vl-3b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-VL-3B-Instruct-AWQ",
         "qwen2.5-vl-3b-instruct-awq"
       ],
       "model_types": [
@@ -32946,11 +30411,9 @@
     {
       "name": "qwen/qwen2.5-vl-72b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-VL-72B-Instruct",
         "qwen2.5-vl-72b-instruct",
         "qwen-2.5-vl-72b-instruct",
         "Qwen2.5-VL-72B",
-        "qwen2.5-vl-72b",
         "Qwen2.5 VL 72B Instruct",
         "Qwen2.5-VL (72B) Instruct"
       ],
@@ -32965,7 +30428,6 @@
     {
       "name": "qwen/qwen2.5-vl-72b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-VL-72B-Instruct-AWQ",
         "qwen2.5-vl-72b-instruct-awq"
       ],
       "model_types": [
@@ -32976,7 +30438,6 @@
     {
       "name": "qwen/qwen2.5-vl-7b-instruct",
       "alias": [
-        "Qwen/Qwen2.5-VL-7B-Instruct",
         "qwen2.5-vl-7b-instruct",
         "qwen-2.5-vl-7b-instruct",
         "Qwen2.5-VL-7b"
@@ -32989,7 +30450,6 @@
     {
       "name": "qwen/qwen2.5-vl-7b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2.5-VL-7B-Instruct-AWQ",
         "qwen2.5-vl-7b-instruct-awq"
       ],
       "model_types": [
@@ -33000,7 +30460,6 @@
     {
       "name": "qwen/qwen2-0.5b",
       "alias": [
-        "Qwen/Qwen2-0.5B",
         "qwen2-0.5b"
       ],
       "model_types": [
@@ -33011,7 +30470,6 @@
     {
       "name": "qwen/qwen2-0.5b-instruct",
       "alias": [
-        "Qwen/Qwen2-0.5B-Instruct",
         "qwen2-0.5b-instruct"
       ],
       "model_types": [
@@ -33022,7 +30480,6 @@
     {
       "name": "qwen/qwen2-0.5b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2-0.5B-Instruct-AWQ",
         "qwen2-0.5b-instruct-awq"
       ],
       "model_types": [
@@ -33033,7 +30490,6 @@
     {
       "name": "qwen/qwen2-0.5b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2-0.5B-Instruct-GGUF",
         "qwen2-0.5b-instruct-gguf"
       ],
       "model_types": [
@@ -33043,7 +30499,6 @@
     {
       "name": "qwen/qwen2-0.5b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4",
         "qwen2-0.5b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33054,7 +30509,6 @@
     {
       "name": "qwen/qwen2-0.5b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2-0.5B-Instruct-GPTQ-Int8",
         "qwen2-0.5b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -33065,7 +30519,6 @@
     {
       "name": "qwen/qwen2-0.5b-instruct-mlx",
       "alias": [
-        "Qwen/Qwen2-0.5B-Instruct-MLX",
         "qwen2-0.5b-instruct-mlx"
       ],
       "model_types": [
@@ -33076,7 +30529,6 @@
     {
       "name": "qwen/qwen2-1.5b",
       "alias": [
-        "Qwen/Qwen2-1.5B",
         "qwen2-1.5b",
         "Qwen 2 (1.5B)"
       ],
@@ -33088,7 +30540,6 @@
     {
       "name": "qwen/qwen2-1.5b-instruct",
       "alias": [
-        "Qwen/Qwen2-1.5B-Instruct",
         "qwen2-1.5b-instruct",
         "Qwen 2 Instruct (1.5B)"
       ],
@@ -33100,7 +30551,6 @@
     {
       "name": "qwen/qwen2-1.5b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2-1.5B-Instruct-AWQ",
         "qwen2-1.5b-instruct-awq"
       ],
       "model_types": [
@@ -33111,7 +30561,6 @@
     {
       "name": "qwen/qwen2-1.5b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2-1.5B-Instruct-GGUF",
         "qwen2-1.5b-instruct-gguf"
       ],
       "model_types": [
@@ -33121,7 +30570,6 @@
     {
       "name": "qwen/qwen2-1.5b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4",
         "qwen2-1.5b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33132,7 +30580,6 @@
     {
       "name": "qwen/qwen2-1.5b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2-1.5B-Instruct-GPTQ-Int8",
         "qwen2-1.5b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -33143,7 +30590,6 @@
     {
       "name": "qwen/qwen2-1.5b-instruct-mlx",
       "alias": [
-        "Qwen/Qwen2-1.5B-Instruct-MLX",
         "qwen2-1.5b-instruct-mlx"
       ],
       "model_types": [
@@ -33154,7 +30600,6 @@
     {
       "name": "qwen/qwen2-57b-a14b",
       "alias": [
-        "Qwen/Qwen2-57B-A14B",
         "qwen2-57b-a14b"
       ],
       "model_types": [
@@ -33165,7 +30610,6 @@
     {
       "name": "qwen/qwen2-57b-a14b-instruct",
       "alias": [
-        "Qwen/Qwen2-57B-A14B-Instruct",
         "qwen2-57b-a14b-instruct"
       ],
       "model_types": [
@@ -33176,7 +30620,6 @@
     {
       "name": "qwen/qwen2-57b-a14b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2-57B-A14B-Instruct-GGUF",
         "qwen2-57b-a14b-instruct-gguf"
       ],
       "model_types": [
@@ -33186,7 +30629,6 @@
     {
       "name": "qwen/qwen2-57b-a14b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-57B-A14B-Instruct-GPTQ-Int4",
         "qwen2-57b-a14b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33197,7 +30639,6 @@
     {
       "name": "qwen/qwen2-72b",
       "alias": [
-        "Qwen/Qwen2-72B",
         "qwen2-72b",
         "Qwen 2 (72B)"
       ],
@@ -33209,9 +30650,7 @@
     {
       "name": "qwen/qwen2-72b-instruct",
       "alias": [
-        "Qwen/Qwen2-72B-Instruct",
         "qwen2-72b-instruct",
-        "Qwen2-72B-Instruct",
         "Qwen2 72B Instruct"
       ],
       "model_types": [
@@ -33222,7 +30661,6 @@
     {
       "name": "qwen/qwen2-72b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2-72B-Instruct-AWQ",
         "qwen2-72b-instruct-awq"
       ],
       "model_types": [
@@ -33233,7 +30671,6 @@
     {
       "name": "qwen/qwen2-72b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2-72B-Instruct-GGUF",
         "qwen2-72b-instruct-gguf"
       ],
       "model_types": [
@@ -33243,7 +30680,6 @@
     {
       "name": "qwen/qwen2-72b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-72B-Instruct-GPTQ-Int4",
         "qwen2-72b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33254,7 +30690,6 @@
     {
       "name": "qwen/qwen2-72b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2-72B-Instruct-GPTQ-Int8",
         "qwen2-72b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -33265,7 +30700,6 @@
     {
       "name": "qwen/qwen2-7b",
       "alias": [
-        "Qwen/Qwen2-7B",
         "qwen2-7b",
         "Qwen 2 (7B)"
       ],
@@ -33277,10 +30711,8 @@
     {
       "name": "qwen/qwen2-7b-instruct",
       "alias": [
-        "Qwen/Qwen2-7B-Instruct",
         "qwen2-7b-instruct",
         "qwen/qwen-2-7b-instruct",
-        "Qwen2-7B-Instruct",
         "qwen-2-7b-instruct",
         "Qwen 2 7B Instruct"
       ],
@@ -33293,7 +30725,6 @@
     {
       "name": "qwen/qwen2-7b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2-7B-Instruct-AWQ",
         "qwen2-7b-instruct-awq"
       ],
       "model_types": [
@@ -33304,7 +30735,6 @@
     {
       "name": "qwen/qwen2-7b-instruct-gguf",
       "alias": [
-        "Qwen/Qwen2-7B-Instruct-GGUF",
         "qwen2-7b-instruct-gguf"
       ],
       "model_types": [
@@ -33314,7 +30744,6 @@
     {
       "name": "qwen/qwen2-7b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-7B-Instruct-GPTQ-Int4",
         "qwen2-7b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33325,7 +30754,6 @@
     {
       "name": "qwen/qwen2-7b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2-7B-Instruct-GPTQ-Int8",
         "qwen2-7b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -33336,7 +30764,6 @@
     {
       "name": "qwen/qwen2-7b-instruct-mlx",
       "alias": [
-        "Qwen/Qwen2-7B-Instruct-MLX",
         "qwen2-7b-instruct-mlx"
       ],
       "model_types": [
@@ -33347,7 +30774,6 @@
     {
       "name": "qwen/qwen2-audio-7b",
       "alias": [
-        "Qwen/Qwen2-Audio-7B",
         "qwen2-audio-7b"
       ],
       "model_types": [
@@ -33360,9 +30786,7 @@
     {
       "name": "qwen/qwen2-audio-7b-instruct",
       "alias": [
-        "Qwen/Qwen2-Audio-7B-Instruct",
-        "qwen2-audio-7b-instruct",
-        "Qwen2-Audio-7B-Instruct"
+        "qwen2-audio-7b-instruct"
       ],
       "model_types": [
         "chat",
@@ -33375,7 +30799,6 @@
     {
       "name": "qwen/qwen2-math-1.5b",
       "alias": [
-        "Qwen/Qwen2-Math-1.5B",
         "qwen2-math-1.5b"
       ],
       "model_types": [
@@ -33386,7 +30809,6 @@
     {
       "name": "qwen/qwen2-math-1.5b-instruct",
       "alias": [
-        "Qwen/Qwen2-Math-1.5B-Instruct",
         "qwen2-math-1.5b-instruct"
       ],
       "model_types": [
@@ -33397,7 +30819,6 @@
     {
       "name": "qwen/qwen2-math-72b",
       "alias": [
-        "Qwen/Qwen2-Math-72B",
         "qwen2-math-72b"
       ],
       "model_types": [
@@ -33408,7 +30829,6 @@
     {
       "name": "qwen/qwen2-math-72b-instruct",
       "alias": [
-        "Qwen/Qwen2-Math-72B-Instruct",
         "qwen2-math-72b-instruct"
       ],
       "model_types": [
@@ -33419,7 +30839,6 @@
     {
       "name": "qwen/qwen2-math-7b",
       "alias": [
-        "Qwen/Qwen2-Math-7B",
         "qwen2-math-7b"
       ],
       "model_types": [
@@ -33430,7 +30849,6 @@
     {
       "name": "qwen/qwen2-math-7b-instruct",
       "alias": [
-        "Qwen/Qwen2-Math-7B-Instruct",
         "qwen2-math-7b-instruct"
       ],
       "model_types": [
@@ -33441,7 +30859,6 @@
     {
       "name": "qwen/qwen2-math-rm-72b",
       "alias": [
-        "Qwen/Qwen2-Math-RM-72B",
         "qwen2-math-rm-72b"
       ],
       "model_types": [
@@ -33452,7 +30869,6 @@
     {
       "name": "qwen/qwen2-vl-2b",
       "alias": [
-        "Qwen/Qwen2-VL-2B",
         "qwen2-vl-2b"
       ],
       "model_types": [
@@ -33463,7 +30879,6 @@
     {
       "name": "qwen/qwen2-vl-2b-instruct",
       "alias": [
-        "Qwen/Qwen2-VL-2B-Instruct",
         "qwen2-vl-2b-instruct"
       ],
       "model_types": [
@@ -33474,7 +30889,6 @@
     {
       "name": "qwen/qwen2-vl-2b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2-VL-2B-Instruct-AWQ",
         "qwen2-vl-2b-instruct-awq"
       ],
       "model_types": [
@@ -33485,7 +30899,6 @@
     {
       "name": "qwen/qwen2-vl-2b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-VL-2B-Instruct-GPTQ-Int4",
         "qwen2-vl-2b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33496,7 +30909,6 @@
     {
       "name": "qwen/qwen2-vl-2b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2-VL-2B-Instruct-GPTQ-Int8",
         "qwen2-vl-2b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -33507,7 +30919,6 @@
     {
       "name": "qwen/qwen2-vl-72b",
       "alias": [
-        "Qwen/Qwen2-VL-72B",
         "qwen2-vl-72b"
       ],
       "model_types": [
@@ -33518,7 +30929,6 @@
     {
       "name": "qwen/qwen2-vl-72b-instruct",
       "alias": [
-        "Qwen/Qwen2-VL-72B-Instruct",
         "qwen2-vl-72b-instruct",
         "qwen/qwen-2-vl-72b-instruct",
         "qwen-2-vl-72b-instruct",
@@ -33536,7 +30946,6 @@
     {
       "name": "qwen/qwen2-vl-72b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2-VL-72B-Instruct-AWQ",
         "qwen2-vl-72b-instruct-awq"
       ],
       "model_types": [
@@ -33547,7 +30956,6 @@
     {
       "name": "qwen/qwen2-vl-72b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-VL-72B-Instruct-GPTQ-Int4",
         "qwen2-vl-72b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33558,7 +30966,6 @@
     {
       "name": "qwen/qwen2-vl-72b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2-VL-72B-Instruct-GPTQ-Int8",
         "qwen2-vl-72b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -33569,7 +30976,6 @@
     {
       "name": "qwen/qwen2-vl-7b",
       "alias": [
-        "Qwen/Qwen2-VL-7B",
         "qwen2-vl-7b"
       ],
       "model_types": [
@@ -33580,7 +30986,6 @@
     {
       "name": "qwen/qwen2-vl-7b-instruct",
       "alias": [
-        "Qwen/Qwen2-VL-7B-Instruct",
         "qwen2-vl-7b-instruct"
       ],
       "model_types": [
@@ -33591,7 +30996,6 @@
     {
       "name": "qwen/qwen2-vl-7b-instruct-awq",
       "alias": [
-        "Qwen/Qwen2-VL-7B-Instruct-AWQ",
         "qwen2-vl-7b-instruct-awq"
       ],
       "model_types": [
@@ -33602,7 +31006,6 @@
     {
       "name": "qwen/qwen2-vl-7b-instruct-gptq-int4",
       "alias": [
-        "Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int4",
         "qwen2-vl-7b-instruct-gptq-int4"
       ],
       "model_types": [
@@ -33613,7 +31016,6 @@
     {
       "name": "qwen/qwen2-vl-7b-instruct-gptq-int8",
       "alias": [
-        "Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int8",
         "qwen2-vl-7b-instruct-gptq-int8"
       ],
       "model_types": [
@@ -33624,7 +31026,6 @@
     {
       "name": "qwen/qwen1.5-0.5b",
       "alias": [
-        "Qwen/Qwen1.5-0.5B",
         "qwen1.5-0.5b"
       ],
       "model_types": [
@@ -33635,7 +31036,6 @@
     {
       "name": "qwen/qwen1.5-0.5b-chat",
       "alias": [
-        "Qwen/Qwen1.5-0.5B-Chat",
         "qwen1.5-0.5b-chat"
       ],
       "model_types": [
@@ -33646,7 +31046,6 @@
     {
       "name": "qwen/qwen1.5-0.5b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-0.5B-Chat-AWQ",
         "qwen1.5-0.5b-chat-awq"
       ],
       "model_types": [
@@ -33657,7 +31056,6 @@
     {
       "name": "qwen/qwen1.5-0.5b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-0.5B-Chat-GGUF",
         "qwen1.5-0.5b-chat-gguf"
       ],
       "model_types": [
@@ -33667,7 +31065,6 @@
     {
       "name": "qwen/qwen1.5-0.5b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-0.5B-Chat-GPTQ-Int4",
         "qwen1.5-0.5b-chat-gptq-int4"
       ],
       "model_types": [
@@ -33678,7 +31075,6 @@
     {
       "name": "qwen/qwen1.5-0.5b-chat-gptq-int8",
       "alias": [
-        "Qwen/Qwen1.5-0.5B-Chat-GPTQ-Int8",
         "qwen1.5-0.5b-chat-gptq-int8"
       ],
       "model_types": [
@@ -33689,7 +31085,6 @@
     {
       "name": "qwen/qwen1.5-1.8b",
       "alias": [
-        "Qwen/Qwen1.5-1.8B",
         "qwen1.5-1.8b"
       ],
       "model_types": [
@@ -33700,7 +31095,6 @@
     {
       "name": "qwen/qwen1.5-1.8b-chat",
       "alias": [
-        "Qwen/Qwen1.5-1.8B-Chat",
         "qwen1.5-1.8b-chat"
       ],
       "model_types": [
@@ -33711,7 +31105,6 @@
     {
       "name": "qwen/qwen1.5-1.8b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-1.8B-Chat-AWQ",
         "qwen1.5-1.8b-chat-awq"
       ],
       "model_types": [
@@ -33722,7 +31115,6 @@
     {
       "name": "qwen/qwen1.5-1.8b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-1.8B-Chat-GGUF",
         "qwen1.5-1.8b-chat-gguf"
       ],
       "model_types": [
@@ -33732,7 +31124,6 @@
     {
       "name": "qwen/qwen1.5-1.8b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-1.8B-Chat-GPTQ-Int4",
         "qwen1.5-1.8b-chat-gptq-int4"
       ],
       "model_types": [
@@ -33743,7 +31134,6 @@
     {
       "name": "qwen/qwen1.5-1.8b-chat-gptq-int8",
       "alias": [
-        "Qwen/Qwen1.5-1.8B-Chat-GPTQ-Int8",
         "qwen1.5-1.8b-chat-gptq-int8"
       ],
       "model_types": [
@@ -33754,7 +31144,6 @@
     {
       "name": "qwen/qwen1.5-110b",
       "alias": [
-        "Qwen/Qwen1.5-110B",
         "qwen1.5-110b"
       ],
       "model_types": [
@@ -33765,7 +31154,6 @@
     {
       "name": "qwen/qwen1.5-110b-chat",
       "alias": [
-        "Qwen/Qwen1.5-110B-Chat",
         "qwen1.5-110b-chat"
       ],
       "model_types": [
@@ -33776,7 +31164,6 @@
     {
       "name": "qwen/qwen1.5-110b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-110B-Chat-AWQ",
         "qwen1.5-110b-chat-awq"
       ],
       "model_types": [
@@ -33787,7 +31174,6 @@
     {
       "name": "qwen/qwen1.5-110b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-110B-Chat-GGUF",
         "qwen1.5-110b-chat-gguf"
       ],
       "model_types": [
@@ -33797,7 +31183,6 @@
     {
       "name": "qwen/qwen1.5-110b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-110B-Chat-GPTQ-Int4",
         "qwen1.5-110b-chat-gptq-int4"
       ],
       "model_types": [
@@ -33808,7 +31193,6 @@
     {
       "name": "qwen/qwen1.5-14b",
       "alias": [
-        "Qwen/Qwen1.5-14B",
         "qwen1.5-14b"
       ],
       "model_types": [
@@ -33819,7 +31203,6 @@
     {
       "name": "qwen/qwen1.5-14b-chat",
       "alias": [
-        "Qwen/Qwen1.5-14B-Chat",
         "qwen1.5-14b-chat"
       ],
       "model_types": [
@@ -33830,7 +31213,6 @@
     {
       "name": "qwen/qwen1.5-14b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-14B-Chat-AWQ",
         "qwen1.5-14b-chat-awq"
       ],
       "model_types": [
@@ -33841,7 +31223,6 @@
     {
       "name": "qwen/qwen1.5-14b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-14B-Chat-GGUF",
         "qwen1.5-14b-chat-gguf"
       ],
       "model_types": [
@@ -33851,7 +31232,6 @@
     {
       "name": "qwen/qwen1.5-14b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-14B-Chat-GPTQ-Int4",
         "qwen1.5-14b-chat-gptq-int4"
       ],
       "model_types": [
@@ -33862,7 +31242,6 @@
     {
       "name": "qwen/qwen1.5-14b-chat-gptq-int8",
       "alias": [
-        "Qwen/Qwen1.5-14B-Chat-GPTQ-Int8",
         "qwen1.5-14b-chat-gptq-int8"
       ],
       "model_types": [
@@ -33873,7 +31252,6 @@
     {
       "name": "qwen/qwen1.5-32b",
       "alias": [
-        "Qwen/Qwen1.5-32B",
         "qwen1.5-32b"
       ],
       "model_types": [
@@ -33884,7 +31262,6 @@
     {
       "name": "qwen/qwen1.5-32b-chat",
       "alias": [
-        "Qwen/Qwen1.5-32B-Chat",
         "qwen1.5-32b-chat"
       ],
       "model_types": [
@@ -33895,7 +31272,6 @@
     {
       "name": "qwen/qwen1.5-32b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-32B-Chat-AWQ",
         "qwen1.5-32b-chat-awq"
       ],
       "model_types": [
@@ -33906,7 +31282,6 @@
     {
       "name": "qwen/qwen1.5-32b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-32B-Chat-GGUF",
         "qwen1.5-32b-chat-gguf"
       ],
       "model_types": [
@@ -33916,7 +31291,6 @@
     {
       "name": "qwen/qwen1.5-32b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-32B-Chat-GPTQ-Int4",
         "qwen1.5-32b-chat-gptq-int4"
       ],
       "model_types": [
@@ -33927,7 +31301,6 @@
     {
       "name": "qwen/qwen1.5-4b",
       "alias": [
-        "Qwen/Qwen1.5-4B",
         "qwen1.5-4b"
       ],
       "model_types": [
@@ -33938,7 +31311,6 @@
     {
       "name": "qwen/qwen1.5-4b-chat",
       "alias": [
-        "Qwen/Qwen1.5-4B-Chat",
         "qwen1.5-4b-chat"
       ],
       "model_types": [
@@ -33949,7 +31321,6 @@
     {
       "name": "qwen/qwen1.5-4b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-4B-Chat-AWQ",
         "qwen1.5-4b-chat-awq"
       ],
       "model_types": [
@@ -33960,7 +31331,6 @@
     {
       "name": "qwen/qwen1.5-4b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-4B-Chat-GGUF",
         "qwen1.5-4b-chat-gguf"
       ],
       "model_types": [
@@ -33970,7 +31340,6 @@
     {
       "name": "qwen/qwen1.5-4b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-4B-Chat-GPTQ-Int4",
         "qwen1.5-4b-chat-gptq-int4"
       ],
       "model_types": [
@@ -33981,7 +31350,6 @@
     {
       "name": "qwen/qwen1.5-4b-chat-gptq-int8",
       "alias": [
-        "Qwen/Qwen1.5-4B-Chat-GPTQ-Int8",
         "qwen1.5-4b-chat-gptq-int8"
       ],
       "model_types": [
@@ -33992,7 +31360,6 @@
     {
       "name": "qwen/qwen1.5-72b",
       "alias": [
-        "Qwen/Qwen1.5-72B",
         "qwen1.5-72b"
       ],
       "model_types": [
@@ -34003,7 +31370,6 @@
     {
       "name": "qwen/qwen1.5-72b-chat",
       "alias": [
-        "Qwen/Qwen1.5-72B-Chat",
         "qwen1.5-72b-chat"
       ],
       "model_types": [
@@ -34014,7 +31380,6 @@
     {
       "name": "qwen/qwen1.5-72b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-72B-Chat-AWQ",
         "qwen1.5-72b-chat-awq"
       ],
       "model_types": [
@@ -34025,7 +31390,6 @@
     {
       "name": "qwen/qwen1.5-72b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-72B-Chat-GGUF",
         "qwen1.5-72b-chat-gguf"
       ],
       "model_types": [
@@ -34035,7 +31399,6 @@
     {
       "name": "qwen/qwen1.5-72b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-72B-Chat-GPTQ-Int4",
         "qwen1.5-72b-chat-gptq-int4"
       ],
       "model_types": [
@@ -34046,7 +31409,6 @@
     {
       "name": "qwen/qwen1.5-72b-chat-gptq-int8",
       "alias": [
-        "Qwen/Qwen1.5-72B-Chat-GPTQ-Int8",
         "qwen1.5-72b-chat-gptq-int8"
       ],
       "model_types": [
@@ -34057,7 +31419,6 @@
     {
       "name": "qwen/qwen1.5-7b",
       "alias": [
-        "Qwen/Qwen1.5-7B",
         "qwen1.5-7b"
       ],
       "model_types": [
@@ -34068,7 +31429,6 @@
     {
       "name": "qwen/qwen1.5-7b-chat",
       "alias": [
-        "Qwen/Qwen1.5-7B-Chat",
         "qwen1.5-7b-chat"
       ],
       "model_types": [
@@ -34079,7 +31439,6 @@
     {
       "name": "qwen/qwen1.5-7b-chat-awq",
       "alias": [
-        "Qwen/Qwen1.5-7B-Chat-AWQ",
         "qwen1.5-7b-chat-awq"
       ],
       "model_types": [
@@ -34090,7 +31449,6 @@
     {
       "name": "qwen/qwen1.5-7b-chat-gguf",
       "alias": [
-        "Qwen/Qwen1.5-7B-Chat-GGUF",
         "qwen1.5-7b-chat-gguf"
       ],
       "model_types": [
@@ -34100,7 +31458,6 @@
     {
       "name": "qwen/qwen1.5-7b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-7B-Chat-GPTQ-Int4",
         "qwen1.5-7b-chat-gptq-int4"
       ],
       "model_types": [
@@ -34111,7 +31468,6 @@
     {
       "name": "qwen/qwen1.5-7b-chat-gptq-int8",
       "alias": [
-        "Qwen/Qwen1.5-7B-Chat-GPTQ-Int8",
         "qwen1.5-7b-chat-gptq-int8"
       ],
       "model_types": [
@@ -34122,7 +31478,6 @@
     {
       "name": "qwen/qwen1.5-moe-a2.7b",
       "alias": [
-        "Qwen/Qwen1.5-MoE-A2.7B",
         "qwen1.5-moe-a2.7b"
       ],
       "model_types": [
@@ -34133,7 +31488,6 @@
     {
       "name": "qwen/qwen1.5-moe-a2.7b-chat",
       "alias": [
-        "Qwen/Qwen1.5-MoE-A2.7B-Chat",
         "qwen1.5-moe-a2.7b-chat"
       ],
       "model_types": [
@@ -34144,7 +31498,6 @@
     {
       "name": "qwen/qwen1.5-moe-a2.7b-chat-gptq-int4",
       "alias": [
-        "Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4",
         "qwen1.5-moe-a2.7b-chat-gptq-int4"
       ],
       "model_types": [
@@ -34798,7 +32151,6 @@
     {
       "name": "qwen/codeqwen1.5-7b",
       "alias": [
-        "Qwen/CodeQwen1.5-7B",
         "codeqwen1.5-7b"
       ],
       "model_types": [
@@ -34809,7 +32161,6 @@
     {
       "name": "qwen/codeqwen1.5-7b-awq",
       "alias": [
-        "Qwen/CodeQwen1.5-7B-AWQ",
         "codeqwen1.5-7b-awq"
       ],
       "model_types": [
@@ -34820,7 +32171,6 @@
     {
       "name": "qwen/codeqwen1.5-7b-chat",
       "alias": [
-        "Qwen/CodeQwen1.5-7B-Chat",
         "codeqwen1.5-7b-chat"
       ],
       "model_types": [
@@ -34831,7 +32181,6 @@
     {
       "name": "qwen/codeqwen1.5-7b-chat-awq",
       "alias": [
-        "Qwen/CodeQwen1.5-7B-Chat-AWQ",
         "codeqwen1.5-7b-chat-awq"
       ],
       "model_types": [
@@ -34842,7 +32191,6 @@
     {
       "name": "qwen/codeqwen1.5-7b-chat-gguf",
       "alias": [
-        "Qwen/CodeQwen1.5-7B-Chat-GGUF",
         "codeqwen1.5-7b-chat-gguf"
       ],
       "model_types": [
@@ -34852,7 +32200,6 @@
     {
       "name": "qwen/qvq-72b-preview",
       "alias": [
-        "Qwen/QVQ-72B-Preview",
         "qvq-72b-preview"
       ],
       "model_types": [
@@ -34865,7 +32212,6 @@
     {
       "name": "qwen/qwen-14b",
       "alias": [
-        "Qwen/Qwen-14B",
         "qwen-14b"
       ],
       "model_types": [
@@ -34876,7 +32222,6 @@
     {
       "name": "qwen/qwen-14b-chat",
       "alias": [
-        "Qwen/Qwen-14B-Chat",
         "qwen-14b-chat"
       ],
       "model_types": [
@@ -34887,7 +32232,6 @@
     {
       "name": "qwen/qwen-14b-chat-int4",
       "alias": [
-        "Qwen/Qwen-14B-Chat-Int4",
         "qwen-14b-chat-int4"
       ],
       "model_types": [
@@ -34898,7 +32242,6 @@
     {
       "name": "qwen/qwen-14b-chat-int8",
       "alias": [
-        "Qwen/Qwen-14B-Chat-Int8",
         "qwen-14b-chat-int8"
       ],
       "model_types": [
@@ -34909,7 +32252,6 @@
     {
       "name": "qwen/qwen-1_8b",
       "alias": [
-        "Qwen/Qwen-1_8B",
         "qwen-1_8b"
       ],
       "model_types": [
@@ -34920,7 +32262,6 @@
     {
       "name": "qwen/qwen-1_8b-chat-int4",
       "alias": [
-        "Qwen/Qwen-1_8B-Chat-Int4",
         "qwen-1_8b-chat-int4"
       ],
       "model_types": [
@@ -34931,7 +32272,6 @@
     {
       "name": "qwen/qwen-1_8b-chat-int8",
       "alias": [
-        "Qwen/Qwen-1_8B-Chat-Int8",
         "qwen-1_8b-chat-int8"
       ],
       "model_types": [
@@ -34942,7 +32282,6 @@
     {
       "name": "qwen/qwen-72b",
       "alias": [
-        "Qwen/Qwen-72B",
         "qwen-72b"
       ],
       "model_types": [
@@ -34953,7 +32292,6 @@
     {
       "name": "qwen/qwen-72b-chat",
       "alias": [
-        "Qwen/Qwen-72B-Chat",
         "qwen-72b-chat"
       ],
       "model_types": [
@@ -34964,7 +32302,6 @@
     {
       "name": "qwen/qwen-72b-chat-int4",
       "alias": [
-        "Qwen/Qwen-72B-Chat-Int4",
         "qwen-72b-chat-int4"
       ],
       "model_types": [
@@ -34975,7 +32312,6 @@
     {
       "name": "qwen/qwen-72b-chat-int8",
       "alias": [
-        "Qwen/Qwen-72B-Chat-Int8",
         "qwen-72b-chat-int8"
       ],
       "model_types": [
@@ -34986,7 +32322,6 @@
     {
       "name": "qwen/qwen-7b",
       "alias": [
-        "Qwen/Qwen-7B",
         "qwen-7b"
       ],
       "model_types": [
@@ -34997,7 +32332,6 @@
     {
       "name": "qwen/qwen-7b-chat",
       "alias": [
-        "Qwen/Qwen-7B-Chat",
         "qwen-7b-chat"
       ],
       "model_types": [
@@ -35008,7 +32342,6 @@
     {
       "name": "qwen/qwen-7b-chat-int4",
       "alias": [
-        "Qwen/Qwen-7B-Chat-Int4",
         "qwen-7b-chat-int4"
       ],
       "model_types": [
@@ -35019,7 +32352,6 @@
     {
       "name": "qwen/qwen-7b-chat-int8",
       "alias": [
-        "Qwen/Qwen-7B-Chat-Int8",
         "qwen-7b-chat-int8"
       ],
       "model_types": [
@@ -35030,7 +32362,6 @@
     {
       "name": "qwen/qwen-audio",
       "alias": [
-        "Qwen/Qwen-Audio",
         "qwen-audio"
       ],
       "model_types": [
@@ -35043,7 +32374,6 @@
     {
       "name": "qwen/qwen-audio-chat",
       "alias": [
-        "Qwen/Qwen-Audio-Chat",
         "qwen-audio-chat"
       ],
       "model_types": [
@@ -35115,7 +32445,6 @@
     {
       "name": "qwen/qwen-image",
       "alias": [
-        "Qwen/Qwen-Image",
         "qwen-image",
         "Qwen Image"
       ],
@@ -35165,7 +32494,6 @@
     {
       "name": "qwen/qwen-image-2512",
       "alias": [
-        "Qwen/Qwen-Image-2512",
         "qwen-image-2512"
       ],
       "model_types": [
@@ -35179,7 +32507,6 @@
     {
       "name": "qwen/qwen-image-bench",
       "alias": [
-        "Qwen/Qwen-Image-Bench",
         "qwen-image-bench"
       ],
       "model_types": [
@@ -35194,7 +32521,6 @@
     {
       "name": "qwen/qwen-image-edit",
       "alias": [
-        "Qwen/Qwen-Image-Edit",
         "qwen-image-edit"
       ],
       "model_types": [
@@ -35208,7 +32534,6 @@
     {
       "name": "qwen/qwen-image-edit-2509",
       "alias": [
-        "Qwen/Qwen-Image-Edit-2509",
         "qwen-image-edit-2509"
       ],
       "model_types": [
@@ -35221,7 +32546,6 @@
     {
       "name": "qwen/qwen-image-edit-2511",
       "alias": [
-        "Qwen/Qwen-Image-Edit-2511",
         "qwen-image-edit-2511"
       ],
       "model_types": [
@@ -35260,7 +32584,6 @@
     {
       "name": "qwen/qwen-image-layered",
       "alias": [
-        "Qwen/Qwen-Image-Layered",
         "qwen-image-layered"
       ],
       "model_types": [
@@ -35474,7 +32797,6 @@
     {
       "name": "qwen/qwen-tokenizer",
       "alias": [
-        "Qwen/Qwen-tokenizer",
         "qwen-tokenizer"
       ],
       "model_types": [
@@ -35518,7 +32840,6 @@
     {
       "name": "qwen/qwen-vl",
       "alias": [
-        "Qwen/Qwen-VL",
         "qwen-vl"
       ],
       "model_types": [
@@ -35529,7 +32850,6 @@
     {
       "name": "qwen/qwen-vl-chat",
       "alias": [
-        "Qwen/Qwen-VL-Chat",
         "qwen-vl-chat"
       ],
       "model_types": [
@@ -35540,7 +32860,6 @@
     {
       "name": "qwen/qwen-vl-chat-int4",
       "alias": [
-        "Qwen/Qwen-VL-Chat-Int4",
         "qwen-vl-chat-int4"
       ],
       "model_types": [
@@ -35589,9 +32908,7 @@
     {
       "name": "qwen/qwq-32b",
       "alias": [
-        "Qwen/QwQ-32B",
         "qwq-32b",
-        "QwQ-32B",
         "Qwen QwQ-32B"
       ],
       "model_types": [
@@ -35606,7 +32923,6 @@
     {
       "name": "qwen/qwq-32b-awq",
       "alias": [
-        "Qwen/QwQ-32B-AWQ",
         "qwq-32b-awq"
       ],
       "model_types": [
@@ -35621,7 +32937,6 @@
     {
       "name": "qwen/qwq-32b-gguf",
       "alias": [
-        "Qwen/QwQ-32B-GGUF",
         "qwq-32b-gguf"
       ],
       "model_types": [
@@ -35636,7 +32951,6 @@
     {
       "name": "qwen/qwq-32b-preview",
       "alias": [
-        "Qwen/QwQ-32B-Preview",
         "qwq-32b-preview"
       ],
       "model_types": [
@@ -35651,7 +32965,6 @@
     {
       "name": "qwen/sae-res-qwen3-1.7b-base-w32k-l0_100",
       "alias": [
-        "Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_100",
         "sae-res-qwen3-1.7b-base-w32k-l0_100"
       ],
       "model_types": [
@@ -35661,7 +32974,6 @@
     {
       "name": "qwen/sae-res-qwen3-1.7b-base-w32k-l0_50",
       "alias": [
-        "Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50",
         "sae-res-qwen3-1.7b-base-w32k-l0_50"
       ],
       "model_types": [
@@ -35671,7 +32983,6 @@
     {
       "name": "qwen/sae-res-qwen3-30b-a3b-base-w128k-l0_100",
       "alias": [
-        "Qwen/SAE-Res-Qwen3-30B-A3B-Base-W128K-L0_100",
         "sae-res-qwen3-30b-a3b-base-w128k-l0_100"
       ],
       "model_types": [
@@ -35681,7 +32992,6 @@
     {
       "name": "qwen/sae-res-qwen3-30b-a3b-base-w32k-l0_50",
       "alias": [
-        "Qwen/SAE-Res-Qwen3-30B-A3B-Base-W32K-L0_50",
         "sae-res-qwen3-30b-a3b-base-w32k-l0_50"
       ],
       "model_types": [
@@ -35691,7 +33001,6 @@
     {
       "name": "qwen/sae-res-qwen3-8b-base-w64k-l0_100",
       "alias": [
-        "Qwen/SAE-Res-Qwen3-8B-Base-W64K-L0_100",
         "sae-res-qwen3-8b-base-w64k-l0_100"
       ],
       "model_types": [
@@ -35701,7 +33010,6 @@
     {
       "name": "qwen/sae-res-qwen3-8b-base-w64k-l0_50",
       "alias": [
-        "Qwen/SAE-Res-Qwen3-8B-Base-W64K-L0_50",
         "sae-res-qwen3-8b-base-w64k-l0_50"
       ],
       "model_types": [
@@ -35711,7 +33019,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-27b-w80k-l0_100",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
         "sae-res-qwen3.5-27b-w80k-l0_100"
       ],
       "model_types": [
@@ -35721,7 +33028,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-27b-w80k-l0_50",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
         "sae-res-qwen3.5-27b-w80k-l0_50"
       ],
       "model_types": [
@@ -35731,7 +33037,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-2b-base-w32k-l0_100",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-2B-Base-W32K-L0_100",
         "sae-res-qwen3.5-2b-base-w32k-l0_100"
       ],
       "model_types": [
@@ -35741,7 +33046,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-2b-base-w32k-l0_50",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-2B-Base-W32K-L0_50",
         "sae-res-qwen3.5-2b-base-w32k-l0_50"
       ],
       "model_types": [
@@ -35751,7 +33055,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-35b-a3b-base-w128k-l0_100",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-35B-A3B-Base-W128K-L0_100",
         "sae-res-qwen3.5-35b-a3b-base-w128k-l0_100"
       ],
       "model_types": [
@@ -35761,7 +33064,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-35b-a3b-base-w32k-l0_50",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-35B-A3B-Base-W32K-L0_50",
         "sae-res-qwen3.5-35b-a3b-base-w32k-l0_50"
       ],
       "model_types": [
@@ -35771,7 +33073,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-9b-base-w64k-l0_100",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-9B-Base-W64K-L0_100",
         "sae-res-qwen3.5-9b-base-w64k-l0_100"
       ],
       "model_types": [
@@ -35781,7 +33082,6 @@
     {
       "name": "qwen/sae-res-qwen3.5-9b-base-w64k-l0_50",
       "alias": [
-        "Qwen/SAE-Res-Qwen3.5-9B-Base-W64K-L0_50",
         "sae-res-qwen3.5-9b-base-w64k-l0_50"
       ],
       "model_types": [
@@ -35791,7 +33091,6 @@
     {
       "name": "qwen/webworld-14b",
       "alias": [
-        "Qwen/WebWorld-14B",
         "webworld-14b"
       ],
       "model_types": [
@@ -35802,7 +33101,6 @@
     {
       "name": "qwen/webworld-32b",
       "alias": [
-        "Qwen/WebWorld-32B",
         "webworld-32b"
       ],
       "model_types": [
@@ -35813,7 +33111,6 @@
     {
       "name": "qwen/webworld-8b",
       "alias": [
-        "Qwen/WebWorld-8B",
         "webworld-8b"
       ],
       "model_types": [
@@ -35824,7 +33121,6 @@
     {
       "name": "qwen/worldpm-72b",
       "alias": [
-        "Qwen/WorldPM-72B",
         "worldpm-72b"
       ],
       "model_types": [
@@ -35835,7 +33131,6 @@
     {
       "name": "qwen/worldpm-72b-helpsteer2",
       "alias": [
-        "Qwen/WorldPM-72B-HelpSteer2",
         "worldpm-72b-helpsteer2"
       ],
       "model_types": [
@@ -35846,7 +33141,6 @@
     {
       "name": "qwen/worldpm-72b-rlhflow",
       "alias": [
-        "Qwen/WorldPM-72B-RLHFLow",
         "worldpm-72b-rlhflow"
       ],
       "model_types": [
@@ -35856,7 +33150,6 @@
     {
       "name": "qwen/worldpm-72b-ultrafeedback",
       "alias": [
-        "Qwen/WorldPM-72B-UltraFeedback",
         "worldpm-72b-ultrafeedback"
       ],
       "model_types": [
@@ -36395,8 +33688,7 @@
       "name": "sao10k/l3-70b-euryale-v2.1",
       "alias": [
         "L3-70B-Euryale-v2.1",
-        "L3 70B Euryale V2.1",
-        "Sao10K/L3-70B-Euryale-v2.1"
+        "L3 70B Euryale V2.1"
       ],
       "model_types": [
         "chat"
@@ -36729,7 +34021,6 @@
     {
       "name": "shengshu-ai/viduq3",
       "alias": [
-        "viduq3",
         "vidu-q3"
       ],
       "model_types": [
@@ -36739,7 +34030,6 @@
     {
       "name": "shengshu-ai/viduq3-turbo",
       "alias": [
-        "viduq3-turbo",
         "vidu-q3-turbo"
       ],
       "model_types": [
@@ -36796,9 +34086,7 @@
       "model_types": [
         "chat"
       ],
-      "alias": [
-        "perplexity/sonar"
-      ]
+      "alias": []
     },
     {
       "name": "sonar-deep-research",
@@ -37260,7 +34548,6 @@
         "video_generation"
       ],
       "alias": [
-        "openai/sora-2",
         "Sora 2"
       ]
     },
@@ -37389,7 +34676,6 @@
     {
       "name": "stability-ai/stable-diffusion-xl-v1",
       "alias": [
-        "stability.stable-diffusion-xl-v1",
         "1024-x-1024/50-steps/stability.stable-diffusion-xl-v1"
       ],
       "model_types": [
@@ -37455,9 +34741,7 @@
     },
     {
       "name": "stability.stable-diffusion-xl-v1",
-      "alias": [
-        "1024-x-1024/50-steps/stability.stable-diffusion-xl-v1"
-      ],
+      "alias": [],
       "max_tokens": 77,
       "model_types": [
         "image_generation"
@@ -37922,9 +35206,7 @@
     },
     {
       "name": "stepfun-ai/step-audio-tts-3b",
-      "alias": [
-        "step-audio-tts-3b"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
@@ -38174,9 +35456,7 @@
     {
       "name": "tencent/DeepSeek-V3.1-Terminus-W4AFP8",
       "alias": [
-        "tencent/deepseek-v3.1-terminus-w4afp8",
-        "DeepSeek-V3.1-Terminus-W4AFP8",
-        "deepseek-v3.1-terminus-w4afp8"
+        "DeepSeek-V3.1-Terminus-W4AFP8"
       ],
       "model_types": [
         "chat"
@@ -38190,9 +35470,7 @@
     {
       "name": "tencent/Covo-Audio-Chat",
       "alias": [
-        "tencent/covo-audio-chat",
-        "Covo-Audio-Chat",
-        "covo-audio-chat"
+        "Covo-Audio-Chat"
       ],
       "model_types": [
         "chat",
@@ -38205,9 +35483,7 @@
     {
       "name": "tencent/DepthCrafter",
       "alias": [
-        "tencent/depthcrafter",
-        "DepthCrafter",
-        "depthcrafter"
+        "DepthCrafter"
       ],
       "model_types": [
         "depth_estimation"
@@ -38216,9 +35492,7 @@
     {
       "name": "tencent/DisCa",
       "alias": [
-        "tencent/disca",
-        "DisCa",
-        "disca"
+        "DisCa"
       ],
       "model_types": [
         "other"
@@ -38227,9 +35501,7 @@
     {
       "name": "tencent/DOGR",
       "alias": [
-        "tencent/dogr",
-        "DOGR",
-        "dogr"
+        "DOGR"
       ],
       "model_types": [
         "chat"
@@ -38239,9 +35511,7 @@
     {
       "name": "tencent/DRIVE-RL",
       "alias": [
-        "tencent/drive-rl",
-        "DRIVE-RL",
-        "drive-rl"
+        "DRIVE-RL"
       ],
       "model_types": [
         "chat"
@@ -38255,9 +35525,7 @@
     {
       "name": "tencent/DRIVE-SFT",
       "alias": [
-        "tencent/drive-sft",
-        "DRIVE-SFT",
-        "drive-sft"
+        "DRIVE-SFT"
       ],
       "model_types": [
         "chat"
@@ -38276,9 +35544,7 @@
     {
       "name": "tencent/Hunyuan-0.5B-Instruct",
       "alias": [
-        "tencent/hunyuan-0.5b-instruct",
-        "Hunyuan-0.5B-Instruct",
-        "hunyuan-0.5b-instruct"
+        "Hunyuan-0.5B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -38288,9 +35554,7 @@
     {
       "name": "tencent/Hunyuan-0.5B-Instruct-AWQ-Int4",
       "alias": [
-        "tencent/hunyuan-0.5b-instruct-awq-int4",
-        "Hunyuan-0.5B-Instruct-AWQ-Int4",
-        "hunyuan-0.5b-instruct-awq-int4"
+        "Hunyuan-0.5B-Instruct-AWQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38300,9 +35564,7 @@
     {
       "name": "tencent/Hunyuan-0.5B-Instruct-FP8",
       "alias": [
-        "tencent/hunyuan-0.5b-instruct-fp8",
-        "Hunyuan-0.5B-Instruct-FP8",
-        "hunyuan-0.5b-instruct-fp8"
+        "Hunyuan-0.5B-Instruct-FP8"
       ],
       "model_types": [
         "chat"
@@ -38312,9 +35574,7 @@
     {
       "name": "tencent/Hunyuan-0.5B-Instruct-GPTQ-Int4",
       "alias": [
-        "tencent/hunyuan-0.5b-instruct-gptq-int4",
-        "Hunyuan-0.5B-Instruct-GPTQ-Int4",
-        "hunyuan-0.5b-instruct-gptq-int4"
+        "Hunyuan-0.5B-Instruct-GPTQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38324,9 +35584,7 @@
     {
       "name": "tencent/Hunyuan-0.5B-Pretrain",
       "alias": [
-        "tencent/hunyuan-0.5b-pretrain",
-        "Hunyuan-0.5B-Pretrain",
-        "hunyuan-0.5b-pretrain"
+        "Hunyuan-0.5B-Pretrain"
       ],
       "model_types": [
         "chat"
@@ -38336,9 +35594,7 @@
     {
       "name": "tencent/Hunyuan-1.8B-Instruct",
       "alias": [
-        "tencent/hunyuan-1.8b-instruct",
-        "Hunyuan-1.8B-Instruct",
-        "hunyuan-1.8b-instruct"
+        "Hunyuan-1.8B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -38348,9 +35604,7 @@
     {
       "name": "tencent/Hunyuan-1.8B-Instruct-AWQ-Int4",
       "alias": [
-        "tencent/hunyuan-1.8b-instruct-awq-int4",
-        "Hunyuan-1.8B-Instruct-AWQ-Int4",
-        "hunyuan-1.8b-instruct-awq-int4"
+        "Hunyuan-1.8B-Instruct-AWQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38360,9 +35614,7 @@
     {
       "name": "tencent/Hunyuan-1.8B-Instruct-FP8",
       "alias": [
-        "tencent/hunyuan-1.8b-instruct-fp8",
-        "Hunyuan-1.8B-Instruct-FP8",
-        "hunyuan-1.8b-instruct-fp8"
+        "Hunyuan-1.8B-Instruct-FP8"
       ],
       "model_types": [
         "chat"
@@ -38372,9 +35624,7 @@
     {
       "name": "tencent/Hunyuan-1.8B-Instruct-GPTQ-Int4",
       "alias": [
-        "tencent/hunyuan-1.8b-instruct-gptq-int4",
-        "Hunyuan-1.8B-Instruct-GPTQ-Int4",
-        "hunyuan-1.8b-instruct-gptq-int4"
+        "Hunyuan-1.8B-Instruct-GPTQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38384,9 +35634,7 @@
     {
       "name": "tencent/Hunyuan-1.8B-Pretrain",
       "alias": [
-        "tencent/hunyuan-1.8b-pretrain",
-        "Hunyuan-1.8B-Pretrain",
-        "hunyuan-1.8b-pretrain"
+        "Hunyuan-1.8B-Pretrain"
       ],
       "model_types": [
         "chat"
@@ -38396,9 +35644,7 @@
     {
       "name": "tencent/Hunyuan-4B-Instruct",
       "alias": [
-        "tencent/hunyuan-4b-instruct",
-        "Hunyuan-4B-Instruct",
-        "hunyuan-4b-instruct"
+        "Hunyuan-4B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -38408,9 +35654,7 @@
     {
       "name": "tencent/Hunyuan-4B-Instruct-AWQ-Int4",
       "alias": [
-        "tencent/hunyuan-4b-instruct-awq-int4",
-        "Hunyuan-4B-Instruct-AWQ-Int4",
-        "hunyuan-4b-instruct-awq-int4"
+        "Hunyuan-4B-Instruct-AWQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38420,9 +35664,7 @@
     {
       "name": "tencent/Hunyuan-4B-Instruct-FP8",
       "alias": [
-        "tencent/hunyuan-4b-instruct-fp8",
-        "Hunyuan-4B-Instruct-FP8",
-        "hunyuan-4b-instruct-fp8"
+        "Hunyuan-4B-Instruct-FP8"
       ],
       "model_types": [
         "chat"
@@ -38432,9 +35674,7 @@
     {
       "name": "tencent/Hunyuan-4B-Instruct-GPTQ-Int4",
       "alias": [
-        "tencent/hunyuan-4b-instruct-gptq-int4",
-        "Hunyuan-4B-Instruct-GPTQ-Int4",
-        "hunyuan-4b-instruct-gptq-int4"
+        "Hunyuan-4B-Instruct-GPTQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38444,9 +35684,7 @@
     {
       "name": "tencent/Hunyuan-4B-Pretrain",
       "alias": [
-        "tencent/hunyuan-4b-pretrain",
-        "Hunyuan-4B-Pretrain",
-        "hunyuan-4b-pretrain"
+        "Hunyuan-4B-Pretrain"
       ],
       "model_types": [
         "chat"
@@ -38456,9 +35694,7 @@
     {
       "name": "tencent/Hunyuan-7B-Instruct",
       "alias": [
-        "tencent/hunyuan-7b-instruct",
-        "Hunyuan-7B-Instruct",
-        "hunyuan-7b-instruct"
+        "Hunyuan-7B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -38468,9 +35704,7 @@
     {
       "name": "tencent/Hunyuan-7B-Instruct-0124",
       "alias": [
-        "tencent/hunyuan-7b-instruct-0124",
-        "Hunyuan-7B-Instruct-0124",
-        "hunyuan-7b-instruct-0124"
+        "Hunyuan-7B-Instruct-0124"
       ],
       "model_types": [
         "chat"
@@ -38480,9 +35714,7 @@
     {
       "name": "tencent/Hunyuan-7B-Instruct-AWQ-Int4",
       "alias": [
-        "tencent/hunyuan-7b-instruct-awq-int4",
-        "Hunyuan-7B-Instruct-AWQ-Int4",
-        "hunyuan-7b-instruct-awq-int4"
+        "Hunyuan-7B-Instruct-AWQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38492,9 +35724,7 @@
     {
       "name": "tencent/Hunyuan-7B-Instruct-FP8",
       "alias": [
-        "tencent/hunyuan-7b-instruct-fp8",
-        "Hunyuan-7B-Instruct-FP8",
-        "hunyuan-7b-instruct-fp8"
+        "Hunyuan-7B-Instruct-FP8"
       ],
       "model_types": [
         "chat"
@@ -38504,9 +35734,7 @@
     {
       "name": "tencent/Hunyuan-7B-Instruct-GPTQ-Int4",
       "alias": [
-        "tencent/hunyuan-7b-instruct-gptq-int4",
-        "Hunyuan-7B-Instruct-GPTQ-Int4",
-        "hunyuan-7b-instruct-gptq-int4"
+        "Hunyuan-7B-Instruct-GPTQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38516,9 +35744,7 @@
     {
       "name": "tencent/Hunyuan-7B-Pretrain",
       "alias": [
-        "tencent/hunyuan-7b-pretrain",
-        "Hunyuan-7B-Pretrain",
-        "hunyuan-7b-pretrain"
+        "Hunyuan-7B-Pretrain"
       ],
       "model_types": [
         "chat"
@@ -38528,9 +35754,7 @@
     {
       "name": "tencent/Hunyuan-7B-Pretrain-0124",
       "alias": [
-        "tencent/hunyuan-7b-pretrain-0124",
-        "Hunyuan-7B-Pretrain-0124",
-        "hunyuan-7b-pretrain-0124"
+        "Hunyuan-7B-Pretrain-0124"
       ],
       "model_types": [
         "chat"
@@ -38540,9 +35764,7 @@
     {
       "name": "tencent/Hunyuan-A13B-Instruct",
       "alias": [
-        "tencent/hunyuan-a13b-instruct",
-        "Hunyuan-A13B-Instruct",
-        "hunyuan-a13b-instruct"
+        "Hunyuan-A13B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -38552,9 +35774,7 @@
     {
       "name": "tencent/Hunyuan-A13B-Instruct-FP8",
       "alias": [
-        "tencent/hunyuan-a13b-instruct-fp8",
-        "Hunyuan-A13B-Instruct-FP8",
-        "hunyuan-a13b-instruct-fp8"
+        "Hunyuan-A13B-Instruct-FP8"
       ],
       "model_types": [
         "chat"
@@ -38564,9 +35784,7 @@
     {
       "name": "tencent/Hunyuan-A13B-Instruct-GGUF",
       "alias": [
-        "tencent/hunyuan-a13b-instruct-gguf",
-        "Hunyuan-A13B-Instruct-GGUF",
-        "hunyuan-a13b-instruct-gguf"
+        "Hunyuan-A13B-Instruct-GGUF"
       ],
       "model_types": [
         "chat"
@@ -38576,9 +35794,7 @@
     {
       "name": "tencent/Hunyuan-A13B-Instruct-GPTQ-Int4",
       "alias": [
-        "tencent/hunyuan-a13b-instruct-gptq-int4",
-        "Hunyuan-A13B-Instruct-GPTQ-Int4",
-        "hunyuan-a13b-instruct-gptq-int4"
+        "Hunyuan-A13B-Instruct-GPTQ-Int4"
       ],
       "model_types": [
         "chat"
@@ -38588,9 +35804,7 @@
     {
       "name": "tencent/Hunyuan-A13B-Pretrain",
       "alias": [
-        "tencent/hunyuan-a13b-pretrain",
-        "Hunyuan-A13B-Pretrain",
-        "hunyuan-a13b-pretrain"
+        "Hunyuan-A13B-Pretrain"
       ],
       "model_types": [
         "chat"
@@ -38599,9 +35813,7 @@
     },
     {
       "name": "tencent/hunyuan-code",
-      "alias": [
-        "hunyuan-code"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
@@ -38609,9 +35821,7 @@
     {
       "name": "tencent/Hunyuan-GameCraft-1.0",
       "alias": [
-        "tencent/hunyuan-gamecraft-1.0",
-        "Hunyuan-GameCraft-1.0",
-        "hunyuan-gamecraft-1.0"
+        "Hunyuan-GameCraft-1.0"
       ],
       "model_types": [
         "video_generation"
@@ -38629,9 +35839,7 @@
     {
       "name": "tencent/Hunyuan-MT-7B",
       "alias": [
-        "tencent/hunyuan-mt-7b",
-        "Hunyuan-MT-7B",
-        "hunyuan-mt-7b"
+        "Hunyuan-MT-7B"
       ],
       "model_types": [
         "chat",
@@ -38642,9 +35850,7 @@
     {
       "name": "tencent/Hunyuan-MT-7B-fp8",
       "alias": [
-        "tencent/hunyuan-mt-7b-fp8",
-        "Hunyuan-MT-7B-fp8",
-        "hunyuan-mt-7b-fp8"
+        "Hunyuan-MT-7B-fp8"
       ],
       "model_types": [
         "chat",
@@ -38655,9 +35861,7 @@
     {
       "name": "tencent/Hunyuan-MT-Chimera-7B",
       "alias": [
-        "tencent/hunyuan-mt-chimera-7b",
-        "Hunyuan-MT-Chimera-7B",
-        "hunyuan-mt-chimera-7b"
+        "Hunyuan-MT-Chimera-7B"
       ],
       "model_types": [
         "chat",
@@ -38668,9 +35872,7 @@
     {
       "name": "tencent/Hunyuan-MT-Chimera-7B-fp8",
       "alias": [
-        "tencent/hunyuan-mt-chimera-7b-fp8",
-        "Hunyuan-MT-Chimera-7B-fp8",
-        "hunyuan-mt-chimera-7b-fp8"
+        "Hunyuan-MT-Chimera-7B-fp8"
       ],
       "model_types": [
         "chat",
@@ -38680,27 +35882,21 @@
     },
     {
       "name": "tencent/hunyuan-pro",
-      "alias": [
-        "hunyuan-pro"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "tencent/hunyuan-standard",
-      "alias": [
-        "hunyuan-standard"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
     },
     {
       "name": "tencent/hunyuan-t1-latest",
-      "alias": [
-        "hunyuan-t1-latest"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
@@ -38725,9 +35921,7 @@
     },
     {
       "name": "tencent/hunyuan-vision",
-      "alias": [
-        "hunyuan-vision"
-      ],
+      "alias": [],
       "model_types": [
         "other"
       ]
@@ -38735,9 +35929,7 @@
     {
       "name": "tencent/Hunyuan3D-1",
       "alias": [
-        "tencent/hunyuan3d-1",
-        "Hunyuan3D-1",
-        "hunyuan3d-1"
+        "Hunyuan3D-1"
       ],
       "model_types": [
         "3d_generation"
@@ -38746,9 +35938,7 @@
     {
       "name": "tencent/Hunyuan3D-2",
       "alias": [
-        "tencent/hunyuan3d-2",
-        "Hunyuan3D-2",
-        "hunyuan3d-2"
+        "Hunyuan3D-2"
       ],
       "model_types": [
         "3d_generation"
@@ -38757,9 +35947,7 @@
     {
       "name": "tencent/Hunyuan3D-2.1",
       "alias": [
-        "tencent/hunyuan3d-2.1",
-        "Hunyuan3D-2.1",
-        "hunyuan3d-2.1"
+        "Hunyuan3D-2.1"
       ],
       "model_types": [
         "3d_generation"
@@ -38768,9 +35956,7 @@
     {
       "name": "tencent/Hunyuan3D-2mini",
       "alias": [
-        "tencent/hunyuan3d-2mini",
-        "Hunyuan3D-2mini",
-        "hunyuan3d-2mini"
+        "Hunyuan3D-2mini"
       ],
       "model_types": [
         "3d_generation"
@@ -38779,9 +35965,7 @@
     {
       "name": "tencent/Hunyuan3D-2mv",
       "alias": [
-        "tencent/hunyuan3d-2mv",
-        "Hunyuan3D-2mv",
-        "hunyuan3d-2mv"
+        "Hunyuan3D-2mv"
       ],
       "model_types": [
         "3d_generation"
@@ -38790,9 +35974,7 @@
     {
       "name": "tencent/Hunyuan3D-Omni",
       "alias": [
-        "tencent/hunyuan3d-omni",
-        "Hunyuan3D-Omni",
-        "hunyuan3d-omni"
+        "Hunyuan3D-Omni"
       ],
       "model_types": [
         "3d_generation"
@@ -38801,9 +35983,7 @@
     {
       "name": "tencent/Hunyuan3D-Part",
       "alias": [
-        "tencent/hunyuan3d-part",
-        "Hunyuan3D-Part",
-        "hunyuan3d-part"
+        "Hunyuan3D-Part"
       ],
       "model_types": [
         "3d_generation"
@@ -38812,9 +35992,7 @@
     {
       "name": "tencent/HunyuanCustom",
       "alias": [
-        "tencent/hunyuancustom",
-        "HunyuanCustom",
-        "hunyuancustom"
+        "HunyuanCustom"
       ],
       "model_types": [
         "video_generation"
@@ -38823,9 +36001,7 @@
     {
       "name": "tencent/HunyuanImage-2.1",
       "alias": [
-        "tencent/hunyuanimage-2.1",
-        "HunyuanImage-2.1",
-        "hunyuanimage-2.1"
+        "HunyuanImage-2.1"
       ],
       "model_types": [
         "image",
@@ -38835,9 +36011,7 @@
     {
       "name": "tencent/HunyuanImage-3.0",
       "alias": [
-        "tencent/hunyuanimage-3.0",
-        "HunyuanImage-3.0",
-        "hunyuanimage-3.0"
+        "HunyuanImage-3.0"
       ],
       "model_types": [
         "image",
@@ -38847,9 +36021,7 @@
     {
       "name": "tencent/HunyuanImage-3.0-Instruct",
       "alias": [
-        "tencent/hunyuanimage-3.0-instruct",
-        "HunyuanImage-3.0-Instruct",
-        "hunyuanimage-3.0-instruct"
+        "HunyuanImage-3.0-Instruct"
       ],
       "model_types": [
         "image_edit",
@@ -38860,9 +36032,7 @@
     {
       "name": "tencent/HunyuanImage-3.0-Instruct-Distil",
       "alias": [
-        "tencent/hunyuanimage-3.0-instruct-distil",
-        "HunyuanImage-3.0-Instruct-Distil",
-        "hunyuanimage-3.0-instruct-distil"
+        "HunyuanImage-3.0-Instruct-Distil"
       ],
       "model_types": [
         "image_edit",
@@ -38873,9 +36043,7 @@
     {
       "name": "tencent/HunyuanOCR",
       "alias": [
-        "tencent/hunyuanocr",
-        "HunyuanOCR",
-        "hunyuanocr"
+        "HunyuanOCR"
       ],
       "model_types": [
         "ocr",
@@ -38886,9 +36054,7 @@
     {
       "name": "tencent/HunyuanPortrait",
       "alias": [
-        "tencent/hunyuanportrait",
-        "HunyuanPortrait",
-        "hunyuanportrait"
+        "HunyuanPortrait"
       ],
       "model_types": [
         "video_generation"
@@ -38897,9 +36063,7 @@
     {
       "name": "tencent/HunyuanVideo",
       "alias": [
-        "tencent/hunyuanvideo",
-        "HunyuanVideo",
-        "hunyuanvideo"
+        "HunyuanVideo"
       ],
       "model_types": [
         "video_generation"
@@ -38908,9 +36072,7 @@
     {
       "name": "tencent/HunyuanVideo-1.5",
       "alias": [
-        "tencent/hunyuanvideo-1.5",
-        "HunyuanVideo-1.5",
-        "hunyuanvideo-1.5"
+        "HunyuanVideo-1.5"
       ],
       "model_types": [
         "video_generation"
@@ -38919,9 +36081,7 @@
     {
       "name": "tencent/HunyuanVideo-Avatar",
       "alias": [
-        "tencent/hunyuanvideo-avatar",
-        "HunyuanVideo-Avatar",
-        "hunyuanvideo-avatar"
+        "HunyuanVideo-Avatar"
       ],
       "model_types": [
         "video_generation"
@@ -38930,9 +36090,7 @@
     {
       "name": "tencent/HunyuanVideo-Foley",
       "alias": [
-        "tencent/hunyuanvideo-foley",
-        "HunyuanVideo-Foley",
-        "hunyuanvideo-foley"
+        "HunyuanVideo-Foley"
       ],
       "model_types": [
         "audio_generation"
@@ -38941,9 +36099,7 @@
     {
       "name": "tencent/HunyuanVideo-I2V",
       "alias": [
-        "tencent/hunyuanvideo-i2v",
-        "HunyuanVideo-I2V",
-        "hunyuanvideo-i2v"
+        "HunyuanVideo-I2V"
       ],
       "model_types": [
         "video_generation"
@@ -38952,9 +36108,7 @@
     {
       "name": "tencent/HunyuanVideo-PromptRewrite",
       "alias": [
-        "tencent/hunyuanvideo-promptrewrite",
-        "HunyuanVideo-PromptRewrite",
-        "hunyuanvideo-promptrewrite"
+        "HunyuanVideo-PromptRewrite"
       ],
       "model_types": [
         "chat"
@@ -38964,9 +36118,7 @@
     {
       "name": "tencent/HunyuanWorld-1",
       "alias": [
-        "tencent/hunyuanworld-1",
-        "HunyuanWorld-1",
-        "hunyuanworld-1"
+        "HunyuanWorld-1"
       ],
       "model_types": [
         "3d_generation"
@@ -38975,9 +36127,7 @@
     {
       "name": "tencent/HunyuanWorld-Mirror",
       "alias": [
-        "tencent/hunyuanworld-mirror",
-        "HunyuanWorld-Mirror",
-        "hunyuanworld-mirror"
+        "HunyuanWorld-Mirror"
       ],
       "model_types": [
         "3d_generation"
@@ -38986,9 +36136,7 @@
     {
       "name": "tencent/HunyuanWorld-Voyager",
       "alias": [
-        "tencent/hunyuanworld-voyager",
-        "HunyuanWorld-Voyager",
-        "hunyuanworld-voyager"
+        "HunyuanWorld-Voyager"
       ],
       "model_types": [
         "video_generation"
@@ -38997,9 +36145,7 @@
     {
       "name": "tencent/HY-Embodied-0.5",
       "alias": [
-        "tencent/hy-embodied-0.5",
-        "HY-Embodied-0.5",
-        "hy-embodied-0.5"
+        "HY-Embodied-0.5"
       ],
       "model_types": [
         "chat",
@@ -39011,9 +36157,7 @@
     {
       "name": "tencent/HY-Embodied-0.5-X",
       "alias": [
-        "tencent/hy-embodied-0.5-x",
-        "HY-Embodied-0.5-X",
-        "hy-embodied-0.5-x"
+        "HY-Embodied-0.5-X"
       ],
       "model_types": [
         "chat",
@@ -39025,9 +36169,7 @@
     {
       "name": "tencent/HY-Motion-1.0",
       "alias": [
-        "tencent/hy-motion-1.0",
-        "HY-Motion-1.0",
-        "hy-motion-1.0"
+        "HY-Motion-1.0"
       ],
       "model_types": [
         "3d_generation"
@@ -39036,9 +36178,7 @@
     {
       "name": "tencent/HY-MT1.5-1.8B",
       "alias": [
-        "tencent/hy-mt1.5-1.8b",
-        "HY-MT1.5-1.8B",
-        "hy-mt1.5-1.8b"
+        "HY-MT1.5-1.8B"
       ],
       "model_types": [
         "chat",
@@ -39049,9 +36189,7 @@
     {
       "name": "tencent/Hy-MT1.5-1.8B-1.25bit",
       "alias": [
-        "tencent/hy-mt1.5-1.8b-1.25bit",
-        "Hy-MT1.5-1.8B-1.25bit",
-        "hy-mt1.5-1.8b-1.25bit"
+        "Hy-MT1.5-1.8B-1.25bit"
       ],
       "model_types": [
         "chat",
@@ -39062,9 +36200,7 @@
     {
       "name": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "alias": [
-        "tencent/hy-mt1.5-1.8b-1.25bit-gguf",
-        "Hy-MT1.5-1.8B-1.25bit-GGUF",
-        "hy-mt1.5-1.8b-1.25bit-gguf"
+        "Hy-MT1.5-1.8B-1.25bit-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39075,9 +36211,7 @@
     {
       "name": "tencent/Hy-MT1.5-1.8B-2bit",
       "alias": [
-        "tencent/hy-mt1.5-1.8b-2bit",
-        "Hy-MT1.5-1.8B-2bit",
-        "hy-mt1.5-1.8b-2bit"
+        "Hy-MT1.5-1.8B-2bit"
       ],
       "model_types": [
         "chat",
@@ -39088,9 +36222,7 @@
     {
       "name": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "alias": [
-        "tencent/hy-mt1.5-1.8b-2bit-gguf",
-        "Hy-MT1.5-1.8B-2bit-GGUF",
-        "hy-mt1.5-1.8b-2bit-gguf"
+        "Hy-MT1.5-1.8B-2bit-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39101,9 +36233,7 @@
     {
       "name": "tencent/HY-MT1.5-1.8B-FP8",
       "alias": [
-        "tencent/hy-mt1.5-1.8b-fp8",
-        "HY-MT1.5-1.8B-FP8",
-        "hy-mt1.5-1.8b-fp8"
+        "HY-MT1.5-1.8B-FP8"
       ],
       "model_types": [
         "chat",
@@ -39114,9 +36244,7 @@
     {
       "name": "tencent/HY-MT1.5-1.8B-GGUF",
       "alias": [
-        "tencent/hy-mt1.5-1.8b-gguf",
-        "HY-MT1.5-1.8B-GGUF",
-        "hy-mt1.5-1.8b-gguf"
+        "HY-MT1.5-1.8B-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39127,9 +36255,7 @@
     {
       "name": "tencent/HY-MT1.5-1.8B-GPTQ-Int4",
       "alias": [
-        "tencent/hy-mt1.5-1.8b-gptq-int4",
-        "HY-MT1.5-1.8B-GPTQ-Int4",
-        "hy-mt1.5-1.8b-gptq-int4"
+        "HY-MT1.5-1.8B-GPTQ-Int4"
       ],
       "model_types": [
         "chat",
@@ -39140,9 +36266,7 @@
     {
       "name": "tencent/HY-MT1.5-7B",
       "alias": [
-        "tencent/hy-mt1.5-7b",
-        "HY-MT1.5-7B",
-        "hy-mt1.5-7b"
+        "HY-MT1.5-7B"
       ],
       "model_types": [
         "chat",
@@ -39153,9 +36277,7 @@
     {
       "name": "tencent/HY-MT1.5-7B-FP8",
       "alias": [
-        "tencent/hy-mt1.5-7b-fp8",
-        "HY-MT1.5-7B-FP8",
-        "hy-mt1.5-7b-fp8"
+        "HY-MT1.5-7B-FP8"
       ],
       "model_types": [
         "chat",
@@ -39166,9 +36288,7 @@
     {
       "name": "tencent/HY-MT1.5-7B-GGUF",
       "alias": [
-        "tencent/hy-mt1.5-7b-gguf",
-        "HY-MT1.5-7B-GGUF",
-        "hy-mt1.5-7b-gguf"
+        "HY-MT1.5-7B-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39179,9 +36299,7 @@
     {
       "name": "tencent/HY-MT1.5-7B-GPTQ-Int4",
       "alias": [
-        "tencent/hy-mt1.5-7b-gptq-int4",
-        "HY-MT1.5-7B-GPTQ-Int4",
-        "hy-mt1.5-7b-gptq-int4"
+        "HY-MT1.5-7B-GPTQ-Int4"
       ],
       "model_types": [
         "chat",
@@ -39192,9 +36310,7 @@
     {
       "name": "tencent/Hy-MT2-1.8B",
       "alias": [
-        "tencent/hy-mt2-1.8b",
-        "Hy-MT2-1.8B",
-        "hy-mt2-1.8b"
+        "Hy-MT2-1.8B"
       ],
       "model_types": [
         "chat",
@@ -39205,9 +36321,7 @@
     {
       "name": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "alias": [
-        "tencent/hy-mt2-1.8b-1.25bit-gguf",
-        "Hy-MT2-1.8B-1.25Bit-GGUF",
-        "hy-mt2-1.8b-1.25bit-gguf"
+        "Hy-MT2-1.8B-1.25Bit-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39218,9 +36332,7 @@
     {
       "name": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "alias": [
-        "tencent/hy-mt2-1.8b-2bit-gguf",
-        "Hy-MT2-1.8B-2Bit-GGUF",
-        "hy-mt2-1.8b-2bit-gguf"
+        "Hy-MT2-1.8B-2Bit-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39231,9 +36343,7 @@
     {
       "name": "tencent/Hy-MT2-1.8B-FP8",
       "alias": [
-        "tencent/hy-mt2-1.8b-fp8",
-        "Hy-MT2-1.8B-FP8",
-        "hy-mt2-1.8b-fp8"
+        "Hy-MT2-1.8B-FP8"
       ],
       "model_types": [
         "chat",
@@ -39244,9 +36354,7 @@
     {
       "name": "tencent/Hy-MT2-1.8B-GGUF",
       "alias": [
-        "tencent/hy-mt2-1.8b-gguf",
-        "Hy-MT2-1.8B-GGUF",
-        "hy-mt2-1.8b-gguf"
+        "Hy-MT2-1.8B-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39257,9 +36365,7 @@
     {
       "name": "tencent/Hy-MT2-30B-A3B",
       "alias": [
-        "tencent/hy-mt2-30b-a3b",
-        "Hy-MT2-30B-A3B",
-        "hy-mt2-30b-a3b"
+        "Hy-MT2-30B-A3B"
       ],
       "model_types": [
         "chat",
@@ -39270,9 +36376,7 @@
     {
       "name": "tencent/Hy-MT2-30B-A3B-FP8",
       "alias": [
-        "tencent/hy-mt2-30b-a3b-fp8",
-        "Hy-MT2-30B-A3B-FP8",
-        "hy-mt2-30b-a3b-fp8"
+        "Hy-MT2-30B-A3B-FP8"
       ],
       "model_types": [
         "chat",
@@ -39283,9 +36387,7 @@
     {
       "name": "tencent/Hy-MT2-7B",
       "alias": [
-        "tencent/hy-mt2-7b",
-        "Hy-MT2-7B",
-        "hy-mt2-7b"
+        "Hy-MT2-7B"
       ],
       "model_types": [
         "chat",
@@ -39296,9 +36398,7 @@
     {
       "name": "tencent/Hy-MT2-7B-FP8",
       "alias": [
-        "tencent/hy-mt2-7b-fp8",
-        "Hy-MT2-7B-FP8",
-        "hy-mt2-7b-fp8"
+        "Hy-MT2-7B-FP8"
       ],
       "model_types": [
         "chat",
@@ -39309,9 +36409,7 @@
     {
       "name": "tencent/Hy-MT2-7B-GGUF",
       "alias": [
-        "tencent/hy-mt2-7b-gguf",
-        "Hy-MT2-7B-GGUF",
-        "hy-mt2-7b-gguf"
+        "Hy-MT2-7B-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39322,9 +36420,7 @@
     {
       "name": "tencent/HY-OmniWeaving",
       "alias": [
-        "tencent/hy-omniweaving",
-        "HY-OmniWeaving",
-        "hy-omniweaving"
+        "HY-OmniWeaving"
       ],
       "model_types": [
         "video_generation"
@@ -39333,9 +36429,7 @@
     {
       "name": "tencent/HY-Video-PRFL",
       "alias": [
-        "tencent/hy-video-prfl",
-        "HY-Video-PRFL",
-        "hy-video-prfl"
+        "HY-Video-PRFL"
       ],
       "model_types": [
         "video_generation"
@@ -39344,9 +36438,7 @@
     {
       "name": "tencent/HY-World-2.0",
       "alias": [
-        "tencent/hy-world-2.0",
-        "HY-World-2.0",
-        "hy-world-2.0"
+        "HY-World-2.0"
       ],
       "model_types": [
         "3d_generation"
@@ -39355,9 +36447,7 @@
     {
       "name": "tencent/HY-WorldPlay",
       "alias": [
-        "tencent/hy-worldplay",
-        "HY-WorldPlay",
-        "hy-worldplay"
+        "HY-WorldPlay"
       ],
       "model_types": [
         "video_generation"
@@ -39366,9 +36456,7 @@
     {
       "name": "tencent/HY-WU",
       "alias": [
-        "tencent/hy-wu",
-        "HY-WU",
-        "hy-wu"
+        "HY-WU"
       ],
       "model_types": [
         "image"
@@ -39377,9 +36465,7 @@
     {
       "name": "tencent/Hy3-preview",
       "alias": [
-        "tencent/hy3-preview",
-        "Hy3-preview",
-        "hy3-preview"
+        "Hy3-preview"
       ],
       "model_types": [
         "chat"
@@ -39393,9 +36479,7 @@
     {
       "name": "tencent/Hy3-preview-Base",
       "alias": [
-        "tencent/hy3-preview-base",
-        "Hy3-preview-Base",
-        "hy3-preview-base"
+        "Hy3-preview-Base"
       ],
       "model_types": [
         "chat"
@@ -39405,9 +36489,7 @@
     {
       "name": "tencent/HY3D-Bench",
       "alias": [
-        "tencent/hy3d-bench",
-        "HY3D-Bench",
-        "hy3d-bench"
+        "HY3D-Bench"
       ],
       "model_types": [
         "3d_generation"
@@ -39416,9 +36498,7 @@
     {
       "name": "tencent/InstantCharacter",
       "alias": [
-        "tencent/instantcharacter",
-        "InstantCharacter",
-        "instantcharacter"
+        "InstantCharacter"
       ],
       "model_types": [
         "image"
@@ -39427,9 +36507,7 @@
     {
       "name": "tencent/KaLM-Embedding-Gemma3-12B-2511",
       "alias": [
-        "tencent/kalm-embedding-gemma3-12b-2511",
-        "KaLM-Embedding-Gemma3-12B-2511",
-        "kalm-embedding-gemma3-12b-2511"
+        "KaLM-Embedding-Gemma3-12B-2511"
       ],
       "model_types": [
         "embedding"
@@ -39440,9 +36518,7 @@
     {
       "name": "tencent/MimicMotion",
       "alias": [
-        "tencent/mimicmotion",
-        "MimicMotion",
-        "mimicmotion"
+        "MimicMotion"
       ],
       "model_types": [
         "video_generation"
@@ -39451,9 +36527,7 @@
     {
       "name": "tencent/Penguin-Encoder",
       "alias": [
-        "tencent/penguin-encoder",
-        "Penguin-Encoder",
-        "penguin-encoder"
+        "Penguin-Encoder"
       ],
       "model_types": [
         "embedding",
@@ -39465,9 +36539,7 @@
     {
       "name": "tencent/Penguin-VL-2B",
       "alias": [
-        "tencent/penguin-vl-2b",
-        "Penguin-VL-2B",
-        "penguin-vl-2b"
+        "Penguin-VL-2B"
       ],
       "model_types": [
         "chat",
@@ -39479,9 +36551,7 @@
     {
       "name": "tencent/Penguin-VL-8B",
       "alias": [
-        "tencent/penguin-vl-8b",
-        "Penguin-VL-8B",
-        "penguin-vl-8b"
+        "Penguin-VL-8B"
       ],
       "model_types": [
         "chat",
@@ -39493,9 +36563,7 @@
     {
       "name": "tencent/POINTS-GUI-G",
       "alias": [
-        "tencent/points-gui-g",
-        "POINTS-GUI-G",
-        "points-gui-g"
+        "POINTS-GUI-G"
       ],
       "model_types": [
         "chat",
@@ -39507,9 +36575,7 @@
     {
       "name": "tencent/POINTS-Reader",
       "alias": [
-        "tencent/points-reader",
-        "POINTS-Reader",
-        "points-reader"
+        "POINTS-Reader"
       ],
       "model_types": [
         "vision",
@@ -39520,9 +36586,7 @@
     {
       "name": "tencent/POINTS-Seeker",
       "alias": [
-        "tencent/points-seeker",
-        "POINTS-Seeker",
-        "points-seeker"
+        "POINTS-Seeker"
       ],
       "model_types": [
         "chat",
@@ -39538,9 +36602,7 @@
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n2",
       "alias": [
-        "tencent/sequential-hidden-decoding-8b-n2",
-        "Sequential-Hidden-Decoding-8B-n2",
-        "sequential-hidden-decoding-8b-n2"
+        "Sequential-Hidden-Decoding-8B-n2"
       ],
       "model_types": [
         "chat"
@@ -39550,9 +36612,7 @@
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n4",
       "alias": [
-        "tencent/sequential-hidden-decoding-8b-n4",
-        "Sequential-Hidden-Decoding-8B-n4",
-        "sequential-hidden-decoding-8b-n4"
+        "Sequential-Hidden-Decoding-8B-n4"
       ],
       "model_types": [
         "chat"
@@ -39562,9 +36622,7 @@
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n8",
       "alias": [
-        "tencent/sequential-hidden-decoding-8b-n8",
-        "Sequential-Hidden-Decoding-8B-n8",
-        "sequential-hidden-decoding-8b-n8"
+        "Sequential-Hidden-Decoding-8B-n8"
       ],
       "model_types": [
         "chat"
@@ -39574,9 +36632,7 @@
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n8-Instruct",
       "alias": [
-        "tencent/sequential-hidden-decoding-8b-n8-instruct",
-        "Sequential-Hidden-Decoding-8B-n8-Instruct",
-        "sequential-hidden-decoding-8b-n8-instruct"
+        "Sequential-Hidden-Decoding-8B-n8-Instruct"
       ],
       "model_types": [
         "chat"
@@ -39586,9 +36642,7 @@
     {
       "name": "tencent/SongGeneration",
       "alias": [
-        "tencent/songgeneration",
-        "SongGeneration",
-        "songgeneration"
+        "SongGeneration"
       ],
       "model_types": [
         "audio_generation"
@@ -39597,9 +36651,7 @@
     {
       "name": "tencent/SongPrep-7B",
       "alias": [
-        "tencent/songprep-7b",
-        "SongPrep-7B",
-        "songprep-7b"
+        "SongPrep-7B"
       ],
       "model_types": [
         "asr"
@@ -39608,9 +36660,7 @@
     {
       "name": "tencent/SRPO",
       "alias": [
-        "tencent/srpo",
-        "SRPO",
-        "srpo"
+        "SRPO"
       ],
       "model_types": [
         "image"
@@ -39619,9 +36669,7 @@
     {
       "name": "tencent/StableToken",
       "alias": [
-        "tencent/stabletoken",
-        "StableToken",
-        "stabletoken"
+        "StableToken"
       ],
       "model_types": [
         "audio_codec"
@@ -39630,9 +36678,7 @@
     {
       "name": "tencent/TCAndon-Router",
       "alias": [
-        "tencent/tcandon-router",
-        "TCAndon-Router",
-        "tcandon-router"
+        "TCAndon-Router"
       ],
       "model_types": [
         "chat"
@@ -39642,9 +36688,7 @@
     {
       "name": "tencent/Tencent-Hunyuan-Large",
       "alias": [
-        "tencent/tencent-hunyuan-large",
-        "Tencent-Hunyuan-Large",
-        "tencent-hunyuan-large"
+        "Tencent-Hunyuan-Large"
       ],
       "model_types": [
         "chat"
@@ -39654,9 +36698,7 @@
     {
       "name": "tencent/Unicom-Unified-Multimodal-Modeling-via-Compressed-Continuous-Semantic-Representations",
       "alias": [
-        "tencent/unicom-unified-multimodal-modeling-via-compressed-continuous-semantic-representations",
-        "Unicom-Unified-Multimodal-Modeling-via-Compressed-Continuous-Semantic-Representations",
-        "unicom-unified-multimodal-modeling-via-compressed-continuous-semantic-representations"
+        "Unicom-Unified-Multimodal-Modeling-via-Compressed-Continuous-Semantic-Representations"
       ],
       "model_types": [
         "image"
@@ -39665,9 +36707,7 @@
     {
       "name": "tencent/Unified_Audio_Schema",
       "alias": [
-        "tencent/unified_audio_schema",
-        "Unified_Audio_Schema",
-        "unified_audio_schema"
+        "Unified_Audio_Schema"
       ],
       "model_types": [
         "chat",
@@ -39679,9 +36719,7 @@
     {
       "name": "tencent/Universal_Audio_Tokenizer",
       "alias": [
-        "tencent/universal_audio_tokenizer",
-        "Universal_Audio_Tokenizer",
-        "universal_audio_tokenizer"
+        "Universal_Audio_Tokenizer"
       ],
       "model_types": [
         "audio_codec"
@@ -39690,9 +36728,7 @@
     {
       "name": "tencent/VersaViT",
       "alias": [
-        "tencent/versavit",
-        "VersaViT",
-        "versavit"
+        "VersaViT"
       ],
       "model_types": [
         "vision"
@@ -39701,9 +36737,7 @@
     {
       "name": "tencent/WeDLM-7B-Base",
       "alias": [
-        "tencent/wedlm-7b-base",
-        "WeDLM-7B-Base",
-        "wedlm-7b-base"
+        "WeDLM-7B-Base"
       ],
       "model_types": [
         "chat"
@@ -39713,9 +36747,7 @@
     {
       "name": "tencent/WeDLM-7B-Instruct",
       "alias": [
-        "tencent/wedlm-7b-instruct",
-        "WeDLM-7B-Instruct",
-        "wedlm-7b-instruct"
+        "WeDLM-7B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -39725,9 +36757,7 @@
     {
       "name": "tencent/WeDLM-8B-Base",
       "alias": [
-        "tencent/wedlm-8b-base",
-        "WeDLM-8B-Base",
-        "wedlm-8b-base"
+        "WeDLM-8B-Base"
       ],
       "model_types": [
         "chat"
@@ -39737,9 +36767,7 @@
     {
       "name": "tencent/WeDLM-8B-Instruct",
       "alias": [
-        "tencent/wedlm-8b-instruct",
-        "WeDLM-8B-Instruct",
-        "wedlm-8b-instruct"
+        "WeDLM-8B-Instruct"
       ],
       "model_types": [
         "chat"
@@ -39749,9 +36777,7 @@
     {
       "name": "tencent/Youtu-Embedding",
       "alias": [
-        "tencent/youtu-embedding",
-        "Youtu-Embedding",
-        "youtu-embedding"
+        "Youtu-Embedding"
       ],
       "model_types": [
         "embedding"
@@ -39762,9 +36788,7 @@
     {
       "name": "tencent/Youtu-HiChunk",
       "alias": [
-        "tencent/youtu-hichunk",
-        "Youtu-HiChunk",
-        "youtu-hichunk"
+        "Youtu-HiChunk"
       ],
       "model_types": [
         "embedding",
@@ -39776,9 +36800,7 @@
     {
       "name": "tencent/Youtu-LLM-2B",
       "alias": [
-        "tencent/youtu-llm-2b",
-        "Youtu-LLM-2B",
-        "youtu-llm-2b"
+        "Youtu-LLM-2B"
       ],
       "model_types": [
         "chat"
@@ -39788,9 +36810,7 @@
     {
       "name": "tencent/Youtu-LLM-2B-Base",
       "alias": [
-        "tencent/youtu-llm-2b-base",
-        "Youtu-LLM-2B-Base",
-        "youtu-llm-2b-base"
+        "Youtu-LLM-2B-Base"
       ],
       "model_types": [
         "chat"
@@ -39800,9 +36820,7 @@
     {
       "name": "tencent/Youtu-LLM-2B-GGUF",
       "alias": [
-        "tencent/youtu-llm-2b-gguf",
-        "Youtu-LLM-2B-GGUF",
-        "youtu-llm-2b-gguf"
+        "Youtu-LLM-2B-GGUF"
       ],
       "model_types": [
         "chat"
@@ -39812,9 +36830,7 @@
     {
       "name": "tencent/Youtu-Parsing",
       "alias": [
-        "tencent/youtu-parsing",
-        "Youtu-Parsing",
-        "youtu-parsing"
+        "Youtu-Parsing"
       ],
       "model_types": [
         "vision",
@@ -39825,9 +36841,7 @@
     {
       "name": "tencent/Youtu-VL-4B-Instruct",
       "alias": [
-        "tencent/youtu-vl-4b-instruct",
-        "Youtu-VL-4B-Instruct",
-        "youtu-vl-4b-instruct"
+        "Youtu-VL-4B-Instruct"
       ],
       "model_types": [
         "chat",
@@ -39839,9 +36853,7 @@
     {
       "name": "tencent/Youtu-VL-4B-Instruct-GGUF",
       "alias": [
-        "tencent/youtu-vl-4b-instruct-gguf",
-        "Youtu-VL-4B-Instruct-GGUF",
-        "youtu-vl-4b-instruct-gguf"
+        "Youtu-VL-4B-Instruct-GGUF"
       ],
       "model_types": [
         "chat",
@@ -39856,9 +36868,7 @@
         "embedding",
         "chat"
       ],
-      "alias": [
-        "openai/text-embedding-3-large"
-      ]
+      "alias": []
     },
     {
       "name": "text-embedding-3-small",
@@ -39866,9 +36876,7 @@
         "embedding",
         "chat"
       ],
-      "alias": [
-        "openai/text-embedding-3-small"
-      ]
+      "alias": []
     },
     {
       "name": "text-embedding-ada-002",
@@ -39876,9 +36884,7 @@
         "embedding",
         "chat"
       ],
-      "alias": [
-        "openai/text-embedding-ada-002"
-      ]
+      "alias": []
     },
     {
       "name": "text-moderation-latest",
@@ -40035,9 +37041,7 @@
         "tts",
         "chat"
       ],
-      "alias": [
-        "openai/tts-1"
-      ]
+      "alias": []
     },
     {
       "name": "tts-1-1106",
@@ -40045,9 +37049,7 @@
         "tts",
         "chat"
       ],
-      "alias": [
-        "openai/tts-1-1106"
-      ]
+      "alias": []
     },
     {
       "name": "tts-1-hd",
@@ -40055,9 +37057,7 @@
         "tts",
         "chat"
       ],
-      "alias": [
-        "openai/tts-1-hd"
-      ]
+      "alias": []
     },
     {
       "name": "tts-1-hd-1106",
@@ -40065,9 +37065,7 @@
         "tts",
         "chat"
       ],
-      "alias": [
-        "openai/tts-1-hd-1106"
-      ]
+      "alias": []
     },
     {
       "name": "tts-hd-1",
@@ -40118,10 +37116,7 @@
     },
     {
       "name": "us.amazon.nova-lite-v1:0",
-      "alias": [
-        "amazon.nova-lite-v1:0",
-        "apac.amazon.nova-lite-v1:0"
-      ],
+      "alias": [],
       "max_tokens": 300000,
       "model_types": [
         "chat"
@@ -40129,9 +37124,7 @@
     },
     {
       "name": "us.amazon.nova-micro-v1:0",
-      "alias": [
-        "amazon.nova-micro-v1:0"
-      ],
+      "alias": [],
       "max_tokens": 300000,
       "model_types": [
         "chat"
@@ -40139,9 +37132,7 @@
     },
     {
       "name": "us.amazon.nova-pro-v1:0",
-      "alias": [
-        "amazon.nova-pro-v1:0"
-      ],
+      "alias": [],
       "max_tokens": 300000,
       "model_types": [
         "chat"
@@ -40149,9 +37140,7 @@
     },
     {
       "name": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-      "alias": [
-        "anthropic.claude-3-5-haiku-20241022-v1:0"
-      ],
+      "alias": [],
       "max_tokens": 200000,
       "model_types": [
         "chat"
@@ -40159,10 +37148,7 @@
     },
     {
       "name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-      "alias": [
-        "anthropic.claude-3-5-sonnet-20241022-v2:0",
-        "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
-      ],
+      "alias": [],
       "max_tokens": 200000,
       "model_types": [
         "chat"
@@ -40197,30 +37183,21 @@
     },
     {
       "name": "veo-3.1-fast-generate-preview",
-      "alias": [
-        "veo-3.1-fast-generate-preview",
-        "models/veo-3.1-fast-generate-preview"
-      ],
+      "alias": [],
       "model_types": [
         "video_generation"
       ]
     },
     {
       "name": "veo-3.1-generate-preview",
-      "alias": [
-        "veo-3.1-generate-preview",
-        "models/veo-3.1-generate-preview"
-      ],
+      "alias": [],
       "model_types": [
         "video_generation"
       ]
     },
     {
       "name": "veo-3.1-lite-generate-preview",
-      "alias": [
-        "veo-3.1-lite-generate-preview",
-        "models/veo-3.1-lite-generate-preview"
-      ],
+      "alias": [],
       "model_types": [
         "video_generation"
       ]
@@ -40254,7 +37231,6 @@
     {
       "name": "vidu/vidu-q3",
       "alias": [
-        "vidu-q3",
         "Vidu Q3"
       ],
       "model_types": [
@@ -40264,7 +37240,6 @@
     {
       "name": "vidu/vidu-q3-turbo",
       "alias": [
-        "vidu-q3-turbo",
         "Vidu Q3 Turbo"
       ],
       "model_types": [
@@ -40372,9 +37347,7 @@
     },
     {
       "name": "voyage/rerank-2.5",
-      "alias": [
-        "rerank-2.5"
-      ],
+      "alias": [],
       "model_types": [
         "rerank"
       ],
@@ -40382,9 +37355,7 @@
     },
     {
       "name": "voyage/rerank-2.5-lite",
-      "alias": [
-        "rerank-2.5-lite"
-      ],
+      "alias": [],
       "model_types": [
         "rerank"
       ],
@@ -40446,9 +37417,7 @@
     },
     {
       "name": "voyage/voyage-3-large",
-      "alias": [
-        "voyage-3-large"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -40473,9 +37442,7 @@
     },
     {
       "name": "voyage/voyage-3.5",
-      "alias": [
-        "voyage-3.5"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -40489,9 +37456,7 @@
     },
     {
       "name": "voyage/voyage-3.5-lite",
-      "alias": [
-        "voyage-3.5-lite"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -40569,9 +37534,7 @@
     },
     {
       "name": "voyage/voyage-code-2",
-      "alias": [
-        "voyage-code-2"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -40580,9 +37543,7 @@
     },
     {
       "name": "voyage/voyage-code-3",
-      "alias": [
-        "voyage-code-3"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -40596,9 +37557,7 @@
     },
     {
       "name": "voyage/voyage-finance-2",
-      "alias": [
-        "voyage-finance-2"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -40629,9 +37588,7 @@
     },
     {
       "name": "voyage/voyage-law-2",
-      "alias": [
-        "voyage-law-2"
-      ],
+      "alias": [],
       "model_types": [
         "embedding"
       ],
@@ -41030,9 +37987,7 @@
     },
     {
       "name": "x-ai/grok-4.20-0309-non-reasoning",
-      "alias": [
-        "grok-4.20-0309-non-reasoning"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41043,7 +37998,6 @@
     {
       "name": "x-ai/grok-4.20-0309-reasoning",
       "alias": [
-        "grok-4.20-0309-reasoning",
         "grok-4-2"
       ],
       "model_types": [
@@ -41054,9 +38008,7 @@
     },
     {
       "name": "x-ai/grok-4.20-multi-agent",
-      "alias": [
-        "grok-4.20-multi-agent"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41070,9 +38022,7 @@
     },
     {
       "name": "x-ai/grok-4.20-multi-agent-0309",
-      "alias": [
-        "grok-4.20-multi-agent-0309"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41086,9 +38036,7 @@
     },
     {
       "name": "x-ai/grok-4.3",
-      "alias": [
-        "grok-4.3"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41102,9 +38050,7 @@
     },
     {
       "name": "x-ai/grok-4-0709",
-      "alias": [
-        "grok-4-0709"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41114,9 +38060,7 @@
     },
     {
       "name": "x-ai/grok-4-1-fast-non-reasoning",
-      "alias": [
-        "grok-4-1-fast-non-reasoning"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41126,9 +38070,7 @@
     },
     {
       "name": "x-ai/grok-4-1-fast-reasoning",
-      "alias": [
-        "grok-4-1-fast-reasoning"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41142,9 +38084,7 @@
     },
     {
       "name": "x-ai/grok-4-fast-non-reasoning",
-      "alias": [
-        "grok-4-fast-non-reasoning"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41154,9 +38094,7 @@
     },
     {
       "name": "x-ai/grok-4-fast-reasoning",
-      "alias": [
-        "grok-4-fast-reasoning"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41166,9 +38104,7 @@
     },
     {
       "name": "x-ai/grok-3",
-      "alias": [
-        "grok-3"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41178,9 +38114,7 @@
     },
     {
       "name": "x-ai/grok-3-mini",
-      "alias": [
-        "grok-3-mini"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41194,9 +38128,7 @@
     },
     {
       "name": "x-ai/grok-build-0.1",
-      "alias": [
-        "grok-build-0.1"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41210,9 +38142,7 @@
     },
     {
       "name": "x-ai/grok-code-fast-1",
-      "alias": [
-        "grok-code-fast-1"
-      ],
+      "alias": [],
       "model_types": [
         "chat",
         "vision",
@@ -41226,9 +38156,7 @@
     },
     {
       "name": "x-ai/grok-imagine-video",
-      "alias": [
-        "grok-imagine-video"
-      ],
+      "alias": [],
       "model_types": [
         "video_generation"
       ]
@@ -41269,9 +38197,7 @@
     },
     {
       "name": "xiaomi/mimo-v2.5",
-      "alias": [
-        "mimo-v2.5"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -41279,9 +38205,7 @@
     },
     {
       "name": "xiaomi/mimo-v2.5-asr",
-      "alias": [
-        "mimo-v2.5-asr"
-      ],
+      "alias": [],
       "model_types": [
         "asr",
         "speech2text"
@@ -41290,10 +38214,7 @@
     },
     {
       "name": "xiaomi/mimo-v2.5-pro",
-      "alias": [
-        "mimo-v2.5-pro",
-        "xiaomimimo/mimo-v2.5-pro"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -41301,9 +38222,7 @@
     },
     {
       "name": "xiaomi/mimo-v2.5-tts",
-      "alias": [
-        "mimo-v2.5-tts"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
@@ -41322,9 +38241,7 @@
     },
     {
       "name": "xiaomi/mimo-v2-tts",
-      "alias": [
-        "mimo-v2-tts"
-      ],
+      "alias": [],
       "model_types": [
         "tts"
       ]
@@ -41406,9 +38323,7 @@
     },
     {
       "name": "xunfei/generalv3.5",
-      "alias": [
-        "generalv3.5"
-      ],
+      "alias": [],
       "model_types": [
         "chat"
       ],
@@ -41518,9 +38433,7 @@
     {
       "name": "zai-org/GLM-5.1",
       "alias": [
-        "zai-org/glm-5.1",
         "GLM-5.1",
-        "glm-5.1",
         "z-ai/glm-5.1",
         "ZHIPU/GLM-5.1",
         "Pro/zai-org/GLM-5.1",
@@ -41540,9 +38453,7 @@
     {
       "name": "zai-org/GLM-5.1-FP8",
       "alias": [
-        "zai-org/glm-5.1-fp8",
-        "GLM-5.1-FP8",
-        "glm-5.1-fp8"
+        "GLM-5.1-FP8"
       ],
       "model_types": [
         "chat"
@@ -41556,9 +38467,7 @@
     {
       "name": "zai-org/GLM-5",
       "alias": [
-        "zai-org/glm-5",
         "GLM-5",
-        "glm-5",
         "z-ai/glm-5",
         "ZHIPU/GLM-5",
         "GLM 5 Fp4"
@@ -41590,9 +38499,7 @@
     {
       "name": "zai-org/GLM-5-FP8",
       "alias": [
-        "zai-org/glm-5-fp8",
-        "GLM-5-FP8",
-        "glm-5-fp8"
+        "GLM-5-FP8"
       ],
       "model_types": [
         "chat"
@@ -41621,9 +38528,7 @@
     {
       "name": "zai-org/GLM-4.7",
       "alias": [
-        "zai-org/glm-4.7",
         "GLM-4.7",
-        "glm-4.7",
         "z-ai/glm-4.7",
         "Pro/zai-org/GLM-4.7",
         "Z-Ai/GLM 4.7"
@@ -41641,9 +38546,7 @@
     {
       "name": "zai-org/GLM-4.7-Flash",
       "alias": [
-        "zai-org/glm-4.7-flash",
         "GLM-4.7-Flash",
-        "glm-4.7-flash",
         "z-ai/glm-4.7-flash"
       ],
       "model_types": [
@@ -41670,9 +38573,7 @@
     {
       "name": "zai-org/GLM-4.7-FP8",
       "alias": [
-        "zai-org/glm-4.7-fp8",
         "GLM-4.7-FP8",
-        "glm-4.7-fp8",
         "Glm 4.7 Fp8"
       ],
       "model_types": [
@@ -41702,9 +38603,7 @@
     {
       "name": "zai-org/GLM-4.6",
       "alias": [
-        "zai-org/glm-4.6",
         "GLM-4.6",
-        "glm-4.6",
         "z-ai/glm-4.6",
         "Z-AI/GLM 4.6",
         "GLM 4.6",
@@ -41723,9 +38622,7 @@
     {
       "name": "zai-org/GLM-4.6-FP8",
       "alias": [
-        "zai-org/glm-4.6-fp8",
-        "GLM-4.6-FP8",
-        "glm-4.6-fp8"
+        "GLM-4.6-FP8"
       ],
       "model_types": [
         "chat"
@@ -41739,9 +38636,7 @@
     {
       "name": "zai-org/GLM-4.6V",
       "alias": [
-        "zai-org/glm-4.6v",
         "GLM-4.6V",
-        "glm-4.6v",
         "z-ai/glm-4.6v",
         "GLM 4.6V"
       ],
@@ -41760,9 +38655,7 @@
     {
       "name": "zai-org/GLM-4.6V-Flash",
       "alias": [
-        "zai-org/glm-4.6v-flash",
         "GLM-4.6V-Flash",
-        "glm-4.6v-flash",
         "glm-4.6-flash"
       ],
       "model_types": [
@@ -41779,9 +38672,7 @@
     {
       "name": "zai-org/GLM-4.6V-FP8",
       "alias": [
-        "zai-org/glm-4.6v-fp8",
-        "GLM-4.6V-FP8",
-        "glm-4.6v-fp8"
+        "GLM-4.6V-FP8"
       ],
       "model_types": [
         "chat",
@@ -41797,9 +38688,7 @@
     {
       "name": "zai-org/GLM-4.5",
       "alias": [
-        "zai-org/glm-4.5",
         "GLM-4.5",
-        "glm-4.5",
         "z-ai/glm-4.5",
         "GLM 4.5",
         "GLM-4_5"
@@ -41817,9 +38706,7 @@
     {
       "name": "zai-org/GLM-4.5-Air",
       "alias": [
-        "zai-org/glm-4.5-air",
         "GLM-4.5-Air",
-        "glm-4.5-air",
         "z-ai/glm-4.5-air",
         "z-ai/glm-4.5-air:free",
         "GLM 4.5 Air (free)",
@@ -41838,9 +38725,7 @@
     {
       "name": "zai-org/GLM-4.5-Air-Base",
       "alias": [
-        "zai-org/glm-4.5-air-base",
-        "GLM-4.5-Air-Base",
-        "glm-4.5-air-base"
+        "GLM-4.5-Air-Base"
       ],
       "model_types": [
         "chat"
@@ -41854,9 +38739,7 @@
     {
       "name": "zai-org/GLM-4.5-Air-FP8",
       "alias": [
-        "zai-org/glm-4.5-air-fp8",
         "GLM-4.5-Air-FP8",
-        "glm-4.5-air-fp8",
         "Glm 4.5 Air Fp8"
       ],
       "model_types": [
@@ -41871,9 +38754,7 @@
     {
       "name": "zai-org/GLM-4.5-Base",
       "alias": [
-        "zai-org/glm-4.5-base",
-        "GLM-4.5-Base",
-        "glm-4.5-base"
+        "GLM-4.5-Base"
       ],
       "model_types": [
         "chat"
@@ -41887,9 +38768,7 @@
     {
       "name": "zai-org/GLM-4.5-FP8",
       "alias": [
-        "zai-org/glm-4.5-fp8",
-        "GLM-4.5-FP8",
-        "glm-4.5-fp8"
+        "GLM-4.5-FP8"
       ],
       "model_types": [
         "chat"
@@ -41903,9 +38782,7 @@
     {
       "name": "zai-org/GLM-4.5V",
       "alias": [
-        "zai-org/glm-4.5v",
         "GLM-4.5V",
-        "glm-4.5v",
         "z-ai/glm-4.5v",
         "GLM-4_5V",
         "GLM 4.5V"
@@ -41925,9 +38802,7 @@
     {
       "name": "zai-org/GLM-4.5V-FP8",
       "alias": [
-        "zai-org/glm-4.5v-fp8",
-        "GLM-4.5V-FP8",
-        "glm-4.5v-fp8"
+        "GLM-4.5V-FP8"
       ],
       "model_types": [
         "chat",
@@ -41943,9 +38818,7 @@
     {
       "name": "zai-org/GLM-4.1V-9B-Base",
       "alias": [
-        "zai-org/glm-4.1v-9b-base",
-        "GLM-4.1V-9B-Base",
-        "glm-4.1v-9b-base"
+        "GLM-4.1V-9B-Base"
       ],
       "model_types": [
         "chat",
@@ -41957,9 +38830,7 @@
     {
       "name": "zai-org/GLM-4.1V-9B-Thinking",
       "alias": [
-        "zai-org/glm-4.1v-9b-thinking",
-        "GLM-4.1V-9B-Thinking",
-        "glm-4.1v-9b-thinking"
+        "GLM-4.1V-9B-Thinking"
       ],
       "model_types": [
         "chat",
@@ -41975,9 +38846,7 @@
     {
       "name": "zai-org/GLM-4-32B-0414",
       "alias": [
-        "zai-org/glm-4-32b-0414",
         "GLM-4-32B-0414",
-        "glm-4-32b-0414",
         "THUDM/GLM-4-32B-0414"
       ],
       "model_types": [
@@ -41989,9 +38858,7 @@
     {
       "name": "zai-org/GLM-4-32B-Base-0414",
       "alias": [
-        "zai-org/glm-4-32b-base-0414",
-        "GLM-4-32B-Base-0414",
-        "glm-4-32b-base-0414"
+        "GLM-4-32B-Base-0414"
       ],
       "model_types": [
         "chat"
@@ -42011,9 +38878,7 @@
     {
       "name": "zai-org/GLM-4-9B-0414",
       "alias": [
-        "zai-org/glm-4-9b-0414",
-        "GLM-4-9B-0414",
-        "glm-4-9b-0414"
+        "GLM-4-9B-0414"
       ],
       "model_types": [
         "chat"
@@ -42203,9 +39068,7 @@
     {
       "name": "zai-org/AutoGLM-Phone-9B",
       "alias": [
-        "zai-org/autoglm-phone-9b",
-        "AutoGLM-Phone-9B",
-        "autoglm-phone-9b"
+        "AutoGLM-Phone-9B"
       ],
       "model_types": [
         "chat",
@@ -42217,9 +39080,7 @@
     {
       "name": "zai-org/AutoGLM-Phone-9B-Multilingual",
       "alias": [
-        "zai-org/autoglm-phone-9b-multilingual",
-        "AutoGLM-Phone-9B-Multilingual",
-        "autoglm-phone-9b-multilingual"
+        "AutoGLM-Phone-9B-Multilingual"
       ],
       "model_types": [
         "chat",
@@ -42232,9 +39093,7 @@
     {
       "name": "zai-org/BPO",
       "alias": [
-        "zai-org/bpo",
-        "BPO",
-        "bpo"
+        "BPO"
       ],
       "model_types": [
         "chat"
@@ -42394,9 +39253,7 @@
     {
       "name": "zai-org/codegeex4-all-9b-GGUF",
       "alias": [
-        "zai-org/codegeex4-all-9b-gguf",
-        "codegeex4-all-9b-GGUF",
-        "codegeex4-all-9b-gguf"
+        "codegeex4-all-9b-GGUF"
       ],
       "model_types": [
         "chat"
@@ -42406,9 +39263,7 @@
     {
       "name": "zai-org/CogAgent",
       "alias": [
-        "zai-org/cogagent",
-        "CogAgent",
-        "cogagent"
+        "CogAgent"
       ],
       "model_types": [
         "chat"
@@ -42437,9 +39292,7 @@
     {
       "name": "zai-org/CogVideo",
       "alias": [
-        "zai-org/cogvideo",
-        "CogVideo",
-        "cogvideo"
+        "CogVideo"
       ],
       "model_types": [
         "image_generation"
@@ -42448,9 +39301,7 @@
     {
       "name": "zai-org/CogVideoX-2b",
       "alias": [
-        "zai-org/cogvideox-2b",
-        "CogVideoX-2b",
-        "cogvideox-2b"
+        "CogVideoX-2b"
       ],
       "model_types": [
         "image_generation"
@@ -42459,9 +39310,7 @@
     {
       "name": "zai-org/CogVideoX-5b",
       "alias": [
-        "zai-org/cogvideox-5b",
-        "CogVideoX-5b",
-        "cogvideox-5b"
+        "CogVideoX-5b"
       ],
       "model_types": [
         "image_generation"
@@ -42470,9 +39319,7 @@
     {
       "name": "zai-org/CogVideoX-5b-I2V",
       "alias": [
-        "zai-org/cogvideox-5b-i2v",
-        "CogVideoX-5b-I2V",
-        "cogvideox-5b-i2v"
+        "CogVideoX-5b-I2V"
       ],
       "model_types": [
         "image_generation"
@@ -42481,9 +39328,7 @@
     {
       "name": "zai-org/CogVideoX1.5-5B",
       "alias": [
-        "zai-org/cogvideox1.5-5b",
-        "CogVideoX1.5-5B",
-        "cogvideox1.5-5b"
+        "CogVideoX1.5-5B"
       ],
       "model_types": [
         "image_generation"
@@ -42492,9 +39337,7 @@
     {
       "name": "zai-org/CogVideoX1.5-5B-I2V",
       "alias": [
-        "zai-org/cogvideox1.5-5b-i2v",
-        "CogVideoX1.5-5B-I2V",
-        "cogvideox1.5-5b-i2v"
+        "CogVideoX1.5-5B-I2V"
       ],
       "model_types": [
         "image_generation"
@@ -42503,9 +39346,7 @@
     {
       "name": "zai-org/CogVideoX1.5-5B-SAT",
       "alias": [
-        "zai-org/cogvideox1.5-5b-sat",
-        "CogVideoX1.5-5B-SAT",
-        "cogvideox1.5-5b-sat"
+        "CogVideoX1.5-5B-SAT"
       ],
       "model_types": [
         "image_generation"
@@ -42514,9 +39355,7 @@
     {
       "name": "zai-org/CogView2",
       "alias": [
-        "zai-org/cogview2",
-        "CogView2",
-        "cogview2"
+        "CogView2"
       ],
       "model_types": [
         "image_generation"
@@ -42525,9 +39364,7 @@
     {
       "name": "zai-org/CogView3-Plus-3B",
       "alias": [
-        "zai-org/cogview3-plus-3b",
-        "CogView3-Plus-3B",
-        "cogview3-plus-3b"
+        "CogView3-Plus-3B"
       ],
       "model_types": [
         "text-to-image",
@@ -42537,9 +39374,7 @@
     {
       "name": "zai-org/CogView4-6B",
       "alias": [
-        "zai-org/cogview4-6b",
         "CogView4-6B",
-        "cogview4-6b",
         "CogView4_6B"
       ],
       "model_types": [
@@ -42550,9 +39385,7 @@
     {
       "name": "zai-org/CogVLM",
       "alias": [
-        "zai-org/cogvlm",
-        "CogVLM",
-        "cogvlm"
+        "CogVLM"
       ],
       "model_types": [
         "chat"
@@ -42623,9 +39456,7 @@
     {
       "name": "zai-org/cogvlm2-llama3-chat-19B",
       "alias": [
-        "zai-org/cogvlm2-llama3-chat-19b",
-        "cogvlm2-llama3-chat-19B",
-        "cogvlm2-llama3-chat-19b"
+        "cogvlm2-llama3-chat-19B"
       ],
       "model_types": [
         "chat",
@@ -42637,9 +39468,7 @@
     {
       "name": "zai-org/cogvlm2-llama3-chat-19B-int4",
       "alias": [
-        "zai-org/cogvlm2-llama3-chat-19b-int4",
-        "cogvlm2-llama3-chat-19B-int4",
-        "cogvlm2-llama3-chat-19b-int4"
+        "cogvlm2-llama3-chat-19B-int4"
       ],
       "model_types": [
         "chat",
@@ -42651,9 +39480,7 @@
     {
       "name": "zai-org/cogvlm2-llama3-chat-19B-tgi",
       "alias": [
-        "zai-org/cogvlm2-llama3-chat-19b-tgi",
-        "cogvlm2-llama3-chat-19B-tgi",
-        "cogvlm2-llama3-chat-19b-tgi"
+        "cogvlm2-llama3-chat-19B-tgi"
       ],
       "model_types": [
         "chat",
@@ -42665,9 +39492,7 @@
     {
       "name": "zai-org/cogvlm2-llama3-chinese-chat-19B",
       "alias": [
-        "zai-org/cogvlm2-llama3-chinese-chat-19b",
-        "cogvlm2-llama3-chinese-chat-19B",
-        "cogvlm2-llama3-chinese-chat-19b"
+        "cogvlm2-llama3-chinese-chat-19B"
       ],
       "model_types": [
         "chat",
@@ -42679,9 +39504,7 @@
     {
       "name": "zai-org/cogvlm2-llama3-chinese-chat-19B-int4",
       "alias": [
-        "zai-org/cogvlm2-llama3-chinese-chat-19b-int4",
-        "cogvlm2-llama3-chinese-chat-19B-int4",
-        "cogvlm2-llama3-chinese-chat-19b-int4"
+        "cogvlm2-llama3-chinese-chat-19B-int4"
       ],
       "model_types": [
         "chat",
@@ -42693,9 +39516,7 @@
     {
       "name": "zai-org/cogvlm2-llama3-chinese-chat-19B-tgi",
       "alias": [
-        "zai-org/cogvlm2-llama3-chinese-chat-19b-tgi",
-        "cogvlm2-llama3-chinese-chat-19B-tgi",
-        "cogvlm2-llama3-chinese-chat-19b-tgi"
+        "cogvlm2-llama3-chinese-chat-19B-tgi"
       ],
       "model_types": [
         "chat",
@@ -42733,8 +39554,7 @@
     {
       "name": "zai-org/embedding-2",
       "alias": [
-        "embedding-2",
-        "Embedding-2"
+        "embedding-2"
       ],
       "model_types": [
         "embedding"
@@ -42746,8 +39566,7 @@
     {
       "name": "zai-org/embedding-3",
       "alias": [
-        "embedding-3",
-        "Embedding-3"
+        "embedding-3"
       ],
       "model_types": [
         "embedding"
@@ -42764,9 +39583,7 @@
     {
       "name": "zai-org/GLM-ASR-Nano-2512",
       "alias": [
-        "zai-org/glm-asr-nano-2512",
-        "GLM-ASR-Nano-2512",
-        "glm-asr-nano-2512"
+        "GLM-ASR-Nano-2512"
       ],
       "model_types": [
         "asr",
@@ -42865,9 +39682,7 @@
     {
       "name": "zai-org/GLM-Image",
       "alias": [
-        "zai-org/glm-image",
-        "GLM-Image",
-        "glm-image"
+        "GLM-Image"
       ],
       "model_types": [
         "text-to-image",
@@ -42887,9 +39702,7 @@
     {
       "name": "zai-org/GLM-OCR",
       "alias": [
-        "zai-org/glm-ocr",
         "GLM-OCR",
-        "glm-ocr",
         "GLM OCR"
       ],
       "model_types": [
@@ -42914,9 +39727,7 @@
     {
       "name": "zai-org/GLM-TTS",
       "alias": [
-        "zai-org/glm-tts",
-        "GLM-TTS",
-        "glm-tts"
+        "GLM-TTS"
       ],
       "model_types": [
         "tts"
@@ -42925,9 +39736,7 @@
     {
       "name": "zai-org/GLM-Z1-32B-0414",
       "alias": [
-        "zai-org/glm-z1-32b-0414",
-        "GLM-Z1-32B-0414",
-        "glm-z1-32b-0414"
+        "GLM-Z1-32B-0414"
       ],
       "model_types": [
         "chat"
@@ -42941,9 +39750,7 @@
     {
       "name": "zai-org/GLM-Z1-9B-0414",
       "alias": [
-        "zai-org/glm-z1-9b-0414",
         "GLM-Z1-9B-0414",
-        "glm-z1-9b-0414",
         "THUDM/GLM-Z1-9B-0414"
       ],
       "model_types": [
@@ -42958,9 +39765,7 @@
     {
       "name": "zai-org/GLM-Z1-Rumination-32B-0414",
       "alias": [
-        "zai-org/glm-z1-rumination-32b-0414",
-        "GLM-Z1-Rumination-32B-0414",
-        "glm-z1-rumination-32b-0414"
+        "GLM-Z1-Rumination-32B-0414"
       ],
       "model_types": [
         "chat"
@@ -42974,9 +39779,7 @@
     {
       "name": "zai-org/Glyph",
       "alias": [
-        "zai-org/glyph",
-        "Glyph",
-        "glyph"
+        "Glyph"
       ],
       "model_types": [
         "chat",
@@ -42988,9 +39791,7 @@
     {
       "name": "zai-org/ImageReward",
       "alias": [
-        "zai-org/imagereward",
-        "ImageReward",
-        "imagereward"
+        "ImageReward"
       ],
       "model_types": [
         "text-to-image",
@@ -43000,9 +39801,7 @@
     {
       "name": "zai-org/Kaleido-14B-S2V",
       "alias": [
-        "zai-org/kaleido-14b-s2v",
-        "Kaleido-14B-S2V",
-        "kaleido-14b-s2v"
+        "Kaleido-14B-S2V"
       ],
       "model_types": [
         "image_generation"
@@ -43011,9 +39810,7 @@
     {
       "name": "zai-org/LongAlign-13B-64k",
       "alias": [
-        "zai-org/longalign-13b-64k",
-        "LongAlign-13B-64k",
-        "longalign-13b-64k"
+        "LongAlign-13B-64k"
       ],
       "model_types": [
         "chat"
@@ -43023,9 +39820,7 @@
     {
       "name": "zai-org/LongAlign-13B-64k-base",
       "alias": [
-        "zai-org/longalign-13b-64k-base",
-        "LongAlign-13B-64k-base",
-        "longalign-13b-64k-base"
+        "LongAlign-13B-64k-base"
       ],
       "model_types": [
         "chat"
@@ -43035,9 +39830,7 @@
     {
       "name": "zai-org/LongAlign-6B-64k",
       "alias": [
-        "zai-org/longalign-6b-64k",
-        "LongAlign-6B-64k",
-        "longalign-6b-64k"
+        "LongAlign-6B-64k"
       ],
       "model_types": [
         "chat"
@@ -43047,9 +39840,7 @@
     {
       "name": "zai-org/LongAlign-6B-64k-base",
       "alias": [
-        "zai-org/longalign-6b-64k-base",
-        "LongAlign-6B-64k-base",
-        "longalign-6b-64k-base"
+        "LongAlign-6B-64k-base"
       ],
       "model_types": [
         "chat"
@@ -43059,9 +39850,7 @@
     {
       "name": "zai-org/LongAlign-7B-64k",
       "alias": [
-        "zai-org/longalign-7b-64k",
-        "LongAlign-7B-64k",
-        "longalign-7b-64k"
+        "LongAlign-7B-64k"
       ],
       "model_types": [
         "chat"
@@ -43071,9 +39860,7 @@
     {
       "name": "zai-org/LongAlign-7B-64k-base",
       "alias": [
-        "zai-org/longalign-7b-64k-base",
-        "LongAlign-7B-64k-base",
-        "longalign-7b-64k-base"
+        "LongAlign-7B-64k-base"
       ],
       "model_types": [
         "chat"
@@ -43083,9 +39870,7 @@
     {
       "name": "zai-org/LongCite-glm4-9b",
       "alias": [
-        "zai-org/longcite-glm4-9b",
-        "LongCite-glm4-9b",
-        "longcite-glm4-9b"
+        "LongCite-glm4-9b"
       ],
       "model_types": [
         "chat"
@@ -43095,9 +39880,7 @@
     {
       "name": "zai-org/LongCite-llama3.1-8b",
       "alias": [
-        "zai-org/longcite-llama3.1-8b",
-        "LongCite-llama3.1-8b",
-        "longcite-llama3.1-8b"
+        "LongCite-llama3.1-8b"
       ],
       "model_types": [
         "chat"
@@ -43107,9 +39890,7 @@
     {
       "name": "zai-org/LongReward-glm4-9b-DPO",
       "alias": [
-        "zai-org/longreward-glm4-9b-dpo",
-        "LongReward-glm4-9b-DPO",
-        "longreward-glm4-9b-dpo"
+        "LongReward-glm4-9b-DPO"
       ],
       "model_types": [
         "chat"
@@ -43119,9 +39900,7 @@
     {
       "name": "zai-org/LongReward-llama3.1-8b-DPO",
       "alias": [
-        "zai-org/longreward-llama3.1-8b-dpo",
-        "LongReward-llama3.1-8b-DPO",
-        "longreward-llama3.1-8b-dpo"
+        "LongReward-llama3.1-8b-DPO"
       ],
       "model_types": [
         "chat"
@@ -43131,9 +39910,7 @@
     {
       "name": "zai-org/LongWriter-glm4-9b",
       "alias": [
-        "zai-org/longwriter-glm4-9b",
-        "LongWriter-glm4-9b",
-        "longwriter-glm4-9b"
+        "LongWriter-glm4-9b"
       ],
       "model_types": [
         "chat"
@@ -43143,9 +39920,7 @@
     {
       "name": "zai-org/LongWriter-llama3.1-8b",
       "alias": [
-        "zai-org/longwriter-llama3.1-8b",
-        "LongWriter-llama3.1-8b",
-        "longwriter-llama3.1-8b"
+        "LongWriter-llama3.1-8b"
       ],
       "model_types": [
         "chat"
@@ -43155,9 +39930,7 @@
     {
       "name": "zai-org/MathGLM",
       "alias": [
-        "zai-org/mathglm",
-        "MathGLM",
-        "mathglm"
+        "MathGLM"
       ],
       "model_types": [
         "chat"
@@ -43166,9 +39939,7 @@
     {
       "name": "zai-org/MathGLM-Vision",
       "alias": [
-        "zai-org/mathglm-vision",
-        "MathGLM-Vision",
-        "mathglm-vision"
+        "MathGLM-Vision"
       ],
       "model_types": [
         "chat"
@@ -43177,9 +39948,7 @@
     {
       "name": "zai-org/MathGLM-Vision-19B",
       "alias": [
-        "zai-org/mathglm-vision-19b",
-        "MathGLM-Vision-19B",
-        "mathglm-vision-19b"
+        "MathGLM-Vision-19B"
       ],
       "model_types": [
         "chat"
@@ -43188,9 +39957,7 @@
     {
       "name": "zai-org/MSAGPT",
       "alias": [
-        "zai-org/msagpt",
-        "MSAGPT",
-        "msagpt"
+        "MSAGPT"
       ],
       "model_types": [
         "chat"
@@ -43199,9 +39966,7 @@
     {
       "name": "zai-org/RealVideo",
       "alias": [
-        "zai-org/realvideo",
-        "RealVideo",
-        "realvideo"
+        "RealVideo"
       ],
       "model_types": [
         "omni"
@@ -43221,9 +39986,7 @@
     {
       "name": "zai-org/SCAIL-2",
       "alias": [
-        "zai-org/scail-2",
-        "SCAIL-2",
-        "scail-2"
+        "SCAIL-2"
       ],
       "model_types": [
         "image_generation"
@@ -43232,9 +39995,7 @@
     {
       "name": "zai-org/SCAIL-Preview",
       "alias": [
-        "zai-org/scail-preview",
-        "SCAIL-Preview",
-        "scail-preview"
+        "SCAIL-Preview"
       ],
       "model_types": [
         "image_generation"
@@ -43243,9 +40004,7 @@
     {
       "name": "zai-org/SSVAE",
       "alias": [
-        "zai-org/ssvae",
-        "SSVAE",
-        "ssvae"
+        "SSVAE"
       ],
       "model_types": [
         "chat"
@@ -43254,9 +40013,7 @@
     {
       "name": "zai-org/SWE-Dev-32B",
       "alias": [
-        "zai-org/swe-dev-32b",
-        "SWE-Dev-32B",
-        "swe-dev-32b"
+        "SWE-Dev-32B"
       ],
       "model_types": [
         "chat"
@@ -43266,9 +40023,7 @@
     {
       "name": "zai-org/SWE-Dev-7B",
       "alias": [
-        "zai-org/swe-dev-7b",
-        "SWE-Dev-7B",
-        "swe-dev-7b"
+        "SWE-Dev-7B"
       ],
       "model_types": [
         "chat"
@@ -43278,9 +40033,7 @@
     {
       "name": "zai-org/SWE-Dev-9B",
       "alias": [
-        "zai-org/swe-dev-9b",
-        "SWE-Dev-9B",
-        "swe-dev-9b"
+        "SWE-Dev-9B"
       ],
       "model_types": [
         "chat"
@@ -43290,9 +40043,7 @@
     {
       "name": "zai-org/UI2Code_N",
       "alias": [
-        "zai-org/ui2code_n",
-        "UI2Code_N",
-        "ui2code_n"
+        "UI2Code_N"
       ],
       "model_types": [
         "chat",
@@ -43304,9 +40055,7 @@
     {
       "name": "zai-org/VisionReward-Image",
       "alias": [
-        "zai-org/visionreward-image",
-        "VisionReward-Image",
-        "visionreward-image"
+        "VisionReward-Image"
       ],
       "model_types": [
         "chat",
@@ -43317,9 +40066,7 @@
     {
       "name": "zai-org/VisionReward-Image-bf16",
       "alias": [
-        "zai-org/visionreward-image-bf16",
-        "VisionReward-Image-bf16",
-        "visionreward-image-bf16"
+        "VisionReward-Image-bf16"
       ],
       "model_types": [
         "chat",
@@ -43332,9 +40079,7 @@
     {
       "name": "zai-org/VisionReward-Video",
       "alias": [
-        "zai-org/visionreward-video",
-        "VisionReward-Video",
-        "visionreward-video"
+        "VisionReward-Video"
       ],
       "model_types": [
         "chat",
@@ -43359,9 +40104,7 @@
     {
       "name": "zai-org/WebGLM",
       "alias": [
-        "zai-org/webglm",
-        "WebGLM",
-        "webglm"
+        "WebGLM"
       ],
       "model_types": [
         "chat"
@@ -43371,9 +40114,7 @@
     {
       "name": "zai-org/WebGLM-2B",
       "alias": [
-        "zai-org/webglm-2b",
-        "WebGLM-2B",
-        "webglm-2b"
+        "WebGLM-2B"
       ],
       "model_types": [
         "chat"
@@ -43423,9 +40164,7 @@
     {
       "name": "zai-org/WebVIA-Agent",
       "alias": [
-        "zai-org/webvia-agent",
-        "WebVIA-Agent",
-        "webvia-agent"
+        "WebVIA-Agent"
       ],
       "model_types": [
         "chat",


### PR DESCRIPTION
### What problem does this PR solve?

  This PR fixes Go admin server startup failure caused by duplicate model aliases in conf/all_models.json.

  The model provider loader builds a global lookup table from both model name and alias values. Some aliases duplicated another model's name or another
  alias, for example amazon.titan-embed-text-v1, which caused startup to fail with a duplicate alias error. This PR removes conflicting duplicate aliases
  while keeping all model definitions intact.
