### PR TITLE
[codex] Fix OpenAI-compatible ASR provider

### DIFF
--- a/docs/guides/models/supported_models.mdx
+++ b/docs/guides/models/supported_models.mdx
@@ -84,6 +84,8 @@ A complete list of model providers supported by RAGFlow, which will continue to 
 If your model is not listed here but has APIs compatible with those of OpenAI, click **OpenAI-API-Compatible** on the **Model providers** page to configure your model.
 :::
 
+OpenAI-compatible speech-to-text services that expose `/v1/audio/transcriptions` can also be configured through **OpenAI-API-Compatible** with the **ASR** model type.
+
 ## Example: AI Badgr (OpenAI-compatible)
 
 You can use **AI Badgr** with RAGFlow via the existing OpenAI-API-Compatible provider.

--- a/rag/llm/sequence2txt_model.py
+++ b/rag/llm/sequence2txt_model.py
@@ -108,6 +108,16 @@ class GPTSeq2txt(Base):
         self.model_name = model_name
 
 
+class OpenAI_APISeq2txt(GPTSeq2txt):
+    _FACTORY_NAME = "OpenAI-API-Compatible"
+
+    def __init__(self, key, model_name="whisper-1", base_url="", **kwargs):
+        if not base_url:
+            raise ValueError("url cannot be None")
+        model_name = model_name.split("___")[0]
+        super().__init__(key, model_name=model_name, base_url=base_url, **kwargs)
+
+
 class StepFunSeq2txt(GPTSeq2txt):
     _FACTORY_NAME = "StepFun"
 

--- a/test/unit_test/rag/llm/test_sequence2txt_openai_api.py
+++ b/test/unit_test/rag/llm/test_sequence2txt_openai_api.py
@@ -1,0 +1,67 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rag.llm.sequence2txt_model import OpenAI_APISeq2txt
+
+
+pytestmark = pytest.mark.p2
+
+
+@patch("rag.llm.sequence2txt_model.OpenAI")
+def test_openai_api_asr_uses_openai_compatible_endpoint(mock_openai):
+    provider = OpenAI_APISeq2txt(
+        key="compatible-secret",
+        model_name="qwen3-asr-1.7b___OpenAI-API",
+        base_url="http://gpustack.internal:9090",
+    )
+
+    mock_openai.assert_called_once_with(api_key="compatible-secret", base_url="http://gpustack.internal:9090/v1")
+    assert provider._FACTORY_NAME == "OpenAI-API-Compatible"
+    assert provider.model_name == "qwen3-asr-1.7b"
+
+
+@patch("rag.llm.sequence2txt_model.OpenAI")
+def test_openai_api_asr_transcription_calls_audio_endpoint(mock_openai, tmp_path):
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"RIFF-test-audio")
+
+    client = MagicMock()
+    client.audio.transcriptions.create.return_value = SimpleNamespace(text="  compatible transcript  ")
+    mock_openai.return_value = client
+    provider = OpenAI_APISeq2txt(
+        key="compatible-secret",
+        model_name="whisper-compatible",
+        base_url="https://compatible.example.com/v1",
+    )
+
+    with patch("rag.llm.sequence2txt_model.num_tokens_from_string", return_value=3):
+        text, token_count = provider.transcription(audio_path)
+
+    assert text == "compatible transcript"
+    assert token_count == 3
+    call = client.audio.transcriptions.create.call_args
+    assert call.kwargs["model"] == "whisper-compatible"
+    assert call.kwargs["file"].closed
+
+
+def test_openai_api_asr_requires_base_url():
+    with pytest.raises(ValueError, match="url cannot be None"):
+        OpenAI_APISeq2txt(key="compatible-secret", model_name="whisper-compatible", base_url="")


### PR DESCRIPTION
Fixes the missing OpenAI-compatible ASR adapter so providers that expose `/v1/audio/transcriptions` can be selected as `OpenAI-API-Compatible` speech models.

What changed:
- add `OpenAI_APISeq2txt` and register it as `OpenAI-API-Compatible`
- strip the stored `___OpenAI-API` suffix before creating the OpenAI client
- document that OpenAI-compatible ASR endpoints can be configured through the ASR model type
- add unit coverage for construction and transcription calls

Validation:
- `uv run --no-sync --with pytest==8.3.5 --with pytest-asyncio --with nltk --with requests --with openai --with tiktoken --with dashscope python -m pytest test\\unit_test\\rag\\llm\\test_sequence2txt_openai_api.py test\\unit_test\\rag\\llm\\test_sequence2txt_funasr.py test\\unit_test\\rag\\llm\\test_sequence2txt_model.py`
- `uv run --no-sync --with ruff ruff check --select F,E9 rag\\llm\\sequence2txt_model.py test\\unit_test\\rag\\llm\\test_sequence2txt_openai_api.py`
- `uv run --no-sync --with ruff ruff format --check rag\\llm\\sequence2txt_model.py test\\unit_test\\rag\\llm\\test_sequence2txt_openai_api.py`

Closes #17096.
