### PR TITLE
Fix: Enforce the 4 MB size limit for avatar image uploads

### DIFF
--- a/web/src/components/avatar-upload.tsx
+++ b/web/src/components/avatar-upload.tsx
@@ -1,6 +1,7 @@
 import { combineRefs } from '@/lib/utils';
 import { transformFile2Base64 } from '@/utils/file-util';
 import { LucidePencil, LucidePlus, LucideX } from 'lucide-react';
+import message from './ui/message';
 import {
   ChangeEventHandler,
   forwardRef,
@@ -13,6 +14,9 @@ import { useTranslation } from 'react-i18next';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { Button } from './ui/button';
 import { Modal } from './ui/modal/modal';
+
+// Maximum size of the image file selected for an avatar, in bytes (4 MB).
+const MaxAvatarFileSize = 4 * 1024 * 1024;
 
 type AvatarUploadProps = {
   value?: string;
@@ -55,13 +59,18 @@ export const AvatarUpload = forwardRef<HTMLInputElement, AvatarUploadProps>(
       async (ev) => {
         const file = ev.target?.files?.[0];
         if (/\.(jpg|jpeg|png|webp|bmp)$/i.test(file?.name ?? '')) {
+          if (file!.size > MaxAvatarFileSize) {
+            message.error(t('knowledgeConfiguration.photoTip'));
+            ev.target.value = '';
+            return;
+          }
           const str = await transformFile2Base64(file!, 1000);
           setImageToCrop(str);
           setIsCropModalOpen(true);
         }
         ev.target.value = '';
       },
-      [],
+      [t],
     );
 
     const handleRemove = useCallback(() => {


### PR DESCRIPTION
### Summary

The avatar upload tip states a 4 MB limit ("You can upload an image up to 4 MB." in every locale), but nothing actually enforced it: the shared `AvatarUpload` component only validated the file extension, so an oversized image (e.g. 18 MB) could be selected, cropped and uploaded successfully.

This PR adds the missing client-side check in `AvatarUpload`: selecting an image larger than 4 MB now shows an error toast (reusing the existing `knowledgeConfiguration.photoTip` text) and aborts before the crop dialog opens. Since this single component backs all avatar upload entries (memory configuration, dataset settings, user profile, chat/search app settings), one fix covers every surface.

Note: the backend only ever receives the cropped 64x64 PNG (a few KB of base64), so the original file size can only be enforced in the browser at selection time — no server-side change is needed.