### PR TITLE
fix(go): resolve tenant model IDs in memory create/update without hard failure

### DIFF
--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"ragflow/internal/common"
 	"ragflow/internal/entity"
 	models "ragflow/internal/entity/models"
@@ -348,12 +349,18 @@ func (s *MemoryService) CreateMemory(tenantID string, req *CreateMemoryRequest) 
 	// tenant_model row) — we leave the tenant_*_id fields nil and proceed.
 	modelProvider := NewModelProviderService()
 	if req.LLMID != "" && req.TenantLLMID == nil {
-		if tenantLLMID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeChat, req.LLMID); err == nil && tenantLLMID != "" {
+		tenantLLMID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeChat, req.LLMID)
+		if err != nil {
+			slog.Warn("CreateMemory: failed to resolve tenant LLM id", "tenant_id", tenantID, "llm_id", req.LLMID, "err", err)
+		} else if tenantLLMID != "" {
 			req.TenantLLMID = &tenantLLMID
 		}
 	}
 	if req.EmbdID != "" && req.TenantEmbdID == nil {
-		if tenantEmbdID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeEmbedding, req.EmbdID); err == nil && tenantEmbdID != "" {
+		tenantEmbdID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeEmbedding, req.EmbdID)
+		if err != nil {
+			slog.Warn("CreateMemory: failed to resolve tenant embedding id", "tenant_id", tenantID, "embd_id", req.EmbdID, "err", err)
+		} else if tenantEmbdID != "" {
 			req.TenantEmbdID = &tenantEmbdID
 		}
 	}
