### PR TITLE
Fix: The documentation for setting page slicing methods in the Go version of a dataset is not displayed.

### DIFF
--- a/web/src/pages/dataset/dataset-setting/utils.ts
+++ b/web/src/pages/dataset/dataset-setting/utils.ts
@@ -9,6 +9,7 @@ export const ImageMap = {
   manual: getImageName('manual', 4),
   picture: getImageName('media', 2),
   naive: getImageName('naive', 2),
+  general: getImageName('naive', 2),
   paper: getImageName('paper', 2),
   presentation: getImageName('presentation', 2),
   qa: getImageName('qa', 2),

--- a/web/src/pages/dataset/setting/index.tsx
+++ b/web/src/pages/dataset/setting/index.tsx
@@ -24,6 +24,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
+import ChunkMethodLearnMore from '../dataset-setting/chunk-method-learn-more';
 import LinkDataSource, {
   IDataSourceNodeProps,
 } from './components/link-data-source';
@@ -35,6 +36,7 @@ import {
   usePipelineDataList,
   useSaveDatasetSetting,
 } from './hooks';
+
 
 export default function DatasetSetting() {
   const { t } = useTranslation();
@@ -177,7 +179,7 @@ export default function DatasetSetting() {
           </header>
         </CardHeader>
 
-        <CardContent className="p-0 flex-1 h-0 flex">
+        <CardContent className="p-0 flex-1 h-0 flex divide-x-0.5">
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(handleSubmit)}
@@ -249,6 +251,12 @@ export default function DatasetSetting() {
               </div>
             </form>
           </Form>
+
+          <div className="flex-1 p-5 overflow-auto">
+            {parseType === ParseType.BuiltIn && builtinPipelineId && (
+              <ChunkMethodLearnMore parserId={builtinPipelineId} />
+            )}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/web/src/pages/dataset/setting/index.tsx
+++ b/web/src/pages/dataset/setting/index.tsx
@@ -37,7 +37,6 @@ import {
   useSaveDatasetSetting,
 } from './hooks';
 
-
 export default function DatasetSetting() {
   const { t } = useTranslation();
 


### PR DESCRIPTION
### Summary

Fix: The documentation for setting page slicing methods in the Go version of a dataset is not displayed.
