### PR TITLE
fix(go-api): reject duplicated MCP server name on update

### DIFF
--- a/internal/service/mcp.go
+++ b/internal/service/mcp.go
@@ -316,6 +316,15 @@ func (s *MCPService) UpdateMCPServer(ctx context.Context, tenantID, mcpID string
 	if serverName != "" && len([]byte(serverName)) > mcpServerNameLimit {
 		return nil, common.CodeDataError, fmt.Errorf("Invalid MCP name or length is %d which is large than 255.", len([]byte(serverName)))
 	}
+	if serverNameProvided && serverName != server.Name {
+		exists, err := s.mcpServerDAO.ExistsByNameAndTenant(ctx, dao.DB, serverName, tenantID)
+		if err != nil {
+			return nil, common.CodeServerError, err
+		}
+		if exists {
+			return nil, common.CodeDataError, errors.New("duplicated MCP server name")
+		}
+	}
 
 	serverURL := server.URL
 	serverURLProvided := false

--- a/internal/service/mcp_test.go
+++ b/internal/service/mcp_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"ragflow/internal/common"
 	"ragflow/internal/entity"
 )
 
@@ -36,6 +37,54 @@ func TestIsValidMCPServerType(t *testing.T) {
 		if isValidMCPServerType(v) {
 			t.Errorf("expected %q to be an invalid MCP server type", v)
 		}
+	}
+}
+
+func TestUpdateMCPServerRejectsDuplicatedName(t *testing.T) {
+	testDB := setupServiceTestDB(t)
+	if err := testDB.AutoMigrate(&entity.MCPServer{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pushServiceDB(t, testDB)
+
+	const tenantID = "tenant-1"
+	for _, srv := range []*entity.MCPServer{
+		{ID: "mcp-1", Name: "alpha", TenantID: tenantID, URL: "http://example.com/sse", ServerType: mcpServerTypeSSE},
+		{ID: "mcp-2", Name: "beta", TenantID: tenantID, URL: "http://example.com/sse", ServerType: mcpServerTypeSSE},
+	} {
+		if err := testDB.Create(srv).Error; err != nil {
+			t.Fatalf("create mcp server: %v", err)
+		}
+	}
+
+	s := NewMCPService()
+	ctx := t.Context()
+
+	nameReq := func(name string) UpdateMCPServerRequest {
+		raw, err := json.Marshal(name)
+		if err != nil {
+			t.Fatalf("marshal name: %v", err)
+		}
+		return UpdateMCPServerRequest{"name": raw}
+	}
+
+	// Renaming to an existing server name of the same tenant is rejected.
+	if _, code, err := s.UpdateMCPServer(ctx, tenantID, "mcp-1", nameReq("beta")); err == nil || code != common.CodeDataError {
+		t.Errorf("expected duplicated name data error, got code=%v err=%v", code, err)
+	}
+
+	// Keeping the current name is allowed.
+	if _, code, err := s.UpdateMCPServer(ctx, tenantID, "mcp-1", nameReq("alpha")); err != nil || code != common.CodeSuccess {
+		t.Errorf("expected success keeping current name, got code=%v err=%v", code, err)
+	}
+
+	// Renaming to a fresh name is allowed.
+	updated, code, err := s.UpdateMCPServer(ctx, tenantID, "mcp-1", nameReq("gamma"))
+	if err != nil || code != common.CodeSuccess {
+		t.Fatalf("expected success renaming to fresh name, got code=%v err=%v", code, err)
+	}
+	if updated.Name != "gamma" {
+		t.Errorf("expected renamed server name %q, got %q", "gamma", updated.Name)
 	}
 }
 


### PR DESCRIPTION
### Summary

The Go `UpdateMCPServer` endpoint only validated the name length, so an MCP server could be renamed to a name already used by another server of the same tenant, while `CreateMCPServer` rejects duplicated names. This inconsistency allowed duplicate MCP server names to appear through the edit/rename flow.

This PR mirrors the Python update API behavior: when a new name is provided and differs from the current one, it checks `ExistsByNameAndTenant` and returns a data error (`duplicated MCP server name`) on conflict. Keeping the current name or renaming to a fresh name still succeeds.

A unit test (`TestUpdateMCPServerRejectsDuplicatedName`, in-memory SQLite, unit tier) covers three cases: renaming to an existing name is rejected, keeping the current name succeeds, and renaming to a fresh name succeeds.