### PR TITLE
i18n: complete Japanese translation for ja.ts

### DIFF
--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -39,7 +39,55 @@ export default {
       submit: '送信',
       japanese: '日本語',
       owner: '所有者',
+      confirm: '確認',
+      back: '戻る',
+      noResults: '結果が見つかりません',
+      selectAll: 'すべて選択',
+      deleteThem: '削除してもよろしいですか？',
+      yes: 'はい',
+      no: 'いいえ',
+      top: '上位 {{top}} 件',
+      descriptionPlaceholder: '説明を入力してください',
+      russian: 'ロシア語',
+      indonesian: 'インドネシア語',
+      indonesia: 'インドネシア語',
+      spanish: 'スペイン語',
+      vietnamese: 'ベトナム語',
+      german: 'ドイツ語',
+      french: 'フランス語',
+      italian: 'イタリア語',
+      turkish: 'トルコ語',
+      dutch: 'オランダ語',
+      viewMore: 'もっと見る',
+      viewLess: '表示を減らす',
+      clear: 'クリア',
+      embedIntoSite: 'Webページに埋め込む',
+      openInNewTab: '新しいタブでチャット',
+      previousPage: '前へ',
+      nextPage: '次へ',
+      previous: '前へ',
+      add: '追加',
+      remove: '削除',
+      search: '検索',
+      reset: 'リセット',
+      noDataFound: 'データが見つかりません。',
+      noData: 'データがありません',
+      promptPlaceholder: '入力するか、「/」で変数をすばやく挿入してください。',
+
+      mcp: {
+        namePlaceholder: '例: My MCP server',
+        nameRequired:
+          '1〜64文字で、英数字、ハイフン、アンダースコアのみ使用できます。',
+        urlPlaceholder: 'https://api.example.com/v1/mcp',
+        tokenPlaceholder: '例: eyJhbGciOiJIUzI1Ni...',
+      },
+
+      selected: '選択済み',
+      seeAll: 'すべて見る',
+      bulkOperate: '一括操作',
+      running: '実行中...',
     },
