### PR TITLE
fix(web): add null-safety guards before saving agent graph

### DIFF
--- a/web/src/pages/agent/hooks/use-save-graph.ts
+++ b/web/src/pages/agent/hooks/use-save-graph.ts
@@ -28,10 +28,15 @@ export const useSaveGraph = (showMessage: boolean = true) => {
       },
       release?: boolean,
     ) => {
+      if (!data || !id) return;
+
+      const dsl = buildDslData(currentNodes, otherParam);
+      if (!dsl) return;
+
       const params: Record<string, any> = {
         id,
-        title: data.title,
-        dsl: buildDslData(currentNodes, otherParam),
+        title: data.title ?? '',
+        dsl,
       };
 
       if (release) {
@@ -86,7 +91,9 @@ export const useWatchAgentChange = (chatDrawerVisible: boolean) => {
   const saveAgent = useCallback(async () => {
     if (!chatDrawerVisible) {
       const ret = await saveGraph();
-      setSaveTime(ret.data.update_time);
+      if (ret?.data?.update_time) {
+        setSaveTime(ret.data.update_time);
+      }
     }
   }, [chatDrawerVisible, saveGraph, setSaveTime]);
 


### PR DESCRIPTION
### Summary

The agent/pipeline canvas occasionally crashes with `TypeError: null has no properties` when the save flow runs before the agent detail fetch has completed. The unguarded `data.title` access and the unconditional `setAgent` call could also fire an aborted request when the user navigated away.

### Changes

- Guard `saveGraph` so it returns early when `useFetchAgent` data or `id` is not yet available.
- Fall back to an empty string when `data.title` is missing.
- Bail out if `buildDslData` returns a falsy value.
- Guard `ret.data.update_time` access in `useWatchAgentChange` so the auto-save handler does not crash on a skipped/undefined response.

### How to test

1. Open an existing agent or pipeline canvas.
2. Throttle the network or refresh the page and immediately interact with the canvas.
3. Confirm that no `TypeError: null has no properties` / `Request aborted` errors appear in the console and the canvas stays interactive.

### Related issues

Fixes the agent canvas blank page / crash reported on stage.ragflow.io.

- [x] I have performed a self-check on the changes.
