### PR TITLE
test: release test_documents_update_patch_and_delete for Go proxy

### DIFF
--- a/test/testcases/restful_api/conftest.py
+++ b/test/testcases/restful_api/conftest.py
@@ -67,7 +67,6 @@ GO_ONLY_SKIPS = {
         "test_chunk_add_keyword_question_and_tag_contract",
         "test_chunk_add_repeated_and_deleted_document_contract",
         "test_chunk_concurrent_add_contract",
-        "test_documents_update_patch_and_delete",
         "test_documents_update_name_contract",
         "test_documents_update_meta_fields_contract",
         "test_documents_metadata_batch_update_contract",


### PR DESCRIPTION
### Summary

Release `test_documents_update_patch_and_delete` from the Go-proxy skip list (`GO_ONLY_SKIPS`).

This test only requires document upload (no parsing) and exercises document name update, delete, and list — all of which Go fully supports on unparsed documents:

- **Update**: `UpdateDatasetDocument` handles name changes without requiring parsed state
- **Delete**: `DeleteDocuments` / `deleteDocumentFull` works on unparsed documents (doc engine delete is a no-op when no chunks exist)
- **List**: Standard document listing works regardless of parse state

The skip reason ("Go ingestion pipeline does not complete document parsing within the test timeout") does not apply — this test never triggers parsing.