### PR TITLE
Fix: fall back to tenant default LLM when template-pinned model is unavailable

### DIFF
--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -84,6 +84,15 @@ import (
 
 const componentNameExtractor = "Extractor"
 
+// resolveExtractorCompositeModel resolves a composite "model@provider"
+// llm_id into driver / model / apiConfig. It is a test seam: production
+// delegates to the shared resolveModelConfig dispatcher; unit tests swap
+// it to inject failures without a live DB (the real dispatcher hits the
+// DAO layer and panics under testing.Main's no-DB harness).
+var resolveExtractorCompositeModel = func(tenantID string, modelType entity.ModelType, modelRef string) (models.ModelDriver, string, *models.APIConfig, int, error) {
+	return resolveModelConfig(tenantID, modelType, modelRef)
+}
+
 // extractorTimeout bounds one LLM chat call. Matches the python
 // `@timeout(60)` default at rag/flow/base.py:60. The pipeline
 // orchestrator (Phase 3) overrides this if a stage-level ceiling
@@ -798,9 +807,21 @@ func resolveExtractorChatConfig(ctx context.Context, compositeLLMID string) (ext
 		}
 	} else {
 		// Composite "model@provider" path: delegate to the shared dispatcher.
-		driver, modelName, apiConfig, _, err = resolveModelConfig(tid, entity.ModelTypeChat, compositeLLMID)
+		driver, modelName, apiConfig, _, err = resolveExtractorCompositeModel(tid, entity.ModelTypeChat, compositeLLMID)
 		if err != nil {
-			return extractorChatConfig{}, fmt.Errorf("extractor: resolve model %q: %w", compositeLLMID, err)
+			// The template may pin a specific model (e.g. the resume
+			// template's "THUDM/GLM-4.1V-9B-Thinking@SILICONFLOW") that
+			// this tenant hasn't configured an instance for. Fall back
+			// to the tenant's default chat LLM instead of failing the
+			// whole pipeline — mirrors the Python side's graceful
+			// handling in chunk_post_processor._resolve_template_chat_llm_id.
+			fallbackDriver, fallbackName, fallbackAPI, _, fbErr := resolveTenantModelByType(tid, entity.ModelTypeChat)
+			if fbErr != nil {
+				return extractorChatConfig{}, fmt.Errorf("extractor: resolve model %q: %w (tenant default also failed: %v)", compositeLLMID, err, fbErr)
+			}
+			driver = fallbackDriver
+			modelName = fallbackName
+			apiConfig = fallbackAPI
 		}
 	}
 

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -19,6 +19,7 @@ package component
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -27,6 +28,8 @@ import (
 	eschema "github.com/cloudwego/eino/schema"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/entity"
+	modelModule "ragflow/internal/entity/models"
 	"ragflow/internal/ingestion/component/schema"
 )
 
@@ -817,3 +820,58 @@ func TestResolveExtractorChatTarget_NoDriver(t *testing.T) {
 		t.Errorf("modelName = %q, want plain-name", modelName)
 	}
 }
+
+// TestResolveExtractorChatConfig_CompositeFallback verifies that when the
+// template-pinned composite model ("model@provider") cannot be resolved
+// (the tenant has no matching provider instance), the Extractor falls back
+// to the tenant's default chat LLM instead of failing. This is the bug
+// behind the resume-template crash: the template hardcodes
+// "THUDM/GLM-4.1V-9B-Thinking@SILICONFLOW", and tenants that haven't
+// provisioned a SILICONFLOW instance named "default" hit
+// `instance "default" lookup failed: record not found`.
+func TestResolveExtractorChatConfig_CompositeFallback(t *testing.T) {
+	origComposite := resolveExtractorCompositeModel
+	origDefault := resolveTenantModelByType
+	defer func() {
+		resolveExtractorCompositeModel = origComposite
+		resolveTenantModelByType = origDefault
+	}()
+
+	// Simulate the tenant lacking the pinned model's provider instance:
+	// the composite resolver fails as the real DAO would.
+	resolveExtractorCompositeModel = func(tenantID string, modelType entity.ModelType, modelRef string) (modelModule.ModelDriver, string, *modelModule.APIConfig, int, error) {
+		return nil, "", nil, 0, fmt.Errorf("instance %q lookup failed: record not found", "default")
+	}
+	fallbackDriver := &modelModule.DummyModel{}
+	resolveTenantModelByType = func(tenantID string, modelType entity.ModelType) (modelModule.ModelDriver, string, *modelModule.APIConfig, int, error) {
+		if modelType != entity.ModelTypeChat {
+			return nil, "", nil, 0, fmt.Errorf("unexpected model type: %s", modelType)
+		}
+		apiConfig := &modelModule.APIConfig{ApiKey: ptr("fallback-key"), BaseURL: ptr("https://fallback.example.com")}
+		return fallbackDriver, "tenant-default-chat", apiConfig, 0, nil
+	}
+
+	ctx := runtime.WithState(context.Background(), runtime.NewCanvasState("run-1", "task-1"))
+	state, _, err := runtime.GetStateFromContext[*runtime.CanvasState](ctx)
+	if err != nil {
+		t.Fatalf("GetStateFromContext: %v", err)
+	}
+	state.SetGlobal("tenant_id", "tenant-1")
+
+	cfg, err := resolveExtractorChatConfig(ctx, "THUDM/GLM-4.1V-9B-Thinking@SILICONFLOW")
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	if cfg.modelName != "tenant-default-chat" {
+		t.Errorf("modelName = %q, want tenant-default-chat (fallback)", cfg.modelName)
+	}
+	if cfg.apiKey != "fallback-key" {
+		t.Errorf("apiKey = %q, want fallback-key (fallback)", cfg.apiKey)
+	}
+	if cfg.baseURL != "https://fallback.example.com" {
+		t.Errorf("baseURL = %q, want https://fallback.example.com (fallback)", cfg.baseURL)
+	}
+}
+
+// ptr is a small helper for building *string test fixtures.
+func ptr(s string) *string { return &s }


### PR DESCRIPTION
**Summary**

When `chunk_method` is set to `resume`, the ingestion pipeline crashes with `instance "default" lookup failed: record not found`, and the document processing fails entirely.

Root cause: The resume template (`ingestion_pipeline_resume.json`) hardcodes `llm_id: "THUDM/GLM-4.1V-9B-Thinking@SILICONFLOW"` in its Extractor component. At runtime, the Go port resolves this composite name by looking up a `TenantModelInstance` named `"default"` under the tenant's SILICONFLOW provider. Most tenants have a SILICONFLOW provider but no instance named `"default"`, so the lookup fails. Unlike the Python side (`chunk_post_processor._resolve_template_chat_llm_id`), which catches the error and skips the template gracefully, the Go port propagated the error and crashed the whole pipeline.

Changes:

- `internal/ingestion/component/extractor.go`: when the template-pinned composite model fails to resolve, fall back to the tenant's default chat LLM (`resolveTenantModelByType`) instead of returning an error — mirrors the Python side's resolution order (template → tenant default). Added `resolveExtractorCompositeModel` as a test seam so the composite-resolution step can be mocked without a live DB.
- `internal/ingestion/component/extractor_test.go`: added `TestResolveExtractorChatConfig_CompositeFallback`, which simulates the `instance "default" lookup failed` error and verifies the fallback returns the tenant default LLM's credentials.

Verification:

- `bash build.sh --test ./internal/ingestion/component/...` passes.