### PR TITLE
fix: render both initials for multi-word names in RAGFlowAvatar

### DIFF
--- a/web/src/components/ragflow-avatar.tsx
+++ b/web/src/components/ragflow-avatar.tsx
@@ -32,7 +32,7 @@ const getInitials = (name?: string) => {
   if (parts.length === 1) {
     return parts[0][0].toUpperCase();
   }
-  return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 };
 
 const getColorForName = (name: string): { from: string; to: string } => {


### PR DESCRIPTION
### Summary

`RAGFlowAvatar` renders a name-based fallback avatar (initials) when no image is
available. The `getInitials` helper was meant to produce a single initial for
one-word names and two initials (first + last word) for multi-word names, but a
copy-paste slip made both branches identical:

```ts
if (parts.length === 1) {
  return parts[0][0].toUpperCase();
}
return parts[0][0].toUpperCase(); // same as the single-word branch
```

As a result the `parts.length === 1` check is dead code and every name — including
multi-word names like "John Doe" — renders just the first letter ("J" instead of
"JD"). The surrounding SVG already sizes its `viewBox` on `initials.length - 1`,
so it was written to accommodate multi-character initials; the layout branch was
simply never reachable.

This PR makes the multi-word branch return the first and last word initials, which
is the intended (and standard) avatar behavior:

```ts
return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
```

One-word names are unchanged. `name` is already guarded as a non-empty string and
`trim().split(/\s+/)` yields non-empty word segments, so the new access is safe.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
