### PR TITLE
test: release test_chunk_update_requires_auth for Go proxy

### DIFF
--- a/test/testcases/restful_api/conftest.py
+++ b/test/testcases/restful_api/conftest.py
@@ -106,7 +106,6 @@ GO_ONLY_SKIPS = {
         "test_chunk_list_keyword_and_invalid_param_contract",
         "test_chunk_list_page_and_page_size_contract",
         "test_chunk_list_concurrent_contract",
-        "test_chunk_update_requires_auth",
         "test_chunk_update_content_and_available_contract",
         "test_chunk_update_keywords_questions_and_tag_contract",
         "test_chunk_update_invalid_target_and_param_contract",


### PR DESCRIPTION
### Summary

Release `test_chunk_update_requires_auth` from the Go-proxy skip list (`GO_ONLY_SKIPS`).

This test only requires document upload (no parsing) and exercises chunk update auth (401 for missing/invalid token). Chunk creation via `_create_chunk_for_update` uses `AddChunk` which works on unparsed documents with the CI TEI embedding service. The auth assertion uses `assert_auth_error` which already has Go-specific message matching (`IS_GO_PROXY` branch).

The skip reason ("Go ingestion pipeline does not complete document parsing within the test timeout") does not apply — this test never triggers parsing.