### PR TITLE
fix: respect REST API page_size limit in useFetchAllKnowledgeList

### DIFF
--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -914,7 +914,7 @@ export const useFetchAllKnowledgeList = (
   const { list, loading, hasNextPage, fetchNextPage } = useFetchKnowledgeList(
     shouldFilterListWithoutDocument,
     keywords,
-    200,
+    100,
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

The REST API enforces a maximum `page_size` of 100 (`REST_API_MAX_PAGE_SIZE`). The `useFetchAllKnowledgeList` hook in `web/src/hooks/use-knowledge-request.ts` was requesting `page_size=200`, which caused a validation error:

```
Field: <page_size> - Message: <Value error, page_size must be less than or equal to 100> - Value: <200>
```

This hook is used by consumers that need the complete knowledge base list (e.g. `useSelectKnowledgeOptions`, `use-select-owners`, `retrieval-node`). When any of these components loaded, the request failed and the list could not be fetched.

The fix reduces the `page_size` from `200` to `100` to stay within the API limit. Since `useFetchAllKnowledgeList` already auto-loads all remaining pages via `useEffect` + `fetchNextPage`, reducing the page size does not affect completeness — it only increases the number of round-trips for datasets exceeding 100 items.