### PR TITLE
feat: add missing qwen models to all_models.json

### DIFF
--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -39274,7 +39274,8 @@
       ],
       "model_types": [
         "chat"
-      ]
+      ],
+      "max_tokens": 1000000
     },
     {
       "name": "qwen/qwen-flash-character-2026-02-26",
@@ -39283,7 +39284,8 @@
       ],
       "model_types": [
         "chat"
-      ]
+      ],
+      "max_tokens": 1000000
     },
     {
       "name": "qwen/qwen3.5-omni-plus-realtime-2026-03-15",
@@ -39386,7 +39388,8 @@
       ],
       "model_types": [
         "chat"
-      ]
+      ],
+      "max_tokens": 131072
     },
     {
       "name": "qwen/qwen3-s2s-flash-realtime-2025-09-22",

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -25061,7 +25061,9 @@
     },
     {
       "name": "qwen/qwen3.5-plus-20260420",
-      "alias": [],
+      "alias": [
+        "qwen3.5-plus-2026-04-20"
+      ],
       "model_types": [
         "chat",
         "vision",
@@ -31040,7 +31042,8 @@
     {
       "name": "qwen/qwen-turbo-2024-09-19",
       "alias": [
-        "qwen-turbo-2024-09-19"
+        "qwen-turbo-2024-09-19",
+        "qwen-turbo-0919"
       ],
       "model_types": [
         "chat"
@@ -31193,7 +31196,8 @@
     {
       "name": "qwen/qwen-1_8b",
       "alias": [
-        "qwen-1_8b"
+        "qwen-1_8b",
+        "qwen-1.8b-chat"
       ],
       "model_types": [
         "chat"
@@ -39189,6 +39193,249 @@
         "default_value": true,
         "clear_thinking": true
       }
+    },
+    {
+      "name": "qwen/qwen-image-2.0-pro-2026-06-22",
+      "alias": [
+        "qwen-image-2.0-pro-2026-06-22"
+      ],
+      "model_types": [
+        "text-to-image",
+        "image_generation",
+        "image"
+      ]
+    },
+    {
+      "name": "qwen/qwen-image-2.0-pro-2026-04-22",
+      "alias": [
+        "qwen-image-2.0-pro-2026-04-22"
+      ],
+      "model_types": [
+        "text-to-image",
+        "image_generation",
+        "image"
+      ]
+    },
+    {
+      "name": "qwen/qwen3.5-ocr",
+      "alias": [
+        "qwen3.5-ocr"
+      ],
+      "model_types": [
+        "ocr",
+        "image2text",
+        "vision"
+      ],
+      "max_tokens": 32768
+    },
+    {
+      "name": "qwen/qwen3.7-max-2026-05-17",
+      "alias": [
+        "qwen3.7-max-2026-05-17"
+      ],
+      "model_types": [
+        "chat",
+        "image2text",
+        "vision",
+        "video_understanding"
+      ],
+      "max_tokens": 1000000,
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen/qwen3.5-livetranslate-flash-realtime-2026-05-19",
+      "alias": [
+        "qwen3.5-livetranslate-flash-realtime-2026-05-19"
+      ],
+      "model_types": [
+        "speech_translation",
+        "audio2text",
+        "speech2text"
+      ]
+    },
+    {
+      "name": "qwen/qwen3.5-livetranslate-flash-realtime",
+      "alias": [
+        "qwen3.5-livetranslate-flash-realtime"
+      ],
+      "model_types": [
+        "speech_translation",
+        "audio2text",
+        "speech2text"
+      ]
+    },
+    {
+      "name": "qwen/qwen-deep-research-2025-12-15",
+      "alias": [
+        "qwen-deep-research-2025-12-15"
+      ],
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "qwen/qwen-flash-character-2026-02-26",
+      "alias": [
+        "qwen-flash-character-2026-02-26"
+      ],
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "qwen/qwen3.5-omni-plus-realtime-2026-03-15",
+      "alias": [
+        "qwen3.5-omni-plus-realtime-2026-03-15"
+      ],
+      "model_types": [
+        "chat",
+        "omni",
+        "image2text",
+        "vision",
+        "video_understanding",
+        "audio2text",
+        "speech2text",
+        "audio_understanding"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen/qwen3.5-omni-plus-realtime",
+      "alias": [
+        "qwen3.5-omni-plus-realtime"
+      ],
+      "model_types": [
+        "chat",
+        "omni",
+        "image2text",
+        "vision",
+        "video_understanding",
+        "audio2text",
+        "speech2text",
+        "audio_understanding"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen/qwen3.5-omni-flash-realtime-2026-03-15",
+      "alias": [
+        "qwen3.5-omni-flash-realtime-2026-03-15"
+      ],
+      "model_types": [
+        "chat",
+        "omni",
+        "image2text",
+        "vision",
+        "video_understanding",
+        "audio2text",
+        "speech2text",
+        "audio_understanding"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen/qwen3.5-omni-flash-realtime",
+      "alias": [
+        "qwen3.5-omni-flash-realtime"
+      ],
+      "model_types": [
+        "chat",
+        "omni",
+        "image2text",
+        "vision",
+        "video_understanding",
+        "audio2text",
+        "speech2text",
+        "audio_understanding"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen/qwen-plus-2025-11-05",
+      "alias": [
+        "qwen-plus-2025-11-05"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_tokens": 1000000,
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      }
+    },
+    {
+      "name": "qwen/qwen-deep-search-planning",
+      "alias": [
+        "qwen-deep-search-planning"
+      ],
+      "model_types": [
+        "chat"
+      ]
+    },
+    {
+      "name": "qwen/qwen3-s2s-flash-realtime-2025-09-22",
+      "alias": [
+        "qwen3-s2s-flash-realtime-2025-09-22"
+      ],
+      "model_types": [
+        "tts"
+      ]
+    },
+    {
+      "name": "qwen/qwen-max-1201",
+      "alias": [
+        "qwen-max-1201"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_tokens": 131072
+    },
+    {
+      "name": "qwen/qwen-max-longcontext",
+      "alias": [
+        "qwen-max-longcontext"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_tokens": 32768
+    },
+    {
+      "name": "qwen/qwen-max-0107",
+      "alias": [
+        "qwen-max-0107"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_tokens": 131072
+    },
+    {
+      "name": "qwen/qwen-1.8b-longcontext-chat",
+      "alias": [
+        "qwen-1.8b-longcontext-chat"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_tokens": 32768
     }
   ]
 }


### PR DESCRIPTION
Add 19 missing qwen models and 3 aliases to all_models.json.

Models added: qwen-image-2.0-pro (2026-06-22, 2026-04-22), qwen3.5-ocr, qwen3.7-max-2026-05-17, qwen3.5-livetranslate-flash-realtime, qwen3.5-omni-plus/flash-realtime, qwen-deep-research-2025-12-15, qwen-flash-character-2026-02-26, qwen-plus-2025-11-05, qwen-deep-search-planning, qwen3-s2s-flash-realtime-2025-09-22, qwen-max-1201/longcontext/0107, qwen-1.8b-longcontext-chat

Aliases: qwen3.5-plus-2026-04-20, qwen-turbo-0919, qwen-1.8b-chat