### PR TITLE
fix: allow .bmp uploads in filename type whitelist

### DIFF
--- a/api/utils/file_utils.py
+++ b/api/utils/file_utils.py
@@ -73,7 +73,7 @@ def filename_type(filename):
         return FileType.AURAL.value
 
     if re.match(
-        r".*\.(jpg|jpeg|png|tif|gif|pcx|tga|exif|fpx|svg|psd|cdr|pcd|dxf|ufo|eps|ai|raw|WMF|webp|avif|apng|icon|ico|mpg|mpeg|avi|rm|rmvb|mov|wmv|asf|dat|asx|wvx|mpe|mpa|mp4|avi|mkv)$", filename
+        r".*\.(jpg|jpeg|png|tif|gif|bmp|pcx|tga|exif|fpx|svg|psd|cdr|pcd|dxf|ufo|eps|ai|raw|WMF|webp|avif|apng|icon|ico|mpg|mpeg|avi|rm|rmvb|mov|wmv|asf|dat|asx|wvx|mpe|mpa|mp4|avi|mkv)$", filename
     ):
         return FileType.VISUAL.value
 

--- a/internal/utility/file.go
+++ b/internal/utility/file.go
@@ -157,7 +157,7 @@ func FilenameType(filename string) FileType {
 	}
 
 	visualExtensions := []string{
-		"jpg", "jpeg", "png", "tif", "gif", "pcx", "tga", "exif", "fpx", "svg", "psd", "cdr",
+		"jpg", "jpeg", "png", "tif", "gif", "bmp", "pcx", "tga", "exif", "fpx", "svg", "psd", "cdr",
 		"pcd", "dxf", "ufo", "eps", "ai", "raw", "WMF", "webp", "avif", "apng", "icon", "ico",
 		"mpg", "mpeg", "avi", "rm", "rmvb", "mov", "wmv", "asf", "dat", "asx", "wvx", "mpe",
 		"mpa", "mp4", "mkv",

--- a/internal/utility/filename_type_test.go
+++ b/internal/utility/filename_type_test.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utility
+
+import "testing"
+
+func TestFilenameTypeBMP(t *testing.T) {
+	cases := []struct {
+		name string
+		want FileType
+	}{
+		{"photo.bmp", FileTypeVISUAL},
+		{"PHOTO.BMP", FileTypeVISUAL},
+		{"path/to/lt50M_bmp_image_table.bmp", FileTypeVISUAL},
+		{"x.png", FileTypeVISUAL},
+		{"bad.exe", FileTypeOTHER},
+	}
+	for _, tc := range cases {
+		if got := FilenameType(tc.name); got != tc.want {
+			t.Fatalf("FilenameType(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Frontend `Images` already includes `bmp` (`web/src/constants/common.ts`), and picture parsing already accepts `.bmp` (`internal/parser/parser/picture_parser.go`, `rag/app/picture.py` via Pillow).
- Upload still rejects `.bmp` because the gate functions omit it from the visual whitelist:
  - Python: `api/utils/file_utils.py` → `filename_type()`
  - Go: `internal/utility/file.go` → `FilenameType()` (used by `document_upload.go`)
- Result: `This type of file has not been supported yet!` even for valid BMP files under size limits.
- This PR adds `bmp` to both whitelist sites and a small Go unit test.

## Why this is inconsistent
| Surface | `.bmp` |
|---|---|
| Frontend `Images` / preview | supported |
| `GetFileType()` (Go) | supported |
| Picture parser / MIME map | supported |
| **Upload `filename_type` / `FilenameType`** | **rejected as OTHER** |

## Test plan
- [x] `go test ./internal/utility/ -run TestFilenameTypeBMP`
- [ ] Upload a small `.bmp` via dataset document API → success (type `visual`, parser `picture`)
- [ ] Confirm `.png` / `.jpg` upload behavior unchanged
- [ ] Confirm unsupported extensions (e.g. `.exe`) still rejected


Made with [Cursor](https://cursor.com)