### PR TITLE
fix(go): uploaded documents should be enabled by default

### DIFF
--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -3499,6 +3499,10 @@ func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID,
 // docToRawMap serialises a freshly created Document into the raw key shape the
 // handler remaps (chunk_num→chunk_count, kb_id→dataset_id, parser_id→chunk_method).
 func docToRawMap(doc *entity.Document) map[string]interface{} {
+	status := "0"
+	if doc.Status != nil {
+		status = *doc.Status
+	}
 	m := map[string]interface{}{
 		"id":            doc.ID,
 		"kb_id":         doc.KbID,
@@ -3512,6 +3516,7 @@ func docToRawMap(doc *entity.Document) map[string]interface{} {
 		"token_num":     doc.TokenNum,
 		"suffix":        doc.Suffix,
 		"run":           "0",
+		"status":        status,
 	}
 	if doc.Name != nil {
 		m["name"] = *doc.Name

--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -569,7 +569,7 @@ func (s *DocumentService) CreateDocument(req *CreateDocumentRequest) (*entity.Do
 		Type:         req.Type,
 		SourceType:   req.Source,
 		Suffix:       ".doc",
-		Status:       func() *string { s := "0"; return &s }(),
+		Status:       func() *string { s := "1"; return &s }(),
 	}
 
 	if err := s.InsertDocument(document); err != nil {
@@ -3466,7 +3466,7 @@ func normalizeWebDocumentName(name, contentType string, blob []byte) string {
 // suffix and content hash. blob may be nil for the empty/virtual document.
 func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID, filename, location, filetype string, parserConfig entity.JSONMap, src string, size int64, blob []byte) *entity.Document {
 	docID := strings.ReplaceAll(uuid.New().String(), "-", "")
-	zero := "0"
+	run := "0"
 	status := "1"
 	suffix := ""
 	if i := strings.LastIndex(filename, "."); i >= 0 {
@@ -3486,7 +3486,7 @@ func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID,
 		Location:     &loc,
 		Size:         size,
 		Suffix:       suffix,
-		Run:          &zero,
+		Run:          &run,
 		Status:       &status,
 	}
 	if blob != nil {
@@ -3499,10 +3499,6 @@ func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID,
 // docToRawMap serialises a freshly created Document into the raw key shape the
 // handler remaps (chunk_num→chunk_count, kb_id→dataset_id, parser_id→chunk_method).
 func docToRawMap(doc *entity.Document) map[string]interface{} {
-	status := "0"
-	if doc.Status != nil {
-		status = *doc.Status
-	}
 	m := map[string]interface{}{
 		"id":            doc.ID,
 		"kb_id":         doc.KbID,
@@ -3516,7 +3512,6 @@ func docToRawMap(doc *entity.Document) map[string]interface{} {
 		"token_num":     doc.TokenNum,
 		"suffix":        doc.Suffix,
 		"run":           "0",
-		"status":        status,
 	}
 	if doc.Name != nil {
 		m["name"] = *doc.Name

--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -3467,6 +3467,7 @@ func normalizeWebDocumentName(name, contentType string, blob []byte) string {
 func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID, filename, location, filetype string, parserConfig entity.JSONMap, src string, size int64, blob []byte) *entity.Document {
 	docID := strings.ReplaceAll(uuid.New().String(), "-", "")
 	zero := "0"
+	status := "1"
 	suffix := ""
 	if i := strings.LastIndex(filename, "."); i >= 0 {
 		suffix = filename[i+1:]
@@ -3486,7 +3487,7 @@ func (s *DocumentService) newDatasetDocument(kb *entity.Knowledgebase, tenantID,
 		Size:         size,
 		Suffix:       suffix,
 		Run:          &zero,
-		Status:       &zero,
+		Status:       &status,
 	}
 	if blob != nil {
 		hash := contentHashHex(blob)


### PR DESCRIPTION
### Summary

This PR fixes a bug in the Go backend where newly uploaded documents in a dataset were created with `Status` set to `"0"` (disabled). As a result, users had to manually enable every uploaded file before it could be used for retrieval or chat, which is inconsistent with the expected behavior.

### Changes

- `internal/service/document.go`:
  - In `CreateDocument`, changed the default document `Status` from `"0"` to `"1"`.
  - In `newDatasetDocument`, changed the default document `Status` from `"0"` to `"1"` and renamed the local variable from `zero` to `run`/`status` to make the intent explicit.

### Verification

- Started the Go backend (admin, API, ingestor) and the frontend with `API_PROXY_SCHEME=go`.
- Logged in as `1@1.com` / `1`.
- Confirmed the issue existed: an existing file showed the **Enable** toggle in the OFF position.
- Uploaded a new file after the fix and confirmed the **Enable** toggle is now ON by default.
- Built the Go binaries with `bash build.sh --go` and ran `bash build.sh --test ./internal/service/...` successfully.

### Notes

- `web/.env.development` was changed to `API_PROXY_SCHEME=go` for local Go-mode testing but is intentionally left unstaged and not included in this commit.

