### PR TITLE
Fix/remove redundant model suffix

### DIFF
--- a/internal/entity/models/base_model.go
+++ b/internal/entity/models/base_model.go
@@ -263,7 +263,7 @@ func ParseListModel(modelList ModelList) []ListModelResponse {
 		if pm != nil {
 			modelEntity = pm.GetModelByNameOrAlias(modelName)
 		}
-		if model.OwnedBy != "" {
+		if model.OwnedBy != "" && !strings.Contains(modelName, model.OwnedBy) {
 			modelName = modelName + "@" + model.OwnedBy
 		}
 		modelResponse.Name = modelName


### PR DESCRIPTION
Summary
LongCat model names were getting a redundant `@OwnedBy` suffix appended, producing `LongCat-2.0@LongCat`. Root cause: `ParseListModel` unconditionally appended `@OwnedBy` whenever `owned_by` was non-empty, but LongCat's model ID (`LongCat-2.0`) already contains the provider name (`LongCat`), making the suffix duplicate.

Changes:
• internal/entity/models/base_model.go: added a `strings.Contains` guard before appending `@OwnedBy` — when the model name already contains the `owned_by` value, the suffix is skipped. Existing behavior for Gitee/Google/FunASR/VolcEngine is unaffected (none of their model names contain the corresponding `owned_by` value).

Verification:
• bash build.sh --test ./internal/entity/models/ — ok (no test changes needed)