### PR TITLE
fix(stats): persist tokens and duration after each chat completion

### DIFF
--- a/api/db/services/api_service.py
+++ b/api/db/services/api_service.py
@@ -91,16 +91,17 @@ class API4ConversationService(CommonService):
     @classmethod
     @DB.connection_context()
     def append_message(cls, id, conversation, tokens: int = 0, duration: float = 0.0):
-        cls.update_by_id(id, conversation)
-        return (
-            cls.model.update(
-                round=cls.model.round + 1,
-                tokens=cls.model.tokens + tokens,
-                duration=cls.model.duration + duration,
+        with DB.atomic():
+            cls.update_by_id(id, conversation)
+            return (
+                cls.model.update(
+                    round=cls.model.round + 1,
+                    tokens=cls.model.tokens + tokens,
+                    duration=cls.model.duration + duration,
+                )
+                .where(cls.model.id == id)
+                .execute()
             )
-            .where(cls.model.id == id)
-            .execute()
-        )
 
     @classmethod
     @DB.connection_context()

--- a/api/db/services/api_service.py
+++ b/api/db/services/api_service.py
@@ -90,9 +90,17 @@ class API4ConversationService(CommonService):
 
     @classmethod
     @DB.connection_context()
-    def append_message(cls, id, conversation):
+    def append_message(cls, id, conversation, tokens: int = 0, duration: float = 0.0):
         cls.update_by_id(id, conversation)
-        return cls.model.update(round=cls.model.round + 1).where(cls.model.id == id).execute()
+        return (
+            cls.model.update(
+                round=cls.model.round + 1,
+                tokens=cls.model.tokens + tokens,
+                duration=cls.model.duration + duration,
+            )
+            .where(cls.model.id == id)
+            .execute()
+        )
 
     @classmethod
     @DB.connection_context()

--- a/api/db/services/api_service.py
+++ b/api/db/services/api_service.py
@@ -120,9 +120,21 @@ class API4ConversationService(CommonService):
 
     @classmethod
     @DB.connection_context()
-    def append_message(cls, id, conversation):
+    def append_message(cls, id, conversation, tokens: int = 0, duration: float = 0.0):
+        # No DB.atomic() here: update_by_id is itself decorated with
+        # @DB.connection_context(), whose exit closes the connection — peewee
+        # refuses that while a transaction is open ("Attempting to close
+        # database while transaction is open").
         cls.update_by_id(id, conversation)
-        return cls.model.update(round=cls.model.round + 1).where(cls.model.id == id).execute()
+        return (
+            cls.model.update(
+                round=cls.model.round + 1,
+                tokens=cls.model.tokens + tokens,
+                duration=cls.model.duration + duration,
+            )
+            .where(cls.model.id == id)
+            .execute()
+        )
 
     @classmethod
     @DB.connection_context()

--- a/api/db/services/api_service.py
+++ b/api/db/services/api_service.py
@@ -121,13 +121,23 @@ class API4ConversationService(CommonService):
     @classmethod
     @DB.connection_context()
     def append_message(cls, id, conversation, tokens: int = 0, duration: float = 0.0):
-        # No DB.atomic() here: update_by_id is itself decorated with
-        # @DB.connection_context(), whose exit closes the connection — peewee
-        # refuses that while a transaction is open ("Attempting to close
-        # database while transaction is open").
-        cls.update_by_id(id, conversation)
+        """Persist a conversation snapshot and bump its usage counters in one UPDATE.
+
+        The counters (``round``, ``tokens``, ``duration``) are incremented
+        server-side rather than taken from the snapshot, so a stale value read
+        by a concurrent request can never overwrite another request's increment,
+        and the message list can never be persisted without its counters.
+        A single statement is used on purpose: wrapping ``update_by_id`` in
+        ``DB.atomic()`` is not possible because it is itself decorated with
+        ``@DB.connection_context()``, whose exit closes the connection while
+        the transaction is still open.
+        """
+        data = {k: v for k, v in conversation.items() if k not in ("id", "round", "tokens", "duration")}
+        data["update_time"] = current_timestamp()
+        data["update_date"] = datetime_format(datetime.now())
         return (
             cls.model.update(
+                **data,
                 round=cls.model.round + 1,
                 tokens=cls.model.tokens + tokens,
                 duration=cls.model.duration + duration,

--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import logging
 import time
 from uuid import uuid4
 from common.constants import StatusEnum
@@ -264,7 +265,7 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
                                            ensure_ascii=False) + "\n\n"
             usage = (last_ans or {}).get("usage", {})
             if not usage:
-                logger.warning("Missing usage in streaming completion for session_id=%s message_id=%s", session_id, message_id)
+                logging.warning("Missing usage in streaming completion for session_id=%s message_id=%s", session_id, message_id)
             API4ConversationService.append_message(
                 conv.id, conv.to_dict(),
                 tokens=usage.get("total_tokens", 0),
@@ -282,7 +283,7 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
             answer = structure_answer(conv, ans, message_id, session_id)
             usage = answer.get("usage", {})
             if not usage:
-                logger.warning("Missing usage in non-stream completion for session_id=%s message_id=%s", session_id, message_id)
+                logging.warning("Missing usage in non-stream completion for session_id=%s message_id=%s", session_id, message_id)
             API4ConversationService.append_message(
                 conv.id, conv.to_dict(),
                 tokens=usage.get("total_tokens", 0),

--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -263,6 +263,8 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
                 yield "data:" + json.dumps({"code": 0, "message": "", "data": ans},
                                            ensure_ascii=False) + "\n\n"
             usage = (last_ans or {}).get("usage", {})
+            if not usage:
+                logger.warning("Missing usage in streaming completion for session_id=%s message_id=%s", session_id, message_id)
             API4ConversationService.append_message(
                 conv.id, conv.to_dict(),
                 tokens=usage.get("total_tokens", 0),
@@ -279,6 +281,8 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
         async for ans in async_chat(dia, msg, False, **kwargs):
             answer = structure_answer(conv, ans, message_id, session_id)
             usage = answer.get("usage", {})
+            if not usage:
+                logger.warning("Missing usage in non-stream completion for session_id=%s message_id=%s", session_id, message_id)
             API4ConversationService.append_message(
                 conv.id, conv.to_dict(),
                 tokens=usage.get("total_tokens", 0),

--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -256,11 +256,18 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
 
     if stream:
         try:
-            async for ans in async_chat(dia, msg, True, **kwargs):
+            last_ans = None
+            async for ans in async_chat(dia, msg, True, session_id=session_id, **kwargs):
                 ans = structure_answer(conv, ans, message_id, session_id)
+                last_ans = ans
                 yield "data:" + json.dumps({"code": 0, "message": "", "data": ans},
                                            ensure_ascii=False) + "\n\n"
-            API4ConversationService.append_message(conv.id, conv.to_dict())
+            usage = (last_ans or {}).get("usage", {})
+            API4ConversationService.append_message(
+                conv.id, conv.to_dict(),
+                tokens=usage.get("total_tokens", 0),
+                duration=usage.get("duration_ms", 0.0),
+            )
         except Exception as e:
             yield "data:" + json.dumps({"code": 500, "message": str(e),
                                         "data": {"answer": "**ERROR**: " + str(e), "reference": []}},
@@ -271,6 +278,11 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
         answer = None
         async for ans in async_chat(dia, msg, False, **kwargs):
             answer = structure_answer(conv, ans, message_id, session_id)
-            API4ConversationService.append_message(conv.id, conv.to_dict())
+            usage = answer.get("usage", {})
+            API4ConversationService.append_message(
+                conv.id, conv.to_dict(),
+                tokens=usage.get("total_tokens", 0),
+                duration=usage.get("duration_ms", 0.0),
+            )
             break
         yield answer

--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -360,10 +360,20 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
 
     if stream:
         try:
+            last_ans = None
             async for ans in rag_agent(dia, msg, True, session_id=session_id, **kwargs):
                 ans = structure_answer(conv, ans, message_id, session_id)
+                last_ans = ans
                 yield "data:" + json.dumps({"code": 0, "message": "", "data": ans}, ensure_ascii=False) + "\n\n"
-            API4ConversationService.append_message(conv.id, conv.to_dict())
+            usage = (last_ans or {}).get("usage", {})
+            if not usage:
+                logger.warning("Missing usage in streaming completion for session_id=%s message_id=%s", session_id, message_id)
+            API4ConversationService.append_message(
+                conv.id,
+                conv.to_dict(),
+                tokens=usage.get("total_tokens", 0),
+                duration=usage.get("duration_ms", 0.0),
+            )
         except Exception as e:
             yield "data:" + json.dumps({"code": 500, "message": str(e), "data": {"answer": "**ERROR**: " + str(e), "reference": []}}, ensure_ascii=False) + "\n\n"
         yield "data:" + json.dumps({"code": 0, "message": "", "data": True}, ensure_ascii=False) + "\n\n"
@@ -372,6 +382,14 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
         answer = None
         async for ans in rag_agent(dia, msg, False, session_id=session_id, **kwargs):
             answer = structure_answer(conv, ans, message_id, session_id)
-            API4ConversationService.append_message(conv.id, conv.to_dict())
+            usage = answer.get("usage", {})
+            if not usage:
+                logger.warning("Missing usage in non-stream completion for session_id=%s message_id=%s", session_id, message_id)
+            API4ConversationService.append_message(
+                conv.id,
+                conv.to_dict(),
+                tokens=usage.get("total_tokens", 0),
+                duration=usage.get("duration_ms", 0.0),
+            )
             break
         yield answer

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -680,8 +680,14 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
     retrieval_ts = timer()
     if not knowledges and prompt_config.get("empty_response"):
         empty_res = prompt_config["empty_response"]
-        yield {"answer": empty_res, "reference": kbinfos, "prompt": "\n\n### Query:\n%s" % " ".join(questions),
-               "audio_binary": tts(tts_mdl, empty_res), "final": True}
+        yield {
+            "answer": empty_res,
+            "reference": kbinfos,
+            "prompt": "\n\n### Query:\n%s" % " ".join(questions),
+            "audio_binary": tts(tts_mdl, empty_res),
+            "final": True,
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "duration_ms": 0},
+        }
         return
 
     kwargs["knowledge"] = "\n------\n" + "\n\n------\n\n".join(knowledges)

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -745,7 +745,18 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             langfuse_generation.update(output=langfuse_output)
             langfuse_generation.end()
 
-        return {"answer": think + answer, "reference": refs, "prompt": re.sub(r"\n", "  \n", prompt), "created_at": time.time()}
+        return {
+            "answer": think + answer,
+            "reference": refs,
+            "prompt": re.sub(r"\n", "  \n", prompt),
+            "created_at": time.time(),
+            "usage": {
+                "prompt_tokens": used_token_count,
+                "completion_tokens": tk_num,
+                "total_tokens": used_token_count + tk_num,
+                "duration_ms": round(total_time_cost, 1),
+            },
+        }
 
     if langfuse_tracer:
         langfuse_generation = langfuse_tracer.start_generation(

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -234,6 +234,7 @@ async def async_chat_solo(dialog, messages, stream=True):
         msg[-1]["content"] += attachments
     if llm_type == "chat" and image_attachments:
         convert_last_user_msg_to_multimodal(msg, image_attachments, factory)
+    prompt_tk = sum(num_tokens_from_string(m.get("content", "")) for m in msg if isinstance(m.get("content"), str))
     if stream:
         if llm_type == "chat":
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting)
@@ -257,9 +258,9 @@ async def async_chat_solo(dialog, messages, stream=True):
             "prompt": "",
             "created_at": time.time(),
             "usage": {
-                "prompt_tokens": 0,
+                "prompt_tokens": prompt_tk,
                 "completion_tokens": tk_num,
-                "total_tokens": tk_num,
+                "total_tokens": prompt_tk + tk_num,
                 "duration_ms": duration_ms,
             },
         }
@@ -280,9 +281,9 @@ async def async_chat_solo(dialog, messages, stream=True):
             "prompt": "",
             "created_at": time.time(),
             "usage": {
-                "prompt_tokens": 0,
+                "prompt_tokens": prompt_tk,
                 "completion_tokens": tk_num,
-                "total_tokens": tk_num,
+                "total_tokens": prompt_tk + tk_num,
                 "duration_ms": duration_ms,
             },
         }

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -239,20 +239,53 @@ async def async_chat_solo(dialog, messages, stream=True):
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting)
         else:
             stream_iter = chat_mdl.async_chat_streamly_delta(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
+        stream_start_ts = timer()
+        full_answer = []
         async for kind, value, state in _stream_with_think_delta(stream_iter):
             if kind == "marker":
                 flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}
                 yield {"answer": "", "reference": {}, "audio_binary": None, "prompt": "", "created_at": time.time(), "final": False, **flags}
                 continue
+            full_answer.append(value)
             yield {"answer": value, "reference": {}, "audio_binary": tts(tts_mdl, value), "prompt": "", "created_at": time.time(), "final": False}
+        tk_num = num_tokens_from_string("".join(full_answer))
+        duration_ms = round((timer() - stream_start_ts) * 1000, 1)
+        yield {
+            "answer": "".join(full_answer),
+            "reference": {},
+            "audio_binary": None,
+            "prompt": "",
+            "created_at": time.time(),
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": tk_num,
+                "total_tokens": tk_num,
+                "duration_ms": duration_ms,
+            },
+        }
     else:
+        call_start_ts = timer()
         if llm_type == "chat":
             answer = await chat_mdl.async_chat(prompt_config.get("system", ""), msg, dialog.llm_setting)
         else:
             answer = await chat_mdl.async_chat(prompt_config.get("system", ""), msg, dialog.llm_setting, images=image_files)
+        duration_ms = round((timer() - call_start_ts) * 1000, 1)
+        tk_num = num_tokens_from_string(answer)
         user_content = msg[-1].get("content", "[content not available]")
         logging.debug("User: {}|Assistant: {}".format(user_content, answer))
-        yield {"answer": answer, "reference": {}, "audio_binary": tts(tts_mdl, answer), "prompt": "", "created_at": time.time()}
+        yield {
+            "answer": answer,
+            "reference": {},
+            "audio_binary": tts(tts_mdl, answer),
+            "prompt": "",
+            "created_at": time.time(),
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": tk_num,
+                "total_tokens": tk_num,
+                "duration_ms": duration_ms,
+            },
+        }
 
 
 def get_models(dialog):

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -290,6 +290,20 @@ class DialogService(CommonService):
         return list(objs)
 
 
+def _usage_dict(prompt_tokens: int, completion_tokens: int, start_ts: float) -> dict:
+    """Build the ``usage`` block attached to a final chat answer.
+
+    Token counts are tokenizer estimates (``num_tokens_from_string``), not
+    provider-reported values; ``duration_ms`` is wall-clock since ``start_ts``.
+    """
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+        "duration_ms": round((timer() - start_ts) * 1000, 1),
+    }
+
+
 async def async_chat_solo(dialog, messages, stream=True, session_id=None):
     if dialog.llm_id:
         if dialog.tenant_llm_id:
