### PR TITLE
migrate: replace zhipuai with zai-sdk to unblock pyjwt CVE fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ dependencies = [
     "setuptools>=78.1.1,<81.0.0",
     "xpinyin==0.7.6",
     "yfinance==0.2.65",
-    "zhipuai==2.0.1",
+    "zai-sdk>=0.2.3,<1.0.0",
     "peewee>=3.17.1,<4.0.0",
     "langgraph==1.2.0",
     #    following modules aren't necessary
@@ -217,9 +217,6 @@ constraint-dependencies = [
     # through excessive resource consumption. (CVSS 8.9)
     # urllib3 < 2.7.0 is vulnerable, pulled in transitively via requests, minio, akshare, and others
     "urllib3>=2.7.0",
-
-
-
 ]
 exclude-dependencies = [
     # crawl4ai>=0.8.6 depends on unclecode-litellm, which installs the same

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -26,7 +26,7 @@ import numpy as np
 import requests
 from ollama import Client
 from openai import OpenAI
-from zhipuai import ZhipuAI
+from zai import ZhipuAiClient
 
 from common import settings
 from common.exceptions import ModelException
@@ -436,7 +436,8 @@ class ZhipuEmbed(Base):
     _FACTORY_NAME = "ZHIPU-AI"
 
     def __init__(self, key, model_name="embedding-2", **kwargs):
-        self.client = ZhipuAI(api_key=key)
+        self.client = ZhipuAiClient(api_key=key)
+        logger.info("ZhipuEmbed initialized: provider=%s, model=%s", self._FACTORY_NAME, model_name)
         self.model_name = model_name
 
     def _max_len(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4039,12 +4039,12 @@ name = "onnxruntime-gpu"
 version = "1.23.2"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
-    { name = "coloredlogs", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "flatbuffers", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "packaging", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "protobuf", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "sympy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/03/05/40d561636e4114b54aa06d2371bfbca2d03e12cfdf5d4b85814802f18a75/onnxruntime_gpu-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e8f75af5da07329d0c3a5006087f4051d8abd133b4be7c9bae8cdab7bea4c26" },
@@ -5085,11 +5085,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.8.0"
+version = "2.13.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/30/72/8259b2bccfe4673330cea843ab23f86858a419d8f1493f66d413a76c7e3b/PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/2b/4f/e04a8067c7c96c364cef7ef73906504e2f40d690811c021e1a1901473a19/PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728" },
 ]
 
 [package.optional-dependencies]
@@ -8149,7 +8149,7 @@ dependencies = [
     { name = "xgboost" },
     { name = "xpinyin" },
     { name = "yfinance" },
-    { name = "zhipuai" },
+    { name = "zai-sdk" },
 ]
 
 [package.dev-dependencies]
@@ -8305,7 +8305,7 @@ requires-dist = [
     { name = "xgboost", specifier = "==1.6.0" },
     { name = "xpinyin", specifier = "==0.7.6" },
     { name = "yfinance", specifier = "==0.2.65" },
-    { name = "zhipuai", specifier = "==2.0.1" },
+    { name = "zai-sdk", specifier = ">=0.2.3,<1.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -10121,18 +10121,20 @@ wheels = [
 ]
 
 [[package]]
-name = "zhipuai"
-version = "2.0.1"
+name = "zai-sdk"
+version = "0.2.3"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "pydantic-core" },
     { name = "pyjwt" },
+    { name = "sniffio" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/a4/90/299e3456ee7ee1e118593552e03b86da2e9adaa0d454e467aeb4b22032a4/zhipuai-2.0.1.tar.gz", hash = "sha256:297bbdbe9393da2d1dc8066c39cf39bb2342f170d86f2b7b7a13ba368c53d701" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/29/e6/f4954be9a8c70260a5de7a83035d5fbe7ec74799d7dd58857a82141c9a2f/zai_sdk-0.2.3.tar.gz", hash = "sha256:1481f6db746e64fe9e7e0da9a3727fd083890613f9eb8e1d14139ff76ef68a57" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/8f/05/c3d4556886b5c6cf8c0b96eb80448ee8154c0dcc87086df018e817779ed4/zhipuai-2.0.1-py3-none-any.whl", hash = "sha256:738033d95696c3d5117dc4487e37d924e3ebbcdfa0072812b3f63a08ff72274a" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4b/18/2b2c012421936ed370436d844e250e9dbdefa20e845d6aeea7152c26a403/zai_sdk-0.2.3-py3-none-any.whl", hash = "sha256:f8d6417f8cff58d5b6cba5c27577ee55aa817ae825c6c88fe883f6f6f9265d90" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Old `zhipuai==2.0.1` SDK (MetaGLM/zhipuai-sdk-python-v4) requires `pyjwt~=2.8.0`, which blocks upgrading pyjwt past 2.8.0 to address active CVEs. The upstream project now recommends the maintained successor [`zai-sdk`](https://github.com/zai-org/z-ai-sdk-python).

`zai-sdk` relaxes the pyjwt constraint to `>=2.9.0,<3.0.0`, allowing pyjwt 2.13.0+. The embedding API surface (`client.embeddings.create`) is identical, no functional changes required.

Related CVE's:

- CVE-2026-48522
- CVE-2026-48524
- CVE-2026-48525
- CVE-2026-48526
- CVE-2026-32597


## Changes

| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | `zhipuai==2.0.1` | `zai-sdk>=0.2.3,<1.0.0` |
| `rag/llm/embedding_model.py` | `from zhipuai import ZhipuAI` | `from zai import ZhipuAiClient` |
| `rag/llm/embedding_model.py` | `ZhipuAI(api_key=key)` | `ZhipuAiClient(api_key=key)` |
| `uv.lock` | pyjwt 2.8.0 / zhipuai 2.0.1 | pyjwt 2.13.0 / zai-sdk 0.2.3 |

- Added `logger.info` on `ZhipuEmbed` initialization (provider + model only, no credentials) so migrated-flow failures are diagnosable in logs without exposing sensitive data.

## Verification

- All 23 embedding unit tests pass (3 Zhipu-specific, 20 general)
- Import and client API surface match the old SDK
- `uv sync` resolves cleanly, pyjwt resolves to `2.13.0`
- Go model driver (`internal/entity/models/zhipu-ai.go`) is unaffected; talks to the GLM API directly over HTTP
