### PR TITLE
Fix Azure embedding endpoint handling

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -315,6 +315,12 @@ def _resolve_azure_credentials(key):
     return key, "2024-02-01"
 
 
+def _normalize_azure_endpoint(base_url):
+    if not base_url:
+        return base_url
+    return base_url.strip().rstrip("/")
+
+
 class AzureEmbed(OpenAIEmbed):
     _FACTORY_NAME = "Azure-OpenAI"
 
@@ -322,7 +328,7 @@ class AzureEmbed(OpenAIEmbed):
         from openai.lib.azure import AzureOpenAI
 
         api_key, api_version = _resolve_azure_credentials(key)
-        self.base_url = ensure_v1(kwargs["base_url"])
+        self.base_url = _normalize_azure_endpoint(kwargs["base_url"])
         self.client = AzureOpenAI(api_key=api_key, azure_endpoint=self.base_url, api_version=api_version)
 
         self.model_name = model_name

--- a/test/unit_test/rag/llm/test_embedding_model.py
+++ b/test/unit_test/rag/llm/test_embedding_model.py
@@ -36,6 +36,7 @@ import pytest
 
 from rag.llm.embedding_model import (
     DEFAULT_MAX_TOKENS,
+    AzureEmbed,
     BedrockEmbed,
     EmbeddingError,
     LocalAIEmbed,
@@ -319,6 +320,30 @@ class TestBatching:
 # --------------------------------------------------------------------------- #
 # 5. Provider-specific request/response shapes
 # --------------------------------------------------------------------------- #
+@pytest.mark.p2
+class TestAzureEmbeddingEndpoint:
+    def test_uses_azure_resource_endpoint_without_openai_v1_suffix(self, monkeypatch):
+        captured = {}
+
+        class FakeAzureOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.embeddings = SimpleNamespace(create=MagicMock())
+
+        monkeypatch.setattr("openai.lib.azure.AzureOpenAI", FakeAzureOpenAI)
+
+        embed = AzureEmbed(
+            json.dumps({"api_key": "azure-key", "api_version": "2024-02-01"}),
+            "text-embedding-3-small",
+            base_url="https://example.openai.azure.com/",
+        )
+
+        assert embed.base_url == "https://example.openai.azure.com"
+        assert captured["azure_endpoint"] == "https://example.openai.azure.com"
+        assert captured["api_key"] == "azure-key"
+        assert captured["api_version"] == "2024-02-01"
+
+
 @pytest.mark.p2
 class TestNvidiaInputType:
     """NVIDIA NIM expects input_type=passage for documents and =query for queries;


### PR DESCRIPTION
### Summary

Fixes #16968.

Azure embedding clients should receive the Azure OpenAI resource endpoint, not an OpenAI-compatible `/v1` endpoint. This PR stops appending `/v1` when initializing `AzureEmbed`, while still trimming whitespace and a trailing slash from the configured endpoint.

### Changes

- Preserve the configured Azure resource endpoint for `AzureOpenAI(azure_endpoint=...)`.
- Keep Azure API key and API version parsing unchanged.
- Add a regression test that verifies the Azure endpoint passed to the SDK does not gain an `/v1` suffix.

### Tests

- `uv sync --python 3.13 --group test --frozen`
- `uv run python -m pytest test/unit_test/rag/llm/test_embedding_model.py::TestAzureEmbeddingEndpoint::test_uses_azure_resource_endpoint_without_openai_v1_suffix -q`
- `uv run python -m pytest test/unit_test/rag/llm/test_embedding_model.py -q`
- `uv run ruff check rag/llm/embedding_model.py test/unit_test/rag/llm/test_embedding_model.py`
- `git diff --check`
