### PR TITLE
fix(deepdoc): guard docling crop against missing page images

### DIFF
--- a/deepdoc/parser/docling_parser.py
+++ b/deepdoc/parser/docling_parser.py
@@ -174,6 +174,20 @@ class DoclingParser(RAGFlowPdfParser):
         if not poss:
             return (None, None) if need_position else None
 
+        # a position tag is emitted even when page rendering failed (__images__ leaves
+        # page_images empty), and a tag can name a page beyond the rendered range, so
+        # indexing page_images below would raise IndexError. mirror
+        # cropout_docling_table and the sibling parsers: bail out when there are no
+        # page images and drop positions that fall outside them.
+        if not getattr(self, "page_images", None):
+            self.logger.warning("[Docling] crop called without page images; skipping image generation.")
+            return (None, None) if need_position else None
+
+        page_count = len(self.page_images)
+        poss = [p for p in poss if p[0] and all(0 <= pn < page_count for pn in p[0])]
+        if not poss:
+            return (None, None) if need_position else None
+
         GAP = 6
         pos = poss[0]
         poss.insert(0, ([pos[0][0]], pos[1], pos[2], max(0, pos[3] - 120), max(pos[3] - GAP, 0)))

--- a/deepdoc/parser/docling_parser.py
+++ b/deepdoc/parser/docling_parser.py
@@ -184,7 +184,13 @@ class DoclingParser(RAGFlowPdfParser):
             return (None, None) if need_position else None
 
         page_count = len(self.page_images)
-        poss = [p for p in poss if p[0] and all(0 <= pn < page_count for pn in p[0])]
+        valid_poss = []
+        for p in poss:
+            if p[0] and all(0 <= pn < page_count for pn in p[0]):
+                valid_poss.append(p)
+            else:
+                self.logger.warning(f"[Docling] Position on pages {p[0]} is out of range for {page_count} rendered page(s); skipping it.")
+        poss = valid_poss
         if not poss:
             return (None, None) if need_position else None
 

--- a/test/unit_test/deepdoc/parser/test_docling_parser_remote.py
+++ b/test/unit_test/deepdoc/parser/test_docling_parser_remote.py
@@ -159,3 +159,32 @@ def test_remote_chunked_request_with_ignored_flag_does_not_log_success(monkeypat
     flat = " ".join(record.getMessage() for record in caplog.records)
     assert "Successfully used native chunking" not in flat
     assert "Server ignored chunking request" in flat
+
+
+@pytest.mark.p2
+def test_crop_without_page_images_returns_none(monkeypatch):
+    """Position tags are emitted even when page rendering failed and left
+    ``page_images`` empty, so ``crop`` must bail out instead of raising
+    IndexError while indexing the empty list."""
+    module = _load_docling_parser(monkeypatch)
+    parser = module.DoclingParser(docling_server_url="http://docling.local")
+    parser.page_images = []
+
+    tag = "@@1\t1.0\t2.0\t3.0\t4.0##"
+    assert parser.crop(tag, need_position=True) == (None, None)
+    assert parser.crop(tag) is None
+
+
+@pytest.mark.p2
+def test_crop_drops_positions_beyond_rendered_pages(monkeypatch):
+    """A tag naming a page past the rendered range must be filtered out rather
+    than indexed, mirroring the range check in cropout_docling_table."""
+    module = _load_docling_parser(monkeypatch)
+    parser = module.DoclingParser(docling_server_url="http://docling.local")
+    # a single rendered page; the sentinel is never indexed because the
+    # out-of-range position is dropped first.
+    parser.page_images = [object()]
+
+    tag = "@@5\t1.0\t2.0\t3.0\t4.0##"
+    assert parser.crop(tag, need_position=True) == (None, None)
+    assert parser.crop(tag) is None


### PR DESCRIPTION
### Summary

`DoclingParser.crop()` indexes `self.page_images` with no guard (`deepdoc/parser/docling_parser.py:181`, and again at the `img0`/`page` lookups below it).

Two realistic conditions lead there with an empty or too-short `page_images`:

- `__images__` sets `self.page_images = []` when local pdfplumber rendering raises, while the remote docling backend still returns text and bboxes — so chunks carry position tags with no page images behind them.
- `_make_line_tag` emits a `@@page\t...##` tag even when its own coordinate-mapping guard fails, and the tag can name a page outside the rendered range.

`crop()` is called from `tokenize_chunks` with `need_position=True`; the resulting `IndexError: list index out of range` is not caught there (only `NotImplementedError` is), so ingestion of the whole document aborts.

The same file already guards this in `cropout_docling_table` (empty check plus `0 <= idx < len(self.page_images)`), and the sibling `pdf_parser` / `mineru_parser` `crop()` implementations do the same — `docling_parser.crop` is the outlier.

This bails out when there are no page images, and drops positions naming pages outside the rendered range, matching those existing patterns.

### Tests

Regression tests added to `test/unit_test/deepdoc/parser/test_docling_parser_remote.py`, reusing its module loader. Both fail with `IndexError` at `docling_parser.py:181` without the guard and pass with it.
