### PR TITLE
fix(go): add missing 'resume' chunk method for new tenants

### DIFF
--- a/internal/service/oauth_login.go
+++ b/internal/service/oauth_login.go
@@ -233,7 +233,7 @@ func (s *UserService) registerOAuthUser(channel string, info *oauth.UserInfo) (*
 		ASRID:     cfg.UserDefaultLLM.DefaultModels.ASRModel.Name,
 		Img2TxtID: cfg.UserDefaultLLM.DefaultModels.Image2TextModel.Name,
 		RerankID:  cfg.UserDefaultLLM.DefaultModels.RerankModel.Name,
-		ParserIDs: "naive:General,qa:Q&A,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
+		ParserIDs: "naive:General,qa:Q&A,resume:Resume,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
 		Status:    &status,
 	}
 	userTenantID := utility.GenerateToken()

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -202,7 +202,7 @@ func (s *UserService) Register(req *RegisterRequest) (*entity.User, common.Error
 		RerankID:  rerankID,
 		TTSID:     ttsID,
 		OCRID:     ocrID,
-		ParserIDs: "naive:General,qa:Q&A,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
+		ParserIDs: "naive:General,qa:Q&A,resume:Resume,manual:Manual,table:Table,paper:Research Paper,book:Book,laws:Laws,presentation:Presentation,picture:Picture,one:One,audio:Audio,email:Email,tag:Tag",
 		Status:    &status,
 	}
 	userTenantID := utility.GenerateToken()


### PR DESCRIPTION
### Summary

The default tenant parser_ids string used when registering new users was missing the 'resume' chunk method. As a result, the built-in chunking method dropdown in the dataset creation dialog did not offer 'Resume'.

This PR adds 'resume:Resume' to the default parser_ids in both the password registration path and the OAuth registration path, aligning them with the admin initialization string and the existing frontend parser list.

### Related issue

Fixes missing 'resume' option when creating a dataset.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Tests

- Verified the default parser_ids string now includes 'resume'.

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/b5169e9b-fb52-4396-acca-ea0233b56462" />

