### PR TITLE
fix(go-agent): add VariableAssigner input form

### DIFF
--- a/internal/agent/component/variable_assigner.go
+++ b/internal/agent/component/variable_assigner.go
@@ -129,6 +129,16 @@ func NewVariableAssignerComponent(params map[string]any) (Component, error) {
 // Name returns the registered component name.
 func (v *VariableAssignerComponent) Name() string { return v.name }
 
+// GetInputForm returns the runtime input form defined by the Python component.
+func (v *VariableAssignerComponent) GetInputForm() map[string]any {
+	return map[string]any{
+		"items": map[string]any{
+			"type": "json",
+			"name": "Items",
+		},
+	}
+}
+
 // Invoke walks the param.variables list, evaluates each tuple against
 // the canvas state, and writes the result back unless the operator
 // returned an "ERROR:..." sentinel. The list of refs that were

--- a/internal/agent/component/variable_assigner.go
+++ b/internal/agent/component/variable_assigner.go
@@ -129,7 +129,7 @@ func NewVariableAssignerComponent(params map[string]any) (Component, error) {
 // Name returns the registered component name.
 func (v *VariableAssignerComponent) Name() string { return v.name }
 
-// GetInputForm returns the runtime input form defined by the Python component.
+// GetInputForm returns the runtime input form consumed by the Agent UI.
 func (v *VariableAssignerComponent) GetInputForm() map[string]any {
 	return map[string]any{
 		"items": map[string]any{

--- a/internal/agent/component/variable_assigner.go
+++ b/internal/agent/component/variable_assigner.go
@@ -133,7 +133,7 @@ func (v *VariableAssignerComponent) Name() string { return v.name }
 func (v *VariableAssignerComponent) GetInputForm() map[string]any {
 	return map[string]any{
 		"items": map[string]any{
-			"type": "json",
+			"type": "line",
 			"name": "Items",
 		},
 	}

--- a/internal/agent/component/variable_assigner_test.go
+++ b/internal/agent/component/variable_assigner_test.go
@@ -257,13 +257,8 @@ func TestVariableAssignerGetInputForm(t *testing.T) {
 	if !ok {
 		t.Fatal("VariableAssigner component does not expose GetInputForm")
 	}
-	want := map[string]any{
-		"items": map[string]any{
-			"type": "json",
-			"name": "Items",
-		},
-	}
-	if got := getter.GetInputForm(); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetInputForm() = %#v, want %#v", got, want)
+	items, ok := getter.GetInputForm()["items"].(map[string]any)
+	if !ok || items["type"] != "line" || items["name"] != "Items" {
+		t.Errorf("GetInputForm()[items] = %#v", items)
 	}
 }

--- a/internal/agent/component/variable_assigner_test.go
+++ b/internal/agent/component/variable_assigner_test.go
@@ -245,3 +245,25 @@ func TestVariableAssigner_Registered(t *testing.T) {
 		t.Errorf("Name()=%q, want VariableAssigner", c.Name())
 	}
 }
+
+func TestVariableAssignerGetInputForm(t *testing.T) {
+	c, err := New("VariableAssigner", map[string]any{
+		"variables": []map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("New(VariableAssigner): %v", err)
+	}
+	getter, ok := c.(interface{ GetInputForm() map[string]any })
+	if !ok {
+		t.Fatal("VariableAssigner component does not expose GetInputForm")
+	}
+	want := map[string]any{
+		"items": map[string]any{
+			"type": "json",
+			"name": "Items",
+		},
+	}
+	if got := getter.GetInputForm(); !reflect.DeepEqual(got, want) {
+		t.Errorf("GetInputForm() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add the runtime input form for VariableAssigner components
- Allow the component input-form endpoint to resolve VariableAssigner nodes

## Testing

- `bash build.sh --test ./internal/agent/component/...`