### PR TITLE
fix(go-agent): fix Tavily tool array schemas

### DIFF
--- a/internal/agent/tool/tavily.go
+++ b/internal/agent/tool/tavily.go
@@ -234,11 +234,13 @@ func (t *TavilyTool) Info(_ context.Context) (*schema.ToolInfo, error) {
 			},
 			"include_domains": {
 				Type:     schema.Array,
+				ElemInfo: &schema.ParameterInfo{Type: schema.String},
 				Desc:     "Domains that search results must include.",
 				Required: false,
 			},
 			"exclude_domains": {
 				Type:     schema.Array,
+				ElemInfo: &schema.ParameterInfo{Type: schema.String},
 				Desc:     "Domains that search results must exclude.",
 				Required: false,
 			},
@@ -254,6 +256,7 @@ func (t *TavilyExtractTool) Info(_ context.Context) (*schema.ToolInfo, error) {
 		ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 			"urls": {
 				Type:     schema.Array,
+				ElemInfo: &schema.ParameterInfo{Type: schema.String},
 				Desc:     "The URLs to extract content from.",
 				Required: true,
 			},

--- a/internal/agent/tool/tavily_test.go
+++ b/internal/agent/tool/tavily_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/cloudwego/eino/schema"
 )
 
 func TestTavily_BuildRequest(t *testing.T) {
@@ -180,6 +182,52 @@ func TestTavily_Info(t *testing.T) {
 	}
 	if !strings.Contains(info.Desc, "Tavily") {
 		t.Errorf("Desc = %q, want to mention Tavily", info.Desc)
+	}
+}
+
+func TestTavily_InfoArraySchemasIncludeStringItems(t *testing.T) {
+	t.Parallel()
+
+	info, err := NewTavilyTool().Info(context.Background())
+	if err != nil {
+		t.Fatalf("Tavily Info: %v", err)
+	}
+	assertToolArrayItemType(t, info, "include_domains")
+	assertToolArrayItemType(t, info, "exclude_domains")
+
+	extractInfo, err := NewTavilyExtractTool().Info(context.Background())
+	if err != nil {
+		t.Fatalf("Tavily Extract Info: %v", err)
+	}
+	assertToolArrayItemType(t, extractInfo, "urls")
+}
+
+func assertToolArrayItemType(t *testing.T, info *schema.ToolInfo, fieldName string) {
+	t.Helper()
+
+	params, err := info.ParamsOneOf.ToJSONSchema()
+	if err != nil {
+		t.Fatalf("convert %s schema: %v", info.Name, err)
+	}
+	rawSchema, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal %s schema: %v", info.Name, err)
+	}
+	var schemaMap map[string]any
+	if err := json.Unmarshal(rawSchema, &schemaMap); err != nil {
+		t.Fatalf("decode %s schema: %v", info.Name, err)
+	}
+	properties, ok := schemaMap["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s schema properties = %#v", info.Name, schemaMap["properties"])
+	}
+	field, ok := properties[fieldName].(map[string]any)
+	if !ok {
+		t.Fatalf("%s schema field %q = %#v", info.Name, fieldName, properties[fieldName])
+	}
+	items, ok := field["items"].(map[string]any)
+	if !ok || items["type"] != "string" {
+		t.Fatalf("%s schema field %q items = %#v, want {type: string}", info.Name, fieldName, field["items"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add string item schemas for Tavily Search domain filters.
- Add the same schema fix for Tavily Extract URLs.
- Add regression coverage for generated tool schemas.

## Testing

- `CGO_ENABLED=0 go test -count=1 ./internal/agent/tool ./internal/agent/component`

<img width="2046" height="622" alt="image" src="https://github.com/user-attachments/assets/2785a89e-16c9-4222-b434-31d7eb9f3ac9" />
