### PR TITLE
fix(web): preserve MCP authorization token across edits

### DIFF
--- a/web/src/pages/user-setting/mcp/edit-mcp-dialog.tsx
+++ b/web/src/pages/user-setting/mcp/edit-mcp-dialog.tsx
@@ -39,7 +39,12 @@ const DefaultValues = {
   name: '',
   server_type: ServerType.SSE,
   url: '',
+  authorization_token: '',
 };
+
+// Mask shown in the token field when editing an existing server that already
+// has a token, so the user knows a secret is stored without exposing it.
+const TokenMask = '********';
 
 export function EditMcpDialog({
   hideModal,
@@ -78,9 +83,15 @@ export function EditMcpDialog({
   }, []);
 
   const handleOk = async (values: z.infer<typeof FormSchema>) => {
+    // When the field still holds the mask, the user did not change the token;
+    // send the previously stored token so it is not overwritten with empty.
+    const token =
+      values.authorization_token === TokenMask
+        ? data.variables?.authorization_token
+        : values.authorization_token;
     const nextValues = {
       ...omit(values, 'authorization_token'),
-      variables: { authorization_token: values.authorization_token },
+      variables: { authorization_token: token },
       headers: { Authorization: 'Bearer ${authorization_token}' },
     };
     if (isTriggeredBySaving) {
@@ -95,7 +106,12 @@ export function EditMcpDialog({
 
   useEffect(() => {
     if (!isEmpty(data)) {
-      form.reset(pick(data, ['name', 'server_type', 'url']));
+      form.reset({
+        ...pick(data, ['name', 'server_type', 'url']),
+        authorization_token: data.variables?.authorization_token
+          ? TokenMask
+          : '',
+      });
     }
   }, [data, form]);
 


### PR DESCRIPTION
### Summary

When reopening the MCP server edit dialog, the \`authorization_token\` field was left empty. Saving without re-entering the token therefore overwrote the stored secret with an empty string, clearing it on the backend.

This change shows a mask in the token field when a token already exists, and restores the previously stored token on save/test when the field is unchanged. As a result the secret survives round-trips through the edit dialog without being re-typed.

- \`web/src/pages/user-setting/mcp/edit-mcp-dialog.tsx\`: populate the token field with a mask when an existing token is present, and substitute the stored token back on save/test when the field is unchanged.