### PR TITLE
fix(web): prevent docx preview zoom from skipping a level

### DIFF
--- a/web/src/components/document-preview/hooks.ts
+++ b/web/src/components/document-preview/hooks.ts
@@ -159,7 +159,12 @@ export const useCatchDocumentError = (url: string) => {
       const { data } = await axios.get(url, { headers: httpHeaders });
       // Only treat as error if response is JSON with an error code
       // Binary data (like PDF) won't have a code property
-      if (data && typeof data === 'object' && 'code' in data && data.code !== 0) {
+      if (
+        data &&
+        typeof data === 'object' &&
+        'code' in data &&
+        data.code !== 0
+      ) {
         setError(data?.message || 'Failed to load document');
       }
     } catch (e) {
@@ -180,23 +185,30 @@ export const useCatchDocumentError = (url: string) => {
 const ZOOM_STEPS = [25, 50, 75, 100, 125, 150, 175, 200] as const;
 
 const clampZoom = (scale: number, direction: 1 | -1): number => {
-  let idx = ZOOM_STEPS.indexOf(scale as (typeof ZOOM_STEPS)[number]);
-  if (idx < 0) {
-    if (direction > 0) {
-      idx = ZOOM_STEPS.findIndex((v) => v > scale);
-    } else {
-      for (let i = ZOOM_STEPS.length - 1; i >= 0; i--) {
-        if (ZOOM_STEPS[i] < scale) {
-          idx = i;
-          break;
-        }
+  const exactIdx = ZOOM_STEPS.indexOf(scale as (typeof ZOOM_STEPS)[number]);
+  let idx: number;
+
+  if (exactIdx >= 0) {
+    // Already on a predefined step: move one step in the zoom direction.
+    idx = exactIdx + direction;
+  } else if (direction > 0) {
+    // Between steps and zooming in: snap up to the next higher step. This
+    // index is already the target, so it must not be advanced again.
+    const next = ZOOM_STEPS.findIndex((v) => v > scale);
+    idx = next < 0 ? ZOOM_STEPS.length - 1 : next;
+  } else {
+    // Between steps and zooming out: snap down to the next lower step.
+    let prev = 0;
+    for (let i = ZOOM_STEPS.length - 1; i >= 0; i--) {
+      if (ZOOM_STEPS[i] < scale) {
+        prev = i;
+        break;
       }
     }
+    idx = prev;
   }
-  idx = Math.max(
-    0,
-    Math.min(ZOOM_STEPS.length - 1, idx < 0 ? 0 : idx + direction),
-  );
+
+  idx = Math.max(0, Math.min(ZOOM_STEPS.length - 1, idx));
   return ZOOM_STEPS[idx] ?? scale;
 };
 


### PR DESCRIPTION
### Summary

Fixes a zoom bug in the DOCX preview: the first "zoom in" or "zoom out" click
skips a level whenever the current zoom is a fit-to-width value.

When a `.docx` document is opened in the preview, `useDocxPreviewZoom` initializes
the zoom to a fit-to-container scale:

```ts
const fitScale = Math.floor((availableWidth / pageWidthPx) * 100);
const clampedFitScale = Math.min(100, fitScale);
```

This value (e.g. `63`, `71`, `88`) is almost never one of the predefined
`ZOOM_STEPS` (`25/50/75/100/125/150/175/200`). In `clampZoom`, when the current
scale sat *between* two steps, the code first located the correct neighbouring
step and then **still added `direction` again**:

```ts
idx = Math.max(
  0,
  Math.min(ZOOM_STEPS.length - 1, idx < 0 ? 0 : idx + direction),
);
```

So the first click overshot by one level. Starting from a `63%` fit scale:

| Action    | Expected | Before (buggy) |
|-----------|----------|----------------|
| Zoom in   | `75%`    | `100%`         |
| Zoom out  | `50%`    | `25%`          |

### Fix

Only advance by `direction` when the scale is already exactly on a step. When
snapping from an off-step scale, the located index is already the target step
in the requested direction, so it must not be advanced a second time. Behaviour
for scales that are already on a step (and the min/max clamp) is unchanged.

### Scope

- Single file: `web/src/components/document-preview/hooks.ts`
- No API/behaviour change beyond the corrected step selection.
- `prettier --check`, `eslint`, and the whitespace pre-commit hooks pass on the
  changed file; `tsc --noEmit` reports no errors in it.
