### PR TITLE
fix(web): avoid flashing empty state when returning to agent list

### DIFF
--- a/web/src/pages/agents/index.tsx
+++ b/web/src/pages/agents/index.tsx
@@ -30,6 +30,7 @@ import { useRenameAgent } from './use-rename-agent';
 export default function Agents() {
   const {
     data,
+    loading: listLoading,
     pagination,
     setPagination,
     searchString,
@@ -170,6 +171,8 @@ export default function Agents() {
             </div>
           )}
         </article>
+      ) : listLoading ? (
+        <article className="size-full" data-testid="agents-list"></article>
       ) : (
         <article
           className="size-full flex items-center justify-center"


### PR DESCRIPTION
### Summary

After opening an agent and navigating back to the agent list page via the "Agents" breadcrumb, the page briefly flashes the "no agents created yet" empty state for one frame before the list renders.

Root cause: `useFetchAgentListByPage` uses `gcTime: 0`, so the list query cache is garbage collected while viewing the agent canvas. On navigating back, the query refetches and `placeholderData` serves `{ canvas: [], total: 0 }` in the meantime, which the page rendered as the empty state.

Fix: use the `loading` flag already returned by the hook and render a blank placeholder while the list is loading with no data, so the empty state only appears after loading has actually finished.