### PR TITLE
Fix: disable agent tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -233,6 +233,7 @@ jobs:
           set -euo pipefail
           PKGS=$(go list ./... 2>/dev/null \
             | grep -v '/internal/storage$' \
+            | grep -v '/internal/agent$' \
             | grep -v '/internal/tokenizer$' \
             | grep -v '/internal/handler$' || true)
           if [ -z "$PKGS" ]; then


### PR DESCRIPTION
### Summary

Per discussion with @yuzhichang , disable agent test firstly.

 https://github.com/infiniflow/ragflow/actions/runs/28562749273/job/84704079689?pr=16521   [0.094ms] [rows:0] SELECT * FROM `tenant_model_instance` WHERE provider_id = "provider-1" AND instance_name = "default" ORDER BY `tenant_model_instance`.`id` LIMIT 1
  --- FAIL: TestInvoke_ProxyDNSPin (2.00s)
      invoke_test.go:375: dial error = Invoke: do: Get "http://8.8.8.8/api": context deadline exceeded; want pinned proxy IP 192.88.99.1:9999 (connection-refused is acceptable; an absent IP means the dialer fell through to the default resolver and the pinning regression went undetected)
  2026/07/02 14:34:58 /home/infiniflow/runners_work/tower01-9dd627fd9c44/ragflow/ragflow/internal/dao/kb.go:79 record not found
  [0.358ms] [rows:0] SELECT * FROM `knowledgebase` WHERE id = "da1" AND status = "1" ORDER BY `knowledgebase`.`id` LIMIT 1
  2026/07/02 14:34:58 /home/infiniflow/runners_work/tower01-9dd627fd9c44/ragflow/ragflow/internal/dao/kb.go:79 record not found
  [0.283ms] [rows:0] SELECT * FROM `knowledgebase` WHERE id = "da1" AND status = "1" ORDER BY `knowledgebase`.`id` LIMIT 1
  2026/07/02 14:34:58 /home/infiniflow/runners_work/tower01-9dd627fd9c44/ragflow/ragflow/internal/dao/kb.go:79 record not found
  [0.523ms] [rows:0] SELECT * FROM `knowledgebase` WHERE id = "da1" AND status = "1" ORDER BY `knowledgebase`.`id` LIMIT 1
  2026/07/02 14:34:58 ExpectPing will have no effect as monitoring pings is disabled. Use MonitorPingsOption to enable.
  FAIL
  FAIL    ragflow/internal/agent/component    2.759s
  ok      ragflow/internal/agent/component/io    0.026s
