### PR TITLE
fix: auth middleware double responses on early rejection

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -129,6 +129,7 @@ func (h *AuthHandler) AuthMiddleware() gin.HandlerFunc {
 				"code":    common.CodeForbidden,
 				"message": "Super user shouldn't access the URL",
 			})
+			c.Abort()
 			return
 		}
 
@@ -141,6 +142,7 @@ func (h *AuthHandler) AuthMiddleware() gin.HandlerFunc {
 				"message": errMsg,
 				"data":    "No",
 			})
+			c.Abort()
 			return
 		}
 


### PR DESCRIPTION
### Summary

As title:

issues:
> I found this long time ago......
<img width="1444" height="1096" alt="image" src="https://github.com/user-attachments/assets/25943649-8d06-4c63-a82c-4146f5dac88b" />

---

<img width="3410" height="387" alt="img_v3_02134_309f920d-80c1-427f-a39a-14dec91cc1eg" src="https://github.com/user-attachments/assets/0c103f57-338a-4707-8cee-b94b60702650" />

fix:

+ Add c.Abort() after superuser rejection in AuthMiddleware to stop downstream handlers from writing a second response.
+ Add c.Abort() after admin/license unavailable rejection so startup-time license failures return a single JSON response.
+ Prevent malformed concatenated JSON responses such as 403 + User not found and 401 license + User not found.
