### PR TITLE
fix: normalize Q&A parser ID key to lowercase 'qa'

### DIFF
--- a/internal/service/oauth_login.go
+++ b/internal/service/oauth_login.go
@@ -233,7 +233,7 @@ func (s *UserService) registerOAuthUser(channel string, info *oauth.UserInfo) (*
 		ASRID:     cfg.UserDefaultLLM.DefaultModels.ASRModel.Name,
 		Img2TxtID: cfg.UserDefaultLLM.DefaultModels.Image2TextModel.Name,
 		RerankID:  cfg.UserDefaultLLM.DefaultModels.RerankModel.Name,
-		ParserIDs: "naive:General,Q&A:Q&A,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
+		ParserIDs: "naive:General,qa:Q&A,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
 		Status:    &status,
 	}
 	userTenantID := utility.GenerateToken()

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -202,7 +202,7 @@ func (s *UserService) Register(req *RegisterRequest) (*entity.User, common.Error
 		RerankID:  rerankID,
 		TTSID:     ttsID,
 		OCRID:     ocrID,
-		ParserIDs: "naive:General,Q&A:Q&A,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
+		ParserIDs: "naive:General,qa:Q&A,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
 		Status:    &status,
 	}
 	userTenantID := utility.GenerateToken()


### PR DESCRIPTION
### Summary

This PR normalizes the parser ID key for the Q&A parser to use lowercase format for consistency with other parser IDs.

**Changes:**
- Updated `ParserIDs` in `internal/service/oauth_login.go`: Changed `'Q&A:Q&A'` → `'qa:Q&A'`
- Updated `ParserIDs` in `internal/service/user.go`: Changed `'Q&A:Q&A'` → `'qa:Q&A'`

**Background:**
The Q&A parser ID used uppercase `Q&A` as its key, while all other parsers use lowercase keys (e.g., `naive`, `manual`, `table`). This change ensures consistency across all default parser IDs assigned during user registration (both OAuth and standard registration flows).