### PR TITLE
fix(py): chat message reference deletion index

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -929,7 +929,8 @@ async def delete_session_message(chat_id, session_id, msg_id):
             assert conv["message"][i + 1]["id"] == msg_id
             conv["message"].pop(i)
             conv["message"].pop(i)
-            conv["reference"].pop(i // 2)
+            ref_index = (i - 1) // 2
+            conv["reference"].pop(ref_index)
             break
         ConversationService.update_by_id(conv["id"], conv)
         return get_json_result(data=_build_session_response(conv))

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -929,7 +929,7 @@ async def delete_session_message(chat_id, session_id, msg_id):
             assert conv["message"][i + 1]["id"] == msg_id
             conv["message"].pop(i)
             conv["message"].pop(i)
-            conv["reference"].pop(max(0, i // 2 - 1))
+            conv["reference"].pop(i // 2)
             break
         ConversationService.update_by_id(conv["id"], conv)
         return get_json_result(data=_build_session_response(conv))


### PR DESCRIPTION
  Fix the reference index used when deleting a chat message pair.

  Each user/assistant message pair shares one reference entry, while the first assistant prologue has no reference. Using `i // 2` correctly removes the reference for the deleted pair and avoids deleting the previous turn's reference.