### PR TITLE
fix: allow empty kb_ids when linking files to datasets

### DIFF
--- a/internal/handler/file.go
+++ b/internal/handler/file.go
@@ -551,17 +551,19 @@ func (h *FileHandler) LinkToDatasets(c *gin.Context) {
 
 	var req document.LinkToDatasetsRequest
 	// Tolerate bind errors: a malformed or empty body simply leaves the fields
-	// empty, which the validate_request-style check below reports as missing
+	// nil, which the validate_request-style check below reports as missing
 	// arguments — matching Python's @validate_request behaviour and code.
 	_ = c.ShouldBindJSON(&req)
 
-	// Mirror Python @validate_request("file_ids", "kb_ids"): missing arguments
-	// return ARGUMENT_ERROR (101) with data=null and the aggregated message.
+	// Mirror Python @validate_request("file_ids", "kb_ids"): a key absent from
+	// the body returns ARGUMENT_ERROR (101) with data=null and the aggregated
+	// message. Python's check is key-presence based, so an explicit empty list
+	// is valid — e.g. kb_ids: [] in replace mode unlinks all datasets.
 	var missing []string
-	if len(req.FileIDs) == 0 {
+	if req.FileIDs == nil {
 		missing = append(missing, "file_ids")
 	}
-	if len(req.KbIDs) == 0 {
+	if req.KbIDs == nil {
 		missing = append(missing, "kb_ids")
 	}
 	if len(missing) > 0 {


### PR DESCRIPTION
### Summary

In the Go file manager, saving the "Link Knowledge Base" dialog after removing all linked datasets sends `kb_ids: []` to `POST /api/v1/files/link-to-datasets`. The Go handler validated arguments by slice length and rejected the empty list with `101 required argument are missing: kb_ids; `, making it impossible to unlink all knowledge bases from a file.

Python's `@validate_request("file_ids", "kb_ids")` only checks key presence (`arg not in input_arguments`), so an explicit empty list is valid — in replace mode it unlinks all datasets (existing file2document mappings and documents are removed, none are created).

This change checks for a nil slice (key absent) instead of an empty slice, matching the Python semantics. An empty body or missing key still returns 101 as before.

Verified with `bash build.sh --test ./internal/handler/...`.