### PR TITLE
Fix: Switching templates results in a few extra data entries in the entity specification.

### DIFF
--- a/web/src/pages/user-setting/compilation-templates/create-next/components/template-configuration.tsx
+++ b/web/src/pages/user-setting/compilation-templates/create-next/components/template-configuration.tsx
@@ -113,7 +113,7 @@ export function TemplateConfiguration({
       return (
         sectionName === activeSectionTab && (
           <SectionFieldGrid
-            key={activeFieldsPath}
+            key={`${activeFieldsPath}-${kind}`}
             fieldsPath={activeFieldsPath}
             sectionName={sectionName}
             onOpenAddField={handleOpenAddField}
@@ -125,6 +125,7 @@ export function TemplateConfiguration({
     [
       activeFieldsPath,
       activeSectionTab,
+      kind,
       handleOpenAddField,
       handleOpenEditField,
     ],

--- a/web/src/pages/user-setting/compilation-templates/edit-next/components/template-configuration.tsx
+++ b/web/src/pages/user-setting/compilation-templates/edit-next/components/template-configuration.tsx
@@ -106,7 +106,7 @@ export function TemplateConfiguration({
       return (
         sectionName === activeSectionTab && (
           <SectionFieldGrid
-            key={activeFieldsPath}
+            key={`${activeFieldsPath}-${kind}`}
             fieldsPath={activeFieldsPath}
             sectionName={sectionName}
             onOpenAddField={handleOpenAddField}
@@ -118,6 +118,7 @@ export function TemplateConfiguration({
     [
       activeFieldsPath,
       activeSectionTab,
+      kind,
       handleOpenAddField,
       handleOpenEditField,
     ],


### PR DESCRIPTION

### Summary

Fix: Switching templates results in a few extra data entries in the entity specification.