### PR TITLE
fix: add region parameter to support china/overseas SoMark base URLs

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -345,7 +345,7 @@ SOMARK_ENV_KEYS = [
     "SOMARK_KEEP_HEADER_FOOTER",
 ]
 SOMARK_DEFAULT_CONFIG = {
-    "SOMARK_BASE_URL": "https://somark.tech/api/v1",
+    "SOMARK_BASE_URL": "https://somark.cn/api/v1",
     "SOMARK_API_KEY": "",
     "SOMARK_IMAGE_FORMAT": "url",
     "SOMARK_FORMULA_FORMAT": "latex",

--- a/deepdoc/parser/somark_parser.py
+++ b/deepdoc/parser/somark_parser.py
@@ -121,7 +121,7 @@ class SoMarkParser(RAGFlowPdfParser):
 
     # /usage quota check only works in SaaS; private deployments fall back
     # to a generic HEAD health check.
-    SAAS_BASE_URL = "https://somark.tech/api/v1"
+    SAAS_BASE_URL = "https://somark.cn/api/v1"
     USAGE_REQUEST_TIMEOUT = 10  # /usage request timeout
 
     # SoMark error codes
@@ -142,11 +142,17 @@ class SoMarkParser(RAGFlowPdfParser):
     POLL_INTERVAL_GROWTH = 1.5  # multiplier applied after each poll
     POLL_REQUEST_TIMEOUT = 30  # single poll request timeout
 
+    _REGION_BASE_URLS = {
+        "china": "https://somark.cn/api/v1",
+        "overseas": "https://somark.ai/api/v1",
+    }
+
     def __init__(
         self,
-        base_url: str,
+        base_url: str = "",
         api_key: str = "",
         *,
+        region: str = "china",
         image_format: str = "url",
         formula_format: str = "latex",
         table_format: str = "html",
@@ -159,7 +165,10 @@ class SoMarkParser(RAGFlowPdfParser):
         enable_image_understanding: bool = True,
         keep_header_footer: bool = False,
     ):
+        if not base_url:
+            base_url = self._REGION_BASE_URLS.get(region, self._REGION_BASE_URLS["china"])
         self.base_url = base_url.strip().rstrip("/")
+        self.region = region
         # Intentionally NOT stripping: caller may want to pass raw key as-is
         # (e.g. for verification where whitespace would also be reported back).
         self.api_key = api_key
@@ -749,7 +758,7 @@ class SoMarkParser(RAGFlowPdfParser):
 
 if __name__ == "__main__":
     parser = SoMarkParser(
-        base_url=os.environ.get("SOMARK_BASE_URL", "https://somark.tech/api/v1"),
+        base_url=os.environ.get("SOMARK_BASE_URL", "https://somark.cn/api/v1"),
         api_key=os.environ.get("SOMARK_API_KEY", ""),
     )
     ok, reason = parser.check_installation()

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -109,7 +109,7 @@ func NewPDFParser() *PDFParser {
 		MinerUPollTimeout:              minerUPollTimeout,
 		PaddleOCRAlgorithm:             "PaddleOCR-VL",
 		OpenDataLoaderTimeout:          600,
-		SoMarkBaseURL:                  "https://somark.tech/api/v1",
+		SoMarkBaseURL:                  "https://somark.cn/api/v1",
 		SoMarkImageFormat:              "url",
 		SoMarkFormulaFormat:            "latex",
 		SoMarkTableFormat:              "html",

--- a/rag/llm/ocr_model.py
+++ b/rag/llm/ocr_model.py
@@ -262,8 +262,9 @@ class SoMarkOcrModel(Base, SoMarkParser):
         base_url = _resolve(
             "somark_base_url",
             "SOMARK_BASE_URL",
-            kwargs.get("base_url", "https://somark.tech/api/v1"),
+            kwargs.get("base_url", ""),
         )
+        region = _resolve("somark_region", "SOMARK_REGION", "china")
         api_key = _resolve("api_key", "SOMARK_API_KEY", key_as_secret)
         image_format = _resolve("somark_image_format", "SOMARK_IMAGE_FORMAT", "url")
         formula_format = _resolve("somark_formula_format", "SOMARK_FORMULA_FORMAT", "latex")
@@ -288,10 +289,12 @@ class SoMarkOcrModel(Base, SoMarkParser):
 
         self.base_url = base_url
         self.api_key = api_key
+        self.region = region
         SoMarkParser.__init__(
             self,
             base_url=base_url,
             api_key=api_key,
+            region=region,
             image_format=image_format,
             formula_format=formula_format,
             table_format=table_format,

--- a/web/src/constants/llm.ts
+++ b/web/src/constants/llm.ts
@@ -216,7 +216,7 @@ export const APIMapUrl = {
   [LLMFactory.TokenPony]: 'https://www.tokenpony.cn/#/user/keys',
   [LLMFactory.DeepInfra]: 'https://deepinfra.com/dash/api_keys',
   [LLMFactory.PaddleOCR]: 'https://www.paddleocr.ai/latest/',
-  [LLMFactory.SoMark]: 'https://somark.tech/workbench/apikey',
+  [LLMFactory.SoMark]: 'https://somark.cn/workbench/apikey',
   [LLMFactory.N1n]: 'https://docs.n1n.ai',
   [LLMFactory.Avian]: 'https://avian.io',
   [LLMFactory.Perplexity]:

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -2000,7 +2000,7 @@ Example: Virtual Hosted Style`,
         baseUrl: 'Base URL',
         baseUrlMessage: 'Please input the Base URL',
         baseUrlPlaceholder:
-          'For SoMark API, fill in https://somark.tech/api/v1; for self-hosted deployment, fill in your local Base URL',
+          'For SoMark API, use https://somark.cn/api/v1 in mainland China; use https://somark.ai/api/v1 outside mainland China (including Taiwan, China; Hong Kong, China; Macau, China; and overseas). For self-hosted deployment, use your local Base URL',
         apiKey: 'API Key',
         apiKeyPlaceholder:
           'Required for SoMark API; leave blank for self-hosted deployment',
@@ -2019,6 +2019,8 @@ Example: Virtual Hosted Style`,
         enableTextCrossPage: 'Enable Text Cross Page',
         enableTableCrossPage: 'Enable Table Cross Page',
         keepHeaderFooter: 'Keep Header Footer',
+        purchaseUrl:
+          'Purchase API: mainland China — https://somark.cn/workbench/purchase; overseas (including Taiwan, China; Hong Kong, China; Macau, China) — https://somark.ai/studio/purchase',
       },
       modelTypes: {
         chat: 'Chat',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1652,7 +1652,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
         baseUrl: 'Base URL',
         baseUrlMessage: '请输入 Base URL',
         baseUrlPlaceholder:
-          '使用 SoMark API 时填写 https://somark.tech/api/v1；私有化部署时填写本地部署的 Base URL',
+          '使用 SoMark API 时中国大陆填写 https://somark.cn/api/v1；中国大陆外（含中国台湾、中国香港、中国澳门及海外）填写 https://somark.ai/api/v1；私有化部署时填写本地部署的 Base URL',
         apiKey: 'API Key',
         apiKeyPlaceholder: '使用 SoMark API 时填写；私有化部署无需填写',
         verifyPassed: '验证通过',
@@ -1670,6 +1670,8 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
         enableTextCrossPage: '文字跨页合并',
         enableTableCrossPage: '表格跨页合并',
         keepHeaderFooter: '保留页眉页脚',
+        purchaseUrl:
+          '购买 API：中国大陆 https://somark.cn/workbench/purchase；海外（含中国台湾、中国香港、中国澳门）https://somark.ai/studio/purchase',
       },
       paddleocr: {
         apiUrl: 'PaddleOCR API URL',


### PR DESCRIPTION
## Summary

Add `region` parameter to SoMark OCR provider to distinguish between China and overseas deployments, and update all `somark.tech` references to the new domain names.

### Changes

| File | Change |
|------|--------|
| `somark_parser.py` | Add `_REGION_BASE_URLS` dict, `region` param with auto-resolve |
| `ocr_model.py` | Resolve `somark_region`/`SOMARK_REGION`, pass to parser |
| `constants.py` | Default base URL → `somark.cn` |
| `pdf_parser_common.go` | Go default URL → `somark.cn` |
| `llm.ts` | API key URL → `somark.cn` |
| `en.ts`, `zh.ts` | Base URL descriptions + purchase URLs for both regions |

### Region behavior
- `region=china` (default): `https://somark.cn/api/v1`
- `region=overseas`: `https://somark.ai/api/v1` (including Taiwan, China; Hong Kong, China; Macau, China; and overseas)

### Purchase URLs
- China: `https://somark.cn/workbench/purchase`
- Overseas: `https://somark.ai/studio/purchase`