@@ -331,17 +345,31 @@ async def async_chat_solo(dialog, messages, stream=True, session_id=None):
         convert_last_user_msg_to_multimodal(msg, image_attachments, factory)
     sys_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     system_prompt = prompt_config.get("system", "").replace("{date}", sys_date)
+    prompt_tk = num_tokens_from_string(system_prompt) + sum(num_tokens_from_string(m["content"]) for m in msg if isinstance(m.get("content"), str))
+    start_ts = timer()
     if stream:
         if model_config["model_type"] == "chat":
             stream_iter = chat_mdl.async_chat_streamly_delta(system_prompt, msg, dialog.llm_setting)
         else:
             stream_iter = chat_mdl.async_chat_streamly_delta(system_prompt, msg, dialog.llm_setting, images=image_files)
+        last_state = None
         async for kind, value, state in _stream_with_think_delta(stream_iter):
+            last_state = state
             if kind == "marker":
                 flags = {"start_to_think": True} if value == "<think>" else {"end_to_think": True}
                 yield {"answer": "", "reference": {}, "audio_binary": None, "prompt": "", "created_at": time.time(), "final": False, **flags}
                 continue
             yield {"answer": value, "reference": {}, "audio_binary": tts(tts_mdl, value), "prompt": "", "created_at": time.time(), "final": False}
