### PR TITLE
fix(go-api): align list sorting with Python

### DIFF
--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -174,7 +174,7 @@ func (h *AgentHandler) WithNewExecutor(f func(taskCtx *task.TaskContext, canvasI
 // @Param keywords query string false "Filter by title keyword"
 // @Param page query int false "Page number (0 = no pagination)"
 // @Param page_size query int false "Items per page (0 = no pagination)"
-// @Param orderby query string false "Order-by field (default: create_time)"
+// @Param orderby query string false "Order-by field (default: update_time for the merged view, create_time otherwise)"
 // @Param desc query bool false "Descending order (default: true)"
 // @Param owner_ids query string false "Comma-separated owner IDs to filter (default: all authorised tenants)"
 // @Param canvas_category query string false "Canvas category (default: agent_canvas)"
@@ -205,8 +205,6 @@ func (h *AgentHandler) ListAgents(c *gin.Context) {
 		}
 	}
 
-	orderby := c.DefaultQuery("orderby", "create_time")
-
 	desc := true
 	if v := c.Query("desc"); v != "" {
 		desc = strings.ToLower(v) != "false"
@@ -230,6 +228,7 @@ func (h *AgentHandler) ListAgents(c *gin.Context) {
 			}
 		}
 	}
+	orderby := resolveAgentListOrderBy(c.Query("orderby"), canvasCategory, canvasType, tags)
 	ctx := c.Request.Context()
 
 	result, code, err := h.agentService.ListAgents(
@@ -251,6 +250,19 @@ func (h *AgentHandler) ListAgents(c *gin.Context) {
 	}
 
 	common.SuccessWithData(c, result, "success")
+}
+
+func resolveAgentListOrderBy(requested, canvasCategory, canvasType string, tags []string) string {
+	// The unfiltered page is the merged agent/template-group view, whose visible
+	// ordering key is update_time. Agent-only filtered views retain their
+	// requested key and default to create_time.
+	if canvasCategory == "" && canvasType == "" && len(tags) == 0 {
+		return "update_time"
+	}
+	if requested == "" {
+		return "create_time"
+	}
+	return requested
 }
 
 // mapAgentError normalises service-layer errors onto the existing
