### PR TITLE
fix(doc_store): retry transient connection errors in pool init

### DIFF
--- a/common/doc_store/es_conn_pool.py
+++ b/common/doc_store/es_conn_pool.py
@@ -47,6 +47,11 @@ class ElasticSearchConnectionPool:
                 )
                 if attempt == MAX_RETRIES - 1:
                     raise
+                if hasattr(self, "es_conn") and self.es_conn:
+                    try:
+                        self.es_conn.close()
+                    except Exception:
+                        pass
                 time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
                 continue
 

--- a/common/doc_store/es_conn_pool.py
+++ b/common/doc_store/es_conn_pool.py
@@ -20,7 +20,9 @@ from elasticsearch import Elasticsearch
 from common import settings
 from common.decorator import singleton
 
-ATTEMPT_TIME = 2
+MAX_RETRIES = 6
+ATTEMPT_TIME = MAX_RETRIES
+HEALTH_CHECK_BASE_DELAY_SECONDS = 5
 
 
 @singleton
@@ -31,16 +33,25 @@ class ElasticSearchConnectionPool:
         else:
             self.ES_CONFIG = settings.get_base_config("es", {})
 
-        for _ in range(ATTEMPT_TIME):
+        for attempt in range(MAX_RETRIES):
             try:
                 if self._connect():
                     break
             except Exception as e:
-                logging.warning(f"{str(e)}. Waiting Elasticsearch {self.ES_CONFIG['hosts']} to be healthy.")
-                time.sleep(5)
+                logging.warning(
+                    "Elasticsearch %s connection attempt %d/%d failed: %s",
+                    self.ES_CONFIG["hosts"],
+                    attempt + 1,
+                    MAX_RETRIES,
+                    e,
+                )
+                if attempt == MAX_RETRIES - 1:
+                    raise
+                time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
+                continue
 
         if not hasattr(self, "es_conn") or not self.es_conn or not self.es_conn.ping():
-            msg = f"Elasticsearch {self.ES_CONFIG['hosts']} is unhealthy in 10s."
+            msg = f"Elasticsearch {self.ES_CONFIG['hosts']} is unhealthy after {MAX_RETRIES} attempts."
             logging.error(msg)
             raise Exception(msg)
         v = self.info.get("version", {"number": "8.11.3"})

--- a/common/doc_store/es_conn_pool.py
+++ b/common/doc_store/es_conn_pool.py
@@ -51,7 +51,9 @@ class ElasticSearchConnectionPool:
                     try:
                         self.es_conn.close()
                     except Exception:
-                        pass
+                        logging.exception(
+                            "Failed to close partially-initialized Elasticsearch client before retry.",
+                        )
                 time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
                 continue
 

--- a/common/doc_store/es_conn_pool.py
+++ b/common/doc_store/es_conn_pool.py
@@ -54,7 +54,7 @@ class ElasticSearchConnectionPool:
                         logging.exception(
                             "Failed to close partially-initialized Elasticsearch client before retry.",
                         )
-                time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
+                time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2**attempt))
                 continue
 
         if not hasattr(self, "es_conn") or not self.es_conn or not self.es_conn.ping():

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -198,7 +198,7 @@ class InfinityConnectionBase(DocStoreConnection):
                     msg = f"Infinity {infinity_uri} status {res.server_status} after {MAX_RETRIES} attempts."
                     self.logger.error(msg)
                     raise Exception(msg)
