### PR TITLE
fix(go-pipline): list agents incorrectly filtering out ingestion pipelines

### DIFF
--- a/internal/dao/user_canvas.go
+++ b/internal/dao/user_canvas.go
@@ -288,9 +288,6 @@ func (dao *UserCanvasDAO) GetList(tenantID string, pageNumber, itemsPerPage int,
 	}
 	if canvasCategory != "" {
 		query = query.Where("canvas_category = ?", canvasCategory)
-	} else {
-		// Default to agent category
-		query = query.Where("canvas_category = ?", "agent_canvas")
 	}
 
 	if canvasType != "" {
@@ -385,8 +382,6 @@ func (dao *UserCanvasDAO) ListByTenantIDs(ownerIDs []string, userID string, page
 
 	if canvasCategory != "" {
 		base = base.Where("user_canvas.canvas_category = ?", canvasCategory)
-	} else {
-		base = base.Where("user_canvas.canvas_category = ?", "agent_canvas")
 	}
 
 	if canvasType != "" {


### PR DESCRIPTION
### Summary

When no canvas_category filter is provided, the DAO defaulted to "agent_canvas", hiding canvases with category "dataflow_canvas" (i.e. ingestion pipelines). Remove the hardcoded default so both categories are returned.

Verified by frontend testing.

<img width="695" height="320" alt="image" src="https://github.com/user-attachments/assets/c534b828-91e1-497d-be6d-9d77688637ef" />
