### PR TITLE
build: move Node.js install to builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,14 +95,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
     UV_HTTP_RETRIES=3
 ENV PATH=/root/.local/bin:$PATH
 
-# nodejs 12.22 on Ubuntu 22.04 is too old
-RUN --mount=type=cache,id=ragflow_apt,target=/var/cache/apt,sharing=locked \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt purge -y nodejs npm && \
-    apt autoremove -y && \
-    apt update && \
-    apt install -y nodejs
-
 # stagehand-server-v3 (Node.js SEA binary used by Browser component
 # in local mode).
 #
@@ -198,6 +190,16 @@ RUN --mount=type=cache,id=ragflow_apt,target=/var/cache/apt,sharing=locked \
 
 # install dependencies from uv.lock file
 COPY pyproject.toml uv.lock ./
+
+# Node.js is only needed in the builder for the frontend build.
+# Kept out of the production image to eliminate npm-bundled CVEs
+# (tar, minimatch, glob, cross-spawn, etc.).
+RUN --mount=type=cache,id=ragflow_apt,target=/var/cache/apt,sharing=locked \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt purge -y nodejs npm && \
+    apt autoremove -y && \
+    apt update && \
+    apt install -y nodejs
 
 # https://github.com/astral-sh/uv/issues/10462
 # uv records index url into uv.lock but doesn't failover among multiple indexes


### PR DESCRIPTION
## Summary
  
Moves the Node.js installation from the `base` Docker stage to the `builder` stage, removing Node.js and npm from the final production image. This eliminates ~20 CVEs in npm-bundled packages that are never used at runtime.
  
  | Package | Severity | CVE |
  |---|---|---|
  | tar | 1 CRITICAL + 7 HIGH + 3 MEDIUM | CVE-2026-59873, CVE-2026-23745, CVE-2026-23950, CVE-2026-24842, CVE-2026-26960, CVE-2026-29786, CVE-2026-31802, CVE-2026-59874, CVE-2026-53655, CVE-2026-59871, CVE-2026-59875 |
  | minimatch | 3 HIGH | CVE-2026-26996, CVE-2026-27903, CVE-2026-27904 |
  | cross-spawn | 1 HIGH | CVE-2024-21538 |
  | glob | 1 HIGH | CVE-2025-64756 |
  | brace-expansion | 2 HIGH + 1 MEDIUM + 1 LOW | CVE-2026-13149, CVE-2026-14257, CVE-2026-33750, CVE-2025-5889 |
  | sigstore | 1 HIGH | CVE-2026-48815 |
  | @sigstore/core | 1 MEDIUM | CVE-2026-48758 |

  Node.js was installed in the `base` stage of the Dockerfile. Both `builder` and `production` inherit from `base`, so Node.js + npm (and all of npm's internally bundled packages) ended up in the final image despite only being needed during the frontend build.
  
  ## Verification
  
  - Image builds successfully
  - `node` and `npm` confirmed absent from final image
  - Frontend `web/dist/index.html` present and correct
  - `docker/entrypoint.sh` contains no references to `node` or `npm`
  - Trivy image scan confirms all Node.js package CVEs are eliminated