### PR TITLE
WIP (review after ingestion fully ready) Go: fix ingestion log detail missing dsl field

### DIFF
--- a/internal/service/dataset/ingestion.go
+++ b/internal/service/dataset/ingestion.go
@@ -108,7 +108,7 @@ func (d *DatasetService) GetIngestionLog(ctx context.Context, datasetID, userID,
 		return nil, common.CodeServerError, fmt.Errorf("get ingestion log: %w", err)
 	}
 
-	return datasetIngestionLogToMap(log), common.CodeSuccess, nil
+	return fileIngestionLogToMap(log), common.CodeSuccess, nil
 }
 
 func datasetIngestionLogToMap(log *entity.PipelineOperationLog) map[string]interface{} {


### PR DESCRIPTION
### Summary

The Go `GetIngestionLog` endpoint (`GET /api/v1/datasets/{dataset_id}/ingestions/{log_id}`) returned the dataset-level field set via `datasetIngestionLogToMap`, which omits `dsl`, `pipeline_title`, `process_begin_at`, `avatar`, and `document_type`. The front-end `dataflow-result` page (opened via the "open" action on the dataset logs page) relies on `dsl.components` to render the pipeline timeline and parsed content, so the page showed empty content when opened from a log entry.

This PR returns the file-level field set (`fileIngestionLogToMap`) for the log detail response, matching the Python reference implementation (`dataset_api_service.get_log`) which explicitly includes `dsl`. Verified with `bash build.sh --test ./internal/service/dataset/...` (all package tests pass).