### PR TITLE
fix: synchronize chat model configuration

### DIFF
--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -413,7 +413,7 @@ async def create():
             req["kb_ids"] = kb_ids
             req.pop("dataset_ids", None)
 
-        if "llm_id" not in req and "tenant_llm_id" not in req:
+        if req.get("llm_id") is None and req.get("tenant_llm_id") is None:
             req["llm_id"] = tenant.tenant_llm_id
         if "rerank_id" not in req and "tenant_rerank_id" not in req:
             req["rerank_id"] = ""

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -275,51 +275,6 @@ def _normalize_completion_messages(req):
     return (messages, msg), None
 
 
-async def _validate_llm_id(llm_id, tenant_id, llm_setting=None):
-    if not llm_id:
-        return None
-
-    conf_model_type = (llm_setting or {}).get("model_type")
-    if isinstance(conf_model_type, str):
-        model_type = conf_model_type if conf_model_type in {"chat", "vision"} else "chat"
-    elif isinstance(conf_model_type, list):
-        model_type = "vision" if "vision" in conf_model_type else "chat"
-    else:
-        model_type = "chat"
-    try:
-        await thread_pool_exec(
-            resolve_model_config,
-            tenant_id=tenant_id,
-            model_type=model_type,
-            model_ref=llm_id,
-        )
-    except Exception as e:
-        logging.error(f"Fail to get model config for {llm_id}: {e}")
-        return f"`llm_id` {llm_id} doesn't exist"
-
-    return None
-
-
-async def _validate_rerank_id(rerank_id, tenant_id):
-    if not rerank_id:
-        return None
-    parts = rerank_id.split("@")
-    llm_name = parts[0]
-    if llm_name in _DEFAULT_RERANK_MODELS:
-        return None
-    try:
-        await thread_pool_exec(
-            resolve_model_config,
-            tenant_id=tenant_id,
-            model_ref=rerank_id,
-            model_type="rerank",
-        )
-    except Exception as e:
-        logging.error(f"Fail to get model config for {rerank_id}: {e}")
-        return f"`rerank_id` {rerank_id} doesn't exist"
-    return None
-
-
 def _llm_model_type(llm_setting):
     model_type = (llm_setting or {}).get("model_type")
     if isinstance(model_type, list):
