### PR TITLE
fix(web): use outline-none instead of outline-0 on focusable controls

### DIFF
--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ import { Link, LinkProps } from 'react-router';
 
 const buttonVariants = cva(
   cn(
-    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-colors outline-0',
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-colors outline-none',
     'disabled:pointer-events-none disabled:opacity-50 rounded border-0.5 border-transparent',
     '[&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0',
   ),

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer size-3.5 shrink-0 rounded-2xs border border-text-disabled outline-0 transition-colors bg-transparent',
+      'peer size-3.5 shrink-0 rounded-2xs border border-text-disabled outline-none transition-colors bg-transparent',
       'hover:border-border-default hover:bg-border-button',
       'focus-visible:border-border-default focus-visible:bg-border-default',
       'disabled:cursor-not-allowed disabled:opacity-50',


### PR DESCRIPTION
### Summary

A focused checkbox in the filter popover (e.g. Agent list filters) renders with a broken, incomplete border: Chromium paints its native platform focus ring (blue/dark depending on OS theme) inside the 14px checkbox, covering its left border.

Root cause: the `Checkbox` and `Button` components use Tailwind's `outline-0`, which only sets `outline-width: 0px`. The browser UA stylesheet applies `outline-style: auto` on `:focus-visible`, and Chromium ignores `outline-width` when `outline-style` is `auto`, so the native focus ring is still painted.

Fix: switch to `outline-none`, which sets `outline-style: solid` with a transparent color and properly overrides the UA rule. Verified with headless Chrome at pixel level: the focused checkbox border is now complete and symmetric on all four sides.