### PR TITLE
fix: prevent share pages from overriding the user's theme preference

### DIFF
--- a/web/src/components/theme-provider.tsx
+++ b/web/src/components/theme-provider.tsx
@@ -1,5 +1,12 @@
 import { ThemeEnum } from '@/constants/common';
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -9,7 +16,7 @@ type ThemeProviderProps = {
 
 type ThemeProviderState = {
   theme: ThemeEnum;
-  setTheme: (theme: ThemeEnum) => void;
+  setTheme: (theme: ThemeEnum, persist?: boolean) => void;
 };
 
 const initialState: ThemeProviderState = {
@@ -25,14 +32,22 @@ export function ThemeProvider({
   storageKey = 'vite-ui-theme',
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<ThemeEnum>(
+  const [theme, setThemeState] = useState<ThemeEnum>(
     () => (localStorage.getItem(storageKey) as ThemeEnum) || defaultTheme,
   );
+  const persistRef = useRef(true);
+
+  const setTheme = useCallback((nextTheme: ThemeEnum, persist = true) => {
+    persistRef.current = persist;
+    setThemeState(nextTheme);
+  }, []);
 
   useEffect(() => {
     const root = window.document.documentElement;
     root.classList.remove(ThemeEnum.Light, ThemeEnum.Dark);
-    localStorage.setItem(storageKey, theme);
+    if (persistRef.current) {
+      localStorage.setItem(storageKey, theme);
+    }
     root.classList.add(theme);
   }, [storageKey, theme]);
 
@@ -73,11 +88,23 @@ export function useSwitchToDarkThemeOnMount() {
 }
 
 export function useSyncThemeFromParams(theme: string | null) {
-  const { setTheme } = useTheme();
+  const { theme: contextTheme, setTheme } = useTheme();
+  const originalThemeRef = useRef<ThemeEnum | null>(null);
 
   useEffect(() => {
     if (theme && (theme === ThemeEnum.Light || theme === ThemeEnum.Dark)) {
-      setTheme(theme as ThemeEnum);
+      if (originalThemeRef.current === null) {
+        originalThemeRef.current = contextTheme;
+      }
+      setTheme(theme as ThemeEnum, false);
     }
-  }, [theme, setTheme]);
+  }, [theme, contextTheme, setTheme]);
+
+  useEffect(() => {
+    return () => {
+      if (originalThemeRef.current !== null) {
+        setTheme(originalThemeRef.current, false);
+      }
+    };
+  }, [setTheme]);
 }


### PR DESCRIPTION
### Summary

Visiting a shared chat/agent link (e.g. `?theme=light`) called `setTheme` through `useSyncThemeFromParams`, and the `ThemeProvider` effect persisted every theme change to `localStorage`. As a result, a user in dark mode who opened a light-themed share page and then returned to the main app would see the app stuck in light mode after a browser refresh, because their stored preference had been silently overwritten.

This PR makes URL-driven theme sync non-destructive:

- `setTheme` now accepts a `persist` flag (default `true`); when `false`, the theme is applied to the document but not written to `localStorage`.
- `useSyncThemeFromParams` uses `persist: false`, so share pages render with the theme from the URL without touching the user's saved preference.
- When leaving a share page, the theme active before entering is restored, so navigating back within the SPA immediately returns to the user's preferred mode without a refresh.

Manual theme toggles in the main app still persist as before.