### PR TITLE
fix(deepdoc): keep zero and false Excel cells in __call__

### DIFF
--- a/deepdoc/parser/excel_parser.py
+++ b/deepdoc/parser/excel_parser.py
@@ -283,7 +283,7 @@ class RAGFlowExcelParser:
             for r in list(rows[1:]):
                 fields = []
                 for i, c in enumerate(r):
-                    if not c.value:
+                    if c.value is None:
                         continue
                     t = str(ti[i].value) if i < len(ti) else ""
                     t += ("：" if t else "") + str(c.value)

--- a/test/unit_test/deepdoc/parser/test_excel_parser.py
+++ b/test/unit_test/deepdoc/parser/test_excel_parser.py
@@ -90,6 +90,21 @@ def test_call_keeps_zero_and_false_cells():
 
 
 @pytest.mark.p2
+def test_call_keeps_empty_string_cells(monkeypatch):
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Note"])
+    ws.append([""])
+
+    monkeypatch.setattr(RAGFlowExcelParser, "_load_excel_to_workbook", lambda _file: wb)
+    lines = RAGFlowExcelParser()(b"unused")
+    assert len(lines) == 1
+    assert "Note：" in lines[0]
+
+
+@pytest.mark.p2
 def test_exact_multiple_does_not_emit_header_only_chunk():
     # 12 data rows with chunk_rows=12 (the value rag/app/naive.py uses).
     chunks = RAGFlowExcelParser().html(_make_xlsx(12), chunk_rows=12)

--- a/test/unit_test/deepdoc/parser/test_excel_parser.py
+++ b/test/unit_test/deepdoc/parser/test_excel_parser.py
@@ -100,8 +100,7 @@ def test_call_keeps_empty_string_cells(monkeypatch):
 
     monkeypatch.setattr(RAGFlowExcelParser, "_load_excel_to_workbook", lambda _file: wb)
     lines = RAGFlowExcelParser()(b"unused")
-    assert len(lines) == 1
-    assert "Note：" in lines[0]
+    assert lines == ["Note："]
 
 
 @pytest.mark.p2

--- a/test/unit_test/deepdoc/parser/test_excel_parser.py
+++ b/test/unit_test/deepdoc/parser/test_excel_parser.py
@@ -68,6 +68,27 @@ def _chunk_has_no_data_cells(chunk):
     return "<td>" not in chunk and "<td></td>" not in chunk
 
 
+def _make_xlsx_with_zero_and_false():
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Amount", "Active"])
+    ws.append([0, False])
+    buf = BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf.read()
+
+
+@pytest.mark.p2
+def test_call_keeps_zero_and_false_cells():
+    lines = RAGFlowExcelParser()(_make_xlsx_with_zero_and_false())
+    assert len(lines) == 1
+    assert "0" in lines[0]
+    assert "False" in lines[0]
+
+
 @pytest.mark.p2
 def test_exact_multiple_does_not_emit_header_only_chunk():
     # 12 data rows with chunk_rows=12 (the value rag/app/naive.py uses).


### PR DESCRIPTION
## Summary
- `ExcelParser.__call__` now skips only `None` cells, not falsy values like `0`, `False`, or `""`.
- Matches the existing `html()` parser behavior and prevents silent data loss during spreadsheet ingestion.

## Test plan
- [x] `.v/bin/python -m ruff check deepdoc/parser/excel_parser.py test/unit_test/deepdoc/parser/test_excel_parser.py`
- [x] `.v/bin/python -m pytest test/unit_test/deepdoc/parser/test_excel_parser.py -q` (4 passed)

Fixes #16313