### PR TITLE
fix(mcp): stop metadata pagination on empty docs page

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -335,37 +335,47 @@ class RAGFlowConnector:
                     doc_id_meta_list = []
                     docs = {}
                     while page:
-                        docs_res = await self._get(f"/datasets/{dataset_id}/documents?page={page}", api_key=api_key)
+                        docs_res = await self._get(
+                            f"/datasets/{dataset_id}/documents",
+                            {"page": page, "page_size": page_size},
+                            api_key=api_key,
+                        )
                         if not docs_res:
                             break
                         docs_data = docs_res.json()
-                        if docs_data.get("code") == 0 and docs_data.get("data", {}).get("docs"):
-                            for doc in docs_data["data"]["docs"]:
-                                doc_id = doc.get("id")
-                                if not doc_id:
-                                    continue
-                                doc_meta = {
-                                    "document_id": doc_id,
-                                    "name": doc.get("name", ""),
-                                    "location": doc.get("location", ""),
-                                    "type": doc.get("type", ""),
-                                    "size": doc.get("size"),
-                                    "chunk_count": doc.get("chunk_count"),
-                                    "create_date": doc.get("create_date", ""),
-                                    "update_date": doc.get("update_date", ""),
-                                    "token_count": doc.get("token_count"),
-                                    "thumbnail": doc.get("thumbnail", ""),
-                                    "dataset_id": doc.get("dataset_id", dataset_id),
-                                    "meta_fields": doc.get("meta_fields", {}),
-                                }
-                                doc_id_meta_list.append((doc_id, doc_meta))
-                                docs[doc_id] = doc_meta
+                        if docs_data.get("code") != 0:
+                            break
+                        data = docs_data.get("data", {}) or {}
+                        page_docs = data.get("docs") or []
+                        if not page_docs:
+                            break
+                        for doc in page_docs:
+                            doc_id = doc.get("id")
+                            if not doc_id:
+                                continue
+                            doc_meta = {
+                                "document_id": doc_id,
+                                "name": doc.get("name", ""),
+                                "location": doc.get("location", ""),
+                                "type": doc.get("type", ""),
+                                "size": doc.get("size"),
+                                "chunk_count": doc.get("chunk_count"),
+                                "create_date": doc.get("create_date", ""),
+                                "update_date": doc.get("update_date", ""),
+                                "token_count": doc.get("token_count"),
+                                "thumbnail": doc.get("thumbnail", ""),
+                                "dataset_id": doc.get("dataset_id", dataset_id),
+                                "meta_fields": doc.get("meta_fields", {}),
+                            }
+                            doc_id_meta_list.append((doc_id, doc_meta))
+                            docs[doc_id] = doc_meta
 
+                        if page * page_size >= data.get("total", len(doc_id_meta_list)):
+                            page = None
+                        else:
                             page += 1
-                            if docs_data.get("data", {}).get("total", 0) - page * page_size <= 0:
-                                page = None
 
-                        self._set_cached_document_metadata_by_dataset(dataset_id, doc_id_meta_list)
+                    self._set_cached_document_metadata_by_dataset(dataset_id, doc_id_meta_list)
                 if docs:
                     document_cache.update(docs)
 

--- a/test/unit_test/mcp/test_server_datasets.py
+++ b/test/unit_test/mcp/test_server_datasets.py
@@ -115,3 +115,59 @@ async def test_list_datasets_clamps_explicit_page_size_to_rest_limit_and_preserv
         "id": "dataset-1",
         "name": "target",
     }
+
+
+@pytest.mark.asyncio
+async def test_document_metadata_cache_stops_on_empty_documents_page(monkeypatch, mcp_server):
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    requests = []
+
+    async def _get(path, params=None, api_key=""):
+        requests.append({"path": path, "params": dict(params or {}), "api_key": api_key})
+        if path == "/datasets":
+            return _FakeResponse({"code": 0, "data": [{"id": "dataset-1", "name": "Dataset 1"}]})
+        if path == "/datasets/dataset-1/documents":
+            return _FakeResponse({"code": 0, "data": {"docs": [], "total": 0}})
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr(connector, "_get", _get)
+
+    document_cache, dataset_cache = await connector._get_document_metadata_cache(
+        ["dataset-1"],
+        api_key="unit-key",
+        force_refresh=True,
+    )
+
+    assert document_cache == {}
+    assert dataset_cache == {"dataset-1": {"name": "Dataset 1", "description": ""}}
+    assert requests == [
+        {"path": "/datasets", "params": {"id": "dataset-1", "page_size": 1}, "api_key": "unit-key"},
+        {"path": "/datasets/dataset-1/documents", "params": {"page": 1, "page_size": 30}, "api_key": "unit-key"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_document_metadata_cache_fetches_final_partial_page(monkeypatch, mcp_server):
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    requests = []
+
+    async def _get(path, params=None, api_key=""):
+        requests.append({"path": path, "params": dict(params or {}), "api_key": api_key})
+        if path == "/datasets":
+            return _FakeResponse({"code": 0, "data": [{"id": "dataset-1", "name": "Dataset 1"}]})
+        if path == "/datasets/dataset-1/documents":
+            page = params["page"]
+            docs = [{"id": f"doc-{idx}", "name": f"Doc {idx}"} for idx in range((page - 1) * 30, min(page * 30, 31))]
+            return _FakeResponse({"code": 0, "data": {"docs": docs, "total": 31}})
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr(connector, "_get", _get)
+
+    document_cache, _ = await connector._get_document_metadata_cache(
+        ["dataset-1"],
+        api_key="unit-key",
+        force_refresh=True,
+    )
+
+    assert len(document_cache) == 31
+    assert [request["params"].get("page") for request in requests if request["path"].endswith("/documents")] == [1, 2]


### PR DESCRIPTION
## What problem does this solve?

Fixes #16248.

The MCP document metadata cache could loop forever when `/datasets/{dataset_id}/documents` returned a successful response with an empty `data.docs` page. In that case, the loop neither advanced `page` nor exited, so it kept requesting the same page until the client timed out.

## What changed?

- Break metadata pagination when the documents response is missing, non-zero, or has an empty `docs` page.
- Pass `page_size` with document metadata requests so the API request and pagination math use the same page size.
- Keep caching behavior intact by storing the collected metadata list after pagination finishes.
- Add unit coverage for empty document pages and a final partial page.

## Test plan

- `/Users/harshkashyap/Projects/OSS/Rag-Flow/ragflow-fork/.v/bin/pytest test/unit_test/mcp/test_server_datasets.py -q`
- `/Users/harshkashyap/Projects/OSS/Rag-Flow/ragflow-fork/.v/bin/ruff check mcp/server/server.py test/unit_test/mcp/test_server_datasets.py`
- `/Users/harshkashyap/Projects/OSS/Rag-Flow/ragflow-fork/.v/bin/ruff format mcp/server/server.py test/unit_test/mcp/test_server_datasets.py --check`