### PR TITLE
fix: custom empty_response not shown in streaming chat (Go mode)

### DIFF
--- a/internal/service/chat_pipeline.go
+++ b/internal/service/chat_pipeline.go
@@ -844,10 +844,19 @@ func (s *ChatPipelineService) AsyncChat(
 		// return the user-configured fallback message (if set).
 		// If empty_response is not configured, fall through to the LLM call
 		// with an empty knowledge context.
+		//
+		// Two results are yielded (mirroring Python dialog_service.py):
+		//   1. Final=false — carries the answer text so streaming consumers
+		//      actually display the fallback message.
+		//   2. Final=true   — closes the stream with the reference/prompt.
 		if len(knowledges) == 0 {
 			if emptyResp, ok := promptConfig["empty_response"].(string); ok && emptyResp != "" {
 				out <- AsyncChatResult{
-					Answer:      emptyResp,
+					Answer:    emptyResp,
+					Reference: map[string]interface{}{},
+				}
+				out <- AsyncChatResult{
+					Answer:      "",
 					Reference:   kbinfos,
 					AudioBinary: s.synthesizeTTS(ttsModel, emptyResp),
 					Prompt:      fmt.Sprintf("\n\n### Query:\n%s", strings.Join(questions, " ")),


### PR DESCRIPTION
### Summary

Fix the issue where a user-configured custom `empty_response` is not displayed in the chat when no knowledge chunks are retrieved (Go mode).

**Root cause:** In the Go chat pipeline (`internal/service/chat_pipeline.go`), the `empty_response` fallback was sent as a single `Final=true` result. The streaming handler in `chat_session.go` ignores the answer text on `Final=true` results (treating them purely as stream-close signals), so the custom `empty_response` message was never displayed to the user.

**Fix:** Mirror the Python `dialog_service.py` behavior by yielding two results:
1. `Final=false` — carries the `empty_response` text so streaming consumers display it.
2. `Final=true` — closes the stream with reference/prompt/TTS metadata, with an empty `Answer` to avoid duplication in non-streaming accumulation mode.