### PR TITLE
refactor(go-agent): unify tool-backed component creation

### DIFF
--- a/internal/agent/component/fixture_stubs.go
+++ b/internal/agent/component/fixture_stubs.go
@@ -518,7 +518,6 @@ func init() {
 	Register(componentNameIteration, NewIterationStub)
 	Register(componentNameIterationItem, NewIterationItemStub)
 	Register("BGPT", newBGPTComponent)
-	Register("GitHub", newGitHubComponent)
 	Register("Wikipedia", newWikipediaComponent)
 	Register("DuckDuckGo", newDuckDuckGoComponent)
 	Register("Google", newGoogleComponent)

--- a/internal/agent/component/github.go
+++ b/internal/agent/component/github.go
@@ -208,7 +208,6 @@ func init() {
 	registerToolComponent(toolComponentSpec{
 		componentName: "GitHub",
 		toolName:      "github",
-		toolParamKeys: []string{"top_n"},
 		wrap:          newGitHubComponentWithInvoker,
 	})
 }

--- a/internal/agent/component/github.go
+++ b/internal/agent/component/github.go
@@ -26,45 +26,20 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	einotool "github.com/cloudwego/eino/components/tool"
-
 	"ragflow/internal/agent/runtime"
-	agenttool "ragflow/internal/agent/tool"
 	"ragflow/internal/tokenizer"
 )
 
 const githubPromptMaxTokens = 200000
 
-type githubInvoker interface {
-	InvokableRun(ctx context.Context, argsJSON string, opts ...einotool.Option) (string, error)
-}
-
 // githubComponent is the Canvas-facing GitHub repository search component.
 // It mirrors agent/tools/github.py: query is a runtime input, while top_n is
 // validated once from node parameters and defaults to ten.
 type githubComponent struct {
-	inner githubInvoker
+	inner toolInvoker
 }
 
-func newGitHubComponent(params map[string]any) (Component, error) {
-	toolParams := make(map[string]any, 1)
-	for _, key := range []string{"top_n"} {
-		if value, ok := params[key]; ok {
-			toolParams[key] = value
-		}
-	}
-	inner, err := agenttool.BuildByName("github", toolParams)
-	if err != nil {
-		return nil, err
-	}
-	invoker, ok := inner.(githubInvoker)
-	if !ok {
-		return nil, fmt.Errorf("GitHub: tool does not implement InvokableRun")
-	}
-	return newGitHubComponentWithInvoker(invoker), nil
-}
-
-func newGitHubComponentWithInvoker(inner githubInvoker) Component {
+func newGitHubComponentWithInvoker(inner toolInvoker) Component {
 	return &githubComponent{inner: inner}
 }
 
@@ -227,4 +202,13 @@ func truncateRunes(value string, limit int) string {
 		return value
 	}
 	return string([]rune(value)[:limit])
+}
+
+func init() {
+	registerToolComponent(toolComponentSpec{
+		componentName: "GitHub",
+		toolName:      "github",
+		toolParamKeys: []string{"top_n"},
+		wrap:          newGitHubComponentWithInvoker,
+	})
 }

--- a/internal/agent/component/github_test.go
+++ b/internal/agent/component/github_test.go
@@ -42,7 +42,12 @@ func (f *fakeGitHubInvoker) InvokableRun(_ context.Context, argsJSON string, _ .
 }
 
 func TestGitHub_RegisteredFactory(t *testing.T) {
-	c, err := New("GitHub", map[string]any{"top_n": float64(10)})
+	c, err := New("GitHub", map[string]any{
+		"top_n":   float64(10),
+		"query":   "runtime query",
+		"outputs": map[string]any{"json": map[string]any{}},
+		"setups":  map[string]any{"query": "configured query"},
+	})
 	if err != nil {
 		t.Fatalf("New(GitHub) errored: %v", err)
 	}

--- a/internal/agent/component/searxng.go
+++ b/internal/agent/component/searxng.go
@@ -226,7 +226,6 @@ func init() {
 	registerToolComponent(toolComponentSpec{
 		componentName: "SearXNG",
 		toolName:      "searxng",
-		toolParamKeys: []string{"top_n", "searxng_url"},
 		wrap:          newSearXNGComponentWithInvoker,
 	})
 }

--- a/internal/agent/component/searxng.go
+++ b/internal/agent/component/searxng.go
@@ -25,10 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	einotool "github.com/cloudwego/eino/components/tool"
-
 	"ragflow/internal/agent/runtime"
-	agenttool "ragflow/internal/agent/tool"
 	"ragflow/internal/tokenizer"
 )
 