+        full_answer = last_state.full_text if last_state else ""
+        yield {
+            "answer": "",
+            "reference": {},
+            "audio_binary": None,
+            "prompt": "",
+            "created_at": time.time(),
+            "final": True,
+            "usage": _usage_dict(prompt_tk, num_tokens_from_string(full_answer), start_ts),
+        }
     else:
         if model_config["model_type"] == "chat":
             answer = await chat_mdl.async_chat(system_prompt, msg, dialog.llm_setting)
@@ -349,7 +377,14 @@ async def async_chat_solo(dialog, messages, stream=True, session_id=None):
             answer = await chat_mdl.async_chat(system_prompt, msg, dialog.llm_setting, images=image_files)
         user_content = msg[-1].get("content", "[content not available]")
         logging.debug("User: {}|Assistant: {}".format(user_content, answer))
-        yield {"answer": answer, "reference": {}, "audio_binary": tts(tts_mdl, answer), "prompt": "", "created_at": time.time()}
+        yield {
+            "answer": answer,
+            "reference": {},
+            "audio_binary": tts(tts_mdl, answer),
+            "prompt": "",
+            "created_at": time.time(),
+            "usage": _usage_dict(prompt_tk, num_tokens_from_string(answer), start_ts),
+        }
 
 
 def get_models(dialog, trace_context=None, langfuse_session_id=None):
