### PR TITLE
Fix tag CSV parser splicing wrong text after a multi-line quoted field

### DIFF
--- a/rag/app/tag.py
+++ b/rag/app/tag.py
@@ -96,12 +96,16 @@ def chunk(filename, binary=None, lang="Chinese", callback=None, **kwargs):
         fails = []
         content = ""
         res = []
-        reader = csv.reader(lines)
+        reader = csv.reader((line + "\n" for line in lines))
+        prev_line_num = 0
 
+        # line_num tracks the physical span when quoted fields cross lines.
         for i, row in enumerate(reader):
+            raw = "\n".join(lines[prev_line_num : reader.line_num])
+            prev_line_num = reader.line_num
             row = [r.strip() for r in row if r.strip()]
             if len(row) != 2:
-                content += "\n" + lines[i]
+                content += "\n" + raw
             elif len(row) == 2:
                 content += "\n" + row[0]
                 res.append(beAdoc(deepcopy(doc), content, row[1], eng, i))


### PR DESCRIPTION
### Summary

The CSV branch of `rag/app/tag.py` iterates `csv.reader(lines)` with `enumerate` and then uses that row index to look back into `lines[]`:

```python
reader = csv.reader(lines)
for i, row in enumerate(reader):
    ...
    if len(row) != 2:
        content += "\n" + lines[i]
```

When a quoted field spans multiple physical lines, `csv.reader` consumes several entries from `lines` to emit a single logical row, so `i` stops matching the physical line index. From that point on, every malformed row appends the wrong, already consumed physical line into `content`, silently corrupting the record. There is no exception, so the bad text just ends up in the index.

This is the same bug that was fixed for the Q&A parser in #16881. That fix was applied to `rag/app/qa.py` but not to `rag/app/tag.py`, and `git grep "csv.reader(lines)"` shows `tag.py` is the only remaining occurrence. This change ports the same approach: feed the reader a generator that re-appends newlines and track `reader.line_num` against the previous value to recover the true physical span consumed by each logical row.

Reproduction, using this CSV:

```
"quoted spanning
two lines",tag1
bad_line_no_comma
good,tag2
```

Before:

```
[('quoted spanningtwo lines', 'tag1'), ('two lines",tag1\ngood', 'tag2')]
```

The second record picked up leftover text from the quoted field instead of the malformed line, and the first record lost its internal newline.

After:

```
[('quoted spanning\ntwo lines', 'tag1'), ('bad_line_no_comma\ngood', 'tag2')]
```

An ordinary comma separated file with no multi-line quoted fields produces identical output before and after the change.

Scope is limited to the desync fix. I noticed that the `.csv` branch parses comma separated input only, while the docstring for this parser mentions TAB as the delimiter and the `.txt` branch does delimiter detection. That looks like a separate issue and is deliberately not addressed here.