### PR TITLE
Fix tag CSV parser ignoring the documented TAB delimiter

### DIFF
--- a/rag/app/tag.py
+++ b/rag/app/tag.py
@@ -92,11 +92,12 @@ def chunk(filename, binary=None, lang="Chinese", callback=None, **kwargs):
         callback(0.1, "Start to parse.")
         txt = get_text(filename, binary)
         lines = txt.split("\n")
+        delimiter = "\t" if any("\t" in line for line in lines) else ","
 
         fails = []
         content = ""
         res = []
-        reader = csv.reader((line + "\n" for line in lines))
+        reader = csv.reader((line + "\n" for line in lines), delimiter=delimiter)
         prev_line_num = 0
 
         # line_num tracks the physical span when quoted fields cross lines.


### PR DESCRIPTION
### What problem does this PR solve?

`rag/app/tag.py` documents TAB as the delimiter that separates content from tags:

> If it's in csv format, it should be UTF-8 encoded. Use TAB as delimiter to separate content and tags.

The `.csv` branch does not honour that. It calls `csv.reader` with no `delimiter` argument, so it always splits on commas regardless of the file's actual delimiter. Two failure modes follow for a genuinely TAB-delimited file:

1. **The line is silently dropped.** If the content field contains a comma, the row splits into three fields, fails the `len(row) == 2` check, and is discarded.

   `the quick, brown fox<TAB>animal,fox` -> no rows parsed at all.

2. **Content and tags are corrupted.** If only the tag field contains a comma, the row splits into exactly two fields by coincidence. The tab and the first tag are left inside the content, and that tag is lost.

   `hello world<TAB>greeting,demo` -> content `hello world\tgreeting`, tags `["demo"]`.

`rag/app/qa.py` already solves this for its own `.csv` branch. `tag.py` is its near-twin and was simply missing the same line.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Change

Detect the delimiter exactly as `qa.py` does, and pass it to `csv.reader`:

```python
delimiter = "\t" if any("\t" in line for line in lines) else ","
reader = csv.reader((line + "\n" for line in lines), delimiter=delimiter)
```

### Verification

Parsing the two cases above through the `.csv` branch, before and after:

| Input | Before | After |
| --- | --- | --- |
| `the quick, brown fox<TAB>animal,fox` | `[]` (row dropped) | `("the quick, brown fox", "animal,fox")` |
| `hello world<TAB>greeting,demo` | `("hello world\tgreeting", "demo")` | `("hello world", "greeting,demo")` |
| `some content,tag1` (plain CSV) | `("some content", "tag1")` | unchanged |

Plain comma-delimited files are unaffected.

### Note on the heuristic

This mirrors `qa.py` deliberately, so the two twins stay consistent. It is worth being explicit that the heuristic is permissive: a single tab anywhere in the file switches the whole file to TAB parsing, so a comma-delimited file containing one stray tab inside a quoted field would be misread. That tradeoff already exists in `qa.py` today and is not introduced here. If you would prefer a stricter test, the `.txt` branch in this same file uses a majority-vote comparison instead, and I am happy to switch both parsers to that in a follow-up.
