### PR TITLE
fix: preserve non-string values in update_metadata_to

### DIFF
--- a/common/metadata_utils.py
+++ b/common/metadata_utils.py
@@ -299,6 +299,14 @@ def dedupe_list(values: list) -> list:
 
 
 def update_metadata_to(metadata, meta):
+    """Merge ``meta`` into ``metadata``.
+
+    String / list[str] values keep the previous multi-value merge + dedupe
+    behavior (used by LLM-extracted metadata). Scalars (bool / int / float /
+    None) and structured values (list[dict], dict, ...) are preserved so that
+    document system fields such as ``_isCurrent`` / ``_version`` and PDF
+    ``outline`` survive merges that later fully replace ``meta_fields``.
+    """
     if not meta:
         return metadata
     if isinstance(meta, str):
@@ -312,21 +320,33 @@ def update_metadata_to(metadata, meta):
 
     for k, v in meta.items():
         if isinstance(v, list):
-            v = [vv for vv in v if isinstance(vv, str)]
-            if not v:
+            if all(isinstance(vv, str) for vv in v):
+                if not v:
+                    continue
+                v = dedupe_list(v)
+            else:
+                # Structured list (e.g. outline [{title, depth}, ...]).
+                if k not in metadata:
+                    metadata[k] = v
                 continue
-            v = dedupe_list(v)
-        if not isinstance(v, list) and not isinstance(v, str):
+        elif isinstance(v, (str, bool, int, float)) or v is None:
+            pass
+        else:
+            # dict / other structured values: keep if absent.
+            if k not in metadata:
+                metadata[k] = v
             continue
+
         if k not in metadata:
             metadata[k] = v
             continue
-        if isinstance(metadata[k], list):
+        if isinstance(metadata[k], list) and isinstance(v, (list, str)):
             if isinstance(v, list):
                 metadata[k].extend(v)
             else:
                 metadata[k].append(v)
-            metadata[k] = dedupe_list(metadata[k])
+            if all(isinstance(x, str) for x in metadata[k]):
+                metadata[k] = dedupe_list(metadata[k])
         else:
             metadata[k] = v
 

--- a/common/metadata_utils.py
+++ b/common/metadata_utils.py
@@ -327,27 +327,71 @@ def update_metadata_to(metadata, meta):
             else:
                 # Structured list (e.g. outline [{title, depth}, ...]).
                 if k not in metadata:
+                    logging.debug(
+                        "update_metadata_to preserve structured list key=%s src=%s",
+                        k,
+                        type(v).__name__,
+                    )
                     metadata[k] = v
+                else:
+                    logging.debug(
+                        "update_metadata_to skip structured list key=%s src=%s dst=%s",
+                        k,
+                        type(v).__name__,
+                        type(metadata[k]).__name__,
+                    )
                 continue
         elif isinstance(v, (str, bool, int, float)) or v is None:
             pass
         else:
             # dict / other structured values: keep if absent.
             if k not in metadata:
+                logging.debug(
+                    "update_metadata_to preserve structured value key=%s src=%s",
+                    k,
+                    type(v).__name__,
+                )
                 metadata[k] = v
+            else:
+                logging.debug(
+                    "update_metadata_to skip structured value key=%s src=%s dst=%s",
+                    k,
+                    type(v).__name__,
+                    type(metadata[k]).__name__,
+                )
             continue
 
         if k not in metadata:
+            if not isinstance(v, (list, str)):
+                logging.debug(
+                    "update_metadata_to preserve scalar key=%s src=%s",
+                    k,
+                    type(v).__name__,
+                )
             metadata[k] = v
             continue
         if isinstance(metadata[k], list) and isinstance(v, (list, str)):
+            if not all(isinstance(x, str) for x in metadata[k]):
+                logging.debug(
+                    "update_metadata_to skip merge into structured list key=%s src=%s dst=%s",
+                    k,
+                    type(v).__name__,
+                    type(metadata[k]).__name__,
+                )
+                continue
             if isinstance(v, list):
                 metadata[k].extend(v)
             else:
                 metadata[k].append(v)
-            if all(isinstance(x, str) for x in metadata[k]):
-                metadata[k] = dedupe_list(metadata[k])
+            metadata[k] = dedupe_list(metadata[k])
         else:
