### PR TITLE
fix(ingestion): eliminate production panics and respect document pipeline config

### DIFF
--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -306,7 +306,10 @@ func (e *Ingestor) executeTask(taskCtx *taskpkg.TaskContext) {
 	common.Info(fmt.Sprintf("Task %s completed", task.ID))
 }
 
-// FIXME: should remove
+// getPipelineID loads the default ingestion pipeline template and creates a
+// new canvas ID. This is the fallback path used when a document does not
+// already have a pipeline assigned (e.g. when the knowledge-base default
+// pipeline is not yet configured).
 func (e *Ingestor) getPipelineID(tenantID string) (string, error) {
 	_, file, _, ok := goruntime.Caller(0)
 	if !ok {
@@ -386,8 +389,13 @@ func (e *Ingestor) defaultRunDocumentTask(ctx context.Context, ingestionTask *en
 		return fmt.Errorf("load task context for %s: %w", ingestionTask.ID, err)
 	}
 
-	if docTaskCtx.PipelineID, err = e.getPipelineID(docTaskCtx.Tenant.ID); err != nil {
-		return fmt.Errorf("get pipeline ID for %s: %w", ingestionTask.ID, err)
+	// Use the document's pipeline if one was already assigned (e.g. from
+	// the knowledge-base configuration in the UI); otherwise create a
+	// default pipeline from the ingestion template as a fallback.
+	if docTaskCtx.PipelineID == "" {
+		if docTaskCtx.PipelineID, err = e.getPipelineID(docTaskCtx.Tenant.ID); err != nil {
+			return fmt.Errorf("get pipeline ID for %s: %w", ingestionTask.ID, err)
+		}
 	}
 
 	return taskpkg.NewTaskHandler(docTaskCtx).Handle()

--- a/internal/ingestion/task/chunk_process.go
+++ b/internal/ingestion/task/chunk_process.go
@@ -147,6 +147,12 @@ func ProcessChunksForDataflow(
 
 		if _, exists := ck["id"]; !exists {
 			text := MustGetChunkTextString(ck, "ProcessChunksForDataflow")
+			if text == "" {
+				// Fallback: use content_with_weight if text is missing or malformed
+				if cwt, ok := ck["content_with_weight"].(string); ok && cwt != "" {
+					text = cwt
+				}
+			}
 			ck["id"] = ChunkID(text, docID)
 		}
 

--- a/internal/ingestion/task/chunk_process.go
+++ b/internal/ingestion/task/chunk_process.go
@@ -138,7 +138,7 @@ func ProcessChunksForDataflow(
 	timeStr := now.Format("2006-01-02 15:04:05")
 	timestamp := float64(now.UnixMicro()) / 1e6
 
-	for _, ck := range chunks {
+	for i, ck := range chunks {
 		ck["doc_id"] = docID
 		ck["kb_id"] = []string{kbID}
 		ck["docnm_kwd"] = docName
@@ -152,6 +152,11 @@ func ProcessChunksForDataflow(
 				if cwt, ok := ck["content_with_weight"].(string); ok && cwt != "" {
 					text = cwt
 				}
+			}
+			if text == "" {
+				// Avoid duplicate IDs: multiple empty-content chunks
+				// would produce the same ChunkID("", docID).
+				text = fmt.Sprintf("position_%d", i)
 			}
 			ck["id"] = ChunkID(text, docID)
 		}

--- a/internal/ingestion/task/chunk_process_test.go
+++ b/internal/ingestion/task/chunk_process_test.go
@@ -259,14 +259,26 @@ func TestProcessChunksForDataflow_GeneratesID(t *testing.T) {
 	}
 }
 
-func TestProcessChunksForDataflow_PanicOnListText(t *testing.T) {
+func TestProcessChunksForDataflow_NonStringTextFallback(t *testing.T) {
 	chunks := []map[string]any{{"text": []any{"bad-shape"}}}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for list-shaped text")
-		}
-	}()
+	// Should not panic — MustGetChunkTextString returns "" and chunk ID
+	// falls back via content_with_weight or uses empty text.
+	result := ProcessChunksForDataflow(chunks, "doc-1", "kb-1", "test-doc.pdf", time.Now())
+	if result == nil {
+		t.Fatal("expected metadata, got nil")
+	}
+}
+
+func TestProcessChunksForDataflow_ContentWithWeightFallbackForID(t *testing.T) {
+	// When text is missing but content_with_weight is present, use it for chunk ID
+	chunks := []map[string]any{{
+		"text":                "",
+		"content_with_weight": "fallback-content",
+	}}
 	_ = ProcessChunksForDataflow(chunks, "doc-1", "kb-1", "test-doc.pdf", time.Now())
+	if id, ok := chunks[0]["id"].(string); !ok || id == "" {
+		t.Errorf("expected non-empty chunk ID from content_with_weight fallback, got %q", id)
+	}
 }
 
 func TestProcessChunksForDataflow_RemovesInternalPipelineFields(t *testing.T) {

--- a/internal/ingestion/task/chunk_process_test.go
+++ b/internal/ingestion/task/chunk_process_test.go
@@ -260,12 +260,20 @@ func TestProcessChunksForDataflow_GeneratesID(t *testing.T) {
 }
 
 func TestProcessChunksForDataflow_NonStringTextFallback(t *testing.T) {
-	chunks := []map[string]any{{"text": []any{"bad-shape"}}}
-	// Should not panic — MustGetChunkTextString returns "" and chunk ID
-	// falls back via content_with_weight or uses empty text.
+	// Multiple chunks with non-string text should get unique IDs
+	chunks := []map[string]any{
+		{"text": []any{"bad-shape"}},
+		{"text": []any{"bad-shape"}},
+	}
 	result := ProcessChunksForDataflow(chunks, "doc-1", "kb-1", "test-doc.pdf", time.Now())
 	if result == nil {
 		t.Fatal("expected metadata, got nil")
+	}
+	// Each chunk must have a unique ID — empty-content chunks should not collide
+	id0 := chunks[0]["id"].(string)
+	id1 := chunks[1]["id"].(string)
+	if id0 == id1 {
+		t.Errorf("expected unique chunk IDs for empty-content chunks, got %q and %q", id0, id1)
 	}
 }
 

--- a/internal/ingestion/task/chunk_utils.go
+++ b/internal/ingestion/task/chunk_utils.go
@@ -123,24 +123,34 @@ func PrepareTextsForDataflowEmbedding(chunks []map[string]any) []string {
 	return texts
 }
 
-// MustGetChunkTextString returns chunk["text"] when it is a string.
-// Missing text is allowed and returns empty string.
-// FIXME: remove panic before production; current panic is intentional for dev/test
-// so list-shaped text payloads are surfaced immediately instead of being written
-// as silent bad data.
-func MustGetChunkTextString(chunk map[string]any, where string) string {
+// GetChunkTextString returns chunk["text"] when it is a string.
+// Missing text is allowed and returns ("", nil).
+// Non-string values (e.g. []string from malformed pipeline output) return
+// ("", error) so callers can decide how to handle degraded data.
+func GetChunkTextString(chunk map[string]any, where string) (string, error) {
 	val, exists := chunk["text"]
 	if !exists || val == nil {
-		return ""
+		return "", nil
 	}
 	text, ok := val.(string)
 	if ok {
-		return text
+		return text, nil
 	}
 
 	msg := fmt.Sprintf("%s: invalid chunk text type %T, expected string, chunk=%v", where, val, chunk)
 	common.Error(msg, nil)
-	panic(msg)
+	return "", fmt.Errorf(msg)
+}
+
+// MustGetChunkTextString is the convenience wrapper that logs non-string text
+// and returns empty string. Use GetChunkTextString if the caller needs to
+// distinguish "missing text" from "malformed text".
+func MustGetChunkTextString(chunk map[string]any, where string) string {
+	text, err := GetChunkTextString(chunk, where)
+	if err != nil {
+		return ""
+	}
+	return text
 }
 
 // AttachVectors attaches embedding vectors to chunks in-place.

--- a/internal/ingestion/task/chunk_utils.go
+++ b/internal/ingestion/task/chunk_utils.go
@@ -17,6 +17,7 @@
 package task
 
 import (
+	"errors"
 	"fmt"
 
 	"ragflow/internal/common"
@@ -137,9 +138,9 @@ func GetChunkTextString(chunk map[string]any, where string) (string, error) {
 		return text, nil
 	}
 
-	msg := fmt.Sprintf("%s: invalid chunk text type %T, expected string, chunk=%v", where, val, chunk)
+	msg := fmt.Sprintf("%s: invalid chunk text type %T, expected string", where, val)
 	common.Error(msg, nil)
-	return "", fmt.Errorf(msg)
+	return "", errors.New(msg)
 }
 
 // MustGetChunkTextString is the convenience wrapper that logs non-string text

--- a/internal/ingestion/task/chunk_utils_test.go
+++ b/internal/ingestion/task/chunk_utils_test.go
@@ -310,26 +310,30 @@ func TestPrepareTexts_MissingTextKey(t *testing.T) {
 	}
 }
 
-func TestPrepareTexts_PanicOnListText(t *testing.T) {
+func TestPrepareTexts_NonStringTextReturnsEmpty(t *testing.T) {
 	chunks := []map[string]any{
 		{"text": []any{"bad-shape"}},
 	}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for list-shaped text")
-		}
-	}()
-	_ = PrepareTextsForDataflowEmbedding(chunks)
+	result := PrepareTextsForDataflowEmbedding(chunks)
+	if result[0] != "" {
+		t.Errorf("expected empty string for non-string text, got %q", result[0])
+	}
 }
 
-func TestMustGetChunkTextString_PanicOnStringSlice(t *testing.T) {
+func TestMustGetChunkTextString_NonStringReturnsEmpty(t *testing.T) {
 	chunk := map[string]any{"text": []string{"bad-shape"}}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for []string text")
-		}
-	}()
-	_ = MustGetChunkTextString(chunk, "unit-test")
+	result := MustGetChunkTextString(chunk, "unit-test")
+	if result != "" {
+		t.Errorf("expected empty string for non-string text, got %q", result)
+	}
+}
+
+func TestGetChunkTextString_NonStringReturnsError(t *testing.T) {
+	chunk := map[string]any{"text": []string{"bad-shape"}}
+	_, err := GetChunkTextString(chunk, "unit-test")
+	if err == nil {
+		t.Error("expected error for non-string text")
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes two production-critical issues in the Go ingestion pipeline:

### 1. Eliminate `MustGetChunkTextString` panic (FIXME resolved)

**Before**: non-string text in chunk (e.g. `[]string` from malformed pipeline output) triggered an **unrecovered panic** that crashed the entire ingestion worker.

**After**: 
- `GetChunkTextString` returns `(string, error)` for safe handling  
- `MustGetChunkTextString` wraps it with logged error + empty string fallback  
- `ProcessChunksForDataflow` uses `content_with_weight` as fallback for chunk ID generation when text is empty
- All existing tests updated to match the non-panicking behavior

### 2. Respect document pipeline ID instead of always using mock template

**Before**: `defaultRunDocumentTask` **unconditionally** overrode `PipelineID` with a new mock canvas from the ingestion template file. Every document used the mock DSL with `full_text`-only search (tokenizer/embedding disabled).

**After**: `LoadFromIngestionTask` already reads the document's assigned pipeline from `doc.PipelineID`. Now `defaultRunDocumentTask` only falls back to the template when no pipeline is assigned, respecting the knowledge-base configuration from the UI.

---

## Files Changed

| File | Change |
|------|--------|
| `internal/ingestion/task/chunk_utils.go` | Replace panic with `GetChunkTextString` returning error |
| `internal/ingestion/task/chunk_process.go` | Add `content_with_weight` fallback for chunk ID |
| `internal/ingestion/task/chunk_utils_test.go` | Update tests: panic→error/safe return |
| `internal/ingestion/service/ingestion_service.go` | Skip mock pipeline when document has PipelineID |

## Verification
- `gofmt -e`: all files pass syntax check ✅
- Tests updated for new non-panicking behavior ✅
- No change to external API or data format ✅