### PR TITLE
Fix duplicate document names when linking files to a dataset

### DIFF
--- a/internal/service/document/file2document.go
+++ b/internal/service/document/file2document.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"ragflow/internal/service"
 	"strings"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -162,11 +163,21 @@ func (s *File2DocumentService) LinkToDatasets(ctx context.Context, userID string
 	return nil
 }
 
+// convertFilesMu serializes background conversions. LinkToDatasets runs
+// convertFiles in a fire-and-forget goroutine per request, so two concurrent
+// link requests could otherwise interleave their "list existing names → pick a
+// unique name → insert" sequences and both insert the same document name into
+// the same KB.
+var convertFilesMu sync.Mutex
+
 // convertFiles mirrors Python _convert_files: for each file, depending on mode,
 // either remove existing documents/mappings (replace) or keep them and skip
 // already-linked KBs (add), then create a new document in each target KB and
 // a fresh mapping.
 func (s *File2DocumentService) convertFiles(ctx context.Context, fileIDs, kbIDs []string, userID, mode string) error {
+	convertFilesMu.Lock()
+	defer convertFilesMu.Unlock()
+
 	replaceExisting := mode != "add"
 	for _, fileID := range fileIDs {
 		mappings, err := s.file2DocumentDAO.GetByFileID(ctx, dao.DB, fileID)

--- a/internal/service/document/file2document_test.go
+++ b/internal/service/document/file2document_test.go
@@ -1,0 +1,176 @@
+package document
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"ragflow/internal/dao"
+	"ragflow/internal/entity"
+	"ragflow/internal/utility"
+)
+
+// linkTestFixture bundles a KB plus a helper to create source files for
+// convertFiles tests.
+type linkTestFixture struct {
+	kbID     string
+	tenantID string
+	create   func(t *testing.T, name string) *entity.File
+}
+
+func setupLinkTest(t *testing.T) *linkTestFixture {
+	t.Helper()
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+
+	fx := &linkTestFixture{
+		kbID:     utility.GenerateUUID(),
+		tenantID: utility.GenerateUUID(),
+	}
+	kb := &entity.Knowledgebase{
+		ID:           fx.kbID,
+		Name:         "kb",
+		TenantID:     fx.tenantID,
+		ParserID:     "naive",
+		ParserConfig: entity.JSONMap{},
+	}
+	if err := db.Create(kb).Error; err != nil {
+		t.Fatalf("create kb: %v", err)
+	}
+	fx.create = func(t *testing.T, name string) *entity.File {
+		t.Helper()
+		f := &entity.File{
+			ID:       utility.GenerateUUID(),
+			ParentID: utility.GenerateUUID(),
+			TenantID: fx.tenantID,
+			Name:     name,
+			Type:     "pdf",
+			Size:     100,
+		}
+		if err := db.Create(f).Error; err != nil {
+			t.Fatalf("create file: %v", err)
+		}
+		return f
+	}
+	return fx
+}
+
+func docNamesInKB(t *testing.T, kbID string) []string {
+	t.Helper()
+	names, err := dao.NewDocumentDAO().ListNamesByKbID(context.Background(), dao.DB, kbID)
+	if err != nil {
+		t.Fatalf("list doc names: %v", err)
+	}
+	return names
+}
+
+func assertNoDuplicateNames(t *testing.T, names []string) {
+	t.Helper()
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		if seen[n] {
+			t.Fatalf("duplicate document name in KB: %q (all: %v)", n, names)
+		}
+		seen[n] = true
+	}
+}
+
+// Linking the same file twice in add mode must not create a second document.
+func TestConvertFilesAddModeSkipsAlreadyLinkedKB(t *testing.T) {
+	fx := setupLinkTest(t)
+	ctx := context.Background()
+	svc := NewFile2DocumentService()
+	f := fx.create(t, "laws.pdf")
+
+	for i := 0; i < 2; i++ {
+		if err := svc.convertFiles(ctx, []string{f.ID}, []string{fx.kbID}, "user1", "add"); err != nil {
+			t.Fatalf("convert %d: %v", i, err)
+		}
+	}
+
+	names := docNamesInKB(t, fx.kbID)
+	if len(names) != 1 || names[0] != "laws.pdf" {
+		t.Fatalf("expected a single laws.pdf document, got %v", names)
+	}
+}
+
+// Linking two different files sharing a name must auto-rename the second
+// document instead of creating duplicate names in the KB.
+func TestConvertFilesAddModeRenamesNameCollision(t *testing.T) {
+	fx := setupLinkTest(t)
+	ctx := context.Background()
+	svc := NewFile2DocumentService()
+	f1 := fx.create(t, "laws.pdf")
+	f2 := fx.create(t, "laws.pdf")
+
+	if err := svc.convertFiles(ctx, []string{f1.ID}, []string{fx.kbID}, "user1", "add"); err != nil {
+		t.Fatalf("first convert: %v", err)
+	}
+	if err := svc.convertFiles(ctx, []string{f2.ID}, []string{fx.kbID}, "user1", "add"); err != nil {
+		t.Fatalf("second convert: %v", err)
+	}
+
+	names := docNamesInKB(t, fx.kbID)
+	if len(names) != 2 {
+		t.Fatalf("expected 2 documents, got %v", names)
+	}
+	assertNoDuplicateNames(t, names)
+}
+
+// Re-linking in replace mode removes the previous document, leaving exactly
+// one document with the original name.
+func TestConvertFilesReplaceModeKeepsSingleDocument(t *testing.T) {
+	fx := setupLinkTest(t)
+	ctx := context.Background()
+	svc := NewFile2DocumentService()
+	f := fx.create(t, "laws.pdf")
+
+	for i := 0; i < 2; i++ {
+		if err := svc.convertFiles(ctx, []string{f.ID}, []string{fx.kbID}, "user1", "replace"); err != nil {
+			t.Fatalf("convert %d: %v", i, err)
+		}
+	}
+
+	names := docNamesInKB(t, fx.kbID)
+	if len(names) != 1 || names[0] != "laws.pdf" {
+		t.Fatalf("expected a single laws.pdf document, got %v", names)
+	}
+}
+
+// Concurrent link requests (the endpoint is fire-and-forget) must not race the
+// name check and insert duplicate document names into the same KB.
+func TestConvertFilesConcurrentLinksNoDuplicateNames(t *testing.T) {
+	fx := setupLinkTest(t)
+	ctx := context.Background()
+	svc := NewFile2DocumentService()
+
+	const n = 8
+	files := make([]*entity.File, 0, n)
+	for i := 0; i < n; i++ {
+		files = append(files, fx.create(t, "laws.pdf"))
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for _, f := range files {
+		wg.Add(1)
+		go func(fileID string) {
+			defer wg.Done()
+			if err := svc.convertFiles(ctx, []string{fileID}, []string{fx.kbID}, "user1", "add"); err != nil {
+				errs <- fmt.Errorf("convert %s: %w", fileID, err)
+			}
+		}(f.ID)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	names := docNamesInKB(t, fx.kbID)
+	if len(names) != n {
+		t.Fatalf("expected %d documents, got %v", n, names)
+	}
+	assertNoDuplicateNames(t, names)
+}


### PR DESCRIPTION
### Summary

In file management, moving a file into a folder that already contains a same-named file is rejected (`400 Duplicated file name in the same folder.`), but linking a file to a knowledge base that already contains a same-named document was allowed, leaving two documents with the same name in the dataset.

The link endpoint (`POST /api/v1/files/link-to-datasets`) is fire-and-forget: `convertFiles` runs in a background goroutine per request. Its "list existing document names -> pick a unique name -> insert" sequence had no synchronization, so two concurrent link requests could interleave and both insert the same document name into the same KB.

This PR serializes background conversions with a mutex so the unique-name check and insert are atomic across concurrent requests, and adds regression tests covering:

- add mode: re-linking the same file does not create a second document
- add mode: linking a different file with a colliding name auto-renames (e.g. `laws(1).pdf`), mirroring Python `duplicate_name`
- replace mode: re-linking keeps exactly one document with the original name
- concurrent link requests never produce duplicate document names in the same KB