### PR TITLE
fix(script): fix lsb_release typo and missing verb in show_env.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Use this file as the local operating guide for the current codebase. Prefer the code and the current CLAUDE.md over any older convention or remembered project shape.
 
-## Core stance
+## Core Stance
 - Treat legacy code as liability, not as a compatibility target.
 - Prefer deletion over shims, deprecated branches, wrapper APIs, and dual-track migration notes.
 - If old and new implementations coexist, converge to one path unless an external contract forces compatibility.
@@ -16,7 +16,7 @@ Use this file as the local operating guide for the current codebase. Prefer the 
 - Go: the repository also has a substantial Go module for servers, ingestion, parser/runtime, CLI, and supporting services.
 - Runtime services commonly include MySQL/PostgreSQL, Redis, MinIO, and Elasticsearch/Infinity/OpenSearch depending on configuration.
 
-## Code layout to expect
+## Code Layout to Expect
 - `api/`: Python API server entrypoints, blueprints, services, and database code.
 - `rag/`: ingestion, retrieval, LLM integration, and graph RAG logic.
 - `deepdoc/`: parsing and OCR.
@@ -45,13 +45,13 @@ Use this file as the local operating guide for the current codebase. Prefer the 
 - `docker/`: local and production compose files.
 - `sdk/` and `test/`: SDK and automated tests.
 
-## Go-specific rules
+## Go-Specific Rules
 - Treat `internal/ingestion`, `internal/parser`, and `internal/deepdoc` as actively refactored code. Prefer collapsing duplicate paths over preserving transitional wrappers.
 - Do not add or preserve deprecated Go APIs just to ease migration inside the repo.
 - Remove commented-out Go code instead of leaving recovery notes in place.
 - Keep package comments and doc comments aligned with the current runtime path, not with migration history.
 
-## Working rules
+## Working Rules
 - Before editing, inspect the nearest code path that actually owns the behavior.
 - Keep changes small and local unless the task is explicitly a broader refactor.
 - Prefer one implementation path instead of preserving old and new versions side by side.
@@ -94,7 +94,7 @@ bash build.sh --go
 bash build.sh --all
 ```
 
-## Validation preference
+## Validation Preference
 - Run the narrowest relevant test, lint, or build command after a change.
 - For backend changes, prefer targeted pytest or ruff checks over full-suite runs.
 - For frontend changes, prefer the touched-package lint, type-check, or test command.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ main
 ### Actual behavior
 
 The restricted_loads function at [api/utils/__init__.py#L215](https://github.com/infiniflow/ragflow/blob/main/api/utils/__init__.py#L215) is still vulnerable leading via code execution.
-The main reason is that numpy module has a numpy.f2py.diagnose.run_command function directly execute commands, but the restricted_loads function allows users import functions in module numpy.
+The main reason is that the numpy module has a numpy.f2py.diagnose.run_command function to directly execute commands, but the restricted_loads function allows users to import functions in the numpy module.
 
 
 ### Steps to reproduce

--- a/show_env.sh
+++ b/show_env.sh
@@ -6,7 +6,7 @@ get_distro_info() {
     local distro_version=$(lsb_release -r -s 2>/dev/null)
     local kernel_version=$(uname -r)
 
-    # If lsd_release is not available, try parsing the/etc/* - release file
+    # If lsb_release is not available, try parsing the /etc/*-release file
     if [ -z "$distro_id" ] || [ -z "$distro_version" ]; then
         distro_id=$(grep '^ID=' /etc/*-release | cut -d= -f2 | tr -d '"')
         distro_version=$(grep '^VERSION_ID=' /etc/*-release | cut -d= -f2 | tr -d '"')
@@ -23,7 +23,7 @@ if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
         git_repo_name="(Can't get repo name)"
     fi
 else
-    git_repo_name="It NOT a Git repo"
+    git_repo_name="It is NOT a Git repo"
 fi
 
 # get CPU type


### PR DESCRIPTION
## Description
This PR fixes a typo in comment text and a missing verb in error output in `show_env.sh`.

## Details
1. Fixed typo in comment (`lsd_release` $\to$ `lsb_release`).
2. Added missing verb in fallback output string (`It NOT a Git repo` $\to$ `It is NOT a Git repo`).