### PR TITLE
fix: always return a Unix timestamp for `created` in OpenAI-compat responses

### DIFF
--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -438,7 +438,7 @@ def get_data_openai(id=None, created=None, model=None, prompt_tokens=0, completi
     return {
         "id": f"{id}",
         "object": object,
-        "created": int(time.time()) if created else None,
+        "created": created if created is not None else int(time.time()),
         "model": model,
         "param": param,
         "usage": {


### PR DESCRIPTION
## Summary

`get_data_openai()` in `api/utils/api_utils.py` returned `"created": null` whenever the caller did not supply a `created` argument, breaking OpenAI-compatible clients that expect an integer Unix timestamp.

## Root Cause

```python
# before
"created": int(time.time()) if created else None,
```

- Default `created=None` → falsy → produces `null`
- Explicit caller timestamp → truthy but immediately replaced by `int(time.time())`

Both behaviours are wrong.  One user-facing path is `api/db/services/canvas_service.py`, which calls `get_data_openai()` for non-streaming agent responses without a `created` value.

## Fix

```python
# after
"created": created if created is not None else int(time.time()),
```

Uses the caller-supplied value when provided; otherwise defaults to the current Unix timestamp.

## Files Changed

- `api/utils/api_utils.py` — one-line fix (+1 / -1)

Closes #16400