### PR TITLE
fix: rename dialog_id to chat_id in chat_channel (backend + frontend)

### DIFF
--- a/api/apps/restful_apis/chat_channel_api.py
+++ b/api/apps/restful_apis/chat_channel_api.py
@@ -43,7 +43,7 @@ async def create_chat_channel():
         "name": req["name"],
         "channel": req["channel"],
         "config": req["config"],
-        "dialog_id": req.get("dialog_id") or None
+        "chat_id": req.get("chat_id") or None
     }
     ChatChannelService.insert(**channel)
 
@@ -89,14 +89,14 @@ async def update_chat_channel(channel_id):
         req = req["data"]
 
     # Validate the connected dialog (if provided) belongs to the channel's tenant.
-    if req.get("dialog_id"):
-        e, dia = DialogService.get_by_id(req["dialog_id"])
+    if req.get("chat_id"):
+        e, dia = DialogService.get_by_id(req["chat_id"])
         if not e:
             return get_data_error_result(message="Can't find this chat assistant!")
         if dia.tenant_id != conn.tenant_id:
             return _chat_channel_auth_error(channel_id, current_user.id)
 
-    update_fields = {fld: req[fld] for fld in ["name", "config", "dialog_id"] if fld in req}
+    update_fields = {fld: req[fld] for fld in ["name", "config", "chat_id"] if fld in req}
     if update_fields:
         ChatChannelService.update_by_id(channel_id, update_fields)
 

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -1253,7 +1253,7 @@ class ChatChannel(DataBaseModel):
     name = CharField(max_length=128, null=False, help_text="Bot name", index=False)
     channel = CharField(max_length=128, null=False, help_text="Chat channel type", index=True)
     config = JSONField(null=False, default={}, help_text="Channel credential & settings")
-    dialog_id = CharField(max_length=32, null=True, default=None, help_text="connected dialog id", index=True)
+    chat_id = CharField(max_length=32, null=True, default=None, help_text="connected chat id", index=True)
     status = IntegerField(default=1, index=True)
 
     def __str__(self):
@@ -1778,6 +1778,7 @@ def migrate_db():
     alter_db_column_type(migrator, "file", "size", BigIntegerField(default=0, index=True))
     alter_db_add_column(migrator, "tenant", "ocr_id", CharField(max_length=128, null=True, help_text="default ocr model ID", index=True))
     alter_db_column_type(migrator, "chat_channel", "status", IntegerField(default=1, index=True))
+    alter_db_rename_column(migrator, "chat_channel", "dialog_id", "chat_id")
     # Drop both the explicit "idx_*" name from later migrations AND the
     # Peewee-auto-derived "<table-as-classname>_<col1>_<col2>" name from the
     # original TenantModelInstance definition (commit dc4b82523). Databases

--- a/api/db/services/chat_channel_service.py
+++ b/api/db/services/chat_channel_service.py
@@ -34,7 +34,7 @@ class ChatChannelService(CommonService):
             cls.model.id,
             cls.model.name,
             cls.model.channel,
-            cls.model.dialog_id,
+            cls.model.chat_id,
             cls.model.status,
             Dialog.name.alias("dialog_name"),
         ]
@@ -43,7 +43,7 @@ class ChatChannelService(CommonService):
             .join(
                 Dialog,
                 join_type=JOIN.LEFT_OUTER,
-                on=(Dialog.id == cls.model.dialog_id),
+                on=(Dialog.id == cls.model.chat_id),
             )
             .where(cls.model.tenant_id == tenant_id)
             .order_by(cls.model.create_time.desc())

--- a/web/src/pages/user-setting/chat-channel/component/added-channel-card.tsx
+++ b/web/src/pages/user-setting/chat-channel/component/added-channel-card.tsx
@@ -58,10 +58,10 @@ export const AddedChannelCard = (props: IAddedChannelCardProps) => {
           >
             <div className="flex flex-col gap-0.5">
               <div className="text-sm text-text-primary">{item.name}</div>
-              {item.dialog_id ? (
+              {item.chat_id ? (
                 <div className="text-xs text-text-secondary flex items-center gap-1">
                   <Link2 size={12} />
-                  {item.dialog_name || item.dialog_id}
+                  {item.dialog_name || item.chat_id}
                 </div>
               ) : (
                 <div className="text-xs text-text-secondary/60">

--- a/web/src/pages/user-setting/chat-channel/component/connect-dialog-modal.tsx
+++ b/web/src/pages/user-setting/chat-channel/component/connect-dialog-modal.tsx
@@ -22,12 +22,12 @@ const ConnectDialogModal = ({
   const { dialogs } = useChatChannelDialogList();
   const { connect, connecting } = useConnectChatChannelDialog();
   const [dialogId, setDialogId] = useState<string | undefined>(
-    channel?.dialog_id ?? undefined,
+    channel?.chat_id ?? undefined,
   );
 
   useEffect(() => {
-    setDialogId(channel?.dialog_id ?? undefined);
-  }, [channel?.id, channel?.dialog_id]);
+    setDialogId(channel?.chat_id ?? undefined);
+  }, [channel?.id, channel?.chat_id]);
 
   const options = useMemo(
     () => (dialogs || []).map((d) => ({ label: d.name, value: d.id })),

--- a/web/src/pages/user-setting/chat-channel/hooks.ts
+++ b/web/src/pages/user-setting/chat-channel/hooks.ts
@@ -166,7 +166,7 @@ export const useConnectChatChannelDialog = () => {
       dialogId: string | null;
     }) => {
       const { data } = await updateChatChannel(params.channelId, {
-        dialog_id: params.dialogId,
+        chat_id: params.dialogId,
       });
       if (data.code === 0) {
         message.success(t('message.operated'));

--- a/web/src/pages/user-setting/chat-channel/interface.ts
+++ b/web/src/pages/user-setting/chat-channel/interface.ts
@@ -11,8 +11,8 @@ export interface IChatChannelBase {
   id: string;
   name: string;
   channel: ChatChannelKey;
-  // Connected assistant (dialog), joined in by the list endpoint.
-  dialog_id?: string | null;
+  // Connected assistant (chat), joined in by the list endpoint.
+  chat_id?: string | null;
   dialog_name?: string | null;
 }
 


### PR DESCRIPTION
## Summary

- The `ChatChannel` DB column was renamed from `dialog_id` to `chat_id` via a migration (added in a prior commit).
- Aligns the REST API layer (`chat_channel_api.py`, `chat_channel_service.py`) to use `chat_id` consistently.
- Updates the frontend (`interface.ts`, `hooks.ts`, `connect-dialog-modal.tsx`, `added-channel-card.tsx`) to read/write `chat_id` instead of `dialog_id`.
- The joined `dialog_name` alias in the list query is unchanged (backend still returns it under that name).

