### PR TITLE
fix(go): shared chatbot session id length

### DIFF
--- a/internal/service/bot_completion.go
+++ b/internal/service/bot_completion.go
@@ -40,7 +40,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"ragflow/internal/agent/canvas"
@@ -284,7 +283,7 @@ func (s *BotService) ChatbotCompletion(
 			},
 		})
 		session = &entity.API4Conversation{
-			ID:       uuid.NewString(),
+			ID:       common.GenerateUUID(),
 			DialogID: dialogID,
 			UserID:   tenantID,
 			Message:  seedMsg,


### PR DESCRIPTION
## Summary
- use the project-standard 32-character ID generator when creating shared chatbot sessions
- fix MySQL insert failures caused by writing 36-character UUID strings into `api_4_conversation.id`