### PR TITLE
fix(go-agent): support task-based run cancellation

### DIFF
--- a/internal/agent/canvas/runner.go
+++ b/internal/agent/canvas/runner.go
@@ -163,6 +163,8 @@ type Runner struct {
 	mu           sync.Mutex
 	interruptIDs map[string]string // key = canvasID + "|" + sessionID; value = eino interrupt id
 	runCancels   map[string]chan struct{}
+	taskCancels  map[string]chan struct{}
+	taskCanvases map[string]string
 }
 
 // NewRunner returns a fresh Runner with the in-memory interrupt-id
@@ -172,6 +174,8 @@ func NewRunner() *Runner {
 	return &Runner{
 		interruptIDs: make(map[string]string),
 		runCancels:   make(map[string]chan struct{}),
+		taskCancels:  make(map[string]chan struct{}),
+		taskCanvases: make(map[string]string),
 	}
 }
 
@@ -259,6 +263,10 @@ func (r *Runner) Run(
 	if taskID == "" {
 		taskID = utility.GenerateToken()
 	}
+	r.mu.Lock()
+	r.taskCancels[taskID] = cancel
+	r.taskCanvases[taskID] = canvasID
+	r.mu.Unlock()
 
 	// Inject the output channel + metadata so the RunFunc can emit
 	// events during execution (workflow_started, node_started,
@@ -274,6 +282,10 @@ func (r *Runner) Run(
 			r.mu.Lock()
 			if r.runCancels[canvasID] == cancel {
 				delete(r.runCancels, canvasID)
+			}
+			if r.taskCancels[taskID] == cancel {
+				delete(r.taskCancels, taskID)
+				delete(r.taskCanvases, taskID)
 			}
 			r.mu.Unlock()
 		}()
@@ -370,6 +382,32 @@ func (r *Runner) Cancel(canvasID string) {
 	default:
 		close(cancel)
 	}
+}
+
+// CancelTask signals an active run identified by the task_id emitted in its
+// events. It returns the owning canvas id when the task is still active.
+func (r *Runner) CancelTask(taskID string) (string, bool) {
+	r.mu.Lock()
+	cancel, ok := r.taskCancels[taskID]
+	canvasID := r.taskCanvases[taskID]
+	r.mu.Unlock()
+	if !ok {
+		return "", false
+	}
+	select {
+	case <-cancel:
+	default:
+		close(cancel)
+	}
+	return canvasID, true
+}
+
+// TaskCanvas returns the canvas owning an active task without cancelling it.
+func (r *Runner) TaskCanvas(taskID string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	canvasID, ok := r.taskCanvases[taskID]
+	return canvasID, ok
 }
 
 // Peek reports whether a paused interrupt id is held for the given

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -493,6 +493,22 @@ func (h *AgentHandler) CancelAgent(c *gin.Context) {
 	common.SuccessWithData(c, true, "success")
 }
 
+// CancelTask cancels an active agent run by the task_id emitted in its events.
+// Unknown and already-completed task ids are treated as successful no-ops.
+func (h *AgentHandler) CancelTask(c *gin.Context) {
+	user, code, msg := GetUser(c)
+	if code != common.CodeSuccess {
+		common.ResponseWithCodeData(c, code, nil, msg)
+		return
+	}
+	if err := h.agentService.CancelTask(c.Request.Context(), user.ID, c.Param("task_id")); err != nil {
+		ec, em := mapAgentError(err)
+		common.ResponseWithCodeData(c, ec, nil, em)
+		return
+	}
+	common.SuccessWithData(c, true, "success")
+}
+
 // publishAgentRequest is the wire shape for POST /api/v1/agents/:canvas_id/publish.
 type publishAgentRequest struct {
 	Title       *string        `json:"title,omitempty"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -260,6 +260,9 @@ func (r *Router) Setup(engine *gin.Engine) {
 		// API v1 route group
 		v1 := authorized.Group("/api/v1")
 		{
+			// Agent stop button compatibility with Python's task API.
+			v1.POST("/tasks/:task_id/cancel", r.agentHandler.CancelTask)
+
 			// Auth routes
 			auth := v1.Group("/auth")
 			{

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -1881,3 +1881,21 @@ func (s *AgentService) CancelAgent(ctx context.Context, userID, canvasID string)
 	}
 	return nil
 }
+
+// CancelTask cancels an active agent run by the task_id exposed to clients.
+// Unknown or already-finished tasks are intentionally idempotent, matching
+// Python's /tasks/<task_id>/cancel endpoint.
+func (s *AgentService) CancelTask(ctx context.Context, userID, taskID string) error {
+	if taskID == "" || s.runner == nil {
+		return nil
+	}
+	canvasID, active := s.runner.TaskCanvas(taskID)
+	if !active {
+		return nil
+	}
+	if _, err := s.loadCanvasForUser(ctx, userID, canvasID); err != nil {
+		return err
+	}
+	s.runner.CancelTask(taskID)
+	return nil
+}


### PR DESCRIPTION
## Summary

- add the task cancellation endpoint used by the agent stop action
- cancel active agent runs by emitted task ID

## Testing

- `bash build.sh --test ./internal/agent/canvas ./internal/router`