### PR TITLE
feat(llm): forward session/user to upstream providers as the user field

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -36,6 +36,7 @@ from api.db.services.llm_service import LLMBundle
 from api.db.services.task_service import has_canceled
 from common.constants import LLMType
 from common.exceptions import TaskCanceledException
+from common.llm_request_context import reset_llm_request_context, set_llm_request_context
 from common.misc_utils import get_uuid, hash_str2int
 from common.token_utils import token_usage_sink, langfuse_run_attrs
 from rag.prompts.generator import chunks_format
@@ -425,9 +426,10 @@ class Canvas(Graph):
 
     async def run(self, **kwargs):
         # Install a fresh per-run token usage sink and Langfuse correlation context,
-        # and guarantee both are torn down when the run ends (even on early return or
-        # exception) so later LLM calls in the same task never inherit a previous
-        # run's sink or session/user attributes.
+        # and forward the originating session/user to upstream LLM providers (as the
+        # OpenAI `user` field). All three are torn down when the run ends (even on
+        # early return or exception) so later LLM calls in the same task never inherit
+        # a previous run's sink, session/user attributes, or forwarded `user` value.
         self._run_token_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "calls": 0}
         _lf_attrs = {}
         _user_id = kwargs.get("user_id")
@@ -438,10 +440,15 @@ class Canvas(Graph):
             _lf_attrs["session_id"] = str(_session_id)[:200]
         sink_token = token_usage_sink.set(self._run_token_usage)
         attrs_token = langfuse_run_attrs.set(_lf_attrs)
+        _req_ctx_token = set_llm_request_context(
+            session_id=kwargs.get("session_id"),
+            user_id=kwargs.get("user_id"),
+        )
         try:
             async for ev in self._run_impl(**kwargs):
                 yield ev
         finally:
+            reset_llm_request_context(_req_ctx_token)
             # reset() can raise if the generator is closed from a different context
             # (e.g. client disconnect); fall back to clearing the values in that case.
             try:
@@ -540,8 +547,9 @@ class Canvas(Graph):
                         await cpn_obj.invoke_async(**(call_kwargs or {}))
                         return
                     # run_in_executor does not propagate context variables; copy the
-                    # current context so the token usage sink / Langfuse attributes set
-                    # by run() remain visible to LLMBundle calls inside sync components.
+                    # current context so the token usage sink, Langfuse run attributes,
+                    # and the LLM request context (the `user` forwarding) set by run()
+                    # remain visible to LLMBundle calls inside sync components.
                     ctx = contextvars.copy_context()
                     await loop.run_in_executor(self._thread_pool, lambda: ctx.run(partial(sync_fn, **(call_kwargs or {}))))
 

--- a/api/db/services/canvas_service.py
+++ b/api/db/services/canvas_service.py
@@ -337,7 +337,9 @@ async def completion(tenant_id, agent_id, session_id=None, **kwargs):
         "files": files,
         "user_id": user_id,
         "inputs": inputs,
-        # Used by Canvas.run to correlate RAGFlow's Langfuse generations by session.
+        # Forwarded into Canvas.run: used both to correlate RAGFlow's Langfuse
+        # generations by session and to forward to upstream LLM providers as the
+        # OpenAI-standard `user` field for session correlation.
         "session_id": session_id,
     }
     if chat_template_kwargs is not None:

