### PR TITLE
fix(web): ignore IME composition Enter in tag input

### DIFF
--- a/web/src/components/edit-tag/__tests__/index.test.tsx
+++ b/web/src/components/edit-tag/__tests__/index.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+// `ui/button` pulls in react-router, whose dev build touches `TextEncoder` at
+// import time (absent in jsdom). We only need a passthrough `Link` here.
+jest.mock('react-router', () => ({
+  Link: ({ children }: { children?: unknown }) => children,
+}));
+
+import EditTag from '..';
+
+describe('EditTag Enter handling', () => {
+  const setup = () => {
+    const onChange = jest.fn();
+    render(
+      React.createElement(EditTag, {
+        value: [],
+        onChange,
+        addButtonTestId: 'add-tag',
+        inputTestId: 'tag-input',
+      }),
+    );
+    fireEvent.click(screen.getByTestId('add-tag'));
+    const input = screen.getByTestId('tag-input');
+    fireEvent.change(input, { target: { value: 'foo' } });
+    return { onChange, input };
+  };
+
+  it('does not confirm the tag on the Enter that ends an IME composition', () => {
+    const { onChange, input } = setup();
+
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('confirms the tag on a plain Enter press', () => {
+    const { onChange, input } = setup();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith(['foo']);
+  });
+});

--- a/web/src/components/edit-tag/index.tsx
+++ b/web/src/components/edit-tag/index.tsx
@@ -103,7 +103,10 @@ const EditTag = React.forwardRef<HTMLDivElement, EditTagsProps>(
             disabled={disabled}
             data-testid={inputTestId}
             onKeyDown={(e) => {
-              if (e?.key === 'Enter') {
+              // Ignore the Enter that confirms an IME (e.g. Chinese/Japanese)
+              // composition, otherwise the half-composed text is committed as a
+              // tag and the input closes before the user finishes typing.
+              if (e?.key === 'Enter' && !e.nativeEvent.isComposing) {
                 handleInputConfirm();
               }
             }}


### PR DESCRIPTION
### Summary

`EditTag` (`web/src/components/edit-tag`) is the small "type a value and press Enter to add a tag" input reused across the app — knowledge-base tags/keywords, chunk keywords, entity types, agent tags, and metadata values. Its keydown handler commits the current input as a tag on **every** `Enter`:

```tsx
onKeyDown={(e) => {
  if (e?.key === 'Enter') {
    handleInputConfirm();
  }
}}
```

This breaks text entry for IME (Input Method Editor) users — Chinese, Japanese, Korean, etc. While composing a word, the user presses `Enter` to confirm/select a candidate from the IME popup. That confirming `Enter` fires the same `keydown`, so `handleInputConfirm()` runs immediately: the half-composed text is committed as a tag and the input closes before the user has finished typing.

The fix guards the handler with `e.nativeEvent.isComposing`, the standard way to tell a composition-confirming `Enter` apart from a real submit `Enter`. The tag is only added once composition has ended; a normal `Enter` still adds the tag exactly as before.

```tsx
if (e?.key === 'Enter' && !e.nativeEvent.isComposing) {
  handleInputConfirm();
}
```

A regression test (`__tests__/index.test.tsx`) covers both paths: an `Enter` fired during composition (`isComposing: true`) must not add a tag, and a plain `Enter` must add it.
