### PR TITLE
Fix: dataflow log sheet shows the previous run's log in Go mode

### DIFF
--- a/web/src/pages/agent/hooks/use-run-dataflow.ts
+++ b/web/src/pages/agent/hooks/use-run-dataflow.ts
@@ -1,5 +1,6 @@
 import message from '@/components/ui/message';
 import { useSendMessageBySSE } from '@/hooks/use-send-message';
+import i18n from '@/locales/config';
 import api from '@/utils/api';
 import { get } from 'lodash';
 import { useCallback, useState } from 'react';
@@ -25,6 +26,13 @@ export function useRunDataflow({
       const success = saveRet?.code === 0;
       if (!success) return;
 
+      // The Go backend runs the dataflow debug synchronously, so the new
+      // message_id only arrives with the run response (seconds later).
+      // Clear the previous polling key first so the log sheet renders the
+      // loading state instead of replaying the previous run's log, which is
+      // still within its Redis TTL and would otherwise look like the current
+      // result.
+      setMessageId('');
       showLogSheet();
       const res = await send({
         agent_id: id,
@@ -34,7 +42,14 @@ export function useRunDataflow({
         files: [fileResponseData.file],
       });
 
-      if (res && res?.response.status === 200 && get(res, 'data.code') === 0) {
+      if (!res) {
+        // send() swallowed a network/parse failure; without a new message_id
+        // the sheet would stay on the previous run's log, so surface it.
+        message.error(i18n.t('message.requestError'));
+        return;
+      }
+
+      if (res?.response.status === 200 && get(res, 'data.code') === 0) {
         // fetch canvas
         setUploadedFileData(fileResponseData.file[0]);
         const msgId = get(res, 'data.data.message_id');


### PR DESCRIPTION
### Summary:

In Go mode, after clicking **Run** on a dataflow (data pipeline) canvas, the log sheet displays the previous run's log instead of the current one.

Root cause: the Go backend executes the dataflow debug run fully synchronously (`AgentChatCompletions` → `runCanvasPipelineDebug`), so the new `message_id` only arrives with the run response — typically 10+ seconds later. The front-end, however, opens the log sheet *before* sending the run request while still holding the previous run's `messageId`. Reopening the sheet also resets the stop-polling flag, so the sheet keeps polling the old Redis key (whose payload is still within its 30-minute TTL) and renders the previous run's log. If the run response never yields a new `message_id` (e.g. a swallowed request failure), the stale log stays indefinitely.

Fix (front-end, `web/src/pages/agent/hooks/use-run-dataflow.ts`):
- Clear the trace polling key (`setMessageId('')`) when a run starts. Since the trace query is `enabled: !!messageId`, the old log is dropped immediately and the sheet shows the loading state until the new `message_id` arrives and the current run's log is fetched.
- Surface a `requestError` toast when the run request fails without returning a response, instead of silently staying on the previous run's log.