### PR TITLE
fix: separate raptor node target from output limit

### DIFF
--- a/rag/advanced_rag/knowlege_compile/raptor.py
+++ b/rag/advanced_rag/knowlege_compile/raptor.py
@@ -32,6 +32,8 @@ from rag.graphrag.utils import (
 )
 from common.misc_utils import thread_pool_exec
 
+from ._common import knowledge_compile_gen_conf
+
 
 class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
     """Build RAPTOR summary layers with the classic or Psi tree strategy."""
@@ -221,10 +223,18 @@ class RecursiveAbstractiveProcessing4TreeOrganizedRetrieval:
                     [
                         {
                             "role": "user",
-                            "content": "Beside the summarization, give a title at the first line of your summarization. Must be in the same language as the paragraphs.",
+                            "content": (
+                                "Beside the summarization, give a title at the first line of your summarization. "
+                                "Must be in the same language as the paragraphs. "
+                                f"Keep the summary concise and target approximately {self._max_token} tokens."
+                            ),
                         }
                     ],
-                    {"max_tokens": max(self._max_token, 512)},  # fix issue:  #10235
+                    # ``max_token`` is the target size of the generated node,
+                    # not the provider's per-request output ceiling. Keep the
+                    # provider budget independent so reasoning tokens cannot
+                    # consume the node-size setting and truncate the summary.
+                    knowledge_compile_gen_conf(self._llm_model),
                 )
                 cnt = re.sub(
                     "(······\n由于长度的原因，回答被截断了，要继续吗？|For the content length reason, it stopped, continue?)",


### PR DESCRIPTION
### What problem does this PR solve?

RAPTOR incorrectly used `max_token` as the LLM request output limit, causing DeepSeek reasoning tokens to consume the budget and truncate tree summaries.

This change treats `max_token` as the target summary size and passes the target length through the prompt instead.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)