### PR TITLE
Fix: agent list owner filter not applied

### DIFF
--- a/api/db/services/canvas_service.py
+++ b/api/db/services/canvas_service.py
@@ -148,21 +148,18 @@ class UserCanvasService(CommonService):
             cls.model.canvas_category,
             cls.model.tags,
         ]
+        owner_filter = cls.model.user_id.in_(joined_tenant_ids) & ((cls.model.permission == TenantPermission.TEAM.value) | (cls.model.user_id == user_id))
         if keywords:
             agents = (
                 cls.model.select(*fields)
                 .join(User, on=(cls.model.user_id == User.id))
                 .where(
-                    (((cls.model.user_id.in_(joined_tenant_ids)) & (cls.model.permission == TenantPermission.TEAM.value)) | (cls.model.user_id == user_id)),
+                    owner_filter,
                     (fn.LOWER(cls.model.title).contains(keywords.lower())),
                 )
             )
         else:
-            agents = (
-                cls.model.select(*fields)
-                .join(User, on=(cls.model.user_id == User.id))
-                .where((((cls.model.user_id.in_(joined_tenant_ids)) & (cls.model.permission == TenantPermission.TEAM.value)) | (cls.model.user_id == user_id)))
-            )
+            agents = cls.model.select(*fields).join(User, on=(cls.model.user_id == User.id)).where(owner_filter)
         if canvas_category:
             agents = agents.where(cls.model.canvas_category == canvas_category)
         if canvas_type:

--- a/internal/dao/user_canvas.go
+++ b/internal/dao/user_canvas.go
@@ -357,28 +357,24 @@ func (dao *UserCanvasDAO) ListByTenantIDs(ownerIDs []string, userID string, page
 	// Canvases owned by any of the ownerIDs that are "team"-permission, plus all owned by userID.
 	base := DB.Model(&entity.UserCanvas{}).
 		Select(`user_canvas.id,
-			user_canvas.avatar,
-			user_canvas.title,
-			user_canvas.description,
-			user_canvas.permission,
-			user_canvas.user_id,
-			user_canvas.user_id AS tenant_id,
-			user.nickname,
-			user.avatar AS tenant_avatar,
-			user_canvas.canvas_type,
-			user_canvas.canvas_category,
-			user_canvas.tags,
-			user_canvas.create_time,
-			user_canvas.update_time`).
+		user_canvas.avatar,
+		user_canvas.title,
+		user_canvas.description,
+		user_canvas.permission,
+		user_canvas.user_id,
+		user_canvas.user_id AS tenant_id,
+		user.nickname,
+		user.avatar AS tenant_avatar,
+		user_canvas.canvas_type,
+		user_canvas.canvas_category,
+		user_canvas.tags,
+		user_canvas.create_time,
+		user_canvas.update_time`).
 		Joins("LEFT JOIN user ON user_canvas.user_id = user.id").
+		Where("user_canvas.user_id IN ?", ownerIDs).
 		Where(
-			DB.Where("user_canvas.user_id IN ? AND user_canvas.permission = ?", ownerIDs, "team").
-				Or("user_canvas.user_id = ?", userID),
-			"user_canvas.user_id IN ?",
-			ownerIDs,
-		).Where(
-		DB.Where("user_canvas.permission = ?", "team").
-			Or("user_canvas.user_id = ?", userID))
+			DB.Where("user_canvas.permission = ?", "team").
+				Or("user_canvas.user_id = ?", userID))
 
 	if canvasCategory != "" {
 		base = base.Where("user_canvas.canvas_category = ?", canvasCategory)


### PR DESCRIPTION
### Summary

Filtering agents by owner (team member) on the Agents page had no effect: selecting a teammate (e.g. `zzz`) still returned all of the caller's own agents. Both the Python and Go backends produced a flawed visibility predicate.

**Root cause:**

- **Python** (`api/db/services/canvas_service.py`, `UserCanvasService.get_by_tenant_ids`): the WHERE clause was `(user_id IN (owner_ids) AND permission = 'team') OR user_id = <current user>`. The unconditional `OR user_id = <current user>` always mixed in every canvas owned by the caller, regardless of the requested `owner_ids`.
- **Go** (`internal/dao/user_canvas.go`, `UserCanvasDAO.ListByTenantIDs`): the DAO tried to add a guarding `user_canvas.user_id IN (owner_ids)` condition via `Where(condDB, "user_canvas.user_id IN ?", ownerIDs)`. However, GORM's `BuildCondition` silently drops the remaining string/value arguments when the first argument is a `*gorm.DB`, so the guarding condition never made it into the SQL and the query degenerated to the same flawed predicate as Python.

Verified with a GORM DryRun:

```
OLD:   WHERE ((user_id IN (?) AND permission = ?) OR user_id = ?) AND (permission = ? OR user_id = ?)  -- guard lost
FIXED: WHERE user_id IN (?) AND (permission = ? OR user_id = ?)
```

**Fix:** both backends now use the single predicate `user_id IN (owner_ids) AND (permission = 'team' OR user_id = <current user>)`:

- When no `owner_ids` are passed, the effective set is all authorized tenants plus the caller, so behavior is identical to before.
- When specific owners are selected, results are correctly restricted to those owners (their team-shared canvases; the caller's own canvases only when the caller is among the selected owners).

Also deduplicated the repeated predicate in the Python keywords / non-keywords branches into a single `owner_filter` expression.

**Validation:** `ruff check` / `ruff format --check` pass; `go vet ./internal/dao/` passes; SQL semantics verified via GORM DryRun.