### PR TITLE
Fix: CI  tags cancel running workflow

### DIFF
--- a/.github/workflows/sep-tests.yml
+++ b/.github/workflows/sep-tests.yml
@@ -25,7 +25,7 @@ on:
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && github.event.label.name != 'ci' && format('-ignore-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sep-tests.yml
+++ b/.github/workflows/sep-tests.yml
@@ -15,7 +15,7 @@ on:
   # — pull_request_target workflows use the workflow files from the default branch, and secrets are available.
   # — pull_request workflows use the workflow files from the pull request branch, and secrets are unavailable.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [synchronize, labeled]
     paths-ignore:
       - 'docs/**'
       - '*.md'


### PR DESCRIPTION
### Summary

1.  Change the CI trigger conditions.  synchronize and  labeled ci
2.  Fix ci: tags canceled running workflow
