### PR TITLE
fix(agent): save draft version on agent update

### DIFF
--- a/internal/dao/user.go
+++ b/internal/dao/user.go
@@ -17,6 +17,8 @@
 package dao
 
 import (
+	"context"
+
 	"ragflow/internal/entity"
 )
 
@@ -50,6 +52,17 @@ func (dao *UserDAO) GetByTenantID(tenantID string) (*entity.User, error) {
 		return nil, err
 	}
 	return &user, nil
+}
+
+// GetNicknameByID returns a user's nickname by string id.
+func (dao *UserDAO) GetNicknameByID(ctx context.Context, id string) (string, error) {
+	var nickname string
+	err := DB.WithContext(ctx).
+		Model(&entity.User{}).
+		Where("id = ?", id).
+		Select("nickname").
+		Scan(&nickname).Error
+	return nickname, err
 }
 
 // GetByEmail get user by email

--- a/internal/dao/user_canvas_version.go
+++ b/internal/dao/user_canvas_version.go
@@ -132,15 +132,6 @@ func (dao *UserCanvasVersionDAO) CreateTx(tx *gorm.DB, v *entity.UserCanvasVersi
 	return tx.Create(v).Error
 }
 
-func (dao *UserCanvasVersionDAO) getReleaseByIDTx(tx *gorm.DB, id string) (bool, error) {
-	var release bool
-	err := tx.Table((&entity.UserCanvasVersion{}).TableName()).
-		Select("`release`").
-		Where("id = ?", id).
-		Scan(&release).Error
-	return release, err
-}
-
 // SaveOrReplaceLatest inserts a new version or refreshes the latest matching
 // draft in place. If the latest matching version is released and the current
 // save is a draft, it creates a new draft to preserve the released snapshot.
