### PR TITLE
fix: chat channel runtime

### DIFF
--- a/api/channels/bootstrap.py
+++ b/api/channels/bootstrap.py
@@ -107,7 +107,7 @@ def _make_chat_handler(ch):
 
         # account_id == chat_channel.id; re-read so a re-connected dialog applies live.
         e, cc = ChatChannelService.get_by_id(ch.account_id)
-        if not e or not cc.dialog_id:
+        if not e or not cc.chat_id:
             LOGGER.info(
                 "[%s:%s] no dialog connected; ignoring message",
                 ch.channel_id,
@@ -115,12 +115,12 @@ def _make_chat_handler(ch):
             )
             return
 
-        e, dia = DialogService.get_by_id(cc.dialog_id)
+        e, dia = DialogService.get_by_id(cc.chat_id)
         if not e:
-            LOGGER.warning("[%s:%s] connected dialog not found: %s", ch.channel_id, ch.account_id, cc.dialog_id)
+            LOGGER.warning("[%s:%s] connected dialog not found: %s", ch.channel_id, ch.account_id, cc.chat_id)
             return
 
-        conv = ConversationService.get_or_create_for_channel(cc.dialog_id, ch.account_id, msg.chat_id)
+        conv = ConversationService.get_or_create_for_channel(cc.chat_id, ch.account_id, msg.chat_id)
         if conv is None:
             LOGGER.warning("[%s:%s] failed to get conversation for chat %s", ch.channel_id, ch.account_id, msg.chat_id)
             return

--- a/api/channels/feishu/channel.py
+++ b/api/channels/feishu/channel.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import lark_oapi as lark
+import lark_oapi.ws.client as lark_ws_client
 from lark_oapi.api.im.v1 import (
     CreateMessageRequest,
     CreateMessageRequestBody,
@@ -73,6 +74,11 @@ class FeishuChannel(Channel):
         # context: already entered"). A dedicated isolated loop avoids that.
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+        # lark_oapi.ws.client stores a module-level `loop` at import time and all
+        # websocket task scheduling goes through that object. Rebind it here so
+        # this Feishu channel uses the thread-local loop instead of the API
+        # server's main loop.
+        lark_ws_client.loop = loop
         try:
             handler = (
                 lark.EventDispatcherHandler.builder("", "")


### PR DESCRIPTION
### What problem does this PR solve?
Fix chat channel message routing to use the connected `chat_id`, and make the Feishu websocket client bind to the thread-local event loop.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)