### PR TITLE
feat(go-api): add datasets/tags GET

### DIFF
--- a/internal/handler/datasets.go
+++ b/internal/handler/datasets.go
@@ -479,6 +479,32 @@ func (h *DatasetsHandler) GetKnowledgeGraph(c *gin.Context) {
 	jsonResponse(c, common.CodeSuccess, result, "success")
 }
 
+// ListTags handles GET /api/v1/datasets/:dataset_id/tags.
+// @Summary List dataset tags
+// @Description List tags for a dataset
+// @Tags datasets
+// @Produce json
+// @Security ApiKeyAuth
+// @Param dataset_id path string true "Dataset ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/datasets/{dataset_id}/tags [get]
+func (h *DatasetsHandler) ListTags(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		jsonError(c, errorCode, errorMessage)
+		return
+	}
+
+	datasetID := strings.TrimSpace(c.Param("dataset_id"))
+	result, code, err := h.datasetsService.ListTags(datasetID, user.ID)
+	if err != nil {
+		jsonError(c, code, err.Error())
+		return
+	}
+
+	jsonResponse(c, common.CodeSuccess, result, "success")
+}
+
 // DeleteKnowledgeGraph handles DELETE /api/v1/datasets/:dataset_id/graph.
 func (h *DatasetsHandler) DeleteKnowledgeGraph(c *gin.Context) {
 	user, errorCode, errorMessage := GetUser(c)

--- a/internal/handler/datasets_list_tags_test.go
+++ b/internal/handler/datasets_list_tags_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"ragflow/internal/common"
+)
+
+func TestDatasetsHandlerListTagsRequiresAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &DatasetsHandler{}
+	r := gin.New()
+	r.GET("/api/v1/datasets/:dataset_id/tags", func(c *gin.Context) {
+		h.ListTags(c)
+	})
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/123e4567-e89b-12d3-a456-426614174000/tags", nil)
+	r.ServeHTTP(resp, req)
+
+	var body struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
+	}
+	if body.Code != int(common.CodeUnauthorized) {
+		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeUnauthorized, resp.Body.String())
+	}
+	if body.Message != "User not found" {
+		t.Fatalf("message=%q want=%q", body.Message, "User not found")
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -263,6 +263,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 				datasets.GET("/:dataset_id", r.datasetsHandler.GetDataset)
 				datasets.PUT("/:dataset_id", r.datasetsHandler.UpdateDataset)
 				datasets.GET("/:dataset_id/graph", r.datasetsHandler.GetKnowledgeGraph)
+				datasets.GET("/:dataset_id/tags", r.datasetsHandler.ListTags)
 				datasets.DELETE("/:dataset_id/tags", r.datasetsHandler.RemoveTags)
 				datasets.GET("/:dataset_id/index", r.datasetsHandler.TraceIndex)
 				datasets.POST("/:dataset_id/index", r.datasetsHandler.RunIndex)

--- a/internal/service/dataset.go
+++ b/internal/service/dataset.go
@@ -25,6 +25,7 @@ import (
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
 	redisengine "ragflow/internal/engine/redis"
+	"ragflow/internal/engine/types"
 	"ragflow/internal/entity"
 	"ragflow/internal/entity/models"
 	"ragflow/internal/server"
@@ -1829,6 +1830,105 @@ func (s *DatasetService) UpdateMetadataConfig(datasetID, tenantID string, req *M
 // Accessible checks if a knowledge base is accessible by a user
 func (s *DatasetService) Accessible(kbID, userID string) bool {
 	return s.kbDAO.Accessible(kbID, userID)
+}
+
+func (s *DatasetService) ListTags(datasetID, userID string) ([]map[string]interface{}, common.ErrorCode, error) {
+	datasetID = strings.TrimSpace(datasetID)
+	if datasetID == "" {
+		return nil, common.CodeDataError, errors.New("Lack of \"Dataset ID\"")
+	}
+
+	normalizedID, err := normalizeDatasetUUID1(datasetID)
+	if err != nil {
+		return nil, common.CodeDataError, err
+	}
+	datasetID = normalizedID
+
+	if !s.kbDAO.Accessible(datasetID, userID) {
+		return nil, common.CodeDataError, errors.New("No authorization.")
+	}
+	if s.docEngine == nil {
+		return nil, common.CodeServerError, errors.New("Document engine is not initialized")
+	}
+
+	kb, err := s.kbDAO.GetByID(datasetID)
+	if err != nil || kb == nil {
+		return nil, common.CodeDataError, errors.New("Invalid Dataset ID")
+	}
+
+	indexName := fmt.Sprintf("ragflow_%s", kb.TenantID)
+	exists, err := s.docEngine.ChunkStoreExists(context.Background(), indexName, datasetID)
+	if err != nil {
+		return nil, common.CodeServerError, fmt.Errorf("failed to inspect chunk store: %w", err)
+	}
+	if !exists {
+		return []map[string]interface{}{}, common.CodeSuccess, nil
+	}
+
+	const pageSize = 10000
+	counts := make(map[string]int)
+	for offset := 0; ; offset += pageSize {
+		searchResp, err := s.docEngine.Search(context.Background(), &types.SearchRequest{
+			IndexNames:   []string{indexName},
+			KbIDs:        []string{datasetID},
+			Offset:       offset,
+			Limit:        pageSize,
+			SelectFields: []string{"tag_kwd"},
+		})
+		if err != nil {
+			return nil, common.CodeServerError, fmt.Errorf("failed to list tags: %w", err)
+		}
+
+		for _, agg := range s.docEngine.GetAggregation(searchResp.Chunks, "tag_kwd") {
+			tag, _ := agg["key"].(string)
+			if tag == "" {
+				continue
+			}
+			switch count := agg["count"].(type) {
+			case int:
+				counts[tag] += count
+			case int32:
+				counts[tag] += int(count)
+			case int64:
+				counts[tag] += int(count)
+			case float64:
+				counts[tag] += int(count)
+			}
+		}
+
+		chunkCount := len(searchResp.Chunks)
+		if chunkCount == 0 || chunkCount < pageSize {
+			break
+		}
+		if searchResp.Total > 0 && int64(offset+chunkCount) >= searchResp.Total {
+			break
+		}
+	}
+
+	if len(counts) == 0 {
+		return []map[string]interface{}{}, common.CodeSuccess, nil
+	}
+
+	tags := make([]string, 0, len(counts))
+	for tag := range counts {
+		tags = append(tags, tag)
+	}
+	sort.Slice(tags, func(i, j int) bool {
+		if counts[tags[i]] != counts[tags[j]] {
+			return counts[tags[i]] > counts[tags[j]]
+		}
+		return tags[i] < tags[j]
+	})
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":   tag,
+			"count": counts[tag],
+		})
+	}
+
+	return result, common.CodeSuccess, nil
 }
 
 // GetIngestionSummary returns dataset-level ingestion counters together with

