### PR TITLE
fix: use split("@", 2) to handle model names containing `@` in list_tenant_added_models

### DIFF
--- a/api/apps/services/models_api_service.py
+++ b/api/apps/services/models_api_service.py
@@ -385,7 +385,7 @@ def list_tenant_added_models(tenant_id: str, model_type_filter: str=None):
             model_records = model_record_map.get(model_record_key, [])
             if not model_records:
                 continue
-            provider_id, instance_id, model_name = model_record_key.split("@")
+            provider_id, instance_id, model_name = model_record_key.split("@", 2)
             model_types = [model.model_type for model in model_records if model.status == ActiveStatusEnum.ACTIVE.value]
             if not model_types:
                 continue


### PR DESCRIPTION
## Summary

`GET /api/v1/models` crashes with `ValueError: too many values to unpack (expected 3)` when any manually-added model has a name that contains `@` — a common pattern for LM-Studio quantisation suffixes (e.g. `llama3.2:3b@q8_0`).

## Root Cause

Model record keys are built as:

```python
instance_model_key = f"{model.provider_id}@{model.instance_id}@{model.model_name}"
```

In `list_tenant_added_models`, these keys are unpacked with:

```python
provider_id, instance_id, model_name = model_record_key.split("@")
```

`split("@")` without a `maxsplit` produces more than 3 parts when `model_name` itself contains `@`, raising `ValueError`.  The exception is unhandled, so the entire `GET /api/v1/models` endpoint returns 500 for that tenant until the server restarts.

## Fix

```python
provider_id, instance_id, model_name = model_record_key.split("@", 2)
```

`split("@", 2)` caps at two splits, placing everything after the second `@` into `model_name` — correctly reconstructing the original value regardless of how many `@` characters it contains.

## Files Changed

- `api/apps/services/models_api_service.py` — one-character fix (+1 / -1)

Closes #16467