### PR TITLE
fix(api): prevent internal RetCode from generating invalid HTTP status codes

### DIFF
--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -254,7 +254,11 @@ def build_error_result(code=RetCode.FORBIDDEN, message="success"):
     response = {"code": code, "message": message}
     response = _safe_jsonify(response)
     if hasattr(response, "status_code"):
-        response.status_code = code
+        try:
+            http_status = int(code)
+        except (TypeError, ValueError):
+            http_status = 400
+        response.status_code = http_status if 200 <= http_status <= 599 else 400
     return response
 
 


### PR DESCRIPTION
Fixes #16208.

**Root cause:**
When `build_error_result` is called (e.g. from External API health checks like Dify), it assigns internal `RetCode` values (like 101 for ARGUMENT_ERROR) directly to the response `status_code`. HTTP 101 forces ASGI servers (like Hypercorn) to attempt a protocol switch/upgrade without a client proposal, crashing the server and dropping the connection.

**Fix:**
This change clamps the HTTP status code. It ensures only valid HTTP status codes (200-599) are applied to the response, falling back to 400 otherwise. This allows connection tests to pass successfully and prevents framework crashes.
