### PR TITLE
docs: fix invalid chunk_method value and NameError in Python SDK reference

### DIFF
--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -646,7 +646,7 @@ A `Document` object contains the following attributes:
     `{"raptor": {"use_raptor": False}}`
   - `chunk_method`=`"presentation"`:  
     `{"raptor": {"use_raptor": False}}`
-  - `chunk_method`=`"picure"`:  
+  - `chunk_method`=`"picture"`:  
     `None`
   - `chunk_method`=`"one"`:  
     `None`
@@ -1893,7 +1893,7 @@ from ragflow_sdk import RAGFlow
 rag_object = RAGFlow(api_key="<YOUR_API_KEY>", base_url="http://<YOUR_BASE_URL>:9380")
 AGENT_id = "AGENT_ID"
 agent = rag_object.get_agent(AGENT_id)
-sessons = agent.list_sessions()
+sessions = agent.list_sessions()
 for session in sessions:
     print(session)
 ```


### PR DESCRIPTION
### Summary

Two errors in `docs/references/python_api_reference.md` that a reader hits by copying the
reference as written.

**1. `chunk_method`=`"picure"` is not a valid value.**

The accepted value is `"picture"` — `ParserType.PICTURE = "picture"` in `common/constants.py`,
and `picture` is what the allow-list in `api/utils/validation_utils.py` checks against:

```python
valid_chunk_method = {"naive", "manual", "qa", "table", "paper", "book", "laws",
                      "presentation", "picture", "one", "knowledge_graph", "email", "tag"}
```

So the documented value fails validation. This was the only occurrence of `picure` in the repo.

**2. The `list_sessions` example raises `NameError`.**

```python
sessons = agent.list_sessions()
for session in sessions:   # `sessions` was never assigned
    print(session)
```

Docs-only, two single-line changes.