### PR TITLE
fix: prevent duplicate MCP server name when editing

### DIFF
--- a/api/apps/restful_apis/mcp_api.py
+++ b/api/apps/restful_apis/mcp_api.py
@@ -184,6 +184,10 @@ async def update(mcp_id: str) -> Response:
     server_name = req.get("name", mcp_server.name)
     if server_name and len(server_name.encode("utf-8")) > 255:
         return get_data_error_result(message=f"Invalid MCP name or length is {len(server_name)} which is large than 255.")
+    if server_name and server_name != mcp_server.name:
+        e, _ = MCPServerService.get_by_name_and_tenant(name=server_name, tenant_id=current_user.id)
+        if e:
+            return get_data_error_result(message="Duplicated MCP server name.")
     url = req.get("url", mcp_server.url)
     hostname, resolved_ip, url_error = _assert_mcp_url_is_safe(url)
     if url_error:


### PR DESCRIPTION
### Summary

This PR fixes the MCP server update endpoint so that editing a server no longer allows names that conflict with another existing server owned by the same tenant. The creation endpoint already rejects duplicate names; this change applies the same validation to the edit endpoint, while still allowing the server to keep its current name.

Fix #ci