### PR TITLE
Fix: On the second page of agent version, switch the page size to empty.

### DIFF
--- a/web/src/components/ui/ragflow-pagination.tsx
+++ b/web/src/components/ui/ragflow-pagination.tsx
@@ -85,10 +85,10 @@ export function RAGFlowPagination({
 
   const handlePageSizeChange = useCallback(
     (size: string) => {
-      onChange?.(currentPage, Number(size));
+      onChange?.(1, Number(size));
       setCurrentPageSize(size);
     },
-    [currentPage, onChange],
+    [onChange],
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

Fix: On the second page of agent version, switch the page size to empty.