### PR TITLE
fix: upgrade axios to 1.15.1, 0.31.1 (CVE-2026-42033)

### DIFF
--- a/agent/sandbox/sandbox_base_image/nodejs/package-lock.json
+++ b/agent/sandbox/sandbox_base_image/nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.9.0"
+        "axios": "^1.15.1"
       }
     },
     "node_modules/asynckit": {
@@ -19,14 +19,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -286,10 +286,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     }
   }
 }

--- a/agent/sandbox/sandbox_base_image/nodejs/package.json
+++ b/agent/sandbox/sandbox_base_image/nodejs/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "axios": "^1.9.0"
+    "axios": "^1.15.1"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade axios from 1.13.6 to 1.15.1, 0.31.1 to fix CVE-2026-42033.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-42033 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-42033` |
| **File** | `agent/sandbox/sandbox_base_image/nodejs/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: axios: Axios: HTTP Transport Hijacking via Prototype Pollution

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-42033` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `agent/sandbox/sandbox_base_image/nodejs/package.json`
- `agent/sandbox/sandbox_base_image/nodejs/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
