### PR TITLE
fix: remove loading spinners during page navigation

### DIFF
--- a/web/src/pages/datasets/index.tsx
+++ b/web/src/pages/datasets/index.tsx
@@ -5,7 +5,6 @@ import ListFilterBar from '@/components/list-filter-bar';
 import { RenameDialog } from '@/components/rename-dialog';
 import { Button } from '@/components/ui/button';
 import { RAGFlowPagination } from '@/components/ui/ragflow-pagination';
-import { Spin } from '@/components/ui/spin';
 import { useFetchNextKnowledgeListByPage } from '@/hooks/use-knowledge-request';
 import { useQueryClient } from '@tanstack/react-query';
 import { pick } from 'lodash';
@@ -73,12 +72,7 @@ export default function Datasets() {
   return (
     <>
       {loading && !kbs?.length ? (
-        <article
-          className="size-full flex items-center justify-center"
-          data-testid="datasets-list"
-        >
-          <Spin size="large" />
-        </article>
+        <article className="size-full" data-testid="datasets-list"></article>
       ) : kbs?.length || searchString ? (
         <article
           className="size-full min-w-0 flex flex-col"

--- a/web/src/pages/files/files-table.tsx
+++ b/web/src/pages/files/files-table.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 
 import { FileIcon } from '@/components/icon-font';
 import { RenameDialog } from '@/components/rename-dialog';
-import { TableEmpty, TableSkeleton } from '@/components/table-skeleton';
+import { TableEmpty } from '@/components/table-skeleton';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { RAGFlowPagination } from '@/components/ui/ragflow-pagination';
@@ -362,7 +362,9 @@ export function FilesTable({
           </TableHeader>
           <TableBody className="max-h-96 overflow-y-auto">
             {loading ? (
-              <TableSkeleton columnsLength={columns.length}></TableSkeleton>
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24" />
+              </TableRow>
             ) : table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
                 <TableRow

--- a/web/src/pages/next-chats/index.tsx
+++ b/web/src/pages/next-chats/index.tsx
@@ -5,7 +5,6 @@ import ListFilterBar from '@/components/list-filter-bar';
 import { RenameDialog } from '@/components/rename-dialog';
 import { Button } from '@/components/ui/button';
 import { RAGFlowPagination } from '@/components/ui/ragflow-pagination';
-import { Spin } from '@/components/ui/spin';
 import { useFetchChatList } from '@/hooks/use-chat-request';
 import { buildOwnersFilter } from '@/utils/list-filter-util';
 import { pick } from 'lodash';
@@ -104,12 +103,7 @@ export default function ChatList() {
   return (
     <>
       {loading && !data.chats?.length ? (
-        <article
-          className="size-full flex items-center justify-center"
-          data-testid="chats-list"
-        >
-          <Spin size="large" />
-        </article>
+        <article className="size-full" data-testid="chats-list"></article>
       ) : data.chats?.length || searchString ? (
         <article
           className="size-full min-w-0 flex flex-col"

--- a/web/src/pages/next-searches/index.tsx
+++ b/web/src/pages/next-searches/index.tsx
@@ -21,6 +21,7 @@ export default function SearchList() {
   // const [isEdit, setIsEdit] = useState(false);
   const {
     data: list,
+    isLoading: loading,
     pagination,
     searchString,
     handleInputChange,
@@ -72,7 +73,9 @@ export default function SearchList() {
 
   return (
     <>
-      {list?.data?.search_apps?.length || searchString ? (
+      {loading && !list?.data?.search_apps?.length ? (
+        <article className="size-full" data-testid="search-list"></article>
+      ) : list?.data?.search_apps?.length || searchString ? (
         <article
           className="size-full min-w-0 flex flex-col"
           data-testid="search-list"

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -81,12 +81,6 @@ export enum Routes {
   AdminMonitoring = `${Admin}/monitoring`,
 }
 
-const defaultRouteFallback = (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-[1px]">
-    <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/70 border-t-transparent" />
-  </div>
-);
-
 type LazyRouteConfig = Omit<RouteObject, 'Component' | 'children'> & {
   Component?: () => Promise<{ default: React.ComponentType<any> }>;
   children?: LazyRouteConfig[];
@@ -94,11 +88,10 @@ type LazyRouteConfig = Omit<RouteObject, 'Component' | 'children'> & {
 
 const withLazyRoute = (
   importer: () => Promise<{ default: React.ComponentType<any> }>,
-  fallback: React.ReactNode = defaultRouteFallback,
 ) => {
   const LazyComponent = lazy(importer);
   const Wrapped: React.FC<any> = (props) => (
-    <Suspense fallback={fallback}>
+    <Suspense fallback={null}>
       <LazyComponent {...props} />
     </Suspense>
   );


### PR DESCRIPTION
### Summary

This PR removes the circular loading spinners that briefly flash when navigating between pages (Datasets, Chats, Files Management, Searches), making their behavior consistent with the Agents page where no spinner is shown.

Changes:
- **`routes.tsx`**: Removed the full-screen circular spinner overlay (`defaultRouteFallback`) used as the `<Suspense>` fallback for lazy-loaded routes. The fallback is now `null`, so chunk loading no longer produces any visual artifact.
- **`datasets/index.tsx`**: Replaced the `<Spin>` loading state with an empty container, matching the Agents page pattern.
- **`next-chats/index.tsx`**: Same — replaced `<Spin>` with an empty container.
- **`next-searches/index.tsx`**: Added the missing `isLoading` check from the data hook so that an empty-card state no longer flashes before data arrives. The loading state renders an empty container instead of a spinner.
- **`files/files-table.tsx`**: Replaced the spinning `Loader2` skeleton with an empty table row during loading.