### PR TITLE
fix(go-agent-web): correct BGPT canvas form watcher usage

### DIFF
--- a/web/src/pages/agent/form/bgpt-form/index.tsx
+++ b/web/src/pages/agent/form/bgpt-form/index.tsx
@@ -81,7 +81,7 @@ function BGPTForm({ node }: INextOperatorForm) {
     resolver: zodResolver(FormSchema),
   });
 
-  useWatchFormChange(form);
+  useWatchFormChange(node?.id, form);
 
   return (
     <Form {...form}>


### PR DESCRIPTION
## Summary

Fixes a page crash when opening the BGPT node configuration in the canvas.

## Root Cause

BGPT was using the tool-form watcher call pattern in a normal canvas component form.

Tool forms use:

useWatchFormChange(form)

Canvas component forms use:

useWatchFormChange(node?.id, form)

Tool is not equal to component. The BGPT canvas component imported the component-level hook but called it like a tool-form hook, so the form argument became undefined and React Hook Form tried to read control from a null context.

## Change

Updated the BGPT canvas form to pass the node id and form instance correctly.

## Validation

Ran ESLint for the changed file:
npx eslint src/pages/agent/form/bgpt-form/index.tsx

<img width="1369" height="1184" alt="image" src="https://github.com/user-attachments/assets/a40c5202-7394-4f26-9da2-08329dcc7fbf" />
