### PR TITLE
fix(agent/tools): DeepL component fails validation and drops errors

### DIFF
--- a/agent/tools/deepl.py
+++ b/agent/tools/deepl.py
@@ -31,7 +31,6 @@ class DeepLParam(ComponentParamBase):
         self.target_lang = 'EN-GB'
 
     def check(self):
-        self.check_positive_integer(self.top_n, "Top N")
         self.check_valid_value(self.source_lang, "Source language",
                                ['AR', 'BG', 'CS', 'DA', 'DE', 'EL', 'EN', 'ES', 'ET', 'FI', 'FR', 'HU', 'ID', 'IT',
                                 'JA', 'KO', 'LT', 'LV', 'NB', 'NL', 'PL', 'PT', 'RO', 'RU', 'SK', 'SL', 'SV', 'TR',
@@ -65,4 +64,4 @@ class DeepL(ComponentBase, ABC):
         except Exception as e:
             if self.check_if_canceled("DeepL processing"):
                 return
-            DeepL.be_output("**Error**:" + str(e))
+            return DeepL.be_output("**Error**:" + str(e))

--- a/test/unit_test/agent/component/test_deepl.py
+++ b/test/unit_test/agent/component/test_deepl.py
@@ -1,0 +1,42 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+
+# DeepL component imports the `deepl` SDK at module load; skip where absent.
+pytest.importorskip("deepl")
+
+from agent.tools.deepl import DeepLParam  # noqa: E402
+
+
+def test_check_passes_with_defaults():
+    # Regression: check() validated an undefined self.top_n and always raised
+    # AttributeError, so a DeepL component could never pass validation.
+    DeepLParam().check()
+
+
+def test_check_rejects_invalid_source_lang():
+    param = DeepLParam()
+    param.source_lang = "XX"
+    with pytest.raises(ValueError):
+        param.check()
+
+
+def test_check_rejects_invalid_target_lang():
+    param = DeepLParam()
+    param.target_lang = "XX"
+    with pytest.raises(ValueError):
+        param.check()


### PR DESCRIPTION
### What problem does this PR solve?

`DeepLParam.check()` validated `self.top_n`, but DeepL has no such parameter (it is not defined on the param class or its base), so `check()` always raised `AttributeError` and a DeepL component could never pass validation. Removed the bogus `top_n` check.

Also fixed the `_run` except branch, which computed `be_output("**Error**...")` but never returned it, silently dropping the error message.

Closes #16329

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Add test cases

### Testing

Added `test/unit_test/agent/component/test_deepl.py` covering `DeepLParam.check()` with valid defaults and rejection of invalid source/target languages.