--- a/internal/service/dataset_list_tags_test.go
+++ b/internal/service/dataset_list_tags_test.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ragflow/internal/common"
+	"ragflow/internal/dao"
+	"ragflow/internal/engine"
+	"ragflow/internal/engine/types"
+	"ragflow/internal/entity"
+)
+
+type listTagsMockEngine struct {
+	engine.DocEngine
+	searchResults    map[string]*types.SearchResult
+	searchErr        error
+	requests         []*types.SearchRequest
+	chunkStoreExists bool
+	chunkStoreErr    error
+}
+
+func (m *listTagsMockEngine) Search(ctx context.Context, req *types.SearchRequest) (*types.SearchResult, error) {
+	if m.searchErr != nil {
+		return nil, m.searchErr
+	}
+	cloned := &types.SearchRequest{
+		IndexNames:   append([]string(nil), req.IndexNames...),
+		KbIDs:        append([]string(nil), req.KbIDs...),
+		Offset:       req.Offset,
+		Limit:        req.Limit,
+		SelectFields: append([]string(nil), req.SelectFields...),
+	}
+	m.requests = append(m.requests, cloned)
+	if len(req.IndexNames) == 0 {
+		return &types.SearchResult{}, nil
+	}
+	if res, ok := m.searchResults[req.IndexNames[0]]; ok {
+		return res, nil
+	}
+	return &types.SearchResult{}, nil
+}
+
+func (m *listTagsMockEngine) GetAggregation(chunks []map[string]interface{}, fieldName string) []map[string]interface{} {
+	counts := make(map[string]int)
+	for _, chunk := range chunks {
+		raw, ok := chunk[fieldName]
+		if !ok || raw == nil {
+			continue
+		}
+		switch value := raw.(type) {
+		case string:
+			for _, tag := range strings.Split(value, "###") {
+				tag = strings.TrimSpace(tag)
+				if tag != "" {
+					counts[tag]++
+				}
+			}
+		case []string:
+			for _, tag := range value {
+				tag = strings.TrimSpace(tag)
+				if tag != "" {
+					counts[tag]++
+				}
+			}
+		}
+	}
+
+	result := make([]map[string]interface{}, 0, len(counts))
+	for tag, count := range counts {
+		result = append(result, map[string]interface{}{
+			"key":   tag,
+			"count": count,
+		})
+	}
+	return result
+}
+
+func (m *listTagsMockEngine) ChunkStoreExists(ctx context.Context, baseName, datasetID string) (bool, error) {
+	if m.chunkStoreErr != nil {
+		return false, m.chunkStoreErr
+	}
+	return m.chunkStoreExists, nil
+}
+
+func (m *listTagsMockEngine) GetType() string { return "mock" }
+
+func (m *listTagsMockEngine) Ping(ctx context.Context) error { return nil }
+
+func (m *listTagsMockEngine) Close() error { return nil }
+
+func testDatasetServiceForListTags(t *testing.T, docEngine engine.DocEngine) *DatasetService {
+	t.Helper()
+	return &DatasetService{
+		kbDAO:     dao.NewKnowledgebaseDAO(),
+		docEngine: docEngine,
+	}
+}
+
+func insertListTagsKB(t *testing.T, datasetID, tenantID, permission string, docNum int64) {
+	t.Helper()
+	kb := &entity.Knowledgebase{
+		ID:           datasetID,
+		TenantID:     tenantID,
+		Name:         "kb-" + datasetID[:6],
+		EmbdID:       "embedding@OpenAI",
+		CreatedBy:    tenantID,
+		Permission:   permission,
+		ParserID:     "naive",
+		ParserConfig: entity.JSONMap{},
+		DocNum:       docNum,
+		Status:       sptr(string(entity.StatusValid)),
+	}
+	if err := dao.DB.Create(kb).Error; err != nil {
+		t.Fatalf("insert test kb: %v", err)
+	}
+}
+
+func TestDatasetServiceListTagsSuccess(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+
+	kbInput := "123e4567-e89b-12d3-a456-426614174000"
+	kbID := strings.ReplaceAll(kbInput, "-", "")
+	insertListTagsKB(t, kbID, "user-1", string(entity.TenantPermissionMe), 2)
+
+	docEngine := &listTagsMockEngine{
+		chunkStoreExists: true,
+		searchResults: map[string]*types.SearchResult{
+			"ragflow_user-1": {
+				Chunks: []map[string]interface{}{
+					{"tag_kwd": "finance###urgent"},
+					{"tag_kwd": "finance"},
+				},
+			},
+		},
+	}
+
+	result, code, err := testDatasetServiceForListTags(t, docEngine).ListTags(kbInput, "user-1")
+	if err != nil {
+		t.Fatalf("ListTags failed: %v", err)
+	}
+	if code != common.CodeSuccess {
+		t.Fatalf("code=%d want=%d", code, common.CodeSuccess)
+	}
+	if len(result) != 2 {
+		t.Fatalf("len(result)=%d want=2 result=%v", len(result), result)
+	}
+	if result[0]["key"] != "finance" || result[0]["count"] != 2 {
+		t.Fatalf("first row=%v want finance/2", result[0])
+	}
+	if result[1]["key"] != "urgent" || result[1]["count"] != 1 {
+		t.Fatalf("second row=%v want urgent/1", result[1])
+	}
+	if len(docEngine.requests) != 1 {
+		t.Fatalf("search requests=%d want=1", len(docEngine.requests))
+	}
+	req := docEngine.requests[0]
+	if len(req.IndexNames) != 1 || req.IndexNames[0] != "ragflow_user-1" {
+		t.Fatalf("IndexNames=%v want [ragflow_user-1]", req.IndexNames)
+	}
+	if len(req.KbIDs) != 1 || req.KbIDs[0] != kbID {
+		t.Fatalf("KbIDs=%v want [%s]", req.KbIDs, kbID)
+	}
+}
+
+func TestDatasetServiceListTagsReturnsEmptyWhenChunkStoreMissing(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+
+	kbInput := "123e4567-e89b-12d3-a456-426614174000"
+	kbID := strings.ReplaceAll(kbInput, "-", "")
+	insertListTagsKB(t, kbID, "user-1", string(entity.TenantPermissionMe), 1)
+
+	docEngine := &listTagsMockEngine{chunkStoreExists: false}
+
+	result, code, err := testDatasetServiceForListTags(t, docEngine).ListTags(kbInput, "user-1")
+	if err != nil {
+		t.Fatalf("ListTags failed: %v", err)
+	}
+	if code != common.CodeSuccess {
+		t.Fatalf("code=%d want=%d", code, common.CodeSuccess)
+	}
+	if len(result) != 0 {
+		t.Fatalf("len(result)=%d want=0 result=%v", len(result), result)
+	}
+	if len(docEngine.requests) != 0 {
+		t.Fatalf("search requests=%d want=0", len(docEngine.requests))
+	}
+}
+
+func TestDatasetServiceListTagsRejectsUnauthorizedDataset(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+
+	kbInput := "123e4567-e89b-12d3-a456-426614174000"
+	kbID := strings.ReplaceAll(kbInput, "-", "")
+	insertListTagsKB(t, kbID, "tenant-9", string(entity.TenantPermissionMe), 1)
+
+	docEngine := &listTagsMockEngine{chunkStoreExists: true}
+
+	_, code, err := testDatasetServiceForListTags(t, docEngine).ListTags(kbInput, "user-1")
+	if err == nil {
+		t.Fatal("expected unauthorized error")
+	}
+	if code != common.CodeDataError {
+		t.Fatalf("code=%d want=%d", code, common.CodeDataError)
+	}
+	if err.Error() != "No authorization." {
+		t.Fatalf("error=%q want=%q", err.Error(), "No authorization.")
+	}
+}
+
+func TestDatasetServiceListTagsReturnsChunkStoreError(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+
+	kbInput := "123e4567-e89b-12d3-a456-426614174000"
+	kbID := strings.ReplaceAll(kbInput, "-", "")
+	insertListTagsKB(t, kbID, "user-1", string(entity.TenantPermissionMe), 1)
+
+	docEngine := &listTagsMockEngine{
+		chunkStoreErr: errors.New("boom"),
+	}
+
+	_, code, err := testDatasetServiceForListTags(t, docEngine).ListTags(kbInput, "user-1")
+	if err == nil {
+		t.Fatal("expected chunk store error")
+	}
+	if code != common.CodeServerError {
+		t.Fatalf("code=%d want=%d", code, common.CodeServerError)
+	}
+	if !strings.Contains(err.Error(), "failed to inspect chunk store: boom") {
+		t.Fatalf("err=%q want contains %q", err.Error(), "failed to inspect chunk store: boom")
+	}
+}


### PR DESCRIPTION
  ## Summary

  This PR adds the Go implementation for GET `/api/v1/datasets/:dataset_id/tags` to improve Python/Go API parity for dataset tag management.

  ## What changed

  - Registered GET `/api/v1/datasets/:dataset_id/tags` in the Go router
  - Added DatasetsHandler.ListTags
  - Added DatasetService.ListTags
  - Reused the existing document engine search + `tag_kwd` aggregation flow to return dataset tag counts
  - Added unit tests for:
      - successful tag listing
      - missing chunk store returning an empty list
      - unauthorized dataset access
      - chunk store inspection failure
      - handler auth failure

  ## Test results

  Passed:

  `/usr/local/go/bin/go test ./internal/service ./internal/handler`