### PR TITLE
fix: persist page size across main page navigation

### DIFF
--- a/web/src/hooks/route-hook.ts
+++ b/web/src/hooks/route-hook.ts
@@ -69,27 +69,36 @@ export const useGetPaginationParams = () => {
   };
 };
 
+const PageSizeStorageKeyPrefix = 'RAGFlowPageSize:';
+
+const getStoredPageSize = (pathname: string) =>
+  Number(localStorage.getItem(`${PageSizeStorageKeyPrefix}${pathname}`));
+
 export const useSetPaginationParams = () => {
   const [queryParameters, setSearchParams] = useSearchParams();
-  // const newQueryParameters: URLSearchParams = useMemo(
-  //   () => new URLSearchParams(queryParameters.toString()),
-  //   [queryParameters],
-  // );
+  const { pathname } = useLocation();
 
   const setPaginationParams = useCallback(
     (page: number = 1, pageSize?: number) => {
       queryParameters.set('page', page.toString());
       if (pageSize) {
         queryParameters.set('size', pageSize.toString());
+        // Persist the page size per main page so it survives navigation
+        // to other pages, where the URL search params are dropped.
+        localStorage.setItem(
+          `${PageSizeStorageKeyPrefix}${pathname}`,
+          pageSize.toString(),
+        );
       }
       setSearchParams(queryParameters);
     },
-    [setSearchParams, queryParameters],
+    [setSearchParams, queryParameters, pathname],
   );
 
   return {
     setPaginationParams,
     page: Number(queryParameters.get('page')) || 1,
-    size: Number(queryParameters.get('size')) || 50,
+    size:
+      Number(queryParameters.get('size')) || getStoredPageSize(pathname) || 50,
   };
 };


### PR DESCRIPTION
### Summary

On list pages (datasets, chats, agents, files, search, etc.), the pagination state lived only in the URL search params (`page`/`size`). After selecting a page size in the bottom-right pagination, switching to another main page drops those params, so coming back reset the page size to the default 50/page.

This PR persists the selected page size per pathname in `localStorage` inside `useSetPaginationParams`. When the URL has no `size` param, the stored value for the current page is used instead of the hardcoded default; the page number is intentionally not remembered. All main list pages go through this hook, so one change fixes them all.