### PR TITLE
fix: always use full hierarchical path for Confluence attachment/page identifiers

### DIFF
--- a/common/data_source/confluence_connector.py
+++ b/common/data_source/confluence_connector.py
@@ -1419,11 +1419,11 @@ class ConfluenceConnector(
             self._document_name_counts[page_title] += 1
             self._document_name_paths[page_title].append(full_path)
 
-            # Use simple name if no duplicates, otherwise use full path
-            if self._document_name_counts[page_title] == 1:
-                semantic_identifier = page_title
-            else:
-                semantic_identifier = full_path
+            # Always use the full hierarchical path as the semantic identifier.
+            # Using a bare name for the first occurrence and a full path for later
+            # duplicates caused asymmetric naming: the first item would keep its
+            # bare name even after a same-named item appeared later (issue #16665).
+            semantic_identifier = full_path
 
             # Get the page content
             page_content = extract_text_from_confluence_html(self.confluence_client, page, self._fetched_titles)
@@ -1579,11 +1579,11 @@ class ConfluenceConnector(
                 self._document_name_counts[attachment_title] += 1
                 self._document_name_paths[attachment_title].append(full_attachment_path)
 
-                # Use simple name if no duplicates, otherwise use full path
-                if self._document_name_counts[attachment_title] == 1:
-                    attachment_semantic_identifier = attachment_title
-                else:
-                    attachment_semantic_identifier = full_attachment_path
+                # Always use the full hierarchical path as the semantic identifier.
+                # Using a bare name for the first occurrence and a full path for later
+                # duplicates caused asymmetric naming: the first item would keep its
+                # bare name even after a same-named item appeared later (issue #16665).
+                attachment_semantic_identifier = full_attachment_path
 
                 primary_owners: list[BasicExpertInfo] | None = None
                 if "version" in attachment and "by" in attachment["version"]:


### PR DESCRIPTION
## Summary

Fixes #16665 — duplicate files during Confluence data source synchronization.

## Root Cause

The connector assigned a **bare filename** (e.g. `logo.png`) to the *first* occurrence of an attachment name, then switched to the full `Space / Page / Name` path only when a duplicate was encountered later in the same sync run.

Because the streaming loop processes documents one at a time, the first occurrence was **never retroactively renamed**. This produced two sync'd documents with inconsistent identifiers — one bare, one fully qualified — which downstream code treated as two distinct files (duplicate).

## Fix

Remove the `if count == 1 → bare name, else → full path` conditional for both pages and attachments. Always use the full hierarchical path (`Space / Page / Attachment`) as the semantic identifier.

This ensures every document gets a **stable, unambiguous identifier** regardless of sync order or whether same-named items appear in the same run.

## Diff Size

2 conditional blocks removed (~10 lines changed in `common/data_source/confluence_connector.py`). No new dependencies, no behavior changes outside the identifier assignment.