@@ -344,7 +299,7 @@ async def _normalize_model_pair(req, tenant_id, name_field, id_field, model_type
     if model_id:
         try:
             await thread_pool_exec(get_model_config_by_id, tenant_id, model_type, model_id)
-        except Exception as e:
+        except LookupError as e:
             logging.error("Fail to get %s config by tenant model id %s: %s", model_type, model_id, e)
             return f"`{id_field}` must be a valid tenant model id"
 
@@ -359,9 +314,9 @@ async def _normalize_model_pair(req, tenant_id, name_field, id_field, model_type
                 try:
                     await thread_pool_exec(get_model_config_by_id, tenant_id, model_type, model_name)
                     resolved_name_id = model_name
-                except Exception:
+                except LookupError:
                     resolved_name_id = await thread_pool_exec(resolve_model_id, tenant_id, model_type, model_name)
-            except Exception as e:
+            except LookupError as e:
                 logging.error("Fail to resolve %s %s: %s", name_field, model_name, e)
                 return f"`{name_field}` {model_name} doesn't exist"
 
@@ -373,7 +328,7 @@ async def _normalize_model_pair(req, tenant_id, name_field, id_field, model_type
     elif model_id:
         try:
             req[name_field] = await thread_pool_exec(get_composite_model_name_by_id, model_id)
-        except Exception as e:
+        except LookupError as e:
             logging.error("Fail to get composite name for %s %s: %s", id_field, model_id, e)
             return f"`{id_field}` must be a valid tenant model id"
     else:
@@ -469,16 +424,6 @@ async def create():
         err = await _normalize_model_pair(req, current_user.id, "rerank_id", "tenant_rerank_id", "rerank")
         if err:
             return get_data_error_result(message=err)
-
-        if "llm_id" in req:
-            err = await _validate_llm_id(req.get("llm_id"), current_user.id, req.get("llm_setting"))
-            if err:
-                return get_data_error_result(message=err)
-
-        if "rerank_id" in req:
-            err = await _validate_rerank_id(req.get("rerank_id"), current_user.id)
-            if err:
-                return get_data_error_result(message=err)
 
         if "prompt_config" in req:
             if not isinstance(req["prompt_config"], dict):
@@ -654,16 +599,6 @@ async def update_chat(chat_id):
         if err:
             return get_data_error_result(message=err)
 
-        if "llm_id" in req:
-            err = await _validate_llm_id(req.get("llm_id"), current_user.id, req.get("llm_setting"))
-            if err:
-                return get_data_error_result(message=err)
-
-        if "rerank_id" in req:
-            err = await _validate_rerank_id(req.get("rerank_id"), current_user.id)
-            if err:
-                return get_data_error_result(message=err)
-
         if "prompt_config" in req:
             if not isinstance(req["prompt_config"], dict):
                 return get_data_error_result(message="`prompt_config` should be an object.")
@@ -734,6 +669,13 @@ async def patch_chat(chat_id):
             req["kb_ids"] = kb_ids
             req.pop("dataset_ids", None)
 
+        if "llm_setting" in req:
+            if not isinstance(req["llm_setting"], dict):
+                return get_data_error_result(message="`llm_setting` should be an object.")
+            llm_setting = deepcopy(current_chat.get("llm_setting") or {})
+            llm_setting.update(req["llm_setting"])
+            req["llm_setting"] = llm_setting
+
         effective_llm_setting = req.get("llm_setting", current_chat.get("llm_setting", {}))
         err = await _normalize_model_pair(req, current_user.id, "llm_id", "tenant_llm_id", _llm_model_type(effective_llm_setting))
         if err:
@@ -741,16 +683,6 @@ async def patch_chat(chat_id):
         err = await _normalize_model_pair(req, current_user.id, "rerank_id", "tenant_rerank_id", "rerank")
         if err:
             return get_data_error_result(message=err)
-
-        if "llm_id" in req:
-            err = await _validate_llm_id(req.get("llm_id"), current_user.id, req.get("llm_setting"))
-            if err:
-                return get_data_error_result(message=err)
-
-        if "rerank_id" in req:
-            err = await _validate_rerank_id(req.get("rerank_id"), current_user.id)
-            if err:
-                return get_data_error_result(message=err)
 
         if "prompt_config" in req:
             if not isinstance(req["prompt_config"], dict):
@@ -761,11 +693,6 @@ async def patch_chat(chat_id):
             # err = _validate_prompt_config(prompt_config)
             # if err:
             #     return get_data_error_result(message=err)
-
-        if "llm_setting" in req:
-            llm_setting = deepcopy(current_chat.get("llm_setting", {}))
-            llm_setting.update(req["llm_setting"])
-            req["llm_setting"] = llm_setting
 
         # if "prompt_config" in req or "kb_ids" in req:
         #     prompt_config = req.get("prompt_config", current_chat.get("prompt_config", {}))

--- a/api/apps/restful_apis/chat_api.py
+++ b/api/apps/restful_apis/chat_api.py
@@ -28,7 +28,14 @@ from werkzeug.exceptions import BadRequest
 
 from api.apps import current_user, login_required
 from api.apps.restful_apis._generation_params import merge_generation_config, pop_generation_config
-from api.db.joint_services.tenant_model_service import get_api_key, get_tenant_default_model_by_type, resolve_model_config
+from api.db.joint_services.tenant_model_service import (
+    get_api_key,
+    get_composite_model_name_by_id,
+    get_model_config_by_id,
+    get_tenant_default_model_by_type,
+    resolve_model_config,
+    resolve_model_id,
+)
 from api.db.services.chunk_feedback_service import ChunkFeedbackService
 from api.db.services.conversation_service import ConversationService, structure_answer
 from api.db.services.dialog_service import DialogService, gen_mindmap, rag_agent
@@ -313,6 +320,70 @@ async def _validate_rerank_id(rerank_id, tenant_id):
     return None
 
 
+def _llm_model_type(llm_setting):
+    model_type = (llm_setting or {}).get("model_type")
+    if isinstance(model_type, list):
+        return "vision" if "vision" in model_type else "chat"
+    return model_type if isinstance(model_type, str) and model_type in {"chat", "vision"} else "chat"
+
+
+async def _normalize_model_pair(req, tenant_id, name_field, id_field, model_type):
+    """Validate and synchronize a model name with its tenant-model ID."""
+    if name_field not in req and id_field not in req:
+        return None
+
+    model_name = req.get(name_field)
+    model_id = req.get(id_field)
+    resolved_name_id = None
+
+    if model_name is not None and not isinstance(model_name, str):
+        return f"`{name_field}` must be a string"
+    if model_id is not None and not isinstance(model_id, str):
+        return f"`{id_field}` must be a tenant model id"
+
+    if model_id:
+        try:
+            await thread_pool_exec(get_model_config_by_id, tenant_id, model_type, model_id)
+        except Exception as e:
+            logging.error("Fail to get %s config by tenant model id %s: %s", model_type, model_id, e)
+            return f"`{id_field}` must be a valid tenant model id"
+
+    if model_name:
+        if model_type == "rerank" and model_name.split("@")[0] in _DEFAULT_RERANK_MODELS:
+            if model_id:
+                return f"`{name_field}` and `{id_field}` must refer to the same model"
+        else:
+            try:
+                # A name field may already contain a tenant model ID. Resolve it
+                # strictly first, then fall back to the composite model name.
+                try:
+                    await thread_pool_exec(get_model_config_by_id, tenant_id, model_type, model_name)
+                    resolved_name_id = model_name
+                except Exception:
+                    resolved_name_id = await thread_pool_exec(resolve_model_id, tenant_id, model_type, model_name)
+            except Exception as e:
+                logging.error("Fail to resolve %s %s: %s", name_field, model_name, e)
+                return f"`{name_field}` {model_name} doesn't exist"
+
+    if model_id and model_name:
+        if resolved_name_id != model_id:
+            return f"`{name_field}` and `{id_field}` must refer to the same model"
+    elif model_name:
+        req[id_field] = resolved_name_id
+    elif model_id:
+        try:
+            req[name_field] = await thread_pool_exec(get_composite_model_name_by_id, model_id)
+        except Exception as e:
+            logging.error("Fail to get composite name for %s %s: %s", id_field, model_id, e)
+            return f"`{id_field}` must be a valid tenant model id"
+    else:
+        # Clearing one side must not leave a stale ID/name on the other side.
+        req[id_field] = None
+        req[name_field] = ""
+
+    return None
+
+
 # def _validate_prompt_config(prompt_config):
 #     for parameter in prompt_config.get("parameters", []):
 #         if parameter.get("optional"):
@@ -386,6 +457,18 @@ async def create():
                 return get_data_error_result(message=kb_ids)
             req["kb_ids"] = kb_ids
             req.pop("dataset_ids", None)
+
+        if "llm_id" not in req and "tenant_llm_id" not in req:
+            req["llm_id"] = tenant.tenant_llm_id
+        if "rerank_id" not in req and "tenant_rerank_id" not in req:
+            req["rerank_id"] = ""
+
+        err = await _normalize_model_pair(req, current_user.id, "llm_id", "tenant_llm_id", _llm_model_type(req.get("llm_setting")))
+        if err:
+            return get_data_error_result(message=err)
+        err = await _normalize_model_pair(req, current_user.id, "rerank_id", "tenant_rerank_id", "rerank")
+        if err:
+            return get_data_error_result(message=err)
 
         if "llm_id" in req:
             err = await _validate_llm_id(req.get("llm_id"), current_user.id, req.get("llm_setting"))
@@ -563,6 +646,14 @@ async def update_chat(chat_id):
             req["kb_ids"] = kb_ids
             req.pop("dataset_ids", None)
 
+        effective_llm_setting = req.get("llm_setting", current_chat.get("llm_setting", {}))
+        err = await _normalize_model_pair(req, current_user.id, "llm_id", "tenant_llm_id", _llm_model_type(effective_llm_setting))
+        if err:
+            return get_data_error_result(message=err)
+        err = await _normalize_model_pair(req, current_user.id, "rerank_id", "tenant_rerank_id", "rerank")
+        if err:
+            return get_data_error_result(message=err)
+
         if "llm_id" in req:
             err = await _validate_llm_id(req.get("llm_id"), current_user.id, req.get("llm_setting"))
             if err:
@@ -642,6 +733,14 @@ async def patch_chat(chat_id):
                 return get_data_error_result(message=kb_ids)
             req["kb_ids"] = kb_ids
             req.pop("dataset_ids", None)
+
+        effective_llm_setting = req.get("llm_setting", current_chat.get("llm_setting", {}))
+        err = await _normalize_model_pair(req, current_user.id, "llm_id", "tenant_llm_id", _llm_model_type(effective_llm_setting))
+        if err:
+            return get_data_error_result(message=err)
+        err = await _normalize_model_pair(req, current_user.id, "rerank_id", "tenant_rerank_id", "rerank")
+        if err:
+            return get_data_error_result(message=err)
 
         if "llm_id" in req:
             err = await _validate_llm_id(req.get("llm_id"), current_user.id, req.get("llm_setting"))

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -1852,7 +1852,7 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         return
     kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
     use_web_search = _should_use_web_search(prompt_config, kwargs.get("internet"))
-    logging.debug("web_search kb=%s tavily=%s internet=%r enabled=%s", bool(dialog.kb_ids), bool(dialog.prompt_config.get("tavily_api_key")), kwargs.get("internet"), use_web_search)
+    logging.debug("web_search kb=%s tavily=%s internet=%r enabled=%s", bool(dialog.kb_ids), bool(prompt_config.get("tavily_api_key")), kwargs.get("internet"), use_web_search)
     tenant_ids = list(set([kb.tenant_id for kb in kbs]))
     # "reasoning" arrives as "1".."4" mapping to the ordered THINKING_MODES
     # (low, medium, high, ultra); fall back to "medium" on anything else.
@@ -1871,7 +1871,7 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         chat_mdl,
         embed_mdl=embd_mdl,
         kb_ids=dialog.kb_ids,
-        tav=Tavily(prompt_config["tavily_api_key"]) if use_web_search else None,
+        tav=Tavily(prompt_config.get("tavily_api_key")) if use_web_search else None,
         do_refer=False,
         thinking_mode=thinking_mode,
     )

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -317,16 +317,6 @@ async def async_chat_solo(dialog, messages, stream=True, session_id=None):
         model_config = get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
 
     chat_mdl = LLMBundle(dialog.tenant_id, model_config, langfuse_session_id=session_id)
-    logging.info(
-        "[rag_agent] solo model selected: dialog_id=%s tenant_id=%s dialog_llm_id=%s tenant_llm_id=%s model=%s factory=%s model_type=%s",
-        getattr(dialog, "id", None),
-        dialog.tenant_id,
-        dialog.llm_id,
-        dialog.tenant_llm_id,
-        model_config.get("llm_name") if model_config else None,
-        model_config.get("llm_factory") if model_config else None,
-        model_config.get("model_type") if model_config else None,
-    )
     factory = model_config.get("llm_factory", "") if model_config else ""
     if "files" in messages[-1]:
         if model_config["model_type"] == "chat":
@@ -1855,42 +1845,12 @@ async def gen_mindmap(question, kb_ids, tenant_id, search_config={}):
 
 async def rag_agent(dialog, messages, stream=True, **kwargs):
     prompt_config = dialog.prompt_config or {}
-    requested_reasoning = kwargs.get("reasoning")
-    configured_reasoning = prompt_config.get("reasoning")
-    history_reasoning = [
-        {
-            "index": index,
-            "role": message.get("role"),
-            "has_reasoning_content": bool(message.get("reasoning_content")),
-            "has_think_tag": "<think>" in str(message.get("content", "")),
-        }
-        for index, message in enumerate(messages)
-        if message.get("role") == "assistant"
-    ]
-    logging.info(
-        "[rag_agent] start: dialog_id=%s tenant_id=%s dialog_llm_id=%s tenant_llm_id=%s requested_reasoning=%r configured_reasoning=%r stream=%s llm_setting=%r history_reasoning=%s",
-        getattr(dialog, "id", None),
-        dialog.tenant_id,
-        dialog.llm_id,
-        dialog.tenant_llm_id,
-        requested_reasoning,
-        configured_reasoning,
-        stream,
-        dialog.llm_setting or {},
-        history_reasoning,
-    )
     assert messages[-1]["role"] == "user", "The last content of this conversation is not from user."
     if not prompt_config.get("reasoning", 0) and not kwargs.get("reasoning"):
-        logging.info(
-            "[rag_agent] route=solo: requested_reasoning=%r configured_reasoning=%r",
-            requested_reasoning,
-            configured_reasoning,
-        )
         async for ans in async_chat(dialog, messages, stream, **kwargs):
             yield ans
         return
     kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
-    model_config = getattr(chat_mdl, "model_config", {}) or {}
     use_web_search = _should_use_web_search(prompt_config, kwargs.get("internet"))
     logging.debug("web_search kb=%s tavily=%s internet=%r enabled=%s", bool(dialog.kb_ids), bool(dialog.prompt_config.get("tavily_api_key")), kwargs.get("internet"), use_web_search)
     tenant_ids = list(set([kb.tenant_id for kb in kbs]))
@@ -1906,18 +1866,6 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         thinking_mode = "medium"
 
     gen_conf = dialog.llm_setting or {}
-    logging.info(
-        "[rag_agent] route=agentic: dialog_id=%s model=%s factory=%s model_type=%s requested_reasoning=%r configured_reasoning=%r thinking_mode=%s gen_conf=%r",
-        getattr(dialog, "id", None),
-        model_config.get("llm_name"),
-        model_config.get("llm_factory"),
-        model_config.get("model_type"),
-        requested_reasoning,
-        configured_reasoning,
-        thinking_mode,
-        gen_conf,
-    )
-
     rag_tools = RAGTools(
         tenant_ids,
         chat_mdl,

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -317,6 +317,16 @@ async def async_chat_solo(dialog, messages, stream=True, session_id=None):
         model_config = get_tenant_default_model_by_type(dialog.tenant_id, LLMType.CHAT)
 
     chat_mdl = LLMBundle(dialog.tenant_id, model_config, langfuse_session_id=session_id)
+    logging.info(
+        "[rag_agent] solo model selected: dialog_id=%s tenant_id=%s dialog_llm_id=%s tenant_llm_id=%s model=%s factory=%s model_type=%s",
+        getattr(dialog, "id", None),
+        dialog.tenant_id,
+        dialog.llm_id,
+        dialog.tenant_llm_id,
+        model_config.get("llm_name") if model_config else None,
+        model_config.get("llm_factory") if model_config else None,
+        model_config.get("model_type") if model_config else None,
+    )
     factory = model_config.get("llm_factory", "") if model_config else ""
     if "files" in messages[-1]:
         if model_config["model_type"] == "chat":
@@ -1844,14 +1854,43 @@ async def gen_mindmap(question, kb_ids, tenant_id, search_config={}):
 
 
 async def rag_agent(dialog, messages, stream=True, **kwargs):
-    logging.debug("Begin rag_agent")
+    prompt_config = dialog.prompt_config or {}
+    requested_reasoning = kwargs.get("reasoning")
+    configured_reasoning = prompt_config.get("reasoning")
+    history_reasoning = [
+        {
+            "index": index,
+            "role": message.get("role"),
+            "has_reasoning_content": bool(message.get("reasoning_content")),
+            "has_think_tag": "<think>" in str(message.get("content", "")),
+        }
+        for index, message in enumerate(messages)
+        if message.get("role") == "assistant"
+    ]
+    logging.info(
+        "[rag_agent] start: dialog_id=%s tenant_id=%s dialog_llm_id=%s tenant_llm_id=%s requested_reasoning=%r configured_reasoning=%r stream=%s llm_setting=%r history_reasoning=%s",
+        getattr(dialog, "id", None),
+        dialog.tenant_id,
+        dialog.llm_id,
+        dialog.tenant_llm_id,
+        requested_reasoning,
+        configured_reasoning,
+        stream,
+        dialog.llm_setting or {},
+        history_reasoning,
+    )
     assert messages[-1]["role"] == "user", "The last content of this conversation is not from user."
-    prompt_config = dialog.prompt_config
     if not prompt_config.get("reasoning", 0) and not kwargs.get("reasoning"):
+        logging.info(
+            "[rag_agent] route=solo: requested_reasoning=%r configured_reasoning=%r",
+            requested_reasoning,
+            configured_reasoning,
+        )
         async for ans in async_chat(dialog, messages, stream, **kwargs):
             yield ans
         return
     kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
+    model_config = getattr(chat_mdl, "model_config", {}) or {}
     use_web_search = _should_use_web_search(prompt_config, kwargs.get("internet"))
     logging.debug("web_search kb=%s tavily=%s internet=%r enabled=%s", bool(dialog.kb_ids), bool(dialog.prompt_config.get("tavily_api_key")), kwargs.get("internet"), use_web_search)
     tenant_ids = list(set([kb.tenant_id for kb in kbs]))
@@ -1865,6 +1904,19 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
         thinking_mode = _mode_labels[_n - 1] if 1 <= _n <= len(_mode_labels) else "medium"
     except (TypeError, ValueError):
         thinking_mode = "medium"
+
+    gen_conf = dialog.llm_setting or {}
+    logging.info(
+        "[rag_agent] route=agentic: dialog_id=%s model=%s factory=%s model_type=%s requested_reasoning=%r configured_reasoning=%r thinking_mode=%s gen_conf=%r",
+        getattr(dialog, "id", None),
+        model_config.get("llm_name"),
+        model_config.get("llm_factory"),
+        model_config.get("model_type"),
+        requested_reasoning,
+        configured_reasoning,
+        thinking_mode,
+        gen_conf,
+    )
 
     rag_tools = RAGTools(
         tenant_ids,
@@ -1934,7 +1986,6 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
     # small models mangle or drop, so the client receives nothing.
     if getattr(chat_mdl, "mdl", None) is not None:
         chat_mdl.mdl.terminal_tools = {"rag"}
-    gen_conf = dialog.llm_setting
     if stream:
         # Surface the agentic pipeline's bracket-tagged progress logs to the
         # client as <think> content, interleaved with the real token stream.

--- a/test/testcases/restful_api/test_chats.py
+++ b/test/testcases/restful_api/test_chats.py
@@ -765,6 +765,15 @@ def _load_chat_routes_unit_module(monkeypatch):
 
     tenant_model_service_mod = ModuleType("api.db.joint_services.tenant_model_service")
     tenant_model_service_mod.get_model_config_from_provider_instance = lambda *_args, **_kwargs: {}
+
+    def _get_model_config_by_id(_tenant_id, _model_type, model_ref):
+        if model_ref == "tenant-llm-id":
+            return {}
+        raise LookupError(f"unknown tenant model id: {model_ref}")
+
+    tenant_model_service_mod.get_model_config_by_id = _get_model_config_by_id
+    tenant_model_service_mod.resolve_model_id = lambda _tenant_id, _model_type, model_name: model_name
+    tenant_model_service_mod.get_composite_model_name_by_id = lambda model_id: model_id
     tenant_model_service_mod.resolve_model_config = lambda *_args, **_kwargs: {}
     tenant_model_service_mod.get_tenant_default_model_by_type = lambda *_args, **_kwargs: {}
     tenant_model_service_mod.get_api_key = lambda *_args, **_kwargs: SimpleNamespace(id=1)
@@ -1149,11 +1158,11 @@ def test_chat_create_accepts_provider_scoped_rerank_id_unit(monkeypatch):
     monkeypatch.setattr(module.KnowledgebaseService, "query", lambda **_kwargs: [_DummyKB()])
     monkeypatch.setattr(module.KnowledgebaseService, "get_by_id", lambda _id: (True, _DummyKB()))
 
-    def _get_model_config_from_provider_instance(**kwargs):
-        query_calls.append(kwargs)
-        return {}
+    def _resolve_model_id(tenant_id, model_type, model_name):
+        query_calls.append({"tenant_id": tenant_id, "model_ref": model_name, "model_type": model_type})
+        return model_name
 
-    monkeypatch.setattr(module, "resolve_model_config", _get_model_config_from_provider_instance)
+    monkeypatch.setattr(module, "resolve_model_id", _resolve_model_id)
 
     def _save(**kwargs):
         saved.update(kwargs)

--- a/test/testcases/restful_api/test_user_tenant_routes_unit.py
+++ b/test/testcases/restful_api/test_user_tenant_routes_unit.py
@@ -1503,6 +1503,15 @@ def _load_chat_routes_unit_module(monkeypatch):
 
     tenant_model_provider_mod = ModuleType("api.db.joint_services.tenant_model_service")
     tenant_model_provider_mod.get_model_config_from_provider_instance = lambda *_args, **_kwargs: {}
+
+    def _get_model_config_by_id(_tenant_id, _model_type, model_ref):
+        if model_ref == "tenant-llm-id":
+            return {}
+        raise LookupError(f"unknown tenant model id: {model_ref}")
+
+    tenant_model_provider_mod.get_model_config_by_id = _get_model_config_by_id
+    tenant_model_provider_mod.resolve_model_id = lambda _tenant_id, _model_type, model_name: model_name
+    tenant_model_provider_mod.get_composite_model_name_by_id = lambda model_id: model_id
     tenant_model_provider_mod.resolve_model_config = lambda *_args, **_kwargs: {}
     tenant_model_provider_mod.get_tenant_default_model_by_type = lambda *_args, **_kwargs: {}
 

--- a/web/src/pages/next-chats/chat/app-settings/chat-settings.tsx
+++ b/web/src/pages/next-chats/chat/app-settings/chat-settings.tsx
@@ -87,6 +87,10 @@ export function ChatSettings({ hasSingleChatBox }: ChatSettingsProps) {
 
     // Add model_type to llm_setting based on the selected llm_id
     if (nextValues.llm_id) {
+      // The model selector returns the tenant model ID. Keep the legacy
+      // llm_id and the tenant-scoped ID synchronized; the backend gives
+      // tenant_llm_id precedence when resolving the chat model.
+      nextValues.tenant_llm_id = nextValues.llm_id;
       nextValues.llm_setting = {
         ...nextValues.llm_setting,
         model_type: findLlmByUuid(nextValues.llm_id)?.model_type || 'chat',

--- a/web/src/pages/next-chats/hooks/use-create-chat.ts
+++ b/web/src/pages/next-chats/hooks/use-create-chat.ts
@@ -39,6 +39,7 @@ export const useCreateChatDialog = () => {
         toc_enhance: false,
       },
       llm_id: defaultModelDictionary?.llm_id,
+      tenant_llm_id: defaultModelDictionary?.llm_id,
       llm_setting: {},
       similarity_threshold: 0.2,
       vector_similarity_weight: 0.3,


### PR DESCRIPTION
### What problem does this PR solve?

- Synchronize `llm_id` with `tenant_llm_id` when creating or updating chats.
- Validate that both identifiers refer to the same chat model.
- Apply the same synchronization and validation rules to rerank models.
- Support completing either identifier when only one is provided.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)