### PR TITLE
fix(go): uploaded documents should be enabled by default

### DIFF
--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -3467,6 +3467,7 @@ func normalizeWebDocumentName(name, contentType string, blob []byte) string {
 func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID, filename, location, filetype string, parserConfig entity.JSONMap, src string, size int64, blob []byte) *entity.Document {
 	docID := strings.ReplaceAll(uuid.New().String(), "-", "")
 	zero := "0"
+	status := "1"
 	suffix := ""
 	if i := strings.LastIndex(filename, "."); i >= 0 {
 		suffix = filename[i+1:]
@@ -3486,7 +3487,7 @@ func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID,
 		Size:         size,
 		Suffix:       suffix,
 		Run:          &zero,
-		Status:       &zero,
+		Status:       &status,
 	}
 	if blob != nil {
 		hash := contentHashHex(blob)


### PR DESCRIPTION
### Summary

This PR fixes the default enabled status for documents uploaded via the Go backend. Previously,  set  to , so uploaded files appeared as disabled in the dataset document list. This change sets the default status to  (enabled), matching the expected behavior and the Python model default.