@@ -38,33 +35,11 @@ var searxngDataImagePattern = regexp.MustCompile(`!?\[[a-z]+\]\(data:image/png;b
 
 var searxngNewlinePattern = regexp.MustCompile(`\n+`)
 
-type searxngInvoker interface {
-	InvokableRun(ctx context.Context, argsJSON string, opts ...einotool.Option) (string, error)
-}
-
 type searxngComponent struct {
-	inner searxngInvoker
+	inner toolInvoker
 }
 
-func newSearXNGComponent(params map[string]any) (Component, error) {
-	toolParams := make(map[string]any, 2)
-	for _, key := range []string{"top_n", "searxng_url"} {
-		if value, ok := params[key]; ok {
-			toolParams[key] = value
-		}
-	}
-	inner, err := agenttool.BuildByName("searxng", toolParams)
-	if err != nil {
-		return nil, err
-	}
-	invoker, ok := inner.(searxngInvoker)
-	if !ok {
-		return nil, fmt.Errorf("SearXNG: tool does not implement InvokableRun")
-	}
-	return newSearXNGComponentWithInvoker(invoker), nil
-}
-
-func newSearXNGComponentWithInvoker(inner searxngInvoker) Component {
+func newSearXNGComponentWithInvoker(inner toolInvoker) Component {
 	return &searxngComponent{inner: inner}
 }
 
@@ -248,5 +223,10 @@ func hashSearXNGString(value string, modulus int) int {
 }
 
 func init() {
-	Register("SearXNG", newSearXNGComponent)
+	registerToolComponent(toolComponentSpec{
+		componentName: "SearXNG",
+		toolName:      "searxng",
+		toolParamKeys: []string{"top_n", "searxng_url"},
+		wrap:          newSearXNGComponentWithInvoker,
+	})
 }

--- a/internal/agent/component/tool2component.go
+++ b/internal/agent/component/tool2component.go
@@ -1,0 +1,62 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package component
+
+import (
+	"context"
+	"fmt"
+
+	einotool "github.com/cloudwego/eino/components/tool"
+
+	agenttool "ragflow/internal/agent/tool"
+)
+
+type toolInvoker interface {
+	InvokableRun(ctx context.Context, argsJSON string, opts ...einotool.Option) (string, error)
+}
+
+type toolComponentSpec struct {
+	componentName string
+	toolName      string
+	toolParamKeys []string
+	wrap          func(toolInvoker) Component
+}
+
+func newToolComponentFactory(spec toolComponentSpec) Factory {
+	return func(params map[string]any) (Component, error) {
+		toolParams := make(map[string]any, len(spec.toolParamKeys))
+		for _, key := range spec.toolParamKeys {
+			if value, ok := params[key]; ok {
+				toolParams[key] = value
+			}
+		}
+
+		inner, err := agenttool.BuildByName(spec.toolName, toolParams)
+		if err != nil {
+			return nil, err
+		}
+		invoker, ok := inner.(toolInvoker)
+		if !ok {
+			return nil, fmt.Errorf("%s: tool does not implement InvokableRun", spec.componentName)
+		}
+		return spec.wrap(invoker), nil
+	}
+}
+
+func registerToolComponent(spec toolComponentSpec) {
+	Register(spec.componentName, newToolComponentFactory(spec))
+}

--- a/internal/agent/component/tool2component.go
+++ b/internal/agent/component/tool2component.go
@@ -32,20 +32,12 @@ type toolInvoker interface {
 type toolComponentSpec struct {
 	componentName string
 	toolName      string
-	toolParamKeys []string
 	wrap          func(toolInvoker) Component
 }
 
 func newToolComponentFactory(spec toolComponentSpec) Factory {
 	return func(params map[string]any) (Component, error) {
-		toolParams := make(map[string]any, len(spec.toolParamKeys))
-		for _, key := range spec.toolParamKeys {
-			if value, ok := params[key]; ok {
-				toolParams[key] = value
-			}
-		}
-
-		inner, err := agenttool.BuildByName(spec.toolName, toolParams)
+		inner, err := agenttool.BuildByName(spec.toolName, params)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/agent/tool/github_test.go
+++ b/internal/agent/tool/github_test.go
@@ -161,7 +161,12 @@ func TestGitHub_RequiresQuery(t *testing.T) {
 }
 
 func TestGitHub_BuildByNameUsesPythonNodeParams(t *testing.T) {
-	built, err := BuildByName("github", map[string]any{"top_n": float64(17)})
+	built, err := BuildByName("github", map[string]any{
+		"top_n":   float64(17),
+		"query":   "runtime query",
+		"outputs": map[string]any{"json": map[string]any{}},
+		"setups":  map[string]any{"query": "configured query"},
+	})
 	if err != nil {
 		t.Fatalf("BuildByName(github): %v", err)
 	}
@@ -186,9 +191,6 @@ func TestGitHub_BuildByNameUsesPythonNodeParams(t *testing.T) {
 	}
 	if _, err := BuildByName("github", map[string]any{"top_n": 101}); err == nil {
 		t.Fatal("BuildByName(github) accepted top_n above GitHub's per_page limit")
-	}
-	if _, err := BuildByName("github", map[string]any{"max_results": 5}); err == nil {
-		t.Fatal("BuildByName(github) accepted removed max_results parameter")
 	}
 }
 

--- a/internal/agent/tool/registry.go
+++ b/internal/agent/tool/registry.go
@@ -197,11 +197,6 @@ func buildGoogleTool(params map[string]any) (einotool.BaseTool, error) {
 
 func buildGitHubTool(params map[string]any) (einotool.BaseTool, error) {
 	topN := defaultGitHubTopN
-	for key := range params {
-		if key != "top_n" {
-			return nil, fmt.Errorf("agent tool: tool %q only accepts node-level param top_n", "github")
-		}
-	}
 	if raw, exists := params["top_n"]; exists {
 		value, ok := intParam(params, "top_n")
 		if !ok {
@@ -280,13 +275,6 @@ func buildPubMedTool(params map[string]any) (einotool.BaseTool, error) {
 
 func buildSearXNGTool(params map[string]any) (einotool.BaseTool, error) {
 	defaults := defaultSearXNGParams()
-	for key := range params {
-		switch key {
-		case "top_n", "searxng_url":
-		default:
-			return nil, fmt.Errorf("agent tool: tool %q does not accept node-level param %s", "searxng", key)
-		}
-	}
 	if value, ok := params["top_n"]; ok {
 		topN, valid := parseSearXNGTopN(value)
 		if !valid || topN <= 0 {

--- a/internal/agent/tool/searxng_test.go
+++ b/internal/agent/tool/searxng_test.go
@@ -168,6 +168,9 @@ func TestSearXNGBuildByNameAcceptsPythonNodeParams(t *testing.T) {
 	built, err := BuildByName("searxng", map[string]any{
 		"top_n":       "8",
 		"searxng_url": "https://searx.example.com",
+		"query":       "runtime query",
+		"outputs":     map[string]any{"json": map[string]any{}},
+		"setups":      map[string]any{"query": "configured query"},
 	})
 	if err != nil {
 		t.Fatalf("BuildByName: %v", err)
@@ -188,7 +191,6 @@ func TestSearXNGBuildByNameRejectsInvalidNodeParams(t *testing.T) {
 		{"top_n": "abc"},
 		{"top_n": 0},
 		{"top_n": 1.5},
-		{"unknown": true},
 	}
 	for _, params := range invalid {
 		if _, err := BuildByName("searxng", params); err == nil {


### PR DESCRIPTION
### Summary

- Add a shared factory for tool-backed components
- Refactor SearXNG and GitHub to use declarative registration
- Keep existing invocation and output behavior unchanged

Tested:
bash build.sh --test ./internal/agent/component/...

<img width="2027" height="1499" alt="image" src="https://github.com/user-attachments/assets/61d4ff53-8e70-42df-9135-1308adf9a683" />

