### PR TITLE
fix(web): return real navigation state from history.location getter

### DIFF
--- a/web/src/utils/__tests__/simple-history-util.test.ts
+++ b/web/src/utils/__tests__/simple-history-util.test.ts
@@ -1,0 +1,34 @@
+import { history } from '../simple-history-util';
+
+describe('simple-history-util history.location', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('exposes the current path segments from window.location', () => {
+    window.history.replaceState(null, '', '/foo?bar=1#baz');
+
+    expect(history.location.pathname).toBe('/foo');
+    expect(history.location.search).toBe('?bar=1');
+    expect(history.location.hash).toBe('#baz');
+  });
+
+  it('reflects the real browser navigation state after replace()', () => {
+    const state = { token: 'abc' };
+    history.replace('/session', state);
+
+    expect(window.history.state).toEqual(state);
+    // Regression: the getter previously read the GlobalHistory instance's
+    // own (never-assigned) `state` field instead of window.history.state,
+    // so it always returned undefined.
+    expect(history.location.state).toEqual(state);
+  });
+
+  it('reflects the real browser navigation state after push()', () => {
+    const state = { from: '/prev' };
+    history.push('/next', state);
+
+    expect(history.location.state).toEqual(state);
+    expect(history.location.state).toEqual(window.history.state);
+  });
+});

--- a/web/src/utils/simple-history-util.ts
+++ b/web/src/utils/simple-history-util.ts
@@ -105,7 +105,7 @@ class GlobalHistory {
       pathname: window.location.pathname,
       search: window.location.search,
       hash: window.location.hash,
-      state: history.state,
+      state: window.history.state,
     };
   }
 


### PR DESCRIPTION
### Summary

`history.location` in `web/src/utils/simple-history-util.ts` never exposes the
real browser navigation state.

The `GlobalHistory` class re-implements a `history`-style navigation object. All
of its `location` getter fields correctly read from the browser globals
(`window.location.pathname/search/hash`), and the sibling `length` getter reads
`window.history.length`. The `state` field, however, reads a bare `history.state`:

```ts
get location() {
  return {
    pathname: window.location.pathname,
    search: window.location.search,
    hash: window.location.hash,
    state: history.state, // <-- bug
  };
}
```

Because the module exports `const history = new GlobalHistory()`, the identifier
`history` inside the class resolves to that instance, not to `window.history`.
The instance's `state` property is declared (`state: any;`) but never assigned by
`push`/`replace`/`handlePopState`, so `history.location.state` is **always
`undefined`** — even right after a `push`/`replace` that stored real state via
`window.history.pushState`/`replaceState`.

The fix reads `window.history.state`, matching the intent and the surrounding
getters:

```ts
state: window.history.state,
```

### Test

Adds `web/src/utils/__tests__/simple-history-util.test.ts` covering the
`location` getter: it verifies the path segments come from `window.location` and
that `history.location.state` reflects the real navigation state after
`push()`/`replace()`. The two state assertions fail against the previous
implementation (returned `undefined`) and pass after the fix.

### Verification

From `web/`:

- `npx prettier --check` on both files: clean
- `npx eslint` on both files: clean (exit 0)
- `npx jest src/utils/__tests__/simple-history-util.test.ts`: 3 passed
- `tsc --noEmit`: no errors introduced on the changed files
