### PR TITLE
fix(mcp): include dataset name in list_datasets output

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -27,7 +27,7 @@ import (
 // either in-process service calls or out-of-process HTTP calls.
 type Connector interface {
 	// ListDatasets returns newline-delimited JSON lines, each containing
-	// at minimum {"id": "...", "description": "..."}.
+	// at minimum {"id": "...", "name": "...", "description": "..."}.
 	ListDatasets(page, pageSize int, orderby string, desc bool) (string, error)
 
 	// ListChats returns newline-delimited JSON lines, each containing

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -242,7 +242,13 @@ class RAGFlowConnector:
 
         result_list = []
         for data in datasets:
-            d = {"description": data["description"], "id": data["id"]}
+            # Include name so MCP clients can pick datasets by human-readable
+            # label (parity with list_chats and GET /api/v1/datasets). #17133
+            d = {
+                "id": data.get("id"),
+                "name": data.get("name"),
+                "description": data.get("description", ""),
+            }
             result_list.append(json.dumps(d, ensure_ascii=False))
         return "\n".join(result_list)
 

--- a/test/unit_test/mcp/test_server_datasets.py
+++ b/test/unit_test/mcp/test_server_datasets.py
@@ -40,7 +40,7 @@ class _FakeResponse:
 
 
 def _datasets(count):
-    return [{"id": f"dataset-{idx}", "description": f"description-{idx}"} for idx in range(count)]
+    return [{"id": f"dataset-{idx}", "name": f"name-{idx}", "description": f"description-{idx}"} for idx in range(count)]
 
 
 @pytest.fixture()
@@ -72,6 +72,7 @@ async def test_list_datasets_default_fetches_all_with_rest_page_size_limit(monke
 
     rows = [json.loads(line) for line in result.splitlines()]
     assert [row["id"] for row in rows] == [f"dataset-{idx}" for idx in range(250)]
+    assert [row["name"] for row in rows] == [f"name-{idx}" for idx in range(250)]
     assert [request["params"]["page"] for request in requests] == [1, 2, 3]
     assert all(request["path"] == "/datasets" for request in requests)
     assert all(request["params"]["page_size"] == 100 for request in requests)
@@ -80,7 +81,7 @@ async def test_list_datasets_default_fetches_all_with_rest_page_size_limit(monke
 @pytest.mark.asyncio
 async def test_resolve_dataset_ids_fetches_all_pages_and_deduplicates(monkeypatch, mcp_server):
     connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
-    datasets = _datasets(101) + [{"id": "dataset-100", "description": "duplicate"}]
+    datasets = _datasets(101) + [{"id": "dataset-100", "name": "name-100", "description": "duplicate"}]
     requests = _stub_dataset_pages(monkeypatch, connector, datasets)
 
     result = await connector.resolve_dataset_ids(api_key="unit-key")
@@ -115,3 +116,27 @@ async def test_list_datasets_clamps_explicit_page_size_to_rest_limit_and_preserv
         "id": "dataset-1",
         "name": "target",
     }
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_includes_name_field(monkeypatch, mcp_server):
+    """MCP list_datasets must surface dataset name (#17133)."""
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    _stub_dataset_pages(
+        monkeypatch,
+        connector,
+        [
+            {
+                "id": "46ea1644813211f1bc41abcb1d4727a4",
+                "name": "B3 Documentation",
+                "description": None,
+            }
+        ],
+    )
+
+    result = await connector.list_datasets(api_key="unit-key")
+    row = json.loads(result.splitlines()[0])
+    assert row["id"] == "46ea1644813211f1bc41abcb1d4727a4"
+    assert row["name"] == "B3 Documentation"
+    assert row["description"] is None or row["description"] == ""
+


### PR DESCRIPTION
### Summary

`ragflow_list_datasets` (and the dataset blurb embedded in other MCP tool descriptions) never returned the dataset `name` field. MCP clients only saw an opaque `id` and optional `description`, even though `GET /api/v1/datasets` already returns `name`.

Root cause: `RAGFlowConnector.list_datasets()` in `mcp/server/server.py` built the output dict with only `id` and `description`. `list_chats()` was already fixed to include `name` (#16638 / #16639); datasets were left behind.

### Change

- Include `name` (via defensive `.get()`, same style as `list_chats`)
- Align Go MCP interface comment for `ListDatasets` (Go connector already returned `name`)
- Unit test: `test_list_datasets_includes_name_field` + assert names in paging test

### Test plan

- [x] `pytest test/unit_test/mcp/test_server_datasets.py -q --noconftest` → **4 passed**

Fixes #17133