@@ -170,11 +161,7 @@ func (dao *UserCanvasVersionDAO) SaveOrReplaceLatest(opts SaveOrReplaceLatestVer
 				return err
 			}
 		} else if opts.sameDSL(latest.DSL) {
-			latestReleased, err := dao.getReleaseByIDTx(tx, latest.ID)
-			if err != nil {
-				return err
-			}
-			if !latestReleased || opts.Release {
+			if !latest.Release || opts.Release {
 				updates := map[string]interface{}{
 					"dsl":     opts.DSL,
 					"release": opts.Release,
@@ -188,6 +175,7 @@ func (dao *UserCanvasVersionDAO) SaveOrReplaceLatest(opts SaveOrReplaceLatestVer
 					return err
 				}
 				latest.DSL = opts.DSL
+				latest.Release = opts.Release
 				if opts.Description != nil {
 					latest.Description = opts.Description
 				}
@@ -200,12 +188,10 @@ func (dao *UserCanvasVersionDAO) SaveOrReplaceLatest(opts SaveOrReplaceLatestVer
 			UserCanvasID: opts.UserCanvasID,
 			Title:        opts.Title,
 			Description:  opts.Description,
+			Release:      opts.Release,
 			DSL:          opts.DSL,
 		}
 		if err := tx.Create(row).Error; err != nil {
-			return err
-		}
-		if err := tx.Model(&entity.UserCanvasVersion{}).Where("id = ?", row.ID).Update("release", opts.Release).Error; err != nil {
 			return err
 		}
 		saved = row

--- a/internal/dao/user_canvas_version.go
+++ b/internal/dao/user_canvas_version.go
@@ -18,6 +18,7 @@ package dao
 
 import (
 	"errors"
+	"reflect"
 
 	"gorm.io/gorm"
 
@@ -29,11 +30,19 @@ import (
 var ErrUserCanvasVersionNotFound = errors.New("user_canvas_version: not found")
 
 // UserCanvasVersionDAO persists and queries UserCanvasVersion rows.
-//
-// One UserCanvasVersion row is created on every agent publish (§2.9); rows
-// are append-only and never updated. Cascade delete of a parent canvas
-// removes all child versions via DeleteByCanvasID.
 type UserCanvasVersionDAO struct{}
+
+// SaveOrReplaceLatestVersionOptions controls a version-history save.
+type SaveOrReplaceLatestVersionOptions struct {
+	NewID           string
+	UserCanvasID    string
+	Title           *string
+	Description     *string
+	DSL             entity.JSONMap
+	Release         bool
+	KeepUnpublished int
+	SameDSL         func(entity.JSONMap) bool
+}
 
 // NewUserCanvasVersionDAO returns a zero-value DAO. The struct is stateless
 // so callers can share a single instance or create their own.
@@ -117,9 +126,112 @@ func (dao *UserCanvasVersionDAO) DeleteByCanvasIDTx(tx *gorm.DB, canvasID string
 	return res.RowsAffected, res.Error
 }
 
-// CreateTx is the transactional variant of Create. Used by
-// service.AgentService.PublishAgent so the new version row and the
-// parent canvas update land in one atomic write.
+// CreateTx is the transactional variant of Create.
 func (dao *UserCanvasVersionDAO) CreateTx(tx *gorm.DB, v *entity.UserCanvasVersion) error {
 	return tx.Create(v).Error
+}
+
+func (dao *UserCanvasVersionDAO) getReleaseByIDTx(tx *gorm.DB, id string) (bool, error) {
+	var release bool
+	err := tx.Table((&entity.UserCanvasVersion{}).TableName()).
+		Select("`release`").
+		Where("id = ?", id).
+		Scan(&release).Error
+	return release, err
+}
+
+// SaveOrReplaceLatest inserts a new version or refreshes the latest matching
+// draft in place. If the latest matching version is released and the current
+// save is a draft, it creates a new draft to preserve the released snapshot.
+func (dao *UserCanvasVersionDAO) SaveOrReplaceLatest(opts SaveOrReplaceLatestVersionOptions) (*entity.UserCanvasVersion, error) {
+	if opts.KeepUnpublished <= 0 {
+		opts.KeepUnpublished = 20
+	}
+	var saved *entity.UserCanvasVersion
+	if err := DB.Transaction(func(tx *gorm.DB) error {
+		var latest entity.UserCanvasVersion
+		err := tx.Where("user_canvas_id = ?", opts.UserCanvasID).
+			Order("create_time DESC").
+			First(&latest).Error
+		if err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+		} else if opts.sameDSL(latest.DSL) {
+			latestReleased, err := dao.getReleaseByIDTx(tx, latest.ID)
+			if err != nil {
+				return err
+			}
+			if !latestReleased || opts.Release {
+				updates := map[string]interface{}{
+					"dsl":     opts.DSL,
+					"release": opts.Release,
+				}
+				if opts.Description != nil {
+					updates["description"] = opts.Description
+				}
+				if err := tx.Model(&entity.UserCanvasVersion{}).
+					Where("id = ?", latest.ID).
+					Updates(updates).Error; err != nil {
+					return err
+				}
+				latest.DSL = opts.DSL
+				if opts.Description != nil {
+					latest.Description = opts.Description
+				}
+				saved = &latest
+				return dao.deleteAllUnpublishedExcessTx(tx, opts.UserCanvasID, opts.KeepUnpublished)
+			}
+		}
+		row := &entity.UserCanvasVersion{
+			ID:           opts.NewID,
+			UserCanvasID: opts.UserCanvasID,
+			Title:        opts.Title,
+			Description:  opts.Description,
+			DSL:          opts.DSL,
+		}
+		if err := tx.Create(row).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&entity.UserCanvasVersion{}).Where("id = ?", row.ID).Update("release", opts.Release).Error; err != nil {
+			return err
+		}
+		saved = row
+		return dao.deleteAllUnpublishedExcessTx(tx, opts.UserCanvasID, opts.KeepUnpublished)
+	}); err != nil {
+		return nil, err
+	}
+	return saved, nil
+}
+
+func (opts SaveOrReplaceLatestVersionOptions) sameDSL(dsl entity.JSONMap) bool {
+	if opts.SameDSL != nil {
+		return opts.SameDSL(dsl)
+	}
+	return reflect.DeepEqual(dsl, opts.DSL)
+}
+
+// DeleteAllUnpublishedExcess keeps the newest keep unpublished versions for a
+// canvas and deletes older unpublished rows. Released versions are never
+// removed by this cleanup.
+func (dao *UserCanvasVersionDAO) DeleteAllUnpublishedExcess(canvasID string, keep int) error {
+	return dao.deleteAllUnpublishedExcessTx(DB, canvasID, keep)
+}
+
+func (dao *UserCanvasVersionDAO) deleteAllUnpublishedExcessTx(tx *gorm.DB, canvasID string, keep int) error {
+	if keep < 0 {
+		keep = 0
+	}
+	var ids []string
+	if err := tx.Table((&entity.UserCanvasVersion{}).TableName()).
+		Where("user_canvas_id = ? AND (`release` = ? OR `release` IS NULL)", canvasID, false).
+		Order("create_time DESC").
+		Pluck("id", &ids).Error; err != nil {
+		return err
+	}
+	if len(ids) <= keep {
+		return nil
+	}
+	ids = ids[keep:]
+	return tx.Where("id IN ?", ids).Delete(&entity.UserCanvasVersion{}).Error
 }

--- a/internal/dao/user_canvas_version.go
+++ b/internal/dao/user_canvas_version.go
@@ -166,6 +166,9 @@ func (dao *UserCanvasVersionDAO) SaveOrReplaceLatest(opts SaveOrReplaceLatestVer
 					"dsl":     opts.DSL,
 					"release": opts.Release,
 				}
+				if opts.Title != nil {
+					updates["title"] = opts.Title
+				}
 				if opts.Description != nil {
 					updates["description"] = opts.Description
 				}
@@ -176,6 +179,9 @@ func (dao *UserCanvasVersionDAO) SaveOrReplaceLatest(opts SaveOrReplaceLatestVer
 				}
 				latest.DSL = opts.DSL
 				latest.Release = opts.Release
+				if opts.Title != nil {
+					latest.Title = opts.Title
+				}
 				if opts.Description != nil {
 					latest.Description = opts.Description
 				}
@@ -221,8 +227,8 @@ func (dao *UserCanvasVersionDAO) deleteAllUnpublishedExcessTx(tx *gorm.DB, canva
 		keep = 0
 	}
 	var ids []string
-	if err := tx.Table((&entity.UserCanvasVersion{}).TableName()).
-		Where("user_canvas_id = ? AND (`release` = ? OR `release` IS NULL)", canvasID, false).
+	if err := tx.Model(&entity.UserCanvasVersion{}).
+		Where(map[string]interface{}{"user_canvas_id": canvasID, "release": false}).
 		Order("create_time DESC").
 		Pluck("id", &ids).Error; err != nil {
 		return err

--- a/internal/dao/user_canvas_version.go
+++ b/internal/dao/user_canvas_version.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"ragflow/internal/entity"
 )
@@ -149,9 +150,20 @@ func (dao *UserCanvasVersionDAO) SaveOrReplaceLatest(opts SaveOrReplaceLatestVer
 	}
 	var saved *entity.UserCanvasVersion
 	if err := DB.Transaction(func(tx *gorm.DB) error {
+		var parent struct {
+			ID string
+		}
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Table((&entity.UserCanvas{}).TableName()).
+			Select("id").
+			Where("id = ?", opts.UserCanvasID).
+			Take(&parent).Error; err != nil {
+			return err
+		}
+
 		var latest entity.UserCanvasVersion
 		err := tx.Where("user_canvas_id = ?", opts.UserCanvasID).
-			Order("create_time DESC").
+			Order("create_time DESC, id DESC").
 			First(&latest).Error
 		if err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/dao/user_canvas_version_test.go
+++ b/internal/dao/user_canvas_version_test.go
@@ -65,8 +65,10 @@ type daoInterface interface {
 	GetByID(id string) (*entity.UserCanvasVersion, error)
 	ListByCanvasID(canvasID string) ([]*entity.UserCanvasVersion, error)
 	GetLatest(canvasID string) (*entity.UserCanvasVersion, error)
+	SaveOrReplaceLatest(opts SaveOrReplaceLatestVersionOptions) (*entity.UserCanvasVersion, error)
 	Delete(id string) error
 	DeleteByCanvasID(canvasID string) (int64, error)
+	DeleteAllUnpublishedExcess(canvasID string, keep int) error
 }
 
 var _ daoInterface = (*UserCanvasVersionDAO)(nil)

--- a/internal/entity/canvas.go
+++ b/internal/entity/canvas.go
@@ -61,6 +61,7 @@ type UserCanvasVersion struct {
 	UserCanvasID string  `gorm:"column:user_canvas_id;size:255;not null;index" json:"user_canvas_id"`
 	Title        *string `gorm:"column:title;size:255" json:"title,omitempty"`
 	Description  *string `gorm:"column:description;type:longtext" json:"description,omitempty"`
+	Release      bool    `gorm:"column:release;not null;default:false;index" json:"release"`
 	DSL          JSONMap `gorm:"column:dsl;type:longtext" json:"dsl,omitempty"`
 	BaseModel
 }

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -600,7 +600,6 @@ func (s *AgentService) PublishAgent(ctx context.Context, userID, canvasID string
 }
 
 func (s *AgentService) saveOrReplaceVersion(ctx context.Context, userID, canvasID string, dsl entity.JSONMap, title string, description *string, release bool) (*entity.UserCanvasVersion, error) {
-	normalizedDSL := entity.JSONMap(dslpkg.NormalizeForCanvas(dsl))
 	nickname, err := s.userDAO.GetNicknameByID(ctx, userID)
 	if err != nil || strings.TrimSpace(nickname) == "" {
 		nickname = userID
@@ -611,13 +610,13 @@ func (s *AgentService) saveOrReplaceVersion(ctx context.Context, userID, canvasI
 		UserCanvasID:    canvasID,
 		Title:           &versionTitle,
 		Description:     description,
-		DSL:             normalizedDSL,
+		DSL:             dsl,
 		Release:         release,
 		KeepUnpublished: 20,
 		SameDSL: func(latestDSL entity.JSONMap) bool {
 			return reflect.DeepEqual(
 				entity.JSONMap(dslpkg.NormalizeForCanvas(latestDSL)),
-				normalizedDSL,
+				dsl,
 			)
 		},
 	})

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -125,6 +126,7 @@ var ErrAgentStorageError = errors.New("agent storage error")
 type AgentService struct {
 	canvasDAO           *dao.UserCanvasDAO
 	canvasTemplateDAO   *dao.CanvasTemplateDAO
+	userDAO             *dao.UserDAO
 	userTenantDAO       *dao.UserTenantDAO
 	versionDAO          *dao.UserCanvasVersionDAO
 	api4ConversationDAO *dao.API4ConversationDAO
@@ -181,6 +183,7 @@ func NewAgentServiceWithOptions(
 	return &AgentService{
 		canvasDAO:           dao.NewUserCanvasDAO(),
 		canvasTemplateDAO:   dao.NewCanvasTemplateDAO(),
+		userDAO:             dao.NewUserDAO(),
 		userTenantDAO:       dao.NewUserTenantDAO(),
 		versionDAO:          dao.NewUserCanvasVersionDAO(),
 		api4ConversationDAO: dao.NewAPI4ConversationDAO(),
@@ -422,7 +425,8 @@ func (s *AgentService) GetAgent(ctx context.Context, userID, canvasID string) (*
 // UpdateAgent applies a draft patch to user_canvas. Settings updates may omit
 // dsl; in that case the existing draft DSL must be preserved.
 func (s *AgentService) UpdateAgent(ctx context.Context, userID, canvasID string, patch map[string]interface{}) error {
-	if _, err := s.loadCanvasForUser(ctx, userID, canvasID); err != nil {
+	canvasInstance, err := s.loadCanvasForUser(ctx, userID, canvasID)
+	if err != nil {
 		return err
 	}
 
@@ -451,9 +455,24 @@ func (s *AgentService) UpdateAgent(ctx context.Context, userID, canvasID string,
 		updates["dsl"] = entity.JSONMap(dslpkg.NormalizeForCanvas(entity.JSONMap(dslMap)))
 	}
 
-	_, err := s.canvasDAO.UpdateFields(canvasID, updates)
+	_, err = s.canvasDAO.UpdateFields(canvasID, updates)
 	if err != nil {
 		return fmt.Errorf("update agent %s: %w", canvasID, err)
+	}
+	if dslValue, ok := updates["dsl"]; ok {
+		dsl, ok := dslValue.(entity.JSONMap)
+		if !ok {
+			return fmt.Errorf("update agent %s: normalized dsl must be an object", canvasID)
+		}
+		title := ""
+		if value, ok := updates["title"]; ok {
+			title, _ = value.(string)
+		} else if canvasInstance.Title != nil {
+			title = *canvasInstance.Title
+		}
+		if _, err := s.saveOrReplaceVersion(ctx, userID, canvasID, dsl, title, nil, false); err != nil {
+			return fmt.Errorf("update agent %s: save version: %w", canvasID, err)
+		}
 	}
 	return nil
 }
@@ -466,11 +485,9 @@ func (s *AgentService) UpdateAgent(ctx context.Context, userID, canvasID string,
 // returned so the caller can render it back to the client without an
 // extra GET.
 //
-// Reset does NOT create a new user_canvas_version row — that mirrors
-// the Python behavior and UpdateAgent: versions are owned by
-// PublishAgent. It also does NOT touch the in-flight run state of any
-// currently executing canvas session; that is owned by the Python task
-// executor and is out of scope for the Go port.
+// Reset does NOT create a new user_canvas_version row. It also does NOT touch
+// the in-flight run state of any currently executing canvas session; that is
+// owned by the Python task executor and is out of scope for the Go port.
 //
 // Errors propagate the same way as GetAgent: a missing canvas, or a
 // canvas that the user has no access to, surfaces as
@@ -580,6 +597,42 @@ func (s *AgentService) PublishAgent(ctx context.Context, userID, canvasID string
 		return nil, err
 	}
 	return row, nil
+}
+
+func (s *AgentService) saveOrReplaceVersion(ctx context.Context, userID, canvasID string, dsl entity.JSONMap, title string, description *string, release bool) (*entity.UserCanvasVersion, error) {
+	normalizedDSL := entity.JSONMap(dslpkg.NormalizeForCanvas(dsl))
+	nickname, err := s.userDAO.GetNicknameByID(ctx, userID)
+	if err != nil || strings.TrimSpace(nickname) == "" {
+		nickname = userID
+	}
+	versionTitle := buildVersionTitle(nickname, title, time.Now())
+	return s.versionDAO.SaveOrReplaceLatest(dao.SaveOrReplaceLatestVersionOptions{
+		NewID:           genID32(),
+		UserCanvasID:    canvasID,
+		Title:           &versionTitle,
+		Description:     description,
+		DSL:             normalizedDSL,
+		Release:         release,
+		KeepUnpublished: 20,
+		SameDSL: func(latestDSL entity.JSONMap) bool {
+			return reflect.DeepEqual(
+				entity.JSONMap(dslpkg.NormalizeForCanvas(latestDSL)),
+				normalizedDSL,
+			)
+		},
+	})
+}
+
+func buildVersionTitle(userNickname, agentTitle string, ts time.Time) string {
+	tenant := strings.TrimSpace(userNickname)
+	if tenant == "" {
+		tenant = "tenant"
+	}
+	title := strings.TrimSpace(agentTitle)
+	if title == "" {
+		title = "agent"
+	}
+	return fmt.Sprintf("%s_%s_%s", tenant, title, ts.Format("2006-01-02 15:04:05"))
 }
 
 // ListVersions returns every version for a canvas the user can see,

--- a/internal/service/agent_test.go
+++ b/internal/service/agent_test.go
@@ -1311,7 +1311,11 @@ func TestUpdateAgentDSLCreatesAndReplacesDraftVersion(t *testing.T) {
 	if err := NewAgentService().UpdateAgent(context.Background(), "user-1", "canvas-version-draft", patch); err != nil {
 		t.Fatalf("first UpdateAgent failed: %v", err)
 	}
-	if err := NewAgentService().UpdateAgent(context.Background(), "user-1", "canvas-version-draft", patch); err != nil {
+	secondPatch := map[string]interface{}{
+		"title": "Renamed Agent",
+		"dsl":   patch["dsl"],
+	}
+	if err := NewAgentService().UpdateAgent(context.Background(), "user-1", "canvas-version-draft", secondPatch); err != nil {
 		t.Fatalf("second UpdateAgent failed: %v", err)
 	}
 
@@ -1322,7 +1326,7 @@ func TestUpdateAgentDSLCreatesAndReplacesDraftVersion(t *testing.T) {
 	if len(versions) != 1 {
 		t.Fatalf("expected same DSL to replace latest draft, got %d versions", len(versions))
 	}
-	if versions[0].Title == nil || !strings.HasPrefix(*versions[0].Title, "owner_Draft Agent_") {
+	if versions[0].Title == nil || !strings.HasPrefix(*versions[0].Title, "owner_Renamed Agent_") {
 		t.Fatalf("unexpected version title: %v", versions[0].Title)
 	}
 	var release bool
@@ -1337,6 +1341,9 @@ func TestUpdateAgentDSLCreatesAndReplacesDraftVersion(t *testing.T) {
 func TestUpdateAgentDSLDoesNotOverwriteLatestReleasedVersion(t *testing.T) {
 	setupAgentSessionServiceTest(t)
 
+	if err := dao.DB.Create(&entity.User{ID: "user-1", Nickname: "owner", Email: "owner@test.com"}).Error; err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
 	dsl := entity.JSONMap{
 		"graph": map[string]any{
 			"nodes": []any{map[string]any{"id": "begin"}},
@@ -1362,6 +1369,7 @@ func TestUpdateAgentDSLDoesNotOverwriteLatestReleasedVersion(t *testing.T) {
 		ID:           "released-version",
 		UserCanvasID: "canvas-released-latest",
 		Title:        sptr("released"),
+		Release:      true,
 		DSL:          dsl,
 		BaseModel: entity.BaseModel{
 			CreateTime: ptr(releasedAt.UnixMilli()),
@@ -1369,9 +1377,6 @@ func TestUpdateAgentDSLDoesNotOverwriteLatestReleasedVersion(t *testing.T) {
 		},
 	}).Error; err != nil {
 		t.Fatalf("failed to seed released version: %v", err)
-	}
-	if err := dao.DB.Table("user_canvas_version").Where("id = ?", "released-version").Update("release", true).Error; err != nil {
-		t.Fatalf("failed to mark version released: %v", err)
 	}
 
 	if err := NewAgentService().UpdateAgent(context.Background(), "user-1", "canvas-released-latest", map[string]interface{}{"dsl": map[string]interface{}(dsl)}); err != nil {

--- a/internal/service/agent_test.go
+++ b/internal/service/agent_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"gorm.io/gorm"
+
 	"ragflow/internal/agent/canvas"
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
@@ -584,18 +586,32 @@ func setupAgentSessionServiceTest(t *testing.T) {
 	t.Helper()
 
 	testDB := setupServiceTestDB(t)
+	sqlDB, err := testDB.DB()
+	if err != nil {
+		t.Fatalf("failed to access sqlite handle: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
 	if err := testDB.AutoMigrate(
 		&entity.User{},
 		&entity.UserCanvas{},
+		&entity.UserCanvasVersion{},
 		&entity.UserTenant{},
 		&entity.API4Conversation{},
 	); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
+	ensureUserCanvasVersionReleaseColumn(t, testDB)
 
 	orig := dao.DB
 	dao.DB = testDB
 	t.Cleanup(func() { dao.DB = orig })
+}
+
+func ensureUserCanvasVersionReleaseColumn(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := db.Exec("ALTER TABLE user_canvas_version ADD COLUMN release boolean DEFAULT false").Error; err != nil && !strings.Contains(err.Error(), "duplicate column") {
+		t.Fatalf("failed to add user_canvas_version.release: %v", err)
+	}
 }
 
 func createAgentSessionTestCanvas(t *testing.T, id, userID string) {
@@ -1269,6 +1285,129 @@ func TestUpdateAgentPersistsDSLAsJSONMap(t *testing.T) {
 	}
 	if _, ok := persisted.DSL["graph"]; !ok {
 		t.Fatalf("DSL graph was not persisted: %#v", persisted.DSL)
+	}
+}
+
+func TestUpdateAgentDSLCreatesAndReplacesDraftVersion(t *testing.T) {
+	setupAgentSessionServiceTest(t)
+
+	if err := dao.DB.Create(&entity.User{ID: "user-1", Nickname: "owner", Email: "owner@test.com"}).Error; err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+	if err := dao.DB.Create(&entity.UserCanvas{
+		ID:             "canvas-version-draft",
+		UserID:         "user-1",
+		Title:          sptr("Draft Agent"),
+		CanvasCategory: "agent_canvas",
+		DSL:            entity.JSONMap{},
+	}).Error; err != nil {
+		t.Fatalf("failed to seed canvas: %v", err)
+	}
+
+	patch := map[string]interface{}{
+		"title": "Draft Agent",
+		"dsl": map[string]interface{}{
+			"graph": map[string]interface{}{
+				"nodes": []interface{}{map[string]interface{}{"id": "begin"}},
+				"edges": []interface{}{},
+			},
+			"components": map[string]interface{}{
+				"begin": map[string]interface{}{
+					"obj": map[string]interface{}{"component_name": "Begin"},
+				},
+			},
+		},
+	}
+	if err := NewAgentService().UpdateAgent(context.Background(), "user-1", "canvas-version-draft", patch); err != nil {
+		t.Fatalf("first UpdateAgent failed: %v", err)
+	}
+	if err := NewAgentService().UpdateAgent(context.Background(), "user-1", "canvas-version-draft", patch); err != nil {
+		t.Fatalf("second UpdateAgent failed: %v", err)
+	}
+
+	versions, err := dao.NewUserCanvasVersionDAO().ListByCanvasID("canvas-version-draft")
+	if err != nil {
+		t.Fatalf("failed to list versions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected same DSL to replace latest draft, got %d versions", len(versions))
+	}
+	if versions[0].Title == nil || !strings.HasPrefix(*versions[0].Title, "owner_Draft Agent_") {
+		t.Fatalf("unexpected version title: %v", versions[0].Title)
+	}
+	var release bool
+	if err := dao.DB.Table("user_canvas_version").Select("release").Where("id = ?", versions[0].ID).Scan(&release).Error; err != nil {
+		t.Fatalf("failed to read release flag: %v", err)
+	}
+	if release {
+		t.Fatal("draft update saved a released version")
+	}
+}
+
+func TestUpdateAgentDSLDoesNotOverwriteLatestReleasedVersion(t *testing.T) {
+	setupAgentSessionServiceTest(t)
+
+	dsl := entity.JSONMap{
+		"graph": map[string]any{
+			"nodes": []any{map[string]any{"id": "begin"}},
+			"edges": []any{},
+		},
+		"components": map[string]any{
+			"begin": map[string]any{
+				"obj": map[string]any{"component_name": "Begin"},
+			},
+		},
+	}
+	if err := dao.DB.Create(&entity.UserCanvas{
+		ID:             "canvas-released-latest",
+		UserID:         "user-1",
+		Title:          sptr("Released Agent"),
+		CanvasCategory: "agent_canvas",
+		DSL:            dsl,
+	}).Error; err != nil {
+		t.Fatalf("failed to seed canvas: %v", err)
+	}
+	releasedAt := time.Now().Add(-time.Minute)
+	if err := dao.DB.Create(&entity.UserCanvasVersion{
+		ID:           "released-version",
+		UserCanvasID: "canvas-released-latest",
+		Title:        sptr("released"),
+		DSL:          dsl,
+		BaseModel: entity.BaseModel{
+			CreateTime: ptr(releasedAt.UnixMilli()),
+			UpdateTime: ptr(releasedAt.UnixMilli()),
+		},
+	}).Error; err != nil {
+		t.Fatalf("failed to seed released version: %v", err)
+	}
+	if err := dao.DB.Table("user_canvas_version").Where("id = ?", "released-version").Update("release", true).Error; err != nil {
+		t.Fatalf("failed to mark version released: %v", err)
+	}
+
+	if err := NewAgentService().UpdateAgent(context.Background(), "user-1", "canvas-released-latest", map[string]interface{}{"dsl": map[string]interface{}(dsl)}); err != nil {
+		t.Fatalf("UpdateAgent failed: %v", err)
+	}
+
+	versions, err := dao.NewUserCanvasVersionDAO().ListByCanvasID("canvas-released-latest")
+	if err != nil {
+		t.Fatalf("failed to list versions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("expected draft save to create a new version beside the released one, got %d", len(versions))
+	}
+	var releasedCount int64
+	if err := dao.DB.Table("user_canvas_version").Where("user_canvas_id = ? AND release = ?", "canvas-released-latest", true).Count(&releasedCount).Error; err != nil {
+		t.Fatalf("failed to count released versions: %v", err)
+	}
+	if releasedCount != 1 {
+		t.Fatalf("released version count = %d, want 1", releasedCount)
+	}
+	var draftCount int64
+	if err := dao.DB.Table("user_canvas_version").Where("user_canvas_id = ? AND release = ?", "canvas-released-latest", false).Count(&draftCount).Error; err != nil {
+		t.Fatalf("failed to count draft versions: %v", err)
+	}
+	if draftCount != 1 {
+		t.Fatalf("draft version count = %d, want 1", draftCount)
 	}
 }
 

--- a/internal/service/agent_test.go
+++ b/internal/service/agent_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"gorm.io/gorm"
-
 	"ragflow/internal/agent/canvas"
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
@@ -600,18 +598,10 @@ func setupAgentSessionServiceTest(t *testing.T) {
 	); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
-	ensureUserCanvasVersionReleaseColumn(t, testDB)
 
 	orig := dao.DB
 	dao.DB = testDB
 	t.Cleanup(func() { dao.DB = orig })
-}
-
-func ensureUserCanvasVersionReleaseColumn(t *testing.T, db *gorm.DB) {
-	t.Helper()
-	if err := db.Exec("ALTER TABLE user_canvas_version ADD COLUMN release boolean DEFAULT false").Error; err != nil && !strings.Contains(err.Error(), "duplicate column") {
-		t.Fatalf("failed to add user_canvas_version.release: %v", err)
-	}
 }
 
 func createAgentSessionTestCanvas(t *testing.T, id, userID string) {


### PR DESCRIPTION
## What

- Save or replace the latest draft `user_canvas_version` when `UpdateAgent` receives updated DSL.
- Preserve released versions by creating a new draft when the latest matching version is already released.
- Keep version cleanup limited to old unpublished drafts.
- Move version persistence details into the DAO layer.

## Testing

- `bash build.sh --test ./internal/service ./internal/dao`
<img width="1556" height="945" alt="image" src="https://github.com/user-attachments/assets/b0cd9329-70ce-41f0-a544-2aa6b9343dc5" />

