### PR TITLE
fix[go]: stop leaking [DONE] sentinel into streamed chat answers

### DIFF
--- a/internal/service/model_chat.go
+++ b/internal/service/model_chat.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -25,6 +26,13 @@ import (
 	"ragflow/internal/common"
 	modelModule "ragflow/internal/entity/models"
 )
+
+// streamDoneSentinel is the OpenAI-style end-of-stream marker model drivers
+// emit as their final sender call. It is a transport signal, not answer text.
+const streamDoneSentinel = "[DONE]"
+
+// errStreamDone aborts the driver loop once the terminal sentinel arrives.
+var errStreamDone = errors.New("chat stream done")
 
 func (m *ModelProviderService) Chat(tenantID, modelID string, messages []modelModule.Message, config *modelModule.ChatConfig) (*modelModule.ChatResponse, error) {
 	chatModel, err := m.GetChatModel(tenantID, modelID)
@@ -51,6 +59,9 @@ func chatStreamWithContext(ctx context.Context, chatModel *modelModule.ChatModel
 				if delta == nil {
 					return nil
 				}
+				if *delta == streamDoneSentinel {
+					return errStreamDone
+				}
 				select {
 				case ch <- *delta:
 					return nil
@@ -58,7 +69,7 @@ func chatStreamWithContext(ctx context.Context, chatModel *modelModule.ChatModel
 					return ctx.Err()
 				}
 			}); err != nil {
-			if err == context.Canceled || err == context.DeadlineExceeded {
+			if errors.Is(err, errStreamDone) || err == context.Canceled || err == context.DeadlineExceeded {
 				return
 			}
 			common.Warn("ChatStreamlyWithSender returned error", zap.Error(err))

--- a/internal/service/model_chat_test.go
+++ b/internal/service/model_chat_test.go
@@ -1,0 +1,65 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"ragflow/internal/common"
+	modelModule "ragflow/internal/entity/models"
+)
+
+// doneEmittingDriver streams the given deltas followed by the terminal
+// "[DONE]" sentinel, mirroring real OpenAI-compatible drivers.
+type doneEmittingDriver struct {
+	*modelModule.DummyModel
+	deltas []string
+}
+
+func (d *doneEmittingDriver) ChatStreamlyWithSender(modelName string, messages []modelModule.Message, apiConfig *modelModule.APIConfig, modelConfig *modelModule.ChatConfig, modelUsage *common.ModelUsage, sender func(*string, *string) error) error {
+	for _, delta := range d.deltas {
+		if err := sender(&delta, nil); err != nil {
+			return err
+		}
+	}
+	done := streamDoneSentinel
+	return sender(&done, nil)
+}
+
+func TestChatStreamWithContextStripsDoneSentinel(t *testing.T) {
+	modelName := "fake-model"
+	chatModel := &modelModule.ChatModel{
+		ModelDriver: &doneEmittingDriver{
+			DummyModel: modelModule.NewDummyModel(nil, modelModule.URLSuffix{}),
+			deltas:     []string{"Hello", " world"},
+		},
+		ModelName: &modelName,
+		APIConfig: &modelModule.APIConfig{},
+	}
+
+	ch := chatStreamWithContext(context.Background(), chatModel, nil, &modelModule.ChatConfig{})
+	var sb strings.Builder
+	for delta := range ch {
+		sb.WriteString(delta)
+	}
+
+	if got := sb.String(); got != "Hello world" {
+		t.Fatalf("expected %q, got %q", "Hello world", got)
+	}
+}


### PR DESCRIPTION
### Summary

In Go mode, model drivers emit the OpenAI-style `[DONE]` marker as their final `sender` call (mirroring the Python convention, where consumers break on it). The channel adapter `chatStreamWithContext` (`internal/service/model_chat.go`) forwarded every delta verbatim into the channel, including this terminal sentinel.

As a result, channel consumers accumulated `[DONE]` as answer text:

- `AskService` (search AI summary) appended it to the final answer, so the rendered AI summary ended with a stray `[DONE]`.
- The mindmap handler (`internal/handler/mindmap.go`) had the same exposure.

Fix: treat `[DONE]` as end-of-stream in the adapter — abort the driver loop via a sentinel error and never forward the marker into the channel. Drivers populate `ToolCallsResult`/`UsageResult` before sending `[DONE]`, so nothing is lost.

Adds `internal/service/model_chat_test.go` covering that the sentinel is stripped while content deltas pass through intact. `bash build.sh --test ./internal/service/...` passes.