### PR TITLE
fix(web): sanitize markdown after preprocessLaTeX (GHSA-jv5f-3mqh-cxwf)

### DIFF
--- a/web/src/components/floating-chat-widget-markdown.tsx
+++ b/web/src/components/floating-chat-widget-markdown.tsx
@@ -14,6 +14,7 @@ import {
   replaceRetrievingToSection,
   replaceTextByOldReg,
   replaceThinkToSection,
+  sanitizeMarkdown,
   showImage,
 } from '@/utils/chat';
 import { citationMarkerReg } from '@/utils/citation-utils';
@@ -70,6 +71,9 @@ const FloatingChatWidgetMarkdown = ({
       replaceThinkToSection,
       replaceRetrievingToSection,
       preprocessLaTeX,
+      // Sanitize last: this renderer previously passed message content to
+      // rehypeRaw without any sanitization at all.
+      sanitizeMarkdown,
     )(nextText);
   }, [content, t]);
 

--- a/web/src/components/highlight-markdown/index.tsx
+++ b/web/src/components/highlight-markdown/index.tsx
@@ -11,7 +11,7 @@ import rehypeRaw from 'rehype-raw';
 
 import 'katex/dist/katex.min.css'; // `rehype-katex` does not import the CSS for you
 
-import { preprocessLaTeX } from '@/utils/chat';
+import { preprocessLaTeX, sanitizeMarkdown } from '@/utils/chat';
 import { citationMarkerReg } from '@/utils/citation-utils';
 import { getDirAttribute } from '@/utils/text-direction';
 import { omit } from 'lodash';
