### PR TITLE
i18n: localize visual input file label in agent form

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -2018,6 +2018,7 @@ Best for: Documents with flowing, contextually connected content — such as boo
       recommended: 'Recommended',
       customerSupport: 'Customer support',
       marketing: 'Marketing',
+      visualInputFile: 'Visual input file',
       consumerApp: 'Consumer app',
       other: 'Other',
       ingestionPipeline: 'Ingestion pipeline',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1678,6 +1678,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       recommended: '推荐',
       customerSupport: '客户支持',
       marketing: '营销',
+      visualInputFile: '视觉输入文件',
       consumerApp: '消费者应用',
       other: '其他',
       agents: '智能体',

--- a/web/src/pages/agent/form/agent-form/index.tsx
+++ b/web/src/pages/agent/form/agent-form/index.tsx
@@ -164,7 +164,7 @@ function AgentForm({ node }: INextOperatorForm) {
           ) && (
             <QueryVariable
               name="visual_files_var"
-              label="Visual Input File"
+              label={t('flow.visualInputFile')}
               types={[VariableType.File]}
             ></QueryVariable>
           )}

--- a/web/src/pages/agent/form/components/query-variable.tsx
+++ b/web/src/pages/agent/form/components/query-variable.tsx
@@ -76,9 +76,9 @@ export function QueryVariable({
       name={name}
       render={({ field }) => (
         <FormItem className={className}>
-          {hideLabel || label || (
-            <FormLabel tooltip={t('flow.queryTip')}>
-              {t('flow.query')}
+          {hideLabel || (
+            <FormLabel tooltip={label ? undefined : t('flow.queryTip')}>
+              {label || t('flow.query')}
             </FormLabel>
           )}
           <FormControl>{renderWidget(field.value, field.onChange)}</FormControl>


### PR DESCRIPTION
### Summary

Localized the "Visual Input File" label in the agent form by replacing the hardcoded English string with a translatable i18n key (`flow.visualInputFile`). Added the corresponding English and Chinese translations.

Also fixed the label styling so that a custom `label` passed to `QueryVariable` is wrapped in the same `FormLabel` component as other form fields, ensuring consistent font/appearance with surrounding labels.

<img width="576" height="819" alt="Screenshot_20260703_152509" src="https://github.com/user-attachments/assets/bee3a265-d909-4c33-a96a-bae526de6844" />

