### PR TITLE
fix(parsing): self-heal 'tasks are ahead in the queue' so stopped parses don't hang

### DIFF
--- a/api/apps/restful_apis/document_api.py
+++ b/api/apps/restful_apis/document_api.py
@@ -1415,6 +1415,9 @@ def _run_sync(user_id:str, req):
             has_unfinished_task = any((task.progress or 0) < 1 for task in tasks)
             if str(doc.run) in [TaskStatus.RUNNING.value, TaskStatus.CANCEL.value] or has_unfinished_task:
                 cancel_all_task_of(doc_id)
+                # Drop the stale "N tasks are ahead in the queue..." text so a
+                # stopped document does not keep looking like it is still waiting.
+                info["progress_msg"] = ""
             else:
                 return RetCode.DATA_ERROR, "Cannot cancel a task that is not in RUNNING status"
         if all([rerun_with_delete, str(doc.run) == TaskStatus.DONE.value]):
@@ -1644,6 +1647,7 @@ async def stop_parse_documents(tenant_id, dataset_id):
                         "run": str(TaskStatus.CANCEL.value),
                         "progress": 0,
                         "chunk_num": 0,
+                        "progress_msg": "",
                     },
                 )
                 index_name = search.index_name(tenant_id)

--- a/api/apps/restful_apis/task_api.py
+++ b/api/apps/restful_apis/task_api.py
@@ -93,7 +93,7 @@ async def _cancel_task(task_id):
         if doc_id and doc_id not in (CANVAS_DEBUG_DOC_ID, GRAPH_RAPTOR_FAKE_DOC_ID):
             _, doc = DocumentService.get_by_id(doc_id)
             if doc and str(doc.run) in (TaskStatus.RUNNING.value, TaskStatus.SCHEDULE.value):
-                DocumentService.update_by_id(doc_id, {"run": TaskStatus.CANCEL.value, "progress": 0})
+                DocumentService.update_by_id(doc_id, {"run": TaskStatus.CANCEL.value, "progress": 0, "progress_msg": ""})
     except Exception as e:
         logging.warning("Failed to update document run status for task %s: %s", task_id, str(e))
 

--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -937,6 +937,7 @@ class DocumentService(CommonService):
                 doc_progress = doc.progress if doc and doc.progress else 0.0
                 special_task_running = False
                 priority = 0
+                own_queued = 0
                 for t in tsks:
                     task_type = (t.task_type or "").lower()
                     if task_type in PIPELINE_SPECIAL_PROGRESS_FREEZE_TASK_TYPES:
@@ -945,6 +946,8 @@ class DocumentService(CommonService):
                         finished = False
                     if t.progress == -1:
                         bad += 1
+                    if (t.progress or 0) == 0:
+                        own_queued += 1
                     prg += t.progress if t.progress >= 0 else 0
                     if (t.progress_msg or "").strip():
                         msg.append(t.progress_msg)
@@ -974,9 +977,13 @@ class DocumentService(CommonService):
                 if msg:
                     info["progress_msg"] = msg
                     if msg.endswith("created task graphrag") or msg.endswith("created task raptor") or msg.endswith("created task mindmap"):
-                        info["progress_msg"] += "\n%d tasks are ahead in the queue..." % get_queue_length(priority)
+                        # Exclude this document's own queued tasks: they are not
+                        # "ahead" of itself, they ARE the work being waited on.
+                        queue_ahead = max(0, get_queue_length(priority) - own_queued)
+                        info["progress_msg"] += "\n%d tasks are ahead in the queue..." % queue_ahead
                 else:
-                    info["progress_msg"] = "%d tasks are ahead in the queue..." % get_queue_length(priority)
+                    queue_ahead = max(0, get_queue_length(priority) - own_queued)
+                    info["progress_msg"] = "%d tasks are ahead in the queue..." % queue_ahead
                 info["update_time"] = current_timestamp()
                 info["update_date"] = get_format_time()
                 (cls.model.update(info).where((cls.model.id == d["id"]) & ((cls.model.run.is_null(True)) | (cls.model.run != TaskStatus.CANCEL.value))).execute())

--- a/api/db/services/document_service.py
+++ b/api/db/services/document_service.py
@@ -16,6 +16,7 @@
 import logging
 import random
 from datetime import datetime
+from time import monotonic
 
 import xxhash
 from peewee import fn, Case, JOIN
