### PR TITLE
fix: implement Go syncer execution engine with RSS data source support

### DIFF
--- a/internal/dao/connector.go
+++ b/internal/dao/connector.go
@@ -343,13 +343,201 @@ const (
 	connectorTaskTypePrune = "prune"
 )
 
+// DueSyncTask is the joined projection of one due sync_logs row with its
+// connector, connector2kb link and knowledgebase, mirroring the task dicts
+// produced by Python SyncLogsService._list_due_tasks_for_freq.
+type DueSyncTask struct {
+	ID               string         `gorm:"column:id"`
+	ConnectorID      string         `gorm:"column:connector_id"`
+	TaskType         string         `gorm:"column:task_type"`
+	KbID             string         `gorm:"column:kb_id"`
+	PollRangeStart   *time.Time     `gorm:"column:poll_range_start"`
+	PollRangeEnd     *time.Time     `gorm:"column:poll_range_end"`
+	NewDocsIndexed   int64          `gorm:"column:new_docs_indexed"`
+	TotalDocsIndexed int64          `gorm:"column:total_docs_indexed"`
+	FromBeginning    *string        `gorm:"column:from_beginning"`
+	ConnectorName    string         `gorm:"column:connector_name"`
+	Source           string         `gorm:"column:source"`
+	TenantID         string         `gorm:"column:tenant_id"`
+	TimeoutSecs      int64          `gorm:"column:timeout_secs"`
+	Config           entity.JSONMap `gorm:"column:config"`
+	RefreshFreq      int64          `gorm:"column:refresh_freq"`
+	PruneFreq        int64          `gorm:"column:prune_freq"`
+	KbName           string         `gorm:"column:kb_name"`
+	AutoParse        string         `gorm:"column:auto_parse"`
+}
+
+// ListDueTasks returns scheduled sync/prune tasks whose connector is scheduled
+// and whose last update is older than the given frequency (minutes), mirroring
+// Python SyncLogsService._list_due_tasks_for_freq (MySQL dialect).
+func (dao *ConnectorDAO) ListDueTasks(ctx context.Context, db *gorm.DB, taskType, freqField string) ([]*DueSyncTask, error) {
+	var tasks []*DueSyncTask
+	err := db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Select(
+			"sync_logs.id",
+			"sync_logs.connector_id",
+			"sync_logs.task_type",
+			"sync_logs.kb_id",
+			"sync_logs.poll_range_start",
+			"sync_logs.poll_range_end",
+			"sync_logs.new_docs_indexed",
+			"sync_logs.total_docs_indexed",
+			"sync_logs.from_beginning",
+			"connector.name AS connector_name",
+			"connector.source",
+			"connector.tenant_id",
+			"connector.timeout_secs",
+			"connector.config",
+			"connector.refresh_freq",
+			"connector.prune_freq",
+			"knowledgebase.name AS kb_name",
+			"connector2kb.auto_parse",
+		).
+		Joins("JOIN connector ON sync_logs.connector_id = connector.id").
+		Joins("JOIN connector2kb ON sync_logs.connector_id = connector2kb.connector_id AND sync_logs.kb_id = connector2kb.kb_id").
+		Joins("JOIN knowledgebase ON sync_logs.kb_id = knowledgebase.id").
+		Where("connector.input_type = ?", "poll").
+		Where("connector.status = ?", string(entity.TaskStatusSchedule)).
+		Where("sync_logs.status = ?", string(entity.TaskStatusSchedule)).
+		Where("sync_logs.task_type = ?", taskType).
+		Where("sync_logs.update_date < NOW() - INTERVAL connector." + freqField + " MINUTE").
+		Distinct().
+		Order("sync_logs.update_time DESC").
+		Scan(&tasks).Error
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+// ClaimTask atomically transitions a scheduled task to running and mirrors the
+// status onto the connector, mirroring Python SyncLogsService.start. It
+// returns false when another worker claimed the task first.
+func (dao *ConnectorDAO) ClaimTask(ctx context.Context, db *gorm.DB, taskID, connectorID string) (bool, error) {
+	now := time.Now().Local()
+	result := db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Where("id = ? AND status = ?", taskID, string(entity.TaskStatusSchedule)).
+		Updates(map[string]interface{}{
+			"status":       string(entity.TaskStatusRunning),
+			"time_started": now,
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return false, nil
+	}
+	if err := db.WithContext(ctx).Model(&entity.Connector{}).
+		Where("id = ?", connectorID).
+		Update("status", string(entity.TaskStatusRunning)).Error; err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// IncreaseDocs accumulates per-batch sync progress, keeping the poll window
+// monotonic, mirroring Python SyncLogsService.increase_docs.
+func (dao *ConnectorDAO) IncreaseDocs(ctx context.Context, db *gorm.DB, taskID string, maxUpdate time.Time, docNum int64, errMsg string, errCount int64) error {
+	return db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Where("id = ?", taskID).
+		Updates(map[string]interface{}{
+			"new_docs_indexed":   gorm.Expr("new_docs_indexed + ?", docNum),
+			"total_docs_indexed": gorm.Expr("total_docs_indexed + ?", docNum),
+			"poll_range_start":   gorm.Expr("COALESCE(GREATEST(poll_range_start, ?), ?)", maxUpdate, maxUpdate),
+			"poll_range_end":     gorm.Expr("COALESCE(GREATEST(poll_range_end, ?), ?)", maxUpdate, maxUpdate),
+			"error_msg":          gorm.Expr("CONCAT(error_msg, ?)", errMsg),
+			"error_count":        gorm.Expr("error_count + ?", errCount),
+		}).Error
+}
+
+// IncreaseRemovedDocs accumulates per-task prune progress, mirroring Python
+// SyncLogsService.increase_removed_docs.
+func (dao *ConnectorDAO) IncreaseRemovedDocs(ctx context.Context, db *gorm.DB, taskID string, removedCount int64, errMsg string, errCount int64) error {
+	return db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Where("id = ?", taskID).
+		Updates(map[string]interface{}{
+			"docs_removed_from_index": gorm.Expr("docs_removed_from_index + ?", removedCount),
+			"error_msg":               gorm.Expr("CONCAT(error_msg, ?)", errMsg),
+			"error_count":             gorm.Expr("error_count + ?", errCount),
+		}).Error
+}
+
+// FinishTask marks a task (and, on success, the connector) with a terminal
+// status, mirroring Python SyncLogsService.done / the failure updates in
+// rag/svr/sync_data_source.py.
+func (dao *ConnectorDAO) FinishTask(ctx context.Context, db *gorm.DB, taskID, connectorID string, status entity.TaskStatus, errMsg, trace string) error {
+	updates := map[string]interface{}{
+		"status": string(status),
+	}
+	if errMsg != "" {
+		updates["error_msg"] = errMsg
+	}
+	if trace != "" {
+		updates["full_exception_trace"] = trace
+	}
+	if err := db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Where("id = ?", taskID).
+		Updates(updates).Error; err != nil {
+		return err
+	}
+	if status == entity.TaskStatusDone {
+		return db.WithContext(ctx).Model(&entity.Connector{}).
+			Where("id = ?", connectorID).
+			Update("status", string(entity.TaskStatusDone)).Error
+	}
+	return nil
+}
+
+// RescheduleTask inserts the next scheduled task for a connector/kb pair
+// (carrying over the poll window from the latest done task) and marks the
+// connector scheduled, mirroring Python SyncLogsService.schedule.
+func (dao *ConnectorDAO) RescheduleTask(ctx context.Context, db *gorm.DB, connectorID, kbID, taskType string) error {
+	if err := dao.pruneOldSyncLogs(ctx, db, connectorID, kbID); err != nil {
+		return err
+	}
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := scheduleConnectorTask(ctx, tx, connectorID, kbID, taskType, false); err != nil {
+			return err
+		}
+		return tx.WithContext(ctx).Model(&entity.Connector{}).
+			Where("id = ?", connectorID).
+			Update("status", string(entity.TaskStatusSchedule)).Error
+	})
+}
+
+// pruneOldSyncLogs caps the log history per connector/kb pair at 100 rows by
+// deleting the oldest 70, mirroring Python SyncLogsService.schedule.
+func (dao *ConnectorDAO) pruneOldSyncLogs(ctx context.Context, db *gorm.DB, connectorID, kbID string) error {
+	var total int64
+	if err := db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Where("connector_id = ? AND kb_id = ?", connectorID, kbID).
+		Count(&total).Error; err != nil {
+		return err
+	}
+	if total <= 100 {
+		return nil
+	}
+	var ids []string
+	if err := db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Where("connector_id = ? AND kb_id = ?", connectorID, kbID).
+		Order("update_time ASC").
+		Limit(70).
+		Pluck("id", &ids).Error; err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return db.WithContext(ctx).Where("id IN ?", ids).Delete(&entity.SyncLogs{}).Error
+}
+
 func createRebuildSyncLog(ctx context.Context, tx *gorm.DB, connectorID, kbID, taskType string, reindex bool) error {
 	fromBeginning := "0"
 	if reindex {
 		fromBeginning = "1"
 	}
 	now := time.Now().Local()
-	return tx.WithContext(ctx).Create(&entity.SyncLogs{
+	row := &entity.SyncLogs{
 		ID:               utility.GenerateToken(),
 		ConnectorID:      connectorID,
 		KbID:             kbID,
@@ -359,7 +547,14 @@ func createRebuildSyncLog(ctx context.Context, tx *gorm.DB, connectorID, kbID, t
 		TimeStarted:      &now,
 		ErrorMsg:         "",
 		TotalDocsIndexed: 0,
-	}).Error
+	}
+	if reindex {
+		// A from-beginning sync is due immediately (Python run_immediately=True).
+		row.UpdateTime = new(int64)
+		epoch := time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local)
+		row.UpdateDate = &epoch
+	}
+	return tx.WithContext(ctx).Create(row).Error
 }
 
 func scheduleConnectorTask(ctx context.Context, tx *gorm.DB, connectorID, kbID, taskType string, reindex bool) error {
@@ -394,7 +589,7 @@ func scheduleConnectorTask(ctx context.Context, tx *gorm.DB, connectorID, kbID, 
 		fromBeginning = "1"
 	}
 	now := time.Now().Local()
-	return tx.WithContext(ctx).Create(&entity.SyncLogs{
+	row := &entity.SyncLogs{
 		ID:               utility.GenerateToken(),
 		ConnectorID:      connectorID,
 		KbID:             kbID,
@@ -405,7 +600,14 @@ func scheduleConnectorTask(ctx context.Context, tx *gorm.DB, connectorID, kbID, 
 		TimeStarted:      &now,
 		ErrorMsg:         "",
 		TotalDocsIndexed: totalDocsIndexed,
-	}).Error
+	}
+	if reindex {
+		// A from-beginning sync is due immediately (Python run_immediately=True).
+		row.UpdateTime = new(int64)
+		epoch := time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local)
+		row.UpdateDate = &epoch
+	}
+	return tx.WithContext(ctx).Create(row).Error
 }
 
 func connectorConfigBool(config map[string]interface{}, key string) bool {

--- a/internal/service/document/document_upload.go
+++ b/internal/service/document/document_upload.go
@@ -117,6 +117,142 @@ func (s *DocumentService) UploadLocalDocuments(ctx context.Context, kb *entity.K
 	return results, errMsgs
 }
 
+// ConnectorDocumentInput is one connector-produced document to import,
+// mirroring the dicts built in Python SyncBase._run_sync_task_logic.
+type ConnectorDocumentInput struct {
+	// ID is the deterministic document row id (hash128 of
+	// kb_id:connector_id:source_doc_id, or its legacy form).
+	ID                 string
+	SemanticIdentifier string
+	Extension          string // e.g. ".txt"
+	Blob               []byte
+	Metadata           map[string]interface{}
+}
+
+// ConnectorUploadResult describes an imported document whose content changed
+// (newly inserted, or an existing row re-uploaded with a new content hash).
+type ConnectorUploadResult struct {
+	Doc      *entity.Document
+	Metadata map[string]interface{}
+	Existed  bool // true when the row already existed (content update)
+}
+
+// UploadConnectorDocuments imports connector-produced documents into a dataset,
+// mirroring the connector path of Python FileService.upload_document: a row id
+// that already exists gets its blob re-uploaded and its size/content_hash
+// refreshed (only a changed hash counts as an update); a new id is inserted
+// with a deduped name and linked into the file manager. src is the document
+// source_type ("<source>/<connector_id>").
+func (s *DocumentService) UploadConnectorDocuments(ctx context.Context, kb *entity.Knowledgebase, tenantID, src string, docs []ConnectorDocumentInput) ([]*ConnectorUploadResult, []string) {
+	storageImpl := storage.GetStorageFactory().GetStorage()
+	if storageImpl == nil {
+		return nil, []string{"storage not initialized"}
+	}
+
+	kbFolder, err := s.ensureKBFolder(ctx, kb, tenantID)
+	if err != nil {
+		return nil, []string{err.Error()}
+	}
+
+	names, err := s.documentDAO.ListNamesByKbID(ctx, dao.DB, kb.ID)
+	if err != nil {
+		return nil, []string{err.Error()}
+	}
+	taken := map[string]bool{}
+	for _, n := range names {
+		taken[n] = true
+	}
+
+	var results []*ConnectorUploadResult
+	var errMsgs []string
+
+	for _, input := range docs {
+		docID := input.ID
+		if docID == "" {
+			docID = utility.GenerateToken()
+		}
+
+		existing, getErr := s.documentDAO.GetByID(ctx, dao.DB, docID)
+		if getErr != nil && !dao.IsNotFoundErr(getErr) {
+			errMsgs = append(errMsgs, input.SemanticIdentifier+": "+getErr.Error())
+			continue
+		}
+
+		if existing != nil {
+			if existing.KbID != kb.ID {
+				errMsgs = append(errMsgs, input.SemanticIdentifier+": Existing document id collision with another knowledge base; skipping update.")
+				continue
+			}
+			newHash := contentHashHex(input.Blob)
+			oldHash := ""
+			if existing.ContentHash != nil {
+				oldHash = *existing.ContentHash
+			}
+			location := ""
+			if existing.Location != nil {
+				location = *existing.Location
+			}
+			if err = storageImpl.Put(kb.ID, location, input.Blob); err != nil {
+				errMsgs = append(errMsgs, input.SemanticIdentifier+": "+err.Error())
+				continue
+			}
+			if err = s.documentDAO.UpdateByID(ctx, dao.DB, docID, map[string]interface{}{
+				"size":         int64(len(input.Blob)),
+				"content_hash": newHash,
+			}); err != nil {
+				errMsgs = append(errMsgs, input.SemanticIdentifier+": "+err.Error())
+				continue
+			}
+			if newHash == oldHash {
+				continue // unchanged content — no re-parse
+			}
+			existing.Size = int64(len(input.Blob))
+			existing.ContentHash = &newHash
+			results = append(results, &ConnectorUploadResult{Doc: existing, Metadata: input.Metadata, Existed: true})
+			continue
+		}
+
+		filename := input.SemanticIdentifier
+		if input.Extension != "" && !strings.HasSuffix(filename, input.Extension) {
+			filename += input.Extension
+		}
+		filename = uniqueUploadName(filename, taken)
+
+		filetype := utility.FilenameType(filename)
+		if filetype == utility.FileTypeOTHER {
+			errMsgs = append(errMsgs, filename+": This type of file has not been supported yet!")
+			continue
+		}
+
+		location := filename
+		for storageImpl.ObjExist(kb.ID, location) {
+			location += "_"
+		}
+		if err = storageImpl.Put(kb.ID, location, input.Blob); err != nil {
+			errMsgs = append(errMsgs, filename+": "+err.Error())
+			continue
+		}
+
+		doc := s.newDatasetDocument(kb, tenantID, filename, location, string(filetype), kb.ParserConfig, src, int64(len(input.Blob)), input.Blob)
+		doc.ID = docID
+		if err = s.InsertDocument(doc); err != nil {
+			_ = storageImpl.Remove(kb.ID, location)
+			errMsgs = append(errMsgs, filename+": "+err.Error())
+			continue
+		}
+		if err = s.addFileFromKB(ctx, doc, kbFolder.ID, kb.TenantID); err != nil {
+			err = s.rollbackAddFileFromKBError(ctx, doc, kb.ID, err)
+			_ = storageImpl.Remove(kb.ID, location)
+			errMsgs = append(errMsgs, filename+": "+err.Error())
+			continue
+		}
+		taken[filename] = true
+		results = append(results, &ConnectorUploadResult{Doc: doc, Metadata: input.Metadata})
+	}
+
+	return results, errMsgs
+}
+
 // UploadEmptyDocument inserts a zero-byte "virtual" document into the dataset.
 func (s *DocumentService) UploadEmptyDocument(ctx context.Context, kb *entity.Knowledgebase, tenantID, name string) (map[string]interface{}, common.ErrorCode, error) {
 	// A transient lookup failure means the existing-name set is unknown; fail

--- a/internal/service/document/document_upload_helpers.go
+++ b/internal/service/document/document_upload_helpers.go
@@ -6,8 +6,14 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
+// Hash128Hex mirrors Python xxhash.xxh128(data).hexdigest(), which backs both
+// content hashes and api/utils/common.hash128 (deterministic document IDs).
+func Hash128Hex(data []byte) string {
+	sum := xxh3.Hash128(data).Bytes()
+	return hex.EncodeToString(sum[:])
+}
+
 // contentHashHex mirrors Python xxhash.xxh128(blob).hexdigest().
 func contentHashHex(blob []byte) string {
-	sum := xxh3.Hash128(blob).Bytes()
-	return hex.EncodeToString(sum[:])
+	return Hash128Hex(blob)
 }

--- a/internal/syncer/rss.go
+++ b/internal/syncer/rss.go
@@ -1,0 +1,362 @@
+//
+// Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package syncer
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"ragflow/internal/utility"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// maxRSSFeedSize caps a single feed document held in memory.
+const maxRSSFeedSize = 64 * 1024 * 1024
+
+// rssDocument is one feed entry materialized as an importable document,
+// mirroring the Python Document model produced by RSSConnector.
+type rssDocument struct {
+	ID                 string
+	SemanticIdentifier string
+	Blob               []byte
+	UpdatedAt          time.Time
+	Metadata           map[string]interface{}
+}
+
+// feedEntry is the normalized union of an RSS <item> and an Atom <entry>.
+type feedEntry struct {
+	ID         string
+	Link       string
+	Title      string
+	Updated    string
+	Published  string
+	Content    string
+	Summary    string
+	Author     string
+	Categories []string
+}
+
+type rssXMLItem struct {
+	GUID           string   `xml:"guid"`
+	Link           string   `xml:"link"`
+	Title          string   `xml:"title"`
+	PubDate        string   `xml:"pubDate"`
+	DCDate         string   `xml:"date"`
+	Description    string   `xml:"description"`
+	ContentEncoded string   `xml:"encoded"`
+	Author         string   `xml:"author"`
+	Categories     []string `xml:"category"`
+}
+
+type atomXMLLink struct {
+	Rel  string `xml:"rel,attr"`
+	Href string `xml:"href,attr"`
+}
+
+type atomXMLCategory struct {
+	Term string `xml:"term,attr"`
+}
+
+type atomXMLEntry struct {
+	ID        string        `xml:"id"`
+	Title     string        `xml:"title"`
+	Links     []atomXMLLink `xml:"link"`
+	Updated   string        `xml:"updated"`
+	Published string        `xml:"published"`
+	Summary   string        `xml:"summary"`
+	Content   string        `xml:"content"`
+	Author    struct {
+		Name string `xml:"name"`
+	} `xml:"author"`
+	Categories []atomXMLCategory `xml:"category"`
+}
+
+type feedXML struct {
+	XMLName xml.Name
+	Channel struct {
+		Items []rssXMLItem `xml:"item"`
+	} `xml:"channel"`
+	Entries []atomXMLEntry `xml:"entry"`
+}
+
+// rssConnector fetches and parses an RSS/Atom feed, mirroring the Python
+// RSSConnector (common/data_source/rss_connector.py).
+type rssConnector struct {
+	feedURL   string
+	batchSize int
+}
+
+func newRSSConnector(feedURL string, batchSize int) *rssConnector {
+	if batchSize < 1 {
+		batchSize = 1
+	}
+	return &rssConnector{feedURL: strings.TrimSpace(feedURL), batchSize: batchSize}
+}
+
+// load returns the feed entries whose entry time falls inside (start, end]
+// (nil bounds are open), batched by batchSize. It mirrors the Python
+// load_from_state (nil bounds) and poll_source (bounded) paths.
+func (c *rssConnector) load(ctx context.Context, start, end *time.Time) ([][]rssDocument, error) {
+	entries, err := c.readFeed(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var batches [][]rssDocument
+	batch := make([]rssDocument, 0, c.batchSize)
+	for _, entry := range entries {
+		updatedAt := resolveEntryTime(entry)
+		if start != nil && !updatedAt.After(*start) {
+			continue
+		}
+		if end != nil && updatedAt.After(*end) {
+			continue
+		}
+		batch = append(batch, c.buildDocument(entry, updatedAt))
+		if len(batch) >= c.batchSize {
+			batches = append(batches, batch)
+			batch = make([]rssDocument, 0, c.batchSize)
+		}
+	}
+	if len(batch) > 0 {
+		batches = append(batches, batch)
+	}
+	return batches, nil
+}
+
+// listEntryIDs returns the deterministic connector-level document ID of every
+// entry in the feed. Used by prune to compute the retain set.
+func (c *rssConnector) listEntryIDs(ctx context.Context) ([]string, error) {
+	entries, err := c.readFeed(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		ids = append(ids, c.buildDocumentID(entry))
+	}
+	return ids, nil
+}
+
+func (c *rssConnector) readFeed(ctx context.Context) ([]feedEntry, error) {
+	if c.feedURL == "" {
+		return nil, fmt.Errorf("feed_url is required")
+	}
+
+	body, _, _, err := utility.FetchRemoteFileSafely(ctx, c.feedURL, maxRSSFeedSize)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed feedXML
+	if err := xml.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse RSS feed: %w", err)
+	}
+
+	entries := make([]feedEntry, 0, len(parsed.Channel.Items)+len(parsed.Entries))
+	for _, item := range parsed.Channel.Items {
+		entries = append(entries, feedEntry{
+			ID:         strings.TrimSpace(item.GUID),
+			Link:       strings.TrimSpace(item.Link),
+			Title:      strings.TrimSpace(item.Title),
+			Updated:    strings.TrimSpace(item.DCDate),
+			Published:  strings.TrimSpace(item.PubDate),
+			Content:    item.ContentEncoded,
+			Summary:    item.Description,
+			Author:     strings.TrimSpace(item.Author),
+			Categories: item.Categories,
+		})
+	}
+	for _, atom := range parsed.Entries {
+		entry := feedEntry{
+			ID:        strings.TrimSpace(atom.ID),
+			Title:     strings.TrimSpace(atom.Title),
+			Updated:   strings.TrimSpace(atom.Updated),
+			Published: strings.TrimSpace(atom.Published),
+			Content:   atom.Content,
+			Summary:   atom.Summary,
+			Author:    strings.TrimSpace(atom.Author.Name),
+		}
+		for _, link := range atom.Links {
+			if link.Href == "" {
+				continue
+			}
+			if entry.Link == "" || link.Rel == "alternate" {
+				entry.Link = strings.TrimSpace(link.Href)
+			}
+		}
+		for _, category := range atom.Categories {
+			if category.Term != "" {
+				entry.Categories = append(entry.Categories, category.Term)
+			}
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func (c *rssConnector) buildDocument(entry feedEntry, updatedAt time.Time) rssDocument {
+	link := strings.TrimSpace(entry.Link)
+	title := strings.TrimSpace(entry.Title)
+	stableKey := c.resolveStableKey(entry)
+	semanticIdentifier := title
+	if semanticIdentifier == "" {
+		semanticIdentifier = link
+	}
+	if semanticIdentifier == "" {
+		semanticIdentifier = stableKey
+	}
+	blob := []byte(buildEntryContent(entry, semanticIdentifier))
+
+	metadata := map[string]interface{}{"feed_url": c.feedURL}
+	if link != "" {
+		metadata["link"] = link
+	}
+	if entry.Author != "" {
+		metadata["author"] = entry.Author
+	}
+	if len(entry.Categories) > 0 {
+		categories := make([]string, 0, len(entry.Categories))
+		for _, category := range entry.Categories {
+			if trimmed := strings.TrimSpace(category); trimmed != "" {
+				categories = append(categories, trimmed)
+			}
+		}
+		if len(categories) > 0 {
+			metadata["categories"] = categories
+		}
+	}
+
+	return rssDocument{
+		ID:                 c.buildDocumentID(entry),
+		SemanticIdentifier: semanticIdentifier,
+		Blob:               blob,
+		UpdatedAt:          updatedAt,
+		Metadata:           metadata,
+	}
+}
+
+func (c *rssConnector) buildDocumentID(entry feedEntry) string {
+	sum := md5.Sum([]byte(c.resolveStableKey(entry)))
+	return "rss:" + hex.EncodeToString(sum[:])
+}
+
+func (c *rssConnector) resolveStableKey(entry feedEntry) string {
+	for _, candidate := range []string{entry.ID, entry.Link, entry.Title, c.feedURL} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return c.feedURL
+}
+
+// buildEntryContent mirrors Python _build_content: the semantic identifier
+// followed by the normalized entry content (or summary/description fallback).
+func buildEntryContent(entry feedEntry, semanticIdentifier string) string {
+	parts := []string{semanticIdentifier}
+	if normalized := normalizeHTMLText(entry.Content); normalized != "" {
+		parts = append(parts, normalized)
+	}
+	if len(parts) == 1 {
+		fallback := entry.Summary
+		if normalized := normalizeHTMLText(fallback); normalized != "" {
+			parts = append(parts, normalized)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n\n"))
+}
+
+// resolveEntryTime mirrors Python _resolve_entry_time: prefer updated, then
+// published, falling back to now.
+func resolveEntryTime(entry feedEntry) time.Time {
+	for _, raw := range []string{entry.Updated, entry.Published} {
+		if parsed, ok := parseFeedTime(raw); ok {
+			return parsed.UTC()
+		}
+	}
+	return time.Now().UTC()
+}
+
+var feedTimeLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	time.RFC1123Z,
+	time.RFC1123,
+	time.RFC850,
+	time.RFC822Z,
+	time.RFC822,
+	time.ANSIC,
+	"2006-01-02T15:04:05Z0700",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05 -0700",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+}
+
+func parseFeedTime(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range feedTimeLayouts {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// normalizeHTMLText extracts plain text from an HTML fragment, mirroring
+// bs4 get_text("\n", strip=True). Non-HTML input passes through trimmed.
+func normalizeHTMLText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if !strings.Contains(value, "<") {
+		return value
+	}
+	node, err := html.Parse(strings.NewReader(value))
+	if err != nil {
+		return value
+	}
+	var segments []string
+	collectHTMLText(node, &segments)
+	return strings.Join(segments, "\n")
+}
+
+func collectHTMLText(node *html.Node, segments *[]string) {
+	if node.Type == html.ElementNode {
+		switch strings.ToLower(node.Data) {
+		case "script", "style", "noscript":
+			return
+		}
+	}
+	if node.Type == html.TextNode {
+		if text := strings.TrimSpace(node.Data); text != "" {
+			*segments = append(*segments, text)
+		}
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		collectHTMLText(child, segments)
+	}
+}

--- a/internal/syncer/rss_test.go
+++ b/internal/syncer/rss_test.go
@@ -1,0 +1,274 @@
+//
+// Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package syncer
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"ragflow/internal/service/document"
+	"ragflow/internal/utility"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHash128HexParity guards parity with Python api/utils/common.hash128
+// (xxhash.xxh128 hexdigest), which backs deterministic connector document IDs.
+func TestHash128HexParity(t *testing.T) {
+	if got := document.Hash128Hex([]byte("kb:conn:rss:x")); got != "448df3288c2b8f167228e4e459156928" {
+		t.Fatalf("Hash128Hex = %s, want 448df3288c2b8f167228e4e459156928", got)
+	}
+}
+
+const testRSSFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example</title>
+    <item>
+      <guid>urn:1</guid>
+      <link>https://example.com/a</link>
+      <title>Alpha</title>
+      <pubDate>Wed, 29 Jul 2026 10:00:00 GMT</pubDate>
+      <description>&lt;p&gt;Hello &lt;b&gt;world&lt;/b&gt;&lt;/p&gt;</description>
+      <author>alice</author>
+      <category>news</category>
+    </item>
+    <item>
+      <guid>urn:2</guid>
+      <link>https://example.com/b</link>
+      <title>Beta</title>
+      <pubDate>Wed, 29 Jul 2026 12:00:00 GMT</pubDate>
+      <content:encoded xmlns:content="http://purl.org/rss/1.0/modules/content/">&lt;p&gt;Full content&lt;/p&gt;</content:encoded>
+    </item>
+  </channel>
+</rss>`
+
+const testAtomFeed = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Atom</title>
+  <entry>
+    <id>tag:example.com,2026:1</id>
+    <title>Gamma</title>
+    <link rel="alternate" href="https://example.com/c"/>
+    <updated>2026-07-29T13:00:00Z</updated>
+    <summary>Atom summary</summary>
+    <author><name>bob</name></author>
+    <category term="tech"/>
+  </entry>
+</feed>`
+
+func serveFeed(t *testing.T, body string) (*httptest.Server, func()) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(body))
+	}))
+
+	origAssert := utility.AssertURLSafe
+	origPinned := utility.PinnedHTTPClient
+	utility.AssertURLSafe = func(rawURL string) (string, string, error) {
+		return "127.0.0.1", "127.0.0.1", nil
+	}
+	utility.PinnedHTTPClient = func(hostname, resolvedIP string, timeout time.Duration) *http.Client {
+		return server.Client()
+	}
+	return server, func() {
+		utility.AssertURLSafe = origAssert
+		utility.PinnedHTTPClient = origPinned
+		server.Close()
+	}
+}
+
+func TestRSSLoadFull(t *testing.T) {
+	server, cleanup := serveFeed(t, testRSSFeed)
+	defer cleanup()
+
+	connector := newRSSConnector(server.URL, 10)
+	batches, err := connector.load(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(batches) != 1 || len(batches[0]) != 2 {
+		t.Fatalf("expected 1 batch of 2 docs, got %+v", batches)
+	}
+
+	first := batches[0][0]
+	wantID := "rss:" + md5Hex("urn:1")
+	if first.ID != wantID {
+		t.Fatalf("doc id = %s, want %s", first.ID, wantID)
+	}
+	if first.SemanticIdentifier != "Alpha" {
+		t.Fatalf("semantic identifier = %q", first.SemanticIdentifier)
+	}
+	if got := string(first.Blob); got != "Alpha\n\nHello\nworld" {
+		t.Fatalf("blob = %q", got)
+	}
+	if first.Metadata["link"] != "https://example.com/a" || first.Metadata["author"] != "alice" {
+		t.Fatalf("metadata = %+v", first.Metadata)
+	}
+	if categories, ok := first.Metadata["categories"].([]string); !ok || len(categories) != 1 || categories[0] != "news" {
+		t.Fatalf("categories = %+v", first.Metadata["categories"])
+	}
+	wantTime := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC)
+	if !first.UpdatedAt.Equal(wantTime) {
+		t.Fatalf("updated at = %v, want %v", first.UpdatedAt, wantTime)
+	}
+
+	second := batches[0][1]
+	if got := string(second.Blob); got != "Beta\n\nFull content" {
+		t.Fatalf("second blob = %q", got)
+	}
+}
+
+func TestRSSLoadPollWindow(t *testing.T) {
+	server, cleanup := serveFeed(t, testRSSFeed)
+	defer cleanup()
+
+	connector := newRSSConnector(server.URL, 10)
+	start := time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC) // exactly entry 1's time — excluded (ts <= start)
+	end := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)   // exactly entry 2's time — included
+	batches, err := connector.load(context.Background(), &start, &end)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(batches) != 1 || len(batches[0]) != 1 {
+		t.Fatalf("expected 1 doc in window, got %+v", batches)
+	}
+	if batches[0][0].SemanticIdentifier != "Beta" {
+		t.Fatalf("in-window doc = %q, want Beta", batches[0][0].SemanticIdentifier)
+	}
+
+	after := time.Date(2026, 7, 29, 13, 0, 0, 0, time.UTC)
+	batches, err = connector.load(context.Background(), &after, nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(batches) != 0 {
+		t.Fatalf("expected no docs after %v, got %+v", after, batches)
+	}
+}
+
+func TestRSSLoadBatching(t *testing.T) {
+	server, cleanup := serveFeed(t, testRSSFeed)
+	defer cleanup()
+
+	connector := newRSSConnector(server.URL, 1)
+	batches, err := connector.load(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(batches) != 2 {
+		t.Fatalf("expected 2 batches with batch_size=1, got %d", len(batches))
+	}
+}
+
+func TestAtomLoad(t *testing.T) {
+	server, cleanup := serveFeed(t, testAtomFeed)
+	defer cleanup()
+
+	connector := newRSSConnector(server.URL, 10)
+	batches, err := connector.load(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(batches) != 1 || len(batches[0]) != 1 {
+		t.Fatalf("expected 1 atom doc, got %+v", batches)
+	}
+	doc := batches[0][0]
+	if doc.ID != "rss:"+md5Hex("tag:example.com,2026:1") {
+		t.Fatalf("doc id = %s", doc.ID)
+	}
+	if doc.Metadata["link"] != "https://example.com/c" || doc.Metadata["author"] != "bob" {
+		t.Fatalf("metadata = %+v", doc.Metadata)
+	}
+	if got := string(doc.Blob); got != "Gamma\n\nAtom summary" {
+		t.Fatalf("blob = %q", got)
+	}
+	wantTime := time.Date(2026, 7, 29, 13, 0, 0, 0, time.UTC)
+	if !doc.UpdatedAt.Equal(wantTime) {
+		t.Fatalf("updated at = %v, want %v", doc.UpdatedAt, wantTime)
+	}
+}
+
+func TestRSSListEntryIDs(t *testing.T) {
+	server, cleanup := serveFeed(t, testRSSFeed)
+	defer cleanup()
+
+	connector := newRSSConnector(server.URL, 10)
+	ids, err := connector.listEntryIDs(context.Background())
+	if err != nil {
+		t.Fatalf("listEntryIDs: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "rss:"+md5Hex("urn:1") || ids[1] != "rss:"+md5Hex("urn:2") {
+		t.Fatalf("ids = %v", ids)
+	}
+}
+
+func TestRSSInvalidFeed(t *testing.T) {
+	server, cleanup := serveFeed(t, "this is not xml")
+	defer cleanup()
+
+	connector := newRSSConnector(server.URL, 10)
+	if _, err := connector.load(context.Background(), nil, nil); err == nil || !strings.Contains(err.Error(), "failed to parse RSS feed") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestParseFeedTime(t *testing.T) {
+	cases := map[string]time.Time{
+		"Wed, 29 Jul 2026 10:00:00 GMT":   time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC),
+		"Wed, 29 Jul 2026 10:00:00 +0200": time.Date(2026, 7, 29, 10, 0, 0, 0, time.FixedZone("", 2*3600)),
+		"2026-07-29T10:00:00Z":            time.Date(2026, 7, 29, 10, 0, 0, 0, time.UTC),
+		"2026-07-29T10:00:00+02:00":       time.Date(2026, 7, 29, 10, 0, 0, 0, time.FixedZone("", 2*3600)),
+		"2026-07-29":                      time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC),
+	}
+	for raw, want := range cases {
+		parsed, ok := parseFeedTime(raw)
+		if !ok {
+			t.Fatalf("parseFeedTime(%q) failed", raw)
+		}
+		if !parsed.Equal(want) {
+			t.Fatalf("parseFeedTime(%q) = %v, want %v", raw, parsed, want)
+		}
+	}
+	if _, ok := parseFeedTime("not a date"); ok {
+		t.Fatalf("parseFeedTime should reject garbage")
+	}
+}
+
+func TestNormalizeHTMLText(t *testing.T) {
+	cases := map[string]string{
+		"":                                   "",
+		"  plain text  ":                     "plain text",
+		"<p>Hello <b>world</b></p>":          "Hello\nworld",
+		"<p>a</p><p>b</p>":                   "a\nb",
+		"<script>var x=1;</script><p>ok</p>": "ok",
+	}
+	for input, want := range cases {
+		if got := normalizeHTMLText(input); got != want {
+			t.Fatalf("normalizeHTMLText(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func md5Hex(value string) string {
+	sum := md5.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -22,11 +22,27 @@ import (
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
 	"ragflow/internal/entity"
+	"ragflow/internal/service/document"
 	"ragflow/internal/utility"
+	"runtime/debug"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
+)
+
+const (
+	connectorTaskTypeSync  = "sync"
+	connectorTaskTypePrune = "prune"
+
+	connectorSourceRSS = "rss"
+
+	// defaultIndexBatchSize mirrors Python common.data_source.config.INDEX_BATCH_SIZE.
+	defaultIndexBatchSize = 2
+	// defaultTimeoutSecs mirrors entity.Connector's timeout_secs default.
+	defaultTimeoutSecs = 3600
 )
 
 // Syncer periodically polls the sync_logs table and dispatches due
@@ -102,43 +118,322 @@ func (s *Syncer) workerLoop(workerID int) {
 	}
 }
 
-// pollAndExecute queries due sync & prune tasks, picks one, and runs it.
+// pollAndExecute queries due sync & prune tasks, claims one, and runs it.
+// One task per poll per worker; the worker count bounds total concurrency.
 func (s *Syncer) pollAndExecute(workerID int) {
-	common.Info(fmt.Sprintf("Syncer worker %d polling for due tasks", workerID))
+	connectorDAO := dao.NewConnectorDAO()
+	for _, candidate := range []struct {
+		taskType  string
+		freqField string
+	}{
+		{connectorTaskTypeSync, "refresh_freq"},
+		{connectorTaskTypePrune, "prune_freq"},
+	} {
+		tasks, err := connectorDAO.ListDueTasks(s.ctx, dao.GetDB(), candidate.taskType, candidate.freqField)
+		if err != nil {
+			common.Error(fmt.Sprintf("Syncer worker %d failed to list due %s tasks", workerID, candidate.taskType), err)
+			continue
+		}
+		for _, task := range tasks {
+			if candidate.taskType == connectorTaskTypePrune {
+				// Prune is opt-in at the connector config level; keep the
+				// scheduler blind to prune_freq until the flag is enabled.
+				if !connectorConfigBool(task.Config, "sync_deleted_files") || task.PruneFreq <= 0 {
+					continue
+				}
+			}
+			claimed, err := connectorDAO.ClaimTask(s.ctx, dao.GetDB(), task.ID, task.ConnectorID)
+			if err != nil {
+				common.Error(fmt.Sprintf("Syncer worker %d failed to claim task %s", workerID, task.ID), err)
+				continue
+			}
+			if !claimed {
+				continue
+			}
+			s.executeTask(task)
+			return
+		}
+	}
 }
 
-// executeSyncTask runs a sync task.
-func (s *Syncer) executeSyncTask(task *entity.SyncLogs) {
+// executeTask runs one claimed task with its configured timeout and handles
+// the done/fail bookkeeping plus rescheduling, mirroring Python
+// SyncBase.__call__ in rag/svr/sync_data_source.py.
+func (s *Syncer) executeTask(task *dao.DueSyncTask) {
+	connectorDAO := dao.NewConnectorDAO()
+	db := dao.GetDB()
+
+	timeoutSecs := task.TimeoutSecs
+	if timeoutSecs <= 0 {
+		timeoutSecs = defaultTimeoutSecs
+	}
+	ctx, cancel := context.WithTimeout(s.ctx, time.Duration(timeoutSecs)*time.Second)
+
+	var runErr error
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				runErr = fmt.Errorf("%v\n%s", recovered, debug.Stack())
+			}
+		}()
+		switch task.TaskType {
+		case connectorTaskTypePrune:
+			runErr = s.executePruneTask(ctx, task)
+		default:
+			runErr = s.executeSyncTask(ctx, task)
+		}
+	}()
+	cancel()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		msg := fmt.Sprintf("Task timeout after %d seconds", timeoutSecs)
+		if finishErr := connectorDAO.FinishTask(context.Background(), db, task.ID, task.ConnectorID, entity.TaskStatusFail, msg, ""); finishErr != nil {
+			common.Error(fmt.Sprintf("Failed to mark task %s failed", task.ID), finishErr)
+		}
+		return
+	}
+	if runErr != nil {
+		if finishErr := connectorDAO.FinishTask(context.Background(), db, task.ID, task.ConnectorID, entity.TaskStatusFail, runErr.Error(), string(debug.Stack())); finishErr != nil {
+			common.Error(fmt.Sprintf("Failed to mark task %s failed", task.ID), finishErr)
+		}
+		return
+	}
+
+	if err := connectorDAO.FinishTask(context.Background(), db, task.ID, task.ConnectorID, entity.TaskStatusDone, "", ""); err != nil {
+		common.Error(fmt.Sprintf("Failed to mark task %s done", task.ID), err)
+		return
+	}
+
+	switch task.TaskType {
+	case connectorTaskTypeSync:
+		if err := connectorDAO.RescheduleTask(context.Background(), db, task.ConnectorID, task.KbID, connectorTaskTypeSync); err != nil {
+			common.Error(fmt.Sprintf("Failed to reschedule sync for connector %s", task.ConnectorID), err)
+		}
+	case connectorTaskTypePrune:
+		if connectorConfigBool(task.Config, "sync_deleted_files") {
+			if err := connectorDAO.RescheduleTask(context.Background(), db, task.ConnectorID, task.KbID, connectorTaskTypePrune); err != nil {
+				common.Error(fmt.Sprintf("Failed to reschedule prune for connector %s", task.ConnectorID), err)
+			}
+		}
+	}
+}
+
+// executeSyncTask runs a sync task: fetch documents from the source, import
+// the changed ones into the knowledge base, and enqueue parsing when the
+// connector link has auto_parse enabled. Mirrors Python SyncBase._run_sync_task_logic.
+func (s *Syncer) executeSyncTask(ctx context.Context, task *dao.DueSyncTask) error {
 	common.Info("Executing sync task",
 		zap.String("task_id", task.ID),
 		zap.String("connector_id", task.ConnectorID),
+		zap.String("source", task.Source),
 		zap.String("kb_id", task.KbID))
-	// TODO: implement actual data-source-specific sync logic.
-	// For now, mark done.
-	s.markTaskDone(task.ID, task.ConnectorID)
-}
 
-// executePruneTask runs a prune (delete stale docs) task.
-func (s *Syncer) executePruneTask(task *entity.SyncLogs) {
-	common.Info("Executing prune task",
+	if task.Source != connectorSourceRSS {
+		return fmt.Errorf("data source %q is not supported by the Go syncer", task.Source)
+	}
+
+	connectorDAO := dao.NewConnectorDAO()
+	db := dao.GetDB()
+
+	kb, err := dao.NewKnowledgebaseDAO().GetByID(ctx, db, task.KbID)
+	if err != nil {
+		return fmt.Errorf("knowledgebase %s: %w", task.KbID, err)
+	}
+
+	connector := newRSSConnector(connectorConfigString(task.Config, "feed_url"), connectorConfigInt(task.Config, "batch_size", defaultIndexBatchSize))
+
+	reindex := task.FromBeginning != nil && *task.FromBeginning == "1"
+	var start, end *time.Time
+	if !reindex && task.PollRangeStart != nil {
+		start = task.PollRangeStart
+		now := time.Now().UTC()
+		end = &now
+	}
+	batches, err := connector.load(ctx, start, end)
+	if err != nil {
+		return err
+	}
+
+	sourceType := fmt.Sprintf("%s/%s", task.Source, task.ConnectorID)
+	existingDocs, err := connectorDAO.ListDocumentsByKBAndSourceType(ctx, db, task.KbID, sourceType)
+	if err != nil {
+		return err
+	}
+	existingDocIDs := make(map[string]bool, len(existingDocs))
+	for _, existingDoc := range existingDocs {
+		existingDocIDs[existingDoc.ID] = true
+	}
+
+	nextUpdate := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	if task.PollRangeStart != nil {
+		nextUpdate = *task.PollRangeStart
+	}
+
+	docSvc := document.NewDocumentService()
+	autoParse := connectorAutoParse(task.AutoParse)
+	addedDocs, updatedDocs := 0, 0
+
+	for _, batch := range batches {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		maxUpdate := batch[0].UpdatedAt
+		for _, doc := range batch {
+			if doc.UpdatedAt.After(maxUpdate) {
+				maxUpdate = doc.UpdatedAt
+			}
+		}
+		if maxUpdate.After(nextUpdate) {
+			nextUpdate = maxUpdate
+		}
+
+		inputs := make([]document.ConnectorDocumentInput, 0, len(batch))
+		for _, doc := range batch {
+			legacyDocID := document.Hash128Hex([]byte(task.ConnectorID + ":" + doc.ID))
+			docID := document.Hash128Hex([]byte(task.KbID + ":" + task.ConnectorID + ":" + doc.ID))
+			if existingDocIDs[legacyDocID] {
+				docID = legacyDocID
+			}
+			inputs = append(inputs, document.ConnectorDocumentInput{
+				ID:                 docID,
+				SemanticIdentifier: doc.SemanticIdentifier,
+				Extension:          ".txt",
+				Blob:               doc.Blob,
+				Metadata:           doc.Metadata,
+			})
+		}
+
+		results, errs := docSvc.UploadConnectorDocuments(ctx, kb, task.TenantID, sourceType, inputs)
+		for _, result := range results {
+			if len(result.Metadata) > 0 {
+				if err := docSvc.SetDocumentMetadata(ctx, result.Doc.ID, result.Metadata); err != nil {
+					common.Warn(fmt.Sprintf("Failed to set metadata for document %s: %v", result.Doc.ID, err))
+				}
+			}
+			if autoParse {
+				opts := document.StartParseOptions{RerunWithDelete: result.Existed}
+				if err := docSvc.StartParseDocuments(ctx, result.Doc, kb, task.TenantID, opts); err != nil {
+					errs = append(errs, err.Error())
+				}
+			}
+			if existingDocIDs[result.Doc.ID] {
+				updatedDocs++
+			} else {
+				addedDocs++
+				existingDocIDs[result.Doc.ID] = true
+			}
+		}
+
+		if err := connectorDAO.IncreaseDocs(ctx, db, task.ID, maxUpdate, int64(len(batch)), strings.Join(errs, "\n"), int64(len(errs))); err != nil {
+			common.Error(fmt.Sprintf("Failed to increase docs for task %s", task.ID), err)
+		}
+	}
+
+	totalChanged := addedDocs + updatedDocs
+	common.Info(fmt.Sprintf("rss sync summary till %s: total=%d, added=%d, updated=%d",
+		nextUpdate.UTC().Format(time.RFC3339), totalChanged, addedDocs, updatedDocs),
 		zap.String("task_id", task.ID),
 		zap.String("connector_id", task.ConnectorID),
 		zap.String("kb_id", task.KbID))
-	// TODO: implement actual prune logic.
-	s.markTaskDone(task.ID, task.ConnectorID)
+	return nil
 }
 
-// markTaskDone updates task and connector status to DONE.
-func (s *Syncer) markTaskDone(taskID, connectorID string) {
-	db := dao.GetDB()
-	now := time.Now().Local()
+// executePruneTask deletes connector documents that no longer exist at the
+// source. Mirrors Python SyncBase._run_prune_task_logic.
+func (s *Syncer) executePruneTask(ctx context.Context, task *dao.DueSyncTask) error {
+	common.Info("Executing prune task",
+		zap.String("task_id", task.ID),
+		zap.String("connector_id", task.ConnectorID),
+		zap.String("source", task.Source),
+		zap.String("kb_id", task.KbID))
 
-	db.Model(&entity.SyncLogs{}).Where("id = ?", taskID).Updates(map[string]interface{}{
-		"status":      string(entity.TaskStatusDone),
-		"update_time": now,
-	})
-	db.Model(&entity.Connector{}).Where("id = ?", connectorID).Updates(map[string]interface{}{
-		"status":      string(entity.TaskStatusDone),
-		"update_time": now,
-	})
+	if !connectorConfigBool(task.Config, "sync_deleted_files") {
+		return nil
+	}
+	if task.Source != connectorSourceRSS {
+		return fmt.Errorf("data source %q is not supported by the Go syncer", task.Source)
+	}
+
+	connectorDAO := dao.NewConnectorDAO()
+	db := dao.GetDB()
+
+	connector := newRSSConnector(connectorConfigString(task.Config, "feed_url"), connectorConfigInt(task.Config, "batch_size", defaultIndexBatchSize))
+	entryIDs, err := connector.listEntryIDs(ctx)
+	if err != nil {
+		common.Warn(fmt.Sprintf("rss prune snapshot retrieval failed (connector_id=%s, kb_id=%s): %v", task.ConnectorID, task.KbID, err))
+		return nil
+	}
+
+	retain := make(map[string]bool, len(entryIDs)*2)
+	for _, entryID := range entryIDs {
+		retain[document.Hash128Hex([]byte(task.ConnectorID+":"+entryID))] = true
+		retain[document.Hash128Hex([]byte(task.KbID+":"+task.ConnectorID+":"+entryID))] = true
+	}
+
+	sourceType := fmt.Sprintf("%s/%s", task.Source, task.ConnectorID)
+	existingDocs, err := connectorDAO.ListDocumentsByKBAndSourceType(ctx, db, task.KbID, sourceType)
+	if err != nil {
+		return err
+	}
+	staleIDs := make([]string, 0)
+	for _, existingDoc := range existingDocs {
+		if !retain[existingDoc.ID] {
+			staleIDs = append(staleIDs, existingDoc.ID)
+		}
+	}
+
+	var removed int64
+	var errs []string
+	if len(staleIDs) > 0 {
+		deleted, err := document.NewDocumentService().DeleteDocuments(ctx, staleIDs, false, task.KbID, task.TenantID)
+		removed = int64(deleted)
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if err := connectorDAO.IncreaseRemovedDocs(ctx, db, task.ID, removed, strings.Join(errs, "\n"), int64(len(errs))); err != nil {
+		common.Error(fmt.Sprintf("Failed to increase removed docs for task %s", task.ID), err)
+	}
+	common.Info(fmt.Sprintf("rss prune summary: deleted=%d, errors=%d", removed, len(errs)),
+		zap.String("task_id", task.ID),
+		zap.String("connector_id", task.ConnectorID),
+		zap.String("kb_id", task.KbID))
+	return nil
+}
+
+func connectorConfigString(config entity.JSONMap, key string) string {
+	if value, ok := config[key].(string); ok {
+		return value
+	}
+	return ""
+}
+
+func connectorConfigInt(config entity.JSONMap, key string, defaultValue int) int {
+	switch value := config[key].(type) {
+	case float64:
+		return int(value)
+	case int64:
+		return int(value)
+	case int:
+		return value
+	case string:
+		if parsed, err := strconv.Atoi(value); err == nil {
+			return parsed
+		}
+	}
+	return defaultValue
+}
+
+func connectorConfigBool(config entity.JSONMap, key string) bool {
+	switch value := config[key].(type) {
+	case bool:
+		return value
+	case string:
+		return value == "1" || value == "true" || value == "TRUE"
+	}
+	return false
+}
+
+func connectorAutoParse(autoParse string) bool {
+	return autoParse != "0" && autoParse != "false"
 }


### PR DESCRIPTION
### Summary

In Go mode, RSS data sources could never be imported into a knowledge base (the Python backend works fine). The Go syncer was a stub: `pollAndExecute` only logged, no `sync_logs` rows were ever consumed, and no RSS connector existed on the Go side, so sync tasks stayed in Schedule/Cancel forever.

This PR implements the full Go sync execution path, mirroring the Python reference (`rag/svr/sync_data_source.py`, `common/data_source/rss_connector.py`, `FileService.upload_document`):

- **Syncer engine** (`internal/syncer`): polls due sync/prune tasks honoring `refresh_freq`/`prune_freq` windows, claims tasks atomically, executes with the connector's `timeout_secs`, performs done/fail status bookkeeping, and reschedules the next run after success (mirrors `SyncBase.__call__`).
- **RSS connector**: SSRF-safe feed fetching (reuses `utility.FetchRemoteFileSafely`), RSS 2.0 + Atom parsing, deterministic document IDs (`rss:md5(...)` + `hash128` with legacy-ID compatibility), HTML-to-text content building, poll-window filtering, and batching.
- **Document import** (`DocumentService.UploadConnectorDocuments`): mirrors `duplicate_and_parse` + `FileService.upload_document` — content-hash dedupe (unchanged docs are not re-parsed), name dedupe, storage upload, file-manager linkage, and `doc_num` counters; parsing is enqueued when the link has `auto_parse` enabled.
- **DAO support**: due-task listing, atomic claim, `increase_docs`/`increase_removed_docs` accumulation, finish/reschedule with 100-row log retention; the first sync after link/rebuild is due immediately (Python `run_immediately=True`).
- **Prune**: when `sync_deleted_files` is enabled, documents that disappeared from the feed are deleted from the knowledge base.

Other sources (S3, Confluence, etc.) remain unimplemented in Go and now fail fast with a clear "not supported by the Go syncer" message instead of being silently marked done.

Verified: unit tests for feed parsing/poll windows/batching/HTML normalization, `Hash128Hex` parity with Python `hash128`, package tests for `syncer`/`dao`/`service/document`, and a full `build.sh --go` build.