### PR TITLE
fix(go): nil pointer dereference in ZhipuAI Embed method

### DIFF
--- a/internal/entity/models/zhipu-ai.go
+++ b/internal/entity/models/zhipu-ai.go
@@ -530,7 +530,7 @@ func (z *ZhipuAIModel) Embed(modelName *string, texts []string, apiConfig *APICo
 	reqBody := map[string]interface{}{}
 	reqBody["model"] = modelName
 	reqBody["input"] = texts
-	if embeddingConfig.Dimension > 0 {
+	if embeddingConfig != nil && embeddingConfig.Dimension > 0 {
 		reqBody["dimensions"] = embeddingConfig.Dimension
 	}
 


### PR DESCRIPTION
### Summary

When verifying model connections, `embeddingConfig` is passed as `nil` to the `Embed` method. The ZhipuAI model directly accesses `embeddingConfig.Dimension` without a nil check, causing a nil pointer dereference panic at `internal/entity/models/zhipu-ai.go:533`.

This PR adds a nil guard (`embeddingConfig != nil`) before accessing the `Dimension` field.

**Stack trace:**
```
runtime error: invalid memory address or nil pointer dereference
  internal/entity/models/zhipu-ai.go:533
  internal/service/model_service.go:1030 (verifyProviderModel)
  internal/service/model_service.go:911 (CheckConnection)
  internal/handler/providers.go:304 (CheckConnection)
```

**Fix:** Added nil check before accessing `embeddingConfig.Dimension`.