@@ -813,7 +848,14 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         # stripping in clean_tts_text).
         escaped_answer = html.escape(empty_res)
         yield {"answer": escaped_answer, "reference": {}, "prompt": "", "audio_binary": None, "final": False}
-        yield {"answer": escaped_answer, "reference": kbinfos, "prompt": "\n\n### Query:\n%s" % " ".join(questions), "audio_binary": tts(tts_mdl, empty_res), "final": True}
+        yield {
+            "answer": escaped_answer,
+            "reference": kbinfos,
+            "prompt": "\n\n### Query:\n%s" % " ".join(questions),
+            "audio_binary": tts(tts_mdl, empty_res),
+            "final": True,
+            "usage": _usage_dict(0, 0, chat_start_ts),
+        }
         return
 
     # Only overwrite kwargs["knowledge"] when retrieval produced something;
@@ -939,7 +981,18 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
             )
             langfuse_generation.end()
 
-        return {"answer": think + answer, "reference": refs, "prompt": re.sub(r"\n", "  \n", prompt), "created_at": time.time()}
+        return {
+            "answer": think + answer,
+            "reference": refs,
+            "prompt": re.sub(r"\n", "  \n", prompt),
+            "created_at": time.time(),
+            "usage": {
+                "prompt_tokens": used_token_count,
+                "completion_tokens": tk_num,
+                "total_tokens": used_token_count + tk_num,
+                "duration_ms": round(total_time_cost, 1),
+            },
+        }
 
     if langfuse_tracer:
         try:
@@ -2005,6 +2058,7 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         async for ans in async_chat(dialog, messages, stream, **kwargs):
             yield ans
         return
+    agent_start_ts = timer()
     kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
 
     # Agentic RAG depends on the outer model being able to call the bound
@@ -2134,7 +2188,14 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         if answer.lower().find("invalid key") >= 0 or answer.lower().find("invalid api") >= 0:
             answer += " Please set LLM API-Key in 'User Setting -> Model providers -> API-Key'"
 
-        return {"answer": think + answer, "reference": refs, "prompt": "", "created_at": time.time()}
+        prompt_tk = num_tokens_from_string(rag_tools.sys_prompt()) + sum(num_tokens_from_string(m["content"]) for m in agent_messages if isinstance(m.get("content"), str))
+        return {
+            "answer": think + answer,
+            "reference": refs,
+            "prompt": "",
+            "created_at": time.time(),
+            "usage": _usage_dict(prompt_tk, num_tokens_from_string(think + answer), agent_start_ts),
+        }
 
     # The agentic-search graph composes the final cited answer itself, so we
     # stream its tokens straight to the client instead of relaying a tool

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -290,6 +290,16 @@ class DialogService(CommonService):
         return list(objs)
 
 
