### PR TITLE
feat(go-agent): fall back to chat for unsupported streams

### DIFF
--- a/internal/agent/component/agent.go
+++ b/internal/agent/component/agent.go
@@ -183,6 +183,9 @@ func runEinoReActAgent(ctx context.Context, p AgentParam) (*schema.Message, erro
 	if err != nil {
 		return nil, fmt.Errorf("create react agent: %w", err)
 	}
+	if chatModel.Inner().ModelDriver.Name() == "jina" {
+		return agent.Generate(ctx, input)
+	}
 
 	opt, future := react.WithMessageFuture()
 	ctx = setArtifactCollector(ctx, future)
@@ -200,10 +203,6 @@ func runEinoReActAgent(ctx context.Context, p AgentParam) (*schema.Message, erro
 			break
 		}
 		if err != nil {
-			<-emitDone
-			if len(chunks) == 0 && !runtime.AgentMessageEventsEmitted(ctx) && ctx.Err() == nil {
-				return agent.Generate(ctx, input)
-			}
 			return nil, err
 		}
 		if chunk == nil {
@@ -212,9 +211,6 @@ func runEinoReActAgent(ctx context.Context, p AgentParam) (*schema.Message, erro
 		chunks = append(chunks, chunk)
 	}
 	if emitErr := <-emitDone; emitErr != nil {
-		if len(chunks) == 0 && !runtime.AgentMessageEventsEmitted(ctx) && ctx.Err() == nil {
-			return agent.Generate(ctx, input)
-		}
 		return nil, emitErr
 	}
 	if len(chunks) == 0 {

--- a/internal/agent/component/agent.go
+++ b/internal/agent/component/agent.go
@@ -212,6 +212,9 @@ func runEinoReActAgent(ctx context.Context, p AgentParam) (*schema.Message, erro
 		chunks = append(chunks, chunk)
 	}
 	if emitErr := <-emitDone; emitErr != nil {
+		if len(chunks) == 0 && !runtime.AgentMessageEventsEmitted(ctx) && ctx.Err() == nil {
+			return agent.Generate(ctx, input)
+		}
 		return nil, emitErr
 	}
 	if len(chunks) == 0 {

--- a/internal/agent/component/agent.go
+++ b/internal/agent/component/agent.go
@@ -200,6 +200,10 @@ func runEinoReActAgent(ctx context.Context, p AgentParam) (*schema.Message, erro
 			break
 		}
 		if err != nil {
+			<-emitDone
+			if len(chunks) == 0 && !runtime.AgentMessageEventsEmitted(ctx) && ctx.Err() == nil {
+				return agent.Generate(ctx, input)
+			}
 			return nil, err
 		}
 		if chunk == nil {


### PR DESCRIPTION
## Summary

- Fall back to non-streaming chat when an Agent provider fails before producing stream output.
- Keep existing behavior after streaming output has begun.

## Testing

- `CGO_ENABLED=0 go test -count=1 ./internal/agent/component`