### PR TITLE
Fix embed dialog language label mistranslation

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1237,7 +1237,7 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       languageTip:
         'Allows sentence rewriting with the specified language or defaults to the latest question if not selected.',
       avatarHidden: 'Hide avatar',
-      locale: 'Locale',
+      locale: 'Language',
       selectLanguage: 'Select a language',
       reasoning: 'Reasoning',
       reasoningTip: `Whether to enable a reasoning workflow during question answering, as seen in models like Deepseek-R1 or OpenAI o1. When enabled, this allows the model to access external knowledge and tackle complex questions in a step-by-step manner, leveraging techniques like chain-of-thought reasoning. This approach enhances the model's ability to provide accurate responses by breaking down problems into manageable steps, improving performance on tasks that require logical reasoning and multi-step thinking.`,

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1156,7 +1156,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       cancel: '取消',
       chatSetting: '聊天设置',
       avatarHidden: '隐藏头像',
-      locale: '地区',
+      locale: '语言',
       tocEnhance: 'PageIndex',
       tocEnhanceTip: `解析文档时生成了目录信息（见General方法的'启用目录抽取'），让大模型返回和用户问题相关的目录项，从而利用目录项拿到相关chunk，对这些chunk在排序中进行加权。这种方法来源于模仿人类查询书本中知识的行为逻辑`,
       batchDeleteSessions: '批量删除',


### PR DESCRIPTION
### Summary

The language selector in the agent/chat "Embed into website" dialog uses the `chat.locale` translation key as its label. This key was mistranslated as '地区' (region) in Simplified Chinese and 'Locale' in English, so the field title read as a region setting instead of a language setting in both locales.

This PR renames the label to '语言' (zh) and 'Language' (en) to match the field's actual purpose: selecting the display language of the embedded chat page.