### PR TITLE
fix(chunker): align custom-delimiter text/json paths with Python

### DIFF
--- a/internal/ingestion/component/chunker/common.go
+++ b/internal/ingestion/component/chunker/common.go
@@ -118,6 +118,38 @@ func splitKeepingDelim(text string, pattern *regexp.Regexp) []string {
 	return out
 }
 
+// splitDroppingDelim mirrors Python's _split_text_by_pattern
+// (token_chunker.py:79-90). Unlike splitKeepingDelim, the captured delimiter
+// is DISCARDED rather than glued to the preceding segment: re.split with a
+// captured group keeps delimiters at odd indices, and only the even-index
+// (text) parts are kept. This is the behaviour the text/markdown/html path
+// must reproduce so a split chunk reads "first sentence here" without the
+// trailing delimiter.
+func splitDroppingDelim(text string, pattern *regexp.Regexp) []string {
+	if pattern == nil {
+		return []string{text}
+	}
+	idxs := pattern.FindAllStringIndex(text, -1)
+	if len(idxs) == 0 {
+		return []string{text}
+	}
+	var out []string
+	cursor := 0
+	for _, idx := range idxs {
+		start, end := idx[0], idx[1]
+		if start == cursor {
+			cursor = end
+			continue
+		}
+		out = append(out, text[cursor:start])
+		cursor = end
+	}
+	if cursor < len(text) {
+		out = append(out, text[cursor:])
+	}
+	return out
+}
+
 // ---------------------------------------------------------------------------
 // chunk-doc helpers
 // ---------------------------------------------------------------------------

