### PR TITLE
refactor(doc_store): require get_scores and create_doc_meta_idx on the connection contract

### DIFF
--- a/common/doc_store/doc_store_base.py
+++ b/common/doc_store/doc_store_base.py
@@ -176,6 +176,14 @@ class DocStoreConnection(ABC):
         raise NotImplementedError("Not implemented")
 
     @abstractmethod
+    def create_doc_meta_idx(self, index_name: str):
+        """
+        Create the per-tenant document metadata index. Called by the
+        document metadata service on every metadata write path.
+        """
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
     def delete_idx(self, index_name: str, dataset_id: str):
         """
         Delete an index with given name
@@ -263,6 +271,15 @@ class DocStoreConnection(ABC):
 
     @abstractmethod
     def get_aggregation(self, res, field_name: str):
+        raise NotImplementedError("Not implemented")
+
+    @abstractmethod
+    def get_scores(self, res) -> dict[str, float]:
+        """
+        Map each hit id to its relevance score. Used to recover the
+        similarity of a KNN-only search without pulling chunk vectors
+        out of the index (see rag/nlp/search.py).
+        """
         raise NotImplementedError("Not implemented")
 
     """

--- a/common/doc_store/infinity_conn_base.py
+++ b/common/doc_store/infinity_conn_base.py
@@ -696,6 +696,19 @@ class InfinityConnectionBase(DocStoreConnection):
             df = res
         return list(df["id"])
 
+    def get_scores(self, res: tuple[pd.DataFrame, int] | pd.DataFrame) -> dict[str, float]:
+        # search() already folds pagerank into the `_score` column of the
+        # result frame, so map each id to it directly.
+        if isinstance(res, tuple):
+            df, count = res
+            if count == 0:
+                return {}
+        else:
+            df = res
+        if df.empty or "id" not in df.columns or "_score" not in df.columns:
+            return {}
+        return {str(rid): float(s) for rid, s in zip(df["id"], df["_score"])}
+
     @abstractmethod
     def get_fields(self, res: tuple[pd.DataFrame, int] | pd.DataFrame, fields: list[str]) -> dict[str, dict]:
         raise NotImplementedError("Not implemented")

--- a/common/doc_store/ob_conn_base.py
+++ b/common/doc_store/ob_conn_base.py
@@ -698,6 +698,17 @@ class OBConnectionBase(DocStoreConnection):
     def get_aggregation(self, res, field_name: str):
         raise NotImplementedError("Not implemented")
 
+    def get_scores(self, res) -> dict[str, float]:
+        # A scored search selects the similarity as `_score` on each row.
+        out = {}
+        for row in res.chunks:
+            doc_id = row.get("id")
+            if doc_id is None:
+                continue
+            score = row.get("_score")
+            out[doc_id] = float(score) if score is not None else 0.0
+        return out
+
     """
     SQL - can be overridden by subclasses
     """

--- a/test/unit_test/common/test_doc_store_contract.py
+++ b/test/unit_test/common/test_doc_store_contract.py
@@ -1,0 +1,66 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Contract tests for DocStoreConnection.
+
+The retriever calls ``get_scores`` (rag/nlp/search.py) and the document
+metadata service calls ``create_doc_meta_idx``
+(api/db/services/doc_metadata_service.py) on every backend, but neither was
+declared ``@abstractmethod``. A backend could omit one, pass a smoke test,
+and only fail at runtime with ``AttributeError`` -- exactly the shape of
+issue #14570 (``'OSConnection' object has no attribute 'create_doc_meta_idx'``).
+The Go DocEngine interface (internal/engine/engine.go) already requires both
+(GetScores, CreateMetadataStore) and compile-enforces them; these tests pin
+the same contract on the Python side so a missing method is caught at
+construction, not in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("numpy")  # doc_store_base imports numpy at module load
+
+from common.doc_store.doc_store_base import DocStoreConnection  # noqa: E402
+
+CONTRACT_METHODS = ("get_scores", "create_doc_meta_idx")
+
+
+def _stub_body():
+    """A concrete implementation of every abstract method on the ABC."""
+    body = {}
+    for name in DocStoreConnection.__abstractmethods__:
+        body[name] = lambda self, *a, **k: None
+    return body
+
+
+@pytest.mark.parametrize("method", CONTRACT_METHODS)
+def test_method_is_abstract(method):
+    assert method in DocStoreConnection.__abstractmethods__
+
+
+@pytest.mark.parametrize("missing", CONTRACT_METHODS)
+def test_backend_missing_a_contract_method_cannot_be_instantiated(missing):
+    body = _stub_body()
+    del body[missing]
+    partial = type("PartialBackend", (DocStoreConnection,), body)
+    with pytest.raises(TypeError, match=missing):
+        partial()
+
+
+def test_backend_implementing_the_full_contract_instantiates():
+    complete = type("CompleteBackend", (DocStoreConnection,), _stub_body())
+    assert complete().get_scores(None) is None


### PR DESCRIPTION
## What

Make `get_scores` and `create_doc_meta_idx` `@abstractmethod` on `DocStoreConnection`, and implement the two that were missing.

## Why

Both methods are called on the connection unconditionally by the runtime:

- `rag/nlp/search.py` calls `self.dataStore.get_scores(res)` to recover KNN similarities.
- `api/db/services/doc_metadata_service.py` calls `create_doc_meta_idx(index_name)` on every metadata write path (3 call sites).

Neither was on the ABC, so a backend could omit one, pass a smoke test, and fail only at runtime with `AttributeError`. That already happened once: issue #14570, `'OSConnection' object has no attribute 'create_doc_meta_idx'`, fixed reactively for a single backend.

The Go side already treats these as contract. `DocEngine` in `internal/engine/engine.go` requires `GetScores` and `CreateMetadataStore`, and every Go backend implements them, compile-enforced. This PR brings the Python contract to the same footing.

## The latent bug this surfaces

Promoting `get_scores` to abstract shows that the Python **Infinity** and **OceanBase** backends never implemented it, even though their Go twins do. The KNN-score recovery path raised `AttributeError` on those engines. This PR adds one implementation per base class:

- Infinity: map each id to the `_score` column that `search()` already writes on the result frame.
- OceanBase: map each result row's id to its `_score`.

Elasticsearch and OpenSearch already implement both methods and are unchanged. All six concrete backend variants (ES, OpenSearch, Infinity x2, OceanBase x2) satisfy the full abstract set.

## Test

`test/unit_test/common/test_doc_store_contract.py` pins the contract: both methods are abstract, a backend missing either cannot be constructed (`TypeError`), and a complete one can. Verified red before this change (the full-contract case fails with the exact `AttributeError: object has no attribute 'get_scores'`) and green after.
