### PR TITLE
fix: improve page index descriptions

### DIFF
--- a/api/db/init_data/compilation_templates/page_index.yaml
+++ b/api/db/init_data/compilation_templates/page_index.yaml
@@ -8,8 +8,9 @@ config:
       compressed descriptions. Extract each heading as an entity. The
       entity's `name` must be the exact clean heading text. For each heading,
       write a strongly compressed summary of only the content belonging to
-      that heading: normally 1–2 sentences and roughly half the length of a
-      normal summary. Keep only the 2–4 most important facts, prioritizing key
+      that heading: normally 1–2 sentences, aiming for about 50–100 English
+      words or 80–180 Chinese characters when the source is long enough. Keep
+      only the 2–4 most important facts, prioritizing key
       numbers, dates, names, locations, and conclusions. Do not copy long
       passages verbatim and do not reduce the description to a generic label.
       For detailed lists, give the overall result and only the most important
@@ -34,7 +35,7 @@ config:
           - If a chunk contains multiple headings, expand them in order:
               - Each heading → {"title":"...","chunk_id":"<chunk_ID>","description":"a compact summary of only that heading's section"}.
           - A parent heading with no direct body must still receive a short higher-level overview based on its child-section content for later merging; do not copy a child's summary verbatim.
-          - Prefer 1–2 concise sentences and roughly half the length of a normal summary; preserve only the most important facts, dates, numbers, names, and conclusions.
+          - Prefer 1–2 concise sentences, aiming for about 50–100 English words or 80–180 Chinese characters when the source is long enough; preserve only the most important facts, dates, numbers, names, and conclusions.
           - When ambiguous, prefer `-1` unless the text strongly looks like a heading.
           - Keep language of "title" the same as the input.
           - Prefix like following must be titles: 第x章, 第N条, 第N节, 1, 1.1, 1.1.1 ...

--- a/api/db/init_data/compilation_templates/page_index.yaml
+++ b/api/db/init_data/compilation_templates/page_index.yaml
@@ -24,19 +24,19 @@ config:
       usable source content at all. Do not invent content.
     fields:
       - type: title
-        description: the exact heading text as the entity name, cleaned of page numbers and leader dots
+        description: the heading text (clean, no page numbers or leader dots)
         rule: |
           - Length restriction:
               • Chinese heading: ≤25 characters
               • English heading: ≤80 characters
-          - `name` must be non-empty (or exactly `-1`).
-          - If any part of a chunk has no valid heading, output that part as {"name":"-1", ...}.
+          - "title" must be non-empty (or exactly "-1").
+          - If any part of a chunk has no valid heading, output that part as {"title":"-1", ...}.
           - If a chunk contains multiple headings, expand them in order:
-              - Each heading → {"name":"...","description":"a compact summary of only that heading's section"}.
+              - Each heading → {"title":"...","chunk_id":"<chunk_ID>","description":"a compact summary of only that heading's section"}.
           - A parent heading with no direct body must still receive a short higher-level overview based on its child-section content for later merging; do not copy a child's summary verbatim.
           - Prefer 1–2 concise sentences and roughly half the length of a normal summary; preserve only the most important facts, dates, numbers, names, and conclusions.
           - When ambiguous, prefer `-1` unless the text strongly looks like a heading.
-          - Keep the language of `name` the same as the input.
+          - Keep language of "title" the same as the input.
           - Prefix like following must be titles: 第x章, 第N条, 第N节, 1, 1.1, 1.1.1 ...
   relation:
     description: >-

--- a/api/db/init_data/compilation_templates/page_index.yaml
+++ b/api/db/init_data/compilation_templates/page_index.yaml
@@ -4,20 +4,39 @@ config:
   kind: page_index
   entity:
     description: >-
-      You are a robust Table-of-Contents (TOC) extractor.
+      You are a robust table-of-contents extractor with source-grounded
+      compressed descriptions. Extract each heading as an entity. The
+      entity's `name` must be the exact clean heading text. For each heading,
+      write a strongly compressed summary of only the content belonging to
+      that heading: normally 1–2 sentences and roughly half the length of a
+      normal summary. Keep only the 2–4 most important facts, prioritizing key
+      numbers, dates, names, locations, and conclusions. Do not copy long
+      passages verbatim and do not reduce the description to a generic label.
+      For detailed lists, give the overall result and only the most important
+      examples. Do not write meta descriptions such as `heading for ...`,
+      `section heading`, or `subheading for ...`. Do not include image
+      captions, `Main article` links, or unrelated tables and lists unless
+      they are the actual content of the heading. If a parent heading has no
+      direct body before the next child heading, generate a short higher-level
+      overview from the available child-section content; do not copy the child
+      description verbatim. This parent overview is needed for later
+      cross-chunk merging. Only use an empty description when there is no
+      usable source content at all. Do not invent content.
     fields:
       - type: title
-        description: the heading text (clean, no page numbers or leader dots)
+        description: the exact heading text as the entity name, cleaned of page numbers and leader dots
         rule: |
           - Length restriction:
               • Chinese heading: ≤25 characters
               • English heading: ≤80 characters
-          - "title" must be non-empty (or exactly "-1").
-          - If any part of a chunk has no valid heading, output that part as {"title":"-1", ...}.
+          - `name` must be non-empty (or exactly `-1`).
+          - If any part of a chunk has no valid heading, output that part as {"name":"-1", ...}.
           - If a chunk contains multiple headings, expand them in order:
-              - Each heading → {"title":"...","chunk_id":"<chunk_ID>"}.
-          - When ambiguous, prefer "-1" unless the text strongly looks like a heading.
-          - Keep language of "title" the same as the input.
+              - Each heading → {"name":"...","description":"a compact summary of only that heading's section"}.
+          - A parent heading with no direct body must still receive a short higher-level overview based on its child-section content for later merging; do not copy a child's summary verbatim.
+          - Prefer 1–2 concise sentences and roughly half the length of a normal summary; preserve only the most important facts, dates, numbers, names, and conclusions.
+          - When ambiguous, prefer `-1` unless the text strongly looks like a heading.
+          - Keep the language of `name` the same as the input.
           - Prefix like following must be titles: 第x章, 第N条, 第N节, 1, 1.1, 1.1.1 ...
   relation:
     description: >-


### PR DESCRIPTION
### What problem does this PR solve?

Improve the PageIndex extraction template so entity descriptions are concise, source-grounded, and useful for later cross-chunk merging.

Parent headings without direct content now receive a higher-level overview instead of an empty description.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)