### PR TITLE
fix: remediate nltk CVEs by constraining to >=3.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,10 @@ constraint-dependencies = [
     # inscriptis 2.7.0 pins lxml<6.0.0, blocking the lxml CVE fix;
     # 2.7.3 relaxes to <6.2.0. Pulled in transitively via ir-datasets -> ranx
     "inscriptis>=2.7.3",
+    # CVE-2025-14009 (CRITICAL), CVE-2026-0846, CVE-2026-0847, CVE-2026-33231,
+    # CVE-2026-33236, CVE-2026-54293 (HIGH), CVE-2026-33230 (MEDIUM):
+    # nltk < 3.10.0 vulnerable; pulled in transitively via crawl4ai, infinity-sdk
+    "nltk>=3.10.0",
 ]
 exclude-dependencies = [
     # crawl4ai>=0.8.6 depends on unclecode-litellm, which installs the same

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ constraints = [
     { name = "inscriptis", specifier = ">=2.7.3" },
     { name = "lxml", specifier = ">=6.1.1" },
     { name = "lxml-html-clean", specifier = ">=0.4.5" },
+    { name = "nltk", specifier = ">=3.10.0" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "trio", specifier = ">=0.26.0", index = "https://pypi.org/simple" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -3921,17 +3922,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.2"
+version = "3.10.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf" },
 ]
 
 [[package]]
@@ -4046,12 +4048,12 @@ name = "onnxruntime-gpu"
 version = "1.23.2"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
-    { name = "coloredlogs", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "flatbuffers", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "packaging", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "protobuf", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "sympy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/03/05/40d561636e4114b54aa06d2371bfbca2d03e12cfdf5d4b85814802f18a75/onnxruntime_gpu-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e8f75af5da07329d0c3a5006087f4051d8abd133b4be7c9bae8cdab7bea4c26" },


### PR DESCRIPTION
## Summary
  
  Remediates five nltk CVEs by adding `nltk>=3.10.0` to `constraint-dependencies` in `pyproject.toml`.
  
  | CVE | Severity | Installed | Fixed in |
  |---|---|---|---|
  | CVE-2025-14009 | CRITICAL | 3.9.2 | 3.9.3 |
  | CVE-2026-0846 | HIGH | 3.9.2 | 3.9.3 |
  | CVE-2026-0847 | HIGH | 3.9.2 | — |
  | CVE-2026-33231 | HIGH | 3.9.2 | 3.9.4 |
  | CVE-2026-33236 | HIGH | 3.9.2 | — |
  | CVE-2026-54293 | HIGH | 3.9.2 | 3.10.0 |
  | CVE-2026-33230 | MEDIUM | 3.9.2 | 3.9.4 |
  
  CVE-2026-0847 and CVE-2026-33236 have no confirmed fixed version.
 
 `nltk` is a transitive dependency (pulled in by `crawl4ai` and `infinity-sdk`). No package in the graph caps it below 3.10.0. It was stuck at 3.9.2 simply because the lockfile had never been re-resolved.
  
  ## Verification
  
  RAGFlow uses nltk for:
  - `from nltk.corpus import wordnet` (synonym expansion in `rag/nlp/synonym.py`)
  - `nltk.download("wordnet"/"punkt_tab")` (data download at startup in `api/validation.py`)
  
The corpus API is unchanged in 3.10.0. The pre-bundled `nltk_data` (wordnet, punkt, punkt_tab) in the Docker image is compatible with the newer package version.
  
  ## Testing
  
  - Full unit test suite passes
  - Verified `wordnet.ensure_loaded()` succeeds with bundled `nltk_data`
  - `uv sync` resolves cleanly