### PR TITLE
fix: Make MCP bulk-manage select-all checkbox reflect selection state

### DIFF
--- a/web/src/pages/user-setting/mcp/index.tsx
+++ b/web/src/pages/user-setting/mcp/index.tsx
@@ -107,7 +107,18 @@ export default function McpServer() {
           <>
             {isSelectionMode && (
               <section className="pb-5 flex items-center">
-                <Checkbox id="all" onCheckedChange={handleSelectAll} />
+                <Checkbox
+                  id="all"
+                  checked={
+                    selectedList.length > 0 &&
+                    selectedList.length === data.mcp_servers.length
+                      ? true
+                      : selectedList.length > 0
+                        ? 'indeterminate'
+                        : false
+                  }
+                  onCheckedChange={handleSelectAll}
+                />
                 <Label
                   className="pl-2 text-text-primary cursor-pointer"
                   htmlFor="all"


### PR DESCRIPTION
### Summary

The "Select all" checkbox in the MCP server bulk-management view was uncontrolled — it had no `checked` prop, so it never displayed a checkmark regardless of how many items were selected. The selection state itself (`selectedList`) updated correctly, but the checkbox provided no visual feedback.

This PR makes the select-all checkbox controlled by deriving its state from `selectedList` vs. the full server list:

- All items selected → `checked` (checkmark)
- Partial selection → `indeterminate` (minus sign)
- None selected → `unchecked`

### Root cause

`Checkbox` (`web/src/components/ui/checkbox.tsx`) only renders its indicator icon when `props.checked === true` or `'indeterminate'`. The select-all checkbox in `web/src/pages/user-setting/mcp/index.tsx` passed only `onCheckedChange`, so the indicator was never shown.

### Changes

`web/src/pages/user-setting/mcp/index.tsx`: Pass a computed `checked` value to the select-all `<Checkbox>`.