### PR TITLE
Go: add more start server parameters

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ CPP_DIR="$PROJECT_ROOT/internal/cpp"
 BUILD_DIR="$CPP_DIR/cmake-build-release"
 RAGFLOW_SERVER_BINARY="$PROJECT_ROOT/bin/ragflow_server"
 ADMIN_SERVER_BINARY="$PROJECT_ROOT/bin/admin_server"
+INGESTOR_BINARY="$PROJECT_ROOT/bin/ingestor"
 RAGFLOW_CLI_BINARY="$PROJECT_ROOT/bin/ragflow_cli"
 
 # office_oxide native library settings
@@ -261,13 +262,16 @@ build_go() {
     export CGO_LDFLAGS="-L${OFFICE_OXIDE_PREFIX}/lib -loffice_oxide -Wl,-rpath,${OFFICE_OXIDE_PREFIX}/lib${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
     echo "Exporting CGO_LDFLAGS: $CGO_LDFLAGS"
 
-    echo "Building RAGFlow binary: $RAGFLOW_SERVER_BINARY, $ADMIN_SERVER_BINARY, and $RAGFLOW_CLI_BINARY"
+    echo "Building RAGFlow binary: $RAGFLOW_SERVER_BINARY, $ADMIN_SERVER_BINARY, $INGESTOR_BINARY, and $RAGFLOW_CLI_BINARY"
     GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} CGO_ENABLED=1 \
         CGO_CFLAGS="$CGO_CFLAGS" CGO_LDFLAGS="$CGO_LDFLAGS" \
         go build -o "$RAGFLOW_SERVER_BINARY" cmd/server_main.go
     GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} CGO_ENABLED=1 \
         CGO_CFLAGS="$CGO_CFLAGS" CGO_LDFLAGS="$CGO_LDFLAGS" \
         go build -o "$ADMIN_SERVER_BINARY" cmd/admin_server.go
+    GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} CGO_ENABLED=1 \
+        CGO_CFLAGS="$CGO_CFLAGS" CGO_LDFLAGS="$CGO_LDFLAGS" \
+        go build -o "$INGESTOR_BINARY" cmd/ingestor.go
     GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} CGO_ENABLED=1 \
         CGO_CFLAGS="$CGO_CFLAGS" CGO_LDFLAGS="$CGO_LDFLAGS" \
         go build -o "$RAGFLOW_CLI_BINARY" cmd/ragflow_cli.go
@@ -282,9 +286,15 @@ build_go() {
         exit 1
     fi
 
+    if [ ! -f "$INGESTOR_BINARY" ]; then
+        echo -e "${RED}Error: Failed to build Ingestor binary${NC}"
+        exit 1
+    fi
+
     echo -e "${GREEN}✓ Go ragflow_server built successfully: $RAGFLOW_SERVER_BINARY${NC}"
     echo -e "${GREEN}✓ Go admin_server built successfully: $ADMIN_SERVER_BINARY${NC}"
     echo -e "${GREEN}✓ Go ragflow_cli built successfully: $RAGFLOW_CLI_BINARY${NC}"
+    echo -e "${GREEN}✓ Go ingestor built successfully: $INGESTOR_BINARY${NC}"
 }
 
 # Clean build artifacts
@@ -294,6 +304,8 @@ clean() {
     rm -rf "$BUILD_DIR"
     rm -f "$RAGFLOW_SERVER_BINARY"
     rm -f "$ADMIN_SERVER_BINARY"
+    rm -f "$INGESTOR_BINARY"
+    rm -f "$RAGFLOW_CLI_BINARY"
 
     echo -e "${GREEN}✓ Build artifacts cleaned${NC}"
 }
