### PR TITLE
fix(go-document): keep upload partial success data as array

### DIFF
--- a/internal/handler/document.go
+++ b/internal/handler/document.go
@@ -971,7 +971,11 @@ func (h *DocumentHandler) uploadLocalDocuments(c *gin.Context, kb *entity.Knowle
 
 	if strings.ToLower(c.DefaultQuery("return_raw_files", "false")) == "true" {
 		if len(errMsgs) > 0 {
-			jsonSuccess(c, gin.H{"documents": data, "errors": errMsgs})
+			c.JSON(http.StatusOK, gin.H{
+				"code":    common.CodeServerError,
+				"message": strings.Join(errMsgs, "\n"),
+				"data":    data,
+			})
 			return
 		}
 		jsonSuccess(c, data)
@@ -982,7 +986,11 @@ func (h *DocumentHandler) uploadLocalDocuments(c *gin.Context, kb *entity.Knowle
 		mapped[i] = mapDocKeysWithRunStatus(d)
 	}
 	if len(errMsgs) > 0 {
-		jsonSuccess(c, gin.H{"documents": mapped, "errors": errMsgs})
+		c.JSON(http.StatusOK, gin.H{
+			"code":    common.CodeServerError,
+			"message": strings.Join(errMsgs, "\n"),
+			"data":    mapped,
+		})
 		return
 	}
 	jsonSuccess(c, mapped)

--- a/internal/handler/document_test.go
+++ b/internal/handler/document_test.go
@@ -692,15 +692,15 @@ func TestUploadDocumentsHandler_LocalReturnsPartialSuccess(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
-	if resp["code"] != float64(common.CodeSuccess) {
-		t.Fatalf("expected success for partial upload, got %v", resp)
+	if resp["code"] != float64(common.CodeServerError) {
+		t.Fatalf("expected server error code for partial upload, got %v", resp)
 	}
-	data := resp["data"].(map[string]interface{})
-	if len(data["documents"].([]interface{})) != 1 {
-		t.Fatalf("expected one successful document, got %v", data["documents"])
+	data := resp["data"].([]interface{})
+	if len(data) != 1 {
+		t.Fatalf("expected one successful document, got %v", data)
 	}
-	if len(data["errors"].([]interface{})) != 1 {
-		t.Fatalf("expected one file error, got %v", data["errors"])
+	if !strings.Contains(resp["message"].(string), "bad.exe") {
+		t.Fatalf("expected failed file in message, got %v", resp["message"])
 	}
 }
 


### PR DESCRIPTION
### Summary

  Keep `data` as the uploaded document array when dataset document upload partially succeeds.

  This matches the Python API behavior and allows parse-on-creation to run for successfully uploaded files when other files in the same folder are unsupported.
