### PR TITLE
fix(connector): disable zero-frequency sync scheduling

### DIFF
--- a/api/apps/restful_apis/connector_api.py
+++ b/api/apps/restful_apis/connector_api.py
@@ -47,9 +47,20 @@ def _connector_auth_error(connector_id: str, user_id: str):
 
 
 def _validate_refresh_freq(req: dict):
-    if "refresh_freq" in req and int(req["refresh_freq"]) < 0:
-        return get_json_result(code=RetCode.ARGUMENT_ERROR, message="refresh_freq must be greater than or equal to 0")
-    return None
+    if "refresh_freq" not in req:
+        return None
+
+    value = req["refresh_freq"]
+    try:
+        refresh_freq = int(value)
+    except (TypeError, ValueError, OverflowError):
+        refresh_freq = -1
+
+    if not isinstance(value, bool) and not (isinstance(value, float) and not value.is_integer()) and refresh_freq >= 0:
+        return None
+
+    LOGGER.warning("invalid refresh_freq: %r", value)
+    return get_json_result(code=RetCode.ARGUMENT_ERROR, message="refresh_freq must be a non-negative integer")
 
 
 @manager.route("/connectors/<connector_id>", methods=["PATCH"])  # noqa: F821

--- a/api/apps/restful_apis/connector_api.py
+++ b/api/apps/restful_apis/connector_api.py
@@ -46,6 +46,12 @@ def _connector_auth_error(connector_id: str, user_id: str):
     return get_json_result(data=False, message="No authorization.", code=RetCode.AUTHENTICATION_ERROR)
 
 
+def _validate_refresh_freq(req: dict):
+    if "refresh_freq" in req and int(req["refresh_freq"]) < 0:
+        return get_json_result(code=RetCode.ARGUMENT_ERROR, message="refresh_freq must be greater than or equal to 0")
+    return None
+
+
 @manager.route("/connectors/<connector_id>", methods=["PATCH"])  # noqa: F821
 @login_required
 async def update_connector(connector_id):
@@ -56,6 +62,8 @@ async def update_connector(connector_id):
     req = await get_request_json()
     if isinstance(req, dict) and isinstance(req.get("data"), dict):
         req = req["data"]
+    if error := _validate_refresh_freq(req):
+        return error
 
     e, conn = ConnectorService.get_by_id(connector_id)
     if not e:
@@ -91,6 +99,8 @@ async def update_connector(connector_id):
 async def create_connector():
     """Create a connector owned by the current tenant."""
     req = await get_request_json()
+    if error := _validate_refresh_freq(req):
+        return error
     if req:
         req["id"] = get_uuid()
         conn = {

--- a/api/db/services/connector_service.py
+++ b/api/db/services/connector_service.py
@@ -316,6 +316,8 @@ class SyncLogsService(CommonService):
             cls.model.status == TaskStatus.SCHEDULE,
             cls.model.task_type == task_type,
         )
+        if task_type == ConnectorTaskType.SYNC:
+            query = query.where((Connector.refresh_freq > 0) | (cls.model.from_beginning == "1"))
 
         database_type = os.getenv("DB_TYPE", "mysql")
         if "postgres" in database_type.lower():

--- a/api/db/services/connector_service.py
+++ b/api/db/services/connector_service.py
@@ -257,7 +257,7 @@ class SyncLogsService(CommonService):
             ConnectorTaskType.SYNC,
             "refresh_freq",
         )
-        return [task for task in tasks if int(task.get("refresh_freq") or 0) > 0]
+        return [task for task in tasks if task.get("reindex") == "1" or int(task.get("refresh_freq") or 0) > 0]
 
     @classmethod
     def list_due_prune_tasks(cls) -> List[dict]:

--- a/api/db/services/connector_service.py
+++ b/api/db/services/connector_service.py
@@ -253,10 +253,11 @@ class SyncLogsService(CommonService):
 
     @classmethod
     def list_due_sync_tasks(cls) -> List[dict]:
