### PR TITLE
fix: align CAJAL template node types

### DIFF
--- a/agent/templates/cajal_scientific_paper_agent.json
+++ b/agent/templates/cajal_scientific_paper_agent.json
@@ -191,8 +191,8 @@
                 "{Agent:NewPumasLick@content}"
               ]
             },
-            "label": "Scientific Draft",
-            "name": "Response"
+            "label": "Message",
+            "name": "Scientific Draft"
           },
           "dragging": false,
           "id": "Message:OrangeYearsShine",
@@ -274,8 +274,8 @@
               "user_prompt": "",
               "visual_files_var": ""
             },
-            "label": "CAJAL Writer",
-            "name": "Knowledge Base Agent"
+            "label": "Agent",
+            "name": "CAJAL Writer"
           },
           "dragging": false,
           "id": "Agent:NewPumasLick",


### PR DESCRIPTION
### What problem does this PR solve?

Fix the CAJAL scientific paper agent template so its custom node names are stored in `name` while `label` remains the actual component type.

This allows the frontend to correctly load the Agent and Message forms and prevents invalid translation keys such as `flow.cAJAL WriterDescription` and `flow.scientific DraftDescription`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)