+
     login: {
       login: 'ログイン',
       signUp: 'サインアップ',
@@ -57,10 +105,17 @@ export default {
       register: 'アカウント作成',
       continue: '続行',
       title: 'スマートアシスタントの構築を開始しましょう。',
+
       description:
         '無料でサインアップして、最先端のRAGテクノロジーを探索してください。ナレッジベースやAIを作成して、ビジネスを強化しましょう。',
+
       review: '500件以上のレビューより',
+      loginTitle: 'アカウントにサインイン',
+      signUpTitle: 'アカウントを作成',
+      start: 'さっそく始めましょう',
+      seeAll: 'すべて表示',
     },
+
     header: {
       knowledgeBase: 'ナレッジベース',
       chat: 'チャット',
@@ -72,7 +127,15 @@ export default {
       fileManager: 'ファイル管理',
       flow: 'エージェント',
       search: '検索',
+      skills: 'スキル',
+      welcome: 'ようこそ',
+      dataset: 'データセット',
+      memories: 'メモリー',
+      discord: 'Discord',
+      github: 'GitHub',
+      help: 'ヘルプ',
     },
+
     knowledgeList: {
       welcome: 'お帰りなさい',
       description: '今日はどのナレッジベースを使用しますか？',
@@ -82,7 +145,10 @@ export default {
       doc: 'ドキュメント',
       searchKnowledgePlaceholder: '検索',
       noMoreData: 'これですべてです。それ以上はありません。',
+      parserRequired: 'チャンク方法は必須です',
+      dataFlowRequired: 'データフローは必須です',
     },
+
     knowledgeDetails: {
       dataset: 'データセット',
       testing: '検索テスト',
@@ -104,19 +170,27 @@ export default {
       disabled: '無効',
       action: 'アクション',
       parsingStatus: 'パースステータス',
+
       parsingStatusTip:
         'ドキュメントの解析時間はさまざまな要因によって異なります。Knowledge Graph、RAPTOR、自動質問抽出、自動キーワード抽出などの機能を有効にすると、処理時間が大幅に増加します。進行バーが止まった場合は、次の2つのFAQをご参照ください: https://ragflow.io/docs/dev/faq#why-does-my-document-parsing-stall-at-under-one-percent.',
+
       processBeginAt: 'プロセス開始時刻',
       processDuration: '処理時間',
       progressMsg: '進行状況メッセージ',
+
       testingDescription:
         'この場所での変更は自動的に保存されないため、注意してください。ここでデフォルト設定を調整した場合、たとえばキーワードの類似度重みなど、チャットアシスタンの設定またはリコール演算子の設定場所で関連する設定を必ず同期して更新してください。',
+
       similarityThreshold: '類似度しきい値',
+
       similarityThresholdTip:
         'RAGFlowは、ユーザークエリとチャンク間の類似度スコアがこのしきい値を下回る場合、そのチャンクを結果から除外します。デフォルトでは、閾値は0.2に設定されています。これは、ハイブリッド類似度スコアが20以上のチャンクのみが取得されることを意味します。',
+
       vectorSimilarityWeight: 'ベクトル類似度の重み',
+
       vectorSimilarityWeightTip:
         'ベクトルコサイン類似度と併用する際のキーワード類似度の重みを設定します。2つの重みの合計は1.0でなければなりません。',
+
       testText: 'テストテキスト',
       testTextPlaceholder: '質問を入力してください',
       testingLabel: 'テスト',
@@ -134,27 +208,35 @@ export default {
       runningStatus3: '成功',
       runningStatus4: '失敗',
       pageRanges: 'ページ範囲',
+
       pageRangesTip:
         '解析されるページの範囲を設定します。この範囲外のページは処理されません。',
+
       fromPlaceholder: '開始',
       fromMessage: '開始ページ番号が不足しています',
       toPlaceholder: '終了',
       toMessage: '終了ページ番号が不足しています（除外）',
       layoutRecognize: 'レイアウト認識',
+
       layoutRecognizeTip:
         'レイアウト分析のためにビジュアルモデルを使用し、文書の構造を理解しやすくします。詳細については、https://ragflow.io/docs/dev/select_pdf_parser をご覧ください。',
+
       taskPageSize: 'タスクページサイズ',
       taskPageSizeMessage: 'タスクページサイズを入力してください',
       taskPageSizeTip: `レイアウト認識中、PDFファイルはチャンクに分割され、処理速度を向上させるために並列処理されます。`,
       addPage: 'ページを追加',
       greaterThan: '現在の値は終了ページより大きくなければなりません',
+
       greaterThanPrevious:
         '現在の値は前の終了ページより大きくなければなりません',
+
       selectFiles: 'ファイルを選択',
       changeSpecificCategory: '特定のカテゴリを変更',
       uploadTitle: 'クリックまたはドラッグしてファイルをアップロード',
+
       uploadDescription:
         '単一または一括アップロードに対応。企業データや禁止されたファイルのアップロードは禁止されています。',
+
       chunk: 'チャンク',
       bulk: '一括',
       cancel: 'キャンセル',
@@ -164,21 +246,191 @@ export default {
       topK: 'トップK',
       topKTip: `Rerank modelと一緒に使用する場合、この設定は指定されたreranking modelに送信するテキストのチャンク数を定義します。`,
       delimiter: `テキストセグメンテーションの区切り文字`,
+
       delimiterTip:
         'デリミタやセパレータは、一つまたは複数の特殊文字で構成できます。複数の文字の場合、バッククォート(``)で囲むようにしてください。たとえば、デリミタを次のように設定した場合: \\n ## ;、テキストは行末、ダブルハッシュ記号(##)、およびセミコロンで分割されます。デリミタを設定する前に、テキストのセグメンテーションとチャンキングのメカニズムを理解していることを確認してください。',
+
       html4excel: 'ExcelをHTMLに変換',
       html4excelTip: `General切片方法と併用してください。無効の場合、表計算ファイル（XLSX、XLS（Excel 97-2003））は行ごとにキーと値のペアとして解析されます。有効の場合、表計算ファイルはHTML表として解析されます。元の表が12行を超える場合、システムは自動的に12行ごとに複数のHTML表に分割します。詳細については、https://ragflow.io/docs/dev/enable_excel2html をご覧ください。`,
       autoKeywords: '自動キーワード',
       autoKeywordsTip: `各チャンクに含まれるキーワードのランキングを向上させるために、自動的にN個のキーワードを抽出します。「システムモデル設定」で指定されたチャットモデルによって追加のトークンが消費されることに注意してください。チャンクリストから追加されたキーワードを確認または更新することができます。詳細は https://ragflow.io/docs/dev/autokeyword_autoquestion をご覧ください。`,
       autoQuestions: '自動質問',
       autoQuestionsTip: `ランキングスコアを向上させるために、「システムモデル設定」で定義されたチャットモデルを使用して、ナレッジベースのチャンクごとにN個の質問を抽出します。 これにより、追加のトークンが消費されることに注意してください。 結果はチャンクリストで表示および編集できます。 質問抽出エラーはチャンク処理をブロックしません。空の結果が元のチャンクに追加されます。詳細は https://ragflow.io/docs/dev/autokeyword_autoquestion をご覧ください。`,
+
+      metadata: {
+        fields: 'フィールド',
+        selectFiles: '{{count}} 件のファイルを選択しました',
+        fieldNameInvalid:
+          'フィールド名には英字とアンダースコアのみ使用できます。',
+        builtIn: '組み込み',
+        generation: '生成',
+        toMetadataSetting: '生成設定',
+        toMetadataSettingTip: '自動メタデータは「設定」で構成してください。',
+        descriptionTip:
+          'このフィールドの値をLLMが抽出する際の手がかりとなる説明や例を入力してください。空欄の場合は、フィールド名が使用されます。',
+        restrictDefinedValuesTip:
+          '列挙モード: LLMの抽出結果を事前定義した値のみに制限します。以下で値を定義してください。',
+        valueExists:
+          '値は既に存在します。重複をマージし、関連するすべてのファイルを統合してよろしいですか？',
+        fieldNameExists:
+          'フィールド名は既に存在します。重複をマージし、関連するすべてのファイルを統合してよろしいですか？',
+        valueSingleExists:
+          '値は既に存在します。重複をマージしてよろしいですか？',
+        fieldSingleNameExists:
+          'フィールド名は既に存在します。重複をマージしてよろしいですか？',
+        fieldExists: 'フィールドは既に存在します。',
+        fieldSetting: 'フィールド設定',
+        changesAffectNewParses: '変更は新規のパース処理にのみ反映されます。',
+        restrictDefinedValues: '定義済みの値に制限',
+        metadataGenerationSettings: 'メタデータ生成設定',
+        manageMetadata: 'メタデータを管理',
+        metadata: 'メタデータ',
+        values: '値',
+        value: '値',
+        action: '操作',
+        field: 'フィールド',
+        type: 'タイプ',
+        description: '説明',
+        fieldName: 'フィールド名',
+        editMetadata: 'メタデータを編集',
+        addMetadata: 'メタデータを追加',
+        deleteWarn: 'この{{field}}は、関連するすべてのファイルから削除されます',
+        deleteManageFieldAllWarn:
+          'このフィールドおよび対応するすべての値が、関連するすべてのファイルから削除されます。',
+        deleteManageValueAllWarn:
+          'この値は、関連するすべてのファイルから削除されます。',
+        deleteManageFieldSingleWarn:
+          'このフィールドおよび対応するすべての値が、このファイルから削除されます。',
+        deleteManageValueSingleWarn: 'この値は、このファイルから削除されます。',
+        deleteSettingFieldWarn:
+          'このフィールドは削除されますが、既存のメタデータには影響しません。',
+        deleteSettingValueWarn:
+          'この値は削除されますが、既存のメタデータには影響しません。',
+      },
+
+      redoAll: '既存のチャンクをクリア',
+      applyAutoMetadataSettings: 'グローバルの自動メタデータ設定を適用',
+      parseFileTip: 'パースしてもよろしいですか？',
+      parseFile: 'ファイルをパース',
+      emptyMetadata: 'メタデータなし',
+      metadataField: 'メタデータフィールド',
+      systemAttribute: 'システム属性',
+      localUpload: 'ローカルアップロード',
+      fileSize: 'ファイルサイズ',
+      fileType: 'ファイルタイプ',
+      uploadedBy: 'アップロード者',
+      notGenerated: '未生成',
+      generatedOn: '生成日時: ',
+      subbarFiles: 'ファイル',
+      generateKnowledgeGraph:
+        'このデータセット内のすべてのドキュメントからエンティティと関係性を抽出します。処理には時間がかかる場合があります。',
+      generateRaptor:
+        'ドキュメントチャンクの再帰的なクラスタリングと要約を行い、階層的なツリー構造を構築します。これにより、長文ドキュメントに対してより文脈を考慮した検索が可能になります。',
+      generateArtifact:
+        'ナレッジコンパイルテンプレートが設定されたすべてのドキュメントから、アーティファクトページ（エンティティ/コンセプト/トピックのwiki）を作成します。実行のたびに、新規追加されたチャンクのみが処理されます。',
+      generateToSkills:
+        'このデータセットから階層的なスキルツリーを構築し、生成されたスキルページを検索・再利用のために保存します。',
+      noWikiPages: 'wikiページはまだありません',
+      clearWikiTitle: 'wikiをクリア',
+      clearWikiDescription:
+        'このデータセット内のすべてのwikiページをクリアしてもよろしいですか？この操作は元に戻せません。',
+      noSkills: 'スキルはまだありません',
+      generate: '生成',
+      raptor: 'RAPTOR',
+      artifact: 'アーティファクト',
+      toSkills: 'スキルへ',
+      processingType: '処理タイプ',
+      dataPipeline: '取り込みパイプラインを切り替え、または設定します。',
+      dataPipelineTitle: '取り込みパイプライン',
+      operations: '操作',
+      taskId: 'タスクID',
+      duration: '所要時間',
+      details: '詳細',
+      status: 'ステータス',
+      task: 'タスク',
+      startDate: '開始日',
+      source: 'ソース',
+      fileName: 'ファイル名',
+      datasetLogs: 'データセット',
+      fileLogs: 'ファイル',
+      overview: 'ログ',
+      success: '成功',
+      failed: '失敗',
+      completed: '完了',
+      datasetLog: 'データセットログ',
+      created: '作成',
+      learnMore: '組み込みパイプラインの概要',
+      general: '全般',
+      chunkMethodTab: 'チャンク方法',
+      testResults: '結果',
+      testSetting: '設定',
+      retrievalTesting: '検索テスト',
+      retrievalTestingDescription:
+        '検索テストを実行し、RAGFlowがLLMに必要な内容を正しく取得できるかを確認します。',
+      Parse: 'パース',
+      knowledgeGraph: 'ナレッジグラフ',
+      compilation: 'コンパイル',
+      export: 'エクスポート',
+      version: 'バージョン',
+      versionHistory: 'バージョン履歴',
+      currentVersion: '現在のバージョン',
+      versionDiff: 'このバージョンでの変更点',
+      noDiffAvailable: '表示する変更はありません',
+      viewingVersion: '表示中のバージョン',
+      commit: 'コミット',
+      confirmCommit: 'コミットを確定',
+      versionContent: 'バージョン内容',
+      versionContentPlaceholder: 'バージョン内容を入力してください',
+      versionContentRequired: 'バージョン内容を入力してください',
+      graph: 'グラフ',
+      graphPlaceholder: 'グラフビューのプレースホルダー',
+      llmWiki: 'LLM Wiki',
+      skills: 'スキル',
+      contents: 'ナビゲーション',
+      topics: 'トピック',
+      concept: 'コンセプト',
+      entity: 'エンティティ',
+      createDirectoryFolder: 'ディレクトリを作成',
+      directoryName: '名前',
+      directoryNamePlaceholder: 'インスタンス名',
+      directoryRule: 'ルール',
+      directoryRulePlaceholder: '入力してください',
+      selectArtifact: 'ナビゲーションから項目を選択すると詳細が表示されます',
+      sourceDocuments: 'ソースドキュメント',
+      compilationTitleSuffix: 'のデータセット',
+      noTestResultsForRuned:
+        '関連する結果が見つかりませんでした。クエリまたはパラメータを調整してください。',
+      noTestResultsForNotRuned:
+        'まだテストが実行されていません。結果はここに表示されます。',
+      keywordSimilarityWeight: 'キーワード類似度の重み',
+      keywordSimilarityWeightTip:
+        'ベクトルのコサイン類似度または再ランクスコアと組み合わせた総合類似度スコアにおける、キーワード類似度の重みを設定します。2つの重みの合計は1.0にする必要があります。',
+      close: '閉じる',
+      enableChildrenDelimiter: '子チャンクを検索に使用する',
+      childrenDelimiter: 'テキストの区切り文字',
+      childrenDelimiterTip:
+        '区切り文字（デリミタ）は、1つまたは複数の特殊文字で構成できます。複数文字の場合は、バッククォート( ``)で囲んでください。例えば、区切り文字を \\n`##`; のように設定すると、テキストは改行、二重ハッシュ記号（##）、セミコロンの位置で分割されます。',
+      redo: '既存の{{chunkNum}}件のチャンクをクリアしますか？',
+      setMetaData: 'メタデータを設定',
+      pleaseInputJson: 'JSONを入力してください',
+      documentMetaTips:
+        '<p>メタデータはJson形式です（検索対象にはなりません）。このドキュメントのチャンクがプロンプトに含まれる場合、メタデータもプロンプトに追加されます。</p>\n<p>例:</p>\n<b>メタデータ:</b><br>\n<code>\n  {\n      "Author": "Alex Dowson",\n      "Date": "2024-11-12"\n  }\n</code><br>\n<b>プロンプトは次のようになります:</b><br>\n<p>Document: the_name_of_document</p>\n<p>Author: Alex Dowson</p>\n<p>Date: 2024-11-12</p>\n<p>関連する断片は以下の通りです:</p>\n<ul>\n<li>  ここにチャンクの内容が入ります…</li>\n<li>  ここにチャンクの内容が入ります…</li>\n</ul>\n',
+      metaData: 'メタデータ',
+      deleteDocumentConfirmContent:
+        'このドキュメントはナレッジグラフに関連付けられています。削除すると、関連するノードおよび関係性の情報も削除されますが、グラフはすぐには更新されません。グラフの更新は、ナレッジグラフ抽出タスクを伴う新規ドキュメントのパース処理中に実行されます。',
+      plainText: 'General',
+      reRankModelWaring: '再ランクモデルの処理には非常に時間がかかります。',
     },
+
     knowledgeConfiguration: {
       imageTableContextWindow: '画像・表コンテキストウィンドウ',
+
       imageTableContextWindowTip:
         '画像と表の上下のテキストをNトークン取得し、より豊かな背景コンテキストを提供します。',
+
       titleDescription:
         'ナレッジベースの設定、特にチャンク方法をここで更新してください。',
+
       name: 'ナレッジベース名',
       photo: 'ナレッジベース写真',
       photoTip: '4 MB までの画像をアップロードできます。す',
@@ -190,12 +442,16 @@ export default {
       embeddingModel: '埋め込みモデル',
       chunkTokenNumber: '推奨チャンクサイズ',
       chunkTokenNumberMessage: 'チャンクトークン数は必須です',
+
       embeddingModelTip:
         'ナレッジベースで使用されるデフォルトの埋め込みモデルです。ナレッジベースにチャンクが作成された後に埋め込みモデルを変更する場合、システムは互換性チェックのためにいくつかのチャンクをランダムに抽出し、新しい埋め込みモデルで再エンコードして新旧ベクトルのコサイン類似度を計算します。サンプルの平均類似度が ≥ 0.9 の場合のみ切り替えできます。平均類似度が 0.9 未満の場合は、変更する前にナレッジベース内のすべてのチャンクを削除する必要があります。',
+
       permissionsTip:
         '「チーム」に設定すると、全てのチームメンバーがナレッジベースを管理できます。',
+
       chunkTokenNumberTip:
         'チャンクのトークンしきい値を設定します。このしきい値を下回る段落は、次の段落と結合され、しきい値を超えた時点でチャンクが作成されます。新しいチャンクは、デリミタが検出されるまで作成されません。このしきい値が超過されていてもです。',
+
       chunkMethod: 'チャンク方法',
       chunkMethodTip: '詳細は右側の説明をご覧ください。',
       upload: 'アップロード',
@@ -209,32 +465,41 @@ export default {
       cancel: 'キャンセル',
       methodTitle: 'チャンク方法の説明',
       methodExamples: '例',
+
       methodExamplesDescription:
         '理解を深めるために、関連するスクリーンショットを参考として提供しております。',
+
       dialogueExamplesTitle: '会話の例',
       methodEmpty: 'ナレッジベースカテゴリの視覚的説明がここに表示されます',
+
       book: `<p>対応ファイル形式は<b>DOCX</b>, <b>PDF</b>, <b>TXT</b>です。</p><p>
       PDF形式の書籍では、解析時間を短縮するため、<i>ページ範囲</i>を設定してください。</p>`,
+
       laws: `<p>対応ファイル形式は<b>DOCX</b>, <b>PDF</b>, <b>TXT</b>です。</p><p>
       法律文書は厳格な書式に従っています。分割ポイントを識別するためにテキストの特徴を使用します。
       </p><p>
       'ARTICLE'に一致する粒度でチャンクが作成され、上位レベルのテキストがすべてチャンクに含まれます。
       </p>`,
+
       manual: `<p>対応するのは<b>PDF</b>のみです。</p><p>
       マニュアルは階層的なセクション構造を持つと仮定され、最下位のセクションタイトルを基にチャンク分割を行います。そのため、同じセクション内の図表は分割されませんが、大きなチャンクサイズになる可能性があります。
       </p>`,
+
       naive: `<p>対応ファイル形式は<b>MD, MDX, DOCX, XLSX, XLS (Excel 97-2003), PPT, PDF, TXT, JPEG, JPG, PNG, TIF, GIF, CSV, JSON, EML, HTML</b>です。</p>
       <p>この方法では、'ナイーブ'な方法でファイルを分割します：</p>
       <p>
       <li>視覚認識モデルを使用してテキストを小さなセグメントに分割します。</li>
       <li>次に、隣接するセグメントを結合し、設定された'チャンクトークン数'のしきい値を超えるとチャンクが作成されます。</li></p>`,
+
       paper: `<p><b>PDF</b>形式のみ対応しています。</p><p>
       論文はセクション単位で分割されます（例：abstract, 1.1, 1.2）。</p><p>
       この方法により、LLMは論文を効果的に要約し、包括的で理解しやすい応答を提供できます。
       ただし、AI会話のコンテキストが増加し、計算コストが増加します。そのため、会話中は「<b>topN</b>」の値を小さくすることを検討してください。</p>`,
+
       presentation: `<p>対応ファイル形式は<b>PDF</b>, <b>PPTX</b>です。</p><p>
       スライドの各ページはチャンクとして扱われ、そのサムネイル画像が保存されます。</p><p>
       <i>このチャンク方法はすべてのPPTファイルに自動的に適用されるため、手動で指定する必要はありません。</i></p>`,
+
       qa: `
       <p>
       このチャンク方法は<b>XLSX</b>および<b>CSV/TXT</b>ファイル形式をサポートします。
@@ -255,11 +520,13 @@ export default {
       </i>
     </p>
       `,
+
       resume: `<p>対応ファイル形式は<b>DOCX</b>, <b>PDF</b>, <b>TXT</b>です。
       </p><p>
       さまざまな形式の履歴書を解析し、構造化データとして整理してリクルーターの候補者検索を支援します。
       </p>
       `,
+
       table: `<p>対応ファイル形式は<b>XLSX</b>および<b>CSV/TXT</b>です。</p><p>
       いくつかの前提条件とヒントはこちらです：
       <ul>
@@ -274,12 +541,14 @@ export default {
     </li>
     <li>テーブルの各行はチャンクとして扱われます。</li>
     </ul>`,
+
       picture: `
     <p>画像ファイルが対応しています。動画対応は近日公開予定です。</p><p>
     この方法ではOCRモデルを使用して画像からテキストを抽出します。
     </p><p>
     OCRモデルで抽出されたテキストが不十分と見なされた場合、指定された視覚LLMが画像の説明を提供します。
     </p>`,
+
       one: `
     <p>対応ファイル形式は<b>DOCX, EXCEL, PDF, TXT</b>です。
     </p><p>
@@ -287,27 +556,37 @@ export default {
     </p><p>
     LLMがその量のコンテキスト長を処理できる場合に、ドキュメント全体を要約する必要があるときに適用されます。
     </p>`,
+
       knowledgeGraph: `<p>対応ファイル形式は<b>DOCX, EXCEL, PPT, IMAGE, PDF, TXT, MD, JSON, EML</b>です。
 
 <p>このアプローチでは、ファイルを'ナイーブ'/'一般'メソッドを使用してチャンクに分割します。ドキュメントをセグメントに分割し、隣接するセグメントを結合してトークン数が'チャンクトークン数'で指定されたしきい値を超えるまで続け、その時点でチャンクが作成されます。</p>
 <p>その後、チャンクはLLMに入力され、ナレッジグラフとマインドマップのエンティティと関係を抽出します。</p>
 <p><b>エンティティタイプ</b>を設定することを忘れないでください。</p>`,
+
       useRaptor: 'RAPTORを使用して検索を強化',
+
       useRaptorTip:
         'マルチホップ質問応答タスクでRAPTORを有効にしてください。詳細は https://ragflow.io/docs/dev/enable_raptor をご覧ください。',
+
       prompt: 'プロンプト',
+
       promptTip:
         'LLMのタスクを説明し、どのように応答すべきかを指定し、他のさまざまな要件を概説するためにシステムプロンプトを使用します。システムプロンプトは、LLMのさまざまなデータ入力として機能するキー（変数）と共に使用されることがよくあります。使用するキーを表示するには、スラッシュ `/` または (x) ボタンを使用します。',
+
       promptMessage: 'プロンプトは必須です',
+
       promptText: `以下の段落を要約してください。数字には注意し、事実を捏造しないでください。段落は以下の通りです：
       {cluster_content}
 上記が要約する内容です。`,
+
       maxToken: '最大トークン数',
       maxTokenTip: '生成された要約チャンクごとの最大トークン数。',
       maxTokenMessage: '最大トークン数は必須です',
       threshold: 'しきい値',
+
       thresholdTip:
         'RAPTORでは、チャンクは意味的な類似性によってクラスタリングされます。しきい値パラメータは、チャンクをまとめるために必要な最小限の類似度を設定します。しきい値が高いほど各クラスタ内のチャンク数は少なくなり、しきい値が低いほど多くのチャンクが1つのクラスタに含まれます。',
+
       thresholdMessage: 'しきい値は必須です',
       maxCluster: '最大クラスター数',
       maxClusterTip: '作成するクラスタの最大数。',
@@ -328,7 +607,142 @@ export default {
       paddleocrAlgorithmTip: 'PaddleOCR解析に使用するアルゴリズム',
       paddleocrSelectAlgorithm: 'アルゴリズムを選択',
       paddleocrModelNamePlaceholder: '例: paddleocr-from-env-1',
+      randomSeedTip:
+        'シードとは、擬似乱数アルゴリズムの起点となる値で、複数回の実行間で同じ出力の再現性を保証します。',
+      datasetDescription: 'データセットの説明を入力してください',
+      overlappedPercentTip: '隣接する2つのチャンク間の重複率です。',
+      globalIndexModelTip:
+        'ナレッジグラフ、RAPTOR、自動メタデータ、自動キーワード、自動質問の生成に使用されます。モデルの性能が生成品質に影響します。',
+      globalIndexModel: 'インデックスモデル',
+      settings: '設定',
+      autoMetadataTip:
+        'メタデータを自動生成します。パース時に新規ファイルへ適用されます。既存ファイルを更新するには再パースが必要です（チャンクは保持されます）。「設定」で指定されたインデックスモデルにより、追加のトークンが消費される点にご注意ください。',
+      autoMetadata: '自動メタデータ',
+      mineruOptions: 'MinerUオプション',
+      mineruParseMethod: 'パース方法',
+      mineruParseMethodTip:
+        'PDFのパース方法: auto（自動検出）、txt（テキスト抽出）、ocr（光学文字認識）',
+      mineruFormulaEnable: '数式認識',
+      mineruFormulaEnableTip:
+        '数式認識を有効にします。注: キリル文字のドキュメントでは正しく動作しない場合があります。',
+      mineruTableEnable: '表認識',
+      mineruTableEnableTip: '表の認識と抽出を有効にします。',
+      overlappedPercent: '重複率（%）',
+      generationScopeTip:
+        'RAPTORをデータセット全体で生成するか、単一のファイルで生成するかを指定します。',
+      scopeDataset: 'データセット',
+      generationScope: '生成範囲',
+      scopeSingleFile: '単一ファイル',
+      autoParse: '自動パース',
+      rebuildTip:
+        'リンクされたデータソースからファイルを再ダウンロードし、再度パースします。',
+      baseInfo: '基本情報',
+      globalIndex: 'グローバルインデックス',
+      dataSource: 'データソース',
+      linkSourceSetTip: 'このデータセットとのデータソース連携を管理します',
+      linkDataSource: 'データソースを連携',
+      tocExtraction: 'PageIndex',
+      tocExtractionTip:
+        ' 既存のチャンクに対して、階層的な目次（ファイルごとに1つのディレクトリ）を生成します。クエリ時にディレクトリ拡張が有効になっている場合、システムは大規模モデルを使用してユーザーの質問に関連するディレクトリ項目を判定し、関連するチャンクを特定します。',
+      deleteGenerateModalContent:
+        "\n        <p>生成された<strong class='text-text-primary'>{{type}}</strong>の結果を削除すると、\n        このデータセットから派生したすべてのエンティティと関係性が削除されます。\n        元のファイルはそのまま残ります。<p>\n        <br/>\n        続行しますか？\n      ",
+      extractRaptor: 'RAPTORを抽出',
+      extractKnowledgeGraph: 'ナレッジグラフを抽出',
+      filterPlaceholder: 'フィルタを入力してください',
+      fileFilterTip: '',
+      fileFilter: 'ファイルフィルタ',
+      setDefaultTip: '',
+      setDefault: 'デフォルトに設定',
+      editLinkDataPipeline: '取り込みパイプラインを編集',
+      linkPipelineSetTip:
+        'このデータセットとの取り込みパイプライン連携を管理します',
+      default: 'デフォルト',
+      dataPipeline: '取り込みパイプラインを切り替え、または設定します。',
+      linkDataPipeline: '取り込みパイプラインを連携',
+      enableAutoGenerate: '自動生成を有効化',
+      teamPlaceholder: 'チームを選択してください。',
+      dataFlowPlaceholder: 'パイプラインを選択してください。',
+      buildItFromScratch: '最初から構築',
+      dataFlow: 'パイプライン',
+      parseType: 'パースタイプ',
+      manualSetup: 'パイプライン',
+      builtIn: '組み込み',
+      portugueseBr: 'ポルトガル語（ブラジル）',
+      tableColumnMode: '列モード',
+      tableColumnModeAuto: '自動',
+      tableColumnModeManual: '手動',
+      tableColumnModeAutoDescription:
+        'すべての列がチャンクテキストに含まれ、メタデータとしても保存されます（RAGFlowのデフォルト）。',
+      tableColumnRoles: '列の役割',
+      tableColumnRolesTip:
+        '各列を、チャンクテキストに含める（ベクトル検索・全文検索の対象になります）、メタデータのみに含める（フィルタ可能）、または両方に含めるかを選択します。変更は新規のパース処理に適用されます。既存ドキュメントに反映するには再パースが必要です。',
+      tableColumnRoleIndexing: 'インデックス化',
+      tableColumnRoleMetadata: 'メタデータ',
+      tableColumnRoleBoth: '両方',
+      tableColumnRolesEmpty:
+        '列の役割を設定するには、CSVまたはExcelファイルをアップロードしてパースしてください。',
+      tableColumnRolesReparseTip:
+        '新しい列の役割を反映するには、既存ドキュメントを再パースしてください。',
+
+      parserLabel: {
+        naive: 'General',
+        general: 'General',
+        qa: 'Q&A',
+        resume: '履歴書',
+        manual: 'マニュアル',
+        table: 'テーブル',
+        paper: '論文',
+        book: '書籍',
+        laws: '法律',
+        presentation: 'プレゼンテーション',
+        picture: '画像',
+        one: '単一',
+        audio: '音声',
+        email: 'メール',
+        tag: 'タグ',
+      },
+
+      tag: '<p>「タグ」チャンク方法を使用するデータセットは、タグセットとして機能します。他のデータセットはこれを使って自身のチャンクにタグ付けを行い、これらのデータセットへのクエリもこのタグセットを使ってタグ付けされます。</p>\n<p>タグセットは、Retrieval-Augmented Generation（RAG）プロセスに直接関与すること<b>はありません</b>。</p>\n<p>このデータセット内の各チャンクは、独立した説明・タグのペアです。</p>\n<p>対応ファイル形式は<b>XLSX</b>および<b>CSV/TXT</b>です:</p>\n<p>ファイルが<b>XLSX</b>形式の場合、ヘッダーなしの2列（タグの説明列とタグ名列）で構成し、説明列がタグ列より前に来るようにしてください。列が適切に構成されていれば、複数シートも使用できます。</p>\n<p>ファイルが<b>CSV/TXT</b>形式の場合、UTF-8でエンコードし、説明とタグの区切りにTABを使用する必要があります。</p>\n<p>タグ列では、タグの区切りに<b>カンマ</b>を使用します。</p>\n<i>上記のルールに従わない行は無視されます。</i>\n',
+      clusteringMethod: 'クラスタリング方法',
+      clusteringMethodTip:
+        'RAPTORのクラスタリング方法を選択してください。AHCはより大きな最大クラスタ値を使用できますが、大規模な入力ではより多くのメモリを必要とする場合があります。',
+      clusteringMethodGmm: 'GMM',
+      clusteringMethodAhc: 'AHC',
+      compilationTemplate: 'コンパイルテンプレート',
+      scopeFile: 'ファイル',
+      vietnamese: 'ベトナム語',
+      tagName: 'タグ',
+      frequency: '頻度',
+      searchTags: 'タグを検索',
+      tagCloud: 'クラウド',
+      tagTable: 'テーブル',
+      tagSet: 'タグセット',
+      tagSetTip:
+        '\n     <p> 1つまたは複数のタグデータセットを選択すると、データセット内のチャンクに自動的にタグが付与されます。詳細は https://ragflow.io/docs/dev/use_tag_sets をご覧ください。</p>\n<p>ユーザーのクエリにも自動的にタグが付与されます。</p>\nこの自動タグ付け機能は、既存のデータセットにドメイン固有の知識をもう一層追加することで、検索精度を向上させます。\n<p>自動タグ付けと自動キーワードの違い:</p>\n<ul>\n  <li>タグデータセットはユーザーが定義したクローズドセットであるのに対し、LLMが抽出するキーワードはオープンセットとみなせます。</li>\n  <li>自動タグ付け機能を実行する前に、指定された形式でタグセットをアップロードする必要があります。</li>\n  <li>自動キーワード機能はLLMに依存しており、多くのトークンを消費します。</li>\n</ul>\n      ',
+      topnTags: '上位N件のタグ',
+      tags: 'タグ',
+      addTag: 'タグを追加',
+      useGraphRag: 'ナレッジグラフ',
+      useGraphRagTip:
+        '現在のデータセットのファイルチャンクに対してナレッジグラフを構築し、入れ子になったロジックを含むマルチホップの質問応答を強化します。詳細は https://ragflow.io/docs/dev/construct_knowledge_graph をご覧ください。',
+      graphRagMethod: '方法',
+      graphRagMethodTip:
+        '\n      Light: （デフォルト）github.com/HKUDS/LightRAG が提供するプロンプトを使用して、エンティティと関係性を抽出します。このオプションは、トークン・メモリ・計算リソースの消費が少なくて済みます。</br>\n      General: github.com/microsoft/graphrag が提供するプロンプトを使用して、エンティティと関係性を抽出します。</br>\n      NER: spaCyのNERとルールベースのキーワード抽出を使用して、エンティティと関係性を抽出します。抽出自体にLLMを必要としないため、高速でリソース効率に優れています。',
+      graphRagBatchChunkTokenSize: 'バッチチャンクのトークンサイズ',
+      graphRagBatchChunkTokenSizeTip:
+        'ナレッジグラフのエンティティ・関係抽出のためにLLMへ送信する、チャンクの各バッチのトークン上限です。NERには適用されません。',
+      resolution: 'エンティティ解決',
+      resolutionTip:
+        'エンティティの重複排除を切り替えるスイッチです。有効にすると、LLMが「2025」と「the year of 2025」、または「IT」と「Information Technology」のような類似エンティティを統合し、より正確なグラフを構築します。',
+      community: 'コミュニティレポート',
+      communityTip:
+        'ナレッジグラフにおいて、コミュニティとは関係性によって結び付けられたエンティティのクラスタです。LLMに各コミュニティの要約（コミュニティレポートと呼ばれます）を生成させることができます。詳細はこちらをご覧ください: https://www.microsoft.com/en-us/research/blog/graphrag-improving-global-search-via-dynamic-community-selection/',
+      theDocumentBeingParsedCannotBeDeleted:
+        'パース中のドキュメントは削除できません',
+      lastWeek: '先週比',
+      top: '上位',
     },
+
     chunk: {
       chunk: 'チャンク',
       createChunk: 'チャンクを作成',
@@ -351,7 +765,40 @@ export default {
       mind: 'マインドマップ',
       question: '質問',
       questionTip: `質問が指定されている場合、チャンクの埋め込みはそれらに基づきます。`,
+      type: 'タイプ',
+
+      docType: {
+        image: '画像',
+        table: 'テーブル',
+        text: 'テキスト',
+      },
+
+      size: 'サイズ',
+      uploadedTime: 'アップロード日時',
+      image: '画像',
+      imageUploaderTitle:
+        '新しい画像をアップロードして、この画像チャンクを更新してください。',
+      chunkResult: 'チャンク結果',
+      chunkResultTip:
+        '埋め込みおよび検索に使用されるチャンク分割済みセグメントを表示します。',
+      representation: '表現形式',
+
+      representationKinds: {
+        knowledge_graph: 'ナレッジグラフ',
+        mind_map: 'マインドマップ',
+        page_index: 'ページインデックス',
+        timeline: 'タイムライン',
+        tree: 'ツリー',
+        raptor: 'RAPTOR',
+      },
+
+      representationUnsupported: 'この表現形式にはまだ対応していません。',
+      representationEmpty: '利用可能な表現テンプレートがありません。',
+      enable: '有効化',
+      disable: '無効化',
+      delete: '削除',
     },
+
     chat: {
       chatSupport: 'チャットサポート',
       replyInstantly: '通常、即座に返信します',
@@ -372,8 +819,10 @@ export default {
       send: '送信',
       sendPlaceholder: 'アシスタントにメッセージを送信...',
       chatConfiguration: 'チャット設定',
+
       chatConfigurationDescription:
         '選択したデータセット（知識ベース）にチャットアシスタントを設定してください！ 💕',
+
       assistantName: 'アシスタント名',
       assistantNameMessage: 'アシスタント名は必須です',
       namePlaceholder: '例: 履歴書アシスタント',
@@ -387,16 +836,22 @@ export default {
       setAnOpenerTip: 'お客様をどのように歓迎しますか？',
       knowledgeBases: 'ナレッジベース',
       knowledgeBasesMessage: '選択してください',
+
       knowledgeBasesTip:
         '関連付けるナレッジベースを選択してください。空のナレッジベースはドロップダウンリストに表示されません。',
+
       system: 'システムプロンプト',
+
       systemInitialValue: `あなたはインテリジェントなアシスタントです。質問に答えるためにナレッジベースの内容を要約してください。ナレッジベースのデータをリストし、詳細に答えてください。すべてのナレッジベースの内容が質問に関連しない場合、回答には「ナレッジベースにはお探しの回答が見つかりません！」という文を含める必要があります。回答はチャット履歴を考慮する必要があります。
       こちらがナレッジベースです：
       {knowledge}
       上記がナレッジベースです。`,
+
       systemMessage: '入力してください！',
+
       systemTip:
         'LLMが質問に答える際に従う指示を設定します。モデルがネイティブで推論をサポートしている場合、推論を停止するためにプロンプトに //no_thinking を追加できます。',
+
       topN: 'トップN',
       topNTip: `類似度スコアがしきい値を超えるチャンクのうち、上位N件のみがLLMに供給されます。`,
       variable: '変数',
@@ -409,8 +864,10 @@ export default {
       modelTip: '大規模言語チャットモデル',
       modelMessage: '選択してください！',
       modelEnabledTools: '有効化されたツール',
+
       modelEnabledToolsTip:
         'モデルで使用するツールを1つ以上選択してください。ツール呼び出しをサポートしていないモデルでは効果がありません。',
+
       freedom: '自由度',
       improvise: '自由に',
       precise: '正確に',
@@ -419,20 +876,28 @@ export default {
       freedomTip: `'正確に'は、LLMが慎重に質問に答えることを意味します。'自由に'は、LLMが多く話し、自由に答えることを望むことを意味します。'バランス'は、慎重さと自由さの間のバランスを取ることを意味します。`,
       temperature: '温度',
       temperatureMessage: '温度は必須です',
+
       temperatureTip:
         'このパラメータは、モデルによる予測のランダム性を制御します。温度が低いほど、モデルは回答に自信を持ち、温度が高いほど、より創造的で多様な回答を生成します。',
+
       topP: 'Top P',
       topPMessage: 'Top Pは必須です',
+
       topPTip:
         '"核サンプリング"とも呼ばれ、このパラメータは、サンプリングする単語の小さなセットを選択するためのしきい値を設定します。最も可能性の高い単語に焦点を当て、可能性の低い単語を切り捨てます。',
+
       presencePenalty: '存在ペナルティ',
       presencePenaltyMessage: '存在ペナルティは必須です',
+
       presencePenaltyTip:
         'これは、会話中に既に登場した単語にペナルティを課すことで、モデルが同じ情報を繰り返すのを防ぎます。',
+
       frequencyPenalty: '頻度ペナルティ',
       frequencyPenaltyMessage: '頻度ペナルティは必須です',
+
       frequencyPenaltyTip:
         '存在ペナルティと同様に、モデルが同じ単語を頻繁に繰り返す傾向を減少させます。',
+
       maxTokens: '最大トークン数',
       maxTokensMessage: '最大トークン数は必須です',
       maxTokensTip: `モデルの最大コンテキストサイズ。無効または不正な値はエラーになります。デフォルトは512。`,
@@ -441,8 +906,10 @@ export default {
       quote: '引用を表示',
       quoteTip: '元のテキストの出典を表示しますか？',
       selfRag: 'Self-RAG',
+
       selfRagTip:
         '詳細は次を参照してください：https://huggingface.co/papers/2310.11511',
+
       overview: 'チャットID',
       pv: 'メッセージ数',
       uv: 'アクティブユーザー数',
@@ -463,8 +930,10 @@ export default {
       embedModalTitle: 'ウェブサイトに埋め込む',
       comingSoon: '近日公開',
       fullScreenTitle: '全画面埋め込み',
+
       fullScreenDescription:
         '以下のiframeをウェブサイトの希望する場所に埋め込んでください',
+
       partialTitle: '部分埋め込み',
       extensionTitle: 'Chrome拡張機能',
       tokenError: 'まずAPIトークンを作成してください！',
@@ -476,54 +945,107 @@ export default {
       regenerate: '再生成',
       read: 'コンテンツを読む',
       tts: 'テキスト読み上げ',
+
       ttsTip:
         '音声変換を使用して音声を再生するには、まず設定でTTS（音声変換モデル）を選択してください。',
+
       relatedQuestion: '関連質問',
       answerTitle: '回答',
       multiTurn: 'マルチターン最適化',
+
       multiTurnTip:
         'マルチラウンドの会話では、ナレッジベースへのクエリが最適化されます。大規模モデルが呼び出され、追加のトークンが消費されます。',
+
       howUseId: 'チャットIDの使い方？',
       description: 'アシスタントの説明',
       descriptionPlaceholder: '例: 履歴書用のチャットアシスタント',
       useKnowledgeGraph: 'ナレッジグラフを使用',
+
       useKnowledgeGraphTip:
         'ナレッジグラフを利用してエンティティや関係をまたいだ検索を行います。マルチホップ質問応答が可能になりますが、検索時間が大幅に増加します。',
+
       keyword: 'キーワード解析',
       keywordTip: `LLMでユーザーの質問を解析し、重要キーワードを抽出して関連性計算で強調します。長文クエリに有効ですが応答速度が遅くなります。`,
+
       languageTip:
         '選択した言語で文をリライトできます。未選択の場合は直近の質問の言語が使われます。',
+
       avatarHidden: 'アバターを非表示',
       locale: 'ロケール',
       selectLanguage: '言語を選択',
       reasoning: '推論',
       reasoningTip: `Deepseek-R1 や OpenAI o1 のように、推論ワークフローを有効にできます。ステップごとの論理展開で複雑な質問への正確さが向上します。`,
+
       tavilyApiKeyTip:
         'ここにTavilyのAPIキーを設定すると、ナレッジベース検索に加えてウェブ検索も利用できます。',
+
       tavilyApiKeyMessage: 'Tavily APIキーを入力してください',
       tavilyApiKeyHelp: '取得方法はこちら',
       crossLanguage: 'クロス言語検索',
       crossLanguageTip: `1つ以上の言語を選択すると、その言語でも検索します。未選択の場合は元の言語で検索します。`,
       createChat: 'チャットを作成',
       metadata: 'メタデータ',
+
       metadataTip:
         'メタデータ（タグ、カテゴリ、アクセス権限など）を使って、関連情報の検索を制御・絞り込みます。',
+
       conditions: '条件',
       addCondition: '条件を追加',
+
       meta: {
         disabled: '無効',
         auto: '自動',
         manual: '手動',
+        semi_auto: '半自動',
       },
+
       cancel: 'キャンセル',
       chatSetting: 'チャット設定',
       showChunkMetadata: 'チャンクのメタデータを表示',
+
       showChunkMetadataTip:
         '取得したテキストチャンクの横に文書メタデータ（タイトル、ページ番号、アップロード日など）を表示します',
+
       metadataFields: 'メタデータフィールド',
+
       metadataFieldsTip:
         '各チャンクに表示するメタデータフィールドを選択してください',
+
+      emptyResponsePlaceholder:
+        'お探しの回答はデータセット内に見つかりませんでした！',
+      knowledgeBasesPlaceholder: '値を選択してください',
+      systemPlaceholder:
+        'あなたは有能なアシスタントです。主な役割は、提供されたナレッジベースの内容のみに基づいて質問に回答することです。\n\n**基本ルール:**\n  - 回答は**必ず**このデータセットのみから導き出してください: {knowledge}。\n  - **情報がある場合**: 内容を要約して詳細な回答を行ってください。\n  - **情報がない場合**: 回答には次の文をそのまま含めてください: "お探しの回答はナレッジベース内に見つかりませんでした！"\n  - **常に**会話履歴全体を考慮してください。',
+      thinking: '思考',
+      thinkingDefault: 'システムデフォルト',
+      thinkingEnabled: '有効',
+      thinkingDisabled: '無効',
+      thinkingLevelLow: '低',
+      thinkingLevelMedium: '中',
+      thinkingLevelHigh: '高',
+      thinkingLevelUltra: '最高',
+      thinkingTip:
+        'Qwen、Kimi、GLMの公式モデルプロバイダーの思考モードのみを制御します。システムデフォルトでは、処理の長時間化を防ぐためQwenの思考を無効にします。',
+      published: '公開済み',
+      publishedTooltip:
+        'この埋め込みに公開バージョンを使用します。有効にすると、生成されるURLに release=true が含まれます。',
+      embedType: '埋め込みタイプ',
+      fullscreenChat: '全画面チャット（従来のiframe）',
+      floatingWidget: 'フローティングウィジェット（Intercomスタイル）',
+      theme: 'テーマ',
+      light: 'ライト',
+      dark: 'ダーク',
+      enableStreaming: 'ストリーミング応答を有効にする',
+      muteWidget: 'ウィジェットの音声をミュート',
+      crossLanguagePlaceholder: '値を選択してください',
+      metadataKeys: 'フィルター可能な項目',
+      tocEnhance: 'PageIndex',
+      tocEnhanceTip:
+        'ドキュメントの解析時に目次情報が生成されます（「全般」方式の「目次抽出を有効にする」オプションを参照）。これにより、大規模モデルはユーザーのクエリに関連する目次項目を返すことができ、これらの項目を使って関連チャンクを取得し、並べ替え時にこれらのチャンクへ重み付けを適用します。この手法は、人間が書籍の中で情報を探す際の行動を模倣したものです。',
+      batchDeleteSessions: '一括削除',
+      deleteSelectedConfirm: '選択した{{count}}件のセッションを削除しますか？',
     },
+
     setting: {
       profile: 'プロファイル',
       avatar: 'アバター‌',
@@ -534,8 +1056,10 @@ export default {
       maxTokensInvalidMessage: '有効な数値を入力してください。',
       maxTokensMinMessage: '最大トークン数は0以上でなければなりません。',
       password: 'パスワード',
+
       passwordDescription:
         'パスワードを変更するには、現在のパスワードを入力してください。',
+
       model: 'モデルプロバイダー',
       modelDescription: 'ここでモデルパラメータとAPIキーを設定します。',
       team: 'チーム',
@@ -560,54 +1084,78 @@ export default {
       currentPasswordMessage: 'パスワードを入力してください！',
       newPassword: '新しいパスワード',
       newPasswordMessage: 'パスワードを入力してください！',
+
       newPasswordDescription:
         '新しいパスワードは8文字以上でなければなりません。',
+
       confirmPassword: '新しいパスワードの確認',
       confirmPasswordMessage: 'パスワードを確認してください！',
+
       confirmPasswordNonMatchMessage:
         '入力した新しいパスワードが一致しません！',
+
       cancel: 'キャンセル',
       addedModels: '追加されたモデル',
       modelsToBeAdded: '追加されるモデル',
       addTheModel: 'モデルを追加',
       apiKey: 'APIキー',
+
       apiKeyMessage:
         'APIキーを入力してください（ローカルにデプロイされたモデルの場合は無視してください）。',
+
       apiKeyTip:
         'APIキーは、対応するLLMサプライヤーに登録することで取得できます。',
+
       showMoreModels: 'さらにモデルを表示',
       hideModels: 'モデルを隠す',
       baseUrl: 'ベースURL',
+
       baseUrlTip:
         'APIキーがOpenAIからのものであれば無視してください。他の中間プロバイダーはAPIキーと共にこのベースURLを提供します。',
+
       tongyiBaseUrlTip:
         '中国ユーザーの場合、記入不要または https://dashscope.aliyuncs.com/compatible-mode/v1 を使用してください。国際ユーザーは https://dashscope-intl.aliyuncs.com/compatible-mode/v1 を使用してください',
+
       siliconBaseUrlTip:
         '中国ユーザーの場合、入力不要または https://api.siliconflow.cn/v1 を使用してください。国際ユーザーは https://api.siliconflow.com/v1 を使用してください',
+
       tongyiBaseUrlPlaceholder: '（国際ユーザーのみ、ヒントをご覧ください）',
+
       minimaxBaseUrlTip:
         '国際ユーザーのみ：https://api.minimax.io/v1 を使用してください。',
+
       minimaxBaseUrlPlaceholder:
         '（国際ユーザーのみ、https://api.minimax.io/v1 を入力してください）',
+
       modify: '変更',
       systemModelSettings: 'デフォルトモデルを設定する',
       chatModel: 'チャットモデル',
+
       chatModelTip:
         '新しく作成されたナレッジベースが使用するデフォルトのチャットLLM。',
+
       embeddingModel: '埋め込みモデル',
+
       embeddingModelTip:
         '新しく作成された各ナレッジベースのデフォルト埋め込みモデルです。ドロップダウンから埋め込みモデルが見つからない場合は、RAGFlowスリムエディション（埋め込みモデルを含まない）を使用しているか、https://ragflow.io/docs/dev/supported_models を確認して、モデルプロバイダーがこのモデルをサポートしているかどうかを確認してください。',
+
       img2txtModel: '画像からテキストへのモデル',
+
       img2txtModelTip:
         '新しく作成された知識ベースごとのデフォルトのimg2txtモデル。それは画像や動画を説明します。ドロップダウンからモデルが見つからない場合は、https://ragflow.io/docs/dev/supported_models を確認して、モデルプロバイダーがこのモデルをサポートしているかどうかを確認してください。',
+
       sequence2txtModel: 'シーケンスからテキストへのモデル',
+
       sequence2txtModelTip:
         '新しく作成されたナレッジベースが使用するデフォルトのASRモデル。音声を対応するテキストに変換するために使用します。ドロップダウンからモデルが見つからない場合は、https://ragflow.io/docs/dev/supported_models を確認して、モデルプロバイダーがこのモデルをサポートしているかどうかを確認してください。',
+
       rerankModel: '再ランクモデル',
       rerankModelTip: `チャンクをrerankingするためのデフォルトのrerankモデル。ドロップダウンからモデルが見つからない場合は、https://ragflow.io/docs/dev/supported_models を確認して、ご使用のモデルプロバイダーがこのモデルをサポートしているかをご確認ください。`,
       ttsModel: 'TTSモデル',
+
       ttsModelTip:
         'デフォルトのtext-to-speechモデル。ドロップダウンからモデルが見つからない場合は、https://ragflow.io/docs/dev/supported_models を確認して、ご使用のモデルプロバイダーがこのモデルをサポートしているかをご確認ください。',
+
       workspace: 'ワークスペース',
       upgrade: 'アップグレード',
       addLlmTitle: 'LLMを追加',
@@ -621,6 +1169,7 @@ export default {
       modelTypeMessage: 'モデルタイプを入力してください！',
       addLlmBaseUrl: 'ベースURL',
       baseUrlNameMessage: 'ベースURLを入力してください！',
+
       paddleocr: {
         apiUrl: 'PaddleOCR API URL',
         apiUrlPlaceholder: '例：https://paddleocr-server.com/layout-parsing',
@@ -632,6 +1181,7 @@ export default {
         modelNameRequired: 'モデル名は必須です',
         apiUrlRequired: 'PaddleOCR API URL は必須です',
       },
+
       vision: 'ビジョンをサポートしていますか？',
       ollamaLink: '{{name}}を統合する方法',
       FishAudioLink: 'FishAudioの使用方法',
@@ -677,15 +1227,20 @@ export default {
       addFishAudioAK: 'Fish Audio APIキー',
       addFishAudioAKMessage: 'APIキーを入力してください',
       addFishAudioRefID: 'FishAudio参照ID',
+
       addFishAudioRefIDMessage:
         '参照IDを入力してください（デフォルトモデルを使用する場合は空白のままにしてください）。',
+
       GoogleModelIDMessage: 'モデルIDを入力してください！',
       addGoogleProjectID: 'プロジェクトID',
       GoogleProjectIDMessage: 'プロジェクトIDを入力してください',
+
       addGoogleServiceAccountKey:
         'サービスアカウントキー（アプリケーションデフォルト認証情報を使用する場合は空白のままにしてください）',
+
       GoogleServiceAccountKeyMessage:
         'Google Cloudサービスアカウントキーをbase64形式で入力してください',
+
       addGoogleRegion: 'Google Cloudリージョン',
       GoogleRegionMessage: 'Google Cloudリージョンを入力してください',
       modelProvidersWarn: `まず<b>設定 > モデルプロバイダー</b>で埋め込みモデルとLLMの両方を追加してください。その後、「デフォルトモデルを設定する」で設定します。`,
@@ -702,11 +1257,650 @@ export default {
       sureDelete: 'このメンバーを削除してもよろしいですか？',
       quit: '退出',
       sureQuit: '参加したチームから退出してもよろしいですか？',
+
       modelsToBeAddedTooltip:
         'モデルプロバイダーがリストにないが「OpenAI互換」を謳っている場合は、OpenAI-API-compatible カードを選択して関連モデルを追加してください。',
+
       dingtalkAITableDescription:
         'Dingtalk AI Table に接続し、指定されたテーブルからレコードを同期します。',
+
+      Verify: '検証',
+      keyValid: 'APIキーは有効です。',
+      keyInvalid: 'APIキーは無効です。',
+      enableToolCall: 'ツール呼び出しを有効化',
+      enableToolCallTip:
+        '選択したモデルタイプがツール呼び出しに対応している場合、このモデルによるツール呼び出しを許可します。',
+      deleteModel: 'モデルを削除',
+      bedrockCredentialsHint:
+        'ヒント: AWS IAM認証を使用する場合は、Access Key / Secret Keyを空欄のままにしてください。',
+      awsAuthModeAccessKeySecret: 'アクセスキー',
+      awsAuthModeIamRole: 'IAMロール',
+      awsAuthModeAssumeRole: 'ロールの引き受け',
+      awsAccessKeyId: 'AWSアクセスキーID',
+      awsSecretAccessKey: 'AWSシークレットアクセスキー',
+      awsRoleArn: 'AWSロールARN',
+      awsRoleArnMessage: 'AWSロールARNを入力してください',
+      awsAssumeRoleTip:
+        'このモードを選択すると、Amazon EC2インスタンスが既存のロールを引き受けてAWSサービスにアクセスします。追加の認証情報は必要ありません。',
+      modelEmptyTip:
+        '利用可能なモデルがありません。<br>右側のパネルからモデルを追加してください。',
+      sourceEmptyTip:
+        'データソースがまだ追加されていません。以下から選択して接続してください。',
+      seconds: '秒',
+      minutes: '分',
+      edit: '編集',
+      cropTip:
+        '選択エリアをドラッグして画像の切り抜き位置を選び、スクロールで拡大縮小できます',
+      cropImage: '画像を切り抜き',
+      selectModelPlaceholder: 'モデルを選択',
+      configureModelTitle: 'モデルを設定',
+      connectorNameTip: 'コネクタを識別するための分かりやすい名前です',
+      syncDeletedFiles: '削除されたファイルを同期',
+      confluenceIsCloudTip:
+        'Confluence Cloudインスタンスの場合はチェックし、Confluence Server/Data Centerの場合はチェックを外してください',
+      confluenceWikiBaseUrlTip:
+        'Confluenceインスタンスのベースとなる URL です（例: https://your-domain.atlassian.net/wiki）',
+      confluenceSpaceKeyTip:
+        '任意項目: 特定のスペースのみを同期対象にする場合はスペースキーを指定してください。空欄にするとアクセス可能なすべてのスペースが同期されます。複数指定する場合はカンマで区切ってください（例: DEV,DOCS,HR）',
+      s3PrefixTip:
+        'ファイルの取得元となるS3バケット内のフォルダパスを指定してください。\n例: general/v2/',
+      S3CompatibleEndpointUrlTip:
+        'S3互換のStorage Boxを使用する場合は必須です。S3互換のエンドポイントURLを指定してください。\n例: https://fsn1.your-objectstorage.com',
+      S3CompatibleAddressingStyleTip:
+        'S3互換のStorage Boxを使用する場合は必須です。S3互換のアドレッシングスタイルを指定してください。\n例: Virtual Hosted Style',
+      addDataSourceModalTitle: '{{name}}コネクタを作成',
+      deleteSourceModalTitle: 'データソースを削除',
+      deleteSourceModalContent:
+        '\n      <p>このデータソースのリンクを削除してもよろしいですか？</p>',
+      deleteSourceModalConfirmText: '確認',
+      errorMsg: 'エラーメッセージ',
+      newDocs: '新規ドキュメント',
+      timeStarted: '開始時刻',
+      log: 'ログ',
+      rssDescription:
+        '公開されているRSSまたはAtomフィードに接続し、フィードのエントリをナレッジベースに同期します。',
+      confluenceDescription:
+        'Confluenceワークスペースと連携してドキュメントを検索します。',
+      s3Description:
+        'AWS S3バケットに接続し、保存されているファイルをインポート・同期します。',
+      google_cloud_storageDescription:
+        'Google Cloud Storageバケットに接続し、ファイルをインポート・同期します。',
+      r2Description:
+        'Cloudflare R2バケットに接続し、ファイルをインポート・同期します。',
+      oci_storageDescription:
+        'Oracle Cloud Object Storageバケットに接続し、ファイルをインポート・同期します。',
+      discordDescription:
+        'Discordサーバーと連携し、チャットデータへのアクセスと分析を行います。',
+      notionDescription:
+        'Notionのページとデータベースを同期し、ナレッジ検索に利用します。',
+      google_driveDescription:
+        'OAuthでGoogle Driveに接続し、特定のフォルダやドライブを同期します。',
+      gmailDescription: 'OAuthでGmailに接続し、メールを同期します。',
+      webdavDescription: 'WebDAVサーバーに接続してファイルを同期します。',
+      webdavRemotePathTip:
+        '任意項目: WebDAVサーバー上のフォルダパスを指定してください（例: /Documents）。空欄にするとルートから同期します。',
+      google_driveTokenTip:
+        'OAuthヘルパーまたはGoogle Cloud Consoleで生成したOAuthトークンのJSONをアップロードしてください。「installed」または「web」アプリケーションのclient_secret JSONをアップロードすることもできます。初回同期時は、OAuthの同意を完了するためブラウザウィンドウが開きます。JSONにリフレッシュトークンが既に含まれている場合は、自動的に再利用されます。',
+      google_drivePrimaryAdminTip:
+        '同期対象のDriveコンテンツにアクセス権を持つメールアドレスです',
+      zendeskDescription:
+        'Zendeskに接続し、チケットや記事などのコンテンツを同期します。',
+      google_driveMyDriveEmailsTip:
+        '「マイドライブ」の内容をインデックス対象にするメールアドレスをカンマ区切りで指定してください（プライマリ管理者を含めてください）。',
+      google_driveSharedFoldersTip:
+        'クロール対象のGoogle Driveフォルダのリンクをカンマ区切りで指定してください。',
+      gmailPrimaryAdminTip:
+        'Gmail / Workspaceへのアクセス権を持つプライマリ管理者のメールアドレスです。ドメイン内のユーザー一覧の取得と、デフォルトの同期アカウントとして使用されます。',
+      gmailTokenTip:
+        'Google Consoleで生成したOAuthのJSONをアップロードしてください。クライアント認証情報のみが含まれている場合は、一度ブラウザベースの検証を実行して長期間有効なリフレッシュトークンを発行してください。',
+      dropboxDescription:
+        'Dropboxに接続し、選択したアカウントのファイルとフォルダを同期します。',
+      teamsDescription:
+        'Microsoft Graph経由でMicrosoft Teamsに接続し、チャネルの投稿と返信を同期します。',
+      teamsTenantIdTip:
+        'Azure ADのテナントIDです。Team.ReadBasic.AllおよびChannelMessage.Read.Allのアプリケーション権限（管理者の同意）を持つアプリが必要です。',
+      slackDescription:
+        'Slackワークスペースに接続し、チャネルのメッセージとスレッドを同期します。',
+      slackBotTokenTip:
+        'Slackボットユーザーのユーザー OAuthトークンです（xoxb- で始まります）。アプリにはchannels:read、channels:history、users:readのスコープが必要です。',
+      slackChannelsTip:
+        '任意項目: 同期するチャネル名を指定してください（例: general）。空欄にするとアクセス可能なすべてのチャネルが同期されます。',
+      sharepointDescription:
+        'Microsoft Graph経由でSharePointサイトに接続し、ドキュメントライブラリを同期します。',
+      sharepointSiteUrlTip:
+        'インデックス対象のSharePointサイトの完全なURLです（例: https://contoso.sharepoint.com/sites/MySite）。Sites.Read.AllおよびFiles.Read.Allのアプリケーション権限（管理者の同意）を持つAzure ADアプリが必要です。',
+      bitbucketDescription: 'Bitbucketに接続し、PRの内容を同期します。',
+      bitbucketTopWorkspaceTip:
+        'インデックス対象のBitbucketワークスペースです（例: https://bitbucket.org/atlassian/workspace の「atlassian」）。',
+      bitbucketRepositorySlugsTip:
+        'リポジトリのスラッグをカンマ区切りで指定してください。例: repo-one,repo-two',
+      bitbucketProjectsTip:
+        'プロジェクトキーをカンマ区切りで指定してください。例: PROJ1,PROJ2',
+      bitbucketWorkspaceTip:
+        'このコネクタはワークスペース内のすべてのリポジトリをインデックスします。',
+      boxDescription: 'Boxドライブに接続し、ファイルとフォルダを同期します。',
+      githubDescription:
+        'GitHubに接続し、検索用にプルリクエストとIssueを同期します。',
+      airtableDescription:
+        'Airtableに接続し、指定したワークスペース内の指定テーブルからファイルを同期します。',
+      gitlabDescription:
+        'GitLabに接続し、リポジトリ、Issue、マージリクエスト、関連ドキュメントを同期します。',
+      asanaDescription:
+        'Asanaに接続し、指定したワークスペースからファイルを同期します。',
+      imapDescription:
+        'IMAPメールボックスに接続し、ナレッジ検索用にメールを同期します。',
+      dropboxAccessTokenTip:
+        'Dropbox App Consoleで、files.metadata.read、files.content.read、sharing.readのスコープを持つ長期間有効なアクセストークンを生成してください。',
+      moodleDescription:
+        'Moodle LMSに接続し、コースコンテンツ、フォーラム、リソースを同期します。',
+      moodleUrlTip:
+        'Moodleインスタンスのベース URLです（例: https://moodle.university.edu）。/webservice や /login は含めないでください。',
+      moodleTokenTip:
+        'Moodleでウェブサービストークンを生成してください: サイト管理 → サーバー → ウェブサービス → トークンの管理から行えます。同期したいコースにユーザーが登録されている必要があります。',
+      seafileDescription:
+        'SeaFileサーバーに接続し、ライブラリ内のファイルとドキュメントを同期します。',
+      seafileUrlTip:
+        'プロトコルを含むSeaFileサーバーの完全なURLです。例: https://seafile.example.com - 末尾のスラッシュやドメイン以降のパスは含めないでください。',
+      seafileAccountScopeTip:
+        '以下のAccount API Tokenでアクセス可能なすべてのライブラリを同期します。',
+      seafileTokenPanelHeading: '以下のいずれかの認証方法を指定してください:',
+      seafileTokenPanelAccountBullet:
+        '- すべてのライブラリへのアクセス権を付与します。',
+      seafileTokenPanelLibraryBullet:
+        '— 単一のライブラリのみに限定されます（より安全です）。',
+      seafileValidationAccountTokenRequired:
+        '「アカウント全体」スコープではAccount API Tokenが必須です',
+      seafileValidationTokenRequired:
+        'Account API TokenまたはLibrary Tokenのいずれかを指定してください',
+      seafileValidationLibraryIdRequired: 'Library IDは必須です',
+      seafileValidationDirectoryPathRequired: 'Directory Pathは必須です',
+      seafileSyncScopeTip:
+        '同期対象の範囲を制御します: (1) アカウント全体 - トークンがアクセス可能なすべてのライブラリを同期します。Account API Tokenが必要です。(2) 単一ライブラリ - 特定の1つのライブラリ内のすべてのファイルを同期します。Library ID、およびAccount API TokenまたはLibrary API Tokenのいずれかが必要です。(3) 特定のディレクトリ - ライブラリ内の特定のフォルダ内のファイルのみを同期します。Library ID、そのライブラリ内のフォルダパス、およびAccount API TokenまたはLibrary API Tokenのいずれかが必要です。',
+      seafileTokenTip:
+        'アカウントレベルのSeaFile APIトークンです。アカウントからアクセス可能なすべてのライブラリへのアクセス権を付与します。同期範囲が「アカウント全体」の場合は必須です。「単一ライブラリ」または「特定のディレクトリ」の場合は、このトークンの代わりにLibrary API Tokenを使用することもできます。',
+      seafileRepoTokenTip:
+        '特定の1つのライブラリのみへのアクセス権を付与する、ライブラリ単位のAPIトークンです。「単一ライブラリ」および「特定のディレクトリ」の同期範囲では、Account API Tokenの代わりに使用できます。',
+      seafileRepoIdTip:
+        '同期したいSeaFileライブラリの一意の識別子（UUID）です。SeaFileのWebインターフェースでライブラリを開いた際のブラウザのアドレスバーで確認できます。例: 7a9e1b3c-4d5f-6a7b-8c9d-0e1f2a3b4c5d。同期範囲が「単一ライブラリ」または「特定のディレクトリ」の場合は必須です。',
+      seafileSyncPathTip:
+        '上記のLibrary IDで指定したライブラリ内で同期するフォルダの絶対パスです。スラッシュ（/）から始まる必要があります。このパス配下のすべてのファイルとサブフォルダが再帰的に対象となります。例: /Documents/Reports。重要: フォルダは指定したライブラリ内に存在している必要があります。ライブラリ外のパスはサポートされていません。同期範囲が「特定のディレクトリ」の場合にのみ使用されます。',
+      seafileIncludeSharedTip:
+        '有効にすると、他のユーザーから共有されたライブラリも同期対象に含まれます。無効にすると、自分のアカウントが所有するライブラリのみが同期されます。同期範囲が「アカウント全体」の場合にのみ適用されます。',
+      seafileBatchSizeTip:
+        '同期時に1バッチあたりで処理・返却されるドキュメント数です。小さい値にするとメモリ使用量は減りますが、全体の処理は遅くなる場合があります。デフォルト: 100。',
+      jiraDescription:
+        'Jiraワークスペースに接続し、Issue、コメント、添付ファイルを同期します。',
+      jiraBaseUrlTip:
+        'Jiraサイトのベース URLです（例: https://your-domain.atlassian.net）。',
+      jiraProjectKeyTip:
+        '任意項目: 同期対象を単一のプロジェクトキーに限定します（例: ENG）。',
+      jiraJqlTip:
+        '任意のJQLフィルタです。空欄にするとプロジェクト/期間フィルタに従います。',
+      jiraBatchSizeTip:
+        '1バッチあたりにJiraへリクエストするIssueの最大数です。',
+      jiraCommentsTip:
+        '生成されるMarkdownドキュメントにJiraのコメントを含めます。',
+      jiraAttachmentsTip:
+        '同期時に添付ファイルを個別のドキュメントとしてダウンロードします。',
+      jiraAttachmentSizeTip:
+        'このバイト数を超える添付ファイルはスキップされます。',
+      jiraLabelsTip: 'インデックス時にスキップするラベルです（カンマ区切り）。',
+      jiraBlacklistTip:
+        '投稿者のメールアドレスがこれらの項目に一致するコメントは無視されます。',
+      jiraScopedTokenTip:
+        'スコープ付きのAtlassianトークン（api.atlassian.com）を使用する場合に有効にしてください。',
+      jiraEmailTip: 'Jiraアカウント/APIトークンに紐づくメールアドレスです。',
+      jiraTokenTip:
+        'https://id.atlassian.com/manage-profile/security/api-tokens で生成したAPIトークンです。',
+      jiraPasswordTip:
+        'Jira Server/Data Center環境向けの任意のパスワードです。',
+      mysqlDescription:
+        'MySQLデータベースに接続し、SQLクエリでテーブルからデータを同期します。',
+      mysqlQueryTip:
+        'データベースからデータを抽出するSQLクエリです（例: SELECT * FROM products WHERE status = "active"）。',
+      mysqlContentColumnsTip:
+        'ベクトル化のためにドキュメントの内容として結合するカラム名をカンマ区切りで指定してください。',
+      mysqlMetadataColumnsTip:
+        'ドキュメントのメタデータとして保存するカラム名をカンマ区切りで指定してください（ベクトル化はされませんが検索可能です）。',
+      mysqlIdColumnTip:
+        'ドキュメントの一意なIDとして使用するカラムです。指定しない場合は、内容のハッシュ値が使用されます。',
+      mysqlTimestampColumnTip:
+        '差分同期に使用する日時/タイムスタンプのカラムです。前回の同期以降に変更された行のみが取得されます。',
+      postgresqlDescription:
+        'PostgreSQLデータベースに接続し、SQLクエリでテーブルからデータを同期します。',
+      postgresqlQueryTip:
+        "データベースからデータを抽出するSQLクエリです（例: SELECT * FROM products WHERE status = 'active'）。",
+      postgresqlContentColumnsTip:
+        'ベクトル化のためにドキュメントの内容として結合するカラム名をカンマ区切りで指定してください。',
+      postgresqlMetadataColumnsTip:
+        'ドキュメントのメタデータとして保存するカラム名をカンマ区切りで指定してください（ベクトル化はされませんが検索可能です）。',
+      postgresqlIdColumnTip:
+        'ドキュメントの一意なIDとして使用するカラムです。指定しない場合は、内容のハッシュ値が使用されます。',
+      postgresqlTimestampColumnTip:
+        '差分同期に使用する日時/タイムスタンプのカラムです。前回の同期以降に変更された行のみが取得されます。',
+      bigqueryDescription:
+        'Google BigQueryに接続し、テーブルまたはカスタムのGoogleSQLクエリから行を同期します。',
+      bigqueryProjectIdTip:
+        'クエリジョブの実行元となるGCPプロジェクトです（例: my-gcp-project）。',
+      bigqueryLocationTip:
+        'クライアントおよびクエリジョブのデフォルトのロケーションです（USやEUなど）。空欄にするとBigQueryが自動的に推測します。',
+      bigqueryServiceAccountJsonTip:
+        'BigQueryへのアクセス権を持つサービスアカウントキーのJSONです。キーファイルの内容全体を貼り付けてください。',
+      bigqueryDatasetIdTip:
+        'テーブルモード用のデータセットIDです。SQLクエリを指定しない場合、Table IDとあわせて必須です。',
+      bigqueryTableIdTip:
+        'テーブルモード用のテーブルIDです。SQLクエリを指定しない場合、Dataset IDとあわせて必須です。',
+      bigqueryQueryTip:
+        'カスタムのGoogleSQLクエリです。Dataset IDおよびTable IDより優先されます。標準SQLのみ使用できます。',
+      bigqueryContentColumnsTip:
+        'ベクトル化のためにドキュメントの内容として結合するカラム名をカンマ区切りで指定してください。',
+      bigqueryMetadataColumnsTip:
+        'ドキュメントのメタデータとして保存するカラム名をカンマ区切りで指定してください（ベクトル化はされませんが検索可能です）。',
+      bigqueryIdColumnTip:
+        'ドキュメントの一意なIDとして使用するカラムです。指定しない場合は、内容のハッシュ値が使用されます。',
+      bigqueryTimestampColumnTip:
+        '差分同期に使用するタイムスタンプ、日時、日付、または数値型のカラムです。前回の同期より新しい行のみが取得されます。',
+      bigqueryMaximumBytesBilledTip:
+        'すべてのクエリジョブに適用される、バイト単位のコスト上限です。デフォルトは1 GiBです。',
+      bigqueryJobTimeoutMsTip:
+        'クエリジョブごとの任意のタイムアウト時間です（ミリ秒単位）。',
+      rest_apiDescription:
+        '柔軟な設定ベースのコネクタを使用して、任意のREST APIエンドポイントをデータソースとして接続します。',
+      onedriveDescription:
+        'OneDriveまたはOneDrive for Businessに接続し、Microsoft Graphの差分クエリでファイルとフォルダをインデックスします。',
+      onedriveTenantIdTip:
+        'Microsoft 365組織のAzure Active DirectoryテナントID（ディレクトリID）です。',
+      onedriveClientIdTip:
+        'Files.Read.All権限を持つAzure ADアプリ登録のアプリケーション（クライアント）IDです。',
+      onedriveClientSecretTip:
+        'Azure ADアプリ登録で生成したクライアントシークレットの値です。',
+      onedriveFolderPathTip:
+        'インデックス対象を限定する任意のサブフォルダパスです（例: /Documents/Reports）。空欄にするとドライブ全体がインデックスされます。',
+      outlookDescription:
+        'Outlook / Microsoft 365のメールボックスに接続し、Microsoft Graphの差分クエリでメッセージをインデックスします。',
+      outlookTenantIdTip:
+        'Microsoft 365組織のAzure Active DirectoryテナントID（ディレクトリID）です。',
+      outlookClientIdTip:
+        'Mail.Read権限を持つAzure ADアプリ登録のアプリケーション（クライアント）IDです。',
+      outlookClientSecretTip:
+        'Azure ADアプリ登録で生成したクライアントシークレットの値です。',
+      outlookFolderTip:
+        '同期するメールフォルダです（例: inbox、sentitems、archive）。デフォルトはinboxです。',
+      outlookUserIdsTip:
+        '同期するメールボックスのUPNまたはオブジェクトIDをカンマ区切りで指定してください。空欄にするとテナント内のすべてのメールボックスが同期されます（User.Read.Allが必要です）。',
+      salesforceDescription:
+        'Salesforce組織に接続し、SOQLによる差分同期でCRMレコード（取引先、取引先責任者、商談、ケース、Knowledge記事）をインデックスします。',
+      salesforceInstanceUrlTip:
+        'Salesforce組織のURLです（例: https://your-domain.my.salesforce.com）。末尾にスラッシュは付けないでください。',
+      salesforceClientIdTip:
+        'Client Credentials Flowが有効でapiスコープを持つConnected AppのConsumer Keyです。',
+      salesforceClientSecretTip:
+        'クライアントクレデンシャル認証に使用するConnected AppのConsumer Secretです。',
+      salesforceObjectsTip:
+        'インデックス対象のSObject API名をカンマ区切りで指定してください。デフォルトはAccount、Contact、Opportunity、Case、Knowledge__kavです。',
+      salesforceApiVersionTip:
+        'Salesforce REST APIのバージョンです（例: v59.0）。組織がサポートするバージョンを使用してください。',
+      azure_blobDescription:
+        'Azure Blob StorageコンテナのBlobをナレッジベースにインデックスします。アカウントキー、接続文字列、SASトークンによる認証に対応しています。変更のないBlobはETagによる指紋照合でスキップされます。',
+      azureBlobAuthModeTip:
+        '認証方法を選択してください。Account KeyおよびConnection Stringにはcontainer_nameが必要です。SAS Tokenにはcontainer_urlとsas_tokenが必要です。',
+      azureBlobAccountNameTip:
+        'Azureストレージアカウント名です（例: mystorageaccount）。account-key認証では必須です。',
+      azureBlobAccountKeyTip:
+        'ストレージアカウントのアクセスキーです（Base64エンコード）。account-key認証では必須です。',
+      azureBlobConnectionStringTip:
+        'Azure Storageの完全な接続文字列です（DefaultEndpointsProtocol=https;AccountName=...;...）。connection-string認証では必須です。',
+      azureBlobContainerUrlTip:
+        'コンテナの完全なHTTPS URLです（例: https://account.blob.core.windows.net/container）。SAS-token認証では必須です。',
+      azureBlobSasTokenTip:
+        'SASのクエリ文字列です（先頭の「?」は含めません）。SAS-token認証では必須です。',
+      azureBlobContainerNameTip:
+        'インデックス対象のコンテナ名です。account-key認証およびconnection-string認証では必須です。',
+      azureBlobPrefixTip:
+        'インデックス対象を仮想フォルダに限定する任意のBlob名プレフィックスです（例: documents/reports/）。空欄にするとコンテナ全体がインデックスされます。',
+      restApiQueryParamsTip:
+        'URLのクエリパラメータとして送信するKey=valueのペアです（1行に1つ）。URLにパラメータを埋め込む代わりにこちらを使用してください。',
+      restApiHeadersTip:
+        'すべてのリクエストに追加で送信するHTTPヘッダーの任意のJSONオブジェクトです。',
+      restApiItemsPathTip:
+        'レスポンス内のアイテム配列を指すフィールド名またはJSONPathです。空欄にすると自動検出を試みます（「items」「results」「data」など）。',
+      restApiIdFieldTip:
+        '各アイテム内で、安定したドキュメントIDの生成に使用するフィールドパスです。空欄にすると内容のハッシュから自動生成されます。',
+      restApiContentFieldsTip:
+        'ドキュメントの内容として連結するアイテムのフィールドをカンマ区切りで指定してください。',
+      restApiMetadataFieldsTip:
+        'メタデータとして保存するアイテムのフィールドをカンマ区切りで指定してください。',
+      restApiNextCursorPathTip:
+        'APIレスポンス内の次ページカーソルを指すJSONPath式です。',
+      restApiPollTimestampFieldTip:
+        '差分同期に使用する、各アイテム内の最終更新日時を表すフィールドパスです。',
+      restApiRequestBodyTip:
+        'POSTリクエストで送信する任意のJSONボディです。クエリパラメータやページネーションとあわせて使用します。',
+      restApiRequestDelayTip:
+        '連続するページリクエストの間の待機時間です（秒単位）。APIのレート制限を回避するのに役立ちます。無効にする場合は0を指定してください。',
+      restApiValidationApiKeyRequired:
+        'Auth TypeがAPI Key (Header)の場合、APIキーは必須です。',
+      restApiValidationApiKeyHeaderNameRequired:
+        'Auth TypeがAPI Key (Header)の場合、APIキーのヘッダー名は必須です。',
+      restApiValidationBearerTokenRequired:
+        'Auth TypeがBearer Tokenの場合、Bearerトークンは必須です。',
+      restApiValidationBasicUsernameRequired:
+        'Auth TypeがBasic Authの場合、ユーザー名は必須です。',
+      restApiValidationBasicPasswordRequired:
+        'Auth TypeがBasic Authの場合、パスワードは必須です。',
+      restApiTestConnection: '接続テスト',
+      restApiTestSuccess: 'REST APIコネクタの検証に成功しました。',
+      restApiTestFailed:
+        'REST APIコネクタの検証に失敗しました。設定とログを確認してください。',
+      availableSourcesDescription: '追加するデータソースを選択してください',
+      availableSources: '利用可能なソース',
+      datasourceDescription: 'データソースと接続を管理します',
+      chatChannels: 'チャットチャネル',
+      chatChannelsDescription: 'チャットチャネルのボットと認証情報を管理します',
+      compilationTemplates: 'コンパイルテンプレート',
+      compilationTemplatesDescription: 'コンパイルテンプレートを管理します',
+      addTemplateGroup: 'テンプレートグループを追加',
+      editTemplateGroup: 'テンプレートグループを編集',
+      groupName: 'グループ名',
+      groupNameRequired: 'グループ名を入力してください',
+      groupDescription: 'グループの説明',
+      templateCount: '{{count}}件のテンプレート',
+      atLeastOneTemplateRequired: '少なくとも1つのテンプレートが必要です',
+      template: 'テンプレート',
+      deleteTemplateGroupModalTitle: 'テンプレートグループを削除',
+      deleteTemplateGroupModalContent:
+        'このテンプレートグループを削除してもよろしいですか？この操作は元に戻せません。',
+      addTemplate: 'テンプレートを追加',
+      noTemplates: 'コンパイルテンプレートはまだありません。',
+      deleteTemplateModalTitle: 'テンプレートを削除',
+      deleteTemplateModalContent:
+        'このテンプレートを削除してもよろしいですか？この操作は元に戻せません。',
+      editTemplate: 'テンプレートを編集',
+      templateName: '名前',
+      templateNameRequired: 'テンプレート名を入力してください',
+      templateDescription: '説明',
+      llmForExtraction: '抽出用LLM',
+      llmForExtractionRequired: 'LLMモデルを選択してください',
+      templateKind: '種類',
+      templateKindRequired: '種類を選択してください',
+      entitySpecification: 'エンティティ仕様',
+      relationSpecification: 'リレーション仕様',
+      conceptSpecification: 'コンセプト仕様',
+      claimSpecification: 'クレーム仕様',
+      field: 'フィールド',
+      fieldType: 'タイプ',
+      fieldTypeRequired: 'タイプを選択してください',
+      fieldDescription: '説明',
+      fieldDescriptionRequired: '説明を入力してください',
+      fieldRule: 'ルール',
+      rulePlaceholder: '抽出ルールを入力',
+      description: '説明',
+      descriptionPlaceholder: '説明を入力してください',
+      addField: 'フィールドを追加',
+      example: 'ページ構成の例',
+      examplePlaceholder: '入力例',
+      instruction: '指示',
+      globalRules: 'グローバルルール',
+      globalRulesPlaceholder: 'グローバルなコンパイルルールを入力してください',
+      raptorTreeSettings: 'RAPTORツリー設定',
+      summarizationPrompt: '要約プロンプト',
+      maxToken: '最大トークン数',
+      maxTokenRequired: '最大トークン数を入力してください',
+      threshold: '閾値',
+      rechunkByTreeLeaves: 'ツリーの葉ノードで再チャンク化',
+      rechunkByTreeLeavesTip:
+        '各葉クラスターの元チャンクを1つの置換用チャンクに統合します。元のチャンクは保持されますが、検索には使用できないマークが付けられます。この設定を有効にできるツリーテンプレートは、グループごとに1つのみです。',
+      jsonPreview: 'JSONプレビュー',
+      processFlow: '処理フロー',
+      processFlowComingSoon: '処理フローのプレビューは近日公開予定です',
+      basicInfo: '基本情報',
+      basicInfoDescription: 'テンプレートグループの基本情報',
+      templateWizardConfiguration: '設定',
+      templateWizardConfigurationDescription: 'テンプレートを設定します',
+      blueprints: 'ブループリント',
+      blueprintsDescription: '必要なブループリントを選択してください',
+      templates: 'テンプレート',
+      addFieldModalTitle: 'フィールドを追加',
+      editFieldModalTitle: 'フィールドを編集',
+      selectFieldType: 'フィールドタイプを選択',
+      blueprintsPlaceholder: 'ブループリントのプレースホルダー',
+      blueprintsPlaceholderDescription:
+        '左側のブループリントライブラリから特定の構造を選択またはカスタマイズして、Wikiのコンテンツ構成と表示形式を定義します。',
+      blueprintsPlaceholderSkip:
+        '特に要件がない場合は、このステップをスキップしても構いません。その場合、システムがデフォルトの構造を自動的に適用します。',
+      useBlueprint: 'このブループリントを使用',
+      channelEmptyTip:
+        'チャットチャンネルはまだ追加されていません。以下から選択して接続してください。',
+      availableChannels: '利用可能なチャンネル',
+      availableChannelsDescription:
+        '追加するチャットチャンネルを選択してください',
+      addChannelModalTitle: '{{name}}ボットを追加',
+      editChannelModalTitle: '{{name}}ボットを編集',
+      deleteChannelModalTitle: 'チャットチャンネルを削除',
+      deleteChannelModalContent:
+        'このチャットチャンネルボットを削除してもよろしいですか?この操作は取り消せません。',
+      connectDialog: 'アシスタントを接続',
+      connectDialogTitle: '{{name}}をアシスタントに接続',
+      selectDialog: 'アシスタントを選択',
+      connectDialogTip:
+        'このチャンネルで受信したメッセージには、接続されたアシスタントが応答します。選択を解除すると接続が解除されます。',
+      notConnected: 'アシスタントが接続されていません',
+
+      chatChannelDesc: {
+        clickclack: 'ClickClackボットを接続',
+        discord: 'Discordボットを接続',
+        dingtalk: 'DingTalkボットを接続',
+        feishu: 'Feishu / Larkボットを接続',
+        googlechat: 'Google Chatボットを接続',
+        irc: 'IRCサーバーに接続',
+        line: 'LINEメッセージングボットを接続',
+        matrix: 'Matrixボットを接続',
+        mattermost: 'Mattermostボットを接続',
+        msteams: 'Microsoft Teamsボットを接続',
+        nextcloud_talk: 'Nextcloud Talkボットを接続',
+        nostr: 'Nostrボットを接続',
+        qqbot: 'QQボットを接続',
+        slack: 'Slackボットを接続',
+        synology_chat: 'Synology Chatボットを接続',
+        telegram: 'Telegramボットを接続',
+        tlon: 'Tlon (Urbit) ボットを接続',
+        twitch: 'Twitchチャットボットを接続',
+        wecom: 'WeComボットを接続',
+        whatsapp: 'WhatsAppボットを接続 (QRペアリング)',
+        yuanbao: 'Tencent Yuanbaoボットを接続',
+        zalo: 'Zaloボットを接続',
+        zalouser: '個人のZaloアカウントを接続',
+      },
+
+      save: '保存',
+      search: '検索',
+      availableModels: '利用可能なモデル',
+      avatarTip: 'これはプロフィールに表示されます。',
+      systemModelDescription: '開始する前にこれらの設定を完了してください',
+      dataSources: 'データソース',
+      usernameMaxLength: '名前は{{max}}文字以内で入力してください。',
+      usernameInvalidCharacters:
+        "名前には英数字、スペース、および . _ ' - のみ使用できます",
+      changePassword: 'パスワードを変更',
+      openaiBaseUrlPlaceholder: 'https://api.openai.com/v1',
+      anthropicBaseUrlPlaceholder: 'https://api.anthropic.com/v1',
+      siliconflowBaseUrlPlaceholder: 'https://api.siliconflow.cn/v1',
+      groupId: 'グループID',
+      providerOrder: 'プロバイダーの順序',
+      paddleocrApiUrl: 'PaddleOCR API URL',
+      paddleocrApiUrlMessage: 'PaddleOCR API URLを入力してください!',
+      paddleocrApiUrlPlaceholder:
+        '例: https://paddleocr-server.com/layout-parsing',
+      paddleocrAccessToken: 'AI Studioアクセストークン',
+      paddleocrAccessTokenMessage: 'PaddleOCR APIのアクセストークン (任意)',
+      paddleocrAccessTokenPlaceholder: 'AI Studioのトークン (任意)',
+      paddleocrAlgorithm: 'PaddleOCRアルゴリズム',
+      paddleocrAlgorithmMessage: 'PaddleOCRアルゴリズムを選択してください',
+      mineruApiserver: 'MinerU APIサーバー',
+      mineruApiserverMessage: 'MinerU APIサーバーのURLを入力してください!',
+      mineruApiserverPlaceholder: '例: http://host.docker.internal:9987',
+      mineruOutputDir: 'MinerU出力ディレクトリ',
+      mineruOutputDirMessage: 'MinerUの出力ディレクトリを入力してください!',
+      mineruOutputDirPlaceholder: '/tmp/mineru',
+      mineruBackend: 'MinerUバックエンド',
+      mineruBackendMessage: 'MinerUバックエンドを選択してください!',
+      mineruSelectBackend: '処理バックエンドを選択',
+      mineruServerUrl: 'MinerUサーバーURL',
+      mineruServerUrlMessage: 'MinerUサーバーURLを入力してください!',
+      mineruServerUrlPlaceholder: '例: http://your-vllm-server:30000',
+      mineruDeleteOutput: '出力ファイルを削除',
+      mineruDeleteOutputMessage: '出力ファイル削除の値が無効です',
+      opendataloaderApiserver: 'OpenDataLoader APIサーバー',
+      opendataloaderApiserverMessage:
+        'OpenDataLoader APIサーバーを入力してください!',
+      opendataloaderApiserverPlaceholder:
+        'http://your-opendataloader-service:9383',
+      default: 'デフォルト',
+      empty: 'データがありません',
+      docLink: 'ドキュメントリンク',
+      addInstance: 'インスタンスを追加',
+      addInstanceText: 'インスタンスを追加',
+      noInstancesConfigured: 'インスタンスはまだ設定されていません。',
+      saveAll: 'すべて保存',
+      editInstanceName: 'インスタンス名を編集',
+      models: 'モデル',
+      instanceName: 'インスタンス名',
+      instanceNameMessage: 'インスタンス名を入力してください!',
+      instanceNameTip:
+        '同一プロバイダー内でこのインスタンスを識別するための一意な名前です。',
+      instanceNamePlaceholder: 'インスタンス名を入力してください',
+      deleteInstance: 'インスタンスを削除',
+      'us-east-2': '米国東部 (オハイオ)',
+      'us-west-1': '米国西部 (北カリフォルニア)',
+      'af-south-1': 'アフリカ (ケープタウン)',
+      'ap-east-1': 'アジアパシフィック (香港)',
+      'ap-south-2': 'アジアパシフィック (ハイデラバード)',
+      'ap-southeast-3': 'アジアパシフィック (ジャカルタ)',
+      'ap-southeast-5': 'アジアパシフィック (マレーシア)',
+      'ap-southeast-4': 'アジアパシフィック (メルボルン)',
+      'ap-south-1': 'アジアパシフィック (ムンバイ)',
+      'ap-northeast-3': 'アジアパシフィック (大阪)',
+      'ap-northeast-2': 'アジアパシフィック (ソウル)',
+      'ap-east-2': 'アジアパシフィック (台北)',
+      'ap-southeast-7': 'アジアパシフィック (タイ)',
+      'ca-central-1': 'カナダ (中部)',
+      'ca-west-1': 'カナダ西部 (カルガリー)',
+      'eu-west-1': '欧州 (アイルランド)',
+      'eu-west-2': '欧州 (ロンドン)',
+      'eu-south-1': '欧州 (ミラノ)',
+      'eu-west-3': '欧州 (パリ)',
+      'eu-south-2': '欧州 (スペイン)',
+      'eu-north-1': '欧州 (ストックホルム)',
+      'eu-central-2': '欧州 (チューリッヒ)',
+      'il-central-1': 'イスラエル (テルアビブ)',
+      'mx-central-1': 'メキシコ (中部)',
+      'me-south-1': '中東 (バーレーン)',
+      'me-central-1': '中東 (アラブ首長国連邦)',
+      'sa-east-1': '南米 (サンパウロ)',
+      'us-gov-east-1': 'AWS GovCloud (米国東部)',
+      inviteTip:
+        '招待できるのは登録済みのユーザーのみです。招待を送る前にアカウントを登録してください。',
+      secretKey: 'シークレットキー',
+      publicKey: '公開鍵',
+      secretKeyMessage: 'シークレットキーを入力してください',
+      publicKeyMessage: '公開鍵を入力してください',
+      hostMessage: 'ホストを入力してください',
+      configuration: '設定',
+      langfuseDescription:
+        'LLMアプリケーションのデバッグと改善のためのトレース、評価、プロンプト管理、メトリクス。',
+      viewLangfuseSDocumentation: 'Langfuseのドキュメントを表示',
+      view: '表示',
+      mcp: 'MCP',
+
+      mineru: {
+        modelNameRequired: 'モデル名は必須です',
+        apiServerRequired: 'MinerU APIサーバー設定は必須です',
+        serverUrlBackendLimit:
+          'MinerUサーバーURLアドレスはHTTPクライアントバックエンドでのみ使用できます',
+        apiserver: 'MinerU APIサーバー設定',
+        outputDir: 'MinerU出力ディレクトリのパス',
+        backend: 'MinerU処理バックエンドの種類',
+        serverUrl: 'MinerUサーバーURLアドレス',
+        deleteOutput: '処理後に出力ファイルを削除',
+        selectBackend: '処理バックエンドを選択',
+
+        backendOptions: {
+          pipeline: '標準パイプライン処理',
+          vlmTransformers: 'Vision Language Model (Transformers使用)',
+          vlmVllmEngine: 'Vision Language Model (vLLMエンジン使用)',
+          vlmHttpClient: 'Vision Language Model (HTTPクライアント経由)',
+          vlmMlxEngine: 'Vision Language Model (MLXエンジン使用)',
+          vlmVllmAsyncEngine:
+            'Vision Language Model (vLLM非同期エンジン使用、実験的機能)',
+          vlmLmdeployEngine:
+            'Vision Language Model (LMDeployエンジン使用、実験的機能)',
+        },
+      },
+
+      somark: {
+        modelNameMessage: 'モデル名を入力してください',
+        baseUrl: 'ベースURL',
+        baseUrlMessage: 'ベースURLを入力してください',
+        baseUrlPlaceholder:
+          'SoMark APIの場合、中国本土では https://somark.cn/api/v1 を、中国本土以外(台湾、香港、マカオ、海外を含む)では https://somark.ai/api/v1 を使用してください。セルフホスト環境の場合は、ローカルのベースURLを使用してください',
+        apiKey: 'APIキー',
+        apiKeyPlaceholder:
+          'SoMark APIを使用する場合は必須です。セルフホスト環境の場合は空欄のままにしてください',
+        verifyPassed: '検証済み',
+        verifyFailed: '検証に失敗しました',
+        sectionElementFormats: '要素フォーマット',
+        imageFormat: '画像フォーマット',
+        formulaFormat: '数式フォーマット',
+        tableFormat: 'テーブルフォーマット',
+        csFormat: '化学構造式フォーマット',
+        sectionFeatureConfig: '機能設定',
+        enableInlineImage: 'インライン画像を有効化',
+        enableTableImage: 'テーブル画像を有効化',
+        enableImageUnderstanding: '画像理解を有効化',
+        enableTitleLevelRecognition: '見出しレベル認識を有効化',
+        enableTextCrossPage: 'ページをまたぐテキストの結合を有効化',
+        enableTableCrossPage: 'ページをまたぐテーブルの結合を有効化',
+        keepHeaderFooter: 'ヘッダー・フッターを保持',
+        purchaseUrl:
+          'API購入: 中国本土 — https://somark.cn/workbench/purchase / 海外(台湾、香港、マカオを含む) — https://somark.ai/studio/purchase',
+      },
+
+      modelTypes: {
+        chat: 'チャット',
+        embedding: '埋め込み',
+        rerank: '再ランク',
+        sequence2text: 'sequence2text',
+        tts: 'TTS',
+        image2text: 'VLM',
+        ocr: 'OCR',
+        speech2text: 'ASR',
+      },
+
+      showToc: 'コンテンツを表示',
+      hideToc: 'コンテンツを非表示',
+      listModels: 'モデル一覧',
+      allModels: 'すべてのモデル',
+      listModelsSearchPlaceholder: 'モデルを検索…',
+      listModelsEmpty: '利用可能なモデルがありません',
+      listModelsLoading: 'モデルを読み込み中…',
+      selectModelBeforeVerify:
+        '検証する前に、少なくとも1つのモデルを選択してください。',
+      addCustomModel: 'カスタムモデルを追加',
+      addCustomModelTitle: 'カスタムモデルを追加',
+      batchAddModels: '表示中のモデルをすべて追加',
+      batchRemoveModels: '表示中のモデルをすべて削除',
+      editCustomModelTitle: 'モデルを編集',
+      modelMaxTokens: '最大トークン数',
+      modelFeatures: 'モデル機能',
+      modelFeatureToolCall: 'ツールコール',
+      modelFeatureFunctionCall: 'ファンクションコール',
+      modelNameRequired: 'モデル名は必須です',
+      modelNameDuplicate: 'モデル名はすでに存在します',
+      modelTypeRequired: '少なくとも1つのモデルタイプを選択してください',
+      modelMaxTokensMessage: '最大トークン数は数値で入力してください',
+      modelMaxTokensMinMessage: '最大トークン数は0以上で入力してください',
     },
+
     message: {
       registered: '登録完了！',
       logout: 'ログアウト',
@@ -736,11 +1930,15 @@ export default {
       503: 'サービスが利用できず、サーバーが一時的に過負荷状態かメンテナンス中です。',
       504: 'ゲートウェイタイムアウト。',
       requestError: 'リクエストエラー',
+
       networkAnomalyDescription:
         'ネットワークに異常があり、サーバーに接続できません。',
+
       networkAnomaly: 'ネットワーク異常',
       hint: 'ヒント',
+      registerDisabled: 'ユーザー登録は無効になっています',
     },
+
     fileManager: {
       name: '名前',
       uploadDate: 'アップロード日',
@@ -755,16 +1953,26 @@ export default {
       parseOnCreation: '作成時に解析',
       directory: 'ディレクトリ',
       uploadTitle: 'クリックまたはドラッグしてファイルをアップロード',
+
       uploadDescription:
         'RAGFlowは、単一またはバッチでのファイルアップロードをサポートします。ローカルにデプロイされた RAGFlow の場合: アップロードごとの合計ファイルサイズ制限は 1GB、バッチアップロードの制限は 32 ファイルです。アカウントごとのファイル総数には制限がありません。cloud.ragflow.io の場合: アップロードごとの合計ファイルサイズ制限は 10MB、各ファイルは 10MB を超えず、アカウントごとに最大 128 ファイルまでです。',
+
       local: 'ローカルアップロード',
       s3: 'S3アップロード',
       preview: 'プレビュー',
       fileError: 'ファイルエラー',
+
       uploadLimit:
         'RAGFlowは、単一またはバッチでのファイルアップロードをサポートします。ローカルにデプロイされた RAGFlow の場合: アップロードごとの合計ファイルサイズ制限は 1GB、バッチアップロードの制限は 32 ファイルです。アカウントごとのファイル総数には制限がありません。cloud.ragflow.io の場合: アップロードごとの合計ファイルサイズ制限は 10MB、各ファイルは 10MB を超えず、アカウントごとに最大 128 ファイルまでです。',
+
       destinationFolder: '保存先フォルダ',
+      uploadFolderTitle: 'フォルダをアップロード',
+      folder: 'フォルダ',
+      files: 'ファイル',
+      pleaseUploadAtLeastOneFile:
+        '少なくとも1つのファイルをアップロードしてください',
     },
+
     flow: {
       cite: '引用',
       citeTip: '引用に関するヒント',
@@ -779,8 +1987,10 @@ export default {
       addField: 'フィールドを追加',
       addMessage: 'メッセージを追加',
       loop: 'ループ',
+
       loopTip:
         'ループは現在のコンポーネントのループ回数の上限です。ループの値を超えると、コンポーネントが現在のタスクを完了できないことを意味します。エージェントを再最適化してください。',
+
       yes: 'はい',
       no: 'いいえ',
       key: 'キー',
@@ -797,14 +2007,18 @@ export default {
       categorizeDescription: `LLMを使用してユーザーの入力を事前定義されたカテゴリに分類するコンポーネント。各カテゴリの名前、説明、例、および対応する次のコンポーネントを指定してください。`,
       relevantDescription: `LLMを使用して、上流の出力がユーザーの最新のクエリに関連しているかどうかを評価するコンポーネント。各判定結果に対して次のコンポーネントを指定してください。`,
       rewriteQuestionDescription: `ナレッジベースから関連情報を取得できなかった場合にユーザーのクエリを修正するコンポーネント。定義されたループの上限に達するまでこのプロセスを繰り返します。上流が「Relevant」、下流が「Retrieval」であることを確認してください。`,
+
       messageDescription:
         '静的メッセージを送信するコンポーネント。複数のメッセージが提供されている場合は、その中からランダムに1つを選択して送信します。下流がインターフェースコンポーネント「Answer」であることを確認してください。',
+
       keywordDescription: `ユーザーの入力からトップNの検索結果を取得するコンポーネント。使用前にTopNの値が適切に設定されていることを確認してください。`,
       switchDescription: `前のコンポーネントの出力に基づいて条件を評価し、それに応じて実行の流れを指示するコンポーネント。ケースを定義し、各ケースのアクションまたは条件が満たされない場合のデフォルトアクションを指定することで、複雑な分岐ロジックを可能にします。`,
       wikipediaDescription: `wikipedia.orgから検索を行うコンポーネントで、TopNを使用して検索結果の数を指定します。既存のナレッジベースを補完します。`,
+
       promptText: `以下の段落を要約してください。数字に注意し、事実を捏造しないでください。段落は次の通りです：
         {input}
   上記は要約する必要がある内容です。`,
+
       createGraph: 'エージェントを作成',
       createFromTemplates: 'テンプレートから作成',
       retrieval: '検索',
@@ -827,11 +2041,15 @@ export default {
       baidu: 'Baidu',
       baiduDescription: `baidu.comから検索を行うコンポーネントで、TopNを使用して検索結果の数を指定します。既存のナレッジベースを補完します。`,
       duckDuckGo: 'DuckDuckGo',
+
       duckDuckGoDescription:
         'duckduckgo.comから検索を行うコンポーネントで、TopNを使用して検索結果の数を指定します。既存のナレッジベースを補完します。',
+
       searXNG: 'SearXNG',
+
       searXNGDescription:
         'SearXNGのインスタンスURLを提供して検索を行うコンポーネント。TopNとインスタンスURLを指定してください。',
+
       docGenerator: 'ドキュメント生成',
       docGeneratorDescription: `Markdown コンテンツからファイルを生成します。`,
       subtitle: 'サブタイトル',
@@ -851,58 +2069,80 @@ export default {
       addPageNumbers: 'ページ番号を追加',
       addTimestamp: 'タイムスタンプを追加',
       watermarkText: '透かしテキスト',
+
       messageHistoryWindowSizeTip:
         'LLMに表示される会話履歴のウィンドウサイズ。大きいほど良いですが、LLMの最大トークン制限に注意してください。',
+
       wikipedia: 'Wikipedia',
       pubMed: 'PubMed',
+
       pubMedDescription:
         'https://pubmed.ncbi.nlm.nih.gov/から検索を行うコンポーネントで、TopNを使用して検索結果の数を指定します。既存のナレッジベースを補完します。',
+
       email: 'メールアドレス',
+
       emailTip:
         'メールアドレスは必須項目です。ここにメールアドレスを入力してください。',
+
       arXiv: 'ArXiv',
+
       arXivDescription:
         'https://arxiv.org/から検索を行うコンポーネントで、TopNを使用して検索結果の数を指定します。既存のナレッジベースを補完します。',
+
       sortBy: '並び替え',
       submittedDate: '提出日',
       lastUpdatedDate: '最終更新日',
       relevance: '関連性',
       google: 'Google',
+
       googleDescription:
         'https://www.google.com/から検索を行うコンポーネントで、TopNを使用して検索結果の数を指定します。既存のナレッジベースを補完します。これにはserpapi.comからのAPIキーが必要です。',
+
       bing: 'Bing',
+
       bingDescription:
         'https://www.bing.com/から検索を行うコンポーネントで、TopNを使用して検索結果の数を指定します。既存のナレッジベースを補完します。これにはmicrosoft.comからのAPIキーが必要です。',
+
       apiKey: 'APIキー',
       country: '国と地域',
       language: '言語',
       googleScholar: 'Google Scholar',
+
       googleScholarDescription:
         'このコンポーネントは、https://scholar.google.com/ から検索結果を取得するために使用されます。通常、ナレッジベースを補完する役割を果たします。Top Nは、調整する必要がある検索結果の数を指定します。',
+
       yearLow: '最小年',
       yearHigh: '最大年',
       patents: '特許',
       data: 'データ',
       deepL: 'DeepL',
+
       deepLDescription:
         'このコンポーネントは、https://www.deepl.com/ から翻訳を取得するために使用されます。通常、より専門的な翻訳結果を提供します。',
+
       authKey: '認証キー',
       sourceLang: 'ソース言語',
       targetLang: 'ターゲット言語',
       gitHub: 'GitHub',
+
       githubDescription:
         'このコンポーネントは、https://github.com/ からリポジトリを検索するために使用されます。Top Nは、調整する検索結果の数を指定します。',
+
       baiduFanyi: 'BaiduFanyi',
+
       baiduFanyiDescription:
         'このコンポーネントは、https://fanyi.baidu.com/ から翻訳を取得するために使用されます。通常、より専門的な翻訳結果を提供します。',
+
       appid: 'アプリID',
       secretKey: 'シークレットキー',
       domain: 'ドメイン',
       transType: '翻訳タイプ',
+
       baiduSecretKeyOptions: {
         translate: '一般翻訳',
         fieldtranslate: '専門分野翻訳',
       },
+
       baiduDomainOptions: {
         it: '情報技術',
         finance: '金融と経済',
@@ -916,6 +2156,7 @@ export default {
         law: '法律と規制',
         contract: '契約',
       },
+
       baiduSourceLangOptions: {
         auto: '自動検出',
         zh: '中国語',
@@ -947,14 +2188,18 @@ export default {
         cht: '繁体字中国語',
         vie: 'ベトナム語',
       },
+
       qWeather: 'QWeather',
+
       qWeatherDescription:
         'このコンポーネントは、https://www.qweather.com/ から天気関連の情報を取得するために使用されます。天気、指数、空気質を取得できます。',
+
       lang: '言語',
       type: 'タイプ',
       webApiKey: 'Web APIキー',
       userType: 'ユーザータイプ',
       timePeriod: '期間',
+
       qWeatherLangOptions: {
         zh: '簡体字中国語',
         'zh-hant': '繁体字中国語',
@@ -988,15 +2233,18 @@ export default {
         is: 'アイスランド語',
         nb: 'ノルウェー語',
       },
+
       qWeatherTypeOptions: {
         weather: '天気予報',
         indices: '天気生活指数',
         airquality: '空気質',
       },
+
       qWeatherUserTypeOptions: {
         free: '無料会員',
         paid: '有料会員',
       },
+
       qWeatherTimePeriodOptions: {
         now: '現在',
         '3d': '3日間',
@@ -1005,10 +2253,13 @@ export default {
         '15d': '15日間',
         '30d': '30日間',
       },
+
       publish: 'API',
       exeSQL: 'ExeSQL',
+
       exeSQLDescription:
         'このコンポーネントは、SQL文を介して対応するリレーショナルデータベースから結果をクエリします。MySQL、PostgreSQL、MariaDBをサポートします。',
+
       dbType: 'データベースタイプ',
       database: 'データベース',
       username: 'ユーザー名',
@@ -1017,6 +2268,7 @@ export default {
       password: 'パスワード',
       switch: 'スイッチ',
       logicalOperator: '論理演算子',
+
       switchOperatorOptions: {
         equal: '等しい',
         notEqual: '等しくない',
@@ -1030,18 +2282,26 @@ export default {
         endWith: 'で終わる',
         empty: '空',
         notEmpty: '空でない',
+        in: '含む',
+        notIn: '含まない',
+        is: '等しい',
+        isNot: '等しくない',
       },
+
       switchLogicOperatorOptions: {
         and: 'かつ',
         or: 'または',
       },
+
       operator: '演算子',
       value: '値',
       useTemplate: 'このテンプレートを使用',
       wenCai: 'WenCai',
       queryType: 'クエリタイプ',
+
       wenCaiDescription:
         'このコンポーネントは、株式、ファンドなど、幅広い金融分野の情報を取得するために使用できます。',
+
       wenCaiQueryTypeOptions: {
         stock: '株式',
         zhishu: '指数',
@@ -1055,21 +2315,30 @@ export default {
         lccp: 'ファイナンス',
         foreign_exchange: '外国通貨',
       },
+
       akShare: 'AkShare',
+
       akShareDescription:
         'このコンポーネントは、Eastmoneyウェブサイトから対応する株式のニュース情報を取得するために使用できます。',
+
       yahooFinance: 'YahooFinance',
+
       yahooFinanceDescription:
         'このコンポーネントは、提供されたティッカーシンボルに基づいて会社情報をクエリします。',
+
       crawler: 'Webクローラー',
+
       crawlerDescription:
         'このコンポーネントは、指定されたURLからHTMLソースコードをクロールするために使用できます。',
+
       proxy: 'プロキシ',
+
       crawlerResultOptions: {
         html: 'HTML',
         markdown: 'Markdown',
         content: 'コンテンツ',
       },
+
       extractType: '抽出タイプ',
       info: '情報',
       history: '履歴',
@@ -1077,8 +2346,10 @@ export default {
       balanceSheet: '貸借対照表',
       cashFlowStatement: 'キャッシュフロー計算書',
       jin10: 'Jin10',
+
       jin10Description:
         'このコンポーネントは、Jin10オープンプラットフォームから金融セクターの情報にアクセスするために使用できます。クイックニュース、カレンダー、相場、参考情報などを含みます。',
+
       flashType: 'フラッシュタイプ',
       filter: 'フィルター',
       contain: '含む',
@@ -1086,12 +2357,14 @@ export default {
       calendarDatashape: 'カレンダーデータ形状',
       symbolsDatatype: 'シンボルデータタイプ',
       symbolsType: 'シンボルタイプ',
+
       jin10TypeOptions: {
         flash: 'クイックニュース',
         calendar: 'カレンダー',
         symbols: '相場',
         news: '参考情報',
       },
+
       jin10FlashTypeOptions: {
         '1': '市場ニュース',
         '2': '先物ニュース',
@@ -1099,33 +2372,42 @@ export default {
         '4': 'A株ニュース',
         '5': '商品・外国為替ニュース',
       },
+
       jin10CalendarTypeOptions: {
         cj: 'マクロ経済データカレンダー',
         qh: '先物カレンダー',
         hk: '香港株式市場カレンダー',
         us: '米国株式市場カレンダー',
       },
+
       jin10CalendarDatashapeOptions: {
         data: 'データ',
         event: 'イベント',
         holiday: '休日',
       },
+
       jin10SymbolsTypeOptions: {
         GOODS: '商品相場',
         FOREX: '外国為替相場',
         FUTURE: '国際市場相場',
         CRYPTO: '暗号通貨相場',
       },
+
       jin10SymbolsDatatypeOptions: {
         symbols: '商品リスト',
         quotes: '最新市場相場',
       },
+
       concentrator: 'コンセントレーター',
+
       concentratorDescription:
         '上流コンポーネントからの出力を受け取り、それを下流コンポーネントへの入力として渡すコンポーネント。',
+
       tuShare: 'TuShare',
+
       tuShareDescription:
         'このコンポーネントは、主流の金融ウェブサイトから金融ニュースの概要を取得し、業界および定量的研究を支援するために使用できます。',
+
       tuShareSrcOptions: {
         sina: '新浪',
         wallstreetcn: '華爾街見聞',
@@ -1135,6 +2417,7 @@ export default {
         fenghuang: '鳳凰網',
         jinrongjie: '金融界',
       },
+
       token: 'トークン',
       src: 'ソース',
       startDate: '開始日',
@@ -1144,17 +2427,22 @@ export default {
       noteDescription: 'メモ',
       notePlaceholder: 'メモを入力してください',
       invoke: '呼び出し',
+
       invokeDescription:
         'このコンポーネントはリモートエンドポイント呼び出しを行うことができます。他のコンポーネントの出力をパラメータとして使用するか、定数パラメータを設定してリモート関数を呼び出します。',
+
       url: 'URL',
       method: 'メソッド',
       timeout: 'タイムアウト',
       headers: 'ヘッダー',
       cleanHtml: 'HTMLをクリーン',
+
       cleanHtmlTip:
         '応答がHTML形式であり、主要なコンテンツのみが必要な場合は、これをオンにしてください。',
+
       invalidUrl:
         '有効なURLまたは{variable_name}または{component@variable}形式の変数プレースホルダーを含むURLである必要があります',
+
       reference: '参照',
       input: '入力',
       output: '出力',
@@ -1167,8 +2455,10 @@ export default {
       pasteFileLink: 'ファイルリンクを貼り付け',
       testRun: 'テスト実行',
       template: 'テンプレート',
+
       templateDescription:
         'このコンポーネントは、さまざまなコンポーネントの出力を組版するために使用されます。1. Jinja2テンプレートをサポートし、最初に入力をオブジェクトに変換してからテンプレートをレンダリングします。2. {parameter}文字列置換を使用する元の方法も同時に保持します',
+
       emailComponent: 'メール',
       emailDescription: '指定されたアドレスにメールを送信',
       smtpServer: 'SMTPホスト',
@@ -1189,8 +2479,10 @@ export default {
       emailSentSuccess: 'メールが正常に送信されました',
       emailSentFailed: 'メールの送信に失敗しました',
       dynamicParameters: '動的パラメータ',
+
       jsonFormatTip:
         '上流コンポーネントは、次の形式のJSON文字列を提供する必要があります：',
+
       toEmailTip: 'to_email: 受信者のメール（必須）',
       ccEmailTip: 'cc_email: CCメール（オプション）',
       subjectTip: 'subject: メールの件名（オプション）',
@@ -1198,8 +2490,10 @@ export default {
       jsonUploadTypeErrorMessage: 'jsonファイルをアップロードしてください',
       jsonUploadContentErrorMessage: 'jsonファイルエラー',
       prompt: 'プロンプト',
+
       promptTip:
         'LLMのタスクを説明し、どのように応答すべきかを指定し、他のさまざまな要件を概説するためにシステムプロンプトを使用します。システムプロンプトは、LLMのさまざまなデータ入力として機能するキー（変数）と共に使用されることがよくあります。使用するキーを表示するには、スラッシュ `/` または (x) ボタンを使用します。',
+
       promptMessage: 'プロンプトは必須です',
       runningHintText: '動作中です...🕞 ',
       tags: 'タグ',
@@ -1207,15 +2501,593 @@ export default {
       created: '作成日',
       id: 'ID',
       logTitle: 'タイトル',
+
+      preprocess: {
+        preprocess: '前処理',
+        mainContent: '本文',
+        abstract: '概要',
+        author: '著者',
+        sectionTitle: 'セクションタイトル',
+      },
+
+      editTags: 'タグを編集',
+      editTagsDescription:
+        'タグを追加してエージェントを整理・絞り込みできます。Enterキーまたはカンマで追加します。',
+      tagsPlaceholder: 'タグを入力してEnterを押してください',
+      tagSuggestionsLabel: '既存のタグ',
+      removeTagAriaLabel: '{{tag}}を削除',
+      includeHeadingContent: '親見出しの内容を分離',
+      includeHeadingContentTip:
+        '有効にすると、チャンクには見出しパスとその内容のみが含まれます。親見出しの直後にある内容は、別のチャンクとして保持されます。',
+      rootAsHeading: '最初のチャンクをグローバルコンテキストとして設定',
+      rootAsHeadingTip:
+        '最初の分割をグローバルな見出しとして扱い、文書階層全体で一貫したコンテキストを維持します。最初のセクションで対象者を特定する履歴書などに最適です。',
+      hierarchyTip:
+        '見出しツリーを構築し、各チャンクが完全な祖先パス(例: 第1部 › 第3章 › 第2節 + 本文)を保持する自己完結型のチャンクを生成します。\n\n最適な用途: 法令、規則、契約書、技術仕様書など、各チャンクが階層内の位置によって識別されるべき、高度に構造化されたテキスト。',
+      groupTip:
+        '選択した見出しレベルで文書をフラットに分割し、隣接する小さなセクションをマージして意味的なつながりを確保します。チャンクには祖先パスは含まれません。\n\n最適な用途: 書籍、マニュアル、レポート、記事など、隣接する段落をまとめて保持することで文章の一貫性が保たれる、流れるような文脈でつながった内容の文書。',
+      enableMultiColumn: '多段組みレイアウトを検出',
+      enableMultiColumnTip:
+        '多段組みのページレイアウトを検出・解析し、正しい読み順を保持します。2段組みや新聞のようなレイアウトのPDFや文書ではこれを有効にしてください。',
+      removeToc: '元の目次を削除',
+      removeTocTip:
+        '元のPDFに含まれる目次を削除し、通常のコンテンツとして解析されたり検索用にチャンク化されたりしないようにします。',
+      removeHeaderFooter: 'ヘッダーとフッターを削除',
+      autoPlay: '音声を自動再生',
+      downloadFileTypeTip: 'ダウンロードするファイルタイプ',
+      downloadFileType: 'ダウンロードファイルタイプ',
+      formatTypeError: '形式または型のエラー',
+      variableNameMessage:
+        '変数名には英字、アンダースコア、数字のみ使用できます',
+      variableDescription: '変数の説明',
+      defaultValue: 'デフォルト値',
+      conversationVariable: '会話変数',
+      recommended: '推奨',
+      customerSupport: 'カスタマーサポート',
+      marketing: 'マーケティング',
+      visualInputFile: '視覚入力ファイル',
+      consumerApp: 'コンシューマーアプリ',
+      other: 'その他',
+      ingestionPipeline: '取り込みパイプライン',
+      agents: 'エージェント',
+      publishedAt: '公開日時',
+      days: '日',
+      beginInput: '開始入力',
+      ref: '変数',
+      stockCode: '銘柄コード',
+      apiKeyPlaceholder:
+        'YOUR_API_KEY(https://serpapi.com/manage-api-key から取得)',
+      flowStart: '開始',
+      flowNum: 'N',
+      test: 'テスト',
+      extractDepth: '抽出深度',
+      format: '形式',
+      basic: '基本',
+      advanced: '高度',
+      general: '一般',
+      searchDepth: '検索深度',
+      tavilyTopic: 'Tavilyのトピック',
+      maxResults: '最大結果数',
+      includeAnswer: '回答を含める',
+      includeRawContent: '生コンテンツを含める',
+      includeImages: '画像を含める',
+      includeImageDescriptions: '画像の説明を含める',
+      includeDomains: '含めるドメイン',
+      ExcludeDomains: '除外するドメイン',
+      Days: '日',
+      comma: 'カンマ',
+      semicolon: 'セミコロン',
+      period: 'ピリオド',
+      lineBreak: '改行',
+      tab: 'タブ',
+      space: 'スペース',
+      delimiters: '区切り文字',
+      one: '単一',
+      oneChunkTitle: '注記',
+      oneChunkDescription:
+        '解析されたすべてのセクションが順番に1つのチャンクにマージされます。',
+      flattenMediaToText: 'ビジョンモデルを無効化',
+      flattenMediaToTextTip:
+        '画像や表のセクションをプレーンテキストとして扱い、ビジョンによる拡張処理をスキップします。',
+      enableChildrenDelimiters: '子チャンクを検索に使用する',
+      merge: 'マージ',
+      split: '分割',
+      script: 'スクリプト',
+      iterationItemDescription:
+        '反復処理における現在の要素を表し、後続のステップで参照・操作できます。',
+      guidingQuestion: '誘導質問',
+      onFailure: '失敗時',
+      userPromptDefaultValue:
+        'これはエージェントに送信する必要がある指示です。',
+      search: '検索',
+      communication: 'コミュニケーション',
+      developer: '開発者',
+      typeCommandORsearch: 'コマンドを入力または検索...',
+      builtIn: '組み込み',
+      ExceptionDefaultValue: '例外時のデフォルト値',
+      exceptionMethod: '例外処理方法',
+      maxRounds: '最大リフレクション回数',
+      delayAfterError: 'エラー後の遅延',
+      maxRetries: '最大リトライ回数',
+      maxSteps: '最大ステップ数',
+      headless: 'ヘッドレス',
+      enableDefaultExtensions: 'デフォルト拡張機能を有効化',
+      enableDefaultExtensionsTip:
+        'browser-useのデフォルト拡張機能(uBlock、Cookie処理、ClearURLs)を有効にします。実行時の拡張機能ダウンロードを避けたい場合は無効にしてください。',
+      chromiumSandbox: 'Chromiumサンドボックス',
+      chromiumSandboxTip:
+        'Chromiumサンドボックスを有効にするかどうかです。Dockerのroot環境では通常無効化されており、通常のホストでは有効化することを推奨します。',
+      persistSession: 'セッションを永続化',
+      persistSessionTip:
+        '有効にすると、このBrowserノードはブラウザセッションを再利用し、ログインの繰り返しを回避します。',
+      uploadSources: 'アップロードソース',
+      uploadSourcesTip:
+        'ファイルID、ファイルURL、または変数に対応しています。複数の値はカンマで区切るか、JSON配列形式(例: ["id1","https://example.com/a.pdf"])で指定できます。',
+      advancedSettings: '詳細設定',
+      addTools: 'ツールを追加',
+      sysPromptDefaultValue:
+        '\n      <role>\n        あなたは親切なアシスタントであり、ユーザーの問題解決に特化したAIアシスタントです。\n        特定の分野が指定されている場合はその分野の専門知識に適応し、指定がない場合はジェネラリストとして対応してください。\n      </role>\n      <instructions>\n        1. ユーザーのリクエストを理解する。\n        2. 論理的なサブタスクに分解する。\n        3. 各サブタスクを順を追って実行し、思考過程を明示する。\n        4. 正確性と一貫性を検証する。\n        5. 最終結果を明確に要約する。\n      </instructions>',
+      singleLineText: '単一行テキスト',
+      multimodalModels: 'マルチモーダルモデル',
+      textOnlyModels: 'テキストのみのモデル',
+      allModels: 'すべてのモデル',
+      codeExecDescription: '独自のPythonまたはJavaScriptロジックを記述します。',
+      stringTransformDescription:
+        'テキストの内容を変更します。現在サポートしている機能: テキストの分割または結合。',
+      foundation: '基盤',
+      tools: 'ツール',
+      dataManipulation: 'データ操作',
+      flow: 'フロー',
+      dialog: '対話',
+      lastSavedAt: '最終保存日時',
+      descriptionMessage: 'これは特定のタスクのためのエージェントです。',
+      msgTip:
+        '上流コンポーネントの変数の内容、または自分で入力したテキストを出力します。',
+      loopDescription:
+        'ループは現在のコンポーネントのループ回数の上限です。ループ回数がこの値を超えた場合、コンポーネントが現在のタスクを完了できないことを意味します。エージェントを再度最適化してください。',
+      exitLoop: 'ループを抜ける',
+      exitLoopDescription:
+        '"break"と同等です。このノードには設定項目はありません。ループ本体がこのノードに到達すると、ループが終了します。',
+      loopVariables: 'ループ変数',
+      maximumLoopCount: '最大ループ回数',
+      loopTerminationCondition: 'ループ終了条件',
+      keenableSearch: 'Keenable',
+      keenableSearchDescription:
+        'AIエージェント向けに構築された検索API、Keenableを利用したWeb検索コンポーネントです。デフォルトではAPIキーなしで動作します(キー不要の無料プラン)。キーを追加するとレート制限が緩和されます。',
+      keenableMode: '検索モード',
+      keenableSite: 'サイト',
+      keenableApiKeyTip:
+        '任意項目です。キー不要の無料プランを使用する場合は空欄のままにしてください。',
+      browser: 'ブラウザ',
+      browserDescription:
+        'ブラウザ操作を自動化します。モデル設定とプロンプト駆動のアクションに対応しています。アップロードソースはファイルIDとURLに対応しており、ダウンロードしたファイルは指定フォルダに保存できます。',
+      channel: 'チャンネル',
+      channelTip:
+        'コンポーネントの入力に対してテキスト検索またはニュース検索を実行します',
+      text: 'テキスト',
+      news: 'ニュース',
+      messageHistoryWindowSize: 'メッセージウィンドウサイズ',
+      bGPT: 'BGPT',
+      bGPTDescription:
+        'BGPTを介して科学論文を検索し、全文研究から構造化されたエビデンス(手法、サンプルサイズ、限界、利益相反、データの入手可能性、盲点、反証プロンプト)を返します。無料プラン超過後はAPIキーを任意で使用できます。',
+      bgptApiKey: 'APIキー',
+      bgptApiKeyTip:
+        '任意項目です。無料プラン(最初の50件)を使用する場合は空欄のままにしてください。',
+      bgptDaysBack: '遡及日数',
+      bgptDaysBackTip: '任意の期間フィルターです(例: 過去1年分なら365)。',
+      gitHubDescription:
+        'https://github.com/ からリポジトリを検索するコンポーネントです。Top Nで検索結果の件数を指定できます。',
+      userId: 'ユーザーID',
+      iteration: '反復',
+      iterationDescription:
+        '入力配列を反復処理し、各要素に対して定義されたロジックを実行するループコンポーネントです。',
+      delimiterTip:
+        '\nこの区切り文字は、入力テキストを複数のテキスト片に分割するために使用され、それぞれが各反復の入力項目として処理されます。',
+
+      delimiterOptions: {
+        comma: 'カンマ',
+        lineBreak: '改行',
+        tab: 'タブ',
+        underline: 'アンダースコア',
+        diagonal: 'スラッシュ',
+        minus: 'ハイフン',
+        semicolon: 'セミコロン',
+      },
+
+      addVariable: '変数を追加',
+      variableSettings: '変数設定',
+      systemPrompt: 'システムプロンプト',
+      userPrompt: 'ユーザープロンプト',
+      tocDataSource: 'データソース',
+      addCategory: 'カテゴリを追加',
+      categoryName: 'カテゴリ名',
+      nextStep: '次のステップ',
+      variableExtractDescription:
+        '会話全体を通じてユーザー情報をグローバル変数に抽出します',
+      variableExtract: '変数',
+      variables: '変数',
+      variablesTip:
+        '空の値を持つ明確なJSONキー変数を設定してください。例:\n      {\n        "UserCode":"",\n        "NumberPhone":""\n      }',
+      datatype: 'HTTPリクエストのMIMEタイプ',
+      insertVariableTip: '変数を入力/挿入',
+      mergePath: 'パスをマージ',
+      mergePathTip:
+        '有効にすると、変数の直後にあるドット付きのサフィックスが、{node@result.name}のようなパスクエリにマージされます。',
+      historyVersion: 'バージョン履歴',
+
+      version: {
+        created: '作成日時',
+        details: 'バージョン詳細',
+        dsl: 'DSL',
+        download: 'ダウンロード',
+        version: 'バージョン',
+        select: 'バージョンが選択されていません',
+      },
+
+      setting: '設定',
+
+      settings: {
+        agentSetting: 'エージェント設定',
+        title: 'タイトル',
+        description: '説明',
+        upload: 'アップロード',
+        photo: '写真',
+        permissions: '権限',
+        permissionsTip: 'ここでチームメンバーの権限を設定できます。',
+        me: '自分',
+        team: 'チーム',
+      },
+
+      noMoreData: 'これ以上データはありません',
+      searchAgentPlaceholder: 'エージェントを検索',
+
+      footer: {
+        profile: 'All rights reserved @ React',
+      },
+
+      layout: {
+        file: 'ファイル',
+        knowledge: 'ナレッジ',
+        chat: 'チャット',
+      },
+
+      infor: '実行情報',
+      knowledgeBasesTip:
+        'このチャットアシスタントに関連付けるデータセットを選択するか、以下でデータセットIDを含む変数を選択してください。',
+      knowledgeBaseVars: 'データセット変数',
+      code: 'コード',
+      codeDescription: '開発者が独自のPythonロジックを記述できるようにします。',
+      dataOperations: 'データ操作',
+      dataOperationsDescription:
+        'Dataオブジェクトに対してさまざまな操作を実行します。',
+      listOperations: 'リスト操作',
+      listOperationsDescription: 'リストに対して操作を実行します。',
+      variableAssigner: '変数代入',
+      variableAssignerDescription:
+        'このコンポーネントはDataオブジェクトに対して操作を実行します。Data内のキーと値の抽出、フィルタリング、編集などが含まれます。',
+      variableAggregator: '変数集約',
+      variableAggregatorDescription:
+        '\nこの処理は、複数の分岐からの変数を1つの変数に集約し、下流ノードの設定を統一します。',
+      inputVariables: '入力変数',
+      openingSwitch: 'オープニングメッセージ切り替え',
+      openingCopy: 'オープニングメッセージ',
+      openingSwitchTip:
+        'ユーザーには最初にこのウェルカムメッセージが表示されます。',
+      modeTip: 'モードはワークフローの開始方法を定義します。',
+      mode: 'モード',
+      conversational: '会話型',
+      task: 'タスク',
+      beginInputTip:
+        'ここで定義した入力パラメータは、下流のワークフロー内のコンポーネントからアクセスできます。',
+      query: 'クエリ変数',
+      switchPromptMessage:
+        'プロンプトの内容が変更されます。既存のプロンプトを破棄してよろしいですか?',
+      queryRequired: 'クエリは必須です',
+      queryTip: '使用する変数を選択してください',
+      agent: 'エージェント',
+      addAgent: 'エージェントを追加',
+      agentDescription:
+        '推論、ツール利用、マルチエージェント連携を備えたエージェントコンポーネントを構築します。',
+      maxRecords: '最大レコード数',
+      createAgent: 'エージェントフロー',
+      stringTransform: 'テキスト処理',
+      userFillUp: '応答待ち',
+      userFillUpDescription:
+        'ワークフローを一時停止し、ユーザーからのメッセージを待ってから処理を続行します。',
+      codeExec: 'コード',
+      tavilySearch: 'Tavily検索',
+      tavilySearchDescription: 'Tavilyサービスによる検索結果です。',
+      tavilyExtract: 'Tavily抽出',
+      tavilyExtractDescription: 'Tavily Extract',
+      log: 'ログ',
+      management: '管理',
+      import: 'インポート',
+      export: 'エクスポート',
+      seconds: '秒',
+      subject: '件名',
+      tag: 'タグ',
+      tagPlaceholder: 'タグを入力してください',
+      descriptionPlaceholder: '説明を入力してください',
+      line: '単一行テキスト',
+      paragraph: '段落テキスト',
+      options: 'ドロップダウン選択肢',
+      file: 'ファイルアップロード',
+      integer: '数値',
+      boolean: '真偽値',
+      object: 'JSONオブジェクト',
+
+      logTimeline: {
+        begin: '開始準備中',
+        agent: 'エージェントが思考中です',
+        userFillUp: 'あなたの入力を待っています',
+        retrieval: 'ナレッジを検索中です',
+        message: 'エージェントの発言',
+        awaitResponse: 'あなたの入力を待っています',
+        switch: '最適な分岐を選択中です',
+        iteration: 'バッチ処理中です',
+        categorize: '情報を分類中です',
+        code: 'スクリプトを実行中です',
+        textProcessing: 'テキストを整形中です',
+        tavilySearch: 'Web検索中です',
+        tavilyExtract: 'ページを読み込み中です',
+        exeSQL: 'データベースに問い合わせ中です',
+        google: 'Web検索中です',
+        wikipedia: 'Wikipediaを検索中です',
+        googleScholar: '論文検索中です',
+        gitHub: 'GitHubを検索中です',
+        email: 'メールを送信中です',
+        httpRequest: 'APIを呼び出し中です',
+        wenCai: '金融データに問い合わせ中です',
+      },
+
+      goto: '失敗時の分岐',
+      comment: 'デフォルト値',
+      sqlStatement: 'SQL文',
+      sqlStatementTip:
+        'ここにSQLクエリを記述します。変数、生のSQL、または変数構文を使った両方の組み合わせを使用できます。',
+      frameworkPrompts: 'フレームワーク',
+      release: '公開',
+      production: '本番環境',
+      productionTooltip:
+        'このバージョンは本番環境に公開されています。APIまたは埋め込みページからアクセスできます。',
+      confirmPublish: '公開を確認',
+      publishIngestionPipeline:
+        'この取り込みパイプラインを公開しようとしています。',
+      publishAgent: 'このエージェントを公開しようとしています',
+      linkedDataset: 'リンクされたデータセット:',
+      lastPublished: '最終公開日時',
+      createFromBlank: '空白から作成',
+      createFromTemplate: 'テンプレートから作成',
+      importJsonFile: 'JSONファイルをインポート',
+      duplicate: '複製',
+      copyOfAgentName: '{{name}} (コピー)',
+      ceateAgent: 'ワークフロー',
+      createPipeline: '取り込みパイプライン',
+      chooseAgentType: 'エージェントタイプを選択',
+      parser: 'パーサー',
+      parserDescription:
+        '後続処理のために、ファイルから生のテキストと構造を抽出します。',
+      tokenizer: 'インデクサー',
+      tokenizerRequired: '先にインデクサーノードを追加してください',
+      tokenizerDescription:
+        '選択した検索方法に応じて、テキストを必要なデータ構造(埋め込み検索の場合はベクトル埋め込みなど)に変換します。',
+      tokenChunker: 'トークンチャンカー',
+      tokenChunkerDescription:
+        'トークン長に基づいてテキストをチャンクに分割します。区切り文字やオーバーラップをオプションで指定できます。',
+      titleChunkerDescription:
+        '見出しの階層構造に基づいてドキュメントをセクションに分割します。正規表現ルールで見出しレベルを定義し、階層モードまたはグループモードを選択してチャンクの構成方法を制御します。',
+      titleChunker: 'タイトルチャンカー',
+      extractor: 'トランスフォーマー',
+      extractorDescription:
+        'LLMを使用して、ドキュメントチャンクから要約や分類などの構造化された知見を抽出します。',
+      compiler: 'コンパイル',
+      compilerDescription:
+        'ナレッジコンパイルテンプレートを使用して、ドキュメントチャンクを構造化された成果物にコンパイルします。',
+      outputFormat: '出力形式',
+      fileFormats: 'ファイル形式',
+
+      fileFormatOptions: {
+        pdf: 'PDF',
+        spreadsheet: 'スプレッドシート',
+        image: '画像',
+        email: 'メール',
+        markdown: 'Markdown',
+        'text&code': 'テキスト・コード',
+        html: 'HTML',
+        doc: 'DOC',
+        docx: 'DOCX',
+        slides: 'PPTX',
+        audio: '音声',
+        video: '動画',
+      },
+
+      fields: 'フィールド',
+      addParser: 'パーサーを追加',
+      rule: 'ルール',
+      addRule: 'ルールを追加',
+      group: 'グループ',
+      hierarchy: '階層',
+      addRegularExpressions: '正規表現を追加',
+      regularExpressions: '正規表現',
+      overlappedPercent: 'オーバーラップ率 (%)',
+      searchMethod: '検索方法',
+      searchMethodTip:
+        'コンテンツの検索方法(全文検索、埋め込み検索、またはその両方)を定義します。\nインデクサーは、選択した方法に対応するデータ構造でコンテンツを保存します。',
+      parserMethod: 'PDFパーサー',
+      tableResultType: 'テーブル結果タイプ',
+      markdownImageResponseType: 'Markdown画像レスポンスタイプ',
+      systemPromptPlaceholder:
+        '画像解析用のシステムプロンプトを入力してください。空欄の場合はシステムのデフォルト値が使用されます',
+      exportJson: 'JSONをエクスポート',
+      viewResult: '結果を表示',
+      running: '実行中',
+      summary: '要約',
+      keywords: 'キーワード',
+      questions: '質問',
+      metadata: 'メタデータ',
+      toc: 'PageIndex',
+      fieldName: '出力先フィールド',
+
+      prompts: {
+        system: {
+          keywords:
+            '役割\nあなたはテキストアナライザーです。\n\nタスク\n与えられたテキストコンテンツから最も重要なキーワード/フレーズを抽出してください。\n\n要件\n- テキストコンテンツを要約し、上位5つの重要なキーワード/フレーズを挙げてください。\n- キーワードは、与えられたテキストコンテンツと同じ言語で記述してください。\n- キーワードは半角英数カンマ(,)で区切ってください。\n- キーワードのみを出力してください。',
+          questions:
+            '役割\nあなたはテキストアナライザーです。\n\nタスク\n与えられたテキストコンテンツについて3つの質問を提案してください。\n\n要件\n- テキストコンテンツを理解・要約したうえで、上位3つの重要な質問を提案してください。\n- 質問同士の意味が重複しないようにしてください。\n- 質問はテキストの主要な内容をできる限り網羅するようにしてください。\n- 質問は、与えられたテキストコンテンツと同じ言語で記述してください。\n- 1行につき1つの質問としてください。\n- 質問のみを出力してください。',
+          summary:
+            '正確な要約者として振る舞ってください。あなたのタスクは、提供されたコンテンツについて、簡潔でありながら原文に忠実な要約を作成することです。\n\n重要な指示:\n1. 正確性: 与えられた情報のみに厳密に基づいて要約してください。明示的に述べられていない新たな事実、結論、解釈を加えないでください。\n2. 言語: 要約は原文と同じ言語で記述してください。\n3. 客観性: 内容の本来の意図とトーンを保ちながら、偏りなく要点を提示してください。主観的な意見を加えないでください。\n4. 簡潔性: 些末な詳細や余分な表現を省き、最も重要なアイデアに焦点を当ててください。',
+          metadata:
+            '与えられたコンテンツから重要な構造化情報を抽出してください。余分なテキストを含まない、有効なJSON文字列のみを出力してください。重要な構造化情報が見つからない場合は、空のJSONオブジェクト({})を出力してください。\n\n重要な構造化情報には、氏名、日付、場所、出来事、重要な事実、数値データ、その他抽出可能なエンティティなどが含まれます。',
+          toc: '',
+        },
+
+        user: {
+          keywords: 'テキストコンテンツ\n[ここにテキストを挿入]',
+          questions: 'テキストコンテンツ\n[ここにテキストを挿入]',
+          summary: '要約対象テキスト:\n[ここにテキストを挿入]',
+          metadata: 'コンテンツ: [ここにコンテンツを挿入]',
+          toc: '[ここにテキストを挿入]',
+        },
+      },
+
+      cancel: 'キャンセル',
+      swicthPromptMessage:
+        'プロンプトの内容が変更されます。既存のプロンプトを破棄してよいか確認してください。',
+
+      tokenizerSearchMethodOptions: {
+        full_text: '全文検索',
+        embedding: '埋め込み',
+      },
+
+      filenameEmbeddingWeight: 'ファイル名埋め込みの重み',
+
+      tokenizerFieldsOptions: {
+        text: '処理済みテキスト',
+        keywords: 'キーワード',
+        questions: '質問',
+        summary: '拡張コンテキスト',
+      },
+
+      imageParseMethodOptions: {
+        ocr: 'OCR',
+      },
+
+      structuredOutput: {
+        configuration: '設定',
+        structuredOutput: '構造化出力',
+      },
+
+      operations: '操作',
+
+      operationsOptions: {
+        selectKeys: 'キーを選択',
+        literalEval: 'リテラル評価',
+        combine: '結合',
+        filterValues: '値をフィルタ',
+        appendOrUpdate: '追加または更新',
+        removeKeys: 'キーを削除',
+        renameKeys: 'キー名を変更',
+      },
+
+      ListOperationsOptions: {
+        nth: 'N番目',
+        head: '先頭',
+        tail: '末尾',
+        sort: '並べ替え',
+        filter: 'フィルタ',
+        dropDuplicates: '重複を削除',
+      },
+
+      sortMethod: '並べ替え方法',
+      strictMode: '厳格モード',
+      strictModeTip:
+        'オフの場合は緩やかな動作となり、無効なnに対して空の結果を返します。オンの場合は厳格な動作となり、範囲外のnに対してエラーを発生させます。',
+
+      SortMethodOptions: {
+        asc: '昇順',
+        desc: '降順',
+      },
+
+      variableAssignerLogicalOperatorOptions: {
+        overwrite: '上書き',
+        clear: 'クリア',
+        set: '設定',
+        add: '加算',
+        subtract: '減算',
+        multiply: '乗算',
+        divide: '除算',
+        append: '追加',
+        extend: '拡張',
+        removeFirst: '先頭を削除',
+        removeLast: '末尾を削除',
+      },
+
+      webhook: {
+        name: 'Webhook',
+        methods: 'メソッド',
+        contentTypes: 'コンテンツタイプ',
+        security: 'セキュリティ',
+        schema: 'スキーマ',
+        response: 'レスポンス',
+        executionMode: '実行モード',
+        executionModeTip:
+          '即時応答: リクエストの検証後、システムは直ちに確認応答を返し、ワークフローはバックグラウンドで非同期に実行を継続します。/最終応答: ワークフローの実行が完了した後にのみ、システムはレスポンスを返します。',
+        authMethods: '認証方法',
+        authType: '認証タイプ',
+        allowAnonymous: '匿名アクセスを許可',
+        allowAnonymousTip:
+          'これを有効にすると、このWebhook URLを知っている誰でもエージェントを実行できるようになります。',
+        limit: 'リクエスト頻度制限',
+        per: '期間',
+        maxBodySize: '最大ボディサイズ',
+        ipWhitelist: 'IPホワイトリスト',
+        tokenHeader: 'トークンヘッダー',
+        tokenValue: 'トークン値',
+        username: 'ユーザー名',
+        password: 'パスワード',
+        algorithm: 'アルゴリズム',
+        secret: 'シークレット',
+        issuer: '発行者',
+        audience: 'オーディエンス',
+        requiredClaims: '必須クレーム',
+        header: 'ヘッダー',
+        status: 'ステータス',
+        headersTemplate: 'ヘッダーテンプレート',
+        bodyTemplate: 'ボディテンプレート',
+        basic: 'Basic',
+        bearer: 'Bearer',
+        apiKey: 'APIキー',
+        queryParameters: 'クエリパラメータ',
+        headerParameters: 'ヘッダーパラメータ',
+        requestBodyParameters: 'リクエストボディパラメータ',
+        immediately: '即時応答',
+        streaming: '最終応答',
+        overview: '概要',
+        logs: 'ログ',
+        agentStatus: 'エージェントステータス:',
+      },
+
+      saveToMemory: 'メモリーに保存',
+      retrievalFrom: '検索元',
+      state: '状態',
+      number: '数値',
+      latestDate: '最新日付',
+      createDate: '作成日',
+      noDataToExport: 'エクスポートするデータがありません',
+      success: '成功',
+      failed: '失敗',
     },
+
     footer: {
       profile: 'All rights reserved @ React',
     },
+
     layout: {
       file: 'ファイル',
       knowledge: 'ナレッジ',
       chat: 'チャット',
     },
+
     language: {
       english: '英語',
       chinese: '中国語',
@@ -1224,6 +3096,595 @@ export default {
       arabic: 'アラビア語',
       turkish: 'トルコ語',
       korean: '韓国語',
+      spanish: 'スペイン語',
+      french: 'フランス語',
+      german: 'ドイツ語',
+      japanese: '日本語',
+      vietnamese: 'ベトナム語',
+      dutch: 'オランダ語',
+    },
+
+    admin: {
+      loginTitle: '管理コンソール',
+      title: 'RAGFlow',
+      confirm: '確認',
+      close: '閉じる',
+      yes: 'はい',
+      no: 'いいえ',
+      delete: '削除',
+      cancel: 'キャンセル',
+      reset: 'リセット',
+      import: 'インポート',
+      description: '説明',
+      noDescription: '説明なし',
+      none: 'なし',
+
+      resourceType: {
+        dataset: 'データセット',
+        chat: 'チャット',
+        agent: 'エージェント',
+        search: '検索',
+        file: 'ファイル',
+        team: 'チーム',
+        memory: 'メモリー',
+      },
+
+      permissionType: {
+        enable: '有効化',
+        read: '読み取り',
+        write: '書き込み',
+        share: '共有',
+      },
+
+      serviceStatus: 'サービスステータス',
+      userManagement: 'ユーザー管理',
+      sandboxSettings: 'サンドボックス設定',
+      registrationWhitelist: '登録ホワイトリスト',
+      roles: 'ロール',
+      monitoring: 'モニタリング',
+
+      sandboxSettingsPage: {
+        description:
+          'コード実行サンドボックスのプロバイダーを設定します。このサンドボックスは、エージェントのCodeコンポーネントで使用されます。',
+        providerSelection: 'プロバイダー選択',
+        providerSelectionDescription:
+          'コード実行用のサンドボックスプロバイダーを選択してください',
+        namedProviderConfiguration: '{{name}} の設定',
+        namedProviderConfigurationDescription:
+          '{{name}} の接続設定を構成します。',
+        saveConfiguration: '設定を保存',
+        saving: '保存中...',
+
+        testConnectionResultModal: {
+          title: '接続テスト結果',
+          testing: 'サンドボックスプロバイダーへの接続をテスト中です...',
+          success: 'サンドボックスプロバイダーへの接続に成功しました',
+          failed: 'サンドボックスプロバイダーへの接続に失敗しました',
+          exitCode: '終了コード',
+          executionTime: '実行時間',
+          stdout: '標準出力',
+          stderr: 'エラー出力 / スタックトレース',
+        },
+
+        testConnection: '接続をテスト',
+        testing: 'テスト中...',
+      },
+
+      selectFile: 'ファイルを選択',
+      noFileSelected: 'ファイルが選択されていません',
+      back: '戻る',
+      active: '有効',
+      inactive: '無効',
+      enable: '有効化',
+      disable: '無効化',
+      all: 'すべて',
+      actions: '操作',
+      newUser: '新規ユーザー',
+      email: 'メールアドレス',
+      name: '名前',
+      nickname: 'ニックネーム',
+      status: 'ステータス',
+      id: 'ID',
+      serviceType: 'サービスタイプ',
+      host: 'ホスト',
+      port: 'ポート',
+      role: 'ロール',
+      user: 'ユーザー',
+      userType: 'ユーザータイプ',
+      superuser: 'スーパーユーザー',
+      normalUser: '一般',
+      createTime: '作成日時',
+      lastLoginTime: '最終ログイン日時',
+      lastUpdateTime: '最終更新日時',
+      isAnonymous: '匿名',
+      isSuperuser: 'スーパーユーザー',
+      deleteUser: 'ユーザーを削除',
+      deleteUserConfirmation: 'このユーザーを削除してもよろしいですか？',
+      createNewUser: '新規ユーザーを作成',
+      changePassword: 'パスワードを変更',
+      newPassword: '新しいパスワード',
+      confirmNewPassword: '新しいパスワード（確認）',
+      password: 'パスワード',
+      confirmPassword: 'パスワード（確認）',
+      invalidEmail: '有効なメールアドレスを入力してください！',
+      passwordRequired: 'パスワードを入力してください！',
+      passwordMinLength: 'パスワードは8文字を超える必要があります。',
+      confirmPasswordRequired: 'パスワードの確認を入力してください！',
+      confirmPasswordDoNotMatch: '入力されたパスワードが一致しません！',
+      read: '読み取り',
+      write: '書き込み',
+      share: '共有',
+      create: '作成',
+      extraInfo: '追加情報',
+      serviceDetail: 'サービス {{name}} の詳細',
+      taskExecutorDetail: 'タスクエグゼキューターの詳細',
+      whitelistManagement: 'ホワイトリスト管理',
+      exportAsExcel: 'Excel形式でエクスポート',
+      importFromExcel: 'Excelをインポート',
+      createEmail: 'メールアドレスを作成',
+      deleteEmail: 'メールアドレスを削除',
+      editEmail: 'メールアドレスを編集',
+      deleteWhitelistEmailConfirmation:
+        'このメールアドレスをホワイトリストから削除してもよろしいですか？この操作は元に戻せません。',
+      importWhitelist: 'ホワイトリストをインポート（Excel）',
+      importSelectExcelFile: 'Excelファイル（.xlsx）',
+      importOverwriteExistingEmails: '既存のメールアドレスを上書き',
+      importInvalidExcelFile: '有効なExcelファイルを選択してください',
+      importFileRequired: 'インポートするファイルを選択してください',
+      importFileTips:
+        'ファイルには、<code>email</code>という名前のヘッダー列を1つだけ含める必要があります。',
+      chunkNum: 'チャンク数',
+      docNum: 'ドキュメント数',
+      tokenNum: '使用トークン数',
+      language: '言語',
+      createDate: '作成日',
+      updateDate: '更新日',
+      permission: '権限',
+      agentTitle: 'エージェントタイトル',
+      canvasCategory: 'キャンバスカテゴリー',
+      newRole: '新規ロール',
+      addNewRole: '新規ロールを追加',
+      roleName: 'ロール名',
+      roleNameRequired: 'ロール名は必須です',
+      resources: 'リソース',
+      editRoleDescription: 'ロールの説明を編集',
+      deleteRole: 'ロールを削除',
+      deleteRoleConfirmation:
+        'このロールを削除してもよろしいですか？この操作は元に戻せません。',
+      alive: '稼働中',
+      timeout: 'タイムアウト',
+      fail: '失敗',
+    },
+
+    skills: {
+      title: 'スキル',
+      selectSpace: 'スキルスペースを選択して開始してください',
+      spacePlaceholder: 'スペース名を入力してください',
+      createSpace: 'スキルスペースを作成',
+      createSpaceTitle: '新しいスキルスペースを作成',
+      createSpaceDescription:
+        'スキルを整理・管理するための新しいスペースを作成します。',
+      spaceName: 'スペース名',
+      spaceNamePlaceholder: '例: my-space',
+      spaceNameRequired: 'スペース名を入力してください',
+      noSpaces:
+        'スキルスペースがまだありません。最初のスペースを作成しましょう。',
+      enterSpace: '開く',
+      spaceCreated: 'スキルスペースを作成しました',
+      spaceDeleted: 'スキルスペースを削除しました',
+      fetchError: 'スキルの取得に失敗しました',
+      deleteSpaceTitle: 'スキルスペースを削除',
+      deleteSpaceDescription:
+        'このスキルスペースを削除してもよろしいですか？この操作は取り消せず、このスペース内のすべてのスキルが完全に削除されます。',
+      deleteSpaceName: 'スペース名',
+      uploadSuccess: 'スキルをアップロードしました',
+      uploadError: 'スキルのアップロードに失敗しました',
+      deleteSuccess: 'スキルを削除しました',
+      deleteError: 'スキルの削除に失敗しました',
+      skillExists:
+        'この名前のスキルは既に存在します。先に削除するか、別の名前を使用してください。',
+      uploadSkill: 'スキルをアップロード',
+      searchPlaceholder: 'スキルを検索...',
+      noSkills:
+        'スキルがまだありません。最初のスキルをアップロードしてください。',
+      noSearchResults: '検索条件に一致するスキルがありません',
+      filesCount: '{{count}} 件のファイル',
+      foldersCount: '{{count}} 件のフォルダ',
+      pageInfo: '{{total}} ページ中 {{current}} ページ目',
+      totalSkills: '合計 {{total}} 件のスキル',
+      backToSkills: 'スキル一覧に戻る',
+      selectFileToView: '表示するファイルを選択してください',
+      skillName: 'スキル名',
+      skillNamePlaceholder: '例: my-awesome-skill',
+      skillNameHelp: '使用できるのは英数字、ハイフン、アンダースコアのみです',
+      source: 'ソース',
+      version: 'バージョン',
+      skillVersion: 'バージョン',
+      skillVersionPlaceholder: '例: 1.0.0',
+      versionFormatHelp:
+        'バージョンはsemver形式で指定してください（例: 1.0.0）',
+      versionRequired: 'バージョンは必須です',
+      selectFilesOrFolder: 'ファイルまたはフォルダを選択',
+      uploadDescription:
+        'スキルファイルをアップロードします。ファイルをドラッグ＆ドロップするか、フォルダを選択してください。',
+      selectFolder: 'フォルダを選択',
+      dragFilesHint: 'または、以下にファイルをドラッグしてください',
+      dragFilesTitle: 'スキルフォルダをここにドラッグ',
+      dragFilesDescription:
+        'スキルフォルダをここにドラッグ＆ドロップするか、下の「フォルダを選択」ボタンを使用してください。',
+      filesSelected: '{{count}} 件のファイルを選択しました',
+      uploading: 'アップロード中...',
+      files: 'ファイル',
+      noFiles: 'ファイルがありません',
+      versionHistory: 'バージョン履歴',
+      selectVersion: 'プレビューするバージョンを選択',
+      latest: '最新',
+
+      metadata: {
+        basic: '基本情報',
+        emoji: '絵文字',
+        skillKey: 'スキルキー',
+        always: '常に有効',
+        primaryEnv: '主要な環境変数',
+        requires: '要件',
+        requiredBins: '必須バイナリ',
+        requiredEnv: '必須環境変数',
+        anyBins: 'いずれか1つが必須',
+        install: '依存関係',
+        links: 'リンク',
+        homepage: 'ホームページ',
+        repository: 'リポジトリ',
+        documentation: 'ドキュメント',
+      },
+
+      validation: {
+        missing_skill_md:
+          '無効なスキルです: SKILL.mdが見つかりません。スキルディレクトリに有効なSKILL.mdファイルが含まれていることを確認してください。',
+        invalid_frontmatter:
+          '無効なスキルです: SKILL.mdには有効なフロントマター（---で開始・終了する）が必要です。',
+        missing_name:
+          '無効なスキルです: SKILL.mdのフロントマターには「name」フィールドが必要です。',
+        invalid_name_format:
+          '無効なスキルです: 「name」は小文字かつURLセーフ（英数字とハイフンのみ）である必要があります。',
+        invalid_version:
+          '無効なスキルです: 「version」は有効なsemver形式である必要があります（例: 1.0.0）。',
+        invalid_metadata:
+          '無効なスキルです: メタデータに無効なフィールドが含まれています。',
+        invalid_file_type:
+          '無効なスキルです: テキスト形式のファイルのみ使用できます。',
+        invalid_path:
+          '無効なスキルです: ファイルパスに無効な文字が含まれています。',
+        file_too_large:
+          '無効なスキルです: 個々のファイルサイズが5MBの上限を超えています。',
+        total_size_exceeded:
+          '無効なスキルです: 合計バンドルサイズが50MBの上限を超えています。',
+        no_files:
+          'ファイルが選択されていません。スキルフォルダを選択してください。',
+        noValidFiles:
+          '有効なファイルが見つかりません。選択内容を確認してください。',
+        junkFilesFound:
+          '一時ファイル（.DS_Storeなど）が検出されました。アップロード前に削除してください。',
+        read_failed:
+          '無効なスキルです: SKILL.mdファイルの読み込みに失敗しました。',
+        invalid: '無効なスキル形式です。',
+        valid: '有効なスキル形式です。アップロードできます。',
+        versionExists:
+          'このバージョンは既に存在します。別のバージョン番号を使用してください。',
+        error: '検証に失敗しました',
+      },
+
+      parsedMetadata: 'SKILL.mdから読み取ったメタデータ:',
+      addSkill: 'スキルを追加',
+      upload: 'アップロード',
+      importFromGit: 'Gitからインポート',
+      gitPlatform: 'プラットフォーム',
+      repoUrl: 'リポジトリURL',
+      repoUrlHelp: 'パスを含むリポジトリURLにも対応しています',
+      accessToken: 'アクセストークン',
+      githubTokenHelp:
+        'プライベートリポジトリの利用や、レート制限の緩和（5000リクエスト/時間）に使用します',
+      giteeTokenHelp:
+        'プライベートリポジトリの利用や、レート制限の緩和（2000リクエスト/時間）に使用します',
+      rateLimitInfo: 'レート制限について',
+      githubRateLimit:
+        'パブリックリポジトリ: IPごとに60リクエスト/時間。トークンを使用すると5000リクエスト/時間になります。',
+      giteeRateLimit:
+        'パブリックリポジトリ: IPごとに1000リクエスト/時間。トークンを使用すると2000リクエスト/時間になります。',
+      import: 'インポート',
+      importing: 'インポート中...',
+      configureSearch: '検索設定',
+    },
+
+    memory: {
+      taskLogDialog: {
+        title: 'メモリー',
+        startTime: '開始時刻',
+        status: 'ステータス',
+        details: '詳細',
+        success: '成功',
+        running: '実行中',
+        failed: '失敗',
+      },
+
+      messages: {
+        forget: '忘却',
+        forgetMessageTip: '忘却してもよろしいですか？',
+        messageDescription:
+          'メモリー抽出は、詳細設定のプロンプトと温度の設定に基づいて行われます。',
+        copied: 'コピーしました！',
+        contentEmbed: 'コンテンツ埋め込み',
+        content: 'コンテンツ',
+        delMessageWarn:
+          '忘却すると、このメッセージはエージェントから取得されなくなります。',
+        forgetMessage: 'メッセージを忘却',
+        sessionId: 'セッションID',
+        agent: 'エージェント',
+        type: '種類',
+        validDate: '有効期限',
+        forgetAt: '忘却日時',
+        source: 'ソース',
+        enable: '有効',
+        action: '操作',
+      },
+
+      config: {
+        descriptionPlaceholder: 'メモリーの説明を入力してください',
+        memorySizeTooltip:
+          '各メッセージのコンテンツ＋埋め込みベクトルを対象とします（≈ コンテンツ + 次元数 × 8バイト）。\n例: 1024次元の埋め込みを持つ1KBのメッセージは約9KBを使用します。デフォルトの5MB上限では、約500件のメッセージを保持できます。',
+        avatar: 'アバター',
+        description: '説明',
+        memorySize: 'メモリーサイズ',
+        advancedSettings: '詳細設定',
+        permission: '権限',
+        onlyMe: '自分のみ',
+        team: 'チーム',
+        storageType: 'ストレージタイプ',
+        storageTypePlaceholder: 'ストレージタイプを選択してください',
+        forgetPolicy: '忘却ポリシー',
+        temperature: '温度',
+        systemPrompt: 'システムプロンプト',
+        systemPromptPlaceholder: 'システムプロンプトを入力してください',
+        userPrompt: 'ユーザープロンプト',
+        userPromptPlaceholder: 'ユーザープロンプトを入力してください',
+      },
+
+      sideBar: {
+        messages: 'メッセージ',
+        configuration: '設定',
+      },
+    },
+
+    skillSearch: {
+      configTitle: 'スキル検索の設定',
+      configDesc: 'スキルのインデックス作成と検索方法を設定します',
+      embeddingModel: '埋め込みモデル',
+      embeddingModelPlaceholder: '埋め込みモデルを選択してください',
+      vectorSimilarityWeight: 'ベクトル類似度の重み',
+      similarityThreshold: '類似度しきい値',
+      topK: '上位K件の結果',
+      indexFields: 'インデックス対象フィールド',
+      indexFieldsDesc: '検索インデックスに含めるフィールドを選択してください',
+      fieldName: '名前',
+      fieldNameDesc: 'スキル名',
+      fieldTags: 'タグ',
+      fieldTagsDesc: 'スキルのタグ',
+      fieldDescription: '説明',
+      fieldDescriptionDesc: 'スキルの説明',
+      fieldContent: 'コンテンツ',
+      fieldContentDesc: 'スキルのコンテンツ（README等）',
+      weight: '重み',
+      pureVector: 'ベクトルのみ',
+      hybrid: 'ハイブリッド',
+      keyword: 'キーワード',
+      vector: 'ベクトル',
+      keywordOnly: 'キーワードのみ',
+      balanced: 'バランス',
+      vectorOnly: 'ベクトルのみ',
+      reindex: 'すべて再インデックス',
+      reindexing: '再インデックス中...',
+      reindexSuccess: '再インデックスしました',
+      pleaseSelectEmbeddingModel: '埋め込みモデルを選択してください',
+      saveSuccess: '保存しました',
+      saveError: '保存に失敗しました',
+      semanticSearchPlaceholder: '意味でスキルを検索...',
+      switchToSemantic: 'セマンティック検索に切り替え',
+      switchToLocal: 'ローカル検索に切り替え',
+    },
+
+    search: {
+      searchApps: '検索アプリ',
+      createSearch: '検索を作成',
+      searchGreeting: '本日はどのようなご用件でしょうか？',
+      profile: 'プロフィールを非表示',
+      locale: 'ロケール',
+      embedCode: '埋め込みコード',
+      id: 'ID',
+      copySuccess: 'コピーしました',
+      welcomeBack: 'おかえりなさい',
+      searchSettings: '検索設定',
+      name: '名前',
+      avatar: 'アバター',
+      description: '説明',
+      datasets: 'データセット',
+      rerankModel: '再ランクモデル',
+      AISummary: 'AI要約',
+      enableWebSearch: 'Web検索を有効にする',
+      enableRelatedSearch: '関連検索を有効にする',
+      showQueryMindmap: 'クエリのマインドマップを表示',
+      embedApp: 'アプリを埋め込む',
+      relatedSearch: '関連検索',
+      descriptionValue: 'あなたは有能なアシスタントです。',
+      okText: '保存',
+      cancelText: 'キャンセル',
+      chooseDataset: '先にデータセットを選択してください',
+      selectLocalePlaceholder: 'ロケールを選択してください',
+    },
+
+    dataflowParser: {
+      result: '結果',
+      parseSummary: '解析サマリー',
+      parseSummaryTip: 'パーサー：DeepDoc',
+      parserMethod: 'パーサー方式',
+      outputFormat: '出力形式',
+      rerunFromCurrentStep: '現在のステップから再実行',
+      rerunFromCurrentStepTip:
+        '変更が検出されました。クリックして再実行してください。',
+      confirmRerun: '再実行プロセスの確認',
+      confirmRerunModalContent:
+        '\n      <p class="text-sm text-text-disabled font-medium mb-2">\n        <span class="text-text-secondary">{{step}}</span> ステップから処理を再実行しようとしています。\n      </p>\n      <p class="text-sm mb-3 text-text-disabled">これにより次が行われます:</p><br />\n      <ul class="list-disc list-inside space-y-1 text-sm text-text-secondary">\n        <li>• 現在のステップ以降の既存の結果を上書きします</li>\n        <li>• 追跡用の新しいログエントリを作成します</li>\n        <li>• それより前のステップは変更されません</li>\n      </ul>',
+      changeStepModalTitle: 'ステップ切り替えの警告',
+      changeStepModalContent:
+        '\n      <p>現在、このステージの結果を編集しています。</p>\n      <p>後のステージに切り替えると、変更内容は失われます。</p>\n      <p>変更を保持するには、「再実行」をクリックして現在のステージを再実行してください。</p> ',
+      changeStepModalConfirmText: '切り替える',
+      changeStepModalCancelText: 'キャンセル',
+      unlinkPipelineModalTitle: '取り込みパイプラインの連携を解除',
+      unlinkPipelineModalConfirmText: '連携解除',
+      unlinkPipelineModalContent:
+        '\n      <p>連携を解除すると、このデータセットは現在の取り込みパイプラインと接続されなくなります。</p>\n      <p>すでに解析中のファイルは、完了するまで処理が続行されます</p>\n      <p>まだ解析されていないファイルは、以降処理されなくなります</p> <br/>\n      <p>続行してもよろしいですか？</p> ',
+      unlinkSourceModalTitle: 'データソースの連携を解除',
+      unlinkSourceModalContent:
+        '\n      <p>このデータソースの連携を解除してもよろしいですか？</p>',
+      unlinkSourceModalConfirmText: '連携解除',
+    },
+
+    memories: {
+      llmTooltip:
+        '会話内容を分析し、重要な情報を抽出して構造化されたメモリーサマリーを生成します。',
+      embeddingModelTooltip:
+        'テキストを数値ベクトルに変換し、意味的な類似検索とメモリー検索に使用します。',
+      embeddingModelError:
+        'メモリータイプは必須であり、「生データ」タイプは削除できません。',
+      memoryTypeTooltip:
+        '生データ: ユーザーとエージェント間の生の対話内容（デフォルトで必須）。\n意味記憶: ユーザーや世界に関する一般的な知識・事実。\nエピソード記憶: 特定の出来事や体験のタイムスタンプ付き記録。\n手続き記憶: 習得したスキル、習慣、自動化された手順。',
+      raw: '生データ',
+      semantic: '意味記憶',
+      episodic: 'エピソード記憶',
+      procedural: '手続き記憶',
+      editName: '名前を編集',
+      memory: 'メモリー',
+      createMemory: 'メモリーを作成',
+      name: '名前',
+      memoryNamePlaceholder: 'メモリー名',
+      memoryType: 'メモリータイプ',
+      embeddingModel: '埋め込みモデル',
+      selectModel: 'モデルを選択',
+      llm: 'LLM',
+      delMemoryWarn:
+        '削除すると、このメモリー内のすべてのメッセージが削除され、エージェントから取得できなくなります。',
+    },
+
+    mcp: {
+      export: 'エクスポート',
+      import: 'インポート',
+      url: 'URL',
+      serverType: 'サーバータイプ',
+      addMCP: 'MCPを追加',
+      editMCP: 'MCPを編集',
+      toolsAvailable: '個の利用可能なツール',
+      mcpServers: 'MCPサーバー',
+      mcpServer: 'MCPサーバー',
+      customizeTheListOfMcpServers: 'MCPサーバーの一覧をカスタマイズ',
+      cachedTools: '個のキャッシュ済みツール',
+      bulkManage: '一括管理',
+      exitBulkManage: '一括管理を終了',
+      selected: '選択済み',
+      noServerSelected: '少なくとも1つのMCPサーバーを選択してください',
+    },
+
+    explore: {
+      title: '起動',
+      canvasList: 'キャンバス一覧',
+      sessions: 'セッション',
+      newSession: '新しいセッション',
+      newSessionLabel: '新しい会話を開始',
+      deleteSession: 'セッションを削除',
+      searchCanvas: 'キャンバスを検索...',
+      searchSessions: 'セッションを検索...',
+      noCanvasSelected: 'キャンバスを選択してください',
+      noSessionSelected: 'セッションを選択するか、新規作成してください',
+      noSessionsFound: 'セッションが見つかりません',
+      createFirstSession: '最初のセッションを作成',
+      noCanvasFound: 'キャンバスが見つかりません',
+      deleteSelectedConfirm:
+        '{{count}} 件のセッションを削除してもよろしいですか？',
+      batchDeleteSessions: 'セッションを削除',
+    },
+
+    empty: {
+      noMCP: '利用可能なMCPサーバーがありません',
+      agentTitle: 'まだエージェントアプリが作成されていません',
+      notFoundAgent: 'エージェントアプリが見つかりません',
+      datasetTitle: 'まだデータセットが作成されていません',
+      notFoundDataset: 'データセットが見つかりません',
+      chatTitle: 'まだチャットアプリが作成されていません',
+      notFoundChat: 'チャットアプリが見つかりません',
+      searchTitle: 'まだ検索アプリが作成されていません',
+      notFoundSearch: '検索アプリが見つかりません',
+      memoryTitle: 'まだメモリーが作成されていません',
+      notFoundMemory: 'メモリーが見つかりません',
+      skillsTitle: 'まだスキルスペースが作成されていません',
+      notFoundSkills: 'スキルスペースが見つかりません',
+      addNow: '今すぐ追加',
+    },
+
+    datasetOverview: {
+      downloadTip: 'データソースからダウンロード中のファイルです。',
+      processingTip: '取り込みパイプラインで処理中のファイルです。',
+      totalFiles: '合計ファイル数',
+      downloading: 'ダウンロード中',
+      downloadSuccessTip: 'ダウンロード成功件数',
+      downloadFailedTip: 'ダウンロード失敗件数',
+      processingSuccessTip: '処理成功件数',
+      processingFailedTip: '処理失敗件数',
+      processing: '処理中',
+      noData: 'ログはまだありません',
+    },
+
+    deleteModal: {
+      delAgent: 'エージェントを削除',
+      delDataset: 'データセットを削除',
+      delSearch: '検索を削除',
+      delFile: 'ファイルを削除',
+      delFiles: 'ファイルを削除',
+      delFilesContent: '{{count}} 件のファイルを選択中',
+      delChat: 'チャットを削除',
+      delMember: 'メンバーを削除',
+      delMemory: 'メモリーを削除',
+    },
+
+    datasetSkill: {
+      folders: 'スキル',
+      empty: '利用可能なスキルがありません',
+      selectFolder: '詳細を表示するスキルを選択してください',
+      currentFolder: 'スキル',
+      noContent: 'コンテンツがありません',
+    },
+
+    llmTools: {
+      bad_calculator: {
+        name: '電卓',
+        description:
+          '2つの数値の合計を計算するツールです（誤った答えを返します）',
+
+        params: {
+          a: '1つ目の数値',
+          b: '2つ目の数値',
+        },
+      },
+    },
+
+    modal: {
+      okText: '確認',
+      cancelText: 'キャンセル',
+    },
+
+    pagination: {
+      total: '合計 {{total}} 件',
+      page: '{{page}} 件 / ページ',
+    },
+
+    knowledgeCompilation: {
+      builtinTemplates: '組み込みテンプレート',
     },
   },
 };


### PR DESCRIPTION
## What

The Japanese locale (`web/src/locales/ja.ts`) was missing translations for **1703 of 2686 keys (~63%)**. Because i18next's `fallbackLng` silently falls back to English for any missing key, most of the UI stayed in English even after selecting 日本語 — e.g. the Settings > Model Providers page, the Agent/Flow builder, dataset configuration panels, and more.

This PR fills in all 1703 missing keys with Japanese translations.

## Approach

- The existing 992 already-translated keys are **completely untouched** — this diff is purely additive (0 deletions), verified via an AST-based patch (not a full-file regeneration) so unrelated lines never get reformatted.
- Terminology is kept consistent with the existing translated keys (e.g. ナレッジベース for "Knowledge Base", チャンク for "Chunk", 再ランクモデル for "Rerank Model", 埋め込みモデル for "Embedding Model").
- Technical/brand terms that shouldn't be translated are kept as-is (API, ID, URL, GitHub, PaddleOCR, search-provider names like DuckDuckGo/SearXNG/PubMed, etc.), matching the convention already used in the existing translated keys.
- `i18next` interpolation placeholders (`{{count}}`, `{{type}}`, ...) and embedded HTML tags are preserved unchanged.
- Two pre-existing minor markup quirks in the English source (`deleteGenerateModalContent`'s unclosed `<p>` tag, `graphRagMethodTip`'s `</br>`) were intentionally left as faithful translations rather than "fixed", since fixing them is out of scope for a translation-only PR and would create inconsistency with the English version.

## Testing

- `prettier --check` passes with the project's existing config (singleQuote, trailingComma: all).
- Verified programmatically that every key present in `en.ts` now has a corresponding `ja.ts` entry, and that none of the previously-existing 992 translations changed value.
- Built the web app (`npm run build`) and manually verified in a running instance that previously-English screens now render fully in Japanese, including: the home dashboard, Settings > Model Providers, Settings > Data Source, the Agent/Flow builder (including node detail panels like the Title Chunker's Hierarchy/Group configuration), and the HTTP API reference page.