@@ -917,8 +929,8 @@ func (h *AgentHandler) ListAgentSessions(c *gin.Context) {
 	keywords := c.Query("keywords")
 	fromDate := c.Query("from_date")
 	toDate := c.Query("to_date")
-	orderby := c.DefaultQuery("orderby", "create_time")
-	desc := c.DefaultQuery("desc", "true") != "false"
+	orderby := c.DefaultQuery("orderby", "update_time")
+	desc := !strings.EqualFold(c.DefaultQuery("desc", "true"), "false")
 	sessionID := c.Query("id")
 	expUserID := c.Query("user_id")
 	includeDSL := c.Query("dsl") == "true"

--- a/internal/handler/agent_test.go
+++ b/internal/handler/agent_test.go
@@ -81,6 +81,160 @@ func setupGinContextWithUserAndDB(t *testing.T, method, path string) (*gin.Conte
 	return c, w, db
 }
 
+func TestResolveAgentListOrderBy(t *testing.T) {
+	tests := []struct {
+		name           string
+		requested      string
+		canvasCategory string
+		canvasType     string
+		tags           []string
+		want           string
+	}{
+		{name: "merged view defaults to update time", want: "update_time"},
+		{name: "merged view always uses update time", requested: "create_time", want: "update_time"},
+		{name: "category filter defaults to create time", canvasCategory: "agent_canvas", want: "create_time"},
+		{name: "type filter defaults to create time", canvasType: "pipeline", want: "create_time"},
+		{name: "tag filter defaults to create time", tags: []string{"reviewed"}, want: "create_time"},
+		{name: "filtered view preserves requested key", requested: "title", canvasCategory: "agent_canvas", want: "title"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := resolveAgentListOrderBy(test.requested, test.canvasCategory, test.canvasType, test.tags)
+			if got != test.want {
+				t.Fatalf("resolveAgentListOrderBy() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestListAgentsDefaultsToUpdateTimeInMergedView(t *testing.T) {
+	c, w, db := setupGinContextWithUserAndDB(t, http.MethodGet, "/api/v1/agents")
+	createdLater := int64(3000)
+	createdEarlier := int64(1000)
+	updatedLater := int64(4000)
+	updatedEarlier := int64(2000)
+	rows := []*entity.UserCanvas{
+		{
+			ID:             "created-later",
+			UserID:         "user-1",
+			Title:          sptr("Created Later"),
+			Permission:     "me",
+			CanvasCategory: "agent_canvas",
+			BaseModel: entity.BaseModel{
+				CreateTime: &createdLater,
+				UpdateTime: &updatedEarlier,
+			},
+		},
+		{
+			ID:             "updated-later",
+			UserID:         "user-1",
+			Title:          sptr("Updated Later"),
+			Permission:     "me",
+			CanvasCategory: "agent_canvas",
+			BaseModel: entity.BaseModel{
+				CreateTime: &createdEarlier,
+				UpdateTime: &updatedLater,
+			},
+		},
+	}
+	if err := db.Create(rows).Error; err != nil {
+		t.Fatalf("create canvases: %v", err)
+	}
+
+	h := NewAgentHandler(t.Context(), service.NewAgentService(), nil)
+	h.ListAgents(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Code int `json:"code"`
+		Data struct {
+			Canvas []struct {
+				ID string `json:"id"`
+			} `json:"canvas"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code != int(common.CodeSuccess) {
+		t.Fatalf("code = %d, body = %s", response.Code, w.Body.String())
+	}
+	if len(response.Data.Canvas) != 2 {
+		t.Fatalf("canvas count = %d, want 2", len(response.Data.Canvas))
+	}
+	if response.Data.Canvas[0].ID != "updated-later" {
+		t.Fatalf("first canvas = %q, want updated-later", response.Data.Canvas[0].ID)
+	}
+}
+
+func TestListAgentSessionsDefaultsToUpdateTime(t *testing.T) {
+	c, w, db := setupGinContextWithUserAndDB(t, http.MethodGet, "/api/v1/agents/canvas-1/sessions")
+	c.Params = gin.Params{{Key: "canvas_id", Value: "canvas-1"}}
+	if err := db.Create(&entity.UserCanvas{
+		ID:             "canvas-1",
+		UserID:         "user-1",
+		Title:          sptr("Agent"),
+		Permission:     "me",
+		CanvasCategory: "agent_canvas",
+	}).Error; err != nil {
+		t.Fatalf("create canvas: %v", err)
+	}
+
+	createdLater := int64(3000)
+	createdEarlier := int64(1000)
+	updatedLater := int64(4000)
+	updatedEarlier := int64(2000)
+	sessions := []*entity.API4Conversation{
+		{
+			ID:        "created-later",
+			DialogID:  "canvas-1",
+			UserID:    "user-1",
+			Message:   json.RawMessage(`[]`),
+			Reference: json.RawMessage(`[]`),
+			BaseModel: entity.BaseModel{CreateTime: &createdLater, UpdateTime: &updatedEarlier},
+		},
+		{
+			ID:        "updated-later",
+			DialogID:  "canvas-1",
+			UserID:    "user-1",
+			Message:   json.RawMessage(`[]`),
+			Reference: json.RawMessage(`[]`),
+			BaseModel: entity.BaseModel{CreateTime: &createdEarlier, UpdateTime: &updatedLater},
+		},
+	}
+	if err := db.Create(sessions).Error; err != nil {
+		t.Fatalf("create sessions: %v", err)
+	}
+
+	h := NewAgentHandler(t.Context(), service.NewAgentService(), nil)
+	h.ListAgentSessions(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Code int `json:"code"`
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Code != int(common.CodeSuccess) {
+		t.Fatalf("code = %d, body = %s", response.Code, w.Body.String())
+	}
+	if len(response.Data) != 2 {
+		t.Fatalf("session count = %d, want 2", len(response.Data))
+	}
+	if response.Data[0].ID != "updated-later" {
+		t.Fatalf("first session = %q, want updated-later", response.Data[0].ID)
+	}
+}
+
 // TestListAgentVersionsHandler_Success verifies the happy path with real DB.
 func TestListAgentVersionsHandler_Success(t *testing.T) {
 	c, w, db := setupGinContextWithUserAndDB(t, "GET", "/api/v1/agents/canvas-1/versions")

--- a/internal/handler/compilation_template_group.go
+++ b/internal/handler/compilation_template_group.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"strconv"
+	"strings"
 
 	"ragflow/internal/common"
 	"ragflow/internal/service"
@@ -67,7 +68,7 @@ func (h *CompilationTemplateGroupHandler) List(c *gin.Context) {
 	keywords := c.Query("keywords")
 	scope := c.Query("scope")
 	orderby := c.DefaultQuery("orderby", "create_time")
-	desc := c.DefaultQuery("desc", "true") != "false"
+	desc := !strings.EqualFold(c.DefaultQuery("desc", "true"), "false")
 
 	groups, err := h.compilationTemplateGroupService.ListSaved(c.Request.Context(), user.ID, keywords, scope, orderby, desc)
 	if err != nil {

--- a/internal/handler/file.go
+++ b/internal/handler/file.go
@@ -105,7 +105,7 @@ func (h *FileHandler) ListFiles(c *gin.Context) {
 	orderby := c.DefaultQuery("orderby", "create_time")
 	desc := true
 	if descStr := c.Query("desc"); descStr != "" {
-		desc = descStr != "false"
+		desc = !strings.EqualFold(descStr, "false")
 	}
 
 	ctx := c.Request.Context()

--- a/internal/handler/file_commit.go
+++ b/internal/handler/file_commit.go
@@ -23,6 +23,7 @@ import (
 	"ragflow/internal/dao"
 	"ragflow/internal/entity"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -214,7 +215,7 @@ func (h *FileCommitHandler) ListCommits(c *gin.Context) {
 	orderBy := c.DefaultQuery("order_by", "create_time")
 	desc := true
 	if descStr := c.Query("desc"); descStr != "" {
-		desc = descStr != "false"
+		desc = !strings.EqualFold(descStr, "false")
 	}
 
 	ctx := c.Request.Context()

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -111,7 +111,7 @@ func (h *SearchHandler) ListSearches(c *gin.Context) {
 
 	desc := true
 	if descStr := c.Query("desc"); descStr != "" {
-		desc = descStr != "false"
+		desc = !strings.EqualFold(descStr, "false")
 	}
 
 	ownerIDs := getOwnerIDs(c)


### PR DESCRIPTION
## Summary

- Sort unfiltered agents and agent sessions by update time
- Normalize case-insensitive descending flags across list handlers

## Testing

- `CGO_ENABLED=0 go test -count=1 ./internal/handler/`