-        return cls._list_due_tasks_for_freq(
+        tasks = cls._list_due_tasks_for_freq(
             ConnectorTaskType.SYNC,
             "refresh_freq",
         )
+        return [task for task in tasks if int(task.get("refresh_freq") or 0) > 0]
 
     @classmethod
     def list_due_prune_tasks(cls) -> List[dict]:

--- a/internal/handler/connector.go
+++ b/internal/handler/connector.go
@@ -100,6 +100,8 @@ func connectorErrorResponse(c *gin.Context, err error) bool {
 		common.ResponseWithCodeData(c, common.CodeDataError, nil, "Can't find this Connector!")
 	case errors.Is(err, service.ErrConnectorTestUnsupported):
 		common.ResponseWithCodeData(c, common.CodeArgumentError, false, err.Error())
+	case errors.Is(err, service.ErrInvalidRefreshFreq):
+		common.ResponseWithCodeData(c, common.CodeArgumentError, nil, err.Error())
 	default:
 		common.ResponseWithHttpCodeData(c, http.StatusInternalServerError, common.CodeServerError, nil, err.Error())
 	}
@@ -262,8 +264,7 @@ func (h *ConnectorHandler) CreateConnector(c *gin.Context) {
 	}
 
 	connector, err := h.connectorService.CreateConnector(user.ID, &req)
-	if err != nil {
-		common.ResponseWithHttpCodeData(c, http.StatusInternalServerError, common.CodeServerError, nil, err.Error())
+	if connectorErrorResponse(c, err) {
 		return
 	}
 

--- a/internal/handler/connector_test.go
+++ b/internal/handler/connector_test.go
@@ -273,6 +273,41 @@ func TestConnectorHandlerTestConnector(t *testing.T) {
 	}
 }
 
+func TestConnectorHandlerCreateConnectorRejectsNegativeRefreshFreq(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &ConnectorHandler{connectorService: fakeConnectorService{err: service.ErrInvalidRefreshFreq}}
+	router := gin.New()
+	router.POST("/api/v1/connectors", func(c *gin.Context) {
+		c.Set("user", &entity.User{ID: "tenant-1"})
+		h.CreateConnector(c)
+	})
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/connectors",
+		strings.NewReader(`{"name":"connector","source":"webdav","config":{},"refresh_freq":-1}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body["code"] != float64(common.CodeArgumentError) {
+		t.Fatalf("code=%v want=%v body=%v", body["code"], common.CodeArgumentError, body)
+	}
+	if body["message"] != "refresh_freq must be a non-negative integer" {
+		t.Fatalf("message=%v body=%v", body["message"], body)
+	}
+}
+
 func TestConnectorHandlerDeleteConnector(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/handler/connector_test.go
+++ b/internal/handler/connector_test.go
@@ -273,38 +273,42 @@ func TestConnectorHandlerTestConnector(t *testing.T) {
 	}
 }
 
-func TestConnectorHandlerCreateConnectorRejectsNegativeRefreshFreq(t *testing.T) {
+func TestConnectorHandlerCreateConnectorRejectsInvalidRefreshFreq(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	h := &ConnectorHandler{connectorService: fakeConnectorService{err: service.ErrInvalidRefreshFreq}}
+	h := &ConnectorHandler{connectorService: service.NewConnectorService()}
 	router := gin.New()
 	router.POST("/api/v1/connectors", func(c *gin.Context) {
 		c.Set("user", &entity.User{ID: "tenant-1"})
 		h.CreateConnector(c)
 	})
 
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/v1/connectors",
-		strings.NewReader(`{"name":"connector","source":"webdav","config":{},"refresh_freq":-1}`),
-	)
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(resp, req)
+	for _, refreshFreq := range []string{"-1", "null"} {
+		t.Run(refreshFreq, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/connectors",
+				strings.NewReader(`{"name":"connector","source":"webdav","config":{},"refresh_freq":`+refreshFreq+`}`),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
-	}
+			if resp.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+			}
 
-	var body map[string]interface{}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
-	if body["code"] != float64(common.CodeArgumentError) {
-		t.Fatalf("code=%v want=%v body=%v", body["code"], common.CodeArgumentError, body)
-	}
-	if body["message"] != "refresh_freq must be a non-negative integer" {
-		t.Fatalf("message=%v body=%v", body["message"], body)
+			var body map[string]interface{}
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if body["code"] != float64(common.CodeArgumentError) {
+				t.Fatalf("code=%v want=%v body=%v", body["code"], common.CodeArgumentError, body)
+			}
+			if body["message"] != "refresh_freq must be a non-negative integer" {
+				t.Fatalf("message=%v body=%v", body["message"], body)
+			}
+		})
 	}
 }
 

--- a/internal/service/connector.go
+++ b/internal/service/connector.go
@@ -79,7 +79,16 @@ var (
 	// ErrConnectorTestUnsupported is returned for connector sources whose
 	// validation path is not yet ported to Go.
 	ErrConnectorTestUnsupported = errors.New("test endpoint currently supports only REST API connectors")
+	// ErrInvalidRefreshFreq is returned when a connector refresh frequency is negative.
+	ErrInvalidRefreshFreq = errors.New("refresh_freq must be a non-negative integer")
 )
+
+func validateRefreshFreq(refreshFreq *int64) error {
+	if refreshFreq != nil && *refreshFreq < 0 {
+		return ErrInvalidRefreshFreq
+	}
+	return nil
+}
 
 // ConnectorService connector service
 type ConnectorService struct {
@@ -236,6 +245,10 @@ func (s *ConnectorService) cancelConnectorTasks(connectorID string) error {
 // CreateConnector creates a connector owned by the current user.
 // Equivalent to Python's create_connector endpoint.
 func (s *ConnectorService) CreateConnector(userID string, req *CreateConnectorRequest) (*entity.Connector, error) {
+	if err := validateRefreshFreq(req.RefreshFreq); err != nil {
+		return nil, err
+	}
+
 	refreshFreq := int64(defaultConnectorFreq)
 	if req.RefreshFreq != nil {
 		refreshFreq = *req.RefreshFreq
@@ -890,6 +903,11 @@ func (s *ConnectorService) UpdateConnector(connectorID, userID string, req *Upda
 
 	if !s.canAccessConnector(connector, userID) {
 		return nil, common.CodeAuthenticationError, fmt.Errorf("No authorization.")
+	}
+	if req != nil {
+		if err := validateRefreshFreq(req.RefreshFreq); err != nil {
+			return nil, common.CodeArgumentError, err
+		}
 	}
 
 	updates := map[string]interface{}{}

--- a/internal/service/connector.go
+++ b/internal/service/connector.go
@@ -83,11 +83,23 @@ var (
 	ErrInvalidRefreshFreq = errors.New("refresh_freq must be a non-negative integer")
 )
 
-func validateRefreshFreq(refreshFreq *int64) error {
-	if refreshFreq != nil && *refreshFreq < 0 {
+func validateRefreshFreq(refreshFreq *int64, present bool) error {
+	if (present && refreshFreq == nil) || (refreshFreq != nil && *refreshFreq < 0) {
 		return ErrInvalidRefreshFreq
 	}
 	return nil
+}
+
+func unmarshalWithRefreshFreqPresence(data []byte, request any) (bool, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(data, request); err != nil {
+		return false, err
+	}
+	_, present := fields["refresh_freq"]
+	return present, nil
 }
 
 // ConnectorService connector service
@@ -111,12 +123,25 @@ type ListConnectorsResponse struct {
 
 // CreateConnectorRequest creates a connector with Python-compatible defaults.
 type CreateConnectorRequest struct {
-	Name        string         `json:"name"`
-	Source      string         `json:"source"`
-	Config      entity.JSONMap `json:"config"`
-	RefreshFreq *int64         `json:"refresh_freq,omitempty"`
-	PruneFreq   *int64         `json:"prune_freq,omitempty"`
-	TimeoutSecs *int64         `json:"timeout_secs,omitempty"`
+	Name           string         `json:"name"`
+	Source         string         `json:"source"`
+	Config         entity.JSONMap `json:"config"`
+	RefreshFreq    *int64         `json:"refresh_freq,omitempty"`
+	PruneFreq      *int64         `json:"prune_freq,omitempty"`
+	TimeoutSecs    *int64         `json:"timeout_secs,omitempty"`
+	refreshFreqSet bool
+}
+
+func (req *CreateConnectorRequest) UnmarshalJSON(data []byte) error {
+	type requestAlias CreateConnectorRequest
+	var decoded requestAlias
+	present, err := unmarshalWithRefreshFreqPresence(data, &decoded)
+	if err != nil {
+		return err
+	}
+	*req = CreateConnectorRequest(decoded)
+	req.refreshFreqSet = present
+	return nil
 }
 
 // RebuildConnectorRequest rebuild connector request.
@@ -245,7 +270,7 @@ func (s *ConnectorService) cancelConnectorTasks(connectorID string) error {
 // CreateConnector creates a connector owned by the current user.
 // Equivalent to Python's create_connector endpoint.
 func (s *ConnectorService) CreateConnector(userID string, req *CreateConnectorRequest) (*entity.Connector, error) {
-	if err := validateRefreshFreq(req.RefreshFreq); err != nil {
+	if err := validateRefreshFreq(req.RefreshFreq, req.refreshFreqSet); err != nil {
 		return nil, err
 	}
 
@@ -880,12 +905,25 @@ func (s *ConnectorService) DeleteConnector(connectorID, userID string) (bool, co
 }
 
 type UpdateConnectorRequest struct {
-	PruneFreq   *int64         `json:"prune_freq,omitempty"`
-	RefreshFreq *int64         `json:"refresh_freq,omitempty"`
-	Config      entity.JSONMap `json:"config,omitempty"`
-	TimeoutSecs *int64         `json:"timeout_secs,omitempty"`
-	Reschedule  bool           `json:"reschedule,omitempty"`
-	Status      string         `json:"status,omitempty"`
+	PruneFreq      *int64         `json:"prune_freq,omitempty"`
+	RefreshFreq    *int64         `json:"refresh_freq,omitempty"`
+	Config         entity.JSONMap `json:"config,omitempty"`
+	TimeoutSecs    *int64         `json:"timeout_secs,omitempty"`
+	Reschedule     bool           `json:"reschedule,omitempty"`
+	Status         string         `json:"status,omitempty"`
+	refreshFreqSet bool
+}
+
+func (req *UpdateConnectorRequest) UnmarshalJSON(data []byte) error {
+	type requestAlias UpdateConnectorRequest
+	var decoded requestAlias
+	present, err := unmarshalWithRefreshFreqPresence(data, &decoded)
+	if err != nil {
+		return err
+	}
+	*req = UpdateConnectorRequest(decoded)
+	req.refreshFreqSet = present
+	return nil
 }
 
 func (s *ConnectorService) UpdateConnector(connectorID, userID string, req *UpdateConnectorRequest) (*entity.Connector, common.ErrorCode, error) {
@@ -905,7 +943,7 @@ func (s *ConnectorService) UpdateConnector(connectorID, userID string, req *Upda
 		return nil, common.CodeAuthenticationError, fmt.Errorf("No authorization.")
 	}
 	if req != nil {
-		if err := validateRefreshFreq(req.RefreshFreq); err != nil {
+		if err := validateRefreshFreq(req.RefreshFreq, req.refreshFreqSet); err != nil {
 			return nil, common.CodeArgumentError, err
 		}
 	}

--- a/internal/service/connector_refresh_freq_test.go
+++ b/internal/service/connector_refresh_freq_test.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -27,23 +28,52 @@ func TestValidateRefreshFreq(t *testing.T) {
 	positive := int64(5)
 
 	tests := []struct {
-		name string
-		freq *int64
-		err  error
+		name    string
+		freq    *int64
+		present bool
+		err     error
 	}{
 		{name: "unset", freq: nil},
 		{name: "zero", freq: &zero},
 		{name: "positive", freq: &positive},
 		{name: "negative", freq: &negative, err: ErrInvalidRefreshFreq},
+		{name: "null", freq: nil, present: true, err: ErrInvalidRefreshFreq},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateRefreshFreq(tt.freq)
+			err := validateRefreshFreq(tt.freq, tt.present)
 			if !errors.Is(err, tt.err) {
 				t.Fatalf("validateRefreshFreq() error = %v, want %v", err, tt.err)
 			}
 		})
+	}
+}
+
+func TestCreateConnectorRejectsNullRefreshFreq(t *testing.T) {
+	var req CreateConnectorRequest
+	if err := json.Unmarshal([]byte(`{"refresh_freq":null}`), &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+
+	connector, err := NewConnectorService().CreateConnector("tenant-1", &req)
+
+	if connector != nil {
+		t.Fatalf("CreateConnector() connector = %#v, want nil", connector)
+	}
+	if !errors.Is(err, ErrInvalidRefreshFreq) {
+		t.Fatalf("CreateConnector() error = %v, want %v", err, ErrInvalidRefreshFreq)
+	}
+}
+
+func TestUpdateConnectorRequestPreservesNullRefreshFreq(t *testing.T) {
+	var req UpdateConnectorRequest
+	if err := json.Unmarshal([]byte(`{"refresh_freq":null}`), &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+
+	if !errors.Is(validateRefreshFreq(req.RefreshFreq, req.refreshFreqSet), ErrInvalidRefreshFreq) {
+		t.Fatal("explicit null refresh_freq was treated as an omitted field")
 	}
 }
 

--- a/internal/service/connector_refresh_freq_test.go
+++ b/internal/service/connector_refresh_freq_test.go
@@ -1,0 +1,61 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateRefreshFreq(t *testing.T) {
+	negative := int64(-1)
+	zero := int64(0)
+	positive := int64(5)
+
+	tests := []struct {
+		name string
+		freq *int64
+		err  error
+	}{
+		{name: "unset", freq: nil},
+		{name: "zero", freq: &zero},
+		{name: "positive", freq: &positive},
+		{name: "negative", freq: &negative, err: ErrInvalidRefreshFreq},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRefreshFreq(tt.freq)
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("validateRefreshFreq() error = %v, want %v", err, tt.err)
+			}
+		})
+	}
+}
+
+func TestCreateConnectorRejectsNegativeRefreshFreq(t *testing.T) {
+	negative := int64(-1)
+
+	connector, err := NewConnectorService().CreateConnector("tenant-1", &CreateConnectorRequest{RefreshFreq: &negative})
+
+	if connector != nil {
+		t.Fatalf("CreateConnector() connector = %#v, want nil", connector)
+	}
+	if !errors.Is(err, ErrInvalidRefreshFreq) {
+		t.Fatalf("CreateConnector() error = %v, want %v", err, ErrInvalidRefreshFreq)
+	}
+}

--- a/test/testcases/restful_api/test_connector_routes_unit.py
+++ b/test/testcases/restful_api/test_connector_routes_unit.py
@@ -422,12 +422,13 @@ def test_connector_basic_routes_and_task_controls(monkeypatch):
 
 
 @pytest.mark.p2
-def test_update_connector_rejects_negative_refresh_frequency(monkeypatch):
+@pytest.mark.parametrize("refresh_freq", [-1, -0.5, 0.5, None, "invalid", True])
+def test_update_connector_rejects_invalid_refresh_frequency(monkeypatch, refresh_freq):
     module = _load_connector_app(monkeypatch)
     update_calls = []
 
     monkeypatch.setattr(module.ConnectorService, "update_by_id", lambda *args: update_calls.append(args))
-    monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"refresh_freq": -1}))
+    monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"refresh_freq": refresh_freq}))
 
     res = _run(module.update_connector("conn-1"))
 
@@ -436,7 +437,8 @@ def test_update_connector_rejects_negative_refresh_frequency(monkeypatch):
 
 
 @pytest.mark.p2
-def test_create_connector_rejects_negative_refresh_frequency(monkeypatch):
+@pytest.mark.parametrize("refresh_freq", [-1, -0.5, 0.5, None, "invalid", True])
+def test_create_connector_rejects_invalid_refresh_frequency(monkeypatch, refresh_freq):
     module = _load_connector_app(monkeypatch)
     save_calls = []
 
@@ -444,7 +446,7 @@ def test_create_connector_rejects_negative_refresh_frequency(monkeypatch):
     monkeypatch.setattr(
         module,
         "get_request_json",
-        lambda: _AwaitableValue({"name": "new", "source": "webdav", "config": {}, "refresh_freq": -1}),
+        lambda: _AwaitableValue({"name": "new", "source": "webdav", "config": {}, "refresh_freq": refresh_freq}),
     )
 
     res = _run(module.create_connector())

--- a/test/testcases/restful_api/test_connector_routes_unit.py
+++ b/test/testcases/restful_api/test_connector_routes_unit.py
@@ -422,6 +422,38 @@ def test_connector_basic_routes_and_task_controls(monkeypatch):
 
 
 @pytest.mark.p2
+def test_update_connector_rejects_negative_refresh_frequency(monkeypatch):
+    module = _load_connector_app(monkeypatch)
+    update_calls = []
+
+    monkeypatch.setattr(module.ConnectorService, "update_by_id", lambda *args: update_calls.append(args))
+    monkeypatch.setattr(module, "get_request_json", lambda: _AwaitableValue({"refresh_freq": -1}))
+
+    res = _run(module.update_connector("conn-1"))
+
+    assert res["code"] == module.RetCode.ARGUMENT_ERROR
+    assert update_calls == []
+
+
+@pytest.mark.p2
+def test_create_connector_rejects_negative_refresh_frequency(monkeypatch):
+    module = _load_connector_app(monkeypatch)
+    save_calls = []
+
+    monkeypatch.setattr(module.ConnectorService, "save", lambda **payload: save_calls.append(payload))
+    monkeypatch.setattr(
+        module,
+        "get_request_json",
+        lambda: _AwaitableValue({"name": "new", "source": "webdav", "config": {}, "refresh_freq": -1}),
+    )
+
+    res = _run(module.create_connector())
+
+    assert res["code"] == module.RetCode.ARGUMENT_ERROR
+    assert save_calls == []
+
+
+@pytest.mark.p2
 def test_connector_by_id_routes_reject_cross_tenant_access(monkeypatch):
     """Verify per-id connector routes stop before body parsing or service access."""
     module = _load_connector_app(monkeypatch)

--- a/test/unit_test/api/db/services/test_connector_service_due_tasks.py
+++ b/test/unit_test/api/db/services/test_connector_service_due_tasks.py
@@ -73,5 +73,7 @@ def test_due_sync_query_filters_disabled_connectors_before_materialization(monke
     assert SyncLogsService._list_due_tasks_for_freq(ConnectorTaskType.SYNC, "refresh_freq") == []
 
     frequency_filter = next(condition for conditions in where_calls for condition in conditions if getattr(condition, "op", None) == "OR")
-    assert (frequency_filter.lhs.lhs, frequency_filter.lhs.op, frequency_filter.lhs.rhs) == (Connector.refresh_freq, ">", 0)
-    assert (frequency_filter.rhs.lhs, frequency_filter.rhs.op, frequency_filter.rhs.rhs) == (SyncLogs.from_beginning, "=", "1")
+    assert frequency_filter.lhs.lhs is Connector.refresh_freq
+    assert (frequency_filter.lhs.op, frequency_filter.lhs.rhs) == (">", 0)
+    assert frequency_filter.rhs.lhs is SyncLogs.from_beginning
+    assert (frequency_filter.rhs.op, frequency_filter.rhs.rhs) == ("=", "1")

--- a/test/unit_test/api/db/services/test_connector_service_due_tasks.py
+++ b/test/unit_test/api/db/services/test_connector_service_due_tasks.py
@@ -1,0 +1,42 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+
+from api.db.services.connector_service import SyncLogsService
+from common.constants import ConnectorTaskType
+
+
+@pytest.mark.p2
+def test_list_due_sync_tasks_excludes_non_positive_refresh_frequencies(monkeypatch):
+    tasks = [
+        {"id": "negative", "refresh_freq": -1},
+        {"id": "zero", "refresh_freq": 0},
+        {"id": "unset", "refresh_freq": None},
+        {"id": "positive", "refresh_freq": 5},
+    ]
+    calls = []
+
+    def _list_due_tasks(cls, task_type, freq_field):
+        calls.append((task_type, freq_field))
+        return tasks
+
+    monkeypatch.setattr(SyncLogsService, "_list_due_tasks_for_freq", classmethod(_list_due_tasks))
+
+    due_tasks = SyncLogsService.list_due_sync_tasks()
+
+    assert due_tasks == [{"id": "positive", "refresh_freq": 5}]
+    assert calls == [(ConnectorTaskType.SYNC, "refresh_freq")]

--- a/test/unit_test/api/db/services/test_connector_service_due_tasks.py
+++ b/test/unit_test/api/db/services/test_connector_service_due_tasks.py
@@ -21,12 +21,13 @@ from common.constants import ConnectorTaskType
 
 
 @pytest.mark.p2
-def test_list_due_sync_tasks_excludes_non_positive_refresh_frequencies(monkeypatch):
+def test_list_due_sync_tasks_excludes_non_positive_refresh_frequencies_unless_reindexing(monkeypatch):
     tasks = [
-        {"id": "negative", "refresh_freq": -1},
-        {"id": "zero", "refresh_freq": 0},
-        {"id": "unset", "refresh_freq": None},
-        {"id": "positive", "refresh_freq": 5},
+        {"id": "negative", "refresh_freq": -1, "reindex": "0"},
+        {"id": "zero", "refresh_freq": 0, "reindex": "0"},
+        {"id": "unset", "refresh_freq": None, "reindex": "0"},
+        {"id": "positive", "refresh_freq": 5, "reindex": "0"},
+        {"id": "reindex", "refresh_freq": 0, "reindex": "1"},
     ]
     calls = []
 
@@ -38,5 +39,8 @@ def test_list_due_sync_tasks_excludes_non_positive_refresh_frequencies(monkeypat
 
     due_tasks = SyncLogsService.list_due_sync_tasks()
 
-    assert due_tasks == [{"id": "positive", "refresh_freq": 5}]
+    assert due_tasks == [
+        {"id": "positive", "refresh_freq": 5, "reindex": "0"},
+        {"id": "reindex", "refresh_freq": 0, "reindex": "1"},
+    ]
     assert calls == [(ConnectorTaskType.SYNC, "refresh_freq")]

--- a/test/unit_test/api/db/services/test_connector_service_due_tasks.py
+++ b/test/unit_test/api/db/services/test_connector_service_due_tasks.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+from api.db.db_models import SyncLogs
 from api.db.services.connector_service import SyncLogsService
 from common.constants import ConnectorTaskType
 
@@ -44,3 +45,33 @@ def test_list_due_sync_tasks_excludes_non_positive_refresh_frequencies_unless_re
         {"id": "reindex", "refresh_freq": 0, "reindex": "1"},
     ]
     assert calls == [(ConnectorTaskType.SYNC, "refresh_freq")]
+
+
+@pytest.mark.p2
+def test_due_sync_query_filters_disabled_connectors_before_materialization(monkeypatch):
+    where_calls = []
+    select = SyncLogs.select
+
+    class Query:
+        def join(self, *_args, **_kwargs):
+            return self
+
+        def where(self, *conditions):
+            where_calls.append(conditions)
+            return self
+
+        def distinct(self):
+            return self
+
+        def order_by(self, *_args):
+            return self
+
+        def dicts(self):
+            return []
+
+    monkeypatch.setattr(SyncLogs, "select", lambda *_fields: Query())
+
+    assert SyncLogsService._list_due_tasks_for_freq(ConnectorTaskType.SYNC, "refresh_freq") == []
+
+    compiled_conditions = [select(SyncLogs.id).where(*conditions).sql() for conditions in where_calls]
+    assert any("refresh_freq` >" in sql and "from_beginning` =" in sql and params[-2:] == [0, "1"] for sql, params in compiled_conditions)

--- a/test/unit_test/api/db/services/test_connector_service_due_tasks.py
+++ b/test/unit_test/api/db/services/test_connector_service_due_tasks.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from api.db.db_models import SyncLogs
+from api.db.db_models import Connector, SyncLogs
 from api.db.services.connector_service import SyncLogsService
 from common.constants import ConnectorTaskType
 
@@ -50,7 +50,6 @@ def test_list_due_sync_tasks_excludes_non_positive_refresh_frequencies_unless_re
 @pytest.mark.p2
 def test_due_sync_query_filters_disabled_connectors_before_materialization(monkeypatch):
     where_calls = []
-    select = SyncLogs.select
 
     class Query:
         def join(self, *_args, **_kwargs):
@@ -73,5 +72,6 @@ def test_due_sync_query_filters_disabled_connectors_before_materialization(monke
 
     assert SyncLogsService._list_due_tasks_for_freq(ConnectorTaskType.SYNC, "refresh_freq") == []
 
-    compiled_conditions = [select(SyncLogs.id).where(*conditions).sql() for conditions in where_calls]
-    assert any("refresh_freq` >" in sql and "from_beginning` =" in sql and params[-2:] == [0, "1"] for sql, params in compiled_conditions)
+    frequency_filter = next(condition for conditions in where_calls for condition in conditions if getattr(condition, "op", None) == "OR")
+    assert (frequency_filter.lhs.lhs, frequency_filter.lhs.op, frequency_filter.lhs.rhs) == (Connector.refresh_freq, ">", 0)
+    assert (frequency_filter.rhs.lhs, frequency_filter.rhs.op, frequency_filter.rhs.rhs) == (SyncLogs.from_beginning, "=", "1")


### PR DESCRIPTION
### Summary

- Exclude connectors with refresh_freq less than or equal to zero from periodic sync scheduling, so zero disables scheduled sync.
- Reject negative refresh_freq values in connector create and update APIs while preserving zero as the disabled value.
- Add regression tests for due-task selection and API validation.

### Scope

Related to #16637.

This PR addresses only the refresh_freq=0 continuous scheduling bug. It intentionally does not add a separate enable toggle or bulk WebDAV settings.

### API behavior

- Before: negative refresh_freq values were accepted, and zero-frequency connectors were continuously considered due.
- After: negative values return an argument error; zero remains valid but is excluded from scheduling; positive frequencies are unchanged.

### Test plan

- [x] 26 focused connector and sync tests pass.
- [x] Ruff lint and format checks pass for all changed files.
- [x] Full unit, RESTful API, and SDK API matrices were compared with main; all shared test outcomes are identical, with only the three new regression tests added as passing cases.

Local full-suite failures caused by unavailable DeepDOC model assets and the backend service not running are unchanged from main.