### PR TITLE
fix(agent): preserve zero temperature setting

### DIFF
--- a/agent/component/llm.py
+++ b/agent/component/llm.py
@@ -70,7 +70,7 @@ class LLMParam(ComponentParamBase):
 
         if int(self.max_tokens) > 0 and get_attr("maxTokensEnabled"):
             conf["max_tokens"] = int(self.max_tokens)
-        if float(self.temperature) > 0 and get_attr("temperatureEnabled"):
+        if float(self.temperature) >= 0 and get_attr("temperatureEnabled"):
             conf["temperature"] = float(self.temperature)
         if float(self.top_p) > 0 and get_attr("topPEnabled"):
             conf["top_p"] = float(self.top_p)

--- a/test/unit_test/agent/component/test_llm_prompt.py
+++ b/test/unit_test/agent/component/test_llm_prompt.py
@@ -59,3 +59,13 @@ def test_fit_messages_uses_default_context_when_max_length_zero():
     )
     assert err is None
     assert msg_fit[-1]["content"] == "User query: test"
+
+
+@pytest.mark.p1
+def test_gen_conf_includes_zero_temperature_when_enabled():
+    """Include an explicitly enabled zero temperature in the model configuration."""
+    param = LLMParam()
+    param.temperature = 0
+    param.temperatureEnabled = True
+
+    assert param.gen_conf()["temperature"] == 0


### PR DESCRIPTION
### Summary

  - Preserve an explicitly enabled `temperature=0` in the Agent LLM configuration.
  - Continue excluding invalid negative temperature values.
  - Add a focused regression test to the existing Agent LLM test file.

  ### Why

  `LLMParam.gen_conf()` only forwards temperature values greater than zero. This causes an explicitly
  configured `temperature=0` to be omitted, allowing the model provider to use its default value
  instead.

  PR #15389 fixed zero-valued parameters in the REST chat completion routes, but the Agent LLM
  component uses a separate configuration path where the issue remains.

  ### Testing

  - `ruff format --check agent/component/llm.py test/unit_test/agent/component/test_llm_prompt.py`
  - `ruff check agent/component/llm.py test/unit_test/agent/component/test_llm_prompt.py`
  - `git diff --check`
  - Targeted pytest pending PR CI; local dependency installation failed

  Fixes #16683