### PR TITLE
Fix: respect IME composition state on Enter key send

### DIFF
--- a/web/src/components/floating-chat-widget.tsx
+++ b/web/src/components/floating-chat-widget.tsx
@@ -446,7 +446,7 @@ const FloatingChatWidget = () => {
 
   const handleKeyPress = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault();
         handleSendMessage();
       }

--- a/web/src/components/message-input/next.tsx
+++ b/web/src/components/message-input/next.tsx
@@ -135,7 +135,7 @@ export function NextMessageInput({
   }, [isUploading, sendLoading, pressEnter]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       submit();
     }


### PR DESCRIPTION
## What

Pressing Enter to confirm IME (e.g. Japanese/Chinese/Korean) text
composition was incorrectly treated as the chat "send" trigger,
causing an unintended message to be sent before the user finished
composing their input.

## Why

`NextMessageInput` and `FloatingChatWidget` both bind their Enter-to-send
handler with only `e.key === 'Enter' && !e.shiftKey`, without checking
whether the Enter key press was part of an IME composition
(`event.nativeEvent.isComposing`). This is a common pitfall for React
`onKeyDown` handlers and breaks the chat input for CJK IME users.

## Fix

Added `&& !e.nativeEvent.isComposing` to the existing Enter/shiftKey
check in both components, so Enter presses used to confirm IME
composition no longer trigger message submission.

## Testing

Built the patched frontend from source and deployed it against a
running RAGFlow instance (Docker, `docker-ragflow-cpu-1` container),
then exercised the actual `NextMessageInput` textarea in the Agent
Canvas chat panel:

- Dispatched `compositionstart` -> typed text -> `keydown` (Enter,
  `isComposing: true`) -> `compositionend`, simulating an IME
  conversion-confirm Enter press. Confirmed the textarea content was
  preserved and no message was sent.
- Dispatched a normal `keydown` (Enter, `isComposing: false`)
  afterwards on the same input and confirmed the message was sent
  and processed by the agent as expected.

Both cases behaved correctly with this fix applied.