### PR TITLE
fix: prevent child delimiter add from submitting form

### DIFF
--- a/web/src/pages/agent/form/token-chunker-form/index.tsx
+++ b/web/src/pages/agent/form/token-chunker-form/index.tsx
@@ -208,6 +208,7 @@ const TokenChunkerForm = ({
                 ))}
 
                 <BlockButton
+                  type="button"
                   onClick={() => childrenDelimiters.append({ value: '\n' })}
                 >
                   {t('common.add')}


### PR DESCRIPTION
### Summary

Fixes the child delimiter **Add** button in the dataset configuration Token Chunker form by setting it to `type="button"`. This prevents the click from submitting the outer dataset settings form, refreshing the page, and blocking users from adding child delimiters.

Validation:
- Ran the targeted ESLint check for `web/src/pages/agent/form/token-chunker-form/index.tsx`.
- Pre-commit checks passed (web dependencies, Prettier, and ESLint).