### PR TITLE
Fix stale references shown while streaming and empty final reply in Go mode

### DIFF
--- a/internal/service/chat_pipeline.go
+++ b/internal/service/chat_pipeline.go
@@ -849,7 +849,11 @@ func (s *ChatPipelineService) AsyncChat(
 		// Two results are yielded (mirroring Python dialog_service.py):
 		//   1. Final=false — carries the answer text so streaming consumers
 		//      actually display the fallback message.
-		//   2. Final=true   — closes the stream with the reference/prompt.
+		//   2. Final=true   — closes the stream with the same full answer plus
+		//      the reference/prompt. Python yields the full answer again in the
+		//      final event (dialog_service.py:807); consumers that only look at
+		//      the final event (e.g. the OpenAI-compatible endpoint) would
+		//      otherwise see an empty reply.
 		if len(knowledges) == 0 {
 			if emptyResp, ok := promptConfig["empty_response"].(string); ok && emptyResp != "" {
 				out <- AsyncChatResult{
@@ -857,7 +861,7 @@ func (s *ChatPipelineService) AsyncChat(
 					Reference: map[string]interface{}{},
 				}
 				out <- AsyncChatResult{
-					Answer:      "",
+					Answer:      emptyResp,
 					Reference:   kbinfos,
 					AudioBinary: s.synthesizeTTS(ttsModel, emptyResp),
 					Prompt:      fmt.Sprintf("\n\n### Query:\n%s", strings.Join(questions, " ")),

--- a/internal/service/chat_session.go
+++ b/internal/service/chat_session.go
@@ -1311,7 +1311,12 @@ func (s *ChatSessionService) Completion(userID string, conversationID string, me
 	var answer strings.Builder
 	var finalRef map[string]interface{}
 	for result := range resultChan {
-		if result.Answer != "" {
+		if result.Final && result.Answer != "" {
+			// The final event carries the complete (decorated) answer;
+			// it replaces any accumulated deltas rather than appending.
+			answer.Reset()
+			answer.WriteString(result.Answer)
+		} else if result.Answer != "" {
 			answer.WriteString(result.Answer)
 		}
 		if result.Reference != nil {
@@ -1673,7 +1678,12 @@ func (s *ChatSessionService) ChatCompletions(
 		var answer strings.Builder
 		var finalRef map[string]interface{}
 		for result := range resultChan {
-			if result.Answer != "" {
+			if result.Final && result.Answer != "" {
+				// The final event carries the complete (decorated) answer;
+				// it replaces any accumulated deltas rather than appending.
+				answer.Reset()
+				answer.WriteString(result.Answer)
+			} else if result.Answer != "" {
 				answer.WriteString(result.Answer)
 			}
 			if result.Reference != nil {

--- a/internal/service/chat_session_test.go
+++ b/internal/service/chat_session_test.go
@@ -822,7 +822,9 @@ func TestCompletion_Success(t *testing.T) {
 	pipeline := &fakePipeline{
 		resultChan: makeResultChan(
 			AsyncChatResult{Answer: "Hello", Reference: map[string]interface{}{"chunks": []interface{}{}}},
-			AsyncChatResult{Answer: " world", Final: true, Reference: map[string]interface{}{"chunks": []interface{}{}}},
+			// The real pipeline's final result carries the complete answer,
+			// not a trailing delta.
+			AsyncChatResult{Answer: "Hello world", Final: true, Reference: map[string]interface{}{"chunks": []interface{}{}}},
 		),
 	}
 

--- a/web/src/pages/next-chats/utils.ts
+++ b/web/src/pages/next-chats/utils.ts
@@ -40,9 +40,20 @@ export const buildMessageItemReference = (
   const referenceIndex = assistantMessages.findIndex(
     (x) => x.id === message.id,
   );
+  // An assistant message that has not received any content yet is still
+  // being generated. Never resolve its reference from the conversation
+  // reference list — the indices only align with completed answers, so the
+  // lookup would surface a stale reference from a previous turn (or from a
+  // previously opened conversation) while the answer is streaming.
+  const isPendingAnswer =
+    message.role === MessageType.Assistant &&
+    !message.content &&
+    isEmpty(message?.reference);
   const reference = !isEmpty(message?.reference)
     ? message?.reference
-    : (conversation?.reference ?? [])[referenceIndex];
+    : isPendingAnswer
+      ? undefined
+      : (conversation?.reference ?? [])[referenceIndex];
 
   return reference ?? { doc_aggs: [], chunks: [], total: 0 };
 };


### PR DESCRIPTION
### Summary

In Go mode, when a previous turn cited documents but the current turn cannot, the chat UI shows the previous turn's referenced documents under the thinking bubble; once thinking completes, the reply is replaced with an empty one. The same stale documents also flash when starting a brand-new conversation.

Root causes:

1. The pending assistant message (no content/reference of its own yet) fell back to the conversation-level reference list by index. That index only aligns with completed answers, so the streaming placeholder surfaced stale references from a previous turn or from a previously opened conversation.
2. The `empty_response` path in the Go chat pipeline yielded its final event with an empty answer, while Python (`dialog_service.py`) yields the full fallback text in the final event. Consumers that read the final event's answer (e.g. the OpenAI-compatible endpoint) therefore received an empty reply.

Changes:

- `internal/service/chat_pipeline.go`: the `empty_response` final event now carries the full fallback answer, matching Python.
- `internal/service/chat_session.go`: non-streaming accumulation loops treat a non-empty final answer as the complete answer (replace, not append), avoiding duplicated text.
- `web/src/pages/next-chats/utils.ts`: `buildMessageItemReference` never resolves a pending (still-generating) assistant message's reference from the conversation reference list.
- `internal/service/chat_session_test.go`: align the test mock with the real pipeline contract (final result carries the complete answer).