### PR TITLE
fix(web): agent log refetch and slider percentage rounding

### DIFF
--- a/web/src/components/copy-to-clipboard.tsx
+++ b/web/src/components/copy-to-clipboard.tsx
@@ -25,7 +25,6 @@ const CopyToClipboard = ({
   const icon = copied ? <LucideCheck /> : <LucideCopy />;
   const trigger = avoidButtonWrapper ? (
     <Button
-      asChild
       variant="transparent"
       size="icon-sm"
       {...buttonProps}

--- a/web/src/components/slider-input-form-field.tsx
+++ b/web/src/components/slider-input-form-field.tsx
@@ -92,9 +92,11 @@ export const SliderInputFormField = forwardRef<
               <FormControl>
                 <SingleFormSlider
                   {...field}
-                  value={percentage ? field.value * 100 : field.value}
+                  value={
+                    percentage ? Math.round(field.value * 100) : field.value
+                  }
                   onChange={(value) =>
-                    field.onChange(percentage ? value / 100 : value)
+                    field.onChange(percentage ? Math.round(value) / 100 : value)
                   }
                   max={displayMax}
                   min={displayMin}
@@ -114,13 +116,13 @@ export const SliderInputFormField = forwardRef<
                   step={displayStep}
                   hideIcons
                   value={
-                    percentage ? (field.value * 100).toFixed(0) : field.value
+                    percentage ? Math.round(field.value * 100) : field.value
                   }
                   onChange={(val) => {
                     const value = Number(val || 0);
-                    if (!isNaN(value)) {
+                    if (value >= 0) {
                       field.onChange(
-                        percentage ? (value / 100).toFixed(0) : value,
+                        percentage ? Math.round(value) / 100 : value,
                       );
                     }
                   }}

--- a/web/src/hooks/use-agent-request.ts
+++ b/web/src/hooks/use-agent-request.ts
@@ -685,7 +685,11 @@ export const useFetchVersion = (
 
 export const useFetchAgentLog = (searchParams: IAgentLogsRequest) => {
   const { id } = useParams();
-  const { data, isFetching: loading } = useQuery<IAgentLogsResponse>({
+  const {
+    data,
+    isFetching: loading,
+    refetch,
+  } = useQuery<IAgentLogsResponse>({
     queryKey: [AgentApiAction.FetchAgentLog, id, searchParams],
     initialData: {} as IAgentLogsResponse,
     gcTime: 0,
@@ -698,7 +702,7 @@ export const useFetchAgentLog = (searchParams: IAgentLogsRequest) => {
     },
   });
 
-  return { data, loading };
+  return { data, loading, refetch };
 };
 
 export const useFetchSessionsByCanvasId = () => {

--- a/web/src/pages/agents/agent-log-page.tsx
+++ b/web/src/pages/agents/agent-log-page.tsx
@@ -126,7 +126,7 @@ const AgentLogPage: React.FC = () => {
     },
   ];
 
-  const { data: logData, loading } = useFetchAgentLog(searchParams);
+  const { data: logData, loading, refetch } = useFetchAgentLog(searchParams);
   const { sessions: data, total } = logData || {};
   const { handleExport, loading: exportLoading } = useExportAgentLogToCSV();
   const [currentDate, setCurrentDate] = useState<DateRange>({
@@ -191,8 +191,18 @@ const AgentLogPage: React.FC = () => {
   };
 
   const handleClickSearch = () => {
-    setPagination((pre) => ({ ...pre, current: 1 }));
-    handleSearch({ page: 1, keywords });
+    const sameParams =
+      pagination.current === 1 &&
+      searchParams.keywords === keywords &&
+      searchParams.from_date === currentDate.from &&
+      searchParams.to_date === currentDate.to;
+
+    if (sameParams) {
+      refetch();
+    } else {
+      setPagination((pre) => ({ ...pre, current: 1 }));
+      handleSearch({ page: 1, keywords });
+    }
   };
   useEffect(() => {
     handleSearch();


### PR DESCRIPTION
### What problem does this PR solve?

fix(web): agent log refetch and slider percentage rounding                                                      
                                                                                                                  
  - agent-log-page: trigger refetch when search params unchanged so the                                           
    search button reliably re-queries logs instead of being a no-op  
                
  - slider-input-form-field: round percentage values to avoid floating-
    point artifacts (e.g. 0.30000000000000004) and fix the number-input
    reject path (previously the NaN guard discarded valid 0 input)

  - copy-to-clipboard: drop stray asChild on the Button trigger that was
    swallowing icon/props

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
