### PR TITLE
fix(go-agent): fall back when model streaming is unsupported

### DIFF
--- a/internal/agent/component/agent.go
+++ b/internal/agent/component/agent.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	einomodel "github.com/cloudwego/eino/components/model"
 	einotool "github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/flow/agent/react"
@@ -139,13 +140,79 @@ type AgentOutput struct {
 // that returns canned *schema.Message values.
 var agentRunner = runEinoReActAgent
 
+const chatStreamUnsupportedMarker = "does not implement ChatStreamlyWithSender"
+
+// agentChatModel keeps the ReAct Agent on its streaming execution path while
+// allowing models without a streaming implementation to use normal chat. The
+// fallback is Agent-specific and only happens before any stream chunk has been
+// emitted, so transport failures and interrupted streams are not retried as a
+// second request.
+type agentChatModel struct {
+	einomodel.ToolCallingChatModel
+}
+
+func (m *agentChatModel) WithTools(tools []*schema.ToolInfo) (einomodel.ToolCallingChatModel, error) {
+	modelWithTools, err := m.ToolCallingChatModel.WithTools(tools)
+	if err != nil {
+		return nil, err
+	}
+	return &agentChatModel{ToolCallingChatModel: modelWithTools}, nil
+}
+
+func (m *agentChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
+	stream, err := m.ToolCallingChatModel.Stream(ctx, input, opts...)
+	if err != nil {
+		if !isChatStreamUnsupported(err) {
+			return nil, err
+		}
+		msg, generateErr := m.Generate(ctx, input, opts...)
+		if generateErr != nil {
+			return nil, generateErr
+		}
+		return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+	}
+
+	out, writer := schema.Pipe[*schema.Message](1)
+	go func() {
+		defer writer.Close()
+		defer stream.Close()
+
+		emitted := false
+		for {
+			msg, recvErr := stream.Recv()
+			if errors.Is(recvErr, io.EOF) {
+				return
+			}
+			if recvErr != nil {
+				if !emitted && isChatStreamUnsupported(recvErr) {
+					msg, generateErr := m.Generate(ctx, input, opts...)
+					_ = writer.Send(msg, generateErr)
+					return
+				}
+				_ = writer.Send(nil, recvErr)
+				return
+			}
+			emitted = true
+			if closed := writer.Send(msg, nil); closed {
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+func isChatStreamUnsupported(err error) bool {
+	return err != nil && strings.Contains(err.Error(), chatStreamUnsupportedMarker)
+}
+
 // runEinoReActAgent creates an eino react agent and runs it against the
 // model built from p.
 func runEinoReActAgent(ctx context.Context, p AgentParam) (*schema.Message, error) {
-	chatModel, err := buildAgentChatModel(ctx, p)
+	baseChatModel, err := buildAgentChatModel(ctx, p)
 	if err != nil {
 		return nil, fmt.Errorf("build model: %w", err)
 	}
+	chatModel := &agentChatModel{ToolCallingChatModel: baseChatModel}
 	tools, err := buildAgentTools(p)
 	if err != nil {
 		return nil, fmt.Errorf("build tools: %w", err)

--- a/internal/agent/component/agent_stream_fallback_test.go
+++ b/internal/agent/component/agent_stream_fallback_test.go
@@ -1,0 +1,114 @@
+package component
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	einomodel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+type agentChatModelStub struct {
+	streamMessages []*schema.Message
+	streamErr      error
+	generateResult *schema.Message
+	generateCalls  int
+}
+
+func (m *agentChatModelStub) Generate(context.Context, []*schema.Message, ...einomodel.Option) (*schema.Message, error) {
+	m.generateCalls++
+	return m.generateResult, nil
+}
+
+func (m *agentChatModelStub) Stream(context.Context, []*schema.Message, ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
+	stream, writer := schema.Pipe[*schema.Message](1)
+	go func() {
+		defer writer.Close()
+		for _, msg := range m.streamMessages {
+			if writer.Send(msg, nil) {
+				return
+			}
+		}
+		if m.streamErr != nil {
+			_ = writer.Send(nil, m.streamErr)
+		}
+	}()
+	return stream, nil
+}
+
+func (m *agentChatModelStub) WithTools([]*schema.ToolInfo) (einomodel.ToolCallingChatModel, error) {
+	return m, nil
+}
+
+func TestAgentChatModelFallsBackWhenStreamingIsUnsupported(t *testing.T) {
+	stub := &agentChatModelStub{
+		streamErr:      errors.New("provider does not implement ChatStreamlyWithSender"),
+		generateResult: schema.AssistantMessage("complete answer", nil),
+	}
+	model := &agentChatModel{ToolCallingChatModel: stub}
+
+	stream, err := model.Stream(context.Background(), []*schema.Message{schema.UserMessage("hello")})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	msg, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if msg == nil || msg.Content != "complete answer" {
+		t.Fatalf("fallback message = %#v, want complete answer", msg)
+	}
+	if _, err = stream.Recv(); !errors.Is(err, io.EOF) {
+		t.Fatalf("second Recv error = %v, want EOF", err)
+	}
+	if stub.generateCalls != 1 {
+		t.Fatalf("Generate calls = %d, want 1", stub.generateCalls)
+	}
+}
+
+func TestAgentChatModelDoesNotFallbackForOtherStreamErrors(t *testing.T) {
+	streamErr := errors.New("connection reset")
+	stub := &agentChatModelStub{
+		streamErr:      streamErr,
+		generateResult: schema.AssistantMessage("unexpected fallback", nil),
+	}
+	model := &agentChatModel{ToolCallingChatModel: stub}
+
+	stream, err := model.Stream(context.Background(), []*schema.Message{schema.UserMessage("hello")})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if _, err = stream.Recv(); !errors.Is(err, streamErr) {
+		t.Fatalf("Recv error = %v, want %v", err, streamErr)
+	}
+	if stub.generateCalls != 0 {
+		t.Fatalf("Generate calls = %d, want 0", stub.generateCalls)
+	}
+}
+
+func TestAgentChatModelDoesNotFallbackAfterStreamOutput(t *testing.T) {
+	streamErr := errors.New("provider does not implement ChatStreamlyWithSender")
+	stub := &agentChatModelStub{
+		streamMessages: []*schema.Message{schema.AssistantMessage("partial", nil)},
+		streamErr:      streamErr,
+		generateResult: schema.AssistantMessage("unexpected fallback", nil),
+	}
+	model := &agentChatModel{ToolCallingChatModel: stub}
+
+	stream, err := model.Stream(context.Background(), []*schema.Message{schema.UserMessage("hello")})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	msg, err := stream.Recv()
+	if err != nil || msg == nil || msg.Content != "partial" {
+		t.Fatalf("first Recv = (%#v, %v), want partial", msg, err)
+	}
+	if _, err = stream.Recv(); !errors.Is(err, streamErr) {
+		t.Fatalf("second Recv error = %v, want %v", err, streamErr)
+	}
+	if stub.generateCalls != 0 {
+		t.Fatalf("Generate calls = %d, want 0", stub.generateCalls)
+	}
+}


### PR DESCRIPTION
## Summary

- Fall back to non-streaming generation when Agent model streaming is unsupported.
- Preserve unrelated stream errors and avoid retrying after partial output.

## Testing

- `CGO_ENABLED=0 go test ./internal/agent/component`