### PR TITLE
Fix: pin torch to a CUDA 12.x build to match onnxruntime-gpu

### DIFF
--- a/common/misc_utils.py
+++ b/common/misc_utils.py
@@ -238,7 +238,18 @@ def pip_install_torch():
         return
     logging.info("Installing pytorch")
     pkg_names = ["torch>=2.5.0,<3.0.0"]
-    subprocess.check_call([sys.executable, "-m", "pip", "install", *pkg_names])
+    # onnxruntime-gpu (pinned in pyproject.toml) needs its CUDA major version to
+    # match torch's. Installing from PyPI's default index pulls whichever CUDA
+    # toolkit torch's latest release bundles, which can drift out of sync and
+    # leave onnxruntime unable to load CUDAExecutionProvider (silent CPU
+    # fallback). Default to a known-compatible CUDA 12.1 build; override via
+    # TORCH_CUDA_INDEX_URL (set to "" to fall back to the default index) if
+    # your environment needs a different index or CUDA minor version.
+    index_url = os.environ.get("TORCH_CUDA_INDEX_URL", "https://download.pytorch.org/whl/cu121")
+    cmd = [sys.executable, "-m", "pip", "install", *pkg_names]
+    if index_url:
+        cmd += ["--index-url", index_url]
+    subprocess.check_call(cmd)
 
 
 async def thread_pool_exec(func, *args, **kwargs):


### PR DESCRIPTION
## Summary
- `pip_install_torch()` installed torch from PyPI's default index without pinning a CUDA build. onnxruntime-gpu (pinned in pyproject.toml) requires CUDA 12.x / cuDNN 9.x, but PyPI's default torch release currently bundles CUDA 13.x libraries. onnxruntime then fails to load `CUDAExecutionProvider` (looking for `libcublasLt.so.12`, only `.so.13` present) and silently falls back to CPU — no error is raised, so GPU-enabled deployments just run OCR/layout/table models on CPU without any indication why.
- Default torch's install to PyTorch's CUDA 12.1 index. Made it overridable via `TORCH_CUDA_INDEX_URL` (set to an empty string to fall back to the default index) so environments with their own mirror or a different CUDA minor version aren't locked out.

## Test plan
- [x] Verified on a live RTX 3070 (Ubuntu 26.04, Docker) deployment: before the fix, `docker exec <container> nvidia-smi` inside the ragflow-gpu container failed to find CUDA libraries and onnxruntime logs showed `Failed to create CUDAExecutionProvider`, falling back to CPU.
- [x] After the fix, deepdoc's `det.onnx`/`rec.onnx`/`layout.onnx`/`tsr.onnx` models all log `uses GPU (device 0, ...)` on load.
- [x] Page-image processing for a 50-page PDF dropped from CPU-fallback speed to ~8s.
- [x] Verified both branches of the new `TORCH_CUDA_INDEX_URL` override (set and empty-string) produce the expected `pip install` command via a dry run.