### PR TITLE
test: release test_documents_metadata_batch_update_contract for Go proxy

### DIFF
--- a/test/testcases/restful_api/conftest.py
+++ b/test/testcases/restful_api/conftest.py
@@ -70,7 +70,6 @@ GO_ONLY_SKIPS = {
         "test_documents_update_patch_and_delete",
         "test_documents_update_name_contract",
         "test_documents_update_meta_fields_contract",
-        "test_documents_metadata_batch_update_contract",
         "test_documents_metadata_update_path",
         "test_documents_delete_invalid_dataset_partial_duplicate_repeat_and_cross_dataset",
         "test_chat_list_concurrent_and_dataset_delete_contract",


### PR DESCRIPTION
### Summary

Release `test_documents_metadata_batch_update_contract` from the Go-proxy skip list (`GO_ONLY_SKIPS`).

This test only requires document upload (no parsing) and exercises metadata batch update. Go's implementation is fully compatible:

- **Validation**: All error messages match ("selector must be an object", "updates and deletes must be lists", "Each update requires key and value", "Each delete requires key", "These documents do not belong to dataset ...")
- **Auth**: 401 handling matches via `assert_auth_error` with Go-specific assertions
- **Metadata store**: Created lazily via `EnsureMetadataStore` — works on unparsed documents
- **Update/delete by IDs and conditions**: `BatchUpdateDocumentMetadatas` resolves doc IDs from DB, applies updates/deletes per document, and writes to the doc engine

The skip reason ("Go ingestion pipeline does not complete document parsing within the test timeout") does not apply — this test never triggers parsing.