### PR TITLE
Fix QA CSV multiline row parsing

### DIFF
--- a/rag/app/qa.py
+++ b/rag/app/qa.py
@@ -284,6 +284,14 @@ def mdQuestionLevel(s):
     return (len(match.group(0)), s.lstrip("#").lstrip()) if match else (0, s)
 
 
+def _qa_delimiter(lines):
+    counts = {
+        delimiter: sum(1 for row in csv.reader(lines, delimiter=delimiter) if len(row) == 2)
+        for delimiter in (",", "\t")
+    }
+    return "\t" if counts["\t"] >= counts[","] else ","
+
+
 def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang="Chinese", callback=None, **kwargs):
     """
     Excel and csv(txt) format files are supported.
@@ -307,57 +315,19 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
             res.append(beAdoc(deepcopy(doc), q, a, eng, ii))
         return res
 
-    elif re.search(r"\.(txt)$", filename, re.IGNORECASE):
-        callback(0.1, "Start to parse.")
-        txt = get_text(filename, binary)
-        lines = txt.split("\n")
-        comma, tab = 0, 0
-        for line in lines:
-            if len(line.split(",")) == 2:
-                comma += 1
-            if len(line.split("\t")) == 2:
-                tab += 1
-        delimiter = "\t" if tab >= comma else ","
-
-        fails = []
-        question, answer = "", ""
-        i = 0
-        while i < len(lines):
-            arr = lines[i].split(delimiter)
-            if len(arr) != 2:
-                if question:
-                    answer += "\n" + lines[i]
-                else:
-                    fails.append(str(i + 1))
-            elif len(arr) == 2:
-                if question and answer:
-                    res.append(beAdoc(deepcopy(doc), question, answer, eng, i))
-                question, answer = arr
-            i += 1
-            if len(res) % 999 == 0:
-                callback(len(res) * 0.6 / len(lines), ("Extract Q&A: {}".format(len(res)) + (f"{len(fails)} failure, line: %s..." % (",".join(fails[:3])) if fails else "")))
-
-        if question:
-            res.append(beAdoc(deepcopy(doc), question, answer, eng, len(lines)))
-
-        callback(0.6, ("Extract Q&A: {}".format(len(res)) + (f"{len(fails)} failure, line: %s..." % (",".join(fails[:3])) if fails else "")))
-
-        return res
-
-    elif re.search(r"\.(csv)$", filename, re.IGNORECASE):
+    elif re.search(r"\.(csv|txt)$", filename, re.IGNORECASE):
         callback(0.1, "Start to parse.")
         txt = get_text(filename, binary)
         lines = txt.split("\n")
         line_count = max(len(lines), 1)
-        delimiter = "\t" if any("\t" in line for line in lines) else ","
+        delimiter = _qa_delimiter(lines)
 
         fails = []
         question, answer = "", ""
         row_num = -1
-        res = []
         reader = csv.reader(StringIO(txt), delimiter=delimiter)
 
-        for row in reader:
+        for row_index, row in enumerate(reader):
             current_line = reader.line_num
             if len(row) != 2:
                 if question:
@@ -370,8 +340,9 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
                     res.append(beAdoc(deepcopy(doc), question, answer, eng, row_num))
                 question, answer = row
                 row_num = current_line
-            if len(res) % 999 == 0:
-                callback(len(res) * 0.6 / line_count, ("Extract Q&A: {}".format(len(res)) + (f"{len(fails)} failure, line: %s..." % (",".join(fails[:3])) if fails else "")))
+            if (row_index + 1) % 999 == 0:
+                progress = min(current_line * 0.6 / line_count, 0.6)
+                callback(progress, ("Extract Q&A: {}".format(len(res)) + (f"{len(fails)} failure, line: %s..." % (",".join(fails[:3])) if fails else "")))
 
         if question:
             res.append(beAdoc(deepcopy(doc), question, answer, eng, row_num))

--- a/rag/app/qa.py
+++ b/rag/app/qa.py
@@ -18,7 +18,7 @@ import logging
 import re
 import csv
 from copy import deepcopy
-from io import BytesIO
+from io import BytesIO, StringIO
 from timeit import default_timer as timer
 from openpyxl import load_workbook
 
@@ -348,28 +348,33 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
         callback(0.1, "Start to parse.")
         txt = get_text(filename, binary)
         lines = txt.split("\n")
+        line_count = max(len(lines), 1)
         delimiter = "\t" if any("\t" in line for line in lines) else ","
 
         fails = []
         question, answer = "", ""
+        row_num = -1
         res = []
-        reader = csv.reader(lines, delimiter=delimiter)
+        reader = csv.reader(StringIO(txt), delimiter=delimiter)
 
-        for i, row in enumerate(reader):
+        for row in reader:
+            current_line = reader.line_num
             if len(row) != 2:
                 if question:
-                    answer += "\n" + lines[i]
+                    answer += "\n" + delimiter.join(row)
+                    row_num = current_line
                 else:
-                    fails.append(str(i + 1))
+                    fails.append(str(current_line))
             elif len(row) == 2:
                 if question and answer:
-                    res.append(beAdoc(deepcopy(doc), question, answer, eng, i))
+                    res.append(beAdoc(deepcopy(doc), question, answer, eng, row_num))
                 question, answer = row
+                row_num = current_line
             if len(res) % 999 == 0:
-                callback(len(res) * 0.6 / len(lines), ("Extract Q&A: {}".format(len(res)) + (f"{len(fails)} failure, line: %s..." % (",".join(fails[:3])) if fails else "")))
+                callback(len(res) * 0.6 / line_count, ("Extract Q&A: {}".format(len(res)) + (f"{len(fails)} failure, line: %s..." % (",".join(fails[:3])) if fails else "")))
 
         if question:
-            res.append(beAdoc(deepcopy(doc), question, answer, eng, len(lines)))
+            res.append(beAdoc(deepcopy(doc), question, answer, eng, row_num))
 
         callback(0.6, ("Extract Q&A: {}".format(len(res)) + (f"{len(fails)} failure, line: %s..." % (",".join(fails[:3])) if fails else "")))
         return res

--- a/test/unit_test/rag/app/test_qa_csv.py
+++ b/test/unit_test/rag/app/test_qa_csv.py
@@ -68,3 +68,37 @@ def test_csv_multiline_quoted_answer_preserves_pairs_and_source_lines():
     assert chunks[0]["top_int"] == [2]
     assert chunks[1]["content_with_weight"] == "Question: Second prompt\tAnswer: second answer"
     assert chunks[1]["top_int"] == [3]
+
+
+@pytest.mark.p2
+def test_txt_multiline_quoted_answer_uses_csv_reader_flow():
+    chunks = qa.chunk(
+        "qa.txt",
+        binary=b'First prompt\t"first line\nsecond line"\nSecond prompt\tsecond answer',
+        lang="English",
+        callback=_noop_callback,
+    )
+
+    assert len(chunks) == 2
+    assert chunks[0]["content_with_weight"] == "Question: First prompt\tAnswer: first line\nsecond line"
+    assert chunks[0]["top_int"] == [2]
+    assert chunks[1]["content_with_weight"] == "Question: Second prompt\tAnswer: second answer"
+    assert chunks[1]["top_int"] == [3]
+
+
+@pytest.mark.p2
+def test_csv_progress_callback_does_not_repeat_when_no_chunks_are_added():
+    callbacks = []
+
+    def collect_callback(*args):
+        callbacks.append(args)
+
+    chunks = qa.chunk(
+        "qa.csv",
+        binary=b"malformed row\nanother malformed row\nQuestion,Answer",
+        lang="English",
+        callback=collect_callback,
+    )
+
+    assert len(chunks) == 1
+    assert [args[0] for args in callbacks] == [0.1, 0.6]

--- a/test/unit_test/rag/app/test_qa_csv.py
+++ b/test/unit_test/rag/app/test_qa_csv.py
@@ -52,3 +52,19 @@ def test_csv_final_pair_uses_last_line_number():
     assert len(chunks) == 2
     assert chunks[0]["top_int"] == [1]
     assert chunks[1]["top_int"] == [2]
+
+
+@pytest.mark.p2
+def test_csv_multiline_quoted_answer_preserves_pairs_and_source_lines():
+    chunks = qa.chunk(
+        "qa.csv",
+        binary=b'First prompt,"first line\nsecond line"\nSecond prompt,second answer',
+        lang="English",
+        callback=_noop_callback,
+    )
+
+    assert len(chunks) == 2
+    assert chunks[0]["content_with_weight"] == "Question: First prompt\tAnswer: first line\nsecond line"
+    assert chunks[0]["top_int"] == [2]
+    assert chunks[1]["content_with_weight"] == "Question: Second prompt\tAnswer: second answer"
+    assert chunks[1]["top_int"] == [3]


### PR DESCRIPTION
### Summary

Fixes #16791.

This PR fixes Q&A CSV parsing when quoted fields contain newline characters. The parser now reads the full CSV text as a stream instead of splitting it into physical lines before passing it to `csv.reader`, preserving multiline question/answer pairs and correct source row attribution.

### Changes

- Parse CSV content with `StringIO` so quoted multiline fields remain intact.
- Use the CSV reader line counter to track physical source line spans.
- Add a regression test for quoted multiline answers.

### Tests

- `uv run python -m pytest test/unit_test/rag/app/test_qa_csv.py -q`