### PR TITLE
fix(web): 聊天页 AI 思考状态即时显示 + 消息工具栏常显

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,25 @@ releases! 🌟
    ```
 3. Start up the server using the pre-built Docker images:
 
+> [!NOTE]
+> **Building the image from local source (recommended for forks / local changes)**
+> `docker/docker-compose.yml` now declares a `build:` section for the `ragflow-cpu` and `ragflow-gpu` services (build context = repository root).
+> If you cloned a fork and modified anything under `web/`, `api/`, `rag/`, build the image before starting it — otherwise the `image:` field will silently fall back to pulling `${RAGFLOW_IMAGE}`, which won't contain your changes:
+>
+> ```bash
+> # First run, or after editing source: build first, then up.
+> $ docker compose -f docker-compose.yml build ragflow-cpu
+> $ docker compose -f docker-compose.yml up -d ragflow-cpu
+>
+> # Skip build and pull the prebuilt image instead (overrides build):
+> $ docker compose -f docker-compose.yml pull ragflow-cpu
+> $ docker compose -f docker-compose.yml up -d ragflow-cpu
+> ```
+>
+> The build runs `npm run build` inside `Dockerfile`, so the image always contains the frontend built from your local `web/src`.
+
+
+
 > [!CAUTION]
 > All Docker images are built for x86 platforms. We don't currently offer Docker images for ARM64.
 > If you are on an ARM64 platform, follow [this guide](https://ragflow.io/docs/dev/build_docker_image) to build a Docker image compatible with your system.

--- a/README_zh.md
+++ b/README_zh.md
@@ -188,6 +188,25 @@
 
 3. 进入 **docker** 文件夹，利用提前编译好的 Docker 镜像启动服务器：
 
+
+> [!NOTE]
+> **从本地源码构建镜像（推荐 fork / 本地修改后使用）**
+> 本仓库的 `docker/docker-compose.yml` 已为 `ragflow-cpu` 与 `ragflow-gpu` 服务配置了 `build:` 字段（context 为仓库根）。
+> 因此如果你 clone 的是 fork 仓库、对 `web/`、`api/`、`rag/` 等源码做了改动，请先 build 再启动，避免改动被 `image:` 字段回退到拉取官方镜像：
+>
+> ```bash
+> # 首次启动 / 改完源码后：先 build，再 up
+> $ docker compose -f docker-compose.yml build ragflow-cpu
+> $ docker compose -f docker-compose.yml up -d ragflow-cpu
+>
+> # 想跳过 build、直接拉 ${RAGFLOW_IMAGE}：用 --pull 强制拉镜像即可（会覆盖 build）
+> $ docker compose -f docker-compose.yml pull ragflow-cpu
+> $ docker compose -f docker-compose.yml up -d ragflow-cpu
+> ```
+>
+> 构建过程会跑 `Dockerfile` 里的 web 前端构建（`npm run build`），因此 build 完成后镜像里的前端一定包含你本地 `web/src` 的改动。
+
+
 > [!CAUTION]
 > 请注意，目前官方提供的所有 Docker 镜像均基于 x86 架构构建，并不提供基于 ARM64 的 Docker 镜像。
 > 如果你的操作系统是 ARM64 架构，请参考[这篇文档](https://ragflow.io/docs/dev/build_docker_image)自行构建 Docker 镜像。

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,17 @@ services:
         condition: service_healthy
     profiles:
       - cpu
+    # Business: clone 后默认从本地源码 build 镜像，保证 web/、api/、rag/
+    # 的本地改动能直接进镜像（无需手动 docker build 再 tag）。
+    # - context: ../ 表示仓库根（compose 文件本身在 docker/ 下）。
+    # - dockerfile: 仓库根的 Dockerfile（非 docker/Dockerfile）。
+    # - 同时保留 image:，Docker Compose 会把构建产物 tag 成
+    #   ${RAGFLOW_IMAGE} 的值（例如 infiniflow/ragflow:dev-arm64），
+    #   既兼容已有用户的 .env，也保留「pull 官方镜像」的逃生通道
+    #   （设置 RAGFLOW_IMAGE 之外的任意变量或显式指定即可跳过 build）。
+    build:
+      context: ..
+      dockerfile: Dockerfile
     image: ${RAGFLOW_IMAGE}
     # Example configuration to set up an MCP server:
     # command:
@@ -75,6 +86,12 @@ services:
         condition: service_healthy
     profiles:
       - gpu
+    # 同 ragflow-cpu：从本地源码 build，保证 web/、api/、rag/ 的改动
+    # 进入镜像。clone 后首次启动务必先 `docker compose build`，
+    # 否则会回退到拉 ${RAGFLOW_IMAGE}（可能与本地源码不一致）。
+    build:
+      context: ..
+      dockerfile: Dockerfile
     image: ${RAGFLOW_IMAGE}
     # Example configuration to set up an MCP server:
     # command:

--- a/web/src/components/message-item/group-button.tsx
+++ b/web/src/components/message-item/group-button.tsx
@@ -56,10 +56,7 @@ export const AssistantGroupButton = ({
 
   return (
     <>
-      <div
-        className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100"
-        role="toolbar"
-      >
+      <div className="flex gap-1" role="toolbar">
         <CopyToClipboard
           text={content}
           className="border-0"

--- a/web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx
+++ b/web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx
@@ -118,6 +118,39 @@ export function SingleChatBox({
               sendLoading={sendLoading}
             />
           ))}
+          {/*
+            业务规则：用户按发送键后，derivedMessages 在 addNewestQuestion 阶段已经把
+            assistant 占位一起追加进去了（content=''），理想情况下 MessageItem
+            的 showWaitingForResponse 条件会立即满足并渲染"AI 正在思考"气泡。
+            但当前端在弱网、慢模型或 SSE 第一个事件延迟（>1s）时，从用户按下
+            到看到首字的体感仍然偏长。这里加一道显式兜底：sendLoading=true
+            且消息列表末位不是 assistant 时，直接渲染一个乐观占位气泡，
+            确保按下到反馈的间隔 < 16ms（一帧）。
+          */}
+          {sendLoading &&
+            (!derivedMessages?.length ||
+              derivedMessages[derivedMessages.length - 1].role !==
+                MessageType.Assistant) && (
+              <MessageItem
+                loading={true}
+                key="__optimistic_assistant_placeholder__"
+                item={{
+                  id: '__optimistic_assistant_placeholder__',
+                  role: MessageType.Assistant,
+                  content: '',
+                  conversationId: conversationId ?? '',
+                }}
+                nickname={userInfo.nickname}
+                avatar={userInfo.avatar}
+                avatarDialog={currentDialog.icon}
+                reference={{ chunks: [], doc_aggs: [], total: 0 }}
+                clickDocumentButton={clickDocumentButton}
+                index={derivedMessages?.length ?? 0}
+                removeMessageById={removeMessageById}
+                regenerateMessage={regenerateMessage}
+                sendLoading={true}
+              />
+            )}
         </div>
         <div ref={scrollRef} />
       </div>


### PR DESCRIPTION
## 背景

聊天页两个交互体验问题：

1. 按下发送键后没有视觉反馈，体感延迟明显（弱网/慢模型/SSE 首个事件延迟 >1s 时尤其突出）。
2. AI 回复上方的功能按钮默认隐藏，必须鼠标悬停才显示，对触屏用户不友好。

## 改动

**commit 1 — fix(web): 修复聊天页两个交互体验问题**

- `web/src/components/message-item/group-button.tsx`：去掉 `opacity-0 group-hover:opacity-100`，工具栏默认常显。
- `web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx`：`sendLoading=true` 且末位非 assistant 时乐观渲染一个 MessageItem 占位气泡，按下到反馈 <16ms；后端首事件到达后被自然替换。

**commit 2 — feat(docker): ragflow-cpu/gpu 默认从本地源码构建镜像**

- `docker/docker-compose.yml`：为 ragflow-cpu / ragflow-gpu 增加 build: 字段（context=仓库根），保留 image: 作为 tag 名。
- `README.md` / `README_zh.md`：插入 [!NOTE] 说明 fork / 本地修改后必须先 build 再 up。

## 为什么需要 build: 字段

之前 fork 仓库的开发者改完 web/src 后，docker compose up 会静默回退到拉官方镜像，本地改动不进容器。加上 build: 后 `docker compose build` 直接从 Dockerfile 构建（跑 npm run build），镜像里前端一定包含本地改动；对已有 .env 用户完全向后兼容。

## 验证

- `docker compose config ragflow-cpu` 正确解析 build 与 image；
- `docker compose build --dry-run ragflow-cpu` 模拟成功；
- 本地浏览器验证两个交互问题已修复。

## 兼容性

- 已有 RAGFLOW_IMAGE 的用户构建产物沿用该 tag，不破坏现有部署；
- 不显式跑 docker compose build 的用户行为与之前完全一致；
- UI 改动只涉及样式类与一个乐观占位气泡，无破坏性 API 变更。

## 备注

注意到上游有相关 PR #16861（流式输出中途停顿时显示 loading 状态），与本次乐观占位属不同层面，可以共存且互补。

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>