### PR TITLE
test(mcp): cover the partial-pagination cache guard

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -334,6 +334,7 @@ class RAGFlowConnector:
                     page_size = 30
                     doc_id_meta_list = []
                     docs = {}
+                    pagination_complete = False
                     while page:
                         # Pass page_size explicitly so the pagination math below stays consistent
                         # with the page size the server actually applies.
@@ -372,16 +373,21 @@ class RAGFlowConnector:
                             doc_id_meta_list.append((doc_id, doc_meta))
                             docs[doc_id] = doc_meta
 
-                        self._set_cached_document_metadata_by_dataset(dataset_id, doc_id_meta_list)
-
                         # Stop when the page came back empty (no more documents) or we have reached
                         # the reported total. Without the empty-page guard, a successful response
                         # carrying an empty ``docs`` list would leave ``page`` unchanged and refetch
                         # the same page forever (issue #16248).
                         if not page_docs or page * page_size >= data.get("total", len(doc_id_meta_list)):
                             page = None
+                            pagination_complete = True
                         else:
                             page += 1
+
+                    # Cache only after pagination finished cleanly. Writing the cache mid-loop would
+                    # persist a partial list for the full TTL if a later page failed (``not docs_res``
+                    # or a non-zero code), making lookups for the unfetched pages silently miss.
+                    if pagination_complete:
+                        self._set_cached_document_metadata_by_dataset(dataset_id, doc_id_meta_list)
                 if docs:
                     document_cache.update(docs)
 

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -335,37 +335,53 @@ class RAGFlowConnector:
                     doc_id_meta_list = []
                     docs = {}
                     while page:
-                        docs_res = await self._get(f"/datasets/{dataset_id}/documents?page={page}", api_key=api_key)
+                        # Pass page_size explicitly so the pagination math below stays consistent
+                        # with the page size the server actually applies.
+                        docs_res = await self._get(f"/datasets/{dataset_id}/documents?page={page}&page_size={page_size}", api_key=api_key)
                         if not docs_res:
                             break
                         docs_data = docs_res.json()
-                        if docs_data.get("code") == 0 and docs_data.get("data", {}).get("docs"):
-                            for doc in docs_data["data"]["docs"]:
-                                doc_id = doc.get("id")
-                                if not doc_id:
-                                    continue
-                                doc_meta = {
-                                    "document_id": doc_id,
-                                    "name": doc.get("name", ""),
-                                    "location": doc.get("location", ""),
-                                    "type": doc.get("type", ""),
-                                    "size": doc.get("size"),
-                                    "chunk_count": doc.get("chunk_count"),
-                                    "create_date": doc.get("create_date", ""),
-                                    "update_date": doc.get("update_date", ""),
-                                    "token_count": doc.get("token_count"),
-                                    "thumbnail": doc.get("thumbnail", ""),
-                                    "dataset_id": doc.get("dataset_id", dataset_id),
-                                    "meta_fields": doc.get("meta_fields", {}),
-                                }
-                                doc_id_meta_list.append((doc_id, doc_meta))
-                                docs[doc_id] = doc_meta
-
-                            page += 1
-                            if docs_data.get("data", {}).get("total", 0) - page * page_size <= 0:
-                                page = None
+                        if docs_data.get("code") != 0:
+                            logging.warning(
+                                "Stopped paginating documents for dataset %s: API returned code=%s message=%r",
+                                dataset_id,
+                                docs_data.get("code"),
+                                docs_data.get("message"),
+                            )
+                            break
+                        data = docs_data.get("data") or {}
+                        page_docs = data.get("docs") or []
+                        for doc in page_docs:
+                            doc_id = doc.get("id")
+                            if not doc_id:
+                                continue
+                            doc_meta = {
+                                "document_id": doc_id,
+                                "name": doc.get("name", ""),
+                                "location": doc.get("location", ""),
+                                "type": doc.get("type", ""),
+                                "size": doc.get("size"),
+                                "chunk_count": doc.get("chunk_count"),
+                                "create_date": doc.get("create_date", ""),
+                                "update_date": doc.get("update_date", ""),
+                                "token_count": doc.get("token_count"),
+                                "thumbnail": doc.get("thumbnail", ""),
+                                "dataset_id": doc.get("dataset_id", dataset_id),
+                                "meta_fields": doc.get("meta_fields", {}),
+                            }
+                            doc_id_meta_list.append((doc_id, doc_meta))
+                            docs[doc_id] = doc_meta
 
                         self._set_cached_document_metadata_by_dataset(dataset_id, doc_id_meta_list)
