### PR TITLE
fix: remediate CVE-2026-59939 by constraining httplib2 to >=0.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,9 @@ constraint-dependencies = [
     # CVE-2026-0994: protobuf < 5.29.6 vulnerable; pulled in transitively via
     # google-api-core, googleapis-common-protos, grpcio-status, opentelemetry-proto
     "protobuf>=5.29.6",
+    # CVE-2026-59939: httplib2 < 0.32.0 vulnerable; pulled in transitively via
+    # google-api-python-client, google-auth-httplib2
+    "httplib2>=0.32.0",
 ]
 exclude-dependencies = [
     # crawl4ai>=0.8.6 depends on unclecode-litellm, which installs the same

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "httplib2", specifier = ">=0.32.0" },
     { name = "inscriptis", specifier = ">=2.7.3" },
     { name = "lxml", specifier = ">=6.1.1" },
     { name = "lxml-html-clean", specifier = ">=0.4.5" },
@@ -2693,14 +2694,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.0"
+version = "0.32.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/52/77/6653db69c1f7ecfe5e3f9726fdadc981794656fcd7d98c4209fecfea9993/httplib2-0.31.0.tar.gz", hash = "sha256:ac7ab497c50975147d4f7b1ade44becc7df2f8954d42b38b3d69c515f531135c" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/8c/a2/0d269db0f6163be503775dc8b6a6fa15820cc9fdc866f6ba608d86b721f2/httplib2-0.31.0-py3-none-any.whl", hash = "sha256:b9cd78abea9b4e43a7714c6e0f8b6b8561a6fc1e95d5dbd367f5bf0ef35f5d24" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
  
  Remediates CVE-2026-59939 (HIGH) in `httplib2` by adding `httplib2>=0.32.0` to `constraint-dependencies` in `pyproject.toml`.
  
  | CVE | Severity | Package | Installed | Fixed in |
  |---|---|---|---|---|
  | CVE-2026-59939 | HIGH | httplib2 | 0.31.0 | 0.32.0 |
  
  `httplib2` is a transitive dependency pulled in by `google-api-python-client` and `google-auth-httplib2`. Both declare `httplib2<1.0.0,>=0.19.0`, allowing 0.32.0 without conflict.
  
  ## Testing
  
  - Full unit test suite passes
  - `uv sync` resolves cleanly