### PR TITLE
Preserve GraphRAG subgraph checkpoints during merge

### DIFF
--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -517,25 +517,29 @@ async def get_graph(tenant_id, kb_id, exclude_rebuild=None):
 async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, change: GraphChange, callback):
     global chat_limiter
     start = asyncio.get_running_loop().time()
+    graph_source_ids = list(dict.fromkeys(graph.graph.get("source_id", [])))
 
     # Build all new chunks first (graph, subgraphs, node/edge embeddings) before
     # deleting anything.  This ensures that if embedding generation or any other
-    # step crashes, the old graph and per-doc subgraph checkpoints remain intact
-    # so the pipeline can resume without re-running earlier phases.
+    # step crashes, the old graph and per-doc subgraph checkpoints remain intact.
+    # Keep extracted-but-not-yet-merged subgraphs out of this rewrite; they are
+    # expensive LLM checkpoints used for GraphRAG resume.
     chunks = [
         {
             "id": get_uuid(),
             "content_with_weight": json.dumps(nx.node_link_data(graph, edges="edges"), ensure_ascii=False),
             "knowledge_graph_kwd": "graph",
             "kb_id": kb_id,
-            "source_id": graph.graph.get("source_id", []),
+            "source_id": graph_source_ids,
             "available_int": 0,
             "removed_kwd": "N",
         }
     ]
 
-    # generate updated subgraphs
-    for source in graph.graph["source_id"]:
+    # Generate updated subgraphs only for documents already merged into this
+    # global graph.  Subgraphs for other documents may be raw extraction
+    # checkpoints from the current run and must survive merge failure.
+    for source in graph_source_ids:
         subgraph = graph.subgraph([n for n in graph.nodes if source in graph.nodes[n]["source_id"]]).copy()
         subgraph.graph["source_id"] = [source]
         for n in subgraph.nodes:
@@ -596,13 +600,23 @@ async def set_graph(tenant_id: str, kb_id: str, embd_mdl, graph: nx.Graph, chang
 
     # All new chunks are ready.  Now delete old data and insert the new data.
     # Deleting only after chunks are built ensures that a crash during embedding
-    # generation above does not destroy the old graph/subgraph checkpoints.
+    # generation above does not destroy checkpoints.  Delete the global graph
+    # record, then only the per-doc subgraphs being rewritten here; never wipe
+    # every subgraph in the dataset, because later extracted-but-unmerged docs
+    # must remain resumable after a merge timeout.
     await thread_pool_exec(
         settings.docStoreConn.delete,
-        {"knowledge_graph_kwd": ["graph", "subgraph"]},
+        {"knowledge_graph_kwd": ["graph"]},
         search.index_name(tenant_id),
         kb_id
     )
+    if graph_source_ids:
+        await thread_pool_exec(
+            settings.docStoreConn.delete,
+            {"knowledge_graph_kwd": ["subgraph"], "source_id": graph_source_ids},
+            search.index_name(tenant_id),
+            kb_id
+        )
 
     if change.removed_nodes:
         BATCH_SIZE = 100

--- a/test/unit_test/rag/graphrag/test_graphrag_utils.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_utils.py
@@ -39,6 +39,7 @@ from rag.graphrag.utils import (
     n_neighbor,
     pack_user_ass_to_openai_messages,
     perform_variable_replacements,
+    set_graph,
     split_string_by_multi_markers,
     tidy_graph,
 )
@@ -214,6 +215,52 @@ class TestGraphChange:
         c2 = GraphChange()
         c1.removed_nodes.add("A")
         assert "A" not in c2.removed_nodes
+
+
+class TestSetGraphCheckpointPersistence:
+    """Tests for GraphRAG graph write-back checkpoint safety."""
+
+    @pytest.mark.p1
+    @pytest.mark.asyncio
+    async def test_set_graph_does_not_delete_unmerged_subgraph_checkpoints(self, monkeypatch):
+        graph = nx.Graph()
+        graph.graph["source_id"] = ["doc_merged_1", "doc_merged_2"]
+        graph.add_node(
+            "A",
+            description="node A",
+            entity_type="standard",
+            source_id=["doc_merged_1"],
+        )
+        graph.add_node(
+            "B",
+            description="node B",
+            entity_type="standard",
+            source_id=["doc_merged_2"],
+        )
+
+        delete_conditions = []
+        inserted_chunks = []
+
+        async def fake_thread_pool_exec(_fn, condition, *_args):
+            delete_conditions.append(condition)
+            return 0
+
+        async def fake_insert_chunks_bounded(chunks, *_args, **_kwargs):
+            inserted_chunks.extend(chunks)
+
+        monkeypatch.setattr(graphrag_utils, "thread_pool_exec", fake_thread_pool_exec)
+        monkeypatch.setattr(graphrag_utils, "insert_chunks_bounded", fake_insert_chunks_bounded)
+        monkeypatch.setattr(graphrag_utils.search, "index_name", lambda tenant_id: f"idx_{tenant_id}")
+
+        await set_graph("tenant_1", "kb_1", None, graph, GraphChange(), callback=None)
+
+        assert {"knowledge_graph_kwd": ["graph"]} in delete_conditions
+        assert {
+            "knowledge_graph_kwd": ["subgraph"],
+            "source_id": ["doc_merged_1", "doc_merged_2"],
+        } in delete_conditions
+        assert {"knowledge_graph_kwd": ["graph", "subgraph"]} not in delete_conditions
+        assert {chunk["knowledge_graph_kwd"] for chunk in inserted_chunks} == {"graph", "subgraph"}
 
 
 class TestHandleSingleEntityExtraction:


### PR DESCRIPTION
## What

- Preserve extracted-but-not-yet-merged GraphRAG subgraph checkpoints during global graph merge.
- Replace the dataset-wide graph/subgraph delete with a graph-only delete plus targeted subgraph replacement for documents already represented by the merged graph.
- Add a regression test to ensure set_graph no longer deletes all subgraph records.

## Why

- Long GraphRAG runs save per-document subgraphs after LLM extraction. During merge, set_graph previously deleted all graph and subgraph records, then recreated only subgraphs represented in the current merged global graph. If merge timed out or failed after expensive extraction had completed, extracted-but-unmerged subgraph checkpoints could be lost, forcing LLM extraction to run again.

## Validation

```
python3 -m py_compile rag/graphrag/utils.py test/unit_test/rag/graphrag/test_graphrag_utils.py
git diff --check
Full pytest was not available in my local environment.
```