### PR TITLE
fix(api): allow knowledge_graph chunk method in dataset validation

### DIFF
--- a/api/utils/validation_utils.py
+++ b/api/utils/validation_utils.py
@@ -828,8 +828,8 @@ class CreateDatasetReq(Base):
     @classmethod
     def validate_chunk_method(cls, v: Any, handler, info: ValidationInfo) -> Any:
         """Wrap validation to unify error messages, including type errors (e.g. list)."""
-        allowed = {"naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag", "resume"}
-        error_msg = "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'"
+        allowed = {"naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag", "resume", "knowledge_graph"}
+        error_msg = "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'"
         try:
             # Run inner validation (type checking)
             result = handler(v)

--- a/test/testcases/restful_api/test_datasets.py
+++ b/test/testcases/restful_api/test_datasets.py
@@ -202,6 +202,7 @@ def test_dataset_update_language_connectors_avatar_and_description_contract(rest
         "naive",
         "book",
         "email",
+        "knowledge_graph",
         "laws",
         "manual",
         "one",
@@ -210,8 +211,10 @@ def test_dataset_update_language_connectors_avatar_and_description_contract(rest
         "presentation",
         "qa",
         "table",
+        "tag",
+        "resume",
     ],
-    ids=["naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table"],
+    ids=["naive", "book", "email", "knowledge_graph", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag", "resume"],
 )
 def test_dataset_update_chunk_method_contract(rest_client, clear_datasets, chunk_method):
     create_res = rest_client.post("/datasets", json={"name": f"dataset_update_chunk_{chunk_method}"})
@@ -897,7 +900,7 @@ def test_dataset_update_chunk_method_invalid_contract(rest_client, clear_dataset
     assert create_payload["code"] == 0, create_payload
     dataset_id = create_payload["data"]["id"]
 
-    expected_chunk_message = "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'"
+    expected_chunk_message = "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'"
     for chunk_method in ("", "unknown", []):
         res = rest_client.put(f"/datasets/{dataset_id}", json=_parser_id_fields(chunk_method))
         assert res.status_code == 200
@@ -1165,6 +1168,7 @@ def test_dataset_create_avatar_and_description_contract(rest_client, clear_datas
         ("naive", "naive"),
         ("book", "book"),
         ("email", "email"),
+        ("knowledge_graph", "knowledge_graph"),
         ("laws", "laws"),
         ("manual", "manual"),
         ("one", "one"),
@@ -1173,8 +1177,10 @@ def test_dataset_create_avatar_and_description_contract(rest_client, clear_datas
         ("presentation", "presentation"),
         ("qa", "qa"),
         ("table", "table"),
+        ("tag", "tag"),
+        ("resume", "resume"),
     ],
-    ids=["naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table"],
+    ids=["naive", "book", "email", "knowledge_graph", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag", "resume"],
 )
 def test_dataset_create_chunk_method_contract(rest_client, clear_datasets, name, chunk_method):
     res = rest_client.post("/datasets", json={"name": name, **_parser_id_fields(chunk_method)})
@@ -1668,7 +1674,7 @@ def test_dataset_create_permission_and_chunk_method_contract(rest_client, clear_
         ("chunk_unknown", "unknown"),
         ("chunk_type_error", []),
     ]
-    expected_chunk_message = "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'"
+    expected_chunk_message = "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'"
     for name, chunk_method in chunk_method_invalid_cases:
         res = rest_client.post("/datasets", json={"name": name, **_parser_id_fields(chunk_method)})
         assert res.status_code == 200

--- a/test/testcases/test_http_api/test_dataset_management/test_create_dataset.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_create_dataset.py
@@ -349,6 +349,7 @@ class TestDatasetCreate:
             ("naive", "naive"),
             ("book", "book"),
             ("email", "email"),
+            ("knowledge_graph", "knowledge_graph"),
             ("laws", "laws"),
             ("manual", "manual"),
             ("one", "one"),
@@ -359,7 +360,7 @@ class TestDatasetCreate:
             ("table", "table"),
             ("tag", "tag"),
         ],
-        ids=["naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag"],
+        ids=["naive", "book", "email", "knowledge_graph", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag"],
     )
     def test_chunk_method(self, HttpApiAuth, name, chunk_method):
         payload = {"name": name, "chunk_method": chunk_method}
@@ -381,7 +382,7 @@ class TestDatasetCreate:
         payload = {"name": name, "chunk_method": chunk_method}
         res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
-        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'" in res["message"], res
+        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'" in res["message"], res
 
     @pytest.mark.p2
     def test_chunk_method_unset(self, HttpApiAuth):
@@ -395,7 +396,7 @@ class TestDatasetCreate:
         payload = {"name": "chunk_method_none", "chunk_method": None}
         res = create_dataset(HttpApiAuth, payload)
         assert res["code"] == 101, res
-        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'" in res["message"], res
+        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'" in res["message"], res
 
     @pytest.mark.p1
     @pytest.mark.parametrize(

--- a/test/testcases/test_http_api/test_dataset_management/test_update_dataset.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_update_dataset.py
@@ -418,6 +418,7 @@ class TestDatasetUpdate:
             "naive",
             "book",
             "email",
+            "knowledge_graph",
             "laws",
             "manual",
             "one",
@@ -428,7 +429,7 @@ class TestDatasetUpdate:
             "table",
             "tag",
         ],
-        ids=["naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag"],
+        ids=["naive", "book", "email", "knowledge_graph", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag"],
     )
     def test_chunk_method(self, HttpApiAuth, add_dataset_func, chunk_method):
         dataset_id = add_dataset_func
@@ -455,7 +456,7 @@ class TestDatasetUpdate:
         payload = {"chunk_method": chunk_method}
         res = update_dataset(HttpApiAuth, dataset_id, payload)
         assert res["code"] == 101, res
-        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'" in res["message"], res
+        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'" in res["message"], res
 
     @pytest.mark.p3
     def test_chunk_method_none(self, HttpApiAuth, add_dataset_func):
@@ -463,7 +464,7 @@ class TestDatasetUpdate:
         payload = {"chunk_method": None}
         res = update_dataset(HttpApiAuth, dataset_id, payload)
         assert res["code"] == 101, res
-        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'" in res["message"], res
+        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'" in res["message"], res
 
     @pytest.mark.skipif(os.getenv("DOC_ENGINE") == "infinity", reason="#8208")
     @pytest.mark.p2

--- a/test/testcases/test_sdk_api/test_dataset_mangement/test_create_dataset.py
+++ b/test/testcases/test_sdk_api/test_dataset_mangement/test_create_dataset.py
@@ -304,6 +304,7 @@ class TestDatasetCreate:
             ("naive", "naive"),
             ("book", "book"),
             ("email", "email"),
+            ("knowledge_graph", "knowledge_graph"),
             ("laws", "laws"),
             ("manual", "manual"),
             ("one", "one"),
@@ -315,7 +316,7 @@ class TestDatasetCreate:
             ("tag", "tag"),
             ("resume", "resume"),
         ],
-        ids=["naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag", "resume"],
+        ids=["naive", "book", "email", "knowledge_graph", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag", "resume"],
     )
     def test_chunk_method(self, client, name, chunk_method):
         payload = {"name": name, "chunk_method": chunk_method}
@@ -339,7 +340,7 @@ class TestDatasetCreate:
         if IS_GO_PROXY:
             assert error_message.startswith("Input should be 'naive', 'book'") and error_message.endswith("or 'tag'"), error_message
         else:
-            assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'" in error_message, error_message
+            assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'" in error_message, error_message
 
     @pytest.mark.p2
     def test_chunk_method_unset(self, client):

--- a/test/testcases/test_sdk_api/test_dataset_mangement/test_update_dataset.py
+++ b/test/testcases/test_sdk_api/test_dataset_mangement/test_update_dataset.py
@@ -299,6 +299,7 @@ class TestDatasetUpdate:
             "naive",
             "book",
             "email",
+            "knowledge_graph",
             "laws",
             "manual",
             "one",
@@ -309,7 +310,7 @@ class TestDatasetUpdate:
             "table",
             "tag",
         ],
