### PR TITLE
fix: lefthook deps serialization

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,4 @@
-# There are 8 fix-capable jobs and 5 pure-check jobs.
+# There are 8 fix-capable jobs and 6 pure-check jobs.
 # Dual-mode pre-commit: by default (local dev) jobs fix and stage changes
 # (`stage_fixed: true` batches the `git add` per job to avoid the index lock
 # that parallel `git add` calls would hit). In CI, set LEFTHOOK_CHECK_ONLY=1
@@ -70,26 +70,28 @@ pre-commit:
         else
           gofmt -w {staged_files}
         fi
-    - name: web-prettier
+    - name: web-deps
       glob: "web/**/*.{css,less,json,js,jsx,ts,tsx}"
-      stage_fixed: true
       run: |
         # Ensure web/node_modules is populated. CI runners don't run `npm install`
         # before lefthook, and `npx` without local node_modules fetches the
-        # latest packages from the registry — which breaks because the pinned
+        # latest packages from the registry - which breaks because the pinned
         # prettier plugins (prettier-plugin-organize-imports,
         # prettier-plugin-packagejson) aren't auto-resolved and ESLint 10
         # requires eslint.config.js.
-        # Use a mkdir-based mutex to prevent parallel npm ci from multiple hooks
-        # racing (ETXTBSY error on esbuild). mkdir is atomic on both Linux and macOS.
-        LOCKDIR=/tmp/ragflow-web-npm-lock
-        while ! mkdir "$LOCKDIR" 2>/dev/null; do sleep 0.5; done
+        # Serialized via lefthook 'deps' from web-prettier/web-eslint instead of
+        # a mkdir mutex, which left stale locks on interrupted commits and
+        # caused subsequent commits to hang forever in 'while ! mkdir'.
         if [ ! -f web/node_modules/.package-lock.json ]; then
-          echo "==> web/node_modules missing or incomplete; running npm ci --prefix web"
+          echo '==> web/node_modules missing or incomplete; running npm ci --prefix web'
           rm -rf web/node_modules
-          npm ci --prefix web --no-audit --no-fund || { rm -rf "$LOCKDIR"; exit 1; }
+          npm ci --prefix web --no-audit --no-fund
         fi
-        rm -rf "$LOCKDIR"
+    - name: web-prettier
+      glob: "web/**/*.{css,less,json,js,jsx,ts,tsx}"
+      stage_fixed: true
+      deps: [web-deps]
+      run: |
         if [ "${LEFTHOOK_CHECK_ONLY:-}" = "1" ]; then
           cd web && printf '%s\n' {staged_files} | sed 's|^web/||' | xargs npx prettier --check --ignore-unknown
         else
@@ -98,16 +100,8 @@ pre-commit:
     - name: web-eslint
       glob: "web/**/*.{js,jsx,ts,tsx}"
       stage_fixed: true
+      deps: [web-deps]
       run: |
-        # Same npm ci guard as web-prettier; mkdir mutex serialises concurrent installs.
-        LOCKDIR=/tmp/ragflow-web-npm-lock
-        while ! mkdir "$LOCKDIR" 2>/dev/null; do sleep 0.5; done
-        if [ ! -f web/node_modules/.package-lock.json ]; then
-          echo "==> web/node_modules missing or incomplete; running npm ci --prefix web"
-          rm -rf web/node_modules
-          npm ci --prefix web --no-audit --no-fund || { rm -rf "$LOCKDIR"; exit 1; }
-        fi
-        rm -rf "$LOCKDIR"
         if [ "${LEFTHOOK_CHECK_ONLY:-}" = "1" ]; then
           cd web && printf '%s\n' {staged_files} | sed 's|^web/||' | xargs npx eslint
         else


### PR DESCRIPTION
### Summary

fix: lefthook deps serialization

Extract npm ci guard into web-deps job; use native deps for serialization instead of a mkdir mutex that could leave stale locks on interrupted commits. Also use single quotes in echo to work around lefthook v2.1.10 stripping double quotes on Windows.
