### PR TITLE
fix(go-agent): support Tavily tool names

### DIFF
--- a/internal/agent/tool/registry.go
+++ b/internal/agent/tool/registry.go
@@ -54,13 +54,17 @@ var registry = map[string]Factory{
 	"search_my_dateset":     buildRetrievalTool,
 	"searxng":               buildSearXNGTool,
 	"tavily":                buildTavilyTool,
-	"tavily_extract":        buildTavilyExtractTool,
-	"tushare":               noConfig("tushare", func() einotool.BaseTool { return NewTushareTool() }),
-	"wencai":                buildWencaiTool,
-	"web_crawler":           noConfig("web_crawler", func() einotool.BaseTool { return NewCrawlerTool() }),
-	"wikipedia":             buildWikipediaTool,
-	"wikipedia_search":      buildWikipediaTool,
-	"yahoo_finance":         buildYahooFinanceTool,
+	// Agent DSL tool lists carry the Python Canvas component_name verbatim.
+	// BuildByName lower-cases names, so register those component names too.
+	"tavilysearch":     buildTavilyTool,
+	"tavily_extract":   buildTavilyExtractTool,
+	"tavilyextract":    buildTavilyExtractTool,
+	"tushare":          noConfig("tushare", func() einotool.BaseTool { return NewTushareTool() }),
+	"wencai":           buildWencaiTool,
+	"web_crawler":      noConfig("web_crawler", func() einotool.BaseTool { return NewCrawlerTool() }),
+	"wikipedia":        buildWikipediaTool,
+	"wikipedia_search": buildWikipediaTool,
+	"yahoo_finance":    buildYahooFinanceTool,
 }
 
 func noConfig(name string, fn func() einotool.BaseTool) Factory {

--- a/internal/agent/tool/registry_test.go
+++ b/internal/agent/tool/registry_test.go
@@ -40,6 +40,30 @@ func TestBuildAll_UnknownTool(t *testing.T) {
 	}
 }
 
+func TestBuildByName_TavilyCanvasComponentNames(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+	}{
+		{name: "TavilySearch"},
+		{name: "TavilyExtract"},
+	} {
+		built, err := BuildByName(tc.name, nil)
+		if err != nil {
+			t.Fatalf("BuildByName(%q): %v", tc.name, err)
+		}
+		switch tc.name {
+		case "TavilySearch":
+			if _, ok := built.(*TavilyTool); !ok {
+				t.Errorf("BuildByName(%q) returned %T, want *TavilyTool", tc.name, built)
+			}
+		case "TavilyExtract":
+			if _, ok := built.(*TavilyExtractTool); !ok {
+				t.Errorf("BuildByName(%q) returned %T, want *TavilyExtractTool", tc.name, built)
+			}
+		}
+	}
+}
+
 func TestBuildAll_AllRegisteredTools(t *testing.T) {
 	// Every key in registry.
 	names := []string{


### PR DESCRIPTION
## Summary

- Register `TavilySearch` and `TavilyExtract` Canvas component names in the Go Agent tool registry.
- Add regression coverage for building both tools by their Python component names.

## Testing

- `bash build.sh --test ./internal/agent/tool/...`
- `bash build.sh --test ./internal/agent/component/...`