### PR TITLE
Port remove_contents_table and short-line filter to GO

### DIFF
--- a/internal/ingestion/component/chunker/group.go
+++ b/internal/ingestion/component/chunker/group.go
@@ -112,6 +112,15 @@ func invokeGroup(_ context.Context, inputs map[string]any, p *titleChunkerParam)
 		zap.String("variant", "group"),
 		zap.Int("records", len(records)),
 	)
+	// Remove table-of-contents entries before heading detection to prevent
+	// TOC entries (e.g. "第一章", "1.1") from being misidentified as real
+	// section headings. Mirrors Python's remove_contents_table in laws.py /
+	// book.py, applied between parser output and heading detection.
+	records = removeContentsTable(records)
+	// Drop short or pure-numeric lines that Python's tree_merge pre-filter
+	// would discard (empty, ≤1 character, or pure-numeric after stripping
+	// "@"-suffixed position info from PDF sections).
+	records = removeShortOrNumericLines(records)
 	if len(records) == 0 {
 		return emptyOutputs(), nil
 	}

--- a/internal/ingestion/component/chunker/hierarchy.go
+++ b/internal/ingestion/component/chunker/hierarchy.go
@@ -145,6 +145,15 @@ func invokeHierarchy(_ context.Context, inputs map[string]any, p *titleChunkerPa
 		zap.String("variant", "hierarchy"),
 		zap.Int("records", len(records)),
 	)
+	// Remove table-of-contents entries before heading detection to prevent
+	// TOC entries (e.g. "第一章", "1.1") from being misidentified as real
+	// section headings. Mirrors Python's remove_contents_table in laws.py /
+	// book.py, applied between parser output and heading detection.
+	records = removeContentsTable(records)
+	// Drop short or pure-numeric lines that Python's tree_merge pre-filter
+	// would discard (empty, ≤1 character, or pure-numeric after stripping
+	// "@"-suffixed position info from PDF sections).
+	records = removeShortOrNumericLines(records)
 	if len(records) == 0 {
 		return emptyOutputs(), nil
 	}

--- a/internal/ingestion/component/chunker/title.go
+++ b/internal/ingestion/component/chunker/title.go
@@ -246,6 +246,42 @@ func beforeAt(s string) string {
 	return strings.TrimSpace(s)
 }
 
