### PR TITLE
fix: fetch all knowledge bases via pagination in link-to-dataset dialog

### DIFF
--- a/web/src/components/knowledge-base-item.tsx
+++ b/web/src/components/knowledge-base-item.tsx
@@ -28,10 +28,12 @@ export function useDisableDifferenceEmbeddingDataset(name: string) {
   const datasetId = useWatch({ name, control: form.control });
   const [searchString, setSearchString] = useState('');
   const debouncedSearchString = useDebounce(searchString, { wait: 500 });
-  const { list: datasetListOrigin, loading } = useFetchKnowledgeList(
-    true,
-    debouncedSearchString,
-  );
+  const {
+    list: datasetListOrigin,
+    loading,
+    handleScroll,
+    hasMore,
+  } = useFetchKnowledgeList(true, debouncedSearchString);
   const datasetCacheRef = useRef(new Map<string, IDataset>());
 
   const datasetList = useMemo(() => {
@@ -96,6 +98,8 @@ export function useDisableDifferenceEmbeddingDataset(name: string) {
     handleSearchChange,
     loading,
     searchString,
+    handleScroll,
+    hasMore,
   };
 }
 
@@ -110,8 +114,14 @@ export function KnowledgeBaseFormField({
 }) {
   const { t } = useTranslation();
 
-  const { datasetOptions, handleSearchChange, loading, searchString } =
-    useDisableDifferenceEmbeddingDataset(name);
+  const {
+    datasetOptions,
+    handleSearchChange,
+    loading,
+    searchString,
+    handleScroll,
+    hasMore,
+  } = useDisableDifferenceEmbeddingDataset(name);
 
   const nextOptions = buildQueryVariableOptionsByShowVariable(showVariable)();
 
@@ -178,6 +188,7 @@ export function KnowledgeBaseFormField({
           onSearchChange={handleSearchChange}
           isSearching={loading}
           shouldFilter={false}
+          onListScroll={hasMore ? handleScroll : undefined}
           {...field}
         />
       )}

--- a/web/src/components/knowledge-base-item.tsx
+++ b/web/src/components/knowledge-base-item.tsx
@@ -32,7 +32,7 @@ export function useDisableDifferenceEmbeddingDataset(name: string) {
     list: datasetListOrigin,
     loading,
     handleScroll,
-    hasMore,
+    hasNextPage,
   } = useFetchKnowledgeList(true, debouncedSearchString);
   const datasetCacheRef = useRef(new Map<string, IDataset>());
 
@@ -99,7 +99,7 @@ export function useDisableDifferenceEmbeddingDataset(name: string) {
     loading,
     searchString,
     handleScroll,
-    hasMore,
+    hasNextPage,
   };
 }
 
@@ -120,7 +120,7 @@ export function KnowledgeBaseFormField({
     loading,
     searchString,
     handleScroll,
-    hasMore,
+    hasNextPage,
   } = useDisableDifferenceEmbeddingDataset(name);
 
   const nextOptions = buildQueryVariableOptionsByShowVariable(showVariable)();
@@ -188,7 +188,7 @@ export function KnowledgeBaseFormField({
           onSearchChange={handleSearchChange}
           isSearching={loading}
           shouldFilter={false}
-          onListScroll={hasMore ? handleScroll : undefined}
+          onListScroll={hasNextPage ? handleScroll : undefined}
           {...field}
         />
       )}

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -192,6 +192,7 @@ interface MultiSelectProps
   onSearchChange?: (value: string) => void;
   isSearching?: boolean;
   shouldFilter?: boolean;
+  onListScroll?: (e: React.UIEvent<HTMLDivElement>) => void;
 }
 
 export const MultiSelect = React.forwardRef<
@@ -217,6 +218,7 @@ export const MultiSelect = React.forwardRef<
       onSearchChange,
       isSearching = false,
       shouldFilter,
+      onListScroll,
       ...props
     },
     ref,
@@ -451,7 +453,7 @@ export const MultiSelect = React.forwardRef<
                 onValueChange={onSearchChange}
               />
             )}
