### PR TITLE
docs: remove retired Go Report Card badge

### DIFF
--- a/internal/harness/README.md
+++ b/internal/harness/README.md
@@ -1,7 +1,6 @@
 # Agent Harness Go
 
 [![Go Reference](https://pkg.go.dev/badge/ragflow/internal/harness.svg)](https://pkg.go.dev/ragflow/internal/harness)
-[![Go Report Card](https://goreportcard.com/badge/ragflow/internal/harness)](https://goreportcard.com/report/ragflow/internal/harness)
 
 A Go framework for building **stateful, multi-agent applications** with LLMs. It provides a **graph-based execution engine** (`graphengine/`) with Pregel-style BSP execution, plus a **full Agent Development Kit** (`agentcore/`) built on top of it — supporting ReAct agents, middleware, workflows, checkpointing, human-in-the-loop, and streaming.
 


### PR DESCRIPTION
### Summary

Remove the Go Report Card badge from `internal/harness/README.md` because the service has been retired and no longer provides a repository grade.

This is a documentation-only change. Validated with `git diff --check`.