### PR TITLE
fix(go-agent): add input form of ListOperationsComponent and VariableAggregatorComponent

### DIFF
--- a/internal/agent/component/list_operations.go
+++ b/internal/agent/component/list_operations.go
@@ -341,6 +341,16 @@ func (l *ListOperationsComponent) Stream(ctx context.Context, inputs map[string]
 	return ch, nil
 }
 
+// GetInputForm returns the runtime input form consumed by the debug UI.
+func (l *ListOperationsComponent) GetInputForm() map[string]any {
+	return map[string]any{
+		"query": map[string]any{
+			"name": "Query",
+			"type": "line",
+		},
+	}
+}
+
 // Inputs returns the public parameter surface (declared so the editor
 // can render per-input hints). All values map to the static DSL param
 // unless overridden via the orchestrator's input map.

--- a/internal/agent/component/variable_aggregator.go
+++ b/internal/agent/component/variable_aggregator.go
@@ -241,6 +241,16 @@ func (v *VariableAggregatorComponent) Stream(ctx context.Context, inputs map[str
 	return ch, nil
 }
 
+// GetInputForm returns the runtime input form consumed by the debug UI.
+func (v *VariableAggregatorComponent) GetInputForm() map[string]any {
+	return map[string]any{
+		"variables": map[string]any{
+			"name": "Variables",
+			"type": "line",
+		},
+	}
+}
+
 // Inputs returns the public parameter surface. The "variables" key
 // accepts a runtime override of the per-group variable list (matching
 // the Python get_input_form contract).


### PR DESCRIPTION
## Summary
- Add `GetInputForm()` for `ListOperationsComponent` to expose `Query` input field in debug UI
- Add `GetInputForm()` for `VariableAggregatorComponent` to expose `Variables` input field in debug UI

## Test
- Verify input form fields render correctly for both components in the debug UI