### PR TITLE
fix: ASR/VLM/TTS models not selectable in default model settings

### DIFF
--- a/internal/entity/types.go
+++ b/internal/entity/types.go
@@ -20,7 +20,7 @@ import "strings"
 
 // ModelType represents the type of model as a bitmask, matching Python's
 // ModelTypeBinary enum (common/constants.py).
-// Bit flags (LSB->MSB): 1=chat, 2=embedding, 4=speech2text, 8=image2text, 16=rerank, 32=tts, 64=ocr.
+// Bit flags (LSB->MSB): 1=chat, 2=embedding, 4=asr, 8=vision, 16=rerank, 32=tts, 64=ocr.
 // A model can belong to multiple types simultaneously.
 type ModelType int
 
@@ -91,10 +91,10 @@ func (mt ModelType) HumanReadable() []string {
 		parts = append(parts, "embedding")
 	}
 	if mt.Has(ModelTypeSpeech2Text) {
-		parts = append(parts, "speech2text")
+		parts = append(parts, "asr")
 	}
 	if mt.Has(ModelTypeImage2Text) {
-		parts = append(parts, "image2text")
+		parts = append(parts, "vision")
 	}
 	if mt.Has(ModelTypeRerank) {
 		parts = append(parts, "rerank")
@@ -115,11 +115,9 @@ func ModelTypeFromString(s string) ModelType {
 		return ModelTypeChat
 	case "embedding":
 		return ModelTypeEmbedding
-	case "speech2text":
+	case "asr", "speech2text":
 		return ModelTypeSpeech2Text
-	case "image2text":
-		return ModelTypeImage2Text
-	case "vision":
+	case "vision", "image2text":
 		return ModelTypeImage2Text
 	case "rerank":
 		return ModelTypeRerank

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -1159,6 +1159,34 @@ func (m *ModelProviderService) ListTenantAddedModels(userID, ownerTenantID, mode
 		return nil, common.CodeServerError, err
 	}
 
+	// Repair records that have model_type == 0. Before the ModelTypeFromString
+	// fix that added "asr" support, models whose factory catalog used the
+	// canonical name "asr" (instead of the legacy "speech2text") were stored
+	// with model_type = 0. Re-derive the correct bitmask from the factory
+	// catalog and persist it so the model shows up in typed queries.
+	providerManager := dao.GetModelProviderManager()
+	for _, rec := range modelRecords {
+		if rec.ModelType != 0 {
+			continue
+		}
+		provInfo := providerInfoByID[rec.ProviderID]
+		if provInfo == nil {
+			continue
+		}
+		factoryModel, lookupErr := providerManager.GetModelByName(provInfo.ProviderName, rec.ModelName)
+		if lookupErr != nil || len(factoryModel.ModelTypes) == 0 {
+			continue
+		}
+		combinedType := entity.ModelType(0)
+		for _, t := range factoryModel.ModelTypes {
+			combinedType |= entity.ModelTypeFromString(t)
+		}
+		if combinedType != 0 {
+			rec.ModelType = int(combinedType)
+			_ = m.modelDAO.UpdateByID(rec.ID, map[string]interface{}{"model_type": int(combinedType)})
+		}
+	}
+
 	var targetRecords []*entity.TenantModel
 	if modelTypeFilterBin != 0 {
 		for _, rec := range modelRecords {
@@ -1171,7 +1199,6 @@ func (m *ModelProviderService) ListTenantAddedModels(userID, ownerTenantID, mode
 	}
 
 	// Build model rank map from factory catalog (mirrors Python's model_rank_map).
-	providerManager := dao.GetModelProviderManager()
 	modelRankMap := make(map[string]int) // key: "providerName@modelName"
 	factoryRankMapping := make(map[string]int)
 	for i := range providerManager.Providers {

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -450,10 +450,14 @@ func ptrStringValue(s *string) string {
 }
 
 func factoryModelTypeName(modelType string) string {
-	if modelType == "image2text" {
+	switch modelType {
+	case "image2text":
 		return "vision"
+	case "speech2text":
+		return "asr"
+	default:
+		return modelType
 	}
-	return modelType
 }
 
 // GetDefaultModelName returns the full default model ID for a tenant and model type
@@ -662,32 +666,32 @@ func (s *TenantService) ListTenantDefaultModels(userID string) ([]ModelItem, err
 		})
 	}
 
-	if ownedTenant.OCRID == "" {
-		return result, nil
+	if ownedTenant.OCRID != "" {
+		defaultOCRModelProvider, defaultOCRModelInstance, defaultOCRModelName, defaultOCRModelEnable, err := s.GetModelInfo(ownedTenant.TenantID, ownedTenant.OCRID, "ocr")
+		if err == nil {
+			result = append(result, ModelItem{
+				ModelProvider: defaultOCRModelProvider,
+				ModelInstance: defaultOCRModelInstance,
+				ModelName:     defaultOCRModelName,
+				ModelID:       ptrStringValue(ownedTenant.TenantOCRID),
+				ModelType:     "ocr",
+				Enable:        defaultOCRModelEnable,
+			})
+		}
 	}
 
-	defaultOCRModelProvider, defaultOCRModelInstance, defaultOCRModelName, defaultOCRModelEnable, err := s.GetModelInfo(ownedTenant.TenantID, ownedTenant.OCRID, "ocr")
-	if err == nil {
-		result = append(result, ModelItem{
-			ModelProvider: defaultOCRModelProvider,
-			ModelInstance: defaultOCRModelInstance,
-			ModelName:     defaultOCRModelName,
-			ModelID:       ptrStringValue(ownedTenant.TenantOCRID),
-			ModelType:     "ocr",
-			Enable:        defaultOCRModelEnable,
-		})
-	}
-
-	defaultTTSModelProvider, defaultTTSModelInstance, defaultTTSModelName, defaultTTSModelEnable, err := s.GetModelInfo(ownedTenant.TenantID, ownedTenant.TTSID, "tts")
-	if err == nil {
-		result = append(result, ModelItem{
-			ModelProvider: defaultTTSModelProvider,
-			ModelInstance: defaultTTSModelInstance,
-			ModelName:     defaultTTSModelName,
-			ModelID:       ptrStringValue(ownedTenant.TenantTTSID),
-			ModelType:     "tts",
-			Enable:        defaultTTSModelEnable,
-		})
+	if ownedTenant.TTSID != "" {
+		defaultTTSModelProvider, defaultTTSModelInstance, defaultTTSModelName, defaultTTSModelEnable, err := s.GetModelInfo(ownedTenant.TenantID, ownedTenant.TTSID, "tts")
+		if err == nil {
+			result = append(result, ModelItem{
+				ModelProvider: defaultTTSModelProvider,
+				ModelInstance: defaultTTSModelInstance,
+				ModelName:     defaultTTSModelName,
+				ModelID:       ptrStringValue(ownedTenant.TenantTTSID),
+				ModelType:     "tts",
+				Enable:        defaultTTSModelEnable,
+			})
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
### Summary

This PR fixes three issues that prevented ASR, VLM, and TTS models from being selected as default models in the system settings page.

**1. Model type name mismatch (ASR & VLM)**

The Go backend's `HumanReadable()` returned legacy names (`"speech2text"`, `"image2text"`) while the frontend expects canonical names (`"asr"`, `"vision"`). The `GET /api/v1/models` endpoint returned `model_type: ["speech2text"]` but the frontend `buildModelTree` filtered by `['asr']`, so the models never appeared in the dropdown.

The Python backend's `get_model_type_human()` already returned canonical names. This PR aligns the Go backend to match.

`ModelTypeFromString()` now also accepts `"asr"` (in addition to the legacy `"speech2text"`) for bidirectional compatibility, since the factory catalog (`conf/models/*.json`) uses the canonical `"asr"`.

**2. Stale database records (ASR)**

Before the `ModelTypeFromString` fix, models with type `"asr"` in the factory catalog were stored with `model_type = 0` in `tenant_model`. This PR adds a runtime auto-repair step in `ListTenantAddedModels` that re-derives the correct bitmask from the factory catalog and persists it, so existing stale records self-heal on the next list request without requiring users to re-add models.

**3. Early return blocking TTS (and OCR) default models**

`ListTenantDefaultModels` had an early `return result, nil` when `OCRID` was empty. Since most users have no OCR model configured (OCR defaults to the built-in deepdoc), the function returned before reaching the TTS block. As a result, a TTS default model could be set but never read back, making it appear unselected after saving. This PR makes the OCR and TTS blocks independently guarded.