### PR TITLE
fix(agent): return DataOperations input form

### DIFF
--- a/internal/agent/component/data_operations.go
+++ b/internal/agent/component/data_operations.go
@@ -279,7 +279,7 @@ func (d *DataOperationsComponent) GetInputForm() map[string]any {
 			}
 		}
 	}
-	return map[string]any{}
+	return res
 }
 
 // Outputs returns the transformed payload.

--- a/internal/agent/component/data_operations_test.go
+++ b/internal/agent/component/data_operations_test.go
@@ -24,6 +24,34 @@ import (
 	"ragflow/internal/agent/canvas"
 )
 
+func TestDataOperations_GetInputForm(t *testing.T) {
+	c, err := NewDataOperationsComponent(map[string]any{
+		"query": []string{
+			"{{sys.query}}",
+			"{{CodeExec:Run@result}}",
+			"{{sys.query}}",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDataOperationsComponent: %v", err)
+	}
+
+	got := c.(*DataOperationsComponent).GetInputForm()
+	want := map[string]any{
+		"sys.query": map[string]any{
+			"name": "sys.query",
+			"type": "line",
+		},
+		"CodeExec:Run@result": map[string]any{
+			"name": "CodeExec:Run@result",
+			"type": "line",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetInputForm = %#v, want %#v", got, want)
+	}
+}
+
 // TestDataOperations_SelectKeys: keep only specified keys.
 func TestDataOperations_SelectKeys(t *testing.T) {
 	c, err := NewDataOperationsComponent(map[string]any{


### PR DESCRIPTION
## Summary

- return the input form collected by `DataOperationsComponent.GetInputForm`
- add a regression test covering system variables, component outputs, and duplicate references

## Root cause

`DataOperationsComponent.GetInputForm` builds its result map from configured query placeholders but returns a new empty map instead, so callers never receive the discovered input fields.

#16927 has now removed the duplicate helper that briefly broke the Go build. This PR is rebased on that fix and is intentionally limited to the remaining `GetInputForm` behavior bug and its regression coverage.

## Validation

- `go test ./internal/agent/component -count=1`
- `go vet ./internal/agent/component`
- `./build.sh --go`
