### PR TITLE
fix(web): correct dataset configuration page title and description

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -350,6 +350,8 @@ Procedural Memory: Learned skills, habits, and automated procedures.`,
         action: 'Action',
       },
       config: {
+        titleDescription:
+          'Update your memory configuration here, particularly the LLM and prompts.',
         descriptionPlaceholder: 'Describe your memory',
         memorySizeTooltip: `Accounts for each message's content + its embedding vector (≈ Content + Dimensions × 8 Bytes).
 Example: A 1 KB message with 1024-dim embedding uses ~9 KB. The 5 MB default limit holds ~500 such messages.`,
@@ -501,7 +503,7 @@ Example: A 1 KB message with 1024-dim embedding uses ~9 KB. The 5 MB default lim
       testing: 'Retrieval testing',
       files: 'files',
       configuration: 'Configuration',
-      nextConfiguration: 'Next configuration',
+      nextConfiguration: 'Dataset configuration',
       knowledgeGraph: 'Knowledge graph',
       compilation: 'Compilation',
       export: 'Export',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -310,6 +310,7 @@ export default {
         action: '操作',
       },
       config: {
+        titleDescription: '在这里更新您的记忆配置，特别是大语言模型和提示词。',
         descriptionPlaceholder: '描述你的记忆',
         memorySizeTooltip: `记录每条消息的内容 + 其嵌入向量（≈ 内容 + 维度 × 8 字节）。
 例如：一条带有 1024 维嵌入的 1 KB 消息大约使用 9 KB。5 MB 的默认限制大约可容纳 500 条此类消息。`,
@@ -447,7 +448,7 @@ export default {
       dataset: '知识库',
       testing: '检索测试',
       configuration: '配置',
-      nextConfiguration: '下个配置',
+      nextConfiguration: '知识库配置',
       knowledgeGraph: '知识图谱',
       compilation: '编译',
       export: '导出',
@@ -678,7 +679,7 @@ export default {
       parseType: '解析方法',
       manualSetup: '选择pipeline',
       builtIn: '内置',
-      titleDescription: '在这里更新您的记忆配置，特别是大语言模型和提示词。',
+      titleDescription: '在这里更新您的知识库配置，特别是大语言模型和提示词。',
       name: '知识库名称',
       photo: '知识库图片',
       photoTip: '你可以上传4MB的文件',

--- a/web/src/pages/memory/memory-setting/index.tsx
+++ b/web/src/pages/memory/memory-setting/index.tsx
@@ -72,42 +72,42 @@ export default function MemoryMessage() {
     <section className="h-full flex flex-col">
       <TopTitle
         title={t('knowledgeDetails.configuration')}
-        description={t('knowledgeConfiguration.titleDescription')}
+        description={t('memory.config.titleDescription')}
       ></TopTitle>
       <div className="flex gap-14 flex-1 min-h-0">
         <MemorySettingProvider data={data}>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(() => {})} className="space-y-6 ">
-            <div className="w-[768px] h-[calc(100vh-300px)] pr-1 overflow-y-auto scrollbar-auto pb-4">
-              <MainContainer className="text-text-secondary !space-y-10">
-                <div className="text-base font-medium text-text-primary">
-                  {t('knowledgeConfiguration.baseInfo')}
-                </div>
-                <BasicInfo></BasicInfo>
-                <Divider />
-                <MemoryModelForm />
-                <AdvancedSettingsForm />
-              </MainContainer>
-            </div>
-            <div className="text-right items-center flex justify-end gap-3 w-[768px]">
-              <Button
-                type="reset"
-                className="bg-transparent text-color-white hover:bg-transparent border-border-button border"
-                onClick={() => {
-                  form.reset();
-                }}
-              >
-                {t('knowledgeConfiguration.cancel')}
-              </Button>
-              <DynamicForm.SavingButton
-                submitLoading={loading}
-                submitFunc={(value) => {
-                  console.log('form-value', value);
-                  onSubmit(value as IMemory);
-                }}
-              ></DynamicForm.SavingButton>
-            </div>
-          </form>
+              <div className="w-[768px] h-[calc(100vh-300px)] pr-1 overflow-y-auto scrollbar-auto pb-4">
+                <MainContainer className="text-text-secondary !space-y-10">
+                  <div className="text-base font-medium text-text-primary">
+                    {t('knowledgeConfiguration.baseInfo')}
+                  </div>
+                  <BasicInfo></BasicInfo>
+                  <Divider />
+                  <MemoryModelForm />
+                  <AdvancedSettingsForm />
+                </MainContainer>
+              </div>
+              <div className="text-right items-center flex justify-end gap-3 w-[768px]">
+                <Button
+                  type="reset"
+                  className="bg-transparent text-color-white hover:bg-transparent border-border-button border"
+                  onClick={() => {
+                    form.reset();
+                  }}
+                >
+                  {t('knowledgeConfiguration.cancel')}
+                </Button>
+                <DynamicForm.SavingButton
+                  submitLoading={loading}
+                  submitFunc={(value) => {
+                    console.log('form-value', value);
+                    onSubmit(value as IMemory);
+                  }}
+                ></DynamicForm.SavingButton>
+              </div>
+            </form>
           </Form>
         </MemorySettingProvider>
       </div>


### PR DESCRIPTION
### Summary

The dataset (knowledge base) configuration page showed incorrect copy:

- The page title was mistranslated as '下个配置' (zh) / 'Next configuration' (en). It is now '知识库配置' / 'Dataset configuration'.
- The page description wrongly referred to memory configuration ('在这里更新您的记忆配置，特别是大语言模型和提示词。'). It now correctly reads '在这里更新您的知识库配置，特别是大语言模型和提示词。'

Since the memory setting page shared the same `knowledgeConfiguration.titleDescription` key (where the memory wording was actually correct), a dedicated `memory.config.titleDescription` key (zh/en) was added and the memory setting page now uses it, so both pages show the correct text.