-        ids=["naive", "book", "email", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag"],
+        ids=["naive", "book", "email", "knowledge_graph", "laws", "manual", "one", "paper", "picture", "presentation", "qa", "table", "tag"],
     )
     def test_chunk_method(self, client, add_dataset_func, chunk_method):
         dataset = add_dataset_func
@@ -339,14 +340,14 @@ class TestDatasetUpdate:
         elif IS_GO_PROXY:
             assert error_message.startswith("Input should be 'naive', 'book'") and error_message.endswith("or 'tag'"), error_message
         else:
-            assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'" in error_message, error_message
+            assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'" in error_message, error_message
 
     @pytest.mark.p3
     def test_chunk_method_none(self, add_dataset_func):
         dataset = add_dataset_func
         with pytest.raises(Exception) as exception_info:
             dataset.update({"chunk_method": None})
-        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag' or 'resume'" in str(exception_info.value), str(
+        assert "Input should be 'naive', 'book', 'email', 'laws', 'manual', 'one', 'paper', 'picture', 'presentation', 'qa', 'table', 'tag', 'resume' or 'knowledge_graph'" in str(exception_info.value), str(
             exception_info.value
         )
 


### PR DESCRIPTION
### Summary

Align dataset create/update `chunk_method` validation with the existing `knowledge_graph` parser support already used in other Ragflow paths.

This change:
- adds `knowledge_graph` to the dataset `chunk_method` validator allowlist
- updates the corresponding validation error message
- extends the related dataset HTTP / SDK / restful tests accordingly

`knowledge_graph` is already treated as a supported parser in other parts of the codebase, including parser configuration and document update flows, but dataset create/update validation still rejected it, creating an avoidable validation mismatch.

Impacted test paths updated in this change:
- `test/testcases/test_http_api/test_dataset_management/test_create_dataset.py`
- `test/testcases/test_http_api/test_dataset_management/test_update_dataset.py`
- `test/testcases/test_sdk_api/test_dataset_mangement/test_create_dataset.py`
- `test/testcases/test_sdk_api/test_dataset_mangement/test_update_dataset.py`
- `test/testcases/restful_api/test_datasets.py`