### PR TITLE
fix: refresh memory sidebar avatar immediately after update

### DIFF
--- a/web/src/pages/memories/hooks.ts
+++ b/web/src/pages/memories/hooks.ts
@@ -18,6 +18,7 @@ import { omit } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router';
+import { MemoryApiAction } from '../memory/constant';
 import {
   CreateMemoryResponse,
   DeleteMemoryProps,
@@ -216,6 +217,9 @@ export const useUpdateMemory = () => {
       message.success(t('message.updated'));
       queryClient.invalidateQueries({
         queryKey: ['memoryDetail', variables.id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [MemoryApiAction.FetchMemoryDetail],
       });
     },
   });

--- a/web/src/pages/memory/sidebar/index.tsx
+++ b/web/src/pages/memory/sidebar/index.tsx
@@ -13,7 +13,6 @@ import { useHandleMenuClick } from './hooks';
 export function SideBar() {
   const pathName = useSecondPathName();
   const { handleMenuClick } = useHandleMenuClick();
-  // refreshCount: be for avatar img sync update on top left
   const { data } = useFetchMemoryBaseConfiguration();
   const { t } = useTranslation();
 


### PR DESCRIPTION
### Summary

After uploading a new avatar on the memory configuration page and saving, the avatar shown in the memory detail sidebar was not updated until a full page refresh.

Root cause: a react-query key mismatch. The sidebar and the configuration page read data via `useFetchMemoryBaseConfiguration`, whose query key is `['fetchMemoryDetail', ...]` (`GET /api/v1/memories/:id/config`), but `useUpdateMemory` only invalidated the unrelated `['memoryDetail', id]` key on success. As a result, the sidebar's cached query was never refetched after an update.

This PR additionally invalidates the `fetchMemoryDetail` query key in `useUpdateMemory`'s `onSuccess`, so the sidebar refetches and shows the new avatar immediately. It also removes a stale comment in the sidebar referring to an unimplemented `refreshCount` mechanism.