### PR TITLE
WIP (review after ingestion fully ready) Fix(ingestion): allow canonical file-family keys in Parser component params

### DIFF
--- a/internal/ingestion/pipeline/pipeline_params.go
+++ b/internal/ingestion/pipeline/pipeline_params.go
@@ -6,15 +6,40 @@ import (
 
 	"ragflow/internal/common"
 	"ragflow/internal/entity"
+	"ragflow/internal/ingestion/component/schema"
 
 	"go.uber.org/zap"
 )
+
+// componentNameParser is the DSL component_name of the Parser component.
+// Unlike scalar-param components, its params map is a dynamic per-filetype
+// setups table keyed by file family (pdf, docx, slides, ...).
+const componentNameParser = "Parser"
+
+// parserFileFamilies is the canonical set of file-family keys the Parser
+// component accepts in its setups table. Built-in DSL templates only bake
+// the subset of families each pipeline enables by default, but users can
+// enable any family from the dataset settings UI, so family keys are
+// validated against this set instead of the DSL defaults.
+var parserFileFamilies = func() map[string]struct{} {
+	allowed := schema.ParserParam{}.Defaults().AllowedOutputFormat
+	out := make(map[string]struct{}, len(allowed))
+	for family := range allowed {
+		out[family] = struct{}{}
+	}
+	return out
+}()
 
 // CleanComponentParams filters rawConfig against the DSL schema given by dslJSON.
 // Keys containing ':' are treated as component IDs; they are kept only when both
 // the cpnID AND the param name exist in the DSL schema. Keys without ':' (legacy
 // flat fields such as chunk_token_num, image_context_size) are dropped with a
 // warning — they do not belong in the new component-params world.
