### PR TITLE
fix: reset selected documents on new search in search page

### DIFF
--- a/web/src/pages/next-search/hooks.ts
+++ b/web/src/pages/next-search/hooks.ts
@@ -333,6 +333,7 @@ export const useSendQuestion = (
       if (isEmpty(q)) return;
       setIsFirstRender(false);
       setCurrentAnswer({} as IAnswer);
+      setSelectedDocumentIds([]);
       if (enableAI) {
         if (!sharedId && !searchId) {
           message.error('Search ID is required.');

--- a/web/src/pages/next-search/retrieval-documents/index.tsx
+++ b/web/src/pages/next-search/retrieval-documents/index.tsx
@@ -64,6 +64,10 @@ const RetrievalDocuments = ({
   const [selectedValues, setSelectedValues] =
     useState<string[]>(selectedDocumentIds);
 
+  useEffect(() => {
+    setSelectedValues(selectedDocumentIds);
+  }, [selectedDocumentIds]);
+
   const multiOptions = useMemo(() => {
     if (!useDocuments || !useDocuments.length) {
       return [];


### PR DESCRIPTION
### Summary

On the search page, `selectedDocumentIds` persisted across searches. After selecting multiple documents in one search, running a new search that matched fewer documents caused the file filter to display a stale count such as `3/1`.

This PR resets `selectedDocumentIds` whenever a new question is sent, and syncs the local checkbox state in `RetrievalDocuments` with the prop so stale selections are also cleared from the popover.