@@ -308,6 +320,10 @@ run() {
         echo -e "${RED}Error: $RAGFLOW_SERVER_BINARY not found. Build first with --all or --go${NC}"
         exit 1
     fi
+    if [ ! -f "$INGESTOR_BINARY" ]; then
+        echo -e "${RED}Error: $INGESTOR_BINARY not found. Build first with --all or --go${NC}"
+        exit 1
+    fi
 
     cd "$PROJECT_ROOT"
 
@@ -320,6 +336,12 @@ run() {
 
     # Give admin_server a moment to bind its listening port (9383) before
     # ragflow_server starts sending heartbeats to it.
+    sleep 1
+
+    print_section "Starting ingestor (background)"
+    "$INGESTOR_BINARY" &
+    INGESTOR_PID=$!
+    trap 'kill "$INGESTOR_PID" 2>/dev/null || true' EXIT INT TERM
     sleep 1
 
     print_section "Starting RAGFlow server (foreground)"
@@ -396,7 +418,7 @@ main() {
             build_cpp
             build_go
             echo -e "\n${GREEN}=== Build completed successfully! ===${NC}"
-            echo "Binary: $RAGFLOW_SERVER_BINARY, $ADMIN_SERVER_BINARY"
+            echo "Binary: $RAGFLOW_SERVER_BINARY, $ADMIN_SERVER_BINARY, $INGESTOR_BINARY, $RAGFLOW_CLI_BINARY"
             ;;
         *)
             echo -e "${RED}Unknown option: $1${NC}"

--- a/cmd/admin_server.go
+++ b/cmd/admin_server.go
@@ -70,7 +70,7 @@ func main() {
 	// Handle --version flag: print version and exit immediately
 	if versionFlag {
 		fmt.Printf("RAGFlow version: %s\n", utility.GetRAGFlowVersion())
-		os.Exit(0)
+		return
 	}
 
 	// Initialize logger

--- a/cmd/admin_server.go
+++ b/cmd/admin_server.go
@@ -41,10 +41,37 @@ import (
 	"ragflow/internal/server"
 )
 
+func printHelp() {
+	fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS]\n\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "RAGFlow Admin Server\n\n")
+	fmt.Fprintf(os.Stderr, "Options:\n")
+	fmt.Fprintf(os.Stderr, "  --config string\tPath to configuration file\n")
+	fmt.Fprintf(os.Stderr, "  -v, --version  \tPrint version information and exit\n")
+	fmt.Fprintf(os.Stderr, "  --debug        \tEnable debug-level logging\n")
+	fmt.Fprintf(os.Stderr, "  --init-superuser\tInitialize superuser account\n")
+	fmt.Fprintf(os.Stderr, "  -h, --help     \tShow this help message and exit\n")
+}
+
 func main() {
 	var configPath string
 	flag.StringVar(&configPath, "config", "", "Path to configuration file")
+	var debugFlag bool
+	flag.BoolVar(&debugFlag, "debug", false, "Enable debug-level logging")
+	var versionFlag bool
+	flag.BoolVar(&versionFlag, "version", false, "Print version information and exit")
+	var initSuperuser bool
+	flag.BoolVar(&initSuperuser, "init-superuser", false, "Initialize superuser account")
+
+	// Custom help message
+	flag.Usage = printHelp
+
 	flag.Parse()
+
+	// Handle --version flag: print version and exit immediately
+	if versionFlag {
+		fmt.Printf("RAGFlow version: %s\n", utility.GetRAGFlowVersion())
+		os.Exit(0)
+	}
 
 	// Initialize logger
 	if err := common.Init("info", "admin_server.log"); err != nil {
@@ -60,10 +87,17 @@ func main() {
 	cfg := server.GetConfig()
 
 	// Reinitialize logger with configured level if different
-	if cfg.Log.Level != "" && cfg.Log.Level != "info" {
-		if err := common.Init(cfg.Log.Level, "admin_server.log"); err != nil {
-			common.Error("Failed to reinitialize logger with configured level", err)
-		}
+	logLevel := cfg.Log.Level
+	if logLevel == "" {
+		logLevel = "info"
+	}
+
+	if debugFlag {
+		logLevel = "debug"
+	}
+
+	if err := common.Init(logLevel, "admin_server.log"); err != nil {
+		common.Error("Failed to reinitialize logger with configured level", err)
 	}
 
 	// Set logger for server package
@@ -109,9 +143,12 @@ func main() {
 	adminService := admin.NewService()
 	adminHandler := admin.NewHandler(adminService)
 
-	// Initialize default admin user
-	if err := adminService.InitDefaultAdmin(); err != nil {
-		common.Error("Failed to initialize default admin user", err)
+	if initSuperuser {
+		// Initialize default admin user
+		if err := adminService.InitDefaultAdmin(); err != nil {
+			common.Error("Failed to initialize default admin user", err)
+		}
+
 	}
 
 	// Initialize router

--- a/cmd/ingestor.go
+++ b/cmd/ingestor.go
@@ -51,11 +51,15 @@ func printIngestionServerHelp() {
 	fmt.Fprintf(os.Stderr, "  --name string\t\tIngestion server name (default: \"default_ingestion\")\n")
 	fmt.Fprintf(os.Stderr, "  --admin-host string\tAdmin server host (overrides config file)\n")
 	fmt.Fprintf(os.Stderr, "  --admin-port int\tAdmin server port (overrides config file)\n")
+	fmt.Fprintf(os.Stderr, "  --version  \tPrint version information and exit\n")
+	fmt.Fprintf(os.Stderr, "  --debug        \tEnable debug-level logging\n")
 	fmt.Fprintf(os.Stderr, "  -h, --help\t\tShow this help message and exit\n")
 	fmt.Fprintf(os.Stderr, "\nExamples:\n")
 	fmt.Fprintf(os.Stderr, "  %s                          # Start with default config\n", os.Args[0])
 	fmt.Fprintf(os.Stderr, "  %s -f /path/to/config.yaml   # Start with custom config file\n", os.Args[0])
 	fmt.Fprintf(os.Stderr, "  %s --admin-host 10.0.0.1 --admin-port 9383\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s --version  \t\t# Show version and exit\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s --debug    \t\t# Start with debug logging\n", os.Args[0])
 }
 
 func main() {
@@ -69,11 +73,21 @@ func main() {
 	flag.StringVar(&name, "name", "default_ingestion", "Ingestion server name")
 	flag.StringVar(&adminHost, "admin-host", "", "Admin server host (overrides config file)")
 	flag.IntVar(&adminPort, "admin-port", 0, "Admin server port (overrides config file)")
+	var debugFlag bool
+	flag.BoolVar(&debugFlag, "debug", false, "Enable debug-level logging")
+	var versionFlag bool
+	flag.BoolVar(&versionFlag, "version", false, "Print version information and exit")
 
 	// Custom help message
 	flag.Usage = printIngestionServerHelp
 
 	flag.Parse()
+
+	// Handle --version flag: print version and exit immediately
+	if versionFlag {
+		fmt.Printf("RAGFlow version: %s\n", utility.GetRAGFlowVersion())
+		return
+	}
 
 	// Initialize logger with default level
 	if err := common.Init("info", "ingestion_server.log"); err != nil {
@@ -104,6 +118,11 @@ func main() {
 	if level == "" {
 		level = "info"
 	}
+
+	if debugFlag {
+		level = "debug"
+	}
+
 	if err := common.Init(level, "ingestion_server.log"); err != nil {
 		common.Error("Failed to reinitialize logger", err)
 	}

--- a/cmd/server_main.go
+++ b/cmd/server_main.go
@@ -57,7 +57,6 @@ func printHelp() {
 	fmt.Fprintf(os.Stderr, "  -p, --port int\t\tServer port (overrides config file)\n")
 	fmt.Fprintf(os.Stderr, "  -v, --version  \tPrint version information and exit\n")
 	fmt.Fprintf(os.Stderr, "  --debug        \tEnable debug-level logging\n")
-	fmt.Fprintf(os.Stderr, "  --init-superuser\tInitialize superuser account\n")
 	fmt.Fprintf(os.Stderr, "  -h, --help     \tShow this help message and exit\n")
 	fmt.Fprintf(os.Stderr, "\nExamples:\n")
 	fmt.Fprintf(os.Stderr, "  %s           \t\t# Start server with config file port\n", os.Args[0])
@@ -77,8 +76,6 @@ func main() {
 	var versionFlag bool
 	flag.BoolVar(&versionFlag, "version", false, "Print version information and exit")
 	flag.BoolVar(&versionFlag, "v", false, "Print version information and exit (shorthand)")
-	var initSuperuserFlag bool
-	flag.BoolVar(&initSuperuserFlag, "init-superuser", false, "Initialize superuser account")
 
 	// Custom help message
 	flag.Usage = printHelp
@@ -188,9 +185,6 @@ func main() {
 	if err := nlp.InitQueryBuilderFromTokenizer(tokenizerCfg.DictPath); err != nil {
 		common.Fatal("Failed to initialize query builder", zap.Error(err))
 	}
-
-	// Store init-superuser flag for later use
-	_ = initSuperuserFlag
 
 	startServer(config)
 

--- a/cmd/server_main.go
+++ b/cmd/server_main.go
@@ -54,12 +54,17 @@ func printHelp() {
 	fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS]\n\n", os.Args[0])
 	fmt.Fprintf(os.Stderr, "RAGFlow Server - Open-source RAG engine based on deep document understanding\n\n")
 	fmt.Fprintf(os.Stderr, "Options:\n")
-	fmt.Fprintf(os.Stderr, "  -p, --port int\tServer port (overrides config file)\n")
-	fmt.Fprintf(os.Stderr, "  -h, --help   \tShow this help message and exit\n")
+	fmt.Fprintf(os.Stderr, "  -p, --port int\t\tServer port (overrides config file)\n")
+	fmt.Fprintf(os.Stderr, "  -v, --version  \tPrint version information and exit\n")
+	fmt.Fprintf(os.Stderr, "  --debug        \tEnable debug-level logging\n")
+	fmt.Fprintf(os.Stderr, "  --init-superuser\tInitialize superuser account\n")
+	fmt.Fprintf(os.Stderr, "  -h, --help     \tShow this help message and exit\n")
 	fmt.Fprintf(os.Stderr, "\nExamples:\n")
-	fmt.Fprintf(os.Stderr, "  %s           # Start server with config file port\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "  %s -p 8080   # Start server on port 8080\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "  %s --port 8080 # Start server on port 8080\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s           \t\t# Start server with config file port\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s -p 8080   \t\t# Start server on port 8080\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s --port 8080 \t# Start server on port 8080\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s --version  \t# Show version and exit\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s --debug    \t# Start server with debug logging\n", os.Args[0])
 }
 
 func main() {
@@ -67,11 +72,24 @@ func main() {
 	var portFlag int
 	flag.IntVar(&portFlag, "port", 0, "Server port (overrides config file)")
 	flag.IntVar(&portFlag, "p", 0, "Server port (shorthand, overrides config file)")
+	var debugFlag bool
+	flag.BoolVar(&debugFlag, "debug", false, "Enable debug-level logging")
+	var versionFlag bool
+	flag.BoolVar(&versionFlag, "version", false, "Print version information and exit")
+	flag.BoolVar(&versionFlag, "v", false, "Print version information and exit (shorthand)")
+	var initSuperuserFlag bool
+	flag.BoolVar(&initSuperuserFlag, "init-superuser", false, "Initialize superuser account")
 
 	// Custom help message
 	flag.Usage = printHelp
 
 	flag.Parse()
+
+	// Handle --version flag: print version and exit immediately
+	if versionFlag {
+		fmt.Printf("RAGFlow version: %s\n", utility.GetRAGFlowVersion())
+		return
+	}
 
 	// Initialize logger with default level
 	// logger.Init("info"); // set debug log level
@@ -100,6 +118,11 @@ func main() {
 	if level == "" {
 		level = "info"
 	}
+
+	if debugFlag {
+		level = "debug"
+	}
+
 	if err := common.Init(level, "server_main.log"); err != nil {
 		common.Error("Failed to reinitialize logger", err)
 	}
@@ -165,6 +188,9 @@ func main() {
 	if err := nlp.InitQueryBuilderFromTokenizer(tokenizerCfg.DictPath); err != nil {
 		common.Fatal("Failed to initialize query builder", zap.Error(err))
 	}
+
+	// Store init-superuser flag for later use
+	_ = initSuperuserFlag
 
 	startServer(config)
 

--- a/cmd/server_main.go
+++ b/cmd/server_main.go
@@ -75,7 +75,6 @@ func main() {
 	flag.BoolVar(&debugFlag, "debug", false, "Enable debug-level logging")
 	var versionFlag bool
 	flag.BoolVar(&versionFlag, "version", false, "Print version information and exit")
-	flag.BoolVar(&versionFlag, "v", false, "Print version information and exit (shorthand)")
 
 	// Custom help message
 	flag.Usage = printHelp

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -1811,6 +1811,7 @@ func (s *Service) InitDefaultAdmin() error {
 			return fmt.Errorf("failed to add tenant for admin: %w", err)
 		}
 
+		common.Info("Init default super user successfully")
 		return nil
 	}
 
@@ -1838,6 +1839,7 @@ func (s *Service) InitDefaultAdmin() error {
 		}
 	}
 
+	common.Info("Init default super user successfully")
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

```
$ ./bin/ragflow_server --version 
RAGFlow version: v0.26.0-65-g549f6109c

$ ./bin/ragflow_server --debug # start server with debug log level

$ ./bin/admin_server --version 
RAGFlow version: v0.26.0-65-g549f6109c

$ ./bin/admin_server --debug # start server with debug log level

$ ./bin/admin_server --init-superuser # init default superuser

$ ./bin/ingestor --version
RAGFlow version: v0.26.0-68-g6f6c39706

$ ./bin/ingestor --debug
```


### Type of change

- [x] New Feature (non-breaking change which adds functionality)
