### PR TITLE
Go: add command, show tasks summary

### DIFF
--- a/internal/admin/enterprise_handler.go
+++ b/internal/admin/enterprise_handler.go
@@ -696,6 +696,21 @@ func (h *Handler) ShowUsersQuotaSummary(c *gin.Context) {
 	success(c, usersQuotaSummary, "")
 }
 
+// ShowIngestionTasksSummary handle show ingestion tasks summary
+func (h *Handler) ShowIngestionTasksSummary(c *gin.Context) {
+	ingestionTasksSummary, err := h.service.ShowIngestionTasksSummary()
+	if err != nil {
+		if errors.Is(err, common.ErrUserNotFound) {
+			errorResponse(c, "User not found", 404)
+			return
+		}
+		errorResponse(c, err.Error(), 500)
+		return
+	}
+
+	success(c, ingestionTasksSummary, "")
+}
+
 // ShowDataSummary handle show data summary
 func (h *Handler) ShowDataSummary(c *gin.Context) {
 	dataSummary, err := h.service.ShowDataSummary()

--- a/internal/admin/enterprise_service.go
+++ b/internal/admin/enterprise_service.go
@@ -389,6 +389,17 @@ func (s *Service) ShowUsersQuotaSummary() (map[string]interface{}, error) {
 	return result, nil
 }
 
+// ShowIngestionTasksSummary show ingestion tasks summary for enterprise edition
+func (s *Service) ShowIngestionTasksSummary() (map[string]interface{}, error) {
+
+	result := map[string]interface{}{
+		"command": "show_ingestion_tasks_summary",
+		"error":   "'Show ingestion tasks summary' is implemented in enterprise edition",
+	}
+
+	return result, nil
+}
+
 // ShowDataSummary show data summary for enterprise edition
 func (s *Service) ShowDataSummary() (map[string]interface{}, error) {
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -88,6 +88,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 			protected.GET("/users/index", r.handler.ListUsersIndex)
 			protected.GET("/users/quota", r.handler.ListUsersQuota)
 			protected.GET("/users/quota/summary", r.handler.ShowUsersQuotaSummary)
+			protected.GET("/ingestion/tasks/summary", r.handler.ShowIngestionTasksSummary)
 			protected.GET("/data/summary", r.handler.ShowDataSummary)
 			protected.GET("/data/orphan", r.handler.ShowDataOrphan)
 			protected.GET("/data/storage", r.handler.ShowDataStorage)
@@ -172,6 +173,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 			protected.DELETE("/ingestion/tasks", r.handler.RemoveIngestionTasks)
 			protected.PUT("/ingestion/tasks", r.handler.StopIngestionTasks)
 			protected.GET("/ingestion/tasks", r.handler.ListIngestionTasks)
+
 		}
 	}
 

--- a/internal/cli/admin_command.go
+++ b/internal/cli/admin_command.go
@@ -2172,6 +2172,36 @@ func (c *CLI) AdminShowQuotaSummaryCommand(cmd *Command) (ResponseIf, error) {
 	return &result, nil
 }
 
+func (c *CLI) AdminShowTasksSummaryCommand(cmd *Command) (ResponseIf, error) {
+
+	if c.Config.CLIMode != AdminMode || c.AdminServerClient.LoginToken == nil {
+		return nil, fmt.Errorf("this command is only allowed in ADMIN mode or already login")
+	}
+
+	apiURL := "/admin/ingestion/tasks/summary"
+
+	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get users quota summary: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to get users quota summary: HTTP %d, body: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	var result CommonDataResponse
+	if err = json.Unmarshal(resp.Body, &result); err != nil {
+		return nil, fmt.Errorf("get users quota summary failed: invalid JSON (%w)", err)
+	}
+
+	if result.Code != 0 {
+		return nil, fmt.Errorf("%s", result.Message)
+	}
+
+	result.Duration = resp.Duration
+	return &result, nil
+}
+
 func (c *CLI) AdminPurgeOrphanCommand(cmd *Command) (ResponseIf, error) {
 
 	if c.Config.CLIMode != AdminMode || c.AdminServerClient.LoginToken == nil {

--- a/internal/cli/admin_parser.go
+++ b/internal/cli/admin_parser.go
@@ -487,6 +487,8 @@ func (p *Parser) parseAdminShowCommand() (*Command, error) {
 		return p.parseAdminShowDataCommand()
 	case TokenQuota:
 		return p.parseAdminShowQuotaCommand()
+	case TokenTasks:
+		return p.parseAdminShowQuotaCommand()
 	default:
 		return nil, fmt.Errorf("unknown SHOW target: %s", p.curToken.Value)
 	}
@@ -2358,6 +2360,26 @@ func (p *Parser) parseAdminShowQuotaCommand() (*Command, error) {
 		cmd = NewCommand("admin_show_quota_summary_command")
 	default:
 		return nil, fmt.Errorf("expected SUMMARY after QUOTA")
+	}
+
+	// Semicolon is optional
+	if p.curToken.Type == TokenSemicolon {
+		p.nextToken()
+	}
+	return cmd, nil
+}
+
+// SHOW TASKS SUMMARY;
+func (p *Parser) parseAdminShowTasksCommand() (*Command, error) {
+	p.nextToken() // consume TASKS
+
+	var cmd *Command
+	switch p.curToken.Type {
+	case TokenSummary:
+		p.nextToken()
+		cmd = NewCommand("admin_show_tasks_summary_command")
+	default:
+		return nil, fmt.Errorf("expected SUMMARY after TASKS")
 	}
 
 	// Semicolon is optional

--- a/internal/cli/cli_http.go
+++ b/internal/cli/cli_http.go
@@ -145,6 +145,8 @@ func (c *CLI) ExecuteAdminCommand(cmd *Command) (ResponseIf, error) {
 		return c.AdminListUsersConditionCommand(cmd)
 	case "admin_show_quota_summary_command":
 		return c.AdminShowQuotaSummaryCommand(cmd)
+	case "admin_show_tasks_summary_command":
+		return c.AdminShowTasksSummaryCommand(cmd)
 	case "admin_show_data_summary_command":
 		return c.AdminShowDataSummaryCommand(cmd)
 	case "admin_show_data_orphan_command":


### PR DESCRIPTION
### What problem does this PR solve?

RAGFlow(admin)> show tasks summary;
+---------+-----------------------------------------------------------------+
| field   | value                                                           |
+---------+-----------------------------------------------------------------+
| command | show_users_quota_summary                                        |
| error   | 'Show users quota summary' is implemented in enterprise edition |
+---------+-----------------------------------------------------------------+

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