@@ -490,7 +497,10 @@ func (s *MemoryService) UpdateMemory(tenantID string, memoryID string, req *Upda
 	if req.LLMID != nil {
 		updateDict["llm_id"] = *req.LLMID
 		if req.TenantLLMID == nil && *req.LLMID != "" {
-			if resolved, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeChat, *req.LLMID); err == nil && resolved != "" {
+			resolved, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeChat, *req.LLMID)
+			if err != nil {
+				slog.Warn("UpdateMemory: failed to resolve tenant LLM id", "tenant_id", tenantID, "llm_id", *req.LLMID, "err", err)
+			} else if resolved != "" {
 				updateDict["tenant_llm_id"] = resolved
 			}
 		}
@@ -499,7 +509,10 @@ func (s *MemoryService) UpdateMemory(tenantID string, memoryID string, req *Upda
 	if req.EmbdID != nil {
 		updateDict["embd_id"] = *req.EmbdID
 		if req.TenantEmbdID == nil && *req.EmbdID != "" {
-			if resolved, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeEmbedding, *req.EmbdID); err == nil && resolved != "" {
+			resolved, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeEmbedding, *req.EmbdID)
+			if err != nil {
+				slog.Warn("UpdateMemory: failed to resolve tenant embedding id", "tenant_id", tenantID, "embd_id", *req.EmbdID, "err", err)
+			} else if resolved != "" {
 				updateDict["tenant_embd_id"] = resolved
 			}
 		}

--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -343,20 +343,19 @@ type ListMemoryResponse struct {
 //	req := &CreateMemoryRequest{Name: "MyMemory", MemoryType: []string{"semantic"}, EmbdID: "embd1", LLMID: "llm1"}
 //	resp, err := service.CreateMemory("tenant123", req)
 func (s *MemoryService) CreateMemory(tenantID string, req *CreateMemoryRequest) (*CreateMemoryResponse, error) {
+	// Resolve tenant model IDs, mirroring Python's ensure_tenant_model_ids_for_params.
+	// Resolution failure is non-fatal (e.g. Builtin models that have no
+	// tenant_model row) — we leave the tenant_*_id fields nil and proceed.
 	modelProvider := NewModelProviderService()
 	if req.LLMID != "" && req.TenantLLMID == nil {
-		tenantLLMID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeChat, req.LLMID)
-		if err != nil {
-			return nil, err
+		if tenantLLMID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeChat, req.LLMID); err == nil && tenantLLMID != "" {
+			req.TenantLLMID = &tenantLLMID
 		}
-		req.TenantLLMID = &tenantLLMID
 	}
 	if req.EmbdID != "" && req.TenantEmbdID == nil {
-		tenantEmbdID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeEmbedding, req.EmbdID)
-		if err != nil {
-			return nil, err
+		if tenantEmbdID, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeEmbedding, req.EmbdID); err == nil && tenantEmbdID != "" {
+			req.TenantEmbdID = &tenantEmbdID
 		}
-		req.TenantEmbdID = &tenantEmbdID
 	}
 
 	if err := common.ValidateName(req.Name); err != nil {
@@ -481,12 +480,29 @@ func (s *MemoryService) UpdateMemory(tenantID string, memoryID string, req *Upda
 		updateDict["permissions"] = perm
 	}
 
+	// Resolve tenant model IDs when llm_id / embd_id is provided, mirroring
+	// Python's ensure_tenant_model_ids_for_params. The frontend sends model
+	// names (or model_id UUIDs); the backend must resolve them to
+	// tenant_model row IDs so downstream code that depends on
+	// tenant_llm_id / tenant_embd_id stays consistent after an update.
+	// Resolution failure is non-fatal (e.g. Builtin models).
+	modelProvider := NewModelProviderService()
 	if req.LLMID != nil {
 		updateDict["llm_id"] = *req.LLMID
+		if req.TenantLLMID == nil && *req.LLMID != "" {
+			if resolved, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeChat, *req.LLMID); err == nil && resolved != "" {
+				updateDict["tenant_llm_id"] = resolved
+			}
+		}
 	}
 
 	if req.EmbdID != nil {
 		updateDict["embd_id"] = *req.EmbdID
+		if req.TenantEmbdID == nil && *req.EmbdID != "" {
+			if resolved, err := modelProvider.ResolveModelID(tenantID, entity.ModelTypeEmbedding, *req.EmbdID); err == nil && resolved != "" {
+				updateDict["tenant_embd_id"] = resolved
+			}
+		}
 	}
 
 	if req.TenantLLMID != nil {

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ import { Link, LinkProps } from 'react-router';
 
 const buttonVariants = cva(
   cn(
-    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-colors outline-0',
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-colors outline-none',
     'disabled:pointer-events-none disabled:opacity-50 rounded border-0.5 border-transparent',
     '[&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0',
   ),

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer size-3.5 shrink-0 rounded-2xs border border-text-disabled outline-0 transition-colors bg-transparent',
+      'peer size-3.5 shrink-0 rounded-2xs border border-text-disabled outline-none transition-colors bg-transparent',
       'hover:border-border-default hover:bg-border-button',
       'focus-visible:border-border-default focus-visible:bg-border-default',
       'disabled:cursor-not-allowed disabled:opacity-50',


### PR DESCRIPTION
### Summary

In Go mode, the memory configuration page could not set LLM and embedding model parameters because the Go `MemoryService` diverged from the Python implementation in two ways:

1. **`CreateMemory` hard-failed on model resolution**: When `ResolveModelID` returned an error (e.g. for Builtin models that have no `tenant_model` row), the entire memory creation was aborted. Python's `ensure_tenant_model_ids_for_params` catches `LookupError` and silently skips, allowing the operation to proceed.

2. **`UpdateMemory` did not resolve tenant model IDs**: When `llm_id` or `embd_id` was updated, the corresponding `tenant_llm_id` / `tenant_embd_id` was never re-resolved, leaving them stale or null. Python's `update_memory` API handler calls `ensure_tenant_model_ids_for_params` before processing the update.

Both are now fixed to match Python behavior:

- `CreateMemory`: resolution failure is non-fatal — if `ResolveModelID` fails or returns empty, the `tenant_*_id` field is left nil and the memory is still created.
- `UpdateMemory`: when `llm_id` / `embd_id` is provided and the corresponding `tenant_*_id` is not explicitly set, the backend resolves it via `ResolveModelID`. Resolution failure is non-fatal.

### Testing

```
bash build.sh --test ./internal/service/...
ok  ragflow/internal/service  1.996s
ok  ragflow/internal/service/chunk  0.202s
ok  ragflow/internal/service/dataset  1.261s
ok  ragflow/internal/service/document  1.012s
ok  ragflow/internal/service/file  0.262s
ok  ragflow/internal/service/graph  0.115s
ok  ragflow/internal/service/nlp  0.024s
```
