### PR TITLE
fix(docker): [URGENT] Docker build fails for all PRs - missing web/scripts/prepare.js during npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -226,6 +226,10 @@ RUN --mount=type=cache,id=ragflow_uv,target=/root/.cache/uv,sharing=locked \
 # Install frontend dependencies — depends only on package manifests so
 # web source / docs changes don't invalidate this layer.
 COPY web/package.json web/package-lock.json web/.npmrc ./web/
+# The `prepare` lifecycle script (npm install) runs `node scripts/prepare.js`,
+# so that file must be present before `npm install` or the build fails with
+# "Cannot find module '/ragflow/web/scripts/prepare.js'".
+COPY web/scripts ./web/scripts
 RUN --mount=type=cache,id=ragflow_npm,target=/root/.npm,sharing=locked \
     cd web && NODE_OPTIONS="--max-old-space-size=8192" npm install
 


### PR DESCRIPTION
## 🚨 Urgent: this breaks the Docker image build for **every** open PR

The `ragflow_tests_elasticsearch` and `ragflow_tests_infinity` jobs — which build the image before running tests — currently **fail on all pull requests**, not just this one. CI is effectively red repo-wide until this lands. **Please review and merge ASAP.**

Example failing runs (from an unrelated PR):
- https://github.com/infiniflow/ragflow/actions/runs/29086020168/job/86341032173
- https://github.com/infiniflow/ragflow/actions/runs/29086020168/job/86341032196

## Symptom

```
Error: Cannot find module '/ragflow/web/scripts/prepare.js'
npm error command sh -c node scripts/prepare.js
ERROR: process "/bin/bash -c cd web && NODE_OPTIONS=..." did not complete successfully: exit code: 1
```

## Root cause

`web/package.json` defines:

```json
"prepare": "node scripts/prepare.js"
```

npm runs the `prepare` lifecycle script during `npm install`. But the frontend-deps layer in the `Dockerfile` only copies the package manifests before installing:

```dockerfile
COPY web/package.json web/package-lock.json web/.npmrc ./web/
RUN ... cd web && npm install     # runs `node scripts/prepare.js` → file not present yet
```

Since `web/scripts/prepare.js` is not in the image at that point, `npm install` aborts and the whole build fails.

## Fix

Copy `web/scripts` before `npm install` so the `prepare` script is present:

```dockerfile
COPY web/package.json web/package-lock.json web/.npmrc ./web/
COPY web/scripts ./web/scripts
RUN ... cd web && npm install
```

- Minimal and safe: `scripts/prepare.js` only installs lefthook git hooks and already no-ops (wrapped in try/catch) inside the image where there is no Git repo.
- Preferred over `--ignore-scripts`, which would also disable dependencies' legitimate install scripts.
- `web/scripts` changes rarely, so build-cache impact on this layer is negligible.

## Verification

Build reaches the frontend `npm install` step without the `MODULE_NOT_FOUND` error. No application code is touched — this is a build-infrastructure fix only.
