### PR TITLE
fix(chat): preserve markdown blocks after reasoning sections

### DIFF
--- a/web/src/utils/__tests__/chat.test.ts
+++ b/web/src/utils/__tests__/chat.test.ts
@@ -1,4 +1,8 @@
-import { preprocessLaTeX } from '../chat';
+import {
+  preprocessLaTeX,
+  replaceRetrievingToSection,
+  replaceThinkToSection,
+} from '../chat';
 
 describe('preprocessLaTeX', () => {
   it('converts block \\[ \\] to $$ $$', () => {
@@ -31,5 +35,26 @@ describe('preprocessLaTeX', () => {
     const content = 'First \\[ a \\] then \\[ b \\right] c \\]';
     const result = preprocessLaTeX(content);
     expect(result).toBe('First $$a$$ then $$ b \\right] c $$');
+  });
+});
+
+describe('reasoning block markdown boundaries', () => {
+  it('keeps markdown parseable after a think block', () => {
+    const result = replaceThinkToSection('<think>reasoning</think>### Heading');
+    expect(result).toContain('</details>\n\n### Heading');
+  });
+
+  it('keeps markdown parseable after a retrieving block', () => {
+    const result = replaceRetrievingToSection(
+      '<retrieving>sources</retrieving>| A | B |\n| --- | --- |\n| 1 | 2 |',
+    );
+    expect(result).toContain(
+      '</details>\n\n| A | B |\n| --- | --- |\n| 1 | 2 |',
+    );
+  });
+
+  it('keeps markdown parseable for a list after a think block', () => {
+    const result = replaceThinkToSection('<think>reasoning</think>1. First');
+    expect(result).toContain('</details>\n\n1. First');
   });
 });

--- a/web/src/utils/chat.ts
+++ b/web/src/utils/chat.ts
@@ -86,7 +86,7 @@ export function replaceThinkToSection(
 
   const result = text.replace(
     pattern,
-    `<details class="think"><summary>${summary}</summary>$1</details>`,
+    `\n\n<details class="think"><summary>${summary}</summary>$1</details>\n\n`,
   );
 
   return result;
@@ -97,7 +97,7 @@ export function replaceRetrievingToSection(text: string = '') {
 
   const result = text.replace(
     pattern,
-    '<details class="retrieving"><summary>Retrieving...</summary>$1</details>',
+    '\n\n<details class="retrieving"><summary>Retrieving...</summary>$1</details>\n\n',
   );
 
   return result;


### PR DESCRIPTION
### What problem does this PR solve?

Chat answers that include a <think>...</think> reasoning block can render the following Markdown as plain text.

For example, when the model streams:
```
<think>...</think>### Title
| A | B |
|---|---|
```
the frontend converts `<think>` into a raw `<details>` HTML block without block-level spacing. As a result, `react-markdown` may keep the following heading/table/list as raw text instead
of parsing it as Markdown.

Before:
<img width="1149" height="612" alt="before" src="https://github.com/user-attachments/assets/42c54408-b5e0-4603-8304-d1f600a950aa" />

After:
<img width="1507" height="735" alt="after" src="https://github.com/user-attachments/assets/e2870226-1f14-4592-9a29-1912847eadc4" />


### Type of change                                                                                                                                                                             
                                                                                                                                                                                               
- [x] Bug Fix (non-breaking change which fixes an issue)        
- [x] New Feature (non-breaking change which adds functionality)

### What is changed?

- Add blank-line boundaries around generated `<details>` blocks for `<think>` content.
- Apply the same boundary handling to `<retrieving>` blocks.
- Add regression tests to ensure Markdown remains parseable after reasoning/retrieving sections.

### Tests
- Manually verified in Docker deployment by copying the rebuilt `web/dist` into the running `ragflow-gpu` container and confirming headings/lists render correctly after the reasoning
block.