### PR TITLE
fix(web): hide folder upload tab for Gmail and Google Drive OAuth JSON upload

### DIFF
--- a/web/src/pages/user-setting/data-source/component/gmail-token-field.tsx
+++ b/web/src/pages/user-setting/data-source/component/gmail-token-field.tsx
@@ -370,6 +370,7 @@ const GmailTokenField = ({ value, onChange }: GmailTokenFieldProps) => {
         onValueChange={handleValueChange}
         accept={{ '*.json': [FileMimeType.Json] }}
         maxFileCount={1}
+        showFolderTab={false}
         description={'Upload your Gmail OAuth JSON file.'}
       />
 

--- a/web/src/pages/user-setting/data-source/component/google-drive-token-field.tsx
+++ b/web/src/pages/user-setting/data-source/component/google-drive-token-field.tsx
@@ -371,6 +371,7 @@ const GoogleDriveTokenField = ({
         onValueChange={handleValueChange}
         accept={{ '*.json': [FileMimeType.Json] }}
         maxFileCount={1}
+        showFolderTab={false}
         description="Upload your Google OAuth JSON file."
       />
 


### PR DESCRIPTION
### Summary

The Gmail and Google Drive data source creation dialogs only accept a single OAuth credential JSON file. However, the shared `FileUploader` component shows both a `Files` and a `Folder` tab by default, which misleads users into thinking they can upload an entire directory and increases the chance of misoperation.

This PR passes `showFolderTab={false}` to the `FileUploader` in `gmail-token-field.tsx` and `google-drive-token-field.tsx`, so only the file upload tab is shown for these OAuth JSON upload fields.