### PR TITLE
feat: add GET /datasets/owners aggregation endpoint

### DIFF
--- a/api/apps/restful_apis/dataset_api.py
+++ b/api/apps/restful_apis/dataset_api.py
@@ -381,6 +381,72 @@ def list_datasets(tenant_id):
         return get_error_data_result(message="Internal server error")
 
 
+@manager.route("/datasets/owners", methods=["GET"])  # noqa: F821
+@login_required
+@add_tenant_id_to_kwargs
+def list_dataset_owners(tenant_id):
+    """
+    List distinct dataset owners with their dataset counts.
+    ---
+    tags:
+      - Datasets
+    security:
+      - ApiKeyAuth: []
+    parameters:
+      - in: query
+        name: ext_keywords
+        type: string
+        required: false
+        description: Keyword filter (matched against dataset names).
+      - in: query
+        name: ext_parser_id
+        type: string
+        required: false
+        description: Parser ID filter.
+      - in: header
+        name: Authorization
+        type: string
+        required: true
+        description: Bearer token for authentication.
+    responses:
+      200:
+        description: Successful operation.
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              tenant_id:
+                type: string
+              nickname:
+                type: string
+              avatar:
+                type: string
+              count:
+                type: integer
+    """
+    args = {}
+    keywords = request.args.get("ext_keywords", "")
+    parser_id = request.args.get("ext_parser_id", "")
+    ext = {}
+    if keywords:
+        ext["keywords"] = keywords
+    if parser_id:
+        ext["parser_id"] = parser_id
+    if ext:
+        args["ext"] = ext
+
+    try:
+        success, result = dataset_api_service.list_dataset_owners(tenant_id, args)
+        if success:
+            return get_result(data=result.get("data"))
+        else:
+            return get_error_data_result(message=result)
+    except Exception as e:
+        logging.exception(e)
+        return get_error_data_result(message="Internal server error")
+
+
 @manager.route("/datasets/<dataset_id>", methods=["GET"])  # noqa: F821
 @login_required
 @add_tenant_id_to_kwargs

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -458,6 +458,27 @@ def list_datasets(tenant_id: str, args: dict):
     return True, {"data": response_data_list, "total": total}
 
 
