### PR TITLE
test: release test_chunk_concurrent_add_contract for Go proxy

### DIFF
--- a/test/testcases/restful_api/conftest.py
+++ b/test/testcases/restful_api/conftest.py
@@ -66,7 +66,6 @@ GO_ONLY_SKIPS = {
         # Without a working Go ingestion pipeline, these indices never exist.
         "test_chunk_add_keyword_question_and_tag_contract",
         "test_chunk_add_repeated_and_deleted_document_contract",
-        "test_chunk_concurrent_add_contract",
         "test_documents_update_patch_and_delete",
         "test_documents_update_name_contract",
         "test_documents_update_meta_fields_contract",


### PR DESCRIPTION
### Summary

Release `test_chunk_concurrent_add_contract` from the Go-proxy skip list (`GO_ONLY_SKIPS`).

This test only requires document upload (no parsing) and exercises concurrent chunk add. Go's `AddChunk` works on unparsed documents:

- Resolves the embedding model from the tenant config (`getEmbeddingModel`)
- Calls the embedding service (TEI in CI provides `BAAI/bge-small-en-v1.5`)
- Inserts into the doc engine which creates indices lazily (`CreateTable` with `ConflictTypeIgnore` in Infinity)

The test only asserts `code == 0` and correct chunk count — no error-path assertions that could mismatch.

The skip reason ("Go ingestion pipeline does not complete document parsing within the test timeout") does not apply — this test never triggers parsing.