### PR TITLE
fix: resolve provider name case mismatch and 301 redirect in Go mode

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -522,8 +522,8 @@ func (r *Router) Setup(engine *gin.Engine) {
 			// provider pool route group
 			provider := v1.Group("/providers")
 			{
-				provider.GET("/", r.providerHandler.ListProviders)
-				provider.PUT("/", r.providerHandler.AddProvider)
+				provider.GET("", r.providerHandler.ListProviders)
+				provider.PUT("", r.providerHandler.AddProvider)
 				provider.GET("/:provider_name", r.providerHandler.ShowProvider)
 				provider.DELETE("/:provider_name", r.providerHandler.DeleteProvider)
 				provider.GET("/:provider_name/models", r.providerHandler.ListModels)
@@ -555,8 +555,8 @@ func (r *Router) Setup(engine *gin.Engine) {
 			{
 				// GET /models returns the tenant's added models across
 				// all instances. Front-end useFetchAllAddedModels consumes this.
-				model.GET("/", r.providerHandler.ListTenantAddedModels)
-				model.PATCH("/", r.tenantHandler.SetModels)
+				model.GET("", r.providerHandler.ListTenantAddedModels)
+				model.PATCH("", r.tenantHandler.SetModels)
 				// Tenant default-model selection (used by the agent page's useFetchDefaultModels hook)
 				model.GET("/default", r.tenantHandler.GetDefaultModels)
 				model.PATCH("/default", r.tenantHandler.SetDefaultModels)
@@ -589,8 +589,8 @@ func (r *Router) Setup(engine *gin.Engine) {
 
 			connectors := v1.Group("/connectors")
 			{
-				connectors.GET("/", r.connectorHandler.ListConnectors)
-				connectors.POST("/", r.connectorHandler.CreateConnector)
+				connectors.GET("", r.connectorHandler.ListConnectors)
+				connectors.POST("", r.connectorHandler.CreateConnector)
 				connectors.POST("/google/oauth/web/start", r.connectorHandler.StartGoogleWebOAuth)
 				connectors.POST("/google/oauth/web/result", r.connectorHandler.PollGoogleWebOAuthResult)
 				connectors.POST("/box/oauth/web/start", r.connectorHandler.StartBoxWebOAuth)

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -155,7 +155,6 @@ type CheckConnectionRequest struct {
 
 func (m *ModelProviderService) AddModelProvider(providerName, userID string) (common.ErrorCode, error) {
 	providerName = strings.TrimSpace(providerName)
-	providerName = strings.ToLower(providerName)
 
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(userID, "owner")
 	if err != nil {
@@ -227,7 +226,10 @@ func (m *ModelProviderService) ListProvidersOfTenant(userID string) ([]map[strin
 			}
 			return nil, common.CodeServerError, err
 		}
-		provider["name"] = providerName
+		// provider["name"] is the catalog name from GetProviderByName (e.g.,
+		// "SILICONFLOW"), which matches Python's factory_info["name"]. Do NOT
+		// override it with providerName (the DB value), which may differ in
+		// case from historical ToLower writes.
 
 		// Set has_instance flag. Mirrors Python's:
 		//   provider_obj = TenantModelProviderService.get_by_tenant_id_and_provider_name(tenant_id, name)
@@ -312,7 +314,6 @@ func (m *ModelProviderService) DeleteModelProvider(userID, providerName string) 
 
 func (m *ModelProviderService) ListSupportedModels(providerName, instanceName, userID string) ([]map[string]interface{}, error) {
 	providerName = strings.TrimSpace(providerName)
-	providerName = strings.ToLower(providerName)
 
 	// Get tenant ID from user
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(userID, "owner")
@@ -397,7 +398,6 @@ type CreateInstanceModelInfo struct {
 
 func (m *ModelProviderService) CreateProviderInstance(providerName, instanceName, apiKey, baseURL, region, userID string, modelInfo []CreateInstanceModelInfo) (common.ErrorCode, error) {
 	providerName = strings.TrimSpace(providerName)
-	providerName = strings.ToLower(providerName)
 
 	// Get tenant ID from user
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(userID, "owner")
@@ -476,7 +476,6 @@ func (m *ModelProviderService) CreateProviderInstance(providerName, instanceName
 // create_name_only_provider_instance in provider_api_service.py:536.
 func (m *ModelProviderService) CreateNameOnlyProviderInstance(providerName, instanceName, userID string) (common.ErrorCode, error) {
 	providerName = strings.TrimSpace(providerName)
-	providerName = strings.ToLower(providerName)
 
 	if instanceName == "default" {
 		return common.CodeBadRequest, errors.New("instance name cannot be 'default'")
@@ -629,7 +628,6 @@ func (m *ModelProviderService) addModelToInstance(tenantID, providerName, instan
 
 func (m *ModelProviderService) ListProviderInstances(providerName, userID string) ([]map[string]interface{}, common.ErrorCode, error) {
 	providerName = strings.TrimSpace(providerName)
-	providerName = strings.ToLower(providerName)
 
 	// Get tenant ID from user
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(userID, "owner")
@@ -1239,7 +1237,6 @@ func (m *ModelProviderService) resolveModelListTenant(userID, ownerTenantID stri
 
 func (m *ModelProviderService) AlterProviderInstance(userID, providerName, instanceIDOrName, newInstanceName, apiKey, baseURL, region string, modelInfo []CreateInstanceModelInfo, verify bool) (common.ErrorCode, error) {
 	providerName = strings.TrimSpace(providerName)
-	providerName = strings.ToLower(providerName)
 
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(userID, "owner")
 	if err != nil {

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -27,7 +27,7 @@ export default {
   listAllAddedModels: `${restAPIv1}/models`,
   defaultModel: `${restAPIv1}/models/default`,
   listProviders: `${restAPIv1}/providers`,
-  addProvider: `${restAPIv1}/providers/`,
+  addProvider: `${restAPIv1}/providers`,
   addProviderInstance: ({ llm_factory }: { llm_factory: string }) =>
     `${restAPIv1}/providers/${llm_factory}/instances`,
   verifyProviderConnection: ({ provider_name }: { provider_name: string }) =>


### PR DESCRIPTION
### Summary

This PR fixes three issues in Go mode that prevent the model provider settings page from working correctly:

1. **301 Moved Permanently on group-level routes**: Gin routes registered with `"/"` (trailing slash) on `/providers`, `/models`, and `/connectors` groups caused 301 redirects when the frontend requests the slashless URL (e.g. `GET /api/v1/providers`). Python registers these routes without a trailing slash. Changed `provider.GET("/")` → `provider.GET("")`, etc. Also removed the trailing slash from `addProvider` in `web/src/utils/api.ts`.

2. **Provider name case mismatch**: The Go service layer called `strings.ToLower(providerName)` before writing to the database, while Python preserves the original casing from `conf/llm_factories.json` (e.g. `"SILICONFLOW"`, `"ZHIPU-AI"`). This caused composite model IDs (e.g. `"gpt-4@OpenAI"`) to embed a provider name that could not be matched against the lowercase DB value during lookup. Removed `strings.ToLower` in 6 service functions to align with Python behavior.

3. **"No instances configured" after saving**: `ListProvidersOfTenant` overwrote the catalog provider name (returned by `GetProviderByName`) with the raw DB column value (`provider["name"] = providerName`). When the DB contained stale lowercase values from the previous `ToLower` code path, the frontend sidebar (which uses catalog names) could not match the `addedProviders` response, causing the instance list to stay empty. Removed the override so the returned name always comes from the catalog, matching Python's `factory_info["name"]`.