### PR TITLE
fix(dataset): apply horizontal layout to auto-keywords and auto-questions form fields

### DIFF
--- a/web/src/components/children-delimiter-form.tsx
+++ b/web/src/components/children-delimiter-form.tsx
@@ -94,7 +94,7 @@ export function ChildrenDelimiterForm() {
           name="parser_config.children_delimiter"
           render={({ field }) => (
             <FormItem className="items-center space-y-0 ">
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 pr-[1px]">
                 <FormLabel
                   required
                   tooltip={t('knowledgeDetails.childrenDelimiterTip')}

--- a/web/src/components/chunk-method-dialog/index.tsx
+++ b/web/src/components/chunk-method-dialog/index.tsx
@@ -52,6 +52,7 @@ import {
   useDefaultParserValues,
   useFillDefaultValueOnMount,
 } from './use-default-parser-values';
+import { FormLayout } from '@/constants/form';
 
 const FormId = 'ChunkMethodDialogForm';
 
@@ -380,8 +381,12 @@ export function ChunkMethodDialog({
                         type={MetadataType.SingleFileSetting}
                         otherData={{ documentId }}
                       />
-                      <AutoKeywordsFormField></AutoKeywordsFormField>
-                      <AutoQuestionsFormField></AutoQuestionsFormField>
+                      <AutoKeywordsFormField
+                        layout={FormLayout.Horizontal}
+                      ></AutoKeywordsFormField>
+                      <AutoQuestionsFormField
+                        layout={FormLayout.Horizontal}
+                      ></AutoQuestionsFormField>
                     </>
                   )}
 

--- a/web/src/components/delimiter-form-field.tsx
+++ b/web/src/components/delimiter-form-field.tsx
@@ -63,7 +63,7 @@ export function DelimiterFormField() {
         }
         return (
           <FormItem className=" items-center space-y-0 ">
-            <div className="flex items-start gap-1">
+            <div className="flex items-start gap-1 pr-[1px]">
               <FormLabel
                 required
                 tooltip={t('knowledgeDetails.delimiterTip')}

--- a/web/src/pages/dataset/dataset-setting/configuration/audio.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/audio.tsx
@@ -4,14 +4,19 @@ import {
 } from '@/components/auto-keywords-form-field';
 import { ConfigurationFormContainer } from '../configuration-form-container';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function AudioConfiguration() {
   return (
     <ConfigurationFormContainer>
       <>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </>
 
       {/* <TagItems></TagItems> */}

--- a/web/src/pages/dataset/dataset-setting/configuration/book.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/book.tsx
@@ -9,6 +9,7 @@ import {
 } from '../configuration-form-container';
 import { useKnowledgeBaseContext } from '../../contexts/knowledge-base-context';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function BookConfiguration() {
   const ownerTenantId = useKnowledgeBaseContext().knowledgeBase?.tenant_id;
@@ -22,8 +23,12 @@ export function BookConfiguration() {
 
       <ConfigurationFormContainer>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </ConfigurationFormContainer>
       {/* <ConfigurationFormContainer>
         <TagItems></TagItems>

--- a/web/src/pages/dataset/dataset-setting/configuration/email.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/email.tsx
@@ -4,14 +4,19 @@ import {
 } from '@/components/auto-keywords-form-field';
 import { ConfigurationFormContainer } from '../configuration-form-container';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function EmailConfiguration() {
   return (
     <ConfigurationFormContainer>
       <>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </>
       {/* <TagItems></TagItems> */}
     </ConfigurationFormContainer>

--- a/web/src/pages/dataset/dataset-setting/configuration/laws.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/laws.tsx
@@ -9,6 +9,7 @@ import {
 } from '../configuration-form-container';
 import { useKnowledgeBaseContext } from '../../contexts/knowledge-base-context';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function LawsConfiguration() {
   const ownerTenantId = useKnowledgeBaseContext().knowledgeBase?.tenant_id;
@@ -22,8 +23,12 @@ export function LawsConfiguration() {
 
       <ConfigurationFormContainer>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </ConfigurationFormContainer>
 
       {/* <ConfigurationFormContainer>

--- a/web/src/pages/dataset/dataset-setting/configuration/manual.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/manual.tsx
@@ -9,6 +9,7 @@ import {
 } from '../configuration-form-container';
 import { useKnowledgeBaseContext } from '../../contexts/knowledge-base-context';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function ManualConfiguration() {
   const ownerTenantId = useKnowledgeBaseContext().knowledgeBase?.tenant_id;
@@ -22,8 +23,12 @@ export function ManualConfiguration() {
 
       <ConfigurationFormContainer>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </ConfigurationFormContainer>
 
       {/* <TagItems></TagItems> */}

--- a/web/src/pages/dataset/dataset-setting/configuration/naive.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/naive.tsx
@@ -18,6 +18,7 @@ import {
   ImageContextWindow,
   OverlappedPercent,
 } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function NaiveConfiguration() {
   const ownerTenantId = useKnowledgeBaseContext().knowledgeBase?.tenant_id;
@@ -41,8 +42,12 @@ export function NaiveConfiguration() {
         <OverlappedPercent />
       </ConfigurationFormContainer>
       <ConfigurationFormContainer>
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
         <ExcelToHtmlFormField></ExcelToHtmlFormField>
         {/* <TagItems></TagItems> */}
       </ConfigurationFormContainer>

--- a/web/src/pages/dataset/dataset-setting/configuration/one.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/one.tsx
@@ -6,6 +6,7 @@ import { LayoutRecognizeFormField } from '@/components/layout-recognize-form-fie
 import { ConfigurationFormContainer } from '../configuration-form-container';
 import { useKnowledgeBaseContext } from '../../contexts/knowledge-base-context';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function OneConfiguration() {
   const ownerTenantId = useKnowledgeBaseContext().knowledgeBase?.tenant_id;
@@ -16,8 +17,12 @@ export function OneConfiguration() {
       ></LayoutRecognizeFormField>
       <>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </>
 
       {/* <TagItems></TagItems> */}

--- a/web/src/pages/dataset/dataset-setting/configuration/paper.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/paper.tsx
@@ -9,6 +9,7 @@ import {
 } from '../configuration-form-container';
 import { useKnowledgeBaseContext } from '../../contexts/knowledge-base-context';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function PaperConfiguration() {
   const ownerTenantId = useKnowledgeBaseContext().knowledgeBase?.tenant_id;
@@ -22,8 +23,12 @@ export function PaperConfiguration() {
 
       <ConfigurationFormContainer>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </ConfigurationFormContainer>
       {/* <ConfigurationFormContainer>
         <TagItems></TagItems>

--- a/web/src/pages/dataset/dataset-setting/configuration/picture.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/picture.tsx
@@ -4,14 +4,19 @@ import {
 } from '@/components/auto-keywords-form-field';
 import { ConfigurationFormContainer } from '../configuration-form-container';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function PictureConfiguration() {
   return (
     <ConfigurationFormContainer>
       <>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </>
       {/* <TagItems></TagItems> */}
     </ConfigurationFormContainer>

--- a/web/src/pages/dataset/dataset-setting/configuration/presentation.tsx
+++ b/web/src/pages/dataset/dataset-setting/configuration/presentation.tsx
@@ -9,6 +9,7 @@ import {
 } from '../configuration-form-container';
 import { useKnowledgeBaseContext } from '../../contexts/knowledge-base-context';
 import { AutoMetadata } from './common-item';
+import { FormLayout } from '@/constants/form';
 
 export function PresentationConfiguration() {
   const ownerTenantId = useKnowledgeBaseContext().knowledgeBase?.tenant_id;
@@ -22,8 +23,12 @@ export function PresentationConfiguration() {
 
       <ConfigurationFormContainer>
         <AutoMetadata />
-        <AutoKeywordsFormField></AutoKeywordsFormField>
-        <AutoQuestionsFormField></AutoQuestionsFormField>
+        <AutoKeywordsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoKeywordsFormField>
+        <AutoQuestionsFormField
+          layout={FormLayout.Horizontal}
+        ></AutoQuestionsFormField>
       </ConfigurationFormContainer>
 
       {/* <ConfigurationFormContainer>

--- a/web/src/pages/dataset/dataset-setting/general-form.tsx
+++ b/web/src/pages/dataset/dataset-setting/general-form.tsx
@@ -38,8 +38,7 @@ export function GeneralForm() {
         render={({ field }) => (
           <FormItem className="items-center space-y-0">
             <div className="flex">
-              <FormLabel className="text-sm whitespace-nowrap w-1/4">
-                <span className="text-red-600">*</span>
+              <FormLabel className="text-sm whitespace-nowrap w-1/4" required>
                 {t('common.name')}
               </FormLabel>
               <FormControl className="w-3/4">


### PR DESCRIPTION
### Summary

fix(dataset): apply horizontal layout to auto-keywords and auto-questions form fields

  - Pass `layout={FormLayout.Horizontal}` to `AutoKeywordsFormField` and `AutoQuestionsFormField` across all chunk method configurations (audio, book, email, laws, manual, naive, one, paper, picture, presentation) and the chunk method dialog.
  - Replace the manually-rendered `<span>*</span>` asterisk in `general-form.tsx` with the `required` prop on `FormLabel`.
  - Add `pr-[1px]` to the delimiter and children-delimiter form fields to prevent layout clipping.