### PR TITLE
fix(web): update lodash dependency to safe version

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -72,7 +72,7 @@
         "jsencrypt": "^3.3.2",
         "jsoneditor": "^10.4.2",
         "lexical": "^0.23.1",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "lucide-react": "^1.7.0",
         "next-themes": "^0.4.6",
         "openai-speech-stream-player": "^1.0.8",
@@ -18757,9 +18757,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/web/package.json
+++ b/web/package.json
@@ -94,7 +94,7 @@
     "jsencrypt": "^3.3.2",
     "jsoneditor": "^10.4.2",
     "lexical": "^0.23.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "lucide-react": "^1.7.0",
     "next-themes": "^0.4.6",
     "openai-speech-stream-player": "^1.0.8",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -204,7 +204,7 @@ importers:
         specifier: ^0.23.1
         version: 0.23.1
       lodash:
-        specifier: ^4.17.23
+        specifier: ^4.18.1
         version: 4.18.1
       lucide-react:
         specifier: ^1.7.0


### PR DESCRIPTION
## What problem does this PR solve?

The web package manifest still declared lodash `^4.17.23`, which keeps dependency metadata on the vulnerable 4.17.x line reported in #16267.

The pnpm lock already resolves lodash to `4.18.1`, but `package.json` and `package-lock.json` still needed to be aligned so package metadata and scanners no longer point at 4.17.x.

Closes #16267.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Security fix / dependency update

## What changed

- Updated `web/package.json` lodash specifier from `^4.17.23` to `^4.18.1`.
- Updated `web/pnpm-lock.yaml` importer specifier while keeping the resolved version at `4.18.1`.
- Regenerated `web/package-lock.json` so npm metadata also resolves lodash to `4.18.1`.

## How has this been tested?

- [x] `pnpm install --lockfile-only --ignore-scripts`
- [x] Verified no `4.17.23` references remain under `web/`.

## Checklist

- [x] I have kept the change scoped to lodash dependency metadata.
- [x] I have not changed application code.
