### PR TITLE
fix: prevent exporting empty MCP server selection

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -3020,6 +3020,7 @@ Important structured information may include: names, dates, locations, events, k
       bulkManage: 'Bulk manage',
       exitBulkManage: 'Exit bulk manage',
       selected: 'Selected',
+      noServerSelected: 'Please select at least one MCP server',
     },
     search: {
       searchApps: 'Search apps',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -2603,6 +2603,7 @@ Tokenizer 会根据所选方式将内容存储为对应的数据结构。`,
       selected: '已选择',
       bulkManage: '批量管理',
       exitBulkManage: '退出批量管理',
+      noServerSelected: '请至少选择一个 MCP 服务器',
     },
     search: {
       searchApps: '搜索',

--- a/web/src/pages/user-setting/mcp/use-export-mcp.ts
+++ b/web/src/pages/user-setting/mcp/use-export-mcp.ts
@@ -1,16 +1,22 @@
+import message from '@/components/ui/message';
 import { useExportMcpServer } from '@/hooks/use-mcp-request';
 import { IMcpServer } from '@/interfaces/database/mcp';
 import { downloadJsonFile } from '@/utils/file-util';
+import i18n from '@/locales/config';
 import { useCallback } from 'react';
 
-export function useExportMcp(mcp: IMcpServer) {
+export function useExportMcp(mcp?: IMcpServer) {
   const { exportMcpServer } = useExportMcpServer();
 
   const handleExportMcpJson = useCallback(
     (ids: string[]) => async () => {
+      if (ids.length === 0) {
+        message.warning(i18n.t('mcp.noServerSelected'));
+        return;
+      }
       const data = await exportMcpServer(ids);
-      if (data.code === 0 && mcp) {
-        downloadJsonFile(data.data, `${mcp.name || 'mcp'}.json`);
+      if (data.code === 0) {
+        downloadJsonFile(data.data, `${mcp?.name || 'mcp'}.json`);
       }
     },
     [exportMcpServer, mcp],


### PR DESCRIPTION
### Summary

This PR fixes a bug in the MCP server batch management UI where clicking **Export** without selecting any MCP server would still call the backend and download an empty JSON file. Now, if no server is selected, a warning is shown and the export is aborted.

### Changes

- Guard  against an empty  array before calling .
- Make the single-server  parameter optional so the bulk-export call site () works without passing an argument.
- Add the  i18n key in both  and .

### Related issue

None.