### PR TITLE
fix: substitute Message variables literally to avoid re.error on regex escapes

### DIFF
--- a/agent/component/message.py
+++ b/agent/component/message.py
@@ -251,6 +251,18 @@ class Message(ComponentBase):
         patt = [r"\{%.*%\}", "{{", "}}"]
         return any([re.search(p, content) for p in patt])
 
+    @staticmethod
+    def _apply_kwargs(content: str, kwargs: dict) -> str:
+        # Substitute the sanitized variable tokens with their concrete values.
+        # Both the token and the value are literals, so use str.replace rather
+        # than re.sub: a value containing regex escape sequences (e.g. a Windows
+        # path like "C:\10" or LaTeX like "\begin") would otherwise be read as a
+        # replacement backreference and raise re.error.
+        for n, v in kwargs.items():
+            if v is not None:
+                content = content.replace(n, str(v))
+        return content
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60)))
     def _invoke(self, **kwargs):
         if self.check_if_canceled("Message processing"):
@@ -273,9 +285,7 @@ class Message(ComponentBase):
         if self.check_if_canceled("Message processing"):
             return
 
-        for n, v in kwargs.items():
-            if v is not None:
-                content = re.sub(n, str(v), content)
+        content = self._apply_kwargs(content, kwargs)
 
         self.set_output("downloads", downloads)
         self.set_output("content", content)

--- a/test/unit_test/agent/component/test_message_kwargs_substitution.py
+++ b/test/unit_test/agent/component/test_message_kwargs_substitution.py
@@ -1,0 +1,31 @@
+import pytest
+
+from agent.component.message import Message
+
+
+@pytest.mark.p1
+def test_apply_kwargs_substitutes_value_with_regex_escapes():
+    # A value containing backslash-digit sequences (e.g. a Windows path) must be
+    # inserted verbatim, not interpreted as a regex replacement backreference.
+    content = Message._apply_kwargs("path is _v end", {"_v": r"C:\10\report"})
+    assert content == r"path is C:\10\report end"
+
+
+@pytest.mark.p1
+def test_apply_kwargs_handles_token_with_regex_metacharacters():
+    # The sanitized token is matched literally, so metacharacters in it are not
+    # treated as a pattern.
+    content = Message._apply_kwargs("value _a[0] here", {"_a[0]": "x"})
+    assert content == "value x here"
+
+
+@pytest.mark.p1
+def test_apply_kwargs_replaces_all_occurrences():
+    content = Message._apply_kwargs("_a and _a", {"_a": "x"})
+    assert content == "x and x"
+
+
+@pytest.mark.p1
+def test_apply_kwargs_skips_none_values():
+    content = Message._apply_kwargs("_a stays", {"_a": None})
+    assert content == "_a stays"


### PR DESCRIPTION
### Summary

The `Message` component renders a template and then substitutes each resolved
variable token with its concrete value. This substitution used
`re.sub(n, str(v), content)`, which treats the replacement string as a regex
template. When a variable's value contains a backslash escape sequence — for
example a Windows path like `C:\10\report`, or LaTeX such as `\begin` — `re.sub`
interprets `\10` / `\g<...>` as a group backreference and raises
`re.error: invalid group reference`, crashing message rendering. The token `n`
was also passed unescaped, so a sanitized token containing regex metacharacters
(e.g. `_a[0]`) failed to match and was silently left unsubstituted.

Both the token and the value are literals here (the token is a sanitized
identifier produced by `get_kwargs`, and the value is arbitrary user/LLM/document
content), so the substitution is now done with `str.replace`, which performs a
plain literal replacement and interprets neither side as a regex. The loop is
extracted into a small `_apply_kwargs` helper so the behavior can be unit-tested.

## What problem does this PR solve?

Fixes a crash (`re.error: invalid group reference`) and a silent
no-substitution bug in the agent `Message` component whenever a substituted
variable value contains backslash escape sequences or the sanitized token
contains regex metacharacters.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Testing done

- Added `test/unit_test/agent/component/test_message_kwargs_substitution.py`
  covering: values with backslash-digit escapes (previously crashed), tokens
  containing regex metacharacters (previously not substituted), multiple
  occurrences, and `None` values being skipped.
- Verified the previous `re.sub` implementation raised
  `re.error: invalid group reference 10` on the escape-sequence input and left
  the metacharacter token unsubstituted; the new `str.replace` implementation
  produces the correct literal output.
- `ruff check` and `ruff format --check` pass on the changed files; pre-commit
  hooks (end-of-file, trailing-whitespace, mixed-line-ending) pass.
