### PR TITLE
Fix flickering document count and total when toggling file filter on search page

### DIFF
--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -1075,7 +1075,7 @@ export const useSelectTestingResult = (): ITestingResult => {
       return mutation.state.data;
     },
   });
-  return (data.at(-1) ?? {
+  return (data.filter((x) => x !== undefined).at(-1) ?? {
     chunks: [],
     documents: [],
     total: 0,
@@ -1109,7 +1109,7 @@ export const useAllTestingResult = (): ITestingResult => {
       return mutation.state.data;
     },
   });
-  return (data.at(-1) ?? {
+  return (data.filter((x) => x !== undefined).at(-1) ?? {
     chunks: [],
     documents: [],
     total: 0,

--- a/web/src/pages/next-search/hooks.ts
+++ b/web/src/pages/next-search/hooks.ts
@@ -149,7 +149,6 @@ export const useTestChunkRetrieval = (
     mutateAsync,
   } = useMutation({
     mutationKey: ['testChunk'], // This method is invalid
-    gcTime: 0,
     mutationFn: async (values: any) => {
       const { data } = await retrievalTestFunc({
         page,
@@ -200,7 +199,6 @@ export const useTestChunkAllRetrieval = (
     mutateAsync,
   } = useMutation({
     mutationKey: ['testChunkAll'], // This method is invalid
-    gcTime: 0,
     mutationFn: async (values: any) => {
       const { data } = await retrievalTestFunc({
         page,


### PR DESCRIPTION
### Summary

On the search page, toggling a checkbox in the document list filter fires two concurrent retrieval requests (`testChunk` filtered and `testChunkAll` unfiltered). The result hooks read the latest mutation via `useMutationState(...).at(-1)`, but a pending mutation has `state.data === undefined`, and both mutations used `gcTime: 0`, which discards the previous successful result immediately. While a request is in flight the hooks therefore fall back to empty data.

When the filtered `testChunk` returns first (with only the selected documents) while `testChunkAll` is still pending, the document-list denominator briefly shows the filtered count (e.g. "1/1") before snapping back (e.g. "1/2"). The same race also makes the "total" counter flash to 0.

Changes:
- `useSelectTestingResult` / `useAllTestingResult` now select the most recent mutation that actually has data, keeping the previous successful result while a new request is pending.
- Removed `gcTime: 0` from both retrieval mutations so the last successful result stays in the mutation cache during the pending window.