### PR TITLE
Docs: Update version references to v0.26.4 in READMEs and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
         <img alt="Static Badge" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Latest%20Release" alt="Latest Release">
@@ -193,12 +193,12 @@ releases! 🌟
 > All Docker images are built for x86 platforms. We don't currently offer Docker images for ARM64.
 > If you are on an ARM64 platform, follow [this guide](https://ragflow.io/docs/dev/build_docker_image) to build a Docker image compatible with your system.
 
-> The command below downloads the `v0.26.3` edition of the RAGFlow Docker image. See the following table for descriptions of different RAGFlow editions. To download a RAGFlow edition different from `v0.26.3`, update the `RAGFLOW_IMAGE` variable accordingly in **docker/.env** before using `docker compose` to start the server.
+> The command below downloads the `v0.26.4` edition of the RAGFlow Docker image. See the following table for descriptions of different RAGFlow editions. To download a RAGFlow edition different from `v0.26.4`, update the `RAGFLOW_IMAGE` variable accordingly in **docker/.env** before using `docker compose` to start the server.
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # Optional: use a stable tag (see releases: https://github.com/infiniflow/ragflow/releases)
    # This step ensures the **entrypoint.sh** file in the code matches the Docker image version.
 

--- a/README_ar.md
+++ b/README_ar.md
@@ -25,7 +25,7 @@
         <img alt="Static Badge" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Latest%20Release" alt="Latest Release">
@@ -193,12 +193,12 @@
 > جميع الصور Docker مصممة لمنصات x86. لا نعرض حاليًا صور Docker لـ ARM64.
 > إذا كنت تستخدم نظامًا أساسيًا ARM64، فاتبع [هذا الدليل](https://ragflow.io/docs/dev/build_docker_image) لإنشاء صورة Docker متوافقة مع نظامك.
 
-> يقوم الأمر أدناه بتنزيل إصدار `v0.26.3` من الصورة RAGFlow Docker. راجع الجدول التالي للحصول على أوصاف لإصدارات RAGFlow المختلفة. لتنزيل إصدار RAGFlow مختلف عن `v0.26.3`، قم بتحديث المتغير `RAGFLOW_IMAGE` وفقًا لذلك في **docker/.env** قبل استخدام `docker compose` لبدء تشغيل الخادم.
+> يقوم الأمر أدناه بتنزيل إصدار `v0.26.4` من الصورة RAGFlow Docker. راجع الجدول التالي للحصول على أوصاف لإصدارات RAGFlow المختلفة. لتنزيل إصدار RAGFlow مختلف عن `v0.26.4`، قم بتحديث المتغير `RAGFLOW_IMAGE` وفقًا لذلك في **docker/.env** قبل استخدام `docker compose` لبدء تشغيل الخادم.
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # Optional: use a stable tag (see releases: https://github.com/infiniflow/ragflow/releases)
    # This step ensures the **entrypoint.sh** file in the code matches the Docker image version.
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@
         <img alt="Badge statique" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Derniere%20version" alt="Dernière version">
@@ -190,12 +190,12 @@ Essayez notre service cloud sur [https://cloud.ragflow.io](https://cloud.ragflow
 > Toutes les images Docker sont construites pour les plateformes x86. Nous ne proposons pas actuellement d'images Docker pour ARM64.
 > Si vous êtes sur une plateforme ARM64, suivez [ce guide](https://ragflow.io/docs/dev/build_docker_image) pour construire une image Docker compatible avec votre système.
 
-> La commande ci-dessous télécharge l'édition `v0.26.3` de l'image Docker RAGFlow. Consultez le tableau suivant pour les descriptions des différentes éditions de RAGFlow. Pour télécharger une édition de RAGFlow différente de `v0.26.3`, mettez à jour la variable `RAGFLOW_IMAGE` dans **docker/.env** avant d'utiliser `docker compose` pour démarrer le serveur.
+> La commande ci-dessous télécharge l'édition `v0.26.4` de l'image Docker RAGFlow. Consultez le tableau suivant pour les descriptions des différentes éditions de RAGFlow. Pour télécharger une édition de RAGFlow différente de `v0.26.4`, mettez à jour la variable `RAGFLOW_IMAGE` dans **docker/.env** avant d'utiliser `docker compose` pour démarrer le serveur.
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # Optionnel : utiliser un tag stable (voir les versions : https://github.com/infiniflow/ragflow/releases)
    # Cette étape garantit que le fichier **entrypoint.sh** dans le code correspond à la version de l'image Docker.
 

--- a/README_id.md
+++ b/README_id.md
@@ -25,7 +25,7 @@
         <img alt="Lencana Daring" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Rilis%20Terbaru" alt="Rilis Terbaru">
@@ -191,12 +191,12 @@ Coba layanan cloud kami di [https://cloud.ragflow.io](https://cloud.ragflow.io).
 > Semua gambar Docker dibangun untuk platform x86. Saat ini, kami tidak menawarkan gambar Docker untuk ARM64.
 > Jika Anda menggunakan platform ARM64, [silakan gunakan panduan ini untuk membangun gambar Docker yang kompatibel dengan sistem Anda](https://ragflow.io/docs/dev/build_docker_image).
 
-> Perintah di bawah ini mengunduh edisi v0.26.3 dari gambar Docker RAGFlow. Silakan merujuk ke tabel berikut untuk deskripsi berbagai edisi RAGFlow. Untuk mengunduh edisi RAGFlow yang berbeda dari v0.26.3, perbarui variabel RAGFLOW_IMAGE di docker/.env sebelum menggunakan docker compose untuk memulai server.
+> Perintah di bawah ini mengunduh edisi v0.26.4 dari gambar Docker RAGFlow. Silakan merujuk ke tabel berikut untuk deskripsi berbagai edisi RAGFlow. Untuk mengunduh edisi RAGFlow yang berbeda dari v0.26.4, perbarui variabel RAGFLOW_IMAGE di docker/.env sebelum menggunakan docker compose untuk memulai server.
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # Opsional: gunakan tag stabil (lihat releases: https://github.com/infiniflow/ragflow/releases)
    # This steps ensures the **entrypoint.sh** file in the code matches the Docker image version.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -25,7 +25,7 @@
         <img alt="Static Badge" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Latest%20Release" alt="Latest Release">
@@ -172,12 +172,12 @@
 > 現在、公式に提供されているすべての Docker イメージは x86 アーキテクチャ向けにビルドされており、ARM64 用の Docker イメージは提供されていません。
 > ARM64 アーキテクチャのオペレーティングシステムを使用している場合は、[このドキュメント](https://ragflow.io/docs/dev/build_docker_image)を参照して Docker イメージを自分でビルドしてください。
 
-> 以下のコマンドは、RAGFlow Docker イメージの v0.26.3 エディションをダウンロードします。異なる RAGFlow エディションの説明については、以下の表を参照してください。v0.26.3 とは異なるエディションをダウンロードするには、docker/.env ファイルの RAGFLOW_IMAGE 変数を適宜更新し、docker compose を使用してサーバーを起動してください。
+> 以下のコマンドは、RAGFlow Docker イメージの v0.26.4 エディションをダウンロードします。異なる RAGFlow エディションの説明については、以下の表を参照してください。v0.26.4 とは異なるエディションをダウンロードするには、docker/.env ファイルの RAGFLOW_IMAGE 変数を適宜更新し、docker compose を使用してサーバーを起動してください。
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # 任意: 安定版タグを利用 (一覧: https://github.com/infiniflow/ragflow/releases)
    # この手順は、コード内の entrypoint.sh ファイルが Docker イメージのバージョンと一致していることを確認します。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -25,7 +25,7 @@
         <img alt="Static Badge" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Latest%20Release" alt="Latest Release">
@@ -174,12 +174,12 @@
 > 모든 Docker 이미지는 x86 플랫폼을 위해 빌드되었습니다. 우리는 현재 ARM64 플랫폼을 위한 Docker 이미지를 제공하지 않습니다.
 > ARM64 플랫폼을 사용 중이라면, [시스템과 호환되는 Docker 이미지를 빌드하려면 이 가이드를 사용해 주세요](https://ragflow.io/docs/dev/build_docker_image).
 
-   > 아래 명령어는 RAGFlow Docker 이미지의 v0.26.3 버전을 다운로드합니다. 다양한 RAGFlow 버전에 대한 설명은 다음 표를 참조하십시오. v0.26.3와 다른 RAGFlow 버전을 다운로드하려면, docker/.env 파일에서 RAGFLOW_IMAGE 변수를 적절히 업데이트한 후 docker compose를 사용하여 서버를 시작하십시오.
+   > 아래 명령어는 RAGFlow Docker 이미지의 v0.26.4 버전을 다운로드합니다. 다양한 RAGFlow 버전에 대한 설명은 다음 표를 참조하십시오. v0.26.4와 다른 RAGFlow 버전을 다운로드하려면, docker/.env 파일에서 RAGFLOW_IMAGE 변수를 적절히 업데이트한 후 docker compose를 사용하여 서버를 시작하십시오.
 
    ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # Optional: use a stable tag (see releases: https://github.com/infiniflow/ragflow/releases)
    # 이 단계는 코드의 entrypoint.sh 파일이 Docker 이미지 버전과 일치하도록 보장합니다.
 

--- a/README_pt_br.md
+++ b/README_pt_br.md
@@ -25,7 +25,7 @@
         <img alt="Badge Estático" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=%C3%9Altima%20Release" alt="Última Release">
@@ -191,12 +191,12 @@ Experimente o nosso serviço na nuvem em [https://cloud.ragflow.io](https://clou
 > Todas as imagens Docker são construídas para plataformas x86. Atualmente, não oferecemos imagens Docker para ARM64.
 > Se você estiver usando uma plataforma ARM64, por favor, utilize [este guia](https://ragflow.io/docs/dev/build_docker_image) para construir uma imagem Docker compatível com o seu sistema.
 
-    > O comando abaixo baixa a edição`v0.26.3` da imagem Docker do RAGFlow. Consulte a tabela a seguir para descrições de diferentes edições do RAGFlow. Para baixar uma edição do RAGFlow diferente da `v0.26.3`, atualize a variável `RAGFLOW_IMAGE` conforme necessário no **docker/.env** antes de usar `docker compose` para iniciar o servidor.
+    > O comando abaixo baixa a edição`v0.26.4` da imagem Docker do RAGFlow. Consulte a tabela a seguir para descrições de diferentes edições do RAGFlow. Para baixar uma edição do RAGFlow diferente da `v0.26.4`, atualize a variável `RAGFLOW_IMAGE` conforme necessário no **docker/.env** antes de usar `docker compose` para iniciar o servidor.
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # Opcional: use uma tag estável (veja releases: https://github.com/infiniflow/ragflow/releases)
    # Esta etapa garante que o arquivo entrypoint.sh no código corresponda à versão da imagem do Docker.
 

--- a/README_tr.md
+++ b/README_tr.md
@@ -25,7 +25,7 @@
         <img alt="Çevrimiçi Demo" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Son%20S%C3%BCr%C3%BCm" alt="Son Sürüm">
@@ -191,12 +191,12 @@ Bulut hizmetimizi [https://cloud.ragflow.io](https://cloud.ragflow.io) adresinde
 > Tüm Docker imajları x86 platformları için oluşturulmuştur. Şu anda ARM64 için Docker imajı sunmuyoruz.
 > ARM64 platformundaysanız, sisteminizle uyumlu bir Docker imajı oluşturmak için [bu kılavuzu](https://ragflow.io/docs/dev/build_docker_image) takip edin.
 
-> Aşağıdaki komut RAGFlow Docker imajının `v0.26.3` sürümünü indirir. Farklı RAGFlow sürümleri için aşağıdaki tabloya bakın. `v0.26.3` dışında bir sürüm indirmek için, `docker compose` ile sunucuyu başlatmadan önce **docker/.env** dosyasındaki `RAGFLOW_IMAGE` değişkenini güncelleyin.
+> Aşağıdaki komut RAGFlow Docker imajının `v0.26.4` sürümünü indirir. Farklı RAGFlow sürümleri için aşağıdaki tabloya bakın. `v0.26.4` dışında bir sürüm indirmek için, `docker compose` ile sunucuyu başlatmadan önce **docker/.env** dosyasındaki `RAGFLOW_IMAGE` değişkenini güncelleyin.
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # İsteğe bağlı: Kararlı bir etiket kullanın (sürümler: https://github.com/infiniflow/ragflow/releases)
    # Bu adım, koddaki **entrypoint.sh** dosyasının Docker imaj sürümüyle eşleşmesini sağlar.
 

--- a/README_tzh.md
+++ b/README_tzh.md
@@ -25,7 +25,7 @@
         <img alt="Static Badge" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Latest%20Release" alt="Latest Release">
@@ -191,12 +191,12 @@
 > 所有 Docker 映像檔都是為 x86 平台建置的。目前，我們不提供 ARM64 平台的 Docker 映像檔。
 > 如果您使用的是 ARM64 平台，請使用 [這份指南](https://ragflow.io/docs/dev/build_docker_image) 來建置適合您系統的 Docker 映像檔。
 
-> 執行以下指令會自動下載 RAGFlow Docker 映像 `v0.26.3`。請參考下表查看不同 Docker 發行版的說明。如需下載不同於 `v0.26.3` 的 Docker 映像，請在執行 `docker compose` 啟動服務之前先更新 **docker/.env** 檔案內的 `RAGFLOW_IMAGE` 變數。
+> 執行以下指令會自動下載 RAGFlow Docker 映像 `v0.26.4`。請參考下表查看不同 Docker 發行版的說明。如需下載不同於 `v0.26.4` 的 Docker 映像，請在執行 `docker compose` 啟動服務之前先更新 **docker/.env** 檔案內的 `RAGFLOW_IMAGE` 變數。
 
 ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # 可選：使用穩定版標籤（查看發佈：https://github.com/infiniflow/ragflow/releases）
    # 此步驟確保程式碼中的 entrypoint.sh 檔案與 Docker 映像版本一致。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -25,7 +25,7 @@
         <img alt="Static Badge" src="https://img.shields.io/badge/Get-Started-4e6b99">
     </a>
     <a href="https://hub.docker.com/r/infiniflow/ragflow" target="_blank">
-        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.3">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/infiniflow/ragflow-stats/main/badges/docker-pulls.json&style=flat-square&logo=docker&logoColor=white" alt="docker pull infiniflow/ragflow:v0.26.4">
     </a>
     <a href="https://github.com/infiniflow/ragflow/releases/latest">
         <img src="https://img.shields.io/github/v/release/infiniflow/ragflow?color=blue&label=Latest%20Release" alt="Latest Release">
@@ -192,12 +192,12 @@
 > 请注意，目前官方提供的所有 Docker 镜像均基于 x86 架构构建，并不提供基于 ARM64 的 Docker 镜像。
 > 如果你的操作系统是 ARM64 架构，请参考[这篇文档](https://ragflow.io/docs/dev/build_docker_image)自行构建 Docker 镜像。
 
-   > 运行以下命令会自动下载 RAGFlow Docker 镜像 `v0.26.3`。请参考下表查看不同 Docker 发行版的描述。如需下载不同于 `v0.26.3` 的 Docker 镜像，请在运行 `docker compose` 启动服务之前先更新 **docker/.env** 文件内的 `RAGFLOW_IMAGE` 变量。
+   > 运行以下命令会自动下载 RAGFlow Docker 镜像 `v0.26.4`。请参考下表查看不同 Docker 发行版的描述。如需下载不同于 `v0.26.4` 的 Docker 镜像，请在运行 `docker compose` 启动服务之前先更新 **docker/.env** 文件内的 `RAGFLOW_IMAGE` 变量。
 
    ```bash
    $ cd ragflow/docker
 
-   # git checkout v0.26.3
+   # git checkout v0.26.4
    # 可选：使用稳定版本标签（查看发布：https://github.com/infiniflow/ragflow/releases）
    # 这一步确保代码中的 entrypoint.sh 文件与 Docker 镜像的版本保持一致。
 

--- a/admin/client/README.md
+++ b/admin/client/README.md
@@ -28,7 +28,7 @@ It consists of a server-side Service and a command-line client (CLI), both imple
    ```bash
    python admin/server/admin_server.py
    ```
-   The service will start and listen for incoming connections from the CLI on the configured port. 
+   The service will start and listen for incoming connections from the CLI on the configured port.
 
 #### Using docker image
 
@@ -48,7 +48,7 @@ It consists of a server-side Service and a command-line client (CLI), both imple
 1.  Ensure the Admin Service is running.
 2.  Install ragflow-cli.
     ```bash
-    pip install ragflow-cli==0.26.3
+    pip install ragflow-cli==0.26.4
     ```
 3.  Launch the CLI client:
     ```bash
@@ -58,9 +58,9 @@ It consists of a server-side Service and a command-line client (CLI), both imple
     The default password is admin.
 
     **Parameters:**
-    
+
     - -h: RAGFlow admin server host address
-    
+
     - -p: RAGFlow admin server port
 
 

--- a/admin/client/pyproject.toml
+++ b/admin/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragflow-cli"
-version = "0.26.3"
+version = "0.26.4"
 description = "Admin Service's client of [RAGFlow](https://github.com/infiniflow/ragflow). The Admin Service provides user management and system monitoring. "
 authors = [{ name = "Lynn", email = "lynn_inf@hotmail.com" }]
 license = { text = "Apache License, Version 2.0" }

--- a/admin/client/uv.lock
+++ b/admin/client/uv.lock
@@ -156,7 +156,7 @@ wheels = [
 
 [[package]]
 name = "ragflow-cli"
-version = "0.26.3"
+version = "0.26.4"
 source = { virtual = "." }
 dependencies = [
     { name = "beartype" },

--- a/docker/.env
+++ b/docker/.env
@@ -167,11 +167,11 @@ API_PROXY_SCHEME=python # use pure python server deployment
 ALLOW_ANY_HOST=0
 
 # The RAGFlow Docker image to download. v0.22+ doesn't include embedding models.
-RAGFLOW_IMAGE=infiniflow/ragflow:v0.26.3
+RAGFLOW_IMAGE=infiniflow/ragflow:v0.26.4
 
 # If you cannot download the RAGFlow Docker image:
-# RAGFLOW_IMAGE=swr.cn-north-4.myhuaweicloud.com/infiniflow/ragflow:v0.26.3
-# RAGFLOW_IMAGE=registry.cn-hangzhou.aliyuncs.com/infiniflow/ragflow:v0.26.3
+# RAGFLOW_IMAGE=swr.cn-north-4.myhuaweicloud.com/infiniflow/ragflow:v0.26.4
+# RAGFLOW_IMAGE=registry.cn-hangzhou.aliyuncs.com/infiniflow/ragflow:v0.26.4
 #
 # - For the `nightly` edition, uncomment either of the following:
 # RAGFLOW_IMAGE=swr.cn-north-4.myhuaweicloud.com/infiniflow/ragflow:nightly

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,9 +12,9 @@
 
 ## 🐳 Docker Compose
 
-- **docker-compose.yml**  
+- **docker-compose.yml**
   Sets up environment for RAGFlow and its dependencies.
-- **docker-compose-base.yml**  
+- **docker-compose-base.yml**
   Sets up environment for RAGFlow's dependencies: Elasticsearch/[Infinity](https://github.com/infiniflow/infinity), MySQL, MinIO, and Redis.
 
 > [!CAUTION]
@@ -26,108 +26,108 @@ The [.env](./.env) file contains important environment variables for Docker.
 
 ### Elasticsearch
 
-- `STACK_VERSION`  
+- `STACK_VERSION`
   The version of Elasticsearch. Defaults to `8.11.3`
-- `ES_PORT`  
+- `ES_PORT`
   The port used to expose the Elasticsearch service to the host machine, allowing **external** access to the service running inside the Docker container.  Defaults to `1200`.
-- `ELASTIC_PASSWORD`  
+- `ELASTIC_PASSWORD`
   The password for Elasticsearch.
 
 ### Kibana
 
-- `KIBANA_PORT`  
+- `KIBANA_PORT`
   The port used to expose the Kibana service to the host machine, allowing **external** access to the service running inside the Docker container. Defaults to `6601`.
-- `KIBANA_USER`  
+- `KIBANA_USER`
   The username for Kibana. Defaults to `rag_flow`.
-- `KIBANA_PASSWORD`  
+- `KIBANA_PASSWORD`
   The password for Kibana. Defaults to `infini_rag_flow`.
 
 ### Resource management
 
-- `MEM_LIMIT`  
+- `MEM_LIMIT`
   The maximum amount of the memory, in bytes, that *a specific* Docker container can use while running. Defaults to `8073741824`.
 
 ### MySQL
 
-- `MYSQL_PASSWORD`  
+- `MYSQL_PASSWORD`
   The password for MySQL.
-- `MYSQL_PORT`  
+- `MYSQL_PORT`
   The port to connect to MySQL from RAGFlow container. Defaults to `3306`. Change this if you use an external MySQL.
-- `EXPOSE_MYSQL_PORT`  
+- `EXPOSE_MYSQL_PORT`
   The port used to expose the MySQL service to the host machine, allowing **external** access to the MySQL database running inside the Docker container. Defaults to `5455`.
 
 ### MinIO
 
-- `MINIO_CONSOLE_PORT`  
+- `MINIO_CONSOLE_PORT`
   The port used to expose the MinIO console interface to the host machine, allowing **external** access to the web-based console running inside the Docker container. Defaults to `9001`
-- `MINIO_PORT`  
+- `MINIO_PORT`
   The port used to expose the MinIO API service to the host machine, allowing **external** access to the MinIO object storage service running inside the Docker container. Defaults to `9000`.
-- `MINIO_USER`  
+- `MINIO_USER`
   The username for MinIO.
-- `MINIO_PASSWORD`  
+- `MINIO_PASSWORD`
   The password for MinIO.
 
 ### Redis
 
-- `REDIS_PORT`  
+- `REDIS_PORT`
   The port used to expose the Redis service to the host machine, allowing **external** access to the Redis service running inside the Docker container. Defaults to `6379`.
-- `REDIS_PASSWORD`  
+- `REDIS_PASSWORD`
   The password for Redis.
 
 ### RAGFlow
 
-- `SVR_HTTP_PORT`  
+- `SVR_HTTP_PORT`
   The port used to expose RAGFlow's HTTP API service to the host machine, allowing **external** access to the service running inside the Docker container. Defaults to `9380`.
-- `RAGFLOW_IMAGE`  
-  The Docker image edition. Defaults to `infiniflow/ragflow:v0.26.3`. The RAGFlow Docker image does not include embedding models.
+- `RAGFLOW_IMAGE`
+  The Docker image edition. Defaults to `infiniflow/ragflow:v0.26.4`. The RAGFlow Docker image does not include embedding models.
 
-  
-> [!TIP]  
-> If you cannot download the RAGFlow Docker image, try the following mirrors.  
-> 
-> - For the `nightly` edition:  
+
+> [!TIP]
+> If you cannot download the RAGFlow Docker image, try the following mirrors.
+>
+> - For the `nightly` edition:
 >   - `RAGFLOW_IMAGE=swr.cn-north-4.myhuaweicloud.com/infiniflow/ragflow:nightly` or,
 >   - `RAGFLOW_IMAGE=registry.cn-hangzhou.aliyuncs.com/infiniflow/ragflow:nightly`.
 
 ### DeepDoc Vision Service (OSS)
 
-- `DEEPDOC_URL`  
+- `DEEPDOC_URL`
   URL for the deepdoc vision API serving DLA (layout analysis), OCR (text detection/recognition), and TSR (table structure recognition). The `deepdoc` service in `docker-compose.yml` provides this endpoint. Defaults to `http://deepdoc:9390`. When unset, the parser falls back to inline ONNX Runtime inference.
 
-  > The OSS deepdoc service runs on CPU using ONNX Runtime models. No GPU required.  
+  > The OSS deepdoc service runs on CPU using ONNX Runtime models. No GPU required.
   > API endpoints: `GET /health`, `GET /model`, `POST /predict/dla`, `POST /predict/tsr`, `POST /predict/ocr`.
 
-- `DEEPDOC_IMAGE`  
+- `DEEPDOC_IMAGE`
   Docker image for the OSS deepdoc service. Defaults to `infiniflow/deepdoc_oss:latest`.
 
 ### Timezone
 
-- `TZ`  
+- `TZ`
   The local time zone. Defaults to `'Asia/Shanghai'`.
 
 ### Hugging Face mirror site
 
-- `HF_ENDPOINT`  
+- `HF_ENDPOINT`
   The mirror site for huggingface.co. It is disabled by default. You can uncomment this line if you have limited access to the primary Hugging Face domain.
 
 ### MacOS
 
-- `MACOS`  
+- `MACOS`
   Optimizations for macOS. It is disabled by default. You can uncomment this line if your OS is macOS.
 
 ### Maximum file size
 
-- `MAX_CONTENT_LENGTH`  
+- `MAX_CONTENT_LENGTH`
   The maximum file size for each uploaded file, in bytes. You can uncomment this line if you wish to change the 128M file size limit. After making the change, ensure you update `client_max_body_size` in nginx/nginx.conf correspondingly.
 
 ### Doc bulk size
 
-- `DOC_BULK_SIZE`  
+- `DOC_BULK_SIZE`
   The number of document chunks processed in a single batch during document parsing. Defaults to `4`.
 
 ### Embedding batch size
 
-- `EMBEDDING_BATCH_SIZE`  
+- `EMBEDDING_BATCH_SIZE`
   The number of text chunks processed in a single batch during embedding vectorization. Defaults to `16`.
 
 ### OceanBase prerequisites
@@ -178,7 +178,7 @@ Before setting `DOC_ENGINE=oceanbase`, make sure the host OS allows the file des
   - `host`: The API server's IP address inside the Docker container. Defaults to `0.0.0.0`.
   - `port`: The API server's serving port inside the Docker container. Defaults to `9380`.
 
-- `deepdoc`  
+- `deepdoc`
   The OSS DeepDoc vision service provides DLA, OCR, and TSR inference via ONNX Runtime.
   Defined in `docker-compose.yml`, it is started automatically as a dependency of `ragflow-cpu` and `ragflow-gpu`.
   - `image`: Docker image. Defaults to `infiniflow/deepdoc_oss:latest`.
@@ -240,8 +240,8 @@ Before setting `DOC_ENGINE=oceanbase`, make sure the host OS allows the file des
     - `scope`: Requested permission scope, a space-separated string. For example, `openid profile email`.
     - `redirect_uri`: Required, URI to which the authorization server redirects during the authentication flow to return results. Must match the callback URI registered with the authentication server. Format: `https://your-app.com/v1/user/oauth/callback/<channel>`. For local configuration, you can directly use `http://127.0.0.1:80/v1/user/oauth/callback/<channel>`.
 
-- `user_default_llm`  
-  The default LLM to use for a new RAGFlow user. It is disabled by default. To enable this feature, uncomment the corresponding lines in **service_conf.yaml.template**.  
+- `user_default_llm`
+  The default LLM to use for a new RAGFlow user. It is disabled by default. To enable this feature, uncomment the corresponding lines in **service_conf.yaml.template**.
   - `factory`: The LLM supplier. Available options:
     - `"OpenAI"`
     - `"DeepSeek"`
@@ -251,7 +251,7 @@ Before setting `DOC_ENGINE=oceanbase`, make sure the host OS allows the file des
     - `"ZHIPU-AI"`
   - `api_key`: The API key for the specified LLM. You will need to apply for your model API key online.
 
-> [!TIP]  
+> [!TIP]
 > If you do not set the default LLM here, configure the default LLM on the **Settings** page in the RAGFlow UI.
 
 
@@ -273,20 +273,20 @@ If you want your instance to be available under `https`, follow these steps:
    ```bash
    # Ubuntu/Debian
    sudo apt update && sudo apt install certbot
-   
+
    # CentOS/RHEL
    sudo yum install certbot
-   
+
    # Obtain certificates (replace with your actual domain)
    sudo certbot certonly --standalone -d your-ragflow-domain.com
    ```
 
-2. **Locate your certificates**  
+2. **Locate your certificates**
    Once generated, your certificates will be located at:
    - Certificate: `/etc/letsencrypt/live/your-ragflow-domain.com/fullchain.pem`
    - Private key: `/etc/letsencrypt/live/your-ragflow-domain.com/privkey.pem`
 
-3. **Update docker-compose.yml**  
+3. **Update docker-compose.yml**
    Add the certificate volumes to the `ragflow` service in your `docker-compose.yml`:
    ```yaml
    services:
@@ -299,10 +299,10 @@ If you want your instance to be available under `https`, follow these steps:
          # Switch to HTTPS nginx configuration
          - ./nginx/ragflow.https.conf:/etc/nginx/conf.d/ragflow.conf
          # ...other existing volumes...
-  
+
    ```
 
-4. **Update nginx configuration**  
+4. **Update nginx configuration**
    Edit `nginx/ragflow.https.conf` and replace `my_ragflow_domain.com` with your actual domain name.
 
 5. **Restart the services**

--- a/docs/administrator/admin/ragflow_cli.md
+++ b/docs/administrator/admin/ragflow_cli.md
@@ -16,9 +16,9 @@ The RAGFlow CLI is a command-line-based system administration tool that offers a
 2. Install ragflow-cli.
 
    ```bash
-   pipx install ragflow-cli==0.26.3
+   pipx install ragflow-cli==0.26.4
    ```
-  > You can also use `uv`, a tool for managing virtual environments and packages, to install RAGFlow CLI: `uv tool install ragflow-cli@0.26.3`.
+  > You can also use `uv`, a tool for managing virtual environments and packages, to install RAGFlow CLI: `uv tool install ragflow-cli@0.26.4`.
 
 3. Launch the CLI client:
 
@@ -30,9 +30,9 @@ The RAGFlow CLI is a command-line-based system administration tool that offers a
     The default password is admin.
 
     **Parameters:**
-    
+
     - -h: RAGFlow admin server host address
-    
+
     - -p: RAGFlow admin server port
 
 ## Default administrative account

--- a/docs/administrator/configurations/configurations.md
+++ b/docs/administrator/configurations/configurations.md
@@ -103,7 +103,7 @@ RAGFlow utilizes MinIO as its object storage solution, leveraging its scalabilit
 - `SVR_HTTP_PORT`
   The port used to expose RAGFlow's HTTP API service to the host machine, allowing **external** access to the service running inside the Docker container. Defaults to `9380`.
 - `RAGFLOW_IMAGE`
-  The Docker image edition. Defaults to `infiniflow/ragflow:v0.26.3` (the RAGFlow Docker image without embedding models).
+  The Docker image edition. Defaults to `infiniflow/ragflow:v0.26.4` (the RAGFlow Docker image without embedding models).
 
 :::tip NOTE
 If you cannot download the RAGFlow Docker image, try the following mirrors.

--- a/docs/administrator/migration/database_schema_and_migration.md
+++ b/docs/administrator/migration/database_schema_and_migration.md
@@ -43,7 +43,7 @@ The [db_schema_sync.py](https://github.com/infiniflow/ragflow/blob/main/tools/sc
 ### Key functions
 
 - **Change detection**: Compares Python model definitions in `api/db/db_models.py` against the live database to identify new tables, added fields, or type mismatches.
-- **Migration generation**: Automatically creates Python migration files (containing `migrate()` and `rollback()` logic) in version-specific directories (e.g., `tools/migrate/v0_26_3/`).
+- **Migration generation**: Automatically creates Python migration files (containing `migrate()` and `rollback()` logic) in version-specific directories (e.g., `tools/migrate/v0_26_4/`).
 - **Schema auditing**: Provides a `--diff` command to view structural discrepancies without applying changes.
 - **Execution management**: Applies pending migrations to the database to bring it up to date with the current software version.
 - **Safety controls**: Prevents accidental data loss by requiring an explicit `--drop` flag to generate `DROP COLUMN` statements for removed fields.

--- a/docs/administrator/upgrade_ragflow.mdx
+++ b/docs/administrator/upgrade_ragflow.mdx
@@ -62,16 +62,16 @@ To upgrade RAGFlow, you must upgrade **both** your code **and** your Docker imag
    git pull
    ```
 
-3. Switch to the latest, officially published release, e.g., `v0.26.3`:
+3. Switch to the latest, officially published release, e.g., `v0.26.4`:
 
    ```bash
-   git checkout -f v0.26.3
+   git checkout -f v0.26.4
    ```
 
 4. Update **ragflow/docker/.env**:
 
    ```bash
-   RAGFLOW_IMAGE=infiniflow/ragflow:v0.26.3
+   RAGFLOW_IMAGE=infiniflow/ragflow:v0.26.4
    ```
 
 5. Update the RAGFlow image and restart RAGFlow:
@@ -92,10 +92,10 @@ No, you do not need to. Upgrading RAGFlow in itself will *not* remove your uploa
 1. From an environment with Internet access, pull the required Docker image.
 2. Save the Docker image to a **.tar** file.
    ```bash
-   docker save -o ragflow.v0.26.3.tar infiniflow/ragflow:v0.26.3
+   docker save -o ragflow.v0.26.4.tar infiniflow/ragflow:v0.26.4
    ```
 3. Copy the **.tar** file to the target server.
 4. Load the **.tar** file into Docker:
    ```bash
-   docker load -i ragflow.v0.26.3.tar
+   docker load -i ragflow.v0.26.4.tar
    ```

--- a/docs/develop/build_docker_image.mdx
+++ b/docs/develop/build_docker_image.mdx
@@ -50,7 +50,7 @@ After building the infiniflow/ragflow:nightly image, you are ready to launch a f
 
 1. Edit Docker Compose Configuration
 
-Open the `docker/.env` file. Find the `RAGFLOW_IMAGE` setting and change the image reference from `infiniflow/ragflow:v0.26.3` to `infiniflow/ragflow:nightly` to use the pre-built image.
+Open the `docker/.env` file. Find the `RAGFLOW_IMAGE` setting and change the image reference from `infiniflow/ragflow:v0.26.4` to `infiniflow/ragflow:nightly` to use the pre-built image.
 
 
 2. Launch the Service

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -147,12 +147,12 @@ When debugging your chat assistant, you can use AI search as a reference to veri
 
 ---
 
-### Get a `Request error 404: undefined` when upgrading to v0.26.3
+### Get a `Request error 404: undefined` when upgrading to v0.26.4
 
 To resolve this issue, do either of the following:
 
-- Pull the latest source code from the [main branch](https://github.com/infiniflow/ragflow), then pull and start the v0.26.3 image.
-- Update `RAGFLOW_IMAGE` from `infiniflow/ragflow:latest` to `infiniflow/ragflow:v0.26.3` in the [.env file](https://github.com/infiniflow/ragflow/blob/main/docker/.env), then restart the service.
+- Pull the latest source code from the [main branch](https://github.com/infiniflow/ragflow), then pull and start the v0.26.4 image.
+- Update `RAGFLOW_IMAGE` from `infiniflow/ragflow:latest` to `infiniflow/ragflow:v0.26.4` in the [.env file](https://github.com/infiniflow/ragflow/blob/main/docker/.env), then restart the service.
 
 ### How to build the RAGFlow image from scratch?
 
@@ -218,7 +218,7 @@ This error is almost always caused by Java not being installed or not accessible
 
 ### `Cannot stat '/etc/nginx/conf.d/ragflow.conf.python': No such file or directory`
 
-To resolve this, either download the missing file from the corresponding tag on [GitHub](https://github.com/infiniflow/ragflow) or update `~/ragflow/docker/docker-compose.yml` as follows: 
+To resolve this, either download the missing file from the corresponding tag on [GitHub](https://github.com/infiniflow/ragflow) or update `~/ragflow/docker/docker-compose.yml` as follows:
 
 ![](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/docker-compose_missing.jpg)
 

--- a/docs/guides/dataset/configure_knowledge_base.md
+++ b/docs/guides/dataset/configure_knowledge_base.md
@@ -24,7 +24,7 @@ _Each time a dataset is created, a folder with the same name is generated in the
 
 ## Configure dataset
 
-The following screenshot shows the configuration page of a dataset. A proper configuration of your dataset is crucial for future AI chats. For example, choosing the wrong embedding model or chunking method would cause unexpected semantic loss or mismatched answers in chats. 
+The following screenshot shows the configuration page of a dataset. A proper configuration of your dataset is crucial for future AI chats. For example, choosing the wrong embedding model or chunking method would cause unexpected semantic loss or mismatched answers in chats.
 
 ![dataset configuration](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/configure_knowledge_base.jpg)
 
@@ -62,14 +62,14 @@ You can also change a file's chunking method on the **Files** page.
 
 <details>
   <summary>From v0.21.0 onward, RAGFlow supports ingestion pipeline for customized data ingestion and cleansing workflows.</summary>
-   
+
   To use a customized data pipeline:
 
   1. On the **Agent** page, click **+ Create agent** > **Create from blank**.
   2. Select **Ingestion pipeline** and name your data pipeline in the popup, then click **Save** to show the data pipeline canvas.
   3. After updating your data pipeline, click **Save** on the top right of the canvas.
   4. Navigate to the **Configuration** page of your dataset, select **Choose pipeline** in **Ingestion pipeline**.
-     
+
      *Your saved data pipeline will appear in the dropdown menu below.*
 
 </details>
@@ -85,9 +85,9 @@ Some embedding models are optimized for specific languages, so performance may b
 ### Upload file
 
 - RAGFlow's File system allows you to link a file to multiple datasets, in which case each target dataset holds a reference to the file.
-- In **Knowledge Base**, you are also given the option of uploading a single file or a folder of files (bulk upload) from your local machine to a dataset, in which case the dataset holds file copies. 
+- In **Knowledge Base**, you are also given the option of uploading a single file or a folder of files (bulk upload) from your local machine to a dataset, in which case the dataset holds file copies.
 
-While uploading files directly to a dataset seems more convenient, we *highly* recommend uploading files to RAGFlow's File system and then linking them to the target datasets. This way, you can avoid permanently deleting files uploaded to the dataset. 
+While uploading files directly to a dataset seems more convenient, we *highly* recommend uploading files to RAGFlow's File system and then linking them to the target datasets. This way, you can avoid permanently deleting files uploaded to the dataset.
 
 ### Parse file
 
@@ -95,14 +95,14 @@ File parsing is a crucial topic in dataset configuration. The meaning of file pa
 
 ![parse file](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/parse_file.jpg)
 
-- As shown above, RAGFlow allows you to use a different chunking method for a particular file, offering flexibility beyond the default method. 
-- As shown above, RAGFlow allows you to enable or disable individual files, offering finer control over dataset-based AI chats. 
+- As shown above, RAGFlow allows you to use a different chunking method for a particular file, offering flexibility beyond the default method.
+- As shown above, RAGFlow allows you to enable or disable individual files, offering finer control over dataset-based AI chats.
 
 ### Intervene with file parsing results
 
-RAGFlow features visibility and explainability, allowing you to view the chunking results and intervene where necessary. To do so: 
+RAGFlow features visibility and explainability, allowing you to view the chunking results and intervene where necessary. To do so:
 
-1. Click on the file that completes file parsing to view the chunking results: 
+1. Click on the file that completes file parsing to view the chunking results:
 
    _You are taken to the **Chunk** page:_
 
@@ -115,7 +115,7 @@ RAGFlow features visibility and explainability, allowing you to view the chunkin
    ![update chunk](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/add_keyword_question.jpg)
 
 :::caution NOTE
-You can add keywords to a file chunk to increase its ranking for queries containing those keywords. This action increases its keyword weight and can improve its position in search list.  
+You can add keywords to a file chunk to increase its ranking for queries containing those keywords. This action increases its keyword weight and can improve its position in search list.
 :::
 
 4. In Retrieval testing, ask a quick question in **Test text** to double-check if your configurations work:
@@ -135,7 +135,7 @@ See [Run retrieval test](./run_retrieval_test.md) for details.
 
 ## Search for dataset
 
-As of RAGFlow v0.26.3, the search feature is still in a rudimentary form, supporting only dataset search by name.
+As of RAGFlow v0.26.4, the search feature is still in a rudimentary form, supporting only dataset search by name.
 
 ![search dataset](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/search_datasets.jpg)
 
@@ -143,7 +143,7 @@ As of RAGFlow v0.26.3, the search feature is still in a rudimentary form, suppor
 
 You are allowed to delete a dataset. Hover your mouse over the three dot of the intended dataset card and the **Delete** option appears. Once you delete a dataset, the associated folder under **root/.knowledge** directory is AUTOMATICALLY REMOVED. The consequence is:
 
-- The files uploaded directly to the dataset are gone;  
-- The file references, which you created from within RAGFlow's File system, are gone, but the associated files still exist. 
+- The files uploaded directly to the dataset are gone;
+- The file references, which you created from within RAGFlow's File system, are gone, but the associated files still exist.
 
 ![delete dataset](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/delete_datasets.jpg)

--- a/docs/guides/manage_files.md
+++ b/docs/guides/manage_files.md
@@ -15,7 +15,7 @@ Compared to uploading files directly to various datasets, uploading them to RAGF
 
 ## Create folder
 
-RAGFlow's file management allows you to establish your file system with nested folder structures. To create a folder in the root directory of RAGFlow: 
+RAGFlow's file management allows you to establish your file system with nested folder structures. To create a folder in the root directory of RAGFlow:
 
 ![create new folder](https://github.com/infiniflow/ragflow/assets/93570324/3a37a5f4-43a6-426d-a62a-e5cd2ff7a533)
 
@@ -25,7 +25,7 @@ Each dataset in RAGFlow has a corresponding folder under the **root/.knowledgeba
 
 ## Upload file
 
-RAGFlow's file management supports file uploads from your local machine, allowing both individual and bulk uploads: 
+RAGFlow's file management supports file uploads from your local machine, allowing both individual and bulk uploads:
 
 ![upload file](https://github.com/infiniflow/ragflow/assets/93570324/5d7ded14-ce2b-4703-8567-9356a978f45c)
 
@@ -47,7 +47,7 @@ RAGFlow's file management allows you to *link* an uploaded file to multiple data
 
 ![link knowledgebase](https://github.com/infiniflow/ragflow/assets/93570324/6c6b8db4-3269-4e35-9434-6089887e3e3f)
 
-You can link your file to one dataset or multiple datasets at one time: 
+You can link your file to one dataset or multiple datasets at one time:
 
 ![link multiple kb](https://github.com/infiniflow/ragflow/assets/93570324/6c508803-fb1f-435d-b688-683066fd7fff)
 
@@ -70,9 +70,9 @@ RAGFlow's file management allows you to rename a file or folder:
 
 ## Delete files or folders
 
-RAGFlow's file management allows you to delete files or folders individually or in bulk. 
+RAGFlow's file management allows you to delete files or folders individually or in bulk.
 
-To delete a file or folder: 
+To delete a file or folder:
 
 ![delete file](https://github.com/infiniflow/ragflow/assets/93570324/85872728-125d-45e9-a0ee-21e9d4cedb8b)
 
@@ -80,7 +80,7 @@ To bulk delete files or folders:
 
 ![bulk delete](https://github.com/infiniflow/ragflow/assets/93570324/519b99ab-ec7f-4c8a-8cea-e0b6dcb3cb46)
 
-> - You are not allowed to delete the **root/.knowledgebase** folder. 
+> - You are not allowed to delete the **root/.knowledgebase** folder.
 > - Deleting files that have been linked to datasets will **AUTOMATICALLY REMOVE** all associated file references across the datasets.
 
 ## Download uploaded file
@@ -89,4 +89,4 @@ RAGFlow's file management allows you to download an uploaded file:
 
 ![download_file](https://github.com/infiniflow/ragflow/assets/93570324/cf3b297f-7d9b-4522-bf5f-4f45743e4ed5)
 
-> As of RAGFlow v0.26.3, bulk download is not supported, nor can you download an entire folder. 
+> As of RAGFlow v0.26.4, bulk download is not supported, nor can you download an entire folder.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -14,9 +14,9 @@ RAGFlow is an open-source RAG (Retrieval-Augmented Generation) engine based on d
 
 This quick start guide describes a general process from:
 
-- Starting up a local RAGFlow server, 
-- Creating a dataset, 
-- Intervening with file parsing, to 
+- Starting up a local RAGFlow server,
+- Creating a dataset,
+- Intervening with file parsing, to
 - Establishing an AI chat based on your datasets.
 
 :::danger IMPORTANT
@@ -49,7 +49,7 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
 
    `vm.max_map_count`. This value sets the maximum number of memory map areas a process may have. Its default value is 65530. While most applications require fewer than a thousand maps, reducing this value can result in abnormal behaviors, and the system will throw out-of-memory errors when a process reaches the limitation.
 
-   RAGFlow v0.26.3 uses Elasticsearch or [Infinity](https://github.com/infiniflow/infinity) for multiple recall. Setting the value of `vm.max_map_count` correctly is crucial to the proper functioning of the Elasticsearch component.
+   RAGFlow v0.26.4 uses Elasticsearch or [Infinity](https://github.com/infiniflow/infinity) for multiple recall. Setting the value of `vm.max_map_count` correctly is crucial to the proper functioning of the Elasticsearch component.
 
 <Tabs
   defaultValue="linux"
@@ -74,7 +74,7 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
    :::caution WARNING
    This change will be reset after a system reboot. If you forget to update the value the next time you start up the server, you may get a `Can't connect to ES cluster` exception.
    :::
-   
+
    1.3. To ensure your change remains permanent, add or update the `vm.max_map_count` value in **/etc/sysctl.conf** accordingly:
 
    ```bash
@@ -148,7 +148,7 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
    ```
    #### If you are on Windows with Docker Desktop WSL 2 backend, then use docker-desktop to set `vm.max_map_count`:
 
-   1.1. Run the following in WSL: 
+   1.1. Run the following in WSL:
    ```bash
    $ wsl -d docker-desktop -u root
    $ sysctl -w vm.max_map_count=262144
@@ -175,7 +175,7 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
    ```
 
    ```bash
-   # Append a line, which reads: 
+   # Append a line, which reads:
    vm.max_map_count = 262144
    ```
    :::
@@ -194,7 +194,7 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
 3. Switch to the current version:
 
    ```bash
-   $ git checkout -f v0.26.3
+   $ git checkout -f v0.26.4
    ```
 4. Use the pre-built Docker images and start up the server:
 
@@ -209,7 +209,7 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
 
    | RAGFlow image tag   | Image size (GB) | Stable?                  |
    | ------------------- | --------------- | ------------------------ |
-   | v0.26.3             | &approx;2       | Stable release           |
+   | v0.26.4             | &approx;2       | Stable release           |
    | nightly             | &approx;2       | _Unstable_ nightly build |
 
    ```mdx-code-block
@@ -234,13 +234,13 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
       / /_/ // /| | / / __ / /_   / // __ \| | /| / /
      / _, _// ___ |/ /_/ // __/  / // /_/ /| |/ |/ /
     /_/ |_|/_/  |_|\____//_/    /_/ \____/ |__/|__/
-   
+
     * Running on all addresses (0.0.0.0)
    ```
 
    :::danger IMPORTANT
    If you skip this confirmation step and directly log in to RAGFlow, your browser may prompt a `network anomaly` error because, at that moment, your RAGFlow may not be fully initialized.
-   :::  
+   :::
 
 6. In your web browser, enter the IP address of your server and log in to RAGFlow.
 
@@ -252,24 +252,24 @@ This section provides instructions on setting up the RAGFlow server on Linux. If
 
 RAGFlow is a RAG engine and needs to work with an LLM to offer grounded, hallucination-free question-answering capabilities. RAGFlow supports most mainstream LLMs. For a complete list of supported models, please refer to [Supported Models](./guides/models/supported_models.mdx).
 
-:::note 
-RAGFlow also supports deploying LLMs locally using Ollama, Xinference, or LocalAI, but this part is not covered in this quick start guide. 
+:::note
+RAGFlow also supports deploying LLMs locally using Ollama, Xinference, or LocalAI, but this part is not covered in this quick start guide.
 :::
 
-To add and configure an LLM: 
+To add and configure an LLM:
 
 1. Click on your logo on the top right of the page **>** **Model providers**.
 
 2. Click on the desired LLM and update the API key accordingly.
 
-3. Click **System Model Settings** to select the default models: 
+3. Click **System Model Settings** to select the default models:
 
-   - Chat model, 
-   - Embedding model, 
+   - Chat model,
+   - Embedding model,
    - Image-to-text model,
    - and more.
 
-> Some models, such as the image-to-text model **qwen-vl-max**, are subsidiary to a specific LLM. And you may need to update your API key to access these models. 
+> Some models, such as the image-to-text model **qwen-vl-max**, are subsidiary to a specific LLM. And you may need to update your API key to access these models.
 
 ## Create your first dataset
 
@@ -285,21 +285,21 @@ To create your first dataset:
 
    ![dataset configuration](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/configure_knowledge_base.jpg)
 
-3. RAGFlow offers multiple chunk templates that cater to different document layouts and file formats. Select the embedding model and chunking method (template) for your dataset. 
+3. RAGFlow offers multiple chunk templates that cater to different document layouts and file formats. Select the embedding model and chunking method (template) for your dataset.
 
-   :::danger IMPORTANT 
-   Once you have selected an embedding model and used it to parse a file, you are no longer allowed to change it. The obvious reason is that we must ensure that all files in a specific dataset are parsed using the *same* embedding model (ensure that they are being compared in the same embedding space). 
+   :::danger IMPORTANT
+   Once you have selected an embedding model and used it to parse a file, you are no longer allowed to change it. The obvious reason is that we must ensure that all files in a specific dataset are parsed using the *same* embedding model (ensure that they are being compared in the same embedding space).
    :::
 
    _You are taken to the **Dataset** page of your dataset._
 
-4. Click **+ Add file** **>** **Local files** to start uploading a particular file to the dataset. 
+4. Click **+ Add file** **>** **Local files** to start uploading a particular file to the dataset.
 
 5. In the uploaded file entry, click the play button to start file parsing:
 
    ![parse file](https://raw.githubusercontent.com/infiniflow/ragflow-docs/main/images/parse_file.jpg)
 
-   :::caution NOTE 
+   :::caution NOTE
    - If your file parsing gets stuck at below 1%, see [this FAQ](./faq.mdx#why-does-my-document-parsing-stall-at-under-one-percent).
    - If your file parsing gets stuck at near completion, see [this FAQ](./faq.mdx#why-does-my-pdf-parsing-stall-near-completion-while-the-log-does-not-show-any-error)
    :::

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,7 +77,7 @@ env:
 ragflow:
   image:
     repository: infiniflow/ragflow
-    tag: v0.26.3
+    tag: v0.26.4
     pullPolicy: IfNotPresent
     pullSecrets: []
   # Optional service configuration overrides

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragflow"
-version = "0.26.3"
+version = "0.26.4"
 description = "[RAGFlow](https://ragflow.io/) is an open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. It offers a streamlined RAG workflow for businesses of any scale, combining LLM (Large Language Models) to provide truthful question-answering capabilities, backed by well-founded citations from various complex formatted data."
 authors = [{ name = "Zhichang Yu", email = "yuzhichang@gmail.com" }]
 license-files = ["LICENSE"]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragflow-sdk"
-version = "0.26.3"
+version = "0.26.4"
 description = "Python client sdk of [RAGFlow](https://github.com/infiniflow/ragflow). RAGFlow is an open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding."
 authors = [{ name = "Zhichang Yu", email = "yuzhichang@gmail.com" }]
 license = { text = "Apache License, Version 2.0" }

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "ragflow-sdk"
-version = "0.26.3"
+version = "0.26.4"
 source = { virtual = "." }
 dependencies = [
     { name = "beartype" },

--- a/test/README.md
+++ b/test/README.md
@@ -24,7 +24,7 @@ source .venv/bin/activate
 **Install SDK:**
 
 ```bash
-uv pip install sdk/python 
+uv pip install sdk/python
 
 ```
 
@@ -33,7 +33,7 @@ uv pip install sdk/python
 ```env
 COMPOSE_PROFILES=${COMPOSE_PROFILES},tei-cpu
 TEI_MODEL=BAAI/bge-small-en-v1.5
-RAGFLOW_IMAGE=infiniflow/ragflow:v0.26.3 #Replace with the image you are using
+RAGFLOW_IMAGE=infiniflow/ragflow:v0.26.4 #Replace with the image you are using
 
 ```
 
@@ -53,14 +53,14 @@ docker compose -f docker/docker-compose.yml up -d
 ```bash
 export HTTP_API_TEST_LEVEL=p2
 export HOST_ADDRESS=http://127.0.0.1:9380  # Ensure that this port is the API port mapped to your localhost
-pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_sdk_api 
+pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_sdk_api
 
 ```
 
 **b) Run http api tests against Elasticsearch:**
 
 ```bash
-pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_http_api 
+pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_http_api
 
 ```
 
@@ -78,7 +78,7 @@ DOC_ENGINE=${DOC_ENGINE:-infinity}
 **Start the container:**
 
 ```bash
-docker compose -f docker/docker-compose.yml down -v 
+docker compose -f docker/docker-compose.yml down -v
 docker compose -f docker/docker-compose.yml up -d
 
 ```
@@ -86,13 +86,13 @@ docker compose -f docker/docker-compose.yml up -d
 **a) Run sdk tests against Infinity:**
 
 ```bash
-DOC_ENGINE=infinity pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_sdk_api 
+DOC_ENGINE=infinity pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_sdk_api
 
 ```
 
 **b) Run http api tests against Infinity:**
 
 ```bash
-DOC_ENGINE=infinity pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_http_api 
+DOC_ENGINE=infinity pytest -s --tb=short --level=${HTTP_API_TEST_LEVEL} test/testcases/test_http_api
 
 ```

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -104,7 +104,7 @@ The script has three mutually exclusive modes:
    ```bash
    # Using config file
    python mysql_migration.py --stages tenant_model_provider --config config.yaml
-   
+
    # Using command line MySQL connection
    python mysql_migration.py --stages tenant_model_provider --host localhost --port 3306 --user root
    ```
@@ -275,8 +275,8 @@ python db_schema_sync.py [OPTIONS]
 ### Version Format
 
 Version must be in format `vxx.xx.xx` where `xx` are digits:
-- Valid: `v0.26.3`, `v1.0.0`, `v10.20.30`
-- Invalid: `0.26.3`, `v0.25`, `v0.26.3.1`
+- Valid: `v0.26.4`, `v1.0.0`, `v10.20.30`
+- Invalid: `0.26.4`, `v0.25`, `v0.26.4.1`
 
 ### Migration File Location
 
@@ -287,7 +287,7 @@ tools/migrate/{version_dir}/
 
 Where `{version_dir}` is the version with `.` replaced by `_`.
 
-Example: Version `v0.26.3` → Directory `tools/migrate/v0_26_3/`
+Example: Version `v0.26.4` → Directory `tools/migrate/v0_26_4/`
 
 ### Examples
 
@@ -295,32 +295,32 @@ Example: Version `v0.26.3` → Directory `tools/migrate/v0_26_3/`
 # List all migrations
 python db_schema_sync.py --list \
     --host localhost --port 3306 --user root --password xxx --database rag_flow \
-    --version v0.26.3
+    --version v0.26.4
 
 # Create a new auto-detected migration (new tables, new fields, type changes only)
 python db_schema_sync.py --create \
     --host localhost --port 3306 --user root --password xxx --database rag_flow \
-    --version v0.26.3
+    --version v0.26.4
 
 # Create a migration including dropped fields (destructive!)
 python db_schema_sync.py --create --drop \
     --host localhost --port 3306 --user root --password xxx --database rag_flow \
-    --version v0.26.3
+    --version v0.26.4
 
 # Create a named migration
 python db_schema_sync.py --create --name add_user_table \
     --host localhost --port 3306 --user root --password xxx --database rag_flow \
-    --version v0.26.3
+    --version v0.26.4
 
 # Run all pending migrations
 python db_schema_sync.py --migrate \
     --host localhost --port 3306 --user root --password xxx --database rag_flow \
-    --version v0.26.3
+    --version v0.26.4
 
 # Show schema differences (including removed fields)
 python db_schema_sync.py --diff \
     --host localhost --port 3306 --user root --password xxx --database rag_flow \
-    --version v0.26.3
+    --version v0.26.4
 ```
 
 ## How It Works

--- a/tools/scripts/db_schema_sync.py
+++ b/tools/scripts/db_schema_sync.py
@@ -52,7 +52,7 @@ def validate_version(version: str) -> bool:
 
 
 def version_to_dirname(version: str) -> str:
-    """Convert version string to valid directory name (e.g., 'v0.26.3' -> 'v0_26_3')"""
+    """Convert version string to valid directory name (e.g., 'v0.26.4' -> 'v0_26_4')"""
     return version.replace(".", "_")
 
 
@@ -838,19 +838,19 @@ def main():
         epilog="""
 Examples:
   # List all migrations
-  python db_schema_sync.py --list --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.3
+  python db_schema_sync.py --list --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.4
 
   # Create migration from model changes
-  python db_schema_sync.py --create --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.3
+  python db_schema_sync.py --create --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.4
 
   # Create migration including dropped fields (destructive!)
-  python db_schema_sync.py --create --drop --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.3
+  python db_schema_sync.py --create --drop --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.4
 
   # Run all pending migrations
-  python db_schema_sync.py --migrate --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.3
+  python db_schema_sync.py --migrate --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.4
 
   # Show schema differences
-  python db_schema_sync.py --diff --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.3
+  python db_schema_sync.py --diff --host localhost --port 3306 --user root --password xxx --database rag_flow --version v0.26.4
 """,
     )
 
@@ -862,7 +862,7 @@ Examples:
     parser.add_argument("--database", type=str, required=True, help="MySQL database name")
 
     # Version option
-    parser.add_argument("--version", "-v", type=str, required=True, help="Version number in format vxx.xx.xx (e.g., v0.26.3)")
+    parser.add_argument("--version", "-v", type=str, required=True, help="Version number in format vxx.xx.xx (e.g., v0.26.4)")
 
     # Action options
     parser.add_argument("--list", "-l", action="store_true", help="List all migrations")
@@ -878,7 +878,7 @@ Examples:
 
     # Validate version format
     if not validate_version(args.version):
-        logger.error(f"Invalid version format: {args.version}. Expected format: vxx.xx.xx (e.g., v0.26.3)")
+        logger.error(f"Invalid version format: {args.version}. Expected format: vxx.xx.xx (e.g., v0.26.4)")
         sys.exit(1)
 
     # Validate at least one action is specified

--- a/tools/scripts/mysql_migration.py
+++ b/tools/scripts/mysql_migration.py
@@ -1381,10 +1381,10 @@ Examples:
   python mysql_migration.py --list-stages
 
   # Check whether migration is needed for a target version
-  python mysql_migration.py --check-database-version --database-version v0.26.3 --config /path/to/config.yaml
+  python mysql_migration.py --check-database-version --database-version v0.26.4 --config /path/to/config.yaml
 
   # Mark database version separately
-  python mysql_migration.py --mark-database-version --database-version v0.26.3 --config /path/to/config.yaml
+  python mysql_migration.py --mark-database-version --database-version v0.26.4 --config /path/to/config.yaml
 
   # Dry run (default - check only, no write) with config file
   python mysql_migration.py --stages tenant_model_provider --config /path/to/config.yaml
@@ -1398,11 +1398,11 @@ Examples:
   # Execute full migration (create tables and migrate data)
   python mysql_migration.py --stages tenant_model_provider --config /path/to/config.yaml --execute
 
-  # Execute migration only when database version is lower than v0.26.3
-  python mysql_migration.py --stages tenant_model_provider --config /path/to/config.yaml --execute --database-version v0.26.3
+  # Execute migration only when database version is lower than v0.26.4
+  python mysql_migration.py --stages tenant_model_provider --config /path/to/config.yaml --execute --database-version v0.26.4
 
   # Execute migration and mark the database version when all stages succeed
-  python mysql_migration.py --stages tenant_model_provider,tenant_model_instance,tenant_model,model_id_config --config /path/to/config.yaml --execute --database-version v0.26.3 --mark-database-version-on-success
+  python mysql_migration.py --stages tenant_model_provider,tenant_model_instance,tenant_model,model_id_config --config /path/to/config.yaml --execute --database-version v0.26.4 --mark-database-version-on-success
 
   # Normalize legacy model IDs in stored configs
   python mysql_migration.py --stages model_id_config --config /path/to/config.yaml --execute

--- a/uv.lock
+++ b/uv.lock
@@ -7880,7 +7880,7 @@ wheels = [
 
 [[package]]
 name = "ragflow"
-version = "0.26.3"
+version = "0.26.4"
 source = { virtual = "." }
 dependencies = [
     { name = "agentrun-sdk" },


### PR DESCRIPTION
### What problem does this PR solve?

- Update version tags in README files (including translations) from v0.26.3 to v0.26.4
- Modify Docker image references and documentation to reflect new version
- Update version badges and image descriptions
- Maintain consistency across all language variants of README files

### Type of change

- [x] Documentation Update