### PR TITLE
fix(agent): reset execution path for new sessions

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -379,6 +379,7 @@ class Canvas(Graph):
         return super().__str__()
 
     def clear_history(self):
+        """Clear conversation and execution state before starting a new session."""
         self.history = []
         if isinstance(self.globals.get("sys.history"), list):
             self.globals["sys.history"] = []

--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -383,6 +383,7 @@ class Canvas(Graph):
         if isinstance(self.globals.get("sys.history"), list):
             self.globals["sys.history"] = []
         self.path = []
+        _logger.debug("Canvas history and execution path reset")
 
     def reset(self, mem=False):
         super().reset()

--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -382,6 +382,7 @@ class Canvas(Graph):
         self.history = []
         if isinstance(self.globals.get("sys.history"), list):
             self.globals["sys.history"] = []
+        self.path = []
 
     def reset(self, mem=False):
         super().reset()

--- a/test/unit_test/agent/test_canvas_session_reset.py
+++ b/test/unit_test/agent/test_canvas_session_reset.py
@@ -6,6 +6,7 @@ from types import ModuleType, SimpleNamespace
 
 
 def _stub(monkeypatch, name, **attrs):
+    """Install a minimal dependency module for the isolated Canvas import."""
     module = ModuleType(name)
     for key, value in attrs.items():
         setattr(module, key, value)
@@ -13,6 +14,7 @@ def _stub(monkeypatch, name, **attrs):
 
 
 def _load_canvas_module(monkeypatch):
+    """Load agent.canvas while replacing its runtime service dependencies."""
     _stub(monkeypatch, "agent.component", component_class=lambda _name: None)
     _stub(monkeypatch, "agent.component.base", ComponentBase=object)
     _stub(monkeypatch, "agent.dsl_migration", normalize_chunker_dsl=lambda dsl: dsl)
@@ -47,6 +49,7 @@ def _load_canvas_module(monkeypatch):
 
 
 def test_clear_history_resets_inherited_execution_path(monkeypatch):
+    """A new session must not inherit the previous replica's workflow path."""
     module = _load_canvas_module(monkeypatch)
     canvas = module.Canvas.__new__(module.Canvas)
     canvas.history = [{"role": "user", "content": "previous session"}]

--- a/test/unit_test/agent/test_canvas_session_reset.py
+++ b/test/unit_test/agent/test_canvas_session_reset.py
@@ -1,0 +1,60 @@
+import contextvars
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _stub(monkeypatch, name, **attrs):
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+def _load_canvas_module(monkeypatch):
+    _stub(monkeypatch, "agent.component", component_class=lambda _name: None)
+    _stub(monkeypatch, "agent.component.base", ComponentBase=object)
+    _stub(monkeypatch, "agent.dsl_migration", normalize_chunker_dsl=lambda dsl: dsl)
+    _stub(monkeypatch, "api.db.joint_services.tenant_model_service", get_tenant_default_model_by_type=lambda *_args: None)
+    _stub(monkeypatch, "api.db.services.file_service", FileService=object)
+    _stub(monkeypatch, "api.db.services.llm_service", LLMBundle=object)
+    _stub(monkeypatch, "api.db.services.task_service", has_canceled=lambda *_args: False)
+    _stub(monkeypatch, "common.constants", LLMType=SimpleNamespace(CHAT="chat"))
+    _stub(
+        monkeypatch,
+        "common.llm_request_context",
+        set_llm_request_context=lambda **_kwargs: None,
+        reset_llm_request_context=lambda _token: None,
+    )
+    _stub(monkeypatch, "common.exceptions", TaskCanceledException=Exception)
+    _stub(monkeypatch, "common.misc_utils", get_uuid=lambda: "uuid", hash_str2int=lambda value: hash(value))
+    _stub(
+        monkeypatch,
+        "common.token_utils",
+        token_usage_sink=contextvars.ContextVar("token_usage_sink", default=None),
+        langfuse_run_attrs=contextvars.ContextVar("langfuse_run_attrs", default=None),
+    )
+    _stub(monkeypatch, "rag.prompts.generator", chunks_format=lambda *_args: [])
+    _stub(monkeypatch, "rag.utils.redis_conn", REDIS_CONN=SimpleNamespace())
+    _stub(monkeypatch, "rag.utils.tts_cache", synthesize_with_cache=lambda *_args, **_kwargs: None)
+
+    module_path = Path(__file__).resolve().parents[3] / "agent" / "canvas.py"
+    spec = importlib.util.spec_from_file_location("test_canvas_session_reset_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_clear_history_resets_inherited_execution_path(monkeypatch):
+    module = _load_canvas_module(monkeypatch)
+    canvas = module.Canvas.__new__(module.Canvas)
+    canvas.history = [{"role": "user", "content": "previous session"}]
+    canvas.globals = {"sys.history": [{"role": "user"}]}
+    canvas.path = ["begin", "fillup"]
+
+    canvas.clear_history()
+
+    assert canvas.history == []
+    assert canvas.globals["sys.history"] == []
+    assert canvas.path == []


### PR DESCRIPTION
### Review scope

- Production diff: `canvas.py` (`+3/-0`).
- Regression evidence: `test_canvas_session_reset.py` (`+63/-0`).
- The reset change and regression test are intentionally atomic; the test proves a new session cannot inherit the prior execution path.

### Summary

Fixes #17145.

New agent sessions load a per-user runtime replica whose DSL may still contain the previous run's execution `path`. The new-session branch calls `Canvas.clear_history()`, but that method only cleared conversation history, so a workflow paused at `UserFillUp` could continue from the inherited path despite receiving a new session ID.

This change clears `Canvas.path` together with the two history stores. Existing sessions are unaffected because the resume branch does not call `clear_history()`.

### Verification

- Added a regression test that loads the real `Canvas.clear_history()` method with isolated dependency stubs.
- Before the fix: the inherited path remained `["begin", "fillup"]`.
- After the fix: history, `sys.history`, and path are all empty.
- `pytest`: 1 passed
- `ruff check` and `ruff format --check` on the new test: passed
- `git diff --check`: passed

Running Ruff across the existing `agent/canvas.py` reports pre-existing warnings unrelated to this one-line change.