### PR TITLE
Fix ingestor Start() sync.Once re-entrant deadlock

### DIFF
--- a/internal/engine/global.go
+++ b/internal/engine/global.go
@@ -88,6 +88,13 @@ func GetMessageQueueEngine() MessageQueue {
 	return messageQueueEngine
 }
 
+// SetMessageQueueEngine installs the global message-queue engine. It exists
+// primarily as a test seam so callers can drive Start() without a real server
+// config; production code uses InitMessageQueueEngine.
+func SetMessageQueueEngine(mq MessageQueue) {
+	messageQueueEngine = mq
+}
+
 func InitMessageQueueEngine(messageQueueType string) error {
 	config := server.GetConfig()
 	switch messageQueueType {

--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -64,10 +64,11 @@ type Ingestor struct {
 	ShutdownCh chan struct{}
 
 	// Worker pool
-	taskChan  chan *taskpkg.TaskContext
-	workerWg  sync.WaitGroup
-	startOnce sync.Once
-	stopOnce  sync.Once // guards close(ShutdownCh) against double-close on repeated Stop
+	taskChan   chan *taskpkg.TaskContext
+	workerWg   sync.WaitGroup
+	startOnce  sync.Once
+	workerOnce sync.Once // guards startWorkerPool; must NOT be startOnce (Start wraps start() in startOnce, and start() calls startWorkerPool -> re-entry deadlock)
+	stopOnce   sync.Once // guards close(ShutdownCh) against double-close on repeated Stop
 
 	ingestionTaskSvc *servicepkg.IngestionTaskService
 	docState         *docStateUpdater
@@ -382,7 +383,7 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 }
 
 func (e *Ingestor) startWorkerPool() {
-	e.startOnce.Do(func() {
+	e.workerOnce.Do(func() {
 		for i := int32(0); i < e.maxConcurrency; i++ {
 			e.workerWg.Add(1)
 			go e.workerLoop(i)

--- a/internal/ingestion/service/ingestor_lifecycle_test.go
+++ b/internal/ingestion/service/ingestor_lifecycle_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"ragflow/internal/common"
+	"ragflow/internal/engine"
 	"ragflow/internal/entity"
 	taskpkg "ragflow/internal/ingestion/task"
 	"ragflow/internal/ingestion/testutil"
@@ -199,4 +200,40 @@ func TestPollCancel_ExitsWhenDoneClosed(t *testing.T) {
 	}
 
 	close(released) // cleanup
+}
+
+// TestStart_FullPathReturnsAndStartsWorkers is a regression test for the
+// sync.Once re-entrancy deadlock. Before the fix, Start() wrapped the whole
+// startup (start()) in e.startOnce.Do, but start() also called startWorkerPool()
+// which nested the SAME startOnce. sync.Once.Do blocks forever when re-entered
+// from inside its own callback, so Start() hung after InitConsumer succeeded:
+// no worker pool, no consumeLoop, and ingestion tasks were never consumed.
+//
+// The test drives the real Start() path (start -> startWorkerPool -> consumeLoop)
+// against an embedded NATS server and asserts Start() returns within a deadline
+// and that workers are actually up.
+func TestStart_FullPathReturnsAndStartsWorkers(t *testing.T) {
+	engine.SetMessageQueueEngine(testutil.SetupNatsEngine(t))
+
+	const concurrency int32 = 2
+	ing := NewIngestor("test-start-fullpath", concurrency, nil)
+	t.Cleanup(func() { ing.Stop(context.Background()) })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ing.Start()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start() returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Start() did not return within 10s; sync.Once re-entrancy deadlock likely")
+	}
+
+	if got := ing.activeWorkers.Load(); got <= 0 {
+		t.Fatalf("expected activeWorkers > 0 after Start(), got %d", got)
+	}
 }


### PR DESCRIPTION
Start() wrapped start() in startOnce while startWorkerPool nested the same Once, deadlocking Start forever. Give worker pool its own Once and add a full-path regression test.