+
+                        # Stop when the page came back empty (no more documents) or we have reached
+                        # the reported total. Without the empty-page guard, a successful response
+                        # carrying an empty ``docs`` list would leave ``page`` unchanged and refetch
+                        # the same page forever (issue #16248).
+                        if not page_docs or page * page_size >= data.get("total", len(doc_id_meta_list)):
+                            page = None
+                        else:
+                            page += 1
                 if docs:
                     document_cache.update(docs)
 

--- a/test/unit_test/mcp/test_document_metadata_pagination.py
+++ b/test/unit_test/mcp/test_document_metadata_pagination.py
@@ -14,6 +14,8 @@
 #  limitations under the License.
 #
 
+"""Unit tests for ``RAGFlowConnector._get_document_metadata_cache`` pagination (issue #16248)."""
+
 import importlib.util
 import urllib.parse
 from pathlib import Path
@@ -22,6 +24,7 @@ import pytest
 
 
 def _load_mcp_server():
+    """Import ``mcp/server/server.py`` as a standalone module for testing."""
     server_path = Path(__file__).resolve().parents[3] / "mcp" / "server" / "server.py"
     spec = importlib.util.spec_from_file_location("ragflow_mcp_server_unit_pagination", server_path)
     module = importlib.util.module_from_spec(spec)
