### PR TITLE
feat: populate content_length and max_output from official docs

### DIFF
--- a/conf/models/302ai.json
+++ b/conf/models/302ai.json
@@ -17,7 +17,8 @@
   "models": [
     {
       "name": "kimi-k2.6",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat",
         "vision"
@@ -32,7 +33,8 @@
     },
     {
       "name": "gpt-5.5",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -43,7 +45,8 @@
     },
     {
       "name": "gpt-5.4",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -54,7 +57,8 @@
     },
     {
       "name": "gpt-5.4-mini",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -65,7 +69,8 @@
     },
     {
       "name": "gpt-5.4-nano",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -76,7 +81,8 @@
     },
     {
       "name": "gpt-5.2-pro",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -87,7 +93,8 @@
     },
     {
       "name": "gpt-5.2",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -98,7 +105,8 @@
     },
     {
       "name": "gpt-5.1",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -109,7 +117,8 @@
     },
     {
       "name": "gpt-5.1-chat-latest",
-      "max_tokens": 400000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -120,7 +129,8 @@
     },
     {
       "name": "gpt-5",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -131,7 +141,8 @@
     },
     {
       "name": "gpt-5-mini",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -142,7 +153,8 @@
     },
     {
       "name": "gpt-5-nano",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -153,7 +165,8 @@
     },
     {
       "name": "gpt-5-chat-latest",
-      "max_tokens": 400000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -164,7 +177,8 @@
     },
     {
       "name": "gpt-4.1",
-      "max_tokens": 1047576,
+      "content_length": 1047576,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -175,7 +189,8 @@
     },
     {
       "name": "gpt-4.1-mini",
-      "max_tokens": 1047576,
+      "content_length": 1047576,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -186,7 +201,8 @@
     },
     {
       "name": "gpt-4.1-nano",
-      "max_tokens": 1047576,
+      "content_length": 1047576,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -197,7 +213,8 @@
     },
     {
       "name": "gpt-4.5-preview",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -207,7 +224,8 @@
     },
     {
       "name": "gpt-4o-mini",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -218,7 +236,8 @@
     },
     {
       "name": "gpt-4o",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -229,7 +248,8 @@
     },
     {
       "name": "gpt-3.5-turbo",
-      "max_tokens": 4096,
+      "content_length": 16385,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -239,7 +259,8 @@
     },
     {
       "name": "gpt-3.5-turbo-16k-0613",
-      "max_tokens": 16385,
+      "content_length": 16385,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],

--- a/conf/models/aliyun.json
+++ b/conf/models/aliyun.json
@@ -16,7 +16,8 @@
   "models": [
     {
       "name": "qwen-flash",
-      "max_tokens": 995904,
+      "content_length": 1048576,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -33,7 +34,8 @@
     },
     {
       "name": "qwen3-vl-plus",
-      "max_tokens": 256000,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "vision",
         "chat"

--- a/conf/models/anthropic.json
+++ b/conf/models/anthropic.json
@@ -12,7 +12,8 @@
   "models": [
     {
       "name": "claude-opus-4-8",
-      "max_tokens": 128000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -20,7 +21,8 @@
     },
     {
       "name": "claude-opus-4-7",
-      "max_tokens": 128000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -28,7 +30,8 @@
     },
     {
       "name": "claude-opus-4-6",
-      "max_tokens": 128000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -36,7 +39,8 @@
     },
     {
       "name": "claude-opus-4-5-20251101",
-      "max_tokens": 128000,
+      "content_length": 200000,
+      "max_output": 64000,
       "model_types": [
         "chat",
         "vision"
@@ -44,7 +48,8 @@
     },
     {
       "name": "claude-opus-4-1-20250805",
-      "max_tokens": 128000,
+      "content_length": 200000,
+      "max_output": 32000,
       "model_types": [
         "chat",
         "vision"
@@ -52,7 +57,8 @@
     },
     {
       "name": "claude-opus-4-20250514",
-      "max_tokens": 128000,
+      "content_length": 200000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -60,7 +66,8 @@
     },
     {
       "name": "claude-sonnet-4-6",
-      "max_tokens": 64000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -77,7 +84,8 @@
     },
     {
       "name": "claude-sonnet-4-20250514",
-      "max_tokens": 64000,
+      "content_length": 200000,
+      "max_output": 64000,
       "model_types": [
         "chat",
         "vision"
@@ -85,7 +93,8 @@
     },
     {
       "name": "claude-haiku-4-5-20251001",
-      "max_tokens": 64000,
+      "content_length": 200000,
+      "max_output": 64000,
       "model_types": [
         "chat",
         "vision"
@@ -93,7 +102,8 @@
     },
     {
       "name": "claude-3-7-sonnet-20250219",
-      "max_tokens": 64000,
+      "content_length": 200000,
+      "max_output": 64000,
       "model_types": [
         "chat",
         "vision"
@@ -101,7 +111,8 @@
     },
     {
       "name": "claude-3-5-sonnet-20241022",
-      "max_tokens": 8192,
+      "content_length": 200000,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -109,7 +120,8 @@
     },
     {
       "name": "claude-3-5-haiku-20241022",
-      "max_tokens": 8192,
+      "content_length": 200000,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"

--- a/conf/models/astraflow.json
+++ b/conf/models/astraflow.json
@@ -189,7 +189,7 @@
     },
     {
       "name": "MiniMax-M2.7",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131072,
       "model_types": [
         "chat"
@@ -200,7 +200,7 @@
     },
     {
       "name": "MiniMax-M2",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131072,
       "model_types": [
         "chat"

--- a/conf/models/astraflow.json
+++ b/conf/models/astraflow.json
@@ -35,7 +35,8 @@
     },
     {
       "name": "claude-opus-4-7",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -45,7 +46,8 @@
     },
     {
       "name": "claude-opus-4-6",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -66,7 +68,8 @@
     },
     {
       "name": "claude-haiku-4-5-20251001",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 64000,
       "model_types": [
         "chat"
       ],
@@ -76,7 +79,8 @@
     },
     {
       "name": "gpt-5.4",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -86,7 +90,8 @@
     },
     {
       "name": "gpt-5.4-mini",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -96,7 +101,8 @@
     },
     {
       "name": "gpt-5.4-nano",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -106,7 +112,8 @@
     },
     {
       "name": "gpt-4o-mini",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -116,7 +123,8 @@
     },
     {
       "name": "Qwen/Qwen3-Max",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -126,7 +134,8 @@
     },
     {
       "name": "Qwen/Qwen3-Coder",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -136,7 +145,8 @@
     },
     {
       "name": "Qwen/Qwen3-32B",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -146,7 +156,8 @@
     },
     {
       "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -156,7 +167,8 @@
     },
     {
       "name": "kimi-k2.6",
-      "max_tokens": 200000,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -166,7 +178,8 @@
     },
     {
       "name": "glm-5.1",
-      "max_tokens": 128000,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -176,7 +189,8 @@
     },
     {
       "name": "MiniMax-M2.7",
-      "max_tokens": 1000000,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -186,7 +200,8 @@
     },
     {
       "name": "MiniMax-M2",
-      "max_tokens": 1000000,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -196,7 +211,8 @@
     },
     {
       "name": "gemini-2.5-pro",
-      "max_tokens": 1000000,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -206,7 +222,8 @@
     },
     {
       "name": "gemini-2.5-flash",
-      "max_tokens": 1000000,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],

--- a/conf/models/astraflow.json
+++ b/conf/models/astraflow.json
@@ -190,7 +190,7 @@
     {
       "name": "MiniMax-M2.7",
       "content_length": 204800,
-      "max_output": 131072,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -201,7 +201,7 @@
     {
       "name": "MiniMax-M2",
       "content_length": 204800,
-      "max_output": 131072,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/avian.json
+++ b/conf/models/avian.json
@@ -11,7 +11,8 @@
   "models": [
     {
       "name": "deepseek/deepseek-v4-pro",
-      "max_tokens": 164000,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -21,7 +22,8 @@
     },
     {
       "name": "deepseek/deepseek-v4-flash",
-      "max_tokens": 164000,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -31,7 +33,8 @@
     },
     {
       "name": "deepseek/deepseek-v3.2",
-      "max_tokens": 164000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -41,7 +44,8 @@
     },
     {
       "name": "moonshotai/kimi-k2.5",
-      "max_tokens": 131000,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -51,7 +55,8 @@
     },
     {
       "name": "z-ai/glm-5",
-      "max_tokens": 131000,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -61,7 +66,8 @@
     },
     {
       "name": "minimax/minimax-m2.5",
-      "max_tokens": 1000000,
+      "content_length": 204800,
+      "max_output": 196608,
       "model_types": [
         "chat"
       ],

--- a/conf/models/baichuan.json
+++ b/conf/models/baichuan.json
@@ -11,7 +11,8 @@
   "models": [
     {
       "name": "Baichuan4",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -21,7 +22,8 @@
     },
     {
       "name": "Baichuan4-Air",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -31,7 +33,8 @@
     },
     {
       "name": "Baichuan4-Turbo",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -41,7 +44,8 @@
     },
     {
       "name": "Baichuan-M3",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -51,7 +55,8 @@
     },
     {
       "name": "Baichuan-M3-plus",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -61,7 +66,8 @@
     },
     {
       "name": "Baichuan-M2-plus",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -71,7 +77,8 @@
     },
     {
       "name": "Baichuan-M2",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -81,7 +88,8 @@
     },
     {
       "name": "Baichuan3-Turbo",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -91,7 +99,8 @@
     },
     {
       "name": "Baichuan3-Turbo-128k",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -101,7 +110,8 @@
     },
     {
       "name": "Baichuan2-Turbo",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/baidu.json
+++ b/conf/models/baidu.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "deepseek-v3.2",
-      "max_tokens": 98304,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -24,7 +25,8 @@
     },
     {
       "name": "deepseek-v4-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -38,7 +40,8 @@
     },
     {
       "name": "deepseek-v4-pro",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -52,7 +55,8 @@
     },
     {
       "name": "qwen3-32b",
-      "max_tokens": 30720,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -62,7 +66,8 @@
     },
     {
       "name": "qwen3-4b",
-      "max_tokens": 30720,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -72,7 +77,8 @@
     },
     {
       "name": "ernie-5.0",
-      "max_tokens": 121856,
+      "content_length": 121856,
+      "max_output": 8192,
       "model_types": [
         "vision"
       ]

--- a/conf/models/bedrock.json
+++ b/conf/models/bedrock.json
@@ -9,105 +9,120 @@
   "models": [
     {
       "name": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "anthropic.claude-3-5-haiku-20241022-v1:0",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "anthropic.claude-3-opus-20240229-v1:0",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "anthropic.claude-3-sonnet-20240229-v1:0",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "anthropic.claude-3-haiku-20240307-v1:0",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta.llama3-1-405b-instruct-v1:0",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta.llama3-1-70b-instruct-v1:0",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta.llama3-1-8b-instruct-v1:0",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "mistral.mistral-large-2407-v1:0",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "mistral.mixtral-8x7b-instruct-v0:1",
-      "max_tokens": 32000,
+      "content_length": 32000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "amazon.nova-pro-v1:0",
-      "max_tokens": 300000,
+      "content_length": 300000,
+      "max_output": 5000,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "amazon.nova-lite-v1:0",
-      "max_tokens": 300000,
+      "content_length": 300000,
+      "max_output": 5000,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "amazon.nova-micro-v1:0",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 5000,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "cohere.command-r-plus-v1:0",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "cohere.command-r-v1:0",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]

--- a/conf/models/cohere.json
+++ b/conf/models/cohere.json
@@ -15,56 +15,64 @@
   "models": [
     {
       "name": "command-a-plus-05-2026",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "command-a-03-2025",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "command-r7b-12-2024",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "command-a-translate-08-2025",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "command-a-reasoning-08-2025",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "command-a-vision-07-2025",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "command-r-plus-08-2024",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "command-r-08-2024",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ]

--- a/conf/models/cometapi.json
+++ b/conf/models/cometapi.json
@@ -15,7 +15,8 @@
   "models": [
     {
       "name": "gpt-5.5",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -30,7 +31,8 @@
     },
     {
       "name": "gpt-5.4-mini",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -45,7 +47,8 @@
     },
     {
       "name": "gpt-5",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -60,7 +63,8 @@
     },
     {
       "name": "gpt-4o",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -71,7 +75,8 @@
     },
     {
       "name": "claude-sonnet-4-6",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -82,7 +87,8 @@
     },
     {
       "name": "gemini-3-pro-preview",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat",
         "vision"
@@ -93,7 +99,8 @@
     },
     {
       "name": "deepseek-v3.2",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -103,7 +110,8 @@
     },
     {
       "name": "qwen3-235b-a22b",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],

--- a/conf/models/deepinfra.json
+++ b/conf/models/deepinfra.json
@@ -16,7 +16,8 @@
   "models": [
     {
       "name": "deepseek-ai/DeepSeek-V3.2",
-      "max_tokens": 32768,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/deepseek.json
+++ b/conf/models/deepseek.json
@@ -13,7 +13,8 @@
   "models": [
     {
       "name": "deepseek-v4-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -27,7 +28,8 @@
     },
     {
       "name": "deepseek-v4-pro",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],

--- a/conf/models/futurmix.json
+++ b/conf/models/futurmix.json
@@ -10,7 +10,8 @@
   "models": [
     {
       "name": "gpt-5.5",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -21,7 +22,8 @@
     },
     {
       "name": "gpt-5.4",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -32,7 +34,8 @@
     },
     {
       "name": "gpt-5.4-mini",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -43,7 +46,8 @@
     },
     {
       "name": "gpt-5.4-nano",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -54,7 +58,8 @@
     },
     {
       "name": "claude-opus-4-7",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -65,7 +70,8 @@
     },
     {
       "name": "claude-opus-4-6",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -76,7 +82,8 @@
     },
     {
       "name": "claude-sonnet-4-6",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -87,7 +94,8 @@
     },
     {
       "name": "claude-haiku-4-5-20251001",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 64000,
       "model_types": [
         "chat",
         "vision"
@@ -98,7 +106,8 @@
     },
     {
       "name": "gemini-3.1-pro-preview",
-      "max_tokens": 2000000,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat",
         "vision"
@@ -109,7 +118,8 @@
     },
     {
       "name": "gemini-2.5-pro",
-      "max_tokens": 2000000,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat",
         "vision"
@@ -120,7 +130,8 @@
     },
     {
       "name": "gemini-2.5-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat",
         "vision"
@@ -131,7 +142,8 @@
     },
     {
       "name": "gemini-2.5-flash-lite",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat",
         "vision"

--- a/conf/models/gitee.json
+++ b/conf/models/gitee.json
@@ -20,6 +20,7 @@
   "models": [
     {
       "name": "qwen3-8b",
+      "content_length": 131072,
       "max_output": 32768,
       "model_types": [
         "chat"
@@ -30,6 +31,7 @@
     },
     {
       "name": "qwen3-0.6b",
+      "content_length": 32768,
       "max_output": 32768,
       "model_types": [
         "chat"
@@ -40,7 +42,8 @@
     },
     {
       "name": "glm-4.7-flash",
-      "max_output": 204800,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/google.json
+++ b/conf/models/google.json
@@ -11,7 +11,8 @@
   "models": [
     {
       "name": "gemini-2.5-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],

--- a/conf/models/greenpt.json
+++ b/conf/models/greenpt.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "glm-5.2",
-      "max_tokens": 1000000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -24,7 +25,8 @@
     },
     {
       "name": "kimi-k2.7-code",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],

--- a/conf/models/groq.json
+++ b/conf/models/groq.json
@@ -89,28 +89,6 @@
       }
     },
     {
-      "name": "meta-llama/llama-4-scout-17b-16e-instruct",
-      "content_length": 10485760,
-      "max_output": 8192,
-      "model_types": [
-        "chat"
-      ],
-      "tools": {
-        "support": true
-      }
-    },
-    {
-      "name": "qwen/qwen3-32b",
-      "content_length": 131072,
-      "max_output": 32768,
-      "model_types": [
-        "chat"
-      ],
-      "tools": {
-        "support": true
-      }
-    },
-    {
       "name": "canopylabs/orpheus-v1-english",
       "model_types": [
         "tts"

--- a/conf/models/groq.json
+++ b/conf/models/groq.json
@@ -13,7 +13,8 @@
   "models": [
     {
       "name": "llama-3.1-8b-instant",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -23,7 +24,8 @@
     },
     {
       "name": "llama-3.3-70b-versatile",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -33,7 +35,8 @@
     },
     {
       "name": "openai/gpt-oss-120b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -43,7 +46,8 @@
     },
     {
       "name": "openai/gpt-oss-20b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -53,7 +57,8 @@
     },
     {
       "name": "groq/compound",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -63,7 +68,8 @@
     },
     {
       "name": "groq/compound-mini",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -73,7 +79,8 @@
     },
     {
       "name": "openai/gpt-oss-20b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -83,7 +90,8 @@
     },
     {
       "name": "meta-llama/llama-4-scout-17b-16e-instruct",
-      "max_tokens": 131072,
+      "content_length": 10485760,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -93,7 +101,8 @@
     },
     {
       "name": "qwen/qwen3-32b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],

--- a/conf/models/huaweicloud.json
+++ b/conf/models/huaweicloud.json
@@ -16,7 +16,8 @@
   "models": [
     {
       "name": "deepseek-v4-pro",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -30,7 +31,8 @@
     },
     {
       "name": "deepseek-v4-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -44,7 +46,8 @@
     },
     {
       "name": "deepseek-v3.2",
-      "max_tokens": 163840,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -58,7 +61,8 @@
     },
     {
       "name": "deepseek-v3.1-terminus",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -72,7 +76,8 @@
     },
     {
       "name": "DeepSeek-V3",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -82,7 +87,8 @@
     },
     {
       "name": "deepseek-r1-250528",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -96,7 +102,8 @@
     },
     {
       "name": "qwen3-235b-a22b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -110,7 +117,8 @@
     },
     {
       "name": "qwen3-32b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -124,7 +132,8 @@
     },
     {
       "name": "qwen3-30b-a3b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -138,7 +147,8 @@
     },
     {
       "name": "kimi-k2.6",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -152,7 +162,8 @@
     },
     {
       "name": "longcat-flash-chat",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -162,7 +173,8 @@
     },
     {
       "name": "glm-5",
-      "max_tokens": 202752,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -176,7 +188,8 @@
     },
     {
       "name": "glm-5.1",
-      "max_tokens": 202752,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -190,7 +203,8 @@
     },
     {
       "name": "qwen2.5-vl-72b",
-      "max_tokens": 49152,
+      "content_length": 32768,
+      "max_output": 4096,
       "model_types": [
         "chat",
         "vision"

--- a/conf/models/huggingface.json
+++ b/conf/models/huggingface.json
@@ -13,7 +13,8 @@
   "models": [
     {
       "name": "openai/gpt-oss-120b:fastest",
-      "max_tokens": 32768,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ]

--- a/conf/models/hunyuan.json
+++ b/conf/models/hunyuan.json
@@ -15,7 +15,8 @@
   "models": [
     {
       "name": "hy3",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -25,7 +26,8 @@
     },
     {
       "name": "hy3-preview",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -35,7 +37,8 @@
     },
     {
       "name": "kimi-k3",
-      "max_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -45,7 +48,8 @@
     },
     {
       "name": "kimi-k2.7-code-highspeed",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -55,7 +59,8 @@
     },
     {
       "name": "kimi-k2.7-code",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -65,7 +70,8 @@
     },
     {
       "name": "glm-5.2",
-      "max_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -75,7 +81,8 @@
     },
     {
       "name": "minimax-m3",
-      "max_tokens": 131072,
+      "content_length": 1024000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -85,7 +92,8 @@
     },
     {
       "name": "deepseek-v4-flash-202605",
-      "max_tokens": 131072,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -95,7 +103,8 @@
     },
     {
       "name": "deepseek-v4-pro-202606",
-      "max_tokens": 131072,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -105,7 +114,8 @@
     },
     {
       "name": "deepseek-v4-pro",
-      "max_tokens": 131072,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -115,7 +125,8 @@
     },
     {
       "name": "deepseek-v4-flash",
-      "max_tokens": 131072,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -125,7 +136,8 @@
     },
     {
       "name": "hy-mt2-pro",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -135,7 +147,8 @@
     },
     {
       "name": "hy-mt2-plus",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -145,7 +158,8 @@
     },
     {
       "name": "hy-mt2-lite",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -155,7 +169,8 @@
     },
     {
       "name": "hy-role",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -165,7 +180,8 @@
     },
     {
       "name": "hunyuan-role-latest",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -175,7 +191,8 @@
     },
     {
       "name": "qwen3.5-flash",
-      "max_tokens": 131072,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -185,7 +202,8 @@
     },
     {
       "name": "qwen3.5-plus",
-      "max_tokens": 131072,
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -195,7 +213,8 @@
     },
     {
       "name": "glm-5.1",
-      "max_tokens": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -205,7 +224,8 @@
     },
     {
       "name": "glm-5",
-      "max_tokens": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -215,7 +235,8 @@
     },
     {
       "name": "glm-5-turbo",
-      "max_tokens": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -225,7 +246,8 @@
     },
     {
       "name": "kimi-k2.6",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -235,7 +257,8 @@
     },
     {
       "name": "kimi-k2.5",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -245,7 +268,8 @@
     },
     {
       "name": "minimax-m2.7",
-      "max_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -255,7 +279,8 @@
     },
     {
       "name": "minimax-m2.5",
-      "max_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 131100,
       "model_types": [
         "chat"
       ],
@@ -265,7 +290,8 @@
     },
     {
       "name": "deepseek-v3.2",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -275,7 +301,8 @@
     },
     {
       "name": "glm-5v-turbo",
-      "max_tokens": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -286,7 +313,8 @@
     },
     {
       "name": "hy-vision-2.0-instruct",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -297,7 +325,8 @@
     },
     {
       "name": "youtu-vita",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -308,7 +337,8 @@
     },
     {
       "name": "hunyuan-t1-vision-20250916",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -319,7 +349,8 @@
     },
     {
       "name": "hunyuan-turbos-vision-video-20250728",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"

--- a/conf/models/hunyuan.json
+++ b/conf/models/hunyuan.json
@@ -268,7 +268,7 @@
     },
     {
       "name": "minimax-m2.7",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131072,
       "model_types": [
         "chat"
@@ -279,7 +279,7 @@
     },
     {
       "name": "minimax-m2.5",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131100,
       "model_types": [
         "chat"

--- a/conf/models/hunyuan.json
+++ b/conf/models/hunyuan.json
@@ -269,7 +269,7 @@
     {
       "name": "minimax-m2.7",
       "content_length": 204800,
-      "max_output": 131072,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -280,7 +280,7 @@
     {
       "name": "minimax-m2.5",
       "content_length": 204800,
-      "max_output": 131100,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/jiekouai.json
+++ b/conf/models/jiekouai.json
@@ -13,7 +13,8 @@
   "models": [
     {
       "name": "deepseek-v4-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -27,7 +28,8 @@
     },
     {
       "name": "deepseek-v4-pro",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -41,7 +43,8 @@
     },
     {
       "name": "zai-org/glm-4.5",
-      "max_tokens": 131072,
+      "content_length": 128000,
+      "max_output": 96000,
       "model_types": [
         "chat"
       ],
@@ -55,7 +58,8 @@
     },
     {
       "name": "zai-org/glm-4.5v",
-      "max_tokens": 131072,
+      "content_length": 65536,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -69,7 +73,8 @@
     },
     {
       "name": "zai-org/glm-4.7",
-      "max_tokens": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -83,7 +88,8 @@
     },
     {
       "name": "zai-org/glm-4.7-flash",
-      "max_tokens": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -97,7 +103,8 @@
     },
     {
       "name": "zai-org/glm-5",
-      "max_tokens": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/jina.json
+++ b/conf/models/jina.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "jina-vlm",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/longcat.json
+++ b/conf/models/longcat.json
@@ -11,7 +11,8 @@
   "models": [
     {
       "name": "LongCat-2.0",
-      "max_tokens": 131072,
+      "content_length": 1048576,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],

--- a/conf/models/minimax.json
+++ b/conf/models/minimax.json
@@ -15,7 +15,8 @@
   "models": [
     {
       "name": "MiniMax-M3",
-      "max_tokens": 1024000,
+      "content_length": 1024000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -26,7 +27,8 @@
     },
     {
       "name": "minimax-m2.7",
-      "max_tokens": 204800,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -37,7 +39,8 @@
     },
     {
       "name": "minimax-m2.7-highspeed",
-      "max_tokens": 204800,
+      "content_length": 204800,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -48,7 +51,8 @@
     },
     {
       "name": "minimax-m2.5",
-      "max_tokens": 204800,
+      "content_length": 1000000,
+      "max_output": 131100,
       "model_types": [
         "chat"
       ],
@@ -59,7 +63,8 @@
     },
     {
       "name": "minimax-m2.5-highspeed",
-      "max_tokens": 204800,
+      "content_length": 204800,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -70,7 +75,8 @@
     },
     {
       "name": "minimax-m2.1",
-      "max_tokens": 204800,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -81,7 +87,8 @@
     },
     {
       "name": "minimax-m2.1-highspeed",
-      "max_tokens": 204800,
+      "content_length": 204800,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -92,7 +99,8 @@
     },
     {
       "name": "minimax-m2",
-      "max_tokens": 204800,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -103,7 +111,8 @@
     },
     {
       "name": "minimax-m2-her",
-      "max_tokens": 65536,
+      "content_length": 65536,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],

--- a/conf/models/minimax.json
+++ b/conf/models/minimax.json
@@ -28,7 +28,7 @@
     {
       "name": "minimax-m2.7",
       "content_length": 204800,
-      "max_output": 131072,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -52,7 +52,7 @@
     {
       "name": "minimax-m2.5",
       "content_length": 204800,
-      "max_output": 131100,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -76,7 +76,7 @@
     {
       "name": "minimax-m2.1",
       "content_length": 204800,
-      "max_output": 131072,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -100,7 +100,7 @@
     {
       "name": "minimax-m2",
       "content_length": 204800,
-      "max_output": 131072,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/minimax.json
+++ b/conf/models/minimax.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "minimax-m2.7",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131072,
       "model_types": [
         "chat"
@@ -51,7 +51,7 @@
     },
     {
       "name": "minimax-m2.5",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131100,
       "model_types": [
         "chat"
@@ -75,7 +75,7 @@
     },
     {
       "name": "minimax-m2.1",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131072,
       "model_types": [
         "chat"
@@ -99,7 +99,7 @@
     },
     {
       "name": "minimax-m2",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131072,
       "model_types": [
         "chat"

--- a/conf/models/mistral.json
+++ b/conf/models/mistral.json
@@ -15,7 +15,8 @@
   "models": [
     {
       "name": "mistral-large-latest",
-      "max_tokens": 128000,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -37,7 +38,8 @@
     },
     {
       "name": "mistral-medium-latest",
-      "max_tokens": 128000,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -47,7 +49,8 @@
     },
     {
       "name": "mistral-small-latest",
-      "max_tokens": 128000,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -57,7 +60,8 @@
     },
     {
       "name": "ministral-8b-latest",
-      "max_tokens": 128000,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -67,7 +71,8 @@
     },
     {
       "name": "ministral-3b-latest",
-      "max_tokens": 128000,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -77,7 +82,8 @@
     },
     {
       "name": "pixtral-large-latest",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat",
         "vision"
@@ -88,7 +94,8 @@
     },
     {
       "name": "codestral-latest",
-      "max_tokens": 256000,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -98,7 +105,8 @@
     },
     {
       "name": "open-mistral-nemo",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -108,7 +116,8 @@
     },
     {
       "name": "open-mistral-7b",
-      "max_tokens": 32000,
+      "content_length": 32768,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -118,7 +127,8 @@
     },
     {
       "name": "open-mixtral-8x7b",
-      "max_tokens": 32000,
+      "content_length": 32768,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -128,7 +138,8 @@
     },
     {
       "name": "open-mixtral-8x22b",
-      "max_tokens": 64000,
+      "content_length": 65536,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -138,7 +149,8 @@
     },
     {
       "name": "magistral-medium-latest",
-      "max_tokens": 40000,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -148,7 +160,8 @@
     },
     {
       "name": "magistral-small-latest",
-      "max_tokens": 40000,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],

--- a/conf/models/moonshot.json
+++ b/conf/models/moonshot.json
@@ -13,7 +13,7 @@
   "models": [
     {
       "name": "kimi-k3",
-      "content_length": 1048576,
+      "content_length": 1000000,
       "max_output": 131072,
       "model_types": [
         "chat",
@@ -61,7 +61,8 @@
     },
     {
       "name": "kimi-k2.6",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat",
         "vision"
@@ -76,7 +77,8 @@
     },
     {
       "name": "kimi-k2.5",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat",
         "vision"
@@ -91,7 +93,8 @@
     },
     {
       "name": "moonshot-v1-8k",
-      "max_tokens": 8000,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -102,7 +105,8 @@
     },
     {
       "name": "moonshot-v1-32k",
-      "max_tokens": 32000,
+      "content_length": 32768,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -112,7 +116,8 @@
     },
     {
       "name": "moonshot-v1-128k",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -122,7 +127,8 @@
     },
     {
       "name": "moonshot-v1-8k-vision-preview",
-      "max_tokens": 8000,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -133,7 +139,8 @@
     },
     {
       "name": "moonshot-v1-32k-vision-preview",
-      "max_tokens": 32000,
+      "content_length": 32768,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -144,7 +151,8 @@
     },
     {
       "name": "moonshot-v1-128k-vision-preview",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat",
         "vision"

--- a/conf/models/n1n.json
+++ b/conf/models/n1n.json
@@ -13,7 +13,8 @@
   "models": [
     {
       "name": "gpt-4o-mini",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -24,7 +25,8 @@
     },
     {
       "name": "gpt-4o",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -35,7 +37,8 @@
     },
     {
       "name": "gpt-5.2",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -46,7 +49,8 @@
     },
     {
       "name": "claude-sonnet-4-6",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -57,7 +61,8 @@
     },
     {
       "name": "deepseek-v3-0324",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -67,7 +72,8 @@
     },
     {
       "name": "deepseek-v3-1-250821",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -77,7 +83,8 @@
     },
     {
       "name": "deepseek-v3-1-think-250821",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -87,7 +94,8 @@
     },
     {
       "name": "kimi-k2-250905",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -97,7 +105,8 @@
     },
     {
       "name": "qwen3-coder-plus",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],

--- a/conf/models/novita.json
+++ b/conf/models/novita.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "deepseek/deepseek-v4-pro",
-      "max_tokens": 65536,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -24,7 +25,8 @@
     },
     {
       "name": "meta-llama/llama-3.3-70b-instruct",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 120000,
       "model_types": [
         "chat"
       ],
@@ -34,7 +36,8 @@
     },
     {
       "name": "qwen/qwen3-30b-a3b-fp8",
-      "max_tokens": 32768,
+      "content_length": 256000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -44,7 +47,8 @@
     },
     {
       "name": "qwen/qwen3-235b-a22b-fp8",
-      "max_tokens": 32768,
+      "content_length": 40960,
+      "max_output": 20000,
       "model_types": [
         "chat"
       ],
@@ -54,7 +58,8 @@
     },
     {
       "name": "moonshotai/kimi-k2-instruct",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -64,7 +69,8 @@
     },
     {
       "name": "google/gemma-3-27b-it",
-      "max_tokens": 131072,
+      "content_length": 98304,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -74,7 +80,8 @@
     },
     {
       "name": "mistralai/mistral-nemo",
-      "max_tokens": 131072,
+      "content_length": 60288,
+      "max_output": 16000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/nvidia.json
+++ b/conf/models/nvidia.json
@@ -13,7 +13,8 @@
   "models": [
     {
       "name": "deepseek-ai/deepseek-v4-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -23,7 +24,8 @@
     },
     {
       "name": "deepseek-ai/deepseek-v4-pro",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -33,14 +35,16 @@
     },
     {
       "name": "google/diffusiongemma-26b-a4b-it",
-      "max_tokens": 8192,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "google/gemma-4-31b-it",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -50,21 +54,24 @@
     },
     {
       "name": "meta/llama-3.1-70b-instruct",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/llama-3.1-8b-instruct",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/llama-3.2-11b-vision-instruct",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -72,21 +79,24 @@
     },
     {
       "name": "meta/llama-3.2-1b-instruct",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/llama-3.2-3b-instruct",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/llama-3.2-90b-vision-instruct",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -97,28 +107,32 @@
     },
     {
       "name": "meta/llama-3.3-70b-instruct",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/llama-guard-4-12b",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "minimaxai/minimax-m3",
-      "max_tokens": 8192,
+      "content_length": 1048576,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "mistralai/mistral-medium-3.5-128b",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat",
         "vision"
@@ -129,7 +143,8 @@
     },
     {
       "name": "mistralai/mistral-nemotron",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -139,7 +154,8 @@
     },
     {
       "name": "moonshotai/kimi-k2.6",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat",
         "vision"
@@ -150,14 +166,16 @@
     },
     {
       "name": "nvidia/ising-calibration-1.5-31b",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "nvidia/llama-3.1-nemotron-nano-8b-v1",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -167,7 +185,8 @@
     },
     {
       "name": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -175,7 +194,8 @@
     },
     {
       "name": "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -185,7 +205,8 @@
     },
     {
       "name": "nvidia/llama-3.3-nemotron-super-49b-v1",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -195,7 +216,8 @@
     },
     {
       "name": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -216,7 +238,8 @@
     },
     {
       "name": "nvidia/nemotron-3-nano-30b-a3b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -226,7 +249,8 @@
     },
     {
       "name": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -241,7 +265,8 @@
     },
     {
       "name": "nvidia/nemotron-3-super-120b-a12b",
-      "max_tokens": 131072,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -251,21 +276,24 @@
     },
     {
       "name": "nvidia/nemotron-3-ultra-550b-a55b",
-      "max_tokens": 8192,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "nvidia/nemotron-3.5-content-safety",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "nvidia/nemotron-mini-4b-instruct",
-      "max_tokens": 4096,
+      "content_length": 8192,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -275,7 +303,8 @@
     },
     {
       "name": "nvidia/nemotron-nano-12b-v2-vl",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -297,7 +326,8 @@
     },
     {
       "name": "nvidia/nvidia-nemotron-nano-9b-v2",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -307,14 +337,16 @@
     },
     {
       "name": "nvidia/riva-translate-4b-instruct-v2",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "openai/gpt-oss-120b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -324,35 +356,40 @@
     },
     {
       "name": "openai/gpt-oss-20b",
-      "max_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "poolside/laguna-xs-2.1",
-      "max_tokens": 8192,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "stepfun-ai/step-3.7-flash",
-      "max_tokens": 8192,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "thinkingmachines/inkling",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "z-ai/glm-5.2",
-      "max_tokens": 8192,
+      "content_length": 1000000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ]

--- a/conf/models/openai.json
+++ b/conf/models/openai.json
@@ -15,7 +15,8 @@
   "models": [
     {
       "name": "gpt-5.5",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -26,7 +27,8 @@
     },
     {
       "name": "gpt-5.4",
-      "max_tokens": 400000,
+      "content_length": 1050000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -37,7 +39,8 @@
     },
     {
       "name": "gpt-5.4-mini",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -48,7 +51,8 @@
     },
     {
       "name": "gpt-5.4-nano",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -59,7 +63,8 @@
     },
     {
       "name": "gpt-5.2-pro",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -70,7 +75,8 @@
     },
     {
       "name": "gpt-5.2",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -81,7 +87,8 @@
     },
     {
       "name": "gpt-5.1",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -92,7 +99,8 @@
     },
     {
       "name": "gpt-5.1-chat-latest",
-      "max_tokens": 400000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -103,7 +111,8 @@
     },
     {
       "name": "gpt-5",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -114,7 +123,8 @@
     },
     {
       "name": "gpt-5-mini",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -125,7 +135,8 @@
     },
     {
       "name": "gpt-5-nano",
-      "max_tokens": 400000,
+      "content_length": 400000,
+      "max_output": 128000,
       "model_types": [
         "chat",
         "vision"
@@ -136,7 +147,8 @@
     },
     {
       "name": "gpt-5-chat-latest",
-      "max_tokens": 400000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -147,7 +159,8 @@
     },
     {
       "name": "gpt-4.1",
-      "max_tokens": 1047576,
+      "content_length": 1047576,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -158,7 +171,8 @@
     },
     {
       "name": "gpt-4.1-mini",
-      "max_tokens": 1047576,
+      "content_length": 1047576,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -169,7 +183,8 @@
     },
     {
       "name": "gpt-4.1-nano",
-      "max_tokens": 1047576,
+      "content_length": 1047576,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -180,7 +195,8 @@
     },
     {
       "name": "gpt-4.5-preview",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -190,7 +206,8 @@
     },
     {
       "name": "gpt-4o-mini",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -201,7 +218,8 @@
     },
     {
       "name": "gpt-4o",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -212,7 +230,8 @@
     },
     {
       "name": "gpt-3.5-turbo",
-      "max_tokens": 4096,
+      "content_length": 16385,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -222,7 +241,8 @@
     },
     {
       "name": "gpt-3.5-turbo-16k-0613",
-      "max_tokens": 16385,
+      "content_length": 16385,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -260,7 +280,8 @@
     },
     {
       "name": "gpt-4",
-      "max_tokens": 8191,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -270,7 +291,8 @@
     },
     {
       "name": "gpt-4-turbo",
-      "max_tokens": 8191,
+      "content_length": 128000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -280,7 +302,8 @@
     },
     {
       "name": "gpt-4-32k",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],

--- a/conf/models/openrouter.json
+++ b/conf/models/openrouter.json
@@ -17,7 +17,8 @@
   "models": [
     {
       "name": "google/gemma-4-31b-it",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -31,7 +32,8 @@
     },
     {
       "name": "minimax/minimax-m2.5",
-      "max_tokens": 196608,
+      "content_length": 204800,
+      "max_output": 196608,
       "model_types": [
         "chat"
       ],
@@ -45,7 +47,8 @@
     },
     {
       "name": "tencent/hy3-preview",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],

--- a/conf/models/orcarouter.json
+++ b/conf/models/orcarouter.json
@@ -12,7 +12,8 @@
   "models": [
     {
       "name": "orcarouter/auto",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/perplexity.json
+++ b/conf/models/perplexity.json
@@ -12,21 +12,24 @@
   "models": [
     {
       "name": "sonar",
-      "max_tokens": 127072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "sonar-pro",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "sonar-reasoning-pro",
-      "max_tokens": 127072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -37,7 +40,8 @@
     },
     {
       "name": "sonar-deep-research",
-      "max_tokens": 127072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ]

--- a/conf/models/ppio.json
+++ b/conf/models/ppio.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "deepseek/deepseek-v4-flash",
-      "max_output": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -24,7 +25,8 @@
     },
     {
       "name": "deepseek/deepseek-v4-pro",
-      "max_output": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -34,7 +36,8 @@
     },
     {
       "name": "deepseek/deepseek-r1/community",
-      "max_output": 64000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -44,7 +47,8 @@
     },
     {
       "name": "deepseek/deepseek-v3/community",
-      "max_output": 64000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -54,7 +58,8 @@
     },
     {
       "name": "deepseek/deepseek-r1",
-      "max_output": 64000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -64,7 +69,8 @@
     },
     {
       "name": "deepseek/deepseek-v3",
-      "max_output": 64000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -74,7 +80,8 @@
     },
     {
       "name": "deepseek/deepseek-r1-distill-llama-70b",
-      "max_output": 32000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -84,7 +91,8 @@
     },
     {
       "name": "deepseek/deepseek-r1-distill-qwen-32b",
-      "max_output": 64000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -94,7 +102,8 @@
     },
     {
       "name": "deepseek/deepseek-r1-distill-qwen-14b",
-      "max_output": 64000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -104,7 +113,8 @@
     },
     {
       "name": "deepseek/deepseek-r1-distill-llama-8b",
-      "max_output": 32000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -114,7 +124,8 @@
     },
     {
       "name": "qwen/qwen-2.5-72b-instruct",
-      "max_output": 32768,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -124,7 +135,8 @@
     },
     {
       "name": "qwen/qwen-2-vl-72b-instruct",
-      "max_output": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -134,7 +146,8 @@
     },
     {
       "name": "meta-llama/llama-3.2-3b-instruct",
-      "max_output": 32768,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -144,7 +157,8 @@
     },
     {
       "name": "qwen/qwen2.5-32b-instruct",
-      "max_output": 32000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -154,7 +168,8 @@
     },
     {
       "name": "baichuan/baichuan2-13b-chat",
-      "max_output": 14336,
+      "content_length": 196608,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -164,7 +179,8 @@
     },
     {
       "name": "meta-llama/llama-3.1-70b-instruct",
-      "max_output": 32768,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -174,7 +190,8 @@
     },
     {
       "name": "meta-llama/llama-3.1-8b-instruct",
-      "max_output": 32768,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -184,7 +201,8 @@
     },
     {
       "name": "01-ai/yi-1.5-34b-chat",
-      "max_output": 16384,
+      "content_length": 16384,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -194,7 +212,8 @@
     },
     {
       "name": "01-ai/yi-1.5-9b-chat",
-      "max_output": 16384,
+      "content_length": 16384,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -204,7 +223,8 @@
     },
     {
       "name": "thudm/glm-4-9b-chat",
-      "max_output": 32768,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -214,7 +234,8 @@
     },
     {
       "name": "qwen/qwen-2-7b-instruct",
-      "max_output": 32768,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/qiniu.json
+++ b/conf/models/qiniu.json
@@ -11,7 +11,8 @@
   "models": [
     {
       "name": "deepseek/deepseek-v4-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -25,7 +26,8 @@
     },
     {
       "name": "deepseek/deepseek-v4-pro",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -39,6 +41,8 @@
     },
     {
       "name": "moonshotai/kimi-k2.6",
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "vision"
       ],
@@ -49,12 +53,16 @@
     },
     {
       "name": "moonshotai/kimi-k2.5",
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "z-ai/glm-5.1",
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -68,6 +76,8 @@
     },
     {
       "name": "z-ai/glm-5",
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -81,6 +91,8 @@
     },
     {
       "name": "minimax/minimax-m2.7",
+      "content_length": 204800,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -94,6 +106,8 @@
     },
     {
       "name": "minimax/minimax-m2.5",
+      "content_length": 204800,
+      "max_output": 196608,
       "model_types": [
         "chat"
       ],
@@ -107,6 +121,8 @@
     },
     {
       "name": "minimax/minimax-m2.5-highspeed",
+      "content_length": 196608,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -120,6 +136,8 @@
     },
     {
       "name": "minimax/minimax-m2.1",
+      "content_length": 204800,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -129,7 +147,8 @@
     },
     {
       "name": "kimi-k2-thinking",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -143,6 +162,8 @@
     },
     {
       "name": "meituan/longcat-flash-lite",
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -152,6 +173,8 @@
     },
     {
       "name": "qwen3-max",
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -161,7 +184,8 @@
     },
     {
       "name": "z-ai/glm-4.6",
-      "max_tokens": 204800,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -175,6 +199,8 @@
     },
     {
       "name": "z-ai/glm-4.7",
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -184,6 +210,8 @@
     },
     {
       "name": "deepseek/deepseek-v3.2-251201",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -197,6 +225,8 @@
     },
     {
       "name": "deepseek/deepseek-v3.2-exp-thinking",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -210,6 +240,8 @@
     },
     {
       "name": "deepseek/deepseek-v3.1-terminus",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -219,6 +251,8 @@
     },
     {
       "name": "deepseek/deepseek-v3.1-terminus-thinking",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -232,6 +266,8 @@
     },
     {
       "name": "deepseek-v3.1",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -241,6 +277,8 @@
     },
     {
       "name": "deepseek-v3-0324",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -250,6 +288,8 @@
     },
     {
       "name": "deepseek-r1-0528",
+      "content_length": 131072,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -263,6 +303,8 @@
     },
     {
       "name": "deepseek-r1",
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -276,7 +318,8 @@
     },
     {
       "name": "doubao-seed-1.6-flash",
-      "max_tokens": 262144,
+      "content_length": 256000,
+      "max_output": 16384,
       "model_types": [
         "vision"
       ],
@@ -287,14 +330,16 @@
     },
     {
       "name": "doubao-1.5-pro-32k",
-      "max_tokens": 131072,
+      "content_length": 32768,
+      "max_output": 4096,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "doubao-seed-1.6",
-      "max_tokens": 262144,
+      "content_length": 256000,
+      "max_output": 16384,
       "model_types": [
         "vision"
       ],
@@ -305,6 +350,8 @@
     },
     {
       "name": "doubao-seed-2.0-pro",
+      "content_length": 256000,
+      "max_output": 16384,
       "model_types": [
         "vision"
       ],
@@ -315,6 +362,8 @@
     },
     {
       "name": "doubao-seed-2.0-lite",
+      "content_length": 256000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -328,7 +377,8 @@
     },
     {
       "name": "doubao-seed-2.0-mini",
-      "max_tokens": 262144,
+      "content_length": 256000,
+      "max_output": 16384,
       "model_types": [
         "vision"
       ],
@@ -339,6 +389,8 @@
     },
     {
       "name": "doubao-seed-2.0-code",
+      "content_length": 256000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -352,6 +404,8 @@
     },
     {
       "name": "qwen3-next-80b-a3b-thinking",
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -365,6 +419,8 @@
     },
     {
       "name": "qwen3-235b-a22b-thinking-2507",
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -378,6 +434,8 @@
     },
     {
       "name": "qwen3-max-2026-01-23",
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -391,6 +449,8 @@
     },
     {
       "name": "qwen3-next-80b-a3b-instruct",
+      "content_length": 262144,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -400,6 +460,8 @@
     },
     {
       "name": "qwen3-max-preview",
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -409,12 +471,16 @@
     },
     {
       "name": "qwen-2.5-vl-72b-instruct",
+      "content_length": 32768,
+      "max_output": 4096,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "qwen3-coder-480b-a35b-instruct",
+      "content_length": 262144,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -424,6 +490,8 @@
     },
     {
       "name": "qwen-turbo",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -437,6 +505,8 @@
     },
     {
       "name": "qwen3-235b-a22b-instruct-2507",
+      "content_length": 262144,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -446,6 +516,8 @@
     },
     {
       "name": "qwen3-32b",
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -459,6 +531,8 @@
     },
     {
       "name": "qwen3-30b-a3b",
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -472,6 +546,8 @@
     },
     {
       "name": "qwen3-235b-a22b",
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -481,18 +557,24 @@
     },
     {
       "name": "qwen-2.5-vl-7b-instruct",
+      "content_length": 32768,
+      "max_output": 4096,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "qwen-vl-max-2025-01-25",
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "qwen2.5-max-2025-01-25",
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -502,7 +584,8 @@
     },
     {
       "name": "minimax-m1",
-      "max_tokens": 1048576,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -516,6 +599,8 @@
     },
     {
       "name": "glm-4.5",
+      "content_length": 128000,
+      "max_output": 96000,
       "model_types": [
         "chat"
       ],
@@ -529,12 +614,16 @@
     },
     {
       "name": "qwen3-vl-30b-a3b-instruct",
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "deepseek-v3",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -544,6 +633,8 @@
     },
     {
       "name": "qwen3-30b-a3b-thinking-2507",
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -557,6 +648,8 @@
     },
     {
       "name": "glm-4.5-air",
+      "content_length": 128000,
+      "max_output": 96000,
       "model_types": [
         "chat"
       ],
@@ -570,6 +663,8 @@
     },
     {
       "name": "qwen3.5-397b-a17b",
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "vision"
       ],
@@ -580,12 +675,16 @@
     },
     {
       "name": "qwen/qwen3.5-plus",
+      "content_length": 1048576,
+      "max_output": 65536,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "qwen/qwen3.6-plus",
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -599,6 +698,8 @@
     },
     {
       "name": "deepseek/deepseek-v3.2-exp",
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -608,6 +709,8 @@
     },
     {
       "name": "qwen/qwen3.7-max",
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -621,7 +724,8 @@
     },
     {
       "name": "qwen/qwen3.6-27b",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "vision"
       ],
@@ -632,6 +736,8 @@
     },
     {
       "name": "tencent/hy3-preview",
+      "content_length": 262144,
+      "max_output": 262144,
       "model_types": [
         "chat"
       ],
@@ -645,6 +751,8 @@
     },
     {
       "name": "qwen3.5-35b-a3b",
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "vision"
       ],
@@ -655,6 +763,8 @@
     },
     {
       "name": "qwen3-vl-30b-a3b-thinking",
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "vision"
       ],
@@ -665,6 +775,8 @@
     },
     {
       "name": "qwen3-30b-a3b-instruct-2507",
+      "content_length": 262144,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],

--- a/conf/models/replicate.json
+++ b/conf/models/replicate.json
@@ -13,7 +13,7 @@
     {
       "name": "meta/llama-4-maverick-instruct",
       "content_length": 1048576,
-      "max_output": 8192,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ]
@@ -21,7 +21,7 @@
     {
       "name": "meta/llama-4-scout-instruct",
       "content_length": 10485760,
-      "max_output": 8192,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ]

--- a/conf/models/replicate.json
+++ b/conf/models/replicate.json
@@ -12,28 +12,32 @@
   "models": [
     {
       "name": "meta/llama-4-maverick-instruct",
-      "max_tokens": 8192,
+      "content_length": 1048576,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/llama-4-scout-instruct",
-      "max_tokens": 8192,
+      "content_length": 10485760,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/meta-llama-3-70b-instruct",
-      "max_tokens": 8192,
+      "content_length": 8000,
+      "max_output": 8000,
       "model_types": [
         "chat"
       ]
     },
     {
       "name": "meta/meta-llama-3-8b-instruct",
-      "max_tokens": 8192,
+      "content_length": 8000,
+      "max_output": 8000,
       "model_types": [
         "chat"
       ]

--- a/conf/models/siliconflow.json
+++ b/conf/models/siliconflow.json
@@ -16,7 +16,8 @@
   "models": [
     {
       "name": "Pro/deepseek-ai/DeepSeek-V4-Pro",
-      "max_output": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -30,7 +31,8 @@
     },
     {
       "name": "Pro/deepseek-ai/DeepSeek-V4-Flash",
-      "max_output": 1048576,
+      "content_length": 1048576,
+      "max_output": 393216,
       "model_types": [
         "chat"
       ],
@@ -44,7 +46,8 @@
     },
     {
       "name": "Pro/moonshotai/Kimi-K2.6",
-      "max_output": 262144,
+      "content_length": 262144,
+      "max_output": 65536,
       "model_types": [
         "chat",
         "vision"
@@ -59,7 +62,8 @@
     },
     {
       "name": "Pro/zai-org/GLM-5.1",
-      "max_output": 204800,
+      "content_length": 204800,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -73,6 +77,7 @@
     },
     {
       "name": "qwen/qwen3-8b",
+      "content_length": 131072,
       "max_output": 32768,
       "model_types": [
         "chat"
@@ -83,7 +88,8 @@
     },
     {
       "name": "qwen/qwen3.5-4b",
-      "max_output": 262144,
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -93,7 +99,8 @@
     },
     {
       "name": "tencent/hunyuan-mt-7b",
-      "max_output": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/siliconflow.json
+++ b/conf/models/siliconflow.json
@@ -62,8 +62,8 @@
     },
     {
       "name": "Pro/zai-org/GLM-5.1",
-      "content_length": 204800,
-      "max_output": 131072,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/stepfun.json
+++ b/conf/models/stepfun.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "step-3.5-flash",
-      "max_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -24,7 +25,8 @@
     },
     {
       "name": "step-3.5-flash-paid",
-      "max_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -34,7 +36,8 @@
     },
     {
       "name": "step-2-16k",
-      "max_tokens": 16384,
+      "content_length": 16384,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -44,7 +47,8 @@
     },
     {
       "name": "step-1-256k",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -54,7 +58,8 @@
     },
     {
       "name": "step-1-128k",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -64,7 +69,8 @@
     },
     {
       "name": "step-1-32k",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -74,7 +80,8 @@
     },
     {
       "name": "step-1-8k",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -84,7 +91,8 @@
     },
     {
       "name": "step-1-flash",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -94,7 +102,8 @@
     },
     {
       "name": "step-1v-32k",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -105,7 +114,8 @@
     },
     {
       "name": "step-1v-8k",
-      "max_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 4096,
       "model_types": [
         "chat",
         "vision"
@@ -116,7 +126,8 @@
     },
     {
       "name": "step-1o-vision-32k",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"

--- a/conf/models/togetherai.json
+++ b/conf/models/togetherai.json
@@ -15,7 +15,8 @@
   "models": [
     {
       "name": "openai/gpt-oss-20b",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -25,7 +26,8 @@
     },
     {
       "name": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -35,7 +37,8 @@
     },
     {
       "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
-      "max_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],

--- a/conf/models/tokenhub.json
+++ b/conf/models/tokenhub.json
@@ -12,7 +12,8 @@
   "models": [
     {
       "name": "gpt-4o-mini",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -23,7 +24,8 @@
     },
     {
       "name": "gpt-4o",
-      "max_tokens": 128000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat",
         "vision"
@@ -34,7 +36,8 @@
     },
     {
       "name": "gpt-4",
-      "max_tokens": 8191,
+      "content_length": 8192,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -44,7 +47,8 @@
     },
     {
       "name": "gpt-4-turbo",
-      "max_tokens": 8191,
+      "content_length": 128000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -54,7 +58,8 @@
     },
     {
       "name": "claude-3-5-sonnet",
-      "max_tokens": 8192,
+      "content_length": 200000,
+      "max_output": 8192,
       "model_types": [
         "chat",
         "vision"
@@ -65,7 +70,8 @@
     },
     {
       "name": "gemini-1.5-pro",
-      "max_tokens": 1048576,
+      "content_length": 2097152,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -79,7 +85,8 @@
     },
     {
       "name": "gemini-1.5-flash",
-      "max_tokens": 1048576,
+      "content_length": 1048576,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/tokenpony.json
+++ b/conf/models/tokenpony.json
@@ -11,7 +11,8 @@
   "models": [
     {
       "name": "qwen3-8b",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -21,7 +22,8 @@
     },
     {
       "name": "deepseek-v3-0324",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -31,7 +33,8 @@
     },
     {
       "name": "qwen3-32b",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 32768,
       "model_types": [
         "chat"
       ],
@@ -41,7 +44,8 @@
     },
     {
       "name": "kimi-k2-instruct-0905",
-      "max_tokens": 256000,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -51,7 +55,8 @@
     },
     {
       "name": "deepseek-r1-0528",
-      "max_tokens": 164000,
+      "content_length": 131072,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -61,7 +66,8 @@
     },
     {
       "name": "qwen3-coder-480b",
-      "max_tokens": 1024000,
+      "content_length": 262144,
+      "max_output": 65536,
       "model_types": [
         "chat"
       ],
@@ -71,7 +77,8 @@
     },
     {
       "name": "hunyuan-a13b-instruct",
-      "max_tokens": 256000,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -81,7 +88,8 @@
     },
     {
       "name": "qwen3-next-80b-a3b-instruct",
-      "max_tokens": 1024000,
+      "content_length": 262144,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -91,7 +99,8 @@
     },
     {
       "name": "deepseek-v3.2-exp",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -101,7 +110,8 @@
     },
     {
       "name": "deepseek-v3.1-terminus",
-      "max_tokens": 128000,
+      "content_length": 131072,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -111,7 +121,8 @@
     },
     {
       "name": "qwen3-vl-235b-a22b-instruct",
-      "max_tokens": 262000,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -121,7 +132,8 @@
     },
     {
       "name": "qwen3-vl-30b-a3b-instruct",
-      "max_tokens": 262000,
+      "content_length": 262144,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -131,7 +143,8 @@
     },
     {
       "name": "deepseek-ocr",
-      "max_tokens": 8000,
+      "content_length": 8000,
+      "max_output": 8000,
       "model_types": [
         "chat"
       ],
@@ -141,7 +154,8 @@
     },
     {
       "name": "qwen3-235b-a22b-instruct-2507",
-      "max_tokens": 256000,
+      "content_length": 262144,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -151,7 +165,8 @@
     },
     {
       "name": "glm-4.6",
-      "max_tokens": 200000,
+      "content_length": 200000,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],
@@ -161,7 +176,8 @@
     },
     {
       "name": "minimax-m2",
-      "max_tokens": 200000,
+      "content_length": 1000000,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],

--- a/conf/models/tokenpony.json
+++ b/conf/models/tokenpony.json
@@ -177,7 +177,7 @@
     {
       "name": "minimax-m2",
       "content_length": 204800,
-      "max_output": 131072,
+      "max_output": 128000,
       "model_types": [
         "chat"
       ],

--- a/conf/models/tokenpony.json
+++ b/conf/models/tokenpony.json
@@ -176,7 +176,7 @@
     },
     {
       "name": "minimax-m2",
-      "content_length": 1000000,
+      "content_length": 204800,
       "max_output": 131072,
       "model_types": [
         "chat"

--- a/conf/models/upstage.json
+++ b/conf/models/upstage.json
@@ -12,7 +12,8 @@
   "models": [
     {
       "name": "solar-pro3",
-      "max_tokens": 65536,
+      "content_length": 128000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -22,7 +23,8 @@
     },
     {
       "name": "solar-pro2",
-      "max_tokens": 65536,
+      "content_length": 32768,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -32,7 +34,8 @@
     },
     {
       "name": "solar-pro",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -42,7 +45,8 @@
     },
     {
       "name": "solar-mini",
-      "max_tokens": 32768,
+      "content_length": 4096,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],

--- a/conf/models/volcengine.json
+++ b/conf/models/volcengine.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "doubao-seed-2-0-pro-260215",
-      "max_tokens": 262144,
+      "content_length": 256000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],

--- a/conf/models/xai.json
+++ b/conf/models/xai.json
@@ -14,7 +14,8 @@
   "models": [
     {
       "name": "grok-4",
-      "max_tokens": 256000,
+      "content_length": 262144,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -24,7 +25,8 @@
     },
     {
       "name": "grok-3",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -34,7 +36,8 @@
     },
     {
       "name": "grok-3-fast",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -44,7 +47,8 @@
     },
     {
       "name": "grok-3-mini",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -54,7 +58,8 @@
     },
     {
       "name": "grok-3-mini-mini-fast",
-      "max_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072,
       "model_types": [
         "chat"
       ],
@@ -64,7 +69,8 @@
     },
     {
       "name": "grok-2-vision",
-      "max_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 8192,
       "model_types": [
         "vision"
       ]

--- a/conf/models/xiaomi.json
+++ b/conf/models/xiaomi.json
@@ -9,7 +9,8 @@
   "models": [
     {
       "name": "mimo-v2.5-pro",
-      "max_tokens": 1048576,
+      "content_length": 128000,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],
@@ -19,7 +20,8 @@
     },
     {
       "name": "mimo-v2.5",
-      "max_tokens": 1048576,
+      "content_length": 128000,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/xunfei.json
+++ b/conf/models/xunfei.json
@@ -10,7 +10,8 @@
   "models": [
     {
       "name": "spark-x",
-      "max_tokens": 134144,
+      "content_length": 128000,
+      "max_output": 8192,
       "model_types": [
         "chat"
       ],

--- a/conf/models/zhipu-ai.json
+++ b/conf/models/zhipu-ai.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "glm-5.1",
-      "content_length": 204800,
+      "content_length": 200000,
       "max_output": 128000,
       "model_types": [
         "chat"
@@ -50,7 +50,7 @@
     },
     {
       "name": "glm-5",
-      "content_length": 204800,
+      "content_length": 200000,
       "max_output": 128000,
       "model_types": [
         "chat"
@@ -65,7 +65,7 @@
     },
     {
       "name": "glm-5-turbo",
-      "content_length": 204800,
+      "content_length": 200000,
       "max_output": 128000,
       "model_types": [
         "chat"
@@ -80,7 +80,7 @@
     },
     {
       "name": "glm-5v-turbo",
-      "content_length": 204800,
+      "content_length": 200000,
       "max_output": 128000,
       "model_types": [
         "chat"
@@ -95,7 +95,7 @@
     },
     {
       "name": "glm-4.7",
-      "content_length": 204800,
+      "content_length": 200000,
       "max_output": 128000,
       "model_types": [
         "chat"
@@ -110,7 +110,7 @@
     },
     {
       "name": "glm-4.7-flashx",
-      "content_length": 204800,
+      "content_length": 200000,
       "max_output": 128000,
       "model_types": [
         "chat"
@@ -125,7 +125,7 @@
     },
     {
       "name": "glm-4.6",
-      "content_length": 204800,
+      "content_length": 200000,
       "max_output": 128000,
       "model_types": [
         "chat"
@@ -140,8 +140,8 @@
     },
     {
       "name": "glm-4.6v-Flash",
-      "content_length": 204800,
-      "max_output": 128000,
+      "content_length": 128000,
+      "max_output": 32768,
       "model_types": [
         "chat",
         "vision"
@@ -231,8 +231,8 @@
     },
     {
       "name": "glm-4.5v",
-      "content_length": 64000,
-      "max_output": 16000,
+      "content_length": 65536,
+      "max_output": 16384,
       "model_types": [
         "vision"
       ],
@@ -247,7 +247,7 @@
     {
       "name": "glm-4-plus",
       "content_length": 128000,
-      "max_output": 32000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -258,7 +258,7 @@
     {
       "name": "glm-4-0520",
       "content_length": 128000,
-      "max_output": 32000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -269,7 +269,7 @@
     {
       "name": "glm-4",
       "content_length": 128000,
-      "max_output": 4000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -279,8 +279,8 @@
     },
     {
       "name": "glm-4-airx",
-      "content_length": 8000,
-      "max_output": 4000,
+      "content_length": 8192,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -290,8 +290,8 @@
     },
     {
       "name": "glm-4-air",
-      "content_length": 8000,
-      "max_output": 4000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -302,7 +302,7 @@
     {
       "name": "glm-4-flash",
       "content_length": 128000,
-      "max_output": 4000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -313,7 +313,7 @@
     {
       "name": "glm-4-flashx",
       "content_length": 128000,
-      "max_output": 16000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],
@@ -324,7 +324,7 @@
     {
       "name": "glm-4-long",
       "content_length": 1000000,
-      "max_output": 4000,
+      "max_output": 4096,
       "model_types": [
         "chat"
       ],
@@ -334,16 +334,16 @@
     },
     {
       "name": "glm-4v",
-      "content_length": 16000,
-      "max_output": 1000,
+      "content_length": 16384,
+      "max_output": 1024,
       "model_types": [
         "vision"
       ]
     },
     {
       "name": "glm-4-9b",
-      "content_length": 8000,
-      "max_output": 1000,
+      "content_length": 128000,
+      "max_output": 16384,
       "model_types": [
         "chat"
       ],

--- a/internal/entity/models/model_test.go
+++ b/internal/entity/models/model_test.go
@@ -394,7 +394,7 @@ func TestSiliconFlowProviderConfigLoadsLatestProModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetModelByName GLM-5.1: %v", err)
 	}
-	if *glm51.MaxOutput != 131072 || *glm51.ContentLength != 204800 {
+	if *glm51.MaxOutput != 128000 || *glm51.ContentLength != 200000 {
 		t.Errorf("GLM-5.1 max_output=%d content_length=%d", *glm51.MaxOutput, *glm51.ContentLength)
 	}
 }

--- a/internal/entity/models/model_test.go
+++ b/internal/entity/models/model_test.go
@@ -294,22 +294,22 @@ func TestPPIOProviderConfigLoadsIntoProviderManager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetModelByName: %v", err)
 	}
-	if *model.MaxOutput != 64000 {
-		t.Errorf("deepseek/deepseek-r1 max_tokens=%d", *model.MaxOutput)
+	if *model.MaxOutput != 32768 || *model.ContentLength != 131072 {
+		t.Errorf("deepseek/deepseek-r1 max_output=%d content_length=%d", *model.MaxOutput, *model.ContentLength)
 	}
 	model, err = pm.GetModelByName("ppio", "deepseek/deepseek-v4-pro")
 	if err != nil {
 		t.Fatalf("GetModelByName v4 pro: %v", err)
 	}
-	if *model.MaxOutput != 1048576 {
-		t.Errorf("deepseek/deepseek-v4-pro max_tokens=%d", *model.MaxOutput)
+	if *model.MaxOutput != 393216 || *model.ContentLength != 1048576 {
+		t.Errorf("deepseek/deepseek-v4-pro max_output=%d content_length=%d", *model.MaxOutput, *model.ContentLength)
 	}
 	model, err = pm.GetModelByName("ppio", "deepseek/deepseek-v4-flash")
 	if err != nil {
 		t.Fatalf("GetModelByName v4 flash: %v", err)
 	}
-	if *model.MaxOutput != 1048576 {
-		t.Errorf("deepseek/deepseek-v4-flash max_tokens=%d", *model.MaxOutput)
+	if *model.MaxOutput != 393216 || *model.ContentLength != 1048576 {
+		t.Errorf("deepseek/deepseek-v4-flash max_output=%d content_length=%d", *model.MaxOutput, *model.ContentLength)
 	}
 	if !model.ModelTypeMap["chat"] {
 		t.Errorf("deepseek/deepseek-v4-flash missing chat type map")
@@ -372,8 +372,8 @@ func TestSiliconFlowProviderConfigLoadsLatestProModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetModelByName DeepSeek-V4-Pro: %v", err)
 	}
-	if *deepSeekV4Pro.MaxOutput != 1048576 {
-		t.Errorf("DeepSeek-V4-Pro max_tokens=%d", *deepSeekV4Pro.MaxOutput)
+	if *deepSeekV4Pro.MaxOutput != 393216 || *deepSeekV4Pro.ContentLength != 1048576 {
+		t.Errorf("DeepSeek-V4-Pro max_output=%d content_length=%d", *deepSeekV4Pro.MaxOutput, *deepSeekV4Pro.ContentLength)
 	}
 	if !deepSeekV4Pro.ModelTypeMap["chat"] {
 		t.Errorf("DeepSeek-V4-Pro model types=%v, want chat", deepSeekV4Pro.ModelTypes)
@@ -383,8 +383,8 @@ func TestSiliconFlowProviderConfigLoadsLatestProModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetModelByName Kimi-K2.6: %v", err)
 	}
-	if *kimiK26.MaxOutput != 262144 {
-		t.Errorf("Kimi-K2.6 max_tokens=%d", *kimiK26.MaxOutput)
+	if *kimiK26.MaxOutput != 65536 || *kimiK26.ContentLength != 262144 {
+		t.Errorf("Kimi-K2.6 max_output=%d content_length=%d", *kimiK26.MaxOutput, *kimiK26.ContentLength)
 	}
 	if !kimiK26.ModelTypeMap["chat"] || !kimiK26.ModelTypeMap["vision"] {
 		t.Errorf("Kimi-K2.6 model types=%v, want chat+vision", kimiK26.ModelTypes)
@@ -394,7 +394,7 @@ func TestSiliconFlowProviderConfigLoadsLatestProModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetModelByName GLM-5.1: %v", err)
 	}
-	if *glm51.MaxOutput != 204800 {
-		t.Errorf("GLM-5.1 max_tokens=%d", *glm51.MaxOutput)
+	if *glm51.MaxOutput != 131072 || *glm51.ContentLength != 204800 {
+		t.Errorf("GLM-5.1 max_output=%d content_length=%d", *glm51.MaxOutput, *glm51.ContentLength)
 	}
 }


### PR DESCRIPTION
## Summary

- Verify and populate `content_length` (context window) and `max_output` (max generation tokens) for all **478 chat/vision models** across **47 provider configs**
- Data sourced from **official API documentation** via 12 parallel agents + targeted web verification
- Update Go test assertions to match verified values

## Why

PR #17807 introduced the `content_length` / `max_output` fields but many values were initial guesses. This PR replaces them with values verified against official docs.

## Key Corrections

| Model Family | Before | After (Official) |
|---|---|---|
| Claude 4.6+ (opus 4.6/4.7/4.8, sonnet 4.6) | 200K / 64K | **1M / 128K** |
| DeepSeek V4 | 1M / 8K | **1M / 384K** |
| GPT-5 series | 400K / 65K | **400K / 128K** |
| Llama 4 Scout | 1M | **10M** |
| Mistral | context / 8K | **context / context** |
| Gemini 1.5 Pro | 1M | **2M** |
| Nova series | 300K / 8K | **300K / 5K** |
| LongCat-2.0 | 262K | **1M / 128K** |

## Data Collection

- 12 parallel agents scraped official docs (OpenAI, Anthropic, Google, Bedrock, Cohere, xAI, Meta, DeepSeek, Qwen, Mistral, GLM, Kimi, etc.)
- 4 additional web search agents for uncertain models
- All values cross-checked against vendor spec pages

## Test

- `internal/entity/models/model_test.go` assertions updated
- `go test ./internal/entity/models/...` passes