+def _prompt_tokens(system_prompt: str, messages: list[dict]) -> int:
+    """Estimate prompt tokens for a system prompt plus a message list.
+
+    Message content may be a plain string or a list of content blocks (after
+    ``convert_last_user_msg_to_multimodal``); only the text blocks are counted,
+    image payloads are ignored.
+    """
+    return num_tokens_from_string(system_prompt) + sum(num_tokens_from_string(_normalize_text_from_content(m.get("content"))) for m in messages)
+
+
 def _usage_dict(prompt_tokens: int, completion_tokens: int, start_ts: float) -> dict:
     """Build the ``usage`` block attached to a final chat answer.
 
@@ -348,7 +358,7 @@ async def async_chat_solo(dialog, messages, stream=True, session_id=None):
         convert_last_user_msg_to_multimodal(msg, image_attachments, factory)
     sys_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     system_prompt = prompt_config.get("system", "").replace("{date}", sys_date)
-    prompt_tk = num_tokens_from_string(system_prompt) + sum(num_tokens_from_string(m["content"]) for m in msg if isinstance(m.get("content"), str))
+    prompt_tk = _prompt_tokens(system_prompt, msg)
     if stream:
         if model_config["model_type"] == "chat":
             stream_iter = chat_mdl.async_chat_streamly_delta(system_prompt, msg, dialog.llm_setting)
@@ -2190,13 +2200,17 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         if answer.lower().find("invalid key") >= 0 or answer.lower().find("invalid api") >= 0:
             answer += " Please set LLM API-Key in 'User Setting -> Model providers -> API-Key'"
 
-        prompt_tk = num_tokens_from_string(rag_tools.sys_prompt()) + sum(num_tokens_from_string(m["content"]) for m in agent_messages if isinstance(m.get("content"), str))
+        # Outer-model estimate plus every LLM call the inner ``rag`` graph made
+        # (recorded per phase by RAGTools' CountingChatModel).
+        llm_stats = getattr(rag_tools, "llm_stats", None)
+        prompt_tk = _prompt_tokens(rag_tools.sys_prompt(), agent_messages) + (sum(llm_stats.prompt_tokens.values()) if llm_stats else 0)
+        completion_tk = num_tokens_from_string(think + answer) + (sum(llm_stats.completion_tokens.values()) if llm_stats else 0)
         return {
             "answer": think + answer,
             "reference": refs,
             "prompt": "",
             "created_at": time.time(),
-            "usage": _usage_dict(prompt_tk, num_tokens_from_string(think + answer), agent_start_ts),
+            "usage": _usage_dict(prompt_tk, completion_tk, agent_start_ts),
         }
 
     # The agentic-search graph composes the final cited answer itself, so we

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -305,6 +305,9 @@ def _usage_dict(prompt_tokens: int, completion_tokens: int, start_ts: float) -> 
 
 
 async def async_chat_solo(dialog, messages, stream=True, session_id=None):
+    # Same timing boundary as async_chat: model resolution and prompt setup
+    # count towards the persisted duration.
+    start_ts = timer()
     if dialog.llm_id:
         if dialog.tenant_llm_id:
             try:
@@ -346,7 +349,6 @@ async def async_chat_solo(dialog, messages, stream=True, session_id=None):
     sys_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     system_prompt = prompt_config.get("system", "").replace("{date}", sys_date)
     prompt_tk = num_tokens_from_string(system_prompt) + sum(num_tokens_from_string(m["content"]) for m in msg if isinstance(m.get("content"), str))
-    start_ts = timer()
     if stream:
         if model_config["model_type"] == "chat":
             stream_iter = chat_mdl.async_chat_streamly_delta(system_prompt, msg, dialog.llm_setting)

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -2200,17 +2200,27 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         if answer.lower().find("invalid key") >= 0 or answer.lower().find("invalid api") >= 0:
             answer += " Please set LLM API-Key in 'User Setting -> Model providers -> API-Key'"
 
-        # Outer-model estimate plus every LLM call the inner ``rag`` graph made
-        # (recorded per phase by RAGTools' CountingChatModel).
+        # Usage of the whole agentic turn, counted once: the outer model
+        # (reasoning + tool call) reports its own usage through the provider,
+        # and every inner ``rag`` graph call is recorded per phase by RAGTools'
+        # CountingChatModel. The final answer is the inner graph's terminal
+        # output, so it is only estimated from text when nothing was recorded.
         llm_stats = getattr(rag_tools, "llm_stats", None)
-        prompt_tk = _prompt_tokens(rag_tools.sys_prompt(), agent_messages) + (sum(llm_stats.prompt_tokens.values()) if llm_stats else 0)
-        completion_tk = num_tokens_from_string(think + answer) + (sum(llm_stats.completion_tokens.values()) if llm_stats else 0)
+        inner_prompt_tk = sum(llm_stats.prompt_tokens.values()) if llm_stats else 0
+        inner_completion_tk = sum(llm_stats.completion_tokens.values()) if llm_stats else 0
+        outer_usage = getattr(getattr(chat_mdl, "mdl", None), "last_usage", None) or {}
+        if outer_usage.get("total_tokens"):
+            outer_prompt_tk = int(outer_usage.get("prompt_tokens") or 0)
+            outer_completion_tk = int(outer_usage.get("completion_tokens") or 0)
+        else:
+            outer_prompt_tk = _prompt_tokens(rag_tools.sys_prompt(), agent_messages)
+            outer_completion_tk = 0 if inner_completion_tk else num_tokens_from_string(think + answer)
         return {
             "answer": think + answer,
             "reference": refs,
             "prompt": "",
             "created_at": time.time(),
-            "usage": _usage_dict(prompt_tk, completion_tk, agent_start_ts),
+            "usage": _usage_dict(outer_prompt_tk + inner_prompt_tk, outer_completion_tk + inner_completion_tk, agent_start_ts),
         }
 
     # The agentic-search graph composes the final cited answer itself, so we

--- a/test/unit_test/api/db/services/test_api_service_append_message.py
+++ b/test/unit_test/api/db/services/test_api_service_append_message.py
@@ -1,0 +1,91 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+``API4ConversationService.append_message`` must persist the conversation
+snapshot and increment ``round`` / ``tokens`` / ``duration`` in a single
+UPDATE, using server-side increments rather than the (possibly stale)
+values carried by the snapshot.
+"""
+
+import pytest
+from peewee import SqliteDatabase
+
+from api.db.db_models import API4Conversation
+from api.db.services.api_service import API4ConversationService
+
+# Bypass @DB.connection_context() (bound to the real pooled database) and
+# exercise the service body against an in-memory SQLite table.
+_append_message = API4ConversationService.append_message.__wrapped__
+
+
+@pytest.fixture
+def sqlite_conv():
+    db = SqliteDatabase(":memory:")
+    with db.bind_ctx([API4Conversation]):
+        db.create_tables([API4Conversation])
+        API4Conversation.create(
+            id="conv-1",
+            dialog_id="dialog-1",
+            user_id="user-1",
+            message=[{"role": "assistant", "content": "Hi"}],
+            reference=[],
+            round=2,
+            tokens=100,
+            duration=50.0,
+        )
+        yield API4Conversation.get_by_id("conv-1")
+    db.close()
+
+
+@pytest.mark.p2
+def test_append_message_persists_snapshot_and_increments_counters(sqlite_conv):
+    executed = []
+    original_execute_sql = API4Conversation._meta.database.execute_sql
+
+    def spy(sql, *args, **kwargs):
+        executed.append(sql)
+        return original_execute_sql(sql, *args, **kwargs)
+
+    API4Conversation._meta.database.execute_sql = spy
+
+    sqlite_conv.message.append({"role": "user", "content": "Hello?"})
+    sqlite_conv.message.append({"role": "assistant", "content": "Hello!"})
+    snapshot = dict(sqlite_conv.to_dict())
+    # Simulate a stale snapshot: counters read before another request's increment.
+    snapshot["round"] = 0
+    snapshot["tokens"] = 0
+    snapshot["duration"] = 0.0
+
+    assert _append_message(API4ConversationService, "conv-1", snapshot, tokens=42, duration=12.5) == 1
+
+    assert len([sql for sql in executed if sql.lstrip().upper().startswith("UPDATE")]) == 1
+
+    row = API4Conversation.get_by_id("conv-1")
+    assert [m["content"] for m in row.message] == ["Hi", "Hello?", "Hello!"]
+    assert row.round == 3
+    assert row.tokens == 142
+    assert row.duration == 62.5
+    assert row.update_time is not None
+
+
+@pytest.mark.p2
+def test_append_message_defaults_leave_tokens_and_duration_unchanged(sqlite_conv):
+    _append_message(API4ConversationService, "conv-1", dict(sqlite_conv.to_dict()))
+
+    row = API4Conversation.get_by_id("conv-1")
+    assert row.round == 3
+    assert row.tokens == 100
+    assert row.duration == 50.0