@@ -28,8 +28,10 @@ const HighLightMarkdown = ({
   // IMPORTANT: preprocessLaTeX() decodes &lt;/&gt;/&amp; back to raw HTML before
   // rehypeRaw parses the markdown. Sanitizing children *before* preprocessLaTeX
   // would let entity-encoded payloads bypass DOMPurify and inject HTML.
-  // Sanitize the *post*-processed string instead. (Coderabbit CRITICAL #3486038798)
-  const processed = children ? preprocessLaTeX(children) : children;
+  // Sanitize the *post*-processed string instead.
+  const processed = children
+    ? sanitizeMarkdown(preprocessLaTeX(children))
+    : children;
   const dir = children
     ? getDirAttribute(children.replace(citationMarkerReg, ''))
     : undefined;

--- a/web/src/components/markdown-content/index.tsx
+++ b/web/src/components/markdown-content/index.tsx
@@ -26,6 +26,7 @@ import {
   replaceRetrievingToSection,
   replaceTextByOldReg,
   replaceThinkToSection,
+  sanitizeMarkdown,
 } from '@/utils/chat';
 import classNames from 'classnames';
 import { omit } from 'lodash';
@@ -65,12 +66,8 @@ const MarkdownContent = ({
   const { setDocumentIds, data: fileThumbnails } =
     useFetchDocumentThumbnailsByIds();
   const contentWithCursor = useMemo(() => {
-    let text = DOMPurify.sanitize(content, {
-      ADD_TAGS: ['think', 'section', 'details', 'summary', 'retrieving'],
-      ADD_ATTR: ['class'],
-    });
+    let text = content;
 
-    // let text = content;
     if (text === '') {
       text = t('chat.searching');
     }
@@ -82,6 +79,9 @@ const MarkdownContent = ({
       (value: string) => replaceThinkToSection(value, thinkSummary),
       replaceRetrievingToSection,
       preprocessLaTeX,
+      // Sanitize last: preprocessLaTeX() decodes entities back into raw markup,
+      // which rehypeRaw then parses.
+      sanitizeMarkdown,
     )(nextText);
   }, [content, loading, t]);
 

--- a/web/src/components/next-markdown-content/index.tsx
+++ b/web/src/components/next-markdown-content/index.tsx
@@ -24,6 +24,7 @@ import {
   replaceRetrievingToSection,
   replaceTextByOldReg,
   replaceThinkToSection,
+  sanitizeMarkdown,
 } from '@/utils/chat';
 import { citationMarkerReg } from '@/utils/citation-utils';
 import { getDirAttribute } from '@/utils/text-direction';
@@ -172,11 +173,8 @@ function MarkdownContent({
   const { setDocumentIds, data: fileThumbnails } =
     useFetchDocumentThumbnailsByIds();
   const contentWithCursor = useMemo(() => {
-    let text = DOMPurify.sanitize(content, {
-      ADD_TAGS: ['think', 'section', 'details', 'summary', 'retrieving'],
-      ADD_ATTR: ['class'],
-    });
-    // let text = content;
+    let text = content;
+
     if (text === '') {
       text = t('chat.searching');
     }
@@ -188,6 +186,9 @@ function MarkdownContent({
       (value: string) => replaceThinkToSection(value, thinkSummary),
       replaceRetrievingToSection,
       preprocessLaTeX,
+      // Sanitize last: preprocessLaTeX() decodes entities back into raw markup,
+      // which rehypeRaw then parses.
+      sanitizeMarkdown,
     )(nextText);
   }, [content, loading, t]);
 

--- a/web/src/pages/next-search/markdown-content/index.tsx
+++ b/web/src/pages/next-search/markdown-content/index.tsx
@@ -22,6 +22,7 @@ import {
   replaceRetrievingToSection,
   replaceTextByOldReg,
   replaceThinkToSection,
+  sanitizeMarkdown,
 } from '@/utils/chat';
 import { citationMarkerReg } from '@/utils/citation-utils';
 import { getDirAttribute } from '@/utils/text-direction';
@@ -66,11 +67,8 @@ const MarkdownContent = ({
   const { setDocumentIds, data: fileThumbnails } =
     useFetchDocumentThumbnailsByIds();
   const contentWithCursor = useMemo(() => {
-    let text = DOMPurify.sanitize(content, {
-      ADD_TAGS: ['think', 'section', 'details', 'summary', 'retrieving'],
-      ADD_ATTR: ['class'],
-    });
-    // let text = content;
+    let text = content;
+
     if (text === '') {
       text = t('chat.searching');
     }
@@ -79,6 +77,9 @@ const MarkdownContent = ({
       replaceThinkToSection,
       replaceRetrievingToSection,
       preprocessLaTeX,
+      // Sanitize last: preprocessLaTeX() decodes entities back into raw markup,
+      // which rehypeRaw then parses.
+      sanitizeMarkdown,
     )(nextText);
   }, [content, t]);
 

--- a/web/src/utils/chat.ts
+++ b/web/src/utils/chat.ts
@@ -3,6 +3,7 @@ import {
   EmptyConversationId,
 } from '@/constants/chat';
 import { IMessage, Message } from '@/interfaces/database/chat';
+import DOMPurify from 'dompurify';
 import { omit } from 'lodash';
 import { v4 as uuid } from 'uuid';
 import {
@@ -77,6 +78,20 @@ export const preprocessLaTeX = (content: string) => {
 
   return inlineProcessedContent;
 };
+
+// Sanitize a *fully preprocessed* markdown string, i.e. run this as the LAST
+// step before handing the value to <Markdown rehypePlugins={[rehypeRaw, ...]}>.
+//
+// preprocessLaTeX() decodes &lt;/&gt;/&amp; back into raw markup, so any
+// sanitization performed before it can be bypassed by entity-encoding the
+// payload: DOMPurify sees inert text, preprocessLaTeX turns that text back into
+// live HTML, and rehypeRaw then parses it. Keeping the sanitizer at the end of
+// the pipeline is what makes the allow-list actually apply to what is rendered.
+export const sanitizeMarkdown = (content: string) =>
+  DOMPurify.sanitize(content, {
+    ADD_TAGS: ['think', 'section', 'details', 'summary', 'retrieving'],
+    ADD_ATTR: ['class'],
+  });
 
 export function replaceThinkToSection(
   text: string = '',

--- a/web/src/utils/tests/chat.test.ts
+++ b/web/src/utils/tests/chat.test.ts
@@ -1,4 +1,4 @@
-import { preprocessLaTeX } from '../chat';
+import { preprocessLaTeX, sanitizeMarkdown } from '../chat';
 
 test('handles double-escaped inline LaTeX', () => {
   const result = preprocessLaTeX('\\\\(\\\\Delta = b^2\\\\)');
@@ -23,4 +23,33 @@ test('handles mixed double-escaped delimiters with HTML entities', () => {
 test('passes through already correct single-escaped delimiters unchanged', () => {
   const result = preprocessLaTeX('\\(x = 1\\)');
   expect(result).toBe('$x = 1$');
+});
+
+// preprocessLaTeX() intentionally decodes &lt;/&gt;/&amp;, so sanitizing before
+// it runs is not effective: the decode turns inert text back into live markup
+// that rehypeRaw then parses. sanitizeMarkdown() must therefore run last.
+test('sanitizeMarkdown drops markup that preprocessLaTeX decoded', () => {
+  const decoded = preprocessLaTeX(
+    'hi &lt;svg&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;/svg&gt;',
+  );
+  expect(decoded).toContain('<script>');
+
+  const sanitized = sanitizeMarkdown(decoded);
+  expect(sanitized).not.toContain('<script>');
+  expect(sanitized).toContain('hi');
+});
+
+test('sanitizeMarkdown drops event-handler attributes', () => {
+  const sanitized = sanitizeMarkdown(
+    preprocessLaTeX('&lt;img src=x onerror="alert(1)"&gt;'),
+  );
+  expect(sanitized).not.toContain('onerror');
+});
+
+test('sanitizeMarkdown keeps the tags the chat renderers rely on', () => {
+  const sanitized = sanitizeMarkdown(
+    '<details class="think"><summary>Thinking...</summary>why</details>',
+  );
+  expect(sanitized).toContain('<details class="think">');
+  expect(sanitized).toContain('<summary>');
 });


### PR DESCRIPTION
### Summary

`preprocessLaTeX()` in `web/src/utils/chat.ts` decodes `&lt;`, `&gt;` and `&amp;` back into raw markup, and every chat/search renderer hands its result to `<Markdown rehypePlugins={[rehypeRaw, ...]}>`. Those renderers ran `DOMPurify.sanitize()` *before* that decode, so markup that arrives entity-encoded is inert text when the allow-list inspects it and live markup again by the time `rehypeRaw` parses it — the sanitizer can be walked past. `FloatingChatWidgetMarkdown` passed message content to `rehypeRaw` with no sanitization at all.

This is the issue reported privately as GHSA-jv5f-3mqh-cxwf (the advisory is not published yet).

This PR moves sanitization to the end of the render pipeline, so the allow-list applies to exactly the string that gets parsed.

### What changed

- `web/src/utils/chat.ts` — new `sanitizeMarkdown()` holding the allow-list in one place (`think`, `section`, `details`, `summary`, `retrieving`, plus `class`; unchanged from the options that were inlined in the renderers).
- `markdown-content`, `next-markdown-content`, `next-search/markdown-content` — the leading `DOMPurify.sanitize()` call becomes the final step of the existing `pipe(...)`.
- `floating-chat-widget-markdown` — gains sanitization; it had none.
- `highlight-markdown` — restores the sanitize pass added in #16409. It was removed again in #16449 as "ineffective after preprocessLaTeX", but the ordering is the other way round: *after* `preprocessLaTeX` is the only point where it is effective, which is what the explanatory comment still sitting in that file already describes.
- `web/src/utils/tests/chat.test.ts` — three tests pinning the ordering, the event-handler stripping, and the tags the chat renderers depend on.

### Validation

`cd web && npx jest --runInBand src/utils/tests/chat.test.ts` — the three new tests pass.

Two pre-existing failures are untouched by this PR; both reproduce identically on `main` at 611e0596:

- `chat.test.ts` — `handles double-escaped inline LaTeX` and `handles mixed double-escaped delimiters with HTML entities` already fail on `main`.
- `highlight-markdown/__tests__/index.test.tsx` — both cases currently error with `ReferenceError: React is not defined` under the `esbuild-jest` transform (classic JSX runtime, and the component has no `React` import), so the regression guard added in #16409 does not assert anything at the moment. I left that alone to keep this PR focused, happy to fix it here if you prefer.

Rendering was checked in a browser against the real plugin stack (react-markdown 9, rehype-raw 7, rehype-katex 7, dompurify 3.3.2): GFM tables, `<think>` / `<retrieving>` sections, inline and block KaTeX, and the `\right]` / `\big)` delimiter handling all render as before. One visible difference: a literal `<` inside an inline code span now renders escaped, because the sanitizer HTML-escapes text before the markdown parser sees it. If that trade-off is unwelcome, the alternative is sanitizing the tree rather than the string — `rehype-sanitize` placed after `rehypeRaw` with a schema extended for the tags listed above — which costs a new dependency, so I went with the smaller change here.
