### PR TITLE
Updated RAGcon model provider (go)

### DIFF
--- a/conf/models/ragcon.json
+++ b/conf/models/ragcon.json
@@ -1,0 +1,16 @@
+{
+  "name": "RAGcon",
+  "url": {
+    "default": "https://connect.ragcon.com/v1"
+  },
+  "url_suffix": {
+    "chat": "chat/completions",
+    "models": "models",
+    "embedding": "embeddings",
+    "rerank": "rerank",
+    "asr": "audio/transcriptions",
+    "tts": "audio/speech"
+  },
+  "class": "ragcon",
+  "models": []
+}

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -111,6 +111,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewNovitaModel(baseURL, urlSuffix), nil
 	case "avian":
 		return NewAvianModel(baseURL, urlSuffix), nil
+	case "ragcon":
+		return NewRAGconModel(baseURL, urlSuffix), nil
 	case "replicate":
 		return NewReplicateModel(baseURL, urlSuffix), nil
 	case "togetherai":

--- a/internal/entity/models/ragcon.go
+++ b/internal/entity/models/ragcon.go
@@ -1,0 +1,894 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RAGconModel implements ModelDriver for RAGcon (https://connect.ragcon.com),
+// a LiteLLM-proxy gateway exposing OpenAI-compatible endpoints for chat,
+// embedding, rerank, ASR and TTS. Model names are user-supplied (no fixed
+// catalog), matching the Ollama/Xinference-style providers.
+type RAGconModel struct {
+	baseModel BaseModel
+}
+
+// NewRAGconModel creates a new RAGcon model instance.
+func NewRAGconModel(baseURL map[string]string, urlSuffix URLSuffix) *RAGconModel {
+	return &RAGconModel{
+		baseModel: BaseModel{
+			BaseURL:    baseURL,
+			URLSuffix:  urlSuffix,
+			httpClient: NewDriverHTTPClient(),
+		},
+	}
+}
+
+func (r *RAGconModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewRAGconModel(baseURL, r.baseModel.URLSuffix)
+}
+
+func (r *RAGconModel) Name() string {
+	return "ragcon"
+}
+
+func (r *RAGconModel) chatURL(apiConfig *APIConfig) (string, error) {
+	baseURL, err := r.baseModel.GetBaseURL(apiConfig)
+	if err != nil {
+		return "", err
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	return fmt.Sprintf("%s/%s", baseURL, r.baseModel.URLSuffix.Chat), nil
+}
+
+func ragconChatMessages(messages []Message) []map[string]interface{} {
+	apiMessages := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		apiMsg := map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+		if msg.ToolCallID != "" {
+			apiMsg["tool_call_id"] = msg.ToolCallID
+		}
+		if len(msg.ToolCalls) > 0 {
+			apiMsg["tool_calls"] = msg.ToolCalls
+		}
+		apiMessages[i] = apiMsg
+	}
+	return apiMessages
+}
+
+func ragconChatPayload(modelName string, messages []Message, stream bool, chatModelConfig *ChatConfig) map[string]interface{} {
+	reqBody := map[string]interface{}{
+		"model":    modelName,
+		"messages": ragconChatMessages(messages),
+		"stream":   stream,
+	}
+	if stream {
+		reqBody["stream_options"] = map[string]interface{}{"include_usage": true}
+	}
+
+	if chatModelConfig != nil {
+		if chatModelConfig.MaxTokens != nil {
+			reqBody["max_tokens"] = *chatModelConfig.MaxTokens
+		}
+		if chatModelConfig.Temperature != nil {
+			reqBody["temperature"] = *chatModelConfig.Temperature
+		}
+		if chatModelConfig.TopP != nil {
+			reqBody["top_p"] = *chatModelConfig.TopP
+		}
+		if chatModelConfig.Stop != nil {
+			reqBody["stop"] = *chatModelConfig.Stop
+		}
+		if chatModelConfig.Tools != nil {
+			reqBody["tools"] = chatModelConfig.Tools
+			tc := "auto"
+			if chatModelConfig.ToolChoice != nil {
+				tc = *chatModelConfig.ToolChoice
+			}
+			reqBody["tool_choice"] = tc
+		}
+	}
+
+	// Qwen3 family: disable thinking by default (mirrors the same policy
+	// applied by the other OpenAI-compatible Go drivers).
+	if strings.Contains(strings.ToLower(modelName), "qwen3") && (chatModelConfig == nil || chatModelConfig.Thinking == nil) {
+		reqBody["enable_thinking"] = false
+	}
+
+	return reqBody
+}
+
+func (r *RAGconModel) ChatWithMessages(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig) (*ChatResponse, error) {
+	if err := r.baseModel.APIConfigCheck(apiConfig); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages is empty")
+	}
+
+	url, err := r.chatURL(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(ragconChatPayload(modelName, messages, false, chatModelConfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RAGcon API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+	firstChoice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid choice format")
+	}
+	messageMap, ok := firstChoice["message"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid message format")
+	}
+
+	var content string
+	if c, ok := messageMap["content"].(string); ok {
+		content = c
+	}
+
+	var reasonContent string
+	if rc, ok := messageMap["reasoning_content"].(string); ok {
+		reasonContent = rc
+	} else if rc, ok := messageMap["reasoning"].(string); ok {
+		reasonContent = rc
+	}
+
+	var toolCalls []map[string]interface{}
+	if tcs, ok := messageMap["tool_calls"].([]interface{}); ok {
+		for _, tc := range tcs {
+			if tcMap, ok := tc.(map[string]interface{}); ok {
+				toolCalls = append(toolCalls, tcMap)
+			}
+		}
+	}
+
+	chatResponse := &ChatResponse{
+		Answer:        &content,
+		ReasonContent: &reasonContent,
+		ToolCalls:     toolCalls,
+	}
+	if pt, ct, tt := extractUsageFromMap(result); tt > 0 {
+		chatResponse.Usage = &ChatUsage{PromptTokens: pt, CompletionTokens: ct, TotalTokens: tt}
+	}
+
+	return chatResponse, nil
+}
+
+func (r *RAGconModel) ChatStreamlyWithSender(modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, sender func(*string, *string) error) error {
+	if err := r.baseModel.APIConfigCheck(apiConfig); err != nil {
+		return err
+	}
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+	if strings.TrimSpace(modelName) == "" {
+		return fmt.Errorf("model name is required")
+	}
+	if len(messages) == 0 {
+		return fmt.Errorf("messages is empty")
+	}
+	if chatModelConfig != nil && chatModelConfig.Stream != nil && !*chatModelConfig.Stream {
+		return fmt.Errorf("stream must be true in ChatStreamlyWithSender")
+	}
+
+	url, err := r.chatURL(apiConfig)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err := json.Marshal(ragconChatPayload(modelName, messages, true, chatModelConfig))
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("RAGcon API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	sawTerminal := false
+	accumulatedToolCalls := make(map[int]map[string]interface{})
+	var streamUsage *ChatUsage
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(line[5:])
+		if data == "" {
+			continue
+		}
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		var event map[string]interface{}
+		if err = json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+
+		if pt, ct, tt := extractUsageFromMap(event); tt > 0 {
+			streamUsage = &ChatUsage{PromptTokens: pt, CompletionTokens: ct, TotalTokens: tt}
+		}
+
+		choices, ok := event["choices"].([]interface{})
+		if !ok || len(choices) == 0 {
+			continue
+		}
+		firstChoice, ok := choices[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		delta, ok := firstChoice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if tcs, ok := delta["tool_calls"].([]interface{}); ok {
+			for _, tc := range tcs {
+				tcMap, ok := tc.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				idxF, ok := tcMap["index"].(float64)
+				if !ok {
+					continue
+				}
+				idx := int(idxF)
+				if existing, hasExisting := accumulatedToolCalls[idx]; hasExisting {
+					if fn, ok := tcMap["function"].(map[string]interface{}); ok {
+						if args, ok := fn["arguments"].(string); ok {
+							if ef, ok := existing["function"].(map[string]interface{}); ok {
+								if ea, ok := ef["arguments"].(string); ok {
+									ef["arguments"] = ea + args
+								} else {
+									ef["arguments"] = args
+								}
+							}
+						}
+					}
+				} else {
+					accumulatedToolCalls[idx] = cloneMap(tcMap)
+				}
+			}
+			continue
+		}
+
+		if reasoningContent, ok := delta["reasoning_content"].(string); ok && reasoningContent != "" {
+			if err := sender(nil, &reasoningContent); err != nil {
+				return err
+			}
+		}
+		if content, ok := delta["content"].(string); ok && content != "" {
+			if err := sender(&content, nil); err != nil {
+				return err
+			}
+		}
+		if finishReason, ok := firstChoice["finish_reason"].(string); ok && finishReason != "" {
+			sawTerminal = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to scan response body: %w", err)
+	}
+	if !sawTerminal {
+		return fmt.Errorf("ragcon: stream ended before [DONE] or finish_reason")
+	}
+
+	if len(accumulatedToolCalls) > 0 && chatModelConfig != nil {
+		tcs := make([]map[string]interface{}, 0, len(accumulatedToolCalls))
+		for _, tc := range accumulatedToolCalls {
+			tcs = append(tcs, tc)
+		}
+		chatModelConfig.ToolCallsResult = &tcs
+	}
+	if streamUsage != nil && chatModelConfig != nil {
+		chatModelConfig.UsageResult = streamUsage
+	}
+
+	endOfStream := "[DONE]"
+	return sender(&endOfStream, nil)
+}
+
+type ragconEmbeddingResponse struct {
+	Data []struct {
+		Embedding []float64 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+}
+
+func (r *RAGconModel) Embed(modelName *string, texts []string, apiConfig *APIConfig, embeddingConfig *EmbeddingConfig) ([]EmbeddingData, error) {
+	if err := r.baseModel.APIConfigCheck(apiConfig); err != nil {
+		return nil, err
+	}
+	if modelName == nil || strings.TrimSpace(*modelName) == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(texts) == 0 {
+		return []EmbeddingData{}, nil
+	}
+
+	baseURL, err := r.baseModel.GetBaseURL(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	url := fmt.Sprintf("%s/%s", baseURL, r.baseModel.URLSuffix.Embedding)
+
+	reqBody := map[string]interface{}{
+		"model": *modelName,
+		"input": texts,
+	}
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
+		reqBody["dimensions"] = embeddingConfig.Dimension
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RAGcon embeddings API error: %s, body: %s", resp.Status, string(body))
+	}
+
+	var parsed ragconEmbeddingResponse
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	embeddings := make([]EmbeddingData, 0, len(parsed.Data))
+	for _, d := range parsed.Data {
+		embeddings = append(embeddings, EmbeddingData{Embedding: d.Embedding, Index: d.Index})
+	}
+	return embeddings, nil
+}
+
+// Rerank POSTs to RAGcon's /rerank endpoint (LiteLLM proxy passthrough).
+func (r *RAGconModel) Rerank(modelName *string, query string, documents []string, apiConfig *APIConfig, rerankConfig *RerankConfig) (*RerankResponse, error) {
+	if err := r.baseModel.APIConfigCheck(apiConfig); err != nil {
+		return nil, err
+	}
+	if modelName == nil || strings.TrimSpace(*modelName) == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+	if len(documents) == 0 {
+		return &RerankResponse{}, nil
+	}
+
+	baseURL, err := r.baseModel.GetBaseURL(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	url := fmt.Sprintf("%s/%s", baseURL, r.baseModel.URLSuffix.Rerank)
+
+	topN := len(documents)
+	if rerankConfig != nil && rerankConfig.TopN != 0 {
+		topN = rerankConfig.TopN
+	}
+
+	reqBody := map[string]interface{}{
+		"model":     *modelName,
+		"query":     query,
+		"documents": documents,
+		"top_n":     topN,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RAGcon rerank API error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var rerankResp struct {
+		Results []struct {
+			Index          int     `json:"index"`
+			RelevanceScore float64 `json:"relevance_score"`
+		} `json:"results"`
+	}
+	if err = json.Unmarshal(body, &rerankResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	var rerankResponse RerankResponse
+	for _, result := range rerankResp.Results {
+		rerankResponse.Data = append(rerankResponse.Data, RerankResult{
+			Index:          result.Index,
+			RelevanceScore: result.RelevanceScore,
+		})
+	}
+	return &rerankResponse, nil
+}
+
+// ListModels returns the model ids visible to the configured API key.
+func (r *RAGconModel) ListModels(apiConfig *APIConfig) ([]ListModelResponse, error) {
+	if err := r.baseModel.APIConfigCheck(apiConfig); err != nil {
+		return nil, err
+	}
+
+	baseURL, err := r.baseModel.GetBaseURL(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	url := fmt.Sprintf("%s/%s", baseURL, r.baseModel.URLSuffix.Models)
+
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var modelList ModelList
+	if err = json.Unmarshal(body, &modelList); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return ParseListModel(modelList), nil
+}
+
+func (r *RAGconModel) CheckConnection(apiConfig *APIConfig) error {
+	_, err := r.ListModels(apiConfig)
+	return err
+}
+
+// Balance is not exposed by RAGcon's LiteLLM proxy.
+func (r *RAGconModel) Balance(apiConfig *APIConfig) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) newASRRequest(ctx context.Context, modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, stream bool) (*http.Request, string, error) {
+	if err := r.baseModel.APIConfigCheck(apiConfig); err != nil {
+		return nil, "", err
+	}
+	if modelName == nil || strings.TrimSpace(*modelName) == "" {
+		return nil, "", fmt.Errorf("model name is required")
+	}
+	if file == nil || *file == "" {
+		return nil, "", fmt.Errorf("file is missing")
+	}
+
+	baseURL, err := r.baseModel.GetBaseURL(apiConfig)
+	if err != nil {
+		return nil, "", err
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	url := fmt.Sprintf("%s/%s", baseURL, strings.TrimPrefix(r.baseModel.URLSuffix.ASR, "/"))
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	// codeql[go/path-injection] False positive: *file is the audio file path the caller passes in to upload. The caller (an operator-supplied pipeline) explicitly chose this path, and the OS access check enforces permissions anyway.
+	audioFile, err := os.Open(*file)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to open audio file: %w", err)
+	}
+	defer audioFile.Close()
+
+	part, err := writer.CreateFormFile("file", filepath.Base(*file))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create multipart file: %w", err)
+	}
+	if _, err = io.Copy(part, audioFile); err != nil {
+		return nil, "", fmt.Errorf("failed to copy audio data: %w", err)
+	}
+	if err = writer.WriteField("model", *modelName); err != nil {
+		return nil, "", fmt.Errorf("failed to write model field: %w", err)
+	}
+
+	responseFormat := ""
+	if asrConfig != nil && asrConfig.Params != nil {
+		if value, ok := asrConfig.Params["response_format"].(string); ok {
+			responseFormat = value
+		}
+		for key, value := range asrConfig.Params {
+			if stream && key == "stream" {
+				continue
+			}
+			if err = writeOpenAIMultipartField(writer, key, value); err != nil {
+				return nil, "", err
+			}
+		}
+	}
+	if stream {
+		if err = writer.WriteField("stream", "true"); err != nil {
+			return nil, "", fmt.Errorf("failed to write stream field: %w", err)
+		}
+	}
+
+	if err = writer.Close(); err != nil {
+		return nil, "", fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &body)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, responseFormat, nil
+}
+
+func (r *RAGconModel) TranscribeAudio(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig) (*ASRResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, responseFormat, err := r.newASRRequest(ctx, modelName, file, apiConfig, asrConfig, false)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RAGcon ASR API error: %s, body: %s", resp.Status, string(respBody))
+	}
+
+	return decodeOpenAIASRResponse(respBody, responseFormat)
+}
+
+func (r *RAGconModel) TranscribeAudioWithSender(modelName *string, file *string, apiConfig *APIConfig, asrConfig *ASRConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+
+	req, responseFormat, err := r.newASRRequest(context.Background(), modelName, file, apiConfig, asrConfig, true)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("RAGcon ASR stream API error: %s, body: %s", resp.Status, string(respBody))
+	}
+
+	if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %w", err)
+		}
+		response, err := decodeOpenAIASRResponse(respBody, responseFormat)
+		if err != nil {
+			return err
+		}
+		if response != nil && response.Text != "" {
+			if err = sender(&response.Text, nil); err != nil {
+				return err
+			}
+		}
+		done := "[DONE]"
+		return sender(&done, nil)
+	}
+
+	sentDelta := false
+	if _, err = ParseSSEStream[struct {
+		Type  string `json:"type"`
+		Delta string `json:"delta"`
+		Text  string `json:"text"`
+	}](resp.Body, func(event struct {
+		Type  string `json:"type"`
+		Delta string `json:"delta"`
+		Text  string `json:"text"`
+	}) error {
+		switch {
+		case event.Delta != "":
+			if err = sender(&event.Delta, nil); err != nil {
+				return err
+			}
+			sentDelta = true
+		case event.Type == "transcript.text.segment" && event.Text != "":
+			if err = sender(&event.Text, nil); err != nil {
+				return err
+			}
+			sentDelta = true
+		case event.Type == "transcript.text.done" && !sentDelta && event.Text != "":
+			if err = sender(&event.Text, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error reading RAGcon ASR stream: %w", err)
+	}
+
+	done := "[DONE]"
+	return sender(&done, nil)
+}
+
+func (r *RAGconModel) newTTSRequest(ctx context.Context, modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, stream bool) (*http.Request, string, error) {
+	if err := r.baseModel.APIConfigCheck(apiConfig); err != nil {
+		return nil, "", err
+	}
+	if modelName == nil || strings.TrimSpace(*modelName) == "" {
+		return nil, "", fmt.Errorf("model name is required")
+	}
+	if audioContent == nil || *audioContent == "" {
+		return nil, "", fmt.Errorf("audio content is empty")
+	}
+
+	baseURL, err := r.baseModel.GetBaseURL(apiConfig)
+	if err != nil {
+		return nil, "", err
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	url := fmt.Sprintf("%s/%s", baseURL, strings.TrimPrefix(r.baseModel.URLSuffix.TTS, "/"))
+
+	reqBody := map[string]interface{}{
+		"model": *modelName,
+		"input": *audioContent,
+	}
+	if ttsConfig != nil && ttsConfig.Params != nil {
+		for key, value := range ttsConfig.Params {
+			reqBody[key] = value
+		}
+	}
+	if ttsConfig != nil && ttsConfig.Format != "" {
+		reqBody["response_format"] = ttsConfig.Format
+	}
+	if stream {
+		if _, ok := reqBody["stream_format"]; !ok {
+			reqBody["stream_format"] = "audio"
+		}
+	}
+
+	voice, ok := reqBody["voice"]
+	if !ok || voice == nil {
+		return nil, "", fmt.Errorf("voice is required")
+	}
+	voiceString, ok := voice.(string)
+	if !ok || strings.TrimSpace(voiceString) == "" {
+		return nil, "", fmt.Errorf("voice is required")
+	}
+
+	streamFormat, _ := reqBody["stream_format"].(string)
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *apiConfig.ApiKey))
+	return req, streamFormat, nil
+}
+
+func (r *RAGconModel) AudioSpeech(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig) (*TTSResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), nonStreamCallTimeout)
+	defer cancel()
+
+	req, _, err := r.newTTSRequest(ctx, modelName, audioContent, apiConfig, ttsConfig, false)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RAGcon TTS API error: %s, body: %s", resp.Status, string(body))
+	}
+
+	return &TTSResponse{Audio: body}, nil
+}
+
+func (r *RAGconModel) AudioSpeechWithSender(modelName *string, audioContent *string, apiConfig *APIConfig, ttsConfig *TTSConfig, sender func(*string, *string) error) error {
+	if sender == nil {
+		return fmt.Errorf("sender is required")
+	}
+
+	req, streamFormat, err := r.newTTSRequest(context.Background(), modelName, audioContent, apiConfig, ttsConfig, true)
+	if err != nil {
+		return err
+	}
+	if streamFormat == "sse" {
+		req.Header.Set("Accept", "text/event-stream")
+	}
+
+	resp, err := r.baseModel.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("RAGcon TTS stream API error: %s, body: %s", resp.Status, string(body))
+	}
+
+	if streamFormat == "sse" || strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		return readOpenAITTSSSEStream(resp.Body, sender)
+	}
+	return readOpenAITTSRawStream(resp.Body, sender)
+}
+
+// OCRFile is not offered by RAGcon.
+func (r *RAGconModel) OCRFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, ocrConfig *OCRConfig) (*OCRFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+// ParseFile is not offered by RAGcon.
+func (r *RAGconModel) ParseFile(modelName *string, content []byte, url *string, apiConfig *APIConfig, parseFileConfig *ParseFileConfig) (*ParseFileResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ListTasks(apiConfig *APIConfig) ([]ListTaskStatus, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}
+
+func (r *RAGconModel) ShowTask(taskID string, apiConfig *APIConfig) (*TaskResponse, error) {
+	return nil, fmt.Errorf("%s, no such method", r.Name())
+}

--- a/internal/entity/models/ragcon_test.go
+++ b/internal/entity/models/ragcon_test.go
@@ -1,0 +1,405 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func newRAGconServer(t *testing.T, handler func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("expected Authorization=Bearer test-key, got %q", got)
+			return
+		}
+		var body map[string]interface{}
+		if r.Method == http.MethodPost && strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+				return
+			}
+			if len(raw) > 0 {
+				if err := json.Unmarshal(raw, &body); err != nil {
+					t.Errorf("unmarshal: %v\nraw=%s", err, string(raw))
+					return
+				}
+			}
+		}
+		handler(t, r, body, w)
+	}))
+}
+
+func newRAGconForTest(baseURL string) *RAGconModel {
+	return NewRAGconModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{
+			Chat:      "chat/completions",
+			Models:    "models",
+			Embedding: "embeddings",
+			Rerank:    "rerank",
+			ASR:       "audio/transcriptions",
+			TTS:       "audio/speech",
+		},
+	)
+}
+
+func TestRAGconName(t *testing.T) {
+	if got := newRAGconForTest("http://unused").Name(); got != "ragcon" {
+		t.Errorf("Name()=%q, want ragcon", got)
+	}
+}
+
+func TestRAGconFactory(t *testing.T) {
+	driver, err := NewModelFactory().CreateModelDriver("RAGcon", map[string]string{"default": "http://unused"}, URLSuffix{})
+	if err != nil {
+		t.Fatalf("CreateModelDriver: %v", err)
+	}
+	if _, ok := driver.(*RAGconModel); !ok {
+		t.Fatalf("driver type=%T, want *RAGconModel", driver)
+	}
+}
+
+func TestRAGconChatHappyPath(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path=%s, want /chat/completions", r.URL.Path)
+		}
+		if body["model"] != "llama-4-maverick" {
+			t.Errorf("model=%v", body["model"])
+		}
+		if body["stream"] != false {
+			t.Errorf("stream=%v, want false", body["stream"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content":           "pong",
+					"reasoning_content": "thought about it",
+				},
+			}},
+			"usage": map[string]interface{}{
+				"prompt_tokens":     3,
+				"completion_tokens": 1,
+				"total_tokens":      4,
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	resp, err := newRAGconForTest(srv.URL).ChatWithMessages(
+		"llama-4-maverick",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if resp.Answer == nil || *resp.Answer != "pong" {
+		t.Errorf("Answer=%v, want pong", resp.Answer)
+	}
+	if resp.ReasonContent == nil || *resp.ReasonContent != "thought about it" {
+		t.Errorf("ReasonContent=%v, want 'thought about it'", resp.ReasonContent)
+	}
+	if resp.Usage == nil || resp.Usage.TotalTokens != 4 {
+		t.Errorf("Usage=%v, want total_tokens=4", resp.Usage)
+	}
+}
+
+func TestRAGconChatRequiresAPIKey(t *testing.T) {
+	_, err := newRAGconForTest("http://unused").ChatWithMessages(
+		"llama-4-maverick",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api-key-required error, got %v", err)
+	}
+}
+
+func TestRAGconChatRequiresMessages(t *testing.T) {
+	apiKey := "test-key"
+	_, err := newRAGconForTest("http://unused").ChatWithMessages(
+		"llama-4-maverick",
+		[]Message{},
+		&APIConfig{ApiKey: &apiKey},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "messages is empty") {
+		t.Errorf("expected messages-empty error, got %v", err)
+	}
+}
+
+func TestRAGconChatSurfacesHTTPError(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"invalid key"}`)
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	_, err := newRAGconForTest(srv.URL).ChatWithMessages(
+		"llama-4-maverick",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 status error, got %v", err)
+	}
+}
+
+func TestRAGconStreamHappyPath(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if body["stream"] != true {
+			t.Errorf("stream=%v, want true", body["stream"])
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			`data: {"choices":[{"delta":{"reasoning_content":"step. "}}]}`+"\n"+
+				`data: {"choices":[{"delta":{"content":"Hello"}}]}`+"\n"+
+				`data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n"+
+				`data: [DONE]`+"\n",
+		)
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	var content, reasoning []string
+	var sawDone bool
+	err := newRAGconForTest(srv.URL).ChatStreamlyWithSender(
+		"llama-4-maverick",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey},
+		nil,
+		func(c *string, r *string) error {
+			if r != nil && *r != "" {
+				reasoning = append(reasoning, *r)
+			}
+			if c != nil && *c == "[DONE]" {
+				sawDone = true
+			}
+			if c != nil && *c != "" && *c != "[DONE]" {
+				content = append(content, *c)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("ChatStreamlyWithSender: %v", err)
+	}
+	if strings.Join(reasoning, "") != "step. " {
+		t.Errorf("reasoning=%q", strings.Join(reasoning, ""))
+	}
+	if strings.Join(content, "") != "Hello world" {
+		t.Errorf("content=%q", strings.Join(content, ""))
+	}
+	if !sawDone {
+		t.Error("expected [DONE] callback")
+	}
+}
+
+func TestRAGconStreamRejectsNilSender(t *testing.T) {
+	apiKey := "test-key"
+	err := newRAGconForTest("http://unused").ChatStreamlyWithSender(
+		"llama-4-maverick",
+		[]Message{{Role: "user", Content: "x"}},
+		&APIConfig{ApiKey: &apiKey},
+		nil,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "sender is required") {
+		t.Errorf("expected sender-required error, got %v", err)
+	}
+}
+
+func TestRAGconEmbed(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path=%s, want /embeddings", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"embedding": []float64{0.1, 0.2}, "index": 0},
+				{"embedding": []float64{0.3, 0.4}, "index": 1},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	model := "text-embedding-3-small"
+	embeddings, err := newRAGconForTest(srv.URL).Embed(&model, []string{"a", "b"}, &APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(embeddings) != 2 || embeddings[1].Index != 1 {
+		t.Errorf("embeddings=%v", embeddings)
+	}
+}
+
+func TestRAGconRerank(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/rerank" {
+			t.Errorf("path=%s, want /rerank", r.URL.Path)
+		}
+		if body["top_n"] != float64(2) {
+			t.Errorf("top_n=%v, want 2", body["top_n"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"results": []map[string]interface{}{
+				{"index": 1, "relevance_score": 0.9},
+				{"index": 0, "relevance_score": 0.2},
+			},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	model := "rerank-v1"
+	resp, err := newRAGconForTest(srv.URL).Rerank(&model, "q", []string{"doc0", "doc1"}, &APIConfig{ApiKey: &apiKey}, &RerankConfig{TopN: 2})
+	if err != nil {
+		t.Fatalf("Rerank: %v", err)
+	}
+	if len(resp.Data) != 2 || resp.Data[0].Index != 1 || resp.Data[0].RelevanceScore != 0.9 {
+		t.Errorf("Data=%v", resp.Data)
+	}
+}
+
+func TestRAGconListModelsAndCheckConnection(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, _ map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/models" {
+			t.Errorf("path=%s, want /models", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"data":[{"id":"llama-4-maverick"},{"id":"gpt-oss-120b"}]}`)
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	cfg := &APIConfig{ApiKey: &apiKey}
+	models, err := newRAGconForTest(srv.URL).ListModels(cfg)
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if joinModelNames(models, ",") != "llama-4-maverick,gpt-oss-120b" {
+		t.Errorf("models=%v", models)
+	}
+	if err := newRAGconForTest(srv.URL).CheckConnection(cfg); err != nil {
+		t.Fatalf("CheckConnection: %v", err)
+	}
+}
+
+func TestRAGconTranscribeAudioPostsMultipart(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/audio/transcriptions" {
+			t.Errorf("path=%s, want /audio/transcriptions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization=%q, want Bearer test-key", got)
+		}
+		if err := r.ParseMultipartForm(1024 * 1024); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		if got := r.FormValue("model"); got != "whisper-1" {
+			t.Errorf("model=%q, want whisper-1", got)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("FormFile: %v", err)
+		}
+		defer file.Close()
+		content, _ := io.ReadAll(file)
+		if string(content) != "audio-bytes" {
+			t.Errorf("file content=%q, want audio-bytes", string(content))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"text": "hello world"})
+	}))
+	defer srv.Close()
+
+	audioPath := t.TempDir() + "/sample.wav"
+	if err := os.WriteFile(audioPath, []byte("audio-bytes"), 0600); err != nil {
+		t.Fatalf("write audio fixture: %v", err)
+	}
+
+	apiKey := "test-key"
+	model := "whisper-1"
+	resp, err := newRAGconForTest(srv.URL).TranscribeAudio(&model, &audioPath, &APIConfig{ApiKey: &apiKey}, nil)
+	if err != nil {
+		t.Fatalf("TranscribeAudio: %v", err)
+	}
+	if resp.Text != "hello world" {
+		t.Fatalf("Text=%q, want hello world", resp.Text)
+	}
+}
+
+func TestRAGconAudioSpeechPostsJSON(t *testing.T) {
+	srv := newRAGconServer(t, func(t *testing.T, r *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		if r.URL.Path != "/audio/speech" {
+			t.Errorf("path=%s, want /audio/speech", r.URL.Path)
+		}
+		if body["voice"] != "alloy" {
+			t.Errorf("voice=%v, want alloy", body["voice"])
+		}
+		w.Write([]byte("raw-audio-bytes"))
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	model := "tts-1"
+	text := "hello"
+	resp, err := newRAGconForTest(srv.URL).AudioSpeech(&model, &text, &APIConfig{ApiKey: &apiKey}, &TTSConfig{Params: map[string]interface{}{"voice": "alloy"}})
+	if err != nil {
+		t.Fatalf("AudioSpeech: %v", err)
+	}
+	if string(resp.Audio) != "raw-audio-bytes" {
+		t.Errorf("Audio=%q", string(resp.Audio))
+	}
+}
+
+func TestRAGconUnsupportedMethodsReturnNoSuchMethod(t *testing.T) {
+	r := newRAGconForTest("http://unused")
+	model := "llama-4-maverick"
+
+	if _, err := r.Balance(&APIConfig{}); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("Balance: expected no such method, got %v", err)
+	}
+	if _, err := r.OCRFile(&model, nil, nil, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("OCRFile: expected no such method, got %v", err)
+	}
+	if _, err := r.ParseFile(&model, nil, nil, &APIConfig{}, nil); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("ParseFile: expected no such method, got %v", err)
+	}
+	if _, err := r.ListTasks(&APIConfig{}); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("ListTasks: expected no such method, got %v", err)
+	}
+	if _, err := r.ShowTask("t1", &APIConfig{}); err == nil || !strings.Contains(err.Error(), "no such method") {
+		t.Errorf("ShowTask: expected no such method, got %v", err)
+	}
+}

--- a/rag/llm/model_meta.py
+++ b/rag/llm/model_meta.py
@@ -477,3 +477,7 @@ class NewAPI(OpenAIAPICompatible):
         except (JSONDecodeError, TypeError):
             pass
         return self.api_key
+
+
+class RAGcon(OpenAIAPICompatible):
+    _FACTORY_NAME = "RAGcon"

--- a/web/src/pages/user-setting/setting-model/provider-schema/constants.ts
+++ b/web/src/pages/user-setting/setting-model/provider-schema/constants.ts
@@ -40,6 +40,7 @@ export const LIST_MODEL_PROVIDERS = new Set<string>([
   LLMFactory.LocalAI,
   LLMFactory.BaiduYiYan,
   LLMFactory.NewAPI,
+  LLMFactory.RAGcon,
 
   // LLMFactory.HuggingFace,
   // LLMFactory.GoogleCloud,


### PR DESCRIPTION
### Summary
We have updated our model driver to work with go.
It is based on OpenAI-API-Compatible model provider.

Draft
#15519

Our old model provider
#13425 
