### PR TITLE
fix: use RESTful pipeline detail API with knowledgeId and logId

### DIFF
--- a/web/src/pages/dataflow-result/hooks.ts
+++ b/web/src/pages/dataflow-result/hooks.ts
@@ -4,7 +4,7 @@ import { useSetModalState, useShowDeleteConfirm } from '@/hooks/common-hooks';
 import { useGetKnowledgeSearchParams } from '@/hooks/route-hook';
 import { useFetchMessageTrace } from '@/hooks/use-agent-request';
 import { useCreateChunk, useDeleteChunk } from '@/hooks/use-chunk-request';
-import kbService from '@/services/knowledge-service';
+import kbService, { getPipelineDetail } from '@/services/knowledge-service';
 import { formatSecondsToHumanReadable } from '@/utils/date';
 import { buildChunkHighlights } from '@/utils/document-util';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -33,6 +33,7 @@ export const useFetchPipelineFileLogDetail = ({
   const { id } = useParams();
   const [searchParams] = useSearchParams();
   const logId = searchParams.get('id') || id;
+  const knowledgeId = searchParams.get('knowledgeId') || '';
 
   let queryKey: (string | number)[] = [];
   if (typeof refreshCount === 'number') {
@@ -45,10 +46,8 @@ export const useFetchPipelineFileLogDetail = ({
     gcTime: 0,
     enabled: !isAgent,
     queryFn: async () => {
-      if (isEdit) {
-        const { data } = await kbService.getPipelineDetail({
-          log_id: logId,
-        });
+      if (isEdit && knowledgeId && logId) {
+        const { data } = await getPipelineDetail(knowledgeId, logId);
         return data?.data ?? {};
       } else {
         return {};


### PR DESCRIPTION
### What problem does this PR solve?

The pipeline file log detail hook (`useFetchPipelineFileLogDetail`) was calling the legacy `kbService.getPipelineDetail({ log_id })` endpoint, which does not match the current RESTful API contract. The backend now expects both `datasetId` and `logId` to construct the correct URL (`GET /api/v1/datasets/{datasetId}/ingestions/{logId}`).

This PR fixes the hook to:
- Use the RESTful `getPipelineDetail(knowledgeId, logId)` helper from `knowledge-service`.
- Read `knowledgeId` from the URL search params.
- Only trigger the request when both `knowledgeId` and `logId` are present, avoiding invalid/empty calls.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):