### PR TITLE
WIP (review after ingestion fully ready) Go: reject canceling documents whose parse is not running

### DIFF
--- a/internal/service/document/document_ingest.go
+++ b/internal/service/document/document_ingest.go
@@ -2,6 +2,7 @@ package document
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"ragflow/internal/dao"
 	"ragflow/internal/service"
@@ -104,6 +105,9 @@ func (s *DocumentService) Ingest(ctx context.Context, userID string, req *Ingest
 		if run == string(entity.TaskStatusCancel) {
 			if err = s.CancelDocParse(ctx, doc); err != nil {
 				common.Error(fmt.Sprintf("go side, start to process %s, run is cancel", doc.ID), err)
+				if errors.Is(err, ErrDocumentParseNotRunning) {
+					return common.CodeDataError, errors.New("Cannot cancel a task that is not in RUNNING status")
+				}
 				return common.CodeDataError, err
 			}
 			if err = s.documentDAO.UpdateByID(ctx, dao.DB, doc.ID, map[string]interface{}{

--- a/internal/service/document/document_parse.go
+++ b/internal/service/document/document_parse.go
@@ -257,6 +257,10 @@ func (s *DocumentService) StopParseDocuments(ctx context.Context, datasetID stri
 	successCount := 0
 	for _, doc := range docs {
 		if cancelErr := s.CancelDocParse(ctx, doc); cancelErr != nil {
+			if errors.Is(cancelErr, ErrDocumentParseNotRunning) {
+				errs = append(errs, "Can't stop parsing document that has not started or already completed")
+				continue
+			}
 			errs = append(errs, cancelErr.Error())
 			continue
 		}
@@ -293,12 +297,28 @@ func (s *DocumentService) validateDocsInDataset(ctx context.Context, docIDs []st
 	return docs, nil
 }
 
+// ErrDocumentParseNotRunning is returned by CancelDocParse when the document
+// is not being parsed (run is neither RUNNING nor CANCEL) and has no
+// unfinished ingestion task. Canceling such a document must be rejected so a
+// completed document is not flipped to CANCEL status.
+var ErrDocumentParseNotRunning = errors.New("document parse is not running")
+
 // CancelDocParse stops the ingestion task for the document by calling
 // RequestStop (STOPPING), then marks the document run status as CANCEL.
 func (s *DocumentService) CancelDocParse(ctx context.Context, doc *entity.Document) error {
 	task, err := s.ingestionTaskDAO.GetByDocumentID(ctx, dao.DB, doc.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get ingestion task for %s: %v", doc.ID, err)
+	}
+
+	docRun := ""
+	if doc.Run != nil {
+		docRun = *doc.Run
+	}
+	hasUnfinishedTask := task != nil &&
+		(task.Status == common.CREATED || task.Status == common.RUNNING || task.Status == common.STOPPING)
+	if docRun != string(entity.TaskStatusRunning) && docRun != string(entity.TaskStatusCancel) && !hasUnfinishedTask {
+		return ErrDocumentParseNotRunning
 	}
 	if task == nil {
 		return fmt.Errorf("no ingestion task found for document %s", doc.ID)

--- a/internal/service/document/document_test.go
+++ b/internal/service/document/document_test.go
@@ -1233,6 +1233,44 @@ func TestStopParseDocuments_UnfinishedTask(t *testing.T) {
 	}
 }
 
+func TestStopParseDocuments_CompletedDocRejected(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+
+	insertTestKB(t, "kb-1", "tenant-1", 1, 10, 5)
+	// Parse already finished: doc DONE with a terminal ingestion task.
+	insertTestDocWithRun(t, "doc-1", "kb-1", string(entity.TaskStatusDone), 10, 5)
+	insertTestIngestionTaskWithStatus(t, "task-1", "user-1", "doc-1", "kb-1", common.COMPLETED)
+
+	svc := testDocumentService(t)
+	ctx := t.Context()
+	result, err := svc.StopParseDocuments(ctx, "kb-1", []string{"doc-1"})
+	if err != nil {
+		t.Fatalf("StopParseDocuments failed: %v", err)
+	}
+
+	sc := result["success_count"].(int)
+	if sc != 0 {
+		t.Fatalf("expected success_count=0, got %d", sc)
+	}
+	errs, ok := result["errors"].([]string)
+	if !ok || len(errs) == 0 {
+		t.Fatal("expected errors in result")
+	}
+	if errs[0] != "Can't stop parsing document that has not started or already completed" {
+		t.Fatalf("unexpected error message: %q", errs[0])
+	}
+
+	// A finished parse must not be flipped to CANCEL.
+	doc, _ := dao.NewDocumentDAO().GetByID(ctx, db, "doc-1")
+	if doc == nil || doc.Run == nil {
+		t.Fatal("doc not found or run is nil")
+	}
+	if *doc.Run != string(entity.TaskStatusDone) {
+		t.Fatalf("expected run=%q, got %q", string(entity.TaskStatusDone), *doc.Run)
+	}
+}
+
 func TestStopParseDocuments_WrongDataset(t *testing.T) {
 	db := setupServiceTestDB(t)
 	pushServiceDB(t, db)
@@ -1981,6 +2019,72 @@ func TestIngest_RerunWithDelete_RejectsBatchWithRunningTask(t *testing.T) {
 	task1, _ := svc.ingestionTaskDAO.GetByDocumentID(ctx, db, "doc-1")
 	if task1 == nil {
 		t.Fatal("doc-1 terminal task should not be deleted when batch is rejected")
+	}
+}
+
+// TestIngest_CancelRejectsCompletedDocument verifies that canceling a document
+// whose parse already finished is rejected and the document stays DONE,
+// mirroring the Python "Cannot cancel a task that is not in RUNNING status".
+func TestIngest_CancelRejectsCompletedDocument(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertUserTenantForAccessCheck(t, "user-1", "tenant-1")
+	insertTestKB(t, "kb-1", "tenant-1", 1, 10, 5)
+	insertTestDocWithRun(t, "doc-1", "kb-1", string(entity.TaskStatusDone), 10, 5)
+	insertTestIngestionTaskWithStatus(t, "task-1", "user-1", "doc-1", "kb-1", common.COMPLETED)
+
+	ctx := t.Context()
+	svc := testDocumentService(t)
+	code, err := svc.Ingest(ctx, "user-1", &IngestDocumentRequest{
+		DocIDs: []string{"doc-1"},
+		Run:    string(entity.TaskStatusCancel),
+	})
+	if err == nil {
+		t.Fatal("expected error when canceling a completed document, got nil")
+	}
+	if code != common.CodeDataError {
+		t.Fatalf("code = %v, want %v", code, common.CodeDataError)
+	}
+	if err.Error() != "Cannot cancel a task that is not in RUNNING status" {
+		t.Fatalf("err = %q", err.Error())
+	}
+
+	doc, _ := dao.NewDocumentDAO().GetByID(ctx, db, "doc-1")
+	if doc == nil || doc.Run == nil {
+		t.Fatal("doc not found or run is nil")
+	}
+	if *doc.Run != string(entity.TaskStatusDone) {
+		t.Fatalf("expected run=%q, got %q", string(entity.TaskStatusDone), *doc.Run)
+	}
+}
+
+func TestIngest_CancelRunningDocument(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertUserTenantForAccessCheck(t, "user-1", "tenant-1")
+	insertTestKB(t, "kb-1", "tenant-1", 1, 10, 5)
+	insertTestDocWithRun(t, "doc-1", "kb-1", string(entity.TaskStatusRunning), 10, 5)
+	insertTestIngestionTaskWithStatus(t, "task-1", "user-1", "doc-1", "kb-1", common.RUNNING)
+
+	ctx := t.Context()
+	svc := testDocumentService(t)
+	code, err := svc.Ingest(ctx, "user-1", &IngestDocumentRequest{
+		DocIDs: []string{"doc-1"},
+		Run:    string(entity.TaskStatusCancel),
+	})
+	if err != nil {
+		t.Fatalf("expected cancel of running document to succeed, got %v", err)
+	}
+	if code != common.CodeSuccess {
+		t.Fatalf("code = %v, want %v", code, common.CodeSuccess)
+	}
+
+	doc, _ := dao.NewDocumentDAO().GetByID(ctx, db, "doc-1")
+	if doc == nil || doc.Run == nil {
+		t.Fatal("doc not found or run is nil")
+	}
+	if *doc.Run != string(entity.TaskStatusCancel) {
+		t.Fatalf("expected run=%q, got %q", string(entity.TaskStatusCancel), *doc.Run)
 	}
 }
 


### PR DESCRIPTION
### Summary

In Go mode, selecting parsed (DONE) documents in a dataset and clicking Cancel flipped the documents to CANCEL status, because `CancelDocParse` called `RequestStop` on the terminal ingestion task, which is a no-op success, and then unconditionally marked the document as CANCEL. The Python backend rejects this case with `Cannot cancel a task that is not in RUNNING status` and leaves the document untouched.

This PR aligns the Go behavior with Python:

- `CancelDocParse` now rejects with a new `ErrDocumentParseNotRunning` sentinel when the document run status is neither RUNNING nor CANCEL and it has no unfinished ingestion task (CREATED/RUNNING/STOPPING).
- The ingest API (`POST /api/v1/documents/ingest`, used by the web UI Cancel button) maps the sentinel to `Cannot cancel a task that is not in RUNNING status` (data error), so finished documents keep their DONE status.
- The stop-parse API (`POST /datasets/<id>/documents/stop`) maps it to `Can't stop parsing document that has not started or already completed`, matching the Python message.

Added tests: completed document rejected by stop API and by ingest cancel (status stays DONE), and canceling a running document still succeeds.