### PR TITLE
Go CLI: fix key commands

### DIFF
--- a/internal/cli/admin_parser.go
+++ b/internal/cli/admin_parser.go
@@ -101,7 +101,7 @@ func (p *Parser) parseAdminListCommands() (*Command, error) {
 	case TokenEnvs:
 		return p.parseAdminListEnvironments()
 	case TokenAvailable:
-		return p.parseListAvailableProviders()
+		return p.parseAdminListAvailableProviders()
 	case TokenProvider:
 		return p.parseAdminListProviderCommands()
 	case TokenProviders:
@@ -181,7 +181,7 @@ func (p *Parser) parseAdminListEnvironments() (*Command, error) {
 	return NewCommand("admin_list_environments"), nil
 }
 
-func (p *Parser) parseListAvailableProviders() (*Command, error) {
+func (p *Parser) parseAdminListAvailableProviders() (*Command, error) {
 	p.nextToken() // consume AVAILABLE
 
 	if p.curToken.Type != TokenProviders {

--- a/internal/cli/admin_parser.go
+++ b/internal/cli/admin_parser.go
@@ -2301,20 +2301,6 @@ func (p *Parser) parseAdminIngestCommand() (*Command, error) {
 	}
 	return cmd, nil
 }
-func (p *Parser) parseAdminUnsetCommand() (*Command, error) {
-	p.nextToken() // consume UNSET
-
-	if p.curToken.Type != TokenToken {
-		return nil, fmt.Errorf("expected TOKEN after UNSET")
-	}
-	p.nextToken()
-
-	// Semicolon is optional
-	if p.curToken.Type == TokenSemicolon {
-		p.nextToken()
-	}
-	return NewCommand("unset_token"), nil
-}
 
 func (p *Parser) parseMessageQueueCommand() (*Command, error) {
 	p.nextToken() // consume MESSAGE_QUEUE

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,7 +37,7 @@ type APIServerConfig struct {
 	Host         string  `yaml:"host"`
 	UserName     *string `yaml:"user_name"`
 	UserPassword *string `yaml:"password"`
-	ApiToken     *string `yaml:"api_token"`
+	APIKey       *string `yaml:"api_key"`
 	KeyFile      *string `yaml:"key_file"`
 	IP           string
 	Port         int
@@ -46,7 +46,7 @@ type APIServerConfig struct {
 // ConfigFile represents the rf.yml configuration file structure
 type ConfigFile struct {
 	Host         string                      `yaml:"host"`      // default API server host
-	APIToken     string                      `yaml:"api_token"` // default API server api token
+	APIKey       string                      `yaml:"api_key"`   // default API server api key
 	UserName     string                      `yaml:"user_name"` // default API server user name
 	Password     string                      `yaml:"password"`  // default API server password
 	APIServerMap map[string]*APIServerConfig `yaml:"api_servers"`
@@ -152,7 +152,7 @@ func ParseArgs(args []string) (*CommandLineConfig, error) {
 		defaultApiServerConfig := &APIServerConfig{
 			UserName:     nil,
 			UserPassword: nil,
-			ApiToken:     nil,
+			APIKey:       nil,
 		}
 
 		configFile := "rf.yml"
@@ -194,7 +194,7 @@ func ParseArgs(args []string) (*CommandLineConfig, error) {
 				}
 			case "-t", "--token":
 				if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-					defaultApiServerConfig.ApiToken = &args[i+1]
+					defaultApiServerConfig.APIKey = &args[i+1]
 					i++
 				}
 			case "-u", "--user":
@@ -263,9 +263,9 @@ func ParseArgs(args []string) (*CommandLineConfig, error) {
 					defaultApiServerConfig.UserPassword = &config.Password
 				}
 			}
-			if config.APIToken != "" {
-				if defaultApiServerConfig.ApiToken == nil {
-					defaultApiServerConfig.ApiToken = &config.APIToken
+			if config.APIKey != "" {
+				if defaultApiServerConfig.APIKey == nil {
+					defaultApiServerConfig.APIKey = &config.APIKey
 				}
 			}
 		} else {
@@ -514,15 +514,15 @@ func NewCLIWithConfig(commandLineConfig *CommandLineConfig) (*CLI, error) {
 		httpClient := NewHTTPClient()
 		httpClient.Host = apiServerConfig.IP
 		httpClient.Port = apiServerConfig.Port
-		if apiServerConfig.ApiToken != nil {
-			httpClient.APIToken = apiServerConfig.ApiToken
-			httpClient.useAPIToken = true
+		if apiServerConfig.APIKey != nil {
+			httpClient.APIKey = apiServerConfig.APIKey
+			httpClient.useAPIKey = true
 		}
 		cli.APIServerClientMap = map[string]*HTTPClient{
 			cli.Config.APIClientConfig.CurrentAPIServer: httpClient,
 		}
 		// Auto-login if user and password are provided (from config file)
-		if apiServerConfig.UserName != nil && apiServerConfig.UserPassword != nil && apiServerConfig.ApiToken == nil {
+		if apiServerConfig.UserName != nil && apiServerConfig.UserPassword != nil && apiServerConfig.APIKey == nil {
 			if err := cli.LoginUserInteractive(*apiServerConfig.UserName, *apiServerConfig.UserPassword); err != nil {
 				line.Close()
 				return nil, fmt.Errorf("auto-login failed: %w", err)
@@ -567,7 +567,7 @@ func (c *CLI) Run() error {
 	switch cliConfig.CLIMode {
 	case APIMode:
 		apiConfig := c.Config.APIClientConfig.APIServerMap[c.Config.APIClientConfig.CurrentAPIServer]
-		if apiConfig.UserName != nil && apiConfig.UserPassword == nil && apiConfig.ApiToken == nil {
+		if apiConfig.UserName != nil && apiConfig.UserPassword == nil && apiConfig.APIKey == nil {
 			// provider username but no password or api token
 			maxAttempts := 3
 			for attempt := 1; attempt <= maxAttempts; attempt++ {

--- a/internal/cli/cli_http.go
+++ b/internal/cli/cli_http.go
@@ -332,7 +332,7 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 		return c.ShowServerVersion(cmd)
 	case "show_current":
 		return c.CommonShowCurrent(cmd)
-	case "list_available_providers":
+	case "api_list_available_providers":
 		return c.CommonAvailableProvidersCommand(cmd)
 	case "show_provider":
 		return c.CommonShowProviderCommand(cmd)
@@ -358,7 +358,7 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 	// Provider instance commands
 	case "create_provider_instance":
 		return c.CreateProviderInstance(cmd)
-	case "list_provider_instances":
+	case "api_list_provider_instances":
 		return c.CommonListProviderInstances(cmd)
 	case "show_provider_instance":
 		return c.CommonShowProviderInstanceCommand(cmd)

--- a/internal/cli/cli_http.go
+++ b/internal/cli/cli_http.go
@@ -340,7 +340,7 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 		return c.CommonListModelsCommand(cmd)
 	case "list_supported_models":
 		return c.ListSupportedModels(cmd)
-	case "list_instance_models":
+	case "api_list_provider_instance_models":
 		return c.CommonListInstanceModels(cmd)
 	case "show_provider_model":
 		return c.CommonShowProviderModelCommand(cmd)

--- a/internal/cli/cli_http.go
+++ b/internal/cli/cli_http.go
@@ -322,12 +322,12 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 		return c.APIListAPIKeysCommand(cmd)
 	case "api_delete_api_key":
 		return c.APIDeleteAPIKeyCommand(cmd)
-	case "set_token":
-		return c.SetToken(cmd)
+	case "api_set_api_key":
+		return c.APISetAPIKey(cmd)
 	case "show_token":
 		return c.ShowToken(cmd)
-	case "unset_token":
-		return c.UnsetToken(cmd)
+	case "api_unset_api_key":
+		return c.APIUnsetAPIKey(cmd)
 	case "show_version":
 		return c.ShowServerVersion(cmd)
 	case "show_current":

--- a/internal/cli/common_command.go
+++ b/internal/cli/common_command.go
@@ -1136,8 +1136,8 @@ func (c *CLI) ListAPIServer(cmd *Command) (ResponseIf, error) {
 		}
 		if c.APIServerClientMap[serverName].LoginToken != nil {
 			element["auth"] = "login"
-		} else if apiServerConfig.ApiToken != nil {
-			element["auth"] = "api token"
+		} else if c.APIServerClientMap[serverName].APIKey != nil {
+			element["auth"] = "api key"
 		} else {
 			element["auth"] = "no auth"
 		}
@@ -1310,7 +1310,7 @@ func (c *CLI) SaveServerConfig(cmd *Command) (ResponseIf, error) {
 			return nil, fmt.Errorf("admin server isn't already login")
 		}
 	case APIMode:
-		if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
 			return nil, fmt.Errorf("API token not set. Please login first")
 		}
 	default:
@@ -1365,8 +1365,8 @@ func (c *CLI) GetAPIServerInfo(serverName string) (ResponseIf, error) {
 		}
 		if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken != nil {
 			result.Data["auth"] = "login"
-		} else if apiServerConfig.ApiToken != nil {
-			result.Data["auth"] = "api token"
+		} else if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey != nil {
+			result.Data["auth"] = "api key"
 		} else {
 			result.Data["auth"] = "no auth"
 		}

--- a/internal/cli/http_client.go
+++ b/internal/cli/http_client.go
@@ -32,13 +32,13 @@ type HTTPClient struct {
 	Host           string
 	Port           int
 	APIVersion     string
-	APIToken       *string
+	APIKey         *string
 	LoginToken     *string
 	ConnectTimeout time.Duration
 	ReadTimeout    time.Duration
 	VerifySSL      bool
 	client         *http.Client
-	useAPIToken    bool
+	useAPIKey      bool
 }
 
 // NewHTTPClient creates a new HTTP client
@@ -85,8 +85,8 @@ func (c *HTTPClient) Headers(authKind string, extra map[string]string) map[strin
 
 	switch authKind {
 	case "api":
-		if c.APIToken != nil {
-			headers["Authorization"] = fmt.Sprintf("Bearer %s", *c.APIToken)
+		if c.APIKey != nil {
+			headers["Authorization"] = fmt.Sprintf("Bearer %s", *c.APIKey)
 		} else if c.LoginToken != nil {
 			// Fallback to login token for API requests (user mode)
 			headers["Authorization"] = fmt.Sprintf("Bearer %s", *c.LoginToken)
@@ -287,8 +287,8 @@ func (c *HTTPClient) UploadMultipart(path string, contentType string, body io.Re
 
 	// Set headers
 	req.Header.Set("Content-Type", contentType)
-	if c.APIToken != nil {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *c.APIToken))
+	if c.APIKey != nil {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *c.APIKey))
 	} else if c.LoginToken != nil {
 		req.Header.Set("Authorization", *c.LoginToken)
 	}
@@ -386,7 +386,7 @@ func (a *httpClientAdapter) Request(method, path string, authKind string, header
 	// Auto-detect auth kind based on available tokens
 	// If authKind is "auto" or empty, determine based on token availability
 	if authKind == "auto" || authKind == "" {
-		if a.client.useAPIToken && a.client.APIToken != nil {
+		if a.client.useAPIKey && a.client.APIKey != nil {
 			authKind = "api"
 		} else if a.client.LoginToken != nil {
 			authKind = "web"

--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -163,13 +163,11 @@ func (p *Parser) parseUserCommand() (*Command, error) {
 	case TokenAlter:
 		return p.parseAlterCommand()
 	case TokenSet:
-		return p.parseSetCommand()
+		return p.parseAPISetCommands()
 	case TokenUnset:
 		return p.parseUnsetCommand()
 	case TokenReset:
 		return p.parseResetCommand()
-	case TokenGenerate:
-		return p.parseGenerateCommand()
 	case TokenImport:
 		return p.parseImportCommand()
 	case TokenInsert:

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -344,13 +344,13 @@ func (c *CLI) APIListDatasetsCommand(cmd *Command) (ResponseIf, error) {
 
 	httpClient := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
 
-	// Determine auth kind based on whether API token is being used
-	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken {
+	// Determine auth kind based on whether API key is being used
+	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey {
 		return nil, fmt.Errorf("no authorization")
 	}
 
 	authKind := "web"
-	if httpClient.useAPIToken {
+	if httpClient.useAPIKey {
 		authKind = "api"
 	}
 
@@ -392,8 +392,8 @@ func (c *CLI) APIListDatasetDocumentsCommand(cmd *Command) (ResponseIf, error) {
 	}
 
 	httpClient := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
-	// Determine auth kind based on whether API token is being used
-	if httpClient.LoginToken == nil && !httpClient.useAPIToken {
+	// Determine auth kind based on whether API key is being used
+	if httpClient.LoginToken == nil && !httpClient.useAPIKey {
 		return nil, fmt.Errorf("no authorization")
 	}
 
@@ -439,13 +439,13 @@ func (c *CLI) APIListAgentsCommand(cmd *Command) (ResponseIf, error) {
 
 	httpClient := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
 
-	// Determine auth kind based on whether API token is being used
-	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken {
+	// Determine auth kind based on whether API key is being used
+	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey {
 		return nil, fmt.Errorf("no authorization")
 	}
 
 	authKind := "web"
-	if httpClient.useAPIToken {
+	if httpClient.useAPIKey {
 		authKind = "api"
 	}
 
@@ -484,13 +484,13 @@ func (c *CLI) APIListChatsCommand(cmd *Command) (ResponseIf, error) {
 
 	httpClient := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
 
-	// Determine auth kind based on whether API token is being used
-	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken {
+	// Determine auth kind based on whether API key is being used
+	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey {
 		return nil, fmt.Errorf("no authorization")
 	}
 
 	authKind := "web"
-	if httpClient.useAPIToken {
+	if httpClient.useAPIKey {
 		authKind = "api"
 	}
 
@@ -529,13 +529,13 @@ func (c *CLI) APIListSearchesCommand(cmd *Command) (ResponseIf, error) {
 
 	httpClient := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
 
-	// Determine auth kind based on whether API token is being used
-	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken {
+	// Determine auth kind based on whether API key is being used
+	if httpClient.LoginToken == nil && !c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey {
 		return nil, fmt.Errorf("no authorization")
 	}
 
 	authKind := "web"
-	if httpClient.useAPIToken {
+	if httpClient.useAPIKey {
 		authKind = "api"
 	}
 
@@ -579,8 +579,8 @@ func (c *CLI) ListDatasetDocumentUserCommand(cmd *Command) (ResponseIf, error) {
 	}
 
 	httpClient := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
-	// Determine auth kind based on whether API token is being used
-	if httpClient.LoginToken == nil && !httpClient.useAPIToken {
+	// Determine auth kind based on whether API key is being used
+	if httpClient.LoginToken == nil && !httpClient.useAPIKey {
 		return nil, fmt.Errorf("no authorization")
 	}
 
@@ -1006,104 +1006,104 @@ func (c *CLI) APIDeleteAPIKeyCommand(cmd *Command) (ResponseIf, error) {
 	return &result, nil
 }
 
-// SetToken sets the API token after validating it
-func (c *CLI) SetToken(cmd *Command) (ResponseIf, error) {
+// APISetAPIKey sets the API key after validating it
+func (c *CLI) APISetAPIKey(cmd *Command) (ResponseIf, error) {
 	if c.Config.CLIMode != APIMode {
 		return nil, fmt.Errorf("this command is only allowed in USER mode")
 	}
 
-	token, ok := cmd.Params["token"].(string)
+	apiKey, ok := cmd.Params["api_key"].(string)
 	if !ok {
-		return nil, fmt.Errorf("token not provided")
+		return nil, fmt.Errorf("key not provided")
 	}
 
 	// Save current token to restore if validation fails
-	savedToken := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken
-	savedUseAPIToken := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken
+	savedToken := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey
+	savedUseAPIToken := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey
 
-	// Set the new token temporarily for validation
-	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken = &token
-	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken = true
+	// Set the new key temporarily for validation
+	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey = &apiKey
+	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey = true
 
 	// Validate token by calling list tokens API
-	resp, err := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].Request("GET", "/tokens", "api", nil, nil)
+	resp, err := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].Request("GET", "/system/tokens", "api", nil, nil)
 	if err != nil {
 		// Restore original token on error
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken = savedToken
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken = savedUseAPIToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey = savedToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey = savedUseAPIToken
 		return nil, fmt.Errorf("failed to validate token: %w", err)
 	}
 
 	if resp.StatusCode != 200 {
 		// Restore original token on error
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken = savedToken
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken = savedUseAPIToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey = savedToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey = savedUseAPIToken
 		return nil, fmt.Errorf("token validation failed: HTTP %d, body: %s", resp.StatusCode, string(resp.Body))
 	}
 
 	var result CommonResponse
 	if err = json.Unmarshal(resp.Body, &result); err != nil {
 		// Restore original token on error
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken = savedToken
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken = savedUseAPIToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey = savedToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey = savedUseAPIToken
 		return nil, fmt.Errorf("token validation failed: invalid JSON (%w)", err)
 	}
 
 	if result.Code != 0 {
 		// Restore original token on error
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken = savedToken
-		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken = savedUseAPIToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey = savedToken
+		c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey = savedUseAPIToken
 		return nil, fmt.Errorf("token validation failed: %s", result.Message)
 	}
 
 	// Token is valid, keep it set
 	var successResult SimpleResponse
 	successResult.Code = 0
-	successResult.Message = "API token set successfully"
+	successResult.Message = "API key set successfully"
 	successResult.Duration = resp.Duration
 	return &successResult, nil
 }
 
-// ShowToken displays the current API token
+// ShowToken displays the current API key
 func (c *CLI) ShowToken(cmd *Command) (ResponseIf, error) {
 	if c.Config.CLIMode != APIMode {
 		return nil, fmt.Errorf("this command is only allowed in USER mode")
 	}
 
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil {
-		return nil, fmt.Errorf("no API token is currently set")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil {
+		return nil, fmt.Errorf("no API key is currently set")
 	}
 
-	//fmt.Printf("Token: %s\n", c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken)
+	//fmt.Printf("Token: %s\n", c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey)
 
 	var result CommonResponse
 	result.Code = 0
 	result.Message = ""
 	result.Data = []map[string]interface{}{
 		{
-			"token": c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken,
+			"token": c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey,
 		},
 	}
 	result.Duration = 0
 	return &result, nil
 }
 
-// UnsetToken removes the current API token
-func (c *CLI) UnsetToken(cmd *Command) (ResponseIf, error) {
+// APIUnsetAPIKey removes the current API key
+func (c *CLI) APIUnsetAPIKey(cmd *Command) (ResponseIf, error) {
 	if c.Config.CLIMode != APIMode {
 		return nil, fmt.Errorf("this command is only allowed in USER mode")
 	}
 
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil {
-		return nil, fmt.Errorf("no API token is currently set")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil {
+		return nil, fmt.Errorf("no API key is currently set")
 	}
 
-	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken = nil
-	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIToken = false
+	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey = nil
+	c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].useAPIKey = false
 
 	var result SimpleResponse
 	result.Code = 0
-	result.Message = "API token unset successfully"
+	result.Message = "API key unset successfully"
 	result.Duration = 0
 	return &result, nil
 }
@@ -1873,8 +1873,8 @@ func (c *CLI) ChatToModel(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) EmbedUserText(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -1956,8 +1956,8 @@ func (c *CLI) EmbedUserText(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) RerankUserDocument(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -2045,8 +2045,8 @@ func (c *CLI) RerankUserDocument(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) TTSUserCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -2253,8 +2253,8 @@ func (c *CLI) TTSUserCommand(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) ASRUserCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -2357,8 +2357,8 @@ func (c *CLI) ASRUserCommand(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) OCRUserCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -2453,8 +2453,8 @@ func (c *CLI) OCRUserCommand(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) ParseFileUserCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -2555,8 +2555,8 @@ func (c *CLI) ParseFileUserCommand(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) ListTasksUserCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -2598,8 +2598,8 @@ func (c *CLI) ListTasksUserCommand(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) ShowTaskUserCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -2647,8 +2647,8 @@ func (c *CLI) ShowTaskUserCommand(cmd *Command) (ResponseIf, error) {
 
 // UseModel sets the current model for chat
 func (c *CLI) UseModel(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 	if c.Config.CLIMode != APIMode {
 		return nil, fmt.Errorf("this command is only allowed in USER mode")
@@ -2687,8 +2687,8 @@ func (c *CLI) UseModel(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) AddCustomModel(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -3170,8 +3170,8 @@ func (c *CLI) RemoveChunks(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) ParseDocumentsUserCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -3295,8 +3295,8 @@ func formatRequestError(action string, err error) error {
 }
 
 func (c *CLI) ListUserIngestionTasks(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -3335,8 +3335,8 @@ func (c *CLI) ListUserIngestionTasks(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) UserStartIngestionCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -3383,8 +3383,8 @@ func (c *CLI) UserStartIngestionCommand(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) UserStopIngestionCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -3422,8 +3422,8 @@ func (c *CLI) UserStopIngestionCommand(cmd *Command) (ResponseIf, error) {
 }
 
 func (c *CLI) UserRemoveTaskCommand(cmd *Command) (ResponseIf, error) {
-	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIToken == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	if c.Config.CLIMode != APIMode {
@@ -3533,8 +3533,8 @@ func (c *CLI) OpenaiChat(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("OPENAI_CHAT is only allowed in USER mode")
 	}
 	httpClient := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer]
-	if httpClient.APIToken == nil && httpClient.LoginToken == nil {
-		return nil, fmt.Errorf("API token not set. Please login first")
+	if httpClient.APIKey == nil && httpClient.LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
 	}
 
 	body, err := buildOpenaiChatRequestBody(cmd)

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -142,14 +142,14 @@ func (p *Parser) parseAPIListCommands() (*Command, error) {
 		return p.parseAPIListSearches()
 	case TokenKeys:
 		return p.parseAPIListAPIKeys()
-	case TokenModel:
-		return p.parseListModelProviders()
 	case TokenSupported:
 		return p.parseListModelsOfProvider()
 	case TokenModels:
 		return p.parseListModelsOfProvider()
 	case TokenProviders:
-		return p.parseListProviders()
+		return p.parseAPIListProviders()
+	case TokenProvider:
+		return p.parseAPIListProviderCommands()
 	case TokenInstances:
 		return p.parseListInstances()
 	case TokenIngestion:
@@ -157,7 +157,7 @@ func (p *Parser) parseAPIListCommands() (*Command, error) {
 	case TokenDefault:
 		return p.parseListDefaultModels()
 	case TokenAvailable:
-		return p.parseListAvailableProviders()
+		return p.parseAPIListAvailableProviders()
 	case TokenFiles:
 		return p.parseListFiles()
 	case TokenQuotedString:
@@ -306,27 +306,45 @@ func (p *Parser) parseAPIListAPIKeys() (*Command, error) {
 	return cmd, nil
 }
 
-func (p *Parser) parseListModelProviders() (*Command, error) {
-	p.nextToken() // consume MODEL
-	if p.curToken.Type != TokenProviders {
-		return nil, fmt.Errorf("expected PROVIDERS")
-	}
-	p.nextToken()
-	// Semicolon is optional for UNSET TOKEN
-	if p.curToken.Type == TokenSemicolon {
-		p.nextToken()
-	}
-	return NewCommand("list_user_model_providers"), nil
-}
-
-// parseListProviders parses LIST PROVIDERS command
-func (p *Parser) parseListProviders() (*Command, error) {
+// parseAPIListProviders parses LIST PROVIDERS command
+func (p *Parser) parseAPIListProviders() (*Command, error) {
 	p.nextToken() // consume PROVIDERS
 	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
 	return NewCommand("list_providers"), nil
+}
+
+// LIST PROVIDER 'provider_name' INSTANCES
+func (p *Parser) parseAPIListProviderCommands() (*Command, error) {
+	p.nextToken() // consume PROVIDER
+
+	providerName, err := p.parseQuotedString()
+	if err != nil {
+		return nil, err
+	}
+	p.nextToken()
+
+	switch p.curToken.Type {
+	case TokenInstances:
+		return p.parseListProviderInstances(providerName)
+	default:
+		return nil, fmt.Errorf("unknown LIST target: %s", p.curToken.Value)
+	}
+}
+
+// LIST PROVIDER 'provider_name' INSTANCES
+func (p *Parser) parseListProviderInstances(providerName string) (*Command, error) {
+	p.nextToken() // consume INSTANCES
+
+	// Semicolon is optional
+	if p.curToken.Type == TokenSemicolon {
+		p.nextToken()
+	}
+	cmd := NewCommand("api_list_provider_instances")
+	cmd.Params["provider_name"] = providerName
+	return cmd, nil
 }
 
 func (p *Parser) parseListDefaultModels() (*Command, error) {
@@ -340,6 +358,16 @@ func (p *Parser) parseListDefaultModels() (*Command, error) {
 		p.nextToken()
 	}
 	return NewCommand("list_user_default_models"), nil
+}
+
+func (p *Parser) parseAPIListAvailableProviders() (*Command, error) {
+	p.nextToken() // consume AVAILABLE
+
+	if p.curToken.Type != TokenProviders {
+		return nil, fmt.Errorf("expected PROVIDERS")
+	}
+
+	return NewCommand("api_list_available_providers"), nil
 }
 
 func (p *Parser) parseListFiles() (*Command, error) {

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -1828,7 +1828,7 @@ func (p *Parser) parseIdentifierList() ([]string, error) {
 	return list, nil
 }
 
-func (p *Parser) parseSetCommand() (*Command, error) {
+func (p *Parser) parseAPISetCommands() (*Command, error) {
 	p.nextToken() // consume SET
 
 	if p.curToken.Type == TokenVar {
@@ -1837,8 +1837,8 @@ func (p *Parser) parseSetCommand() (*Command, error) {
 	if p.curToken.Type == TokenDefault {
 		return p.parseSetDefault()
 	}
-	if p.curToken.Type == TokenToken {
-		return p.parseSetToken()
+	if p.curToken.Type == TokenKey {
+		return p.parseAPISetAPIKey()
 	}
 	if p.curToken.Type == TokenMetadata {
 		return p.parseSetMeta()
@@ -1929,26 +1929,26 @@ func (p *Parser) parseSetDefault() (*Command, error) {
 	}
 
 	p.nextToken()
-	// Semicolon is optional for UNSET TOKEN
+	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
 	return cmd, nil
 }
 
-func (p *Parser) parseSetToken() (*Command, error) {
-	p.nextToken() // consume TOKEN
+func (p *Parser) parseAPISetAPIKey() (*Command, error) {
+	p.nextToken() // consume KEY
 
-	tokenValue, err := p.parseQuotedString()
+	apiKey, err := p.parseQuotedString()
 	if err != nil {
 		return nil, err
 	}
-
-	cmd := NewCommand("set_token")
-	cmd.Params["token"] = tokenValue
-
 	p.nextToken()
-	// Semicolon is optional for UNSET TOKEN
+
+	cmd := NewCommand("api_set_api_key")
+	cmd.Params["api_key"] = apiKey
+
+	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
@@ -2032,37 +2032,6 @@ func (p *Parser) parseResetCommand() (*Command, error) {
 	p.nextToken() // pass MODEL
 
 	// Semicolon is optional for UNSET TOKEN
-	if p.curToken.Type == TokenSemicolon {
-		p.nextToken()
-	}
-	return cmd, nil
-}
-
-func (p *Parser) parseGenerateCommand() (*Command, error) {
-	p.nextToken() // consume GENERATE
-	if p.curToken.Type != TokenToken {
-		return nil, fmt.Errorf("expected TOKEN")
-	}
-	p.nextToken()
-	if p.curToken.Type != TokenFor {
-		return nil, fmt.Errorf("expected FOR")
-	}
-	p.nextToken()
-	if p.curToken.Type != TokenUser {
-		return nil, fmt.Errorf("expected USER")
-	}
-	p.nextToken()
-
-	userName, err := p.parseQuotedString()
-	if err != nil {
-		return nil, err
-	}
-
-	cmd := NewCommand("generate_token")
-	cmd.Params["user_name"] = userName
-
-	p.nextToken()
-	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
@@ -3639,8 +3608,6 @@ func (p *Parser) parseUserStatement() (*Command, error) {
 		return p.parseCreateCommand()
 	case TokenDrop:
 		return p.parseDropCommand()
-	case TokenSet:
-		return p.parseSetCommand()
 	case TokenUnset:
 		return p.parseUnsetCommand()
 	case TokenReset:
@@ -3669,16 +3636,16 @@ func (p *Parser) parseUserStatement() (*Command, error) {
 func (p *Parser) parseUnsetCommand() (*Command, error) {
 	p.nextToken() // consume UNSET
 
-	if p.curToken.Type != TokenToken {
+	if p.curToken.Type != TokenKey {
 		return nil, fmt.Errorf("expected TOKEN after UNSET")
 	}
 	p.nextToken()
 
-	// Semicolon is optional for UNSET TOKEN
+	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
-	return NewCommand("unset_token"), nil
+	return NewCommand("api_unset_api_key"), nil
 }
 
 // parseGetCommand parses: GET CHUNK or GET METADATA

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -329,6 +329,8 @@ func (p *Parser) parseAPIListProviderCommands() (*Command, error) {
 	switch p.curToken.Type {
 	case TokenInstances:
 		return p.parseListProviderInstances(providerName)
+	case TokenInstance:
+		return p.parseListProviderInstanceModels(providerName)
 	default:
 		return nil, fmt.Errorf("unknown LIST target: %s", p.curToken.Value)
 	}
@@ -344,6 +346,31 @@ func (p *Parser) parseListProviderInstances(providerName string) (*Command, erro
 	}
 	cmd := NewCommand("api_list_provider_instances")
 	cmd.Params["provider_name"] = providerName
+	return cmd, nil
+}
+
+// LIST PROVIDER 'provider_name' INSTANCE 'instance_name' MODELS
+func (p *Parser) parseListProviderInstanceModels(providerName string) (*Command, error) {
+	p.nextToken() // consume INSTANCE
+
+	instanceName, err := p.parseQuotedString()
+	if err != nil {
+		return nil, err
+	}
+	p.nextToken()
+
+	if p.curToken.Type != TokenModels {
+		return nil, fmt.Errorf("expected MODELS")
+	}
+	p.nextToken()
+
+	// Semicolon is optional
+	if p.curToken.Type == TokenSemicolon {
+		p.nextToken()
+	}
+	cmd := NewCommand("api_list_provider_instance_models")
+	cmd.Params["provider_name"] = providerName
+	cmd.Params["instance_name"] = instanceName
 	return cmd, nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

```
RAGFlow(api/default)> set key 'ragflow-JgnarFSCUiV99oOvvMDei7ZzZg1cVlqGd1AMHrHeKE4';
SUCCESS
RAGFlow(api/default)> unset key;
SUCCESS

RAGFlow(api/default)> list provider 'zhipu-ai' instances;

RAGFlow(api/default)> list providers;

RAGFlow(api/default)> list available providers;

RAGFlow(api/default)> list provider 'zhipu-ai' instance 'test' models;
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

