### PR TITLE
docs: add DaoXE OpenAI-API-Compatible example

### DIFF
--- a/docs/guides/models/supported_models.mdx
+++ b/docs/guides/models/supported_models.mdx
@@ -94,6 +94,23 @@ To configure AI Badgr:
 
 AI Badgr implements OpenAI-compatible endpoints for `/v1/chat/completions`, `/v1/embeddings`, and `/v1/models`, so no additional code changes in RAGFlow are required.
 
+## Example: DaoXE (OpenAI-compatible)
+
+You can use **DaoXE** with RAGFlow via the existing OpenAI-API-Compatible provider.
+
+DaoXE is a multi-model multi-protocol AI API gateway (OpenAI Chat Completions / Responses, Anthropic Messages, and image-compatible endpoints where available). RAGFlow connects through the OpenAI-compatible chat and embedding path.
+
+To configure DaoXE:
+
+- **Provider**: `OpenAI-API-Compatible`
+- **Base URL**: `https://daoxe.com/v1`
+- **API Key**: your DaoXE API key (from the DaoXE dashboard)
+- **Model**: any chat or embedding model ID available to your DaoXE account (confirm on the [pricing/catalog page](https://daoxe.com/pricing); model availability can vary by account)
+
+DaoXE implements OpenAI-compatible endpoints for `/v1/chat/completions`, `/v1/embeddings`, and `/v1/models`, so no additional code changes in RAGFlow are required.
+
+> DaoXE is **not available in mainland China**.
+
 :::note
 The list of supported models is extracted from [this source](https://github.com/infiniflow/ragflow/blob/main/rag/llm/__init__.py) and may not be the most current. For the latest supported model list, please refer to the Python file.
 :::


### PR DESCRIPTION
## What

Adds a short **DaoXE** configuration example to `docs/guides/models/supported_models.mdx`, next to the existing AI Badgr OpenAI-compatible example.

## Why

RAGFlow already supports any OpenAI-compatible endpoint via **OpenAI-API-Compatible**. DaoXE is a multi-model multi-protocol AI API gateway that exposes OpenAI-compatible chat/embedding routes at `https://daoxe.com/v1`, so it works without code changes—same pattern as the AI Badgr docs example.

## Config (docs only)

| Field | Value |
| --- | --- |
| Provider | `OpenAI-API-Compatible` |
| Base URL | `https://daoxe.com/v1` |
| API Key | DaoXE dashboard key |
| Model | Account-visible chat/embedding model ID ([catalog](https://daoxe.com/pricing); availability can vary by account) |

## Notes

- Does **not** add a first-class provider factory or hard-coded model IDs.
- States that DaoXE is **not available in mainland China**.
- Mentions multi-protocol surface for accuracy; RAGFlow uses the OpenAI-compatible chat/embedding path.

## References

- https://daoxe.com
- https://daoxe.com/pricing
- https://github.com/seven7763/DaoXE-AI

## Checklist

- [x] Docs-only change
- [x] Follows existing OpenAI-API-Compatible example style
- [x] No secrets / paid inference in CI