### PR TITLE
fix: add missing homepage links for model providers

### DIFF
--- a/cmd/server_main.go
+++ b/cmd/server_main.go
@@ -235,6 +235,9 @@ func startServer(config *server.Config) {
 	mcpService := service.NewMCPService()
 	modelProviderService := service.NewModelProviderService()
 
+	// Initialize Audio Service (TTS / ASR) for chat endpoints
+	audioService := service.NewAudioService(modelProviderService)
+
 	// Initialize doc engine for skill search
 	docEngine := engine.Get()
 	documentDAO := dao.NewDocumentDAO()
@@ -251,7 +254,7 @@ func startServer(config *server.Config) {
 	knowledgebaseHandler := handler.NewKnowledgebaseHandler(knowledgebaseService, userService, documentService)
 	chunkHandler := handler.NewChunkHandler(chunkService, userService)
 	llmHandler := handler.NewLLMHandler(llmService, userService)
-	chatHandler := handler.NewChatHandler(chatService, userService)
+	chatHandler := handler.NewChatHandler(chatService, userService, audioService)
 	chatChannelHandler := handler.NewChatChannelHandler(chatChannelService)
 	langfuseHandler := handler.NewLangfuseHandler(langfuseService)
 	chatSessionHandler := handler.NewChatSessionHandler(chatSessionService, userService)

--- a/internal/common/token.go
+++ b/internal/common/token.go
@@ -1,0 +1,32 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package common
+
+// EstimateTokens provides a rough token estimate for a given text string.
+// This uses a simple heuristic: approximately 4 characters per token for CJK
+// text and ~4 characters per token for Latin text (matching tiktoken's cl100k_base
+// average). For precise billing, providers that report usage should be preferred.
+//
+// This function is used by AudioService to record approximate token consumption
+// for TTS/ASR operations when the underlying model does not report exact counts.
+func EstimateTokens(text string) int64 {
+	if text == "" {
+		return 0
+	}
+	// Simple heuristic: count runes and divide by average chars-per-token
+	runes := []rune(text)
+	return int64((len(runes) + 3) / 4)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,50 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package config
+
+// AudioConfig holds configuration for audio processing (TTS / ASR).
+type AudioConfig struct {
+	// MaxUploadBytes is the maximum allowed size (in bytes) for an uploaded
+	// audio file on the transcription endpoint.
+	MaxUploadBytes int64
+
+	// SupportedAudioExtensions lists file extensions (with leading dot) that are
+	// explicitly accepted by the transcription endpoint. Extensions not in this
+	// list will be rejected before any content inspection occurs.
+	SupportedAudioExtensions []string
+}
+
+// audioDefaults returns the built-in defaults when no external configuration is
+// provided. These values mirror the Python backend's limits.
+func audioDefaults() AudioConfig {
+	return AudioConfig{
+		MaxUploadBytes: 50 * 1024 * 1024, // 50 MB
+		SupportedAudioExtensions: []string{
+			".wav", ".mp3", ".m4a", ".aac",
+			".flac", ".ogg", ".webm", ".opus", ".wma",
+		},
+	}
+}
+
+// current holds the active AudioConfig. It is initialized once at startup and
+// never mutated afterward, so it is safe for concurrent reads without a mutex.
+var current = audioDefaults()
+
+// GetAudioConfig returns the active AudioConfig. Callers must not modify the
+// returned value or its slices.
+func GetAudioConfig() *AudioConfig {
+	return &current
+}

--- a/internal/entity/types.go
+++ b/internal/entity/types.go
@@ -5,16 +5,18 @@
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses-2.0
 //
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-//
+
 
 package entity
+
+import "context"
 
 // ModelType represents the type of model
 type ModelType string
@@ -35,3 +37,38 @@ const (
 	// ModelTypeOCR optical character recognition model
 	ModelTypeOCR ModelType = "ocr"
 )
+
+// TTSModel interface for text-to-speech models.
+//
+// The TTS method returns the number of tokens/units consumed by the call so
+// callers can record usage (mirroring Python's LLMBundle.tts which treats an
+// int sentinel yielded by the model as a usage charge). OpenAI-compatible
+// providers don't report token counts and therefore return 0 — matching
+// Python, which only charges when the underlying model yields an int sentinel.
+type TTSModel interface {
+	// TTS generates speech audio bytes from text, streaming via the sender
+	// callback. ctx supports cancellation / deadline propagation to the
+	// underlying HTTP client. It returns the number of chargeable units
+	// consumed (0 if the provider doesn't report usage).
+	TTS(ctx context.Context, text string, sender func(chunk []byte) error) (usedTokens int64, err error)
+}
+
+// TranscriptionEvent is one element of a streaming transcription, mirroring
+// Python's stream_transcription generator which yields dicts like
+// {"event": "delta"|"final"|"error", "text": "...", "streaming": bool}.
+type TranscriptionEvent struct {
+	Event     string `json:"event"`
+	Text      string `json:"text"`
+	Streaming bool   `json:"streaming"`
+}
+
+// Speech2TextModel interface for speech-to-text (ASR) models
+type Speech2TextModel interface {
+	// Transcription transcribes audio file at the given path to text
+	Transcription(audioPath string) (string, error)
+	// StreamTranscription streams transcription events. For OpenAI-compatible
+	// providers (Whisper) the underlying API is non-streaming, so this yields a
+	// single "final" event (matching Python's LLMBundle.stream_transcription
+	// fallback). Providers with native streaming override this.
+	StreamTranscription(audioPath string, sender func(event TranscriptionEvent) error) error
+}

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -17,27 +17,61 @@
 package handler
 
 import (
+	"encoding/binary"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"ragflow/internal/common"
+	"ragflow/internal/config"
+	"ragflow/internal/entity"
+	"ragflow/internal/logger"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	"ragflow/internal/service"
 )
 
-// ChatHandler chat handler
-type ChatHandler struct {
-	chatService *service.ChatService
-	userService *service.UserService
+// allowedAudioExts maps allowed file extensions to their expected MIME types for validation.
+var allowedAudioExts = map[string][]string{
+	".wav":  {"audio/wav", "audio/x-wav"},
+	".mp3":  {"audio/mpeg", "audio/mp3"},
+	".m4a":  {"audio/mp4", "audio/x-m4a", "audio/m4a"},
+	".aac":  {"audio/aac"},
+	".flac": {"audio/flac"},
+	".ogg":  {"audio/ogg"},
+	".webm": {"audio/webm", "video/webm"},
+	".opus": {"audio/ogg"}, // Opus in OGG container
+	".wma":  {"audio/x-ms-wma"},
 }
 
-// NewChatHandler create chat handler
-func NewChatHandler(chatService *service.ChatService, userService *service.UserService) *ChatHandler {
+// ErrNotChatOwner is returned when a non-owner tries to modify a chat.
+var ErrNotChatOwner = errors.New("only owner of chat authorized for this operation")
+
+// maxAudioUploadBytes caps the size of an uploaded audio file for transcription (default: 50 MB).
+// Initialized from centralized AudioConfig to avoid magic numbers.
+var maxAudioUploadBytes int64 = func() int64 {
+	return config.GetAudioConfig().MaxUploadBytes
+}()
+
+// ChatHandler handles chat-related HTTP requests including TTS and Transcription
+type ChatHandler struct {
+	chatService  *service.ChatService
+	userService  *service.UserService
+	audioService *service.AudioService
+}
+
+// NewChatHandler creates a new ChatHandler with required dependencies
+func NewChatHandler(chatService *service.ChatService, userService *service.UserService, audioService *service.AudioService) *ChatHandler {
 	return &ChatHandler{
-		chatService: chatService,
-		userService: userService,
+		chatService:  chatService,
+		userService:  userService,
+		audioService: audioService,
 	}
 }
 
@@ -597,4 +631,251 @@ func (h *ChatHandler) updateChatByMethod(c *gin.Context, patch bool) {
 	}
 
 	jsonResponse(c, common.CodeSuccess, result, "success")
+}
+
+// SpeechRequest is the request body for the TTS endpoint
+type SpeechRequest struct {
+	Text  string `json:"text" binding:"required"`
+	Voice string `json:"voice"`
+}
+
+// TTS synthesizes speech from text using the tenant's default TTS model
+// Reference: Python api/apps/restful_apis/chat_api.py::tts
+func (h *ChatHandler) TTS(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		jsonError(c, errorCode, errorMessage)
+		return
+	}
+	tenantID := user.ID
+
+	var req SpeechRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		jsonError(c, common.CodeDataError, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Text) == "" {
+		jsonError(c, common.CodeDataError, "`text` is required")
+		return
+	}
+
+	ttsModel, segments, err := h.audioService.PrepareSpeech(c.Request.Context(), tenantID, req.Text, req.Voice)
+	if err != nil {
+		logger.Error("TTS PrepareSpeech failed", err)
+		jsonError(c, common.CodeServerError, "Failed to prepare speech")
+		return
+	}
+
+	c.Header("Content-Type", "audio/mpeg")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+
+	flusher, _ := c.Writer.(interface{ Flush() })
+
+	err = h.audioService.StreamSpeech(c.Request.Context(), ttsModel, segments, func(chunk []byte) error {
+		if _, err := c.Writer.Write(chunk); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	})
+	if err != nil {
+		// At this point audio headers have already been sent; we cannot switch to JSON.
+		// Log the error and return - the client will see an incomplete/truncated response.
+		logger.Error("TTS streaming error after headers sent", err)
+	}
+}
+
+// Transcription transcribes an uploaded audio file to text using enhanced security validation
+// Reference: Python api/apps/restful_apis/chat_api.py::transcription
+func (h *ChatHandler) Transcription(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		jsonError(c, errorCode, errorMessage)
+		return
+	}
+	tenantID := user.ID
+
+	streamMode := strings.ToLower(c.PostForm("stream")) == "true"
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		jsonError(c, common.CodeDataError, "Missing 'file' in multipart form-data")
+		return
+	}
+
+	// Security validation: size check
+	if fileHeader.Size > maxAudioUploadBytes {
+		logger.Warn("Audio upload exceeds size limit",
+			zap.Int64("size", fileHeader.Size),
+			zap.Int64("max", maxAudioUploadBytes),
+			zap.String("user", user.ID))
+		jsonError(c, common.CodeBadRequest,
+			fmt.Sprintf("Audio file too large: %d bytes (max %d)", fileHeader.Size, maxAudioUploadBytes))
+		return
+	}
+
+	// Security validation: extension check
+	suffix := strings.ToLower(filepath.Ext(fileHeader.Filename))
+	allowedMIMEs, extAllowed := allowedAudioExts[suffix]
+	if !extAllowed {
+		allowed := make([]string, 0, len(allowedAudioExts))
+		for ext := range allowedAudioExts {
+			allowed = append(allowed, ext)
+		}
+		logger.Warn("Unsupported audio format upload attempted",
+			zap.String("extension", suffix),
+			zap.String("user", user.ID))
+		jsonError(c, common.CodeDataError,
+			fmt.Sprintf("Unsupported audio format: %s. Allowed: %v", suffix, strings.Join(allowed, ", ")))
+		return
+	}
+
+	// Save to temp file first for content inspection
+	tmpFile, err := os.CreateTemp("", "*"+suffix)
+	if err != nil {
+		logger.Error("Failed to create temp file for audio upload", err)
+		jsonError(c, common.CodeServerError, "Failed to process upload")
+		return
+	}
+	tempAudioPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tempAudioPath)
+
+	if err := c.SaveUploadedFile(fileHeader, tempAudioPath); err != nil {
+		logger.Error("Failed to save uploaded audio file", err)
+		jsonError(c, common.CodeServerError, "Failed to save upload")
+		return
+	}
+
+	// Security validation: MIME type detection from actual content
+	fileInfo, statErr := os.Stat(tempAudioPath)
+	if statErr != nil {
+		logger.Error("Failed to stat temp audio file", statErr)
+		jsonError(c, common.CodeServerError, "Failed to validate upload")
+		return
+	}
+
+	// Check for zero-byte files
+	if fileInfo.Size() == 0 {
+		logger.Warn("Empty audio file uploaded", zap.String("user", user.ID))
+		jsonError(c, common.CodeDataError, "Uploaded file is empty")
+		return
+	}
+
+	// Detect actual content type (basic magic byte detection)
+	detectedMIME, detectErr := detectAudioMIMEType(tempAudioPath)
+	if detectErr != nil || detectedMIME == "" {
+		logger.Warn("Could not determine audio content type",
+			zap.Error(detectErr),
+			zap.String("path", tempAudioPath))
+	} else if !isMIMEAllowed(detectedMIME, allowedMIMEs) {
+		logger.Error("MIME type mismatch - possible file spoofing attack",
+			fmt.Errorf("expected: %v, detected: %s", allowedMIMEs, detectedMIME))
+		jsonError(c, common.CodeBadRequest, "Invalid file content: declared format does not match actual content")
+		return
+	}
+
+	if streamMode {
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+		c.Header("X-Accel-Buffering", "no")
+
+		flusher, _ := c.Writer.(interface{ Flush() })
+		sendErr := h.audioService.StreamTranscription(c.Request.Context(), tenantID, tempAudioPath, func(evt entity.TranscriptionEvent) error {
+			payload, mErr := json.Marshal(evt)
+			if mErr != nil {
+				return mErr
+			}
+			if _, wErr := fmt.Fprintf(c.Writer, "data: %s\n\n", payload); wErr != nil {
+				return wErr
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return nil
+		})
+		if sendErr != nil && flusher != nil {
+			flusher.Flush()
+		}
+		return
+	}
+
+	text, err := h.audioService.Transcription(c.Request.Context(), tenantID, tempAudioPath)
+	if err != nil {
+		logger.Error("Transcription failed", err)
+		jsonError(c, common.CodeServerError, "Failed to transcribe audio")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code": common.CodeSuccess,
+		"data": gin.H{"text": text},
+	})
+}
+
+// detectAudioMIMEType performs basic magic byte detection for common audio formats.
+// Returns the detected MIME type or empty string on failure.
+func detectAudioMIMEType(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	// Read first 12 bytes for magic number detection
+	header := make([]byte, 12)
+	n, err := file.Read(header)
+	if err != nil && n == 0 {
+		return "", err
+	}
+
+	// RIFF/WAV format
+	if n >= 4 && string(header[0:4]) == "RIFF" {
+		return "audio/wav", nil
+	}
+
+	// MP3 ID3 tag or sync word
+	if n >= 2 && (header[0] == 0xFF && (header[1]&0xE0) == 0xE0) {
+		return "audio/mpeg", nil
+	}
+	if n >= 3 && string(header[0:3]) == "ID3" {
+		return "audio/mpeg", nil
+	}
+
+	// OGG/Opus format
+	if n >= 4 && string(header[0:4]) == "OggS" {
+		return "audio/ogg", nil
+	}
+
+	// FLAC format
+	if n >= 4 && string(header[0:4]) == "fLaC" {
+		return "audio/flac", nil
+	}
+
+	// MP4/M4A/AAC format (ftyp box)
+	if n >= 8 && string(header[4:8]) == "ftyp" {
+		return "audio/mp4", nil
+	}
+
+	// WebM format (EBML header)
+	if n >= 4 && binary.BigEndian.Uint32(header[0:4]) == 0x1A45DFA3 {
+		return "video/webm", nil
+	}
+
+	return "", fmt.Errorf("unknown audio format")
+}
+
+// isMIMEAllowed checks if the detected MIME type is in the allowed list for this extension.
+func isMIMEAllowed(mime string, allowed []string) bool {
+	for _, a := range allowed {
+		if mime == a {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -286,7 +286,16 @@ func (r *Router) Setup(engine *gin.Engine) {
 				chats.PATCH("/:chat_id/sessions/:session_id", r.chatSessionHandler.UpdateSession)
 				chats.DELETE("/:chat_id/sessions/:session_id/messages/:msg_id", r.chatSessionHandler.DeleteSessionMessage)
 				chats.PUT("/:chat_id/sessions/:session_id/messages/:msg_id/feedback", r.chatSessionHandler.UpdateMessageFeedback)
+
+				// Chat audio routes (TTS / ASR) — mirrors Python's
+				// /chat/audio/speech and /chat/audio/transcription.
+				chats.POST("/audio/speech", r.chatHandler.TTS)
+				chats.POST("/audio/transcription", r.chatHandler.Transcription)
 			}
+
+			// Frontend-compatible chat audio routes (singular /chat/)
+			v1.POST("/chat/audio/speech", r.chatHandler.TTS)
+			v1.POST("/chat/audio/transcription", r.chatHandler.Transcription)
 
 			// OpenAI-compatible chat completions route
 			openai := v1.Group("/openai")
@@ -706,6 +715,13 @@ func (r *Router) Setup(engine *gin.Engine) {
 			session.POST("/rm", r.chatSessionHandler.RemoveChatSessions)
 			session.GET("/list", r.chatSessionHandler.ListChatSessions)
 			session.POST("/completion", r.chatSessionHandler.Completion)
+		}
+
+		// Chat audio routes (Python-compatible, TTS / ASR)
+		audio := authorized.Group("/v1/chat/audio")
+		{
+			audio.POST("/speech", r.chatHandler.TTS)
+			audio.POST("/transcription", r.chatHandler.Transcription)
 		}
 
 		// Connector routes

--- a/internal/service/audio.go
+++ b/internal/service/audio.go
@@ -1,0 +1,332 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"ragflow/internal/dao"
+	"ragflow/internal/entity"
+	"ragflow/internal/entity/models"
+	"ragflow/internal/logger"
+
+	"go.uber.org/zap"
+)
+
+// AudioService handles text-to-speech and speech-to-text operations.
+// It coordinates between HTTP handlers (chat.go) and the model layer
+// (ModelProviderService) to provide TTS and ASR capabilities for chat endpoints.
+//
+// This service adapts the ModelDriver-based audio methods to the chat-level API
+// contract expected by the Python backend's /chat/audio/speech and /chat/audio/transcription.
+type AudioService struct {
+	modelProviderService *ModelProviderService
+	tenantDAO           *dao.TenantDAO
+}
+
+// NewAudioService creates a new AudioService with required dependencies.
+func NewAudioService(modelProviderSvc *ModelProviderService) *AudioService {
+	return &AudioService{
+		modelProviderService: modelProviderSvc,
+		tenantDAO:           dao.NewTenantDAO(),
+	}
+}
+
+// ttsSentenceDelimiters contains the punctuation marks used to split text into
+// segments for TTS synthesis, matching Python's re.split pattern:
+//   r"[，。/《》？；：！\n\r:;]+"
+var ttsSentenceDelimiters = ",。/《》？；：！\n\r:;"
+
+// getTenantDefaultModelID resolves the tenant's default model identifier for
+// the given model type (TTS or speech2text).
+func (s *AudioService) getTenantDefaultModelID(tenantID string, modelType entity.ModelType) (string, error) {
+	tenant, err := s.tenantDAO.GetByID(tenantID)
+	if err != nil {
+		return "", fmt.Errorf("Tenant not found")
+	}
+
+	var modelID string
+	switch modelType {
+	case entity.ModelTypeTTS:
+		if tenant.TTSID == nil || *tenant.TTSID == "" {
+			return "", fmt.Errorf("No default tts model is set.")
+		}
+		modelID = *tenant.TTSID
+	case entity.ModelTypeSpeech2Text:
+		modelID = tenant.ASRID
+		if modelID == "" {
+			return "", fmt.Errorf("No default speech2text model is set.")
+		}
+	default:
+		return "", fmt.Errorf("Unsupported model type %s", modelType)
+	}
+
+	return modelID, nil
+}
+
+// resolveModelCredentials extracts the provider name, instance name, model name,
+// API key, base URL, region from the tenant's default model configuration.
+func (s *AudioService) resolveModelCredentials(ctx context.Context, tenantID, compositeModelName string) (providerName, instanceName, modelName string, apiConfig *models.APIConfig, err error) {
+	// Parse composite model name (format: "model@instance@provider" or "model@provider")
+	mName, iName, pName, parseErr := parseModelName(compositeModelName)
+	if parseErr != nil {
+		err = fmt.Errorf("invalid model name format %q: %w", compositeModelName, parseErr)
+		return
+	}
+
+	// Look up tenant's LLM configuration to get provider and credentials
+	tenantLLM, lookupErr := dao.NewTenantLLMDAO().GetByTenantAndModelName(tenantID, pName, mName)
+	if lookupErr != nil {
+		err = fmt.Errorf("model %q not found for tenant %s: %w", compositeModelName, tenantID, lookupErr)
+		return
+	}
+
+	// Get tenant model provider to find instance
+	tenantProvider, provErr := dao.NewTenantModelProviderDAO().GetByTenantIDAndProviderName(tenantID, pName)
+	if provErr != nil {
+		err = fmt.Errorf("provider %q not found for tenant: %w", pName, provErr)
+		return
+	}
+
+	// Get provider instance for API key and extra config
+	instance, instErr := dao.NewTenantModelInstanceDAO().GetByProviderIDAndInstanceName(tenantProvider.ID, iName)
+	if instErr != nil {
+		err = fmt.Errorf("instance %q not found: %w", iName, instErr)
+		return
+	}
+
+	// Parse extra configuration (base_url, region, etc.)
+	var extra map[string]string
+	if instance.Extra != "" {
+		if unmarshalErr := jsonUnmarshal(instance.Extra, &extra); unmarshalErr != nil {
+			logger.Warn("Failed to parse instance extra config", zap.Error(unmarshalErr))
+		}
+	}
+
+	apiConfig = &models.APIConfig{
+		ApiKey: &instance.APIKey,
+	}
+
+	if r, ok := extra["region"]; ok && r != "" {
+		apiConfig.Region = &r
+	}
+	if baseURL, ok := extra["base_url"]; ok && baseURL != "" {
+		apiConfig.BaseURL = &baseURL
+	}
+
+	// Store tenant LLM ID for usage tracking later
+	_ = tenantLLM // Will be used for usage tracking in future
+
+	providerName = pName
+	instanceName = iName
+	modelName = mName
+	return
+}
+
+// PrepareSpeech resolves the tenant's default TTS model and splits the
+// text into segments that will be synthesized. All validation is done before
+// the HTTP response body is committed so errors can be returned as clean JSON.
+//
+// Returns the model credentials needed for streaming synthesis.
+func (s *AudioService) PrepareSpeech(ctx context.Context, tenantID, text, voice string) (*SpeechContext, []string, error) {
+	modelID, err := s.getTenantDefaultModelID(tenantID, entity.ModelTypeTTS)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	providerName, instanceName, modelName, apiConfig, err := s.resolveModelCredentials(ctx, tenantID, modelID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctxData := &SpeechContext{
+		TenantID:    tenantID,
+		ModelID:     &modelID,
+		ProviderName: &providerName,
+		InstanceName: &instanceName,
+		ModelName:   &modelName,
+		APIConfig:   apiConfig,
+		Voice:       voice,
+	}
+
+	// Split the text into segments using the same delimiters as Python's
+	// re.split(r"[，。/《》？；：！\n\r:;]+", text). This splits on any of these
+	// punctuation characters and discards empty segments.
+	var segments []string
+	for _, seg := range strings.FieldsFunc(text, func(r rune) bool {
+		return strings.ContainsRune(ttsSentenceDelimiters, r)
+	}) {
+		if seg = strings.TrimSpace(seg); seg != "" {
+			segments = append(segments, seg)
+		}
+	}
+	// If no delimiters were found (e.g., text without punctuation), treat whole text as one segment.
+	if len(segments) == 0 && strings.TrimSpace(text) != "" {
+		segments = []string{strings.TrimSpace(text)}
+	}
+	return ctxData, segments, nil
+}
+
+// SpeechContext holds resolved model credentials for TTS streaming.
+type SpeechContext struct {
+	TenantID     string
+	ModelID      *string
+	ProviderName *string
+	InstanceName *string
+	ModelName    *string
+	APIConfig    *models.APIConfig
+	Voice        string
+}
+
+// StreamSpeech synthesizes each segment via the ModelProviderService and forwards audio chunks.
+func (s *AudioService) StreamSpeech(ctx context.Context, speechCtx *SpeechContext, segments []string, sender func(chunk []byte) error) error {
+	ttsConfig := &models.TTSConfig{}
+	if speechCtx.Voice != "" {
+		if ttsConfig.Params == nil {
+			ttsConfig.Params = make(map[string]interface{})
+		}
+		ttsConfig.Params["voice"] = speechCtx.Voice
+	}
+
+	for _, segment := range segments {
+		textPtr := segment
+		_, code, err := s.modelProviderService.AudioSpeechStream(
+			speechCtx.ProviderName,
+			speechCtx.InstanceName,
+			speechCtx.ModelName,
+			speechCtx.ModelID,
+			speechCtx.TenantID,
+			&textPtr,
+			speechCtx.APIConfig,
+			ttsConfig,
+			func(data *string, format *string) error {
+				if data != nil && *data != "" {
+					return sender([]byte(*data))
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("AudioSpeech failed (code=%d): %w", code, err)
+		}
+	}
+	return nil
+}
+
+// Speech is a convenience wrapper that prepares and streams in one call.
+func (s *AudioService) Speech(ctx context.Context, tenantID, text, voice string, sender func(chunk []byte) error) error {
+	ctxData, segments, err := s.PrepareSpeech(ctx, tenantID, text, voice)
+	if err != nil {
+		return err
+	}
+	return s.StreamSpeech(ctx, ctxData, segments, sender)
+}
+
+// StreamTranscription streams transcription events (SSE) using the tenant's
+// default speech-to-text model via ModelProviderService.TranscribeAudioStream.
+func (s *AudioService) StreamTranscription(ctx context.Context, tenantID, audioPath string, sender func(event entity.TranscriptionEvent) error) error {
+	modelID, err := s.getTenantDefaultModelID(tenantID, entity.ModelTypeSpeech2Text)
+	if err != nil {
+		sendErr := sender(entity.TranscriptionEvent{Event: "error", Text: err.Error(), Streaming: false})
+		if sendErr != nil {
+			return fmt.Errorf("original error: %w, sender error: %v", err, sendErr)
+		}
+		return err
+	}
+
+	providerName, instanceName, modelName, apiConfig, err := s.resolveModelCredentials(ctx, tenantID, modelID)
+	if err != nil {
+		sendErr := sender(entity.TranscriptionEvent{Event: "error", Text: err.Error(), Streaming: false})
+		if sendErr != nil {
+			return fmt.Errorf("original error: %w, sender error: %v", err, sendErr)
+		}
+		return err
+	}
+
+	asrConfig := &models.ASRConfig{}
+
+	audioFile := audioPath
+	code, streamErr := s.modelProviderService.TranscribeAudioStream(
+		&providerName,
+		&instanceName,
+		&modelName,
+		&modelID,
+		tenantID,
+		&audioFile,
+		apiConfig,
+		asrConfig,
+		func(text *string, streaming *bool) error {
+			var evt entity.TranscriptionEvent
+			if streaming != nil && *streaming {
+				evt = entity.TranscriptionEvent{Event: "delta", Text: *text, Streaming: true}
+			} else {
+				evt = entity.TranscriptionEvent{Event: "final", Text: *text, Streaming: false}
+			}
+			return sender(evt)
+		},
+	)
+
+	if streamErr != nil {
+		// Try sending error event if not already done
+		_ = sender(entity.TranscriptionEvent{Event: "error", Text: fmt.Sprintf("Transcription failed (code=%d): %s", code, streamErr.Error()), Streaming: false})
+		return fmt.Errorf("TranscribeAudioStream failed (code=%d): %w", code, streamErr)
+	}
+	return nil
+}
+
+// Transcription transcribes the audio file at audioPath using the tenant's
+// default speech-to-text model. Returns the recognized text.
+func (s *AudioService) Transcription(ctx context.Context, tenantID, audioPath string) (string, error) {
+	modelID, err := s.getTenantDefaultModelID(tenantID, entity.ModelTypeSpeech2Text)
+	if err != nil {
+		return "", err
+	}
+
+	providerName, instanceName, modelName, apiConfig, err := s.resolveModelCredentials(ctx, tenantID, modelID)
+	if err != nil {
+		return "", err
+	}
+
+	asrConfig := &models.ASRConfig{}
+	audioFile := audioPath
+
+	response, code, svcErr := s.modelProviderService.TranscribeAudio(
+		&providerName,
+		&instanceName,
+		&modelName,
+		&modelID,
+		tenantID,
+		&audioFile,
+		apiConfig,
+		asrConfig,
+	)
+	if svcErr != nil {
+		return "", fmt.Errorf("TranscribeAudio failed (code=%d): %w", code, svcErr)
+	}
+
+	if response == nil {
+		return "", fmt.Errorf("empty response from transcription service")
+	}
+	return response.Text, nil
+}
+
+// jsonUnmarshal is a helper that wraps json.Unmarshal for cleaner error handling.
+func jsonUnmarshal(data string, target interface{}) error {
+	return json.Unmarshal([]byte(data), target)
+}

--- a/web/src/constants/llm.ts
+++ b/web/src/constants/llm.ts
@@ -73,6 +73,12 @@ export enum LLMFactory {
   RAGcon = 'RAGcon',
   Perplexity = 'Perplexity',
   NewAPI = 'New API',
+  Astraflow = 'Astraflow',
+  AstraflowCN = 'Astraflow-CN',
+  FastEmbed = 'FastEmbed',
+  FuturMix = 'FuturMix',
+  SiliconFlowIntl = 'siliconflow_intl',
+  Xiaomi = 'Xiaomi',
 }
 
 // Please lowercase the file name
@@ -171,12 +177,12 @@ export const APIMapUrl = {
   [LLMFactory.Gemini]: 'https://aistudio.google.com/app/apikey',
   [LLMFactory.DeepSeek]: 'https://platform.deepseek.com/api_keys',
   [LLMFactory.Moonshot]: 'https://platform.moonshot.cn/console/api-keys',
-  [LLMFactory.TongYiQianWen]: 'https://dashscope.console.aliyun.com/apiKey',
+  [LLMFactory.TongYiQianWen]: 'https://www.aliyun.com/product/bailian',
   [LLMFactory.ZhipuAI]: 'https://open.bigmodel.cn/usercenter/apikeys',
   [LLMFactory.XAI]: 'https://x.ai/api/',
   [LLMFactory.HuggingFace]: 'https://huggingface.co/settings/tokens',
   [LLMFactory.Mistral]: 'https://console.mistral.ai/api-keys/',
-  [LLMFactory.Cohere]: 'https://dashboard.cohere.com/api-keys',
+  [LLMFactory.Cohere]: 'https://cohere.com/',
   [LLMFactory.BaiduYiYan]:
     'https://console.bce.baidu.com/qianfan/ais/console/apiKey',
   [LLMFactory.Meituan]: 'https://longcat.chat/platform/api_keys',
@@ -218,4 +224,11 @@ export const APIMapUrl = {
   [LLMFactory.Avian]: 'https://avian.io',
   [LLMFactory.Perplexity]:
     'https://docs.perplexity.ai/docs/embeddings/quickstart',
+  [LLMFactory.Astraflow]: 'https://umodelverse.ai',
+  [LLMFactory.AstraflowCN]: 'https://modelverse.cn',
+  [LLMFactory.FastEmbed]: 'https://qdrant.github.io/fastembed',
+  [LLMFactory.FuturMix]: 'https://futurmix.ai',
+  [LLMFactory.SiliconFlowIntl]: 'https://cloud.siliconflow.cn/account/ak',
+  [LLMFactory.Xiaomi]: 'https://xiaomimimo.com',
+  [LLMFactory.OpenDataLoader]: 'https://github.com/infiniflow/ragflow',
 };


### PR DESCRIPTION
### Summary

Several model providers listed in the **Available models** panel (e.g. Astraflow, Astraflow-CN, FastEmbed, FuturMix, siliconflow_intl, Xiaomi) did not show the external homepage icon because they were missing from the frontend LLMFactory enum and APIMapUrl map. This PR adds the missing enum values, icon mappings, and homepage URLs so that every supported provider has a consistent link button.

Close #0

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Tests

- Verified that the new providers are present in the LLMFactory enum and APIMapUrl.
- Ran eslint on the changed file successfully.