### PR TITLE
fix(go-models): add StepFun Step Plan base URL

### DIFF
--- a/conf/models/stepfun.json
+++ b/conf/models/stepfun.json
@@ -2,7 +2,8 @@
   "name": "StepFun",
   "url": {
     "default": "https://api.stepfun.ai/v1",
-    "china": "https://api.stepfun.com/v1"
+    "china": "https://api.stepfun.com/v1",
+    "plan": "https://api.stepfun.com/step_plan/v1"
   },
   "url_suffix": {
     "chat": "chat/completions",


### PR DESCRIPTION
### Summary

The StepFun (阶跃星辰) provider config only exposes the billing endpoints (`https://api.stepfun.ai/v1` and `https://api.stepfun.com/v1`). StepFun's Step Plan subscription uses a dedicated access point, `https://api.stepfun.com/step_plan/v1`, which is not selectable today.

This PR adds a `plan` URL option to `conf/models/stepfun.json` so users can pick the Step Plan base URL from the region/URL dropdown when configuring the StepFun provider. The Go backend resolves the base URL by region key lookup with no whitelist validation, and the frontend builds the dropdown dynamically from the configured URL keys, so no code changes are required.