### PR TITLE
fix(mindmap): search mindmap only shows root node

### DIFF
--- a/internal/handler/mindmap.go
+++ b/internal/handler/mindmap.go
@@ -71,10 +71,14 @@ func runMindMap(config mindMapRunConfig) (mindMapNode, error) {
 	if err != nil {
 		return mindMapNode{}, err
 	}
-	if response == nil || response.Answer == nil {
-		return mindMapNode{ID: "root", Children: []mindMapNode{}}, nil
+	if response == nil || response.Answer == nil || strings.TrimSpace(*response.Answer) == "" {
+		return fallbackMindMapFromSections(sections), nil
 	}
-	return parseMindMapMarkdown(*response.Answer), nil
+	node := parseMindMapMarkdown(*response.Answer)
+	if len(node.Children) == 0 && node.ID == "root" {
+		return fallbackMindMapFromSections(sections), nil
+	}
+	return node, nil
 }
 
 func searchConfigFromDetail(detail map[string]interface{}) map[string]interface{} {
@@ -223,6 +227,21 @@ func mindMapPrompt(inputText string) string {
 
 -TEXT-
 ` + inputText + "\n"
+}
+
+func fallbackMindMapFromSections(sections []string) mindMapNode {
+	root := mindMapNode{ID: "root", Children: []mindMapNode{}}
+	for _, section := range sections {
+		section = cleanMindMapText(section)
+		if section == "" {
+			continue
+		}
+		if len(section) > 80 {
+			section = section[:80] + "..."
+		}
+		root.Children = append(root.Children, mindMapNode{ID: section, Children: []mindMapNode{}})
+	}
+	return root
 }
 
 type mindMapNode struct {

--- a/web/src/pages/next-search/hooks.ts
+++ b/web/src/pages/next-search/hooks.ts
@@ -62,6 +62,23 @@ export const useGetSharedSearchParams = () => {
   };
 };
 
+const buildFallbackMindMap = (question: string, chunks: any[]) => {
+  const root: any = { id: question || 'root', children: [] };
+  const seen = new Set<string>();
+  for (const chunk of chunks) {
+    const content =
+      chunk?.content_with_weight || chunk?.content || chunk?.text || '';
+    const text = String(content).trim();
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    root.children.push({
+      id: text.length > 80 ? text.slice(0, 80) + '...' : text,
+      children: [],
+    });
+  }
+  return root;
+};
+
 export const useSearchFetchMindMap = () => {
   const [searchParams] = useSearchParams();
   const sharedId = searchParams.get('shared_id');
@@ -75,10 +92,18 @@ export const useSearchFetchMindMap = () => {
   } = useMutation({
     mutationKey: ['fetchMindMap'],
     gcTime: 0,
-    mutationFn: async (params: IAskRequestBody) => {
+    mutationFn: async (params: IAskRequestBody & { chunks?: any[] }) => {
       try {
         const ret = await fetchMindMapFunc(params);
-        return ret?.data?.data ?? {};
+        const mindMap = ret?.data?.data ?? {};
+        const isEmptyTree =
+          !mindMap ||
+          (mindMap.id === 'root' &&
+            (!mindMap.children || mindMap.children.length === 0));
+        if (isEmptyTree && params?.question && params?.chunks?.length) {
+          return buildFallbackMindMap(params.question, params.chunks);
+        }
+        return mindMap;
       } catch (error: any) {
         if (has(error, 'message')) {
           message.error(error.message);
@@ -96,6 +121,7 @@ export const useShowMindMapDrawer = (
   kbIds: string[],
   question: string,
   searchId = '',
+  chunks: any[] = [],
 ) => {
   const { visible, showModal, hideModal } = useSetModalState();
   const ref = useRef<any>();
@@ -107,6 +133,10 @@ export const useShowMindMapDrawer = (
   } = useSearchFetchMindMap();
 
   const handleShowModal = useCallback(() => {
+    showModal();
+  }, [showModal]);
+
+  useEffect(() => {
     const searchParams = {
       question: trim(question),
       kb_ids: kbIds,
@@ -117,10 +147,9 @@ export const useShowMindMapDrawer = (
       !isEqual(searchParams, ref.current)
     ) {
       ref.current = searchParams;
-      fetchMindMap(searchParams);
+      fetchMindMap({ ...searchParams, chunks });
     }
-    showModal();
-  }, [fetchMindMap, showModal, question, kbIds, searchId]);
+  }, [fetchMindMap, question, kbIds, searchId, chunks]);
 
   return {
     mindMap,
@@ -514,6 +543,8 @@ export const useSearching = ({
     searchData.search_config.summary,
   ]);
 
+  const { chunks, total } = useSelectTestingResult();
+
   const {
     mindMapVisible,
     hideMindMapModal,
@@ -524,8 +555,8 @@ export const useSearching = ({
     searchData.search_config.kb_ids,
     searchStr,
     searchData.id,
+    chunks,
   );
-  const { chunks, total } = useSelectTestingResult();
 
   const handleSearch = useCallback(
     (value: string) => {


### PR DESCRIPTION
### Summary

The search mind-map (思维导图) only shows a single "root" node when the LLM returns an empty or unparsable markdown answer. This PR fixes the issue by adding a fallback tree built from the retrieved chunks on both the Go backend and the frontend, so the mind map always displays meaningful content.

### What changed

- `internal/handler/mindmap.go`
  - Return a fallback tree from the retrieved sections when the LLM answer is empty or parsing yields no children.
  - Trim whitespace from the LLM answer before deciding it is empty.

- `web/src/pages/next-search/hooks.ts`
  - Pass current retrieval chunks to the mind-map request.
  - If the API returns an empty `root` node, build a fallback tree from the chunk contents.
  - Move the mind-map fetch into a `useEffect` so it reloads when the question, `kb_ids`, `search_id`, or chunks change.

### How to verify

- Run the Go mind-map parser test: `bash build.sh --test ./internal/handler -run TestParseMindMapMarkdown`
- The frontend changes pass the pre-commit checks (prettier + eslint).

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Related issue

- Search mind map cannot display correctly (only shows "root").
