### PR TITLE
fix(go-agent): retrieval empty results, KB selector paging, and begin custom inputs

### DIFF
--- a/cmd/ragflow_server.go
+++ b/cmd/ragflow_server.go
@@ -715,6 +715,9 @@ func startServer(ctx context.Context, config *server.Config) {
 	docEngine := engine.Get()
 	documentDAO := dao.NewDocumentDAO()
 	agenttool.SetRetrievalService(agenttool.NewNLPRetrievalAdapterFromDeps(docEngine, documentDAO))
+	// Wire the model provider so agent retrieval resolves each kb's
+	// embedding model (hybrid search) and the node's rerank model.
+	agenttool.SetRetrievalModelProvider(modelProviderService)
 	common.Info("agent: retrieval service adapter installed")
 
 	// Initialize handler layer

--- a/internal/agent/component/begin.go
+++ b/internal/agent/component/begin.go
@@ -115,6 +115,10 @@ func (b *BeginComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[str
 	mapsCopy(out, inputs)
 	if fallbackKey != "" {
 		out[fallbackKey] = fallbackValue
+		// Persist into the reserved "begin" namespace the same way
+		// request-supplied inputs are seeded, so {begin@<key>} refs
+		// resolve even when the DSL node id is e.g. begin_0.
+		state.SetVar("begin", fallbackKey, fallbackValue)
 	}
 	return out, nil
 }

--- a/internal/agent/component/begin.go
+++ b/internal/agent/component/begin.go
@@ -47,13 +47,15 @@ const componentNameBegin = "Begin"
 // ParamBase surface is intentionally omitted for P0 — Begin is trivial
 // and needs no validation beyond what the State writes perform.
 type BeginComponent struct {
-	name string
+	name   string
+	params map[string]any
 }
 
-// NewBeginComponent constructs a Begin component. It accepts the DSL params
-// map but does not retain it (Begin has no per-instance configuration).
-func NewBeginComponent(_ map[string]any) (Component, error) {
-	return &BeginComponent{name: componentNameBegin}, nil
+// NewBeginComponent constructs a Begin component. It retains the DSL
+// params so Invoke can apply the single-input sys.query fallback
+// (mirroring Python Begin._merge_runtime_inputs).
+func NewBeginComponent(params map[string]any) (Component, error) {
+	return &BeginComponent{name: componentNameBegin, params: params}, nil
 }
 
 // Name returns the registered component name. Used by the registry and
@@ -77,6 +79,20 @@ func (b *BeginComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[str
 	query, _ := inputs["query"].(string)
 	state.Sys["query"] = query
 
+	// Custom-input fallback (mirrors Python Begin._merge_runtime_inputs):
+	// when the request carried no runtime inputs (nothing seeded into
+	// Outputs["begin"] by the service layer) and the DSL declares
+	// exactly one input field, sys.query becomes that field's value so
+	// downstream {begin@<key>} references resolve.
+	var fallbackKey, fallbackValue string
+	if beginBucketEmpty(state) {
+		if fieldKey, ok := b.singleDeclaredInputKey(); ok {
+			if q, _ := state.Sys["query"].(string); q != "" {
+				fallbackKey, fallbackValue = fieldKey, q
+			}
+		}
+	}
+
 	// Optional user_id — present in interactive chat flows, absent in
 	// background jobs. Always a string when set; cast failure silently
 	// drops the value (mirrors Python's getattr fallback).
@@ -95,9 +111,35 @@ func (b *BeginComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[str
 	}
 
 	// Passthrough: a shallow copy keeps the caller's map un-aliased.
-	out := make(map[string]any, len(inputs))
+	out := make(map[string]any, len(inputs)+1)
 	mapsCopy(out, inputs)
+	if fallbackKey != "" {
+		out[fallbackKey] = fallbackValue
+	}
 	return out, nil
+}
+
+// beginBucketEmpty reports whether no begin outputs have been seeded
+// for this run (i.e. the request did not carry runtime inputs).
+func beginBucketEmpty(state *runtime.CanvasState) bool {
+	if state == nil || state.Outputs == nil {
+		return true
+	}
+	return len(state.Outputs["begin"]) == 0
+}
+
+// singleDeclaredInputKey returns the sole declared custom input key
+// from the DSL params ("inputs" map), or false when the node declares
+// zero or multiple fields.
+func (b *BeginComponent) singleDeclaredInputKey() (string, bool) {
+	declared, ok := b.params["inputs"].(map[string]any)
+	if !ok || len(declared) != 1 {
+		return "", false
+	}
+	for key := range declared {
+		return key, true
+	}
+	return "", false
 }
 
 // Stream is a synchronous facade over Invoke for P0. SSE streaming of

--- a/internal/agent/component/begin_test.go
+++ b/internal/agent/component/begin_test.go
@@ -184,6 +184,11 @@ func TestBegin_SingleInputFallsBackToSysQuery(t *testing.T) {
 	if got := out["color"]; got != "红色" {
 		t.Errorf("outputs[color] = %v, want 红色 (sys.query fallback)", got)
 	}
+	// The fallback must also land in the reserved "begin" namespace so
+	// {begin@color} references resolve even with node ids like begin_0.
+	if got, _ := state.GetVar("begin@color"); got != "红色" {
+		t.Errorf("begin@color = %v, want 红色 (sys.query fallback)", got)
+	}
 }
 
 // TestBegin_SeededInputsWinOverFallback: when the service layer

--- a/internal/agent/component/begin_test.go
+++ b/internal/agent/component/begin_test.go
@@ -160,3 +160,56 @@ func TestBegin_EmptyWebhookPayload(t *testing.T) {
 		t.Errorf("state.Sys[webhook_payload] should not be set for empty payload; got %v", state.Sys["webhook_payload"])
 	}
 }
+
+// TestBegin_SingleInputFallsBackToSysQuery pins the Python parity fix
+// (Begin._merge_runtime_inputs): when no runtime inputs were seeded
+// and the DSL declares exactly one custom input field, sys.query
+// becomes that field's output so {begin@<key>} references resolve.
+func TestBegin_SingleInputFallsBackToSysQuery(t *testing.T) {
+	c, err := NewBeginComponent(map[string]any{
+		"inputs": map[string]any{
+			"color": map[string]any{"name": "我最喜欢的颜色", "type": "line"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBeginComponent: %v", err)
+	}
+	state := canvas.NewCanvasState("run-1", "task-1")
+	ctx := canvas.WithState(context.Background(), state)
+
+	out, err := c.Invoke(ctx, nil, map[string]any{"query": "红色"})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := out["color"]; got != "红色" {
+		t.Errorf("outputs[color] = %v, want 红色 (sys.query fallback)", got)
+	}
+}
+
+// TestBegin_SeededInputsWinOverFallback: when the service layer
+// already seeded Outputs["begin"] (runtime inputs), the sys.query
+// fallback must not overwrite them.
+func TestBegin_SeededInputsWinOverFallback(t *testing.T) {
+	c, err := NewBeginComponent(map[string]any{
+		"inputs": map[string]any{
+			"color": map[string]any{"name": "我最喜欢的颜色", "type": "line"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBeginComponent: %v", err)
+	}
+	state := canvas.NewCanvasState("run-1", "task-1")
+	state.SetVar("begin", "color", "蓝色")
+	ctx := canvas.WithState(context.Background(), state)
+
+	out, err := c.Invoke(ctx, nil, map[string]any{"query": "红色"})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if _, exists := out["color"]; exists {
+		t.Errorf("fallback should not fire when begin outputs are seeded; got color=%v", out["color"])
+	}
+	if got, _ := state.GetVar("begin@color"); got != "蓝色" {
+		t.Errorf("begin@color = %v, want seeded 蓝色", got)
+	}
+}

--- a/internal/agent/component/retrieval_swap_test.go
+++ b/internal/agent/component/retrieval_swap_test.go
@@ -96,6 +96,35 @@ func TestSearchMyDataset_AliasDelegatesToRealWrapper(t *testing.T) {
 	}
 }
 
+// TestRetrieval_EmptyResultFillsEmptyResponse pins the Python
+// parity fix: when the search returns no chunks, the component must
+// still surface `formalized_content` carrying the configured
+// empty_response — previously the output map was empty (only the
+// canvas-injected _created_time/_elapsed_time showed in the log),
+// and the downstream Agent concluded the knowledge base had no
+// relevant content without any visible reason.
+func TestRetrieval_EmptyResultFillsEmptyResponse(t *testing.T) {
+	prev := agenttool.GetRetrievalService()
+	agenttool.SetSimpleRetrievalService()
+	t.Cleanup(func() { agenttool.SetRetrievalService(prev) })
+
+	c, err := New(componentNameRetrieval, map[string]any{
+		"kb_ids":         []any{"kb-1"},
+		"empty_response": "no hits found",
+	})
+	if err != nil {
+		t.Fatalf("New(Retrieval): %v", err)
+	}
+	// Empty query → the service returns no chunks.
+	out, err := c.Invoke(context.Background(), nil, map[string]any{"query": ""})
+	if err != nil {
+		t.Fatalf("Retrieval Invoke errored: %v", err)
+	}
+	if fc, _ := out["formalized_content"].(string); fc != "no hits found" {
+		t.Errorf("formalized_content = %q, want empty_response %q", fc, "no hits found")
+	}
+}
+
 // TestRetrieval_InputsSurfaceMatchesStub guards against accidental
 // regression in the Inputs() description surface when swapping from
 // the stub to the wrapper. The v1 DSL fixture set uses these keys

--- a/internal/agent/component/retrieval_swap_test.go
+++ b/internal/agent/component/retrieval_swap_test.go
@@ -125,6 +125,34 @@ func TestRetrieval_EmptyResultFillsEmptyResponse(t *testing.T) {
 	}
 }
 
+// TestIsEmptyRetrievalEnvelope pins the gating for the empty_response
+// fallback: only a confirmed zero-result envelope (parsed object with
+// an empty chunks array) qualifies. Raw non-JSON output, error stubs,
+// envelopes with chunks but no rendered text, and bare {} objects
+// must not be labeled as empty results.
+func TestIsEmptyRetrievalEnvelope(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		decoded map[string]any
+		want    bool
+	}{
+		{"nil envelope", nil, false},
+		{"raw non-JSON output", map[string]any{"_raw": "not json at all"}, false},
+		{"bare empty object", map[string]any{}, false},
+		{"error stub with null chunks", map[string]any{"stub": true, "_ERROR": "boom", "chunks": nil}, false},
+		{"confirmed empty result", map[string]any{"chunks": []any{}}, true},
+		{"chunks without rendered text", map[string]any{"chunks": []any{map[string]any{"id": "ck-1"}}}, false},
+		{"empty result with blank formalized_content", map[string]any{"chunks": []any{}, "formalized_content": ""}, true},
+	}
+	for _, tc := range cases {
+		if got := isEmptyRetrievalEnvelope(tc.decoded); got != tc.want {
+			t.Errorf("%s: isEmptyRetrievalEnvelope = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 // TestRetrieval_InputsSurfaceMatchesStub guards against accidental
 // regression in the Inputs() description surface when swapping from
 // the stub to the wrapper. The v1 DSL fixture set uses these keys

--- a/internal/agent/component/universe_a_wrappers.go
+++ b/internal/agent/component/universe_a_wrappers.go
@@ -183,11 +183,32 @@ func (c *retrievalComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map
 	// Match Python's Retrieval component: when the search yields no
 	// chunks, the node still surfaces `formalized_content` carrying
 	// the configured empty_response so downstream prompts see the
-	// fallback text instead of an empty output map.
-	if fc, _ := decoded["formalized_content"].(string); strings.TrimSpace(fc) == "" && c.params.EmptyResponse != "" {
-		decoded["formalized_content"] = c.params.EmptyResponse
+	// fallback text instead of an empty output map. The fallback only
+	// applies to a confirmed empty-result envelope — raw non-JSON
+	// output, error stubs, envelopes with chunks but no rendered
+	// text, and unrelated empty objects ({}) are left untouched.
+	if c.params.EmptyResponse != "" && isEmptyRetrievalEnvelope(decoded) {
+		if fc, _ := decoded["formalized_content"].(string); strings.TrimSpace(fc) == "" {
+			decoded["formalized_content"] = c.params.EmptyResponse
+		}
 	}
 	return decoded, nil
+}
+
+// isEmptyRetrievalEnvelope reports whether decoded is a confirmed
+// zero-result retrieval envelope: a parsed JSON object (no "_raw"
+// fallback wrapper) whose "chunks" field is present as an empty
+// array. A missing/null "chunks" field (error stubs, {}), non-empty
+// chunks, or non-object envelopes do not qualify.
+func isEmptyRetrievalEnvelope(decoded map[string]any) bool {
+	if decoded == nil {
+		return false
+	}
+	if _, raw := decoded["_raw"]; raw {
+		return false
+	}
+	chunks, ok := decoded["chunks"].([]any)
+	return ok && len(chunks) == 0
 }
 
 func (c *retrievalComponent) Stream(_ context.Context, _ *gorm.DB, _ map[string]any) (<-chan map[string]any, error) {

--- a/internal/agent/component/universe_a_wrappers.go
+++ b/internal/agent/component/universe_a_wrappers.go
@@ -179,7 +179,15 @@ func (c *retrievalComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map
 	common.Debug("agent retrieval component: output",
 		zap.String("tool_output", out),
 	)
-	return parseToolEnvelope(out), nil
+	decoded := parseToolEnvelope(out)
+	// Match Python's Retrieval component: when the search yields no
+	// chunks, the node still surfaces `formalized_content` carrying
+	// the configured empty_response so downstream prompts see the
+	// fallback text instead of an empty output map.
+	if fc, _ := decoded["formalized_content"].(string); strings.TrimSpace(fc) == "" && c.params.EmptyResponse != "" {
+		decoded["formalized_content"] = c.params.EmptyResponse
+	}
+	return decoded, nil
 }
 
 func (c *retrievalComponent) Stream(_ context.Context, _ *gorm.DB, _ map[string]any) (<-chan map[string]any, error) {

--- a/internal/agent/tool/retrieval.go
+++ b/internal/agent/tool/retrieval.go
@@ -64,6 +64,7 @@ type retrievalArgs struct {
 	KeywordsSimilarityWeight *float64 `json:"keywords_similarity_weight,omitempty"`
 	UseKG                    bool     `json:"use_kg,omitempty"`
 	SimilarityThreshold      float64  `json:"similarity_threshold,omitempty"`
+	RerankID                 string   `json:"rerank_id,omitempty"`
 }
 
 // retrievalResult is the JSON shape returned to the model. The `_ERROR`
@@ -170,6 +171,7 @@ func (r *RetrievalTool) InvokableRun(ctx context.Context, argumentsInJSON string
 		KeywordsSimilarityWeight: args.KeywordsSimilarityWeight,
 		UseKG:                    args.UseKG,
 		SimilarityThreshold:      args.SimilarityThreshold,
+		RerankID:                 args.RerankID,
 		TenantID:                 retrievalTenantID(ctx),
 	})
 	if err != nil {
@@ -229,6 +231,9 @@ func (r *RetrievalTool) mergeDefaults(args retrievalArgs) retrievalArgs {
 	}
 	if args.SimilarityThreshold <= 0 {
 		args.SimilarityThreshold = r.defaults.SimilarityThreshold
+	}
+	if args.RerankID == "" {
+		args.RerankID = r.defaults.RerankID
 	}
 	args.UseKG = args.UseKG || r.defaults.UseKG
 	return args

--- a/internal/agent/tool/retrieval.go
+++ b/internal/agent/tool/retrieval.go
@@ -71,10 +71,14 @@ type retrievalArgs struct {
 // field matches the Python tool's output convention; downstream components
 // can pattern-match on it.
 type retrievalResult struct {
-	FormalizedContent string         `json:"formalized_content,omitempty"`
-	Chunks            []chunkPayload `json:"chunks,omitempty"`
-	Stub              bool           `json:"stub,omitempty"`
-	Error             string         `json:"_ERROR,omitempty"`
+	FormalizedContent string `json:"formalized_content,omitempty"`
+	// Chunks deliberately has no omitempty: a successful search always
+	// carries the field (empty array for zero hits) so downstream
+	// consumers can distinguish a confirmed empty-result envelope
+	// ({"chunks": []}) from unrelated shapes such as {} or raw output.
+	Chunks []chunkPayload `json:"chunks"`
+	Stub   bool           `json:"stub,omitempty"`
+	Error  string         `json:"_ERROR,omitempty"`
 }
 
 // chunkPayload is the minimal chunk shape we surface. We don't try to

--- a/internal/agent/tool/retrieval_nlp.go
+++ b/internal/agent/tool/retrieval_nlp.go
@@ -137,11 +137,14 @@ func (a *NLPRetrievalAdapter) Search(ctx context.Context, db *gorm.DB, req Retri
 		topN = 8
 	}
 
-	tenantIDs, err := a.resolveTenantIDs(ctx, db, req)
+	tenantIDs, kbs, err := a.resolveTenantIDs(ctx, db, req)
 	if err != nil {
 		return nil, err
 	}
 	nlpReq := nlpRequestFromRetrieval(req, tenantIDs, topN)
+	if err := attachRetrievalModels(ctx, req, kbs, nlpReq); err != nil {
+		return nil, err
+	}
 
 	res, err := a.svc.Retrieval(ctx, nlpReq)
 	if err != nil {
@@ -183,7 +186,7 @@ func nlpRequestFromRetrieval(req RetrievalRequest, tenantIDs []string, topN int)
 	return nlpReq
 }
 
-func (a *NLPRetrievalAdapter) resolveTenantIDs(ctx context.Context, db *gorm.DB, req RetrievalRequest) ([]string, error) {
+func (a *NLPRetrievalAdapter) resolveTenantIDs(ctx context.Context, db *gorm.DB, req RetrievalRequest) ([]string, []*entity.Knowledgebase, error) {
 	seen := map[string]struct{}{}
 	tenantIDs := make([]string, 0, 1)
 	appendTenantID := func(tenantID string) {
@@ -201,12 +204,12 @@ func (a *NLPRetrievalAdapter) resolveTenantIDs(ctx context.Context, db *gorm.DB,
 	appendTenantID(req.TenantID)
 	datasetIDs := compactStrings(req.DatasetIDs)
 	if len(datasetIDs) == 0 || a == nil || a.kbDAO == nil {
-		return tenantIDs, nil
+		return tenantIDs, nil, nil
 	}
 
 	kbs, err := a.kbDAO.GetByIDs(ctx, db, datasetIDs)
 	if err != nil {
-		return nil, fmt.Errorf("retrieval: resolve dataset tenants: %w", err)
+		return nil, nil, fmt.Errorf("retrieval: resolve dataset tenants: %w", err)
 	}
 	for _, kb := range kbs {
 		if kb == nil {
@@ -215,9 +218,74 @@ func (a *NLPRetrievalAdapter) resolveTenantIDs(ctx context.Context, db *gorm.DB,
 		appendTenantID(kb.TenantID)
 	}
 	if len(tenantIDs) == 0 {
-		return nil, fmt.Errorf("retrieval: no valid knowledge bases found for dataset_ids %v", datasetIDs)
+		return nil, nil, fmt.Errorf("retrieval: no valid knowledge bases found for dataset_ids %v", datasetIDs)
 	}
-	return tenantIDs, nil
+	return tenantIDs, kbs, nil
+}
+
+// attachRetrievalModels resolves the knowledge base's embedding
+// model (and the optional rerank model) and mounts them on the nlp
+// request so the search runs hybrid (fulltext + vector + fusion)
+// instead of the keyword-only fallback. This mirrors Python's
+// agent/tools/retrieval.py, which resolves the kb's embd_id via
+// resolve_model_config before calling settings.retriever.retrieval —
+// without it the Go canvas retrieval returned empty results because
+// the keyword-only scores rarely pass the similarity threshold.
+//
+// When no RetrievalModelProvider is wired (unit tests, dev stubs),
+// the request is left untouched and retrieval stays keyword-only.
+func attachRetrievalModels(ctx context.Context, req RetrievalRequest, kbs []*entity.Knowledgebase, nlpReq *nlp.RetrievalRequest) error {
+	provider := GetRetrievalModelProvider()
+	if provider == nil {
+		return nil
+	}
+
+	// All kbs must share one embedding model — mixing models makes
+	// the query vector incomparable across indexes (same contract as
+	// Python's `assert len(embd_nms) == 1`).
+	embdID := ""
+	for _, kb := range kbs {
+		if kb == nil || strings.TrimSpace(kb.EmbdID) == "" {
+			continue
+		}
+		if embdID == "" {
+			embdID = kb.EmbdID
+			continue
+		}
+		if kb.EmbdID != embdID {
+			return fmt.Errorf("retrieval: knowledge bases use different embedding models (%q vs %q)", embdID, kb.EmbdID)
+		}
+	}
+
+	// The embedding model is resolved against the calling tenant
+	// (the canvas owner), matching Python's
+	// `resolve_model_config(canvas.tenant_id, EMBEDDING, embd_id)`.
+	// Fall back to the kb's tenant when the request carries none.
+	tenantID := strings.TrimSpace(req.TenantID)
+	if tenantID == "" {
+		for _, kb := range kbs {
+			if kb != nil && strings.TrimSpace(kb.TenantID) != "" {
+				tenantID = kb.TenantID
+				break
+			}
+		}
+	}
+
+	if embdID != "" && tenantID != "" {
+		emb, err := provider.GetEmbeddingModel(ctx, tenantID, embdID)
+		if err != nil {
+			return fmt.Errorf("retrieval: resolve embedding model %q: %w", embdID, err)
+		}
+		nlpReq.EmbeddingModel = emb
+	}
+	if req.RerankID != "" && tenantID != "" {
+		rerank, err := provider.GetRerankModel(tenantID, req.RerankID)
+		if err != nil {
+			return fmt.Errorf("retrieval: resolve rerank model %q: %w", req.RerankID, err)
+		}
+		nlpReq.RerankModel = rerank
+	}
+	return nil
 }
 
 // translateChunk converts one nlp chunk map into a RetrievalChunk.

--- a/internal/agent/tool/retrieval_nlp_test.go
+++ b/internal/agent/tool/retrieval_nlp_test.go
@@ -32,6 +32,8 @@ import (
 	"testing"
 
 	"ragflow/internal/entity"
+	modelModule "ragflow/internal/entity/models"
+	"ragflow/internal/service/nlp"
 
 	"gorm.io/gorm"
 )
@@ -283,7 +285,7 @@ func TestNLPRequestFromRetrieval_FallsBackToTopNHeadroom(t *testing.T) {
 
 func TestNLPRetrievalAdapter_ResolveTenantIDsStaysWithinRequestTenant(t *testing.T) {
 	a := &NLPRetrievalAdapter{}
-	got, err := a.resolveTenantIDs(nil, nil, RetrievalRequest{
+	got, _, err := a.resolveTenantIDs(nil, nil, RetrievalRequest{
 		TenantID:   "tenant-a",
 		DatasetIDs: []string{"kb-1", "kb-2", "kb-missing"},
 	})
@@ -309,7 +311,7 @@ func TestNLPRetrievalAdapter_ResolveTenantIDsFromDatasetIDs(t *testing.T) {
 			},
 		},
 	}
-	got, err := a.resolveTenantIDs(nil, nil, RetrievalRequest{
+	got, kbs, err := a.resolveTenantIDs(nil, nil, RetrievalRequest{
 		DatasetIDs: []string{"kb-1", "kb-2", "kb-3", " "},
 	})
 	if err != nil {
@@ -317,6 +319,9 @@ func TestNLPRetrievalAdapter_ResolveTenantIDsFromDatasetIDs(t *testing.T) {
 	}
 	if len(got) != 2 || got[0] != "tenant-a" || got[1] != "tenant-b" {
 		t.Fatalf("tenantIDs=%v want [tenant-a tenant-b]", got)
+	}
+	if len(kbs) != 3 {
+		t.Fatalf("kbs len=%d want 3", len(kbs))
 	}
 }
 
@@ -328,7 +333,7 @@ func TestNLPRetrievalAdapter_ResolveTenantIDsKeepsRequestTenantFirst(t *testing.
 			},
 		},
 	}
-	got, err := a.resolveTenantIDs(nil, nil, RetrievalRequest{
+	got, _, err := a.resolveTenantIDs(nil, nil, RetrievalRequest{
 		TenantID:   "tenant-a",
 		DatasetIDs: []string{"kb-1"},
 	})
@@ -337,6 +342,127 @@ func TestNLPRetrievalAdapter_ResolveTenantIDsKeepsRequestTenantFirst(t *testing.
 	}
 	if len(got) != 2 || got[0] != "tenant-a" || got[1] != "tenant-b" {
 		t.Fatalf("tenantIDs=%v want [tenant-a tenant-b]", got)
+	}
+}
+
+// fakeRetrievalModelProvider records the refs it was asked to
+// resolve and returns placeholder models.
+type fakeRetrievalModelProvider struct {
+	embTenant    string
+	embRef       string
+	rerankTenant string
+	rerankRef    string
+	err          error
+}
+
+func (f *fakeRetrievalModelProvider) GetEmbeddingModel(_ context.Context, tenantID, modelRef string) (*modelModule.EmbeddingModel, error) {
+	f.embTenant, f.embRef = tenantID, modelRef
+	if f.err != nil {
+		return nil, f.err
+	}
+	modelName := modelRef
+	return modelModule.NewEmbeddingModel(nil, &modelName, nil, 0), nil
+}
+
+func (f *fakeRetrievalModelProvider) GetRerankModel(tenantID, modelRef string) (*modelModule.RerankModel, error) {
+	f.rerankTenant, f.rerankRef = tenantID, modelRef
+	if f.err != nil {
+		return nil, f.err
+	}
+	modelName := modelRef
+	return modelModule.NewRerankModel(nil, &modelName, nil), nil
+}
+
+// TestAttachRetrievalModels_ResolvesKbEmbeddingModel pins the
+// production fix: the adapter must resolve the kb's embd_id via the
+// injected provider and mount it on the nlp request — otherwise the
+// search runs keyword-only and the similarity threshold filters out
+// every chunk (the "agent gets no answer from the knowledge base"
+// bug).
+func TestAttachRetrievalModels_ResolvesKbEmbeddingModel(t *testing.T) {
+	provider := &fakeRetrievalModelProvider{}
+	SetRetrievalModelProvider(provider)
+	t.Cleanup(func() { SetRetrievalModelProvider(nil) })
+
+	nlpReq := &nlp.RetrievalRequest{}
+	err := attachRetrievalModels(
+		context.Background(),
+		RetrievalRequest{TenantID: "tenant-a", RerankID: "rerank-1"},
+		[]*entity.Knowledgebase{{ID: "kb-1", TenantID: "tenant-b", EmbdID: "bge-m3@Builtin"}},
+		nlpReq,
+	)
+	if err != nil {
+		t.Fatalf("attachRetrievalModels: %v", err)
+	}
+	if nlpReq.EmbeddingModel == nil {
+		t.Fatal("EmbeddingModel is nil — hybrid search would be skipped")
+	}
+	if provider.embTenant != "tenant-a" || provider.embRef != "bge-m3@Builtin" {
+		t.Errorf("embedding resolved with tenant/ref = %q/%q, want tenant-a/bge-m3@Builtin",
+			provider.embTenant, provider.embRef)
+	}
+	if nlpReq.RerankModel == nil {
+		t.Fatal("RerankModel is nil — rerank_id was dropped")
+	}
+	if provider.rerankRef != "rerank-1" {
+		t.Errorf("rerank ref = %q, want rerank-1", provider.rerankRef)
+	}
+}
+
+func TestAttachRetrievalModels_FallsBackToKbTenant(t *testing.T) {
+	provider := &fakeRetrievalModelProvider{}
+	SetRetrievalModelProvider(provider)
+	t.Cleanup(func() { SetRetrievalModelProvider(nil) })
+
+	nlpReq := &nlp.RetrievalRequest{}
+	err := attachRetrievalModels(
+		context.Background(),
+		RetrievalRequest{},
+		[]*entity.Knowledgebase{{ID: "kb-1", TenantID: "tenant-b", EmbdID: "bge-m3@Builtin"}},
+		nlpReq,
+	)
+	if err != nil {
+		t.Fatalf("attachRetrievalModels: %v", err)
+	}
+	if provider.embTenant != "tenant-b" {
+		t.Errorf("embedding tenant = %q, want tenant-b (kb tenant fallback)", provider.embTenant)
+	}
+}
+
+func TestAttachRetrievalModels_MixedEmbeddingModelsError(t *testing.T) {
+	provider := &fakeRetrievalModelProvider{}
+	SetRetrievalModelProvider(provider)
+	t.Cleanup(func() { SetRetrievalModelProvider(nil) })
+
+	nlpReq := &nlp.RetrievalRequest{}
+	err := attachRetrievalModels(
+		context.Background(),
+		RetrievalRequest{TenantID: "tenant-a"},
+		[]*entity.Knowledgebase{
+			{ID: "kb-1", TenantID: "tenant-a", EmbdID: "emb-a"},
+			{ID: "kb-2", TenantID: "tenant-a", EmbdID: "emb-b"},
+		},
+		nlpReq,
+	)
+	if err == nil {
+		t.Fatal("expected mixed-embedding-model error, got nil")
+	}
+}
+
+func TestAttachRetrievalModels_NoProviderKeepsKeywordOnly(t *testing.T) {
+	SetRetrievalModelProvider(nil)
+	nlpReq := &nlp.RetrievalRequest{}
+	err := attachRetrievalModels(
+		context.Background(),
+		RetrievalRequest{TenantID: "tenant-a"},
+		[]*entity.Knowledgebase{{ID: "kb-1", TenantID: "tenant-a", EmbdID: "emb-a"}},
+		nlpReq,
+	)
+	if err != nil {
+		t.Fatalf("attachRetrievalModels: %v", err)
+	}
+	if nlpReq.EmbeddingModel != nil {
+		t.Error("EmbeddingModel should stay nil without a provider")
 	}
 }
 

--- a/internal/agent/tool/retrieval_service.go
+++ b/internal/agent/tool/retrieval_service.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"sync"
 
+	modelModule "ragflow/internal/entity/models"
+
 	"gorm.io/gorm"
 )
 
@@ -55,6 +57,11 @@ type RetrievalRequest struct {
 	KeywordsSimilarityWeight *float64
 	UseKG                    bool
 	SimilarityThreshold      float64
+	// RerankID is the optional rerank model reference declared on the
+	// Retrieval node (Python RetrievalParam.rerank_id). Empty means no
+	// external rerank model — the nlp service reranks with the
+	// built-in token/vector combination instead.
+	RerankID string
 	// TenantID is the calling tenant (== user_id in RAGFlow's data model).
 	// Optional for the nlp adapter; the KG adapter uses it to resolve the
 	// tenant's default chat + embedding models. Reads from
@@ -106,6 +113,40 @@ func GetRetrievalService() RetrievalService {
 	retrievalServiceMu.RLock()
 	defer retrievalServiceMu.RUnlock()
 	return retrievalServiceImpl
+}
+
+// RetrievalModelProvider resolves the tenant-scoped models the
+// retrieval path needs: the knowledge base's embedding model (for
+// hybrid fulltext+vector search) and the optional rerank model.
+// *service.ModelProviderService satisfies this interface; it is
+// injected at boot because internal/service imports the agent
+// packages (importing it from here would create a cycle).
+type RetrievalModelProvider interface {
+	GetEmbeddingModel(ctx context.Context, tenantID, modelRef string) (*modelModule.EmbeddingModel, error)
+	GetRerankModel(tenantID, modelRef string) (*modelModule.RerankModel, error)
+}
+
+var (
+	retrievalModelProviderMu   sync.RWMutex
+	retrievalModelProviderImpl RetrievalModelProvider
+)
+
+// SetRetrievalModelProvider installs the model provider used by the
+// retrieval adapters to resolve embedding/rerank models. Passing nil
+// reverts to "no provider": retrieval then degrades to keyword-only
+// search (the pre-hybrid behaviour).
+func SetRetrievalModelProvider(p RetrievalModelProvider) {
+	retrievalModelProviderMu.Lock()
+	defer retrievalModelProviderMu.Unlock()
+	retrievalModelProviderImpl = p
+}
+
+// GetRetrievalModelProvider returns the installed provider, or nil
+// when none was wired at boot.
+func GetRetrievalModelProvider() RetrievalModelProvider {
+	retrievalModelProviderMu.RLock()
+	defer retrievalModelProviderMu.RUnlock()
+	return retrievalModelProviderImpl
 }
 
 type stubRetrievalService struct{}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -64,7 +64,7 @@ type agentFileService interface {
 // NewAgentHandler assigns the concrete *service.AgentService — which
 // satisfies this interface because its RunAgent signature matches.
 type chatAgentService interface {
-	RunAgent(ctx context.Context, userID, canvasID, sessionID, version string, userInput any, files []map[string]interface{}) (<-chan canvas.RunEvent, error)
+	RunAgent(ctx context.Context, userID, canvasID, sessionID, version string, userInput any, beginInputs map[string]any, files []map[string]interface{}) (<-chan canvas.RunEvent, error)
 }
 
 // documentAccessChecker is the minimal surface RerunAgent needs
@@ -392,7 +392,7 @@ func (h *AgentHandler) RunAgent(c *gin.Context) {
 	sessionID := c.Query("session_id")
 	userInput := readUserInput(c)
 
-	events, err := h.chatRunner.RunAgent(c.Request.Context(), user.ID, canvasID, sessionID, version, userInput, nil)
+	events, err := h.chatRunner.RunAgent(c.Request.Context(), user.ID, canvasID, sessionID, version, userInput, nil, nil)
 	if err != nil {
 		ec, em := mapAgentError(err)
 		common.ResponseWithCodeData(c, ec, nil, em)
@@ -1008,7 +1008,7 @@ func (h *AgentHandler) AgentChatCompletions(c *gin.Context) {
 		}, userInputMeta(userInput)...)...,
 	)
 
-	events, err := h.chatRunner.RunAgent(c.Request.Context(), user.ID, req.AgentID, req.SessionID, "", userInput, req.Files)
+	events, err := h.chatRunner.RunAgent(c.Request.Context(), user.ID, req.AgentID, req.SessionID, "", userInput, req.Inputs, req.Files)
 	if err != nil {
 		common.Warn("agent chat completions: RunAgent failed",
 			append([]zap.Field{

--- a/internal/handler/agent_test.go
+++ b/internal/handler/agent_test.go
@@ -715,7 +715,7 @@ type stubChatRunner struct {
 	err    error
 }
 
-func (s *stubChatRunner) RunAgent(_ context.Context, _, _, _, _ string, _ any, _ []map[string]interface{}) (<-chan canvas.RunEvent, error) {
+func (s *stubChatRunner) RunAgent(_ context.Context, _, _, _, _ string, _ any, _ map[string]any, _ []map[string]interface{}) (<-chan canvas.RunEvent, error) {
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -941,7 +941,7 @@ type captureChatRunner struct {
 	capturedFiles *[]map[string]interface{}
 }
 
-func (c *captureChatRunner) RunAgent(_ context.Context, _, _, _, _ string, userInput any, files []map[string]interface{}) (<-chan canvas.RunEvent, error) {
+func (c *captureChatRunner) RunAgent(_ context.Context, _, _, _, _ string, userInput any, _ map[string]any, files []map[string]interface{}) (<-chan canvas.RunEvent, error) {
 	*c.captured = userInput
 	if c.capturedFiles != nil {
 		*c.capturedFiles = files

--- a/internal/handler/agent_wait_for_user_test.go
+++ b/internal/handler/agent_wait_for_user_test.go
@@ -94,7 +94,7 @@ func (f *waitFakeAgentService) DeleteAgent(context.Context, string, string) erro
 // RunAgent mimics service.AgentService.RunAgent for the test
 // driver. It loads the canvas (a no-op in tests), builds a RunFunc
 // from the supplied stub, and hands off to the orchestrator.
-func (f *waitFakeAgentService) RunAgent(ctx context.Context, userID, canvasID, sessionID, version string, userInput any, _ []map[string]interface{}) (<-chan canvas.RunEvent, error) {
+func (f *waitFakeAgentService) RunAgent(ctx context.Context, userID, canvasID, sessionID, version string, userInput any, _ map[string]any, _ []map[string]interface{}) (<-chan canvas.RunEvent, error) {
 	_ = ctx
 	_ = userID
 	_ = version
@@ -151,7 +151,7 @@ func waitForUserRoutes(svc *waitFakeAgentService) *gin.Engine {
 		canvasID := c.Param("canvas_id")
 		sessionID := c.Query("session_id")
 		userInput := c.Query("user_input")
-		events, err := svc.RunAgent(c.Request.Context(), "user-wait", canvasID, sessionID, "", userInput, nil)
+		events, err := svc.RunAgent(c.Request.Context(), "user-wait", canvasID, sessionID, "", userInput, nil, nil)
 		if err != nil {
 			// We never expect a non-nil err from the fake,
 			// but be defensive.

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -87,7 +87,7 @@ func (s *AgentService) RunAgentWithWebhook(
 	if payload != nil {
 		ctx = context.WithValue(ctx, webhookPayloadKey{}, payload)
 	}
-	return s.RunAgent(ctx, userID, canvasID, "", "", "", nil)
+	return s.RunAgent(ctx, userID, canvasID, "", "", "", nil, nil)
 }
 
 func emitAgentMessageEvents(emit func(string, string), answer, thinking string, reference any) {
@@ -923,7 +923,14 @@ func (s *AgentService) DeleteVersion(ctx context.Context, userID, canvasID, vers
 // The per-run RunFunc is built by buildRunFunc — see its doc comment
 // for the full production chain (real Compile/Invoke, resume path,
 // error-layering contract).
-func (s *AgentService) RunAgent(ctx context.Context, userID, canvasID, sessionID, version string, userInput any, files []map[string]interface{}) (<-chan canvas.RunEvent, error) {
+//
+// beginInputs carries the Begin node's custom input values submitted
+// with the request (the 试运行 panel / chat form). Each entry is either
+// a raw value or a BeginQuery-shaped object carrying a "value" field.
+// They are seeded as the Begin component's outputs so downstream
+// references like {begin@<key>} resolve — mirroring Python's
+// Begin._invoke (agent/component/begin.py).
+func (s *AgentService) RunAgent(ctx context.Context, userID, canvasID, sessionID, version string, userInput any, beginInputs map[string]any, files []map[string]interface{}) (<-chan canvas.RunEvent, error) {
 	canvasRow, err := s.loadCanvasForUser(ctx, userID, canvasID)
 	if err != nil {
 		return nil, err
@@ -1047,6 +1054,9 @@ func (s *AgentService) RunAgent(ctx context.Context, userID, canvasID, sessionID
 	}
 	if userInput != nil {
 		root["user_input"] = userInput
+	}
+	if len(beginInputs) > 0 {
+		root["begin_inputs"] = beginInputs
 	}
 	if len(files) > 0 {
 		root["files"] = files
@@ -1277,6 +1287,13 @@ func (s *AgentService) buildRunFunc(canvasID string, versionRow *entity.UserCanv
 		state.SetMemory(c.Memory)
 		state.EnsureSysDate()
 		state.Sys["query"] = userInput
+		// Seed the Begin component's outputs from the request's custom
+		// inputs (试运行 panel / chat form). Mirrors Python Begin._invoke:
+		// each submitted field becomes Outputs["begin"][<key>] so
+		// downstream references like {begin@<key>} resolve.
+		if beginInputs, ok := root["begin_inputs"].(map[string]any); ok {
+			seedBeginInputOutputs(state, beginInputs)
+		}
 		state.AppendCurrentUser(userInput)
 		state.AppendSysHistory("user: " + renderUserHistoryValue(userInput))
 		if uid, ok := root["user_id"].(string); ok && uid != "" {
@@ -1657,6 +1674,22 @@ func (s *AgentService) persistAgentRunSession(
 	}
 	session.Round++
 	return s.api4ConversationDAO.Update(ctx, dao.DB, session)
+}
+
+// seedBeginInputOutputs flattens the request's begin inputs into the
+// Begin component's output bucket. Entries may be raw values or
+// BeginQuery-shaped objects carrying a "value" field (the frontend
+// sends the latter via transferInputsArrayToObject).
+func seedBeginInputOutputs(state *canvas.CanvasState, inputs map[string]any) {
+	for key, raw := range inputs {
+		if field, ok := raw.(map[string]any); ok {
+			if value, exists := field["value"]; exists {
+				state.SetVar("begin", key, value)
+				continue
+			}
+		}
+		state.SetVar("begin", key, raw)
+	}
 }
 
 func buildPersistedAgentDSL(runDSL map[string]any, state *canvas.CanvasState) entity.JSONMap {

--- a/internal/service/agent_run_e2e_test.go
+++ b/internal/service/agent_run_e2e_test.go
@@ -204,7 +204,7 @@ func TestRunAgent_RealCanvas_BeginMessage(t *testing.T) {
 		"canvas-hello",
 		"session-hello",
 		"", // latest version
-		"world", nil)
+		"world", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestRunAgent_SessionHistoryFeedsSysHistoryAndPersists(t *testing.T) {
 	svc := NewAgentService()
 	run := func(input string) canvas.MessageEvent {
 		t.Helper()
-		events, err := svc.RunAgent(context.Background(), "user-1", "canvas-history", "session-history", "", input, nil)
+		events, err := svc.RunAgent(context.Background(), "user-1", "canvas-history", "session-history", "", input, nil, nil)
 		if err != nil {
 			t.Fatalf("RunAgent(%q): %v", input, err)
 		}
@@ -391,7 +391,7 @@ func TestRunAgent_NewSessionPersistsHistoryForNextTurn(t *testing.T) {
 	makeCanvasWithDSL(t, "canvas-new-session", "user-1", "tenant-1", "v-new-session", dsl)
 
 	svc := NewAgentService()
-	events, err := svc.RunAgent(context.Background(), "user-1", "canvas-new-session", "", "", "1", nil)
+	events, err := svc.RunAgent(context.Background(), "user-1", "canvas-new-session", "", "", "1", nil, nil)
 	if err != nil {
 		t.Fatalf("first RunAgent: %v", err)
 	}
@@ -411,7 +411,7 @@ func TestRunAgent_NewSessionPersistsHistoryForNextTurn(t *testing.T) {
 		t.Fatal("persisted session has an empty ID")
 	}
 
-	events, err = svc.RunAgent(context.Background(), "user-1", "canvas-new-session", session.ID, "", "1", nil)
+	events, err = svc.RunAgent(context.Background(), "user-1", "canvas-new-session", session.ID, "", "1", nil, nil)
 	if err != nil {
 		t.Fatalf("second RunAgent: %v", err)
 	}
@@ -474,6 +474,7 @@ func TestRunAgent_RejectsSessionOwnedByAnotherUser(t *testing.T) {
 		"session-foreign",
 		"",
 		"attempted overwrite",
+		nil,
 		nil,
 	)
 	if err == nil {
@@ -599,7 +600,7 @@ func TestRunAgent_RealCanvas_WaitForUserResume(t *testing.T) {
 		"canvas-fillup",
 		"session-fillup",
 		"",
-		"please ask", nil)
+		"please ask", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 1: %v", err)
 	}
@@ -636,7 +637,7 @@ func TestRunAgent_RealCanvas_WaitForUserResume(t *testing.T) {
 		"canvas-fillup",
 		"session-fillup", // SAME sessionID as run 1
 		"",
-		"my follow-up", nil)
+		"my follow-up", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 2: %v", err)
 	}
@@ -718,6 +719,7 @@ func TestRunAgent_InterruptPersistsPartialAssistantHistory(t *testing.T) {
 		"session-partial",
 		"",
 		"question",
+		nil,
 		nil,
 	)
 	if err != nil {
@@ -806,7 +808,7 @@ func TestRunAgent_RealCanvas_WaitForUserResume_EventSemantics(t *testing.T) {
 		"canvas-fillup-events",
 		"session-fillup-events",
 		"",
-		"please ask", nil)
+		"please ask", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 1: %v", err)
 	}
@@ -829,7 +831,7 @@ func TestRunAgent_RealCanvas_WaitForUserResume_EventSemantics(t *testing.T) {
 		"canvas-fillup-events",
 		"session-fillup-events",
 		"",
-		"my follow-up", nil)
+		"my follow-up", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 2: %v", err)
 	}
@@ -947,7 +949,7 @@ func TestRunAgent_RealCanvas_GroupedParallelOuterFollower(t *testing.T) {
 		"canvas-parallel",
 		"session-parallel",
 		"",
-		"a,b,c", nil)
+		"a,b,c", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent: %v", err)
 	}
@@ -1017,7 +1019,7 @@ func TestRunAgent_AllFixture_LoopInterruptResume(t *testing.T) {
 		"canvas-all",
 		"session-all-loop",
 		"",
-		"loop", nil)
+		"loop", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 1: %v", err)
 	}
@@ -1057,7 +1059,7 @@ func TestRunAgent_AllFixture_LoopInterruptResume(t *testing.T) {
 		"canvas-all",
 		"session-all-loop",
 		"",
-		"loop", nil)
+		"loop", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 2: %v", err)
 	}
@@ -1080,6 +1082,7 @@ func TestRunAgent_AllFixture_LoopInterruptResume(t *testing.T) {
 
 	events3, err := svc.RunAgent(
 		context.Background(), "user-1", "canvas-all", "session-all-loop", "", "1", nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("RunAgent run 3: %v", err)
@@ -1143,7 +1146,7 @@ func TestRunAgent_AllFixture_LoopInterruptResume_MultiTurn(t *testing.T) {
 			"canvas-all-multi",
 			sessionID,
 			"",
-			input, nil)
+			input, nil, nil)
 		if err != nil {
 			t.Fatalf("RunAgent run %d (%q): %v", i+1, input, err)
 		}
@@ -1236,7 +1239,7 @@ func TestRunAgent_AllFixture_IterationFormatsItems(t *testing.T) {
 		"canvas-all-iteration",
 		sessionID,
 		"",
-		"iteration", nil)
+		"iteration", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 1: %v", err)
 	}
@@ -1265,7 +1268,7 @@ func TestRunAgent_AllFixture_IterationFormatsItems(t *testing.T) {
 		"canvas-all-iteration",
 		sessionID,
 		"",
-		"iteration", nil)
+		"iteration", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 2: %v", err)
 	}
@@ -1288,6 +1291,7 @@ func TestRunAgent_AllFixture_IterationFormatsItems(t *testing.T) {
 
 	events3, err := svc.RunAgent(
 		context.Background(), "user-1", "canvas-all-iteration", sessionID, "", "a,b,c,d,e", nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("RunAgent run 3: %v", err)
@@ -1346,7 +1350,7 @@ func TestRunAgent_AllFixture_VarAssigner(t *testing.T) {
 		"canvas-all-var-assigner",
 		"session-all-var-assigner",
 		"",
-		"var_assigner", nil)
+		"var_assigner", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent: %v", err)
 	}
@@ -1370,6 +1374,7 @@ func TestRunAgent_AllFixture_VarAssigner(t *testing.T) {
 		"session-all-var-assigner",
 		"",
 		"var_assigner",
+		nil,
 		nil,
 	)
 	if err != nil {
@@ -1430,7 +1435,7 @@ func TestRunAgent_AllFixture_DataOps(t *testing.T) {
 		"canvas-all-data-ops",
 		"session-all-data-ops",
 		"",
-		"data_ops", nil)
+		"data_ops", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent: %v", err)
 	}
@@ -1454,6 +1459,7 @@ func TestRunAgent_AllFixture_DataOps(t *testing.T) {
 		"session-all-data-ops",
 		"",
 		"data_ops",
+		nil,
 		nil,
 	)
 	if err != nil {
@@ -1536,7 +1542,7 @@ func TestRunAgent_RealCanvas_CompileFails(t *testing.T) {
 		"canvas-bogus",
 		"session-bogus",
 		"",
-		"hello", nil)
+		"hello", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent returned sync error: %v", err)
 	}
@@ -1608,7 +1614,7 @@ func TestRunAgent_AllFixture_CategorizeResume(t *testing.T) {
 		"canvas-all-categorize",
 		"session-all-categorize",
 		"",
-		"categorize", nil)
+		"categorize", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 1: %v", err)
 	}
@@ -1636,7 +1642,7 @@ func TestRunAgent_AllFixture_CategorizeResume(t *testing.T) {
 		"canvas-all-categorize",
 		"session-all-categorize",
 		"",
-		"categorize", nil)
+		"categorize", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent run 2: %v", err)
 	}
@@ -1671,6 +1677,7 @@ func TestRunAgent_AllFixture_CategorizeResume(t *testing.T) {
 		"session-all-categorize",
 		"",
 		"hello",
+		nil,
 		nil,
 	)
 	if err != nil {
@@ -1766,7 +1773,7 @@ func TestRunAgent_RealCanvas_InvokeFails(t *testing.T) {
 		"canvas-invoke-fail",
 		"session-invoke-fail",
 		"",
-		"hello", nil)
+		"hello", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent returned sync error: %v", err)
 	}
@@ -1873,7 +1880,7 @@ func TestRunAgent_RunTracker_AttachCheckpoint_CallSequence(t *testing.T) {
 		"canvas-cp",
 		"session-cp",
 		"", // latest version
-		"world", nil)
+		"world", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent: %v", err)
 	}
@@ -2047,7 +2054,7 @@ func TestRunAgent_FilesPopulateIteration(t *testing.T) {
 		canvasID,
 		sessionID,
 		"",
-		"hello-files", testFiles)
+		"hello-files", nil, testFiles)
 	if err != nil {
 		t.Fatalf("RunAgent with files: %v", err)
 	}
@@ -2115,6 +2122,7 @@ func TestRunAgent_MissingUploadEmitsError(t *testing.T) {
 		"session-missing-upload",
 		"",
 		"hello",
+		nil,
 		[]map[string]interface{}{{
 			"id":         "missing",
 			"name":       "missing.txt",
@@ -2192,7 +2200,7 @@ func TestRunAgent_NoFilesRunsNormally(t *testing.T) {
 		canvasID,
 		sessionID,
 		"",
-		"hello-nofiles", nil)
+		"hello-nofiles", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent without files: %v", err)
 	}

--- a/internal/service/agent_test.go
+++ b/internal/service/agent_test.go
@@ -536,7 +536,7 @@ func TestRunAgent_VersionBelongsToOtherCanvas(t *testing.T) {
 		"canvas-1",      // we're running canvas-1…
 		"",              // session ID auto-generated
 		"v-on-canvas-2", // …with a version that belongs to canvas-2
-		"hi", nil)
+		"hi", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when version belongs to a different canvas (IDOR guard)")
 	}
@@ -582,7 +582,7 @@ func TestRunAgent_VersionNotFound(t *testing.T) {
 		"canvas-1",
 		"",
 		"does-not-exist",
-		"hi", nil)
+		"hi", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when explicit version id does not exist")
 	}
@@ -639,7 +639,7 @@ func TestRunAgent_NoVersionPublishedPlaceholder(t *testing.T) {
 		"canvas-empty",
 		"test-session",
 		"", // no explicit version → use GetLatest, which returns ErrUserCanvasVersionNotFound
-		"hi", nil)
+		"hi", nil, nil)
 	if err != nil {
 		t.Fatalf("RunAgent should proceed with placeholder when no version published: %v", err)
 	}
@@ -748,7 +748,7 @@ func TestRunAgent_StorageErrorFromCanvasAccess(t *testing.T) {
 		"canvas-1",
 		"",
 		"",
-		"hi", nil)
+		"hi", nil, nil)
 	if err == nil {
 		t.Fatal("expected storage error from closed DB")
 	}
@@ -1942,5 +1942,25 @@ func TestAgentHistoryRenderingMatchesPythonShapes(t *testing.T) {
 	want := `{'content': 'it\'s ready\nnext', 'ok': True}`
 	if assistant != want {
 		t.Fatalf("rendered assistant history = %q, want %q", assistant, want)
+	}
+}
+
+// TestSeedBeginInputOutputs pins the 试运行/custom-input wiring: the
+// request's begin inputs must land in Outputs["begin"] so downstream
+// references like {begin@<key>} resolve (Python Begin._invoke parity).
+func TestSeedBeginInputOutputs(t *testing.T) {
+	state := canvas.NewCanvasState("run-1", "task-1")
+	seedBeginInputOutputs(state, map[string]any{
+		// BeginQuery-shaped entry (frontend transferInputsArrayToObject).
+		"color": map[string]any{"name": "我最喜欢的颜色", "value": "红色", "type": "line"},
+		// Raw value entry (API callers may post plain values).
+		"city": "上海",
+	})
+
+	if got, err := state.GetVar("begin@color"); err != nil || got != "红色" {
+		t.Errorf("begin@color = %v (err=%v), want 红色", got, err)
+	}
+	if got, err := state.GetVar("begin@city"); err != nil || got != "上海" {
+		t.Errorf("begin@city = %v (err=%v), want 上海", got, err)
 	}
 }

--- a/internal/service/bot.go
+++ b/internal/service/bot.go
@@ -171,7 +171,7 @@ func (s *BotService) AgentbotCompletion(
 		userInput["question"] = req.Question
 	}
 	ch, err := s.agentService.RunAgent(ctx, tenantID, agentID,
-		req.SessionID, "", userInput, req.Files)
+		req.SessionID, "", userInput, nil, req.Files)
 	if err != nil {
 		return nil, common.CodeDataError, err
 	}

--- a/web/src/components/knowledge-base-item.tsx
+++ b/web/src/components/knowledge-base-item.tsx
@@ -152,7 +152,6 @@ export function KnowledgeBaseFormField({
                 icon: () => (
                   <RAGFlowAvatar
                     className="size-4 mr-2"
-                    avatar={String(x.label ?? '')}
                     name={String(x.label ?? '')}
                   />
                 ),

--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -898,6 +898,22 @@ export const useFetchKnowledgeList = (
       : all;
   }, [data, shouldFilterListWithoutDocument]);
 
+  // Server-side pagination + client-side chunk_count filtering can
+  // filter out an entire page (e.g. the newest datasets are all
+  // empty), leaving an empty, unscrollable list that never triggers
+  // handleScroll. Auto-fetch the next page until the filtered list
+  // has something to show or the pages run out.
+  const shouldAutoLoadNextPage =
+    shouldFilterListWithoutDocument &&
+    list.length === 0 &&
+    hasNextPage &&
+    !isFetching;
+  useEffect(() => {
+    if (shouldAutoLoadNextPage) {
+      fetchNextPage();
+    }
+  }, [shouldAutoLoadNextPage, fetchNextPage]);
+
   const handleScroll = useCallback(
     (e: React.UIEvent<HTMLDivElement>) => {
       const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;


### PR DESCRIPTION
### Summary

Three fixes for the Go-mode agent canvas:

**1. Agent retrieval returned no chunks.** The NLP retrieval adapter never resolved the knowledge base's embedding model, so searches ran keyword-only and the results were filtered out by the similarity threshold — downstream Agent components concluded the knowledge base had no relevant content. The adapter now resolves the kb's embedding model (and the node's optional rerank model) through an injected `RetrievalModelProvider` and mounts them on the nlp request, enabling hybrid (fulltext + vector + fusion) search, matching the Python canvas. The `rerank_id` node param is also threaded through (previously dropped silently), and when nothing is found the node's `empty_response` is surfaced as `formalized_content` instead of an empty output map.

**2. Knowledge base selector showed an empty list.** Server-side pagination combined with the client-side `chunk_count > 0` filter could filter out an entire page, leaving an empty, unscrollable dropdown that never triggered the next-page load. The list now auto-fetches the next page while the filtered result is empty and more pages exist. Also fixed variable option icons being rendered as image URLs, which fired bogus `/sys.*` img requests per option.

**3. Begin custom inputs (test-run panel / chat form) were dropped.** `RunAgent` ignored the request's `inputs`, so `{begin@<key>}` references (e.g. in a Retrieval query) never resolved in Go mode. Begin inputs are now threaded through `RunAgent` and seeded as the Begin component's outputs, and the Begin component applies the single-input `sys.query` fallback, mirroring Python's `Begin._invoke`.

Tests: `bash build.sh --test ./internal/agent/... ./internal/service/ ./cmd/...` all pass; new unit tests cover the model attachment, empty-response fill, begin input seeding, and the sys.query fallback.