### PR TITLE
Feat: add open-in-new-tab button to search share embed dialog

### DIFF
--- a/web/src/locales/ar.ts
+++ b/web/src/locales/ar.ts
@@ -55,7 +55,7 @@ export default {
       submit: 'إرسال',
       clear: 'مسح',
       embedIntoSite: 'تضمين في صفحة الويب',
-      openInNewTab: 'الدردشة في علامة تبويب جديدة',
+      openInNewTab: 'فتح في علامة تبويب جديدة',
       previousPage: 'سابق',
       nextPage: 'التالي',
       add: 'يضيف',

--- a/web/src/locales/de.ts
+++ b/web/src/locales/de.ts
@@ -49,7 +49,7 @@ export default {
       submit: 'Absenden',
       clear: 'Leeren',
       embedIntoSite: 'In Webseite einbetten',
-      openInNewTab: 'Chat in neuem Tab',
+      openInNewTab: 'In neuem Tab öffnen',
       previousPage: 'Zurück',
       nextPage: 'Weiter',
       add: 'Hinzufügen',

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -61,7 +61,7 @@ export default {
       submit: 'Submit',
       clear: 'Clear',
       embedIntoSite: 'Embed into webpage',
-      openInNewTab: 'Chat in new tab',
+      openInNewTab: 'Open in new tab',
       previousPage: 'Previous',
       nextPage: 'Next',
       previous: 'Previous',

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -60,7 +60,7 @@ export default {
       submit: 'Soumettre',
       clear: 'Effacer',
       embedIntoSite: 'Intégrer dans la page web',
-      openInNewTab: 'Chat dans un nouvel onglet',
+      openInNewTab: 'Ouvrir dans un nouvel onglet',
       previousPage: 'Précédent',
       nextPage: 'Suivant',
       previous: 'Précédent',

--- a/web/src/locales/it.ts
+++ b/web/src/locales/it.ts
@@ -59,7 +59,7 @@ export default {
       submit: 'Invia',
       clear: 'Cancella',
       embedIntoSite: 'Incorpora nella pagina web',
-      openInNewTab: 'Chat in una nuova scheda',
+      openInNewTab: 'Apri in una nuova scheda',
       previousPage: 'Precedente',
       nextPage: 'Successivo',
       previous: 'Precedente',

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -62,7 +62,7 @@ export default {
       viewLess: '表示を減らす',
       clear: 'クリア',
       embedIntoSite: 'Webページに埋め込む',
-      openInNewTab: '新しいタブでチャット',
+      openInNewTab: '新しいタブで開く',
       previousPage: '前へ',
       nextPage: '次へ',
       previous: '前へ',

--- a/web/src/locales/ko.ts
+++ b/web/src/locales/ko.ts
@@ -60,7 +60,7 @@ export default {
       submit: '적용',
       clear: '초기화',
       embedIntoSite: '웹페이지에 임베드',
-      openInNewTab: '새 탭에서 채팅',
+      openInNewTab: '새 탭에서 열기',
       previousPage: '이전',
       nextPage: '다음',
       previous: '이전',

--- a/web/src/locales/pt-br.ts
+++ b/web/src/locales/pt-br.ts
@@ -37,7 +37,7 @@ export default {
       pleaseInput: 'Por favor, insira',
       submit: 'Enviar',
       embedIntoSite: 'Incorporar no site',
-      openInNewTab: 'Chat em nova aba',
+      openInNewTab: 'Abrir em nova aba',
       previousPage: 'Anterior',
       nextPage: 'Próxima',
       owner: 'Proprietário',

--- a/web/src/locales/ru.ts
+++ b/web/src/locales/ru.ts
@@ -56,7 +56,7 @@ export default {
       submit: 'Отправить',
       clear: 'Очистить',
       embedIntoSite: 'Встроить на веб-страницу',
-      openInNewTab: 'Чат в новой вкладке',
+      openInNewTab: 'Открыть в новой вкладке',
       previousPage: 'Назад',
       nextPage: 'Вперед',
       add: 'Добавить',

--- a/web/src/locales/tr.ts
+++ b/web/src/locales/tr.ts
@@ -59,7 +59,7 @@ export default {
       submit: 'Gönder',
       clear: 'Temizle',
       embedIntoSite: 'Web sayfasına göm',
-      openInNewTab: 'Yeni sekmede sohbet et',
+      openInNewTab: 'Yeni sekmede aç',
       previousPage: 'Önceki',
       nextPage: 'Sonraki',
       previous: 'Önceki',

--- a/web/src/locales/vi.ts
+++ b/web/src/locales/vi.ts
@@ -40,7 +40,7 @@ export default {
       spanish: 'Tiếng Tây Ban Nha',
       japanese: 'Tiếng Nhật',
       embedIntoSite: 'Nhúng vào trang web',
-      openInNewTab: 'Chat trong tab mới',
+      openInNewTab: 'Mở trong tab mới',
       nextPage: 'Tới',
       previousPage: 'Lùi',
       owner: 'Chủ sở hữu',

--- a/web/src/locales/zh-traditional.ts
+++ b/web/src/locales/zh-traditional.ts
@@ -37,7 +37,7 @@ export default {
       pleaseInput: '請輸入',
       submit: '提交',
       embedIntoSite: '嵌入網站',
-      openInNewTab: '在新標籤頁中聊天',
+      openInNewTab: '在新標籤頁中開啟',
       previousPage: '上一頁',
       nextPage: '下一頁',
       add: '添加',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -50,7 +50,7 @@ export default {
       submit: '提交',
       clear: '清空',
       embedIntoSite: '嵌入网站',
-      openInNewTab: '在新标签页中聊天',
+      openInNewTab: '在新标签页中打开',
       previousPage: '上一页',
       nextPage: '下一页',
       previous: '上一步',

--- a/web/src/pages/next-search/embed-app-modal.tsx
+++ b/web/src/pages/next-search/embed-app-modal.tsx
@@ -1,4 +1,5 @@
 import HighLightMarkdown from '@/components/highlight-markdown';
+import { Button } from '@/components/ui/button';
 import message from '@/components/ui/message';
 import { Modal } from '@/components/ui/modal/modal';
 import { RAGFlowSelect } from '@/components/ui/select';
@@ -9,6 +10,7 @@ import {
 } from '@/constants/common';
 import { useTranslate } from '@/hooks/common-hooks';
 import { useFetchTenantInfo } from '@/hooks/use-user-setting-request';
+import { ExternalLink } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 type IEmbedAppModalProps = {
@@ -47,6 +49,10 @@ const EmbedAppModal = (props: IEmbedAppModalProps) => {
     }
     return src;
   }, [beta, from, token, hideAvatar, locale, url, tenantId]);
+
+  const handleOpenInNewTab = useCallback(() => {
+    window.open(generateIframeSrc(), '_blank');
+  }, [generateIframeSrc]);
 
   // ... existing code ...
   const text = useMemo(() => {
@@ -106,6 +112,18 @@ const EmbedAppModal = (props: IEmbedAppModalProps) => {
           {/* <pre className="text-sm whitespace-pre-wrap">{text}</pre> */}
           <HighLightMarkdown>{text}</HighLightMarkdown>
           {/* </div> */}
+        </div>
+
+        {/* Open In New Tab */}
+        <div className="mb-6">
+          <Button
+            onClick={handleOpenInNewTab}
+            className="w-full"
+            variant="secondary"
+          >
+            <ExternalLink className="mr-2 h-4 w-4" />
+            {t('openInNewTab', { keyPrefix: 'common' })}
+          </Button>
         </div>
 
         {/* ID Field */}


### PR DESCRIPTION
### Summary

The search share "Embed into site" dialog was missing the "Open in new tab" button that the chat share embed dialog already provides, making it impossible to preview the shared search page directly from the dialog.

This PR:
- Adds an "Open in new tab" button (with `ExternalLink` icon, matching the chat share dialog style) to the search share embed dialog (`web/src/pages/next-search/embed-app-modal.tsx`). It reuses the generated iframe URL, so the opened page respects the selected options (hide avatar, locale, etc.).
- Generalizes the shared `common.openInNewTab` locale string (previously chat-specific, e.g. "Chat in new tab") to a generic "Open in new tab" wording across all 13 locale files, so both the chat and search share dialogs share the same key consistently.