### PR TITLE
fix(elasticsearch/test): make -tags integration tier compile

### DIFF
--- a/internal/engine/elasticsearch/kg_test.go
+++ b/internal/engine/elasticsearch/kg_test.go
@@ -20,10 +20,11 @@ package elasticsearch
 
 import (
 	"context"
-	"ragflow/internal/common"
 	"testing"
 
+	"ragflow/internal/common"
 	"ragflow/internal/engine/types"
+	"ragflow/internal/server/config"
 )
 
 // TestKGSearchSelectFields verifies that SelectFields overrides default output
@@ -75,7 +76,7 @@ func TestKGSearchSelectFields(t *testing.T) {
 
 // getTestConfig returns a minimal ES config for testing.
 // Reads from environment or uses defaults pointing to localhost.
-func getTestConfig() map[string]interface{} {
+func getTestConfig() config.ElasticsearchConfig {
 	hosts := common.GetEnv(common.EnvESHost)
 	if hosts == "" {
 		hosts = "http://localhost:1200"
@@ -88,9 +89,9 @@ func getTestConfig() map[string]interface{} {
 	if password == "" {
 		password = "infini_rag_flow"
 	}
-	return map[string]interface{}{
-		"hosts":    []string{hosts},
-		"username": username,
-		"password": password,
+	return config.ElasticsearchConfig{
+		Hosts:    hosts,
+		Username: username,
+		Password: password,
 	}
 }


### PR DESCRIPTION
## Problem
`kg_test.go`'s `getTestConfig()` returned `map[string]interface{}`, which no longer matches `NewEngine`'s `config.ElasticsearchConfig` signature after the config package moved to `internal/server/config`. This broke compilation of the `elasticsearch` package under `-tags integration` (kg_test.go:38).

## Fix
Make `getTestConfig()` return the typed `config.ElasticsearchConfig` so the integration tier builds again.

## Scope
Fixes test compilation only; no production code changed. Unrelated to PR #17802 (kb_id single-string + T0 read-back baseline), so it is tracked in its own PR to keep that refactor focused.

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy)