### PR TITLE
fix(api): default delimiter must be a real newline, not the r"\n" escape

### DIFF
--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -390,7 +390,7 @@ def get_parser_config(chunk_method, parser_config):
         "one": None,
         "knowledge_graph": {
             "chunk_token_num": 8192,
-            "delimiter": r"\n",
+            "delimiter": "\n",
             "entity_types": ["organization", "person", "location", "event", "time"],
             "raptor": {"use_raptor": False},
             "graphrag": {"use_graphrag": False},

--- a/api/utils/validation_utils.py
+++ b/api/utils/validation_utils.py
@@ -396,7 +396,7 @@ class ParentChildConfig(Base):
     """Dataset parser configuration for parent-child chunking."""
 
     use_parent_child: Annotated[bool, Field(default=False)]
-    children_delimiter: Annotated[str, Field(default=r"\n", min_length=1)]
+    children_delimiter: Annotated[str, Field(default="\n", min_length=1)]
 
 
 class AutoMetadataField(Base):
@@ -424,7 +424,7 @@ class ParserConfig(Base):
     auto_keywords: Annotated[int, Field(default=0, ge=0, le=32)]
     auto_questions: Annotated[int, Field(default=0, ge=0, le=10)]
     chunk_token_num: Annotated[int, Field(default=512, ge=1, le=2048)]
-    delimiter: Annotated[str, Field(default=r"\n", min_length=1)]
+    delimiter: Annotated[str, Field(default="\n", min_length=1)]
     graphrag: Annotated[GraphragConfig, Field(default_factory=lambda: GraphragConfig(use_graphrag=False))]
     html4excel: Annotated[bool, Field(default=False)]
     layout_recognize: Annotated[str, Field(default="DeepDOC")]

--- a/test/unit_test/api/utils/test_default_delimiter.py
+++ b/test/unit_test/api/utils/test_default_delimiter.py
@@ -1,0 +1,50 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""The API default delimiters must be an actual newline, not the raw 2-char
+escape ``r"\\n"``.
+
+A default stored as ``r"\\n"`` reaches ``rag.nlp.delim.parse_delimiter_field`` as
+a backslash followed by the letter ``n``. The canonical parser honours bare
+characters, so it then splits documents on every ``n`` (``"information"`` ->
+``"i"``, ``"formatio"``) and on the stray backslash. An actual newline parses to
+a single newline delimiter. The frontend already sends a real newline and the
+``naive`` default already uses one; these guard the ``knowledge_graph`` and
+``ParserConfig`` / ``ParentChildConfig`` defaults that did not.
+"""
+
+from api.utils.api_utils import get_parser_config
+from api.utils.validation_utils import ParentChildConfig, ParserConfig
+from rag.nlp.delim import parse_delimiter_field
+
+
+def _assert_real_newline(delimiter):
+    assert delimiter == "\n", f"default delimiter should be a real newline, got {delimiter!r}"
+    # A real newline parses to a single newline delimiter. The raw escape would
+    # instead parse to ["\\", "n"] and shred the document on the letter n.
+    assert parse_delimiter_field(delimiter) == ["\n"]
+
+
+def test_parser_config_delimiter_default_is_real_newline():
+    _assert_real_newline(ParserConfig().delimiter)
+
+
+def test_parent_child_children_delimiter_default_is_real_newline():
+    _assert_real_newline(ParentChildConfig().children_delimiter)
+
+
+def test_knowledge_graph_delimiter_default_is_real_newline():
+    _assert_real_newline(get_parser_config("knowledge_graph", None)["delimiter"])


### PR DESCRIPTION
Found this reading arXiv chunks back from storage, every `n` was gone. "analysis increasingly involves information" came back as "a\nalysis i\ncreasi\ngly i\nvolves i\nformatio". No error, chunk count normal, status 100%. The stored .txt on disk was fine.

The cause - a dataset created via the API without an explicit delimiter stores the default as the escape `\n` (backslash + the literal letter n). Two chunker paths read it and disagree. `deepdoc/parser/txt_parser.py` runs the delimiter through a `unicode_escape` round-trip (`txt_parser.py:34`), so `\n` becomes a real newline and it splits correctly. But `rag/nlp/get_delimiters` (used by `naive_merge`) does not decode. It splits the delimiter into individual characters (`list(delimiter)`), so `\n` becomes backslash and the letter n, and every oversized section gets split on the letter n and drops it.

For a `.txt` file both run. `TxtParser` splits it into sections (fine, it decoded), then `naive_merge` re-splits every oversized section on the letter n. So the corpus comes back with every n gone. It hid for a long time. Non-Latin corpora look fine (no `n` to lose), and small sections never reach the `naive_merge` re-split.

Reproduced on v0.26.4 (the version I ingested arxiv with, image `infiniflow/ragflow:v0.26.4`) and still on current main `611e0596`. The repro is a normal API create with a `parser_config` present but no `delimiter`, then a large `.txt`.

Fix, both in `get_delimiters` - decode escape sequences the same way `txt_parser` does, so `\n` splits on a newline. And drop bare ASCII-letter delimiter characters with a warning, keeping backtick-quoted delimiters, so any residual letter degrades to no split instead of silent corruption. `txt_parser` keeps the same letter guard and stays whole when nothing is left to split on.

`markdown_parser.get_delimiters` is backtick-only already and is safe. Go `compileDelimPattern` compiles only backtick delimiters and splits oversized sections on a fixed newline/punctuation pattern, so Go never char-splits the config delimiter. Added Go tests that assert it.

Splitting a document on a letter is never a real config, so nothing legitimate changes. Normal delimiters (newline, `!?。；！？`, backtick groups) are untouched.

Tests - `test/unit_test/deepdoc/parser/test_txt_parser.py`, `test/unit_test/rag/test_naive_merge.py`, and `internal/ingestion/component/chunker/delimiter_safety_test.go` cover the letter delimiter (red before the fix), the `\n` escape, normal delimiters, the all-letters case, and the Go parity.



---

UPD: main refactored the delimiter parsers into one canonical helper `rag.nlp.delim.parse_delimiter_field` (#17383), so the original two-path fix no longer applies - `get_delimiters` and the txt_parser inline split are gone.

Re-checked against current main and the shred is still live, but the cause narrows to the stored default, not the parser. The canonical parser is correct on a real newline. What reaches it as backslash + n is the default itself - three configs default the delimiter to a raw `r"\n"` (a Python raw string, so backslash + the literal letter n):

- `api/utils/api_utils.py:393` (knowledge_graph)
- `api/utils/validation_utils.py:427` (ParserConfig)
- `api/utils/validation_utils.py:399` (ParentChildConfig children_delimiter)

`parse_delimiter_field(r"\n")` returns `['\\', 'n']` and splits "information" into "i","formatio". The `naive` default at `api_utils.py:341` is already a real `"\n"` and the frontend sends a real newline, so these three were just missed.

Fix is now those three defaults, `r"\n"` -> `"\n"`, matching the `naive` default. No parser change, so `delim.py` and its tests are untouched. Regression test in `test/unit_test/api/utils/test_default_delimiter.py` asserts the three defaults parse to a single newline. Dropped the old txt_parser / naive_merge / Go changes - they targeted code that no longer exists.
