### PR TITLE
fix(admin): use POST for admin logout API

### DIFF
--- a/admin/server/routes.py
+++ b/admin/server/routes.py
@@ -52,7 +52,7 @@ def login():
         return error_response(str(e), 500)
 
 
-@admin_bp.route("/logout", methods=["GET"])
+@admin_bp.route("/logout", methods=["POST"])
 @login_required
 def logout():
     try:

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -58,7 +58,6 @@ func (r *Router) Setup(engine *gin.Engine) {
 		protected := admin.Group("")
 		protected.Use(r.handler.AuthMiddleware())
 		{
-			protected.GET("/logout", r.handler.Logout)
 			protected.POST("/logout", r.handler.Logout)
 			// Auth
 			protected.GET("/auth", r.handler.AuthCheck)

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -58,6 +58,7 @@ func (r *Router) Setup(engine *gin.Engine) {
 		protected := admin.Group("")
 		protected.Use(r.handler.AuthMiddleware())
 		{
+			protected.GET("/logout", r.handler.Logout)
 			protected.POST("/logout", r.handler.Logout)
 			// Auth
 			protected.GET("/auth", r.handler.AuthCheck)

--- a/web/src/services/admin-service.ts
+++ b/web/src/services/admin-service.ts
@@ -150,7 +150,7 @@ type ResponseData<D = NonNullable<unknown>> = {
 
 export const login = (params: { email: string; password: string }) =>
   request.post<ResponseData<AdminService.LoginData>>(adminLogin, params);
-export const logout = () => request.get<ResponseData<boolean>>(adminLogout);
+export const logout = () => request.post<ResponseData<boolean>>(adminLogout);
 export const listUsers = () =>
   request.get<ResponseData<AdminService.ListUsersItem[]>>(adminListUsers, {});
 


### PR DESCRIPTION
### Summary

In Go mode, the admin UI's **Log out** button fails with a 404 error (`hint: 404 The requested resource was not found`).

Root cause: the admin frontend calls `GET /api/v1/admin/logout`, but the Go admin router only registers `POST /logout`.

This PR converges all callers on `POST /logout`:

- Admin UI (`web/src/services/admin-service.ts`): switch the logout request from GET to POST.
- Python-mode admin server (`admin/server/routes.py`): change the `/logout` route to `methods=["POST"]`.
- Go router (`internal/admin/router.go`): keeps the existing `POST /logout` route (unchanged).

The CLI already calls `POST /admin/logout`, so after this change all paths use a single method.