### PR TITLE
Test(handler): fix failing TestSearchHandlerUpdateRejectsInvalidSearchID assertion

### DIFF
--- a/internal/handler/search_handler_test.go
+++ b/internal/handler/search_handler_test.go
@@ -94,7 +94,7 @@ func TestSearchHandlerUpdateRejectsInvalidSearchID(t *testing.T) {
 	if resp["code"] != float64(common.CodeAuthenticationError) {
 		t.Fatalf("expected code 109, got %v", resp["code"])
 	}
-	if !strings.Contains(resp["message"].(string), "no authorization") {
+	if !strings.Contains(strings.ToLower(resp["message"].(string)), "no authorization") {
 		t.Fatalf("expected 'no authorization' in message, got %v", resp["message"])
 	}
 }


### PR DESCRIPTION
### Summary

`TestSearchHandlerUpdateRejectsInvalidSearchID` fails on `main`:

```
--- FAIL: TestSearchHandlerUpdateRejectsInvalidSearchID (0.00s)
    search_handler_test.go:98: expected 'no authorization' in message, got No authorization.
```

`UpdateSearch` answers an unauthorized `search_id` with `"No authorization."` (`internal/handler/search.go:337`), which mirrors the Python API's message verbatim, but the assertion searched for the lowercase `"no authorization"`.

The fix lowercases the response before the substring check rather than changing the handler's message: the capitalized text is the contract the Python API exposes, so the test — not the handler — was wrong.

`bash build.sh --test -run TestSearchHandler ./internal/handler/` passes.