### PR TITLE
fix(web): make raw memory type non-removable in multi-select

### DIFF
--- a/web/src/pages/memories/constants/index.tsx
+++ b/web/src/pages/memories/constants/index.tsx
@@ -11,7 +11,7 @@ export enum MemoryType {
   Procedural = 'procedural',
 }
 export const MemoryOptions = (t: TFunction) => [
-  { label: t('memories.raw'), value: MemoryType.Raw },
+  { label: t('memories.raw'), value: MemoryType.Raw, disabled: true },
   { label: t('memories.semantic'), value: MemoryType.Semantic },
   { label: t('memories.episodic'), value: MemoryType.Episodic },
   { label: t('memories.procedural'), value: MemoryType.Procedural },


### PR DESCRIPTION
### Summary

In the memory configuration dialogs, the `raw` memory type is required (form validation rejects submissions that don't include it), but the `MultiSelect` still rendered a remove ("x") button on the raw badge, allowing users to deselect it via the badge, the dropdown, clear-all, or Backspace.

This PR marks the `raw` option as `disabled` in `MemoryOptions` (`web/src/pages/memories/constants/index.tsx`). The existing option-level `disabled` handling in `MultiSelect` then:

- hides the remove button on the raw badge,
- prevents toggling it off in the dropdown,
- preserves it on clear-all and Backspace (`preserveDisabledValues`).

Both the memory creation dialog (`createMemoryFields`) and the memory settings form (`memory-model-form.tsx`) reuse `MemoryOptions`, so the fix applies to both.