@@ -30,6 +33,8 @@ def _load_mcp_server():
 
 
 class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` returning a fixed JSON payload."""
+
     status_code = 200
 
     def __init__(self, payload):
@@ -40,11 +45,13 @@ class _FakeResponse:
 
 
 def _docs(count):
+    """Build ``count`` minimal document records, each with a unique id."""
     return [{"id": f"doc-{idx}", "name": f"name-{idx}"} for idx in range(count)]
 
 
 @pytest.fixture()
 def mcp_server():
+    """Load the MCP server module once per test."""
     return _load_mcp_server()
 
 
@@ -80,8 +87,7 @@ def _stub_documents(monkeypatch, connector, *, docs, code=0, total=None, cap=50)
 @pytest.mark.p2
 @pytest.mark.asyncio
 async def test_empty_docs_page_breaks_instead_of_looping(monkeypatch, mcp_server):
-    # The regression from issue #16248: a successful response carrying an empty
-    # ``docs`` list must terminate pagination, not refetch the same page forever.
+    """A successful response with an empty ``docs`` list must stop, not refetch forever (#16248)."""
     connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
     doc_requests = _stub_documents(monkeypatch, connector, docs=[], total=0)
 
@@ -94,7 +100,7 @@ async def test_empty_docs_page_breaks_instead_of_looping(monkeypatch, mcp_server
 @pytest.mark.p2
 @pytest.mark.asyncio
 async def test_nonzero_code_stops_pagination(monkeypatch, mcp_server):
-    # A non-success response code must also stop the loop rather than spin on it.
+    """A non-success response code must stop the loop rather than spin on it."""
     connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
     doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(10), code=100)
 
@@ -107,9 +113,11 @@ async def test_nonzero_code_stops_pagination(monkeypatch, mcp_server):
 @pytest.mark.p2
 @pytest.mark.asyncio
 async def test_paginates_through_exact_multiple_last_page(monkeypatch, mcp_server):
-    # 60 docs at page_size 30 = two full pages. The previous termination math
-    # (``total - page * page_size <= 0`` after incrementing) stopped after page 1
-    # and silently dropped the final page; the fix must fetch both.
+    """60 docs at page_size 30 = two full pages; the final page must not be dropped.
+
+    The previous termination math (``total - page * page_size <= 0`` after
+    incrementing) stopped after page 1 and silently dropped the last page.
+    """
     connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
     doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(60))
 
@@ -122,6 +130,7 @@ async def test_paginates_through_exact_multiple_last_page(monkeypatch, mcp_serve
 @pytest.mark.p2
 @pytest.mark.asyncio
 async def test_paginates_partial_last_page(monkeypatch, mcp_server):
+    """A partial final page (45 docs over two pages) must be fetched in full."""
     connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
     doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(45))
 
@@ -134,7 +143,7 @@ async def test_paginates_partial_last_page(monkeypatch, mcp_server):
 @pytest.mark.p2
 @pytest.mark.asyncio
 async def test_request_includes_explicit_page_size(monkeypatch, mcp_server):
-    # page_size must be sent so the server's page size matches the math used here.
+    """page_size must be sent so the server's page size matches the math used here."""
     connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
     doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(5))
 
@@ -142,3 +151,32 @@ async def test_request_includes_explicit_page_size(monkeypatch, mcp_server):
 
     assert doc_requests
     assert all("page_size=30" in path for path in doc_requests)
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_partial_pagination_failure_is_not_cached(monkeypatch, mcp_server):
+    """If a later page fails, the partial result must not be cached and served as complete.
+
+    Page 1 succeeds (30 of 60 docs) but page 2 returns a non-zero code. The call
+    still surfaces what it fetched, but nothing is cached, so a subsequent lookup
+    re-fetches instead of serving an incomplete list for the whole TTL.
+    """
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    page_1 = _docs(30)
+
+    async def _get(path, params=None, api_key=""):
+        if "/documents" in path:
+            qs = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
+            page = int(qs.get("page", ["1"])[0])
+            if page == 1:
+                return _FakeResponse({"code": 0, "data": {"docs": page_1, "total": 60}})
+            return _FakeResponse({"code": 100, "data": {}})  # later page fails
+        return _FakeResponse({"code": 0, "data": [{"name": "ds", "description": "d"}]})
+
+    monkeypatch.setattr(connector, "_get", _get)
+
+    document_cache, _ = await connector._get_document_metadata_cache(["ds-1"], api_key="k")
+
+    assert len(document_cache) == 30
+    assert connector._get_cached_document_metadata_by_dataset("ds-1") is None

--- a/test/unit_test/mcp/test_document_metadata_pagination.py
+++ b/test/unit_test/mcp/test_document_metadata_pagination.py
@@ -1,0 +1,144 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import importlib.util
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+
+def _load_mcp_server():
+    server_path = Path(__file__).resolve().parents[3] / "mcp" / "server" / "server.py"
+    spec = importlib.util.spec_from_file_location("ragflow_mcp_server_unit_pagination", server_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _docs(count):
+    return [{"id": f"doc-{idx}", "name": f"name-{idx}"} for idx in range(count)]
+
+
+@pytest.fixture()
+def mcp_server():
+    return _load_mcp_server()
+
+
+def _stub_documents(monkeypatch, connector, *, docs, code=0, total=None, cap=50):
+    """Stub ``connector._get`` to page through ``docs`` for the documents endpoint.
+
+    Returns the list of recorded ``/documents`` request paths so a test can assert
+    how many pages were fetched. ``cap`` is a safety valve: before this fix an empty
+    page would loop forever, so once the recorded count exceeds ``cap`` the stub
+    raises. ``_get_document_metadata_cache`` swallows that exception, so the recorded
+    request count still surfaces the runaway instead of hanging the test.
+    """
+    doc_requests = []
+    total = len(docs) if total is None else total
+
+    async def _get(path, params=None, api_key=""):
+        if "/documents" in path:
+            doc_requests.append(path)
+            if len(doc_requests) > cap:
+                raise RuntimeError(f"runaway pagination: {len(doc_requests)} requests for {path}")
+            qs = urllib.parse.parse_qs(urllib.parse.urlparse(path).query)
+            page = int(qs.get("page", ["1"])[0])
+            page_size = int(qs.get("page_size", ["30"])[0])
+            start = (page - 1) * page_size
+            return _FakeResponse({"code": code, "data": {"docs": docs[start : start + page_size], "total": total}})
+        # Dataset-info lookup (`/datasets?id=...&page_size=1`).
+        return _FakeResponse({"code": 0, "data": [{"name": "ds", "description": "d"}]})
+
+    monkeypatch.setattr(connector, "_get", _get)
+    return doc_requests
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_empty_docs_page_breaks_instead_of_looping(monkeypatch, mcp_server):
+    # The regression from issue #16248: a successful response carrying an empty
+    # ``docs`` list must terminate pagination, not refetch the same page forever.
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    doc_requests = _stub_documents(monkeypatch, connector, docs=[], total=0)
+
+    document_cache, _ = await connector._get_document_metadata_cache(["ds-1"], api_key="k")
+
+    assert document_cache == {}
+    assert len(doc_requests) == 1
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_nonzero_code_stops_pagination(monkeypatch, mcp_server):
+    # A non-success response code must also stop the loop rather than spin on it.
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(10), code=100)
+
+    document_cache, _ = await connector._get_document_metadata_cache(["ds-1"], api_key="k")
+
+    assert document_cache == {}
+    assert len(doc_requests) == 1
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_paginates_through_exact_multiple_last_page(monkeypatch, mcp_server):
+    # 60 docs at page_size 30 = two full pages. The previous termination math
+    # (``total - page * page_size <= 0`` after incrementing) stopped after page 1
+    # and silently dropped the final page; the fix must fetch both.
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(60))
+
+    document_cache, _ = await connector._get_document_metadata_cache(["ds-1"], api_key="k")
+
+    assert len(document_cache) == 60
+    assert len(doc_requests) == 2
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_paginates_partial_last_page(monkeypatch, mcp_server):
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(45))
+
+    document_cache, _ = await connector._get_document_metadata_cache(["ds-1"], api_key="k")
+
+    assert len(document_cache) == 45
+    assert len(doc_requests) == 2
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_request_includes_explicit_page_size(monkeypatch, mcp_server):
+    # page_size must be sent so the server's page size matches the math used here.
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    doc_requests = _stub_documents(monkeypatch, connector, docs=_docs(5))
+
+    await connector._get_document_metadata_cache(["ds-1"], api_key="k")
+
+    assert doc_requests
+    assert all("page_size=30" in path for path in doc_requests)

--- a/test/unit_test/mcp/test_document_metadata_pagination.py
+++ b/test/unit_test/mcp/test_document_metadata_pagination.py
@@ -62,9 +62,12 @@ def _fresh_connector(mcp_server):
     return connector
 
 
-def _stub_get(monkeypatch, connector, total, *, code=0, page_size=30, guard=100):
+def _stub_get(monkeypatch, connector, total, *, code=0, page_size=30, guard=100, fail_from_page=None):
     """Mock RAGFlowConnector._get: serves the dataset-info call and a paginated
-    documents endpoint backed by ``total`` synthetic documents."""
+    documents endpoint backed by ``total`` synthetic documents.
+
+    ``fail_from_page`` makes the documents endpoint start reporting a non-zero
+    code from that page on, so a run can succeed partway and then fail."""
     all_docs = [{"id": f"doc-{i}", "name": f"name-{i}"} for i in range(total)]
     doc_requests = []
 
@@ -75,6 +78,8 @@ def _stub_get(monkeypatch, connector, total, *, code=0, page_size=30, guard=100)
                 raise _LoopGuard(f"pagination did not terminate after {guard} requests")
             page = int(re.search(r"[?&]page=(\d+)", path).group(1))
             requested_size = int(re.search(r"[?&]page_size=(\d+)", path).group(1))
+            if fail_from_page is not None and page >= fail_from_page:
+                return _FakeResponse({"code": 100, "message": "backend error"})
             start = (page - 1) * requested_size
             return _FakeResponse({"code": code, "data": {"docs": all_docs[start : start + requested_size], "total": total}})
         # dataset-info lookup (/datasets?id=...)
@@ -135,3 +140,22 @@ async def test_documents_request_sends_explicit_page_size(monkeypatch, mcp_serve
 
     assert doc_requests
     assert "page_size=30" in doc_requests[0]
+
+
+@pytest.mark.p2
+@pytest.mark.asyncio
+async def test_partial_pagination_failure_is_not_cached(monkeypatch, mcp_server):
+    """A run that fails midway must not cache the pages it already fetched.
+
+    The cache write is guarded by ``pagination_succeeded`` so a dataset whose
+    first page lands but whose second page errors is not served as a complete
+    document list for the rest of the TTL; the next call re-fetches instead.
+    """
+    connector = _fresh_connector(mcp_server)
+    doc_requests = _stub_get(monkeypatch, connector, total=60, fail_from_page=2)
+
+    document_cache, _ = await connector._get_document_metadata_cache(["ds-partial"], api_key="k")
+
+    assert len(doc_requests) == 2  # page 1 succeeded, page 2 failed
+    assert document_cache == {}
+    assert connector._get_cached_document_metadata_by_dataset("ds-partial") is None


### PR DESCRIPTION
The infinite-loop fix this PR opened with is already on `main` — #16285 landed the empty-page termination back in June, and #19138 added the `pagination_succeeded` guard on 2 September. Rebasing left nothing to merge, so rather than close this I've reduced the branch to the one thing `main` still lacks: a test for that guard.

`test_document_metadata_pagination.py` currently covers termination (empty dataset, API error) and full traversal across pages, but nothing exercises a run that succeeds partway and *then* fails. That is the case the guard exists for: without it the pages already fetched are cached as if they were the complete document list, and every metadata lookup for that dataset is served a truncated list until the TTL expires.

**Added:** `test_partial_pagination_failure_is_not_cached` — page 1 lands, page 2 reports a non-zero code, and the test asserts that nothing was cached for the dataset. `_stub_get` gains a `fail_from_page` knob to express "succeeds partway, then fails".

Checked against the unguarded code: removing the `if pagination_succeeded:` guard from `mcp/server/server.py` makes this test fail (`assert {'doc-0': ...} == {}`) while the other nine keep passing, so it anchors the behaviour rather than restating it.

```
pytest test/unit_test/mcp/test_document_metadata_pagination.py   # 10 passed
ruff check / ruff format --check                                 # clean
```

Closes nothing on its own — #16248 was already fixed by #16285/#19138.
