### PR TITLE
fix(rag/utils): ensure_v1 must recognize v1beta/v1alpha-style version suffixes

### DIFF
--- a/rag/utils/url_utils.py
+++ b/rag/utils/url_utils.py
@@ -20,9 +20,10 @@ from urllib.parse import urlparse, urlunparse
 def ensure_v1(url: str) -> str:
     """Ensure the URL ends with a versioned path segment like ``/v1``.
 
-    If the path already contains a segment matching ``v{digit}`` (e.g. ``/v1``,
-    ``/v2``, ``/v3``), the URL is returned unchanged.  Otherwise the base host
-    is kept and ``/v1`` is appended.
+    If the path already contains a segment starting with ``v{digit}`` (e.g.
+    ``/v1``, ``/v2``, ``/v3``, ``/v1beta``, ``/v1alpha1``), the URL is
+    returned unchanged.  Otherwise the base host is kept and ``/v1`` is
+    appended.
 
     Examples::
 
@@ -34,6 +35,8 @@ def ensure_v1(url: str) -> str:
         'https://api.example.com/v2/chat'
         >>> ensure_v1("https://api.example.com/api/v3")
         'https://api.example.com/api/v3'
+        >>> ensure_v1("https://generativelanguage.googleapis.com/v1beta/openai/")
+        'https://generativelanguage.googleapis.com/v1beta/openai/'
     """
     if not url:
         return url
@@ -41,8 +44,9 @@ def ensure_v1(url: str) -> str:
     parsed = urlparse(url)
     path = parsed.path.rstrip("/")
 
-    # Check if any path segment matches v{digit}, e.g. /v1, /v2, /v3
-    if re.search(r"/v\d+(?:/|$)", path + "/"):
+    # Check if any path segment starts with v{digit}, e.g. v1, v2beta, v1alpha1
+    segments = path.split("/")
+    if any(re.match(r"^v\d+", segment) for segment in segments):
         return url
 
     # No versioned segment found – append /v1

--- a/test/unit_test/rag/utils/test_url_utils.py
+++ b/test/unit_test/rag/utils/test_url_utils.py
@@ -1,0 +1,59 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+Unit tests for rag/utils/url_utils.py module.
+"""
+
+import pytest
+from rag.utils.url_utils import ensure_v1
+
+
+class TestEnsureV1:
+    def test_empty_url_returned_unchanged(self):
+        assert ensure_v1("") == ""
+
+    def test_bare_host_gets_v1_appended(self):
+        assert ensure_v1("https://api.example.com") == "https://api.example.com/v1"
+
+    def test_already_versioned_unchanged(self):
+        assert ensure_v1("https://api.example.com/v1") == "https://api.example.com/v1"
+
+    def test_versioned_with_trailing_path_unchanged(self):
+        assert ensure_v1("https://api.example.com/v2/chat") == "https://api.example.com/v2/chat"
+
+    def test_versioned_with_leading_path_unchanged(self):
+        assert ensure_v1("https://api.example.com/api/v3") == "https://api.example.com/api/v3"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://generativelanguage.googleapis.com/v1beta/openai/",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+            "https://example.com/v1alpha1",
+        ],
+    )
+    def test_version_suffix_with_letters_is_recognized(self, url):
+        """A path segment like v1beta/v1alpha1 is already versioned - real
+        OpenAI-compatible endpoints (e.g. Google's Gemini API) use this
+        pattern, and ensure_v1 must not append a second /v1 onto it."""
+        assert ensure_v1(url) == url
+
+    def test_non_version_segment_starting_with_v_still_gets_v1(self):
+        """A segment like 'vendors' merely starting with the letter v (with
+        no digit right after) is not a version segment - /v1 must still be
+        appended."""
+        assert ensure_v1("https://api.example.com/vendors/list") == "https://api.example.com/vendors/list/v1"


### PR DESCRIPTION
### Summary

`ensure_v1()` checks whether a URL's path already contains a versioned segment before appending `/v1`, but its regex required the version segment to be followed immediately by `/` or end-of-string (`/v\d+(?:/|$)`). Real OpenAI-compatible endpoints commonly use a version suffix with a letter directly after the digits, not just a bare `v{digit}` segment — most notably **Google's Gemini API**, whose OpenAI-compatibility layer lives at `https://generativelanguage.googleapis.com/v1beta/openai/`.

`ensure_v1` is used across `rag/llm/{chat_model,embedding_model,cv_model,tts_model,sequence2txt_model}.py` (30+ call sites) to normalize the user-configured `base_url` for any "OpenAI API compatible" provider before handing it to the `openai.OpenAI` client, so this was silently mangling Gemini's own compat endpoint into `.../v1beta/openai/v1` — a URL that doesn't exist — breaking every request with no clear indication of why.

```python
>>> ensure_v1("https://generativelanguage.googleapis.com/v1beta/openai/")
'https://generativelanguage.googleapis.com/v1beta/openai/v1'   # before this fix - wrong
```

(For context, `v1alpha`/`v1beta`-style suffixes aren't a one-off — this same pattern already appears elsewhere in this codebase, e.g. `deepdoc/parser/docling_parser.py`'s `/v1alpha/convert/source` endpoints.)

### Fix

Instead of requiring the whole path segment to equal `v{digit}`, check whether each path segment *starts with* `v{digit}` — so `/v1beta`, `/v1alpha1`, etc. are correctly recognized as already versioned, while a segment like `/vendors` (starts with "v" but no digit right after) still correctly gets `/v1` appended.

### Testing

Added `test/unit_test/rag/utils/test_url_utils.py` covering the existing docstring examples plus the new Gemini `v1beta` case and a regression guard for the `vendors`-style false-positive. Confirmed via `git stash` that the 3 new `v1beta`/`v1alpha1` cases fail against the pre-fix code and pass after; the pre-existing cases pass unchanged.

Ran with `pytest` + `ruff check` + `ruff format --check` — all clean on the changed files. (Note: I could not run the full `test/unit_test` suite locally since my sandbox's outbound network couldn't complete the NLTK `wordnet` corpus download that the shared `conftest.py` fetches on first run — unrelated to this change, which touches only `rag/utils/url_utils.py`.)

### AI disclosure

Developed with AI assistance (Claude Code), which located the gap by tracing where `ensure_v1` is called and cross-referencing real-world OpenAI-compatible endpoint URL shapes. I reviewed the diff, independently verified the bug and the fix by executing both against the actual function (including confirming the real Gemini `v1beta` compat URL is what triggers it), and ran the tests/linters myself before opening this PR.