### PR TITLE
fix(go-agent): Yahoofinance input and run

### DIFF
--- a/internal/agent/component/fixture_stubs.go
+++ b/internal/agent/component/fixture_stubs.go
@@ -505,4 +505,5 @@ func init() {
 	Register(componentNameAnswer, NewAnswerStub)
 	Register(componentNameIteration, NewIterationStub)
 	Register(componentNameIterationItem, NewIterationItemStub)
+	Register("YahooFinance", newYahooFinanceComponent)
 }

--- a/internal/agent/component/universe_a_wrappers.go
+++ b/internal/agent/component/universe_a_wrappers.go
@@ -821,14 +821,72 @@ func toFloatParam(v any) float64 {
 	return 0
 }
 
+// yahooFinanceComponent delegates to internal/agent/tool/YahooFinanceTool.
+type yahooFinanceComponent struct {
+	inner *agenttool.YahooFinanceTool
+}
+
+func newYahooFinanceComponent(_ map[string]any) (Component, error) {
+	return &yahooFinanceComponent{inner: agenttool.NewYahooFinanceTool()}, nil
+}
+
+func (c *yahooFinanceComponent) Name() string { return "YahooFinance" }
+
+func (c *yahooFinanceComponent) Inputs() map[string]string {
+	return map[string]string{
+		"stock_code": "Stock symbol to look up (e.g. AAPL, MSFT, 0005.HK).",
+	}
+}
+
+func (c *yahooFinanceComponent) Outputs() map[string]string {
+	return map[string]string{
+		"report": "Stock quote data (JSON).",
+	}
+}
+
+func (c *yahooFinanceComponent) Invoke(ctx context.Context, inputs map[string]any) (map[string]any, error) {
+	stockCode, _ := inputs["stock_code"].(string)
+	if strings.TrimSpace(stockCode) == "" {
+		return map[string]any{"_ERROR": "stock_code is required"}, nil
+	}
+	toolInput := map[string]any{
+		"symbols": []string{stockCode},
+	}
+	argsJSON, _ := json.Marshal(toolInput)
+	out, err := c.inner.InvokableRun(ctx, string(argsJSON))
+	if err != nil {
+		if out != "" {
+			return parseToolEnvelope(out), nil
+		}
+		return nil, fmt.Errorf("canvas: YahooFinance: %w", err)
+	}
+	result := parseToolEnvelope(out)
+	return map[string]any{"report": result["results"]}, nil
+}
+
+func (c *yahooFinanceComponent) GetInputForm() map[string]any {
+	return map[string]any{
+		"stock_code": map[string]any{
+			"type": "line",
+			"name": "Stock code/Company name",
+		},
+	}
+}
+
+func (c *yahooFinanceComponent) Stream(_ context.Context, _ map[string]any) (<-chan map[string]any, error) {
+	return nil, nil
+}
+
 // Compile-time interface checks.
 var (
 	_ Component = (*retrievalComponent)(nil)
 	_ Component = (*tavilySearchComponent)(nil)
 	_ Component = (*exesqlComponent)(nil)
 	_ Component = (*codeExecComponent)(nil)
+	_ Component = (*yahooFinanceComponent)(nil)
 )
 
 // Compile-time check that the eino InvokableTool methods we call
 // are reachable (catches a future refactor that renames them).
 var _ einotool.InvokableTool = (*agenttool.TavilyTool)(nil)
+var _ einotool.InvokableTool = (*agenttool.YahooFinanceTool)(nil)


### PR DESCRIPTION
## Summary

Debugging YahooFinance component in agent canvas returns "unknown component" and "no input_form".
YahooFinance was only registered as an eino tool, not as a runtime component. The component factory only searches the runtime registry.
- `universe_a_wrappers.go`: add `yahooFinanceComponent` wrapper delegating to `agenttool.YahooFinanceTool` with `GetInputForm()`
- `fixture_stubs.go`: register `"YahooFinance"` component

## TEST
`go build` and `go test ./internal/agent/component/...` all pass.