### PR TITLE
fix(ci): allow preflight to cancel duplicate runs

### DIFF
--- a/.github/workflows/sep-tests.yml
+++ b/.github/workflows/sep-tests.yml
@@ -31,14 +31,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ragflow_preflight:
-    name: ragflow_preflight
+  check_duplicate_push:
+    name: check duplicate push
+    if: ${{ github.event_name == 'push' }}
+    runs-on: [ "self-hosted", "ragflow-test" ]
     permissions:
       actions: write
       contents: read
+    steps:
+      - name: Ensure workspace ownership
+        run: |
+          echo "chown -R ${USER} ${GITHUB_WORKSPACE}" && sudo chown -R ${USER} ${GITHUB_WORKSPACE}
+
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Cancel duplicate push
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HEAD=$(git rev-parse HEAD)
+          # Find a PR that introduced a given commit
+          PR_NUMBER=$(gh pr list --repo "${GITHUB_REPOSITORY}" --search "${HEAD}" --state merged --json number --jq '.[0].number')
+          echo "HEAD=${HEAD}"
+          echo "PR_NUMBER=${PR_NUMBER}"
+          if [[ -n "${PR_NUMBER}" ]]; then
+            PR_SHA_FP=${RUNNER_WORKSPACE_PREFIX}/artifacts/${GITHUB_REPOSITORY}/PR_${PR_NUMBER}
+            if [[ -f "${PR_SHA_FP}" ]]; then
+              read -r PR_SHA PR_RUN_ID < "${PR_SHA_FP}"
+              # Calculate the hash of the current workspace content
+              HEAD_SHA=$(git rev-parse HEAD^{tree})
+              if [[ "${HEAD_SHA}" == "${PR_SHA}" ]]; then
+                echo "Cancel myself since the workspace content hash is the same with PR #${PR_NUMBER} merged. See ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${PR_RUN_ID} for details."
+                gh run cancel "${GITHUB_RUN_ID}" --repo "${GITHUB_REPOSITORY}"
+                while true; do
+                  status=$(gh run view "${GITHUB_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --json status -q .status)
+                  [ "${status}" = "completed" ] && break
+                  sleep 5
+                done
+                exit 1
+              fi
+            fi
+          fi
+
+  ragflow_preflight:
+    name: ragflow_preflight
+    needs: check_duplicate_push
+    permissions:
+      contents: read
     # https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution
     # https://github.com/orgs/community/discussions/26261
-    if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci') && (github.event.action != 'labeled' || github.event.label.name == 'ci')) }}
+    if: ${{ always() && (needs.check_duplicate_push.result == 'success' || needs.check_duplicate_push.result == 'skipped') && (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci') && (github.event.action != 'labeled' || github.event.label.name == 'ci'))) }}
     runs-on: [ "self-hosted", "ragflow-test" ]
     outputs:
       http_api_test_level: ${{ steps.test_level.outputs.http_api_test_level }}
@@ -61,35 +107,10 @@ jobs:
           fetch-tags: true
           allow-unsafe-pr-checkout: true
 
-      - name: Check workflow duplication
+      - name: Prepare workflow artifacts
         if: ${{ !cancelled() && !failure() }}
         run: |
-          if [[ ${GITHUB_EVENT_NAME} != "pull_request" && ${GITHUB_EVENT_NAME} != "pull_request_target" && ${GITHUB_EVENT_NAME} != "schedule" ]]; then
-            HEAD=$(git rev-parse HEAD)
-            # Find a PR that introduced a given commit
-            gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-            PR_NUMBER=$(gh pr list --search ${HEAD} --state merged --json number --jq .[0].number)
-            echo "HEAD=${HEAD}"
-            echo "PR_NUMBER=${PR_NUMBER}"
-            if [[ -n "${PR_NUMBER}" ]]; then
-              PR_SHA_FP=${RUNNER_WORKSPACE_PREFIX}/artifacts/${GITHUB_REPOSITORY}/PR_${PR_NUMBER}
-              if [[ -f "${PR_SHA_FP}" ]]; then
-                read -r PR_SHA PR_RUN_ID < "${PR_SHA_FP}"
-                # Calculate the hash of the current workspace content
-                HEAD_SHA=$(git rev-parse HEAD^{tree})
-                if [[ "${HEAD_SHA}" == "${PR_SHA}" ]]; then
-                  echo "Cancel myself since the workspace content hash is the same with PR #${PR_NUMBER} merged. See ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${PR_RUN_ID} for details."
-                  gh run cancel ${GITHUB_RUN_ID}
-                  while true; do
-                    status=$(gh run view ${GITHUB_RUN_ID} --json status -q .status)
-                    [ "${status}" = "completed" ] && break
-                    sleep 5
-                  done
-                  exit 1
-                fi
-              fi
-            fi
-          elif [[ ${GITHUB_EVENT_NAME} == "pull_request" || ${GITHUB_EVENT_NAME} == "pull_request_target" ]]; then
+          if [[ ${GITHUB_EVENT_NAME} == "pull_request" || ${GITHUB_EVENT_NAME} == "pull_request_target" ]]; then
             PR_NUMBER=${{ github.event.pull_request.number }}
             PR_SHA_FP=${RUNNER_WORKSPACE_PREFIX}/artifacts/${GITHUB_REPOSITORY}/PR_${PR_NUMBER}
             # Calculate the hash of the current workspace content

--- a/.github/workflows/sep-tests.yml
+++ b/.github/workflows/sep-tests.yml
@@ -33,6 +33,9 @@ concurrency:
 jobs:
   ragflow_preflight:
     name: ragflow_preflight
+    permissions:
+      actions: write
+      contents: read
     # https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution
     # https://github.com/orgs/community/discussions/26261
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci') && (github.event.action != 'labeled' || github.event.label.name == 'ci')) }}


### PR DESCRIPTION
### Summary

Move duplicate-push cancellation into a dedicated `check_duplicate_push` job that runs only for trusted `push` events and holds the minimal `actions: write` permission. Keep `ragflow_preflight`, which checks out and executes pull request code, restricted to `contents: read`.

The preflight job waits for the push-only duplicate check before starting. Pull request and scheduled runs continue when that job is skipped. PR runs still record their tree hash for the later push comparison.

This fixes reproducible `HTTP 403: Resource not accessible by integration` failures when a `main` push has the same tree as a previously tested PR:

- https://github.com/infiniflow/ragflow/actions/runs/30967404513
- https://github.com/infiniflow/ragflow/actions/runs/30906528300

Validation: `actionlint v1.7.7`; YAML parse and exact permission-isolation assertions; `git diff --check`.