### PR TITLE
Fix QA DOCX table parser dropping cells between repeated text

### DIFF
--- a/rag/app/qa.py
+++ b/rag/app/qa.py
@@ -229,6 +229,8 @@ class Docx(DocxParser):
                         if c.text == r.cells[j].text:
                             span += 1
                             i = j
+                        else:
+                            break
                     i += 1
                     html += f"<td>{c.text}</td>" if span == 1 else f"<td colspan='{span}'>{c.text}</td>"
                 html += "</tr>"


### PR DESCRIPTION
### What problem does this PR solve?

The merged-cell scan in `rag/app/qa.py`'s `Docx` handler never stops at the first non-matching cell. The inner loop keeps scanning to the end of the row, so any **later, non-adjacent** cell that happens to share text with the current one is folded into the `colspan`, and every cell in between is dropped from the generated HTML.

The same loop exists in three sibling parsers, and all three break out of the scan correctly:

- `rag/app/manual.py`
- `rag/app/naive.py`
- `rag/app/laws.py`

`rag/app/qa.py` is the only copy missing the `else: break`. The loops are otherwise identical.

### Impact

The most common trigger is blank cells, which routinely repeat within a row. A row like `["Name", "", "Age", ""]` renders as:

```html
<td>Name</td><td colspan='2'></td>
```

`Age` is gone. The two blank cells are treated as a merged pair even though they are not adjacent, and the real content between them is discarded along with the cells it belonged to.

This HTML is passed to `tokenize_table()` in the docx `chunk()` path, so the dropped content is silently absent from what gets indexed and searched. There is no error and nothing in the logs.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Change

Add the `else: break` that the three sibling parsers already have.

### Verification

Running the row-building loop from `qa.py` and from `manual.py` over the same inputs, before and after:

| Row | qa.py before | qa.py after / siblings |
| --- | --- | --- |
| `Name, "", Age, ""` | `<td>Name</td><td colspan='2'></td>` | `<td>Name</td><td></td><td>Age</td><td></td>` |
| `A, B, A, D` | `<td colspan='2'>A</td><td>D</td>` | `<td>A</td><td>B</td><td>A</td><td>D</td>` |
| `M, M, X` (real merge) | `<td colspan='2'>M</td><td>X</td>` | unchanged |
| `Z, Z, Z` | `<td colspan='3'>Z</td>` | unchanged |
| `a, b, c` | `<td>a</td><td>b</td><td>c</td>` | unchanged |

Genuine adjacent merges and rows without repeated text are unaffected. After the change, `qa.py` produces byte-identical output to `manual.py` on every case above.