--- a/common/llm_request_context.py
+++ b/common/llm_request_context.py
@@ -1,0 +1,77 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Per-request identifiers forwarded to upstream LLM providers.
+
+An agent run (or any LLM-issuing flow) installs the originating ``session_id`` /
+``user_id`` here. The chat model layer reads it and forwards an end-user
+identifier as the OpenAI-standard ``user`` request field, which providers such as
+OpenAI and OpenRouter include in the request body. This lets upstream activity be
+correlated back to the session/user that produced it.
+
+The value is a small dict (or ``None`` when no request context is active), e.g.
+``{"session_id": "...", "user_id": "..."}``.
+"""
+
+import contextvars
+import logging
+
+llm_request_context: contextvars.ContextVar = contextvars.ContextVar("ragflow_llm_request_context", default=None)
+
+
+def set_llm_request_context(session_id: str | None = None, user_id: str | None = None):
+    """Install the current request identifiers and return the reset token.
+
+    Pass the returned token to ``reset_llm_request_context`` (typically in a
+    ``finally`` block) so the value does not leak to later calls in the same task.
+    """
+    ctx = {}
+    if session_id:
+        ctx["session_id"] = str(session_id)[:128]
+    if user_id:
+        ctx["user_id"] = str(user_id)[:128]
+    # Log only presence flags, never the raw identifiers.
+    logging.debug("Installing LLM request context (session=%s, user=%s)", bool(session_id), bool(user_id))
+    return llm_request_context.set(ctx or None)
+
+
+def reset_llm_request_context(token) -> None:
+    """Reset the request context installed by ``set_llm_request_context``.
+
+    If the token is stale or was created in a different context (for example when
+    an async generator is closed on client disconnect), fall back to clearing the
+    active value instead of raising.
+    """
+    try:
+        llm_request_context.reset(token)
+    except (ValueError, RuntimeError):
+        # The context may be reset from a different context (e.g. an async generator
+        # closed on client disconnect -> ValueError) or with an already-consumed
+        # token (Python 3.13+ -> RuntimeError); fall back to clearing the value.
+        logging.debug("LLM request context reset failed; clearing active context")
+        llm_request_context.set(None)
+
+
+def current_llm_user() -> str | None:
+    """Return the identifier to forward as the provider ``user`` field.
+
+    Prefers ``session_id`` (so upstream activity can be traced per chat session),
+    falling back to ``user_id``. Returns ``None`` when no context is active.
+    """
+    ctx = llm_request_context.get()
+    if not ctx:
+        return None
+    return ctx.get("session_id") or ctx.get("user_id") or None

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -31,6 +31,7 @@ import openai
 from openai import AsyncOpenAI, OpenAI
 from enum import StrEnum
 
+from common.llm_request_context import current_llm_user
 from common.misc_utils import thread_pool_exec
 from common.token_utils import num_tokens_from_string, total_token_count_from_response, usage_from_response
 from rag.llm import FACTORY_DEFAULT_BASE_URL, LITELLM_PROVIDER_PREFIX, SupportedLiteLLMProvider
@@ -2181,6 +2182,15 @@ class LiteLLMBase(ABC):
             "num_retries": self.max_retries,
             **kwargs,
         }
+        # Forward the originating session/user as the OpenAI-standard `user` field so
+        # providers (OpenAI, OpenRouter, ...) receive it in the request body and
+        # upstream activity can be correlated back to the session. An explicit
+        # caller-supplied `user` (including an empty string to suppress it) wins, so
+        # check key presence rather than truthiness.
+        if "user" not in completion_args:
+            request_user = current_llm_user()
+            if request_user:
+                completion_args["user"] = request_user
         if stream:
             completion_args.update(
                 {

--- a/test/unit_test/common/test_llm_request_context.py
+++ b/test/unit_test/common/test_llm_request_context.py
@@ -1,0 +1,138 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Unit tests for the LLM request-context user-forwarding precedence rules.
+
+Covers the behaviour flagged in review: (1) session_id is preferred over
+user_id, (2) an explicit caller-supplied ``user`` overrides the context value,
+and (3) a caller-supplied empty ``user`` suppresses forwarding entirely.
+"""
+import types
+
+import pytest
+
+from common.llm_request_context import (
+    current_llm_user,
+    llm_request_context,
+    reset_llm_request_context,
+    set_llm_request_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_context():
+    """Ensure every test starts and ends with no active request context."""
+    token = llm_request_context.set(None)
+    yield
+    try:
+        llm_request_context.reset(token)
+    except ValueError:
+        llm_request_context.set(None)
+
+
+@pytest.mark.p2
+class TestCurrentLlmUser:
+    def test_no_active_context_returns_none(self):
+        assert current_llm_user() is None
+
+    def test_session_id_preferred_over_user_id(self):
+        token = set_llm_request_context(session_id="sess-1", user_id="user-1")
+        try:
+            assert current_llm_user() == "sess-1"
+        finally:
+            reset_llm_request_context(token)
+
+    def test_falls_back_to_user_id_without_session(self):
+        token = set_llm_request_context(session_id=None, user_id="user-1")
+        try:
+            assert current_llm_user() == "user-1"
+        finally:
+            reset_llm_request_context(token)
+
+    def test_empty_identifiers_return_none(self):
+        token = set_llm_request_context(session_id=None, user_id=None)
+        try:
+            assert current_llm_user() is None
+        finally:
+            reset_llm_request_context(token)
+
+    def test_identifier_is_truncated_to_128_chars(self):
+        token = set_llm_request_context(session_id="s" * 200)
+        try:
+            assert current_llm_user() == "s" * 128
+        finally:
+            reset_llm_request_context(token)
+
+
+@pytest.mark.p2
+class TestSetResetLifecycle:
+    def test_reset_restores_previous_context(self):
+        outer = set_llm_request_context(session_id="outer")
+        try:
+            inner = set_llm_request_context(session_id="inner")
+            assert current_llm_user() == "inner"
+            reset_llm_request_context(inner)
+            assert current_llm_user() == "outer"
+        finally:
+            reset_llm_request_context(outer)
+
+    def test_reset_with_stale_token_does_not_raise(self):
+        token = set_llm_request_context(session_id="x")
+        reset_llm_request_context(token)
+        # Resetting again with the now-stale token must fall back, not raise
+        # (mirrors an async generator closed from a different context).
+        reset_llm_request_context(token)
+        assert current_llm_user() is None
+
+
+@pytest.mark.p2
+class TestCompletionArgsUserPrecedence:
+    """Exercise the provider chokepoint: LiteLLMBase._construct_completion_args."""
+
+    def _construct(self, **kwargs):
+        chat_model = pytest.importorskip("rag.llm.chat_model")
+        # provider="" keeps every provider-specific branch inert, so only the
+        # generic completion_args + user-forwarding path is exercised.
+        fake = types.SimpleNamespace(model_name="m", api_key="k", max_retries=0, provider="")
+        return chat_model.LiteLLMBase._construct_completion_args(fake, [], False, False, **kwargs)
+
+    def test_context_user_applied_when_caller_omits_it(self):
+        token = set_llm_request_context(session_id="sess-9", user_id="user-9")
+        try:
+            args = self._construct()
+            assert args["user"] == "sess-9"
+        finally:
+            reset_llm_request_context(token)
+
+    def test_caller_user_overrides_context(self):
+        token = set_llm_request_context(session_id="sess-9")
+        try:
+            args = self._construct(user="explicit-caller")
+            assert args["user"] == "explicit-caller"
+        finally:
+            reset_llm_request_context(token)
+
+    def test_caller_empty_user_suppresses_forwarding(self):
+        token = set_llm_request_context(session_id="sess-9")
+        try:
+            args = self._construct(user="")
+            # Key presence (not truthiness) is honoured: the empty string wins.
+            assert args["user"] == ""
+        finally:
+            reset_llm_request_context(token)
+
+    def test_no_context_leaves_user_unset(self):
+        args = self._construct()
+        assert "user" not in args


### PR DESCRIPTION
### What problem does this PR solve?

Today, when an agent run calls an upstream LLM provider, the request carries no
identifier tying it back to the chat session that produced it. As a result,
provider-side activity (for example OpenRouter's request logs / analytics, or
OpenAI's abuse monitoring) cannot be correlated with the originating session or
user.

This PR forwards the originating `session_id` (falling back to `user_id`) to the
provider using the **OpenAI-standard `user` request field**, which OpenAI- and
OpenRouter-compatible backends include in the request body.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

### How it works

1. **`common/llm_request_context.py` (new)** — a `ContextVar` that holds the
   per-request `{session_id, user_id}`, with `set`/`reset` helpers and
   `current_llm_user()` (prefers `session_id`, falls back to `user_id`).
2. **`agent/canvas.py`** — `Canvas.run()` installs the request context for the
   duration of the run and resets it in a `finally` (so it never leaks to later
   calls in the same task). The original body is delegated to `_run_impl()`.
3. **`rag/llm/chat_model.py`** — `LiteLLMBase._construct_completion_args` sets the
   `user` field from the active request context. This is the single point all
   LiteLLM provider calls (OpenAI, OpenRouter, Anthropic, Gemini, DeepSeek, …) go
   through, so it covers plain, streaming and tool-calling paths. A
   caller-supplied `user` still takes precedence.
4. **`api/db/services/canvas_service.py`** — forwards `session_id` into the run
   kwargs.

### Why a ContextVar

LLM calls in an agent run originate from many places that each build their own
`LLMBundle` (e.g. cross-language translation / keyword helpers, the Agent
component, and nested sub-agents). A run-scoped `ContextVar` is the least-invasive
way to make the originating identifier available at the single provider chokepoint
without threading it through every call signature. Nested agents run in the same
async context and thread-pool tools inherit a copied context, so they are covered
too.

### Behavior / compatibility

- No wire-format or API change for clients; only an extra `user` field is added to
  the provider request when a session/user is known.
- If no request context is active (non-agent flows, background jobs), behavior is
  unchanged.
- Providers that ignore the `user` field are unaffected.

### Notes

- Scope is intentionally limited to the agent (canvas) path, which is the common
  case. The same `set_llm_request_context(...)` helper can be wired into the
  dialog/chat path in a follow-up if desired.
