### PR TITLE
refa: update LongCat model configuration

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -6214,16 +6214,9 @@
             "url": "https://api.longcat.chat/openai",
             "llm": [
                 {
-                    "llm_name": "LongCat-Flash-Chat",
-                    "tags": "LLM,CHAT,8000",
-                    "max_tokens": 8000,
-                    "model_type": "chat",
-                    "is_tools": true
-                },
-                {
-                    "llm_name": "LongCat-Flash-Thinking",
-                    "tags": "LLM,CHAT,8000",
-                    "max_tokens": 8000,
+                    "llm_name": "LongCat-2.0",
+                    "tags": "LLM,CHAT,131k",
+                    "max_tokens": 131072,
                     "model_type": "chat",
                     "is_tools": true
                 }


### PR DESCRIPTION
### What problem does this PR solve?

Updates the LongCat provider configuration to use the new `LongCat-2.0` chat model and its larger output capacity.

### What changed?

- Replaced `LongCat-Flash-Chat` and `LongCat-Flash-Thinking` with `LongCat-2.0`.
- Updated the model tags to `131k`.
- Increased `max_tokens` from `8000` to `131072`.

### Type of change

- [x] Refactor (no functional code change)