--- a/internal/ingestion/component/chunker/custom_delim_test.go
+++ b/internal/ingestion/component/chunker/custom_delim_test.go
@@ -1,0 +1,159 @@
+package chunker
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// custom_delim_test pins the backtick-wrapped newline delimiter behaviour of
+// TokenChunker against Python's rag/flow/chunker/token_chunker.py.
+//
+// There are two distinct, path-specific divergences that this file locks down:
+//
+//  1. text/markdown/html path: Python's _split_text_by_pattern (token_chunker.py:79-90)
+//     uses re.split with a captured group and keeps only the even-index
+//     (text) parts, so the delimiter is DROPPED. Go's splitKeepingDelim glues
+//     the delimiter to the end of the preceding segment, so a chunk reads
+//     "first sentence here\n" instead of "first sentence here". The fix makes
+//     the text path drop the delimiter like Python.
+//
+//  2. json path: Python's _build_json_chunks + _finalize_json_chunks never
+//     strip the chunk text, so the delimiter's trailing newline survives
+//     ("first segment line one\n"). Go's invokeJSONPayload ran every chunk
+//     through strings.TrimSpace, which deleted that newline. The fix stops
+//     trimming, so the newline is kept like Python.
+//
+// doc_type_kwd is intentionally asserted to remain present on every chunk.
+// It is a load-bearing Go field (index column + media dispatch) and is NOT
+// part of the divergence; it is classified go_intentional in known_diffs.json,
+// not a bug to fix here.
+
+const backtickNewline = "`\n`"
+
+func invokeTokenChunks(t *testing.T, params, input map[string]any) []map[string]any {
+	t.Helper()
+	c, err := NewTokenChunker(params)
+	if err != nil {
+		t.Fatalf("NewTokenChunker: %v", err)
+	}
+	out, err := c.Invoke(context.Background(), nil, input)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if msg, ok := out["_ERROR"].(string); ok && msg != "" {
+		t.Fatalf("Go returned _ERROR: %s", msg)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	return chunks
+}
+
+func chunkTexts(chunks []map[string]any) []string {
+	out := make([]string, 0, len(chunks))
+	for _, c := range chunks {
+		if s, ok := c["text"].(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestCustomDelimTextDropsDelimiter reproduces token__text_backtick.
+func TestCustomDelimTextDropsDelimiter(t *testing.T) {
+	params := map[string]any{"chunk_token_size": float64(128), "delimiters": []string{backtickNewline}}
+	input := map[string]any{
+		"name": "t", "output_format": "text",
+		"text": "first sentence here\nsecond sentence here\nthird sentence here",
+	}
+	chunks := invokeTokenChunks(t, params, input)
+
+	want := []string{"first sentence here", "second sentence here", "third sentence here"}
+	if len(chunks) != len(want) {
+		t.Fatalf("chunk count: want %d got %d (%v)", len(want), len(chunks), chunkTexts(chunks))
+	}
+	for i, w := range want {
+		got := chunks[i]["text"].(string)
+		if got != w {
+			t.Errorf("chunk[%d] text: want %q got %q", i, w, got)
+		}
+		if kd, _ := chunks[i]["doc_type_kwd"].(string); kd != "text" {
+			t.Errorf("chunk[%d] doc_type_kwd: Go must keep it, want %q got %q", i, "text", kd)
+		}
+	}
+}
+
+// TestCustomDelimJSONKeepsNewline reproduces token__json_backtick.
+func TestCustomDelimJSONKeepsNewline(t *testing.T) {
+	params := map[string]any{"chunk_token_size": float64(128), "delimiters": []string{backtickNewline}}
+	input := map[string]any{
+		"name": "t", "output_format": "json",
+		"json": []map[string]any{
+			{"text": "first segment line one\nfirst segment line two", "doc_type_kwd": "text"},
+			{"text": "second segment line one\nsecond segment line two", "doc_type_kwd": "text"},
+		},
+	}
+	chunks := invokeTokenChunks(t, params, input)
+
+	want := []string{
+		"first segment line one\n", "first segment line two",
+		"second segment line one\n", "second segment line two",
+	}
+	if len(chunks) != len(want) {
+		t.Fatalf("chunk count: want %d got %d (%v)", len(want), len(chunks), chunkTexts(chunks))
+	}
+	for i, w := range want {
+		got := chunks[i]["text"].(string)
+		if got != w {
+			t.Errorf("chunk[%d] text: want %q got %q", i, w, got)
+		}
+		if kd, _ := chunks[i]["doc_type_kwd"].(string); kd != "text" {
+			t.Errorf("chunk[%d] doc_type_kwd: Go must keep it, want %q got %q", i, "text", kd)
+		}
+	}
+}
+
+// TestCustomDelimMarkdownDropsDelimiter reproduces token__markdown_backtick:
+// the delimiter is dropped and no chunk text ends with a newline.
+func TestCustomDelimMarkdownDropsDelimiter(t *testing.T) {
+	params := map[string]any{"chunk_token_size": float64(128), "delimiters": []string{backtickNewline}}
+	input := map[string]any{
+		"name": "t", "output_format": "markdown",
+		"markdown": "# Title\n\nParagraph one.\n\nParagraph two.",
+	}
+	chunks := invokeTokenChunks(t, params, input)
+	if len(chunks) == 0 {
+		t.Fatal("want >=1 chunk, got 0")
+	}
+	for i, c := range chunks {
+		got := c["text"].(string)
+		if strings.HasSuffix(got, "\n") {
+			t.Errorf("chunk[%d] text ends with delimiter newline: %q", i, got)
+		}
+		if kd, _ := c["doc_type_kwd"].(string); kd != "text" {
+			t.Errorf("chunk[%d] doc_type_kwd: Go must keep it, want %q got %q", i, "text", kd)
+		}
+	}
+}
+
+// TestCustomDelimHTMLDropsDelimiter reproduces token__html_backtick.
+func TestCustomDelimHTMLDropsDelimiter(t *testing.T) {
+	params := map[string]any{"chunk_token_size": float64(128), "delimiters": []string{backtickNewline}}
+	input := map[string]any{
+		"name": "t", "output_format": "html",
+		"html": "<p>one</p>\n<p>two</p>\n<p>three</p>",
+	}
+	chunks := invokeTokenChunks(t, params, input)
+	want := []string{"<p>one</p>", "<p>two</p>", "<p>three</p>"}
+	if len(chunks) != len(want) {
+		t.Fatalf("chunk count: want %d got %d (%v)", len(want), len(chunks), chunkTexts(chunks))
+	}
+	for i, w := range want {
+		got := chunks[i]["text"].(string)
+		if got != w {
+			t.Errorf("chunk[%d] text: want %q got %q", i, w, got)
+		}
+		if kd, _ := chunks[i]["doc_type_kwd"].(string); kd != "text" {
+			t.Errorf("chunk[%d] doc_type_kwd: Go must keep it, want %q got %q", i, "text", kd)
+		}
+	}
+}

--- a/internal/ingestion/component/chunker/delimiter_case_sensitive_test.go
+++ b/internal/ingestion/component/chunker/delimiter_case_sensitive_test.go
@@ -179,9 +179,9 @@ func TestTokenChunker_BacktickEndSplitsOnlyAtLowercase(t *testing.T) {
 			got = append(got, text)
 		}
 	}
-	// splitKeepingDelim glues the matched delimiter onto the preceding
-	// segment: "the end" | " and End and END come"
-	want := []string{"the end", "and End and END come"}
+	// Python's _split_text_by_pattern drops the matched delimiter and
+	// .strip()s each segment: "the" | "and End and END come"
+	want := []string{"the", "and End and END come"}
 	if len(got) != len(want) {
 		t.Fatalf("chunks = %#v, want %#v", got, want)
 	}
@@ -217,8 +217,9 @@ func TestTokenChunker_BacktickASplitsOnlyAtLowercase(t *testing.T) {
 			got = append(got, text)
 		}
 	}
-	// "B" + "a" glued → "Ba"; remainder "Ab"
-	want := []string{"Ba", "Ab"}
+	// "B" + "a" glued → "Ba"; remainder "Ab". Python drops the matched
+	// delimiter and .strip()s, leaving "B" | "Ab".
+	want := []string{"B", "Ab"}
 	if len(got) != len(want) {
 		t.Fatalf("chunks = %#v, want %#v", got, want)
 	}

--- a/internal/ingestion/component/chunker/token.go
+++ b/internal/ingestion/component/chunker/token.go
@@ -304,13 +304,18 @@ func (c *TokenChunkerComponent) invokeTextPayload(_ context.Context, text string
 		return c.mergeByTokenSize(text, childrenPattern)
 	}
 
-	parts := splitKeepingDelim(text, delimPattern)
+	parts := splitDroppingDelim(text, delimPattern)
 	cleaned := make([]string, 0, len(parts))
 	for _, p := range parts {
-		if strings.TrimSpace(p) == "" {
+		// Python's text path keeps only the even-index (text) parts from
+		// _split_text_by_pattern and then .strip()s each one
+		// (token_chunker.py:316-338), so the delimiter is dropped and
+		// surrounding whitespace is trimmed.
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
 			continue
 		}
-		cleaned = append(cleaned, p)
+		cleaned = append(cleaned, trimmed)
 	}
 	if len(cleaned) == 0 {
 		return emptyOutputs()
@@ -652,7 +657,7 @@ func (c *TokenChunkerComponent) invokeJSONPayload(ctx context.Context, items []s
 		// the merge paths may carry @@...## markers that must not leak into
 		// indexed/embedded chunk text. Crop above reads positions, not text,
 		// so the ordering is safe.
-		m.Text = removeTag(strings.TrimSpace(m.Text))
+		m.Text = removeTag(m.Text)
 		if m.Text == "" {
 			continue
 		}

--- a/internal/ingestion/component/chunker/token_test.go
+++ b/internal/ingestion/component/chunker/token_test.go
@@ -132,10 +132,10 @@ func TestTokenChunker_DelimNeverStandaloneChunk(t *testing.T) {
 			t.Errorf("chunk[%d] is the bare delimiter %q", i, text)
 		}
 	}
-	if got, want := chunks[0]["text"], "alpha section\n666"; got != want {
+	if got, want := chunks[0]["text"], "alpha section"; got != want {
 		t.Errorf("chunk[0] text = %q, want %q", got, want)
 	}
-	if got, want := chunks[1]["text"], "\nbeta section"; got != want {
+	if got, want := chunks[1]["text"], "beta section"; got != want {
 		t.Errorf("chunk[1] text = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the `go_bug` custom-delimiter newline divergences tracked in `known_diffs.json` (these rules live in the parity-infra PR #17735; this PR is the production fix only):

- `token-custom-delim-newline-and-field` — text / markdown / html paths with a backtick delimiter kept the delimiter glued to the preceding segment. Now the text path **drops** the delimiter and `.strip()`s each segment, mirroring Python's `_split_text_by_pattern` + `.strip()` (`rag/flow/chunker/token_chunker.py:316-338`). A chunk now reads `first sentence here` instead of `first sentence here` + trailing newline.
- `token-json-custom-delim-drops-newline` — the json path ran every chunk through `strings.TrimSpace`, which deleted the delimiter's trailing newline that Python keeps (`_build_json_chunks` / `_finalize_json_chunks` never strip). The json path no longer trims, so `first segment line one` + trailing newline survives like Python.

### `doc_type_kwd` is intentionally kept

The divergence rule also listed `doc_type_kwd` as a Go-only field. It is **not** a defect: `doc_type_kwd` is a load-bearing Go field (Infinity index column + media/PDF dispatch — `engine/infinity/chunk.go:741`, `*_vision_dispatch.go`, `media_dispatch.go`, `parser.go`). Python's JSON path emits it too (`token_chunker.py:125`); only its text path omits it. It is reclassified as `go_intentional` (extra_fields) in `known_diffs.json` (part of #17735), **not** removed here.

### Changes

- `common.go`: add `splitDroppingDelim` (delimiter discarded, mirrors Python).
- `token.go`: text path uses `splitDroppingDelim` + per-segment `TrimSpace`; json path drops the `TrimSpace` in `invokeJSONPayload`.
- Updated 3 existing unit tests that encoded the old keep-delimiter behaviour.
- Added `custom_delim_test.go`: 4 self-contained RED→GREEN tests reproducing the parity cases (`token__text/markdown/html/json_backtick`); they also assert `doc_type_kwd:"text"` stays present.

### Test plan

`bash build.sh --test ./internal/ingestion/component/chunker/` — green, including the 4 new tests and no regression to the existing suite.

## Note

Independent of #17729 / #17735 / #17739; based on `upstream/main`. The `known_diffs.json` rules `token-custom-delim-newline-and-field` and `token-json-custom-delim-drops-newline` should be removed/reclassified once this lands (handled in #17735).
