### PR TITLE
fix(connector): propagate WebDAV root listing error to prevent silent prune of all documents

### DIFF
--- a/common/data_source/webdav_connector.py
+++ b/common/data_source/webdav_connector.py
@@ -235,7 +235,8 @@ class WebDAVConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
                         
         except Exception as e:
             logging.error(f"Error listing directory {path}: {e}")
-            
+            raise
+
         return files
 
     def _yield_webdav_documents(


### PR DESCRIPTION
## Summary

Closes #16636

A transient WebDAV listing failure (network timeout, auth error, server outage) could silently delete **every document** in a knowledge base during the next sync prune cycle.

## Root cause

`_list_files_recursive()` swallows the exception from the root-level `client.ls(path)` call and returns an empty `files = []`:

```python
except Exception as e:
    logging.error(f"Error listing directory {path}: {e}")
    # falls through and returns []
return files
```

Downstream, `_collect_prune_snapshot()` only guards against `None`, not `[]`:

```python
if file_list is None:   # empty list passes this guard
    return None
```

So `cleanup_stale_documents_for_task()` receives an empty retain set and deletes everything.

## Fix

Add `raise` after the logging call so the exception propagates up through `retrieve_all_slim_docs_perm_sync()` to `_collect_prune_snapshot()`, where the existing `except Exception` handler catches it, logs it, and **returns `None`** — which already aborts the prune cycle safely.

```python
except Exception as e:
    logging.error(f"Error listing directory {path}: {e}")
    raise   # ← propagate so callers can detect listing failure
```

Sub-directory errors (inner `try/except` blocks) continue to be caught-and-skipped as before — only the root listing failure is now propagated.

## Impact

- Before: any root listing failure → silent deletion of all synced documents.
- After: root listing failure → prune aborted, documents preserved, error logged.