### PR TITLE
fix(web): fix team member status badge hover text readability

### DIFF
--- a/web/src/pages/user-setting/setting-team/user-table.tsx
+++ b/web/src/pages/user-setting/setting-team/user-table.tsx
@@ -23,9 +23,12 @@ import { TenantRole } from '../constants';
 import { useHandleDeleteUser } from './hooks';
 
 const ColorMap: Record<string, string> = {
-  [TenantRole.Normal]: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
-  [TenantRole.Invite]: 'bg-accent-primary-5 bg-accent-primary rounded-sm',
-  [TenantRole.Owner]: 'bg-red-100 text-red-800',
+  [TenantRole.Normal]:
+    'bg-gray-100 text-gray-700 hover:bg-gray-200 hover:text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  [TenantRole.Invite]:
+    'bg-accent-primary-5 text-accent-primary hover:bg-accent-primary/10 rounded-sm',
+  [TenantRole.Owner]:
+    'bg-red-100 text-red-800 hover:bg-red-200 hover:text-red-800',
 };
 
 const UserTable = ({ searchUser }: { searchUser: string }) => {


### PR DESCRIPTION
### Summary

The Badge component's default variant adds `hover:bg-primary/80` which conflicts with the custom role badge background colors when hovering over member status badges in the team member table (User Settings → Team). This caused the background and text colors to become indistinguishable, making the text unreadable on hover.

**Changes:**
- Added explicit `hover:bg-*` and `hover:text-*` overrides for each `TenantRole` in the `ColorMap`
- **Normal**: added `hover:bg-gray-200 hover:text-gray-700` to maintain readable contrast on hover
- **Invite**: fixed duplicate `bg` classes (`bg-accent-primary-5 bg-accent-primary` → `bg-accent-primary-5 text-accent-primary`), added `hover:bg-accent-primary/10`
- **Owner**: added `hover:bg-red-200 hover:text-red-800` for consistent hover behavior

**Before:** Hovering over a member status badge made the text unreadable because the default blue hover background conflicted with the badge text color.
**After:** Each role badge now has a proper hover state that preserves text readability.