### PR TITLE
fix: add separator before edit tags

### DIFF
--- a/web/src/pages/agents/agent-dropdown.tsx
+++ b/web/src/pages/agents/agent-dropdown.tsx
@@ -9,10 +9,15 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useDeleteAgent, useDuplicateAgent } from '@/hooks/use-agent-request';
+import { useDeleteAgent } from '@/hooks/use-agent-request';
 import { IFlow } from '@/interfaces/database/agent';
-import { MouseEventHandler, PropsWithChildren, useCallback, useState } from 'react';
 import { PenLine, Tag, Trash2 } from 'lucide-react';
+import {
+  MouseEventHandler,
+  PropsWithChildren,
+  useCallback,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { AgentTagEditor } from './agent-tag-editor';
 import { useRenameAgent } from './use-rename-agent';
@@ -55,6 +60,7 @@ export function AgentDropdown({
           <DropdownMenuItem onClick={handleShowAgentRenameModal}>
             {t('common.rename')} <PenLine />
           </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onClick={handleEditTags}>
             {t('flow.editTags')} <Tag />
           </DropdownMenuItem>


### PR DESCRIPTION
### What problem does this PR solve?

This PR adds a separator between the Rename and Edit Tags actions in the agent list dropdown.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)