### PR TITLE
fix(parser): propagate cancellation while waiting for vision figure futures

### DIFF
--- a/deepdoc/parser/figure_parser.py
+++ b/deepdoc/parser/figure_parser.py
@@ -13,10 +13,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 import logging
 
 from PIL import Image
+
+from common.exceptions import TaskCanceledException
 
 from common.constants import LLMType
 from api.db.services.llm_service import LLMBundle
@@ -61,6 +63,8 @@ def vision_figure_parser_docx_wrapper(sections, tbls, callback=None, **kwargs):
             docx_vision_parser = VisionFigureParser(vision_model=vision_model, figures_data=figures_data, **kwargs)
             boosted_figures = docx_vision_parser(callback=callback)
             tbls.extend(boosted_figures)
+        except TaskCanceledException:
+            raise
         except Exception as e:
             callback(0.8, f"Visual model error: {e}. Skipping figure parsing enhancement.")
     return tbls
@@ -94,6 +98,8 @@ def vision_figure_parser_figure_xlsx_wrapper(images, callback=None, **kwargs):
             callback(0.22, "Parsing images...")
             boosted_figures = parser(callback=callback)
             tbls.extend(boosted_figures)
+        except TaskCanceledException:
+            raise
         except Exception as e:
             callback(0.25, f"Excel visual model error: {e}. Skipping vision enhancement.")
     return tbls
@@ -136,6 +142,8 @@ def vision_figure_parser_pdf_wrapper(tbls, callback=None, **kwargs):
             boosted_figures = docx_vision_parser(callback=callback)
             tbls = [item for item in tbls if not is_figure_item(item)]
             tbls.extend(boosted_figures)
+        except TaskCanceledException:
+            raise
         except Exception as e:
             callback(0.8, f"Visual model error: {e}. Skipping figure parsing enhancement.")
     return tbls
@@ -187,12 +195,23 @@ def vision_figure_parser_docx_wrapper_naive(chunks, idx_lst, callback=None, **kw
                     except Exception:
                         pass
 
-        with ThreadPoolExecutor(max_workers=10) as executor:
-            futures = [executor.submit(worker, idx, chunks[idx]) for idx in idx_lst]
-
-            for future in as_completed(futures):
-                idx, description = future.result()
-                chunks[idx]["text"] += description
+        executor = ThreadPoolExecutor(max_workers=10)
+        pending = {executor.submit(worker, idx, chunks[idx]) for idx in idx_lst}
+        try:
+            while pending:
+                done, pending = wait(pending, timeout=1.0, return_when=FIRST_COMPLETED)
+                for future in done:
+                    idx, description = future.result()
+                    chunks[idx]["text"] += description
+                if callback:
+                    callback(0.75, "")
+        except Exception:
+            for f in pending:
+                f.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
+        else:
+            executor.shutdown(wait=True)
 
 
 shared_executor = ThreadPoolExecutor(max_workers=10)
@@ -249,7 +268,7 @@ class VisionFigureParser:
         return self.assembled
 
     def __call__(self, **kwargs):
-        callback = kwargs.get("callback", lambda prog, msg: None)
+        callback = kwargs.get("callback") or (lambda prog, msg: None)
 
         @timeout(30, 3)
         def process(figure_idx, figure_binary):
@@ -278,14 +297,19 @@ class VisionFigureParser:
             )
             return figure_idx, description_text
 
-        futures = []
-        for idx, img_binary in enumerate(self.figures or []):
-            futures.append(shared_executor.submit(process, idx, img_binary))
-
-        for future in as_completed(futures):
-            figure_num, txt = future.result()
-            if txt:
-                self.descriptions[figure_num] = txt + "\n".join(self.descriptions[figure_num])
+        pending = {shared_executor.submit(process, idx, img_binary) for idx, img_binary in enumerate(self.figures or [])}
+        try:
+            while pending:
+                done, pending = wait(pending, timeout=1.0, return_when=FIRST_COMPLETED)
+                for future in done:
+                    figure_num, txt = future.result()
+                    if txt:
+                        self.descriptions[figure_num] = txt + "\n".join(self.descriptions[figure_num])
+                callback(0.75, "")
+        except Exception:
+            for f in pending:
+                f.cancel()
+            raise
 
         self._assemble()
 


### PR DESCRIPTION
## What

`vision_figure_parser_docx_wrapper_naive` and `VisionFigureParser.__call__` submit every figure's vision-LLM call to a `ThreadPoolExecutor` and then block on `as_completed()` until all of them finish, without ever calling `callback()` in between. Task cancellation is only observed at `callback()` call sites — it checks a Redis flag and raises `TaskCanceledException` — so cancelling a dataflow run while it's inside one of these loops has no visible effect until every submitted vision call finishes or hits its own timeout (minutes, on a slow/busy vision backend).

The three call sites that wrap `VisionFigureParser` (`vision_figure_parser_docx_wrapper`, `vision_figure_parser_pdf_wrapper`, `vision_figure_parser_figure_xlsx_wrapper`) also catch `TaskCanceledException` inside their generic `except Exception as e:` handler, which logs a "visual model error" and continues — i.e. a cancellation would be silently turned into a logged error instead of stopping the pipeline.

## Fix

- Replace the unbounded `as_completed()` wait with `wait(..., timeout=1.0, return_when=FIRST_COMPLETED)`, polling once a second so a cancellation is observed while other figures are still in flight, rather than only after the whole batch drains.
- On `TaskCanceledException` (or any other exception), cancel every future that hasn't started running yet, and unwind the executor without waiting for stragglers; on normal completion, shut it down normally.
- Re-raise `TaskCanceledException` explicitly in the three wrapper functions instead of letting the broad `except Exception` absorb it.
- Guard against an explicit `callback=None` (`kwargs.get("callback", default)` only substitutes the default when the key is absent, not when its value is `None`).

## What this does *not* fix

`concurrent.futures` has no API to forcibly abort a future that's already running — a vision call whose HTTP request is in flight will run to completion (or its own `@timeout(30, 3)`) regardless of this change. This fix stops *new* vision calls from starting once a cancellation is observed; it does not abort ones already sent to the backend.

## Testing

Verified against a live RAGFlow + Ollama deployment, cancelling a dataflow test run on a PDF with several figures still pending:

- Before: the Cancel button had no observable effect — the backend kept logging vision requests to Ollama for 3+ minutes with no cancellation message in the task log.
- After: the task log showed `Task ... has been canceled` (checked roughly once a second, matching the new poll interval) and `TaskCanceledException` / `handle_task canceled` within about a minute of pressing Cancel — bounded by the already-in-flight requests' own timeout, not by this change.

No automated test is included; this is concurrency/cancellation behavior that's awkward to assert deterministically without a real (or heavily mocked) backend and a real ThreadPoolExecutor. Open to suggestions on how the maintainers would want this covered.
