### PR TITLE
fix(web): prevent search popover from flashing at top-left on checkbox toggle

### DIFF
--- a/web/src/pages/next-search/retrieval-documents/index.tsx
+++ b/web/src/pages/next-search/retrieval-documents/index.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/hooks/use-knowledge-request';
 import { cn } from '@/lib/utils';
 import { CheckIcon, ChevronDown, Files, XIcon } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface IProps {
@@ -52,10 +52,15 @@ const RetrievalDocuments = ({
     }
   }, [isTesting, setLoading]);
 
-  const { documents: useDocuments } = {
-    documents:
-      documentsAll?.length > documents?.length ? documentsAll : documents,
-  };
+  const latestDocuments =
+    documentsAll?.length > documents?.length ? documentsAll : documents;
+  // Keep the last non-empty list so the popover anchor is not unmounted
+  // while a new testing request is pending.
+  const documentsRef = useRef(latestDocuments);
+  if (latestDocuments?.length) {
+    documentsRef.current = latestDocuments;
+  }
+  const useDocuments = documentsRef.current;
   const [selectedValues, setSelectedValues] =
     useState<string[]>(selectedDocumentIds);
 
@@ -115,7 +120,7 @@ const RetrievalDocuments = ({
   return (
     <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
       <PopoverTrigger asChild>
-        {useDocuments?.length && (
+        {useDocuments?.length > 0 && (
           <Button
             onClick={handleTogglePopover}
             className={cn(


### PR DESCRIPTION
### Summary

On the search page, toggling a document checkbox in the file list popover briefly flashes a search box at the top-left corner of the viewport.

**Root cause:** toggling a checkbox fires the `testChunk` and `testChunkAll` mutations. While they are pending, `useSelectTestingResult`/`useAllTestingResult` read the latest mutation's `state.data`, which is `undefined`, and fall back to an empty document list. The `RetrievalDocuments` popover trigger (`{useDocuments?.length && <Button>}`) is therefore unmounted for a moment; with its anchor gone, Radix positions the popover content (which contains the search input) at the top-left of the viewport until the request finishes.

**Fix:** keep the last non-empty document list via a ref so the popover anchor stays mounted during refetches, and use an explicit `length > 0` check to avoid rendering a literal `0` as the `PopoverTrigger` child when the list is empty.