### PR TITLE
fix: remove trailing space in human-readable duration labels

### DIFF
--- a/web/src/utils/date.ts
+++ b/web/src/utils/date.ts
@@ -56,9 +56,9 @@ export function formatSecondsToHumanReadable(seconds: number): string {
   const s = seconds % 60;
   const formattedSeconds = s === 0 ? '0' : s.toFixed(3).replace(/\.?0+$/, '');
   const parts = [];
-  if (h > 0) parts.push(`${h}h `);
-  if (m > 0) parts.push(`${m}m `);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
   if (s || parts.length === 0) parts.push(`${formattedSeconds}s`);
 
-  return parts.join('');
+  return parts.join(' ');
 }

--- a/web/src/utils/tests/date.test.ts
+++ b/web/src/utils/tests/date.test.ts
@@ -1,0 +1,34 @@
+import { formatSecondsToHumanReadable } from '../date';
+
+describe('formatSecondsToHumanReadable', () => {
+  test('formats sub-minute durations in seconds', () => {
+    expect(formatSecondsToHumanReadable(0)).toBe('0s');
+    expect(formatSecondsToHumanReadable(30)).toBe('30s');
+  });
+
+  test('strips trailing zeros from fractional seconds', () => {
+    expect(formatSecondsToHumanReadable(1.5)).toBe('1.5s');
+  });
+
+  test('does not emit a trailing space for whole minutes or hours', () => {
+    expect(formatSecondsToHumanReadable(60)).toBe('1m');
+    expect(formatSecondsToHumanReadable(3600)).toBe('1h');
+    expect(formatSecondsToHumanReadable(7200)).toBe('2h');
+  });
+
+  test('does not emit a trailing space when seconds are zero', () => {
+    expect(formatSecondsToHumanReadable(3660)).toBe('1h 1m');
+    expect(formatSecondsToHumanReadable(5400)).toBe('1h 30m');
+  });
+
+  test('joins non-zero hour/minute/second parts with a single space', () => {
+    expect(formatSecondsToHumanReadable(90)).toBe('1m 30s');
+    expect(formatSecondsToHumanReadable(125)).toBe('2m 5s');
+    expect(formatSecondsToHumanReadable(3661)).toBe('1h 1m 1s');
+  });
+
+  test('returns "0s" for negative or non-numeric input', () => {
+    expect(formatSecondsToHumanReadable(-5)).toBe('0s');
+    expect(formatSecondsToHumanReadable(NaN)).toBe('0s');
+  });
+});


### PR DESCRIPTION
### Summary

`formatSecondsToHumanReadable` (`web/src/utils/date.ts`) builds a human-readable
duration string ("1h 30m 5s"). It appended a trailing space to every hour and
minute part and then joined the parts with an empty string:

```ts
if (h > 0) parts.push(`${h}h `);
if (m > 0) parts.push(`${m}m `);
if (s || parts.length === 0) parts.push(`${formattedSeconds}s`);
return parts.join('');
```

The seconds part is omitted when the leftover seconds are zero, so any duration
that lands on a whole minute or hour rendered with a dangling trailing space:

| input (seconds) | before  | after     |
| --------------- | ------- | --------- |
| 60              | `"1m "` | `"1m"`    |
| 3600            | `"1h "` | `"1h"`    |
| 3660            | `"1h 1m "` | `"1h 1m"` |
| 5400            | `"1h 30m "` | `"1h 30m"` |
| 90              | `"1m 30s"` | `"1m 30s"` (unchanged) |
| 3661            | `"1h 1m 1s"` | `"1h 1m 1s"` (unchanged) |

These strings are user-visible: the helper feeds the duration columns in the
dataset overview table (`pages/dataset/dataset-overview/overview-table.tsx`), the
document list (`pages/dataset/dataset/hooks.ts`), and the dataflow result view
(`pages/dataflow-result/hooks.ts`). The stray space causes inconsistent column
alignment and leaves whitespace on copy.

### What changed

- Build the parts without a trailing space and join them with a single space, so
  whole-minute/hour durations render cleanly and multi-part output is unchanged.
- Added a focused unit test (`web/src/utils/tests/date.test.ts`) covering the
  regression cases and the existing behavior (fractional seconds, negative/NaN
  input, multi-part durations).

### Testing

From `web/`:

- `npx prettier --check src/utils/date.ts src/utils/tests/date.test.ts` — clean.
- `npx eslint src/utils/date.ts src/utils/tests/date.test.ts` — clean.
- `npx jest src/utils/tests/date.test.ts` — 6/6 passing.

No linked issue; found by code inspection. Change is confined to `web/`.
