### PR TITLE
remediate CVE's by upgrading mcp to >=1.28.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "markdown>=3.8.1,<4.0.0",
     "markdown-to-json==2.1.1",
     "markdownify>=1.2.0",
-    "mcp>=1.19.0",
+    "mcp>=1.28.1,<2.0.0",
     "mini-racer>=0.12.4,<0.13.0",
     "minio==7.2.4",
     "mistralai==0.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -3606,7 +3606,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.19.0"
+version = "1.28.1"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3615,15 +3615,18 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/69/2b/916852a5668f45d8787378461eaa1244876d77575ffef024483c94c0649c/mcp-1.19.0.tar.gz", hash = "sha256:213de0d3cd63f71bc08ffe9cc8d4409cc87acffd383f6195d2ce0457c021b5c1" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/ce/a3/3e71a875a08b6a830b88c40bc413bff01f1650f1efe8a054b5e90a9d4f56/mcp-1.19.0-py3-none-any.whl", hash = "sha256:f5907fe1c0167255f916718f376d05f09a830a215327a3ccdd5ec8a519f2e572" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df" },
 ]
 
 [[package]]
@@ -8225,7 +8228,7 @@ requires-dist = [
     { name = "markdown", specifier = ">=3.8.1,<4.0.0" },
     { name = "markdown-to-json", specifier = "==2.1.1" },
     { name = "markdownify", specifier = ">=1.2.0" },
-    { name = "mcp", specifier = ">=1.19.0" },
+    { name = "mcp", specifier = ">=1.28.1,<2.0.0" },
     { name = "mini-racer", specifier = ">=0.12.4,<0.13.0" },
     { name = "minio", specifier = "==7.2.4" },
     { name = "mistralai", specifier = "==0.4.2" },


### PR DESCRIPTION
## Summary
  
  Remediates HIGH severity CVEs in the `mcp` package by bumping from `>=1.19.0` to `>=1.28.1,<2` in `pyproject.toml`.
  
  | CVE | Severity | Package | Installed | Fixed in |
  |---|---|---|---|---|
  | CVE-2025-66416 | HIGH | mcp | 1.19.0 | 1.23.0 |
  | CVE-2026-52869 | HIGH | mcp | 1.19.0 | 1.27.2 |
  | CVE-2026-59950 | HIGH | mcp | 1.19.0 | 1.28.1 |

  Raised lower bound to `>=1.28.1`, added `<2` upper bound per the MCP SDK maintainers' recommendation to avoid unstable major releases.
  
  ## Verification
  
  All module paths RAGFlow imports from `mcp` remain present and unchanged in 1.28.1:
  
  - `mcp.client.session.ClientSession`
  - `mcp.client.sse.sse_client`
  - `mcp.client.streamable_http.streamablehttp_client`
  - `mcp.types.CallToolResult, ListToolsResult, TextContent, Tool`
  - `mcp.server.lowlevel.Server`
  - `mcp.server.sse.SseServerTransport`
  - `mcp.server.streamable_http_manager.StreamableHTTPSessionManager`
  
  Import smoke test confirmed all seven paths resolve correctly.
  
  ## Testing
  
  - MCP unit tests pass (`test/unit_test/mcp/`)
  - All MCP import paths verified present and functional on 1.28.1
  - `uv sync` resolves cleanly, no unexpected transitive version jumps