### PR TITLE
fix(stats): use UserCanvas join for agent sessions in /system/stats

### DIFF
--- a/api/db/services/api_service.py
+++ b/api/db/services/api_service.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 import peewee
 
-from api.db.db_models import DB, API4Conversation, APIToken, Dialog
+from api.db.db_models import DB, API4Conversation, APIToken, Dialog, UserCanvas
 from api.db.services.common_service import CommonService
 from common.time_utils import current_timestamp, datetime_format
 
@@ -99,21 +99,26 @@ class API4ConversationService(CommonService):
     def stats(cls, tenant_id, from_date, to_date, source=None):
         if len(to_date) == 10:
             to_date += " 23:59:59"
-        return cls.model.select(
+        base = cls.model.select(
             cls.model.create_date.truncate("day").alias("dt"),
-            peewee.fn.COUNT(
-                cls.model.id).alias("pv"),
-            peewee.fn.COUNT(
-                cls.model.user_id.distinct()).alias("uv"),
-            peewee.fn.SUM(
-                cls.model.tokens).alias("tokens"),
-            peewee.fn.SUM(
-                cls.model.duration).alias("duration"),
-            peewee.fn.AVG(
-                cls.model.round).alias("round"),
-            peewee.fn.SUM(
-                cls.model.thumb_up).alias("thumb_up")
-        ).join(Dialog, on=((cls.model.dialog_id == Dialog.id) & (Dialog.tenant_id == tenant_id))).where(
+            peewee.fn.COUNT(cls.model.id).alias("pv"),
+            peewee.fn.COUNT(cls.model.user_id.distinct()).alias("uv"),
+            peewee.fn.SUM(cls.model.tokens).alias("tokens"),
+            peewee.fn.SUM(cls.model.duration).alias("duration"),
+            peewee.fn.AVG(cls.model.round).alias("round"),
+            peewee.fn.SUM(cls.model.thumb_up).alias("thumb_up")
+        )
+        if source == "agent":
+            query = base.join(
+                UserCanvas,
+                on=((cls.model.dialog_id == UserCanvas.id) & (UserCanvas.user_id == tenant_id))
+            )
+        else:
+            query = base.join(
+                Dialog,
+                on=((cls.model.dialog_id == Dialog.id) & (Dialog.tenant_id == tenant_id))
+            )
+        return query.where(
             cls.model.create_date >= from_date,
             cls.model.create_date <= to_date,
             cls.model.source == source


### PR DESCRIPTION
## What problem does this PR solve?

`GET /api/v1/system/stats?canvas_id=xxx` always returns empty arrays for agent sessions.

**Root cause**: `API4ConversationService.stats()` always joins with the `dialog` table:

```python
.join(Dialog, on=((cls.model.dialog_id == Dialog.id) & (Dialog.tenant_id == tenant_id)))
```

However, `api_4_conversation.dialog_id` stores different values depending on the session type:

| `source` | `dialog_id` points to | JOIN result |
|---|---|---|
| `NULL` (chatbot) | `dialog.id` | ✅ matches |
| `"agent"` | `user_canvas.id` | ❌ never matches |

For agent sessions, `dialog_id` is set to `user_canvas.id` (see `agent_api.py`):
```python
"dialog_id": cvs.id,   # cvs = UserCanvas record
"source": "agent",
```

The `INNER JOIN dialog` then finds no matching rows, silently returning empty stats.

**Fix**: branch on `source == "agent"` to join `user_canvas` (filtered by `user_id == tenant_id`) instead of `dialog` (filtered by `tenant_id`). The tenant ownership invariant holds in both cases — `user_canvas.user_id` equals the tenant's ID for canvases they own.

```python
if source == "agent":
    query = base.join(
        UserCanvas,
        on=((cls.model.dialog_id == UserCanvas.id) & (UserCanvas.user_id == tenant_id))
    )
else:
    query = base.join(
        Dialog,
        on=((cls.model.dialog_id == Dialog.id) & (Dialog.tenant_id == tenant_id))
    )
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Created agent sessions via `POST /api/v1/agents/{id}/sessions` + completions
- [x] Confirmed sessions exist in `api_4_conversation` with `source="agent"` and `dialog_id` pointing to `user_canvas.id`
- [x] Called `GET /api/v1/system/stats?canvas_id=xxx` — returns correct `pv` and `round` values after fix
- [x] Called `GET /api/v1/system/stats` (without `canvas_id`) — chatbot session stats unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)