### PR TITLE
fix(html_parser): keep text before the first block element

### DIFF
--- a/deepdoc/parser/html_parser.py
+++ b/deepdoc/parser/html_parser.py
@@ -159,7 +159,10 @@ class RAGFlowHtmlParser:
                 if title_flag:
                     content = f"{TITLE_TAGS[tag_name]} {content}"
                 if last_block_id != block_id:
-                    if last_block_id is not None:
+                    # Flush whatever is buffered, including loose text that
+                    # precedes the first block (last_block_id is None there),
+                    # which was otherwise overwritten and lost.
+                    if current_content:
                         block_content.append(current_content)
                     current_content = content
                     last_block_id = block_id

--- a/test/unit_test/deepdoc/parser/test_html_parser.py
+++ b/test/unit_test/deepdoc/parser/test_html_parser.py
@@ -148,3 +148,25 @@ def test_parser_txt_extracts_bodyless_html_fragment():
     joined = "\n".join(chunks)
     assert "# Title" in joined
     assert "Fragment text" in joined
+
+
+def test_parser_txt_keeps_text_before_first_block():
+    # Loose text (or an inline element) that precedes the first block element
+    # must not be dropped. The block-change flush was guarded on there being a
+    # previous block, so the buffered preamble was overwritten and lost.
+    joined = "\n".join(RAGFlowHtmlParser.parser_txt("<body>Preamble text.<h1>Title</h1><p>Body.</p></body>", chunk_token_num=512))
+    assert "Preamble text." in joined
+    assert "# Title" in joined
+    assert "Body." in joined
+
+    inline = "\n".join(RAGFlowHtmlParser.parser_txt("<body><span>Notice.</span><h2>Section</h2><p>Body.</p></body>", chunk_token_num=512))
+    assert "Notice." in inline
+
+
+def test_parser_txt_keeps_loose_text_between_and_after_blocks():
+    # Control: loose text surrounded by / following blocks was already kept and
+    # must stay that way.
+    between = "\n".join(RAGFlowHtmlParser.parser_txt("<p>One.</p>loose<p>Two.</p>", chunk_token_num=512))
+    assert "loose" in between
+    trailing = "\n".join(RAGFlowHtmlParser.parser_txt("<p>Only.</p>tail", chunk_token_num=512))
+    assert "tail" in trailing


### PR DESCRIPTION
### What problem does this PR solve?

When an HTML document opens with loose text (or an inline element such as `<span>`/`<a>`) **before** the first block element, that leading text is silently dropped from the parsed output.

```python
RAGFlowHtmlParser.parser_txt(
    "<body>Preamble text before any block element.<h1>Title</h1><p>Body.</p></body>", 512
)
# before: ['# Title\nBody.']                                  <- "Preamble text..." lost
# after:  ['Preamble text before any block element.\n# Title\nBody.']
```

`merge_block_text` buffers loose text (which has no `block_id`) into `current_content`, but on a block change it only flushes when a previous block existed:

```python
if last_block_id != block_id:
    if last_block_id is not None:      # False for the very first block
        block_content.append(current_content)
    current_content = content          # overwrites the buffered preamble
```

For the first block `last_block_id` is `None`, so the flush is skipped and the buffered preamble is overwritten and lost. This hits every HTML/HTM ingestion path (`rag/app/naive.py`, `one.py`, `book.py`, `laws.py`, and `email.py` — HTML email bodies very commonly open with loose text or an inline element).

### What's changed

Flush whenever content is buffered (`if current_content:`) instead of only when a previous block existed. Loose text that precedes the first block is now kept; loose text **between** and **after** blocks is unchanged (it was already preserved, and the added control test locks that in). One-line behavior change plus regression tests in `test/unit_test/deepdoc/parser/test_html_parser.py`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

---

*Disclosure: this contribution is AI-authored and autonomous (Claude Code, on this account) — an AI found the bug, wrote the fix and tests, and ran the verification; the human account holder reviews every change and is accountable for it. It is verified and re-runnable from the diff (the three preamble cases lose their leading text before the change and keep it after; control cases and the existing `chunk_block` tests are unchanged — `test_html_parser.py` 6 passed). The heavy integration CI (`ragflow_tests_*`) needs a maintainer `ci` label to run.*

