### PR TITLE
Go CLI: fix mode switch

### DIFF
--- a/internal/cli/admin_parser.go
+++ b/internal/cli/admin_parser.go
@@ -2260,7 +2260,7 @@ func (p *Parser) parseAdminUseCommand() (*Command, error) {
 	case TokenAdmin:
 		return p.parseUseAdminServer()
 	default:
-		return nil, fmt.Errorf("expected MODEL or SKILL after USE")
+		return nil, fmt.Errorf("expected API or ADMIN after USE")
 	}
 }
 

--- a/internal/cli/common_command.go
+++ b/internal/cli/common_command.go
@@ -71,8 +71,21 @@ func (c *CLI) LoginUserInteractive(email, password string) error {
 		password = strings.TrimSpace(password)
 	}
 
+	var baseURL string
+	var httpClient *HTTPClient
+	switch c.Config.CLIMode {
+	case AdminMode:
+		baseURL = "/admin/login"
+		httpClient = c.AdminServerClient
+	case APIMode:
+		baseURL = "/auth/login"
+		httpClient = c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
+	default:
+		return fmt.Errorf("invalid server type")
+	}
+
 	// Login
-	token, err := c.loginUser(email, password)
+	token, err := c.loginUser(httpClient, baseURL, email, password)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		fmt.Println("Can't access server for login (connection failed)")
@@ -159,7 +172,7 @@ func (c *CLI) PingServer(iterations int) (ResponseIf, error) {
 }
 
 // loginUser performs the actual login request
