### PR TITLE
Fix: right-anchored split in web parseModelValue / parseModelUuid

### DIFF
--- a/web/src/utils/llm-util.ts
+++ b/web/src/utils/llm-util.ts
@@ -43,29 +43,64 @@ export function buildModelValue(model: {
   return `${model.model_name}@${model.model_instance}@${model.model_provider}`;
 }
 
-/** Parse "modelName@instanceName@providerName" */
+/**
+ * Parse "modelName@instanceName@providerName" (or the 2-part
+ * "modelName@providerName" form where the instance defaults to "default").
+ *
+ * The composite key is right-anchored: the *last* '@'-separated field is the
+ * provider, the second-to-last is the instance, and everything to the left of
+ * the second-to-last '@' is the bare model name. Some model names legitimately
+ * contain '@' themselves (e.g. LM Studio embedding IDs such as
+ * `text-embedding-nomic-embed-text-v1.5@q8_0`), producing four-`@` composite
+ * keys like `text-embedding-nomic-embed-text-v1.5@q8_0@lmstudio@LM-Studio`.
+ *
+ * A naive `split("@")` (or anchoring on the first '@') mis-parses these keys
+ * — PATCH /api/v1/models/default then sends `model_name="…v1.5"` and
+ * `model_instance="q8_0@lmstudio"`, and the server replies
+ * `Instance 'q8_0@lmstudio' not found for provider 'LM-Studio'`.
+ *
+ * Right-anchored split mirrors `api/db/joint_services/tenant_model_service.py`
+ * `split_model_name` and the Go `parseModelName` (PR #16468 family).
+ */
 export function parseModelValue(val: string) {
   if (!val) return null;
-  const firstAt = val.indexOf('@');
   const lastAt = val.lastIndexOf('@');
-  if (firstAt === -1 || firstAt === lastAt) return null;
+  if (lastAt === -1) return null;
+  const secondLastAt = val.lastIndexOf('@', lastAt - 1);
+  if (secondLastAt === -1) {
+    // 2-part form: "modelName@providerName" — instance defaults to "default".
+    return {
+      model_name: val.substring(0, lastAt),
+      model_instance: 'default',
+      model_provider: val.substring(lastAt + 1),
+    };
+  }
   return {
-    model_name: val.substring(0, firstAt),
-    model_instance: val.substring(firstAt + 1, lastAt),
+    model_name: val.substring(0, secondLastAt),
+    model_instance: val.substring(secondLastAt + 1, lastAt),
     model_provider: val.substring(lastAt + 1),
   };
 }
 
 // Extract model name and factory ID from a model UUID
-// Supports both "model_name@factory_id" and "model_name@factory_id#instance_name"
+// Supports both "model_name@factory_id" and "model_name@factory_id#instance_name".
+// Uses right-anchored split for the same reason as parseModelValue:
+// model names may contain '@' themselves, so a naive split('@') drops the
+// last portion of the model name into factoryId.
 export function parseModelUuid(uuid: string): {
   modelName: string;
   factoryId: string;
 } {
   const hashIndex = uuid.indexOf('#');
   const core = hashIndex === -1 ? uuid : uuid.slice(0, hashIndex);
-  const [modelName, factoryId] = core.split('@');
-  return { modelName, factoryId };
+  const lastAt = core.lastIndexOf('@');
+  if (lastAt === -1) {
+    return { modelName: core, factoryId: '' };
+  }
+  return {
+    modelName: core.substring(0, lastAt),
+    factoryId: core.substring(lastAt + 1),
+  };
 }
 
 // Model parameter to tenant parameter mapping

--- a/web/src/utils/tests/llm-util.test.ts
+++ b/web/src/utils/tests/llm-util.test.ts
@@ -1,0 +1,117 @@
+import { buildModelValue, parseModelUuid, parseModelValue } from '../llm-util';
+
+// Composite model keys are right-anchored:
+// "model_name@instance_name@provider_name" or "model_name@provider_name".
+// Model names may legally contain '@' (LM Studio IDs like
+// "text-embedding-nomic-embed-text-v1.5@q8_0"), so the parser must split from
+// the right and only treat the last two '@'-separated fields as instance and
+// provider. Mirrors api/db/joint_services/tenant_model_service.py
+// split_model_name (PR #16468).
+
+describe('parseModelValue — right-anchored split', () => {
+  test('plain 3-part composite', () => {
+    expect(parseModelValue('gemma@lmstudio@LM-Studio')).toEqual({
+      model_name: 'gemma',
+      model_instance: 'lmstudio',
+      model_provider: 'LM-Studio',
+    });
+  });
+
+  test('2-part composite defaults instance to "default"', () => {
+    expect(parseModelValue('gemma@LM-Studio')).toEqual({
+      model_name: 'gemma',
+      model_instance: 'default',
+      model_provider: 'LM-Studio',
+    });
+  });
+
+  test('4-part composite with embedded "@" in model name (LM Studio embedding)', () => {
+    expect(
+      parseModelValue(
+        'text-embedding-nomic-embed-text-v1.5@q8_0@lmstudio@LM-Studio',
+      ),
+    ).toEqual({
+      model_name: 'text-embedding-nomic-embed-text-v1.5@q8_0',
+      model_instance: 'lmstudio',
+      model_provider: 'LM-Studio',
+    });
+  });
+
+  test('quants with multiple "@" in model name still anchor on the last two', () => {
+    expect(parseModelValue('org/model@sha@q8_0@default@Builtin')).toEqual({
+      model_name: 'org/model@sha@q8_0',
+      model_instance: 'default',
+      model_provider: 'Builtin',
+    });
+  });
+
+  test('returns null for empty input', () => {
+    expect(parseModelValue('')).toBeNull();
+  });
+
+  test('returns null when no "@" is present', () => {
+    expect(parseModelValue('plain-model-name')).toBeNull();
+  });
+});
+
+describe('buildModelValue round-trips parseModelValue', () => {
+  test('simple triplet', () => {
+    const v = buildModelValue({
+      model_name: 'gemma',
+      model_instance: 'lmstudio',
+      model_provider: 'LM-Studio',
+    });
+    expect(v).toBe('gemma@lmstudio@LM-Studio');
+    expect(parseModelValue(v)).toEqual({
+      model_name: 'gemma',
+      model_instance: 'lmstudio',
+      model_provider: 'LM-Studio',
+    });
+  });
+
+  test('round-trip survives embedded "@" in model name', () => {
+    const v = buildModelValue({
+      model_name: 'text-embedding-nomic-embed-text-v1.5@q8_0',
+      model_instance: 'lmstudio',
+      model_provider: 'LM-Studio',
+    });
+    expect(v).toBe(
+      'text-embedding-nomic-embed-text-v1.5@q8_0@lmstudio@LM-Studio',
+    );
+    expect(parseModelValue(v)).toEqual({
+      model_name: 'text-embedding-nomic-embed-text-v1.5@q8_0',
+      model_instance: 'lmstudio',
+      model_provider: 'LM-Studio',
+    });
+  });
+});
+
+describe('parseModelUuid — right-anchored', () => {
+  test('simple "model@factory" splits on the last "@"', () => {
+    expect(parseModelUuid('gpt-4@ZHIPU-AI')).toEqual({
+      modelName: 'gpt-4',
+      factoryId: 'ZHIPU-AI',
+    });
+  });
+
+  test('preserves embedded "@" in the model name (LM Studio)', () => {
+    expect(parseModelUuid('text-embedding-nomic-embed-text-v1.5@q8_0@lmstudio')).toEqual({
+      modelName: 'text-embedding-nomic-embed-text-v1.5@q8_0',
+      factoryId: 'lmstudio',
+    });
+  });
+
+  test('ignores "#instance" suffix when splitting the factory portion', () => {
+    expect(parseModelUuid('gpt-4@ZHIPU-AI#CI')).toEqual({
+      modelName: 'gpt-4',
+      factoryId: 'ZHIPU-AI',
+    });
+  });
+
+  test('returns empty factoryId when no "@" is present', () => {
+    expect(parseModelUuid('plain-model')).toEqual({
+      modelName: 'plain-model',
+      factoryId: '',
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #16468.

PR #16468 fixed the Python (`api/db/joint_services/tenant_model_service.py
split_model_name`) and Go (`internal/service/model_service.go parseModelName`)
parsers to right-anchor the '@'-split on the composite
"model_name@instance@provider" key, but the matching helper in the front-end
(`web/src/utils/llm-util.ts parseModelValue`) was missed.

parseModelValue used `split('@')` (anchored on the first '@'), which silently
mangles composite keys whose model_name itself contains '@' (e.g. LM Studio
embedding IDs like `text-embedding-nomic-embed-text-v1.5@q8_0`):

  text-embedding-nomic-embed-text-v1.5@q8_0@lmstudio@LM-Studio

became

  model_name:     text-embedding-nomic-embed-text-v1.5
  model_instance: q8_0@lmstudio
  model_provider: LM-Studio

`PATCH /api/v1/models/default` then sent those to the server, which returned
HTTP 200 with body `{"code": 102, "message": "Instance 'q8_0@lmstudio' not
found for provider 'LM-Studio'"}`. The UI swallowed the body-level error
code, so the failure was silent: no toast, the Embedding field stayed empty.

This change makes parseModelValue do a right-anchored split that mirrors the
Python `split_model_name` `rsplit('@', 2)` exactly:

  - 3-part form: model_name@instance@provider -> same three fields.
  - 2-part form: model_name@provider -> model_instance defaults to "default"
    (matching Python).
  - 4+-part form (embedded '@' in model name): last two fields are anchored
    as instance and provider, everything to the left is the bare model name.

`parseModelUuid` is updated to the same right-anchored split so the
factoryId portion of `model_name@factory_id[#instance]` keeps the last '@'
as the separator even when the model name itself contains '@'.

Adds jest cases under `web/src/utils/tests/llm-util.test.ts` (12 total)
covering the plain 3-part, 2-part, 4-part, multi-'@' name, buildModelValue
round-trip and parseModelUuid variants.

Note for reviewers: the front-end is bundled into the published docker
image, so a release containing this fix will need `docker compose build
--no-cache ragflow-cpu` (or equivalent) for it to be visible to end users.

Refs #16468, #16467
