### PR TITLE
fix(document_service): prevent NoneType error on progress_msg.strip()

### DIFF
--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -945,7 +945,7 @@ class DocumentService(CommonService):
                     if t.progress == -1:
                         bad += 1
                     prg += t.progress if t.progress >= 0 else 0
-                    if t.progress_msg.strip():
+                    if (t.progress_msg or "").strip():
                         msg.append(t.progress_msg)
                     priority = max(priority, t.priority)
                 prg /= len(tsks)


### PR DESCRIPTION
### What problem does this PR solve?

When I run RAGFlow_server.py:
```
2026-06-24 10:27:01,938 ERROR    3413485 fetch task exception
Traceback (most recent call last):
  File "/home/infiniflow/Documents/development/ragflow/api/db/services/document_service.py", line 948, in _sync_progress
    if t.progress_msg.strip():
       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'

```

fixed: 
```python
if t.progress_msg.strip():

# fix:
if (t.progress_msg or "").strip():
```

Fix crash in `_sync_progress` when `progress_msg` is `None`.

#### Root Cause
`progress_msg` from task records can be `None`, causing:

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