-            <CommandList className="mt-2">
+            <CommandList className="mt-2" onScroll={onListScroll}>
               <CommandEmpty>
                 {isSearching ? t('common.searching') : t('common.noDataFound')}
               </CommandEmpty>

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -918,14 +918,14 @@ export const useFetchAllKnowledgeList = (
 };
 
 export const useSelectKnowledgeOptions = () => {
-  const { list, loading, handleScroll, hasNextPage } = useFetchKnowledgeList();
+  const { list } = useFetchAllKnowledgeList();
 
   const options = list?.map((item) => ({
     label: item.name,
     value: item.id,
   }));
 
-  return { options, loading, handleScroll, hasMore: hasNextPage };
+  return options;
 };
 
 //#region tags

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -51,7 +51,7 @@ import {
 } from '@tanstack/react-query';
 import { useDebounce } from 'ahooks';
 import { omit } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import {
   useGetPaginationWithRouter,
@@ -826,56 +826,106 @@ export const useClearWiki = () => {
   return { data, loading, clearWiki: mutateAsync };
 };
 
+const KNOWLEDGE_LIST_PAGE_SIZE = 10;
+
 export const useFetchKnowledgeList = (
   shouldFilterListWithoutDocument: boolean = false,
   keywords = '',
 ): {
   list: IDataset[];
   loading: boolean;
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
 } => {
-  const { data, isFetching: loading } = useQuery({
-    queryKey: [
-      KnowledgeApiAction.FetchKnowledgeList,
-      shouldFilterListWithoutDocument,
-      keywords,
-    ],
-    initialData: [],
-    gcTime: 0, // https://tanstack.com/query/latest/docs/framework/react/guides/caching?from=reactQueryV3
-    queryFn: async () => {
-      const pageSize = 200;
-      const all: IDataset[] = [];
-      let page = 1;
-      // Loop through pages until all knowledge bases are fetched.
-      let hasMore = true;
-      while (hasMore) {
+  const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
+    useInfiniteQuery<{ items: IDataset[] }>({
+      queryKey: [
+        KnowledgeApiAction.FetchKnowledgeList,
+        shouldFilterListWithoutDocument,
+        keywords,
+      ],
+      gcTime: 0,
+      initialPageParam: 1,
+      queryFn: async ({ pageParam }) => {
+        const page = pageParam as number;
         const { data } = await listDataset({
           page,
-          page_size: pageSize,
+          page_size: KNOWLEDGE_LIST_PAGE_SIZE,
           ...(keywords ? { ext: { keywords } } : {}),
         });
-        const pageData = data?.data ?? [];
-        all.push(...pageData);
-        hasMore = pageData.length >= pageSize;
-        page++;
-      }
-      return shouldFilterListWithoutDocument
-        ? all.filter((x: IDataset) => x.chunk_count > 0)
-        : all;
-    },
-  });
+        return { items: (data?.data ?? []) as IDataset[] };
+      },
+      getNextPageParam: (lastPage, allPages) =>
+        lastPage.items.length >= KNOWLEDGE_LIST_PAGE_SIZE
+          ? allPages.length + 1
+          : undefined,
+    });
 
-  return { list: data, loading };
+  const list = useMemo(() => {
+    const all = data?.pages.flatMap((page) => page.items) ?? [];
+    return shouldFilterListWithoutDocument
+      ? all.filter((x) => x.chunk_count > 0)
+      : all;
+  }, [data, shouldFilterListWithoutDocument]);
+
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+      const threshold = 50;
+      if (
+        scrollHeight - scrollTop - clientHeight <= threshold &&
+        hasNextPage &&
+        !isFetchingNextPage
+      ) {
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage],
+  );
+
+  return {
+    list,
+    loading: isFetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    handleScroll,
+  };
+};
+
+/**
+ * For consumers that need the COMPLETE list (no scroll UI).
+ * Auto-loads all pages sequentially until exhausted.
+ */
+export const useFetchAllKnowledgeList = (
+  shouldFilterListWithoutDocument: boolean = false,
+  keywords = '',
+): { list: IDataset[]; loading: boolean } => {
+  const { list, loading, hasNextPage, fetchNextPage } = useFetchKnowledgeList(
+    shouldFilterListWithoutDocument,
+    keywords,
+  );
+
+  useEffect(() => {
+    if (hasNextPage && !loading) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, loading, fetchNextPage]);
+
+  return { list, loading };
 };
 
 export const useSelectKnowledgeOptions = () => {
-  const { list } = useFetchKnowledgeList();
+  const { list, loading, handleScroll, hasNextPage } = useFetchKnowledgeList();
 
   const options = list?.map((item) => ({
     label: item.name,
     value: item.id,
   }));
 
-  return options;
+  return { options, loading, handleScroll, hasMore: hasNextPage };
 };
 
 //#region tags

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -842,19 +842,25 @@ export const useFetchKnowledgeList = (
     initialData: [],
     gcTime: 0, // https://tanstack.com/query/latest/docs/framework/react/guides/caching?from=reactQueryV3
     queryFn: async () => {
-      const { data } = await listDataset(
-        keywords
-          ? {
-              ext: {
-                keywords,
-              },
-            }
-          : undefined,
-      );
-      const list = data?.data ?? [];
+      const pageSize = 200;
+      const all: IDataset[] = [];
+      let page = 1;
+      // Loop through pages until all knowledge bases are fetched.
+      let hasMore = true;
+      while (hasMore) {
+        const { data } = await listDataset({
+          page,
+          page_size: pageSize,
+          ...(keywords ? { ext: { keywords } } : {}),
+        });
+        const pageData = data?.data ?? [];
+        all.push(...pageData);
+        hasMore = pageData.length >= pageSize;
+        page++;
+      }
       return shouldFilterListWithoutDocument
-        ? list.filter((x: IDataset) => x.chunk_count > 0)
-        : list;
+        ? all.filter((x: IDataset) => x.chunk_count > 0)
+        : all;
     },
   });
 

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -233,7 +233,9 @@ export const useCreateKnowledge = () => {
         message.success(
           i18n.t(`message.${params?.id ? 'modified' : 'created'}`),
         );
-        queryClient.invalidateQueries({ queryKey: ['fetchKnowledgeList'] });
+        queryClient.invalidateQueries({
+          queryKey: [KnowledgeApiAction.FetchKnowledgeList],
+        });
       }
       return data;
     },
