### PR TITLE
fix: remediate CVE's by bumping pyasn1 constraint to >=0.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ test = [
 [tool.uv]
 constraint-dependencies = [
     # CVE-2026-30922: Denial of Service via unbounded recursion in ASN.1 decoding (CVSS 7.5 HIGH)
-    # CVE-2026-59885, CVE-2026-59886: additional HIGH vulnerabilities fixed in 0.6.4
+    # CVE-2026-59884, CVE-2026-59885, CVE-2026-59886: additional HIGH vulnerabilities fixed in 0.6.4
     # pyasn1 < 0.6.4 is vulnerable; pulled in transitively via google-auth / rsa / pyasn1-modules
     "pyasn1>=0.6.4",
     # Python 3.13 added pathlib.PurePath.parser as a public class attribute holding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,8 +202,9 @@ test = [
 [tool.uv]
 constraint-dependencies = [
     # CVE-2026-30922: Denial of Service via unbounded recursion in ASN.1 decoding (CVSS 7.5 HIGH)
-    # pyasn1 < 0.6.3 is vulnerable; pulled in transitively via google-auth / rsa / pyasn1-modules
-    "pyasn1>=0.6.3",
+    # CVE-2026-59885, CVE-2026-59886: additional HIGH vulnerabilities fixed in 0.6.4
+    # pyasn1 < 0.6.4 is vulnerable; pulled in transitively via google-auth / rsa / pyasn1-modules
+    "pyasn1>=0.6.4",
     # Python 3.13 added pathlib.PurePath.parser as a public class attribute holding
     # the posixpath/ntpath module. trio<0.26 introspects all Path class attributes to
     # generate async forwards and raises TypeError on any non-callable attribute it

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ constraints = [
     { name = "lxml", specifier = ">=6.1.1" },
     { name = "lxml-html-clean", specifier = ">=0.4.5" },
     { name = "nltk", specifier = ">=3.10.0" },
-    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "trio", specifier = ">=0.26.0", index = "https://pypi.org/simple" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
@@ -4868,11 +4868,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
  
  Remediates three HIGH severity CVEs in `pyasn1` by bumping the existing `constraint-dependencies` entry from `>=0.6.3` to `>=0.6.4` in `pyproject.toml`.
  
  | CVE | Severity | Package | Installed | Fixed in |
  |---|---|---|---|---|
  | CVE-2026-59884 | HIGH | pyasn1 | 0.6.3 | 0.6.4 |
  | CVE-2026-59885 | HIGH | pyasn1 | 0.6.3 | 0.6.4 |
  | CVE-2026-59886 | HIGH | pyasn1 | 0.6.3 | 0.6.4 |


  `pyasn1` is a transitive dependency (pulled in via `google-auth` / `rsa` / `pyasn1-modules`). A previous constraint (`>=0.6.3`) was added for CVE-2026-30922 but two additional vulnerabilities were disclosed that require 0.6.4.
  
  ## Testing
  
  - Full unit test suite passes
  - `uv sync` resolves cleanly