### PR TITLE
Go: disable thinking for search ask summary to fix truncated AI summary

### DIFF
--- a/internal/entity/models/openai.go
+++ b/internal/entity/models/openai.go
@@ -124,10 +124,14 @@ func (o *OpenAIModel) ChatWithMessages(modelName string, messages []Message, api
 		}
 	}
 
-	// Qwen3 family: disable thinking by default (matches Python's
-	// _apply_model_family_policies in rag/llm/chat_model.py:119-121).
-	if strings.Contains(strings.ToLower(modelName), "qwen3") && (chatModelConfig == nil || chatModelConfig.Thinking == nil) {
-		reqBody["enable_thinking"] = false
+	// Qwen3 family: disable thinking unless explicitly enabled (matches
+	// Python's _apply_model_family_policies in rag/llm/chat_model.py:119-121).
+	if strings.Contains(strings.ToLower(modelName), "qwen3") {
+		if chatModelConfig != nil && chatModelConfig.Thinking != nil {
+			reqBody["enable_thinking"] = *chatModelConfig.Thinking
+		} else {
+			reqBody["enable_thinking"] = false
+		}
 	}
 
 	jsonData, err := json.Marshal(reqBody)
@@ -302,9 +306,13 @@ func (o *OpenAIModel) ChatStreamlyWithSender(modelName string, messages []Messag
 		}
 	}
 
-	// Qwen3 family: disable thinking by default.
-	if strings.Contains(strings.ToLower(modelName), "qwen3") && (chatModelConfig == nil || chatModelConfig.Thinking == nil) {
-		reqBody["enable_thinking"] = false
+	// Qwen3 family: disable thinking unless explicitly enabled.
+	if strings.Contains(strings.ToLower(modelName), "qwen3") {
+		if chatModelConfig != nil && chatModelConfig.Thinking != nil {
+			reqBody["enable_thinking"] = *chatModelConfig.Thinking
+		} else {
+			reqBody["enable_thinking"] = false
+		}
 	}
 
 	jsonData, err := json.Marshal(reqBody)

--- a/internal/service/ask_service.go
+++ b/internal/service/ask_service.go
@@ -186,7 +186,12 @@ func (s *AskService) run(ctx context.Context, llm StreamingLLM, userID, question
 		{Role: "system", Content: sysPrompt},
 		{Role: "user", Content: question},
 	}
-	genConf := &modelModule.ChatConfig{Temperature: ptrFloat64(0.1)}
+	// Thinking is disabled: summarization does not need reasoning. With
+	// thinking enabled, the reasoning (which drafts the summary) streams
+	// first, then collapses into a hidden think block, and the provider may
+	// emit only a fragment as the visible answer once the reasoning has
+	// consumed the output budget.
+	genConf := &modelModule.ChatConfig{Temperature: ptrFloat64(0.1), Thinking: ptrBool(false)}
 
 	ch, err := llm.ChatStream(ctx, messages, genConf)
 	if err != nil {
@@ -279,3 +284,4 @@ func toFloat64Slice(v interface{}) []float64 {
 
 func ptrInt(v int) *int             { return &v }
 func ptrFloat64(v float64) *float64 { return &v }
+func ptrBool(v bool) *bool          { return &v }


### PR DESCRIPTION
### Summary

In Go mode, the AI summary on the search page appears truncated: the first part streams and displays, then disappears, and only a mid-sentence fragment remains.

Root cause: with a thinking-enabled chat model, the reasoning (which drafts the summary) streams first and is shown while the think block is unclosed. Once `</think>` arrives, the frontend collapses the whole reasoning block into a hidden `Thinking...` details element, so the drafted part vanishes. Since the reasoning has consumed the output budget, the provider then emits only a fragment as the visible answer.

Fix:
- `internal/service/ask_service.go`: pass `Thinking: false` in the ask summary generation config — summarization does not need reasoning, and this keeps the full output budget for the answer.
- `internal/entity/models/openai.go` (streaming and non-streaming): the qwen3 `enable_thinking` policy now honors an explicit `Thinking` setting instead of skipping the auto-disable whenever it is set (previously an explicit `false` would have re-enabled thinking for qwen3).

Verified: `internal/service` and `internal/entity/models` package tests pass; reproduced the collapse behavior end-to-end with a scripted thinking-model stream through the Ask pipeline and the frontend SSE reducer.