### PR TITLE
Fix: On the multi-model comparison chat page, if there is more than one window, each window can be deleted.

### DIFF
--- a/web/src/constants/agent.tsx
+++ b/web/src/constants/agent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { setInitialChatVariableEnabledFieldValue } from '@/utils/chat';
 import {
   Circle,

--- a/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
+++ b/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
@@ -226,7 +226,7 @@ const ChatCard = forwardRef(function ChatCard(
                 <p>{t('chat.applyModelConfigs')}</p>
               </TooltipContent>
             </Tooltip>
-            {!isLatestChat || chatBoxIds.length === 3 ? (
+            {chatBoxIds.length > 1 && (
               <Button
                 variant="ghost"
                 size="icon-sm"
@@ -236,7 +236,8 @@ const ChatCard = forwardRef(function ChatCard(
               >
                 <Trash2 />
               </Button>
-            ) : (
+            )}
+            {isLatestChat && idx < 2 && (
               <Button
                 variant="ghost"
                 size="icon-sm"


### PR DESCRIPTION


### Summary

Fix: On the multi-model comparison chat page, if there is more than one window, each window can be deleted.