### PR TITLE
fix: preserve raptor tree titles

### DIFF
--- a/rag/advanced_rag/knowlege_compile/raptor.py
+++ b/rag/advanced_rag/knowlege_compile/raptor.py
@@ -231,12 +231,14 @@ class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
                     "",
                     cnt,
                 )
+                cnt = str(cnt or "").strip()
                 logging.debug(f"SUM: {cnt}")
 
                 self._check_task_canceled(task_id, "before embedding")
 
                 embds = await self._embedding_encode(cnt)
-                return cnt.split("\n")[0], cnt, embds
+                title = cnt.splitlines()[0].strip() if cnt else ""
+                return title, cnt, embds
         except TaskCanceledException:
             raise
         except Exception as exc:


### PR DESCRIPTION
### What problem does this PR solve?

RAPTOR summaries with leading whitespace could produce empty tree node titles, causing parent-child relations to be discarded as self-loops.

This change trims the model output before extracting the first-line title.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)