### PR TITLE
Go CLI: list provider instance models, sync and list provider

### DIFF
--- a/internal/cli/cli_http.go
+++ b/internal/cli/cli_http.go
@@ -126,11 +126,9 @@ func (c *CLI) ExecuteAdminCommand(cmd *Command) (ResponseIf, error) {
 	case "admin_list_provider_models":
 		return c.CommonListModelsCommand(cmd)
 	case "admin_list_provider_instance_models":
-		return c.CommonListInstanceModels(cmd)
+		return c.CommonListInstanceModelsCommand(cmd)
 	case "admin_list_provider_instances":
 		return c.CommonListProviderInstances(cmd)
-	case "list_supported_models":
-		return c.ListSupportedModels(cmd)
 	case "admin_show_model":
 		return c.CommonShowModel(cmd)
 	case "admin_list_providers":
@@ -338,10 +336,10 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 		return c.CommonShowProviderCommand(cmd)
 	case "list_provider_models":
 		return c.CommonListModelsCommand(cmd)
-	case "list_supported_models":
-		return c.ListSupportedModels(cmd)
 	case "api_list_provider_instance_models":
-		return c.CommonListInstanceModels(cmd)
+		return c.CommonListInstanceModelsCommand(cmd)
+	case "api_list_provider_instance_models_sync":
+		return c.CommonListInstanceModelsSyncCommand(cmd)
 	case "show_provider_model":
 		return c.CommonShowProviderModelCommand(cmd)
 	case "show_model":
@@ -351,8 +349,8 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 	// Provider commands
 	case "add_provider":
 		return c.AddProvider(cmd)
-	case "list_providers":
-		return c.ListProviders(cmd)
+	case "api_list_providers":
+		return c.APIListProviders(cmd)
 	case "delete_provider":
 		return c.DeleteProvider(cmd)
 	// Provider instance commands

--- a/internal/cli/cli_http.go
+++ b/internal/cli/cli_http.go
@@ -409,7 +409,7 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 		return c.SetDefaultModel(cmd)
 	case "reset_default_model":
 		return c.ResetDefaultModel(cmd)
-	case "list_user_default_models":
+	case "api_list_default_models":
 		return c.ListDefaultModels(cmd)
 	case "list_tasks_user_command":
 		return c.ListTasksUserCommand(cmd)
@@ -447,7 +447,7 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 		return c.UserStartIngestionCommand(cmd)
 	case "user_stop_ingestion_command":
 		return c.UserStopIngestionCommand(cmd)
-	case "user_list_ingestion_tasks":
+	case "api_list_ingestion_tasks":
 		return c.ListUserIngestionTasks(cmd)
 	case "user_remove_task_command":
 		return c.UserRemoveTaskCommand(cmd)

--- a/internal/cli/common_command.go
+++ b/internal/cli/common_command.go
@@ -473,7 +473,7 @@ func (c *CLI) CommonListProviderInstances(cmd *Command) (ResponseIf, error) {
 	return &result, nil
 }
 
-func (c *CLI) CommonListInstanceModels(cmd *Command) (ResponseIf, error) {
+func (c *CLI) CommonListInstanceModelsCommand(cmd *Command) (ResponseIf, error) {
 
 	providerName, ok := cmd.Params["provider_name"].(string)
 	if !ok {
@@ -559,7 +559,7 @@ func (c *CLI) CommonListModelsCommand(cmd *Command) (ResponseIf, error) {
 	return &result, nil
 }
 
-func (c *CLI) ListSupportedModels(cmd *Command) (ResponseIf, error) {
+func (c *CLI) CommonListInstanceModelsSyncCommand(cmd *Command) (ResponseIf, error) {
 
 	providerName, ok := cmd.Params["provider_name"].(string)
 	if !ok {

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -1327,9 +1327,8 @@ func (c *CLI) AddProvider(cmd *Command) (ResponseIf, error) {
 	return &result, nil
 }
 
-// ListProviders lists all providers
-// LIST PROVIDERS
-func (c *CLI) ListProviders(cmd *Command) (ResponseIf, error) {
+// APIListProviders lists added providers
+func (c *CLI) APIListProviders(cmd *Command) (ResponseIf, error) {
 	if c.Config.CLIMode != APIMode {
 		return nil, fmt.Errorf("this command is only allowed in USER mode")
 	}

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -133,7 +133,7 @@ func (p *Parser) parseAPIListCommands() (*Command, error) {
 	case TokenDatasets:
 		return p.parseAPIListDatasets()
 	case TokenDataset:
-		return p.parseAPIListDatasetDocuments()
+		return p.parseAPIListDatasetCommands()
 	case TokenAgents:
 		return p.parseAPIListAgents()
 	case TokenChats:
@@ -190,7 +190,7 @@ func (p *Parser) parseAPIListDatasets() (*Command, error) {
 }
 
 // LIST DATASET 'dataset_name' DOCUMENTS;
-func (p *Parser) parseAPIListDatasetDocuments() (*Command, error) {
+func (p *Parser) parseAPIListDatasetCommands() (*Command, error) {
 	p.nextToken() // consume DATASET
 
 	datasetID, err := p.parseQuotedString()
@@ -199,17 +199,58 @@ func (p *Parser) parseAPIListDatasetDocuments() (*Command, error) {
 	}
 	p.nextToken()
 
-	if p.curToken.Type != TokenDocuments {
-		return nil, fmt.Errorf("expected DOCUMENTS")
+	switch p.curToken.Type {
+	case TokenDocuments:
+		return p.parseAPIListDatasetDocuments(datasetID)
+	case TokenFiles:
+		return p.parseAPIListDatasetFiles(datasetID)
+	case TokenIngestion:
+		return p.parseAPIListDatasetIngestionTasks(datasetID)
+	default:
+		return nil, fmt.Errorf("unknown LIST target: %s", p.curToken.Value)
+	}
+}
+
+func (p *Parser) parseAPIListDatasetDocuments(datasetID string) (*Command, error) {
+	p.nextToken() // consume DOCUMENTS
+
+	// Semicolon is optional
+	if p.curToken.Type == TokenSemicolon {
+		p.nextToken()
 	}
 
 	cmd := NewCommand("api_list_dataset_documents")
 	cmd.Params["dataset_id"] = datasetID
+	return cmd, nil
+}
 
-	// Semicolon is optional for UNSET TOKEN
+func (p *Parser) parseAPIListDatasetFiles(datasetName string) (*Command, error) {
+	p.nextToken() // consume FILES
+
+	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
+
+	cmd := NewCommand("api_list_dataset_files")
+	cmd.Params["dataset_name"] = datasetName
+	return cmd, nil
+}
+
+func (p *Parser) parseAPIListDatasetIngestionTasks(datasetName string) (*Command, error) {
+	p.nextToken() // consume INGESTION
+
+	if p.curToken.Type != TokenTasks {
+		return nil, fmt.Errorf("expected TASKS")
+	}
+
+	// Semicolon is optional
+	if p.curToken.Type == TokenSemicolon {
+		p.nextToken()
+	}
+
+	cmd := NewCommand("api_list_ingestion_tasks")
+	cmd.Params["dataset_name"] = datasetName
 	return cmd, nil
 }
 

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -313,7 +313,7 @@ func (p *Parser) parseAPIListProviders() (*Command, error) {
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
-	return NewCommand("list_providers"), nil
+	return NewCommand("api_list_providers"), nil
 }
 
 // LIST PROVIDER 'provider_name' INSTANCES
@@ -350,6 +350,7 @@ func (p *Parser) parseListProviderInstances(providerName string) (*Command, erro
 }
 
 // LIST PROVIDER 'provider_name' INSTANCE 'instance_name' MODELS
+// LIST PROVIDER 'provider_name' INSTANCE 'instance_name' MODELS SYNC, get model list by API from remote server
 func (p *Parser) parseListProviderInstanceModels(providerName string) (*Command, error) {
 	p.nextToken() // consume INSTANCE
 
@@ -364,11 +365,15 @@ func (p *Parser) parseListProviderInstanceModels(providerName string) (*Command,
 	}
 	p.nextToken()
 
+	cmd := NewCommand("api_list_provider_instance_models")
+	if p.curToken.Type == TokenSync {
+		cmd = NewCommand("api_list_provider_instance_models_sync")
+	}
+
 	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
-	cmd := NewCommand("api_list_provider_instance_models")
 	cmd.Params["provider_name"] = providerName
 	cmd.Params["instance_name"] = instanceName
 	return cmd, nil

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -150,12 +150,10 @@ func (p *Parser) parseAPIListCommands() (*Command, error) {
 		return p.parseAPIListProviders()
 	case TokenProvider:
 		return p.parseAPIListProviderCommands()
-	case TokenInstances:
-		return p.parseListInstances()
 	case TokenIngestion:
-		return p.parseUserListIngestionTasks()
+		return p.parseAPIListIngestionTasks()
 	case TokenDefault:
-		return p.parseListDefaultModels()
+		return p.parseAPIListDefaultModels()
 	case TokenAvailable:
 		return p.parseAPIListAvailableProviders()
 	case TokenFiles:
@@ -379,7 +377,7 @@ func (p *Parser) parseListProviderInstanceModels(providerName string) (*Command,
 	return cmd, nil
 }
 
-func (p *Parser) parseListDefaultModels() (*Command, error) {
+func (p *Parser) parseAPIListDefaultModels() (*Command, error) {
 	p.nextToken() // consume DEFAULT
 	if p.curToken.Type != TokenModels {
 		return nil, fmt.Errorf("expected MODELS")
@@ -389,7 +387,7 @@ func (p *Parser) parseListDefaultModels() (*Command, error) {
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
-	return NewCommand("list_user_default_models"), nil
+	return NewCommand("api_list_default_models"), nil
 }
 
 func (p *Parser) parseAPIListAvailableProviders() (*Command, error) {
@@ -1591,31 +1589,6 @@ optionsLoop:
 	if region != "" {
 		cmd.Params["region"] = region
 	}
-
-	p.nextToken()
-	// Semicolon is optional
-	if p.curToken.Type == TokenSemicolon {
-		p.nextToken()
-	}
-	return cmd, nil
-}
-
-// parseListInstances parses LIST INSTANCES FROM PROVIDER <name> command
-func (p *Parser) parseListInstances() (*Command, error) {
-	p.nextToken() // consume INSTANCES
-
-	if p.curToken.Type != TokenFrom {
-		return nil, fmt.Errorf("expected FROM")
-	}
-	p.nextToken()
-
-	providerName, err := p.parseQuotedString()
-	if err != nil {
-		return nil, fmt.Errorf("expected provider name after FROM PROVIDER: %w", err)
-	}
-
-	cmd := NewCommand("list_provider_instances")
-	cmd.Params["provider_name"] = providerName
 
 	p.nextToken()
 	// Semicolon is optional
@@ -4203,7 +4176,7 @@ func (p *Parser) parseUserStopIngestion() (*Command, error) {
 	return cmd, nil
 }
 
-func (p *Parser) parseUserListIngestionTasks() (*Command, error) {
+func (p *Parser) parseAPIListIngestionTasks() (*Command, error) {
 	p.nextToken() // consume Ingestion
 
 	if p.curToken.Type != TokenTasks {
@@ -4211,7 +4184,7 @@ func (p *Parser) parseUserListIngestionTasks() (*Command, error) {
 	}
 	p.nextToken() // consume TASKS
 
-	cmd := NewCommand("user_list_ingestion_tasks")
+	cmd := NewCommand("api_list_ingestion_tasks")
 
 	if p.curToken.Type == TokenFrom {
 		p.nextToken()


### PR DESCRIPTION
### What problem does this PR solve?

```
RAGFlow(api/default)> list provider 'zhipu-ai' instance 'test' models sync;
+------------+---------------+------------+-------------+------------------+---------------------------------------------+
| dimensions | max_dimension | max_tokens | model_types | name             | thinking                                    |
+------------+---------------+------------+-------------+------------------+---------------------------------------------+
|            |               | 128000     | [chat]      | glm-4.5@z-ai     | map[clear_thinking:true default_value:true] |
|            |               | 128000     | [chat]      | glm-4.5-air@z-ai | map[clear_thinking:true default_value:true] |
|            |               | 202752     | [chat]      | glm-4.6@z-ai     | map[clear_thinking:true default_value:true] |
|            |               | 202752     | [chat]      | glm-4.7@z-ai     | map[clear_thinking:true default_value:true] |
|            |               | 202752     | [chat]      | glm-5@z-ai       | map[clear_thinking:true default_value:true] |
|            |               | 200000     | [chat]      | glm-5-turbo@z-ai | map[clear_thinking:true default_value:true] |
|            |               | 202752     | [chat]      | glm-5.1@z-ai     | map[clear_thinking:true default_value:true] |
|            |               |            | [chat]      | glm-5.2@z-ai     |                                             |
+------------+---------------+------------+-------------+------------------+---------------------------------------------+

RAGFlow(api/default)> list provider 'zhipu-ai' instance 'test' models;

RAGFlow(api/default)> list dataset 'aaa' ingestion tasks;

RAGFlow(api/default)> list dataset '0abe79f9423311f1ad8d38a74640adcc' documents;

```

