### PR TITLE
fix: substitute UserFillUp tips placeholders literally to avoid re.error

### DIFF
--- a/agent/component/fillup.py
+++ b/agent/component/fillup.py
@@ -14,7 +14,6 @@
 #  limitations under the License.
 #
 import json
-import re
 from functools import partial
 
 from agent.component.base import ComponentParamBase, ComponentBase
@@ -81,7 +80,7 @@ class UserFillUp(ComponentBase):
                     ans = v
                 if not ans:
                     ans = ""
-                content = re.sub(r"\{%s\}" % k, ans, content)
+                content = content.replace("{%s}" % k, ans)
 
             self.set_output("tips", content)
         layout_recognize = self._param.layout_recognize or None

--- a/test/testcases/test_web_api/test_canvas_app/test_fillup_unit.py
+++ b/test/testcases/test_web_api/test_canvas_app/test_fillup_unit.py
@@ -208,3 +208,26 @@ def test_user_fillup_reentry_keeps_optional_file_value(monkeypatch):
 
     assert component._param.inputs["text"]["value"] is None
     assert component._param.inputs["doc"]["value"] == ["file-id"]
+
+
+@pytest.mark.p2
+def test_user_fillup_tips_substitution_is_literal_for_regex_like_values(monkeypatch):
+    # A form value containing a regex backreference-like sequence (e.g. a Windows
+    # path such as "C:\\1files") must be inserted into the tips template verbatim.
+    # It must not raise "invalid group reference" nor be reinterpreted as a regex
+    # replacement group.
+    module = _load_fillup_module(monkeypatch)
+
+    component = module.UserFillUp.__new__(module.UserFillUp)
+    component._param = SimpleNamespace(
+        enable_tips=True,
+        tips="Path is {path}",
+        layout_recognize="",
+        inputs={},
+        outputs={},
+    )
+    component.get_input_elements_from_text = lambda _text: {"path": {"value": r"C:\1files"}}
+
+    component._invoke(inputs={})
+
+    assert component._param.outputs["tips"]["value"] == r"Path is C:\1files"


### PR DESCRIPTION
### Summary

`UserFillUp` renders its `tips` template by substituting each form field's value into placeholders like `{field}`. It did this with `re.sub(r"\{%s\}" % k, ans, content)`, where the user/upstream-supplied value `ans` is passed as the **replacement** string.

`re.sub` interprets backslash escapes and group references in the replacement, so any field value containing one breaks the render:

- `C:\1files` (a Windows path) → `re.error: invalid group reference 1`, crashing the canvas run.
- `price \2 each` → `re.error: invalid group reference 2`.
- `\g<0>` → silently reinterpreted as the matched placeholder instead of being inserted literally.

The field key `k` was also injected into the **pattern** unescaped, so a key containing a regex metacharacter would match incorrectly.

The substitution is a plain literal placeholder replacement, so this switches to `str.replace("{%s}" % k, ans)`, which inserts the value verbatim and drops the now-unused `import re`. This fixes both the crash and the `\g<...>` corruption, and removes the unescaped-key hazard.

Added a regression test (`test_user_fillup_tips_substitution_is_literal_for_regex_like_values`) that feeds a `C:\1files` value through the tips path and asserts it appears verbatim — it fails with `re.error: invalid group reference 1` before this change and passes after.

No behavior change for normal values; the placeholder syntax is unchanged.
