### PR TITLE
fix: mask stored provider API key with fixed-length dots

### DIFF
--- a/web/src/pages/user-setting/setting-model/instance-card/components/masked-api-key-input.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/components/masked-api-key-input.tsx
@@ -1,0 +1,111 @@
+/*
+ *  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { cn } from '@/lib/utils';
+import { Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
+
+/**
+ * Fixed-length mask rendered while the key is hidden. Inside a password
+ * input it produces a constant dot count, so the stored key's length is
+ * not leaked through the UI.
+ */
+export const API_KEY_DISPLAY_MASK = '********';
+
+interface MaskedApiKeyInputProps {
+  value?: string;
+  onChange?: (value: string) => void;
+  onBlur?: () => void;
+  name?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Password input for an already-stored API key.
+ *
+ * - Hidden (default): renders a fixed-length mask regardless of the
+ *   key's real length.
+ * - Revealed (eye toggle): renders the real stored key, editable.
+ * - Focusing the masked field starts a fresh entry: the first keystroke
+ *   replaces the stored key; focusing out without typing keeps it.
+ */
+export function MaskedApiKeyInput({
+  value = '',
+  onChange,
+  onBlur,
+  name,
+  placeholder,
+  disabled,
+}: MaskedApiKeyInputProps) {
+  const [show, setShow] = useState(false);
+  // Non-null while the user is typing a replacement key into the masked
+  // field; back to null restores the fixed-mask display.
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const displayValue =
+    draft !== null ? draft : show || !value ? value : API_KEY_DISPLAY_MASK;
+
+  return (
+    <div className="relative w-full">
+      <input
+        name={name}
+        type={show ? 'text' : 'password'}
+        className={cn(
+          'flex h-8 w-full rounded-md border-0.5 border-border-button bg-bg-input px-3 py-2 outline-none text-sm text-text-primary',
+          'placeholder:text-text-disabled',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-primary',
+          'disabled:cursor-not-allowed disabled:opacity-50 transition-colors',
+        )}
+        style={{ paddingInlineEnd: '40px' }}
+        value={displayValue}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoComplete="off"
+        onFocus={() => {
+          // Start a fresh entry so the first keystroke replaces the
+          // stored key instead of appending to the mask.
+          if (!show && draft === null && value) {
+            setDraft('');
+          }
+        }}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          onChange?.(e.target.value);
+        }}
+        onBlur={() => {
+          setDraft(null);
+          onBlur?.();
+        }}
+      />
+      <button
+        type="button"
+        tabIndex={-1}
+        className="p-2 text-text-secondary absolute border-0 end-1 top-[50%] translate-y-[-50%]"
+        onClick={() => {
+          setShow(!show);
+          setDraft(null);
+        }}
+      >
+        {show ? (
+          <EyeOff className="size-[1em]" />
+        ) : (
+          <Eye className="size-[1em]" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/web/src/pages/user-setting/setting-model/instance-card/hooks.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/hooks.tsx
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import { DynamicFormRef } from '@/components/dynamic-form';
+import { DynamicFormRef, FormFieldType } from '@/components/dynamic-form';
 import {
   useDeleteProviderInstance,
   useFetchAvailableProviders,
@@ -24,8 +24,10 @@ import {
 import { IProviderInstance } from '@/interfaces/database/llm';
 import { IModelInfo } from '@/interfaces/request/llm';
 import { RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
+import { ControllerRenderProps } from 'react-hook-form';
 import { useProviderFields } from '../provider-schema/hooks';
 import { SelectOption } from '../provider-schema/types';
+import { MaskedApiKeyInput } from './components/masked-api-key-input';
 import {
   API_KEY_NESTED_FIELDS,
   ApiKeyNestedField,
@@ -673,6 +675,7 @@ export function useFormFields(
   initialValues: Record<string, any>,
   baseUrlOptions: SelectOption[] | undefined,
   hideWhenInstanceExists: (values: any) => boolean,
+  hasStoredApiKey?: boolean,
 ) {
   const { fields, defaultValues } = useProviderFields({
     llmFactory: providerName,
@@ -689,8 +692,30 @@ export function useFormFields(
   });
 
   const formFields = useMemo(
-    () => fields.filter((f) => f.name !== 'instance_name'),
-    [fields],
+    () =>
+      fields
+        .filter((f) => f.name !== 'instance_name')
+        .map((f) =>
+          // A saved instance's key must render with a fixed-length mask
+          // (the native password input would leak the key's length via
+          // its dot count). Swap the plain password field for the masked
+          // input; the form value itself still carries the real key, so
+          // reveal / save / verify behave as before.
+          hasStoredApiKey && f.name === 'api_key'
+            ? {
+                ...f,
+                type: FormFieldType.Custom,
+                render: (fieldProps: ControllerRenderProps) => (
+                  <MaskedApiKeyInput
+                    {...fieldProps}
+                    placeholder={f.placeholder}
+                    disabled={f.disabled}
+                  />
+                ),
+              }
+            : f,
+        ),
+    [fields, hasStoredApiKey],
   );
 
   const defaultValuesKey = JSON.stringify(defaultValues);

--- a/web/src/pages/user-setting/setting-model/instance-card/provider-instance-card.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/provider-instance-card.tsx
@@ -141,6 +141,9 @@ const GenericProviderInstanceCard = forwardRef<
     initialValues,
     baseUrlOptions,
     hideWhenInstanceExists,
+    // Saved cards with a persisted key render the api_key field through
+    // the fixed-length masked input (see useFormFields).
+    !isDraft && Boolean(instanceDetails?.api_key),
   );
   useFormResetOnDetailsLoad(
     formRef,


### PR DESCRIPTION
### Summary

The model provider settings page rendered the stored API key in a standard password input, so the number of dots matched the key's real length and leaked it through the UI (e.g. ZHIPU-AI vs SILICONFLOW showed different dot counts).

This PR adds a dedicated `MaskedApiKeyInput` for saved provider instances:

- Hidden (default): always renders a fixed-length mask regardless of the key's real length, so the dot count no longer leaks key-length information.
- Revealed (eye toggle): shows the real stored key, editable as before.
- Focusing the masked field starts a fresh entry: the first keystroke replaces the stored key; blurring without typing keeps it.

The form value still carries the real key, so save, connection verification, and dirty tracking behave exactly as before. Draft (new instance) cards keep the standard password input.