### PR TITLE
feat: add /api/v1/language endpoint for Go/Python runtime detection

### DIFF
--- a/api/apps/restful_apis/system_api.py
+++ b/api/apps/restful_apis/system_api.py
@@ -62,6 +62,12 @@ def version():
     return get_json_result(data=get_ragflow_version())
 
 
+@manager.route("/language", methods=["GET"])  # noqa: F821
+def language():
+    """Backend runtime language detection for front-end compatibility."""
+    return get_json_result(data={"language": "python"})
+
+
 @manager.route("/system/status", methods=["GET"])  # noqa: F821
 @login_required
 def status():

--- a/api/apps/restful_apis/system_api.py
+++ b/api/apps/restful_apis/system_api.py
@@ -65,6 +65,7 @@ def version():
 @manager.route("/language", methods=["GET"])  # noqa: F821
 def language():
     """Backend runtime language detection for front-end compatibility."""
+    logging.info("Language endpoint called, returning python")
     return get_json_result(data={"language": "python"})
 
 

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -260,3 +260,9 @@ func (h *SystemHandler) ListEnvironments(c *gin.Context) {
 
 	common.SuccessWithData(c, environments, "SUCCESS")
 }
+
+// Language returns the backend runtime language so the front end can
+// choose the appropriate code path (Go vs Python).
+func (h *SystemHandler) Language(c *gin.Context) {
+	common.SuccessWithData(c, map[string]string{"language": "go"}, "success")
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -159,6 +159,9 @@ func (r *Router) Setup(engine *gin.Engine) {
 		apiNoAuth.GET("/system/config", r.systemHandler.GetConfig)
 		apiNoAuth.GET("/system/version", r.systemHandler.GetVersion)
 		apiNoAuth.GET("/system/healthz", r.systemHandler.Healthz)
+		// Backend runtime language detection. The front end calls this once
+		// to choose between Go and Python code paths.
+		apiNoAuth.GET("/language", r.systemHandler.Language)
 
 		// Pipeline catalog. Public static data (shipped with the binary),
 		// no auth required. The front end uses it to populate the parser

--- a/web/src/hooks/use-user-setting-request.tsx
+++ b/web/src/hooks/use-user-setting-request.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/interfaces/database/user-setting';
 import { ISetLangfuseConfigRequestBody } from '@/interfaces/request/system';
 import { DEFAULT_LANGUAGE_CODE, supportedLanguages } from '@/locales/config';
+import kbService from '@/services/knowledge-service';
+import { fetchBackendLanguage } from '@/utils/backend-runtime';
 import userService, {
   addTenantUser,
   agreeTenant,
@@ -102,6 +104,25 @@ export const useSelectParserList = (): Array<{
   const { data: tenantInfo } = useFetchTenantInfo(true);
   const { t } = useTranslation();
 
+  // Detect backend runtime language (Go vs Python) so we can choose
+  // the matching parser-list code path at runtime.
+  const { data: backendLang } = useQuery({
+    queryKey: ['backendLanguage'],
+    queryFn: fetchBackendLanguage,
+    staleTime: Infinity,
+  });
+
+  // Go backend: fetch pipeline catalog dynamically.
+  const { data: pipelineListData } = useQuery({
+    queryKey: ['listPipelines'],
+    queryFn: async () => {
+      const { data } = await kbService.listPipelines();
+      return data;
+    },
+    staleTime: Infinity,
+    enabled: backendLang === 'go',
+  });
+
   const defaultParsers = useMemo(
     () => [
       { value: 'naive', label: t('knowledgeConfiguration.parserLabel.naive') },
@@ -135,6 +156,25 @@ export const useSelectParserList = (): Array<{
   );
 
   const parserList = useMemo(() => {
+    // Go backend: prefer the dynamic pipeline catalog from the API.
+    if (backendLang === 'go') {
+      const pipelineList: Array<{ parser_id: string; title: string; dsl: Record<string, any> }> =
+        pipelineListData?.data ?? [];
+      if (pipelineList.length > 0) {
+        const labelFromAPI = (parserId: string, title: string) => {
+          const key = `knowledgeConfiguration.parserLabel.${parserId}`;
+          const translated = t(key);
+          return translated !== key ? translated : title;
+        };
+        return pipelineList.map((item) => ({
+          value: item.parser_id,
+          label: labelFromAPI(item.parser_id, item.title),
+        }));
+      }
+    }
+
+    // Python backend (or fallback): use tenant-level parser_ids or
+    // the hardcoded default parsers.
     const parserArray: Array<string> = tenantInfo?.parser_ids?.split(',') ?? [];
     const filteredArray = parserArray.filter((x) => x.trim() !== '');
 
@@ -146,7 +186,7 @@ export const useSelectParserList = (): Array<{
       const arr = x.split(':');
       return { value: arr[0], label: arr[1] };
     });
-  }, [tenantInfo, defaultParsers]);
+  }, [tenantInfo, defaultParsers, backendLang, pipelineListData, t]);
 
   return parserList;
 };

--- a/web/src/hooks/use-user-setting-request.tsx
+++ b/web/src/hooks/use-user-setting-request.tsx
@@ -11,7 +11,10 @@ import {
 import { ISetLangfuseConfigRequestBody } from '@/interfaces/request/system';
 import { DEFAULT_LANGUAGE_CODE, supportedLanguages } from '@/locales/config';
 import kbService from '@/services/knowledge-service';
-import { fetchBackendLanguage } from '@/utils/backend-runtime';
+import {
+  getBackendLanguage,
+  subscribeBackendLanguage,
+} from '@/utils/backend-runtime';
 import userService, {
   addTenantUser,
   agreeTenant,
@@ -20,7 +23,8 @@ import userService, {
   listTenantUser,
 } from '@/services/user-service';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useWarnEmptyModel } from './use-warn-empty-model';
@@ -109,13 +113,11 @@ export const useSelectParserList = (): Array<{
   // the matching parser-list code path at runtime.
   // fetchBackendLanguage / getBackendLanguage handle their own caching
   // internally; no need for an extra useQuery layer.
-  const [backendLang, setBackendLang] = useState<string | null>(
-    getBackendLanguage(),
+  const backendLang = useSyncExternalStore(
+    subscribeBackendLanguage,
+    getBackendLanguage,
+    getBackendLanguage,
   );
-
-  useEffect(() => {
-    fetchBackendLanguage().then(setBackendLang);
-  }, []);
 
   // Go backend: fetch pipeline catalog dynamically.
   const { data: pipelineListData } = useQuery({

--- a/web/src/hooks/use-user-setting-request.tsx
+++ b/web/src/hooks/use-user-setting-request.tsx
@@ -40,6 +40,8 @@ export const enum UserSettingApiAction {
   AgreeTenant = 'agreeTenant',
   SetLangfuseConfig = 'setLangfuseConfig',
   DeleteLangfuseConfig = 'deleteLangfuseConfig',
+  BackendLanguage = 'backendLanguage',
+  ListPipelines = 'listPipelines',
   FetchLangfuseConfig = 'fetchLangfuseConfig',
 }
 
@@ -107,14 +109,14 @@ export const useSelectParserList = (): Array<{
   // Detect backend runtime language (Go vs Python) so we can choose
   // the matching parser-list code path at runtime.
   const { data: backendLang } = useQuery({
-    queryKey: ['backendLanguage'],
+    queryKey: [UserSettingApiAction.BackendLanguage],
     queryFn: fetchBackendLanguage,
     staleTime: Infinity,
   });
 
   // Go backend: fetch pipeline catalog dynamically.
   const { data: pipelineListData } = useQuery({
-    queryKey: ['listPipelines'],
+    queryKey: [UserSettingApiAction.ListPipelines],
     queryFn: async () => {
       const { data } = await kbService.listPipelines();
       return data;

--- a/web/src/hooks/use-user-setting-request.tsx
+++ b/web/src/hooks/use-user-setting-request.tsx
@@ -20,7 +20,7 @@ import userService, {
   listTenantUser,
 } from '@/services/user-service';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useWarnEmptyModel } from './use-warn-empty-model';
@@ -40,7 +40,6 @@ export const enum UserSettingApiAction {
   AgreeTenant = 'agreeTenant',
   SetLangfuseConfig = 'setLangfuseConfig',
   DeleteLangfuseConfig = 'deleteLangfuseConfig',
-  BackendLanguage = 'backendLanguage',
   ListPipelines = 'listPipelines',
   FetchLangfuseConfig = 'fetchLangfuseConfig',
 }
@@ -108,11 +107,15 @@ export const useSelectParserList = (): Array<{
 
   // Detect backend runtime language (Go vs Python) so we can choose
   // the matching parser-list code path at runtime.
-  const { data: backendLang } = useQuery({
-    queryKey: [UserSettingApiAction.BackendLanguage],
-    queryFn: fetchBackendLanguage,
-    staleTime: Infinity,
-  });
+  // fetchBackendLanguage / getBackendLanguage handle their own caching
+  // internally; no need for an extra useQuery layer.
+  const [backendLang, setBackendLang] = useState<string | null>(
+    getBackendLanguage(),
+  );
+
+  useEffect(() => {
+    fetchBackendLanguage().then(setBackendLang);
+  }, []);
 
   // Go backend: fetch pipeline catalog dynamically.
   const { data: pipelineListData } = useQuery({

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -778,6 +778,7 @@ Example: A 1 KB message with 1024-dim embedding uses ~9 KB. The 5 MB default lim
         'Re-parse existing documents for the new column roles to take effect.',
       parserLabel: {
         naive: 'General',
+        general: 'General',
         qa: 'Q&A',
         resume: 'Resume',
         manual: 'Manual',

--- a/web/src/services/knowledge-service.ts
+++ b/web/src/services/knowledge-service.ts
@@ -19,6 +19,7 @@ const {
   documentThumbnails,
   documentIngest,
   listTagByKnowledgeIds,
+  listPipelines,
   setMeta,
   getMeta,
   getMetaKeys,
@@ -65,6 +66,10 @@ const methods = {
   retrievalTestShare: {
     url: retrievalTestShare,
     method: 'post',
+  },
+  listPipelines: {
+    url: listPipelines,
+    method: 'get',
   },
   pipelineRerun: {
     url: api.pipelineRerun,

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -181,6 +181,7 @@ export default {
     `${restAPIv1}/datasets/${datasetId}/ingestions/${logId}`,
   fetchPipelineDatasetLogs: (datasetId: string) =>
     `${restAPIv1}/datasets/${datasetId}/ingestions`,
+  listPipelines: `${restAPIv1}/pipelines?type=builtin`,
   runIndex: (datasetId: string, indexType: string) =>
     `${restAPIv1}/datasets/${datasetId}/index?type=${indexType.toLowerCase()}`,
   traceIndex: (datasetId: string, indexType: string) =>

--- a/web/src/utils/backend-runtime.ts
+++ b/web/src/utils/backend-runtime.ts
@@ -1,33 +1,40 @@
 /**
  * Backend runtime language detection.
  *
- * Fetches /api/v1/language at runtime (once, then caches) so the front end
- * can choose between Go-specific and Python-specific code paths without a
- * build-time flag.
+ * Fetches /api/v1/language once at module load (app start) and caches the
+ * result. Components subscribe via React's useSyncExternalStore; there is no
+ * per-component fetch or useEffect.
  *
- * Pattern: same lightweight fetch-once approach as enterprise billingStatus.ts.
+ * Pattern: module-level fetch + listener set, same subscription approach as
+ * enterprise billingStatus.ts.
  */
 
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
 let backendLanguage: string | null = null;
-let fetching: Promise<string> | null = null;
 
-export const fetchBackendLanguage = async (): Promise<string> => {
-  if (backendLanguage) return backendLanguage;
-  if (fetching) return fetching;
+// Kick off the fetch at module load — app start, not component mount.
+const promise: Promise<string> = fetch('/api/v1/language')
+  .then((r) => r.json())
+  .then((body: { data?: { language?: string } }) => {
+    backendLanguage = body.data?.language === 'go' ? 'go' : 'python';
+    listeners.forEach((fn) => fn());
+    return backendLanguage;
+  })
+  .catch(() => {
+    backendLanguage = 'python';
+    listeners.forEach((fn) => fn());
+    return 'python';
+  });
 
-  fetching = (async () => {
-    try {
-      const res = await fetch('/api/v1/language');
-      const body = await res.json();
-      backendLanguage = body.data?.language === 'go' ? 'go' : 'python';
-      return backendLanguage;
-    } catch {
-      backendLanguage = 'python';
-      return 'python';
-    }
-  })();
-
-  return fetching;
-};
+export const fetchBackendLanguage = (): Promise<string> => promise;
 
 export const getBackendLanguage = (): string | null => backendLanguage;
+
+export const subscribeBackendLanguage = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};

--- a/web/src/utils/backend-runtime.ts
+++ b/web/src/utils/backend-runtime.ts
@@ -1,0 +1,33 @@
+/**
+ * Backend runtime language detection.
+ *
+ * Fetches /api/v1/language at runtime (once, then caches) so the front end
+ * can choose between Go-specific and Python-specific code paths without a
+ * build-time flag.
+ *
+ * Pattern: same lightweight fetch-once approach as enterprise billingStatus.ts.
+ */
+
+let backendLanguage: string | null = null;
+let fetching: Promise<string> | null = null;
+
+export const fetchBackendLanguage = async (): Promise<string> => {
+  if (backendLanguage) return backendLanguage;
+  if (fetching) return fetching;
+
+  fetching = (async () => {
+    try {
+      const res = await fetch('/api/v1/language');
+      const body = await res.json();
+      backendLanguage = body.data?.language === 'go' ? 'go' : 'python';
+      return backendLanguage;
+    } catch {
+      backendLanguage = 'python';
+      return 'python';
+    }
+  })();
+
+  return fetching;
+};
+
+export const getBackendLanguage = (): string | null => backendLanguage;


### PR DESCRIPTION
Both backends serve GET /api/v1/language. Frontend calls it once and caches. By this way, front end can know the backend is go or python and thus can determine which part of logic to load.