### PR TITLE
docs: fix grammar and missing articles in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ main
 ### Actual behavior
 
 The restricted_loads function at [api/utils/__init__.py#L215](https://github.com/infiniflow/ragflow/blob/main/api/utils/__init__.py#L215) is still vulnerable leading via code execution.
-The main reason is that numpy module has a numpy.f2py.diagnose.run_command function directly execute commands, but the restricted_loads function allows users import functions in module numpy.
+The main reason is that the numpy module has a numpy.f2py.diagnose.run_command function to directly execute commands, but the restricted_loads function allows users to import functions in the numpy module.
 
 
 ### Steps to reproduce


### PR DESCRIPTION
## Description
This PR fixes grammar and missing articles in `SECURITY.md`.

## Details
Updated sentence phrasing (`numpy module has...` $\to$ `the numpy module has...` and `function directly execute` $\to$ `function to directly execute`).