### PR TITLE
Fix: sample_rate in siliconflow tts model call

### DIFF
--- a/rag/llm/tts_model.py
+++ b/rag/llm/tts_model.py
@@ -407,7 +407,7 @@ class SILICONFLOWTTS(HTTPBasedTTS):
             "input": text,
             "voice": f"{self.model_name}:{voice}",
             "response_format": "mp3",
-            "sample_rate": 123,
+            "sample_rate": 32000,
             "stream": True,
             "speed": 1,
             "gain": 0,


### PR DESCRIPTION
### Summary

Set a valid value as `sample_rate`.
