### PR TITLE
fix(go-models): add stream_options.include_usage for DeepSeek and Azure OpenAI streaming

### DIFF
--- a/internal/entity/models/azure_openai.go
+++ b/internal/entity/models/azure_openai.go
@@ -201,6 +201,11 @@ func (a *AzureOpenAIModel) ChatStreamlyWithSender(ctx context.Context, modelName
 		}
 	}
 
+	// Request token usage in streaming response. Azure OpenAI only
+	// includes usage in the final chunk when stream_options.include_usage
+	// is set.
+	reqBody["stream_options"] = map[string]any{"include_usage": true}
+
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)

--- a/internal/entity/models/deepseek.go
+++ b/internal/entity/models/deepseek.go
@@ -192,6 +192,10 @@ func (d *DeepSeekModel) ChatStreamlyWithSender(ctx context.Context, modelName st
 		}
 	}
 
+	// Request token usage in streaming response. DeepSeek only includes
+	// usage when stream_options.include_usage is set.
+	reqBody["stream_options"] = map[string]any{"include_usage": true}
+
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)


### PR DESCRIPTION
## Summary

DeepSeek and Azure OpenAI require `stream_options.include_usage=true` to return token usage in streaming responses. Without it, all streaming calls report zero usage to ClickHouse and the UI shows no token stats.

## Changes

- `internal/entity/models/deepseek.go`: add `stream_options.include_usage` in `ChatStreamlyWithSender`
- `internal/entity/models/azure_openai.go`: add `stream_options.include_usage` in `ChatStreamlyWithSender`

## Test plan

- [x] Verify DeepSeek streaming calls now report usage
- [x] Verify Azure OpenAI streaming calls now report usage