### PR TITLE
Allow skipping database initialization

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,6 +36,7 @@ function usage() {
 ENABLE_WEBSERVER=1 # Default to enable web server
 ENABLE_TASKEXECUTOR=1  # Default to enable task executor
 ENABLE_DATASYNC=1
+ENABLE_DB_INIT=1
 ENABLE_MCP_SERVER=0
 ENABLE_ADMIN_SERVER=0 # Default close admin server
 INIT_SUPERUSER_ARGS="" # Default to not initialize superuser
@@ -81,6 +82,10 @@ for arg in "$@"; do
       ;;
     --disable-datasync)
       ENABLE_DATASYNC=0
+      shift
+      ;;
+    --disable-db-init)
+      ENABLE_DB_INIT=0
       shift
       ;;
     --enable-mcpserver)
@@ -270,7 +275,10 @@ function wait_for_server() {
 # Start components based on flags
 # -----------------------------------------------------------------------------
 ensure_docling
-ensure_db_init
+
+if [[ "${ENABLE_DB_INIT}" -eq 1 ]]; then
+  ensure_db_init
+fi
 
 if [[ "${INIT_MODEL_PROVIDER_TABLES}" -eq 1 ]]; then
     echo "Running model provider table migrations..."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,8 @@ function usage() {
     echo "  --disable-datasync                      Disables synchronization of datasource workers."
     echo "  --enable-mcpserver                      Enables the MCP server."
     echo "  --enable-adminserver                    Enables the Admin server."
+    echo "  --init-db=<1|0>                         Force or disable initializing the database. If omitted, the"
+    echo "                                          database is initialized only if the webserver is enabled."
     echo "  --init-model-provider-tables            Run model provider table migrations and exit."
     echo "  --init-superuser                        Initializes the superuser."
     echo "  --consumer-no-beg=<num>                 Start range for consumers (if using range-based)."
@@ -102,6 +104,10 @@ for arg in "$@"; do
       ENABLE_ADMIN_SERVER=1
       shift
       ;;
+    --init-db=*)
+      INIT_DB="${arg#*=}"
+      shift
+      ;;
     --init-model-provider-tables)
       INIT_MODEL_PROVIDER_TABLES=1
       shift
@@ -167,6 +173,8 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+INIT_DB=${INIT_DB:-$ENABLE_WEBSERVER} # Default is to init the db only if running the webserver
 
 # -----------------------------------------------------------------------------
 # Replace env variables in the service_conf.yaml file
@@ -303,9 +311,12 @@ if [[ "${ENABLE_ADMIN_SERVER}" -eq 1 ]]; then
     fi
 fi
 
+if [[ "${INIT_DB}" -eq 1 ]]; then
+    ensure_db_init
+fi
+
 if [[ "${ENABLE_WEBSERVER}" -eq 1 ]]; then
     ensure_docling
-    ensure_db_init
 
     echo "Starting nginx..."
     /usr/sbin/nginx -c /etc/nginx/nginx.conf


### PR DESCRIPTION
### What problem does this PR solve?

When deploying ragflow as microservices, with separate pods for ragflow, taskexecutor, datasync, mcp, admin and so on, running the database initialization is redundant and, in case of the MCP server, requires much more memory than really needed.

Adding an entrypoint flag to disable this allows to selectively run database initialization, or even extract database initialization into a separate init container if so desired.

My current workaround in my deployment is to make the MCP service use `sed` to edit the entrypoint.sh script before executing it: https://github.com/scout-ch/tractor-k8s-shared-cosinus-ragflow/commit/68efcafeb56b27bc42fff8c80ab2c99a769e7265

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):
