### PR TITLE
fix(bedrock): report the expected key schema instead of a JSONDecodeError (#17373)

### DIFF
--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -35,7 +35,7 @@ from common.misc_utils import thread_pool_exec
 from common.llm_request_context import current_llm_user
 from common.token_utils import num_tokens_from_string, total_token_count_from_response, usage_from_response
 from rag.llm import FACTORY_DEFAULT_BASE_URL, LITELLM_PROVIDER_PREFIX, SupportedLiteLLMProvider
-from rag.llm.key_utils import _normalize_replicate_key
+from rag.llm.key_utils import _normalize_replicate_key, _resolve_bedrock_credentials
 from rag.llm.tool_decorator import FunctionToolSession, is_tool
 from rag.nlp import is_chinese, is_english
 from rag.utils.url_utils import ensure_v1
@@ -2247,7 +2247,7 @@ class LiteLLMBase(ABC):
             completion_args.pop("api_key", None)
             completion_args.pop("api_base", None)
 
-            bedrock_key = json.loads(self.api_key)
+            bedrock_key = _resolve_bedrock_credentials(self.api_key)
             mode = bedrock_key.get("auth_mode")
             if not mode:
                 logging.error("Bedrock auth_mode is not provided in the key")

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -36,7 +36,7 @@ from common.misc_utils import thread_pool_exec
 from common.llm_request_context import current_llm_user
 from common.token_utils import num_tokens_from_string, total_token_count_from_response, usage_from_response
 from rag.llm import FACTORY_DEFAULT_BASE_URL, LITELLM_PROVIDER_PREFIX, SupportedLiteLLMProvider
-from rag.llm.key_utils import _normalize_replicate_key
+from rag.llm.key_utils import _normalize_replicate_key, _resolve_bedrock_credentials
 from rag.llm.mws_utils import mws_api_url, require_mws_token
 from rag.llm.tool_decorator import FunctionToolSession, is_tool
 from rag.nlp import is_chinese, is_english
@@ -2858,7 +2858,7 @@ class LiteLLMBase(ABC):
             completion_args.pop("api_key", None)
             completion_args.pop("api_base", None)
 
-            bedrock_key = json.loads(self.api_key)
+            bedrock_key = _resolve_bedrock_credentials(self.api_key)
             mode = bedrock_key.get("auth_mode")
             if not mode:
                 logging.error("Bedrock auth_mode is not provided in the key")

--- a/rag/llm/cv_model.py
+++ b/rag/llm/cv_model.py
@@ -32,6 +32,7 @@ from openai import OpenAI, AsyncOpenAI
 from openai.lib.azure import AzureOpenAI, AsyncAzureOpenAI
 
 from common.token_utils import num_tokens_from_string, total_token_count_from_response
+from rag.llm.key_utils import _resolve_bedrock_credentials
 from rag.nlp import is_english
 from rag.prompts.generator import vision_llm_describe_prompt
 from rag.utils.url_utils import ensure_v1
@@ -1442,7 +1443,7 @@ class BedrockCV(Base):
         Base.__init__(self, **kwargs)
 
     def _parse_credentials(self, key):
-        bedrock_key = json.loads(key)
+        bedrock_key = _resolve_bedrock_credentials(key)
         self.auth_mode = bedrock_key.get("auth_mode", "")
         self.aws_region = bedrock_key.get("bedrock_region", "us-east-1")
         self.aws_ak = bedrock_key.get("bedrock_ak", "")

--- a/rag/llm/cv_model.py
+++ b/rag/llm/cv_model.py
@@ -32,6 +32,7 @@ from openai.lib.azure import AzureOpenAI, AsyncAzureOpenAI
 
 from common.aimlapi_utils import attribution_headers
 from common.token_utils import num_tokens_from_string, total_token_count_from_response
+from rag.llm.key_utils import _resolve_bedrock_credentials
 from rag.nlp import is_english
 from rag.prompts.generator import vision_llm_describe_prompt
 from rag.utils.url_utils import ensure_v1
@@ -1374,7 +1375,7 @@ class BedrockCV(Base):
     def _parse_credentials(self, key):
         from botocore.utils import validate_region_name
 
-        bedrock_key = json.loads(key)
+        bedrock_key = _resolve_bedrock_credentials(key)
         self.auth_mode = bedrock_key.get("auth_mode", "")
         self.aws_region = bedrock_key.get("bedrock_region")
         if not self.aws_region:

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -31,7 +31,7 @@ from zai import ZhipuAiClient
 from common import settings
 from common.exceptions import ModelException
 from common.token_utils import num_tokens_from_string, truncate, total_token_count_from_response
-from rag.llm.key_utils import _normalize_replicate_key
+from rag.llm.key_utils import _normalize_replicate_key, _resolve_bedrock_credentials
 from rag.utils.url_utils import ensure_v1
 import logging
 import base64
@@ -670,7 +670,7 @@ class BedrockEmbed(Base):
         #   - "access_key_secret": requires `bedrock_ak` + `bedrock_sk`.
         #   - "iam_role": requires `aws_role_arn` and assumes role via STS.
         #   - else: treated as "assume_role" (default AWS credential chain).
-        key = json.loads(key)
+        key = _resolve_bedrock_credentials(key)
         mode = key.get("auth_mode")
         if not mode:
             logging.error("Bedrock auth_mode is not provided in the key")

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -33,7 +33,7 @@ from common.aimlapi_utils import attribution_headers
 from common.exceptions import ModelException
 from common.llm_request_context import openai_user_kwargs
 from common.token_utils import num_tokens_from_string, truncate, total_token_count_from_response
-from rag.llm.key_utils import _normalize_replicate_key
+from rag.llm.key_utils import _normalize_replicate_key, _resolve_bedrock_credentials
 from rag.llm.mws_utils import mws_api_url, require_mws_token
 from rag.utils.url_utils import append_api_path, ensure_v1
 import logging
@@ -694,7 +694,7 @@ class BedrockEmbed(Base):
         #   - "iam_role": requires `aws_role_arn` and assumes role via STS.
         #   - "assume_role": uses the default AWS credential chain.
         #   - "bedrock_api_key": uses a request-scoped Bearer token.
-        key = json.loads(key)
+        key = _resolve_bedrock_credentials(key)
         mode = key.get("auth_mode")
         if not mode:
             logging.error("Bedrock auth_mode is not provided in the key")

--- a/rag/llm/key_utils.py
+++ b/rag/llm/key_utils.py
@@ -31,4 +31,33 @@ def _normalize_replicate_key(key):
     return key
 
 
-__all__ = ["_normalize_replicate_key"]
+_BEDROCK_KEY_HINT = (
+    "Bedrock credentials must be a JSON object carrying at least 'auth_mode' and "
+    "'bedrock_region', for example "
+    '{"auth_mode": "access_key_secret", "bedrock_region": "us-east-1", '
+    '"bedrock_ak": "...", "bedrock_sk": "..."}. '
+    "See conf/models/bedrock.json for the full schema."
+)
+
+
+def _resolve_bedrock_credentials(key):
+    """Return the credential dict encoded in a Bedrock ``key``.
+
+    Every Bedrock connector reads its credentials from a JSON object. A bare
+    string in that field - a plain AWS access key, say - used to reach
+    ``json.loads`` unguarded and surface a ``JSONDecodeError`` raised from
+    inside the connector, which tells the operator nothing about what to fix.
+    """
+    if isinstance(key, dict):
+        payload = key
+    else:
+        try:
+            payload = json.loads(key)
+        except (TypeError, ValueError) as e:
+            raise ValueError(_BEDROCK_KEY_HINT) from e
+    if not isinstance(payload, dict):
+        raise ValueError(_BEDROCK_KEY_HINT)
+    return payload
+
+
+__all__ = ["_normalize_replicate_key", "_resolve_bedrock_credentials"]

--- a/rag/llm/key_utils.py
+++ b/rag/llm/key_utils.py
@@ -113,4 +113,33 @@ def _resolve_provider_credentials(key):
     return payload
 
 
-__all__ = ["_normalize_replicate_key", "_resolve_provider_credentials"]
+_BEDROCK_KEY_HINT = (
+    "Bedrock credentials must be a JSON object carrying at least 'auth_mode' and "
+    "'bedrock_region', for example "
+    '{"auth_mode": "access_key_secret", "bedrock_region": "us-east-1", '
+    '"bedrock_ak": "...", "bedrock_sk": "..."}. '
+    "See conf/models/bedrock.json for the full schema."
+)
+
+
+def _resolve_bedrock_credentials(key):
+    """Return the credential dict encoded in a Bedrock ``key``.
+
+    Every Bedrock connector reads its credentials from a JSON object. A bare
+    string in that field - a plain AWS access key, say - used to reach
+    ``json.loads`` unguarded and surface a ``JSONDecodeError`` raised from
+    inside the connector, which tells the operator nothing about what to fix.
+    """
+    if isinstance(key, dict):
+        payload = key
+    else:
+        try:
+            payload = json.loads(key)
+        except (TypeError, ValueError) as e:
+            raise ValueError(_BEDROCK_KEY_HINT) from e
+    if not isinstance(payload, dict):
+        raise ValueError(_BEDROCK_KEY_HINT)
+    return payload
+
+
+__all__ = ["_normalize_replicate_key", "_resolve_bedrock_credentials", "_resolve_provider_credentials"]

--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -27,6 +27,7 @@ from yarl import URL
 
 from common.log_utils import log_exception
 from common.token_utils import num_tokens_from_string, truncate, total_token_count_from_response
+from rag.llm.key_utils import _resolve_bedrock_credentials
 
 
 class Base(ABC):
@@ -315,7 +316,7 @@ class BedrockRerank(Base):
     def __init__(self, key, model_name, **kwargs):
         import boto3
 
-        key = json.loads(key)
+        key = _resolve_bedrock_credentials(key)
         mode = key.get("auth_mode")
         if not mode:
             logging.error("Bedrock auth_mode is not provided in the key")

--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -28,6 +28,7 @@ import requests
 
 from common.log_utils import log_exception
 from common.token_utils import num_tokens_from_string, truncate, total_token_count_from_response, usage_from_response
+from rag.llm.key_utils import _resolve_bedrock_credentials
 from rag.llm.mws_utils import mws_api_url, require_mws_token
 from rag.utils.url_utils import append_api_path, ensure_v1
 
@@ -490,7 +491,7 @@ class BedrockRerank(Base):
         import boto3
         from botocore.utils import validate_region_name
 
-        key = json.loads(key)
+        key = _resolve_bedrock_credentials(key)
         mode = key.get("auth_mode")
         if not mode:
             logging.error("Bedrock auth_mode is not provided in the key")

--- a/test/unit_test/rag/llm/test_bedrock_key_parsing.py
+++ b/test/unit_test/rag/llm/test_bedrock_key_parsing.py
@@ -1,0 +1,74 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Unit tests for Bedrock credential parsing.
+
+Bedrock credentials are stored as a JSON object. A bare string in that field
+used to reach ``json.loads`` unguarded, so an operator who pasted a plain AWS
+access key got a ``JSONDecodeError`` traceback out of the connector internals
+instead of being told what the field expects.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rag.llm.key_utils import _resolve_bedrock_credentials
+from rag.llm.rerank_model import BedrockRerank
+
+pytestmark = pytest.mark.p1
+
+CREDENTIALS = {
+    "auth_mode": "access_key_secret",
+    "bedrock_region": "us-east-1",
+    "bedrock_ak": "AKIA_TEST",
+    "bedrock_sk": "secret_test",
+}
+
+
+def test_json_object_is_parsed():
+    assert _resolve_bedrock_credentials(json.dumps(CREDENTIALS)) == CREDENTIALS
+
+
+def test_dict_is_passed_through():
+    assert _resolve_bedrock_credentials(CREDENTIALS) == CREDENTIALS
+
+
+@pytest.mark.parametrize("key", ["AKIAIOSFODNN7EXAMPLE", "", None, 42])
+def test_key_that_is_not_json_reports_the_expected_schema(key):
+    with pytest.raises(ValueError, match="auth_mode"):
+        _resolve_bedrock_credentials(key)
+
+
+@pytest.mark.parametrize("key", ["[]", '"AKIAIOSFODNN7EXAMPLE"', "42"])
+def test_json_that_is_not_an_object_is_rejected(key):
+    with pytest.raises(ValueError, match="auth_mode"):
+        _resolve_bedrock_credentials(key)
+
+
+def test_connector_reports_the_schema_instead_of_a_decode_error():
+    with patch("boto3.client") as client_factory:
+        client_factory.return_value = MagicMock()
+        with pytest.raises(ValueError, match="auth_mode"):
+            BedrockRerank("AKIAIOSFODNN7EXAMPLE", "amazon.rerank-v1:0")
+
+
+def test_valid_key_still_reaches_the_connector():
+    with patch("boto3.client") as client_factory:
+        client_factory.return_value = MagicMock()
+        BedrockRerank(json.dumps(CREDENTIALS), "amazon.rerank-v1:0")
+    assert client_factory.call_args.kwargs["aws_access_key_id"] == "AKIA_TEST"


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #17373.

Bedrock credentials are stored as a JSON object (see `conf/models/bedrock.json`), but every connector passed the field straight to `json.loads`:

| File | Class |
|---|---|
| `rag/llm/chat_model.py` | `LiteLLMBase._build_completion_args` (Bedrock branch) |
| `rag/llm/cv_model.py` | `BedrockCV._parse_credentials` |
| `rag/llm/embedding_model.py` | `BedrockEmbed.__init__` |
| `rag/llm/rerank_model.py` | `BedrockRerank.__init__` |

An operator who pastes a plain AWS access key (or any other non-JSON string) into that field gets a `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` raised from inside `rag/llm` internals. Nothing in that traceback names the field or the schema it expects, so the mistake is undiagnosable from the UI.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### What's changed

All four sites now resolve credentials through `_resolve_bedrock_credentials()` in `rag/llm/key_utils.py`, which reports what the field expects:

```
Bedrock credentials must be a JSON object carrying at least 'auth_mode' and
'bedrock_region', for example {"auth_mode": "access_key_secret", "bedrock_region":
"us-east-1", "bedrock_ak": "...", "bedrock_sk": "..."}. See conf/models/bedrock.json
for the full schema.
```

It raises `ValueError`, matching the `auth_mode` validation that already follows each of these call sites, so callers see no new exception type. A JSON value that parses but is not an object (`"[]"`, `"42"`) is rejected the same way instead of failing later on `.get()`.

Valid keys are unaffected: the helper returns the same dict `json.loads` did, and dicts are passed through unchanged.

New `test/unit_test/rag/llm/test_bedrock_key_parsing.py` covers the helper (valid JSON, dict passthrough, non-JSON input, JSON that is not an object) plus the `BedrockRerank` entry point, asserting a plain key surfaces the schema message and a valid key still wires the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
