### PR TITLE
fix(web): collapse overflowing tags on agent cards

### DIFF
--- a/web/src/pages/agents/agent-card.tsx
+++ b/web/src/pages/agents/agent-card.tsx
@@ -3,9 +3,15 @@ import { MoreButton } from '@/components/more-button';
 import { SharedBadge } from '@/components/shared-badge';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card';
 import { AgentCategory } from '@/constants/agent';
 import { useNavigatePage } from '@/hooks/logic-hooks/navigate-hooks';
 import { AgentListItemType, IFlow } from '@/interfaces/database/agent';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { CanvasCategoryToFlowType, FlowType, FlowTypeConfig } from './constant';
 import { AgentDropdown } from './agent-dropdown';
 import { useRenameAgent } from './use-rename-agent';
@@ -44,14 +50,105 @@ function AgentTags({ tags }: { tags?: string }) {
     .split(',')
     .map((t) => t.trim())
     .filter(Boolean);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(list.length);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const measure = measureRef.current;
+    if (!container || !measure) return;
+
+    const update = () => {
+      const children = Array.from(measure.children) as HTMLElement[];
+      const ellipsis = children.pop();
+      if (!ellipsis) return;
+
+      const gap = 4;
+      const maxWidth = container.clientWidth;
+      const widthOf = (els: HTMLElement[]) =>
+        els.reduce((acc, el) => acc + el.offsetWidth, 0) +
+        gap * Math.max(els.length - 1, 0);
+
+      // Keep only the tags that fit in a single row.
+      let count = children.length;
+      while (count > 0 && widthOf(children.slice(0, count)) > maxWidth) {
+        count -= 1;
+      }
+      // Reserve space for the ellipsis trigger when truncated.
+      if (count < children.length) {
+        while (
+          count > 0 &&
+          widthOf(children.slice(0, count)) + gap + ellipsis.offsetWidth >
+            maxWidth
+        ) {
+          count -= 1;
+        }
+      }
+      setVisibleCount(count);
+    };
+
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [tags]);
+
   if (list.length === 0) return null;
+
+  const visible = list.slice(0, visibleCount);
+  const truncated = visibleCount < list.length;
+
   return (
-    <div className="flex flex-wrap gap-1 mt-1">
-      {list.map((tag) => (
-        <Badge key={tag} variant="secondary" className="text-xs font-normal">
-          {tag}
+    <div ref={containerRef} className="relative mt-1">
+      {/* Hidden row used to measure the natural width of each tag */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        className="pointer-events-none invisible absolute flex gap-1 whitespace-nowrap"
+      >
+        {list.map((tag) => (
+          <Badge key={tag} variant="secondary" className="text-xs font-normal">
+            {tag}
+          </Badge>
+        ))}
+        <Badge variant="secondary" className="text-xs font-normal">
+          ...
         </Badge>
-      ))}
+      </div>
+      <div className="flex gap-1 overflow-hidden">
+        {visible.map((tag) => (
+          <Badge key={tag} variant="secondary" className="text-xs font-normal">
+            {tag}
+          </Badge>
+        ))}
+        {truncated && (
+          <HoverCard openDelay={100} closeDelay={100}>
+            <HoverCardTrigger asChild>
+              <Badge
+                variant="secondary"
+                className="text-xs font-normal cursor-pointer"
+              >
+                ...
+              </Badge>
+            </HoverCardTrigger>
+            <HoverCardContent>
+              <div className="flex flex-wrap gap-1">
+                {list.map((tag) => (
+                  <Badge
+                    key={tag}
+                    variant="secondary"
+                    className="text-xs font-normal"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </HoverCardContent>
+          </HoverCard>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Summary

On the Agents page, every tag of an agent was rendered with `flex flex-wrap` inside the card. When an agent had many tags, the tags wrapped into multiple lines and stretched its card, forcing all other cards in the same grid row to the same height and breaking the layout.

This PR limits tags to a single row on the agent card:

- A hidden measurement row computes how many tags actually fit the card width; only those are rendered.
- Overflowing tags collapse into a `...` badge, and hovering it reveals the full tag list in a `HoverCard` (same interaction as the SaaS version).
- A `ResizeObserver` recalculates the visible tag count whenever the card width changes (window resize / grid reflow).
- Measurement runs in `useLayoutEffect` before paint, so there is no flicker.

Only `web/src/pages/agents/agent-card.tsx` is touched.