### PR TITLE
fix: drop static catalog check when resolving tenant default models

### DIFF
--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -526,10 +526,9 @@ func (s *TenantService) GetModelInfo(ctx context.Context, tenantID string, defau
 		return nil, nil, nil, false, err
 	}
 
-	// Check if the model exists and is active. The tenant_model row is the
-	// source of truth here — providers with an empty factory catalog (e.g.
-	// OpenAI-API-Compatible, whose models are user-defined) cannot be
-	// validated against the catalog. Mirrors Python's _get_model_info.
+	// Check if the model exists and is active. Model type validity is
+	// enforced on the save path against the tenant_model record, so models
+	// added online that are absent from the static catalog still resolve.
 	modelEntity, err := s.modelDAO.GetModelByProviderIDAndInstanceIDAndModelName(ctx, dao.DB, modelProvider.ID, modelInstance.ID, modelName)
 	if err != nil {
 		if !dao.IsNotFoundErr(err) {


### PR DESCRIPTION
### Summary

In Go mode, the default-model dialog shows an empty field after selecting certain models (e.g. `nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1`, `BAAI/bge-large-en-v1.5`), even though saving succeeds.

Root cause: `GetModelInfo` (internal/service/tenant.go) required the model to exist in Go's static model catalog (`conf/models/*.json`) and to advertise the requested model type there. Models added via online discovery (e.g. NVIDIA instance reconciliation) or written by the Python backend (e.g. BAAI pool models, which have no `conf/models` entry at all) fail that check, so `ListTenantDefaultModels` silently drops the entry and `GET /api/v1/models/default` omits it, leaving the dialog field blank on reopen.

Fix: align with Python's `_get_model_info` by validating against the `tenant_model` DB record only — model-type validity is already enforced on the save path (`checkModelAvailable`). Also removes the now-unused `factoryModelTypeName` helper.

Verified with `bash build.sh --test ./internal/service/` (all passing).