### PR TITLE
test: release test_chunk_list_concurrent_contract for Go proxy

### DIFF
--- a/test/testcases/restful_api/conftest.py
+++ b/test/testcases/restful_api/conftest.py
@@ -105,7 +105,6 @@ GO_ONLY_SKIPS = {
         "test_chunk_list_default_get_id_and_invalid_target_contract",
         "test_chunk_list_keyword_and_invalid_param_contract",
         "test_chunk_list_page_and_page_size_contract",
-        "test_chunk_list_concurrent_contract",
         "test_chunk_update_requires_auth",
         "test_chunk_update_content_and_available_contract",
         "test_chunk_update_keywords_questions_and_tag_contract",


### PR DESCRIPTION
### Summary

Release `test_chunk_list_concurrent_contract` from the Go-proxy skip list (`GO_ONLY_SKIPS`).

This test only requires document upload (no parsing) and exercises concurrent chunk list. Chunks are created via `_reset_chunk_batch` (POST chunk add) which works on unparsed documents. Go's `ListChunks` returns `data.total` and `data.chunks` matching the Python contract. The test only asserts `code == 0` and `total == 5` — no error-path assertions.

The skip reason ("Go ingestion pipeline does not complete document parsing within the test timeout") does not apply — this test never triggers parsing.