### PR TITLE
test: release test_dataset_create_embedding_model_contract for Go proxy

### DIFF
--- a/test/testcases/restful_api/conftest.py
+++ b/test/testcases/restful_api/conftest.py
@@ -53,7 +53,6 @@ GO_ONLY_SKIPS = {
         "test_dataset_create_parser_config_bugfix_contract",
         "test_dataset_create_parser_config_invalid_contract",
         "test_dataset_create_parser_config_defaults_and_extra_fields_contract",
-        "test_dataset_create_embedding_model_contract",
         # Empty path (e.g. /chats//sessions) triggers a 405/404 framework
         # response in Go rather than the Python contract's code-100 envelope.
         "test_session_create_validation_and_deleted_chat_contract",


### PR DESCRIPTION
### Summary

Release `test_dataset_create_embedding_model_contract` from the Go-proxy skip list (`GO_ONLY_SKIPS`) in `test/testcases/restful_api/conftest.py`.

This test was incorrectly grouped under the skip reason "Go CreateDataset does not accept parser_config in the request body." However, the test does **not** send `parser_config` at all — it only exercises `embedding_model` validation, resolution, and response echoing on dataset creation, all of which the Go handler fully supports:

- `CreateDatasetRequest` includes `EmbeddingModel *string`
- The service validates the `model@provider` format
- It verifies model availability and resolves the model ID
- The response echoes back `embedding_model`

The test already contains Go-specific assertions (`IS_GO_PROXY` branch at line 1265 that checks for `"lookup failed: record not found"` in the error message), confirming it was designed to work in Go mode.