### PR TITLE
fix: prevent collapse button from overlapping expanded content in next-search

### DIFF
--- a/web/src/pages/next-search/expandable-content.tsx
+++ b/web/src/pages/next-search/expandable-content.tsx
@@ -84,24 +84,24 @@ export default function ExpandableContent({
         <div className="absolute bottom-0 left-0 right-0 h-20 bg-gradient-to-t from-bg-base to-transparent pointer-events-none" />
       )}
 
-      {isOverflowing && (
+      {isOverflowing && !isExpanded && (
         <Button
           size="sm"
           onClick={toggleExpand}
           className="absolute bottom-2 left-1/2 -translate-x-1/2"
         >
-          {isExpanded ? (
-            <>
-              <ChevronUp size={14} />
-              <span>{t('common.viewLess')}</span>
-            </>
-          ) : (
-            <>
-              <ChevronDown size={14} />
-              <span>{t('common.viewMore')}</span>
-            </>
-          )}
+          <ChevronDown size={14} />
+          <span>{t('common.viewMore')}</span>
         </Button>
+      )}
+
+      {isOverflowing && isExpanded && (
+        <div className="flex justify-center pt-2">
+          <Button size="sm" onClick={toggleExpand}>
+            <ChevronUp size={14} />
+            <span>{t('common.viewLess')}</span>
+          </Button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
### Summary

On the next-search page, long chunk text is rendered inside an `ExpandableContent` component. When the content is expanded, the "View less" (收起) button was absolutely positioned at the bottom of the container (`absolute bottom-2`), which caused it to float on top of and obscure the last lines of the expanded text.

This PR fixes the issue by rendering the "View less" button in normal document flow (centered below the content) when the content is expanded, while keeping the collapsed-state "View more" button absolutely positioned over the gradient fade as before.