### PR TITLE
WIP (review after ingestion fully ready) fix: drop garbled embedded PDF chars when OCR cannot recover them

### DIFF
--- a/internal/deepdoc/parser/pdf/parser.go
+++ b/internal/deepdoc/parser/pdf/parser.go
@@ -273,10 +273,11 @@ func (p *Parser) processPage(ctx context.Context, engine pdf.PDFEngine, pg int,
 //   - Clean embedded chars (count > 0 and not garbled):
 //     use ocrMergeChars, which detect-merges chars into boxes and falls
 //     back to single-image OCR recognize for empty boxes.
-//   - Garbled or empty chars: use ocrDetectAndRecognize for full OCR,
-//     then fall back to ocrMergeChars if detect succeeds but recognize
-//     produced no useful output. Synthetic chars are appended to support
-//     subsequent median calculations.
+//   - Garbled or empty chars: use ocrDetectAndRecognize for full OCR.
+//     Synthetic chars are appended to support subsequent median
+//     calculations. When OCR cannot recover a garbled page the embedded
+//     chars are dropped outright (matching Python DeepDOC, which clears
+//     page chars) so U+FFFD garbage never reaches the output.
 //
 // updatedChars includes synthetic OCR chars when detect+recognize was
 // used; callers must use the returned slice instead of the original.
@@ -307,9 +308,10 @@ func (p *Parser) processPageBoxes(ctx context.Context, pageImg image.Image, char
 ) ([]pdf.TextBox, []pdf.TextChar, bool) {
 	var ocrBoxes []pdf.TextBox
 	ocrUsed := false
+	garbledPage := len(chars) > 0 && util.IsGarbledPage(chars)
 
 	if !p.Config.SkipOCR && renderErr == nil && pageImg != nil {
-		hasCleanChars := len(chars) > 0 && !isScanNoise && !util.IsGarbledPage(chars)
+		hasCleanChars := len(chars) > 0 && !isScanNoise && !garbledPage
 		if hasCleanChars {
 			ocrBoxes = p.ocrMergeChars(ctx, pageImg, chars, docAnalyzer, pg)
 			ocrUsed = ocrBoxes != nil
@@ -328,6 +330,12 @@ func (p *Parser) processPageBoxes(ctx context.Context, pageImg image.Image, char
 						break
 					}
 				}
+			} else if garbledPage {
+				// OCR could not recover the page. Drop the garbled embedded
+				// chars instead of emitting U+FFFD garbage (Python DeepDOC
+				// clears page chars the same way).
+				slog.Warn("processPageBoxes: dropping garbled embedded chars after OCR failure", "page", pg)
+				chars = nil
 			} else if len(chars) > 0 {
 				// Detect failed but chars exist: try the merge path.
 				ocrBoxes = p.ocrMergeChars(ctx, pageImg, chars, docAnalyzer, pg)
@@ -336,7 +344,7 @@ func (p *Parser) processPageBoxes(ctx context.Context, pageImg image.Image, char
 		}
 	}
 
-	if !ocrUsed && len(chars) > 0 {
+	if !ocrUsed && len(chars) > 0 && !garbledPage {
 		if ocrBoxes == nil {
 			ocrBoxes = lyt.CharsToBoxes(chars, pg, p.Config.SortByTop)
 		}

--- a/internal/deepdoc/parser/pdf/parser_test.go
+++ b/internal/deepdoc/parser/pdf/parser_test.go
@@ -238,7 +238,41 @@ func TestOCR_FallbackIntegration_NoDeepDoc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Garbled embedded chars must be dropped when OCR cannot recover them
+	// (Python DeepDOC clears page chars); they must never leak into sections.
+	for i, s := range result.Sections {
+		if strings.Contains(s.Text, "\ufffd") {
+			t.Errorf("section %d contains U+FFFD garbage: %q", i, s.Text)
+		}
+	}
 	t.Logf("garbled Chars: %d sections", len(result.Sections))
+}
+
+func TestNoDeepDoc_ReplacementCharPage_Dropped(t *testing.T) {
+	// pdf_oxide emits U+FFFD for unmappable CID glyphs (subset font without
+	// a usable ToUnicode CMap). With no DeepDoc OCR backend the page must
+	// produce no text instead of leaking replacement characters.
+	chars := make([]pdf.TextChar, 30)
+	for i := range chars {
+		chars[i] = pdf.TextChar{
+			X0: 50 + float64(i*10), X1: 58 + float64(i*10),
+			Top: 100, Bottom: 112,
+			Text: "\ufffd", FontName: "ABCDEF+SimSun", PageNumber: 0,
+		}
+	}
+	mockEng := &MockEngine{Chars: map[int][]pdf.TextChar{0: chars}, NumPages: 1}
+	mockDLA := &MockDocAnalyzer{Healthy: true}
+
+	p := NewParser(pdf.DefaultParserConfig())
+	result, err := p.ParseRaw(context.Background(), mockEng, mockDLA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, s := range result.Sections {
+		if strings.Contains(s.Text, "\ufffd") {
+			t.Errorf("section %d contains U+FFFD garbage: %q", i, s.Text)
+		}
+	}
 }
 
 func TestNoDeepDoc_PdfOxideUnmapped_KeepsChars(t *testing.T) {

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -313,13 +313,16 @@ func emptyPDFResult(filename string) ParseResult {
 func deepDocAnalyzerFromEnv() deepdoctype.DocAnalyzer {
 	baseURL := strings.TrimSpace(common.GetEnv(common.EnvDeepDocURL))
 	if baseURL == "" {
+		slog.Warn("deepdoc analyzer: DEEPDOC_URL is not set; OCR/DLA disabled, garbled or scanned PDF pages yield no text")
 		return &deepdocpdf.MockDocAnalyzer{Healthy: true}
 	}
 	client, err := inference.NewClient(baseURL)
 	if err != nil {
+		slog.Warn("deepdoc analyzer: client init failed; OCR/DLA disabled", "url", baseURL, "err", err)
 		return &deepdocpdf.MockDocAnalyzer{Healthy: true}
 	}
 	if !client.Health() {
+		slog.Warn("deepdoc analyzer: service unhealthy; OCR/DLA disabled", "url", baseURL)
 		return &deepdocpdf.MockDocAnalyzer{Healthy: true}
 	}
 	// Wrap with Redis-backed cache (1h TTL) so repeated


### PR DESCRIPTION
### Summary

When a PDF page contains garbled embedded text (U+FFFD replacement characters from unmappable CID glyphs in subset fonts without a usable ToUnicode CMap) and OCR cannot recover the content, the garbled characters were previously leaked into the parser output. This matches a real-world scenario where `pdf_oxide` emits U+FFFD for glyphs it cannot map.

**The fix:**
- Detect garbled pages via `util.IsGarbledPage(chars)` upfront and cache the result
- When OCR fails to recover a garbled page, **drop the garbled embedded chars** instead of emitting U+FFFD garbage — matching the Python DeepDOC behavior which clears page chars
- Add a guard so garbled pages never enter the `CharsToBoxes` fallback path
- Add warning logs in `deepDocAnalyzerFromEnv()` when the DeepDoc analyzer is unavailable, so users understand why garbled or scanned pages produce no text

**Tests added:**
- `TestNoDeepDoc_ReplacementCharPage_Dropped`: verifies that a page of pure U+FFFD chars produces no sections with replacement characters
- Extended `TestOCR_FallbackIntegration_NoDeepDoc` to assert no U+FFFD leaks into any section

**Files changed:**
- `internal/deepdoc/parser/pdf/parser.go` — core fix
- `internal/deepdoc/parser/pdf/parser_test.go` — test coverage
- `internal/parser/parser/pdf_parser_common.go` — diagnostic logging