### PR TITLE
fix: show resolved embedding model display name in dataset list

### DIFF
--- a/internal/dao/kb.go
+++ b/internal/dao/kb.go
@@ -182,6 +182,7 @@ func (dao *KnowledgebaseDAO) GetByTenantIDs(ctx context.Context, db *gorm.DB, te
 			knowledgebase.language, knowledgebase.description, knowledgebase.tenant_id,
 			knowledgebase.permission, knowledgebase.doc_num, knowledgebase.token_num,
 			knowledgebase.chunk_num, knowledgebase.parser_id, knowledgebase.embd_id,
+			knowledgebase.tenant_embd_id,
 			user.nickname, user.avatar as tenant_avatar, knowledgebase.update_time`).
 		Joins("LEFT JOIN user ON knowledgebase.tenant_id = user.id").
 		Where("((knowledgebase.tenant_id IN ? AND knowledgebase.permission = ?) OR knowledgebase.tenant_id = ?) AND knowledgebase.status = ?",

--- a/internal/entity/dataset.go
+++ b/internal/entity/dataset.go
@@ -235,6 +235,7 @@ type KnowledgebaseListItem struct {
 	ChunkNum     int64   `json:"chunk_num"`
 	ParserID     string  `json:"parser_id"`
 	EmbdID       string  `json:"embd_id"`
+	TenantEmbdID *string `json:"tenant_embd_id,omitempty"`
 	Nickname     string  `json:"nickname"`
 	TenantAvatar *string `json:"tenant_avatar,omitempty"`
 	UpdateTime   *int64  `json:"update_time,omitempty"`

--- a/internal/service/dataset/crud.go
+++ b/internal/service/dataset/crud.go
@@ -383,11 +383,20 @@ func (d *DatasetService) ListDatasets(ctx context.Context, id, name string, page
 	}
 
 	data := make([]map[string]interface{}, 0, len(kbs))
+	modelNameCache := make(map[string]string)
 	for _, kb := range kbs {
 		if kb == nil {
 			continue
 		}
-		data = append(data, datasetListItemToMap(kb))
+		item := datasetListItemToMap(kb)
+		// Mirror the memory list: surface the concrete model display name
+		// (modelName@instance@provider) instead of a raw tenant_model ID.
+		tenantEmbdID := ptrStringValue(kb.TenantEmbdID)
+		if tenantEmbdID == "" && isHexID(kb.EmbdID) {
+			tenantEmbdID = kb.EmbdID
+		}
+		item["embedding_model"] = service.ResolveTenantModelDisplayName(tenantEmbdID, kb.EmbdID, modelNameCache)
+		data = append(data, item)
 	}
 
 	return data, total, common.CodeSuccess, nil

--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -1469,8 +1469,8 @@ func (s *MemoryService) ListMemories(ctx context.Context, userID string, tenantI
 		}
 		memoryMap := map[string]interface{}{
 			"id":           resp.ID,
-			"llm_id":       resolveTenantModelDisplayName(ptrStringValue(resp.TenantLLMID), resp.LLMID, modelNameCache),
-			"embd_id":      resolveTenantModelDisplayName(ptrStringValue(resp.TenantEmbdID), resp.EmbdID, modelNameCache),
+			"llm_id":       ResolveTenantModelDisplayName(ptrStringValue(resp.TenantLLMID), resp.LLMID, modelNameCache),
+			"embd_id":      ResolveTenantModelDisplayName(ptrStringValue(resp.TenantEmbdID), resp.EmbdID, modelNameCache),
 			"name":         resp.Name,
 			"avatar":       resp.Avatar,
 			"tenant_id":    resp.TenantID,
@@ -1491,10 +1491,10 @@ func (s *MemoryService) ListMemories(ctx context.Context, userID string, tenantI
 	}, nil
 }
 
-// resolveTenantModelDisplayName turns a tenant_model ID into
+// ResolveTenantModelDisplayName turns a tenant_model ID into
 // modelName@instance@provider. rawModelID is the API-facing fallback
-// stored on memory.llm_id / memory.embd_id.
-func resolveTenantModelDisplayName(tenantModelID, rawModelID string, cache map[string]string) string {
+// stored on memory.llm_id / memory.embd_id / knowledgebase.embd_id.
+func ResolveTenantModelDisplayName(tenantModelID, rawModelID string, cache map[string]string) string {
 	tenantModelID = strings.TrimSpace(tenantModelID)
 	rawModelID = strings.TrimSpace(rawModelID)
 	if tenantModelID == "" || strings.Contains(tenantModelID, "@") {


### PR DESCRIPTION
### Summary

The dataset list API (`GET /api/v1/datasets`) returned the raw `knowledgebase.embd_id` value. When a dataset's embedding model is stored as a tenant_model reference, this value is a 32-char hex tenant_model ID, so the knowledge base selector in the UI displayed an unreadable ID (e.g. `e21f824a8f8749b88d5a4d7d50eabe`) instead of the concrete model name.

This PR mirrors the memory list behavior: the tenant_model ID is resolved to its `modelName@instance@provider` display name (e.g. `BAAI/bge-m3@s-1@SILICONFLOW`) when building the dataset list response.

Changes:
- Export `ResolveTenantModelDisplayName` in `internal/service/memory.go` so both the memory list and the dataset list share a single resolution path.
- Add `TenantEmbdID` to `KnowledgebaseListItem` and select `knowledgebase.tenant_embd_id` in `GetByTenantIDs`.
- In `ListDatasets`, resolve `embedding_model` to the display name with a per-request cache, falling back to the raw value when resolution fails or the value is already a `name@provider` string; a hex `embd_id` without `tenant_embd_id` is also resolved directly.