### PR TITLE
fix: restore dataflow rerun and detail payload

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -790,7 +790,12 @@ def get_ingestion_log(dataset_id: str, tenant_id: str, log_id: str):
     if not log:
         return False, "Log not found"
 
-    return True, log.to_dict()
+    result = log.to_dict()
+    # Be explicit here: the dataflow-result page needs the full DSL payload to
+    # rebuild the timeline and right-side parser view. Some serialization paths
+    # can omit JSON fields from Peewee model dicts, so keep it attached here.
+    result["dsl"] = log.dsl or {}
+    return True, result
 
 
 def delete_index(dataset_id: str, tenant_id: str, index_type: str, wipe: bool = True):

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -141,7 +141,7 @@ export default {
     `${restAPIv1}/datasets/${datasetId}/index?type=${indexType.toLowerCase()}`,
   unbindPipelineTask: (datasetId: string, indexType: string, wipe?: boolean) =>
     `${restAPIv1}/datasets/${datasetId}/${indexType.toLowerCase()}${wipe === false ? '?wipe=false' : ''}`,
-  pipelineRerun: `${webAPI}/canvas/rerun`,
+  pipelineRerun: `${restAPIv1}/agents/rerun`,
   getMetaData: (datasetId: string) =>
     `${restAPIv1}/datasets/${datasetId}/metadata/summary`,
   updateDocumentsMetadata: (datasetId: string) =>


### PR DESCRIPTION
### What problem does this PR solve?
Restores the dataflow rerun endpoint mapping and makes the ingestion detail response always include the DSL payload so the dataflow result page can render the timeline and right-side parser view reliably.

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)