### PR TITLE
Fix: video description duplicated in the index

### DIFF
--- a/rag/app/picture.py
+++ b/rag/app/picture.py
@@ -60,7 +60,6 @@ def chunk(filename, binary, tenant_id, lang, callback=None, **kwargs):
             video_prompt = str(parser_config.get("video_prompt", "") or "")
             ans = asyncio.run(cv_mdl.async_chat(system="", history=[], gen_conf={}, video_bytes=binary, filename=filename, video_prompt=video_prompt))
             callback(0.8, "CV LLM respond: %s ..." % ans[:32])
-            ans += "\n" + ans
             tokenize(doc, ans, eng, language=lang)
             return [doc]
         except Exception as e:


### PR DESCRIPTION
### Problem

Uploading a video to a knowledge base indexes every description twice. In `rag/app/picture.py`, the video branch of `chunk()` runs `ans += "\n" + ans` right before `tokenize(doc, ans, ...)`, so the vision model's answer is concatenated with itself and the doubled text is what gets tokenized and stored.

### Root cause

The adjacent image branch does `txt += "\n" + ans`, combining two *distinct* sources (the OCR text `txt` and the CV description `ans`). The video branch has only one source (`ans`), so `ans += "\n" + ans` is a copy-paste leftover (from #10671) that just duplicates it.

### Fix

Remove the self-concatenation and tokenize `ans` once.

Fixes #16846.
