### PR TITLE
docs: correct firecrawl README paths to tools/firecrawl

### DIFF
--- a/tools/firecrawl/README.md
+++ b/tools/firecrawl/README.md
@@ -41,7 +41,7 @@ This integration implements the requirements from [Firecrawl Issue #2167](https:
 ## 📁 **File Structure**
 
 ```
-intergrations/firecrawl/
+tools/firecrawl/
 ├── __init__.py                 # Package initialization
 ├── firecrawl_connector.py      # API communication with Firecrawl
 ├── firecrawl_config.py         # Configuration management
@@ -144,7 +144,7 @@ The integration includes comprehensive testing:
 
 ```bash
 # Run the test suite
-cd intergrations/firecrawl
+cd tools/firecrawl
 python3 -c "
 import sys
 sys.path.append('.')


### PR DESCRIPTION
### Summary

`tools/firecrawl/README.md` documents the integration as living in `intergrations/firecrawl`,
in both the file-structure block and the test command. No such directory exists — under that
spelling or the correct one. The files the README lists (`firecrawl_connector.py`,
`firecrawl_config.py`, `firecrawl_processor.py`, `firecrawl_ui.py`, `ragflow_integration.py`)
are all in `tools/firecrawl`, so `cd intergrations/firecrawl` fails for anyone following the
testing section.

Two lines, path only.

### Note (not changed here)

`tools/firecrawl/INSTALLATION.md` tells the reader to `git clone https://github.com/firecrawl/firecrawl.git`
and `cd firecrawl/ragflow-firecrawl-integration`, then install from a `plugin/firecrawl/` layout.
That describes a different repository and a packaging this tree doesn't have, so it looks like it
needs a rewrite rather than a path correction — I've left it alone rather than guess at the
intended install flow. Glad to follow up if you can say which layout is the real one.