### PR TITLE
fix: remediate litellm CVEs by upgrading from 1.82.5 to 1.84.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,12 +157,11 @@ dependencies = [
     #    "xxhash>=3.5.0,<4.0.0",
     #    "trio>=0.17.0,<0.29.0",
     #    "click>=8.1.8",
-    # 1.88.0 ships a broken `litellm.integrations.custom_logger`
-    # (imports `AgenticLoopPlan` from a sibling types module where the
-    # symbol is missing — see PR #15952 CI run 27414495913), and the
-    # 1.82.6/1.82.7/1.82.8 minors have a broken `litellm.caching.caching`
-    # import chain. Pin to a single known-good 1.82.x release.
-    "litellm==1.82.5",
+    # litellm < 1.84.0 vulnerable to multiple CVE's. Previously pinned to 1.82.5 due to broken
+    # imports in 1.82.6–1.82.8 (caching) and 1.88.0 (custom_logger); both
+    # issues are resolved in 1.84.0. Exact pin retained due to litellm's
+    # history of introducing regressions on minor bumps.
+    "litellm==1.84.0",
     #    "pip>=25.2",
     #    "imageio-ffmpeg>=0.6.0",
     #    "cryptography==46.0.3",

--- a/uv.lock
+++ b/uv.lock
@@ -3391,7 +3391,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.82.5"
+version = "1.84.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3407,9 +3407,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/d7/f0/ec42ee14b388ce1d08a1df638f894ed7f1e6ac35b9daf0588ff7f7d52262/litellm-1.82.5.tar.gz", hash = "sha256:7988a9b48c8ccd9e5ebced80a4dfce9ce87083b303c3f67082450a4ad6dd312f" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/dd/e9/8941b7e72a187000561d932c0f2f2ed2b0fd080dfc33ba6e05961d45ca7d/litellm-1.84.0.tar.gz", hash = "sha256:b8ad0cbea11a5941b18d5af973017a340abd3d3ab41cb86e5401b970626d71a6" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/68/1f/b6c8043eec81eade53a4d0e15a50b788ab0e82661e01a25e0b8536a4dca0/litellm-1.82.5-py3-none-any.whl", hash = "sha256:e1012ab816352215c4e00776dd48b0c68058b537888a8ff82cca62af19e6fb11" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/01/a6/77fa1bbf5e42eb596b06318b3f7e6af5d0f44028046d1d598c6a595d028f/litellm-1.84.0-py3-none-any.whl", hash = "sha256:2a58d6041e6aa27d1a28dc8d8828ab500fef1a00ef74ca65e60899035010c2f2" },
 ]
 
 [[package]]
@@ -8229,7 +8229,7 @@ requires-dist = [
     { name = "langgraph", specifier = "==1.2.0" },
     { name = "lark-oapi", specifier = ">=1.2.0" },
     { name = "line-bot-sdk", specifier = ">=3.0.0" },
-    { name = "litellm", specifier = "==1.82.5" },
+    { name = "litellm", specifier = "==1.84.0" },
     { name = "mammoth", specifier = ">=1.11.0" },
     { name = "markdown", specifier = ">=3.8.1,<4.0.0" },
     { name = "markdown-to-json", specifier = "==2.1.1" },


### PR DESCRIPTION
 ## Summary
  
  Remediates nine litellm CVEs (3 CRITICAL, 6 HIGH) by upgrading the exact pin from `==1.82.5` to `==1.84.0` in `pyproject.toml`.
  
  | CVE | Severity | Fixed in |
  |---|---|---|
  | CVE-2026-35030 | CRITICAL | 1.83.0 |
  | CVE-2026-42208 | CRITICAL | 1.83.7 |
  | CVE-2026-49468 | CRITICAL | 1.84.0 |
  | CVE-2026-35029 | HIGH | 1.83.0 |
  | CVE-2026-40217 | HIGH | 1.83.10 |
  | CVE-2026-42203 | HIGH | 1.83.7 |
  | CVE-2026-42271 | HIGH | 1.83.7 |
  | CVE-2026-47101 | HIGH | 1.83.14 |
  | CVE-2026-47102 | HIGH | 1.83.10 |
  
  `litellm` was pinned to `==1.82.5` because versions 1.82.6 - 1.82.8 had a broken `litellm.caching.caching` import chain, and 1.88.0 had a broken `litellm.integrations.custom_logger` import.
  Both issues are resolved in 1.84.0.
The exact pin is retained (rather than a range) due to litellm's history of introducing regressions on minor bumps.
  
  ## Verification
  
  - Verified all litellm import paths RAGFlow uses:
    - `import litellm` &rarr; OK
    - `litellm.acompletion` / `litellm.completion` &rarr; present
    - `from litellm import logging` &rarr; OK
    - `from litellm.caching import caching` &rarr; OK (previously broken in 1.82.6 - 1.82.8)
    - `from litellm.integrations import custom_logger` &rarr; OK (previously broken in 1.88.0)
  - Reviewed [v1.84.0 release notes](https://docs.litellm.ai/release_notes/v1.84.0/v1-84-0) &rarr; all behaviour changes are proxy-server-side; RAGFlow uses litellm as an in-process library only
  - RAGFlow's call pattern (`litellm.acompletion(**args, drop_params=True, timeout=...)`) is unchanged in 1.84.0.
  
  ## Testing
  
  - Full unit test suite passes
  - Import checks verified
  - Previously broken import paths (`litellm.caching.caching`, `litellm.integrations.custom_logger`) confirmed fixed