### PR TITLE
Fix: XLSX multi-sheet files being parsed as first sheet only

### DIFF
--- a/internal/service/chunk/chunk.go
+++ b/internal/service/chunk/chunk.go
@@ -17,22 +17,17 @@
 package chunk
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/csv"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"image"
 	"image/color"
 	"image/draw"
 	"image/jpeg"
-	"io"
 	"math"
 	"math/rand"
-	"path/filepath"
 	"ragflow/internal/common"
 	"ragflow/internal/engine/redis"
 	"ragflow/internal/entity"
@@ -1140,87 +1135,7 @@ func estimatePDFPageCount(binary []byte) int64 {
 }
 
 func estimateTableRowCount(name string, binary []byte) int {
-	switch strings.ToLower(filepath.Ext(name)) {
-	case ".xlsx":
-		if rows, err := countXLSXRows(binary); err == nil {
-			return rows
-		}
-	case ".csv", ".tsv", ".txt":
-		return countDelimitedRows(name, binary)
-	}
-	return 0
-}
-
-func countDelimitedRows(name string, binary []byte) int {
-	reader := csv.NewReader(bytes.NewReader(binary))
-	reader.FieldsPerRecord = -1
-	reader.ReuseRecord = true
-	if strings.EqualFold(filepath.Ext(name), ".tsv") {
-		reader.Comma = '\t'
-	}
-	rows := 0
-	for {
-		_, err := reader.Read()
-		if err == nil {
-			rows++
-			continue
-		}
-		if err == io.EOF {
-			break
-		}
-		rows += bytes.Count(binary, []byte{'\n'})
-		if len(binary) > 0 && binary[len(binary)-1] != '\n' {
-			rows++
-		}
-		break
-	}
-	return rows
-}
-
-func countXLSXRows(binary []byte) (int, error) {
-	zipReader, err := zip.NewReader(bytes.NewReader(binary), int64(len(binary)))
-	if err != nil {
-		return 0, err
-	}
-	maxRows := 0
-	for _, file := range zipReader.File {
-		if !strings.HasPrefix(file.Name, "xl/worksheets/") || !strings.HasSuffix(file.Name, ".xml") {
-			continue
-		}
-		rows, err := countWorksheetRows(file)
-		if err != nil {
-			return 0, err
-		}
-		if rows > maxRows {
-			maxRows = rows
-		}
-	}
-	return maxRows, nil
-}
-
-func countWorksheetRows(file *zip.File) (int, error) {
-	reader, err := file.Open()
-	if err != nil {
-		return 0, err
-	}
-	defer reader.Close()
-
-	decoder := xml.NewDecoder(reader)
-	rows := 0
-	for {
-		token, err := decoder.Token()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return 0, err
-		}
-		start, ok := token.(xml.StartElement)
-		if ok && start.Name.Local == "row" {
-			rows++
-		}
-	}
-	return rows, nil
+	return utility.CountSpreadsheetRows(name, binary)
 }
 
 func docName(doc *entity.Document) string {

--- a/internal/service/dataset.go
+++ b/internal/service/dataset.go
@@ -17,18 +17,12 @@
 package service
 
 import (
-	"archive/zip"
-	"bytes"
 	"context"
-	"encoding/csv"
 	"encoding/json"
-	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"math/rand"
-	"path/filepath"
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
@@ -1530,87 +1524,7 @@ func datasetEstimatePDFPageCount(binary []byte) int64 {
 }
 
 func datasetEstimateTableRowCount(name string, binary []byte) int {
-	switch strings.ToLower(filepath.Ext(name)) {
-	case ".xlsx":
-		if rows, err := datasetCountXLSXRows(binary); err == nil {
-			return rows
-		}
-	case ".csv", ".tsv", ".txt":
-		return datasetCountDelimitedRows(name, binary)
-	}
-	return 0
-}
-
-func datasetCountDelimitedRows(name string, binary []byte) int {
-	reader := csv.NewReader(bytes.NewReader(binary))
-	reader.FieldsPerRecord = -1
-	reader.ReuseRecord = true
-	if strings.EqualFold(filepath.Ext(name), ".tsv") {
-		reader.Comma = '\t'
-	}
-	rows := 0
-	for {
-		_, err := reader.Read()
-		if err == nil {
-			rows++
-			continue
-		}
-		if err == io.EOF {
-			break
-		}
-		rows += bytes.Count(binary, []byte{'\n'})
-		if len(binary) > 0 && binary[len(binary)-1] != '\n' {
-			rows++
-		}
-		break
-	}
-	return rows
-}
-
-func datasetCountXLSXRows(binary []byte) (int, error) {
-	zipReader, err := zip.NewReader(bytes.NewReader(binary), int64(len(binary)))
-	if err != nil {
-		return 0, err
-	}
-	maxRows := 0
-	for _, file := range zipReader.File {
-		if !strings.HasPrefix(file.Name, "xl/worksheets/") || !strings.HasSuffix(file.Name, ".xml") {
-			continue
-		}
-		rows, err := datasetCountWorksheetRows(file)
-		if err != nil {
-			return 0, err
-		}
-		if rows > maxRows {
-			maxRows = rows
-		}
-	}
-	return maxRows, nil
-}
-
-func datasetCountWorksheetRows(file *zip.File) (int, error) {
-	reader, err := file.Open()
-	if err != nil {
-		return 0, err
-	}
-	defer reader.Close()
-
-	decoder := xml.NewDecoder(reader)
-	rows := 0
-	for {
-		token, err := decoder.Token()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return 0, err
-		}
-		start, ok := token.(xml.StartElement)
-		if ok && start.Name.Local == "row" {
-			rows++
-		}
-	}
-	return rows, nil
+	return utility.CountSpreadsheetRows(name, binary)
 }
 
 func (d *DatasetService) DeleteIndex(userID, datasetID, indexType string, wipe bool) (common.ErrorCode, error) {

--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -17,12 +17,8 @@
 package service
 
 import (
-	"archive/zip"
-	"bytes"
 	"context"
-	"encoding/csv"
 	"encoding/json"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -1775,86 +1771,7 @@ func documentEstimatePDFPageCount(binary []byte) int64 {
 }
 
 func documentEstimateTableRowCount(name string, binary []byte) int {
-	switch strings.ToLower(filepath.Ext(name)) {
-	case ".xlsx":
-		if rows, err := documentCountXLSXRows(binary); err == nil {
-			return rows
-		}
-	case ".csv", ".tsv", ".txt":
-		return documentCountDelimitedRows(name, binary)
-	}
-	return 0
-}
-
-func documentCountDelimitedRows(name string, binary []byte) int {
-	reader := csv.NewReader(bytes.NewReader(binary))
-	reader.FieldsPerRecord = -1
-	reader.ReuseRecord = true
-	if strings.EqualFold(filepath.Ext(name), ".tsv") {
-		reader.Comma = '\t'
-	}
-	rows := 0
-	for {
-		_, err := reader.Read()
-		if err == nil {
-			rows++
-			continue
-		}
-		if err == io.EOF {
-			break
-		}
-		rows += bytes.Count(binary, []byte{'\n'})
-		if len(binary) > 0 && binary[len(binary)-1] != '\n' {
-			rows++
-		}
-		break
-	}
-	return rows
-}
-
-func documentCountXLSXRows(binary []byte) (int, error) {
-	zipReader, err := zip.NewReader(bytes.NewReader(binary), int64(len(binary)))
-	if err != nil {
-		return 0, err
-	}
-	maxRows := 0
-	for _, file := range zipReader.File {
-		if !strings.HasPrefix(file.Name, "xl/worksheets/") || !strings.HasSuffix(file.Name, ".xml") {
-			continue
-		}
-		rows, err := documentCountWorksheetRows(file)
-		if err != nil {
-			return 0, err
-		}
-		if rows > maxRows {
-			maxRows = rows
-		}
-	}
-	return maxRows, nil
-}
-
-func documentCountWorksheetRows(file *zip.File) (int, error) {
-	reader, err := file.Open()
-	if err != nil {
-		return 0, err
-	}
-	defer reader.Close()
-	decoder := xml.NewDecoder(reader)
-	rows := 0
-	for {
-		token, err := decoder.Token()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return 0, err
-		}
-		start, ok := token.(xml.StartElement)
-		if ok && start.Name.Local == "row" {
-			rows++
-		}
-	}
-	return rows, nil
+	return utility.CountSpreadsheetRows(name, binary)
 }
 
 func (s *DocumentService) beginDocumentParse(docID string) error {

--- a/internal/utility/spreadsheet_rows.go
+++ b/internal/utility/spreadsheet_rows.go
@@ -1,0 +1,85 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package utility
+
+import (
+	"bytes"
+	"encoding/csv"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// CountSpreadsheetRows estimates how many logical rows a table document contains.
+// XLSX sums all worksheet rows so task pagination covers every sheet.
+func CountSpreadsheetRows(name string, binary []byte) int {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".xlsx":
+		if rows, err := countXLSXRows(binary); err == nil {
+			return rows
+		}
+	case ".csv", ".tsv", ".txt":
+		return countDelimitedRows(name, binary)
+	}
+	return 0
+}
+
+func countDelimitedRows(name string, binary []byte) int {
+	reader := csv.NewReader(bytes.NewReader(binary))
+	reader.FieldsPerRecord = -1
+	reader.ReuseRecord = true
+	if strings.EqualFold(filepath.Ext(name), ".tsv") {
+		reader.Comma = '\t'
+	}
+	rows := 0
+	for {
+		_, err := reader.Read()
+		if err == nil {
+			rows++
+			continue
+		}
+		if err == io.EOF {
+			break
+		}
+		rows += bytes.Count(binary, []byte{'\n'})
+		if len(binary) > 0 && binary[len(binary)-1] != '\n' {
+			rows++
+		}
+		break
+	}
+	return rows
+}
+
+func countXLSXRows(binary []byte) (int, error) {
+	book, err := excelize.OpenReader(bytes.NewReader(binary))
+	if err != nil {
+		return 0, err
+	}
+	defer book.Close()
+
+	totalRows := 0
+	for _, sheet := range book.GetSheetList() {
+		rows, err := book.GetRows(sheet)
+		if err != nil {
+			return 0, err
+		}
+		totalRows += len(rows)
+	}
+	return totalRows, nil
+}

--- a/internal/utility/spreadsheet_rows_test.go
+++ b/internal/utility/spreadsheet_rows_test.go
@@ -1,0 +1,55 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package utility
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/xuri/excelize/v2"
+)
+
+func TestCountSpreadsheetRowsUsesSummedXLSXRows(t *testing.T) {
+	book := excelize.NewFile()
+	t.Cleanup(func() { _ = book.Close() })
+	if err := book.SetSheetName("Sheet1", "First"); err != nil {
+		t.Fatalf("rename first sheet: %v", err)
+	}
+	if _, err := book.NewSheet("Second"); err != nil {
+		t.Fatalf("create second sheet: %v", err)
+	}
+	for row := 1; row <= 3; row++ {
+		if err := book.SetCellInt("First", "A"+strconv.Itoa(row), int64(row)); err != nil {
+			t.Fatalf("write first sheet: %v", err)
+		}
+	}
+	for row := 1; row <= 5; row++ {
+		if err := book.SetCellInt("Second", "A"+strconv.Itoa(row), int64(row)); err != nil {
+			t.Fatalf("write second sheet: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := book.Write(&buf); err != nil {
+		t.Fatalf("write workbook: %v", err)
+	}
+
+	if got := CountSpreadsheetRows("book.xlsx", buf.Bytes()); got != 8 {
+		t.Fatalf("CountSpreadsheetRows() = %d, want 8", got)
+	}
+}


### PR DESCRIPTION
## What & why

Multi-sheet `.xlsx` files were ingested as if they only contained their
largest single worksheet — rows belonging to the other sheets never made it
into chunks.

The root cause is in **task pagination**, not in the parser. When a table
document is queued, `ChunkService.tableParseTaskRanges`
(`internal/service/chunk/chunk.go`) splits it into 3000-row parse tasks based
on an estimated row count:

```go
rows := estimateTableRowCount(docName(doc), binary)
for row := 0; row < rows; row += 3000 {
    ranges = append(ranges, parsePageRange{from: row, to: min(row+3000, rows)})
}
```
The XLSX branch of that estimate returned the row count of the largest
single worksheet (maxRows), not the workbook total. So for a workbook with
sheets of, say, 2000 / 2000 / 2000 rows, the estimate was 2000 and only one
task covering rows [0, 2000) was created — rows 2000–6000 (the 2nd and 3rd
sheets) had no task covering them and were dropped.

The Go XLSX parser (internal/parser/parser/xlsx_parser.go) already
iterates every sheet, so the content was available — it just never got a task
range that reached it.

## Fix
Add utility.CountSpreadsheetRows (internal/utility/spreadsheet_rows.go),
which counts XLSX rows by summing every worksheet via excelize, so the
generated task ranges cover the whole workbook.
Collapse the three near-duplicate row-counting implementations in
chunk.go, dataset.go, and document.go into that single shared helper.

### Why not deal with`.xls` files?

`.xls` doesn't suffer from this bug. It isn't handled by
`CountSpreadsheetRows`, so it returns `0`, and the caller falls back to a single
task covering the whole document (`tableParseTaskRanges` → `[0,
maximumTaskPageNumber]`) — every sheet is already processed. The dropped-sheet
bug only occurs when a *wrong positive* row count is returned (the old
max-of-sheets logic), which only the `.xlsx` path produced.

Adding an `.xls` branch wouldn't help anyway: excelize (the only spreadsheet
library in `go.mod`) reads the OOXML family only, not the legacy BIFF `.xls`
binary format, so it would fall back to the same single-task path.

## Scope
Go-only. Per the ongoing Python→Go migration, no Python code is touched.

## Testing
Unit test internal/utility/spreadsheet_rows_test.go: a workbook with a
3-row sheet and a 5-row sheet → CountSpreadsheetRows returns 8 (sum),
which is distinct from the old max-of-sheets result (5) and from
first-sheet-only (3), so the test fails on either regression.

``` shell
$ go test ./internal/utility/ -run TestCountSpreadsheetRowsUsesSummedXLSXRows -v
=== RUN   TestCountSpreadsheetRowsUsesSummedXLSXRows
--- PASS: TestCountSpreadsheetRowsUsesSummedXLSXRows (0.00s)
PASS
ok  	ragflow/internal/utility	0.478s
```