@@ -1102,8 +1103,65 @@ def queue_raptor_o_graphrag_tasks(sample_doc, ty, priority, fake_doc_id="", doc_
     return task["id"]
 
 
+# Short-lived cache for the genuine queued-task backlog so the per-document
+# progress sync does not issue a COUNT query for every document each cycle.
+_PENDING_TASK_COUNT_CACHE = {"value": 0, "expire_at": 0.0}
+_PENDING_TASK_COUNT_TTL_SECONDS = 3.0
+
+
+def get_pending_task_count():
+    """Count tasks that are genuinely still waiting to be processed.
+
+    A task counts as "waiting" when it has not started yet (progress == 0) and
+    its document is still actively running (run == RUNNING and progress in
+    [0, 1)). Cancelled, failed and finished documents are excluded, so the
+    figure drops back to reality as soon as the user stops parsing.
+
+    Returns None when the count cannot be determined, so callers can fall back
+    to the raw Redis stream lag.
+    """
+    now = monotonic()
+    if _PENDING_TASK_COUNT_CACHE.get("expire_at", 0.0) > now:
+        return _PENDING_TASK_COUNT_CACHE["value"]
+    try:
+        count = int(
+            Task.select(fn.COUNT(Task.id))
+            .join(Document, on=(Task.doc_id == Document.id))
+            .where(
+                (Task.progress == 0)
+                & (Document.run == TaskStatus.RUNNING.value)
+                & (Document.progress >= 0)
+                & (Document.progress < 1)
+            )
+            .scalar()
+            or 0
+        )
+    except Exception:
+        logging.exception("get_pending_task_count failed")
+        return None
+    _PENDING_TASK_COUNT_CACHE["value"] = count
+    _PENDING_TASK_COUNT_CACHE["expire_at"] = now + _PENDING_TASK_COUNT_TTL_SECONDS
+    return count
+
+
 def get_queue_length(priority, suffix="common"):
+    """Return how many tasks are ahead in the processing queue.
+
+    The Redis stream consumer-group ``lag`` counts every message that has not
+    yet been delivered to a task executor, including messages whose tasks were
+    already cancelled/stopped. Those messages only stop counting once an
+    executor happens to read them, so after a user stops parsing the lag can
+    stay inflated indefinitely and parsing appears to hang forever
+    ("N tasks are ahead in the queue...").
+
+    To keep the figure honest, the raw lag is capped by the number of tasks
+    that are genuinely still waiting in the database, which self-heals the
+    moment work is cancelled or completes.
+    """
     group_info = REDIS_CONN.queue_info(settings.get_svr_queue_name(priority, suffix), SVR_CONSUMER_GROUP_NAME)
-    if not group_info:
-        return 0
-    return int(group_info.get("lag", 0) or 0)
+    lag = int(group_info.get("lag", 0) or 0) if group_info else 0
+
+    pending = get_pending_task_count()
+    if pending is None:
+        return lag
+    return min(lag, pending)

--- a/test/unit_test/api/db/services/test_get_queue_length.py
+++ b/test/unit_test/api/db/services/test_get_queue_length.py
@@ -1,0 +1,136 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import sys
+import types
+import warnings
+
+import pytest
+
+# xgboost imports pkg_resources and emits a deprecation warning that is promoted
+# to error in our pytest configuration; ignore it for this unit test module.
+warnings.filterwarnings(
+    "ignore",
+    message="pkg_resources is deprecated as an API.*",
+    category=UserWarning,
+)
+
+
+def _install_cv2_stub_if_unavailable():
+    try:
+        import cv2  # noqa: F401
+        return
+    except Exception:
+        pass
+
+    stub = types.ModuleType("cv2")
+
+    def _missing(*_args, **_kwargs):
+        raise RuntimeError("cv2 runtime call is unavailable in this test environment")
+
+    def _module_getattr(name):
+        if name.isupper():
+            return 0
+        return _missing
+
+    stub.__getattr__ = _module_getattr
+    sys.modules["cv2"] = stub
+
+
+_install_cv2_stub_if_unavailable()
+
+from api.db.services import document_service as ds  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_pending_cache(monkeypatch):
+    """Disable the short-lived backlog cache so each test is deterministic."""
+    monkeypatch.setattr(ds, "_PENDING_TASK_COUNT_CACHE", {"value": 0, "expire_at": 0.0})
+    monkeypatch.setattr(ds, "_PENDING_TASK_COUNT_TTL_SECONDS", 0.0)
+    yield
+
+
+def _patch_lag(monkeypatch, lag):
+    """Make REDIS_CONN.queue_info report a given consumer-group lag."""
+    group_info = None if lag is None else {"lag": lag}
+    monkeypatch.setattr(ds.REDIS_CONN, "queue_info", lambda *_a, **_k: group_info)
+
+
+def _patch_pending(monkeypatch, pending):
+    monkeypatch.setattr(ds, "get_pending_task_count", lambda: pending)
+
+
+@pytest.mark.p2
+class TestGetQueueLength:
+    def test_lag_capped_by_genuine_pending(self, monkeypatch):
+        # Redis still reports 34 undelivered messages, but only 5 tasks are
+        # genuinely waiting -> the user must not see "34 tasks ahead".
+        _patch_lag(monkeypatch, 34)
+        _patch_pending(monkeypatch, 5)
+        assert ds.get_queue_length(0) == 5
+
+    def test_self_heals_to_zero_after_stop(self, monkeypatch):
+        # Everything was cancelled: no genuine backlog -> queue length is 0
+        # even though stale messages are still sitting in the Redis stream.
+        _patch_lag(monkeypatch, 34)
+        _patch_pending(monkeypatch, 0)
+        assert ds.get_queue_length(0) == 0
+
+    def test_reports_lag_when_smaller_than_pending(self, monkeypatch):
+        # Some waiting tasks were already delivered (in flight), so lag is the
+        # tighter, truthful bound.
+        _patch_lag(monkeypatch, 2)
+        _patch_pending(monkeypatch, 9)
+        assert ds.get_queue_length(0) == 2
+
+    def test_falls_back_to_lag_when_db_unavailable(self, monkeypatch):
+        # If the backlog cannot be computed we keep the previous behaviour.
+        _patch_lag(monkeypatch, 7)
+        _patch_pending(monkeypatch, None)
+        assert ds.get_queue_length(0) == 7
+
+    def test_missing_group_info_is_zero(self, monkeypatch):
+        _patch_lag(monkeypatch, None)
+        _patch_pending(monkeypatch, 5)
+        assert ds.get_queue_length(0) == 0
+
+    def test_null_lag_value_is_treated_as_zero(self, monkeypatch):
+        monkeypatch.setattr(ds.REDIS_CONN, "queue_info", lambda *_a, **_k: {"lag": None})
+        _patch_pending(monkeypatch, 5)
+        assert ds.get_queue_length(0) == 0
+
+
+@pytest.mark.p2
+class TestGetPendingTaskCount:
+    def test_returns_none_on_db_error(self, monkeypatch):
+        def _boom(*_a, **_k):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(ds.Task, "select", _boom)
+        assert ds.get_pending_task_count() is None
+
+    def test_uses_cache_within_ttl(self, monkeypatch):
+        monkeypatch.setattr(ds, "_PENDING_TASK_COUNT_TTL_SECONDS", 60.0)
+        monkeypatch.setattr(
+            ds,
+            "_PENDING_TASK_COUNT_CACHE",
+            {"value": 11, "expire_at": ds.monotonic() + 60.0},
+        )
+
+        def _boom(*_a, **_k):
+            raise AssertionError("DB must not be queried while cache is valid")
+
+        monkeypatch.setattr(ds.Task, "select", _boom)
+        assert ds.get_pending_task_count() == 11


### PR DESCRIPTION
## Summary

When parsing documents (especially large files), users keep seeing a stale `N tasks are ahead in the queue...` message (e.g. `34 tasks are ahead in the queue...`) and parsing appears to hang **forever**, even after every parse job has been stopped.

### Root cause

`get_queue_length()` returned the raw Redis stream consumer-group `lag`:

```python
def get_queue_length(priority, suffix="common"):
    group_info = REDIS_CONN.queue_info(settings.get_svr_queue_name(priority, suffix), SVR_CONSUMER_GROUP_NAME)
    if not group_info:
        return 0
    return int(group_info.get("lag", 0) or 0)
```

`lag` counts **every undelivered message** in the stream, including messages whose tasks were already cancelled/stopped. Stopping a parse only sets the DB `run=CANCEL` and the Redis `{task_id}-cancel` flag — it does **not** remove the already-queued messages from the stream. Those messages only stop counting toward `lag` once a task executor happens to read and `ack` them. While an executor is busy on a large file (or after a crash/restart), the cancelled messages stay in `lag`, so the figure never returns to 0 and the document looks stuck in an infinite queue.

Additionally, `_sync_progress` skips documents with `run=CANCEL`, so the last `N tasks are ahead in the queue...` text stays frozen on a stopped document.

## Changes

- **Self-healing queue length**: `get_queue_length()` now caps the raw Redis `lag` by the number of tasks that are *genuinely* still waiting in the database (`Task.progress == 0` on a document whose `run == RUNNING` and `progress` in `[0, 1)`). The value drops back to reality the instant work is cancelled or finishes. A short in-process cache (3 s) avoids issuing a `COUNT` per document on every progress-sync cycle.
- **Safe fallback**: if the DB count can't be determined, it falls back to the previous raw-`lag` behaviour.
- **Clear stale message on stop**: the `N tasks are ahead in the queue...` progress message is cleared when a document parse is stopped/cancelled (single-document run, bulk stop, and per-task stop paths).
- **Tests**: added unit tests covering the capping, self-heal-to-zero, lag-smaller-than-pending, DB-unavailable fallback, missing-group and null-lag cases.

## Test plan

- [x] `python -m py_compile` on all changed files
- [ ] `uv run pytest test/unit_test/api/db/services/test_get_queue_length.py`
- [ ] Manual: queue several large-file parses, stop them, confirm the queue count returns to 0 and documents no longer show a frozen `N tasks are ahead in the queue...`
