### PR TITLE
Fix: respect IME composition state on Enter key in dataset creating dialog

### DIFF
--- a/web/src/pages/datasets/dataset-creating-dialog.tsx
+++ b/web/src/pages/datasets/dataset-creating-dialog.tsx
@@ -173,7 +173,7 @@ export function DatasetCreatingDialog({
       <DialogContent
         className="sm:max-w-[425px] focus-visible:!outline-none flex flex-col"
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && !e.shiftKey) {
+          if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
             e.preventDefault();
             const form = document.getElementById(FormId) as HTMLFormElement;
             form?.requestSubmit();


### PR DESCRIPTION
## What

Pressing Enter to confirm IME (e.g. Japanese) text conversion in the knowledge base name field of the "Create knowledge base" dialog was incorrectly treated as the dialog's submit trigger. The composition-confirm Enter both let the IME finish composing and triggered the dialog's Enter handler, which called `preventDefault()` and `form.requestSubmit()` — causing input like "アルゴ" to be duplicated as "アルゴアルゴ".

## Fix

Check `event.nativeEvent.isComposing` alongside the existing Enter/shiftKey check in `DatasetCreatingDialog`'s `onKeyDown`, matching the same fix already applied to `NextMessageInput` and `FloatingChatWidget` in #16922.

## Test plan

- [x] Verified locally: typing an IME word (e.g. "アルゴ") in the knowledge base name field and pressing Enter to confirm composition no longer duplicates the text.