--- a/test/unit_test/api/db/services/test_dialog_service_usage.py
+++ b/test/unit_test/api/db/services/test_dialog_service_usage.py
@@ -122,6 +122,42 @@ def test_async_chat_final_event_carries_usage(monkeypatch, stream):
     _assert_usage(final_events[0]["usage"])
 
 
+def test_prompt_tokens_counts_text_blocks_in_structured_content():
+    plain = [{"role": "user", "content": "What is RAGFlow?"}]
+    structured = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is RAGFlow?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+        }
+    ]
+    assert dialog_service._prompt_tokens("sys", plain) > dialog_service._prompt_tokens("sys", [])
+    assert dialog_service._prompt_tokens("sys", structured) == dialog_service._prompt_tokens("sys", plain)
+
+
+@pytest.mark.p2
+def test_async_chat_solo_usage_counts_multimodal_prompt(monkeypatch):
+    chat_mdl = _StreamingChatModel("A picture of the RAGFlow logo.")
+    _stub_solo_dependencies(monkeypatch, chat_mdl)
+    # Turn the last user message into content blocks, as the multimodal path does.
+    monkeypatch.setattr(
+        dialog_service,
+        "convert_last_user_msg_to_multimodal",
+        lambda msg, _uris, _factory: msg.__setitem__(
+            -1, {"role": "user", "content": [{"type": "text", "text": msg[-1]["content"]}, {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]}
+        ),
+    )
+    monkeypatch.setattr(dialog_service, "get_files_content", lambda _m, _t: ("", ["data:image/png;base64,AAAA"], []))
+
+    events = _collect(dialog_service.async_chat_solo(_make_solo_dialog(), [{"role": "user", "content": "What is on this picture?"}], stream=False))
+
+    usage = events[-1]["usage"]
+    assert usage["prompt_tokens"] == dialog_service._prompt_tokens("You are helpful.", [{"role": "user", "content": "What is on this picture?"}])
+    assert usage["prompt_tokens"] > 0
+
+
 def test_usage_dict_shape():
     usage = dialog_service._usage_dict(3, 4, dialog_service.timer())
     assert usage["total_tokens"] == 7

--- a/test/unit_test/api/db/services/test_dialog_service_usage.py
+++ b/test/unit_test/api/db/services/test_dialog_service_usage.py
@@ -1,0 +1,129 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Every final answer produced by the chat services must carry a ``usage`` block
+(``prompt_tokens``, ``completion_tokens``, ``total_tokens``, ``duration_ms``)
+so that ``async_iframe_completion`` can persist tokens/duration on the
+``api_4_conversation`` row instead of always writing zeros.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from test_dialog_service_final_answer import _KB, _LLM_CONFIG, _StreamingChatModel, _StubRetriever, _collect, _make_dialog
+
+from api.db.services import dialog_service
+
+_USAGE_KEYS = {"prompt_tokens", "completion_tokens", "total_tokens", "duration_ms"}
+
+
+def _assert_usage(usage, *, expect_completion_tokens=True):
+    assert set(usage.keys()) == _USAGE_KEYS
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+    assert usage["duration_ms"] >= 0
+    if expect_completion_tokens:
+        assert usage["completion_tokens"] > 0
+        assert usage["prompt_tokens"] > 0
+
+
+def _stub_solo_dependencies(monkeypatch, chat_mdl):
+    monkeypatch.setattr(dialog_service, "resolve_model_type", lambda _tid, _llm_id: ["chat"])
+    monkeypatch.setattr(dialog_service, "resolve_model_config", lambda _tid, _type, _llm_id: _LLM_CONFIG)
+    monkeypatch.setattr(dialog_service, "LLMBundle", lambda *_args, **_kwargs: chat_mdl)
+
+
+def _make_solo_dialog():
+    dialog = _make_dialog(None)
+    dialog.kb_ids = []
+    dialog.prompt_config["system"] = "You are helpful."
+    return dialog
+
+
+@pytest.mark.p2
+@pytest.mark.parametrize("stream", [True, False])
+def test_async_chat_solo_final_event_carries_usage(monkeypatch, stream):
+    chat_mdl = _StreamingChatModel("RAGFlow is a RAG engine with deep document understanding.")
+    _stub_solo_dependencies(monkeypatch, chat_mdl)
+
+    events = _collect(dialog_service.async_chat_solo(_make_solo_dialog(), [{"role": "user", "content": "What is RAGFlow?"}], stream=stream))
+
+    final_events = [e for e in events if e.get("final", True)]
+    assert len(final_events) == 1, final_events
+    _assert_usage(final_events[0]["usage"])
+    # Intermediate deltas never carry usage.
+    assert all("usage" not in e for e in events if e.get("final") is False)
+
+
+@pytest.mark.p2
+def test_async_chat_empty_response_carries_usage(monkeypatch):
+    """No knowledge retrieved + configured empty_response: still a final event with usage."""
+    chat_mdl = _StreamingChatModel("unused")
+
+    class _EmptyRetriever(_StubRetriever):
+        async def retrieval(self, *_args, **_kwargs):
+            return {"chunks": [], "doc_aggs": [], "total": 0}
+
+    monkeypatch.setattr(dialog_service, "resolve_model_type", lambda _tid, _llm_id: ["chat"])
+    monkeypatch.setattr(dialog_service, "resolve_model_config", lambda _tid, _type, _llm_id: _LLM_CONFIG)
+    monkeypatch.setattr(dialog_service.TenantLangfuseService, "filter_by_tenant", lambda tenant_id: None)
+    monkeypatch.setattr(dialog_service, "get_models", lambda _dialog, **_kwargs: ([_KB], chat_mdl, None, chat_mdl, None))
+    monkeypatch.setattr(dialog_service.KnowledgebaseService, "get_field_map", lambda _kb_ids: {})
+    monkeypatch.setattr(dialog_service.KnowledgebaseService, "get_by_ids", lambda _ids: [_KB])
+    monkeypatch.setattr(dialog_service.settings, "retriever", _EmptyRetriever(), raising=False)
+    monkeypatch.setattr(dialog_service, "label_question", lambda _q, _kbs: "")
+    monkeypatch.setattr(dialog_service, "kb_prompt", lambda _kbinfos, _max_tokens, **_kw: [])
+
+    dialog = _make_dialog(chat_mdl)
+    dialog.prompt_config["empty_response"] = "Sorry, nothing found."
+
+    events = _collect(dialog_service.async_chat(dialog, [{"role": "user", "content": "What is RAGFlow?"}], stream=True, quote=True))
+
+    final_events = [e for e in events if e.get("final") is True]
+    assert len(final_events) == 1, final_events
+    assert "Sorry, nothing found." in final_events[0]["answer"]
+    _assert_usage(final_events[0]["usage"], expect_completion_tokens=False)
+    assert final_events[0]["usage"]["total_tokens"] == 0
+
+
+@pytest.mark.p2
+@pytest.mark.parametrize("stream", [True, False])
+def test_async_chat_final_event_carries_usage(monkeypatch, stream):
+    chat_mdl = _StreamingChatModel("RAGFlow handles document parsing with deep understanding.")
+    retriever = _StubRetriever()
+
+    monkeypatch.setattr(dialog_service, "resolve_model_type", lambda _tid, _llm_id: ["chat"])
+    monkeypatch.setattr(dialog_service, "resolve_model_config", lambda _tid, _type, _llm_id: _LLM_CONFIG)
+    monkeypatch.setattr(dialog_service.TenantLangfuseService, "filter_by_tenant", lambda tenant_id: None)
+    monkeypatch.setattr(dialog_service, "get_models", lambda _dialog, **_kwargs: ([_KB], chat_mdl, None, chat_mdl, None))
+    monkeypatch.setattr(dialog_service.KnowledgebaseService, "get_field_map", lambda _kb_ids: {})
+    monkeypatch.setattr(dialog_service.KnowledgebaseService, "get_by_ids", lambda _ids: [_KB])
+    monkeypatch.setattr(dialog_service.settings, "retriever", retriever, raising=False)
+    monkeypatch.setattr(dialog_service, "label_question", lambda _q, _kbs: "")
+    monkeypatch.setattr(dialog_service, "kb_prompt", lambda _kbinfos, _max_tokens, **_kw: ["RAGFlow is a RAG engine."])
+
+    events = _collect(dialog_service.async_chat(_make_dialog(chat_mdl), [{"role": "user", "content": "What is RAGFlow?"}], stream=stream, quote=True))
+
+    final_events = [e for e in events if e.get("final", True)]
+    assert len(final_events) == 1, final_events
+    _assert_usage(final_events[0]["usage"])
+
+
+def test_usage_dict_shape():
+    usage = dialog_service._usage_dict(3, 4, dialog_service.timer())
+    assert usage["total_tokens"] == 7
+    assert isinstance(usage["duration_ms"], float)
+    assert SimpleNamespace(**usage).duration_ms >= 0

--- a/test/unit_test/api/db/services/test_dialog_service_usage.py
+++ b/test/unit_test/api/db/services/test_dialog_service_usage.py
@@ -25,6 +25,9 @@ from types import SimpleNamespace
 import pytest
 
 from test_dialog_service_final_answer import _KB, _LLM_CONFIG, _StreamingChatModel, _StubRetriever, _collect, _make_dialog
+from test_dialog_service_rag_agent_messages import _DIALOG as _AGENT_DIALOG
+from test_dialog_service_rag_agent_messages import _KB as _AGENT_KB
+from test_dialog_service_rag_agent_messages import _RecordingChatModel
 
 from api.db.services import dialog_service
 
@@ -156,6 +159,77 @@ def test_async_chat_solo_usage_counts_multimodal_prompt(monkeypatch):
     usage = events[-1]["usage"]
     assert usage["prompt_tokens"] == dialog_service._prompt_tokens("You are helpful.", [{"role": "user", "content": "What is on this picture?"}])
     assert usage["prompt_tokens"] > 0
+
+
+# ---------------------------------------------------------------------------
+# rag_agent (agentic path): outer model + inner graph, each counted once
+# ---------------------------------------------------------------------------
+
+_AGENT_ANSWER = "RAGFlow is a RAG engine."
+_AGENT_QUESTION = [{"role": "user", "content": "What is RAGFlow?"}]
+
+
+def _make_stub_rag_tools(inner_prompt: dict | None, inner_completion: dict | None):
+    class _StubRAGTools:
+        def __init__(self, *_args, **_kwargs):
+            self.kbinfos = {"chunks": [], "doc_aggs": []}
+            self.tools = []
+            if inner_prompt is not None:
+                self.llm_stats = SimpleNamespace(prompt_tokens=dict(inner_prompt), completion_tokens=dict(inner_completion))
+
+        def sys_prompt(self):
+            return "You are a helpful assistant."
+
+    return _StubRAGTools
+
+
+def _drive_rag_agent_usage(monkeypatch, chat_mdl, rag_tools_cls):
+    monkeypatch.setattr(dialog_service, "get_models", lambda _dialog, **_kw: ([_AGENT_KB], None, None, chat_mdl, None))
+    monkeypatch.setattr(dialog_service, "RAGTools", rag_tools_cls)
+    monkeypatch.setattr(dialog_service, "tts", lambda _mdl, _text: None)
+    events = _collect(dialog_service.rag_agent(_AGENT_DIALOG, list(_AGENT_QUESTION), False, reasoning="2"))
+    assert len(events) == 1, events
+    return events[0]["usage"]
+
+
+@pytest.mark.p2
+def test_rag_agent_usage_does_not_count_inner_answer_twice(monkeypatch):
+    """Inner graph recorded usage, outer model did not: the answer text is NOT re-estimated."""
+    chat_mdl = _RecordingChatModel()
+    rag_tools_cls = _make_stub_rag_tools({"planner": 100, "agent": 250}, {"planner": 20, "agent": 80})
+
+    usage = _drive_rag_agent_usage(monkeypatch, chat_mdl, rag_tools_cls)
+
+    expected_outer_prompt = dialog_service._prompt_tokens("You are a helpful assistant.", _AGENT_QUESTION)
+    assert usage["prompt_tokens"] == expected_outer_prompt + 350
+    assert usage["completion_tokens"] == 100
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+
+@pytest.mark.p2
+def test_rag_agent_usage_adds_outer_provider_usage_to_inner_counters(monkeypatch):
+    """Both sides reported usage: exact sum, no tokenizer estimate involved."""
+    chat_mdl = _RecordingChatModel()
+    chat_mdl.mdl = SimpleNamespace(last_usage={"prompt_tokens": 40, "completion_tokens": 15, "total_tokens": 55})
+    rag_tools_cls = _make_stub_rag_tools({"agent": 300}, {"agent": 60})
+
+    usage = _drive_rag_agent_usage(monkeypatch, chat_mdl, rag_tools_cls)
+
+    assert usage == {"prompt_tokens": 340, "completion_tokens": 75, "total_tokens": 415, "duration_ms": usage["duration_ms"]}
+    assert chat_mdl.mdl.terminal_tools == {"rag"}
+
+
+@pytest.mark.p2
+def test_rag_agent_usage_falls_back_to_estimates_when_nothing_recorded(monkeypatch):
+    """No provider usage anywhere (or no llm_stats at all): estimate prompt and answer from text."""
+    chat_mdl = _RecordingChatModel()
+    rag_tools_cls = _make_stub_rag_tools(None, None)
+
+    usage = _drive_rag_agent_usage(monkeypatch, chat_mdl, rag_tools_cls)
+
+    assert usage["prompt_tokens"] == dialog_service._prompt_tokens("You are a helpful assistant.", _AGENT_QUESTION)
+    assert usage["completion_tokens"] == dialog_service.num_tokens_from_string(_AGENT_ANSWER)
+    assert usage["completion_tokens"] > 0
 
 
 def test_usage_dict_shape():


### PR DESCRIPTION
## Summary

- `decorate_answer()` in `dialog_service.py` already computed `tk_num`, `used_token_count`, and `total_time_cost` but only encoded them as text in `prompt` — they were never returned in the dict
- `append_message()` in `api_service.py` always called `round + 1` but left `tokens` and `duration` unchanged (no parameters to pass them)
- `async_iframe_completion()` in `conversation_service.py` called `append_message()` without capturing usage from the last streamed answer

## Changes

- **`api/db/services/dialog_service.py`**: every final answer now carries a `usage` dict (`prompt_tokens`, `completion_tokens`, `total_tokens`, `duration_ms`):
  - `async_chat` — `decorate_answer()` return value and the `empty_response` path
  - `async_chat_solo` — streaming now emits a `final: True` event carrying usage (same shape as `async_chat`); non-streaming carries it on its single yield
  - `rag_agent` — the agentic (reasoning) path's `decorate_answer()`, since the chatbot endpoint now routes through `rag_agent`
- **`api/db/services/api_service.py`**: add `tokens: int = 0` and `duration: float = 0.0` parameters to `append_message()`. The conversation snapshot and the server-side increments of `round` / `tokens` / `duration` are written in a **single UPDATE** (no more `update_by_id` + second counter UPDATE), so the message list can never be persisted without its counters and a stale snapshot can never overwrite a concurrent request's increment. `DB.atomic()` is not an option here: `update_by_id` is `@DB.connection_context()`-decorated and closing the connection inside an open transaction raises peewee's *"Attempting to close database while transaction is open"* (observed in production on an earlier revision of this PR).
- **`api/db/services/conversation_service.py`**: capture `last_ans` from the streaming loop in `async_iframe_completion()`, extract `usage`, and pass `total_tokens` / `duration_ms` to `append_message()` — both streaming and non-streaming paths; warn when usage is missing
- **`test/unit_test/api/db/services/test_api_service_append_message.py`**: in-memory SQLite test asserting the single UPDATE, the increments and the default call
- **`test/unit_test/api/db/services/test_dialog_service_usage.py`**: unit tests asserting the `usage` block on `async_chat` (stream/non-stream, `empty_response`) and `async_chat_solo` (stream/non-stream)

## Test plan

- [x] `pytest test/unit_test/api/db/services/test_api_service_append_message.py test/unit_test/api/db/services/test_dialog_service_usage.py test/unit_test/api/db/services/test_dialog_service_final_answer.py`
- [ ] Start a chatbot session via the iframe/API (`POST /api/v1/chat/completions`)
- [ ] Query `api_4_conversation` table: verify `round` increments and `tokens` / `duration` are non-zero after each turn
- [ ] Call `GET /api/v1/stats` and confirm `tokens` and `duration` aggregates are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