@@ -828,6 +830,20 @@ export const useClearWiki = () => {
 
 const KNOWLEDGE_LIST_PAGE_SIZE = 10;
 
+export const KnowledgeListKeys = {
+  list: (
+    shouldFilterListWithoutDocument: boolean,
+    keywords: string,
+    pageSize: number,
+  ) =>
+    [
+      KnowledgeApiAction.FetchKnowledgeList,
+      shouldFilterListWithoutDocument,
+      keywords,
+      pageSize,
+    ] as const,
+};
+
 export const useFetchKnowledgeList = (
   shouldFilterListWithoutDocument: boolean = false,
   keywords = '',
@@ -842,12 +858,11 @@ export const useFetchKnowledgeList = (
 } => {
   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
     useInfiniteQuery<{ items: IDataset[] }>({
-      queryKey: [
-        KnowledgeApiAction.FetchKnowledgeList,
+      queryKey: KnowledgeListKeys.list(
         shouldFilterListWithoutDocument,
         keywords,
         pageSize,
-      ],
+      ),
       gcTime: 0,
       initialPageParam: 1,
       queryFn: async ({ pageParam }) => {

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -831,6 +831,7 @@ const KNOWLEDGE_LIST_PAGE_SIZE = 10;
 export const useFetchKnowledgeList = (
   shouldFilterListWithoutDocument: boolean = false,
   keywords = '',
+  pageSize: number = KNOWLEDGE_LIST_PAGE_SIZE,
 ): {
   list: IDataset[];
   loading: boolean;
@@ -845,6 +846,7 @@ export const useFetchKnowledgeList = (
         KnowledgeApiAction.FetchKnowledgeList,
         shouldFilterListWithoutDocument,
         keywords,
+        pageSize,
       ],
       gcTime: 0,
       initialPageParam: 1,
@@ -852,15 +854,13 @@ export const useFetchKnowledgeList = (
         const page = pageParam as number;
         const { data } = await listDataset({
           page,
-          page_size: KNOWLEDGE_LIST_PAGE_SIZE,
+          page_size: pageSize,
           ...(keywords ? { ext: { keywords } } : {}),
         });
         return { items: (data?.data ?? []) as IDataset[] };
       },
       getNextPageParam: (lastPage, allPages) =>
-        lastPage.items.length >= KNOWLEDGE_LIST_PAGE_SIZE
-          ? allPages.length + 1
-          : undefined,
+        lastPage.items.length >= pageSize ? allPages.length + 1 : undefined,
     });
 
   const list = useMemo(() => {
@@ -897,7 +897,8 @@ export const useFetchKnowledgeList = (
 
 /**
  * For consumers that need the COMPLETE list (no scroll UI).
- * Auto-loads all pages sequentially until exhausted.
+ * Uses a large page size to minimize round-trips, and auto-loads
+ * until exhausted.
  */
 export const useFetchAllKnowledgeList = (
   shouldFilterListWithoutDocument: boolean = false,
@@ -906,6 +907,7 @@ export const useFetchAllKnowledgeList = (
   const { list, loading, hasNextPage, fetchNextPage } = useFetchKnowledgeList(
     shouldFilterListWithoutDocument,
     keywords,
+    200,
   );
 
   useEffect(() => {

--- a/web/src/pages/agent/canvas/node/retrieval-node.tsx
+++ b/web/src/pages/agent/canvas/node/retrieval-node.tsx
@@ -1,6 +1,6 @@
 import { NodeCollapsible } from '@/components/collapse';
 import { RAGFlowAvatar } from '@/components/ragflow-avatar';
-import { useFetchKnowledgeList } from '@/hooks/use-knowledge-request';
+import { useFetchAllKnowledgeList } from '@/hooks/use-knowledge-request';
 import { useFetchAllMemoryList } from '@/hooks/use-memory-request';
 import { BaseNode } from '@/interfaces/database/agent';
 import { NodeProps, Position } from '@xyflow/react';
@@ -25,7 +25,7 @@ function InnerRetrievalNode({
 }: NodeProps<BaseNode<RetrievalFormSchemaType>>) {
   const knowledgeBaseIds: string[] = get(data, 'form.dataset_ids', []);
   const memoryIds: string[] = get(data, 'form.memory_ids', []);
-  const { list: knowledgeList } = useFetchKnowledgeList(true);
+  const { list: knowledgeList } = useFetchAllKnowledgeList(true);
 
   const { getLabel } = useGetVariableLabelOrTypeByValue({ nodeId: id });
 

--- a/web/src/pages/dataset/dataset-setting/components/tag-item.tsx
+++ b/web/src/pages/dataset/dataset-setting/components/tag-item.tsx
@@ -18,7 +18,11 @@ export const TagSetItem = () => {
   const { t } = useTranslation();
   const form = useFormContext();
 
-  const { list: knowledgeList } = useFetchKnowledgeList(true);
+  const {
+    list: knowledgeList,
+    handleScroll,
+    hasNextPage,
+  } = useFetchKnowledgeList(true);
 
   const knowledgeOptions = knowledgeList
     .filter((x) => x.chunk_method === 'tag')
@@ -60,6 +64,7 @@ export const TagSetItem = () => {
                 <MultiSelect
                   options={knowledgeOptions}
                   onValueChange={field.onChange}
+                  onListScroll={hasNextPage ? handleScroll : undefined}
                   // placeholder={t('chat.knowledgeBasesMessage')}
                   variant="inverted"
                   maxCount={10}

--- a/web/src/pages/dataset/dataset-setting/components/tag-item.tsx
+++ b/web/src/pages/dataset/dataset-setting/components/tag-item.tsx
@@ -10,7 +10,9 @@ import {
 import { MultiSelect } from '@/components/ui/multi-select';
 import { FormLayout } from '@/constants/form';
 import { useFetchKnowledgeList } from '@/hooks/use-knowledge-request';
+import { useDebounce } from 'ahooks';
 import DOMPurify from 'dompurify';
+import { useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -18,11 +20,15 @@ export const TagSetItem = () => {
   const { t } = useTranslation();
   const form = useFormContext();
 
+  const [searchString, setSearchString] = useState('');
+  const debouncedSearchString = useDebounce(searchString, { wait: 500 });
+
   const {
     list: knowledgeList,
     handleScroll,
     hasNextPage,
-  } = useFetchKnowledgeList(true);
+    loading,
+  } = useFetchKnowledgeList(true, debouncedSearchString);
 
   const knowledgeOptions = knowledgeList
     .filter((x) => x.chunk_method === 'tag')
@@ -64,6 +70,10 @@ export const TagSetItem = () => {
                 <MultiSelect
                   options={knowledgeOptions}
                   onValueChange={field.onChange}
+                  searchValue={searchString}
+                  onSearchChange={setSearchString}
+                  isSearching={loading}
+                  shouldFilter={false}
                   onListScroll={hasNextPage ? handleScroll : undefined}
                   // placeholder={t('chat.knowledgeBasesMessage')}
                   variant="inverted"

--- a/web/src/pages/datasets/use-select-owners.ts
+++ b/web/src/pages/datasets/use-select-owners.ts
@@ -1,10 +1,10 @@
 import { FilterCollection } from '@/components/list-filter-bar/interface';
-import { useFetchKnowledgeList } from '@/hooks/use-knowledge-request';
+import { useFetchAllKnowledgeList } from '@/hooks/use-knowledge-request';
 import { buildOwnersFilter } from '@/utils/list-filter-util';
 import { useTranslation } from 'react-i18next';
 
 export function useSelectOwners() {
-  const { list } = useFetchKnowledgeList();
+  const { list } = useFetchAllKnowledgeList();
   const { t } = useTranslation();
 
   const filters: FilterCollection[] = [

--- a/web/src/pages/files/hooks.ts
+++ b/web/src/pages/files/hooks.ts
@@ -86,7 +86,7 @@ export const useHandleConnectToKnowledge = () => {
   const [record, setRecord] = useState<IFile>({} as IFile);
   const [documentIds, setDocumentIds] = useState<string[]>([]);
   const [mode, setMode] = useState<ConnectFileToKnowledgeMode>('replace');
-  const knowledgeOptions = useSelectKnowledgeOptions();
+  const { options: knowledgeOptions } = useSelectKnowledgeOptions();
 
   const initialValue = useMemo(() => {
     return Array.isArray(record?.kbs_info)

--- a/web/src/pages/files/link-to-dataset-dialog.tsx
+++ b/web/src/pages/files/link-to-dataset-dialog.tsx
@@ -47,7 +47,7 @@ function LinkToDatasetForm({
     },
   });
 
-  const options = useSelectKnowledgeOptions();
+  const { options, handleScroll, hasMore } = useSelectKnowledgeOptions();
 
   function onSubmit(data: z.infer<typeof FormSchema>) {
     onConnectToKnowledgeOk(data.knowledgeIds);
@@ -77,6 +77,7 @@ function LinkToDatasetForm({
                   defaultValue={field.value}
                   placeholder={t('fileManager.pleaseSelect')}
                   maxCount={100}
+                  onListScroll={hasMore ? handleScroll : undefined}
                   //   {...field}
                   modalPopover
                 />

--- a/web/src/pages/files/link-to-dataset-dialog.tsx
+++ b/web/src/pages/files/link-to-dataset-dialog.tsx
@@ -15,10 +15,12 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { MultiSelect } from '@/components/ui/multi-select';
-import { useSelectKnowledgeOptions } from '@/hooks/use-knowledge-request';
+import { useFetchKnowledgeList } from '@/hooks/use-knowledge-request';
 import { IModalProps } from '@/interfaces/common';
+import { useDebounce } from 'ahooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Link2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -47,7 +49,21 @@ function LinkToDatasetForm({
     },
   });
 
-  const { options, handleScroll, hasMore } = useSelectKnowledgeOptions();
+  const [searchString, setSearchString] = useState('');
+  const debouncedSearchString = useDebounce(searchString, { wait: 500 });
+  const { list, loading, handleScroll, hasNextPage } = useFetchKnowledgeList(
+    false,
+    debouncedSearchString,
+  );
+
+  const options = useMemo(
+    () =>
+      list.map((item) => ({
+        label: item.name,
+        value: item.id,
+      })),
+    [list],
+  );
 
   function onSubmit(data: z.infer<typeof FormSchema>) {
     onConnectToKnowledgeOk(data.knowledgeIds);
@@ -77,7 +93,11 @@ function LinkToDatasetForm({
                   defaultValue={field.value}
                   placeholder={t('fileManager.pleaseSelect')}
                   maxCount={100}
-                  onListScroll={hasMore ? handleScroll : undefined}
+                  searchValue={searchString}
+                  onSearchChange={setSearchString}
+                  isSearching={loading}
+                  shouldFilter={false}
+                  onListScroll={hasNextPage ? handleScroll : undefined}
                   //   {...field}
                   modalPopover
                 />


### PR DESCRIPTION
### Summary

Fix: the file management "link to dataset" dialog only displayed the 30 most recently created knowledge bases because `useFetchKnowledgeList` called the dataset list API without pagination parameters, hitting the Go backend default `page_size=30`. Knowledge bases beyond the first page were invisible and unsearchable in the selection dropdown.

This PR fixes the issue by looping through pages (`page_size=200`) until all knowledge bases are loaded, ensuring the complete list is available for both display and client-side search in the MultiSelect component.

The fix also benefits other consumers of `useFetchKnowledgeList`:
- Agent retrieval node knowledge base selector
- Dataset settings tag item
- Knowledge base item component
- Owner selection filter