### PR TITLE
refactor: remove unused contentToText helper from Ollama driver

### DIFF
--- a/internal/entity/models/ollama.go
+++ b/internal/entity/models/ollama.go
@@ -33,26 +33,6 @@ type OllamaModel struct {
 	baseModel BaseModel
 }
 
-// contentToText extracts a plain-text string from a Message.Content value.
-// Content may be a raw string or an OpenAI-style multimodal array
-// ([]interface{} where each element is {"type": "text", "text": "..."}).
-// The first non-empty "text" value found is returned; empty string on no match.
-func contentToText(content interface{}) string {
-	switch c := content.(type) {
-	case string:
-		return c
-	case []interface{}:
-		for _, item := range c {
-			if part, ok := item.(map[string]interface{}); ok {
-				if text, ok := part["text"].(string); ok && text != "" {
-					return text
-				}
-			}
-		}
-	}
-	return ""
-}
-
 // NewOllamaModel creates a new Ollama AI model instance
 func NewOllamaModel(baseURL map[string]string, urlSuffix URLSuffix) *OllamaModel {
 	return &OllamaModel{


### PR DESCRIPTION
### Summary

`contentToText` in `internal/entity/models/ollama.go` has no callers anywhere in the repository. This PR deletes it.

Both `OllamaModel.ChatWithMessages` and `OllamaModel.ChatStreamlyWithSender` build their request payload through the shared `buildRequestBody` → `buildChatMessages` path (`internal/entity/models/base_model.go:324`, `:373`), which copies `Message.Content` straight into the payload. Neither path reaches the helper.

`staticcheck` flags it as `U1000`. There is no Go linter wired into CI, which is presumably why it went unnoticed.

1 file, -20 lines. Pure deletion — no behavior change, no signature change, no test touched. `strings` is still used elsewhere in the file, so no import change either.

### How I verified it's dead

```
$ grep -rn "contentToText" --include="*.go" .
internal/entity/models/ollama.go:36:// contentToText extracts a plain-text string from a Message.Content value.
internal/entity/models/ollama.go:40:func contentToText(content interface{}) string {
```

Only the declaration and its own doc comment. I also swept the package for unreferenced package-private functions with comments and string literals stripped first (so a name appearing only in prose doesn't count as a use), and cross-checked against `staticcheck`; both agree.

### Verification

```
$ gofmt -l internal/entity/models/ollama.go
(no output)

$ go vet ./internal/entity/models/
(no output)

$ go test ./internal/entity/models/
ok  	ragflow/internal/entity/models	4.358s

$ staticcheck -checks=U1000 ./internal/entity/models/     # before
18 findings, including:
internal/entity/models/ollama.go:40:6: func contentToText is unused (U1000)

$ staticcheck -checks=U1000 ./internal/entity/models/     # after
17 findings, ollama.go entry gone, nothing else changed
```

I re-ran the package tests with the parent version of the file checked back in (`git checkout 36ae39b -- internal/entity/models/ollama.go`) and they pass identically, so the `ok` above isn't an artifact of the edit.

**One caveat about my local setup, stated plainly:** `bash build.sh --test` (the command `CLAUDE.md` prescribes) does not run on this machine — the native static libs it fetches ship as `native-linux-x86_64` and I'm on darwin/arm64. I built `librag_tokenizer_c_api.a` from `internal/binding/cpp` locally and ran the one package directly instead. `internal/entity/models` has no `office_oxide` / `pdfium` / `pdf_oxide` / `import "C"` references, so I believe the direct package run is equivalent here, but CI is the authority on that, not me. For the same reason I did **not** try to produce a repo-wide `U1000` count — several packages don't compile locally without those libs, so any total I quoted would be wrong.

### Notes for the reviewer

**Scope.** There are 17 other `U1000` findings in this same package: unused `*ModelInfo` / `*ModelCatalogItem` response types in `avian.go`, `cometapi.go`, `futurmix.go`, `gpustack.go`, `groq.go`, `longcat.go`, `n1n.go`, `perplexity.go`, `ppio.go`, `togetherai.go`, `model.go`, plus a test helper in `model_test.go`. I deliberately kept this PR to the single symbol rather than bundling them, because the response structs in particular may be intentional documentation of provider API shapes — that's your call, not mine. Happy to open follow-ups, or a wider sweep, if you'd like. Wiring `golangci-lint`/`staticcheck` into CI would stop this class from accumulating, if that's of interest.

**Relationship to #17332.** I found this while looking into that issue, but **this PR does not fix it and I'm not claiming it.** #17332 reports that Ollama vision requests drop images and points at `contentToText` as the mechanism, citing it as "used at `:98`, `:218`". On current `main` those two lines are the `buildRequestBody` call and the SSE-parsing loop respectively — not calls to the helper. My clone is shallow (2 commits), so I can't tell you when or in which commit the call sites went away, only that they aren't there now.

That means the *mechanism* described in #17332 is stale, but the *symptom* may well be real: `buildChatMessages` emits only `role`/`content`, so there is still no Ollama-native `images` field on either path. I didn't want to bundle a speculative vision feature into a dead-code deletion, so #17332 deserves a separate look by someone who can test against a real multimodal Ollama model.

---

I used an AI assistant (Claude Code) to help find and verify this change. I reviewed every line and ran the checks above myself.
