### PR TITLE
[codex] Fix oversized dataflow operation log DSL

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -44,6 +44,22 @@ from rag.utils.redis_conn import REDIS_CONN
 from rag.utils.tts_cache import synthesize_with_cache
 
 _logger = logging.getLogger(__name__)
+_DENSE_VECTOR_FIELD_RE = re.compile(r"^q_\d+_vec$")
+
+
+def _strip_dense_vector_fields(value):
+    if isinstance(value, dict):
+        return {key: _strip_dense_vector_fields(item) for key, item in value.items() if not (isinstance(key, str) and _DENSE_VECTOR_FIELD_RE.match(key))}
+    if isinstance(value, list):
+        return [_strip_dense_vector_fields(item) for item in value]
+    return value
+
+
+def _serialize_default(obj):
+    if callable(obj):
+        return None
+    logging.warning("Graph.__str__: JSON fallback via str() for type=%s", type(obj).__name__)
+    return str(obj)
 
 
 class Graph:
@@ -116,7 +132,15 @@ class Graph:
 
         self.path = self.dsl["path"]
 
-    def __str__(self):
+    def _component_to_dict(self, component, scrub_vectors=False):
+        if scrub_vectors and hasattr(component, "_param") and hasattr(component._param, "as_dict"):
+            return {
+                "component_name": component.component_name,
+                "params": _strip_dense_vector_fields(component._param.as_dict()),
+            }
+        return json.loads(str(component))
+
+    def to_dsl_dict(self, *, scrub_vectors=False):
         self.dsl["path"] = self.path
         self.dsl["task_id"] = self.task_id
         dsl = {"components": {}}
@@ -134,7 +158,7 @@ class Graph:
                 dsl["components"][k] = {}
             for c in cpn.keys():
                 if c == "obj":
-                    dsl["components"][k][c] = json.loads(str(cpn["obj"]))
+                    dsl["components"][k][c] = self._component_to_dict(cpn["obj"], scrub_vectors=scrub_vectors)
                     continue
                 try:
                     dsl["components"][k][c] = deepcopy(cpn[c])
@@ -142,13 +166,19 @@ class Graph:
                     logging.warning("Graph.__str__: deepcopy failed for component '%s' key '%s' (type=%s): %s. Using shallow reference.", k, c, type(cpn[c]).__name__, e)
                     dsl["components"][k][c] = cpn[c]
 
-        def _serialize_default(obj):
-            if callable(obj):
-                return None
-            logging.warning("Graph.__str__: JSON fallback via str() for type=%s", type(obj).__name__)
-            return str(obj)
+        if scrub_vectors:
+            dsl = _strip_dense_vector_fields(dsl)
+        return dsl
 
+    def to_dsl_json(self, *, scrub_vectors=False):
+        dsl = self.to_dsl_dict(scrub_vectors=scrub_vectors)
         return json.dumps(dsl, ensure_ascii=False, default=_serialize_default)
+
+    def to_operation_log_json(self):
+        return self.to_dsl_json(scrub_vectors=True)
+
+    def __str__(self):
+        return self.to_dsl_json()
 
     def reset(self):
         self.path = []

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -800,7 +800,7 @@ async def run_dataflow(task: dict):
     if not chunks:
         get_recording_context().record("pipeline_output_count", 0)
         get_recording_context().record("pipeline_output_type", "empty")
-        ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=str(pipeline))
+        ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=pipeline.to_operation_log_json())
         get_recording_context().save_func_return_value("PipelineOperationLogService.create", ret)
         return
 
@@ -830,7 +830,7 @@ async def run_dataflow(task: dict):
 
     # An empty normalized payload means "nothing parsed", so stop before embedding/indexing.
     if not chunks:
-        ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=str(pipeline))
+        ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=pipeline.to_operation_log_json())
         get_recording_context().save_func_return_value("PipelineOperationLogService.create", ret)
         return
 
@@ -878,7 +878,7 @@ async def run_dataflow(task: dict):
             raise
         except Exception as e:
             set_progress(task_id, prog=-1, msg=f"[ERROR]: {e}")
-            ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=str(pipeline))
+            ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=pipeline.to_operation_log_json())
             get_recording_context().save_func_return_value("PipelineOperationLogService.create", ret)
             return
 
@@ -928,7 +928,7 @@ async def run_dataflow(task: dict):
     set_progress(task_id, prog=0.82, msg="[DOC Engine]:\nStart to index...")
     e = await insert_chunks(task_id, task["tenant_id"], task["kb_id"], chunks, partial(set_progress, task_id, 0, 100000000))
     if not e:
-        ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=str(pipeline))
+        ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=pipeline.to_operation_log_json())
         get_recording_context().save_func_return_value("PipelineOperationLogService.create", ret)
         return
 
@@ -939,7 +939,7 @@ async def run_dataflow(task: dict):
     get_recording_context().save_func_return_value("DocumentService.increment_chunk_num", ret)
     logging.info("[Done], chunks({}), token({}), elapsed:{:.2f}".format(len(chunks), embedding_token_consumption, task_time_cost))
     get_recording_context().record("dataflow_chunks", chunks)
-    ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=str(pipeline))
+    ret = PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=pipeline.to_operation_log_json())
     get_recording_context().save_func_return_value("PipelineOperationLogService.create", ret)
 
 

--- a/rag/svr/task_executor_refactor/dataflow_service.py
+++ b/rag/svr/task_executor_refactor/dataflow_service.py
@@ -358,7 +358,7 @@ class DataflowService:
         if self._task_context.write_interceptor:
             self._task_context.write_interceptor.intercept("PipelineOperationLogService.create")
         else:
