### PR TITLE
fix(web): sanitize agent rerun modal HTML against stored XSS

### DIFF
--- a/web/src/pages/dataflow-result/components/rerun-button/__tests__/index.test.tsx
+++ b/web/src/pages/dataflow-result/components/rerun-button/__tests__/index.test.tsx
@@ -1,0 +1,13 @@
+import DOMPurify from 'dompurify';
+
+describe('rerun modal content sanitization', () => {
+  it('strips unsafe html from interpolated pipeline step names', () => {
+    const step = '<img src=x onerror="alert(1)"><script>alert(1)</script>';
+    const html = `You are about to rerun the process starting from the <span class="text-text-secondary">${step}</span> step.`;
+    const sanitized = DOMPurify.sanitize(html);
+
+    expect(sanitized).not.toMatch(/onerror/i);
+    expect(sanitized).not.toContain('<script');
+    expect(sanitized).toContain('img');
+  });
+});

--- a/web/src/pages/dataflow-result/components/rerun-button/index.tsx
+++ b/web/src/pages/dataflow-result/components/rerun-button/index.tsx
@@ -2,6 +2,7 @@ import { TimelineNode } from '@/components/originui/timeline';
 import SvgIcon from '@/components/svg-icon';
 import { Button } from '@/components/ui/button';
 import { Modal } from '@/components/ui/modal/modal';
+import DOMPurify from 'dompurify';
 import { CircleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 interface RerunButtonProps {
@@ -11,7 +12,7 @@ interface RerunButtonProps {
   loading?: boolean;
 }
 const RerunButton = (props: RerunButtonProps) => {
-  const { className, step, onRerun, loading } = props;
+  const { step, onRerun, loading } = props;
   const { t } = useTranslation();
   const clickFunc = () => {
     console.log('click rerun button');
@@ -22,9 +23,11 @@ const RerunButton = (props: RerunButtonProps) => {
       children: (
         <div
           dangerouslySetInnerHTML={{
-            __html: t('dataflowParser.confirmRerunModalContent', {
-              step: step?.title,
-            }),
+            __html: DOMPurify.sanitize(
+              t('dataflowParser.confirmRerunModalContent', {
+                step: step?.title,
+              }),
+            ),
           }}
         ></div>
       ),


### PR DESCRIPTION
## Problem

Agent pipeline node names (`data.name` in the DSL graph) are stored as plain strings and rendered in the dataflow "Rerun from current step" confirmation modal. The modal uses `dangerouslySetInnerHTML` with an i18next template where `escapeValue: false`, so a malicious node name can execute script in another user's browser (stored XSS). Reported in #16507 / GHSA-9hj6-h23v-37hx.

## Fix

Sanitize the interpolated modal HTML with `DOMPurify` before rendering, consistent with other dataflow UI components (`chunk-card`, `category-panel`, etc.).

## Verification

```bash
cd web
npm ci
npm test -- --testPathPattern=rerun-button --no-coverage
npx eslint src/pages/dataflow-result/components/rerun-button/index.tsx
```

Fixes #16507
