### PR TITLE
fix: add document name display in testing result cards

### DIFF
--- a/web/src/pages/dataset/testing/testing-result.tsx
+++ b/web/src/pages/dataset/testing/testing-result.tsx
@@ -85,6 +85,9 @@ export function TestingResult({
                   <Card className="px-5 py-2.5 bg-transparent shadow-none">
                     <ChunkTitle item={x}></ChunkTitle>
                     <p className="!mt-2.5"> {x.content_with_weight}</p>
+                    <div className="mt-2.5 text-right text-xs text-text-sub-title-invert">
+                      {x.doc_name || x.docnm_kwd}
+                    </div>
                   </Card>
                 </article>
               ))}


### PR DESCRIPTION
### Summary

fix: add document name display in testing result cards
