### PR TITLE
fix(web): file list total count doesn't match displayed rows

### DIFF
--- a/web/src/pages/files/files-table.tsx
+++ b/web/src/pages/files/files-table.tsx
@@ -114,8 +114,8 @@ export function FilesTable({
 
   // Sort files with skills folder first, then by time
   // Filter out skills folder if not in hybrid/go mode
-  const sortedFiles = useMemo(() => {
-    if (!files) return [];
+  const { sortedFiles, hiddenCount } = useMemo(() => {
+    if (!files) return { sortedFiles: [] as IFile[], hiddenCount: 0 };
 
     // Filter out skills folder if feature is disabled
     const filteredFiles = isSkillsEnabled
@@ -126,7 +126,7 @@ export function FilesTable({
           return !isSkills;
         });
 
-    return [...filteredFiles].sort((a, b) => {
+    const sorted = [...filteredFiles].sort((a, b) => {
       const aIsSkills =
         isFolderType(a.type) && a.name.toLowerCase() === 'skills';
       const bIsSkills =
@@ -139,7 +139,14 @@ export function FilesTable({
       // Then sort by create_time desc (newest first)
       return (b.create_time || 0) - (a.create_time || 0);
     });
+
+    return { sortedFiles: sorted, hiddenCount: files.length - filteredFiles.length };
   }, [files, isSkillsEnabled]);
+
+  // Keep the displayed total consistent with the rows actually shown:
+  // client-side filtered rows (e.g. the skills folder when the feature is
+  // disabled) are still included in the server-side total.
+  const displayTotal = Math.max((total ?? 0) - hiddenCount, 0);
 
   const columns: ColumnDef<IFile>[] = [
     {
@@ -329,7 +336,7 @@ export function FilesTable({
       rowSelection,
       pagination: currentPagination,
     },
-    rowCount: total ?? 0,
+    rowCount: displayTotal,
     debugTable: true,
   });
 
@@ -393,7 +400,7 @@ export function FilesTable({
       <footer className="flex items-center justify-end pb-5 mt-4">
         <RAGFlowPagination
           {...pick(pagination, 'current', 'pageSize')}
-          total={total}
+          total={displayTotal}
           onChange={(page, pageSize) => {
             setPagination({ page, pageSize });
           }}


### PR DESCRIPTION
### Summary

In the file manager, the pagination total did not match the number of rows actually displayed (e.g. showing "5 total" while only 4 rows were rendered).

The backend counts the `skills` folder in the file list total (it is auto-initialized under the root folder), but the frontend filters the `skills` folder out of the table when the skills feature is disabled (non-go/hybrid builds). The pagination component and table `rowCount` still used the raw server-side total, causing the mismatch.

This PR tracks the number of client-side hidden rows when filtering and subtracts it from the total used by the table `rowCount` and the pagination component, keeping the displayed total consistent with the rendered rows. Go/hybrid builds are unaffected (no rows are hidden there).