+var pureNumberPattern = regexp.MustCompile(`^[0-9]+$`)
+
+// shortOrNumericLine mirrors Python's tree_merge pre-filter:
+//
+//	sections = [(t, o) for t, o in sections if t and
+//	    len(t.split("@")[0].strip()) > 1 and
+//	    not re.match(r"[0-9]+$", t.split("@")[0].strip())]
+//
+// Returns true when the text is too short (≤1 character after stripping
+// the "@" suffix) or is a pure-numeric line, meaning it should not be
+// treated as a heading.
+func shortOrNumericLine(text string) bool {
+	clean := beforeAt(text)
+	if clean == "" {
+		return true
+	}
+	if utf8.RuneCountInString(clean) <= 1 {
+		return true
+	}
+	return pureNumberPattern.MatchString(clean)
+}
+
+// removeShortOrNumericLines filters out text records that Python's
+// tree_merge would drop: empty, single-character, or pure-numeric lines.
+// Non-text records (images, tables) are always kept.
+func removeShortOrNumericLines(records []lineRecord) []lineRecord {
+	out := make([]lineRecord, 0, len(records))
+	for _, rec := range records {
+		if rec.isText() && shortOrNumericLine(rec.text) {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
 // matchLayoutLevel mirrors common.py:match_layout_level. When the
 // record's layout field flags it as a section/title/head and the text is
 // title-like (not not_title), the record is promoted to `fallback_level`

--- a/internal/ingestion/component/chunker/toc.go
+++ b/internal/ingestion/component/chunker/toc.go
@@ -1,0 +1,168 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package chunker
+
+import (
+	"regexp"
+	"strings"
+)
+
+// tocTitlePattern mirrors the Python regex:
+//
+//	re.match(r"(contents|目录|目次|table of contents|致谢|acknowledge)$", ...)
+//
+// Used to detect section headers that introduce a table-of-contents block.
+var tocTitlePattern = regexp.MustCompile(`(?i)^(contents|目录|目次|table of contents|致谢|acknowledge)$`)
+
+// tocCollapseSpaceRe collapses consecutive whitespace characters (space,
+// ideographic space, fullwidth space). Mirrors Python's:
+//
+//	re.sub(r"( | |\u3000)+", "", get(i).split("@@")[0])
+var tocCollapseSpaceRe = regexp.MustCompile(`[ \x{3000}]+`)
+
+// isEnglishTextPattern mirrors Python's is_english character pattern:
+//
+//	r"[`a-zA-Z0-9\s.,':;/\"?<>!\(\)\-]+"
+//
+// A text that full-matches this consists entirely of ASCII alphanumeric,
+// whitespace, and common punctuation. The backtick is omitted as it is
+// irrelevant for section texts.
+var isEnglishTextPattern = regexp.MustCompile(`^[a-zA-Z0-9\s.,':;"/?<>!()\-]+$`)
+
+// removeContentsTable mirrors Python's rag/nlp/__init__.py:remove_contents_table.
+// It removes table-of-contents entries from the record stream before heading
+// detection, preventing TOC entries (like "第一章", "1.1" etc.) from being
+// misidentified as real section headings and fragmenting the chunk output.
+//
+// Algorithm:
+//  1. Scan for a line matching the TOC title pattern.
+//  2. Pop the TOC header and the next non-empty line (first TOC entry), which
+//     provides the prefix pattern.
+//  3. For non-English text, the prefix is the first 3 characters; for English,
+//     the prefix is the first 2 words (matching Python's `eng` branch).
+//  4. Scan forward (up to 128 records) to find the next line starting with the
+//     same prefix — this marks the end of the TOC block.
+//  5. Remove all entries from the TOC header position to just before the found
+//     line, leaving the non-TOC content intact.
+func removeContentsTable(records []lineRecord) []lineRecord {
+	eng := isEnglishRecords(records)
+	i := 0
+	for i < len(records) {
+		text := tocText(records[i])
+		if !tocTitlePattern.MatchString(tocCollapseSpaceRe.ReplaceAllString(text, "")) {
+			i++
+			continue
+		}
+		// Pop the TOC header line.
+		records = append(records[:i], records[i+1:]...)
+		if i >= len(records) {
+			break
+		}
+		// Get the prefix from the next line (first TOC entry).
+		prefix := tocPrefix(records[i], eng)
+		for prefix == "" {
+			records = append(records[:i], records[i+1:]...)
+			if i >= len(records) {
+				break
+			}
+			prefix = tocPrefix(records[i], eng)
+		}
+		if i >= len(records) || prefix == "" {
+			break
+		}
+		// Pop the first TOC entry (used only to determine the prefix).
+		records = append(records[:i], records[i+1:]...)
+		if i >= len(records) || prefix == "" {
+			break
+		}
+		// Scan forward to find a line that starts with the same prefix.
+		// When found, remove all TOC entries between the header and that line.
+		for j := i; j < len(records) && j < i+128; j++ {
+			if !strings.HasPrefix(tocText(records[j]), prefix) {
+				continue
+			}
+			records = append(records[:i], records[j:]...)
+			break
+		}
+	}
+	return records
+}
+
+// tocText extracts the clean text from a lineRecord, stripping the "@@"
+// suffix and whitespace. Mirrors Python's inline `get(i)` helper:
+//
+//	(sections[i] if isinstance(sections[i], type("")) else sections[i][0]).strip()
+//
+// and the subsequent `.split("@@")[0]` call.
+func tocText(r lineRecord) string {
+	text := r.text
+	if idx := strings.Index(text, "@@"); idx >= 0 {
+		text = text[:idx]
+	}
+	return strings.TrimSpace(text)
+}
+
+// tocPrefix computes the prefix used to identify TOC entries within a
+// block. Mirrors Python's:
+//
+//	prefix = get(i)[:3] if not eng else " ".join(get(i).split()[:2])
+func tocPrefix(r lineRecord, eng bool) string {
+	text := tocText(r)
+	if !eng {
+		// Use rune slicing to match Python's character-level [:3].
+		// Go's default byte-slicing would return only one
+		// 3-byte CJK character instead of three characters.
+		runes := []rune(text)
+		if len(runes) < 3 {
+			return text
+		}
+		return string(runes[:3])
+	}
+	words := strings.Fields(text)
+	if len(words) >= 2 {
+		return strings.Join(words[:2], " ")
+	}
+	return text
+}
+
+// isEnglishRecords samples up to 200 text records and returns true when
+// >80% of sampled records consist entirely of ASCII alphanumeric,
+// whitespace, and punctuation characters. Mirrors Python's:
+//
+//	is_english(random_choices([t for t, _ in sections], k=200))
+func isEnglishRecords(records []lineRecord) bool {
+	const sampleSize = 200
+	count := 0
+	eng := 0
+	for _, r := range records {
+		t := strings.TrimSpace(r.text)
+		if t == "" {
+			continue
+		}
+		count++
+		if isEnglishTextPattern.MatchString(t) {
+			eng++
+		}
+		if count >= sampleSize {
+			break
+		}
+	}
+	if count == 0 {
+		return false
+	}
+	return float64(eng)/float64(count) > 0.8
+}

--- a/internal/ingestion/component/chunker/toc_test.go
+++ b/internal/ingestion/component/chunker/toc_test.go
@@ -1,0 +1,569 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package chunker
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// tocText
+// ---------------------------------------------------------------------------
+
+func TestTocText_Basic(t *testing.T) {
+	r := lineRecord{text: "Hello World"}
+	if got := tocText(r); got != "Hello World" {
+		t.Errorf("tocText = %q, want %q", got, "Hello World")
+	}
+}
+
+func TestTocText_StripsAtAtSuffix(t *testing.T) {
+	r := lineRecord{text: "第一章 概述@@0.5"}
+	if got := tocText(r); got != "第一章 概述" {
+		t.Errorf("tocText = %q, want %q", got, "第一章 概述")
+	}
+}
+
+func TestTocText_StripsWhitespace(t *testing.T) {
+	r := lineRecord{text: "  第一章 概述  "}
+	if got := tocText(r); got != "第一章 概述" {
+		t.Errorf("tocText = %q, want %q", got, "第一章 概述")
+	}
+}
+
+func TestTocText_AtAtOnly(t *testing.T) {
+	r := lineRecord{text: "@@0.5"}
+	if got := tocText(r); got != "" {
+		t.Errorf("tocText = %q, want %q", got, "")
+	}
+}
+
+func TestTocText_EmptyString(t *testing.T) {
+	r := lineRecord{text: ""}
+	if got := tocText(r); got != "" {
+		t.Errorf("tocText = %q, want %q", got, "")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tocPrefix
+// ---------------------------------------------------------------------------
+
+func TestTocPrefix_CJK_ThreeChars(t *testing.T) {
+	// Python's get(i)[:3] slices code points, not bytes.
+	// "第一章 概述"[:3] → "第一章" (3 characters, 9 bytes).
+	// Go must use []rune conversion to get the same result.
+	r := lineRecord{text: "第一章 概述"}
+	if got := tocPrefix(r, false); got != "第一章" {
+		t.Errorf("tocPrefix(eng=false) = %q, want %q", got, "第一章")
+	}
+}
+
+func TestTocPrefix_CJK_ShortText(t *testing.T) {
+	r := lineRecord{text: "AB"}
+	if got := tocPrefix(r, false); got != "AB" {
+		t.Errorf("tocPrefix(eng=false, short) = %q, want %q", got, "AB")
+	}
+}
+
+func TestTocPrefix_CJK_EmptyText(t *testing.T) {
+	r := lineRecord{text: ""}
+	if got := tocPrefix(r, false); got != "" {
+		t.Errorf("tocPrefix(eng=false, empty) = %q, want %q", got, "")
+	}
+}
+
+func TestTocPrefix_English_TwoWords(t *testing.T) {
+	r := lineRecord{text: "Chapter One Introduction"}
+	got := tocPrefix(r, true)
+	if got != "Chapter One" {
+		t.Errorf("tocPrefix(eng=true) = %q, want %q", got, "Chapter One")
+	}
+}
+
+func TestTocPrefix_English_SingleWord(t *testing.T) {
+	r := lineRecord{text: "Introduction"}
+	got := tocPrefix(r, true)
+	if got != "Introduction" {
+		t.Errorf("tocPrefix(eng=true, single) = %q, want %q", got, "Introduction")
+	}
+}
+
+func TestTocPrefix_English_EmptyText(t *testing.T) {
+	r := lineRecord{text: ""}
+	got := tocPrefix(r, true)
+	if got != "" {
+		t.Errorf("tocPrefix(eng=true, empty) = %q, want %q", got, "")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isEnglishRecords
+// ---------------------------------------------------------------------------
+
+func TestIsEnglishRecords_AllEnglish(t *testing.T) {
+	records := []lineRecord{
+		{text: "Hello world"},
+		{text: "This is a test"},
+		{text: "Numbers 123 and symbols."},
+		{text: `Text with "double quotes" inside`},
+	}
+	if !isEnglishRecords(records) {
+		t.Error("expected English records to be detected as English")
+	}
+}
+
+func TestIsEnglishRecords_AllChinese(t *testing.T) {
+	records := []lineRecord{
+		{text: "第一章 概述"},
+		{text: "这是一个测试"},
+		{text: "目录"},
+	}
+	if isEnglishRecords(records) {
+		t.Error("expected Chinese records not to be detected as English")
+	}
+}
+
+func TestIsEnglishRecords_MixedBelowThreshold(t *testing.T) {
+	// 20% English, 80% Chinese — should NOT be English (>80% threshold).
+	records := []lineRecord{
+		{text: "Hello world"},
+		{text: "第一章 概述"},
+		{text: "第二章节"},
+		{text: "第三部分"},
+		{text: "第四章内容"},
+	}
+	if isEnglishRecords(records) {
+		t.Error("expected mixed records with 20% English to not pass >80% threshold")
+	}
+}
+
+func TestIsEnglishRecords_EmptyRecords(t *testing.T) {
+	if isEnglishRecords(nil) {
+		t.Error("nil records should return false")
+	}
+	if isEnglishRecords([]lineRecord{}) {
+		t.Error("empty records should return false")
+	}
+}
+
+func TestIsEnglishRecords_SkipsEmptyText(t *testing.T) {
+	records := []lineRecord{
+		{text: "Hello"},
+		{text: ""},
+		{text: "   "},
+		{text: "World"},
+	}
+	if !isEnglishRecords(records) {
+		t.Error("empty/blank lines should be skipped, both are English")
+	}
+}
+
+func TestIsEnglishRecords_ExactlyAtThreshold(t *testing.T) {
+	// 4 of 5 = 80% — NOT English (threshold is >0.8, strictly greater).
+	records := []lineRecord{
+		{text: "Hello"},
+		{text: "World"},
+		{text: "Test"},
+		{text: "Line"},
+		{text: "这是一个中文句子"},
+	}
+	if isEnglishRecords(records) {
+		t.Error("80% English should NOT pass the >0.8 threshold")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// removeContentsTable
+// ---------------------------------------------------------------------------
+
+func TestRemoveContentsTable_EmptyRecords(t *testing.T) {
+	got := removeContentsTable(nil)
+	if len(got) != 0 {
+		t.Errorf("nil input: got %d records, want 0", len(got))
+	}
+	got = removeContentsTable([]lineRecord{})
+	if len(got) != 0 {
+		t.Errorf("empty input: got %d records, want 0", len(got))
+	}
+}
+
+func TestRemoveContentsTable_NoTOC(t *testing.T) {
+	records := []lineRecord{
+		{text: "第一章 概述"},
+		{text: "这是正文内容"},
+		{text: "第二章 详情"},
+	}
+	got := removeContentsTable(records)
+	if len(got) != 3 {
+		t.Errorf("no TOC: got %d records, want 3", len(got))
+	}
+}
+
+func TestRemoveContentsTable_CJK_RemovesTOCBlock(t *testing.T) {
+	// Simulates a Chinese document with a TOC section.
+	records := []lineRecord{
+		{text: "第一章 概述"},
+		{text: "这是正文内容"},
+		{text: "目录"},
+		{text: "第一章 概述"},
+		{text: "第二章 详情"},
+		{text: "第一节 背景"},
+		{text: "第一章 概述"}, // This matches the prefix "第一章" — marks end of TOC
+		{text: "真实正文内容"},
+	}
+	got := removeContentsTable(records)
+
+	// Expected: "第一章 概述", "这是正文内容", "第一章 概述", "真实正文内容"
+	// The TOC block (lines 2-6, 0-indexed) should be removed,
+	// leaving: line 0, line 1, and from line 6 onward.
+	if len(got) == 0 {
+		t.Fatal("got empty result after TOC removal")
+	}
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 4 {
+		t.Errorf("want 4 records, got %d: %v", len(texts), texts)
+	}
+	if texts[0] != "第一章 概述" {
+		t.Errorf("texts[0] = %q, want %q", texts[0], "第一章 概述")
+	}
+	if texts[1] != "这是正文内容" {
+		t.Errorf("texts[1] = %q, want %q", texts[1], "这是正文内容")
+	}
+	if texts[2] != "第一章 概述" {
+		t.Errorf("texts[2] = %q, want %q", texts[2], "第一章 概述")
+	}
+	if texts[3] != "真实正文内容" {
+		t.Errorf("texts[3] = %q, want %q", texts[3], "真实正文内容")
+	}
+}
+
+func TestRemoveContentsTable_English_RemovesTOCBlock(t *testing.T) {
+	records := []lineRecord{
+		{text: "Chapter 1 Overview"},
+		{text: "Main body text here"},
+		{text: "Contents"},
+		{text: "Chapter 1 Overview"},
+		{text: "Chapter 2 Details"},
+		{text: "Section 1.1 Background"},
+		{text: "Chapter 1 Overview"}, // Matches prefix "Chapter 1" — marks end of TOC
+		{text: "Real body content"},
+	}
+	got := removeContentsTable(records)
+	if len(got) == 0 {
+		t.Fatal("got empty result after English TOC removal")
+	}
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 4 {
+		t.Errorf("want 4 records, got %d: %v", len(texts), texts)
+	}
+	if texts[2] != "Chapter 1 Overview" {
+		t.Errorf("texts[2] = %q, want %q", texts[2], "Chapter 1 Overview")
+	}
+}
+
+func TestRemoveContentsTable_TOCWithAtAtSuffix(t *testing.T) {
+	// @@ suffixes should be stripped before matching.
+	records := []lineRecord{
+		{text: "前言"},
+		{text: "目录@@0.8"},
+		{text: "第一章 概述@@0.9"},
+		{text: "第一章 概述"}, // Matched prefix — end of TOC
+		{text: "正文开始"},
+	}
+	got := removeContentsTable(records)
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 3 {
+		t.Errorf("want 3 records, got %d: %v", len(texts), texts)
+	}
+	// "前言" stays, TOC block removed, "第一章 概述" and "正文开始" remain.
+	if texts[0] != "前言" {
+		t.Errorf("texts[0] = %q", texts[0])
+	}
+	if texts[1] != "第一章 概述" {
+		t.Errorf("texts[1] = %q", texts[1])
+	}
+}
+
+func TestRemoveContentsTable_TOCAtBeginning(t *testing.T) {
+	records := []lineRecord{
+		{text: "目录"},
+		{text: "第一章 概述"},
+		{text: "第一章 概述"}, // End of TOC
+		{text: "正文"},
+	}
+	got := removeContentsTable(records)
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 2 {
+		t.Errorf("want 2 records, got %d: %v", len(texts), texts)
+	}
+	if texts[0] != "第一章 概述" || texts[1] != "正文" {
+		t.Errorf("unexpected: %v", texts)
+	}
+}
+
+func TestRemoveContentsTable_TOCAtEnd_NoMatch(t *testing.T) {
+	// TOC at the end with no matching prefix within 128 lines.
+	records := []lineRecord{
+		{text: "正文内容"},
+		{text: "目录"},
+		{text: "第一章 概述"},
+	}
+	got := removeContentsTable(records)
+	// TOC header popped, then first TOC entry popped, then
+	// no matching prefix found within 128 lines → loop breaks at line 96.
+	// The remaining records (nothing after the TOC block) stay.
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 1 {
+		t.Errorf("want 1 record, got %d: %v", len(texts), texts)
+	}
+	if texts[0] != "正文内容" {
+		t.Errorf("texts[0] = %q", texts[0])
+	}
+}
+
+func TestRemoveContentsTable_128LineBoundary(t *testing.T) {
+	// Build a TOC with >128 entries — the forward scan stops at 128.
+	records := []lineRecord{
+		{text: "前言"},
+		{text: "目录"},
+	}
+	// Add first TOC entry after "目录"
+	records = append(records, lineRecord{text: "第一章 概述"})
+	// Add 150 TOC entries (all with different prefixes, so no match within 128).
+	for range 150 {
+		records = append(records, lineRecord{text: "其他内容"})
+	}
+	// The matching line is at position beyond 128 — won't be found.
+	records = append(records, lineRecord{text: "第一章 概述"})
+	records = append(records, lineRecord{text: "正文"})
+
+	got := removeContentsTable(records)
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	// "前言" stays. TOC header popped, first entry popped.
+	// 128-item scan finds no match (all "其他内容").
+	// Loop breaks on i >= len(records) || prefix == "". Remaining records (150 + 2) stay.
+	if len(texts) != 153 {
+		t.Errorf("want 153 records, got %d", len(texts))
+	}
+	if texts[0] != "前言" {
+		t.Errorf("texts[0] = %q", texts[0])
+	}
+}
+
+func TestRemoveContentsTable_TOCWithoutPrefix(t *testing.T) {
+	// TOC title exists but the line right after is empty — prefix will be "".
+	records := []lineRecord{
+		{text: "目录"},
+	}
+	got := removeContentsTable(records)
+	if len(got) != 0 {
+		t.Errorf("TOC-only: got %d records, want 0", len(got))
+	}
+}
+
+func TestRemoveContentsTable_WhitespaceInTOCTitle(t *testing.T) {
+	// Collapsed whitespace in TOC title still matches the pattern.
+	records := []lineRecord{
+		{text: "前言"},
+		{text: "目  录"}, // Extra spaces — collapsing matches "目录"
+		{text: "第一章 概述"},
+		{text: "第一章 概述"}, // Matches
+		{text: "正文"},
+	}
+	got := removeContentsTable(records)
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 3 {
+		t.Errorf("want 3 records, got %d: %v", len(texts), texts)
+	}
+}
+
+func TestRemoveContentsTable_MultipleTOCs(t *testing.T) {
+	// A document with two TOC blocks — both should be removed.
+	// CJK document (most records are Chinese) → eng=false, prefix is first 3 runes.
+	records := []lineRecord{
+		{text: "目录"},
+		{text: "第一章 概述"},
+		{text: "第二章 详情"},
+		{text: "第一章 概述"}, // End of first TOC (prefix "第一章")
+		{text: "正文插入"},
+		{text: "Contents"},
+		{text: "Chapter 1 Overview"},
+		{text: "Chapter 1 Overview"}, // End of second TOC (prefix "Cha" in CJK mode)
+		{text: "Final body"},
+	}
+	got := removeContentsTable(records)
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	// First TOC removes: "目录", "第一章 概述"(first entry), "第二章 详情".
+	// Second TOC removes: "Contents", "Chapter 1 Overview"(first entry).
+	// Remaining: "第一章 概述", "正文插入", "Chapter 1 Overview"(match), "Final body".
+	if len(texts) != 4 {
+		t.Errorf("want 4 records, got %d: %v", len(texts), texts)
+	}
+}
+
+func TestRemoveContentsTable_AcknowledgeTitle(t *testing.T) {
+	// "acknowledge" and "致谢" match tocTitlePattern.
+	records := []lineRecord{
+		{text: "前言"},
+		{text: "致谢"},
+		{text: "感谢 领导"}, // CJK prefix "感谢" (first 3 runes)
+		{text: "感谢 领导"}, // Matches prefix — end of TOC
+		{text: "正文内容"},
+	}
+	got := removeContentsTable(records)
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 3 {
+		t.Errorf("want 3 records, got %d: %v", len(texts), texts)
+	}
+	if texts[0] != "前言" || texts[1] != "感谢 领导" || texts[2] != "正文内容" {
+		t.Errorf("unexpected: %v", texts)
+	}
+}
+
+func TestRemoveContentsTable_CaseInsensitive(t *testing.T) {
+	records := []lineRecord{
+		{text: "Chapter 1 Introduction"},
+		{text: "Main body"},
+		{text: "CONTENTS"}, // Must match case-insensitively
+		{text: "Chapter 1 Introduction"},
+		{text: "Chapter 1 Introduction"}, // Matches "Chapter 1"
+		{text: "After TOC body"},
+	}
+	got := removeContentsTable(records)
+	texts := make([]string, len(got))
+	for i, r := range got {
+		texts[i] = r.text
+	}
+	if len(texts) != 4 {
+		t.Errorf("want 4 records, got %d: %v", len(texts), texts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tocCollapseSpaceRe
+// ---------------------------------------------------------------------------
+
+func TestTocCollapseSpaceRe_CollapsesSpaces(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"hello world", "helloworld"},
+		{"目  录", "目录"},
+		{"a \u3000 b", "ab"},
+		{"no-spaces", "no-spaces"},
+	}
+	for _, tt := range tests {
+		got := tocCollapseSpaceRe.ReplaceAllString(tt.input, "")
+		if got != tt.want {
+			t.Errorf("tocCollapseSpaceRe(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tocTitlePattern
+// ---------------------------------------------------------------------------
+
+func TestTocTitlePattern_Matches(t *testing.T) {
+	matches := []string{
+		"contents", "CONTENTS", "Contents",
+		"目录", "目次",
+		"table of contents", "TABLE OF CONTENTS",
+		"致谢", "acknowledge", "ACKNOWLEDGE",
+	}
+	for _, m := range matches {
+		if !tocTitlePattern.MatchString(m) {
+			t.Errorf("tocTitlePattern should match %q", m)
+		}
+	}
+}
+
+func TestTocTitlePattern_NonMatches(t *testing.T) {
+	nonMatches := []string{
+		"table of content", // singular
+		"catalog",
+		"index",
+		"目录 ",
+		" 目录",
+		"contents.", // trailing punctuation
+	}
+	for _, m := range nonMatches {
+		if tocTitlePattern.MatchString(m) {
+			t.Errorf("tocTitlePattern should NOT match %q", m)
+		}
+	}
+}
+
+// TestRemoveContentsTable_SpaceNormalization verifies the Python-faithful
+// behaviour of removeContentsTable: Python's remove_contents_table collapses
+// ALL whitespace (re.sub(r"( | |\u3000)+", "", ...)) before matching the TOC
+// title pattern, not just trimming. So TOC headers padded with leading or
+// trailing spaces (or full-width spaces) are still detected and removed in
+// both Python and Go. This is the function-level counterpart to the raw
+// tocTitlePattern anchoring test above.
+func TestRemoveContentsTable_SpaceNormalization(t *testing.T) {
+	paddedHeaders := []string{
+		"目录 ",
+		" 目录",
+		" 目录 ",
+		"目\u3000录", // full-width (ideographic) space
+	}
+	for _, header := range paddedHeaders {
+		records := []lineRecord{
+			{text: "正文"},
+			{text: header}, // must be detected and removed
+			{text: "第一章 总则"},
+			{text: "其他内容"},
+			{text: "正文内容"},
+		}
+		got := removeContentsTable(records)
+		for _, r := range got {
+			if strings.TrimSpace(r.text) == strings.TrimSpace(header) {
+				t.Errorf("padded TOC header %q should be removed, got %v", header, got)
+			}
+		}
+	}
+}

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -115,10 +115,16 @@ func applyRemoveTOC(result *deepdoctype.ParseResult) {
 
 func removePDFTOC(result *deepdoctype.ParseResult) {
 	sections := result.Sections
+	// Detect English to mirror Python's `eng` parameter: use first-2-words
+	// prefix for English documents vs first-3-characters for CJK documents.
+	eng := isEnglishSections(sections)
 	i := 0
 	for i < len(sections) {
 		text := sectionText(sections[i])
-		if !pdfTOCTitlePattern.MatchString(strings.ToLower(strings.TrimSpace(text))) {
+		// Collapse whitespace and strip "@@" suffix before matching, mirroring
+		// Python's re.sub(r"( | |\u3000)+", "", get(i).split("@@")[0]).
+		text = stripAndCollapse(text)
+		if !pdfTOCTitlePattern.MatchString(strings.ToLower(text)) {
 			i++
 			continue
 		}
@@ -126,13 +132,13 @@ func removePDFTOC(result *deepdoctype.ParseResult) {
 		if i >= len(sections) {
 			break
 		}
-		prefix := sectionTextPrefix(sections[i], 3)
+		prefix := sectionTextPrefixExpr(sections[i], eng)
 		for prefix == "" {
 			sections = append(sections[:i], sections[i+1:]...)
 			if i >= len(sections) {
 				break
 			}
-			prefix = sectionTextPrefix(sections[i], 3)
+			prefix = sectionTextPrefixExpr(sections[i], eng)
 		}
 		if i >= len(sections) || prefix == "" {
 			break
@@ -152,17 +158,83 @@ func removePDFTOC(result *deepdoctype.ParseResult) {
 	result.Sections = sections
 }
 
+// stripAndCollapse strips the "@@" suffix and collapses consecutive
+// whitespace characters (space, ideographic space) into a single empty
+// string. Mirrors Python's:
+//
+//	re.sub(r"( | |\u3000)+", "", get(i).split("@@")[0])
+func stripAndCollapse(s string) string {
+	if idx := strings.Index(s, "@@"); idx >= 0 {
+		s = s[:idx]
+	}
+	s = strings.TrimSpace(s)
+	return spaceCollapseRe.ReplaceAllString(s, "")
+}
+
+var spaceCollapseRe = regexp.MustCompile(`[ \x{3000}]+`)
+
+// sectionTextPrefixExpr computes the TOC prefix matching Python's:
+//
+//	prefix = get(i)[:3] if not eng else " ".join(get(i).split()[:2])
+func sectionTextPrefixExpr(s deepdoctype.Section, eng bool) string {
+	text := sectionText(s)
+	if !eng {
+		// Use rune slicing to match Python's character-level [:3].
+		// Go's default byte-slicing would return only one
+		// 3-byte CJK character instead of three characters.
+		runes := []rune(text)
+		if len(runes) < 3 {
+			return text
+		}
+		return string(runes[:3])
+	}
+	words := strings.Fields(text)
+	if len(words) >= 2 {
+		return strings.Join(words[:2], " ")
+	}
+	return text
+}
+
+// isEnglishSections mirrors Python's is_english + random_choices
+// sampling over section texts. Returns true when >80% of sampled
+// section texts consist entirely of ASCII alphanumeric / whitespace /
+// punctuation characters.
+func isEnglishSections(sections []deepdoctype.Section) bool {
+	const sampleSize = 200
+	var texts []string
+	for _, s := range sections {
+		t := strings.TrimSpace(s.Text)
+		if t == "" {
+			continue
+		}
+		texts = append(texts, t)
+		if len(texts) >= sampleSize {
+			break
+		}
+	}
+	if len(texts) == 0 {
+		return false
+	}
+	eng := 0
+	for _, t := range texts {
+		if isEnglishTextPattern.MatchString(strings.TrimSpace(t)) {
+			eng++
+		}
+	}
+	return float64(eng)/float64(len(texts)) > 0.8
+}
+
+// isEnglishTextPattern mirrors Python's is_english character pattern:
+//
+//	r"[`a-zA-Z0-9\s.,':;/\"?<>!\(\)\-]+"
+//
+// The backtick is omitted as it is irrelevant for section texts.
+var isEnglishTextPattern = regexp.MustCompile(`^[a-zA-Z0-9\s.,':;"/?<>!()\-]+$`)
+
 func sectionText(s deepdoctype.Section) string {
 	return strings.TrimSpace(s.Text)
 }
 
-func sectionTextPrefix(s deepdoctype.Section, n int) string {
-	text := sectionText(s)
-	if len(text) < n {
-		return text
-	}
-	return text[:n]
-}
 func removePDFTOCByOutlines(result *deepdoctype.ParseResult, outlines []deepdoctype.Outline) {
 	if result == nil || len(outlines) == 0 {
 		return


### PR DESCRIPTION
### Summary

Fix the following issues:

---

🟡 P1 — remove_contents_table（中影响）

Python laws.py 在 tree_merge 前调用了 remove_contents_table(sections, eng)（rag/nlp/__init__.py:937），用于移除目录区域。

行为：检测到 "Contents"/"目录"/"TABLE OF CONTENTS" 等标记行后，删除该行及后续 128 行内匹配相同前缀的行。

为什么影响：目录条目（如"第一章"、"1.1"等）恰好匹配标题正则。不加此步骤：
- 目录条目被当作真实标题节点
- chunk 划分被这些假标题打断
- 产出大量无意义的小 chunk

触发条件：文档包含目录，且目录条目格式与正文标题格式一致。

修复位置：应放在 Parser 输出后、TitleChunker 输入前。需要决定是作为 Parser 的预处理还是 TitleChunker 的预处理。

---
🟢 P3 — 短行过滤（低）

Python tree_merge 内部过滤：
sections = [(t, o) for t, o in sections if t and len(t.split("@")[0].strip()) > 1 and not re.match(r"[0-9]+$", t.split("@")[0].strip())]
- 去掉空行
- 去掉长度 ≤ 1 的行
- 去掉纯数字行

Go TitleChunker 没有此过滤。纯数字行如 "1" 或 "2" 可能被匹配为标题（匹配 [0-9]{1,2}[\. 、] 中的 [0-9]{1,2}），引入无关标题节点。

修复成本：极低，在 resolveTitleLevels 加一行过滤即可。