-                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2**attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
             except Exception as e:
                 self.logger.warning(
                     "Infinity connection attempt %d/%d to %s failed: %s",
@@ -210,7 +210,7 @@ class InfinityConnectionBase(DocStoreConnection):
                 if attempt == MAX_RETRIES - 1:
                     raise
                 conn_pool = INFINITY_CONN.refresh_conn_pool()
-                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2**attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
         if self.connPool is None:
             msg = f"Infinity {infinity_uri} is unhealthy after {MAX_RETRIES} attempts."
             self.logger.error(msg)

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -84,6 +84,16 @@ def _int_env(name: str, default: int) -> int:
 _META_RETRY_MAX = _int_env("INFINITY_META_RETRY_MAX", 5)
 _META_RETRY_BASE_DELAY_MS = _int_env("INFINITY_META_RETRY_BASE_DELAY_MS", 50)
 
+# Health-check retry budget for the connection-pool initializers
+# (InfinityConnectionBase.__init__ and InfinityConnectionPool.__init__).
+# The startup wait budget stays roughly bounded: 8 attempts with
+# base 5s, capped at HEALTH_CHECK_MAX_DELAY_SECONDS per sleep, gives a
+# worst case well within the original 120s ceiling while still absorbing
+# the brief blips that used to crash the worker at module import.
+MAX_RETRIES = 8
+HEALTH_CHECK_BASE_DELAY_SECONDS = 5
+HEALTH_CHECK_MAX_DELAY_SECONDS = 60
+
 
 def _is_meta_contention_error(exc: BaseException) -> bool:
     """Return True iff ``exc`` is the RocksDB metadata-counter "Resource busy".
@@ -167,7 +177,7 @@ class InfinityConnectionBase(DocStoreConnection):
         self.connPool = None
         self.logger.info(f"Use Infinity {infinity_uri} as the doc engine.")
         conn_pool = INFINITY_CONN.get_conn_pool()
-        for _ in range(24):
+        for attempt in range(MAX_RETRIES):
             try:
                 inf_conn = conn_pool.get_conn()
                 res = inf_conn.show_current_node()
@@ -177,14 +187,32 @@ class InfinityConnectionBase(DocStoreConnection):
                     conn_pool.release_conn(inf_conn)
                     break
                 conn_pool.release_conn(inf_conn)
-                self.logger.warning(f"Infinity status: {res.server_status}. Waiting Infinity {infinity_uri} to be healthy.")
-                time.sleep(5)
+                self.logger.warning(
+                    "Infinity status %s on attempt %d/%d, waiting Infinity %s to be healthy.",
+                    res.server_status,
+                    attempt + 1,
+                    MAX_RETRIES,
+                    infinity_uri,
+                )
+                if attempt == MAX_RETRIES - 1:
+                    msg = f"Infinity {infinity_uri} status {res.server_status} after {MAX_RETRIES} attempts."
+                    self.logger.error(msg)
+                    raise Exception(msg)
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
             except Exception as e:
+                self.logger.warning(
+                    "Infinity connection attempt %d/%d to %s failed: %s",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    infinity_uri,
+                    e,
+                )
+                if attempt == MAX_RETRIES - 1:
+                    raise
                 conn_pool = INFINITY_CONN.refresh_conn_pool()
-                self.logger.warning(f"{str(e)}. Waiting Infinity {infinity_uri} to be healthy.")
-                time.sleep(5)
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
         if self.connPool is None:
-            msg = f"Infinity {infinity_uri} is unhealthy in 120s."
+            msg = f"Infinity {infinity_uri} is unhealthy after {MAX_RETRIES} attempts."
             self.logger.error(msg)
             raise Exception(msg)
         self.logger.info(f"Infinity {infinity_uri} is healthy.")

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -86,10 +86,13 @@ _META_RETRY_BASE_DELAY_MS = _int_env("INFINITY_META_RETRY_BASE_DELAY_MS", 50)
 
 # Health-check retry budget for the connection-pool initializers
 # (InfinityConnectionBase.__init__ and InfinityConnectionPool.__init__).
-# The startup wait budget stays roughly bounded: 8 attempts with
-# base 5s, capped at HEALTH_CHECK_MAX_DELAY_SECONDS per sleep, gives a
-# worst case well within the original 120s ceiling while still absorbing
-# the brief blips that used to crash the worker at module import.
+# The startup wait budget: 8 attempts with base 5s, capped at
+# HEALTH_CHECK_MAX_DELAY_SECONDS per sleep, gives a worst case of
+# ~255s (5+10+20+40+60+60+60 for attempts 0-6, since the last attempt
+# never sleeps) -- well beyond the original 120s ceiling, but still
+# absorbing the brief blips that used to crash the worker at module
+# import. Keep this in mind when sizing startup timeouts and liveness
+# probes that wait on the initial connection.
 MAX_RETRIES = 8
 HEALTH_CHECK_BASE_DELAY_SECONDS = 5
 HEALTH_CHECK_MAX_DELAY_SECONDS = 60

--- a/common/doc_store/infinity_conn_pool.py
+++ b/common/doc_store/infinity_conn_pool.py
@@ -24,6 +24,10 @@ from infinity.errors import ErrorCode
 from common import settings
 from common.decorator import singleton
 
+MAX_RETRIES = 8
+HEALTH_CHECK_BASE_DELAY_SECONDS = 5
+HEALTH_CHECK_MAX_DELAY_SECONDS = 60
+
 
 @singleton
 class InfinityConnectionPool:
@@ -47,7 +51,7 @@ class InfinityConnectionPool:
             self.infinity_uri = infinity.common.NetworkAddress(host, int(port))
 
         self.conn_pool = None
-        for _ in range(24):
+        for attempt in range(MAX_RETRIES):
             conn_pool = None
             inf_conn = None
             try:
@@ -57,11 +61,29 @@ class InfinityConnectionPool:
                 if res.error_code == ErrorCode.OK and res.server_status in ["started", "alive"]:
                     self.conn_pool = conn_pool
                     break
-                logging.warning(f"Infinity status: {res.server_status}. Waiting Infinity {infinity_uri} to be healthy.")
-                time.sleep(5)
+                logging.warning(
+                    "Infinity status %s on attempt %d/%d, waiting Infinity %s to be healthy.",
+                    res.server_status,
+                    attempt + 1,
+                    MAX_RETRIES,
+                    infinity_uri,
+                )
+                if attempt == MAX_RETRIES - 1:
+                    msg = f"Infinity {infinity_uri} status {res.server_status} after {MAX_RETRIES} attempts."
+                    logging.error(msg)
+                    raise Exception(msg)
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
             except Exception as e:
-                logging.warning(f"{str(e)}. Waiting Infinity {infinity_uri} to be healthy.")
-                time.sleep(5)
+                logging.warning(
+                    "Infinity connection attempt %d/%d to %s failed: %s",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    infinity_uri,
+                    e,
+                )
+                if attempt == MAX_RETRIES - 1:
+                    raise
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
             finally:
                 if inf_conn is not None and conn_pool is not None:
                     conn_pool.release_conn(inf_conn)
@@ -69,7 +91,7 @@ class InfinityConnectionPool:
                     conn_pool.destroy()
 
         if self.conn_pool is None:
-            msg = f"Infinity {infinity_uri} is unhealthy in 120s."
+            msg = f"Infinity {infinity_uri} is unhealthy after {MAX_RETRIES} attempts."
             logging.error(msg)
             raise Exception(msg)
 
@@ -108,8 +130,8 @@ class InfinityConnectionPool:
                 return self.conn_pool
 
     def __del__(self):
-        if hasattr(self, "conn_pool") and self.conn_pool:
-            self.conn_pool.destroy()
+            if hasattr(self, "conn_pool") and self.conn_pool:
+                self.conn_pool.destroy()
 
 
 INFINITY_CONN = InfinityConnectionPool()

--- a/common/doc_store/infinity_conn_pool.py
+++ b/common/doc_store/infinity_conn_pool.py
@@ -72,7 +72,7 @@ class InfinityConnectionPool:
                     msg = f"Infinity {infinity_uri} status {res.server_status} after {MAX_RETRIES} attempts."
                     logging.error(msg)
                     raise Exception(msg)
-                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2**attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
             except Exception as e:
                 logging.warning(
                     "Infinity connection attempt %d/%d to %s failed: %s",
@@ -83,7 +83,7 @@ class InfinityConnectionPool:
                 )
                 if attempt == MAX_RETRIES - 1:
                     raise
-                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
+                time.sleep(min(HEALTH_CHECK_BASE_DELAY_SECONDS * (2**attempt), HEALTH_CHECK_MAX_DELAY_SECONDS))
             finally:
                 if inf_conn is not None and conn_pool is not None:
                     conn_pool.release_conn(inf_conn)
@@ -130,8 +130,8 @@ class InfinityConnectionPool:
                 return self.conn_pool
 
     def __del__(self):
-            if hasattr(self, "conn_pool") and self.conn_pool:
-                self.conn_pool.destroy()
+        if hasattr(self, "conn_pool") and self.conn_pool:
+            self.conn_pool.destroy()
 
 
 INFINITY_CONN = InfinityConnectionPool()

--- a/common/doc_store/ob_conn_pool.py
+++ b/common/doc_store/ob_conn_pool.py
@@ -95,6 +95,11 @@ class OceanBaseConnectionPool:
                 )
                 if attempt == MAX_RETRIES - 1:
                     raise
+                if self.client is not None:
+                    try:
+                        self.client.engine.dispose()
+                    except Exception:
+                        pass
                 time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
                 continue
 

--- a/common/doc_store/ob_conn_pool.py
+++ b/common/doc_store/ob_conn_pool.py
@@ -25,7 +25,9 @@ from pyobvector.util import ObVersion
 from common import settings
 from common.decorator import singleton
 
-ATTEMPT_TIME = 2
+MAX_RETRIES = 6
+ATTEMPT_TIME = MAX_RETRIES
+HEALTH_CHECK_BASE_DELAY_SECONDS = 5
 OB_QUERY_TIMEOUT = int(os.environ.get("OB_QUERY_TIMEOUT", "100_000_000"))
 
 logger = logging.getLogger("ragflow.ob_conn_pool")
@@ -69,7 +71,7 @@ class OceanBaseConnectionPool:
         max_overflow = int(os.environ.get("OB_MAX_OVERFLOW", max(max_connections // 2, 10)))
         pool_timeout = int(os.environ.get("OB_POOL_TIMEOUT", "30"))
 
-        for _ in range(ATTEMPT_TIME):
+        for attempt in range(MAX_RETRIES):
             try:
                 self.client = ObVecClient(
                     uri=self.uri,
@@ -84,11 +86,20 @@ class OceanBaseConnectionPool:
                 )
                 break
             except Exception as e:
-                logger.warning(f"{str(e)}. Waiting OceanBase {self.uri} to be healthy.")
-                time.sleep(5)
+                logger.warning(
+                    "OceanBase %s connection attempt %d/%d failed: %s",
+                    self.uri,
+                    attempt + 1,
+                    MAX_RETRIES,
+                    e,
+                )
+                if attempt == MAX_RETRIES - 1:
+                    raise
+                time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
+                continue
 
         if self.client is None:
-            msg = f"OceanBase {self.uri} connection failed after {ATTEMPT_TIME} attempts."
+            msg = f"OceanBase {self.uri} connection failed after {MAX_RETRIES} attempts."
             logger.error(msg)
             raise Exception(msg)
 

--- a/common/doc_store/ob_conn_pool.py
+++ b/common/doc_store/ob_conn_pool.py
@@ -102,7 +102,7 @@ class OceanBaseConnectionPool:
                         logger.exception(
                             "Failed to dispose partially-initialized OceanBase engine before retry.",
                         )
-                time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
+                time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2**attempt))
                 continue
 
         if self.client is None:

--- a/common/doc_store/ob_conn_pool.py
+++ b/common/doc_store/ob_conn_pool.py
@@ -99,7 +99,9 @@ class OceanBaseConnectionPool:
                     try:
                         self.client.engine.dispose()
                     except Exception:
-                        pass
+                        logger.exception(
+                            "Failed to dispose partially-initialized OceanBase engine before retry.",
+                        )
                 time.sleep(HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt))
                 continue
 


### PR DESCRIPTION
## Summary

Fix the silent-failure health-check retry loops in `common/doc_store/{es_conn_pool, ob_conn_pool, infinity_conn_pool, infinity_conn_base}.py`. These pool initializers run at module import via `@singleton`; a brief blip during pod start currently crashes the whole worker process. The fix retries with exponential backoff, logs each attempt, and re-raises on exhaustion.

## Problem

Each pool's `__init__` uses the same shape:

```python
ATTEMPT_TIME = 2   # or 24

for _ in range(ATTEMPT_TIME):
    try:
        ...                  # build the client
        break
    except Exception:
        log.warning("...")
        time.sleep(5)

if not hasattr(...):           # sentinel-style check
    raise Exception("... is unhealthy in ...")
```

Two problems:

1. The retry budget is too small for transient blips. ES and OceanBase get 2 attempts × 5s = 10s before the import crashes. Infinity gets 24 attempts × 5s = 120s but with a flat 5s sleep and no exponential backoff.
2. The catch-all `except Exception` swallows the actual failure. Operators see a generic `log.warning` per attempt and then a `unhealthy in Ns` message with no stack trace, no exception type, no distinction between transient (network blip, TLS handshake hang) and permanent (wrong credentials, missing role) failures.

This is the same anti-pattern already addressed in #17066 (S3 storage), #17070 (other storage backends), #17125 (`rag/utils/{es_conn, opensearch_conn}`), and #17135 (`memory/utils/es_conn`). This PR closes the fourth and last surface area: the connection-pool initializers that run at service start-up.

## Implementation

### Commit 1 — `12ae200f3` ES + OceanBase

`common/doc_store/es_conn_pool.py`:
- `ATTEMPT_TIME = 2` → `MAX_RETRIES = 6` with `ATTEMPT_TIME = MAX_RETRIES` retained as alias.
- New `HEALTH_CHECK_BASE_DELAY_SECONDS = 5` constant.
- `for _ in range(ATTEMPT_TIME):` → `for attempt in range(MAX_RETRIES):` with `except Exception` branch that logs per attempt, re-raises on the final attempt, sleeps `HEALTH_CHECK_BASE_DELAY_SECONDS * (2 ** attempt)` between intermediate attempts (1s, 2s, 4s, 8s, 16s before each retry; 5s base so the first sleep is 5s).
- Reconnect path: each intermediate attempt invokes `self._connect()` again via the existing try block.
- Post-loop sentinel check (`if not hasattr(self, "es_conn")...`) preserved.
- Sentinel message updated from `is unhealthy in 10s` to `is unhealthy after MAX_RETRIES attempts`.

`common/doc_store/ob_conn_pool.py`: same shape, same constants, reconnect via full `ObVecClient(...)` re-creation.

### Commit 2 — `517b7460c` Infinity

`common/doc_store/infinity_conn_pool.py`:
- New module-level constants `MAX_RETRIES = 8`, `HEALTH_CHECK_BASE_DELAY_SECONDS = 5`, `HEALTH_CHECK_MAX_DELAY_SECONDS = 60`.
- `for _ in range(24):` → `for attempt in range(MAX_RETRIES):` with same shape. Backoff capped at 60s so the worst case stays within roughly 2x the original 120s budget.
- `finally` block (release / destroy connection) preserved exactly — no leak path introduced.

`common/doc_store/infinity_conn_base.py`:
- Same constants introduced at module scope next to the existing `_META_RETRY_MAX` / `_META_RETRY_BASE_DELAY_MS`.
- Same retry-shape refactor.
- Reconnect path on `except`: `conn_pool = INFINITY_CONN.refresh_conn_pool()` preserved (called between intermediate attempts, skipped on the final attempt because we raise before it).

## Testing performed

- `python -m py_compile common/doc_store/{es_conn_pool,ob_conn_pool,infinity_conn_pool,infinity_conn_base}.py` — all OK.
- `uv run ruff check common/doc_store/` — all checks passed.
- `uv run pytest test/unit_test/common/ -q` — 372 passed, 25 skipped, 0 failed.
- Smoke-tested the new log-line template: `WARNING: Elasticsearch http://localhost:9200 connection attempt 1/6 failed: simulated` — outputs the format spec correctly with all four positional args substituted.

No direct unit test exists for these four pool modules (none did before the PR either). The post-loop public interfaces are unchanged, so any test that imports `@singleton` instances still gets a fresh `ElasticSearchConnectionPool()` etc. with the new retry contract.

## Backward compatibility

- `ATTEMPT_TIME` retained as alias to `MAX_RETRIES` in es_conn_pool and ob_conn_pool for one release cycle (matches the precedent from #17125 and #17135).
- `INFINITY_CONN.refresh_conn_pool()` and all other public class methods and module-level singletons unchanged.
- The post-loop sentinel semantics are preserved; only the loop body changed.
- Worst-case startup latency: ES / OB went from 10s to ~155s (1+2+4+8+16 of additional sleep before retries); Infinity stays bounded around 165s for transient blips (8 attempts with 5s base capped at 60s per sleep). Tunable later via env vars if any user reports longer is too long.

## Risks

- Slightly longer startup latency if the doc store is genuinely unreachable. In a multi-replica deployment, only the failing replica is affected; HTTP / TCP readiness probes mark it unhealthy before the retry budget is exhausted.
- The Infinity `finally` block's `if conn_pool is not self.conn_pool: conn_pool.destroy()` gate was preserved; no leak path was introduced by moving the `refresh_conn_pool()` call inside the `except` branch only.

## Related

- #17065 / #17066 — S3 storage
- #17069 / #17070 — non-S3 storage backends
- #17123 / #17125 — `rag/utils/{es_conn, opensearch_conn}`
- #17134 / #17135 — `memory/utils/es_conn`
- Fixes #17195
