### PR TITLE
fix: make cross-language retrieval deterministic

### DIFF
--- a/rag/prompts/generator.py
+++ b/rag/prompts/generator.py
@@ -303,7 +303,9 @@ async def cross_languages(tenant_id, llm_id, query, languages=[]):
     rendered_sys_prompt = PROMPT_JINJA_ENV.from_string(CROSS_LANGUAGES_SYS_PROMPT_TEMPLATE).render()
     rendered_user_prompt = PROMPT_JINJA_ENV.from_string(CROSS_LANGUAGES_USER_PROMPT_TEMPLATE).render(query=query, languages=languages)
 
-    ans = await chat_mdl.async_chat(rendered_sys_prompt, [{"role": "user", "content": rendered_user_prompt}], {"temperature": 0.2})
+    # Cross-language expansion feeds directly into retrieval. Sampling here can
+    # make the retrieval test and an agent search different rewritten queries.
+    ans = await chat_mdl.async_chat(rendered_sys_prompt, [{"role": "user", "content": rendered_user_prompt}], {"temperature": 0})
     if ans.find("**ERROR**") >= 0:
         logging.info("[cross_languages] LLM returned error, falling back to original query")
         return query

--- a/test/unit_test/rag/prompts/test_generator_message_fit_in.py
+++ b/test/unit_test/rag/prompts/test_generator_message_fit_in.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import asyncio
 import importlib.util
 import sys
 from pathlib import Path
@@ -170,3 +171,35 @@ def test_message_fit_in_zero_budget_preserves_non_empty_messages(monkeypatch):
     assert used_tokens == expected_total
     assert trimmed[0]["content"] == "s" * system_len
     assert trimmed[-1]["content"] == user_content
+
+
+@pytest.mark.p1
+def test_cross_languages_uses_deterministic_generation(monkeypatch):
+    generator = _load_generator_module(monkeypatch)
+    captured = {}
+
+    class _ChatModel:
+        async def async_chat(self, system_prompt, messages, generation_config):
+            captured["system_prompt"] = system_prompt
+            captured["messages"] = messages
+            captured["generation_config"] = generation_config
+            return "English translation===中文翻译"
+
+    constants = sys.modules["common.constants"]
+    constants.LLMType = SimpleNamespace(CHAT="chat", VISION="vision")
+
+    llm_service = ModuleType("api.db.services.llm_service")
+    llm_service.LLMBundle = lambda *_args, **_kwargs: _ChatModel()
+    monkeypatch.setitem(sys.modules, "api.db.services.llm_service", llm_service)
+
+    tenant_model_service = ModuleType("api.db.joint_services.tenant_model_service")
+    tenant_model_service.resolve_model_config = lambda *_args, **_kwargs: {}
+    tenant_model_service.get_tenant_default_model_by_type = lambda *_args, **_kwargs: {}
+    tenant_model_service.resolve_model_type = lambda *_args, **_kwargs: "chat"
+    monkeypatch.setitem(sys.modules, "api.db.joint_services.tenant_model_service", tenant_model_service)
+
+    result = asyncio.run(generator.cross_languages("tenant-1", None, "original query", ["English", "Chinese"]))
+
+    assert result == "English translation\n中文翻译"
+    assert captured["generation_config"] == {"temperature": 0}
+    assert captured["messages"]

--- a/test/unit_test/rag/prompts/test_generator_message_fit_in.py
+++ b/test/unit_test/rag/prompts/test_generator_message_fit_in.py
@@ -176,6 +176,8 @@ def test_message_fit_in_zero_budget_preserves_non_empty_messages(monkeypatch):
 @pytest.mark.p1
 def test_cross_languages_uses_deterministic_generation(monkeypatch):
     generator = _load_generator_module(monkeypatch)
+    generator.CROSS_LANGUAGES_SYS_PROMPT_TEMPLATE = "Translate the query."
+    generator.CROSS_LANGUAGES_USER_PROMPT_TEMPLATE = "Query: {{ query }}\nLanguages: {{ languages | join(', ') }}"
     captured = {}
 
     class _ChatModel:
@@ -202,4 +204,8 @@ def test_cross_languages_uses_deterministic_generation(monkeypatch):
 
     assert result == "English translation\n中文翻译"
     assert captured["generation_config"] == {"temperature": 0}
-    assert captured["messages"]
+    assert len(captured["messages"]) == 1
+    assert captured["messages"][0]["role"] == "user"
+    assert "original query" in captured["messages"][0]["content"]
+    assert "English" in captured["messages"][0]["content"]
+    assert "Chinese" in captured["messages"][0]["content"]


### PR DESCRIPTION
### Summary

Fixes #17296.

The Knowledge Retrieval Test and Agent Retrieval both invoke cross-language query expansion before calling the shared retriever. That expansion used `temperature: 0.2`, so two otherwise identical retrieval runs could send different translated queries to embedding and reranking, producing different candidates and ordering.

This change:
- makes cross-language query expansion deterministic by using zero-temperature generation;
- adds a regression test that captures the LLM generation config and verifies the normalized multilingual query output;
- leaves retrieval behavior unchanged when cross-language search is disabled.

### Root cause

The divergence was introduced before retrieval: cross-language expansion sampled an LLM independently in the Test and Agent paths. Visible retrieval settings could therefore match while the actual query passed to `settings.retriever.retrieval()` differed.

### Checks

- `python -m pytest test/unit_test/rag/prompts/test_generator_message_fit_in.py -q` (6 passed)
- `ruff check --select E4,E7,E9,F rag/prompts/generator.py test/unit_test/rag/prompts/test_generator_message_fit_in.py`
- `ruff check test/unit_test/rag/prompts/test_generator_message_fit_in.py`
- `python -m py_compile rag/prompts/generator.py test/unit_test/rag/prompts/test_generator_message_fit_in.py`
- `git diff --check`