### PR TITLE
fix: honor the thinking toggle for Moonshot kimi models in the Go chat pipeline

### DIFF
--- a/internal/entity/models/moonshot.go
+++ b/internal/entity/models/moonshot.go
@@ -82,12 +82,12 @@ func validateMoonshotModelName(modelName string) (string, error) {
 }
 
 // applyMoonshotThinkingPolicy injects the `thinking` directive into the
-// request body and applies the kimi-k2.5/k2.6 parameter policy (mirroring
-// the Python `_apply_model_family_policies` behavior): those models ignore
-// temperature and require pinned top_p / penalty values.
+// request body for any model, and applies the kimi-k2.5/k2.6 parameter
+// policy (mirroring the Python `_apply_model_family_policies` behavior)
+// only to those models: they ignore temperature and require pinned top_p /
+// penalty values.
 func applyMoonshotThinkingPolicy(reqBody map[string]interface{}, modelName string, chatModelConfig *ChatConfig) {
-	thinkingSet := chatModelConfig != nil && chatModelConfig.Thinking != nil
-	if thinkingSet {
+	if chatModelConfig != nil && chatModelConfig.Thinking != nil {
 		thinkingType := "disabled"
 		if *chatModelConfig.Thinking {
 			thinkingType = "enabled"
@@ -96,7 +96,7 @@ func applyMoonshotThinkingPolicy(reqBody map[string]interface{}, modelName strin
 	}
 
 	modelLower := strings.ToLower(modelName)
-	if thinkingSet || strings.Contains(modelLower, "kimi-k2.5") || strings.Contains(modelLower, "kimi-k2.6") {
+	if strings.Contains(modelLower, "kimi-k2.5") || strings.Contains(modelLower, "kimi-k2.6") {
 		delete(reqBody, "temperature")
 		reqBody["top_p"] = 0.95
 		reqBody["n"] = 1

--- a/internal/entity/models/moonshot.go
+++ b/internal/entity/models/moonshot.go
@@ -81,6 +81,30 @@ func validateMoonshotModelName(modelName string) (string, error) {
 	return strings.TrimSpace(modelName), nil
 }
 
+// applyMoonshotThinkingPolicy injects the `thinking` directive into the
+// request body and applies the kimi-k2.5/k2.6 parameter policy (mirroring
+// the Python `_apply_model_family_policies` behavior): those models ignore
+// temperature and require pinned top_p / penalty values.
+func applyMoonshotThinkingPolicy(reqBody map[string]interface{}, modelName string, chatModelConfig *ChatConfig) {
+	thinkingSet := chatModelConfig != nil && chatModelConfig.Thinking != nil
+	if thinkingSet {
+		thinkingType := "disabled"
+		if *chatModelConfig.Thinking {
+			thinkingType = "enabled"
+		}
+		reqBody["thinking"] = map[string]interface{}{"type": thinkingType}
+	}
+
+	modelLower := strings.ToLower(modelName)
+	if thinkingSet || strings.Contains(modelLower, "kimi-k2.5") || strings.Contains(modelLower, "kimi-k2.6") {
+		delete(reqBody, "temperature")
+		reqBody["top_p"] = 0.95
+		reqBody["n"] = 1
+		reqBody["presence_penalty"] = 0.0
+		reqBody["frequency_penalty"] = 0.0
+	}
+}
+
 func (m *MoonshotModel) ChatWithMessages(ctx context.Context, modelName string, messages []Message, apiConfig *APIConfig, chatModelConfig *ChatConfig, modelUsage *common.ModelUsage) (*ChatResponse, error) {
 	if err := m.baseModel.APIConfigCheck(apiConfig); err != nil {
 		return nil, err
@@ -99,21 +123,7 @@ func (m *MoonshotModel) ChatWithMessages(ctx context.Context, modelName string, 
 	}
 	url := fmt.Sprintf("%s/%s", resolvedBaseURL, m.baseModel.URLSuffix.Chat)
 	reqBody := buildRequestBody(chatModelConfig, modelName, messages, false)
-
-	if chatModelConfig != nil {
-		if chatModelConfig.Thinking != nil {
-			if *chatModelConfig.Thinking {
-				reqBody["thinking"] = map[string]interface{}{
-					"type": "enabled",
-				}
-			} else {
-				reqBody["thinking"] = map[string]interface{}{
-					"type": "disabled",
-				}
-			}
-		}
-
-	}
+	applyMoonshotThinkingPolicy(reqBody, modelName, chatModelConfig)
 
 	body, err := m.baseModel.doRequest(ctx, url, apiConfig, reqBody, nonStreamCallTimeout)
 	if err != nil {
@@ -146,20 +156,7 @@ func (m *MoonshotModel) ChatStreamlyWithSender(ctx context.Context, modelName st
 	}
 	url := fmt.Sprintf("%s/%s", resolvedBaseURL, m.baseModel.URLSuffix.Chat)
 	reqBody := buildRequestBody(chatModelConfig, modelName, messages, true)
-
-	if chatModelConfig != nil {
-		if chatModelConfig.Thinking != nil {
-			if *chatModelConfig.Thinking {
-				reqBody["thinking"] = map[string]interface{}{
-					"type": "enabled",
-				}
-			} else {
-				reqBody["thinking"] = map[string]interface{}{
-					"type": "disabled",
-				}
-			}
-		}
-	}
+	applyMoonshotThinkingPolicy(reqBody, modelName, chatModelConfig)
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/entity/models/moonshot_test.go
+++ b/internal/entity/models/moonshot_test.go
@@ -186,6 +186,105 @@ func TestMoonshotChatSupportsTools(t *testing.T) {
 	}
 }
 
+func TestMoonshotChatNonKimiThinkingPreservesSampling(t *testing.T) {
+	withSSRFBypass(t)
+	ctx := t.Context()
+	srv := newMoonshotServer(t, func(t *testing.T, _ *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		thinking, ok := body["thinking"].(map[string]interface{})
+		if !ok || thinking["type"] != "enabled" {
+			t.Errorf("thinking=%#v, want type=enabled", body["thinking"])
+		}
+		if body["temperature"] != 0.7 {
+			t.Errorf("temperature=%v, want 0.7", body["temperature"])
+		}
+		if body["top_p"] != 0.8 {
+			t.Errorf("top_p=%v, want 0.8", body["top_p"])
+		}
+		for _, key := range []string{"n", "presence_penalty", "frequency_penalty"} {
+			if _, ok := body[key]; ok {
+				t.Errorf("%s=%v, want absent for non-Kimi model", key, body[key])
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "pong"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	thinking := true
+	temperature := 0.7
+	topP := 0.8
+	resp, err := newMoonshotForTest(srv.URL).ChatWithMessages(
+		ctx,
+		"moonshot-v1-8k",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{
+			Thinking:    &thinking,
+			Temperature: &temperature,
+			TopP:        &topP,
+		}, nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if resp.Answer == nil || *resp.Answer != "pong" {
+		t.Errorf("Answer=%v, want pong", resp.Answer)
+	}
+}
+
+func TestMoonshotChatKimiThinkingAppliesSamplingPolicy(t *testing.T) {
+	withSSRFBypass(t)
+	ctx := t.Context()
+	srv := newMoonshotServer(t, func(t *testing.T, _ *http.Request, body map[string]interface{}, w http.ResponseWriter) {
+		thinking, ok := body["thinking"].(map[string]interface{})
+		if !ok || thinking["type"] != "enabled" {
+			t.Errorf("thinking=%#v, want type=enabled", body["thinking"])
+		}
+		if _, ok := body["temperature"]; ok {
+			t.Errorf("temperature=%v, want deleted", body["temperature"])
+		}
+		if body["top_p"] != 0.95 {
+			t.Errorf("top_p=%v, want 0.95", body["top_p"])
+		}
+		if body["n"] != float64(1) {
+			t.Errorf("n=%v, want 1", body["n"])
+		}
+		if body["presence_penalty"] != 0.0 {
+			t.Errorf("presence_penalty=%v, want 0", body["presence_penalty"])
+		}
+		if body["frequency_penalty"] != 0.0 {
+			t.Errorf("frequency_penalty=%v, want 0", body["frequency_penalty"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{"content": "pong"},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	thinking := true
+	temperature := 0.7
+	resp, err := newMoonshotForTest(srv.URL).ChatWithMessages(
+		ctx,
+		"kimi-k2.5",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Thinking: &thinking, Temperature: &temperature}, nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if resp.Answer == nil || *resp.Answer != "pong" {
+		t.Errorf("Answer=%v, want pong", resp.Answer)
+	}
+}
+
 func TestMoonshotChatParsesCompletionSchema(t *testing.T) {
 	withSSRFBypass(t)
 	ctx := t.Context()

--- a/internal/entity/models/reasoning_family_provider_test.go
+++ b/internal/entity/models/reasoning_family_provider_test.go
@@ -174,3 +174,99 @@ func assertThinkingResponse(t *testing.T, resp *ChatResponse) {
 		t.Fatalf("ReasonContent=%v, want reasoning", resp.ReasonContent)
 	}
 }
+
+// TestMoonshotChatSendsThinkingDisabled verifies that disabling thinking
+// produces `thinking: {type: "disabled"}` on the wire and applies the
+// kimi-k2.6 parameter policy (temperature dropped, top_p/penalties pinned),
+// mirroring the Python model-family policy.
+func TestMoonshotChatSendsThinkingDisabled(t *testing.T) {
+	withSSRFBypass(t)
+	ctx := t.Context()
+	srv := newReasoningFamilyChatServer(t, func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if body["model"] != "kimi-k2.6" {
+			t.Errorf("model=%v, want kimi-k2.6", body["model"])
+		}
+		thinking, ok := body["thinking"].(map[string]interface{})
+		if !ok || thinking["type"] != "disabled" {
+			t.Errorf("thinking=%#v, want {type: disabled}", body["thinking"])
+		}
+		if _, present := body["temperature"]; present {
+			t.Errorf("temperature=%v, want absent", body["temperature"])
+		}
+		if body["top_p"] != 0.95 {
+			t.Errorf("top_p=%v, want 0.95", body["top_p"])
+		}
+		if body["n"] != float64(1) {
+			t.Errorf("n=%v, want 1", body["n"])
+		}
+		if body["presence_penalty"] != float64(0) || body["frequency_penalty"] != float64(0) {
+			t.Errorf("penalties=%v/%v, want 0/0", body["presence_penalty"], body["frequency_penalty"])
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content": "<think>\nreasoning</think>\nanswer",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	thinking := false
+	temperature := 0.0
+	topP := 0.0
+	resp, err := NewMoonshotModel(
+		map[string]string{"default": srv.URL},
+		URLSuffix{Chat: "chat/completions"},
+	).ChatWithMessages(
+		ctx,
+		"kimi-k2.6",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{Thinking: &thinking, Temperature: &temperature, TopP: &topP},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	assertThinkingResponse(t, resp)
+}
+
+// TestMoonshotChatOmitsThinkingWhenUnset verifies no thinking directive is
+// sent when the config leaves it unset (the UI "default" option).
+func TestMoonshotChatOmitsThinkingWhenUnset(t *testing.T) {
+	withSSRFBypass(t)
+	ctx := t.Context()
+	srv := newReasoningFamilyChatServer(t, func(t *testing.T, body map[string]interface{}, w http.ResponseWriter) {
+		if _, present := body["thinking"]; present {
+			t.Errorf("thinking=%#v, want absent", body["thinking"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]interface{}{
+					"content": "<think>\nreasoning</think>\nanswer",
+				},
+			}},
+		})
+	})
+	defer srv.Close()
+
+	apiKey := "test-key"
+	resp, err := NewMoonshotModel(
+		map[string]string{"default": srv.URL},
+		URLSuffix{Chat: "chat/completions"},
+	).ChatWithMessages(
+		ctx,
+		"moonshot-v1-8k",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &apiKey},
+		&ChatConfig{},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	assertThinkingResponse(t, resp)
+}

--- a/internal/service/chat_pipeline.go
+++ b/internal/service/chat_pipeline.go
@@ -4174,6 +4174,38 @@ func kbTenantIDStrings(kbs []*entity.Knowledgebase) []string {
 	return out
 }
 
+// thinkingFromSetting normalizes the `thinking` setting into a *bool.
+// The web UI stores it as an enum string ("default" / "enabled" /
+// "disabled"); older dialogs and API callers may use a bool or the
+// {"type": "enabled"|"disabled"} dict form. Returns nil for "default"
+// or unrecognized values so no thinking directive is sent.
+func thinkingFromSetting(v interface{}) *bool {
+	switch t := v.(type) {
+	case bool:
+		return &t
+	case string:
+		return thinkingFromString(t)
+	case map[string]interface{}:
+		if s, ok := t["type"].(string); ok {
+			return thinkingFromString(s)
+		}
+	}
+	return nil
+}
+
+func thinkingFromString(s string) *bool {
+	var b bool
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "enabled":
+		b = true
+	case "disabled":
+		b = false
+	default:
+		return nil
+	}
+	return &b
+}
+
 // BuildChatConfig converts the dialog's LLM setting (with optional
 // per-request overrides) into a typed ChatConfig for the LLM driver.
 // Dialog values are read first; request config values win when present.
@@ -4184,8 +4216,8 @@ func BuildChatConfig(dialog *entity.Chat, config map[string]interface{}) *modelM
 		if v, ok := dialog.LLMSetting["stream"].(bool); ok {
 			cfg.Stream = &v
 		}
-		if v, ok := dialog.LLMSetting["thinking"].(bool); ok {
-			cfg.Thinking = &v
+		if v, present := dialog.LLMSetting["thinking"]; present {
+			cfg.Thinking = thinkingFromSetting(v)
 		}
 		if v, ok := dialog.LLMSetting["max_tokens"].(float64); ok {
 			i := int(v)
@@ -4224,8 +4256,8 @@ func BuildChatConfig(dialog *entity.Chat, config map[string]interface{}) *modelM
 		if v, ok := config["stream"].(bool); ok {
 			cfg.Stream = &v
 		}
-		if v, ok := config["thinking"].(bool); ok {
-			cfg.Thinking = &v
+		if v, present := config["thinking"]; present {
+			cfg.Thinking = thinkingFromSetting(v)
 		}
 		if v, ok := config["max_tokens"].(float64); ok {
 			i := int(v)

--- a/internal/service/chat_pipeline_test.go
+++ b/internal/service/chat_pipeline_test.go
@@ -1462,3 +1462,48 @@ func TestBuildChatConfig_FromEmptyDialog(t *testing.T) {
 		t.Fatalf("expected temperature %v, got %v", temp, cfg.Temperature)
 	}
 }
+
+// TestBuildChatConfig_ThinkingForms pins down the accepted `thinking`
+// representations: the web UI stores an enum string ("default"/"enabled"/
+// "disabled"), while API callers may use a bool or {"type": ...} dict.
+func TestBuildChatConfig_ThinkingForms(t *testing.T) {
+	cases := []struct {
+		name  string
+		value interface{}
+		want  *bool
+	}{
+		{"string enabled", "enabled", ptrBool(true)},
+		{"string disabled", "disabled", ptrBool(false)},
+		{"string default", "default", nil},
+		{"bool true", true, ptrBool(true)},
+		{"bool false", false, ptrBool(false)},
+		{"dict enabled", map[string]interface{}{"type": "enabled"}, ptrBool(true)},
+		{"dict disabled", map[string]interface{}{"type": "disabled"}, ptrBool(false)},
+		{"unknown string", "auto", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dialog := &entity.Chat{LLMSetting: entity.JSONMap{"thinking": tc.value}}
+			cfg := BuildChatConfig(dialog, nil)
+			if tc.want == nil {
+				if cfg.Thinking != nil {
+					t.Fatalf("expected nil Thinking, got %v", *cfg.Thinking)
+				}
+				return
+			}
+			if cfg.Thinking == nil || *cfg.Thinking != *tc.want {
+				t.Fatalf("expected Thinking %v, got %v", *tc.want, cfg.Thinking)
+			}
+		})
+	}
+}
+
+// TestBuildChatConfig_ThinkingRequestOverride verifies a request-level
+// string override wins over the dialog setting.
+func TestBuildChatConfig_ThinkingRequestOverride(t *testing.T) {
+	dialog := &entity.Chat{LLMSetting: entity.JSONMap{"thinking": "enabled"}}
+	cfg := BuildChatConfig(dialog, map[string]interface{}{"thinking": "disabled"})
+	if cfg.Thinking == nil || *cfg.Thinking {
+		t.Fatalf("expected Thinking=false from request override, got %v", cfg.Thinking)
+	}
+}


### PR DESCRIPTION
### Summary

Disabling the "Thinking" switch in the chat dialog had no effect for Moonshot kimi models (e.g. kimi-k2.6) served by the Go backend: the assistant still returned a Thought block. The Python backend handles this correctly.

Root cause: the web UI stores the thinking switch in `llm_setting` as an enum string (`default`/`enabled`/`disabled`), but `BuildChatConfig` in `internal/service/chat_pipeline.go` only asserted a `bool`. The failed type assertion silently left `ChatConfig.Thinking` nil, so the Moonshot driver never sent `thinking: {type: "disabled"}` and kimi-k2.6 kept its default reasoning behavior.

Changes:
- `BuildChatConfig` now normalizes the `thinking` setting from all forms used across the product: bool, enum string, and the `{"type": "enabled"|"disabled"}` dict (matching the Python `_thinking_type` handling). `default` means no directive is sent. Applies to both dialog settings and per-request overrides.
- The Moonshot driver gains a single `applyMoonshotThinkingPolicy` (deduplicating the stream/non-stream paths) that injects the `thinking` directive and applies the kimi-k2.5/k2.6 parameter policy — drop `temperature`, pin `top_p=0.95`, `n=1`, `presence_penalty=0`, `frequency_penalty=0` — mirroring the Python model-family policy.
- Added unit tests covering the accepted thinking forms, request-level override, and the Moonshot wire payload for both disabled and unset thinking.