+def list_dataset_owners(tenant_id: str, args: dict):
+    """List distinct dataset owners with their dataset counts.
+
+    :param tenant_id: tenant ID of the current user
+    :param args: optional query arguments (keywords, parser_id, owner_ids)
+    :return: (success, result)
+    """
+    ext_fields = args.get("ext", {}) if args else {}
+    keywords = ext_fields.get("keywords", "")
+    parser_id = ext_fields.get("parser_id")
+
+    if ext_fields.get("owner_ids", []):
+        tenant_ids = ext_fields["owner_ids"]
+    else:
+        tenants = TenantService.get_joined_tenants_by_user_id(tenant_id)
+        tenant_ids = [m["tenant_id"] for m in tenants]
+
+    owners = KnowledgebaseService.get_owners(tenant_ids, tenant_id, keywords, parser_id)
+    return True, {"data": owners}
+
+
 async def get_knowledge_graph(dataset_id: str, tenant_id: str):
     """
     Get knowledge graph for a dataset.

--- a/api/db/services/knowledgebase_service.py
+++ b/api/db/services/knowledgebase_service.py
@@ -22,7 +22,7 @@ from api.db.db_models import DB, Document, Knowledgebase, User, UserCanvas
 from api.db.services.common_service import CommonService
 from common.time_utils import current_timestamp, datetime_format
 from api.db.services import duplicate_name
-from api.db.services.user_service import TenantService
+from api.db.services.user_service import TenantService, UserService
 from common.misc_utils import get_uuid
 from common.constants import StatusEnum
 from api.constants import DATASET_NAME_LIMIT
@@ -500,6 +500,34 @@ class KnowledgebaseService(CommonService):
         kbs = kbs.paginate(page_number, items_per_page)
 
         return list(kbs.dicts()), total
+
+    @classmethod
+    @DB.connection_context()
+    def get_owners(cls, joined_tenant_ids, user_id, keywords=None, parser_id=None):
+        """Return a list of distinct owners with their dataset counts.
+
+        Each item: {tenant_id, nickname, avatar, count}
+        """
+        kbs = cls.model.select()
+        if keywords:
+            kbs = kbs.where(fn.LOWER(cls.model.name).contains(keywords.lower()))
+        if parser_id:
+            kbs = kbs.where(cls.model.parser_id == parser_id)
+        kbs = kbs.where(cls._visibility_and_status_filter(joined_tenant_ids, user_id))
+
+        rows = list(kbs.select(cls.model.tenant_id, fn.COUNT(cls.model.id).alias("count")).group_by(cls.model.tenant_id).dicts())
+
+        if not rows:
+            return []
+
+        users = UserService.get_by_ids([r["tenant_id"] for r in rows])
+        user_map = {u.id: u.to_dict() for u in users}
+
+        for r in rows:
+            user_dict = user_map.get(r["tenant_id"], {})
+            r["nickname"] = user_dict.get("nickname", "")
+            r["avatar"] = user_dict.get("avatar", "")
+        return rows
 
     @classmethod
     @DB.connection_context()

--- a/internal/dao/kb.go
+++ b/internal/dao/kb.go
@@ -226,6 +226,40 @@ func (dao *KnowledgebaseDAO) GetByTenantIDs(tenantIDs []string, userID string, p
 	return kbs, total, nil
 }
 
+// DatasetOwner is a distinct dataset owner with their dataset count.
+type DatasetOwner struct {
+	TenantID string `json:"tenant_id"`
+	Nickname string `json:"nickname"`
+	Avatar   string `json:"avatar"`
+	Count    int64  `json:"count"`
+}
+
+// GetOwnersByTenantIDs returns distinct dataset owners with dataset counts.
+// This matches the Python KnowledgebaseService.get_owners method.
+func (dao *KnowledgebaseDAO) GetOwnersByTenantIDs(tenantIDs []string, userID string, keywords, parserID string) ([]*DatasetOwner, error) {
+	var owners []*DatasetOwner
+
+	query := DB.Model(&entity.Knowledgebase{}).
+		Select(`knowledgebase.tenant_id, user.nickname, user.avatar, COUNT(knowledgebase.id) as count`).
+		Joins("LEFT JOIN user ON knowledgebase.tenant_id = user.id").
+		Where("((knowledgebase.tenant_id IN ? AND knowledgebase.permission = ?) OR knowledgebase.tenant_id = ?) AND knowledgebase.status = ?",
+			tenantIDs, string(entity.TenantPermissionTeam), userID, string(entity.StatusValid))
+
+	if keywords != "" {
+		query = query.Where("LOWER(knowledgebase.name) LIKE ?", "%"+strings.ToLower(keywords)+"%")
+	}
+
+	if parserID != "" {
+		query = query.Where("knowledgebase.parser_id = ?", parserID)
+	}
+
+	if err := query.Group("knowledgebase.tenant_id, user.nickname, user.avatar").Scan(&owners).Error; err != nil {
+		return nil, err
+	}
+
+	return owners, nil
+}
+
 // GetAllByTenantIDs retrieves all permitted knowledge bases by tenant IDs
 // This matches the Python get_all_kb_by_tenant_ids method
 func (dao *KnowledgebaseDAO) GetAllByTenantIDs(tenantIDs []string, userID string) ([]*entity.Knowledgebase, error) {

--- a/internal/handler/dataset.go
+++ b/internal/handler/dataset.go
@@ -140,6 +140,30 @@ func (h *DatasetsHandler) ListDatasets(c *gin.Context) {
 	})
 }
 
+// ListDatasetOwners handles GET /api/v1/datasets/owners.
+func (h *DatasetsHandler) ListDatasetOwners(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		common.ErrorWithCode(c, errorCode, errorMessage)
+		return
+	}
+
+	// Query params mirror the Python REST API route.
+	keywords := c.Query("ext_keywords")
+	parserID := c.Query("ext_parser_id")
+
+	owners, code, err := h.datasetsService.ListDatasetOwners(user.ID, nil, keywords, parserID)
+	if err != nil {
+		common.ErrorWithCode(c, code, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code": common.CodeSuccess,
+		"data": owners,
+	})
+}
+
 // CreateDataset handles POST /api/v1/datasets.
 func (h *DatasetsHandler) CreateDataset(c *gin.Context) {
 	user, errorCode, errorMessage := GetUser(c)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -354,6 +354,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 			datasets := v1.Group("/datasets")
 			{
 				datasets.GET("", r.datasetsHandler.ListDatasets)
+				datasets.GET("/owners", r.datasetsHandler.ListDatasetOwners)
 				datasets.GET("/tags/aggregation", r.datasetsHandler.AggregateTags)
 				datasets.GET("/:dataset_id", r.datasetsHandler.GetDataset)
 				datasets.PUT("/:dataset_id", r.datasetsHandler.UpdateDataset)

--- a/internal/service/dataset/crud.go
+++ b/internal/service/dataset/crud.go
@@ -393,6 +393,37 @@ func (d *DatasetService) ListDatasets(id, name string, page, pageSize int, order
 	return data, total, common.CodeSuccess, nil
 }
 
+// ListDatasetOwners returns distinct dataset owners with their dataset counts.
+// This matches the Python list_dataset_owners service function.
+func (d *DatasetService) ListDatasetOwners(userID string, ownerIDs []string, keywords, parserID string) ([]*dao.DatasetOwner, common.ErrorCode, error) {
+	tenantIDs := make([]string, 0, len(ownerIDs))
+	for _, ownerID := range ownerIDs {
+		ownerID = strings.TrimSpace(ownerID)
+		if ownerID != "" {
+			tenantIDs = append(tenantIDs, ownerID)
+		}
+	}
+	if len(tenantIDs) == 0 {
+		joinedTenants, err := d.tenantDAO.GetJoinedTenantsByUserID(userID)
+		if err != nil {
+			return nil, common.CodeServerError, errors.New("Database operation failed")
+		}
+		for _, joinedTenant := range joinedTenants {
+			if joinedTenant == nil || joinedTenant.TenantID == "" {
+				continue
+			}
+			tenantIDs = append(tenantIDs, joinedTenant.TenantID)
+		}
+	}
+
+	owners, err := d.kbDAO.GetOwnersByTenantIDs(tenantIDs, userID, strings.TrimSpace(keywords), strings.TrimSpace(parserID))
+	if err != nil {
+		return nil, common.CodeServerError, errors.New("Database operation failed")
+	}
+
+	return owners, common.CodeSuccess, nil
+}
+
 // ptrStringValue safely dereferences a *string.
 func ptrStringValue(s *string) string {
 	if s == nil {

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -34,6 +34,7 @@ import kbService, {
   listArtifactTopics,
   listArtifacts,
   listDataset,
+  listDatasetOwners,
   listTag,
   listWikiCommits,
   removeTag,
@@ -81,6 +82,7 @@ export const enum KnowledgeApiAction {
   FetchMetadata = 'fetchMetadata',
   FetchMetadataKeys = 'fetchMetadataKeys',
   FetchKnowledgeList = 'fetchKnowledgeList',
+  FetchDatasetOwners = 'fetchDatasetOwners',
   RemoveKnowledgeGraph = 'removeKnowledgeGraph',
   ClearWiki = 'clearWiki',
 }
@@ -924,6 +926,28 @@ export const useFetchAllKnowledgeList = (
   }, [hasNextPage, loading, fetchNextPage]);
 
   return { list, loading };
+};
+
+export const useFetchDatasetOwners = (keywords = '') => {
+  const debouncedKeywords = useDebounce(keywords, { wait: 500 });
+
+  const { data, isFetching: loading } = useQuery({
+    queryKey: [KnowledgeApiAction.FetchDatasetOwners, debouncedKeywords],
+    gcTime: 0,
+    queryFn: async () => {
+      const { data } = await listDatasetOwners(
+        debouncedKeywords ? { ext_keywords: debouncedKeywords } : undefined,
+      );
+      return (data?.data ?? []) as Array<{
+        tenant_id: string;
+        nickname: string;
+        avatar: string;
+        count: number;
+      }>;
+    },
+  });
+
+  return { owners: data ?? [], loading };
 };
 
 export const useSelectKnowledgeOptions = () => {

--- a/web/src/pages/datasets/index.tsx
+++ b/web/src/pages/datasets/index.tsx
@@ -41,7 +41,7 @@ export default function Datasets() {
     loading,
   } = useFetchNextKnowledgeListByPage();
 
-  const owners = useSelectOwners();
+  const owners = useSelectOwners(searchString);
 
   const {
     datasetRenameLoading,

--- a/web/src/pages/datasets/use-select-owners.ts
+++ b/web/src/pages/datasets/use-select-owners.ts
@@ -1,14 +1,21 @@
 import { FilterCollection } from '@/components/list-filter-bar/interface';
-import { useFetchAllKnowledgeList } from '@/hooks/use-knowledge-request';
-import { buildOwnersFilter } from '@/utils/list-filter-util';
+import { useFetchDatasetOwners } from '@/hooks/use-knowledge-request';
 import { useTranslation } from 'react-i18next';
 
-export function useSelectOwners() {
-  const { list } = useFetchAllKnowledgeList();
+export function useSelectOwners(keywords = '') {
+  const { owners } = useFetchDatasetOwners(keywords);
   const { t } = useTranslation();
 
   const filters: FilterCollection[] = [
-    buildOwnersFilter(list, undefined, t('common.owner')),
+    {
+      field: 'owner',
+      list: owners.map((item) => ({
+        id: item.tenant_id,
+        label: item.nickname,
+        count: item.count,
+      })),
+      label: t('common.owner'),
+    },
   ];
 
   return filters;

--- a/web/src/services/knowledge-service.ts
+++ b/web/src/services/knowledge-service.ts
@@ -267,6 +267,11 @@ export function deleteKnowledgeGraph(knowledgeId: string) {
 export const listDataset = (params?: IFetchKnowledgeListRequestParams) =>
   request.get(api.kbList, { params });
 
+export const listDatasetOwners = (params?: {
+  ext_keywords?: string;
+  ext_parser_id?: string;
+}) => request.get(api.datasetOwners, { params });
+
 export const updateKb = (datasetId: string, data: Record<string, any>) =>
   request.put(api.updateKb(datasetId), { data });
 

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -140,6 +140,7 @@ export default {
   checkEmbedding: (datasetId: string) =>
     `${restAPIv1}/datasets/${datasetId}/embedding/check`,
   kbList: `${restAPIv1}/datasets`,
+  datasetOwners: `${restAPIv1}/datasets/owners`,
   createKb: `${restAPIv1}/datasets`,
   updateKb: (datasetId: string) => `${restAPIv1}/datasets/${datasetId}`,
   rmKb: `${restAPIv1}/datasets`,


### PR DESCRIPTION
### Summary

When navigating to the datasets list page, the backend `GET /api/v1/datasets` endpoint was called **twice**:

1. `useFetchNextKnowledgeListByPage()` — fetches the current page for the card grid and pagination (correct).
2. `useSelectOwners()` → `useFetchAllKnowledgeList()` — fetched **all** datasets (auto-paginating through every page) solely to build the "Owner" filter dropdown.

This redundant full-list fetch was wasteful, especially for users with hundreds of datasets.

This PR adds a lightweight `GET /api/v1/datasets/owners` aggregation endpoint that returns distinct owners with their dataset counts directly from the database (`GROUP BY tenant_id`), eliminating the need to fetch full dataset records on the client side.

**Backend changes:**
- `KnowledgebaseService.get_owners()` — `GROUP BY tenant_id` aggregation query returning `tenant_id`, `nickname`, `avatar`, and dataset `count`
- `dataset_api_service.list_dataset_owners()` — service layer wrapper with keywords/parser_id filtering
- `GET /api/v1/datasets/owners` route

**Frontend changes:**
- `useFetchDatasetOwners()` hook with debounced keyword support
- `listDatasetOwners()` service function + `datasetOwners` API constant
- `useSelectOwners()` refactored to use the new endpoint instead of `useFetchAllKnowledgeList`
- `datasets/index.tsx` passes `searchString` to `useSelectOwners`

**After this change, visiting the datasets page makes:**
- `GET /datasets?page=1&page_size=50` — paginated list
- `GET /datasets/owners` — lightweight aggregation (no full dataset records)