### PR TITLE
fix: prevent memory name from auto-appending (1) on description update

### DIFF
--- a/api/db/services/memory_service.py
+++ b/api/db/services/memory_service.py
@@ -150,7 +150,9 @@ class MemoryService(CommonService):
         if "memory_type" in update_dict and isinstance(update_dict["memory_type"], list):
             update_dict["memory_type"] = calculate_memory_type(update_dict["memory_type"])
         if "name" in update_dict:
-            update_dict["name"] = duplicate_name(cls.query, name=update_dict["name"], tenant_id=tenant_id)
+            existing = cls.model.select().where((cls.model.id == memory_id) & (cls.model.tenant_id == tenant_id)).first()
+            if not existing or existing.name != update_dict["name"]:
+                update_dict["name"] = duplicate_name(cls.query, name=update_dict["name"], tenant_id=tenant_id)
         update_dict.update({"update_time": current_timestamp(), "update_date": get_format_time()})
 
         return cls.model.update(update_dict).where(cls.model.id == memory_id).execute()


### PR DESCRIPTION
### Summary

When updating a memory's description (or any other field) via the memory settings page, the backend always runs the name through `duplicate_name`, even if the name in the update request matches the current name. This causes the name to be appended with `(1)` every time the form is saved, even though the user did not change the name.

### Fix

In `MemoryService.update_by_id`, check the existing memory name for the current `memory_id` and only call `duplicate_name` when the requested name is actually different from the current one.

### Verification

The issue was reproduced on the memory settings page: after saving a description change, the memory name changed from `mmr` to `mmr(1)`. With the fix, the name stays `mmr` while the description is updated.

/ci