-            PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=str(pipeline))
+            PipelineOperationLogService.create(document_id=doc_id, pipeline_id=dataflow_id, task_type=PipelineTaskType.PARSE, dsl=pipeline.to_operation_log_json())
 
     @classmethod
     def _get_kb_by_id(cls, kb_id: str):

--- a/test/unit_test/agent/test_canvas_operation_log_serialization.py
+++ b/test/unit_test/agent/test_canvas_operation_log_serialization.py
@@ -1,0 +1,109 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from test.unit_test.agent.test_canvas_at_split import _load_canvas_module
+
+
+class _ParamStub:
+    def as_dict(self):
+        return {
+            "outputs": {
+                "output_format": {"type": "str", "value": "chunks"},
+                "_elapsed_time": {"type": "float", "value": 1.25},
+                "chunks": {
+                    "type": "Array",
+                    "value": [
+                        {
+                            "text": "chunk text",
+                            "q_1024_vec": [0.1, 0.2],
+                            "metadata": {
+                                "source": "unit-test",
+                                "q_3_vec": [0.3, 0.4, 0.5],
+                            },
+                        }
+                    ],
+                },
+            }
+        }
+
+
+class _ComponentStub:
+    component_name = "Tokenizer"
+
+    def __init__(self):
+        self._param = _ParamStub()
+
+    def __str__(self):
+        return json.dumps(
+            {
+                "component_name": self.component_name,
+                "params": self._param.as_dict(),
+            }
+        )
+
+
+def _make_graph(canvas_mod):
+    graph = canvas_mod.Graph.__new__(canvas_mod.Graph)
+    graph.dsl = {
+        "components": {},
+        "graph": {"nodes": [{"id": "Tokenizer", "data": {"name": "Tokenizer"}}]},
+        "globals": {},
+        "path": ["Tokenizer"],
+    }
+    graph.components = {
+        "Tokenizer": {
+            "obj": _ComponentStub(),
+            "downstream": [],
+            "upstream": [],
+        }
+    }
+    graph.path = ["Tokenizer"]
+    graph.task_id = "task-1"
+    return graph
+
+
+@pytest.mark.p2
+def test_operation_log_serialization_strips_dense_vectors(monkeypatch):
+    canvas_mod = _load_canvas_module(monkeypatch)
+    graph = _make_graph(canvas_mod)
+
+    payload = json.loads(graph.to_operation_log_json())
+    chunk = payload["components"]["Tokenizer"]["obj"]["params"]["outputs"]["chunks"]["value"][0]
+
+    assert "q_1024_vec" not in chunk
+    assert "q_3_vec" not in chunk["metadata"]
+    assert chunk["text"] == "chunk text"
+    assert chunk["metadata"]["source"] == "unit-test"
+    assert payload["components"]["Tokenizer"]["obj"]["params"]["outputs"]["output_format"]["value"] == "chunks"
+    assert payload["components"]["Tokenizer"]["obj"]["params"]["outputs"]["_elapsed_time"]["value"] == 1.25
+
+
+@pytest.mark.p2
+def test_string_serialization_keeps_runtime_outputs(monkeypatch):
+    canvas_mod = _load_canvas_module(monkeypatch)
+    graph = _make_graph(canvas_mod)
+
+    payload = json.loads(str(graph))
+    chunk = payload["components"]["Tokenizer"]["obj"]["params"]["outputs"]["chunks"]["value"][0]
+
+    assert chunk["q_1024_vec"] == [0.1, 0.2]
+    assert chunk["metadata"]["q_3_vec"] == [0.3, 0.4, 0.5]


### PR DESCRIPTION
Fixes #17466.

## What changed

- Added an operation-log serialization path for dataflow `Graph` objects that recursively removes dense vector fields named like `q_<dim>_vec`.
- Updated both dataflow task executors to persist the scrubbed operation-log DSL instead of `str(pipeline)`.
- Added unit coverage to verify operation-log serialization removes vectors while default graph string serialization still preserves runtime outputs.

## Why

Dataflow pipeline logs persisted component outputs into `pipeline_operation_log.dsl`, including embedding vectors attached to chunk payloads. Large documents can therefore generate oversized INSERT payloads and mark the document as failed after ingestion has otherwise completed.

## Impact

The result UI can still read normal component outputs, chunks, `output_format`, and `_elapsed_time`, but dense embedding vectors are no longer stored in the operation-log DSL.

## Tests

- `uv run --no-sync --with pytest==8.3.5 --with pytest-asyncio --with nltk python -m pytest test\\unit_test\\agent\\test_canvas_operation_log_serialization.py test\\unit_test\\agent\\test_canvas_at_split.py`
- `python -m py_compile agent\\canvas.py rag\\svr\\task_executor.py rag\\svr\\task_executor_refactor\\dataflow_service.py test\\unit_test\\agent\\test_canvas_operation_log_serialization.py`
- `uv run --no-sync --with ruff ruff format --check agent\\canvas.py rag\\svr\\task_executor.py rag\\svr\\task_executor_refactor\\dataflow_service.py test\\unit_test\\agent\\test_canvas_operation_log_serialization.py`
- `uv run --no-sync --with ruff ruff check --select F,E9 agent\\canvas.py rag\\svr\\task_executor.py rag\\svr\\task_executor_refactor\\dataflow_service.py test\\unit_test\\agent\\test_canvas_operation_log_serialization.py`
- `git diff --check`
