### PR TITLE
fix(agent/component): Switch crashes when upstream variable is None

### DIFF
--- a/agent/component/switch.py
+++ b/agent/component/switch.py
@@ -97,6 +97,12 @@ class Switch(ComponentBase, ABC):
         self.set_output("_next", self._param.end_cpn_ids)
 
     def process_operator(self, input: Any, operator: str, value: Any) -> bool:
+        # Upstream variables may resolve to None; treat them as empty so the
+        # string operators below don't raise AttributeError on None.lower().
+        if input is None:
+            input = ""
+        if value is None:
+            value = ""
         if operator == "contains":
             return True if value.lower() in input.lower() else False
         elif operator == "not contains":

--- a/test/unit_test/agent/component/test_switch.py
+++ b/test/unit_test/agent/component/test_switch.py
@@ -57,3 +57,33 @@ def test_switch_non_empty_and_condition_still_matches():
 
     assert cpn.output("_next") == ["case_target"]
     assert cpn.output("next") == ["case_target"]
+
+
+def test_switch_none_upstream_value_routes_to_else():
+    # Regression: a None upstream value used to raise AttributeError on
+    # None.lower() for the string operators instead of routing to else.
+    param = SwitchParam()
+    param.conditions = [
+        {
+            "logical_operator": "and",
+            "items": [{"cpn_id": "answer", "operator": "contains", "value": "yes"}],
+            "to": ["case_target"],
+        }
+    ]
+    param.end_cpn_ids = ["else_target"]
+
+    cpn = _switch(param, {"answer": None})
+    cpn._invoke()
+
+    assert cpn.output("_next") == ["else_target"]
+    assert cpn.output("next") == ["else_target"]
+
+
+def test_process_operator_handles_none_for_string_operators():
+    cpn = Switch.__new__(Switch)
+    for operator in ["contains", "not contains", "start with", "end with"]:
+        # Must not raise on a None input/value.
+        assert cpn.process_operator(None, operator, "yes") in (True, False)
+        assert cpn.process_operator("yes", operator, None) in (True, False)
+    assert cpn.process_operator(None, "empty", "") is True
+    assert cpn.process_operator(None, "not empty", "") is False


### PR DESCRIPTION
### What problem does this PR solve?

`Switch.process_operator` called `input.lower()`/`value.lower()` for the `contains`/`not contains`/`start with`/`end with` operators. When an upstream canvas variable resolved to `None`, this raised `AttributeError` instead of routing to the else branch.

This PR coerces `None` input/value to `""` at the top of `process_operator` so the string operators evaluate to `False` and the component falls through to the else destination.

Closes #16315

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Add test cases

### Testing

Added regression tests in `test/unit_test/agent/component/test_switch.py`:
- a `None` upstream value with a `contains` condition routes to the else branch instead of crashing
- `process_operator` handles `None` input/value for all string operators and `empty`/`not empty`