### PR TITLE
fix: skip min-max normalization when all reranker scores are non-positive

### DIFF
--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -72,12 +72,21 @@ class Base(ABC):
         (Cohere, Jina, Voyage, ...) are returned unchanged, so their absolute
         magnitudes, ``similarity_threshold`` semantics and reported
         ``vector_similarity`` are preserved. Only out-of-range output (e.g.
-        NVIDIA's unbounded, often negative logits) is rescaled: a batch with a
-        usable spread is min-max mapped onto ``[0, 1]`` (which stops a negative
-        logit from dragging a relevant chunk below pure keyword matches once
-        weighted by ``vtweight``), while a spreadless batch (including a single
-        candidate) has no relative signal and is clamped instead, so a lone
-        high score is not silently zeroed.
+        NVIDIA's unbounded logits) is rescaled: a batch with a usable spread is
+        min-max mapped onto ``[0, 1]`` (which stops a negative logit from
+        dragging a relevant chunk below pure keyword matches once weighted by
+        ``vtweight``), while a spreadless batch (including a single candidate)
+        has no relative signal and is clamped instead, so a lone high score is
+        not silently zeroed.
+
+        A special case guards against manufacturing false confidence: when the
+        *best* raw score in the batch is non-positive (``max_rank <= 0``), the
+        entire batch represents weak or absent matches. Applying min-max
+        rescaling in that situation would map the least-bad score to 1.0,
+        presenting uniformly-poor results as highly confident to the downstream
+        fusion step. Instead, scores are clipped to ``[0, 1]`` directly, so
+        they all land at (or near) zero and signal "nothing strong was found"
+        (issue #16621).
         """
         if rank.size == 0:
             return rank
@@ -86,6 +95,11 @@ class Base(ABC):
 
         if min_rank >= 0.0 and max_rank <= 1.0:
             return rank
+        # All scores are non-positive: the whole batch is a weak/absent match.
+        # Clip rather than rescale to avoid forcing max → 1.0 when no chunk
+        # actually has high similarity (issue #16621).
+        if max_rank <= 0.0:
+            return np.clip(rank, 0.0, 1.0)
         span = max_rank - min_rank
         if span < 1e-3:
             return np.clip(rank, 0.0, 1.0)


### PR DESCRIPTION
## Summary

Fixes #16621 — min-max normalization manufactures false confidence when a reranker returns uniformly weak/negative scores.

## Root Cause

`Base._normalize_rank()` in `rag/llm/rerank_model.py` applies min-max rescaling to any scores that fall outside `[0, 1]`. When all raw scores are non-positive (e.g. `[-1.0, -1.5, -2.0]` from a query with no strong matches), this forces the best score to `1.0`.

The downstream hybrid fusion step then weights that score at `vtweight` (typically 0.7), treating a uniformly-weak batch as a highly confident match. The issue author's example: scores `[0.3, 0.2, 0.1]` are already guarded (they pass the `max <= 1.0` early-return), but all-negative scores from providers like NVIDIA are not.

## Fix

Add one guard before the min-max step:

```python
if max_rank <= 0.0:
    return np.clip(rank, 0.0, 1.0)
```

When the best score in the batch is <= 0, clip all values to `[0, 1]` instead of rescaling. This preserves the "nothing strong was found" signal (all scores land at or near 0) rather than inflating the best to 1.0.

Batches with at least one positive score continue to use min-max rescaling so providers with mixed-sign logits are still normalized correctly.

## Impact

- **All-negative batches** (e.g. NVIDIA logits when no chunk strongly matches): scores collapse to 0 instead of being stretched to 1.0.
- **Mixed batches** (positive and negative scores): unchanged — min-max still applies.
- **Already-calibrated `[0, 1]` providers** (Cohere, Jina, Voyage): unchanged — early-return still applies.

## Diff Size

+5 lines in `rag/llm/rerank_model.py` (one new guard + inline comment).
