### PR TITLE
feat(web): submit retrieval testing form on Enter, newline on Shift+Enter

### DIFF
--- a/web/src/pages/dataset/testing/testing-form.tsx
+++ b/web/src/pages/dataset/testing/testing-form.tsx
@@ -120,7 +120,15 @@ export default function TestingForm({
             render={({ field }) => (
               <FormItem>
                 <FormControl>
-                  <Textarea {...field}></Textarea>
+                  <Textarea
+                    {...field}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        form.handleSubmit(onSubmit)();
+                      }
+                    }}
+                  ></Textarea>
                 </FormControl>
 
                 <FormMessage />


### PR DESCRIPTION
### Summary

On the knowledge base **Retrieval Testing** page, the question text input previously required clicking the Run button to execute a test. This PR improves the UX of the textarea in `web/src/pages/dataset/testing/testing-form.tsx`:

- **Enter**: submits the form and runs the retrieval test (same validation path as the Run button).
- **Shift+Enter**: inserts a newline, preserving the default multi-line behavior.

This matches the common keyboard interaction pattern of chat/query inputs.