+//
+// Parser components are the exception to the param-name rule: their params
+// map is a per-filetype setups table, so any canonical file-family key is
+// accepted even when the DSL template does not bake a default for it (e.g.
+// "slides" in the general template).
 func CleanComponentParams(dslJSON []byte, rawConfig map[string]interface{}) map[string]interface{} {
 	schemas, err := ExtractAllComponentParams(dslJSON)
 	if err != nil {
@@ -23,13 +48,20 @@ func CleanComponentParams(dslJSON []byte, rawConfig map[string]interface{}) map[
 		return rawConfig
 	}
 
-	validCPNs := make(map[string]map[string]struct{}, len(schemas))
+	type componentSchema struct {
+		isParser  bool
+		paramKeys map[string]struct{}
+	}
+	validCPNs := make(map[string]componentSchema, len(schemas))
 	for _, s := range schemas {
 		keys := make(map[string]struct{}, len(s.ParamsDefaults))
 		for k := range s.ParamsDefaults {
 			keys[k] = struct{}{}
 		}
-		validCPNs[s.CpnID] = keys
+		validCPNs[s.CpnID] = componentSchema{
+			isParser:  s.ComponentName == componentNameParser,
+			paramKeys: keys,
+		}
 	}
 
 	result := make(map[string]interface{}, len(rawConfig))
@@ -39,7 +71,7 @@ func CleanComponentParams(dslJSON []byte, rawConfig map[string]interface{}) map[
 				zap.String("key", key))
 			continue
 		}
-		validKeys, ok := validCPNs[key]
+		cpn, ok := validCPNs[key]
 		if !ok {
 			common.Warn("CleanComponentParams: dropping unknown cpnID",
 				zap.String("cpnID", key))
@@ -51,12 +83,18 @@ func CleanComponentParams(dslJSON []byte, rawConfig map[string]interface{}) map[
 		}
 		cleaned := make(map[string]any, len(params))
 		for pk, pv := range params {
-			if _, ok := validKeys[pk]; ok {
+			if _, ok := cpn.paramKeys[pk]; ok {
 				cleaned[pk] = pv
-			} else {
-				common.Warn("CleanComponentParams: dropping unknown param",
-					zap.String("cpnID", key), zap.String("param", pk))
+				continue
 			}
+			if cpn.isParser {
+				if _, ok := parserFileFamilies[pk]; ok {
+					cleaned[pk] = pv
+					continue
+				}
+			}
+			common.Warn("CleanComponentParams: dropping unknown param",
+				zap.String("cpnID", key), zap.String("param", pk))
 		}
 		if len(cleaned) > 0 {
 			result[key] = cleaned
@@ -69,30 +107,71 @@ func CleanComponentParams(dslJSON []byte, rawConfig map[string]interface{}) map[
 // defaults for every component, then overlaying the cleaned incoming overrides.
 // This ensures all components from the current pipeline are present while
 // stripping stale params from other pipelines.
+//
+// Parser components follow different merge semantics: their per-filetype
+// setups table is user-driven, so when the incoming config carries a Parser
+// entry, the incoming file-family set is authoritative — families the user
+// removed (e.g. pdf) are not resurrected from the DSL defaults, and families
+// the template does not bake (e.g. slides) are kept.
 func BuildParserConfig(dslJSON []byte, rawConfig map[string]interface{}) entity.JSONMap {
 	cleaned := CleanComponentParams(dslJSON, rawConfig)
-	defaults, err := ComponentParamsDefaults(dslJSON)
+	schemas, err := ExtractAllComponentParams(dslJSON)
 	if err != nil {
 		common.Warn("BuildParserConfig: failed to extract DSL defaults, using cleaned only",
 			zap.Error(err))
 		return entity.JSONMap(cleaned)
 	}
-	result := make(entity.JSONMap, len(defaults))
-	for cpnID, params := range defaults {
-		base := make(map[string]interface{}, len(params))
-		for k, v := range params {
+	result := make(entity.JSONMap, len(schemas))
+	for _, s := range schemas {
+		base := deepCopyMapStr(s.ParamsDefaults)
+		over, hasOver := cleaned[s.CpnID].(map[string]any)
+		if s.ComponentName == componentNameParser && hasOver {
+			result[s.CpnID] = buildParserComponentConfig(base, over)
+			continue
+		}
+		if hasOver {
+			for k, v := range over {
+				base[k] = v
+			}
+		}
+		result[s.CpnID] = base
+	}
+	return result
+}
+
+// buildParserComponentConfig merges incoming overrides into a Parser
+// component's per-filetype setups table. The incoming family set is
+// authoritative: each kept family's setup is overlaid on its DSL default
+// base when one exists so template-baked fields survive, families absent
+// from the incoming config are dropped, and families without a DSL default
+// are taken as-is. Non-family params (if any) come from the DSL defaults
+// plus incoming overrides.
+func buildParserComponentConfig(defaults map[string]any, over map[string]any) map[string]interface{} {
+	base := make(map[string]interface{}, len(defaults)+len(over))
+	for k, v := range defaults {
+		if _, isFamily := parserFileFamilies[k]; !isFamily {
 			base[k] = v
 		}
-		if over, ok := cleaned[cpnID]; ok {
-			if om, ok := over.(map[string]any); ok {
-				for k, v := range om {
-					base[k] = v
+	}
+	for k, v := range over {
+		if _, isFamily := parserFileFamilies[k]; isFamily {
+			if def, ok := defaults[k].(map[string]any); ok {
+				if vm, ok := v.(map[string]any); ok {
+					merged := make(map[string]interface{}, len(def)+len(vm))
+					for dk, dv := range def {
+						merged[dk] = dv
+					}
+					for dk, dv := range vm {
+						merged[dk] = dv
+					}
+					base[k] = merged
+					continue
 				}
 			}
 		}
-		result[cpnID] = base
+		base[k] = v
 	}
-	return result
+	return base
 }
 
 // ResolveComponentParamsDefaults takes DSL JSON bytes and returns the

--- a/internal/ingestion/pipeline/pipeline_params_test.go
+++ b/internal/ingestion/pipeline/pipeline_params_test.go
@@ -214,6 +214,98 @@ func TestBuildParserConfig_AllComponentsPresent(t *testing.T) {
 	}
 }
 
+func TestCleanComponentParams_ParserAcceptsUnknownFamilyKey(t *testing.T) {
+	dslJSON := generalDSL(t)
+	raw := map[string]any{
+		"Parser:HipSignsRhyme": map[string]any{
+			// "slides" is a canonical family but has no default in the
+			// general-template fixture.
+			"slides": map[string]any{"output_format": "json", "order_index": float64(0)},
+		},
+	}
+	result := CleanComponentParams(dslJSON, raw)
+	params, ok := result["Parser:HipSignsRhyme"].(map[string]any)
+	if !ok {
+		t.Fatal("expected Parser:HipSignsRhyme to pass through")
+	}
+	if _, ok := params["slides"]; !ok {
+		t.Error("expected canonical family key 'slides' to be kept")
+	}
+}
+
+func TestCleanComponentParams_ParserStillDropsUnknownParam(t *testing.T) {
+	dslJSON := generalDSL(t)
+	raw := map[string]any{
+		"Parser:HipSignsRhyme": map[string]any{
+			"not_a_family": map[string]any{"foo": "bar"},
+		},
+	}
+	result := CleanComponentParams(dslJSON, raw)
+	if _, ok := result["Parser:HipSignsRhyme"]; ok {
+		t.Error("expected non-family param 'not_a_family' to be dropped")
+	}
+}
+
+// TestBuildParserConfig_ParserFamilySetIsAuthoritative covers the dataset
+// settings flow where the user replaces one file type with another
+// (pdf → slides): the removed family must not be resurrected from the DSL
+// defaults, the added family must survive even without a DSL default, and
+// per-family order_index must be preserved.
+func TestBuildParserConfig_ParserFamilySetIsAuthoritative(t *testing.T) {
+	dslJSON := generalDSL(t)
+	overrides := map[string]any{
+		"Parser:HipSignsRhyme": map[string]any{
+			"slides": map[string]any{"output_format": "json", "order_index": float64(0)},
+			"docx":   map[string]any{"output_format": "markdown", "order_index": float64(1)},
+		},
+	}
+	result := BuildParserConfig(dslJSON, overrides)
+	parser, ok := result["Parser:HipSignsRhyme"].(map[string]any)
+	if !ok {
+		t.Fatal("expected Parser:HipSignsRhyme in result")
+	}
+	if _, ok := parser["pdf"]; ok {
+		t.Error("expected removed family 'pdf' to stay removed")
+	}
+	slides, ok := parser["slides"].(map[string]any)
+	if !ok {
+		t.Fatal("expected added family 'slides' to be kept")
+	}
+	if slides["order_index"] != float64(0) {
+		t.Errorf("expected slides order_index=0, got %v", slides["order_index"])
+	}
+	docx, ok := parser["docx"].(map[string]any)
+	if !ok {
+		t.Fatal("expected family 'docx' to be kept")
+	}
+	if docx["output_format"] != "markdown" {
+		t.Errorf("expected docx output_format overridden, got %v", docx["output_format"])
+	}
+	if docx["order_index"] != float64(1) {
+		t.Errorf("expected docx order_index=1, got %v", docx["order_index"])
+	}
+}
+
+// TestBuildParserConfig_ParserWithoutOverrideKeepsDefaults ensures the
+// defaults-fill path still applies when the incoming config carries no
+// entry for the Parser component at all.
+func TestBuildParserConfig_ParserWithoutOverrideKeepsDefaults(t *testing.T) {
+	dslJSON := generalDSL(t)
+	overrides := map[string]any{
+		"Chunker:LegalReadersDecide": map[string]any{
+			"chunk_size": float64(1024),
+		},
+	}
+	result := BuildParserConfig(dslJSON, overrides)
+	parser, ok := result["Parser:HipSignsRhyme"].(map[string]any)
+	if !ok {
+		t.Fatal("expected Parser:HipSignsRhyme in result")
+	}
+	if _, ok := parser["pdf"]; !ok {
+		t.Error("expected DSL default family 'pdf' to be present")
+	}
+}
+
 // --- ResolveComponentParamsDefaults ---
 
 func TestResolveComponentParamsDefaults_Basic(t *testing.T) {


### PR DESCRIPTION
### Summary

CleanComponentParams dropped any param key not present in the DSL template ParamsDefaults, but the Parser component uses a per-filetype setups table whose keys are file families (pdf, docx, slides). Users can enable any family from the dataset settings UI even when the DSL template does not bake a default for it, so those keys were wrongly stripped during config cleaning.

This PR validates Parser param keys against the canonical family set (schema.ParserParam defaults) instead of the DSL template defaults, and makes BuildParserConfig treat the incoming family set as authoritative:
- Removed families are not resurrected from DSL defaults.
- Added families survive even without a DSL default.
- Per-family order_index is preserved.

Tests added:
- TestCleanComponentParams_ParserAcceptsUnknownFamilyKey - canonical family keys (e.g. slides) without a DSL default are kept.
- TestCleanComponentParams_ParserStillDropsUnknownParam - non-family keys on a Parser component are still dropped.
- TestBuildParserConfig_ParserFamilySetIsAuthoritative - replacing pdf with slides keeps the new family, drops the old one, and preserves order_index.
- TestBuildParserConfig_ParserWithoutOverrideKeepsDefaults - DSL defaults still apply when no Parser override is provided.
