### PR TITLE
docs(api): correct retrieval missing dataset IDs error

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -2952,7 +2952,7 @@ Failure:
 ```json
 {
     "code": 102,
-    "message": "`datasets` is required."
+    "message": "`dataset_ids` is required."
 }
 ```
 


### PR DESCRIPTION
### Summary

Correct the documented failure response for `POST /api/v1/retrieval`.

The endpoint requires `dataset_ids` and returns `` `dataset_ids` is required. `` when the field is missing, but the HTTP API reference showed `` `datasets` is required. ``. This change aligns the example with the handler and existing regression tests.

### Verification

- `git diff --check`
- Confirmed the exact message in `api/apps/restful_apis/chunk_api.py`
- Confirmed the contract in `test/testcases/restful_api/test_retrieval.py`
- Confirmed the stale `datasets` message no longer appears in the HTTP reference

### Scope

Documentation only; no runtime behavior changes.
