### PR TITLE
fix: show telegram chat channel

### DIFF
--- a/web/src/pages/user-setting/chat-channel/index.tsx
+++ b/web/src/pages/user-setting/chat-channel/index.tsx
@@ -58,7 +58,12 @@ const ChatChannel = () => {
   const { chatChannelInfo } = useChatChannelInfo();
   const channelTemplates: IChatChannelInfo[] = Object.values(ChatChannelKey)
     .filter(
-      (id) => [ChatChannelKey.DISCORD, ChatChannelKey.FEISHU].includes(id), // Show only Discord and Feishu
+      (id) =>
+        [
+          ChatChannelKey.DISCORD,
+          ChatChannelKey.FEISHU,
+          ChatChannelKey.TELEGRAM,
+        ].includes(id), // Show only Discord and Feishu
     )
     .map((id) => ({
       id,


### PR DESCRIPTION
### What problem does this PR solve?
Show Telegram in the chat channel picker alongside the existing Discord and Feishu entries.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)