+            if not isinstance(v, (list, str)):
+                logging.debug(
+                    "update_metadata_to replace scalar key=%s src=%s dst=%s",
+                    k,
+                    type(v).__name__,
+                    type(metadata[k]).__name__,
+                )
             metadata[k] = v
 
     return metadata

--- a/test/unit_test/common/test_update_metadata_to.py
+++ b/test/unit_test/common/test_update_metadata_to.py
@@ -1,0 +1,44 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+
+from common.metadata_utils import update_metadata_to
+
+
+def test_update_metadata_to_merges_string_lists():
+    base = {"tags": ["a"]}
+    update_metadata_to(base, {"tags": ["a", "b"]})
+    assert base["tags"] == ["a", "b"]
+
+
+def test_update_metadata_to_preserves_bool_int_when_merging_existing():
+    # Same call shape as outline persist: new fields first, existing doc meta second.
+    merged = update_metadata_to(
+        {"outline": [{"title": "Ch1", "depth": 0}]},
+        {
+            "_isCurrent": True,
+            "_version": 1,
+            "_processStatus": 4,
+            "category_code": "02",
+        },
+    )
+    assert merged["_isCurrent"] is True
+    assert merged["_version"] == 1
+    assert merged["_processStatus"] == 4
+    assert merged["category_code"] == "02"
+    assert merged["outline"] == [{"title": "Ch1", "depth": 0}]
+
+
+def test_update_metadata_to_keeps_first_outline_when_existing_also_has_outline():
+    merged = update_metadata_to(
+        {"outline": [{"title": "new", "depth": 0}]},
+        {"outline": [{"title": "old", "depth": 1}], "_version": 2},
+    )
+    assert merged["outline"] == [{"title": "new", "depth": 0}]
+    assert merged["_version"] == 2
+
+
+def test_update_metadata_to_skips_empty_string_list():
+    base = {"tags": ["a"]}
+    update_metadata_to(base, {"tags": [], "other": []})
+    assert base == {"tags": ["a"]}

--- a/test/unit_test/common/test_update_metadata_to.py
+++ b/test/unit_test/common/test_update_metadata_to.py
@@ -42,3 +42,37 @@ def test_update_metadata_to_skips_empty_string_list():
     base = {"tags": ["a"]}
     update_metadata_to(base, {"tags": [], "other": []})
     assert base == {"tags": ["a"]}
+
+
+def test_update_metadata_to_preserves_float_and_none():
+    merged = update_metadata_to({}, {"score": 1.5, "note": None})
+    assert merged["score"] == 1.5
+    assert merged["note"] is None
+
+
+def test_update_metadata_to_preserves_dict_when_absent():
+    merged = update_metadata_to({}, {"extra": {"a": 1}})
+    assert merged["extra"] == {"a": 1}
+
+
+def test_update_metadata_to_skips_dict_when_present():
+    base = {"extra": {"a": 1}}
+    update_metadata_to(base, {"extra": {"b": 2}})
+    assert base["extra"] == {"a": 1}
+
+
+def test_update_metadata_to_inserts_structured_list_when_absent():
+    merged = update_metadata_to({}, {"outline": [{"title": "Ch1", "depth": 0}]})
+    assert merged["outline"] == [{"title": "Ch1", "depth": 0}]
+
+
+def test_update_metadata_to_does_not_append_string_to_structured_list():
+    base = {"outline": [{"title": "Ch1", "depth": 0}]}
+    update_metadata_to(base, {"outline": "chapter"})
+    assert base["outline"] == [{"title": "Ch1", "depth": 0}]
+
+
+def test_update_metadata_to_does_not_extend_structured_list_with_strings():
+    base = {"outline": [{"title": "Ch1", "depth": 0}]}
+    update_metadata_to(base, {"outline": ["a", "b"]})
+    assert base["outline"] == [{"title": "Ch1", "depth": 0}]


### PR DESCRIPTION
## Summary
- Broaden `update_metadata_to` to keep `bool` / `int` / `float` / `None` and structured values (e.g. PDF `outline` list[dict]) while retaining string / list[str] merge+dedupe for LLM metadata.
- Fixes document system fields (`_isCurrent`, `_version`, `_processStatus`) being dropped when parse persists PDF outline via full `meta_fields` replace.

## Test plan
- [ ] Unit tests in `test/unit_test/common/test_update_metadata_to.py`
- [ ] Upload a PDF with existing `_version` / `_isCurrent` metadata, parse with MinerU/manual, confirm fields remain and `outline` is present
