### PR TITLE
fix(dataset): preserve disabled RAPTOR and GraphRAG settings

### DIFF
--- a/web/src/pages/dataset/dataset-setting/hooks.test.tsx
+++ b/web/src/pages/dataset/dataset-setting/hooks.test.tsx
@@ -1,0 +1,78 @@
+import { useFetchKnowledgeBaseConfiguration } from '@/hooks/use-knowledge-request';
+import { renderHook } from '@testing-library/react';
+import { useFetchKnowledgeConfigurationOnMount } from './hooks';
+
+jest.mock('@/hooks/use-knowledge-request', () => ({
+  useFetchKnowledgeBaseConfiguration: jest.fn(),
+}));
+jest.mock('@/hooks/common-hooks', () => ({
+  useSetModalState: jest.fn(),
+}));
+jest.mock('@/hooks/use-user-setting-request', () => ({
+  useSelectParserList: jest.fn(() => []),
+}));
+jest.mock('@/services/knowledge-service', () => ({
+  checkEmbedding: jest.fn(),
+}));
+jest.mock('react-router', () => ({
+  useParams: jest.fn(() => ({})),
+  useSearchParams: jest.fn(() => [new URLSearchParams()]),
+}));
+
+const mockUseFetchKnowledgeBaseConfiguration = jest.mocked(
+  useFetchKnowledgeBaseConfiguration,
+);
+
+function renderConfigurationHook(parserConfig: Record<string, unknown>) {
+  mockUseFetchKnowledgeBaseConfiguration.mockReturnValue({
+    data: {
+      name: 'Dataset',
+      parser_config: parserConfig,
+      embedding_model: 'BAAI/bge-large-zh-v1.5',
+      chunk_method: 'naive',
+    },
+    loading: false,
+  } as never);
+
+  const reset = jest.fn();
+  const form = {
+    formState: {
+      defaultValues: {
+        parser_config: {
+          raptor: { use_raptor: true },
+          graphrag: { use_graphrag: true },
+        },
+      },
+    },
+    reset,
+  } as never;
+
+  renderHook(() => useFetchKnowledgeConfigurationOnMount(form));
+
+  return reset.mock.calls[0][0].parser_config;
+}
+
+describe('useFetchKnowledgeConfigurationOnMount', () => {
+  it('preserves explicitly disabled RAPTOR and GraphRAG settings', () => {
+    const parserConfig = renderConfigurationHook({
+      raptor: {
+        use_raptor: false,
+        ext: { clustering_method: 'gmm' },
+      },
+      graphrag: { use_graphrag: false },
+    });
+
+    expect(parserConfig.raptor.use_raptor).toBe(false);
+    expect(parserConfig.graphrag.use_graphrag).toBe(false);
+  });
+
+  it('keeps form defaults when saved settings omit the enable flags', () => {
+    const parserConfig = renderConfigurationHook({
+      raptor: { ext: { clustering_method: 'gmm' } },
+      graphrag: {},
+    });
+
+    expect(parserConfig.raptor.use_raptor).toBe(true);
+    expect(parserConfig.graphrag.use_graphrag).toBe(true);
+  });
+});

--- a/web/src/pages/dataset/dataset-setting/hooks.ts
+++ b/web/src/pages/dataset/dataset-setting/hooks.ts
@@ -42,12 +42,10 @@ export const useFetchKnowledgeConfigurationOnMount = (
         ...knowledgeDetails.parser_config?.raptor,
         clustering_method:
           knowledgeDetails.parser_config?.raptor?.ext?.clustering_method,
-        use_raptor: true,
       },
       graphrag: {
         ...form.formState?.defaultValues?.parser_config?.graphrag,
         ...knowledgeDetails.parser_config?.graphrag,
-        use_graphrag: true,
       },
     };
     const formValues = {


### PR DESCRIPTION
### Summary

Preserve explicitly saved `false` values for RAPTOR and GraphRAG when hydrating the dataset Configuration form. The existing form defaults still apply when either enable flag is absent.

Adds hook-level regression coverage for both explicit disablement and default fallback behavior.

Fixes #17654

### Verification

- `npx jest --runInBand --runTestsByPath src/pages/dataset/dataset-setting/hooks.test.tsx src/hooks/tests/parser-config-utils.test.ts`
- `npx oxfmt --check src/pages/dataset/dataset-setting/hooks.ts src/pages/dataset/dataset-setting/hooks.test.tsx`
- `npx oxlint src/pages/dataset/dataset-setting/hooks.ts src/pages/dataset/dataset-setting/hooks.test.tsx`
- `npm run build`
- `git diff HEAD^ --check`

Repository-wide `npm run type-check`, `npm run lint`, and `npm run format:check` remain red on pre-existing files outside this change; the touched files pass their focused checks.