### PR TITLE
Fix: Blueprints cannot be displayed when selecting wiki.

### DIFF
--- a/web/src/constants/compilation.ts
+++ b/web/src/constants/compilation.ts
@@ -1,5 +1,5 @@
 export const enum CompilationTemplateKind {
-  Artifacts = 'artifacts',
+  Artifacts = 'wiki',
   KnowledgeGraph = 'knowledge_graph',
   Timeline = 'timeline',
   PageIndex = 'page_index',

--- a/web/src/constants/knowledge.ts
+++ b/web/src/constants/knowledge.ts
@@ -161,7 +161,7 @@ export enum GenerateType {
 export enum TraceType {
   Graph = 'graph',
   Raptor = 'raptor',
-  Artifact = 'artifact',
+  Artifact = 'wiki',
   Skill = 'skill',
   MindMap = 'mindmap',
   Timeline = 'timeline',


### PR DESCRIPTION
### Summary

Fix: Blueprints cannot be displayed when selecting wiki.