### PR TITLE
fix(common,internal): round instead of truncate in normalize_overlapped_percent (closes #17418)

### DIFF
--- a/internal/ingestion/component/chunker/token_test.go
+++ b/internal/ingestion/component/chunker/token_test.go
@@ -395,7 +395,11 @@ func TestNormalizeOverlappedPercent(t *testing.T) {
 	}{
 		{"zero", 0, 0},
 		{"fraction 0.1 -> 10", 0.1, 10},
+		{"fraction 0.29 -> 29 (round, was 28 trunc)", 0.29, 29},
+		{"fraction 0.3 -> 30", 0.3, 30},
 		{"fraction 0.5 -> 50", 0.5, 50},
+		{"fraction 0.57 -> 57 (round, was 56 trunc)", 0.57, 57},
+		{"fraction 0.93 -> 90 (clamp after round)", 0.93, 90},
 		{"fraction 0.95 -> 90 (clamp)", 0.95, 90},
 		{"percent 15", 15, 15},
 		{"int truncation 33.3 -> 33", 33.3, 33},
@@ -413,6 +417,8 @@ func TestNormalizeOverlappedPercent(t *testing.T) {
 		{"huge 1e300 -> 90", 1e300, 90},
 		{"huge -1e300 -> 0", -1e300, 0},
 		{"huge math.MaxFloat64 -> 90", math.MaxFloat64, 90},
+		{"huge math.MaxFloat64 +1 -> 90 (clamp pre-round)", math.MaxFloat64 + 1, 90},
+		{`numeric string fraction "0.29" -> 29`, "0.29", 29},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -491,6 +497,8 @@ func TestTokenChunkerParam_ValidateOverlappedRange(t *testing.T) {
 		wantErr bool
 	}{
 		{"fraction 0.3 -> 30", 0.3, 30, false},
+		{"fraction 0.29 -> 29 (round, was 28 trunc)", 0.29, 29, false},
+		{"fraction 0.57 -> 57 (round, was 56 trunc)", 0.57, 57, false},
 		{"percent 0", 0, 0, false},
 		{"percent 30", 30, 30, false},
 		{"percent 90 (boundary)", 90, 90, false},

--- a/internal/ingestion/component/schema/chunker.go
+++ b/internal/ingestion/component/schema/chunker.go
@@ -293,7 +293,12 @@ func clampOverlappedPercent(value float64) float64 {
 	if value > 90 {
 		value = 90
 	}
-	value = float64(int(value))
+	// Round rather than truncate so fraction inputs like 0.29 normalize
+	// to 29 (user expectation) rather than 28. Mirrors Python's
+	// common/float_utils.py:50-58 fix for #17418. We still clamp
+	// before rounding so out-of-int-range values (e.g. 1e300) land on
+	// 90, not an implementation-defined int.
+	value = math.Round(value)
 	return value
 }
 
@@ -308,7 +313,10 @@ func (p *TokenChunkerParam) Validate() error {
 	// rather than silently clamped — eliminating the latent footgun where a
 	// fraction passed to a struct bypassed normalization.
 	if v := p.OverlappedPercent; 0 < v && v < 1 {
-		p.OverlappedPercent = float64(int(v * 100))
+		// Round rather than truncate so fraction inputs like 0.29 normalize
+		// to 29 (user expectation) rather than 28. Mirrors Python's
+		// common/float_utils.py:50-58 fix for #17418.
+		p.OverlappedPercent = math.Round(v * 100)
 	}
 	switch p.DelimiterMode {
 	case "token_size", "delimiter":


### PR DESCRIPTION
## Summary

`normalize_overlapped_percent` in both Python and Go used `int()` after
multiplying a `[0,1)` fraction by 100. IEEE-754 representation of values
like `0.29` lands just below an integer (`28.999999999999996`), so
`int()` rounds DOWN to `28` instead of the `29` a user expects. Same
off-by-one for `0.57 -> 56`, etc.

| Input | Old (int) | New (round) |
|---|---|---|
| `0.1` | 10 | 10 |
| `0.29` | **28** | **29** |
| `0.3` | 30 | 30 |
| `0.57` | **56** | **57** |
| `0.93` | 90 (trunc 92 → clamp) | 90 (round 93 → clamp) |
| `0.95` | 90 | 90 |
| `33.3` | 33 | 33 |

The Go port in `internal/ingestion/component/schema/chunker.go` has the
same bug at two sites (`clampOverlappedPercent` and
`TokenChunkerParam.Validate`), so the fix is applied in lockstep to
preserve the Python ↔ Go parity that the Go-ingestion migration
(PR #17396) is built on.

## Changes

`common/float_utils.py`:
- Replace `int(value)` with `round(value)` in `normalize_overlapped_percent`.
  Comment notes the banker's-rounding behavior of `round()` (which
  matches `int()` for half-integer edges like `0.3 * 100`).

`internal/ingestion/component/schema/chunker.go`:
- Same one-line swap in two places (`clampOverlappedPercent` and
  `TokenChunkerParam.Validate`). Clamp runs before round so out-of-int
  values like `1e300` still land on 90 (not an implementation-defined
  int). `math` is already imported.

## Tests

`test/unit_test/common/test_float_utils.py`:
- New `TestNormalizeOverlappedPercent` class with 22 parametrized
  cases: the issue's `0.29 / 0.57 / 0.93` row, plus clamp, fraction,
  string, bad-string, huge / negative / already-integer inputs.
  A `_expected()` reference re-implements the post-fix behavior in the
  test itself so a future regression to int-truncation flips specific
  integer expectations to the wrong number and the test fails.

`internal/ingestion/component/chunker/token_test.go`:
- `TestNormalizeOverlappedPercent` gains `0.29 / 0.57 / 0.93` rows plus
  a string-fraction case.
- `TestTokenChunkerParam_ValidateOverlappedRange` adds the same
  fractional cases so the strict direct-construction path is covered.

Local verification:
- Python: `pytest test/unit_test/common/test_float_utils.py` — 30/30
  pass, ruff check + format clean.
- Go: `go test ./internal/ingestion/component/schema/` — 9/9 pass,
  `go vet` clean. The wider `chunker` test build fails on this
  machine due to a pre-existing missing C header
  (`office_oxide.h`) that is unrelated to this change; my Go test
  additions are referenced by `go build` for the schema package,
  which is the only one this change actually touches.

## Out of scope (follow-up)

The Python helper has a pre-existing `int()`-before-clamp path that
raises `OverflowError` on `math.inf` / `-math.inf` (the Go side
clamp-then-round avoids this). I did not fix that here because the
issue is scoped to fractional rounding and the Python inf path has
never been reachable from the UI. A separate issue + PR can flip
the Python clamp/round order if anyone cares.

## Backward compatibility

- Already-integer inputs (`15`, `"10"`, `33.3`) are unchanged.
- `0.29`, `0.57` and similar sub-1 inputs that were off-by-one are
  now correct.
- The clamp at 90 still wins on values that would round above it
  (`0.93 -> 93 -> clamp to 90`, `0.95 -> 95 -> clamp to 90`).

Closes #17418
