### PR TITLE
Go: only unlink file-manager files when deleting documents from a knowledge base

### DIFF
--- a/internal/service/document/document_crud.go
+++ b/internal/service/document/document_crud.go
@@ -376,7 +376,9 @@ func (s *DocumentService) rollbackAddFileFromKBError(doc *entity.Document, kbID 
 
 // cleanupFileReferences deletes file2document mappings for docID, and for each
 // referenced file, only hard-deletes the file record and its storage blob when
-// no other document still references the same file_id.
+// the file is a knowledgebase-owned upload (source_type == knowledgebase) and
+// no other document still references the same file_id. Files linked from file
+// management are only unlinked — the file record and blob stay intact.
 func (s *DocumentService) cleanupFileReferences(docID string) {
 	mappings, mapErr := s.file2DocumentDAO.GetByDocumentID(docID)
 	if mapErr != nil {
@@ -402,7 +404,8 @@ func (s *DocumentService) cleanupFileReferences(docID string) {
 		common.Logger.Warn(fmt.Sprintf("cleanupFileReferences: failed to delete f2d for %s: %v", docID, delErr))
 	}
 
-	// For each file, only delete the record and blob when no other doc references it
+	// For each file, only delete the record and blob when it is a
+	// knowledgebase-owned upload and no other doc references it
 	for _, fileID := range fileIDs {
 		remaining, remErr := s.file2DocumentDAO.GetByFileID(fileID)
 		if remErr != nil {
@@ -418,6 +421,9 @@ func (s *DocumentService) cleanupFileReferences(docID string) {
 		if fErr != nil || file == nil {
 			common.Logger.Warn(fmt.Sprintf("cleanupFileReferences: file not found %s: %v", fileID, fErr))
 			continue
+		}
+		if entity.FileSource(file.SourceType) != entity.FileSourceKnowledgebase {
+			continue // linked from file management — unlink only, keep the file
 		}
 		if _, delErr := fileDAO.DeleteByIDs([]string{fileID}); delErr != nil {
 			common.Logger.Warn(fmt.Sprintf("cleanupFileReferences: failed to delete file %s: %v", fileID, delErr))


### PR DESCRIPTION
### Summary

Deleting a document from a knowledge base in Go mode incorrectly hard-deleted the underlying file record and storage blob whenever no other document referenced it. Files linked from the file manager to a KB thus disappeared from the file manager instead of just being unlinked.

This PR aligns the Go behavior with the existing Python implementation (`FileService.delete_docs`): only delete the file record and storage blob when the file is a knowledgebase-owned upload (`source_type == "knowledgebase"`). For files linked from file management (`source_type == ""` or `"local"`), only the `file2document` mapping is removed, keeping the file intact in the file manager.