### PR TITLE
fix: unify 'BASE URL' to 'Base URL' in locale files

### DIFF
--- a/web/src/locales/ar.ts
+++ b/web/src/locales/ar.ts
@@ -951,7 +951,7 @@ export default {
       moodleDescription:
         'Connect to your Moodle LMS to sync course content, forums, and resources.',
       moodleUrlTip:
-        'The BASE URL of your Moodle instance (e.g., https://moodle.university.edu). Do not include /webservice or /login.',
+        'The Base URL of your Moodle instance (e.g., https://moodle.university.edu). Do not include /webservice or /login.',
       moodleTokenTip:
         'Generate a web service token in Moodle: Go to Site administration → Server → Web services → Manage tokens. The user must be enrolled in the courses you want to sync.',
       seafileDescription:
@@ -987,7 +987,7 @@ export default {
       jiraDescription:
         'Connect your Jira workspace to sync issues, comments, and attachments.',
       jiraBaseUrlTip:
-        'BASE URL of your Jira site (e.g., https://your-domain.atlassian.net).',
+        'Base URL of your Jira site (e.g., https://your-domain.atlassian.net).',
       jiraProjectKeyTip:
         'Optional: limit syncing to a single project key (e.g., ENG).',
       jiraJqlTip:

--- a/web/src/locales/bg.ts
+++ b/web/src/locales/bg.ts
@@ -1149,9 +1149,9 @@ The above is the content you need to summarize.`,
         'API ключът може да бъде получен чрез регистрация при съответния LLM доставчик.',
       showMoreModels: 'Преглед на модели',
       hideModels: 'Скрий модели',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
-        'Ако вашият API ключ е от OpenAI, просто го игнорирайте. Всеки друг междинен доставчик ще предостави този BASE URL с API ключа.',
+        'Ако вашият API ключ е от OpenAI, просто го игнорирайте. Всеки друг междинен доставчик ще предостави този Base URL с API ключа.',
       tongyiBaseUrlTip:
         'За китайски потребители не е необходимо да попълвате или използвайте https://dashscope.aliyuncs.com/compatible-mode/v1. За международни потребители използвайте https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
       siliconBaseUrlTip:
@@ -1191,8 +1191,8 @@ The above is the content you need to summarize.`,
       modelNameMessage: 'Моля, въведете името на модела!',
       modelType: 'Тип модел',
       modelTypeMessage: 'Моля, въведете типа на модела!',
-      addLlmBaseUrl: 'BASE URL',
-      baseUrlNameMessage: 'Моля, въведете вашия BASE URL',
+      addLlmBaseUrl: 'Base URL',
+      baseUrlNameMessage: 'Моля, въведете вашия Base URL',
       paddleocr: {
         apiUrl: 'PaddleOCR API URL',
         apiUrlPlaceholder:

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1264,7 +1264,7 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       confluenceIsCloudTip:
         'Check if this is a Confluence Cloud instance, uncheck for Confluence Server/Data Center',
       confluenceWikiBaseUrlTip:
-        'The BASE URL of your Confluence instance (e.g., https://your-domain.atlassian.net/wiki)',
+        'The Base URL of your Confluence instance (e.g., https://your-domain.atlassian.net/wiki)',
       confluenceSpaceKeyTip:
         'Optional: Specify a space key to limit syncing to a specific space. Leave empty to sync all accessible spaces. For multiple spaces, separate with commas (e.g., DEV,DOCS,HR)',
       s3PrefixTip: `Specify the folder path within your S3 bucket to fetch files from.
@@ -1361,7 +1361,7 @@ Example: Virtual Hosted Style`,
       moodleDescription:
         'Connect to your Moodle LMS to sync course content, forums, and resources.',
       moodleUrlTip:
-        'The BASE URL of your Moodle instance (e.g., https://moodle.university.edu). Do not include /webservice or /login.',
+        'The Base URL of your Moodle instance (e.g., https://moodle.university.edu). Do not include /webservice or /login.',
       moodleTokenTip:
         'Generate a web service token in Moodle: Go to Site administration → Server → Web services → Manage tokens. The user must be enrolled in the courses you want to sync.',
       seafileDescription:
@@ -1417,7 +1417,7 @@ Example: Virtual Hosted Style`,
       jiraDescription:
         'Connect your Jira workspace to sync issues, comments, and attachments.',
       jiraBaseUrlTip:
-        'BASE URL of your Jira site (e.g., https://your-domain.atlassian.net).',
+        'Base URL of your Jira site (e.g., https://your-domain.atlassian.net).',
       jiraProjectKeyTip:
         'Optional: limit syncing to a single project key (e.g., ENG).',
       jiraJqlTip:
@@ -1756,9 +1756,9 @@ Example: Virtual Hosted Style`,
         'The API KEY can be obtained by registering the corresponding LLM supplier.',
       showMoreModels: 'View models',
       hideModels: 'Hide models',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
-        'If your API KEY is from OpenAI, just ignore it. Any other intermediate providers will give this BASE URL with the API KEY.',
+        'If your API KEY is from OpenAI, just ignore it. Any other intermediate providers will give this Base URL with the API KEY.',
       tongyiBaseUrlTip:
         'For Chinese users, no need to fill in or use https://dashscope.aliyuncs.com/compatible-mode/v1. For international users, use https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
       siliconBaseUrlTip:
@@ -1844,8 +1844,8 @@ Example: Virtual Hosted Style`,
       modelNameMessage: 'Please input your model name!',
       modelType: 'Model type',
       modelTypeMessage: 'Please input your model type!',
-      addLlmBaseUrl: 'BASE URL',
-      baseUrlNameMessage: 'Please input your BASE URL',
+      addLlmBaseUrl: 'Base URL',
+      baseUrlNameMessage: 'Please input your Base URL',
       paddleocr: {
         apiUrl: 'PaddleOCR API URL',
         apiUrlPlaceholder:
@@ -1997,10 +1997,10 @@ Example: Virtual Hosted Style`,
       },
       somark: {
         modelNameMessage: 'Please input your model name',
-        baseUrl: 'BASE URL',
-        baseUrlMessage: 'Please input the BASE URL',
+        baseUrl: 'Base URL',
+        baseUrlMessage: 'Please input the Base URL',
         baseUrlPlaceholder:
-          'For SoMark API, use https://somark.cn/api/v1 in mainland China; use https://somark.ai/api/v1 outside mainland China (including Taiwan, China; Hong Kong, China; Macau, China; and overseas). For self-hosted deployment, use your local BASE URL',
+          'For SoMark API, use https://somark.cn/api/v1 in mainland China; use https://somark.ai/api/v1 outside mainland China (including Taiwan, China; Hong Kong, China; Macau, China; and overseas). For self-hosted deployment, use your local Base URL',
         apiKey: 'API KEY',
         apiKeyPlaceholder:
           'Required for SoMark API; leave blank for self-hosted deployment',

--- a/web/src/locales/id.ts
+++ b/web/src/locales/id.ts
@@ -539,9 +539,9 @@ export default {
         'Kunci API dapat diperoleh dengan mendaftar ke penyedia LLM yang sesuai.',
       showMoreModels: 'Tampilkan lebih banyak model',
       hideModels: 'Sembunyikan model',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
-        'Jika kunci API Anda berasal dari OpenAI, abaikan saja. Penyedia perantara lainnya akan memberikan BASE URL ini dengan kunci API.',
+        'Jika kunci API Anda berasal dari OpenAI, abaikan saja. Penyedia perantara lainnya akan memberikan Base URL ini dengan kunci API.',
       tongyiBaseUrlTip:
         'Untuk pengguna Tiongkok, tidak perlu diisi atau gunakan https://dashscope.aliyuncs.com/compatible-mode/v1. Untuk pengguna internasional, gunakan https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
       siliconBaseUrlTip:
@@ -580,8 +580,8 @@ export default {
       modelNameMessage: 'Silakan masukkan nama model Anda!',
       modelType: 'Jenis Model',
       modelTypeMessage: 'Silakan masukkan jenis model Anda!',
-      addLlmBaseUrl: 'BASE URL',
-      baseUrlNameMessage: 'Silakan masukkan BASE URL Anda',
+      addLlmBaseUrl: 'Base URL',
+      baseUrlNameMessage: 'Silakan masukkan Base URL Anda',
       paddleocr: {
         apiUrl: 'URL API PaddleOCR',
         apiUrlPlaceholder:

--- a/web/src/locales/ko.ts
+++ b/web/src/locales/ko.ts
@@ -1518,7 +1518,7 @@ export default {
       apiKeyTip: '해당 LLM 공급업체에 등록하여 API 키를 얻을 수 있습니다.',
       showMoreModels: '모델 보기',
       hideModels: '모델 숨기기',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
         'API 키가 OpenAI에서 발급된 경우 무시하세요. 다른 중간 제공업체는 API 키와 함께 이 기본 URL을 제공합니다.',
       tongyiBaseUrlTip:

--- a/web/src/locales/ru.ts
+++ b/web/src/locales/ru.ts
@@ -1257,7 +1257,7 @@ export default {
         'API ключ можно получить, зарегистрировавшись у соответствующего поставщика LLM.',
       showMoreModels: 'Показать модели',
       hideModels: 'Скрыть модели',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
         'Если ваш API ключ от OpenAI, просто проигнорируйте это. Любые другие промежуточные провайдеры дадут этот базовый url вместе с API ключом.',
       tongyiBaseUrlTip:

--- a/web/src/locales/vi.ts
+++ b/web/src/locales/vi.ts
@@ -583,7 +583,7 @@ export default {
         'Khóa API có thể được lấy bằng cách đăng ký nhà cung cấp LLM tương ứng.',
       showMoreModels: 'Hiển thị thêm mô hình',
       hideModels: 'Ẩn mô hình',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
         'Nếu khóa API của bạn từ OpenAI, chỉ cần bỏ qua nó. Bất kỳ nhà cung cấp trung gian nào khác sẽ cung cấp URL cơ sở này với khóa API.',
       siliconBaseUrlTip:

--- a/web/src/locales/zh-traditional.ts
+++ b/web/src/locales/zh-traditional.ts
@@ -642,7 +642,7 @@ export default {
       apiKeyTip: 'API KEY可以通過註冊相應的LLM供應商來獲取。',
       showMoreModels: '展示更多模型',
       hideModels: '隱藏模型',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
         '如果您的 API 密鑰來自 OpenAI，請忽略它。任何其他中間提供商都會提供帶有 API 密鑰的基本 URL。',
       tongyiBaseUrlTip:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1266,7 +1266,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
         '请在 Dropbox App Console 生成 Access Token，并勾选 files.metadata.read、files.content.read、sharing.read 等必要权限。',
       jiraDescription: '接入 Jira 工作区，持续同步Issues、评论与附件。',
       jiraBaseUrlTip:
-        'Jira 的 BASE URL，例如：https://your-domain.atlassian.net。',
+        'Jira 的 Base URL，例如：https://your-domain.atlassian.net。',
       jiraProjectKeyTip: '可选：仅同步指定的项目（如 RAG）。',
       jiraJqlTip: '可选：自定义 JQL 过滤条件，留空则使用项目 / 时间范围。',
       jiraBatchSizeTip: '每次向 Jira 请求的 Issue 数量上限。',
@@ -1452,7 +1452,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       apiKeyTip: 'API KEY可以通过注册相应的LLM供应商来获取。',
       showMoreModels: '展示更多模型',
       hideModels: '隐藏模型',
-      baseUrl: 'BASE URL',
+      baseUrl: 'Base URL',
       baseUrlTip:
         '如果您的 API 密钥来自 OpenAI，请忽略它。 任何其他中间提供商都会提供带有 API 密钥的基本 URL。',
       tongyiBaseUrlTip:
@@ -1652,10 +1652,10 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       },
       somark: {
         modelNameMessage: '请输入模型名称',
-        baseUrl: 'BASE URL',
-        baseUrlMessage: '请输入 BASE URL',
+        baseUrl: 'Base URL',
+        baseUrlMessage: '请输入 Base URL',
         baseUrlPlaceholder:
-          '使用 SoMark API 时中国大陆填写 https://somark.cn/api/v1；中国大陆外（含中国台湾、中国香港、中国澳门及海外）填写 https://somark.ai/api/v1；私有化部署时填写本地部署的 BASE URL',
+          '使用 SoMark API 时中国大陆填写 https://somark.cn/api/v1；中国大陆外（含中国台湾、中国香港、中国澳门及海外）填写 https://somark.ai/api/v1；私有化部署时填写本地部署的 Base URL',
         apiKey: 'API KEY',
         apiKeyPlaceholder: '使用 SoMark API 时填写；私有化部署无需填写',
         verifyPassed: '验证通过',


### PR DESCRIPTION
### Summary

The model-provider settings UI and several data-source descriptions displayed the label as 'BASE URL' in all caps, which is inconsistent with the rest of the UI copy. This PR renames every occurrence of 'BASE URL' to 'Base URL' across all locale files (en, zh, zh-traditional, ar, bg, id, ko, ru, vi) for consistent capitalization. No functional changes.