### PR TITLE
fix: validate GraphRAG query rewrite keywords

### DIFF
--- a/rag/graphrag/search.py
+++ b/rag/graphrag/search.py
@@ -32,6 +32,24 @@ from common import settings
 from common.doc_store.doc_store_base import OrderByExpr
 
 
+def _string_keywords(value: object, limit: int | None = None) -> list[str]:
+    if not isinstance(value, list):
+        return []
+
+    keywords = [item.strip() for item in value if isinstance(item, str) and item.strip()]
+    return keywords[:limit] if limit is not None else keywords
+
+
+def _query_rewrite_keywords(value: object) -> tuple[list[str], list[str]]:
+    if not isinstance(value, dict):
+        return [], []
+
+    return (
+        _string_keywords(value.get("answer_type_keywords", [])),
+        _string_keywords(value.get("entities_from_query", []), limit=5),
+    )
+
+
 class KGSearch(Dealer):
     async def _chat(self, llm_bdl, system, history, gen_conf):
         response = get_llm_cache(llm_bdl.llm_name, system, history, gen_conf)
@@ -49,17 +67,13 @@ class KGSearch(Dealer):
         result = await self._chat(llm, hint_prompt, [{"role": "user", "content": "Output:"}], {})
         try:
             keywords_data = json_repair.loads(result)
-            type_keywords = keywords_data.get("answer_type_keywords", [])
-            entities_from_query = keywords_data.get("entities_from_query", [])[:5]
-            return type_keywords, entities_from_query
-        except json_repair.JSONDecodeError:
+            return _query_rewrite_keywords(keywords_data)
+        except json.JSONDecodeError:
             try:
                 result = result.replace(hint_prompt[:-1], "").replace("user", "").replace("model", "").strip()
                 result = "{" + result.split("{")[1].split("}")[0] + "}"
                 keywords_data = json_repair.loads(result)
-                type_keywords = keywords_data.get("answer_type_keywords", [])
-                entities_from_query = keywords_data.get("entities_from_query", [])[:5]
-                return type_keywords, entities_from_query
+                return _query_rewrite_keywords(keywords_data)
             # Handle parsing error
             except Exception as e:
                 logging.exception(f"JSON parsing error: {result} -> {e}")
@@ -164,6 +178,10 @@ class KGSearch(Dealer):
             logging.exception(e)
             ents = [qst]
             pass
+
+        if not ents:
+            logging.warning("Query rewrite returned no valid string entities; falling back to the original question")
+            ents = [qst]
 
         ents_from_query = self.get_relevant_ents_by_keywords(ents, filters, idxnms, kb_ids, emb_mdl, ent_sim_threshold)
         ents_from_types = self.get_relevant_ents_by_types(ty_kwds, filters, idxnms, kb_ids, 10000)

--- a/test/unit_test/rag/graphrag/test_search_query_keywords.py
+++ b/test/unit_test/rag/graphrag/test_search_query_keywords.py
@@ -1,0 +1,90 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _Dealer:
+    def __init__(self, data_store=None):
+        self.dataStore = data_store
+
+
+nlp_search = sys.modules["rag.nlp.search"]
+original_dealer = nlp_search.Dealer
+original_index_name = nlp_search.index_name
+nlp_search.Dealer = _Dealer  # type: ignore[attr-defined]
+nlp_search.index_name = lambda tenant_id: f"idx-{tenant_id}"  # type: ignore[attr-defined]
+
+import rag.graphrag.search as search_module
+from rag.graphrag.search import KGSearch
+
+nlp_search.Dealer = original_dealer  # type: ignore[attr-defined]
+nlp_search.index_name = original_index_name  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_keeps_only_non_empty_string_keywords(monkeypatch):
+    async def get_entity_type_samples(_idxnms, _kb_ids):
+        return {}
+
+    monkeypatch.setattr(search_module, "get_entity_type2samples", get_entity_type_samples)
+
+    search = KGSearch()
+    search._chat = AsyncMock(
+        return_value='{"answer_type_keywords":[" INDUSTRY ",{"nested":true},"",42],"entities_from_query":[{"industries":[]}," entity-1 ",null,"entity-2","entity-3","entity-4","entity-5","entity-6"]}'
+    )
+
+    type_keywords, entities = await search.query_rewrite(MagicMock(), "question", ["idx"], ["kb"])
+
+    assert type_keywords == ["INDUSTRY"]
+    assert entities == ["entity-1", "entity-2", "entity-3", "entity-4", "entity-5"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", ["null", '"unexpected"', '[{"entity": "unexpected"}]'])
+async def test_query_rewrite_rejects_non_object_json(monkeypatch, response):
+    async def get_entity_type_samples(_idxnms, _kb_ids):
+        return {}
+
+    monkeypatch.setattr(search_module, "get_entity_type2samples", get_entity_type_samples)
+
+    search = KGSearch()
+    search._chat = AsyncMock(return_value=response)
+
+    type_keywords, entities = await search.query_rewrite(MagicMock(), "question", ["idx"], ["kb"])
+
+    assert type_keywords == []
+    assert entities == []
+
+
+@pytest.mark.asyncio
+async def test_retrieval_falls_back_to_question_when_rewrite_has_no_string_entities(monkeypatch):
+    monkeypatch.setattr(search_module, "index_name", lambda tenant_id: f"idx-{tenant_id}")
+
+    search = KGSearch()
+    search.get_filters = MagicMock(return_value={"kb_ids": ["kb"]})
+    search.query_rewrite = AsyncMock(return_value=([], []))
+    search.get_relevant_ents_by_keywords = MagicMock(return_value={})
+    search.get_relevant_ents_by_types = MagicMock(return_value={})
+    search.get_relevant_relations_by_txt = MagicMock(return_value={})
+    search._community_retrieval_ = MagicMock(return_value="")
+
+    await search.retrieval("original question", "tenant", ["kb"], MagicMock(), MagicMock())
+
+    keywords = search.get_relevant_ents_by_keywords.call_args.args[0]
+    assert keywords == ["original question"]


### PR DESCRIPTION
### Summary

GraphRAG query rewriting assumes that both `answer_type_keywords` and `entities_from_query` are lists of strings. When an LLM returns a structured object inside either list, entity retrieval calls `", ".join(keywords)` and raises:

```text
TypeError: sequence item 0: expected str instance, dict found
```

This PR:

- keeps only non-empty string keywords returned by query rewriting;
- applies the five-entity limit after validation;
- falls back to the original question when no valid entity strings remain, so GraphRAG retrieval degrades safely instead of failing the chat request;
- adds regression coverage for malformed structured output and the fallback path.

### Tests

```text
pytest -q --confcutdir=test/unit_test/rag/graphrag test/unit_test/rag/graphrag
115 passed
```

The fix was also replayed against a malformed synthetic query-rewrite response in a running RAGFlow service, and the GraphRAG retrieval fallback completed without the `join()` TypeError.
