### PR TITLE
fix: wrap long log messages in agent pipeline log sheet

### DIFF
--- a/web/src/pages/agent/pipeline-log-sheet/dataflow-timeline.tsx
+++ b/web/src/pages/agent/pipeline-log-sheet/dataflow-timeline.tsx
@@ -90,10 +90,12 @@ export function DataflowTimeline({ traceList }: DataflowTimelineProps) {
                             key={idx}
                             className="text-text-secondary text-xs space-x-2 py-2.5 !m-0"
                           >
-                            <span>{x.datetime}</span>
+                            <span className="whitespace-nowrap">
+                              {x.datetime}
+                            </span>
                             {item.component_id !== 'END' && (
                               <span
-                                className={cn({
+                                className={cn('break-all', {
                                   'text-state-error':
                                     x.message.startsWith('[ERROR]'),
                                 })}
@@ -101,7 +103,7 @@ export function DataflowTimeline({ traceList }: DataflowTimelineProps) {
                                 {x.message}
                               </span>
                             )}
-                            <span>
+                            <span className="whitespace-nowrap">
                               {x.elapsed_time.toString().slice(0, 6)}s
                             </span>
                           </section>


### PR DESCRIPTION
### Summary

In the agent pipeline run log sheet, long unbroken log message text (e.g. component names such as `TokenChunker:Modern...`) could not wrap and overflowed the timeline card boundary, causing the text to visually bleed outside the card.

This PR adds `break-all` to the log message span in `web/src/pages/agent/pipeline-log-sheet/dataflow-timeline.tsx` so long messages wrap inside the card, and adds `whitespace-nowrap` to the datetime and elapsed-time spans so these short fields are never split across lines.