### PR TITLE
Fix: add StepFun china region base URL (api.stepfun.com)

### DIFF
--- a/conf/models/stepfun.json
+++ b/conf/models/stepfun.json
@@ -1,7 +1,8 @@
 {
   "name": "StepFun",
   "url": {
-    "default": "https://api.stepfun.ai/v1"
+    "default": "https://api.stepfun.ai/v1",
+    "china": "https://api.stepfun.com/v1"
   },
   "url_suffix": {
     "chat": "chat/completions",


### PR DESCRIPTION
## Summary
- StepFun serves domestic (China) and international markets from different domains.
- Add a `china` region URL (`api.stepfun.com`) alongside the existing `default` (`api.stepfun.ai`) so tenants in China can route correctly.

## Change
- `conf/models/stepfun.json`: add `"china": "https://api.stepfun.com/v1"` to the `url` map.

## Why
- Chinese AI/LLM providers commonly maintain separate URLs for domestic vs. international markets. Keeping both options available matches the existing pattern used by other providers (e.g. GiteeAI).