### PR TITLE
feat(frontend): add AuthenticatedImg component for authorized image requests

### DIFF
--- a/web/src/components/document-preview/hooks.ts
+++ b/web/src/components/document-preview/hooks.ts
@@ -155,9 +155,19 @@ export const useCatchDocumentError = (url: string) => {
   const [error, setError] = useState<string>('');
 
   const fetchDocument = useCallback(async () => {
-    const { data } = await axios.get(url, { headers: httpHeaders });
-    if (data.code !== 0) {
-      setError(data?.message);
+    try {
+      const { data } = await axios.get(url, { headers: httpHeaders });
+      // Only treat as error if response is JSON with an error code
+      // Binary data (like PDF) won't have a code property
+      if (data && typeof data === 'object' && 'code' in data && data.code !== 0) {
+        setError(data?.message || 'Failed to load document');
+      }
+    } catch (e) {
+      // Network errors or non-2xx responses
+      const errMsg = e instanceof Error ? e.message : 'Failed to load document';
+      if (errMsg) {
+        setError(errMsg);
+      }
     }
   }, [url, httpHeaders]);
   useEffect(() => {

--- a/web/src/components/document-preview/hooks.ts
+++ b/web/src/components/document-preview/hooks.ts
@@ -129,10 +129,10 @@ export const useFetchExcel = (filePath: string) => {
     myExcelPreviewer
       ?.preview(jsonFile.data)
       .then(() => {
-        console.log('succeed');
         setStatus(true);
       })
       .catch((e) => {
+        // eslint-disable-next-line no-console
         console.warn('failed', e);
         myExcelPreviewer.destroy();
         setStatus(false);

--- a/web/src/components/document-preview/index.tsx
+++ b/web/src/components/document-preview/index.tsx
@@ -23,9 +23,11 @@ const DocumentPreview = function ({
   setWidthAndHeight,
   url,
 }: PreviewProps & Partial<IProps>) {
+  const isPdf = fileType === 'pdf';
+
   return (
     <>
-      {fileType === 'pdf' && highlights && setWidthAndHeight && (
+      {isPdf && (
         <section className="h-full">
           <PdfPreviewer
             className={className}

--- a/web/src/components/file-icon/index.tsx
+++ b/web/src/components/file-icon/index.tsx
@@ -2,7 +2,9 @@ import { getExtension } from '@/utils/document-util';
 import SvgIcon from '../svg-icon';
 
 import { useFetchDocumentThumbnailsByIds } from '@/hooks/use-document-request';
-import { useEffect } from 'react';
+import { Authorization } from '@/constants/authorization';
+import { getAuthorization } from '@/utils/authorization-util';
+import { useEffect, useState } from 'react';
 import styles from './index.module.less';
 
 interface IProps {
@@ -17,14 +19,51 @@ const FileIcon = ({ name, id }: IProps) => {
     useFetchDocumentThumbnailsByIds();
   const fileThumbnail = fileThumbnails[id];
 
+  const [blobUrl, setBlobUrl] = useState<string>('');
+
   useEffect(() => {
     if (id) {
       setDocumentIds([id]);
     }
   }, [id, setDocumentIds]);
 
-  return fileThumbnail ? (
-    <img src={fileThumbnail} className={styles.thumbnailImg}></img>
+  // Fetch authenticated image URL and convert to blob URL for <img> tag
+  useEffect(() => {
+    if (!fileThumbnail || !fileThumbnail.startsWith('/api/v1/')) {
+      setBlobUrl(fileThumbnail || '');
+      return;
+    }
+
+    let cancelled = false;
+    const authorization = getAuthorization();
+
+    const fetchImage = async () => {
+      try {
+        const response = await fetch(fileThumbnail, {
+          headers: { [Authorization]: authorization },
+        });
+        if (response.ok && !cancelled) {
+          const blob = await response.blob();
+          const url = URL.createObjectURL(blob);
+          setBlobUrl(url);
+          return () => URL.revokeObjectURL(url);
+        }
+      } catch {
+        // Silently fail, will show fallback icon
+      }
+      if (!cancelled) {
+        setBlobUrl('');
+      }
+    };
+
+    fetchImage();
+    return () => {
+      cancelled = true;
+    };
+  }, [fileThumbnail]);
+
+  return blobUrl ? (
+    <img src={blobUrl} className={styles.thumbnailImg}></img>
   ) : (
     <SvgIcon name={`file-icon/${fileExtension}`} width={24}></SvgIcon>
   );

--- a/web/src/components/file-icon/index.tsx
+++ b/web/src/components/file-icon/index.tsx
@@ -2,9 +2,8 @@ import { getExtension } from '@/utils/document-util';
 import SvgIcon from '../svg-icon';
 
 import { useFetchDocumentThumbnailsByIds } from '@/hooks/use-document-request';
-import { Authorization } from '@/constants/authorization';
-import { getAuthorization } from '@/utils/authorization-util';
-import { useEffect, useState } from 'react';
+import { useAuthenticatedImageUrl } from '@/components/image';
+import { useEffect } from 'react';
 import styles from './index.module.less';
 
 interface IProps {
@@ -18,49 +17,13 @@ const FileIcon = ({ name, id }: IProps) => {
   const { data: fileThumbnails, setDocumentIds } =
     useFetchDocumentThumbnailsByIds();
   const fileThumbnail = fileThumbnails[id];
-
-  const [blobUrl, setBlobUrl] = useState<string>('');
+  const blobUrl = useAuthenticatedImageUrl(fileThumbnail);
 
   useEffect(() => {
     if (id) {
       setDocumentIds([id]);
     }
   }, [id, setDocumentIds]);
-
-  // Fetch authenticated image URL and convert to blob URL for <img> tag
-  useEffect(() => {
-    if (!fileThumbnail || !fileThumbnail.startsWith('/api/v1/')) {
-      setBlobUrl(fileThumbnail || '');
-      return;
-    }
-
-    let cancelled = false;
-    const authorization = getAuthorization();
-
-    const fetchImage = async () => {
-      try {
-        const response = await fetch(fileThumbnail, {
-          headers: { [Authorization]: authorization },
-        });
-        if (response.ok && !cancelled) {
-          const blob = await response.blob();
-          const url = URL.createObjectURL(blob);
-          setBlobUrl(url);
-          return () => URL.revokeObjectURL(url);
-        }
-      } catch {
-        // Silently fail, will show fallback icon
-      }
-      if (!cancelled) {
-        setBlobUrl('');
-      }
-    };
-
-    fetchImage();
-    return () => {
-      cancelled = true;
-    };
-  }, [fileThumbnail]);
 
   return blobUrl ? (
     <img src={blobUrl} className={styles.thumbnailImg}></img>

--- a/web/src/components/floating-chat-widget-markdown.tsx
+++ b/web/src/components/floating-chat-widget-markdown.tsx
@@ -1,4 +1,4 @@
-import Image from '@/components/image';
+import Image, { AuthenticatedImg } from '@/components/image';
 import SvgIcon from '@/components/svg-icon';
 
 import { MarkdownRemarkPlugins } from '@/constants/markdown-remark-plugins';
@@ -197,7 +197,7 @@ const FloatingChatWidgetMarkdown = ({
             {documentId && (
               <section className="flex gap-1 justify-center">
                 {fileThumbnail ? (
-                  <img
+                  <AuthenticatedImg
                     src={fileThumbnail}
                     alt={document?.doc_name}
                     className="w-6 h-6 rounded"

--- a/web/src/components/image/index.tsx
+++ b/web/src/components/image/index.tsx
@@ -1,7 +1,6 @@
 import { Authorization } from '@/constants/authorization';
 import { restAPIv1 } from '@/utils/api';
 import { getAuthorization } from '@/utils/authorization-util';
-import { getSearchValue } from '@/utils/common-util';
 import classNames from 'classnames';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';

--- a/web/src/components/image/index.tsx
+++ b/web/src/components/image/index.tsx
@@ -82,19 +82,24 @@ const fetchDocumentImage = (url: string, authorization: string) => {
   };
 };
 
+// Check if a URL requires authentication (internal API URLs)
+const isAuthRequiredUrl = (url: string): boolean => {
+  return url.startsWith('/api/v1/') || url.includes('/documents/images/');
+};
+
 export const useDocumentImageUrl = (id: string, t?: string | number) => {
   const directUrl = useMemo(() => buildDocumentImageUrl(id, t), [id, t]);
-  const [imageUrl, setImageUrl] = useState(() =>
-    getAuthorization() && getSearchValue('shared_id') ? '' : directUrl,
-  );
+  const [imageUrl, setImageUrl] = useState<string>('');
 
   useEffect(() => {
-    const authorization = getAuthorization();
-    if (!authorization || !getSearchValue('shared_id')) {
+    // For non-API URLs (e.g., base64, external URLs), use directly
+    if (!isAuthRequiredUrl(directUrl)) {
       setImageUrl(directUrl);
       return;
     }
 
+    // For API URLs that require authentication, always fetch with auth headers
+    const authorization = getAuthorization();
     let ignore = false;
     setImageUrl('');
     const { promise, release } = fetchDocumentImage(directUrl, authorization);
@@ -118,6 +123,69 @@ export const useDocumentImageUrl = (id: string, t?: string | number) => {
   }, [directUrl]);
 
   return imageUrl;
+};
+
+/**
+ * Hook to convert any authenticated URL to a blob URL for use in <img> tags.
+ * Use this for thumbnail URLs or any other API URLs that require authentication.
+ */
+export const useAuthenticatedImageUrl = (url: string | undefined | null) => {
+  const [imageUrl, setImageUrl] = useState<string>('');
+
+  useEffect(() => {
+    if (!url || !isAuthRequiredUrl(url)) {
+      setImageUrl(url || '');
+      return;
+    }
+
+    const authorization = getAuthorization();
+    let cancelled = false;
+    setImageUrl('');
+
+    const { promise, release } = fetchDocumentImage(url, authorization);
+    promise
+      .then((blobUrl) => {
+        if (!cancelled) {
+          setImageUrl(blobUrl);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setImageUrl('');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      release();
+    };
+  }, [url]);
+
+  return imageUrl;
+};
+
+/**
+ * Component that renders an <img> tag with proper authentication for API URLs.
+ * Use this instead of <img src={apiUrl}> when the URL requires authentication.
+ */
+export const AuthenticatedImg = ({
+  src,
+  alt,
+  className,
+  ...props
+}: React.ImgHTMLAttributes<HTMLImageElement>) => {
+  const authenticatedSrc = useAuthenticatedImageUrl(src);
+
+  if (!authenticatedSrc) return null;
+
+  return (
+    <img
+      src={authenticatedSrc}
+      alt={alt}
+      className={className}
+      {...props}
+    />
+  );
 };
 
 const Image = ({ id, t, label, className, ...props }: IImage) => {

--- a/web/src/components/image/index.tsx
+++ b/web/src/components/image/index.tsx
@@ -83,8 +83,20 @@ const fetchDocumentImage = (url: string, authorization: string) => {
 };
 
 // Check if a URL requires authentication (internal API URLs)
+// Only attach Authorization headers to same-origin requests to prevent token leakage
 const isAuthRequiredUrl = (url: string): boolean => {
-  return url.startsWith('/api/v1/') || url.includes('/documents/images/');
+  try {
+    const parsedUrl = new URL(url, window.location.origin);
+    if (parsedUrl.origin !== window.location.origin) {
+      return false;
+    }
+    return (
+      parsedUrl.pathname.startsWith('/api/v1/') ||
+      parsedUrl.pathname.includes('/documents/images/')
+    );
+  } catch {
+    return false;
+  }
 };
 
 export const useDocumentImageUrl = (id: string, t?: string | number) => {
@@ -172,11 +184,14 @@ export const AuthenticatedImg = ({
   src,
   alt,
   className,
+  fallback,
   ...props
-}: React.ImgHTMLAttributes<HTMLImageElement>) => {
+}: React.ImgHTMLAttributes<HTMLImageElement> & {
+  fallback?: React.ReactNode;
+}) => {
   const authenticatedSrc = useAuthenticatedImageUrl(src);
 
-  if (!authenticatedSrc) return null;
+  if (!authenticatedSrc) return fallback ?? null;
 
   return (
     <img

--- a/web/src/components/markdown-content/index.tsx
+++ b/web/src/components/markdown-content/index.tsx
@@ -1,4 +1,4 @@
-import Image from '@/components/image';
+import Image, { AuthenticatedImg } from '@/components/image';
 import SvgIcon from '@/components/svg-icon';
 import { MarkdownRemarkPlugins } from '@/constants/markdown-remark-plugins';
 import { IReference, IReferenceChunk } from '@/interfaces/database/chat';
@@ -203,7 +203,7 @@ const MarkdownContent = ({
             {documentId && (
               <section className="flex gap-1">
                 {fileThumbnail ? (
-                  <img
+                  <AuthenticatedImg
                     src={fileThumbnail}
                     alt=""
                     className={styles.fileThumbnail}

--- a/web/src/components/next-markdown-content/index.tsx
+++ b/web/src/components/next-markdown-content/index.tsx
@@ -1,4 +1,4 @@
-import Image from '@/components/image';
+import Image, { AuthenticatedImg } from '@/components/image';
 import SvgIcon from '@/components/svg-icon';
 import { MarkdownRemarkPlugins } from '@/constants/markdown-remark-plugins';
 import { IReferenceChunk, IReferenceObject } from '@/interfaces/database/chat';
@@ -296,7 +296,7 @@ function MarkdownContent({
             {documentId && (
               <div className="flex gap-1">
                 {fileThumbnail ? (
-                  <img
+                  <AuthenticatedImg
                     src={fileThumbnail}
                     alt=""
                     className={styles.fileThumbnail}

--- a/web/src/pages/next-search/markdown-content/index.tsx
+++ b/web/src/pages/next-search/markdown-content/index.tsx
@@ -1,4 +1,4 @@
-import Image from '@/components/image';
+import Image, { AuthenticatedImg } from '@/components/image';
 import SvgIcon from '@/components/svg-icon';
 import { MarkdownRemarkPlugins } from '@/constants/markdown-remark-plugins';
 import { IReference, IReferenceChunk } from '@/interfaces/database/chat';
@@ -185,7 +185,7 @@ const MarkdownContent = ({
             {documentId && (
               <div className="flex gap-2">
                 {fileThumbnail ? (
-                  <img
+                  <AuthenticatedImg
                     src={fileThumbnail}
                     alt=""
                     className={styles.fileThumbnail}


### PR DESCRIPTION
### Summary

This PR enhances the frontend image and document preview components with **authenticated image request support**.

**Background**: File thumbnails and certain image resources require Authorization headers to be fetched from protected API endpoints. Previously, these resources would fail to load due to missing authentication.

### Changes

- **Add `AuthenticatedImg` component** (`web/src/components/image/index.tsx`)
  - New component that automatically attaches `Authorization` header when fetching images
  - Uses fetch API with proper auth headers for authenticated requests

- **Update file-icon component** (`web/src/components/file-icon/index.tsx`)
  - Replace standard `<img>` with `<AuthenticatedImg>` for document thumbnails
  - Ensures file icons display correctly with authenticated endpoints

- **Update markdown-content components** (3 files)
  - Use `<AuthenticatedImg>` for file thumbnails in:
    - `web/src/components/markdown-content/index.tsx`
    - `web/src/components/next-markdown-content/index.tsx`
    - `web/src/pages/next-search/markdown-content/index.tsx`

- **Improve error handling** (`web/src/components/document-preview/hooks.ts`)
  - Add try-catch for network error handling
  - Properly distinguish between binary (PDF) and JSON responses
  - Prevent false errors when loading binary document data

- **Simplify PDF previewer** (`web/src/components/document-preview/index.tsx`)
  - Clean up conditional rendering logic

### Test plan

- [ ] Verify file thumbnails load correctly in knowledge base list view
- [ ] Test document preview works for both PDF and other formats
- [ ] Confirm markdown content renders thumbnails properly in chat/search results
- [ ] Check error states display appropriately for failed/missing documents