### PR TITLE
fix(embedding): do not append /v1 to Ollama native embedding base_url

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -469,7 +469,10 @@ class OllamaEmbed(Base):
     _special_tokens = ["<|endoftext|>"]
 
     def __init__(self, key, model_name, **kwargs):
-        self.base_url = ensure_v1(kwargs["base_url"])
+        # Native ollama.Client builds paths like "/api/embed" directly off this
+        # host; unlike the OpenAI-compatible providers below, it must NOT go
+        # through ensure_v1 (which appends "/v1") or every request 404s.
+        self.base_url = kwargs["base_url"].rstrip("/")
         self.client = Client(host=self.base_url) if not key or key == "x" else Client(host=self.base_url, headers={"Authorization": f"Bearer {key}"})
         self.model_name = model_name
         self.keep_alive = kwargs.get("ollama_keep_alive", int(os.environ.get("OLLAMA_KEEP_ALIVE", -1)))


### PR DESCRIPTION
## What

`OllamaEmbed.__init__` (in `rag/llm/embedding_model.py`) calls `ensure_v1(kwargs["base_url"])` before constructing the native `ollama.Client`. `ensure_v1()` unconditionally appends `/v1` to any base_url that doesn't already contain a versioned path segment.

That helper is meant for the OpenAI-compatible client providers (`OpenAIEmbed`, `LocalAIEmbed`, `AzureEmbed`, `XinferenceEmbed`, etc.), which construct an `openai.OpenAI(...)`-family client whose base_url is expected to include `/v1` (the SDK appends `/embeddings` relative to it).

The native `ollama.Client` (used only by `OllamaEmbed`) is different: its `embed()` call builds the request path directly off the configured host (`POST /api/embed`), with no `/v1` segment in Ollama's own API. Applying `ensure_v1` here turns `http://host:11434` into `http://host:11434/v1`, so every embedding request resolves to a nonexistent path and 404s.

## Why this matters

Any user with an Ollama-backed embedding model provider (a very common local-LLM setup) currently cannot use it in RAGFlow at all — document parsing fails immediately with:

```
OllamaEmbed embedding request failed
...
ollama._types.ResponseError: 404 page not found (status code: 404)
```

## Fix

Stop routing the Ollama embedding base_url through `ensure_v1`; use the configured host as-is (only trimming a trailing slash), matching how the native `ollama.Client` expects it.

## Testing

Reproduced and verified against a live Ollama instance (Ollama 0.32.0, model `qwen3-embedding:4b`) running behind the same Docker network RAGFlow uses:

- Before the fix: `ollama.Client(host=base_url).embed(...)` succeeds against the raw host, but fails with `404 page not found` once `/v1` is appended to the host — exactly reproducing the error seen when RAGFlow tries to parse a document against an Ollama embedding model.
- After the fix: parsed two real documents (an `.xlsx` and a `.pdf`) end-to-end against the same Ollama embedding model inside a running RAGFlow instance — both completed with `run: DONE`, generating and embedding chunks successfully (previously they failed instantly at the "bind embedding model" step).

No other provider classes were touched: the OpenAI-compatible embedding/chat classes still rely on `ensure_v1` as before, and Ollama's chat path (via `LiteLLMBase`) does not call `ensure_v1` at all, so it is unaffected.