-func (c *CLI) loginUser(email, password string) (string, error) {
+func (c *CLI) loginUser(httpClient *HTTPClient, baseURL, email, password string) (string, error) {
 	publicKey, err := c.GetPublicKeyPEM()
 	if err != nil {
 		return "", fmt.Errorf("failed to get public key: %w", err)
@@ -178,15 +191,7 @@ func (c *CLI) loginUser(email, password string) (string, error) {
 	}
 
 	var resp *Response
-	switch c.Config.CLIMode {
-	case AdminMode:
-		resp, err = c.AdminServerClient.Request("POST", "/admin/login", "", nil, payload)
-	case APIMode:
-		resp, err = c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].Request("POST", "/auth/login", "", nil, payload)
-	default:
-		return "", fmt.Errorf("invalid server type")
-	}
-
+	resp, err = httpClient.Request("POST", baseURL, "", nil, payload)
 	if err != nil {
 		return "", err
 	}
@@ -1159,10 +1164,6 @@ func (c *CLI) AddAPIServer(cmd *Command) (ResponseIf, error) {
 	if !ok {
 		return nil, fmt.Errorf("server port not provided")
 	}
-	apiServerToken, ok := cmd.Params["server_token"].(string)
-	if !ok {
-		apiServerToken = ""
-	}
 
 	if c.Config.APIClientConfig.APIServerMap == nil {
 		c.Config.APIClientConfig.APIServerMap = make(map[string]*APIServerConfig)
@@ -1175,9 +1176,6 @@ func (c *CLI) AddAPIServer(cmd *Command) (ResponseIf, error) {
 	}
 	c.Config.APIClientConfig.APIServerMap[apiServerName].IP = apiServerIP
 	c.Config.APIClientConfig.APIServerMap[apiServerName].Port = apiServerPort
-	if apiServerToken != "" {
-		c.Config.APIClientConfig.APIServerMap[apiServerName].ApiToken = &apiServerToken
-	}
 
 	if c.APIServerClientMap == nil {
 		c.APIServerClientMap = make(map[string]*HTTPClient)
@@ -1206,7 +1204,7 @@ func (c *CLI) AddAPIServer(cmd *Command) (ResponseIf, error) {
 
 	var result SimpleResponse
 	result.Code = 0
-	result.Message = "api server deleted successfully"
+	result.Message = "api server added successfully"
 	result.Duration = 0
 	return &result, nil
 }
@@ -1219,6 +1217,11 @@ func (c *CLI) DeleteAPIServer(cmd *Command) (ResponseIf, error) {
 	if apiServerName == c.Config.APIClientConfig.CurrentAPIServer {
 		return nil, fmt.Errorf("cannot delete current api server")
 	}
+
+	if c.APIServerClientMap[apiServerName] == nil && c.Config.APIClientConfig.APIServerMap[apiServerName] == nil {
+		return nil, fmt.Errorf("api server: %s not found", apiServerName)
+	}
+
 	delete(c.Config.APIClientConfig.APIServerMap, apiServerName)
 	delete(c.APIServerClientMap, apiServerName)
 	var result SimpleResponse
@@ -1280,15 +1283,17 @@ func (c *CLI) AddAdminServer(cmd *Command) (ResponseIf, error) {
 
 func (c *CLI) DeleteAdminServer(cmd *Command) (ResponseIf, error) {
 
-	if c.AdminServerClient != nil && c.AdminServerClient.LoginToken != nil {
-		return nil, fmt.Errorf("admin server already login, please logout")
+	if c.AdminServerClient == nil && c.Config.AdminClientConfig == nil {
+		return nil, fmt.Errorf("admin server not exists")
 	}
 
-	if c.Config.AdminClientConfig == nil {
-		return nil, fmt.Errorf("admin server not set")
+	if c.AdminServerClient != nil {
+		c.AdminServerClient = nil
 	}
 
-	c.Config.AdminClientConfig = nil
+	if c.Config.AdminClientConfig != nil {
+		c.Config.AdminClientConfig = nil
+	}
 
 	var result SimpleResponse
 	result.Code = 0
@@ -1569,6 +1574,7 @@ func (c *CLI) UseAdminServer(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("admin server not added")
 	}
 
+	c.Config.APIClientConfig.CurrentAPIServer = ""
 	c.Config.CLIMode = AdminMode
 
 	var result SimpleResponse

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -1025,7 +1025,7 @@ func (p *Parser) parseAddAdminServer() (*Command, error) {
 	return cmd, nil
 }
 
-// syntax: add api 'abc' host '127.0.0.1:9333' token 'xxx' user 'ccc' password 'ppp'
+// syntax: ADD API 'abc' HOST '127.0.0.1:9333';
 func (p *Parser) parseAddAPIServer() (*Command, error) {
 	p.nextToken() // consume API
 
@@ -1036,7 +1036,7 @@ func (p *Parser) parseAddAPIServer() (*Command, error) {
 	p.nextToken() // consume model name
 
 	if p.curToken.Type != TokenHost {
-		return nil, fmt.Errorf("expected TO")
+		return nil, fmt.Errorf("expected HOST")
 	}
 	p.nextToken()
 
@@ -1051,33 +1051,10 @@ func (p *Parser) parseAddAPIServer() (*Command, error) {
 		return nil, err
 	}
 
-	var token string
-
-optionsLoop:
-	for {
-		switch p.curToken.Type {
-		case TokenToken:
-			p.nextToken()
-			token, err = p.parseQuotedString()
-			if err != nil {
-				return nil, err
-			}
-		case TokenSemicolon:
-			p.nextToken()
-			break optionsLoop // done
-		default:
-			// No more options to process
-			break optionsLoop
-		}
-	}
-
 	cmd := NewCommand("add_api_server")
 	cmd.Params["server_name"] = serverName
 	cmd.Params["server_ip"] = ip
 	cmd.Params["server_port"] = port
-	if token != "" {
-		cmd.Params["server_token"] = token
-	}
 
 	return cmd, nil
 }
@@ -1106,11 +1083,6 @@ func (p *Parser) parseDeleteAPIServer() (*Command, error) {
 // syntax: delete admin server 'abc'
 func (p *Parser) parseDeleteAdminServer() (*Command, error) {
 	p.nextToken() // consume ADMIN
-
-	if p.curToken.Type != TokenServer {
-		return nil, fmt.Errorf("expected server name")
-	}
-	p.nextToken() // consume SERVER
 
 	cmd := NewCommand("delete_admin_server")
 


### PR DESCRIPTION
### What problem does this PR solve?

```
RAGFlow(api/default)> add admin host '127.0.0.1:9383';
SUCCESS
RAGFlow(api/default)> use admin;
SUCCESS
RAGFlow(admin)> delete api 'default';
SUCCESS
RAGFlow(admin)> delete api 'default';
CLI error: api server: default not found
RAGFlow(admin)> add api 'default' host '127.0.0.1:9384';
SUCCESS
RAGFlow(admin)> use api 'default';
SUCCESS
RAGFlow(api/default)> delete admin
SUCCESS
RAGFlow(api/default)> delete admin;
CLI error: admin server not exists
RAGFlow(api/default)> list api server;
+------------+---------------+-----------------+---------+
| api_server | api_server_ip | api_server_port | auth    |
+------------+---------------+-----------------+---------+
| default    | 127.0.0.1     | 9384            | no auth |
+------------+---------------+-----------------+---------+
RAGFlow(api/default)> add admin host '127.0.0.1:9383';
SUCCESS
RAGFlow(api/default)> show admin server;
+-------------------+-----------+
| field             | value     |
+-------------------+-----------+
| admin_server_ip   | 127.0.0.1 |
| admin_server_port | 9383      |
| auth              | no auth   |
+-------------------+-----------+
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
