### PR TITLE
feat: update all_models.json to content_length + max_output

### DIFF
--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -17595,7 +17595,7 @@
       },
       "max_completion_tokens": 131072,
       "content_length": 204800,
-      "max_output": 131072
+      "max_output": 16384
     },
     {
       "name": "minimaxai/MiniMax-M2.5",
@@ -17632,7 +17632,7 @@
       },
       "max_completion_tokens": 131072,
       "content_length": 204800,
-      "max_output": 131072
+      "max_output": 16384
     },
     {
       "name": "minimaxai/MiniMax-Text-01",
@@ -38990,7 +38990,7 @@
         "vision",
         "image2text"
       ],
-      "content_length": 131072,
+      "content_length": 262144,
       "max_output": 131072
     },
     {
@@ -39005,7 +39005,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "content_length": 131072,
+      "content_length": 262144,
       "max_output": 131072
     },
     {
@@ -39365,8 +39365,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 200000,
-      "max_output": 128000
+      "content_length": 204800,
+      "max_output": 131072
     },
     {
       "name": "zai-org/GLM-5.1-FP8",

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -17595,7 +17595,7 @@
       },
       "max_completion_tokens": 131072,
       "content_length": 204800,
-      "max_output": 16384
+      "max_output": 128000
     },
     {
       "name": "minimaxai/MiniMax-M2.5",
@@ -17613,7 +17613,7 @@
       },
       "max_completion_tokens": 131100,
       "content_length": 204800,
-      "max_output": 196608
+      "max_output": 128000
     },
     {
       "name": "minimaxai/MiniMax-M2.7",
@@ -17632,7 +17632,7 @@
       },
       "max_completion_tokens": 131072,
       "content_length": 204800,
-      "max_output": 16384
+      "max_output": 128000
     },
     {
       "name": "minimaxai/MiniMax-Text-01",
@@ -39349,8 +39349,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 204800,
-      "max_output": 131072
+      "content_length": 200000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-5.1-FP8",

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -38878,22 +38878,6 @@
         "xai/grok-4.3",
         "grok-4.3-latest",
         "grok-latest",
-        "grok-3",
-        "grok-3-latest",
-        "grok-3-beta",
-        "grok-3-fast",
-        "grok-3-fast-latest",
-        "grok-3-fast-beta",
-        "grok-3-mini",
-        "grok-3-mini-latest",
-        "grok-3-mini-beta",
-        "grok-3-mini-fast",
-        "grok-3-mini-fast-latest",
-        "grok-3-mini-fast-beta",
-        "grok-3-mini-high",
-        "grok-3-mini-high-beta",
-        "grok-3-mini-fast-high",
-        "grok-3-mini-fast-high-beta",
         "grok-4-0709",
         "grok-4",
         "grok-4-latest",
@@ -38990,7 +38974,7 @@
         "vision",
         "image2text"
       ],
-      "content_length": 262144,
+      "content_length": 131072,
       "max_output": 131072
     },
     {
@@ -39005,7 +38989,7 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "content_length": 262144,
+      "content_length": 131072,
       "max_output": 131072
     },
     {

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -291,7 +291,7 @@
         "image2text"
       ],
       "content_length": 300000,
-      "max_output": 300000
+      "max_output": 5000
     },
     {
       "name": "amazon/nova-micro-v1",
@@ -302,8 +302,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 300000,
-      "max_output": 300000
+      "content_length": 128000,
+      "max_output": 5000
     },
     {
       "name": "amazon/nova-premier-v1",
@@ -327,7 +327,7 @@
         "image2text"
       ],
       "content_length": 300000,
-      "max_output": 300000
+      "max_output": 5000
     },
     {
       "name": "amazon/titan-embed-text-v1",
@@ -777,7 +777,7 @@
         "image2text"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 8192
     },
     {
       "name": "anthropic/claude-3-5-sonnet-20241022",
@@ -791,7 +791,7 @@
         "image2text"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 8192
     },
     {
       "name": "anthropic/claude-3-haiku-20240307",
@@ -1508,8 +1508,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "Baichuan-M2-Plus",
@@ -1527,8 +1527,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "Baichuan-Text-Embedding",
@@ -1552,8 +1552,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "Baichuan2-Turbo-192k",
@@ -1571,8 +1571,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "Baichuan3-Turbo-128k",
@@ -1582,8 +1582,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "Baichuan4",
@@ -1593,8 +1593,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "Baichuan4-Air",
@@ -1604,8 +1604,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "Baichuan4-Turbo",
@@ -1615,8 +1615,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "baidu/ernie-5.0-thinking-exp",
@@ -3305,7 +3305,7 @@
         "chat"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 8192
     },
     {
       "name": "claude-3-5-haiku-latest",
@@ -3329,7 +3329,7 @@
         "chat"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 8192
     },
     {
       "name": "claude-3-5-sonnet-latest",
@@ -3345,7 +3345,7 @@
         "chat"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 64000
     },
     {
       "name": "claude-3-7-sonnet-20250219-thinking",
@@ -3402,7 +3402,7 @@
         "support": true
       },
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 64000
     },
     {
       "name": "claude-haiku-4-5-20251001-thinking",
@@ -3423,7 +3423,7 @@
       ],
       "alias": [],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 32000
     },
     {
       "name": "claude-opus-4-1-20250805-thinking",
@@ -3443,7 +3443,7 @@
         "chat"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 16384
     },
     {
       "name": "claude-opus-4-20250514-thinking",
@@ -3466,7 +3466,7 @@
         "claude-opus-4.5"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 64000
     },
     {
       "name": "claude-opus-4-5-20251101-thinking",
@@ -3490,8 +3490,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 200000,
-      "max_output": 200000
+      "content_length": 1000000,
+      "max_output": 128000
     },
     {
       "name": "claude-opus-4-7",
@@ -3508,7 +3508,7 @@
         "support": true
       },
       "content_length": 1000000,
-      "max_output": 1000000
+      "max_output": 128000
     },
     {
       "name": "claude-opus-4-7-thinking",
@@ -3534,7 +3534,7 @@
         "clear_thinking": true
       },
       "content_length": 1000000,
-      "max_output": 1000000
+      "max_output": 128000
     },
     {
       "name": "claude-opus-4.6-fast",
@@ -3560,7 +3560,7 @@
         "chat"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 64000
     },
     {
       "name": "claude-sonnet-4-20250514-thinking",
@@ -3584,7 +3584,7 @@
         "support": true
       },
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 64000
     },
     {
       "name": "claude-sonnet-4-5-20250929-thinking",
@@ -3617,7 +3617,7 @@
         "support": true
       },
       "content_length": 1000000,
-      "max_output": 1000000
+      "max_output": 128000
     },
     {
       "name": "claude-sonnet-4-6-thinking",
@@ -3727,7 +3727,7 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 4096
     },
     {
       "name": "cohere/embed-v4.0",
@@ -3908,7 +3908,7 @@
         "chat"
       ],
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "cohere/command-a-plus-05-2026",
@@ -3921,7 +3921,7 @@
         "image2text"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 65536
     },
     {
       "name": "cohere/command-a-reasoning-08-2025",
@@ -3936,7 +3936,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "cohere/command-a-translate-08-2025",
@@ -3960,7 +3960,7 @@
         "image2text"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "cohere/command-light",
@@ -4026,7 +4026,7 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 4096
     },
     {
       "name": "cohere/command-r-plus",
@@ -4059,7 +4059,7 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 4096
     },
     {
       "name": "CompVis/stable-diffusion-v1-4",
@@ -4352,8 +4352,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 131072,
+      "max_output": 32768
     },
     {
       "name": "deepseek/deepseek-r1-turbo",
@@ -4384,8 +4384,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 64000,
-      "max_output": 64000
+      "content_length": 131072,
+      "max_output": 32768
     },
     {
       "name": "deepseek/deepseek-v3/community",
@@ -4399,8 +4399,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 64000,
-      "max_output": 64000
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-v4-flash",
@@ -4491,8 +4491,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-v3.2-exp",
@@ -4503,8 +4503,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-v3.2-exp-base",
@@ -4539,8 +4539,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-v3.1-base",
@@ -4564,8 +4564,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-v3-0324",
@@ -4605,8 +4605,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-v3-base",
@@ -4870,8 +4870,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 65536
     },
     {
       "name": "deepseek-ai/DeepSeek-R1-0528-Turbo",
@@ -4898,8 +4898,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 32768
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-32b",
@@ -4911,7 +4911,7 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 32768
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-7b",
@@ -4957,7 +4957,7 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 32768
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-llama-8b",
@@ -5297,8 +5297,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 8192,
-      "max_output": 8192
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "deepseek-ocr-2",
@@ -5331,8 +5331,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 32768
     },
     {
       "name": "deepseek-r1-0528",
@@ -5351,8 +5351,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 65536
     },
     {
       "name": "deepseek-r1-2025-01-20",
@@ -5430,7 +5430,7 @@
         "clear_thinking": true
       },
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 32768
     },
     {
       "name": "deepseek-r1-distill-qwen-32b",
@@ -5513,8 +5513,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-v3-1-think-250821",
@@ -5527,7 +5527,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-v3-aliyun",
@@ -5571,8 +5573,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-v3.1-huoshan",
@@ -5598,8 +5600,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-v3.1-thinking",
@@ -5630,8 +5632,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-v3.2-exp",
@@ -5649,8 +5651,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 163840,
-      "max_output": 163840
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "deepseek-v3.2-exp-thinking",
@@ -6341,7 +6343,7 @@
         "support": true
       },
       "content_length": 256000,
-      "max_output": 256000
+      "max_output": 16384
     },
     {
       "name": "doubao-seed-character-251128",
@@ -7042,7 +7044,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 4096
     },
     {
       "name": "glm-4-0520",
@@ -7053,7 +7057,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 4096
     },
     {
       "name": "glm-4-5-air-20250728",
@@ -7089,7 +7093,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 16384
     },
     {
       "name": "glm-4-air-250414",
@@ -7107,8 +7111,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 8000,
-      "max_output": 8000
+      "content_length": 8192,
+      "max_output": 4096
     },
     {
       "name": "glm-4-flash",
@@ -7119,7 +7123,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 16384
     },
     {
       "name": "glm-4-flash-250414",
@@ -7141,7 +7145,7 @@
         "support": true
       },
       "content_length": 1000000,
-      "max_output": 1000000
+      "max_output": 4096
     },
     {
       "name": "glm-4-plus",
@@ -7152,7 +7156,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 4096
     },
     {
       "name": "glm-4.1v-thinking-flash",
@@ -7187,7 +7191,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 96000
     },
     {
       "name": "glm-4.5-flash",
@@ -7198,7 +7202,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 96000
     },
     {
       "name": "glm-4.5-x",
@@ -7209,7 +7213,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 96000
     },
     {
       "name": "glm-4.7-coding-preview",
@@ -7232,7 +7236,7 @@
         "clear_thinking": true
       },
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 128000
     },
     {
       "name": "glm-4.7-preview",
@@ -7249,8 +7253,8 @@
         "image2text",
         "vision"
       ],
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 16384,
+      "max_output": 1024
     },
     {
       "name": "glm-4v-plus",
@@ -7279,7 +7283,7 @@
         "support": true
       },
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 128000
     },
     {
       "name": "glm-5v-turbo",
@@ -7298,7 +7302,7 @@
         "support": true
       },
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 128000
     },
     {
       "name": "glm-asr-2512",
@@ -7517,7 +7521,7 @@
         "clear_thinking": true
       },
       "content_length": 1048576,
-      "max_output": 1048576
+      "max_output": 65536
     },
     {
       "name": "google/gemini-3.1-pro-preview-customtools",
@@ -7605,7 +7609,7 @@
         "clear_thinking": true
       },
       "content_length": 1048576,
-      "max_output": 1048576
+      "max_output": 65536
     },
     {
       "name": "google/gemini-2.5-computer-use-preview-10-2025",
@@ -7641,7 +7645,7 @@
         "clear_thinking": true
       },
       "content_length": 1048576,
-      "max_output": 1048576
+      "max_output": 65536
     },
     {
       "name": "google/gemini-2.5-flash-image",
@@ -7680,7 +7684,7 @@
         "clear_thinking": true
       },
       "content_length": 1048576,
-      "max_output": 1048576
+      "max_output": 65536
     },
     {
       "name": "google/gemini-2.5-flash-lite-preview-06-17",
@@ -7771,7 +7775,7 @@
         "clear_thinking": true
       },
       "content_length": 1048576,
-      "max_output": 1048576
+      "max_output": 65536
     },
     {
       "name": "google/gemini-2.5-pro-preview-06-05",
@@ -8390,7 +8394,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 98304,
+      "max_output": 16384
     },
     {
       "name": "google/gemma-3-27b-it-qat-q4_0-gguf",
@@ -10449,8 +10455,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 4000,
-      "max_output": 4000
+      "content_length": 16385,
+      "max_output": 4096
     },
     {
       "name": "gpt-3.5-turbo-0125",
@@ -10515,8 +10521,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 8000,
-      "max_output": 8000
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "gpt-4-0125-preview",
@@ -10553,8 +10559,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 4096
     },
     {
       "name": "gpt-4-32k-0613",
@@ -10640,8 +10646,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 1047576,
+      "max_output": 32768
     },
     {
       "name": "gpt-4.1-2025-04-14",
@@ -10661,8 +10667,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 1047576,
+      "max_output": 32768
     },
     {
       "name": "gpt-4.1-mini-2025-04-14",
@@ -10682,8 +10688,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 1047576,
+      "max_output": 32768
     },
     {
       "name": "gpt-4.1-nano-2025-04-14",
@@ -10708,7 +10714,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 16384
     },
     {
       "name": "gpt-4o-2024-08-06",
@@ -10787,7 +10793,9 @@
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 16384
     },
     {
       "name": "gpt-4o-mini-2024-07-18",
@@ -10950,8 +10958,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 400000,
-      "max_output": 400000
+      "content_length": 128000,
+      "max_output": 16384
     },
     {
       "name": "gpt-5-codex-2025-09-15",
@@ -11113,7 +11121,7 @@
         "support": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 16384
     },
     {
       "name": "gpt-5.1-codex-2025-11-13",
@@ -11219,7 +11227,7 @@
         "support": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "gpt-5.2-pro-2025-12-11",
@@ -11314,7 +11322,7 @@
         "support": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "gpt-5.4-nano-2026-03-17",
@@ -11689,7 +11697,7 @@
         "support": true
       },
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "groq/compound-mini",
@@ -11704,7 +11712,7 @@
         "support": true
       },
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "Gryphe/MythoMax-L2-13b-turbo",
@@ -14352,7 +14360,7 @@
         "image2text"
       ],
       "content_length": 32768,
-      "max_output": 32768
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-vlm-mlx",
@@ -14570,7 +14578,7 @@
         "support": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 131072
     },
     {
       "name": "kimi-k2-thinking",
@@ -14585,7 +14593,7 @@
         "support": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 131072
     },
     {
       "name": "kimi-k2-thinking-turbo",
@@ -14627,7 +14635,7 @@
         "support": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 131072
     },
     {
       "name": "kimi-latest",
@@ -15198,7 +15206,7 @@
         "support": true
       },
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 32768
     },
     {
       "name": "llama-4-maverick",
@@ -15405,7 +15413,7 @@
         "chat"
       ],
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "meituan-longcat/longcat-flash-lite-fp8",
@@ -15674,7 +15682,7 @@
         "image2text"
       ],
       "content_length": 1048576,
-      "max_output": 1048576
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP4",
@@ -15786,7 +15794,7 @@
       ],
       "max_completion_tokens": 8192,
       "content_length": 10485760,
-      "max_output": 10485760
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Instruct-FP8-Lora",
@@ -16130,8 +16138,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 8192,
-      "max_output": 8192
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "meta-llama/Llama-3-8b-chat-hf",
@@ -16159,8 +16167,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 8192,
-      "max_output": 8192
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "meta-llama/Llama-2-13b",
@@ -17225,8 +17233,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 1048576,
-      "max_output": 1048576
+      "content_length": 128000,
+      "max_output": 8192
     },
     {
       "name": "mimo-v2.5-asr",
@@ -17252,8 +17260,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 1048576,
-      "max_output": 1048576
+      "content_length": 128000,
+      "max_output": 8192
     },
     {
       "name": "minimax/hailuo-02",
@@ -17325,8 +17333,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 204800,
-      "max_output": 204800
+      "content_length": 196608,
+      "max_output": 16384
     },
     {
       "name": "minimax/minimax-m2.7-highspeed",
@@ -17459,7 +17467,7 @@
         "support": true
       },
       "content_length": 1024000,
-      "max_output": 1024000
+      "max_output": 131072
     },
     {
       "name": "MiniMax-Voice-Clone",
@@ -17568,8 +17576,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 204800,
+      "max_output": 131072
     },
     {
       "name": "minimaxai/MiniMax-M2.1",
@@ -17586,8 +17594,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 204800,
+      "max_output": 16384
     },
     {
       "name": "minimaxai/MiniMax-M2.5",
@@ -17604,8 +17612,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131100,
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 204800,
+      "max_output": 196608
     },
     {
       "name": "minimaxai/MiniMax-M2.7",
@@ -17623,8 +17631,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 204800,
+      "max_output": 16384
     },
     {
       "name": "minimaxai/MiniMax-Text-01",
@@ -17841,8 +17849,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 256000,
-      "max_output": 256000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistral/magistral-medium-latest",
@@ -17852,8 +17860,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 40000,
-      "max_output": 40000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistral/magistral-small-latest",
@@ -17863,8 +17871,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 40000,
-      "max_output": 40000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistral/ministral-3b-latest",
@@ -17874,8 +17882,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistral/ministral-8b-latest",
@@ -17885,8 +17893,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistral/mistral-embed",
@@ -17907,8 +17915,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistral/mistral-medium-latest",
@@ -17918,8 +17926,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistral/mistral-small-latest",
@@ -17929,8 +17937,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistral/open-mistral-7b",
@@ -17940,8 +17948,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistral/open-mistral-nemo",
@@ -17951,8 +17959,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistral/open-mixtral-8x22b",
@@ -17962,8 +17970,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 64000,
-      "max_output": 64000
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "mistral/open-mixtral-8x7b",
@@ -17973,8 +17981,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistral/pixtral-large-latest",
@@ -18277,8 +18285,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 131072,
-      "max_output": 131072
+      "content_length": 60288,
+      "max_output": 16000
     },
     {
       "name": "mistralai/Mistral-Nemo-Instruct-2407",
@@ -18584,8 +18592,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "moonshot-v1-128k-vision-preview",
@@ -18597,8 +18605,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "moonshot-v1-32k",
@@ -18608,8 +18616,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "moonshot-v1-32k-vision-preview",
@@ -18621,8 +18629,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "moonshot-v1-8k",
@@ -18632,8 +18640,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 8000,
-      "max_output": 8000
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "moonshot-v1-8k-vision-preview",
@@ -18645,8 +18653,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 8000,
-      "max_output": 8000
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "moonshotai/Kimi-Audio-7B",
@@ -18742,7 +18750,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 131072
     },
     {
       "name": "moonshotai/kimi-k2-thinking",
@@ -18781,7 +18789,7 @@
       },
       "max_completion_tokens": 262144,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 131072
     },
     {
       "name": "moonshotai/Kimi-K2.5-fp4",
@@ -18829,7 +18837,7 @@
       },
       "max_completion_tokens": 262144,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 131072
     },
     {
       "name": "moonshotai/kimi-k2.7-code",
@@ -19336,7 +19344,7 @@
         "support": true
       },
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "nvidia/DeepSeek-V3.2-NVFP4",
@@ -19402,8 +19410,8 @@
         "vision",
         "image2text"
       ],
-      "content_length": 262144,
-      "max_output": 262144
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
@@ -19412,7 +19420,9 @@
       ],
       "model_types": [
         "moderation"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "nvidia/Audio2Emotion-v3.0",
@@ -21731,7 +21741,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 8192
     },
     {
       "name": "nvidia/nemotron-3-super-120b-a12b:free",
@@ -21755,8 +21767,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 512288,
-      "max_output": 512288
+      "content_length": 262144,
+      "max_output": 8192
     },
     {
       "name": "nvidia/nemotron-3.5-asr-streaming-0.6b",
@@ -22932,7 +22944,7 @@
         "clear_thinking": true
       },
       "content_length": 1050000,
-      "max_output": 1050000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.5-all",
@@ -22993,7 +23005,7 @@
         "clear_thinking": true
       },
       "content_length": 1050000,
-      "max_output": 1050000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.4-image-2",
@@ -23025,7 +23037,7 @@
         "clear_thinking": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.4-nano",
@@ -23131,7 +23143,7 @@
         "clear_thinking": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.2-chat",
@@ -23200,7 +23212,7 @@
         "clear_thinking": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.1-chat",
@@ -23294,7 +23306,7 @@
         "clear_thinking": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5-chat",
@@ -23394,7 +23406,7 @@
         "clear_thinking": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5-nano",
@@ -23411,7 +23423,7 @@
         "clear_thinking": true
       },
       "content_length": 400000,
-      "max_output": 400000
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5-pro",
@@ -23617,7 +23629,7 @@
         "image2text"
       ],
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 4096
     },
     {
       "name": "openai/gpt-4-turbo-preview",
@@ -25224,7 +25236,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 8192
     },
     {
       "name": "orcarouter/fusion",
@@ -25490,8 +25504,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "Pixverse/Pixverse-6-I2V",
@@ -26161,8 +26175,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 131072,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3.7-max-preview",
@@ -26197,7 +26211,7 @@
       },
       "max_completion_tokens": 65536,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3.6-max-preview",
@@ -26349,8 +26363,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 262144,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3.5-plus-20260420",
@@ -26510,7 +26524,7 @@
       },
       "max_completion_tokens": 65536,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3.5-35b-a3b-base",
@@ -26569,7 +26583,7 @@
       },
       "max_completion_tokens": 65536,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3.5-plus-2026-02-15",
@@ -26827,7 +26841,7 @@
         "support": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3.5-4b-base",
@@ -26862,8 +26876,8 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 1048576,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3.5-omni-flash",
@@ -26921,8 +26935,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 65536,
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 1048576,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-asr-flash-2026-02-10",
@@ -26977,7 +26991,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-max-thinking",
@@ -27400,7 +27414,7 @@
       "tools": {
         "support": true
       },
-      "content_length": 32768,
+      "content_length": 131072,
       "max_output": 32768
     },
     {
@@ -27415,7 +27429,7 @@
       "tools": {
         "support": true
       },
-      "content_length": 32768,
+      "content_length": 131072,
       "max_output": 32768
     },
     {
@@ -27742,7 +27756,7 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 32768,
+      "content_length": 131072,
       "max_output": 32768
     },
     {
@@ -27762,8 +27776,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32768,
-      "max_output": 32768
+      "content_length": 40960,
+      "max_output": 20000
     },
     {
       "name": "qwen/qwen3-235b-a22b-gguf",
@@ -27802,7 +27816,7 @@
       ],
       "max_completion_tokens": 16384,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 16384
     },
     {
       "name": "qwen/qwen3-235b-a22b-instruct-2507-fp8",
@@ -27875,7 +27889,7 @@
       },
       "max_completion_tokens": 32768,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-thinking-2507-fp8",
@@ -27900,7 +27914,7 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 32768,
+      "content_length": 131072,
       "max_output": 32768
     },
     {
@@ -27932,8 +27946,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32768,
-      "max_output": 32768
+      "content_length": 256000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen3-30b-a3b-gguf",
@@ -27966,7 +27980,7 @@
         "chat"
       ],
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 16384
     },
     {
       "name": "qwen/qwen3-30b-a3b-instruct-2507-fp8",
@@ -28036,7 +28050,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-thinking-2507-fp8",
@@ -28144,7 +28158,7 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 32768,
+      "content_length": 131072,
       "max_output": 32768
     },
     {
@@ -28499,7 +28513,7 @@
         "support": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-coder-480b-a35b-instruct-fp8",
@@ -28555,8 +28569,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 262144,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-embedding-0.6b",
@@ -28684,7 +28698,7 @@
       },
       "max_completion_tokens": 65536,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-max-preview",
@@ -28699,7 +28713,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct",
@@ -28719,7 +28733,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 16384
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct-fp8",
@@ -28758,7 +28772,7 @@
       },
       "max_completion_tokens": 32768,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-thinking-fp8",
@@ -29056,7 +29070,7 @@
       },
       "max_completion_tokens": 32768,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b-instruct-fp8",
@@ -29257,7 +29271,7 @@
       },
       "max_completion_tokens": 32768,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-instruct-fp8",
@@ -29305,7 +29319,7 @@
       },
       "max_completion_tokens": 32768,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-thinking-fp8",
@@ -29721,7 +29735,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-vl-rerank",
@@ -30058,7 +30074,7 @@
         "support": true
       },
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-32b-instruct-awq",
@@ -30195,7 +30211,7 @@
       ],
       "max_completion_tokens": 8192,
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen2.5-72b-instruct-awq",
@@ -30967,8 +30983,8 @@
         "image2text"
       ],
       "max_completion_tokens": 32768,
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 32768,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-vl-72b-instruct-awq",
@@ -30991,8 +31007,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 32768,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-vl-7b-instruct-awq",
@@ -31289,8 +31305,8 @@
         "chat"
       ],
       "max_completion_tokens": 32768,
-      "content_length": 32768,
-      "max_output": 32768
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen2-7b-instruct-awq",
@@ -31531,7 +31547,7 @@
       ],
       "max_completion_tokens": 120000,
       "content_length": 32768,
-      "max_output": 32768
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen2-vl-72b-instruct-awq",
@@ -32548,7 +32564,9 @@
         "image2text",
         "vision",
         "video_understanding"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-vl-plus-2025-01-25",
@@ -33096,8 +33114,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 1048576,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-flash-us",
@@ -33505,7 +33523,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-vl",
@@ -34774,7 +34794,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "solar-pro2",
@@ -34786,7 +34808,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 4096
     },
     {
       "name": "solar-pro3",
@@ -34798,7 +34822,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 4096
     },
     {
       "name": "sonar",
@@ -34806,16 +34832,16 @@
         "chat"
       ],
       "alias": [],
-      "content_length": 200000,
-      "max_output": 200000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "sonar-deep-research",
       "model_types": [
         "chat"
       ],
-      "content_length": 127000,
-      "max_output": 127000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "sonar-pro",
@@ -34823,7 +34849,7 @@
         "chat"
       ],
       "content_length": 200000,
-      "max_output": 200000
+      "max_output": 8192
     },
     {
       "name": "sonar-reasoning",
@@ -34838,8 +34864,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 127000,
-      "max_output": 127000
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "sophnet/GLM-5",
@@ -35605,8 +35631,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "step-1v-32k",
@@ -35616,8 +35642,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "step-1v-8k",
@@ -35627,8 +35653,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 8000,
-      "max_output": 8000
+      "content_length": 8192,
+      "max_output": 4096
     },
     {
       "name": "step-2-16k",
@@ -35641,8 +35667,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 16000,
-      "max_output": 16000
+      "content_length": 16384,
+      "max_output": 8192
     },
     {
       "name": "step-2-16k-exp",
@@ -38894,8 +38920,8 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 262144,
+      "max_output": 131072
     },
     {
       "name": "x-ai/grok-4-0709",
@@ -39043,8 +39069,8 @@
         "image2text",
         "vision"
       ],
-      "content_length": 131072,
-      "max_output": 131072
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "xai/grok-beta",
@@ -39314,7 +39340,9 @@
       },
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-5.1",
@@ -39337,8 +39365,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 202752,
-      "max_output": 202752
+      "content_length": 204800,
+      "max_output": 131072
     },
     {
       "name": "zai-org/GLM-5.1-FP8",
@@ -39371,8 +39399,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 202752,
-      "max_output": 202752
+      "content_length": 200000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-5-FP4",
@@ -39436,8 +39464,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 202752,
-      "max_output": 202752
+      "content_length": 200000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.7-Flash",
@@ -39517,8 +39545,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 202752,
-      "max_output": 202752
+      "content_length": 200000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.6-FP8",
@@ -39790,8 +39818,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 8000,
-      "max_output": 8000
+      "content_length": 128000,
+      "max_output": 16384
     },
     {
       "name": "zai-org/GLM-4-9B-0414",

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -1516,8 +1516,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "Baichuan-M3",
@@ -5900,8 +5900,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 32000,
-      "max_output": 32000
+      "content_length": 32768,
+      "max_output": 4096
     },
     {
       "name": "doubao-1.5-ui-tars-250328",
@@ -8006,7 +8006,9 @@
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 8192
     },
     {
       "name": "google/embeddinggemma-300m",
@@ -8683,7 +8685,9 @@
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "google/gemma-4-31B-it-assistant",
@@ -15390,7 +15394,7 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "meituan-longcat/longcat-flash-chat-fp8",
@@ -15850,7 +15854,7 @@
       ],
       "max_completion_tokens": 120000,
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 120000
     },
     {
       "name": "meta-llama/Llama-3.3-70B-Instruct-FP8-Lora",
@@ -15980,7 +15984,7 @@
       ],
       "max_completion_tokens": 32000,
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Llama-3.2-3B-Instruct-QLORA_INT4_EO8",
@@ -16098,7 +16102,7 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Llama-3.1-8B",
@@ -16123,7 +16127,7 @@
       ],
       "max_completion_tokens": 16384,
       "content_length": 131072,
-      "max_output": 131072
+      "max_output": 8192
     },
     {
       "name": "meta-llama/llama-3-70b-instruct",
@@ -17333,8 +17337,8 @@
       "tools": {
         "support": true
       },
-      "content_length": 196608,
-      "max_output": 16384
+      "content_length": 204800,
+      "max_output": 131072
     },
     {
       "name": "minimax/minimax-m2.7-highspeed",
@@ -17350,7 +17354,7 @@
         "clear_thinking": true
       },
       "content_length": 204800,
-      "max_output": 204800
+      "max_output": 131072
     },
     {
       "name": "minimax/minimax-m3",
@@ -17433,7 +17437,7 @@
         "chat"
       ],
       "content_length": 1000000,
-      "max_output": 1000000
+      "max_output": 131072
     },
     {
       "name": "MiniMax-M2.1-highspeed",
@@ -17444,8 +17448,8 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "content_length": 1000000,
-      "max_output": 1000000
+      "content_length": 204800,
+      "max_output": 131072
     },
     {
       "name": "minimax-m3",
@@ -17577,7 +17581,7 @@
       },
       "max_completion_tokens": 131072,
       "content_length": 204800,
-      "max_output": 131072
+      "max_output": 128000
     },
     {
       "name": "minimaxai/MiniMax-M2.1",
@@ -18735,7 +18739,7 @@
       },
       "max_completion_tokens": 32768,
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 131072
     },
     {
       "name": "moonshotai/Kimi-K2-Instruct-0905",
@@ -20040,8 +20044,8 @@
       "model_types": [
         "chat"
       ],
-      "content_length": 262144,
-      "max_output": 262144
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "nvidia/nvidia-nemotron-nano-9b-v2-base",
@@ -21663,8 +21667,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 32768,
-      "content_length": 262144,
-      "max_output": 262144
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning",
@@ -21680,8 +21684,8 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "content_length": 262144,
-      "max_output": 262144
+      "content_length": 131072,
+      "max_output": 8192
     },
     {
       "name": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -21802,7 +21806,9 @@
       "model_types": [
         "moderation",
         "vision"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "nvidia/Nemotron-4-340B-Instruct",
@@ -28525,7 +28531,7 @@
         "chat"
       ],
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-coder-flash",
@@ -35851,7 +35857,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 32768
     },
     {
       "name": "stepfun-ai/Step-3.5-Flash-Base",
@@ -35936,8 +35942,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 256000,
-      "content_length": 262144,
-      "max_output": 262144
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "stepfun-ai/Step-3.7-Flash-FP8",
@@ -36637,7 +36643,7 @@
         "chat"
       ],
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "tencent/Hunyuan-A13B-Instruct-FP8",
@@ -36715,8 +36721,8 @@
         "chat",
         "translation"
       ],
-      "content_length": 262144,
-      "max_output": 262144
+      "content_length": 32768,
+      "max_output": 8192
     },
     {
       "name": "tencent/Hunyuan-MT-7B-fp8",
@@ -37354,7 +37360,7 @@
         "clear_thinking": true
       },
       "content_length": 262144,
-      "max_output": 262144
+      "max_output": 8192
     },
     {
       "name": "tencent/Hy3-preview-Base",
@@ -37882,7 +37888,7 @@
         "chat"
       ],
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 16384
     },
     {
       "name": "THUDM/GLM-Z1-32B-0414",
@@ -39465,8 +39471,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 128000,
-      "content_length": 202752,
-      "max_output": 202752
+      "content_length": 200000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.7-fp4",
@@ -39583,7 +39589,7 @@
         "clear_thinking": true
       },
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 32768
     },
     {
       "name": "zai-org/GLM-4.6V-FP8",
@@ -39619,7 +39625,7 @@
       },
       "max_completion_tokens": 98304,
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 96000
     },
     {
       "name": "zai-org/GLM-4.5-Air",
@@ -39639,7 +39645,7 @@
       },
       "max_completion_tokens": 98304,
       "content_length": 128000,
-      "max_output": 128000
+      "max_output": 96000
     },
     {
       "name": "zai-org/GLM-4.5-Air-Base",
@@ -39720,8 +39726,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 16384,
-      "content_length": 128000,
-      "max_output": 128000
+      "content_length": 65536,
+      "max_output": 16384
     },
     {
       "name": "zai-org/GLM-4.5V-FP8",
@@ -41543,79 +41549,7 @@
       "max_output": 4096
     },
     {
-      "name": "Qwen/Qwen3-Max",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 8192
-    },
-    {
-      "name": "Qwen/Qwen3-Coder",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 65536
-    },
-    {
-      "name": "Qwen/Qwen3-32B",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 32768
-    },
-    {
-      "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 8192
-    },
-    {
-      "name": "glm-5.1",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
-      "name": "MiniMax-M2.7",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 204800,
-      "max_output": 131072
-    },
-    {
-      "name": "MiniMax-M2",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 204800,
-      "max_output": 131072
-    },
-    {
-      "name": "moonshotai/kimi-k2.5",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 131072
-    },
-    {
       "name": "Baichuan-M3-plus",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 32768,
-      "max_output": 8192
-    },
-    {
-      "name": "Baichuan-M2-plus",
       "model_types": [
         "chat"
       ],
@@ -41711,54 +41645,6 @@
       "max_output": 4096
     },
     {
-      "name": "deepseek-ai/DeepSeek-V3.2",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 8192
-    },
-    {
-      "name": "glm-4.7-flash",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
-      "name": "DeepSeek-V3",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 8192
-    },
-    {
-      "name": "longcat-flash-chat",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 8192
-    },
-    {
-      "name": "glm-5",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
-      "name": "qwen2.5-vl-72b",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 32768,
-      "max_output": 4096
-    },
-    {
       "name": "openai/gpt-oss-120b:fastest",
       "model_types": [
         "chat"
@@ -41772,14 +41658,6 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 8192
-    },
-    {
-      "name": "hy3-preview",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
       "max_output": 8192
     },
     {
@@ -41887,83 +41765,11 @@
       "max_output": 8192
     },
     {
-      "name": "zai-org/glm-4.5",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 128000,
-      "max_output": 96000
-    },
-    {
-      "name": "zai-org/glm-4.5v",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 65536,
-      "max_output": 16384
-    },
-    {
-      "name": "zai-org/glm-4.7",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
-      "name": "zai-org/glm-4.7-flash",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
-      "name": "zai-org/glm-5",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
       "name": "LongCat-2.0",
       "model_types": [
         "chat"
       ],
       "content_length": 1048576,
-      "max_output": 131072
-    },
-    {
-      "name": "MiniMax-M3",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 1024000,
-      "max_output": 131072
-    },
-    {
-      "name": "minimax-m2.7-highspeed",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 204800,
-      "max_output": 131072
-    },
-    {
-      "name": "minimax-m2.5-highspeed",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 204800,
-      "max_output": 131072
-    },
-    {
-      "name": "minimax-m2.1-highspeed",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 204800,
       "max_output": 131072
     },
     {
@@ -41973,38 +41779,6 @@
       ],
       "content_length": 65536,
       "max_output": 16384
-    },
-    {
-      "name": "meta-llama/llama-3.3-70b-instruct",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 120000
-    },
-    {
-      "name": "moonshotai/kimi-k2-instruct",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 131072
-    },
-    {
-      "name": "google/diffusiongemma-26b-a4b-it",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 8192
-    },
-    {
-      "name": "google/gemma-4-31b-it",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 262144
     },
     {
       "name": "meta/llama-3.1-70b-instruct",
@@ -42071,14 +41845,6 @@
       "max_output": 8192
     },
     {
-      "name": "minimaxai/minimax-m3",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 1048576,
-      "max_output": 16384
-    },
-    {
       "name": "mistralai/mistral-medium-3.5-128b",
       "model_types": [
         "chat"
@@ -42092,14 +41858,6 @@
         "chat"
       ],
       "content_length": 131072,
-      "max_output": 131072
-    },
-    {
-      "name": "moonshotai/kimi-k2.6",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
       "max_output": 131072
     },
     {
@@ -42127,30 +41885,6 @@
       "max_output": 8192
     },
     {
-      "name": "nvidia/nemotron-3-nano-30b-a3b",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 8192
-    },
-    {
-      "name": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 8192
-    },
-    {
-      "name": "nvidia/nemotron-3.5-content-safety",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 8192,
-      "max_output": 8192
-    },
-    {
       "name": "nvidia/nemotron-mini-4b-instruct",
       "model_types": [
         "chat"
@@ -42164,14 +41898,6 @@
         "chat"
       ],
       "content_length": 8192,
-      "max_output": 8192
-    },
-    {
-      "name": "nvidia/nvidia-nemotron-nano-9b-v2",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
       "max_output": 8192
     },
     {
@@ -42191,14 +41917,6 @@
       "max_output": 8192
     },
     {
-      "name": "stepfun-ai/step-3.7-flash",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 32768,
-      "max_output": 8192
-    },
-    {
       "name": "thinkingmachines/inkling",
       "model_types": [
         "chat"
@@ -42215,43 +41933,11 @@
       "max_output": 128000
     },
     {
-      "name": "tencent/hy3-preview",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 262144
-    },
-    {
-      "name": "meta-llama/llama-3.2-3b-instruct",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 8192
-    },
-    {
       "name": "baichuan/baichuan2-13b-chat",
       "model_types": [
         "chat"
       ],
       "content_length": 196608,
-      "max_output": 8192
-    },
-    {
-      "name": "meta-llama/llama-3.1-70b-instruct",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
-      "max_output": 8192
-    },
-    {
-      "name": "meta-llama/llama-3.1-8b-instruct",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 131072,
       "max_output": 8192
     },
     {
@@ -42271,28 +41957,12 @@
       "max_output": 8192
     },
     {
-      "name": "thudm/glm-4-9b-chat",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 128000,
-      "max_output": 16384
-    },
-    {
       "name": "doubao-seed-1.6-flash",
       "model_types": [
         "chat"
       ],
       "content_length": 256000,
       "max_output": 16384
-    },
-    {
-      "name": "doubao-1.5-pro-32k",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 32768,
-      "max_output": 4096
     },
     {
       "name": "doubao-seed-1.6",
@@ -42343,30 +42013,6 @@
       "max_output": 8192
     },
     {
-      "name": "minimax-m1",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 1000000,
-      "max_output": 131072
-    },
-    {
-      "name": "glm-4.5",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 128000,
-      "max_output": 96000
-    },
-    {
-      "name": "glm-4.5-air",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 128000,
-      "max_output": 96000
-    },
-    {
       "name": "Pro/deepseek-ai/DeepSeek-V4-Pro",
       "model_types": [
         "chat"
@@ -42389,22 +42035,6 @@
       ],
       "content_length": 262144,
       "max_output": 65536
-    },
-    {
-      "name": "tencent/hunyuan-mt-7b",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 32768,
-      "max_output": 8192
-    },
-    {
-      "name": "step-3.5-flash",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 32768
     },
     {
       "name": "step-3.5-flash-paid",
@@ -42455,14 +42085,6 @@
       "max_output": 4096
     },
     {
-      "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 65536
-    },
-    {
       "name": "claude-3-5-sonnet",
       "model_types": [
         "chat"
@@ -42487,22 +42109,6 @@
       "max_output": 8192
     },
     {
-      "name": "hunyuan-a13b-instruct",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 262144,
-      "max_output": 8192
-    },
-    {
-      "name": "glm-4.6",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
       "name": "solar-pro",
       "model_types": [
         "chat"
@@ -42525,30 +42131,6 @@
       ],
       "content_length": 128000,
       "max_output": 8192
-    },
-    {
-      "name": "glm-4.7",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 200000,
-      "max_output": 128000
-    },
-    {
-      "name": "glm-4.6v-Flash",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 128000,
-      "max_output": 32768
-    },
-    {
-      "name": "glm-4.5v",
-      "model_types": [
-        "chat"
-      ],
-      "content_length": 65536,
-      "max_output": 16384
     },
     {
       "name": "glm-4-flashx",

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -17595,7 +17595,7 @@
       },
       "max_completion_tokens": 131072,
       "content_length": 204800,
-      "max_output": 16384
+      "max_output": 131072
     },
     {
       "name": "minimaxai/MiniMax-M2.5",
@@ -17632,7 +17632,7 @@
       },
       "max_completion_tokens": 131072,
       "content_length": 204800,
-      "max_output": 16384
+      "max_output": 131072
     },
     {
       "name": "minimaxai/MiniMax-Text-01",
@@ -39365,8 +39365,8 @@
         "clear_thinking": true
       },
       "max_completion_tokens": 131072,
-      "content_length": 204800,
-      "max_output": 131072
+      "content_length": 200000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-5.1-FP8",
@@ -41541,6 +41541,1038 @@
       ],
       "content_length": 32768,
       "max_output": 32768
+    },
+    {
+      "name": "gpt-4.5-preview",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 16384
+    },
+    {
+      "name": "gpt-3.5-turbo-16k-0613",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 16385,
+      "max_output": 4096
+    },
+    {
+      "name": "Qwen/Qwen3-Max",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 8192
+    },
+    {
+      "name": "Qwen/Qwen3-Coder",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 65536
+    },
+    {
+      "name": "Qwen/Qwen3-32B",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 32768
+    },
+    {
+      "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 8192
+    },
+    {
+      "name": "glm-5.1",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "MiniMax-M2.7",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 204800,
+      "max_output": 131072
+    },
+    {
+      "name": "MiniMax-M2",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 204800,
+      "max_output": 131072
+    },
+    {
+      "name": "moonshotai/kimi-k2.5",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 131072
+    },
+    {
+      "name": "Baichuan-M3-plus",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "Baichuan-M2-plus",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "ernie-5.0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 121856,
+      "max_output": 8192
+    },
+    {
+      "name": "anthropic.claude-3-opus-20240229-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 4096
+    },
+    {
+      "name": "anthropic.claude-3-sonnet-20240229-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 4096
+    },
+    {
+      "name": "anthropic.claude-3-haiku-20240307-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 4096
+    },
+    {
+      "name": "meta.llama3-1-405b-instruct-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta.llama3-1-70b-instruct-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta.llama3-1-8b-instruct-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "mistral.mistral-large-2407-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 4096
+    },
+    {
+      "name": "mistral.mixtral-8x7b-instruct-v0:1",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32000,
+      "max_output": 4096
+    },
+    {
+      "name": "cohere.command-r-plus-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 4096
+    },
+    {
+      "name": "cohere.command-r-v1:0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 4096
+    },
+    {
+      "name": "deepseek-ai/DeepSeek-V3.2",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "glm-4.7-flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "DeepSeek-V3",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "longcat-flash-chat",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "glm-5",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "qwen2.5-vl-72b",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 4096
+    },
+    {
+      "name": "openai/gpt-oss-120b:fastest",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 131072
+    },
+    {
+      "name": "hy3",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "hy3-preview",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 8192
+    },
+    {
+      "name": "kimi-k3",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1000000,
+      "max_output": 131072
+    },
+    {
+      "name": "kimi-k2.7-code-highspeed",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 131072
+    },
+    {
+      "name": "deepseek-v4-flash-202605",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1048576,
+      "max_output": 393216
+    },
+    {
+      "name": "deepseek-v4-pro-202606",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1048576,
+      "max_output": 393216
+    },
+    {
+      "name": "hy-mt2-pro",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "hy-mt2-plus",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "hy-mt2-lite",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "hy-role",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "hunyuan-role-latest",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "hy-vision-2.0-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "youtu-vita",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "hunyuan-t1-vision-20250916",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "hunyuan-turbos-vision-video-20250728",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "zai-org/glm-4.5",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 96000
+    },
+    {
+      "name": "zai-org/glm-4.5v",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 65536,
+      "max_output": 16384
+    },
+    {
+      "name": "zai-org/glm-4.7",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "zai-org/glm-4.7-flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "zai-org/glm-5",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "LongCat-2.0",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1048576,
+      "max_output": 131072
+    },
+    {
+      "name": "MiniMax-M3",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1024000,
+      "max_output": 131072
+    },
+    {
+      "name": "minimax-m2.7-highspeed",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 204800,
+      "max_output": 131072
+    },
+    {
+      "name": "minimax-m2.5-highspeed",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 204800,
+      "max_output": 131072
+    },
+    {
+      "name": "minimax-m2.1-highspeed",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 204800,
+      "max_output": 131072
+    },
+    {
+      "name": "minimax-m2-her",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 65536,
+      "max_output": 16384
+    },
+    {
+      "name": "meta-llama/llama-3.3-70b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 120000
+    },
+    {
+      "name": "moonshotai/kimi-k2-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 131072
+    },
+    {
+      "name": "google/diffusiongemma-26b-a4b-it",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 8192
+    },
+    {
+      "name": "google/gemma-4-31b-it",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 262144
+    },
+    {
+      "name": "meta/llama-3.1-70b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta/llama-3.1-8b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta/llama-3.2-11b-vision-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta/llama-3.2-1b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta/llama-3.2-3b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta/llama-3.2-90b-vision-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta/llama-3.3-70b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta/llama-guard-4-12b",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "minimaxai/minimax-m3",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1048576,
+      "max_output": 16384
+    },
+    {
+      "name": "mistralai/mistral-medium-3.5-128b",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 262144
+    },
+    {
+      "name": "mistralai/mistral-nemotron",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 131072
+    },
+    {
+      "name": "moonshotai/kimi-k2.6",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 131072
+    },
+    {
+      "name": "nvidia/ising-calibration-1.5-31b",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/llama-3.1-nemotron-nano-8b-v1",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/llama-3.3-nemotron-super-49b-v1",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/nemotron-3-nano-30b-a3b",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/nemotron-3.5-content-safety",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/nemotron-mini-4b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 4096
+    },
+    {
+      "name": "nvidia/nemotron-nano-12b-v2-vl",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/nvidia-nemotron-nano-9b-v2",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "nvidia/riva-translate-4b-instruct-v2",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "poolside/laguna-xs-2.1",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 8192
+    },
+    {
+      "name": "stepfun-ai/step-3.7-flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "thinkingmachines/inkling",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 8192
+    },
+    {
+      "name": "z-ai/glm-5.2",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1000000,
+      "max_output": 128000
+    },
+    {
+      "name": "tencent/hy3-preview",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 262144
+    },
+    {
+      "name": "meta-llama/llama-3.2-3b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "baichuan/baichuan2-13b-chat",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 196608,
+      "max_output": 8192
+    },
+    {
+      "name": "meta-llama/llama-3.1-70b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "meta-llama/llama-3.1-8b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "01-ai/yi-1.5-34b-chat",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 16384,
+      "max_output": 8192
+    },
+    {
+      "name": "01-ai/yi-1.5-9b-chat",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 16384,
+      "max_output": 8192
+    },
+    {
+      "name": "thudm/glm-4-9b-chat",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 16384
+    },
+    {
+      "name": "doubao-seed-1.6-flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 256000,
+      "max_output": 16384
+    },
+    {
+      "name": "doubao-1.5-pro-32k",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 4096
+    },
+    {
+      "name": "doubao-seed-1.6",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 256000,
+      "max_output": 16384
+    },
+    {
+      "name": "doubao-seed-2.0-pro",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 256000,
+      "max_output": 16384
+    },
+    {
+      "name": "doubao-seed-2.0-lite",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 256000,
+      "max_output": 16384
+    },
+    {
+      "name": "doubao-seed-2.0-mini",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 256000,
+      "max_output": 16384
+    },
+    {
+      "name": "doubao-seed-2.0-code",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 256000,
+      "max_output": 16384
+    },
+    {
+      "name": "qwen2.5-max-2025-01-25",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "minimax-m1",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1000000,
+      "max_output": 131072
+    },
+    {
+      "name": "glm-4.5",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 96000
+    },
+    {
+      "name": "glm-4.5-air",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 96000
+    },
+    {
+      "name": "Pro/deepseek-ai/DeepSeek-V4-Pro",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1048576,
+      "max_output": 393216
+    },
+    {
+      "name": "Pro/deepseek-ai/DeepSeek-V4-Flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1048576,
+      "max_output": 393216
+    },
+    {
+      "name": "Pro/moonshotai/Kimi-K2.6",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 65536
+    },
+    {
+      "name": "tencent/hunyuan-mt-7b",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "step-3.5-flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 32768
+    },
+    {
+      "name": "step-3.5-flash-paid",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 32768
+    },
+    {
+      "name": "step-1-256k",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 8192
+    },
+    {
+      "name": "step-1-128k",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 8192
+    },
+    {
+      "name": "step-1-32k",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 8192
+    },
+    {
+      "name": "step-1-8k",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 4096
+    },
+    {
+      "name": "step-1-flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 8192,
+      "max_output": 4096
+    },
+    {
+      "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 65536
+    },
+    {
+      "name": "claude-3-5-sonnet",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 8192
+    },
+    {
+      "name": "gemini-1.5-pro",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 2097152,
+      "max_output": 8192
+    },
+    {
+      "name": "gemini-1.5-flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 1048576,
+      "max_output": 8192
+    },
+    {
+      "name": "hunyuan-a13b-instruct",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 8192
+    },
+    {
+      "name": "glm-4.6",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "solar-pro",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 32768,
+      "max_output": 4096
+    },
+    {
+      "name": "grok-3-mini-mini-fast",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 131072,
+      "max_output": 131072
+    },
+    {
+      "name": "spark-x",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 8192
+    },
+    {
+      "name": "glm-4.7",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 200000,
+      "max_output": 128000
+    },
+    {
+      "name": "glm-4.6v-Flash",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 32768
+    },
+    {
+      "name": "glm-4.5v",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 65536,
+      "max_output": 16384
+    },
+    {
+      "name": "glm-4-flashx",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 128000,
+      "max_output": 16384
     }
   ]
 }

--- a/conf/all_models.json
+++ b/conf/all_models.json
@@ -14,20 +14,22 @@
       "alias": [
         "abab6.5s"
       ],
-      "max_tokens": 245000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 245000,
+      "max_output": 245000
     },
     {
       "name": "abab7-chat-preview",
       "alias": [
         "abab7-preview"
       ],
-      "max_tokens": 245000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 245000,
+      "max_output": 245000
     },
     {
       "name": "ACE-Step/acestep-v15-xl-sft",
@@ -44,10 +46,11 @@
         "DeepCoder-14B-Preview",
         "Deepcoder 14B Preview"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "ai21/jamba-large-1.7",
@@ -55,31 +58,35 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "ai_infer_test_1",
-      "max_tokens": 200000,
       "max_completion_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "ai_infer_test_2",
-      "max_tokens": 200000,
       "max_completion_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "ai_infer_test_3",
-      "max_tokens": 200000,
       "max_completion_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "aion-labs/aion-1.0",
@@ -87,11 +94,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "aion-labs/aion-1.0-mini",
@@ -99,11 +107,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "aion-labs/aion-2.0",
@@ -111,11 +120,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "aion-labs/aion-rp-llama-3.1-8b",
@@ -123,7 +133,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "alibaba/wan2.6",
@@ -131,8 +142,7 @@
         "wan2.6",
         "wan-2-6"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "alibaba/wan2.7",
@@ -140,77 +150,82 @@
         "wan2.7",
         "wan2-7"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "allam-2-7b",
-      "max_tokens": 4096,
       "max_completion_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "allenai/olmOCR-7B-0725-FP8",
       "alias": [
         "olmOCR-7B-0725-FP8"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "allenai/olmOCR-7B-0825",
       "alias": [
         "olmOCR-7B-0825"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "allenai/olmOCR-7B-1025",
       "alias": [
         "olmOCR-7B-1025"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "allenai/olmOCR-2",
       "alias": [
         "olmOCR-2"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "allenai/olmOCR-2-7B-1025",
       "alias": [
         "olmOCR-2-7B-1025"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat",
         "image2text",
         "vision",
         "ocr"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "allenai/Molmo-7B-D-0924",
@@ -218,10 +233,11 @@
         "Molmo-7B-D-0924",
         "Molmo 7B D 0924"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "allenai/olmo-3-32b-think",
@@ -229,21 +245,23 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "allenai/Olmo-3.1-32B-Instruct",
       "alias": [
         "Olmo-3.1-32B-Instruct"
       ],
-      "max_tokens": 65536,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "amazon/nova-2-lite-v1",
@@ -254,11 +272,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "amazon/nova-lite-v1",
@@ -271,7 +290,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 300000
+      "content_length": 300000,
+      "max_output": 300000
     },
     {
       "name": "amazon/nova-micro-v1",
@@ -282,7 +302,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 300000
+      "content_length": 300000,
+      "max_output": 300000
     },
     {
       "name": "amazon/nova-premier-v1",
@@ -292,7 +313,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "amazon/nova-pro-v1",
@@ -304,7 +326,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 300000
+      "content_length": 300000,
+      "max_output": 300000
     },
     {
       "name": "amazon/titan-embed-text-v1",
@@ -312,9 +335,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1536,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "amazon/nova-2-Lite",
@@ -326,29 +350,28 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "amazon.titan-embed-text-v1",
-      "max_tokens": 8192,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "animate-anyone-detect-gen2",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "animate-anyone-gen2",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "animate-anyone-template-gen2",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "anthracite-org/magnum-v4-72b",
@@ -356,7 +379,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "anthropic/claude-fable-5",
@@ -368,11 +392,12 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-mythos-5",
@@ -383,11 +408,12 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-sonnet-5",
@@ -417,7 +443,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-haiku-4-5-20251001",
@@ -432,11 +459,12 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-sonnet-4-5-20250929",
@@ -448,11 +476,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-opus-4-1-20250805",
@@ -462,7 +491,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-opus-4-20250514",
@@ -472,11 +502,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-sonnet-4-20250514",
@@ -488,7 +519,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-opus-4",
@@ -500,11 +532,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-opus-4-1",
@@ -516,11 +549,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-opus-4-5",
@@ -533,11 +567,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-opus-4-6",
@@ -551,11 +586,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-opus-4-6-fast",
@@ -568,11 +604,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-opus-4-7",
@@ -585,11 +622,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-opus-4-7-fast",
@@ -602,11 +640,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-opus-4-8",
@@ -619,11 +658,12 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-opus-4-8-fast",
@@ -636,11 +676,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-sonnet-4",
@@ -652,11 +693,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-sonnet-4-5",
@@ -670,11 +712,12 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-sonnet-4-6",
@@ -688,11 +731,12 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-sonnet-4-7",
@@ -704,11 +748,12 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-3-7-sonnet-20250219",
@@ -718,7 +763,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-3-5-haiku-20241022",
@@ -730,7 +776,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-3-5-sonnet-20241022",
@@ -743,7 +790,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-3-haiku-20240307",
@@ -753,7 +801,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/Claude Mythos  Preview",
@@ -775,7 +824,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-3-haiku",
@@ -787,33 +837,36 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-4-opus",
       "alias": [
         "claude-4-opus"
       ],
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "image2text",
         "vision",
         "ocr"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-4-sonnet",
       "alias": [
         "claude-4-sonnet"
       ],
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "image2text",
         "vision",
         "ocr"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-fable-latest",
@@ -826,11 +879,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-haiku-latest",
@@ -843,11 +897,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "anthropic/claude-opus-latest",
@@ -860,11 +915,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "anthropic/claude-sonnet-latest",
@@ -877,11 +933,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "arcee-ai/coder-large",
@@ -889,7 +946,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "arcee-ai/trinity-large-thinking",
@@ -897,11 +955,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "arcee-ai/trinity-mini",
@@ -912,11 +971,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "arcee-ai/virtuoso-large",
@@ -924,7 +984,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "arize-ai/qwen-2-1.5b-instruct",
@@ -932,17 +993,19 @@
         "qwen-2-1.5b-instruct",
         "Arize AI Qwen 2 1.5B Instruct"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "ascend-tribe/pangu-pro-moe",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "audio1.0",
@@ -959,10 +1022,11 @@
       "alias": [
         "chronos-hermes-13b-v2"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "azure/gpt-4o",
@@ -970,20 +1034,22 @@
         "azure/global-standard/gpt-4o-2024-08-06",
         "azure/eu/gpt-4o"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "azure/gpt-4o-mini",
       "alias": [
         "azure/global-standard/gpt-4o-mini"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "azure/o1-preview",
@@ -991,28 +1057,30 @@
         "azure/eu/o1-preview",
         "openai/o1-preview"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "azure/o3-mini",
       "alias": [
         "azure/eu/o3-mini"
       ],
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "azure_tts",
@@ -1029,7 +1097,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 1024
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "BAAI/bge-base-en-v1.5",
@@ -1037,19 +1106,21 @@
         "bge-base-en-v1.5",
         "BAAI-Bge-Base-1.5"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "BAAI/bge-large-en-v1.5",
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 512,
-      "max_dimension": 1024
+      "max_dimension": 1024,
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "BAAI/bge-large-zh-v1.5",
@@ -1062,11 +1133,12 @@
       "alias": [
         "bge-en-icl"
       ],
-      "max_tokens": 8192,
       "max_dimension": 4096,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "BAAI/bge-m3",
@@ -1076,20 +1148,22 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1024,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "BAAI/bge-m3-multi",
       "alias": [
         "bge-m3-multi"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1024,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "babbage-002",
@@ -1107,7 +1181,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuanmed-ocr-7b",
@@ -1119,7 +1194,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuan-13b-base",
@@ -1129,7 +1205,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan-13b-chat",
@@ -1139,7 +1216,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan-7b",
@@ -1149,7 +1227,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan-audio-base",
@@ -1161,7 +1240,8 @@
         "asr",
         "tts"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuan-audio-instruct",
@@ -1174,7 +1254,8 @@
         "tts",
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuan-m1-14b-base",
@@ -1184,7 +1265,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuan-m1-14b-instruct",
@@ -1194,7 +1276,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuan-m2-32b",
@@ -1206,12 +1289,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baichuan-inc/baichuan-m2-32b-gptq-int4",
@@ -1221,11 +1305,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baichuan-inc/baichuan-m2-32b-q4_k_m-gguf",
@@ -1235,11 +1320,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baichuan-inc/baichuan-m3-235b",
@@ -1249,11 +1335,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baichuan-inc/baichuan-m3-235b-fp8",
@@ -1263,11 +1350,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baichuan-inc/baichuan-m3-235b-gptq-int4",
@@ -1277,11 +1365,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baichuan-inc/baichuan-m3-235b-q4_k_m-gguf",
@@ -1291,11 +1380,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baichuan-inc/baichuan-omni-1d5",
@@ -1312,7 +1402,8 @@
         "tts",
         "video_understanding"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuan-omni-1d5-base",
@@ -1329,7 +1420,8 @@
         "tts",
         "video_understanding"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baichuan-inc/baichuan2-13b-base",
@@ -1339,7 +1431,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan2-13b-chat",
@@ -1349,7 +1442,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan2-13b-chat-4bits",
@@ -1359,7 +1453,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan2-7b-base",
@@ -1369,7 +1464,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan2-7b-chat",
@@ -1379,7 +1475,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan2-7b-chat-4bits",
@@ -1389,7 +1486,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "baichuan-inc/baichuan2-7b-intermediate-checkpoints",
@@ -1399,34 +1497,38 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "Baichuan-M2",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan-M2-Plus",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan-M3",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan-Text-Embedding",
@@ -1436,77 +1538,85 @@
     },
     {
       "name": "Baichuan2-53B",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan2-Turbo",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan2-Turbo-192k",
-      "max_tokens": 192000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 192000,
+      "max_output": 192000
     },
     {
       "name": "Baichuan3-Turbo",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan3-Turbo-128k",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Baichuan4",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan4-Air",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Baichuan4-Turbo",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "baidu/ernie-5.0-thinking-exp",
@@ -1514,7 +1624,6 @@
         "ernie-5.0-thinking-exp",
         "Ernie 5.0 Thinking Exp"
       ],
-      "max_tokens": 183000,
       "max_completion_tokens": 64000,
       "model_types": [
         "chat",
@@ -1524,18 +1633,21 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 183000,
+      "max_output": 183000
     },
     {
       "name": "baidu/ernie-4.5-0.3b",
-      "max_tokens": 120000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "ernie-4.5-0.3b"
       ],
-      "max_completion_tokens": 8000
+      "max_completion_tokens": 8000,
+      "content_length": 120000,
+      "max_output": 120000
     },
     {
       "name": "baidu/ernie-4.5-0.3b-base-paddle",
@@ -1545,7 +1657,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-0.3b-base-pt",
@@ -1555,7 +1668,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-0.3b-paddle",
@@ -1565,7 +1679,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-0.3b-pt",
@@ -1575,11 +1690,11 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-21B-a3b",
-      "max_tokens": 120000,
       "model_types": [
         "chat"
       ],
@@ -1587,7 +1702,9 @@
         "ernie-4.5-21B-a3b",
         "ERNIE 4.5 21B A3B"
       ],
-      "max_completion_tokens": 8000
+      "max_completion_tokens": 8000,
+      "content_length": 120000,
+      "max_output": 120000
     },
     {
       "name": "baidu/ernie-4.5-21b-a3b-base-paddle",
@@ -1597,7 +1714,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-21b-a3b-base-pt",
@@ -1607,7 +1725,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-21b-a3b-paddle",
@@ -1617,7 +1736,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-21b-a3b-pt",
@@ -1627,7 +1747,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-21b-a3b-thinking",
@@ -1637,19 +1758,21 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ERNIE-4.5-300B-A47B",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-2bits-paddle",
@@ -1659,7 +1782,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-2bits-tp2-paddle",
@@ -1669,7 +1793,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-2bits-tp4-paddle",
@@ -1679,7 +1804,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-base-paddle",
@@ -1689,7 +1815,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-base-pt",
@@ -1699,7 +1826,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-fp8-paddle",
@@ -1709,7 +1837,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-paddle",
@@ -1720,8 +1849,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 12000
+      "max_completion_tokens": 12000,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-pt",
@@ -1731,7 +1861,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-300b-a47b-w4a8c8-tp4-paddle",
@@ -1741,11 +1872,11 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b",
-      "max_tokens": 30000,
       "model_types": [
         "chat",
         "image2text",
@@ -1759,7 +1890,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 30000,
+      "max_output": 30000
     },
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-base-paddle",
@@ -1770,7 +1903,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-base-pt",
@@ -1781,7 +1915,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-paddle",
@@ -1794,7 +1929,8 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-pt",
@@ -1807,7 +1943,8 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-28b-a3b-thinking",
@@ -1820,16 +1957,16 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b",
-      "max_tokens": 123000,
       "model_types": [
         "chat",
         "image2text",
@@ -1843,7 +1980,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 123000,
+      "max_output": 123000
     },
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-base-paddle",
@@ -1854,7 +1993,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-base-pt",
@@ -1865,7 +2005,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-paddle",
@@ -1878,7 +2019,8 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-4.5-vl-424b-a47b-pt",
@@ -1891,14 +2033,14 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/cobuddy",
       "alias": [
         "cobuddy"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 65536,
       "model_types": [
         "chat"
@@ -1906,7 +2048,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "baidu/ernie-image",
@@ -1942,8 +2086,7 @@
       "alias": [
         "nava"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "baidu/qianfan-ocr",
@@ -1955,7 +2098,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baidu/qianfan-vl-3b",
@@ -1967,7 +2111,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baidu/qianfan-vl-70b",
@@ -1979,11 +2124,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 32768,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baidu/qianfan-vl-8b",
@@ -1995,11 +2141,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 32768,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "baidubce-irag-1.0",
@@ -2511,48 +2658,42 @@
       "alias": [
         "video_eraser"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Bria/video_foreground_mask",
       "alias": [
         "video_foreground_mask"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Bria/video_increase_resolution",
       "alias": [
         "video_increase_resolution"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Bria/video_mask_by_key_points",
       "alias": [
         "video_mask_by_key_points"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Bria/video_mask_by_prompt",
       "alias": [
         "video_mask_by_prompt"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Bria/video_remove_background",
       "alias": [
         "video_remove_background"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "bria/bria-remove-background",
@@ -2624,18 +2765,18 @@
     },
     {
       "name": "bunny",
-      "max_tokens": 262144,
       "max_completion_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "ByteDance/Seed-1.8",
       "alias": [
         "Seed-1.8"
       ],
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "image2text",
@@ -2644,14 +2785,15 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "ByteDance/Seed-2.0-code",
       "alias": [
         "Seed-2.0-code"
       ],
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "image2text",
@@ -2660,14 +2802,15 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "ByteDance/Seed-2.0-mini",
       "alias": [
         "Seed-2.0-mini"
       ],
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "image2text",
@@ -2676,14 +2819,15 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "ByteDance/Seed-2.0-pro",
       "alias": [
         "Seed-2.0-pro"
       ],
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "image2text",
@@ -2692,7 +2836,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "ByteDance/Seedance-1.0-lite",
@@ -2700,8 +2846,7 @@
         "Seedance-1.0-lite",
         "ByteDance Seedance 1.0 Lite"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "ByteDance/Seedance-1.0-pro",
@@ -2709,16 +2854,14 @@
         "Seedance-1.0-pro",
         "ByteDance Seedance 1.0 Pro"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "ByteDance/Seedance-1.5-Pro",
       "alias": [
         "Seedance-1.5-Pro"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "ByteDance/Seedance-2.0",
@@ -2726,8 +2869,7 @@
         "Seedance-2.0",
         "ByteDance Seedance 2.0"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "ByteDance/Seedream-4",
@@ -2768,14 +2910,16 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "ByteDance-Seed/Seed-OSS-36B-Instruct",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "ByteDance-Seed/Seedream-3.0",
@@ -2824,7 +2968,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "bytedance-seed/doubao-seedance-1-5-pro",
@@ -2832,8 +2977,7 @@
         "doubao-seedance-1-5-pro",
         "doubao-seedance-1-5-pro-251215"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "bytedance-seed/doubao-seedream-4-5-251128",
@@ -2861,7 +3005,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "bytedance-seed/doubao-1-5-pro-32k-250115",
@@ -2871,15 +3016,15 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "bytedance-seed/doubao-seedance-2-0",
       "alias": [
         "doubao-seedance-2-0"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "bytedance-seed/seed-1.6",
@@ -2890,11 +3035,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "bytedance-seed/seed-1.6-flash",
@@ -2905,11 +3051,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "bytedance-seed/seed-2.0-lite",
@@ -2920,11 +3067,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "bytedance-seed/seed-2.0-mini",
@@ -2935,11 +3083,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "byteplus/dreamina-seedance-2-0-260128",
@@ -2955,11 +3104,12 @@
       "alias": [
         "orpheus-v1-english"
       ],
-      "max_tokens": 4000,
       "max_completion_tokens": 50000,
       "model_types": [
         "tts"
-      ]
+      ],
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "canopylabs/orpheus-3b-0.1-ft",
@@ -2976,11 +3126,12 @@
       "alias": [
         "orpheus-arabic-saudi"
       ],
-      "max_tokens": 4000,
       "max_completion_tokens": 50000,
       "model_types": [
         "tts"
-      ]
+      ],
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "cartesia/sonic",
@@ -2998,10 +3149,11 @@
         "sonic-2",
         "Cartesia Sonic 2"
       ],
-      "max_tokens": 448,
       "model_types": [
         "tts"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "cartesia/sonic-3",
@@ -3009,73 +3161,83 @@
         "sonic-3",
         "Cartesia Sonic 3"
       ],
-      "max_tokens": 448,
       "model_types": [
         "tts"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "cc-3-5-haiku-20241022",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-haiku-4-5-20251001",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-opus-4-1-20250805",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-opus-4-5-20251101",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-opus-4-7",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-opus-4-8",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-sonnet-4-20250514",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-sonnet-4-5-20250929",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cc-sonnet-4-6",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "chanjing-cicada1.0",
@@ -3091,22 +3253,23 @@
     },
     {
       "name": "chanjing-video",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "chat-latest",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "chatgpt-4o-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "ClarityAI/creative",
@@ -3130,67 +3293,74 @@
     },
     {
       "name": "claude-3-5-haiku",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-5-haiku-20241022",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-5-haiku-latest",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-5-sonnet-20240620",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-5-sonnet-20241022",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-5-sonnet-latest",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-7-sonnet-20250219",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-7-sonnet-20250219-thinking",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-7-sonnet-latest",
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "image2text",
@@ -3199,15 +3369,18 @@
       ],
       "alias": [
         "anthropic/claude-3-7-sonnet-latest"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-3-haiku-20240307",
       "alias": [],
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-haiku-4-5-20251001",
@@ -3215,7 +3388,6 @@
         "anthropic/claude-haiku-4-5",
         "claude-haiku-4.5"
       ],
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "vision",
@@ -3228,72 +3400,81 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-haiku-4-5-20251001-thinking",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-1-20250805",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-1-20250805-thinking",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-20250514",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-20250514-thinking",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-5-20251101",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "claude-opus-4.5"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-5-20251101-thinking",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-6",
@@ -3306,14 +3487,14 @@
       "alias": [
         "claude-opus-4.6"
       ],
-      "max_tokens": 200000,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-opus-4-7",
-      "max_tokens": 1000000,
       "model_types": [
         "chat",
         "image2text",
@@ -3325,21 +3506,23 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "claude-opus-4-7-thinking",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "claude-opus-4-8",
       "alias": [
         "claude-opus-4.8"
       ],
-      "max_tokens": 1000000,
       "model_types": [
         "chat",
         "vision",
@@ -3349,7 +3532,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "claude-opus-4.6-fast",
@@ -3371,50 +3556,53 @@
     },
     {
       "name": "claude-sonnet-4-20250514",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-sonnet-4-20250514-thinking",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-sonnet-4-5-20250929",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-sonnet-4-5-20250929-thinking",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "claude-sonnet-4-6",
       "alias": [
         "claude-sonnet-4.6"
       ],
-      "max_tokens": 1000000,
       "model_types": [
         "chat",
         "vision",
@@ -3427,18 +3615,21 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "claude-sonnet-4-6-thinking",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "clipdrop",
@@ -3448,51 +3639,57 @@
     },
     {
       "name": "codegeex-4",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "coder-claude-3-5-sonnet-20240620",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "coder-claude-3-5-sonnet-20241022",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "codex-mini-latest",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "cognitivecomputations/dolphin-2.6-mixtral-8x7b",
       "alias": [
         "dolphin-2.6-mixtral-8x7b"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "cognitivecomputations/dolphin-2.9.1-llama-3-70b",
       "alias": [
         "dolphin-2.9.1-llama-3-70b"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
@@ -3500,12 +3697,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "cogvideox",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "cogview-4",
@@ -3529,7 +3726,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "cohere/embed-v4.0",
@@ -3555,7 +3753,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "cohere/rerank-v4.0-pro",
@@ -3565,7 +3764,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "cohere/rerank-v3.5",
@@ -3575,7 +3775,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "cohere/embed-english-light-v3.0",
@@ -3629,7 +3830,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "cohere/rerank-multilingual-v3.0",
@@ -3639,7 +3841,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "cohere/embed-english-light-v2.0",
@@ -3692,7 +3895,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4000
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "cohere/command-a-03-2025",
@@ -3703,7 +3907,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "cohere/command-a-plus-05-2026",
@@ -3715,7 +3920,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "cohere/command-a-reasoning-08-2025",
@@ -3725,11 +3931,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "cohere/command-a-translate-08-2025",
@@ -3739,7 +3946,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "cohere/command-a-vision-07-2025",
@@ -3751,7 +3959,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "cohere/command-light",
@@ -3761,7 +3970,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4000
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "cohere/command-light-nightly",
@@ -3771,7 +3981,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4000
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "cohere/command-nightly",
@@ -3781,7 +3992,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4000
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "cohere/command-r",
@@ -3791,7 +4003,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "cohere/command-r-03-2024",
@@ -3801,7 +4014,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "cohere/command-r-08-2024",
@@ -3811,7 +4025,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "cohere/command-r-plus",
@@ -3821,7 +4036,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "cohere/command-r-plus-04-2024",
@@ -3831,7 +4047,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "cohere/command-r-plus-08-2024",
@@ -3841,7 +4058,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "CompVis/stable-diffusion-v1-4",
@@ -3872,11 +4090,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "deepcogito/cogito-v2-1-671b",
@@ -3884,31 +4103,35 @@
         "cogito-v2-1-671b",
         "Cogito v2.1 671B"
       ],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepcogito/cogito-v2-preview-deepseek-671b",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepcogito/cogito-v2-preview-llama-405B",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepcogito/cogito-v2-preview-llama-70B",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepcogito/cogito-v1-preview-llama-70B",
@@ -3916,10 +4139,11 @@
         "cogito-v1-preview-llama-70B",
         "Cogito V1 Preview Llama 70B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepcogito/cogito-v1-preview-llama-70B-Turbo",
@@ -3927,10 +4151,11 @@
         "cogito-v1-preview-llama-70B-Turbo",
         "Cogito V1 Preview Llama 70B Turbo"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepcogito/cogito-v1-preview-llama-8B",
@@ -3938,10 +4163,11 @@
         "cogito-v1-preview-llama-8B",
         "Cogito V1 Preview Llama 8B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepcogito/cogito-v1-preview-qwen-14B",
@@ -3949,10 +4175,11 @@
         "cogito-v1-preview-qwen-14B",
         "Cogito V1 Preview Qwen 14B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepcogito/cogito-v1-preview-qwen-32B",
@@ -3960,10 +4187,11 @@
         "cogito-v1-preview-qwen-32B",
         "Cogito V1 Preview Qwen 32B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepgram/aura-2",
@@ -3971,10 +4199,11 @@
         "aura-2",
         "Deepgram Aura 2"
       ],
-      "max_tokens": 448,
       "model_types": [
         "audio_generation"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "deepgram/nova-3-en",
@@ -3982,11 +4211,12 @@
         "nova-3-en",
         "Deepgram Nova 3"
       ],
-      "max_tokens": 448,
       "model_types": [
         "asr",
         "speech2text"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "deepgram/nova-3-multi",
@@ -3994,21 +4224,23 @@
         "nova-3-multi",
         "Deepgram Nova 3 Multilingual"
       ],
-      "max_tokens": 448,
       "model_types": [
         "asr",
         "speech2text"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "deepinfra/airoboros-70b",
       "alias": [
         "airoboros-70b"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepl",
@@ -4018,28 +4250,30 @@
     },
     {
       "name": "deepl-en",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "deepl-ja",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "deepl-zh",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "deepseek/deepseek-ocr-2",
-      "max_tokens": 8192,
       "model_types": [
         "chat",
         "image2text",
@@ -4049,11 +4283,12 @@
       "alias": [
         "DeepSeek-OCR 2"
       ],
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "deepseek/deepseek-v3.1",
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
@@ -4064,22 +4299,24 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek/deepseek-v3-0324",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "DeepSeek V3 0324"
       ],
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "deepseek/deepseek-v3-turbo",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
@@ -4087,22 +4324,24 @@
         "deepseek-v3-turbo",
         "DeepSeek V3 (Turbo)"
       ],
-      "max_completion_tokens": 16000
+      "max_completion_tokens": 16000,
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek/deepseek-prover-v2-671b",
-      "max_tokens": 160000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "Deepseek Prover V2 671B"
       ],
-      "max_completion_tokens": 160000
+      "max_completion_tokens": 160000,
+      "content_length": 160000,
+      "max_output": 160000
     },
     {
       "name": "deepseek/deepseek-r1-distill-llama-8b",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
@@ -4112,11 +4351,12 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "deepseek/deepseek-r1-turbo",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
@@ -4127,11 +4367,12 @@
       "alias": [
         "DeepSeek R1 (Turbo)"
       ],
-      "max_completion_tokens": 16000
+      "max_completion_tokens": 16000,
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek/deepseek-r1/community",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
@@ -4142,11 +4383,12 @@
       "max_completion_tokens": 8000,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek/deepseek-v3/community",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
@@ -4156,7 +4398,9 @@
       "max_completion_tokens": 8000,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek-ai/deepseek-v4-flash",
@@ -4171,14 +4415,15 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 393216
     },
     {
       "name": "deepseek-ai/deepseek-v4-flash-base",
@@ -4189,7 +4434,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 393216
     },
     {
       "name": "deepseek-ai/deepseek-v4-pro",
@@ -4203,14 +4449,15 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 393216
     },
     {
       "name": "deepseek-ai/deepseek-v4-pro-base",
@@ -4221,7 +4468,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 393216
     },
     {
       "name": "deepseek-ai/deepseek-ocr-2",
@@ -4229,7 +4477,8 @@
       "model_types": [
         "ocr"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-v3.2",
@@ -4242,7 +4491,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3.2-exp",
@@ -4253,7 +4503,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3.2-exp-base",
@@ -4263,7 +4514,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3.2-speciale",
@@ -4274,7 +4526,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3.1",
@@ -4286,7 +4539,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3.1-base",
@@ -4296,7 +4550,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3.1-terminus",
@@ -4309,7 +4564,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3-0324",
@@ -4321,17 +4577,19 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/DeepSeek-V3-0324-Turbo",
       "alias": [
         "DeepSeek-V3-0324-Turbo"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "deepseek-ai/deepseek-v3",
@@ -4347,7 +4605,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v3-base",
@@ -4357,7 +4616,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v2.5",
@@ -4367,7 +4627,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v2.5-1210",
@@ -4377,7 +4638,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-base",
@@ -4387,7 +4649,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-instruct",
@@ -4397,7 +4660,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-instruct-0724",
@@ -4407,7 +4671,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-lite-base",
@@ -4417,7 +4682,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-coder-v2-lite-instruct",
@@ -4427,7 +4693,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-math-v2",
@@ -4438,7 +4705,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-prover-v2-671b",
@@ -4448,7 +4716,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-prover-v2-7b",
@@ -4458,7 +4727,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "deepseek-ai/deepseek-v2",
@@ -4468,7 +4738,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v2-chat",
@@ -4478,7 +4749,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v2-chat-0628",
@@ -4488,7 +4760,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v2-lite",
@@ -4498,7 +4771,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-v2-lite-chat",
@@ -4508,7 +4782,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-coder-7b-base-v1.5",
@@ -4518,7 +4793,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-coder-7b-instruct-v1.5",
@@ -4528,7 +4804,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-base",
@@ -4538,7 +4815,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-rl",
@@ -4548,7 +4826,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1.5-sft",
@@ -4558,7 +4837,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-prover-v1",
@@ -4568,7 +4848,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-r2",
@@ -4589,21 +4870,23 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/DeepSeek-R1-0528-Turbo",
       "alias": [
         "DeepSeek-R1-0528-Turbo"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "deepseek-ai/deepseek-r1",
@@ -4615,7 +4898,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-32b",
@@ -4626,7 +4910,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-7b",
@@ -4636,17 +4921,19 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-ai/DeepSeek-R1-Turbo",
       "alias": [
         "DeepSeek-R1-Turbo"
       ],
-      "max_tokens": 40960,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 40960,
+      "max_output": 40960
     },
     {
       "name": "deepseek-ai/deepseek-r1-0528-qwen3-8b",
@@ -4658,7 +4945,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-llama-70b",
@@ -4668,7 +4956,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-llama-8b",
@@ -4678,7 +4967,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-1.5b",
@@ -4686,7 +4976,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-ai/deepseek-r1-distill-qwen-14b",
@@ -4694,7 +4985,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-ai/deepseek-r1-zero",
@@ -4704,7 +4996,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-ai/deepseek-vl2",
@@ -4714,7 +5007,8 @@
       "model_types": [
         "image2text"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-vl2-small",
@@ -4724,7 +5018,8 @@
       "model_types": [
         "image2text"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-vl2-tiny",
@@ -4734,7 +5029,8 @@
       "model_types": [
         "image2text"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-coder-1.3b-base",
@@ -4744,7 +5040,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-coder-1.3b-instruct",
@@ -4754,7 +5051,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-coder-33b-base",
@@ -4764,7 +5062,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-coder-33b-instruct",
@@ -4775,7 +5074,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-coder-5.7bmqa-base",
@@ -4785,7 +5085,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-coder-6.7b-base",
@@ -4795,7 +5096,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-coder-6.7b-instruct",
@@ -4805,7 +5107,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-llm-67b-base",
@@ -4815,7 +5118,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-llm-67b-chat",
@@ -4825,7 +5129,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-llm-7b-base",
@@ -4835,7 +5140,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-llm-7b-chat",
@@ -4845,7 +5151,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-base",
@@ -4855,7 +5162,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-instruct",
@@ -4865,7 +5173,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-math-7b-rl",
@@ -4875,7 +5184,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-moe-16b-base",
@@ -4885,7 +5195,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-moe-16b-chat",
@@ -4895,7 +5206,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "deepseek-ai/deepseek-ocr",
@@ -4903,7 +5215,8 @@
       "model_types": [
         "ocr"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ai/deepseek-vl-1.3b-base",
@@ -4913,7 +5226,8 @@
       "model_types": [
         "image2text"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-vl-1.3b-chat",
@@ -4923,7 +5237,8 @@
       "model_types": [
         "image2text"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-vl-7b-base",
@@ -4933,7 +5248,8 @@
       "model_types": [
         "image2text"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/deepseek-vl-7b-chat",
@@ -4943,7 +5259,8 @@
       "model_types": [
         "image2text"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "deepseek-ai/Janus-Pro-1B",
@@ -4970,7 +5287,6 @@
       "alias": [
         "deepseek/deepseek-ocr"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "ocr",
         "chat",
@@ -4980,20 +5296,23 @@
       "max_completion_tokens": 8192,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "deepseek-ocr-2",
       "alias": [
         "Deepseek OCR 2"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "ocr",
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "deepseek-r1",
@@ -5001,7 +5320,6 @@
         "deepseek-r1-searching",
         "DeepSeek R1"
       ],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
@@ -5012,7 +5330,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-r1-0528",
@@ -5020,7 +5340,6 @@
         "DeepSeek R1 0528",
         "DeepSeek R1 0528 NVFP4"
       ],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
@@ -5031,7 +5350,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-r1-2025-01-20",
@@ -5041,92 +5362,6 @@
     },
     {
       "name": "deepseek-r1-aliyun",
-      "max_tokens": 64000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "deepseek-r1-baidu",
-      "max_tokens": 64000,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "deepseek-r1-distill-llama-70b",
-      "alias": [
-        "DeepSeek R1 Distill LLama 70B"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat"
-      ],
-      "max_completion_tokens": 8192,
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "deepseek-r1-distill-qwen-1.5b",
-      "alias": [
-        "DeepSeek R1 Distill Qwen 1.5B"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat"
-      ],
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "deepseek-r1-distill-qwen-14b",
-      "alias": [
-        "deepseek/deepseek-r1-distill-qwen-14b",
-        "DeepSeek R1 Distill Qwen 14B"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat"
-      ],
-      "max_completion_tokens": 16384,
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "deepseek-r1-distill-qwen-32b",
-      "alias": [
-        "DeepSeek R1 Distill Qwen 32B"
-      ],
-      "max_tokens": 131072,
-      "model_types": [
-        "chat"
-      ],
-      "max_completion_tokens": 32000,
-      "thinking": {
-        "default_value": true,
-        "clear_thinking": true
-      }
-    },
-    {
-      "name": "deepseek-r1-distill-qwen-7b",
-      "alias": [
-        "DeepSeek R1 Distill Qwen 7B"
-      ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
       ],
@@ -5134,55 +5369,152 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 8192
+      "content_length": 64000,
+      "max_output": 64000
+    },
+    {
+      "name": "deepseek-r1-baidu",
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      },
+      "content_length": 64000,
+      "max_output": 64000
+    },
+    {
+      "name": "deepseek-r1-distill-llama-70b",
+      "alias": [
+        "DeepSeek R1 Distill LLama 70B"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_completion_tokens": 8192,
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      },
+      "content_length": 131072,
+      "max_output": 131072
+    },
+    {
+      "name": "deepseek-r1-distill-qwen-1.5b",
+      "alias": [
+        "DeepSeek R1 Distill Qwen 1.5B"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      },
+      "content_length": 131072,
+      "max_output": 131072
+    },
+    {
+      "name": "deepseek-r1-distill-qwen-14b",
+      "alias": [
+        "deepseek/deepseek-r1-distill-qwen-14b",
+        "DeepSeek R1 Distill Qwen 14B"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_completion_tokens": 16384,
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      },
+      "content_length": 131072,
+      "max_output": 131072
+    },
+    {
+      "name": "deepseek-r1-distill-qwen-32b",
+      "alias": [
+        "DeepSeek R1 Distill Qwen 32B"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "max_completion_tokens": 32000,
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      },
+      "content_length": 131072,
+      "max_output": 131072
+    },
+    {
+      "name": "deepseek-r1-distill-qwen-7b",
+      "alias": [
+        "DeepSeek R1 Distill Qwen 7B"
+      ],
+      "model_types": [
+        "chat"
+      ],
+      "thinking": {
+        "default_value": true,
+        "clear_thinking": true
+      },
+      "max_completion_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "deepseek-r1-huoshan",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek-r1-huoshan-0528",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "deepseek-reasoner",
       "alias": [
         "deepseek/deepseek-reasoner"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "deepseek-v3-0324",
       "alias": [],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
       "max_completion_tokens": 16384,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-v3-1-think-250821",
@@ -5199,24 +5531,27 @@
     },
     {
       "name": "deepseek-v3-aliyun",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek-v3-baidu",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek-v3-huoshan",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "deepseek-v3.1",
@@ -5225,7 +5560,6 @@
         "deepseek-v3-1",
         "Deepseek V3.1 NVFP4"
       ],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
@@ -5236,21 +5570,23 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-v3.1-huoshan",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "deepseek-v3.1-terminus",
       "alias": [
         "Deepseek V3.1 Terminus"
       ],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
@@ -5261,18 +5597,21 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-v3.1-thinking",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "deepseek-v3.2",
@@ -5280,7 +5619,6 @@
         "Deepseek V3.2",
         "deepseek-v3-2"
       ],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
@@ -5291,14 +5629,15 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-v3.2-exp",
       "alias": [
         "Deepseek V3.2 Exp"
       ],
-      "max_tokens": 163840,
       "model_types": [
         "chat"
       ],
@@ -5309,75 +5648,84 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "deepseek-v3.2-exp-thinking",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "deepseek-v3.2-thinking",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "dev/glm46",
       "alias": [
         "glm46"
       ],
-      "max_tokens": 256000,
       "max_completion_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "devstral-2512",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "devstral-medium-2507",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "devstral-small-2505",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "mistralai/Devstral-Small-2505",
         "Devstral Small 2505"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "devstral-small-2507",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "mistralai/Devstral-Small-2507"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "doc2x",
@@ -5425,22 +5773,24 @@
       "alias": [
         "doubao-1-5-lite-32k"
       ],
-      "max_tokens": 32768,
       "max_completion_tokens": 12288,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "doubao-1-5-pro-256k-250115",
       "alias": [
         "doubao-1-5-pro-256k"
       ],
-      "max_tokens": 262144,
       "max_completion_tokens": 12288,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "doubao-1-5-pro-32k-250115",
@@ -5449,11 +5799,12 @@
         "doubao-1-5-pro-32k-character-250228",
         "doubao-1-5-pro-32k-character-250715"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 12288,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "doubao-1-5-thinking-pro-250415",
@@ -5463,7 +5814,6 @@
         "doubao-1-5-thinking-pro-m-250415",
         "doubao-1-5-thinking-pro-m-250428"
       ],
-      "max_tokens": 96000,
       "model_types": [
         "chat",
         "vision",
@@ -5473,14 +5823,15 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 96000,
+      "max_output": 96000
     },
     {
       "name": "doubao-1-5-thinking-pro-vision-250415",
       "alias": [
         "Doubao-1.5-Thinking-Pro-Vision"
       ],
-      "max_tokens": 96000,
       "model_types": [
         "chat",
         "image2text",
@@ -5489,7 +5840,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 96000,
+      "max_output": 96000
     },
     {
       "name": "doubao-1-5-thinking-vision-pro-250428",
@@ -5497,7 +5850,6 @@
         "Doubao-1.5-Thinking-Vision-Pro-0428",
         "doubao-1-5-thinking-vision-pro"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
@@ -5507,41 +5859,47 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "doubao-1-5-vision-pro-32k-250115",
       "alias": [
         "doubao-1-5-vision-pro-32k"
       ],
-      "max_tokens": 32768,
       "max_completion_tokens": 12288,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "Doubao-1.5-lite-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Doubao-1.5-pro-256k",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Doubao-1.5-pro-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "doubao-1.5-ui-tars-250328",
@@ -5549,7 +5907,6 @@
         "doubao-1-5-ui-tars",
         "doubao-1-5-ui-tars-250428"
       ],
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "vision",
@@ -5559,11 +5916,12 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "doubao-1.5-vision-lite-250315",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
@@ -5572,11 +5930,12 @@
       "alias": [
         "doubao-1-5-vision-lite"
       ],
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "doubao-1.5-vision-pro-250328",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
@@ -5585,16 +5944,19 @@
       "alias": [
         "doubao-1-5-vision-pro"
       ],
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Doubao-1.5-vision-pro-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "doubao-embedding-large-text-240915",
@@ -5602,10 +5964,11 @@
         "doubao-embedding-large",
         "doubao-embedding-large-text-250515"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "doubao-embedding-text-240515",
@@ -5628,7 +5991,8 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "doubao-lite-128k-240428",
@@ -5639,8 +6003,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 4096
+      "max_completion_tokens": 4096,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "doubao-lite-32k-240428",
@@ -5654,8 +6019,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
-      "max_completion_tokens": 4096
+      "max_completion_tokens": 4096,
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "doubao-lite-4k-240328",
@@ -5668,19 +6034,21 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096,
-      "max_completion_tokens": 4096
+      "max_completion_tokens": 4096,
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "Doubao-pro-128k",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "doubao-pro-128k-240515",
         "doubao-pro-128k-240628"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "doubao-pro-256k-241115",
@@ -5693,7 +6061,6 @@
     },
     {
       "name": "Doubao-pro-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
@@ -5712,7 +6079,9 @@
         "doubao-pro-32k-character-241215",
         "doubao-pro-32k-241215"
       ],
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "doubao-pro-4k-240515",
@@ -5733,12 +6102,10 @@
       "alias": [
         "doubao-seaweed"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "doubao-seed-1-6-250615",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5752,11 +6119,12 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-1-6-flash-250615",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5770,11 +6138,12 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-1-6-flash-250715",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5784,14 +6153,15 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-1-6-lite-251015",
       "alias": [
         "doubao-seed-1-6-lite"
       ],
-      "max_tokens": 262144,
       "max_completion_tokens": 65536,
       "model_types": [
         "chat",
@@ -5801,11 +6171,12 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "doubao-seed-1-6-thinking-250615",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5818,11 +6189,12 @@
       "alias": [
         "doubao-seed-1-6-thinking"
       ],
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-1-6-thinking-250715",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5832,11 +6204,12 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-1-6-vision-250815",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "image2text",
@@ -5849,25 +6222,27 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-1-8-251215",
-      "max_tokens": 224000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 224000,
+      "max_output": 224000
     },
     {
       "name": "doubao-seed-1-8-251228",
       "alias": [
         "doubao-seed-1-8"
       ],
-      "max_tokens": 262144,
       "max_completion_tokens": 65536,
       "model_types": [
         "chat",
@@ -5877,7 +6252,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "doubao-seed-1.6-250615",
@@ -5887,7 +6264,6 @@
     },
     {
       "name": "doubao-seed-2-0-code-preview-260215",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5900,11 +6276,12 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-2-0-lite-260215",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5920,11 +6297,12 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-2-0-mini-260215",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5940,11 +6318,12 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-2-0-pro-260215",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5960,22 +6339,24 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-character-251128",
       "alias": [
         "doubao-seed-character"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "doubao-seed-code-preview-251028",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -5988,25 +6369,29 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-code-preview-latest",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "doubao-seed-translation-250915",
       "alias": [
         "doubao-seed-translation"
       ],
-      "max_tokens": 4096,
       "max_completion_tokens": 3072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "doubao-seed3d-1-0-250928",
@@ -6028,46 +6413,40 @@
     },
     {
       "name": "doubao-seedance-1-0-lite-i2v-250428",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "doubao-seedance-1-0-lite-i2v"
       ]
     },
     {
       "name": "doubao-seedance-1-0-lite-t2v-250428",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "doubao-seedance-1-0-lite-t2v"
       ]
     },
     {
       "name": "doubao-seedance-1-0-pro-250528",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "doubao-seedance-1-0-pro"
       ]
     },
     {
       "name": "doubao-seedance-1-0-pro-fast-251015",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "doubao-seedance-1-0-pro-fast"
       ]
     },
     {
       "name": "doubao-seedance-2-0-260128",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": []
     },
     {
       "name": "doubao-seedance-2-0-fast-260128",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "doubao-seedance-2-0-fast"
       ]
@@ -6144,7 +6523,6 @@
     },
     {
       "name": "Doubao-Vision-Lite-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
@@ -6153,11 +6531,12 @@
       "alias": [
         "doubao-vision-lite-32k-241015"
       ],
-      "max_completion_tokens": 4096
+      "max_completion_tokens": 4096,
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Doubao-vision-pro-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
@@ -6166,7 +6545,9 @@
       "alias": [
         "doubao-vision-pro-32k-241028"
       ],
-      "max_completion_tokens": 4096
+      "max_completion_tokens": 4096,
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "doubao_tts_hd",
@@ -6176,23 +6557,24 @@
     },
     {
       "name": "dreamina-seedance-2-0-fast-260128",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "dubbingx",
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "elephant",
-      "max_tokens": 262144,
       "max_completion_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "Embedding-V1",
@@ -6202,13 +6584,11 @@
     },
     {
       "name": "emo-detect-v1",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "emo-v1",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "ERNIE-3.5-8K",
@@ -6218,65 +6598,71 @@
     },
     {
       "name": "ernie-4.0-8k",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "ernie-4.0-turbo-128k",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "ernie-4.0-turbo-8k",
       "alias": [
         "ERNIE-4.0-Turbo"
       ],
-      "max_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "ernie-4.5-8k-preview",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "ernie-4.5-turbo-128k",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "ernie-4.5-turbo-vl-32k",
-      "max_tokens": 8000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "ernie-5.0-thinking-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "ernie-5.0-thinking-preview",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "vision",
@@ -6289,7 +6675,9 @@
       "alias": [
         "baidu/ernie-5.0-thinking-preview"
       ],
-      "max_completion_tokens": 64000
+      "max_completion_tokens": 64000,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "ERNIE-Character-8K",
@@ -6349,17 +6737,19 @@
     },
     {
       "name": "ernie-x1-turbo-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "ernie-x1.1-preview",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "essentialai/rnj-1-instruct",
@@ -6370,7 +6760,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "exaai",
@@ -6384,25 +6775,26 @@
         "cwm",
         "Facebook CWM"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "farui-plus",
-      "max_tokens": 12000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 12000,
+      "max_output": 12000
     },
     {
       "name": "FastVideo/LTX2-Distilled-Diffusers",
       "alias": [
         "LTX2-Distilled-Diffusers"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "firecrawl",
@@ -6518,7 +6910,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 448
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "flux.1-kontext-pro",
@@ -6630,10 +7023,11 @@
       "alias": [
         "Spark Max"
       ],
-      "max_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "glif",
@@ -6652,13 +7046,14 @@
     },
     {
       "name": "glm-4-0520",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4-5-air-20250728",
@@ -6674,7 +7069,6 @@
       "alias": [
         "glm-4-7"
       ],
-      "max_tokens": 204800,
       "max_completion_tokens": 131072,
       "model_types": [
         "chat"
@@ -6682,137 +7076,151 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 204800,
+      "max_output": 204800
     },
     {
       "name": "glm-4-air",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4-air-250414",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "glm-4-airx",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "glm-4-flash",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4-flash-250414",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4-long",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "glm-4-plus",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4.1v-thinking-flash",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "glm-4.1v-thinking-flashx",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "glm-4.5-airx",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4.5-flash",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4.5-x",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "glm-4.7-coding-preview",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "glm-4.7-flashx",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
@@ -6822,36 +7230,40 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "glm-4.7-preview",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "glm-4v",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "glm-4v-plus",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "glm-5-turbo",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
@@ -6865,11 +7277,12 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "glm-5v-turbo",
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "vision",
@@ -6883,7 +7296,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "glm-asr-2512",
@@ -6894,14 +7309,15 @@
     },
     {
       "name": "glm-for-coding",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "glm-tts-clone",
@@ -6911,31 +7327,35 @@
     },
     {
       "name": "glm-z1-air",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "glm-z1-airx",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "glm-z1-flash",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "glm-zero-preview",
-      "max_tokens": 16000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "google/gemini-3.5-flash",
@@ -6950,11 +7370,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-3.5-live-translate-preview",
@@ -6967,7 +7388,8 @@
         "audio2text",
         "tts"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "google/gemini-3.5-pro",
@@ -7003,7 +7425,8 @@
         "image_edit",
         "image_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "google/gemini-3.1-flash-lite",
@@ -7018,11 +7441,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-3.1-flash-lite-preview",
@@ -7037,11 +7461,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-3.1-flash-live-preview",
@@ -7057,7 +7482,8 @@
         "tts",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "google/gemini-3.1-flash-tts-preview",
@@ -7069,7 +7495,8 @@
         "tts",
         "audio_generation"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "google/gemini-3.1-pro-preview",
@@ -7085,11 +7512,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-3.1-pro-preview-customtools",
@@ -7104,11 +7532,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-3-flash",
@@ -7135,11 +7564,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-3-pro-image",
@@ -7154,7 +7584,8 @@
         "image_edit",
         "image_understanding"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "google/gemini-3-pro-preview",
@@ -7169,11 +7600,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.5-computer-use-preview-10-2025",
@@ -7186,7 +7618,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "google/gemini-2.5-flash",
@@ -7203,11 +7636,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.5-flash-image",
@@ -7222,7 +7656,8 @@
         "image_edit",
         "image_understanding"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "google/gemini-2.5-flash-lite",
@@ -7240,11 +7675,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.5-flash-lite-preview-06-17",
@@ -7258,11 +7694,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.5-flash-native-audio-preview-12-2025",
@@ -7278,7 +7715,8 @@
         "tts",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "google/gemini-2.5-flash-preview-05-20",
@@ -7292,11 +7730,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.5-flash-preview-tts",
@@ -7308,7 +7747,8 @@
         "tts",
         "audio_generation"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "google/gemini-2.5-pro",
@@ -7326,11 +7766,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.5-pro-preview-06-05",
@@ -7344,11 +7785,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.5-pro-preview-tts",
@@ -7360,7 +7802,8 @@
         "tts",
         "audio_generation"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "google/gemini-2.0-flash-20250609",
@@ -7374,7 +7817,8 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/DiarizationLM-8b-Fisher-v2",
@@ -7398,7 +7842,8 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-2.0-flash-lite",
@@ -7414,7 +7859,8 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/metricx-24-hybrid-large-v2p6",
@@ -7646,11 +8092,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-pro-latest",
@@ -7665,11 +8112,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "google/gemini-robotics-er-1.6-preview",
@@ -7683,7 +8131,8 @@
         "vision",
         "robotics"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "google/gemma-2-27b-it",
@@ -7691,7 +8140,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "google/gemma-2-2b",
@@ -8583,7 +9033,8 @@
         "image_generation",
         "image"
       ],
-      "max_tokens": 480
+      "content_length": 480,
+      "max_output": 480
     },
     {
       "name": "google/imagen-4.0-generate-001",
@@ -8595,7 +9046,8 @@
         "image_generation",
         "image"
       ],
-      "max_tokens": 480
+      "content_length": 480,
+      "max_output": 480
     },
     {
       "name": "google/imagen-4.0-ultra-generate-001",
@@ -8607,7 +9059,8 @@
         "image_generation",
         "image"
       ],
-      "max_tokens": 480
+      "content_length": 480,
+      "max_output": 480
     },
     {
       "name": "google/lyria-3-clip-preview",
@@ -8618,7 +9071,8 @@
       "model_types": [
         "audio_generation"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "google/lyria-3-pro-preview",
@@ -8629,7 +9083,8 @@
       "model_types": [
         "audio_generation"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "google/lyria-realtime-exp",
@@ -8722,8 +9177,7 @@
         "omni-fast",
         "gemini-omni-fast"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/paligemma-3b-mix-224-keras",
@@ -9888,8 +10342,7 @@
         "models/veo-3.1-fast-generate-preview",
         "veo-3.1-fast-generate-preview"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/veo-3.1-generate-preview",
@@ -9897,8 +10350,7 @@
         "models/veo-3.1-generate-preview",
         "veo-3.1-generate-preview"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/veo-3.1-lite-generate-preview",
@@ -9906,24 +10358,21 @@
         "models/veo-3.1-lite-generate-preview",
         "veo-3.1-lite-generate-preview"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/veo3",
       "alias": [
         "veo3"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/veo3-fast",
       "alias": [
         "veo3-fast"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/veo3.1",
@@ -9931,8 +10380,7 @@
         "veo3.1",
         "veo3-1"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/veo3.1-fast",
@@ -9940,8 +10388,7 @@
         "veo3.1-fast",
         "veo3-1-fast"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/veo4",
@@ -9949,8 +10396,7 @@
         "veo4",
         "veo-4"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "google/videoprism-base-f16r288",
@@ -9988,70 +10434,76 @@
         "gpt-3.5-sonnet-20240620-cursor",
         "gpt-4o-sonnet-cursor"
       ],
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "gpt-3.5-turbo",
-      "max_tokens": 4000,
       "model_types": [
         "chat"
       ],
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "gpt-3.5-turbo-0125",
-      "max_tokens": 16000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-3.5-turbo-0125"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "gpt-3.5-turbo-1106",
-      "max_tokens": 4000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-3.5-turbo-1106"
-      ]
+      ],
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "gpt-3.5-turbo-16k",
-      "max_tokens": 16000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "gpt-3.5-turbo-instruct",
-      "max_tokens": 4000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "gpt-3.7-sonnet-20250219-cursor",
       "alias": [
         "claude-3.7-sonnet"
       ],
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "gpt-4",
-      "max_tokens": 8000,
       "model_types": [
         "chat",
         "vision",
@@ -10062,87 +10514,98 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "gpt-4-0125-preview",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4-0613",
-      "max_tokens": 16000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-4-0613"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "gpt-4-1106-preview",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-4-32k-0613",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-4-gizmo-*",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4-opus-20250514-cursor",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "gpt-4-opus-4-20250514-cursor",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "gpt-4-plus",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4-sonnet-20250514-cursor",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "gpt-4-turbo-2024-04-09",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "vision",
@@ -10150,7 +10613,9 @@
       ],
       "alias": [
         "openai/gpt-4-turbo-2024-04-09"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4-turbo-preview",
@@ -10168,64 +10633,69 @@
     },
     {
       "name": "gpt-4.1",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "gpt-4.1-2025-04-14",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "gpt-4.1-mini",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "gpt-4.1-mini-2025-04-14",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "gpt-4.1-nano",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "gpt-4.1-nano-2025-04-14",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "gpt-4o",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "vision",
@@ -10236,69 +10706,78 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-2024-08-06",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-2024-11-20",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-audio-preview",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision",
         "tts"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-audio-preview-2024-10-01",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-audio-preview-2024-12-17",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision",
         "tts"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-audio-preview-2025-06-03",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-image-generation",
-      "max_tokens": 128000,
       "model_types": [
         "text-to-image",
         "image_generation"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-mini",
@@ -10312,11 +10791,12 @@
     },
     {
       "name": "gpt-4o-mini-2024-07-18",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-mini-audio-preview",
@@ -10344,12 +10824,13 @@
     },
     {
       "name": "gpt-4o-mini-transcribe",
-      "max_tokens": 16000,
       "model_types": [
         "chat",
         "asr",
         "speech2text"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "gpt-4o-mini-tts",
@@ -10377,10 +10858,11 @@
     },
     {
       "name": "gpt-4o-plus",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-4o-realtime-preview",
@@ -10402,29 +10884,32 @@
     },
     {
       "name": "gpt-4o-transcribe",
-      "max_tokens": 16000,
       "model_types": [
         "chat",
         "asr",
         "speech2text"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "gpt-4o-transcribe-diarize",
-      "max_tokens": 16000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "gpt-5-2025-08-07",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-5-2025-08-07"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-chat",
@@ -10458,14 +10943,15 @@
     },
     {
       "name": "gpt-5-chat-latest",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-codex-2025-09-15",
@@ -10479,24 +10965,27 @@
     },
     {
       "name": "gpt-5-codex-high",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-codex-low",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-codex-medium",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-image",
@@ -10524,27 +11013,28 @@
     },
     {
       "name": "gpt-5-mini-2025-08-07",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-5-mini-2025-08-07"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-nano-2025-08-07",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-5-nano-2025-08-07"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-pro",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
@@ -10552,21 +11042,23 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-pro-2025-10-06",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-5-pro-2025-10-06"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5-thinking",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
@@ -10576,17 +11068,20 @@
       },
       "alias": [
         "gpt-5-thinking-all"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.1-2025-11-13",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-5.1-2025-11-13"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.1-chat",
@@ -10610,14 +11105,15 @@
     },
     {
       "name": "gpt-5.1-chat-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-5.1-codex-2025-11-13",
@@ -10641,31 +11137,34 @@
     },
     {
       "name": "gpt-5.1-plus",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.1-thinking-plus",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.2-2025-12-11",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "openai/gpt-5.2-2025-12-11"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.2-chat",
@@ -10689,11 +11188,12 @@
     },
     {
       "name": "gpt-5.2-chat-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-5.2-codex-2026-01-14",
@@ -10707,7 +11207,6 @@
     },
     {
       "name": "gpt-5.2-pro",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
@@ -10718,7 +11217,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.2-pro-2025-12-11",
@@ -10755,11 +11256,12 @@
     },
     {
       "name": "gpt-5.3-chat-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "gpt-5.3-codex-2026-02-24",
@@ -10785,7 +11287,6 @@
     },
     {
       "name": "gpt-5.4-mini-2026-03-17",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
@@ -10795,11 +11296,12 @@
       },
       "alias": [
         "openai/gpt-5.4-mini-2026-03-17"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.4-nano",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
@@ -10810,11 +11312,12 @@
       "alias": [],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.4-nano-2026-03-17",
-      "max_tokens": 400000,
       "model_types": [
         "chat"
       ],
@@ -10824,7 +11327,9 @@
       },
       "alias": [
         "openai/gpt-5.4-nano-2026-03-17"
-      ]
+      ],
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "gpt-5.4-pro-2026-03-05",
@@ -10832,14 +11337,15 @@
         "gpt-5.4-pro",
         "openai/gpt-5.4-pro-2026-03-05"
       ],
-      "max_tokens": 1050000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1050000,
+      "max_output": 1050000
     },
     {
       "name": "gpt-5.5-2026-04-24",
@@ -10859,12 +11365,10 @@
     },
     {
       "name": "gpt-audio-2025-08-28",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "gpt-image-1",
-      "max_tokens": 32000,
       "model_types": [
         "text-to-image",
         "image_generation",
@@ -10874,7 +11378,9 @@
       ],
       "alias": [
         "gpt-image-1-all"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-image-1-2025-04-15",
@@ -10884,7 +11390,6 @@
     },
     {
       "name": "gpt-image-1-mini",
-      "max_tokens": 32000,
       "model_types": [
         "text-to-image",
         "image_generation",
@@ -10892,11 +11397,12 @@
         "image_edit",
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-image-1.5",
-      "max_tokens": 32000,
       "model_types": [
         "text-to-image",
         "image_generation",
@@ -10907,7 +11413,9 @@
       "alias": [
         "gpt-image-1.5-all",
         "GPT Image 1.5"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-image-2",
@@ -10931,10 +11439,11 @@
     },
     {
       "name": "gpt-realtime",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-realtime-1.5",
@@ -10944,24 +11453,27 @@
     },
     {
       "name": "gpt-realtime-2025-08-28",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-realtime-mini",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "gpt-realtime-mini-2025-10-06",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "grok-3-deepsearch",
@@ -11009,10 +11521,11 @@
     },
     {
       "name": "grok-4.1",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "grok-4.1-image",
@@ -11045,7 +11558,6 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_tokens": 1000000,
       "alias": [
         "xai/grok-4.20-non-reasoning",
         "grok-4.20-non-reasoning",
@@ -11057,7 +11569,9 @@
         "grok-4.20-experimental-beta-0304-non-reasoning",
         "grok-4.20-experimental-beta-non-reasoning-latest",
         "grok-4-20-non-reasoning"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "grok-4.20-0309-reasoning",
@@ -11068,7 +11582,6 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_tokens": 1000000,
       "alias": [
         "xai/grok-4.20-reasoning",
         "grok-4.20-reasoning",
@@ -11080,11 +11593,12 @@
         "grok-4.20-experimental-beta-0304-reasoning",
         "grok-4.20-experimental-beta-reasoning-latest",
         "grok-4-20-reasoning"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "grok-4.20-multi-agent-0309",
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -11100,11 +11614,12 @@
         "grok-4.20-multi-agent-beta-latest",
         "grok-4.20-multi-agent-experimental-beta-0304",
         "grok-4.20-multi-agent-experimental-beta-latest"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "grok-build-0.1",
-      "max_tokens": 256000,
       "model_types": [
         "chat",
         "vision",
@@ -11115,7 +11630,9 @@
         "grok-code-fast-1",
         "grok-code-fast",
         "grok-code-fast-1-0825"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "grok-imagine-image",
@@ -11145,8 +11662,7 @@
     },
     {
       "name": "grok-imagine-video-1.5-preview",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "xai/grok-imagine-video-1.5-preview",
         "grok-imagine-video-1.5-2026-05-30"
@@ -11154,51 +11670,52 @@
     },
     {
       "name": "grok-video-3",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "grok-video-3-10s",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "groq/compound",
       "alias": [
         "compound"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 8192,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "groq/compound-mini",
       "alias": [
         "compound-mini"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 8192,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "Gryphe/MythoMax-L2-13b-turbo",
       "alias": [
         "MythoMax-L2-13b-turbo"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "gryphe/mythomax-l2-13b",
@@ -11209,8 +11726,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096,
-      "max_completion_tokens": 3200
+      "max_completion_tokens": 3200,
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "gt-4p",
@@ -11223,8 +11741,7 @@
     },
     {
       "name": "happyhorse-1.0-i2v",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "alibaba/happyhorse-1.0-i2v",
         "HappyHorse 1.0 I2V"
@@ -11232,8 +11749,7 @@
     },
     {
       "name": "happyhorse-1.0-r2v",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "alibaba/happyhorse-1.0-r2v",
         "HappyHorse 1.0 R2V"
@@ -11241,8 +11757,7 @@
     },
     {
       "name": "happyhorse-1.0-t2v",
-      "model_types": [
-      ],
+      "model_types": [],
       "alias": [
         "alibaba/happyhorse-1.0-t2v",
         "HappyHorse 1.0 T2V"
@@ -11260,10 +11775,11 @@
         "Holo3-35B-A3B",
         "Holo3 35B A3b"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "hedra",
@@ -11388,96 +11904,109 @@
     },
     {
       "name": "hunyuan-code",
-      "max_tokens": 4000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "hunyuan-functioncall",
-      "max_tokens": 28000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 28000,
+      "max_output": 28000
     },
     {
       "name": "hunyuan-lite",
-      "max_tokens": 250000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 250000,
+      "max_output": 250000
     },
     {
       "name": "hunyuan-pro",
-      "max_tokens": 28000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 28000,
+      "max_output": 28000
     },
     {
       "name": "hunyuan-role",
-      "max_tokens": 4000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "hunyuan-standard",
-      "max_tokens": 30000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 30000,
+      "max_output": 30000
     },
     {
       "name": "hunyuan-standard-256K",
-      "max_tokens": 250000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 250000,
+      "max_output": 250000
     },
     {
       "name": "hunyuan-t1-20250321",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "hunyuan-t1-20250711",
-      "max_tokens": 28000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 28000,
+      "max_output": 28000
     },
     {
       "name": "hunyuan-t1-latest",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "hunyuan-turbos-20250226",
-      "max_tokens": 24000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 24000,
+      "max_output": 24000
     },
     {
       "name": "hunyuan-turbos-20250716",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "hunyuan-vision",
-      "max_tokens": 4000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "hyper3d-gen2-260112",
@@ -11490,18 +12019,15 @@
     },
     {
       "name": "I2V-01",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "I2V-01-Director",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "I2V-01-live",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "ibm-granite/granite-4.0-h-micro",
@@ -11509,7 +12035,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131000
+      "content_length": 131000,
+      "max_output": 131000
     },
     {
       "name": "ibm-granite/granite-4.1-8b",
@@ -11517,7 +12044,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "ibm-granite/granite-embedding-278m-multilingual:1f76d42a05f120e12272746d5a2d86b525c13420773f795a4cbef9117d8685f1",
@@ -11525,9 +12053,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "ideogram",
@@ -11577,29 +12106,32 @@
     {
       "name": "imagen-4.0-fast-generate-001",
       "alias": [],
-      "max_tokens": 480,
       "model_types": [
         "text-to-image",
         "image_generation"
-      ]
+      ],
+      "content_length": 480,
+      "max_output": 480
     },
     {
       "name": "imagen-4.0-generate-001",
       "alias": [],
-      "max_tokens": 480,
       "model_types": [
         "text-to-image",
         "image_generation"
-      ]
+      ],
+      "content_length": 480,
+      "max_output": 480
     },
     {
       "name": "imagen-4.0-ultra-generate-001",
       "alias": [],
-      "max_tokens": 480,
       "model_types": [
         "text-to-image",
         "image_generation"
-      ]
+      ],
+      "content_length": 480,
+      "max_output": 480
     },
     {
       "name": "inception/mercury-2",
@@ -11607,32 +12139,36 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "inclusionAI/Ling-flash-2.0",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "inclusionAI/Ling-mini-2.0",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "inclusionAI/Ring-flash-2.0",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "inclusionai/ling-2.6-1t",
@@ -11642,8 +12178,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "inclusionai/ling-2.6-flash",
@@ -11653,8 +12190,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "inclusionai/ring-2.6-1t",
@@ -11664,12 +12202,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "inflection/inflection-3-pi",
@@ -11677,7 +12216,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "inflection/inflection-3-productivity",
@@ -11685,47 +12225,52 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "internlm/internlm2_5-7b-chat",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "intfloat/e5-base-v2",
       "alias": [
         "e5-base-v2"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "intfloat/e5-large-v2",
       "alias": [
         "e5-large-v2"
       ],
-      "max_tokens": 512,
       "max_dimension": 1024,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "intfloat/multilingual-e5-large",
       "alias": [
         "multilingual-e5-large"
       ],
-      "max_tokens": 512,
       "max_dimension": 1024,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "intfloat/multilingual-e5-large-instruct",
@@ -11733,11 +12278,12 @@
         "multilingual-e5-large-instruct",
         "Multilingual E5 Large Instruct"
       ],
-      "max_tokens": 512,
       "max_dimension": 1024,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "inworld-ai/inworld-tts-1.5-max",
@@ -11801,7 +12347,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11810,7 +12355,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-classification",
@@ -11823,7 +12370,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11832,7 +12378,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-classification-GGUF",
@@ -11845,7 +12393,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11854,7 +12401,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-classification-mlx",
@@ -11867,7 +12416,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11876,7 +12424,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-clustering",
@@ -11889,7 +12439,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11898,7 +12447,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-clustering-GGUF",
@@ -11911,7 +12462,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11920,7 +12470,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-clustering-mlx",
@@ -11933,7 +12485,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11942,7 +12493,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-mlx",
@@ -11955,7 +12508,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11964,7 +12516,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -11977,7 +12531,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -11986,7 +12539,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-retrieval-GGUF",
@@ -11999,7 +12554,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12008,7 +12562,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-retrieval-mlx",
@@ -12021,7 +12577,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12030,7 +12585,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-text-matching",
@@ -12043,7 +12600,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12052,7 +12608,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-text-matching-GGUF",
@@ -12065,7 +12623,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12074,7 +12631,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-nano-text-matching-mlx",
@@ -12087,7 +12646,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12096,7 +12654,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small",
@@ -12109,7 +12669,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12118,7 +12677,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-classification",
@@ -12131,7 +12692,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12140,7 +12700,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-classification-GGUF",
@@ -12153,7 +12715,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12162,7 +12723,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-classification-mlx",
@@ -12175,7 +12738,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12184,7 +12746,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-clustering",
@@ -12197,7 +12761,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12206,7 +12769,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-clustering-GGUF",
@@ -12219,7 +12784,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12228,7 +12792,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-clustering-mlx",
@@ -12241,7 +12807,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12250,7 +12815,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-mlx",
@@ -12263,7 +12830,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12272,7 +12838,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -12285,7 +12853,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12294,7 +12861,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-retrieval-GGUF",
@@ -12307,7 +12876,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12316,7 +12884,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-retrieval-mlx",
@@ -12329,7 +12899,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12338,7 +12907,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-text-matching",
@@ -12351,7 +12922,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12360,7 +12930,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-text-matching-GGUF",
@@ -12373,7 +12945,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12382,7 +12953,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-omni-small-text-matching-mlx",
@@ -12395,7 +12968,6 @@
         "audio",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12404,7 +12976,9 @@
         256,
         512,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano",
@@ -12414,7 +12988,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12424,7 +12997,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-classification",
@@ -12434,7 +13009,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12444,7 +13018,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-classification-GGUF",
@@ -12454,7 +13030,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12464,7 +13039,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-classification-mlx",
@@ -12474,7 +13051,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12484,7 +13060,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-clustering",
@@ -12494,7 +13072,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12504,7 +13081,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-clustering-GGUF",
@@ -12514,7 +13093,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12524,7 +13102,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-clustering-mlx",
@@ -12534,7 +13114,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12544,7 +13123,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-mlx",
@@ -12554,7 +13135,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12564,7 +13144,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-retrieval",
@@ -12574,7 +13156,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12584,7 +13165,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-retrieval-GGUF",
@@ -12594,7 +13177,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12604,7 +13186,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-retrieval-mlx",
@@ -12614,7 +13198,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12624,7 +13207,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-text-matching",
@@ -12634,7 +13219,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12644,7 +13228,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-text-matching-GGUF",
@@ -12654,7 +13240,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12664,7 +13249,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-nano-text-matching-mlx",
@@ -12674,7 +13261,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12684,7 +13270,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small",
@@ -12694,7 +13282,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12704,7 +13291,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-classification",
@@ -12714,7 +13303,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12724,7 +13312,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-classification-GGUF",
@@ -12734,7 +13324,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12744,7 +13333,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-classification-mlx",
@@ -12754,7 +13345,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12764,7 +13354,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-clustering",
@@ -12774,7 +13366,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12784,7 +13375,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-clustering-GGUF",
@@ -12794,7 +13387,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12804,7 +13396,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-clustering-mlx",
@@ -12814,7 +13408,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12824,7 +13417,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-mlx",
@@ -12834,7 +13429,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12844,7 +13438,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-retrieval",
@@ -12854,7 +13450,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12864,7 +13459,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-retrieval-GGUF",
@@ -12874,7 +13471,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12884,7 +13480,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-retrieval-mlx",
@@ -12894,7 +13492,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12904,7 +13501,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-text-matching",
@@ -12914,7 +13513,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12924,7 +13522,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-text-matching-GGUF",
@@ -12934,7 +13534,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12944,7 +13543,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v5-text-small-text-matching-mlx",
@@ -12954,7 +13555,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -12964,7 +13564,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4",
@@ -12975,7 +13577,6 @@
         "embedding",
         "vision"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -12983,7 +13584,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4-mlx-8bit",
@@ -12994,7 +13597,6 @@
         "embedding",
         "vision"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -13002,7 +13604,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4-text-code-GGUF",
@@ -13012,7 +13616,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -13020,7 +13623,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4-text-matching-GGUF",
@@ -13030,7 +13635,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -13038,7 +13642,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4-text-retrieval-GGUF",
@@ -13048,7 +13654,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -13056,7 +13661,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4-vllm-code",
@@ -13067,7 +13674,6 @@
         "embedding",
         "vision"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -13075,7 +13681,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4-vllm-retrieval",
@@ -13086,7 +13694,6 @@
         "embedding",
         "vision"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -13094,7 +13701,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v4-vllm-text-matching",
@@ -13105,7 +13714,6 @@
         "embedding",
         "vision"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
       "dimensions": [
         128,
@@ -13113,7 +13721,9 @@
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-embeddings-v3",
@@ -13123,7 +13733,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -13133,7 +13742,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v3-hf",
@@ -13143,7 +13754,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -13153,7 +13763,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v3-small-ci",
@@ -13163,7 +13775,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1024,
       "dimensions": [
         32,
@@ -13173,7 +13784,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-reranker-v3",
@@ -13183,7 +13796,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-reranker-v3-GGUF",
@@ -13193,7 +13807,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-reranker-v3-mlx",
@@ -13203,7 +13818,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-bert-v2-qk-devlin-norm-1e-2",
@@ -13232,7 +13848,6 @@
         "embedding",
         "vision"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1024,
       "dimensions": [
         64,
@@ -13241,7 +13856,9 @@
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-colbert-v2",
@@ -13251,11 +13868,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 128,
       "dimensions": [
         128
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-colbert-v2-64",
@@ -13265,11 +13883,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 64,
       "dimensions": [
         64
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v2-base-code",
@@ -13279,11 +13898,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 768,
       "dimensions": [
         768
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v2-base-de",
@@ -13293,11 +13913,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 768,
       "dimensions": [
         768
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v2-base-en",
@@ -13307,11 +13928,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 768,
       "dimensions": [
         768
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v2-base-es",
@@ -13321,11 +13943,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 768,
       "dimensions": [
         768
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v2-base-zh",
@@ -13335,11 +13958,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 768,
       "dimensions": [
         768
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embeddings-v2-small-en",
@@ -13349,11 +13973,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 512,
       "dimensions": [
         512
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-reranker-v2-base-multilingual",
@@ -13363,7 +13988,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/ReaderLM-v2",
@@ -13373,7 +13999,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "jinaai/jina-clip-v1",
@@ -13384,7 +14011,6 @@
         "embedding",
         "vision"
       ],
-      "max_tokens": 8192,
       "max_dimension": 768,
       "dimensions": [
         64,
@@ -13392,7 +14018,9 @@
         256,
         512,
         768
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-colbert-v1-en",
@@ -13402,11 +14030,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 128,
       "dimensions": [
         128
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-embedding-b-en-v1",
@@ -13416,11 +14045,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
       "dimensions": [
         768
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "jinaai/jina-embedding-l-en-v1",
@@ -13430,11 +14060,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 512,
       "max_dimension": 1024,
       "dimensions": [
         1024
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "jinaai/jina-embedding-s-en-v1",
@@ -13444,11 +14075,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 512,
       "max_dimension": 512,
       "dimensions": [
         512
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "jinaai/jina-embedding-t-en-v1",
@@ -13458,11 +14090,12 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 512,
       "max_dimension": 312,
       "dimensions": [
         312
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "jinaai/jina-reranker-v1-tiny-en",
@@ -13472,7 +14105,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 512
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "jinaai/jina-reranker-v1-turbo-en",
@@ -13482,7 +14116,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 512
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "jinaai/clip-models",
@@ -13573,14 +14208,15 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         256,
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-code-embeddings-0.5b-GGUF",
@@ -13590,14 +14226,15 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         256,
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-code-embeddings-0.5b-mlx",
@@ -13607,14 +14244,15 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         256,
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-code-embeddings-1.5b",
@@ -13624,14 +14262,15 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         256,
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-code-embeddings-1.5b-GGUF",
@@ -13641,14 +14280,15 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         256,
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-code-embeddings-1.5b-mlx",
@@ -13658,14 +14298,15 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "dimensions": [
         256,
         512,
         768,
         1024
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-reranker-m0",
@@ -13675,7 +14316,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-reranker-m0-debug",
@@ -13685,7 +14327,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-reranker-m0-GGUF",
@@ -13695,7 +14338,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "jinaai/jina-vlm",
@@ -13707,7 +14351,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/jina-vlm-mlx",
@@ -13719,7 +14364,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/Phi-3-tiny-untrained",
@@ -13738,7 +14384,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "jinaai/reader-lm-1.5b",
@@ -13748,7 +14395,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "jinaai/starcoder-1b-textbook",
@@ -13767,7 +14415,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/text-seg-lm-qwen2-0.5b-cot-topic-chunking",
@@ -13777,7 +14426,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/text-seg-lm-qwen2-0.5b-summary-chunking",
@@ -13787,7 +14437,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "jinaai/xlm-roberta-flash-implementation",
@@ -13821,43 +14472,48 @@
     },
     {
       "name": "kat-coder",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
       ],
-      "max_completion_tokens": 128000
+      "max_completion_tokens": 128000,
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "KAT-Coder-Air-V1",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "KAT-Coder-Exp-72B-1010",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "KAT-Coder-Pro-V1",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "kimi-for-coding",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "kimi-k2",
@@ -13871,30 +14527,34 @@
       "alias": [
         "kimi-k2-thinking-251104"
       ],
-      "max_tokens": 262144,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "kimi-k2-0711-preview",
-      "max_tokens": 128000,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "kimi-k2-0905-preview",
-      "max_tokens": 262144,
-      "model_types": [
-        "chat"
-      ]
-    },
-    {
-      "name": "kimi-k2-250711",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
-      "max_completion_tokens": 32768
+      "content_length": 128000,
+      "max_output": 128000
+    },
+    {
+      "name": "kimi-k2-0905-preview",
+      "model_types": [
+        "chat"
+      ],
+      "content_length": 262144,
+      "max_output": 262144
+    },
+    {
+      "name": "kimi-k2-250711",
+      "model_types": [
+        "chat"
+      ],
+      "max_completion_tokens": 32768,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "kimi-k2-250905",
@@ -13905,15 +14565,15 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_tokens": 262144,
       "max_completion_tokens": 32768,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "kimi-k2-thinking",
-      "max_tokens": 262144,
       "model_types": [
         "chat"
       ],
@@ -13923,25 +14583,29 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "kimi-k2-thinking-turbo",
-      "max_tokens": 262144,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "kimi-k2-turbo-preview",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "kimi-k2.7-code",
@@ -13954,7 +14618,6 @@
         "Kimi K2.7 Code",
         "kimi/kimi-k2.7-code"
       ],
-      "max_tokens": 262144,
       "max_completion_tokens": 262144,
       "thinking": {
         "default_value": true,
@@ -13962,14 +14625,17 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "kimi-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "kling/kling-v3",
@@ -13991,18 +14657,15 @@
     },
     {
       "name": "Kling-3.0",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Kling-3.0-Omni",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kling-advanced-custom-elements",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kling-advanced-lip-sync",
@@ -14024,8 +14687,7 @@
     },
     {
       "name": "kling-custom-elements",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kling-custom-voices",
@@ -14035,8 +14697,7 @@
     },
     {
       "name": "kling-effects",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kling-image",
@@ -14077,8 +14738,7 @@
     },
     {
       "name": "Kling-O1",
-      "model_types": [
-      ],
+      "model_types": [],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -14093,8 +14753,7 @@
     },
     {
       "name": "kling-omni-video",
-      "model_types": [
-      ],
+      "model_types": [],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -14171,8 +14830,7 @@
     },
     {
       "name": "kling-video",
-      "model_types": [
-      ],
+      "model_types": [],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -14180,8 +14838,7 @@
     },
     {
       "name": "kling-video-extend",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "klingai",
@@ -14194,10 +14851,11 @@
       "alias": [
         "LLaMA2-13B-Tiefighter"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "kolors-virtual-try-on-v1",
@@ -14217,8 +14875,7 @@
         "kling_advanced_lip_syn",
         "kling-advanced-lip-syn"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_audio_text_to_audio",
@@ -14236,32 +14893,28 @@
         "kling_audio_video_to_audio",
         "kling-audio-video-to-audio"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_avatar_image2video",
       "alias": [
         "kling_avatar_image2video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_effects",
       "alias": [
         "kling_effects"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_extend",
       "alias": [
         "kling_extend"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_identify_face",
@@ -14269,8 +14922,7 @@
         "kling_identify_face",
         "kling-identify-face"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_image",
@@ -14297,8 +14949,7 @@
       "alias": [
         "kling_image_recognize"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_multi_elements_submit",
@@ -14306,8 +14957,7 @@
         "kling_multi_elements_submit",
         "kling-multi-elements-submit"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_multi_image2image",
@@ -14335,8 +14985,7 @@
       "alias": [
         "kling_video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kuaishou/kling_virtual_try_on",
@@ -14350,10 +14999,11 @@
     },
     {
       "name": "Kwaipilot/KAT-Dev",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "kwaipilot/kat-coder-pro-v2",
@@ -14361,7 +15011,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "kwaipilot/kat-coder-pro",
@@ -14369,22 +15020,24 @@
         "kat-coder-pro",
         "Kat Coder Pro"
       ],
-      "max_tokens": 256000,
       "max_completion_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "kwaipilot/kat-dev-72b-exp",
       "alias": [
         "kat-dev-72b-exp"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 65536,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "kwaivgI/kling-1.6-pro",
@@ -14392,8 +15045,7 @@
         "kling-1.6-pro",
         "Kling 1.6 Pro"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kwaivgI/kling-1.6-standard",
@@ -14401,8 +15053,7 @@
         "kling-1.6-standard",
         "Kling 1.6 Standard"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kwaivgI/kling-2.0-master",
@@ -14410,8 +15061,7 @@
         "kling-2.0-master",
         "Kling 2.0 Master"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kwaivgI/kling-2.1-master",
@@ -14419,8 +15069,7 @@
         "kling-2.1-master",
         "Kling 2.1 Master"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kwaivgI/kling-2.1-pro",
@@ -14428,8 +15077,7 @@
         "kling-2.1-pro",
         "Kling 2.1 Pro"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "kwaivgI/kling-2.1-standard",
@@ -14437,8 +15085,7 @@
         "kling-2.1-standard",
         "Kling 2.1 Standard"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "liquid/lfm-2-24b-a2b",
@@ -14446,7 +15093,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "liquid/lfm-2.5-1.2b-instruct:free",
@@ -14454,7 +15102,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "liquid/lfm-2.5-1.2b-thinking:free",
@@ -14462,45 +15111,46 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "LiquidAI/LFM2-24B-A2B",
       "alias": [
         "LFM2-24B-A2B"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "liveportrait",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "liveportrait-detect",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "lizpreciatior/lzlv_70b_fp16_hf",
       "alias": [
         "lzlv_70b_fp16_hf"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "llama-3-70b",
@@ -14528,87 +15178,97 @@
     },
     {
       "name": "llama-3.1-8b-instant",
-      "max_tokens": 131072,
       "max_completion_tokens": 131072,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "llama-3.3-70b-versatile",
-      "max_tokens": 131072,
       "max_completion_tokens": 32768,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "llama-4-maverick",
       "alias": [
         "meta-llama/llama-4-maverick"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "llama-4-scout",
       "alias": [
         "meta-llama/llama-4-scout"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "llama3.1-405b",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "llama3.1-70b",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "llama3.1-8b",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "llama3.2-11b",
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "llama3.2-90b",
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "llama3.3-70b",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "longcat-flash",
@@ -14641,7 +15301,6 @@
     },
     {
       "name": "M2-her",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
@@ -14651,18 +15310,21 @@
       },
       "alias": [
         "minimax/m2-her"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "MAI-DS-R1",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "mancer/weaver",
@@ -14670,17 +15332,19 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "mattshumer/Reflection-Llama-3.1-70B",
       "alias": [
         "Reflection-Llama-3.1-70B"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meituan-longcat/longcat-audio-codec",
@@ -14717,7 +15381,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-chat-fp8",
@@ -14727,7 +15392,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-lite",
@@ -14738,7 +15404,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "meituan-longcat/longcat-flash-lite-fp8",
@@ -14748,7 +15415,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "meituan-longcat/longcat-flash-omni",
@@ -14764,7 +15432,8 @@
         "tts",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-omni-fp8",
@@ -14780,7 +15449,8 @@
         "tts",
         "video_understanding"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-prover",
@@ -14790,11 +15460,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-thinking",
@@ -14804,11 +15475,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-thinking-2601",
@@ -14818,11 +15490,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-thinking-2601-fp8",
@@ -14832,11 +15505,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-thinking-fp8",
@@ -14846,11 +15520,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-flash-thinking-zigzag",
@@ -14860,11 +15535,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "meituan-longcat/longcat-heavymode-summary",
@@ -14874,11 +15550,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meituan-longcat/longcat-image",
@@ -14941,24 +15618,21 @@
       "alias": [
         "LongCat-Video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "meituan-longcat/longcat-video-avatar",
       "alias": [
         "LongCat-Video-Avatar"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "meituan-longcat/longcat-video-avatar-1.5",
       "alias": [
         "LongCat-Video-Avatar-1.5"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "meituan-longcat/wbench-weights",
@@ -14985,7 +15659,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
@@ -14998,7 +15673,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP4",
@@ -15006,12 +15682,13 @@
         "Llama-4-Maverick-17B-128E-Instruct-FP4",
         "Llama 4 Maverick 17B 128E Instruct Nvfp4"
       ],
-      "max_tokens": 1048576,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
@@ -15025,8 +15702,9 @@
         "image2text",
         "ocr"
       ],
-      "max_tokens": 1048576,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-Original",
@@ -15038,7 +15716,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-Original",
@@ -15050,17 +15729,19 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-Turbo",
       "alias": [
         "Llama-4-Maverick-17B-128E-Instruct-Turbo"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Llama-4-Maverick-17B-128E-Original",
@@ -15072,7 +15753,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E",
@@ -15085,7 +15767,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 10485760
+      "content_length": 10485760,
+      "max_output": 10485760
     },
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
@@ -15101,8 +15784,9 @@
         "image2text",
         "ocr"
       ],
-      "max_tokens": 10485760,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 10485760,
+      "max_output": 10485760
     },
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Instruct-FP8-Lora",
@@ -15110,12 +15794,13 @@
         "Llama-4-Scout-17B-16E-Instruct-FP8-Lora",
         "Llama 4 Scout 17B 16E Instruct Fp8 Lora"
       ],
-      "max_tokens": 10485760,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 10485760,
+      "max_output": 10485760
     },
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Instruct-Original",
@@ -15127,7 +15812,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 10485760
+      "content_length": 10485760,
+      "max_output": 10485760
     },
     {
       "name": "meta-llama/Llama-4-Scout-17B-16E-Original",
@@ -15139,7 +15825,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 10485760
+      "content_length": 10485760,
+      "max_output": 10485760
     },
     {
       "name": "meta-llama/Llama-3.3-70B-Instruct",
@@ -15153,8 +15840,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 120000
+      "max_completion_tokens": 120000,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.3-70B-Instruct-FP8-Lora",
@@ -15162,10 +15850,11 @@
         "Llama-3.3-70B-Instruct-FP8-Lora",
         "Llama 3.3 70B Instruct FP8 Lora"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
@@ -15173,13 +15862,14 @@
         "Llama-3.3-70B-Instruct-Turbo",
         "Meta Llama 3.3 70B Instruct Turbo"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-11B-Vision",
@@ -15191,7 +15881,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
@@ -15205,7 +15896,8 @@
         "image2text",
         "ocr"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-1B",
@@ -15216,7 +15908,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-1B-Instruct",
@@ -15228,8 +15921,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 32000
+      "max_completion_tokens": 32000,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-1B-Instruct-QLORA_INT4_EO8",
@@ -15239,7 +15933,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-1B-Instruct-SpinQuant_INT4_EO8",
@@ -15249,7 +15944,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-3B",
@@ -15260,7 +15956,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-3B-Instruct",
@@ -15273,8 +15970,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 32000
+      "max_completion_tokens": 32000,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-3B-Instruct-QLORA_INT4_EO8",
@@ -15284,7 +15982,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-3B-Instruct-SpinQuant_INT4_EO8",
@@ -15294,7 +15993,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-90B-Vision",
@@ -15306,7 +16006,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.2-90B-Vision-Instruct",
@@ -15319,7 +16020,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-405B",
@@ -15330,7 +16032,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-405B-FP8",
@@ -15340,7 +16043,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-405B-Instruct",
@@ -15351,7 +16055,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-405B-Instruct-FP8",
@@ -15361,7 +16066,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-70B",
@@ -15371,7 +16077,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-70B-Instruct",
@@ -15382,7 +16089,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-8B",
@@ -15392,7 +16100,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-3.1-8B-Instruct",
@@ -15404,8 +16113,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/llama-3-70b-instruct",
@@ -15416,11 +16126,12 @@
         "Meta-Llama-3-70B-Instruct",
         "meta/meta-llama-3-70b-instruct"
       ],
-      "max_tokens": 8192,
       "max_completion_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Llama-3-8b-chat-hf",
@@ -15428,10 +16139,11 @@
         "Llama-3-8b-chat-hf",
         "Meta Llama 3 8B Instruct Reference"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/llama-3-8b-instruct",
@@ -15443,11 +16155,12 @@
         "meta/meta-llama-3-8b-instruct",
         "Meta Llama 3 8B Instruct"
       ],
-      "max_tokens": 8192,
       "max_completion_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Llama-2-13b",
@@ -15457,7 +16170,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-13b-chat",
@@ -15467,7 +16181,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-13b-chat-hf",
@@ -15477,7 +16192,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-13b-hf",
@@ -15487,7 +16203,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-70b",
@@ -15497,7 +16214,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-70b-chat",
@@ -15507,7 +16225,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-70b-chat-hf",
@@ -15517,7 +16236,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-70b-hf",
@@ -15527,7 +16247,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-7b",
@@ -15537,7 +16258,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-7b-chat",
@@ -15547,7 +16269,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-7b-chat-hf",
@@ -15557,7 +16280,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Llama-2-7b-hf",
@@ -15567,7 +16291,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/CodeLlama-13b-hf",
@@ -15577,7 +16302,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-13b-Instruct-hf",
@@ -15587,7 +16313,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-13b-Python-hf",
@@ -15597,7 +16324,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-34b-hf",
@@ -15607,7 +16335,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-34b-Instruct-hf",
@@ -15617,7 +16346,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-34b-Python-hf",
@@ -15627,7 +16357,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-70b-hf",
@@ -15637,7 +16368,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-70b-Instruct-hf",
@@ -15647,7 +16379,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-70b-Python-hf",
@@ -15657,7 +16390,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-7b-hf",
@@ -15667,7 +16401,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-7b-Instruct-hf",
@@ -15677,7 +16412,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/CodeLlama-7b-Python-hf",
@@ -15687,7 +16423,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/Llama-Guard-3-11B-Vision",
@@ -15699,7 +16436,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-Guard-3-1B",
@@ -15709,7 +16447,8 @@
       "model_types": [
         "moderation"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-Guard-3-1B-INT4",
@@ -15719,7 +16458,8 @@
       "model_types": [
         "moderation"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-Guard-3-8B",
@@ -15730,7 +16470,8 @@
         "moderation",
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-Guard-3-8B-INT8",
@@ -15740,7 +16481,8 @@
       "model_types": [
         "moderation"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-Guard-4-12B",
@@ -15755,7 +16497,8 @@
         "chat",
         "ocr"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Llama-Prompt-Guard-2-22M",
@@ -15765,8 +16508,9 @@
       "model_types": [
         "moderation"
       ],
-      "max_tokens": 512,
-      "max_completion_tokens": 512
+      "max_completion_tokens": 512,
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "meta-llama/Llama-Prompt-Guard-2-86M",
@@ -15776,8 +16520,9 @@
       "model_types": [
         "moderation"
       ],
-      "max_tokens": 512,
-      "max_completion_tokens": 512
+      "max_completion_tokens": 512,
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "meta-llama/LlamaGuard-7b",
@@ -15787,7 +16532,8 @@
       "model_types": [
         "moderation"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Meta-Llama-3-70B",
@@ -15797,7 +16543,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Meta-Llama-3-70B-Instruct-Turbo",
@@ -15805,10 +16552,11 @@
         "Meta-Llama-3-70B-Instruct-Turbo",
         "Meta Llama 3 70B Instruct Turbo"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Meta-Llama-3-8B",
@@ -15818,7 +16566,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Meta-Llama-3-8B-Instruct-Lite",
@@ -15826,20 +16575,22 @@
         "Meta-Llama-3-8B-Instruct-Lite",
         "Meta Llama 3 8B Instruct Lite"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "meta-llama/Meta-Llama-3.1-405B-Instruct",
       "alias": [
         "Meta-Llama-3.1-405B-Instruct"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "meta-llama/Meta-Llama-3.1-70B",
@@ -15847,20 +16598,22 @@
         "Meta-Llama-3.1-70B",
         "Llama 3.1 70B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Meta-Llama-3.1-70B-Instruct",
       "alias": [
         "Meta-Llama-3.1-70B-Instruct"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
@@ -15868,10 +16621,11 @@
         "Meta-Llama-3.1-70B-Instruct-Turbo",
         "Meta Llama 3.1 70B Instruct Turbo"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Meta-Llama-3.1-8B",
@@ -15879,20 +16633,22 @@
         "Meta-Llama-3.1-8B",
         "Meta Llama 3.1 8B"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "meta-llama/Meta-Llama-3.1-8B-Instruct",
       "alias": [
         "Meta-Llama-3.1-8B-Instruct"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
@@ -15900,10 +16656,11 @@
         "Meta-Llama-3.1-8B-Instruct-Turbo",
         "Meta Llama 3.1 8B Instruct Turbo"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "meta-llama/Meta-Llama-Guard-2-8B",
@@ -15913,7 +16670,8 @@
       "model_types": [
         "moderation"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "meta-llama/Prompt-Guard-86M",
@@ -15929,10 +16687,11 @@
       "alias": [
         "Phi-3-medium-4k-instruct"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "microsoft/phi-4",
@@ -15942,7 +16701,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "microsoft/phi-4-mini-instruct",
@@ -15950,39 +16710,43 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "microsoft/Phi-4-multimodal-instruct",
       "alias": [
         "Phi-4-multimodal-instruct"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "microsoft/phi-4-reasoning-plus",
       "alias": [
         "phi-4-reasoning-plus"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "microsoft/WizardLM-2-7B",
       "alias": [
         "WizardLM-2-7B"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "microsoft/wizardlm-2-8x22b",
@@ -15993,8 +16757,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536,
-      "max_completion_tokens": 8000
+      "max_completion_tokens": 8000,
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "midjourney/mj_fast_blend",
@@ -16203,8 +16968,7 @@
         "mj_fast_video",
         "mj-fast-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "midjourney/mj_fast_zoom",
@@ -16419,18 +17183,18 @@
     },
     {
       "name": "mimo-v2-omni",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "mimo-v2-pro",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
@@ -16439,11 +17203,12 @@
         "clear_thinking": true
       },
       "alias": [],
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "mimo-v2.5",
-      "max_tokens": 1048576,
       "model_types": [
         "chat",
         "image2text",
@@ -16459,18 +17224,20 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "mimo-v2.5-asr",
-      "max_tokens": 8192,
       "model_types": [
         "asr"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "mimo-v2.5-pro",
-      "max_tokens": 1048576,
       "model_types": [
         "chat"
       ],
@@ -16484,7 +17251,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "minimax/hailuo-02",
@@ -16492,8 +17261,7 @@
         "hailuo-02",
         "MiniMax Hailuo 02"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "minimax/happyhorse-1.0",
@@ -16501,8 +17269,7 @@
         "happyhorse-1.0",
         "happy-horse-1-0"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "minimax/minimax-m1",
@@ -16510,11 +17277,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimax/minimax-m2-her",
@@ -16522,14 +17290,14 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "minimax/minimax-m2.1-h",
       "alias": [
         "minimax-m2.1-h"
       ],
-      "max_tokens": 204800,
       "max_completion_tokens": 131072,
       "model_types": [
         "chat"
@@ -16537,7 +17305,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 204800,
+      "max_output": 204800
     },
     {
       "name": "minimax/minimax-m2.5-highspeed",
@@ -16548,14 +17318,15 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 204800,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 204800,
+      "max_output": 204800
     },
     {
       "name": "minimax/minimax-m2.7-highspeed",
@@ -16566,11 +17337,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 204800,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 204800,
+      "max_output": 204800
     },
     {
       "name": "minimax/minimax-m3",
@@ -16578,11 +17350,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1024000,
+      "max_output": 1024000
     },
     {
       "name": "minimax/minimax_video-01",
@@ -16590,8 +17363,7 @@
         "minimax_video-01",
         "minimax-video-01"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "minimax/video-01-director",
@@ -16599,8 +17371,7 @@
         "video-01-director",
         "MiniMax 01 Director"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "MiniMax-File-Upload",
@@ -16610,19 +17381,19 @@
     },
     {
       "name": "minimax-for-coding",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "MiniMax-Hailuo-02",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "MiniMax-Hailuo-2.3",
@@ -16650,25 +17421,26 @@
     },
     {
       "name": "MiniMax-M1",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "MiniMax-M2.1-highspeed",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimax-m3",
-      "max_tokens": 1024000,
       "model_types": [
         "chat",
         "vision",
@@ -16685,7 +17457,9 @@
       "max_completion_tokens": 131072,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1024000,
+      "max_output": 1024000
     },
     {
       "name": "MiniMax-Voice-Clone",
@@ -16705,14 +17479,15 @@
         "MiniMax-M2.5-FP4",
         "MiniMax M2.5 FP4"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "minimaxai/MiniMax-M1-40k",
@@ -16723,11 +17498,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 40000,
+      "max_output": 40000
     },
     {
       "name": "minimaxai/MiniMax-M1-40k-hf",
@@ -16737,11 +17513,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 40000,
+      "max_output": 40000
     },
     {
       "name": "minimaxai/MiniMax-M1-80k",
@@ -16753,12 +17530,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 80000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 40000
+      "max_completion_tokens": 40000,
+      "content_length": 80000,
+      "max_output": 80000
     },
     {
       "name": "minimaxai/MiniMax-M1-80k-hf",
@@ -16768,11 +17546,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 80000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 80000,
+      "max_output": 80000
     },
     {
       "name": "minimaxai/MiniMax-M2",
@@ -16784,12 +17563,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/MiniMax-M2.1",
@@ -16801,12 +17581,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/MiniMax-M2.5",
@@ -16818,12 +17599,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131100
+      "max_completion_tokens": 131100,
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/MiniMax-M2.7",
@@ -16836,12 +17618,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/MiniMax-Text-01",
@@ -16852,11 +17635,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/MiniMax-Text-01-hf",
@@ -16866,11 +17650,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/MiniMax-VL-01",
@@ -16882,11 +17667,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/SynLogic-32B",
@@ -16896,11 +17682,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/SynLogic-7B",
@@ -16910,11 +17697,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/SynLogic-Mix-3-32B",
@@ -16924,11 +17712,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "minimaxai/VTP-Base-f16d64",
@@ -16943,7 +17732,8 @@
       "dimensions": [
         512
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "minimaxai/VTP-Large-f16d64",
@@ -16958,7 +17748,8 @@
       "dimensions": [
         512
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "minimaxai/VTP-Small-f16d64",
@@ -16973,7 +17764,8 @@
       "dimensions": [
         512
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "minimaxi-image-01",
@@ -16996,39 +17788,39 @@
     },
     {
       "name": "minimaxi_text2voice",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "minimaxi_video-01",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "minimaxi_video-01-live2d",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "ministral-14b-2512",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "ministral-3b-2512",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "ministral-8b-2512",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral/mistral-ocr-2512",
@@ -17038,7 +17830,8 @@
       "model_types": [
         "ocr"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "mistral/codestral-latest",
@@ -17048,7 +17841,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "mistral/magistral-medium-latest",
@@ -17058,7 +17852,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40000
+      "content_length": 40000,
+      "max_output": 40000
     },
     {
       "name": "mistral/magistral-small-latest",
@@ -17068,7 +17863,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40000
+      "content_length": 40000,
+      "max_output": 40000
     },
     {
       "name": "mistral/ministral-3b-latest",
@@ -17078,7 +17874,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral/ministral-8b-latest",
@@ -17088,7 +17885,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral/mistral-embed",
@@ -17109,7 +17907,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral/mistral-medium-latest",
@@ -17119,7 +17918,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral/mistral-small-latest",
@@ -17129,7 +17929,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral/open-mistral-7b",
@@ -17139,7 +17940,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32000
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "mistral/open-mistral-nemo",
@@ -17149,7 +17951,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral/open-mixtral-8x22b",
@@ -17159,7 +17962,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 64000
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "mistral/open-mixtral-8x7b",
@@ -17169,7 +17973,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32000
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "mistral/pixtral-large-latest",
@@ -17178,35 +17983,40 @@
         "chat",
         "vision"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral-large-2",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral-large-2411",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral-large-2512",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistral-small-2503",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistralai/Mistral-7B-Instruct-v0.3",
@@ -17214,10 +18024,11 @@
         "Mistral-7B-Instruct-v0.3",
         "Mistral (7B) Instruct v0.3"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/Mistral-7B-Instruct-v0.2",
@@ -17225,10 +18036,11 @@
         "Mistral-7B-Instruct-v0.2",
         "mistral-7b"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/Mistral-7B-Instruct-v0.1",
@@ -17236,10 +18048,11 @@
         "Mistral-7B-Instruct-v0.1",
         "Mistral (7B) Instruct v0.1"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/Mistral-7B-v0.1",
@@ -17247,10 +18060,11 @@
         "Mistral-7B-v0.1",
         "Mistral 7B v0.1"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/Mixtral-8x22B-Instruct-v0.1",
@@ -17258,10 +18072,11 @@
         "Mixtral-8x22B-Instruct-v0.1",
         "Mixtral 8X22b Instruct V0.1"
       ],
-      "max_tokens": 65536,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
@@ -17269,10 +18084,11 @@
         "Mixtral-8x7B-Instruct-v0.1",
         "Mixtral-8x7B Instruct v0.1"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/Mixtral-8x7B-Instruct-v0.1-FP8-Lora",
@@ -17280,10 +18096,11 @@
         "Mixtral-8x7B-Instruct-v0.1-FP8-Lora",
         "Mixtral 8x7B Instruct V0.1 FP8 Lora"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/Mixtral-8x7B-v0.1",
@@ -17291,10 +18108,11 @@
         "Mixtral-8x7B-v0.1",
         "Mixtral 8X7b V0.1"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/codestral-2508",
@@ -17302,7 +18120,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "mistralai/devstral-2512",
@@ -17310,7 +18129,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistralai/Magistral-Small-2506",
@@ -17318,10 +18138,11 @@
         "Magistral-Small-2506",
         "Magistral Small 2506"
       ],
-      "max_tokens": 40960,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 40960,
+      "max_output": 40960
     },
     {
       "name": "mistralai/ministral-14b-2512",
@@ -17331,7 +18152,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistralai/Ministral-3-14B-Instruct-2512",
@@ -17339,10 +18161,11 @@
         "Ministral-3-14B-Instruct-2512",
         "Ministral 3 14B Instruct 2512"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistralai/ministral-3b-2512",
@@ -17352,7 +18175,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistralai/ministral-8b-2512",
@@ -17362,7 +18186,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistralai/mistral-7b-instruct",
@@ -17370,7 +18195,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/mistral-large",
@@ -17378,7 +18204,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistralai/mistral-large-2407",
@@ -17386,7 +18213,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistralai/mistral-large-2512",
@@ -17396,7 +18224,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistralai/mistral-medium-3",
@@ -17406,7 +18235,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistralai/mistral-medium-3-5",
@@ -17416,11 +18246,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistralai/mistral-medium-3.1",
@@ -17430,7 +18261,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistralai/mistral-nemo",
@@ -17441,21 +18273,23 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 16000,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistralai/Mistral-Nemo-Instruct-2407",
       "alias": [
         "Mistral-Nemo-Instruct-2407"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "mistralai/mistral-saba",
@@ -17463,7 +18297,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/mistral-small-24b-instruct-2501",
@@ -17474,7 +18309,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/mistral-small-2603",
@@ -17484,11 +18320,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "mistralai/mistral-small-3.1-24b-instruct",
@@ -17498,17 +18335,19 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
       "alias": [
         "Mistral-Small-3.1-24B-Instruct-2503"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistralai/mistral-small-3.2-24b-instruct",
@@ -17518,20 +18357,22 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "alias": [
         "Mistral-Small-3.2-24B-Instruct-2506"
       ],
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision",
         "ocr"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "mistralai/mixtral-8x22b-instruct",
@@ -17539,18 +18380,20 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "mistralai/Voxtral-Mini-3B-2507",
       "alias": [
         "Voxtral-Mini-3B-2507"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "asr",
         "speech2text"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mistralai/voxtral-small-24b-2507",
@@ -17563,7 +18406,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mixedbread-ai/mxbai-rerank-large-v2",
@@ -17571,10 +18415,11 @@
         "mxbai-rerank-large-v2",
         "Mxbai Rerank Large V2"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "rerank"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "mj_blend",
@@ -17719,8 +18564,7 @@
       "alias": [
         "mj-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "mj_zoom",
@@ -17734,17 +18578,17 @@
     },
     {
       "name": "moonshot-v1-128k",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "moonshot-v1-128k-vision-preview",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
@@ -17752,21 +18596,23 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "moonshot-v1-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "moonshot-v1-32k-vision-preview",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
@@ -17774,21 +18620,23 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "moonshot-v1-8k",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "moonshot-v1-8k-vision-preview",
-      "max_tokens": 8000,
       "model_types": [
         "chat",
         "image2text",
@@ -17796,7 +18644,9 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "moonshotai/Kimi-Audio-7B",
@@ -17807,7 +18657,8 @@
         "audio",
         "tts"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "moonshotai/Kimi-Audio-7B-Instruct",
@@ -17818,7 +18669,8 @@
         "audio",
         "tts"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "moonshotai/Kimi-Dev-72B",
@@ -17828,15 +18680,15 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/kimi-k2-0905",
-      "max_tokens": 262144,
       "model_types": [
         "chat"
       ],
@@ -17844,7 +18696,9 @@
         "kimi-k2-0905",
         "Kimi K2 0905"
       ],
-      "max_completion_tokens": 262144
+      "max_completion_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-K2-Base",
@@ -17854,7 +18708,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-K2-Instruct",
@@ -17866,12 +18721,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-K2-Instruct-0905",
@@ -17881,11 +18737,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/kimi-k2-thinking",
@@ -17895,7 +18752,6 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -17903,7 +18759,9 @@
       "max_completion_tokens": 262144,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-K2.5",
@@ -17917,12 +18775,13 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 262144
+      "max_completion_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-K2.5-fp4",
@@ -17930,24 +18789,26 @@
         "Kimi-K2.5-fp4",
         "Kimi K2.5 Fp4"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-K2.5-Turbo",
       "alias": [
         "Kimi-K2.5-Turbo"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-K2.6",
@@ -17962,12 +18823,13 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 262144
+      "max_completion_tokens": 262144,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/kimi-k2.7-code",
@@ -17977,11 +18839,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/kimi-latest",
@@ -17993,11 +18856,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-Linear-48B-A3B-Base",
@@ -18007,7 +18871,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-Linear-48B-A3B-Instruct",
@@ -18017,11 +18882,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-VL-A3B-Instruct",
@@ -18033,7 +18899,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-VL-A3B-Thinking",
@@ -18045,11 +18912,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Kimi-VL-A3B-Thinking-2506",
@@ -18061,11 +18929,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Moonlight-16B-A3B",
@@ -18075,7 +18944,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/Moonlight-16B-A3B-Instruct",
@@ -18085,11 +18955,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "moonshotai/MoonViT-SO-400M",
@@ -18099,7 +18970,8 @@
       "model_types": [
         "vision"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "morph/morph-v3-fast",
@@ -18107,7 +18979,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 81920
+      "content_length": 81920,
+      "max_output": 81920
     },
     {
       "name": "morph/morph-v3-large",
@@ -18115,7 +18988,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "music-1.5",
@@ -18161,7 +19035,6 @@
       "alias": [
         "nex-n2-pro"
       ],
-      "max_tokens": 262144,
       "max_completion_tokens": 262144,
       "model_types": [
         "chat",
@@ -18171,7 +19044,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nex-agi/nex-n2-pro:free",
@@ -18181,61 +19056,67 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nim/mistralai/mixtral-8x22b-instruct-v01",
       "alias": [
         "mixtral-8x22b-instruct-v01"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "nim/mistralai/mixtral-8x7b-instruct-v01",
       "alias": [
         "mixtral-8x7b-instruct-v01"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "nim/nvidia/llama-3.3-nemotron-super-49b-v1",
       "alias": [
         "llama-3.3-nemotron-super-49b-v1"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "nim/nv-mistralai/mistral-nemo-12b-instruct",
       "alias": [
         "mistral-nemo-12b-instruct"
       ],
-      "max_tokens": 16384,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "NousResearch/Hermes-3-Llama-3.1-405B",
       "alias": [
         "Hermes-3-Llama-3.1-405B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
@@ -18243,10 +19124,11 @@
         "Nous-Hermes-2-Mixtral-8x7B-DPO",
         "Nous Hermes 2 Mixtral 8X7B Dpo"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "nousresearch/hermes-2-pro-llama-3-8b",
@@ -18254,11 +19136,12 @@
         "hermes-2-pro-llama-3-8b",
         "Hermes 2 Pro Llama 3 8B"
       ],
-      "max_tokens": 8192,
       "max_completion_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "nousresearch/hermes-3-llama-3.1-405b:free",
@@ -18266,7 +19149,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nousresearch/hermes-3-llama-3.1-70b",
@@ -18276,7 +19160,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nousresearch/hermes-4-405b",
@@ -18284,11 +19169,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nousresearch/hermes-4-70b",
@@ -18296,11 +19182,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nousresearch/nous-hermes-llama2-13b",
@@ -18308,21 +19195,23 @@
         "nous-hermes-llama2-13b",
         "Nous Hermes Llama2 13B"
       ],
-      "max_tokens": 4096,
       "max_completion_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "NovaSky-AI/Sky-T1-32B-Preview",
       "alias": [
         "Sky-T1-32B-Preview"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0",
@@ -18334,7 +19223,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/GLM-5-NVFP4",
@@ -18344,7 +19234,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/DeepSeek-V4-Flash-NVFP4",
@@ -18354,11 +19245,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 393216
     },
     {
       "name": "nvidia/DeepSeek-V4-Pro-NVFP4",
@@ -18368,11 +19260,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 393216
     },
     {
       "name": "nvidia/llama-4-scout-17b-16e-instruct-fp8",
@@ -18382,7 +19275,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 10485760
+      "content_length": 10485760,
+      "max_output": 10485760
     },
     {
       "name": "nvidia/llama-4-scout-17b-16e-instruct-nvfp4",
@@ -18392,7 +19286,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 10485760
+      "content_length": 10485760,
+      "max_output": 10485760
     },
     {
       "name": "nvidia/Qwen3.5-122B-A10B-NVFP4",
@@ -18402,7 +19297,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Llama-3.3-70B-Instruct-Eagle3",
@@ -18421,7 +19317,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
@@ -18431,14 +19328,15 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/DeepSeek-V3.2-NVFP4",
@@ -18448,11 +19346,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "nvidia/DeepSeek-V3.1-NVFP4",
@@ -18462,11 +19361,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "nvidia/Llama-3.1-Nemotron-70B-Instruct",
@@ -18474,10 +19374,11 @@
         "Llama-3.1-Nemotron-70B-Instruct",
         "nim/nvidia/llama-3.1-nemotron-70b-instruct"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
@@ -18485,10 +19386,11 @@
         "Llama-3.1-Nemotron-70B-Instruct-HF",
         "Llama 3.1 Nemotron 70B Instruct HF"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
@@ -18500,7 +19402,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
@@ -18528,7 +19431,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/nemotron-page-elements-v3",
@@ -18549,7 +19453,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 448
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "nvidia/Qwen3-235B-A22B-Eagle3",
@@ -18559,7 +19464,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-235B-A22B-Instruct-2507-NVFP4",
@@ -18569,7 +19475,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-235B-A22B-Thinking-2507-Eagle3",
@@ -18579,11 +19486,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-235B-A22B-Thinking-2507-FP4-Eagle3",
@@ -18593,11 +19501,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-235B-A22B-Thinking-2507-NVFP4",
@@ -18607,11 +19516,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-30B-A3B-Thinking-2507-Eagle3",
@@ -18621,11 +19531,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-8B-DMS-8x",
@@ -18635,7 +19546,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-Coder-480B-A35B-Instruct-NVFP4",
@@ -18645,7 +19557,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-Nemotron-14B-BRRM",
@@ -18655,7 +19568,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/qwen3-nemotron-235b-a22b-genrm",
@@ -18665,11 +19579,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-Nemotron-235B-A22B-GenRM-2603",
@@ -18679,11 +19594,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/qwen3-nemotron-32b-genrm-principle",
@@ -18693,11 +19609,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/qwen3-nemotron-32b-rlbff",
@@ -18707,7 +19624,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-Nemotron-8B-BRRM",
@@ -18717,7 +19635,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
@@ -18727,7 +19646,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-Next-80B-A3B-Thinking-NVFP4",
@@ -18737,11 +19657,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4",
@@ -18753,7 +19674,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Qwen2.5-CascadeRL-RM-72B",
@@ -18774,7 +19696,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/qwen2.5-vl-7b-instruct-nvfp4",
@@ -18786,7 +19709,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/Qwen2.5-VL-7B-Surg-CholecT50",
@@ -18798,7 +19722,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/audio2face-3d-v2.3.1-claire",
@@ -18933,7 +19858,8 @@
       ],
       "max_dimension": 2048,
       "dimensions": [],
-      "max_tokens": 10240
+      "content_length": 10240,
+      "max_output": 10240
     },
     {
       "name": "nvidia/llama-nemotron-embed-vl-1b-v2-fp8",
@@ -18964,7 +19890,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 10240
+      "content_length": 10240,
+      "max_output": 10240
     },
     {
       "name": "nvidia/nemotron-colembed-vl-4b-v2",
@@ -19034,7 +19961,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nvidia-nemotron-nano-12b-v2-base",
@@ -19044,14 +19972,14 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL",
       "alias": [
         "NVIDIA-Nemotron-Nano-12B-v2-VL"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "image2text",
@@ -19061,7 +19989,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/nvidia-nemotron-nano-12b-v2-vl-bf16",
@@ -19074,7 +20004,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nvidia-nemotron-nano-12b-v2-vl-fp8",
@@ -19086,7 +20017,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
@@ -19098,7 +20030,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nvidia-nemotron-nano-9b-v2-base",
@@ -19108,7 +20041,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8",
@@ -19118,7 +20052,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese",
@@ -19128,7 +20063,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4",
@@ -19138,7 +20074,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/parakeet-tdt-0.6b-v2",
@@ -19177,7 +20114,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Riva-Translate-4B-Instruct-v1.1",
@@ -19268,7 +20206,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/llama-nemoretriever-colembed-1b-v1",
@@ -19953,16 +20892,14 @@
       "alias": [
         "cosmos-predict2.5-14b"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/Cosmos-Predict2.5-2B",
       "alias": [
         "Cosmos-Predict2.5-2B"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/cosmos-reason1-7b",
@@ -19998,32 +20935,28 @@
       "alias": [
         "cosmos-transfer-lidargen"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/cosmos-transfer1-7b",
       "alias": [
         "cosmos-transfer1-7b"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/Cosmos-Transfer2.5-2B",
       "alias": [
         "Cosmos-Transfer2.5-2B"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/Cosmos3-Nano",
       "alias": [
         "Cosmos3-Nano"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/Cosmos3-Super",
@@ -20051,7 +20984,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/difix",
@@ -20070,15 +21004,15 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/DreamDojo",
       "alias": [
         "DreamDojo"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/eagle2.5-8b",
@@ -20224,7 +21158,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/Gemma-4-31B-IT-NVFP4",
@@ -20234,7 +21169,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/geotransolver_drivaerml",
@@ -20298,7 +21234,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/gpt-oss-120b-Eagle3-short-context",
@@ -20308,7 +21245,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/gpt-oss-120b-Eagle3-throughput",
@@ -20318,7 +21256,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/GR00T-H",
@@ -20463,7 +21402,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/isaaclab-arena-envs",
@@ -20491,11 +21431,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Kimi-K2-Thinking-NVFP4",
@@ -20505,11 +21446,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Kimi-K2.5-NVFP4",
@@ -20519,7 +21461,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Kimi-K2.5-Thinking-Eagle3",
@@ -20529,11 +21472,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Kimi-K2.6-Eagle3",
@@ -20543,7 +21487,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Kimi-K2.6-NVFP4",
@@ -20553,7 +21498,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/KVzap-linear-Llama-3.1-8B-Instruct",
@@ -20572,7 +21518,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/KVzap-linear-Qwen3-8B",
@@ -20582,7 +21529,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/KVzap-mlp-Llama-3.1-8B-Instruct",
@@ -20601,7 +21549,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/KVzap-mlp-Qwen3-8B",
@@ -20611,7 +21560,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/llama-nv-embed-reasoning-3b",
@@ -20652,7 +21602,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "nvidia/music-flamingo-2601-hf",
@@ -20671,11 +21622,12 @@
         "nemotron-3-asr-streaming-0.6b",
         "Nvidia Nemotron 3 ASR Streaming 0.6B"
       ],
-      "max_tokens": 448,
       "model_types": [
         "asr",
         "speech2text"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "nvidia/Nemotron-3-Content-Safety",
@@ -20693,7 +21645,6 @@
         "Nemotron-3-Nano-30B-A3B",
         "Nemotron 3 Nano 30B A3B"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
       ],
@@ -20701,14 +21652,15 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning",
       "alias": [
         "Nemotron-3-Nano-Omni-30B-A3B-Reasoning"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat",
         "image2text",
@@ -20717,7 +21669,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -20727,11 +21681,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning-fp8",
@@ -20739,14 +21694,15 @@
         "nemotron-3-nano-omni-30b-a3b-reasoning-fp8",
         "Nemotron 3 Nano Omni 30B A3b Reasoning Fp8"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
@@ -20758,11 +21714,12 @@
         "video_understanding",
         "audio_understanding"
       ],
-      "max_tokens": 256000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "nvidia/nemotron-3-super-120b-a12b",
@@ -20782,11 +21739,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "nvidia/nemotron-3-ultra-550b-a55b",
@@ -20794,10 +21752,11 @@
         "nemotron-3-ultra-550b-a55b",
         "NVIDIA Nemotron 3 Ultra 550B A55B NVFP4"
       ],
-      "max_tokens": 512288,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 512288,
+      "max_output": 512288
     },
     {
       "name": "nvidia/nemotron-3.5-asr-streaming-0.6b",
@@ -20809,7 +21768,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 448
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -20837,10 +21797,11 @@
       "alias": [
         "Nemotron-4-340B-Instruct"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "nvidia/Nemotron-4-Mini-Hindi-4B-Base",
@@ -20850,7 +21811,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Cascade-14B-Thinking",
@@ -20860,11 +21822,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Cascade-8B",
@@ -20874,11 +21837,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Cascade-8B-Intermediate-ckpts",
@@ -20888,11 +21852,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Cascade-8B-Thinking",
@@ -20902,11 +21867,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nemotron-climb-fasttext-classifiers",
@@ -20916,7 +21882,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nemotron-climb-proxy-models",
@@ -20926,20 +21893,22 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Content-Safety-3.5",
       "alias": [
         "Nemotron-Content-Safety-3.5"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "image2text",
         "vision",
         "ocr"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/nemotron-content-safety-reasoning-4b",
@@ -20958,7 +21927,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Flash-1B",
@@ -20968,7 +21938,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Flash-3B",
@@ -20978,7 +21949,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Flash-3B-Instruct",
@@ -20988,7 +21960,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nemotron-h-4b-base-8k",
@@ -20998,7 +21971,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "nvidia/nemotron-h-4b-instruct-128k",
@@ -21008,7 +21982,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-14B",
@@ -21018,7 +21993,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-14B-Base",
@@ -21028,7 +22004,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-3B",
@@ -21038,7 +22015,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -21048,7 +22026,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-8B",
@@ -21058,7 +22037,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-8B-Base",
@@ -21068,7 +22048,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -21080,7 +22061,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nemotron-orchestrator-8b",
@@ -21090,11 +22072,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Research-GooseReason-4B-Instruct",
@@ -21104,11 +22087,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nemotron-research-reasoning-qwen-1.5b",
@@ -21118,11 +22102,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/nemotron-speech-streaming-en-0.6b",
@@ -21132,7 +22117,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Terminal-14B",
@@ -21142,11 +22128,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Terminal-32B",
@@ -21156,11 +22143,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/Nemotron-Terminal-8B",
@@ -21170,11 +22158,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NitroGen",
@@ -21222,7 +22211,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -21234,7 +22224,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
@@ -21244,7 +22235,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
@@ -21254,7 +22246,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
@@ -21264,7 +22257,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
@@ -21274,7 +22268,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -21284,21 +22279,23 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
       "alias": [
         "NVIDIA-Nemotron-3-Super-120B-A12B"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16",
@@ -21308,7 +22305,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -21316,10 +22314,11 @@
         "NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
         "Nvidia Nemotron 3 Super 120B A12b Bf16"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -21327,17 +22326,17 @@
         "NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
         "Nvidia Nemotron 3 Super 120B A12b Fp8"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
       "alias": [
         "NVIDIA-Nemotron-3-Ultra-550B-A55B"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat",
         "image2text",
@@ -21346,7 +22345,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-Base-BF16",
@@ -21356,7 +22357,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
@@ -21369,7 +22371,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-GenRM",
@@ -21379,11 +22382,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
@@ -21393,7 +22397,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -21403,7 +22408,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -21413,7 +22419,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -21423,15 +22430,15 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "nvidia/NVILA-8B-HD-Video",
       "alias": [
         "NVILA-8B-HD-Video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/nvpanoptix-3d",
@@ -21447,8 +22454,7 @@
       "alias": [
         "omni-dreams-models"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "nvidia/omnivinci",
@@ -21578,7 +22584,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "nvidia/RNAPro-Private-Best-500M",
@@ -21645,20 +22652,22 @@
     },
     {
       "name": "o1",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "o1-all"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o1-2024-12-17",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o1-mini",
@@ -21694,10 +22703,11 @@
     },
     {
       "name": "o1-plus",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "o1-preview",
@@ -21743,7 +22753,6 @@
     },
     {
       "name": "o3",
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "vision",
@@ -21751,47 +22760,54 @@
       ],
       "alias": [
         "o3-all"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o3-2025-04-16",
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o3-deep-research",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o3-deep-research-2025-06-26",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o3-mini",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "o3-mini-all"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "o3-mini-2025-01-31",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "o3-mini-high-all",
@@ -21805,7 +22821,6 @@
     },
     {
       "name": "o3-pro",
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "vision",
@@ -21813,18 +22828,20 @@
       ],
       "alias": [
         "o3-pro-all"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o3-pro-2025-06-10",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o4-mini",
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "vision",
@@ -21832,30 +22849,35 @@
       ],
       "alias": [
         "o4-mini-all"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o4-mini-2025-04-16",
-      "max_tokens": 200000,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o4-mini-deep-research",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "o4-mini-deep-research-2025-06-26",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/gpt-6",
@@ -21905,11 +22927,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1050000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1050000,
+      "max_output": 1050000
     },
     {
       "name": "openai/gpt-5.5-all",
@@ -21931,11 +22954,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1050000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1050000,
+      "max_output": 1050000
     },
     {
       "name": "openai/gpt-5.5-pro",
@@ -21947,11 +22971,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1050000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1050000,
+      "max_output": 1050000
     },
     {
       "name": "openai/gpt-5.4",
@@ -21963,11 +22988,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1050000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1050000,
+      "max_output": 1050000
     },
     {
       "name": "openai/gpt-5.4-image-2",
@@ -21979,11 +23005,12 @@
         "image_generation",
         "image"
       ],
-      "max_tokens": 272000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 272000,
+      "max_output": 272000
     },
     {
       "name": "openai/gpt-5.4-mini",
@@ -21993,11 +23020,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.4-nano",
@@ -22007,11 +23035,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.4-pro",
@@ -22021,11 +23050,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1050000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1050000,
+      "max_output": 1050000
     },
     {
       "name": "openai/gpt-5.3",
@@ -22045,7 +23075,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.3-chat-latest",
@@ -22066,11 +23097,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.3-codex-spark",
@@ -22094,11 +23126,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.2-chat",
@@ -22108,7 +23141,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.2-chat-latest",
@@ -22118,7 +23152,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.2-codex",
@@ -22128,11 +23163,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.2-pro",
@@ -22142,11 +23178,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.1",
@@ -22158,11 +23195,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.1-chat",
@@ -22172,7 +23210,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5.1-chat-latest",
@@ -22184,7 +23223,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.1-codex",
@@ -22194,11 +23234,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.1-codex-max",
@@ -22208,11 +23249,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5.1-codex-mini",
@@ -22222,11 +23264,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-search-api-2025-10-14",
@@ -22246,11 +23289,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-chat",
@@ -22260,7 +23304,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-5-chat-latest",
@@ -22270,7 +23315,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-codex",
@@ -22280,11 +23326,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-codex-mini",
@@ -22308,11 +23355,12 @@
         "image2text",
         "image_generation"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-image-mini",
@@ -22324,11 +23372,12 @@
         "image_generation",
         "image"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-mini",
@@ -22340,11 +23389,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-nano",
@@ -22356,11 +23406,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-pro",
@@ -22370,11 +23421,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-5-search-api",
@@ -22393,7 +23445,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "openai/gpt-4.1-mini-2025-04-14",
@@ -22403,7 +23456,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "openai/gpt-4.1-nano-2025-04-14",
@@ -22413,7 +23467,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "openai/gpt-4.1",
@@ -22423,7 +23478,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1047576
+      "content_length": 1047576,
+      "max_output": 1047576
     },
     {
       "name": "openai/gpt-4.1-mini",
@@ -22433,7 +23489,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1047576
+      "content_length": 1047576,
+      "max_output": 1047576
     },
     {
       "name": "openai/gpt-4.1-nano",
@@ -22443,7 +23500,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1047576
+      "content_length": 1047576,
+      "max_output": 1047576
     },
     {
       "name": "openai/gpt-4o-mini-tts-2025-03-20",
@@ -22490,7 +23548,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o",
@@ -22500,7 +23559,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o-2024-08-06",
@@ -22510,7 +23570,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o-mini-2024-07-18",
@@ -22520,7 +23581,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o-2024-05-13",
@@ -22532,7 +23594,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4",
@@ -22540,7 +23603,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8191
+      "content_length": 8191,
+      "max_output": 8191
     },
     {
       "name": "openai/gpt-4-turbo",
@@ -22552,7 +23616,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4-turbo-preview",
@@ -22560,7 +23625,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o-image",
@@ -22580,7 +23646,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o-mini-audio-preview",
@@ -22606,7 +23673,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o-mini-tts",
@@ -22623,7 +23691,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-4o-transcribe",
@@ -22639,7 +23708,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16385
+      "content_length": 16385,
+      "max_output": 16385
     },
     {
       "name": "openai/gpt-3.5-turbo-0613",
@@ -22649,7 +23719,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4095
+      "content_length": 4095,
+      "max_output": 4095
     },
     {
       "name": "openai/gpt-3.5-turbo-16k",
@@ -22657,7 +23728,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16385
+      "content_length": 16385,
+      "max_output": 16385
     },
     {
       "name": "openai/gpt-3.5-turbo-instruct",
@@ -22665,7 +23737,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4095
+      "content_length": 4095,
+      "max_output": 4095
     },
     {
       "name": "openai/whisper-large-v3",
@@ -22677,8 +23750,9 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 448,
-      "max_completion_tokens": 448
+      "max_completion_tokens": 448,
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "openai/whisper-large-v3-turbo",
@@ -22689,8 +23763,9 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 448,
-      "max_completion_tokens": 448
+      "max_completion_tokens": 448,
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "openai/whisper-large-v2",
@@ -22710,7 +23785,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o3-2025-04-16",
@@ -22771,7 +23847,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "openai/circuit-sparsity",
@@ -22866,7 +23943,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "openai/deep-research-preview-04-2026",
@@ -22877,7 +23955,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "openai/diffusers-cd_bedroom256_l2",
@@ -22971,7 +24050,8 @@
         "audio_understanding",
         "audio"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-audio-1.5",
@@ -22993,7 +24073,8 @@
         "audio_understanding",
         "audio"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/gpt-chat-latest",
@@ -23005,7 +24086,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-image-1",
@@ -23023,7 +24105,8 @@
         "image",
         "image_generation"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "openai/gpt-image-1.5",
@@ -23064,11 +24147,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1050000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1050000,
+      "max_output": 1050000
     },
     {
       "name": "openai/gpt-mini-latest",
@@ -23081,11 +24165,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 400000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 400000,
+      "max_output": 400000
     },
     {
       "name": "openai/gpt-oss-120b",
@@ -23100,7 +24185,6 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -23108,21 +24192,24 @@
       "max_completion_tokens": 65536,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "openai/gpt-oss-120b-Turbo",
       "alias": [
         "gpt-oss-120b-Turbo"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "openai/gpt-oss-20b",
@@ -23137,7 +24224,6 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -23145,7 +24231,9 @@
       "max_completion_tokens": 65536,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "openai/gpt-oss-safeguard-120b",
@@ -23155,11 +24243,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "openai/gpt-oss-safeguard-20b",
@@ -23170,12 +24259,13 @@
         "chat",
         "moderation"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "openai/gpt-realtime-1.5",
@@ -23239,11 +24329,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o1-mini",
@@ -23253,11 +24344,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openai/o1-pro",
@@ -23269,11 +24361,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o3",
@@ -23283,11 +24376,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o3-deep-research",
@@ -23297,11 +24391,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o3-mini",
@@ -23309,11 +24404,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o3-mini-high",
@@ -23323,11 +24419,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o3-pro",
@@ -23337,11 +24434,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o4-mini",
@@ -23351,11 +24449,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o4-mini-deep-research",
@@ -23365,11 +24464,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/o4-mini-high",
@@ -23381,11 +24481,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openai/omni-moderation-latest",
@@ -23404,7 +24505,8 @@
       "model_types": [
         "other"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "openai/shap-e",
@@ -23428,8 +24530,7 @@
     {
       "name": "openai/sora-2",
       "alias": [],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "openai/sora-2-pro",
@@ -23437,8 +24538,7 @@
         "sora-2-pro",
         "Sora 2 Pro"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "openai/text-embedding-3-large",
@@ -23626,22 +24726,24 @@
       "alias": [
         "MiniCPM-Llama3-V-2_5"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "openchat/openchat-3.6-8b",
       "alias": [
         "openchat-3.6-8b"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "openchat/openchat-7b",
@@ -23649,31 +24751,34 @@
         "openchat-7b",
         "OpenChat 7B"
       ],
-      "max_tokens": 4096,
       "max_completion_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "openchat/openchat_3.5",
       "alias": [
         "openchat_3.5"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "opendatalab/mineru-html-v1.1-hunyuan0.5b-compact",
       "alias": [
         "MinerU-HTML-v1.1-hunyuan0.5B-compact"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "opendatalab/mineru-diffusion-v1-0320-2.5b",
@@ -23691,29 +24796,30 @@
       "alias": [
         "belt_road_hungarian_beta1"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "translation"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/belt_road_hungarian_beta2",
       "alias": [
         "belt_road_hungarian_beta2"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "translation"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/chartverse-2b",
       "alias": [
         "ChartVerse-2B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
@@ -23722,14 +24828,15 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/chartverse-4b",
       "alias": [
         "ChartVerse-4B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
@@ -23738,14 +24845,15 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/chartverse-8b",
       "alias": [
         "ChartVerse-8B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
@@ -23754,204 +24862,223 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/chartverse-coder",
       "alias": [
         "ChartVerse-Coder"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/meta-rater-1b-25raters",
       "alias": [
         "meta-rater-1b-25raters"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-1b-cleanliness",
       "alias": [
         "meta-rater-1b-cleanliness"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-1b-professionalism",
       "alias": [
         "meta-rater-1b-professionalism"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-1b-random",
       "alias": [
         "meta-rater-1b-random"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-1b-readability",
       "alias": [
         "meta-rater-1b-readability"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-1b-reasoning",
       "alias": [
         "meta-rater-1b-reasoning"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-3b-25raters",
       "alias": [
         "meta-rater-3b-25raters"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-3b-random",
       "alias": [
         "meta-rater-3b-random"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-7b-25raters",
       "alias": [
         "meta-rater-7b-25raters"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-7b-random",
       "alias": [
         "meta-rater-7b-random"
       ],
-      "max_tokens": 1024,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "opendatalab/meta-rater-cleanliness-rating",
       "alias": [
         "meta-rater-cleanliness-rating"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "classification"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "opendatalab/meta-rater-professionalism-rating",
       "alias": [
         "meta-rater-professionalism-rating"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "classification"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "opendatalab/meta-rater-readability-rating",
       "alias": [
         "meta-rater-readability-rating"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "classification"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "opendatalab/meta-rater-reasoning-rating",
       "alias": [
         "meta-rater-reasoning-rating"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "classification"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "opendatalab/mineru-html",
       "alias": [
         "MinerU-HTML"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/mineru2.0-2505-0.9b",
       "alias": [
         "MinerU2.0-2505-0.9B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
         "image2text",
         "ocr"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/mineru2.5-2509-1.2b",
       "alias": [
         "MinerU2.5-2509-1.2B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
         "image2text",
         "ocr"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/mineru2.5-pro-2604-1.2b",
       "alias": [
         "MinerU2.5-Pro-2604-1.2B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
@@ -23961,14 +25088,15 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/mineru2.5-pro-2605-1.2b",
       "alias": [
         "MinerU2.5-Pro-2605-1.2B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
@@ -23978,7 +25106,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "opendatalab/pdf-extract-kit",
@@ -24007,12 +25137,13 @@
       "alias": [
         "TRivia-3B"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "openrouter/auto",
@@ -24025,11 +25156,12 @@
         "audio_understanding",
         "image_generation"
       ],
-      "max_tokens": 2000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "openrouter/bodybuilder",
@@ -24037,7 +25169,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openrouter/free",
@@ -24047,11 +25180,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "openrouter/fusion",
@@ -24059,7 +25193,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "openrouter/owl-alpha",
@@ -24067,7 +25202,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048756
+      "content_length": 1048756,
+      "max_output": 1048756
     },
     {
       "name": "openrouter/pareto-code",
@@ -24075,7 +25211,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "orcarouter/auto",
@@ -24129,7 +25266,8 @@
       "model_types": [
         "ocr"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "paddleocr/pp-structurev3",
@@ -24137,7 +25275,8 @@
       "model_types": [
         "ocr"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "paddleocr-vl-0.9b",
@@ -24150,19 +25289,21 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "paddlepaddle/paddleocr-vl",
       "alias": [],
-      "max_tokens": 16384,
       "max_completion_tokens": 16384,
       "model_types": [
         "chat",
         "vision",
         "image2text",
         "ocr"
-      ]
+      ],
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "paraformer-8k-v2",
@@ -24197,12 +25338,13 @@
       "alias": [
         "Pearl-ai Gemma-4-31B-it-pearl"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "perceptron/perceptron-mk1",
@@ -24213,11 +25355,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 32768,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "perplexity/sonar",
@@ -24227,7 +25370,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 127072
+      "content_length": 127072,
+      "max_output": 127072
     },
     {
       "name": "perplexity/sonar-deep-research",
@@ -24235,11 +25379,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "perplexity/sonar-pro",
@@ -24249,7 +25394,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "perplexity/sonar-pro-search",
@@ -24259,11 +25405,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 200000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "perplexity/sonar-reasoning-pro",
@@ -24273,62 +25420,68 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Phi-4-mini-reasoning",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Phi-4-reasoning",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Phind/Phind-CodeLlama-34B-v2",
       "alias": [
         "Phind-CodeLlama-34B-v2"
       ],
-      "max_tokens": 4096,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "pika",
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "pix",
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "pixtral-large-2411",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "pixtral-large-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
@@ -24336,39 +25489,37 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Pixverse/Pixverse-6-I2V",
       "alias": [
         "Pixverse-6-I2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Pixverse/Pixverse-6-T2V",
       "alias": [
         "Pixverse-6-T2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Pixverse/Pixverse-T2V",
       "alias": [
         "Pixverse-T2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Pixverse/Pixverse-T2V-HD",
       "alias": [
         "Pixverse-T2V-HD"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "pixverse/pixverse-v6",
@@ -24376,8 +25527,7 @@
         "pixverse-v6",
         "PixVerse v6"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "pixverse/pixverse-v5.6",
@@ -24385,8 +25535,7 @@
         "pixverse-v5.6",
         "PixVerse v5.6"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "pixverse/pixverse-v5",
@@ -24394,13 +25543,11 @@
         "pixverse-v5",
         "PixVerse v5"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "pixverse-image-template",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "pixverse-lipsync",
@@ -24434,8 +25581,7 @@
     },
     {
       "name": "pixverse-restyle",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "pixverse-sound-effect",
@@ -24457,8 +25603,7 @@
     },
     {
       "name": "pixverse-video",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "playai-tts",
@@ -24472,11 +25617,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "poolside/laguna-xs.2:free",
@@ -24484,22 +25630,24 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "ppio-4b",
       "alias": [
         "PPIO 4B"
       ],
-      "max_tokens": 128000,
       "max_completion_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "prime-intellect/intellect-3",
@@ -24507,11 +25655,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "PP-ChatOCRv4",
@@ -24524,93 +25673,105 @@
     },
     {
       "name": "Pro/deepseek-ai/DeepSeek-V3.2-Exp",
-      "max_tokens": 160000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 160000,
+      "max_output": 160000
     },
     {
       "name": "Pro/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Pro/moonshotai/Kimi-K2-Instruct-0905",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Pro/moonshotai/Kimi-K2-Thinking",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "Pro/moonshotai/Kimi-K2.5",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "Pro/Qwen/Qwen2-7B-Instruct",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Pro/Qwen/Qwen2.5-7B-Instruct",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Pro/Qwen/Qwen2.5-Coder-7B-Instruct",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Pro/THUDM/glm-4-9b-chat",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Pro/THUDM/GLM-4.1V-9B-Thinking",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "Pro/zai-org/GLM-5",
-      "max_tokens": 198000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 198000,
+      "max_output": 198000
     },
     {
       "name": "PrunaAI/p-image",
@@ -24637,69 +25798,74 @@
       "alias": [
         "p-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "PrunaAI/p-video-avatar",
       "alias": [
         "p-video-avatar"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "qvq-max",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qvq-max-2025-03-25",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qvq-max-2025-05-15",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qvq-max-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "vision",
         "image2text"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qvq-plus",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qvq-plus-2025-05-15",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qvq-plus-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Qwen/Qwen3.5-35B-A3B-Lora",
@@ -24707,20 +25873,22 @@
         "Qwen3.5-35B-A3B-Lora",
         "Qwen3.5 35B A3b LoRa"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "Qwen/Qwen3.5-9B-FP8",
       "alias": [
         "Qwen3.5-9B-FP8"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "Qwen/Qwen3-235B-A22B-Instruct-2507-tput",
@@ -24728,10 +25896,11 @@
         "Qwen3-235B-A22B-Instruct-2507-tput",
         "Qwen3 235B A22B Instruct 2507 FP8 Throughput"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "Qwen/Qwen3-30B-A3B-Instruct-2507-Lora",
@@ -24739,10 +25908,11 @@
         "Qwen3-30B-A3B-Instruct-2507-Lora",
         "Qwen3 30B A3B Instruct 2507 Lora"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "Qwen/Qwen3-8B-Lora",
@@ -24750,53 +25920,58 @@
         "Qwen3-8B-Lora",
         "Qwen3 8B Lora"
       ],
-      "max_tokens": 40960,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 40960,
+      "max_output": 40960
     },
     {
       "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
       "alias": [
         "Qwen3-Coder-480B-A35B-Instruct-Turbo"
       ],
-      "max_tokens": 262144,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "Qwen/Qwen3-Embedding-0.6B-batch",
       "alias": [
         "Qwen3-Embedding-0.6B-batch"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "Qwen/Qwen3-Embedding-4B-batch",
       "alias": [
         "Qwen3-Embedding-4B-batch"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2560,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "Qwen/Qwen3-Embedding-8B-batch",
       "alias": [
         "Qwen3-Embedding-8B-batch"
       ],
-      "max_tokens": 32768,
       "max_dimension": 4096,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "Qwen/Qwen3-TTS",
@@ -24818,10 +25993,11 @@
     },
     {
       "name": "Qwen/Qwen2.5-72B-Instruct-128K",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "Qwen/Qwen2.5-72B-Instruct-Turbo",
@@ -24829,10 +26005,11 @@
         "Qwen2.5-72B-Instruct-Turbo",
         "Qwen2.5 72B Instruct Turbo"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "Qwen/Qwen2.5-7B-Instruct-Turbo",
@@ -24840,10 +26017,11 @@
         "Qwen2.5-7B-Instruct-Turbo",
         "Qwen2.5 7B Instruct Turbo"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-vl-ocr-2025-11-20",
@@ -24904,11 +26082,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.7-plus",
@@ -24923,11 +26102,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.7-plus-2026-05-26",
@@ -24940,11 +26120,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.7-max-2026-05-20",
@@ -24955,11 +26136,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.7-max",
@@ -24971,7 +26153,6 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -24979,7 +26160,9 @@
       "max_completion_tokens": 65536,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.7-max-preview",
@@ -24989,11 +26172,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.6-27b",
@@ -25007,12 +26191,13 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.6-max-preview",
@@ -25023,11 +26208,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.6-flash-2026-04-16",
@@ -25040,11 +26226,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.6-35b-a3b",
@@ -25058,12 +26245,13 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.6-plus-2026-04-02",
@@ -25078,11 +26266,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.6-27b-fp8",
@@ -25095,11 +26284,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.6-35b-a3b-fp8",
@@ -25113,11 +26303,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.6-flash",
@@ -25130,11 +26321,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.6-plus",
@@ -25149,7 +26341,6 @@
         "video_understanding",
         "ocr"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -25157,7 +26348,9 @@
       "max_completion_tokens": 65536,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.5-plus-20260420",
@@ -25170,11 +26363,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.5-omni-flash-2026-03-15",
@@ -25229,11 +26423,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-9b-base",
@@ -25246,11 +26441,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-122b-a10b",
@@ -25264,7 +26460,6 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
@@ -25272,7 +26467,9 @@
       "max_completion_tokens": 65536,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-27b",
@@ -25286,12 +26483,13 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-35b-a3b",
@@ -25306,12 +26504,13 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-35b-a3b-base",
@@ -25324,11 +26523,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-flash-2026-02-23",
@@ -25343,11 +26543,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.5-397b-a17b",
@@ -25362,12 +26563,13 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-plus-2026-02-15",
@@ -25382,11 +26584,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.5-0.8b",
@@ -25399,11 +26602,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-0.8b-base",
@@ -25416,11 +26620,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-122b-a10b-fp8",
@@ -25434,11 +26639,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-122b-a10b-gptq-int4",
@@ -25451,11 +26657,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-27b-fp8",
@@ -25468,11 +26675,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-27b-gptq-int4",
@@ -25485,11 +26693,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-2b",
@@ -25502,11 +26711,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-2b-base",
@@ -25519,11 +26729,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-35b-a3b-fp8",
@@ -25536,11 +26747,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-35b-a3b-gptq-int4",
@@ -25553,11 +26765,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-397b-a17b-fp8",
@@ -25570,11 +26783,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-397b-a17b-gptq-int4",
@@ -25587,11 +26801,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-4b",
@@ -25604,14 +26819,15 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-4b-base",
@@ -25624,11 +26840,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3.5-flash",
@@ -25641,11 +26858,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.5-omni-flash",
@@ -25698,12 +26916,13 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3-asr-flash-2026-02-10",
@@ -25753,11 +26972,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-max-thinking",
@@ -25768,11 +26988,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-tts-instruct-flash-realtime-2026-01-22",
@@ -25999,7 +27220,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3-max-2025-09-23",
@@ -26009,11 +27231,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-plus-2025-09-23",
@@ -26123,7 +27346,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3-coder-plus-2025-07-22",
@@ -26133,7 +27357,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3-14b",
@@ -26145,7 +27370,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-base",
@@ -26156,7 +27382,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-32b",
@@ -26169,11 +27396,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "max_completion_tokens": 40960,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b",
@@ -26184,10 +27412,11 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b-base",
@@ -26198,7 +27427,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-coder-next",
@@ -26210,8 +27440,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-coder-next-base",
@@ -26221,7 +27452,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-0.6b",
@@ -26232,7 +27464,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-base",
@@ -26243,7 +27476,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-fp8",
@@ -26253,7 +27487,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-gguf",
@@ -26263,7 +27498,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-gptq-int8",
@@ -26273,7 +27509,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-mlx-4bit",
@@ -26283,7 +27520,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-mlx-6bit",
@@ -26293,7 +27531,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-mlx-8bit",
@@ -26303,7 +27542,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-0.6b-mlx-bf16",
@@ -26313,7 +27553,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b",
@@ -26324,7 +27565,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-base",
@@ -26335,7 +27577,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-fp8",
@@ -26345,7 +27588,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-gguf",
@@ -26355,7 +27599,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-gptq-int8",
@@ -26365,7 +27610,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-mlx-4bit",
@@ -26375,7 +27621,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-mlx-6bit",
@@ -26385,7 +27632,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-mlx-8bit",
@@ -26395,7 +27643,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-1.7b-mlx-bf16",
@@ -26405,7 +27654,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-awq",
@@ -26415,7 +27665,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-fp8",
@@ -26425,7 +27676,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-gguf",
@@ -26435,7 +27687,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-mlx-4bit",
@@ -26445,7 +27698,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-mlx-6bit",
@@ -26455,7 +27709,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-mlx-8bit",
@@ -26465,7 +27720,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-14b-mlx-bf16",
@@ -26475,7 +27731,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b",
@@ -26485,7 +27742,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-fp8",
@@ -26496,7 +27754,6 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "max_completion_tokens": 20000,
       "thinking": {
         "default_value": true,
@@ -26504,7 +27761,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-gguf",
@@ -26514,7 +27773,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-gptq-int4",
@@ -26524,7 +27784,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-instruct-2507",
@@ -26539,8 +27800,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-235b-a22b-instruct-2507-fp8",
@@ -26551,7 +27813,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-235b-a22b-mlx-4bit",
@@ -26561,7 +27824,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-mlx-6bit",
@@ -26571,7 +27835,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-mlx-8bit",
@@ -26581,7 +27846,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-mlx-bf16",
@@ -26591,7 +27857,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-235b-a22b-thinking-2507",
@@ -26602,12 +27869,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-235b-a22b-thinking-2507-fp8",
@@ -26617,11 +27885,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-30b-a3b",
@@ -26631,7 +27900,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-base",
@@ -26642,7 +27912,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-fp8",
@@ -26653,7 +27924,6 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "max_completion_tokens": 20000,
       "thinking": {
         "default_value": true,
@@ -26661,7 +27931,9 @@
       },
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-gguf",
@@ -26671,7 +27943,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-gptq-int4",
@@ -26681,7 +27954,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-instruct-2507",
@@ -26691,7 +27965,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-30b-a3b-instruct-2507-fp8",
@@ -26701,7 +27976,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-30b-a3b-mlx-4bit",
@@ -26711,7 +27987,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-mlx-6bit",
@@ -26721,7 +27998,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-mlx-8bit",
@@ -26731,7 +28009,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-mlx-bf16",
@@ -26741,7 +28020,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -26751,11 +28031,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-30b-a3b-thinking-2507-fp8",
@@ -26765,11 +28046,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-32b-awq",
@@ -26779,7 +28061,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-32b-fp8",
@@ -26790,12 +28073,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "max_completion_tokens": 20000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-32b-gguf",
@@ -26805,7 +28089,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-32b-mlx-4bit",
@@ -26815,7 +28100,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-32b-mlx-6bit",
@@ -26825,7 +28111,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-32b-mlx-8bit",
@@ -26835,7 +28122,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-32b-mlx-bf16",
@@ -26845,7 +28133,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b",
@@ -26855,7 +28144,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-awq",
@@ -26865,7 +28155,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-base",
@@ -26876,7 +28167,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-fp8",
@@ -26887,12 +28179,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "max_completion_tokens": 8192,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-gguf",
@@ -26902,7 +28195,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-instruct-2507",
@@ -26913,7 +28207,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-4b-instruct-2507-fp8",
@@ -26923,7 +28218,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-4b-mlx-4bit",
@@ -26933,7 +28229,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-mlx-6bit",
@@ -26943,7 +28240,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-mlx-8bit",
@@ -26953,7 +28251,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-mlx-bf16",
@@ -26963,7 +28262,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-4b-saferl",
@@ -26973,7 +28273,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40960
+      "content_length": 40960,
+      "max_output": 40960
     },
     {
       "name": "qwen/qwen3-4b-thinking-2507",
@@ -26983,11 +28284,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-4b-thinking-2507-fp8",
@@ -26997,11 +28299,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-8b-awq",
@@ -27011,7 +28314,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b-fp8",
@@ -27022,8 +28326,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
-      "max_completion_tokens": 20000
+      "max_completion_tokens": 20000,
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b-gguf",
@@ -27033,7 +28338,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b-mlx-4bit",
@@ -27043,7 +28349,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b-mlx-6bit",
@@ -27053,7 +28360,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b-mlx-8bit",
@@ -27063,7 +28371,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-8b-mlx-bf16",
@@ -27073,7 +28382,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-asr-0.6b",
@@ -27084,7 +28394,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-asr-1.7b",
@@ -27095,7 +28406,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-asr-flash",
@@ -27150,8 +28462,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-coder-30b-a3b-instruct-fp8",
@@ -27161,7 +28474,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-coder-480b-a35b-instruct",
@@ -27180,11 +28494,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "max_completion_tokens": 65536,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-coder-480b-a35b-instruct-fp8",
@@ -27195,7 +28510,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-coder-flash",
@@ -27205,7 +28521,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3-coder-next-fp8",
@@ -27216,7 +28533,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-coder-next-gguf",
@@ -27226,7 +28544,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-coder-plus",
@@ -27236,7 +28555,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3-embedding-0.6b",
@@ -27246,9 +28566,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-embedding-0.6b-gguf",
@@ -27258,9 +28579,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 1024,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-embedding-4b",
@@ -27270,9 +28592,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2560,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-embedding-4b-gguf",
@@ -27282,9 +28605,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2560,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-embedding-8b",
@@ -27294,9 +28618,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 4096,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-embedding-8b-gguf",
@@ -27306,9 +28631,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 4096,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-forcedaligner-0.6b",
@@ -27318,7 +28644,8 @@
       "model_types": [
         "asr"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-livetranslate-flash",
@@ -27351,12 +28678,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-max-preview",
@@ -27366,11 +28694,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct",
@@ -27384,12 +28713,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "max_completion_tokens": 32768,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct-fp8",
@@ -27400,7 +28730,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-instruct-gguf",
@@ -27421,12 +28752,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-thinking-fp8",
@@ -27436,11 +28768,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-next-80b-a3b-thinking-gguf",
@@ -27467,7 +28800,8 @@
         "caption",
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-omni-30b-a3b-instruct",
@@ -27486,8 +28820,9 @@
         "audio_understanding",
         "tts"
       ],
-      "max_tokens": 65536,
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-omni-30b-a3b-thinking",
@@ -27505,12 +28840,13 @@
         "speech2text",
         "audio_understanding"
       ],
-      "max_tokens": 65536,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-omni-captioner",
@@ -27564,7 +28900,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-reranker-4b",
@@ -27574,7 +28911,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-reranker-8b",
@@ -27584,7 +28922,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-tts-12hz-0.6b-base",
@@ -27594,7 +28933,8 @@
       "model_types": [
         "tts"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-tts-12hz-0.6b-customvoice",
@@ -27604,7 +28944,8 @@
       "model_types": [
         "tts"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-tts-12hz-1.7b-base",
@@ -27614,7 +28955,8 @@
       "model_types": [
         "tts"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-tts-12hz-1.7b-customvoice",
@@ -27624,7 +28966,8 @@
       "model_types": [
         "tts"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-tts-12hz-1.7b-voicedesign",
@@ -27634,7 +28977,8 @@
       "model_types": [
         "tts"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/qwen3-tts-flash",
@@ -27680,7 +29024,8 @@
       "model_types": [
         "tts"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b",
@@ -27690,7 +29035,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b-instruct",
@@ -27704,12 +29050,13 @@
         "vision",
         "ocr"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b-instruct-fp8",
@@ -27721,11 +29068,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b-instruct-gguf",
@@ -27735,11 +29083,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b-thinking",
@@ -27752,12 +29101,13 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b-thinking-fp8",
@@ -27767,11 +29117,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-235b-a22b-thinking-gguf",
@@ -27781,11 +29132,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-2b-instruct",
@@ -27795,11 +29147,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-2b-instruct-fp8",
@@ -27809,11 +29162,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-2b-instruct-gguf",
@@ -27823,11 +29177,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-2b-thinking",
@@ -27837,11 +29192,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-2b-thinking-fp8",
@@ -27851,11 +29207,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-2b-thinking-gguf",
@@ -27865,11 +29222,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b",
@@ -27879,7 +29237,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-instruct",
@@ -27892,12 +29251,13 @@
         "vision",
         "ocr"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-instruct-fp8",
@@ -27907,11 +29267,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-instruct-gguf",
@@ -27921,11 +29282,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-thinking",
@@ -27937,12 +29299,13 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-thinking-fp8",
@@ -27952,11 +29315,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-30b-a3b-thinking-gguf",
@@ -27966,11 +29330,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-32b",
@@ -27991,11 +29356,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-32b-instruct-fp8",
@@ -28005,11 +29371,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-32b-instruct-gguf",
@@ -28019,11 +29386,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-32b-thinking",
@@ -28033,11 +29401,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-32b-thinking-fp8",
@@ -28047,11 +29416,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-32b-thinking-gguf",
@@ -28061,11 +29431,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-4b-instruct",
@@ -28077,11 +29448,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-4b-instruct-fp8",
@@ -28091,11 +29463,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-4b-instruct-gguf",
@@ -28105,11 +29478,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-4b-thinking",
@@ -28121,11 +29495,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-4b-thinking-fp8",
@@ -28135,11 +29510,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-4b-thinking-gguf",
@@ -28149,11 +29525,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-8b-instruct",
@@ -28165,12 +29542,13 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-8b-instruct-fp8",
@@ -28180,11 +29558,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-8b-instruct-gguf",
@@ -28194,11 +29573,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-8b-thinking",
@@ -28210,11 +29590,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-8b-thinking-fp8",
@@ -28224,11 +29605,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-8b-thinking-gguf",
@@ -28238,11 +29620,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "qwen/qwen3-vl-embedding",
@@ -28252,7 +29635,6 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 2560,
       "dimensions": [
         256,
@@ -28262,7 +29644,9 @@
         1536,
         2048,
         2560
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3-vl-embedding-2b",
@@ -28272,9 +29656,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 2048,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-vl-embedding-8b",
@@ -28284,9 +29669,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 32768,
       "max_dimension": 4096,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-vl-flash",
@@ -28345,8 +29731,9 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 30000,
-      "max_documents": 500
+      "max_documents": 500,
+      "content_length": 30000,
+      "max_output": 30000
     },
     {
       "name": "qwen/qwen3-vl-reranker-2b",
@@ -28356,7 +29743,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3-vl-reranker-8b",
@@ -28366,7 +29754,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3guard-gen-0.6b",
@@ -28376,7 +29765,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3guard-gen-4b",
@@ -28386,7 +29776,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3guard-gen-8b",
@@ -28396,7 +29787,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3guard-stream-0.6b",
@@ -28406,7 +29798,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3guard-stream-4b",
@@ -28416,7 +29809,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen3guard-stream-8b",
@@ -28426,7 +29820,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen2.5-0.5b",
@@ -28436,7 +29831,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-0.5b-instruct",
@@ -28446,7 +29842,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-0.5b-instruct-awq",
@@ -28456,7 +29853,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-0.5b-instruct-gguf",
@@ -28475,7 +29873,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-0.5b-instruct-gptq-int8",
@@ -28485,7 +29884,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-1.5b",
@@ -28496,7 +29896,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-1.5b-instruct",
@@ -28507,7 +29908,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-1.5b-instruct-awq",
@@ -28517,7 +29919,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-1.5b-instruct-gguf",
@@ -28536,7 +29939,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-1.5b-instruct-gptq-int8",
@@ -28546,7 +29950,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-14b",
@@ -28557,7 +29962,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-14b-instruct",
@@ -28568,7 +29974,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-14b-instruct-1m",
@@ -28578,7 +29985,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-14b-instruct-awq",
@@ -28588,7 +29996,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-14b-instruct-gguf",
@@ -28598,7 +30007,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-14b-instruct-gptq-int4",
@@ -28608,7 +30018,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-14b-instruct-gptq-int8",
@@ -28618,7 +30029,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-32b",
@@ -28629,7 +30041,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-32b-instruct",
@@ -28640,11 +30053,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "max_completion_tokens": 32000,
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-32b-instruct-awq",
@@ -28654,7 +30068,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-32b-instruct-gguf",
@@ -28664,7 +30079,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-32b-instruct-gptq-int4",
@@ -28674,7 +30090,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-32b-instruct-gptq-int8",
@@ -28684,7 +30101,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-3b",
@@ -28694,7 +30112,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-3b-instruct",
@@ -28705,7 +30124,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-3b-instruct-awq",
@@ -28715,7 +30135,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-3b-instruct-gguf",
@@ -28734,7 +30155,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-3b-instruct-gptq-int8",
@@ -28744,7 +30166,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-72b",
@@ -28755,7 +30178,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-72b-instruct",
@@ -28769,8 +30193,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-72b-instruct-awq",
@@ -28780,7 +30205,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-72b-instruct-gguf",
@@ -28790,7 +30216,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-72b-instruct-gptq-int4",
@@ -28800,7 +30227,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-72b-instruct-gptq-int8",
@@ -28810,7 +30238,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-7b",
@@ -28821,7 +30250,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-7b-instruct",
@@ -28833,8 +30263,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-7b-instruct-1m",
@@ -28844,7 +30275,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-7b-instruct-awq",
@@ -28854,7 +30286,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-7b-instruct-gguf",
@@ -28864,7 +30297,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-7b-instruct-gptq-int4",
@@ -28874,7 +30308,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-7b-instruct-gptq-int8",
@@ -28884,7 +30319,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2.5-coder-0.5b",
@@ -28894,7 +30330,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct",
@@ -28904,7 +30341,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct-awq",
@@ -28914,7 +30352,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct-gguf",
@@ -28933,7 +30372,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-0.5b-instruct-gptq-int8",
@@ -28943,7 +30383,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-1.5b",
@@ -28953,7 +30394,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct",
@@ -28963,7 +30405,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct-awq",
@@ -28973,7 +30416,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct-gguf",
@@ -28992,7 +30436,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-1.5b-instruct-gptq-int8",
@@ -29002,7 +30447,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-14b",
@@ -29012,7 +30458,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-14b-instruct",
@@ -29022,7 +30469,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-14b-instruct-awq",
@@ -29032,7 +30480,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-14b-instruct-gguf",
@@ -29051,7 +30500,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-14b-instruct-gptq-int8",
@@ -29061,7 +30511,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-32b",
@@ -29071,7 +30522,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-32b-instruct",
@@ -29083,7 +30535,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-32b-instruct-awq",
@@ -29093,7 +30546,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-32b-instruct-gguf",
@@ -29112,7 +30566,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-32b-instruct-gptq-int8",
@@ -29122,7 +30577,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-3b",
@@ -29132,7 +30588,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-3b-instruct",
@@ -29142,7 +30599,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-3b-instruct-awq",
@@ -29152,7 +30610,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-3b-instruct-gguf",
@@ -29171,7 +30630,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-3b-instruct-gptq-int8",
@@ -29181,7 +30641,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-7b",
@@ -29191,7 +30652,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-7b-instruct",
@@ -29201,7 +30663,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-7b-instruct-awq",
@@ -29211,7 +30674,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-7b-instruct-gguf",
@@ -29230,7 +30694,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-coder-7b-instruct-gptq-int8",
@@ -29240,7 +30705,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-math-1.5b",
@@ -29250,7 +30716,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-1.5b-instruct",
@@ -29260,7 +30727,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-72b",
@@ -29270,7 +30738,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-72b-instruct",
@@ -29280,7 +30749,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-7b",
@@ -29290,7 +30760,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-7b-instruct",
@@ -29300,7 +30771,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-7b-prm800k",
@@ -29310,7 +30782,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-prm-72b",
@@ -29320,7 +30793,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-prm-7b",
@@ -29330,7 +30804,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-math-rm-72b",
@@ -29340,7 +30815,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2.5-max",
@@ -29367,7 +30843,8 @@
         "audio_understanding",
         "tts"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-omni-7b",
@@ -29385,7 +30862,8 @@
         "audio_understanding",
         "tts"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-omni-7b-awq",
@@ -29403,7 +30881,8 @@
         "audio_understanding",
         "tts"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-omni-7b-gptq-int4",
@@ -29421,7 +30900,8 @@
         "audio_understanding",
         "tts"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2.5-vl-32b-instruct",
@@ -29435,7 +30915,8 @@
         "vision",
         "ocr"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2.5-vl-32b-instruct-awq",
@@ -29445,7 +30926,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2.5-vl-3b-instruct",
@@ -29456,7 +30938,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2.5-vl-3b-instruct-awq",
@@ -29466,7 +30949,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2.5-vl-72b-instruct",
@@ -29482,8 +30966,9 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 128000,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2.5-vl-72b-instruct-awq",
@@ -29493,7 +30978,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2.5-vl-7b-instruct",
@@ -29505,7 +30991,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2.5-vl-7b-instruct-awq",
@@ -29515,7 +31002,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen2-0.5b",
@@ -29525,7 +31013,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2-0.5b-instruct",
@@ -29535,7 +31024,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-0.5b-instruct-awq",
@@ -29545,7 +31035,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-0.5b-instruct-gguf",
@@ -29564,7 +31055,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-0.5b-instruct-gptq-int8",
@@ -29574,7 +31066,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-0.5b-instruct-mlx",
@@ -29584,7 +31077,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-1.5b",
@@ -29595,7 +31089,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2-1.5b-instruct",
@@ -29606,7 +31101,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-1.5b-instruct-awq",
@@ -29616,7 +31112,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-1.5b-instruct-gguf",
@@ -29635,7 +31132,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-1.5b-instruct-gptq-int8",
@@ -29645,7 +31143,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-1.5b-instruct-mlx",
@@ -29655,7 +31154,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-57b-a14b",
@@ -29665,7 +31165,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2-57b-a14b-instruct",
@@ -29675,7 +31176,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-57b-a14b-instruct-gguf",
@@ -29694,7 +31196,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-72b",
@@ -29705,7 +31208,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2-72b-instruct",
@@ -29716,7 +31220,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-72b-instruct-awq",
@@ -29726,7 +31231,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-72b-instruct-gguf",
@@ -29745,7 +31251,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-72b-instruct-gptq-int8",
@@ -29755,7 +31262,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-7b",
@@ -29766,7 +31274,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen2-7b-instruct",
@@ -29779,8 +31288,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-7b-instruct-awq",
@@ -29790,7 +31300,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-7b-instruct-gguf",
@@ -29809,7 +31320,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-7b-instruct-gptq-int8",
@@ -29819,7 +31331,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-7b-instruct-mlx",
@@ -29829,7 +31342,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-audio-7b",
@@ -29841,7 +31355,8 @@
         "speech2text",
         "audio_understanding"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen2-audio-7b-instruct",
@@ -29854,7 +31369,8 @@
         "speech2text",
         "audio_understanding"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen2-math-1.5b",
@@ -29864,7 +31380,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2-math-1.5b-instruct",
@@ -29874,7 +31391,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2-math-72b",
@@ -29884,7 +31402,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2-math-72b-instruct",
@@ -29894,7 +31413,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2-math-7b",
@@ -29904,7 +31424,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2-math-7b-instruct",
@@ -29914,7 +31435,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2-math-rm-72b",
@@ -29924,7 +31446,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "qwen/qwen2-vl-2b",
@@ -29934,7 +31457,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-2b-instruct",
@@ -29944,7 +31468,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-2b-instruct-awq",
@@ -29954,7 +31479,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-2b-instruct-gptq-int4",
@@ -29964,7 +31490,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-2b-instruct-gptq-int8",
@@ -29974,7 +31501,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-72b",
@@ -29984,7 +31512,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-72b-instruct",
@@ -30000,8 +31529,9 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 32768,
-      "max_completion_tokens": 120000
+      "max_completion_tokens": 120000,
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-72b-instruct-awq",
@@ -30011,7 +31541,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-72b-instruct-gptq-int4",
@@ -30021,7 +31552,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-72b-instruct-gptq-int8",
@@ -30031,7 +31563,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-7b",
@@ -30041,7 +31574,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-7b-instruct",
@@ -30051,7 +31585,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-7b-instruct-awq",
@@ -30061,7 +31596,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-7b-instruct-gptq-int4",
@@ -30071,7 +31607,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen2-vl-7b-instruct-gptq-int8",
@@ -30081,7 +31618,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-0.5b",
@@ -30091,7 +31629,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-0.5b-chat",
@@ -30101,7 +31640,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-0.5b-chat-awq",
@@ -30111,7 +31651,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-0.5b-chat-gguf",
@@ -30130,7 +31671,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-0.5b-chat-gptq-int8",
@@ -30140,7 +31682,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-1.8b",
@@ -30150,7 +31693,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-1.8b-chat",
@@ -30160,7 +31704,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-1.8b-chat-awq",
@@ -30170,7 +31715,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-1.8b-chat-gguf",
@@ -30189,7 +31735,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-1.8b-chat-gptq-int8",
@@ -30199,7 +31746,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-110b",
@@ -30209,7 +31757,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-110b-chat",
@@ -30219,7 +31768,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-110b-chat-awq",
@@ -30229,7 +31779,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-110b-chat-gguf",
@@ -30248,7 +31799,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-14b",
@@ -30258,7 +31810,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-14b-chat",
@@ -30268,7 +31821,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-14b-chat-awq",
@@ -30278,7 +31832,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-14b-chat-gguf",
@@ -30297,7 +31852,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-14b-chat-gptq-int8",
@@ -30307,7 +31863,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-32b",
@@ -30317,7 +31874,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-32b-chat",
@@ -30327,7 +31885,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-32b-chat-awq",
@@ -30337,7 +31896,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-32b-chat-gguf",
@@ -30356,7 +31916,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-4b",
@@ -30366,7 +31927,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-4b-chat",
@@ -30376,7 +31938,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-4b-chat-awq",
@@ -30386,7 +31949,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-4b-chat-gguf",
@@ -30405,7 +31969,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-4b-chat-gptq-int8",
@@ -30415,7 +31980,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-72b",
@@ -30425,7 +31991,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-72b-chat",
@@ -30435,7 +32002,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-72b-chat-awq",
@@ -30445,7 +32013,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-72b-chat-gguf",
@@ -30464,7 +32033,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-72b-chat-gptq-int8",
@@ -30474,7 +32044,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-7b",
@@ -30484,7 +32055,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-7b-chat",
@@ -30494,7 +32066,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-7b-chat-awq",
@@ -30504,7 +32077,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-7b-chat-gguf",
@@ -30523,7 +32097,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-7b-chat-gptq-int8",
@@ -30533,7 +32108,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-moe-a2.7b",
@@ -30543,7 +32119,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen1.5-moe-a2.7b-chat",
@@ -30553,7 +32130,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen1.5-moe-a2.7b-chat-gptq-int4",
@@ -30563,7 +32141,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-image-2.0-2026-03-03",
@@ -30642,7 +32221,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-plus-2025-12-01-us",
@@ -30708,7 +32288,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-flash-2025-07-28-us",
@@ -30718,7 +32299,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-plus-2025-07-28",
@@ -31217,7 +32799,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/codeqwen1.5-7b-awq",
@@ -31227,7 +32810,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/codeqwen1.5-7b-chat",
@@ -31237,7 +32821,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/codeqwen1.5-7b-chat-awq",
@@ -31247,7 +32832,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "qwen/codeqwen1.5-7b-chat-gguf",
@@ -31268,7 +32854,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwen/qwen-14b",
@@ -31278,7 +32865,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-14b-chat",
@@ -31288,7 +32876,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-14b-chat-int4",
@@ -31298,7 +32887,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-14b-chat-int8",
@@ -31308,7 +32898,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-1_8b",
@@ -31319,7 +32910,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-1_8b-chat-int4",
@@ -31329,7 +32921,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-1_8b-chat-int8",
@@ -31339,7 +32932,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-72b",
@@ -31349,7 +32943,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-72b-chat",
@@ -31359,7 +32954,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-72b-chat-int4",
@@ -31369,7 +32965,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-72b-chat-int8",
@@ -31379,7 +32976,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-7b",
@@ -31389,7 +32987,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-7b-chat",
@@ -31399,7 +32998,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-7b-chat-int4",
@@ -31409,7 +33009,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-7b-chat-int8",
@@ -31419,7 +33020,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-audio",
@@ -31431,7 +33033,8 @@
         "speech2text",
         "audio_understanding"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "qwen/qwen-audio-chat",
@@ -31444,7 +33047,8 @@
         "speech2text",
         "audio_understanding"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "qwen/qwen-coder-plus",
@@ -31492,7 +33096,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-flash-us",
@@ -31502,7 +33107,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-image",
@@ -31768,8 +33374,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "qwen/qwen-mt-turbo",
@@ -31823,11 +33430,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-plus-character",
@@ -31907,7 +33515,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-vl-chat",
@@ -31917,7 +33526,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-vl-chat-int4",
@@ -31927,7 +33537,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "qwen/qwen-vl-max",
@@ -31976,11 +33587,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwq-32b-awq",
@@ -31990,11 +33602,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwq-32b-gguf",
@@ -32004,11 +33617,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwq-32b-preview",
@@ -32018,11 +33632,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/sae-res-qwen3-1.7b-base-w32k-l0_100",
@@ -32158,7 +33773,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40960
+      "content_length": 40960,
+      "max_output": 40960
     },
     {
       "name": "qwen/webworld-32b",
@@ -32168,7 +33784,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40960
+      "content_length": 40960,
+      "max_output": 40960
     },
     {
       "name": "qwen/webworld-8b",
@@ -32178,7 +33795,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 40960
+      "content_length": 40960,
+      "max_output": 40960
     },
     {
       "name": "qwen/worldpm-72b",
@@ -32188,7 +33806,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "qwen/worldpm-72b-helpsteer2",
@@ -32198,7 +33817,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "qwen/worldpm-72b-rlhflow",
@@ -32217,7 +33837,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "qwen-flash-character",
@@ -32227,38 +33848,43 @@
     },
     {
       "name": "qwen-max-2024-04-03",
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen-max-2024-04-28",
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen-plus-2024-07-23",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "qwen-turbo-2024-06-24",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "qwen-turbo-2025-02-11",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen2-5-72b-20240919",
@@ -32298,10 +33924,11 @@
     },
     {
       "name": "qwen3-rerank",
-      "max_tokens": 30000,
       "model_types": [
         "rerank"
-      ]
+      ],
+      "content_length": 30000,
+      "max_output": 30000
     },
     {
       "name": "qwq-72b-preview",
@@ -32315,24 +33942,27 @@
     },
     {
       "name": "qwq-plus",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwq-plus-2025-03-05",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "qwq-plus-latest",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "recraft-ai/recraft-v3",
@@ -32366,7 +33996,8 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "rekaai/reka-flash-3",
@@ -32374,11 +34005,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "relace/relace-apply-3",
@@ -32386,7 +34018,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "relace/relace-search",
@@ -32394,7 +34027,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "replicate/all-mpnet-base-v2:b6b7585c9640cd7a9572c6e129c9549d79c9c31f0d3fdce7baac7c67ca38f305",
@@ -32402,9 +34036,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 384,
       "max_dimension": 768,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 384,
+      "max_output": 384
     },
     {
       "name": "rerank-2.5",
@@ -32461,10 +34096,11 @@
         "rime-arcana-v3-turbo",
         "Rime Labs Arcana v3 Turbo"
       ],
-      "max_tokens": 448,
       "model_types": [
         "audio_generation"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "rime-labs/rime-mist-v3",
@@ -32472,10 +34108,11 @@
         "rime-mist-v3",
         "Rime Labs Mist v3"
       ],
-      "max_tokens": 448,
       "model_types": [
         "audio_generation"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "rime-labs/rime-mist-v3-omni",
@@ -32483,10 +34120,11 @@
         "rime-mist-v3-omni",
         "Rime Labs Mist v3 Omni"
       ],
-      "max_tokens": 448,
       "model_types": [
         "audio_generation"
-      ]
+      ],
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "rime-labs/rime-arcana-v2",
@@ -32575,8 +34213,7 @@
         "runway_act_one",
         "runway-act-one"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "runwayml/runway_video",
@@ -32584,8 +34221,7 @@
         "runway_video",
         "runway-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "runwayml/runway_video2video",
@@ -32593,8 +34229,7 @@
         "runway_video2video",
         "runway-video2video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "runwayml/runwayml_character_performance",
@@ -32602,8 +34237,7 @@
         "runwayml_character_performance",
         "runwayml-character-performance"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "runwayml/runwayml_image_to_video",
@@ -32611,8 +34245,7 @@
         "runwayml_image_to_video",
         "runwayml-image-to-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "runwayml/runwayml_text_to_image",
@@ -32631,8 +34264,7 @@
         "runwayml_upscale_video",
         "runwayml-upscale-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "runwayml/runwayml_video_to_video",
@@ -32640,25 +34272,26 @@
         "runwayml_video_to_video",
         "runwayml-video-to-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "s1",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "s2",
       "alias": [
         "s3"
       ],
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "Salesforce/Llama-Rank-V1",
@@ -32666,10 +34299,11 @@
         "Llama-Rank-V1",
         "Salesforce Llama Rank V1 (8B)"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "rerank"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "Sao10K/L3-8B-Stheno-v3.2",
@@ -32680,48 +34314,53 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192,
-      "max_completion_tokens": 32000
+      "max_completion_tokens": 32000,
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "Sao10K/L3.3-70B-Euryale-v2.3",
       "alias": [
         "L3.3-70B-Euryale-v2.3"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "Sao10K/L3.1-70B-Euryale-v2.2",
       "alias": [
         "L3.1-70B-Euryale-v2.2"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "Sao10K/L3-8B-Lunaris-v1",
       "alias": [
         "L3-8B-Lunaris-v1"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "Sao10K/L3-8B-Lunaris-v1-Turbo",
       "alias": [
         "L3-8B-Lunaris-v1-Turbo"
       ],
-      "max_tokens": 8192,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "sao10k/l31-70b-euryale-v2.2",
@@ -32732,12 +34371,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192,
       "max_completion_tokens": 8192,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "sao10k/l3-70b-euryale-v2.1",
@@ -32748,8 +34388,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "sao10k/l3-8b-lunaris",
@@ -32760,8 +34401,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "sao10k/l3-lunaris-8b",
@@ -32769,7 +34411,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "sao10k/l3.1-70b-hanami-x1",
@@ -32777,7 +34420,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16000
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "sao10k/l3.1-euryale-70b",
@@ -32785,7 +34429,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "sao10k/l3.3-euryale-70b",
@@ -32793,7 +34438,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "sarvamai/sarvam-m",
@@ -32801,10 +34447,11 @@
         "sarvam-m",
         "Sarvam M"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "searchapi",
@@ -32856,23 +34503,19 @@
     },
     {
       "name": "Seedance 2.0",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "seedance-1-0-pro-250528",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "seedance-1-0-pro-fast-251015",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "seedance-1-5-pro-251215",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "seededit_v3.0",
@@ -32904,140 +34547,155 @@
     },
     {
       "name": "SenseChat-5",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "SenseChat-Turbo",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sensenova-6.7-flash-lite",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "SenseNova-V6-5-Pro",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "SenseNova-V6-5-Turbo",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "SenseNova-V6-Pro",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "SenseNova-V6-Reasoner",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "SenseNova-V6-Turbo",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sentence-transformers/all-MiniLM-L12-v2",
       "alias": [
         "all-MiniLM-L12-v2"
       ],
-      "max_tokens": 512,
       "max_dimension": 384,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "sentence-transformers/all-MiniLM-L6-v2",
       "alias": [
         "all-MiniLM-L6-v2"
       ],
-      "max_tokens": 512,
       "max_dimension": 384,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "sentence-transformers/all-mpnet-base-v2",
       "alias": [
         "all-mpnet-base-v2"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "sentence-transformers/paraphrase-MiniLM-L6-v2",
       "alias": [
         "paraphrase-MiniLM-L6-v2"
       ],
-      "max_tokens": 512,
       "max_dimension": 384,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "sentence-transformers/clip-ViT-B-32-multilingual-v1",
       "alias": [
         "clip-ViT-B-32-multilingual-v1"
       ],
-      "max_tokens": 512,
       "max_dimension": 512,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
       "alias": [
         "multi-qa-mpnet-base-dot-v1"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "sentence-transformers/clip-ViT-B-32",
       "alias": [
         "clip-ViT-B-32"
       ],
-      "max_tokens": 77,
       "max_dimension": 512,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 77,
+      "max_output": 77
     },
     {
       "name": "sesame/csm-1b",
@@ -33050,24 +34708,27 @@
     },
     {
       "name": "sf/zai-org/GLM-4.5-Air",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sf/zai-org/GLM-4.5V",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "sf/zai-org/GLM-4.6",
-      "max_tokens": 198000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 198000,
+      "max_output": 198000
     },
     {
       "name": "shengshu-ai/viduq3",
@@ -33075,8 +34736,7 @@
         "vidu-q3",
         "viduq3"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "shengshu-ai/viduq3-turbo",
@@ -33084,19 +34744,19 @@
         "vidu-q3-turbo",
         "viduq3-turbo"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "shibing624/text2vec-base-chinese",
       "alias": [
         "text2vec-base-chinese"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "slides_glm_agent",
@@ -33142,225 +34802,253 @@
     },
     {
       "name": "sonar",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
       ],
-      "alias": []
+      "alias": [],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "sonar-deep-research",
-      "max_tokens": 127000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 127000,
+      "max_output": 127000
     },
     {
       "name": "sonar-pro",
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "sonar-reasoning",
-      "max_tokens": 127000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 127000,
+      "max_output": 127000
     },
     {
       "name": "sonar-reasoning-pro",
-      "max_tokens": 127000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 127000,
+      "max_output": 127000
     },
     {
       "name": "sophnet/GLM-5",
-      "max_tokens": 202000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 202000,
+      "max_output": 202000
     },
     {
       "name": "sophnet/GLM-4.7",
-      "max_tokens": 202000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 202000,
+      "max_output": 202000
     },
     {
       "name": "sophnet/GLM-4.6",
-      "max_tokens": 202000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 202000,
+      "max_output": 202000
     },
     {
       "name": "sophnet/GLM-4.6V",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/GLM-4.5V",
-      "max_tokens": 66000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 66000,
+      "max_output": 66000
     },
     {
       "name": "sophnet/DeepSeek-V3.2",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/DeepSeek-V3.2-Exp",
-      "max_tokens": 163000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 163000,
+      "max_output": 163000
     },
     {
       "name": "sophnet/DeepSeek-V3.2-Fast",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/DeepSeek-V3.1",
-      "max_tokens": 163000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 163000,
+      "max_output": 163000
     },
     {
       "name": "sophnet/DeepSeek-V3.1-Fast",
-      "max_tokens": 163000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 163000,
+      "max_output": 163000
     },
     {
       "name": "sophnet/DeepSeek-v3",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/DeepSeek-V3-0324",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/DeepSeek-V3-Fast",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sophnet/Qwen3-14B",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen3-235B-A22B",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen3-235B-A22B-Instruct-2507",
-      "max_tokens": 262000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 262000,
+      "max_output": 262000
     },
     {
       "name": "sophnet/Qwen3-235B-A22B-Thinking-2507",
-      "max_tokens": 80000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 80000,
+      "max_output": 80000
     },
     {
       "name": "sophnet/Qwen3-30B-A3B-Instruct-2507",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "sophnet/Qwen3-30B-A3B-Thinking-2507",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "sophnet/Qwen3-32B",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen3-Coder",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "sophnet/Qwen3-Next-80B-A3B-Instruct",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "sophnet/Qwen3-Next-80B-A3B-Thinking",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "sophnet/Qwen3-VL-235B-A22B-Instruct",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen3-VL-235B-A22B-Thinking",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
@@ -33369,227 +35057,254 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen2.5-32B-Instruct",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen2.5-72B-Instruct",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen2.5-7B-Instruct",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen2.5-VL-32B-Instruct",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen2.5-VL-72B-Instruct",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Qwen2.5-VL-7B-Instruct",
-      "max_tokens": 128000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/DeepSeek-Math-V2",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/DeepSeek-Prover-V2",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/MiMo-V2-Flash",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "sophnet/Qwen2-VL-72B-Instruct",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sophnet/Qwen2-VL-7B-Instruct",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sophnet/DeepSeek-R1",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "sophnet/DeepSeek-R1-0528",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/DeepSeek-R1-Distill-Llama-70B",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sophnet/DeepSeek-R1-Distill-Qwen-32B",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sophnet/DeepSeek-R1-Distill-Qwen-7B",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "sophnet/Kimi-K2",
       "alias": [
         "sophnet/Kimi-K2Kimi-K2"
       ],
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "sophnet/Kimi-K2-0905",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "sophnet/Kimi-K2-Thinking",
-      "max_tokens": 256000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "sophnet/LongCat-Flash-Chat",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/LongCat-Flash-Thinking",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/MiniMax-M2",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "sophnet/MiniMax-M2.1",
-      "max_tokens": 1000000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "sophnet/QwQ-32B",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "sophnet/Seed-OSS-36B-Instruct",
-      "max_tokens": 512000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 512000,
+      "max_output": 512000
     },
     {
       "name": "sophnet2",
@@ -33602,13 +35317,14 @@
     },
     {
       "name": "sora-2",
-      "max_tokens": 60000,
       "model_types": [
         "chat"
       ],
       "alias": [
         "Sora 2"
-      ]
+      ],
+      "content_length": 60000,
+      "max_output": 60000
     },
     {
       "name": "SparkDesk-v1.1",
@@ -33711,7 +35427,8 @@
         "minimax/speech-2.6-turbo",
         "Minimax Speech 2.6 Turbo"
       ],
-      "max_tokens": 448
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "speech-2.8-hd",
@@ -33730,7 +35447,8 @@
         "minimax/speech-2.8-turbo",
         "Minimax Speech 2.8 Turbo"
       ],
-      "max_tokens": 448
+      "content_length": 448,
+      "max_output": 448
     },
     {
       "name": "stability-ai/stable-diffusion-xl-v1",
@@ -33741,7 +35459,8 @@
         "image_generation",
         "image"
       ],
-      "max_tokens": 77
+      "content_length": 77,
+      "max_output": 77
     },
     {
       "name": "stability-ai/sdxl",
@@ -33801,10 +35520,11 @@
     {
       "name": "stability.stable-diffusion-xl-v1",
       "alias": [],
-      "max_tokens": 77,
       "model_types": [
         "image_generation"
-      ]
+      ],
+      "content_length": 77,
+      "max_output": 77
     },
     {
       "name": "stabilityai/sd3.5",
@@ -33877,7 +35597,6 @@
     },
     {
       "name": "step-1o-vision-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat",
         "image2text",
@@ -33885,54 +35604,61 @@
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "step-1v-32k",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "step-1v-8k",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "step-2-16k",
       "alias": [
         "step-2-mini"
       ],
-      "max_tokens": 16000,
       "model_types": [
         "chat"
       ],
       "tools": {
         "support": true
-      }
+      },
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "step-2-16k-exp",
-      "max_tokens": 16000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "step-3",
-      "max_tokens": 64000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "step-image-edit-2",
@@ -33943,14 +35669,15 @@
     },
     {
       "name": "step-r1-v-mini",
-      "max_tokens": 100000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 100000,
+      "max_output": 100000
     },
     {
       "name": "step-tts-2",
@@ -33979,7 +35706,8 @@
       "model_types": [
         "image"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/Step-Audio-R1.1",
@@ -33990,7 +35718,8 @@
         "audio",
         "speech"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/Step-Audio-R1",
@@ -34000,7 +35729,8 @@
       "model_types": [
         "audio"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/GELab-Zero-4B-preview",
@@ -34011,7 +35741,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "stepfun-ai/NextStep-1-f8ch16-Tokenizer",
@@ -34021,7 +35752,8 @@
       "model_types": [
         "other"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/NextStep-1.1",
@@ -34031,7 +35763,8 @@
       "model_types": [
         "image"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/NextStep-1.1-Pretrain",
@@ -34041,7 +35774,8 @@
       "model_types": [
         "image"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/NextStep-1.1-Pretrain-256px",
@@ -34051,7 +35785,8 @@
       "model_types": [
         "image"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/PaCoRe-8B",
@@ -34061,7 +35796,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/RLVR-8B-0926",
@@ -34071,7 +35807,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.5-Flash",
@@ -34083,11 +35820,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.5-Flash-Base",
@@ -34097,11 +35835,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.5-Flash-Base-Midtrain",
@@ -34111,11 +35850,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.5-Flash-FP8",
@@ -34125,11 +35865,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.5-Flash-GGUF-Q4_K_S",
@@ -34139,7 +35880,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.5-Flash-GGUF-Q8_0",
@@ -34149,7 +35891,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.7-Flash",
@@ -34162,12 +35905,13 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 256000
+      "max_completion_tokens": 256000,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.7-Flash-FP8",
@@ -34179,11 +35923,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.7-Flash-GGUF",
@@ -34195,11 +35940,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-3.7-Flash-NVFP4",
@@ -34211,11 +35957,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/Step-Audio-2-mini",
@@ -34226,7 +35973,8 @@
         "audio",
         "speech"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/Step-Audio-2-mini-Base",
@@ -34236,7 +35984,8 @@
       "model_types": [
         "audio"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/Step-Audio-2-mini-Think",
@@ -34246,7 +35995,8 @@
       "model_types": [
         "audio"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/Step-Audio-EditX",
@@ -34257,7 +36007,8 @@
         "audio",
         "speech_edit"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/Step-Audio-EditX-AWQ-4bit",
@@ -34267,7 +36018,8 @@
       "model_types": [
         "audio"
       ],
-      "max_tokens": 0
+      "content_length": 0,
+      "max_output": 0
     },
     {
       "name": "stepfun-ai/step-audio-tts-3b",
@@ -34288,7 +36040,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "stepfun-ai/step3-fp8",
@@ -34300,7 +36053,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "stepfun-ai/Step3-VL-10B",
@@ -34311,7 +36065,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "stepfun-ai/Step3-VL-10B-Base",
@@ -34322,7 +36077,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "stepfun-ai/Step3-VL-10B-FP8",
@@ -34333,7 +36089,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "stepfun-ai/StepFun-Formalizer-32B",
@@ -34343,11 +36100,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/StepFun-Formalizer-7B",
@@ -34357,11 +36115,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/StepFun-Prover-Preview-32B",
@@ -34371,11 +36130,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "stepfun-ai/StepFun-Prover-Preview-7B",
@@ -34385,11 +36145,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "suno-api",
@@ -34402,16 +36163,14 @@
       "alias": [
         "suno-concat-open"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "suno_lyrics_open",
       "alias": [
         "suno-lyrics-open"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "suno_music_open",
@@ -34427,16 +36186,14 @@
       "alias": [
         "suno-persona-open"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "suno_upload_open",
       "alias": [
         "suno-upload-open"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "suno_uploads",
@@ -34452,16 +36209,14 @@
       "alias": [
         "suno-upsample-tags"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "suno_upsample_open",
       "alias": [
         "suno-upsample-open"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "switchpoint/router",
@@ -34469,11 +36224,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "syn-pro",
@@ -34486,13 +36242,11 @@
     },
     {
       "name": "T2V-01",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "T2V-01-Director",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tavily",
@@ -34506,11 +36260,12 @@
         "openhermes-2.5-mistral-7b",
         "Openhermes2.5 Mistral 7B"
       ],
-      "max_tokens": 4096,
       "max_completion_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "tencent/DeepSeek-V3.1-Terminus-W4AFP8",
@@ -34520,11 +36275,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Covo-Audio-Chat",
@@ -34537,7 +36293,8 @@
         "asr",
         "tts"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/DepthCrafter",
@@ -34565,7 +36322,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/DRIVE-RL",
@@ -34575,11 +36333,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/DRIVE-SFT",
@@ -34589,7 +36348,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/hunyuan",
@@ -34608,7 +36368,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-0.5B-Instruct-AWQ-Int4",
@@ -34618,7 +36379,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-0.5B-Instruct-FP8",
@@ -34628,7 +36390,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-0.5B-Instruct-GPTQ-Int4",
@@ -34638,7 +36401,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-0.5B-Pretrain",
@@ -34648,7 +36412,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-1.8B-Instruct",
@@ -34658,7 +36423,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-1.8B-Instruct-AWQ-Int4",
@@ -34668,7 +36434,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-1.8B-Instruct-FP8",
@@ -34678,7 +36445,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-1.8B-Instruct-GPTQ-Int4",
@@ -34688,7 +36456,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-1.8B-Pretrain",
@@ -34698,7 +36467,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-4B-Instruct",
@@ -34708,7 +36478,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-4B-Instruct-AWQ-Int4",
@@ -34718,7 +36489,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-4B-Instruct-FP8",
@@ -34728,7 +36500,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-4B-Instruct-GPTQ-Int4",
@@ -34738,7 +36511,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-4B-Pretrain",
@@ -34748,7 +36522,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-7B-Instruct",
@@ -34758,7 +36533,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-7B-Instruct-0124",
@@ -34768,7 +36544,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-7B-Instruct-AWQ-Int4",
@@ -34778,7 +36555,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-7B-Instruct-FP8",
@@ -34788,7 +36566,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-7B-Instruct-GPTQ-Int4",
@@ -34798,7 +36577,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-7B-Pretrain",
@@ -34808,7 +36588,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-7B-Pretrain-0124",
@@ -34818,7 +36599,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-A13B-Instruct",
@@ -34828,7 +36610,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-A13B-Instruct-FP8",
@@ -34838,7 +36621,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-A13B-Instruct-GGUF",
@@ -34848,7 +36632,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-A13B-Instruct-GPTQ-Int4",
@@ -34858,7 +36643,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-A13B-Pretrain",
@@ -34868,7 +36654,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/hunyuan-code",
@@ -34882,8 +36669,7 @@
       "alias": [
         "Hunyuan-GameCraft-1.0"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/hunyuan-large",
@@ -34903,7 +36689,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-MT-7B-fp8",
@@ -34914,7 +36701,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-MT-Chimera-7B",
@@ -34925,7 +36713,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hunyuan-MT-Chimera-7B-fp8",
@@ -34936,7 +36725,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/hunyuan-pro",
@@ -35052,8 +36842,7 @@
       "alias": [
         "HunyuanCustom"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HunyuanImage-2.1",
@@ -35113,32 +36902,28 @@
       "alias": [
         "HunyuanPortrait"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HunyuanVideo",
       "alias": [
         "HunyuanVideo"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HunyuanVideo-1.5",
       "alias": [
         "HunyuanVideo-1.5"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HunyuanVideo-Avatar",
       "alias": [
         "HunyuanVideo-Avatar"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HunyuanVideo-Foley",
@@ -35154,8 +36939,7 @@
       "alias": [
         "HunyuanVideo-I2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HunyuanVideo-PromptRewrite",
@@ -35165,7 +36949,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HunyuanWorld-1",
@@ -35190,8 +36975,7 @@
       "alias": [
         "HunyuanWorld-Voyager"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HY-Embodied-0.5",
@@ -35203,7 +36987,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-Embodied-0.5-X",
@@ -35215,7 +37000,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-Motion-1.0",
@@ -35235,7 +37021,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT1.5-1.8B-1.25bit",
@@ -35246,7 +37033,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -35257,7 +37045,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT1.5-1.8B-2bit",
@@ -35268,7 +37057,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -35279,7 +37069,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-MT1.5-1.8B-FP8",
@@ -35290,7 +37081,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-MT1.5-1.8B-GGUF",
@@ -35301,7 +37093,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-MT1.5-1.8B-GPTQ-Int4",
@@ -35312,7 +37105,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-MT1.5-7B",
@@ -35323,7 +37117,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-MT1.5-7B-FP8",
@@ -35334,7 +37129,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-MT1.5-7B-GGUF",
@@ -35345,7 +37141,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-MT1.5-7B-GPTQ-Int4",
@@ -35356,7 +37153,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-1.8B",
@@ -35367,7 +37165,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
@@ -35378,7 +37177,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -35389,7 +37189,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-1.8B-FP8",
@@ -35400,7 +37201,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-1.8B-GGUF",
@@ -35411,7 +37213,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-30B-A3B",
@@ -35422,7 +37225,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-30B-A3B-FP8",
@@ -35433,7 +37237,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-7B",
@@ -35444,7 +37249,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-7B-FP8",
@@ -35455,7 +37261,8 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy-MT2-7B-GGUF",
@@ -35466,23 +37273,22 @@
         "chat",
         "translation"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY-OmniWeaving",
       "alias": [
         "HY-OmniWeaving"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HY-Video-PRFL",
       "alias": [
         "HY-Video-PRFL"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HY-World-2.0",
@@ -35498,8 +37304,7 @@
       "alias": [
         "HY-WorldPlay"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/HY-WU",
@@ -35518,11 +37323,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Hy3-preview-Base",
@@ -35532,7 +37338,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/HY3D-Bench",
@@ -35568,8 +37375,7 @@
       "alias": [
         "MimicMotion"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "tencent/Penguin-Encoder",
@@ -35593,7 +37399,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Penguin-VL-8B",
@@ -35605,7 +37412,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/POINTS-GUI-G",
@@ -35617,7 +37425,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/POINTS-Reader",
@@ -35628,7 +37437,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/POINTS-Seeker",
@@ -35640,11 +37450,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n2",
@@ -35654,7 +37465,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n4",
@@ -35664,7 +37476,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n8",
@@ -35674,7 +37487,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Sequential-Hidden-Decoding-8B-n8-Instruct",
@@ -35684,7 +37498,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/SongGeneration",
@@ -35730,7 +37545,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Tencent-Hunyuan-Large",
@@ -35740,7 +37556,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Unicom-Unified-Multimodal-Modeling-via-Compressed-Continuous-Semantic-Representations",
@@ -35761,7 +37578,8 @@
         "audio",
         "asr"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Universal_Audio_Tokenizer",
@@ -35789,7 +37607,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/WeDLM-7B-Instruct",
@@ -35799,7 +37618,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/WeDLM-8B-Base",
@@ -35809,7 +37629,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/WeDLM-8B-Instruct",
@@ -35819,7 +37640,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Youtu-Embedding",
@@ -35852,7 +37674,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Youtu-LLM-2B-Base",
@@ -35862,7 +37685,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Youtu-LLM-2B-GGUF",
@@ -35872,7 +37696,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Youtu-Parsing",
@@ -35883,7 +37708,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Youtu-VL-4B-Instruct",
@@ -35895,7 +37721,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "tencent/Youtu-VL-4B-Instruct-GGUF",
@@ -35907,7 +37734,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 262144
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "text-embedding-3-large",
@@ -35945,7 +37773,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "thedrummer/skyfall-36b-v2",
@@ -35953,7 +37782,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "thedrummer/rocinante-12b",
@@ -35961,7 +37791,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "thedrummer/unslopnemo-12b",
@@ -35969,33 +37800,35 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "thenlper/gte-base",
       "alias": [
         "gte-base"
       ],
-      "max_tokens": 512,
       "max_dimension": 768,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "thenlper/gte-large",
       "alias": [
         "gte-large"
       ],
-      "max_tokens": 512,
       "max_dimension": 1024,
       "model_types": [
         "embedding"
-      ]
+      ],
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "THUDM/GLM-4.1V-9B-Thinking",
-      "max_tokens": 64000,
       "model_types": [
         "chat",
         "vision",
@@ -36005,45 +37838,52 @@
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32000
+      "max_completion_tokens": 32000,
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "THUDM/GLM-4-9B-0414",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "THUDM/glm-4-9b-chat",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "THUDM/GLM-Z1-32B-0414",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "THUDM/GLM-Z1-Rumination-32B-0414",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "togethercomputer/EssentialAI-RNJ-1-Instruct",
       "alias": [
         "EssentialAI-RNJ-1-Instruct"
       ],
-      "max_tokens": 32768,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "togethercomputer/meta-llama-3.1-8B-Instruct-AWQ-INT4",
@@ -36051,10 +37891,11 @@
         "meta-llama-3.1-8B-Instruct-AWQ-INT4",
         "Meta Llama 3.1 8B Instruct Awq Int4"
       ],
-      "max_tokens": 131072,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "tokenhub-chat-test",
@@ -36064,17 +37905,19 @@
     },
     {
       "name": "tongyi-intent-detect-v3",
-      "max_tokens": 8000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "Tongyi-Zhiwen/QwenLong-L1-32B",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "tripo3d",
@@ -36122,24 +37965,27 @@
     },
     {
       "name": "u1",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "u1-pro",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "u2",
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "undi95/remm-slerp-l2-13b",
@@ -36147,7 +37993,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 6144
+      "content_length": 6144,
+      "max_output": 6144
     },
     {
       "name": "upstage/solar-pro-3",
@@ -36155,64 +38002,72 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "us.amazon.nova-lite-v1:0",
       "alias": [],
-      "max_tokens": 300000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 300000,
+      "max_output": 300000
     },
     {
       "name": "us.amazon.nova-pro-v1:0",
       "alias": [],
-      "max_tokens": 300000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 300000,
+      "max_output": 300000
     },
     {
       "name": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
       "alias": [],
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
       "alias": [],
-      "max_tokens": 200000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 200000,
+      "max_output": 200000
     },
     {
       "name": "v0-1.0-md",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "v0-1.5-lg",
-      "max_tokens": 512000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 512000,
+      "max_output": 512000
     },
     {
       "name": "v0-1.5-md",
-      "max_tokens": 128000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "vectorizer",
@@ -36232,8 +38087,7 @@
         "vidu-2.0",
         "Vidu 2.0"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "vidu/vidu-q1",
@@ -36241,24 +38095,21 @@
         "vidu-q1",
         "Vidu Q1"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "vidu/vidu-q3",
       "alias": [
         "Vidu Q3"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "vidu/vidu-q3-turbo",
       "alias": [
         "Vidu Q3 Turbo"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "vidu-tts",
@@ -36268,18 +38119,15 @@
     },
     {
       "name": "vidu2.0",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "viduq1",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "viduq1-classic",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "viduq2",
@@ -36297,18 +38145,15 @@
     },
     {
       "name": "viduq2-turbo",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "viduq3-mix",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "viduq3-pro",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "voyage/rerank-1",
@@ -36318,7 +38163,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "voyage/rerank-2",
@@ -36328,7 +38174,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 16000
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "voyage/rerank-2-lite",
@@ -36338,7 +38185,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "voyage/rerank-2.5",
@@ -36346,7 +38194,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32000
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "voyage/rerank-2.5-lite",
@@ -36354,7 +38203,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 32000
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "voyage/rerank-lite-1",
@@ -36364,7 +38214,8 @@
       "model_types": [
         "rerank"
       ],
-      "max_tokens": 4000
+      "content_length": 4000,
+      "max_output": 4000
     },
     {
       "name": "voyage/voyage-01",
@@ -36721,24 +38572,21 @@
         "Wan2.7-R2V",
         "Wan 2.7 R2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.1-T2V-1.3B",
       "alias": [
         "Wan2.1-T2V-1.3B"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.1-T2V-14B",
       "alias": [
         "Wan2.1-T2V-14B"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.2-I2V-A14B",
@@ -36746,8 +38594,7 @@
         "Wan2.2-I2V-A14B",
         "Wan 2.2 I2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.2-T2V-A14B",
@@ -36755,16 +38602,14 @@
         "Wan2.2-T2V-A14B",
         "Wan 2.2 T2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.6-I2V",
       "alias": [
         "Wan2.6-I2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.6-image",
@@ -36802,8 +38647,7 @@
       "alias": [
         "Wan2.6-T2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.7-I2V",
@@ -36811,8 +38655,7 @@
         "Wan2.7-I2V",
         "Wan 2.7 I2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "Wan-AI/Wan2.7-Image-Edit",
@@ -36830,8 +38673,7 @@
         "wan2.7-t2v",
         "Wan 2.7 T2V"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2-1-14b-i2v-250225",
@@ -36840,28 +38682,23 @@
         "wan2-1-14b-t2v-250225",
         "wan2-1-14b-flf2v-250417"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.2-animate-mix",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.2-animate-move",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.2-kf2v-flash",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.2-t2v-plus",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.5-i2i-preview",
@@ -36872,28 +38709,23 @@
     },
     {
       "name": "wan2.5-i2v-preview",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.6-i2v-flash",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.6-i2v-us",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.6-r2v",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.6-r2v-flash",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wan2.7-image",
@@ -36913,8 +38745,7 @@
     },
     {
       "name": "wan2.7-videoedit",
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "wanx2.0-t2i-turbo",
@@ -36942,7 +38773,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1040000
+      "content_length": 1040000,
+      "max_output": 1040000
     },
     {
       "name": "x-ai/grok-4.20",
@@ -36954,11 +38786,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-4.20-0309-non-reasoning",
@@ -36968,7 +38801,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-4.20-0309-reasoning",
@@ -36989,11 +38823,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-4.20-multi-agent-0309",
@@ -37003,11 +38838,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-4.3",
@@ -37054,11 +38890,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "x-ai/grok-4-0709",
@@ -37068,7 +38905,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 256000
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "x-ai/grok-4-1-fast-non-reasoning",
@@ -37078,7 +38916,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-4-1-fast-reasoning",
@@ -37088,11 +38927,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-4-fast-non-reasoning",
@@ -37102,7 +38942,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-4-fast-reasoning",
@@ -37112,7 +38953,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 2000000
+      "content_length": 2000000,
+      "max_output": 2000000
     },
     {
       "name": "x-ai/grok-3",
@@ -37122,7 +38964,8 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "x-ai/grok-3-mini",
@@ -37132,11 +38975,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 131072,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "x-ai/grok-build-0.1",
@@ -37146,11 +38990,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 256000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "x-ai/grok-code-fast-1",
@@ -37160,11 +39005,12 @@
         "vision",
         "image2text"
       ],
-      "max_tokens": 256000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 256000,
+      "max_output": 256000
     },
     {
       "name": "x-ai/grok-imagine-video",
@@ -37172,8 +39018,7 @@
         "grok-imagine-video",
         "xai/grok-imagine-video"
       ],
-      "model_types": [
-      ]
+      "model_types": []
     },
     {
       "name": "xai/grok-2-1212",
@@ -37184,7 +39029,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "xai/grok-2-vision-1212",
@@ -37197,7 +39043,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "xai/grok-beta",
@@ -37207,7 +39054,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "xiaomi/mimo-v2.5",
@@ -37215,7 +39063,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "xiaomi/mimo-v2.5-asr",
@@ -37224,7 +39073,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "xiaomi/mimo-v2.5-pro",
@@ -37232,7 +39082,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "xiaomi/mimo-v2.5-tts",
@@ -37250,11 +39101,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "xiaomi/mimo-v2-tts",
@@ -37291,12 +39143,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32000
+      "max_completion_tokens": 32000,
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "xiaomimimo/mimo-v2-pro",
@@ -37304,11 +39157,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "XpucT/Deliberate",
@@ -37328,7 +39182,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "xunfei/generalv3",
@@ -37338,7 +39193,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "xunfei/generalv3.5",
@@ -37346,7 +39202,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "xunfei/lite",
@@ -37356,7 +39213,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "xunfei/max-32k",
@@ -37366,7 +39224,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "xunfei/pro-128k",
@@ -37376,7 +39235,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "yi-lightning",
@@ -37389,12 +39249,13 @@
       "alias": [
         "yi-vision-v2"
       ],
-      "max_tokens": 16000,
       "model_types": [
         "chat",
         "image2text",
         "vision"
-      ]
+      ],
+      "content_length": 16000,
+      "max_output": 16000
     },
     {
       "name": "z-ai/glm-5-turbo",
@@ -37402,11 +39263,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 262144,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 262144,
+      "max_output": 262144
     },
     {
       "name": "z-image-turbo",
@@ -37427,7 +39289,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "zai-org/glm-10b-chinese",
@@ -37437,7 +39300,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "zai-org/glm-5.2",
@@ -37468,12 +39332,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-5.1-FP8",
@@ -37483,11 +39348,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-5",
@@ -37500,26 +39366,28 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-5-FP4",
       "alias": [
         "GLM-5-FP4"
       ],
-      "max_tokens": 202752,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-5-FP8",
@@ -37529,11 +39397,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/glm-5v-turbo",
@@ -37544,11 +39413,12 @@
         "image2text",
         "video_understanding"
       ],
-      "max_tokens": 204800,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 204800,
+      "max_output": 204800
     },
     {
       "name": "zai-org/GLM-4.7",
@@ -37561,12 +39431,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-4.7-Flash",
@@ -37577,12 +39448,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 128000
+      "max_completion_tokens": 128000,
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-4.7-fp4",
@@ -37590,10 +39462,11 @@
         "GLM-4.7-fp4",
         "GLM 4.7 FP4"
       ],
-      "max_tokens": 202752,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-4.7-FP8",
@@ -37604,18 +39477,18 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/glm-4.7-h",
       "alias": [
         "glm-4.7-h"
       ],
-      "max_tokens": 204800,
       "max_completion_tokens": 131072,
       "model_types": [
         "chat"
@@ -37623,7 +39496,9 @@
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 204800,
+      "max_output": 204800
     },
     {
       "name": "zai-org/GLM-4.6",
@@ -37637,12 +39512,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 131072
+      "max_completion_tokens": 131072,
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-4.6-FP8",
@@ -37652,11 +39528,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 202752,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 202752,
+      "max_output": 202752
     },
     {
       "name": "zai-org/GLM-4.6V",
@@ -37670,12 +39547,13 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.6V-Flash",
@@ -37688,11 +39566,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.6V-FP8",
@@ -37704,11 +39583,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5",
@@ -37721,12 +39601,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 98304
+      "max_completion_tokens": 98304,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5-Air",
@@ -37740,12 +39621,13 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 98304
+      "max_completion_tokens": 98304,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5-Air-Base",
@@ -37755,11 +39637,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5-Air-FP8",
@@ -37770,11 +39653,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5-Base",
@@ -37784,11 +39668,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5-FP8",
@@ -37798,11 +39683,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5V",
@@ -37817,12 +39703,13 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
       },
-      "max_completion_tokens": 16384
+      "max_completion_tokens": 16384,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.5V-FP8",
@@ -37834,11 +39721,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4.1V-9B-Base",
@@ -37850,7 +39738,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/GLM-4.1V-9B-Thinking",
@@ -37862,11 +39751,12 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 65536,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/GLM-4-32B-0414",
@@ -37877,8 +39767,9 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
-      "max_completion_tokens": 32000
+      "max_completion_tokens": 32000,
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-4-32B-Base-0414",
@@ -37888,7 +39779,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/glm-4-9b",
@@ -37898,7 +39790,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "zai-org/GLM-4-9B-0414",
@@ -37908,7 +39801,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/glm-4-9b-chat",
@@ -37918,7 +39812,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/glm-4-9b-chat-1m",
@@ -37928,7 +39823,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024000
+      "content_length": 1024000,
+      "max_output": 1024000
     },
     {
       "name": "zai-org/glm-4-9b-chat-1m-hf",
@@ -37938,7 +39834,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024000
+      "content_length": 1024000,
+      "max_output": 1024000
     },
     {
       "name": "zai-org/glm-4-9b-chat-hf",
@@ -37948,7 +39845,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/glm-4-9b-hf",
@@ -37958,7 +39856,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "zai-org/glm-4-voice-9b",
@@ -37968,7 +39867,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/glm-4-voice-decoder",
@@ -37996,7 +39896,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-2b",
@@ -38006,7 +39907,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "zai-org/cogagent-9b-20241220",
@@ -38018,7 +39920,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/agentlm-13b",
@@ -38028,7 +39931,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "zai-org/agentlm-70b",
@@ -38038,7 +39942,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "zai-org/agentlm-7b",
@@ -38048,7 +39953,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "zai-org/androidgen-glm-4-9b",
@@ -38058,7 +39964,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/androidgen-llama-3-70b",
@@ -38068,7 +39975,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 16384
+      "content_length": 16384,
+      "max_output": 16384
     },
     {
       "name": "zai-org/apar-13b",
@@ -38078,7 +39986,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/apar-7b",
@@ -38088,7 +39997,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/AutoGLM-Phone-9B",
@@ -38100,7 +40010,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 64000
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "zai-org/AutoGLM-Phone-9B-Multilingual",
@@ -38112,8 +40023,9 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 64000,
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "content_length": 64000,
+      "max_output": 64000
     },
     {
       "name": "zai-org/BPO",
@@ -38123,7 +40035,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 4096
+      "content_length": 4096,
+      "max_output": 4096
     },
     {
       "name": "zai-org/chatglm-6b",
@@ -38133,7 +40046,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/chatglm-6b-int4",
@@ -38143,7 +40057,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/chatglm-6b-int4-qe",
@@ -38153,7 +40068,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/chatglm-6b-int8",
@@ -38163,7 +40079,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/chatglm2-6b",
@@ -38173,7 +40090,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "zai-org/chatglm2-6b-32k",
@@ -38183,7 +40101,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "zai-org/chatglm2-6b-32k-int4",
@@ -38193,7 +40112,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "zai-org/chatglm2-6b-int4",
@@ -38203,7 +40123,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "zai-org/chatglm3-6b",
@@ -38213,7 +40134,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/chatglm3-6b-128k",
@@ -38223,7 +40145,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/chatglm3-6b-32k",
@@ -38233,7 +40156,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "zai-org/chatglm3-6b-base",
@@ -38243,7 +40167,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "zai-org/codegeex2-6b",
@@ -38253,7 +40178,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/codegeex2-6b-int4",
@@ -38263,7 +40189,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/codegeex4-all-9b",
@@ -38273,7 +40200,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/codegeex4-all-9b-GGUF",
@@ -38283,7 +40211,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/CogAgent",
@@ -38302,7 +40231,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogagent-vqa-hf",
@@ -38312,7 +40242,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/CogVideo",
@@ -38424,7 +40355,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogvlm-base-490-hf",
@@ -38434,7 +40366,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogvlm-chat-hf",
@@ -38444,7 +40377,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogvlm-grounding-base-hf",
@@ -38454,7 +40388,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogvlm-grounding-generalist-hf",
@@ -38464,7 +40399,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogvlm2-llama3-caption",
@@ -38476,7 +40412,8 @@
         "video_understanding",
         "vision"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogvlm2-llama3-chat-19B",
@@ -38488,7 +40425,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/cogvlm2-llama3-chat-19B-int4",
@@ -38500,7 +40438,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/cogvlm2-llama3-chat-19B-tgi",
@@ -38512,7 +40451,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/cogvlm2-llama3-chinese-chat-19B",
@@ -38524,7 +40464,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/cogvlm2-llama3-chinese-chat-19B-int4",
@@ -38536,7 +40477,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/cogvlm2-llama3-chinese-chat-19B-tgi",
@@ -38548,7 +40490,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/cogvlm2-video-llama3-base",
@@ -38561,7 +40504,8 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/cogvlm2-video-llama3-chat",
@@ -38574,7 +40518,8 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/embedding-2",
@@ -38584,9 +40529,10 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 1024,
-      "dimensions": []
+      "dimensions": [],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/embedding-3",
@@ -38596,14 +40542,15 @@
       "model_types": [
         "embedding"
       ],
-      "max_tokens": 8192,
       "max_dimension": 2048,
       "dimensions": [
         256,
         512,
         1024,
         2048
-      ]
+      ],
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/GLM-ASR-Nano-2512",
@@ -38614,7 +40561,8 @@
         "asr",
         "speech2text"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/glm-edge-1.5b-chat",
@@ -38624,7 +40572,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-edge-1.5b-chat-gguf",
@@ -38634,7 +40583,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-edge-4b-chat",
@@ -38644,7 +40594,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-edge-4b-chat-gguf",
@@ -38654,7 +40605,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-edge-v-2b",
@@ -38666,7 +40618,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-edge-v-2b-gguf",
@@ -38678,7 +40631,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-edge-v-5b",
@@ -38690,7 +40644,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/glm-edge-v-5b-gguf",
@@ -38702,7 +40657,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 8192
+      "content_length": 8192,
+      "max_output": 8192
     },
     {
       "name": "zai-org/GLM-Image",
@@ -38722,7 +40678,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "zai-org/GLM-OCR",
@@ -38736,8 +40693,9 @@
         "vision",
         "ocr"
       ],
-      "max_tokens": 655380,
-      "max_completion_tokens": 32000
+      "max_completion_tokens": 32000,
+      "content_length": 655380,
+      "max_output": 655380
     },
     {
       "name": "zai-org/glm-roberta-large",
@@ -38747,7 +40705,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 512
+      "content_length": 512,
+      "max_output": 512
     },
     {
       "name": "zai-org/GLM-TTS",
@@ -38766,11 +40725,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-Z1-9B-0414",
@@ -38781,11 +40741,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/GLM-Z1-Rumination-32B-0414",
@@ -38795,11 +40756,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/Glyph",
@@ -38811,7 +40773,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/ImageReward",
@@ -38840,7 +40803,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/LongAlign-13B-64k-base",
@@ -38850,7 +40814,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/LongAlign-6B-64k",
@@ -38860,7 +40825,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/LongAlign-6B-64k-base",
@@ -38870,7 +40836,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/LongAlign-7B-64k",
@@ -38880,7 +40847,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/LongAlign-7B-64k-base",
@@ -38890,7 +40858,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/LongCite-glm4-9b",
@@ -38900,7 +40869,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/LongCite-llama3.1-8b",
@@ -38910,7 +40880,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/LongReward-glm4-9b-DPO",
@@ -38920,7 +40891,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/LongReward-llama3.1-8b-DPO",
@@ -38930,7 +40902,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/LongWriter-glm4-9b",
@@ -38940,7 +40913,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1048576
+      "content_length": 1048576,
+      "max_output": 1048576
     },
     {
       "name": "zai-org/LongWriter-llama3.1-8b",
@@ -38950,7 +40924,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/MathGLM",
@@ -39043,7 +41018,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/SWE-Dev-7B",
@@ -39053,7 +41029,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 163840
+      "content_length": 163840,
+      "max_output": 163840
     },
     {
       "name": "zai-org/SWE-Dev-9B",
@@ -39063,7 +41040,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 128000
+      "content_length": 128000,
+      "max_output": 128000
     },
     {
       "name": "zai-org/UI2Code_N",
@@ -39075,7 +41053,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zai-org/VisionReward-Image",
@@ -39112,7 +41091,8 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/visualglm-6b",
@@ -39124,7 +41104,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 2048
+      "content_length": 2048,
+      "max_output": 2048
     },
     {
       "name": "zai-org/WebGLM",
@@ -39134,7 +41115,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "zai-org/WebGLM-2B",
@@ -39144,7 +41126,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1024
+      "content_length": 1024,
+      "max_output": 1024
     },
     {
       "name": "zai-org/webrl-glm-4-9b",
@@ -39154,7 +41137,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 8000
+      "content_length": 8000,
+      "max_output": 8000
     },
     {
       "name": "zai-org/webrl-llama-3.1-70b",
@@ -39164,7 +41148,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/webrl-llama-3.1-8b",
@@ -39174,7 +41159,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/webrl-orm-llama-3.1-8b",
@@ -39184,7 +41170,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "zai-org/WebVIA-Agent",
@@ -39196,7 +41183,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 65536
+      "content_length": 65536,
+      "max_output": 65536
     },
     {
       "name": "zhipu-embedding-2",
@@ -39227,44 +41215,48 @@
       "alias": [
         "WiseDiag-Z1"
       ],
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "zzkj-genetics",
       "alias": [
         "WiseDiag-Genetics"
       ],
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "zzkj-lite",
       "alias": [
         "WiseDiag-Z1 Lite"
       ],
-      "max_tokens": 32000,
       "model_types": [
         "chat"
-      ]
+      ],
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "zzkj-think",
       "alias": [
         "WiseDiag-Z1 Think"
       ],
-      "max_tokens": 32000,
       "model_types": [
         "chat"
       ],
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 32000,
+      "max_output": 32000
     },
     {
       "name": "qwen/qwen-image-2.0-pro-2026-06-22",
@@ -39298,7 +41290,8 @@
         "image2text",
         "vision"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen3.7-max-2026-05-17",
@@ -39311,11 +41304,12 @@
         "vision",
         "video_understanding"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.5-livetranslate-flash-realtime-2026-05-19",
@@ -39347,7 +41341,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-flash-character-2026-02-26",
@@ -39357,7 +41352,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen3.5-omni-plus-realtime-2026-03-15",
@@ -39447,11 +41443,12 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 1000000,
       "thinking": {
         "default_value": true,
         "clear_thinking": true
-      }
+      },
+      "content_length": 1000000,
+      "max_output": 1000000
     },
     {
       "name": "qwen/qwen-deep-search-planning",
@@ -39461,7 +41458,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen3-s2s-flash-realtime-2025-09-22",
@@ -39480,7 +41478,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen-max-longcontext",
@@ -39490,7 +41489,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     },
     {
       "name": "qwen/qwen-max-0107",
@@ -39500,7 +41500,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 131072
+      "content_length": 131072,
+      "max_output": 131072
     },
     {
       "name": "qwen/qwen-1.8b-longcontext-chat",
@@ -39510,7 +41511,8 @@
       "model_types": [
         "chat"
       ],
-      "max_tokens": 32768
+      "content_length": 32768,
+      "max_output": 32768
     }
   ]
 }

--- a/conf/model.md
+++ b/conf/model.md
@@ -10,7 +10,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 |---|---|---|---|
 | `name` | string | Yes | Canonical model identifier (e.g. `gpt-4o`, `claude-opus-4-8`). Must be unique within a provider file. |
 | `content_length` | integer | No | Maximum **context window** in tokens — the total number of tokens (input + output) the model can process in a single request. Previously named `max_tokens` (until PR #17807). |
-| `max_output` | integer | No | Maximum **output generation** in tokens — the upper bound for tokens the model will generate in a response. Previously encoded in the same `max_tokens` field. |
+| `max_output` | integer | No | Maximum **output generation** in tokens — the upper bound for tokens the model will generate in a response. This may be a fixed vendor limit, or dynamic (equal to `content_length - input_tokens`). See vendor table below. |
 | `model_types` | string[] | Yes | Capabilities of the model. Common values: `chat`, `vision`, `embedding`, `rerank`, `asr`, `tts`, `ocr`, `doc_parse`. |
 | `thinking` | object | No | Extended-thinking configuration. `default_value` (bool) sets whether thinking is on by default; `clear_thinking` (bool) enables the API to disable thinking per-request. |
 | `tools` | object | No | Tool-use capability. `support` (bool) indicates whether the model supports function/tool calling. |
@@ -31,6 +31,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 │                                                     │
 │  ┌─────────────────────────────────────────────┐    │
 │  │        max_output (generated tokens)         │    │
+│  │  May be fixed OR dynamic (context - input)   │    │
 │  └─────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────┘
 ```
@@ -38,6 +39,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 - `content_length` is the **total** budget (input + output).
 - `max_output` is the **generation** budget alone.
 - For most models, `max_output <= content_length`. Some vendors set them equal (output can fill the entire window).
+- **Dynamic max_output**: Some models (e.g. Kimi K2.6) define max_output as `content_length - input_tokens`. In these cases, the configured `max_output` represents the upper bound; the actual available output decreases as the prompt grows.
 
 ### Migration Note
 
@@ -68,13 +70,13 @@ A quick test: if `n & (n-1) == 0`, the value is a power of 2 (binary). Otherwise
 | **Google (Gemini)** | Binary (1M, 2M) | Binary (8K, 64K) | [Google AI Docs](https://ai.google.dev/gemini-api/docs/models/gemini) |
 | **Google (Gemma)** | Binary | Binary | [Gemma Docs](https://ai.google.dev/gemma/docs) |
 | **Meta (Llama)** | Binary | Binary | [Llama Model Cards](https://github.com/meta-llama/llama-models) |
-| **DeepSeek** | Binary (128K, 1M) | Binary (8K, 32K, 64K, 384K) | [DeepSeek API Docs](https://api-docs.deepseek.com/) |
+| **DeepSeek** | Varies by model — binary (128K, 1M) | Varies by model — binary (8K, 32K, 64K, 384K) | [DeepSeek API Docs](https://api-docs.deepseek.com/) |
 | **Alibaba (Qwen)** | Binary (32K, 128K, 256K, 1M) | Binary (8K, 16K, 32K, 64K) | [Alibaba Bailian Docs](https://help.aliyun.com/zh/model-studio/) |
-| **Moonshot (Kimi)** | Binary (256K, 1M) | Binary (128K) | [Kimi API Docs](https://platform.kimi.com/docs/api/models-overview) |
+| **Moonshot (Kimi)** | Binary (256K = 262144, 1M = 1048576) | Dynamic — up to `content_length - input_tokens` (API default 32768) | [Kimi API Docs](https://platform.kimi.com/docs/api/models-overview) |
 | **Mistral** | Binary | Binary (= content_length) | [Mistral Docs](https://docs.mistral.ai/getting-started/models/models_overview/) |
 | **NVIDIA** | Binary | Binary | [NVIDIA NIM Docs](https://build.nvidia.com/nemotron) |
 | **xAI (Grok)** | Decimal (131K, 262K) | Decimal (128K, 131K) | [xAI Docs](https://docs.x.ai/docs/models) |
-| **GLM (Zhipu)** | Decimal (128K, 200K, 204K, 1M) | Decimal (4K, 16K, 96K, 128K) | [Zhipu AI Docs](https://docs.bigmodel.cn/cn/guide/start/model-overview) |
+| **GLM (Zhipu)** | Decimal (128000, 200000, 204800, 1000000) | Decimal (4096, 16384, 96000, 128000) | [Zhipu AI Docs](https://docs.bigmodel.cn/cn/guide/start/model-overview) |
 | **MiniMax** | Decimal (1M, 204K, 196K) | Decimal (131K, 16K) | [MiniMax Docs](https://platform.minimaxi.com/docs/guides/text-generation) |
 | **Cohere** | Decimal (128K, 256K) | Decimal (4K, 8K, 32K, 64K) | [Cohere Docs](https://docs.cohere.com/docs/models) |
 | **Baichuan** | Decimal (32K, 128K, 192K) | Decimal (8K) | [Baichuan Docs](https://platform.baichuan-ai.com/docs) |

--- a/conf/model.md
+++ b/conf/model.md
@@ -78,8 +78,44 @@ A quick test: if `n & (n-1) == 0`, the value is a power of 2 (binary). Otherwise
 | **MiniMax** | Decimal (1M, 204K, 196K) | Decimal (131K, 16K) | [MiniMax Docs](https://platform.minimaxi.com/docs/guides/text-generation) |
 | **Cohere** | Decimal (128K, 256K) | Decimal (4K, 8K, 32K, 64K) | [Cohere Docs](https://docs.cohere.com/docs/models) |
 | **Baichuan** | Decimal (32K, 128K, 192K) | Decimal (8K) | [Baichuan Docs](https://platform.baichuan-ai.com/docs) |
-| **Amazon Nova** | Decimal (128K, 300K) | Decimal (5K) | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) |
+| **Amazon (Bedrock / Nova)** | Decimal (128K, 300K) | Decimal (5K) | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) |
 | **Perplexity** | Decimal (128K, 200K) | Binary (128K) | [Perplexity Docs](https://docs.perplexity.ai/docs/sonar/models) |
+| **Tencent (Hunyuan)** | Decimal (32K, 131K, 262K) | Decimal (8K, 64K) | [Tencent Cloud Docs](https://cloud.tencent.com/document/product/1759) |
+| **Xiaomi (MiMo)** | Binary (1M) | Binary (8K) | [MiMo Docs](https://huggingface.co/XiaomiMiMo) |
+| **HuggingFace** | Varies (hosted models) | Varies | [HuggingFace Model Cards](https://huggingface.co/docs/hub/model-cards) |
+
+### Aggregators & Platforms
+
+The following providers are **aggregators** — they host models from multiple upstream creators. Their `content_length` / `max_output` values inherit from the underlying model, not from a native convention of their own. When updating an aggregator's model entry, refer to the upstream creator's documentation (see table above).
+
+| Aggregator | Notes |
+|---|---|
+| **302ai** | Hosts OpenAI, Anthropic, Google, etc. |
+| **Alibaba Cloud (Bailian)** | Hosts Qwen and third-party models |
+| **Aliyun** | Chinese cloud platform |
+| **AstraFlow** | Multi-provider aggregator |
+| **Avian** | Multi-provider aggregator |
+| **Baidu (Qianwen)** | Ernie + third-party models |
+| **CometAPI** | Multi-provider aggregator |
+| **DeepInfra** | Open-source model hosting |
+| **FuturMix** | Multi-provider aggregator |
+| **GiteeAI** | Chinese aggregator |
+| **GreenPT** | GLM-based models |
+| **Huawei Cloud** | Hosts GLM, Kimi, etc. |
+| **JieKouAI** | Multi-provider aggregator |
+| **LongCat** | Meituan's model platform |
+| **N1N** | Multi-provider aggregator |
+| **Novita** | Open-source model hosting |
+| **OpenRouter** | Multi-provider router |
+| **OrcaRouter** | Auto-routing layer |
+| **PPIO** | Edge AI platform |
+| **Qiniu** | Chinese cloud platform |
+| **Replicate** | Open-source model hosting |
+| **SiliconFlow** | Chinese aggregator |
+| **TogetherAI** | Open-source model hosting |
+| **TokenHub** | Multi-provider aggregator |
+| **TokenPony** | Multi-provider aggregator |
+| **Volcengine (Doubao)** | ByteDance's cloud (hosts Doubao + third-party) |
 
 ### Key Takeaways
 

--- a/conf/model.md
+++ b/conf/model.md
@@ -1,0 +1,106 @@
+# Model Configuration Reference
+
+This document explains the JSON field conventions used in `conf/models/*.json` and `conf/all_models.json`, and the decimal vs. binary conventions used by different model vendors.
+
+## JSON Fields
+
+Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in the global catalog (`conf/all_models.json`) supports the following fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Canonical model identifier (e.g. `gpt-4o`, `claude-opus-4-8`). Must be unique within a provider file. |
+| `content_length` | integer | No | Maximum **context window** in tokens — the total number of tokens (input + output) the model can process in a single request. Previously named `max_tokens` (until PR #17807). |
+| `max_output` | integer | No | Maximum **output generation** in tokens — the upper bound for tokens the model will generate in a response. Previously encoded in the same `max_tokens` field. |
+| `model_types` | string[] | Yes | Capabilities of the model. Common values: `chat`, `vision`, `embedding`, `rerank`, `asr`, `tts`, `ocr`, `doc_parse`. |
+| `thinking` | object | No | Extended-thinking configuration. `default_value` (bool) sets whether thinking is on by default; `clear_thinking` (bool) enables the API to disable thinking per-request. |
+| `tools` | object | No | Tool-use capability. `support` (bool) indicates whether the model supports function/tool calling. |
+| `class` | string | No | Provider-specific model class used to select the correct driver (e.g. `glm`, `kimi`). |
+| `alias` | string[] | No | Alternative names for the same model. Used for model lookup when a tenant refers to the model by an alias. |
+| `rank` | integer | No | Sort priority (lower = higher rank). Used when ordering model lists in the UI. |
+
+### Relationship Between Fields
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  content_length                      │
+│  (total context window: input + output combined)    │
+│                                                     │
+│  ┌─────────────────────────────────────────────┐    │
+│  │           prompt tokens (input)              │    │
+│  └─────────────────────────────────────────────┘    │
+│                                                     │
+│  ┌─────────────────────────────────────────────┐    │
+│  │        max_output (generated tokens)         │    │
+│  └─────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────┘
+```
+
+- `content_length` is the **total** budget (input + output).
+- `max_output` is the **generation** budget alone.
+- For most models, `max_output <= content_length`. Some vendors set them equal (output can fill the entire window).
+
+### Migration Note
+
+Before PR #17807, a single `max_tokens` field served double duty — it was documented as the context window but often used as the output cap at runtime. The split into `content_length` + `max_output` removes this ambiguity:
+
+- **Old `max_tokens`** → `content_length` (context window, the original intent).
+- **New `max_output`** → the actual generation cap, verified against vendor docs.
+
+## Decimal vs. Binary Conventions
+
+Different vendors express context windows using different numerical conventions. **This configuration preserves the exact numbers from each vendor's official documentation**, even when vendors disagree on whether "128K" means 128,000 or 131,072.
+
+### How to Identify
+
+| Convention | Pattern | Example |
+|---|---|---|
+| **Decimal (base-10)** | Round numbers in powers of 10 | 128,000 · 200,000 · 400,000 · 1,000,000 |
+| **Binary (base-2)** | Powers of 2 (exact) | 131,072 = 2^17 · 262,144 = 2^18 · 1,048,576 = 2^20 |
+
+A quick test: if `n & (n-1) == 0`, the value is a power of 2 (binary). Otherwise, it is decimal.
+
+### Vendor Breakdown
+
+| Vendor | `content_length` convention | `max_output` convention | Source |
+|---|---|---|---|
+| **OpenAI** | Binary | Binary | [OpenAI Models](https://developers.openai.com/api/docs/models/) |
+| **Anthropic** | Decimal (200K, 1M) | Binary (8K, 16K, 32K, 64K, 128K) | [Anthropic Docs](https://docs.anthropic.com/en/docs/about-claude/models) |
+| **Google (Gemini)** | Binary (1M, 2M) | Binary (8K, 64K) | [Google AI Docs](https://ai.google.dev/gemini-api/docs/models/gemini) |
+| **Google (Gemma)** | Binary | Binary | [Gemma Docs](https://ai.google.dev/gemma/docs) |
+| **Meta (Llama)** | Binary | Binary | [Llama Model Cards](https://github.com/meta-llama/llama-models) |
+| **DeepSeek** | Binary (128K, 1M) | Binary (8K, 32K, 64K, 384K) | [DeepSeek API Docs](https://api-docs.deepseek.com/) |
+| **Alibaba (Qwen)** | Binary (32K, 128K, 256K, 1M) | Binary (8K, 16K, 32K, 64K) | [Alibaba Bailian Docs](https://help.aliyun.com/zh/model-studio/) |
+| **Moonshot (Kimi)** | Binary (256K, 1M) | Binary (128K) | [Kimi API Docs](https://platform.kimi.com/docs/api/models-overview) |
+| **Mistral** | Binary | Binary (= content_length) | [Mistral Docs](https://docs.mistral.ai/getting-started/models/models_overview/) |
+| **NVIDIA** | Binary | Binary | [NVIDIA NIM Docs](https://build.nvidia.com/nemotron) |
+| **xAI (Grok)** | Decimal (131K, 262K) | Decimal (128K, 131K) | [xAI Docs](https://docs.x.ai/docs/models) |
+| **GLM (Zhipu)** | Decimal (128K, 200K, 204K, 1M) | Decimal (4K, 16K, 96K, 128K) | [Zhipu AI Docs](https://docs.bigmodel.cn/cn/guide/start/model-overview) |
+| **MiniMax** | Decimal (1M, 204K, 196K) | Decimal (131K, 16K) | [MiniMax Docs](https://platform.minimaxi.com/docs/guides/text-generation) |
+| **Cohere** | Decimal (128K, 256K) | Decimal (4K, 8K, 32K, 64K) | [Cohere Docs](https://docs.cohere.com/docs/models) |
+| **Baichuan** | Decimal (32K, 128K, 192K) | Decimal (8K) | [Baichuan Docs](https://platform.baichuan-ai.com/docs) |
+| **Amazon Nova** | Decimal (128K, 300K) | Decimal (5K) | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) |
+| **Perplexity** | Decimal (128K, 200K) | Binary (128K) | [Perplexity Docs](https://docs.perplexity.ai/docs/sonar/models) |
+
+### Key Takeaways
+
+1. **Never round or convert** a value to match a different convention. If Anthropic says 200K, write `200000` — not `2097152` or `262144`.
+2. **OpenAI, Google, Meta, NVIDIA, DeepSeek, Qwen, Kimi, Mistral** all use binary (powers of 2).
+3. **Anthropic, xAI, GLM/Zhipu, MiniMax, Cohere, Baichuan, Amazon** use decimal (powers of 10, or vendor-specific round numbers).
+4. **Some vendors mix conventions** within their own catalog (e.g. Anthropic uses decimal for context but binary for output).
+5. **When in doubt**, check the official API documentation linked above. The number in this config should match the vendor's stated limit exactly.
+
+## How to Add a New Model
+
+1. Determine the model's `content_length` (context window) and `max_output` (generation cap) from the **official API documentation**.
+2. Use the exact number stated — do not convert between decimal and binary.
+3. Add the entry to the appropriate `conf/models/<provider>.json` file.
+4. If the model is also listed in `conf/all_models.json`, update that entry too (or add it).
+5. Run `go test ./internal/entity/models/...` to verify the config loads correctly.
+
+## How to Update an Existing Model
+
+1. Find the latest official spec from the vendor's documentation.
+2. Update `content_length` and/or `max_output` to match.
+3. If the model appears in multiple provider files (e.g. DeepSeek models appear in `deepseek.json`, `ppio.json`, `qiniu.json`), update all copies.
+4. Update `conf/all_models.json` if the model has an entry there.
+5. Run `go test ./internal/entity/models/...` to verify.

--- a/conf/model.md
+++ b/conf/model.md
@@ -30,6 +30,8 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 | `thinking` | object | No | Extended-thinking configuration (see [Thinking Object](#thinking-object)). |
 | `tools` | object | No | Tool-use capability (see [Tools Object](#tools-object)). |
 | `class` | string | No | Provider-specific model class used to select the correct driver (e.g. `glm`, `kimi`). |
+| `max_dimension` | integer | No | Maximum supported embedding dimension. Used by `embedding`-type models (e.g. `1536`). |
+| `dimensions` | integer[] | No | Supported embedding dimensions (e.g. `[256, 512, 1024, 1536]`). Empty array `[]` (or omitted) when the model exposes a single dimension via `max_dimension`. |
 | `alias` | string[] | No | Alternative names for the same model. Used for model lookup when a tenant refers to the model by an alias. **Must be unique across all models.** |
 | `rank` | integer | No | Sort priority (lower = higher rank). Used when ordering model lists in the UI. |
 

--- a/conf/model.md
+++ b/conf/model.md
@@ -2,6 +2,21 @@
 
 This document explains the JSON field conventions used in `conf/models/*.json` and `conf/all_models.json`, and the decimal vs. binary conventions used by different model vendors.
 
+## Table of Contents
+
+- [JSON Fields](#json-fields)
+- [Field Relationship Diagram](#field-relationship-diagram)
+- [Migration Note](#migration-note)
+- [Decimal vs. Binary Conventions](#decimal-vs-binary-conventions)
+- [Vendor Breakdown](#vendor-breakdown)
+- [Aggregators & Platforms](#aggregators--platforms)
+- [How to Add a New Model](#how-to-add-a-new-model)
+- [How to Update an Existing Model](#how-to-update-an-existing-model)
+- [Quick Reference](#quick-reference)
+- [Troubleshooting](#troubleshooting)
+
+---
+
 ## JSON Fields
 
 Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in the global catalog (`conf/all_models.json`) supports the following fields:
@@ -10,15 +25,56 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 |---|---|---|---|
 | `name` | string | Yes | Canonical model identifier (e.g. `gpt-4o`, `claude-opus-4-8`). Must be unique within a provider file. |
 | `content_length` | integer | No | Maximum **context window** in tokens — the total number of tokens (input + output) the model can process in a single request. Previously named `max_tokens` (until PR #17807). |
-| `max_output` | integer | No | Maximum **output generation** in tokens — the upper bound for tokens the model will generate in a response. This may be a fixed vendor limit, or dynamic (equal to `content_length - input_tokens`). See vendor table below. |
+| `max_output` | integer | No | Maximum **output generation** in tokens — the upper bound for tokens the model will generate. May be a fixed vendor limit, or dynamic (`content_length - input_tokens`). See [Vendor Breakdown](#vendor-breakdown). |
 | `model_types` | string[] | Yes | Capabilities of the model. Common values: `chat`, `vision`, `embedding`, `rerank`, `asr`, `tts`, `ocr`, `doc_parse`. |
-| `thinking` | object | No | Extended-thinking configuration. `default_value` (bool) sets whether thinking is on by default; `clear_thinking` (bool) enables the API to disable thinking per-request. |
-| `tools` | object | No | Tool-use capability. `support` (bool) indicates whether the model supports function/tool calling. |
+| `thinking` | object | No | Extended-thinking configuration (see [Thinking Object](#thinking-object)). |
+| `tools` | object | No | Tool-use capability (see [Tools Object](#tools-object)). |
 | `class` | string | No | Provider-specific model class used to select the correct driver (e.g. `glm`, `kimi`). |
-| `alias` | string[] | No | Alternative names for the same model. Used for model lookup when a tenant refers to the model by an alias. |
+| `alias` | string[] | No | Alternative names for the same model. Used for model lookup when a tenant refers to the model by an alias. **Must be unique across all models.** |
 | `rank` | integer | No | Sort priority (lower = higher rank). Used when ordering model lists in the UI. |
 
-### Relationship Between Fields
+### Example Entry
+
+```json
+{
+  "name": "claude-opus-4-8",
+  "content_length": 1000000,
+  "max_output": 128000,
+  "model_types": ["chat", "vision"],
+  "thinking": {
+    "default_value": true,
+    "clear_thinking": true
+  },
+  "tools": {
+    "support": true
+  }
+}
+```
+
+### Thinking Object
+
+```json
+{
+  "thinking": {
+    "default_value": true,    // Whether thinking mode is enabled by default
+    "clear_thinking": true    // Whether the API can disable thinking per-request
+  }
+}
+```
+
+### Tools Object
+
+```json
+{
+  "tools": {
+    "support": true           // Whether the model supports function/tool calling
+  }
+}
+```
+
+---
+
+## Field Relationship Diagram
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -41,12 +97,16 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 - For most models, `max_output <= content_length`. Some vendors set them equal (output can fill the entire window).
 - **Dynamic max_output**: Some models (e.g. Kimi K2.6) define max_output as `content_length - input_tokens`. In these cases, the configured `max_output` represents the upper bound; the actual available output decreases as the prompt grows.
 
-### Migration Note
+---
+
+## Migration Note
 
 Before PR #17807, a single `max_tokens` field served double duty — it was documented as the context window but often used as the output cap at runtime. The split into `content_length` + `max_output` removes this ambiguity:
 
 - **Old `max_tokens`** → `content_length` (context window, the original intent).
 - **New `max_output`** → the actual generation cap, verified against vendor docs.
+
+---
 
 ## Decimal vs. Binary Conventions
 
@@ -61,7 +121,9 @@ Different vendors express context windows using different numerical conventions.
 
 A quick test: if `n & (n-1) == 0`, the value is a power of 2 (binary). Otherwise, it is decimal.
 
-### Vendor Breakdown
+---
+
+## Vendor Breakdown
 
 | Vendor | `content_length` convention | `max_output` convention | Source |
 |---|---|---|---|
@@ -77,7 +139,7 @@ A quick test: if `n & (n-1) == 0`, the value is a power of 2 (binary). Otherwise
 | **NVIDIA** | Binary | Binary | [NVIDIA NIM Docs](https://build.nvidia.com/nemotron) |
 | **xAI (Grok)** | Decimal (131K, 262K) | Decimal (128K, 131K) | [xAI Docs](https://docs.x.ai/docs/models) |
 | **GLM (Zhipu)** | Decimal (128000, 200000, 204800, 1000000) | Decimal (4096, 16384, 96000, 128000) | [Zhipu AI Docs](https://docs.bigmodel.cn/cn/guide/start/model-overview) |
-| **MiniMax** | Decimal (1M, 204K, 196K) | Decimal (131K, 16K) | [MiniMax Docs](https://platform.minimaxi.com/docs/guides/text-generation) |
+| **MiniMax** | Decimal (204800 = 200K) | Decimal (128000 = 128K) | [MiniMax Docs](https://platform.minimaxi.com/docs/guides/text-generation) |
 | **Cohere** | Decimal (128K, 256K) | Decimal (4K, 8K, 32K, 64K) | [Cohere Docs](https://docs.cohere.com/docs/models) |
 | **Baichuan** | Decimal (32K, 128K, 192K) | Decimal (8K) | [Baichuan Docs](https://platform.baichuan-ai.com/docs) |
 | **Amazon (Bedrock / Nova)** | Decimal (128K, 300K) | Decimal (5K) | [AWS Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) |
@@ -86,7 +148,17 @@ A quick test: if `n & (n-1) == 0`, the value is a power of 2 (binary). Otherwise
 | **Xiaomi (MiMo)** | Binary (1M) | Binary (8K) | [MiMo Docs](https://huggingface.co/XiaomiMiMo) |
 | **HuggingFace** | Varies (hosted models) | Varies | [HuggingFace Model Cards](https://huggingface.co/docs/hub/model-cards) |
 
-### Aggregators & Platforms
+### Key Takeaways
+
+1. **Never round or convert** a value to match a different convention. If Anthropic says 200K, write `200000` — not `2097152` or `262144`.
+2. **OpenAI, Google, Meta, NVIDIA, DeepSeek, Qwen, Kimi, Mistral** all use binary (powers of 2).
+3. **Anthropic, xAI, GLM/Zhipu, MiniMax, Cohere, Baichuan, Amazon** use decimal (powers of 10, or vendor-specific round numbers).
+4. **Some vendors mix conventions** within their own catalog (e.g. Anthropic uses decimal for context but binary for output).
+5. **When in doubt**, check the official API documentation linked above. The number in this config should match the vendor's stated limit exactly.
+
+---
+
+## Aggregators & Platforms
 
 The following providers are **aggregators** — they host models from multiple upstream creators. Their `content_length` / `max_output` values inherit from the underlying model, not from a native convention of their own. When updating an aggregator's model entry, refer to the upstream creator's documentation (see table above).
 
@@ -119,13 +191,7 @@ The following providers are **aggregators** — they host models from multiple u
 | **TokenPony** | Multi-provider aggregator |
 | **Volcengine (Doubao)** | ByteDance's cloud (hosts Doubao + third-party) |
 
-### Key Takeaways
-
-1. **Never round or convert** a value to match a different convention. If Anthropic says 200K, write `200000` — not `2097152` or `262144`.
-2. **OpenAI, Google, Meta, NVIDIA, DeepSeek, Qwen, Kimi, Mistral** all use binary (powers of 2).
-3. **Anthropic, xAI, GLM/Zhipu, MiniMax, Cohere, Baichuan, Amazon** use decimal (powers of 10, or vendor-specific round numbers).
-4. **Some vendors mix conventions** within their own catalog (e.g. Anthropic uses decimal for context but binary for output).
-5. **When in doubt**, check the official API documentation linked above. The number in this config should match the vendor's stated limit exactly.
+---
 
 ## How to Add a New Model
 
@@ -135,6 +201,8 @@ The following providers are **aggregators** — they host models from multiple u
 4. If the model is also listed in `conf/all_models.json`, update that entry too (or add it).
 5. Run `go test ./internal/entity/models/...` to verify the config loads correctly.
 
+---
+
 ## How to Update an Existing Model
 
 1. Find the latest official spec from the vendor's documentation.
@@ -142,3 +210,69 @@ The following providers are **aggregators** — they host models from multiple u
 3. If the model appears in multiple provider files (e.g. DeepSeek models appear in `deepseek.json`, `ppio.json`, `qiniu.json`), update all copies.
 4. Update `conf/all_models.json` if the model has an entry there.
 5. Run `go test ./internal/entity/models/...` to verify.
+
+---
+
+## Quick Reference
+
+### Common model_types Values
+
+| Type | Description |
+|---|---|
+| `chat` | Text generation / conversation |
+| `vision` | Image understanding (multimodal) |
+| `embedding` | Text embedding vectors |
+| `rerank` | Document re-ranking |
+| `asr` | Automatic speech recognition (speech-to-text) |
+| `tts` | Text-to-speech |
+| `ocr` | Optical character recognition |
+| `doc_parse` | Document parsing (PDF, DOCX, etc.) |
+
+### Token Count Rule of Thumb
+
+| Language | Tokens per character |
+|---|---|
+| English | ~0.3 tokens/char (1 token ≈ 4 chars) |
+| Chinese | ~0.6 tokens/char (1 token ≈ 1.5 chars) |
+| Code | ~0.4 tokens/char |
+
+Example: A 10,000-character English document ≈ 3,000 tokens.
+
+### Validation Command
+
+```bash
+go test ./internal/entity/models/...
+```
+
+This loads all provider configs and `conf/all_models.json`, checking for:
+- Valid JSON syntax
+- Unique aliases across all models
+- Correct field types
+
+---
+
+## Troubleshooting
+
+### Duplicate Alias Error
+
+```
+InitProviderManager: duplicate alias "X" for models "A" and "B"
+```
+
+**Cause**: Two models share the same alias. Aliases must be globally unique.
+
+**Fix**: In `conf/all_models.json`, find the conflicting entries and remove or rename the duplicate alias. Also check `conf/models/*.json` files for the same alias.
+
+### Model Not Found
+
+**Cause**: Model name or alias mismatch between tenant configuration and provider catalog.
+
+**Fix**: Check both `conf/all_models.json` (aliases) and the specific `conf/models/<provider>.json` for the model name.
+
+### Context Length Mismatch
+
+**Symptom**: API returns errors about exceeding context limits.
+
+**Cause**: `content_length` in config does not match the vendor's actual limit.
+
+**Fix**: Verify against official vendor documentation and update accordingly.

--- a/conf/model.md
+++ b/conf/model.md
@@ -31,7 +31,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 | `tools` | object | No | Tool-use capability (see [Tools Object](#tools-object)). |
 | `class` | string | No | Provider-specific model class used to select the correct driver (e.g. `glm`, `kimi`). |
 | `max_dimension` | integer | No | Maximum supported embedding dimension. Used by `embedding`-type models (e.g. `1536`). |
-| `dimensions` | integer[] | No | Supported embedding dimensions (e.g. `[256, 512, 1024, 1536]`). Empty array `[]` (or omitted) when the model exposes a single dimension via `max_dimension`. |
+| `dimensions` | integer[] | No | Supported embedding dimensions (e.g. `[256, 512, 1024, 1536]`). When non-empty, a requested dimension must match one of these values. When empty `[]` (or omitted), any dimension up to `max_dimension` is accepted. |
 | `alias` | string[] | No | Alternative names for the same model. Used for model lookup when a tenant refers to the model by an alias. **Must be unique across all models.** |
 | `rank` | integer | No | Sort priority (lower = higher rank). Used when ordering model lists in the UI. |
 

--- a/conf/model.md
+++ b/conf/model.md
@@ -25,7 +25,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 |---|---|---|---|
 | `name` | string | Yes | Canonical model identifier (e.g. `gpt-4o`, `claude-opus-4-8`). Must be unique within a provider file. |
 | `content_length` | integer | No | Maximum **context window** in tokens — the total number of tokens (input + output) the model can process in a single request. Previously named `max_tokens` (until PR #17807). |
-| `max_output` | integer | No | Maximum **output generation** in tokens — the upper bound for tokens the model will generate. May be a fixed vendor limit, or dynamic (`content_length - input_tokens`). See [Vendor Breakdown](#vendor-breakdown). |
+| `max_output` | integer | No | Maximum **output generation** in tokens — the upper bound for tokens the model will generate. It may be a fixed vendor limit, or dynamic (computed as `content_length - input_tokens`). See [Vendor Breakdown](#vendor-breakdown). |
 | `model_types` | string[] | Yes | Capabilities of the model. Common values: `chat`, `vision`, `embedding`, `rerank`, `asr`, `tts`, `ocr`, `doc_parse`. |
 | `thinking` | object | No | Extended-thinking configuration (see [Thinking Object](#thinking-object)). |
 | `tools` | object | No | Tool-use capability (see [Tools Object](#tools-object)). |
@@ -53,7 +53,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 
 ### Thinking Object
 
-```json
+```jsonc
 {
   "thinking": {
     "default_value": true,    // Whether thinking mode is enabled by default
@@ -64,7 +64,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 
 ### Tools Object
 
-```json
+```jsonc
 {
   "tools": {
     "support": true           // Whether the model supports function/tool calling
@@ -76,7 +76,7 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 
 ## Field Relationship Diagram
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │                  content_length                      │
 │  (total context window: input + output combined)    │
@@ -103,8 +103,11 @@ Each model entry in a provider JSON file (`conf/models/<provider>.json`) or in t
 
 Before PR #17807, a single `max_tokens` field served double duty — it was documented as the context window but often used as the output cap at runtime. The split into `content_length` + `max_output` removes this ambiguity:
 
-- **Old `max_tokens`** → `content_length` (context window, the original intent).
-- **New `max_output`** → the actual generation cap, verified against vendor docs.
+- **Old `max_tokens`** → used only as migration context; do not copy it blindly.
+- **New `content_length`** → set the vendor-documented context window.
+- **New `max_output`** → set the vendor-documented generation cap.
+
+Every migrated model **must define both `content_length` and `max_output`**, each taken from the official vendor model specification.
 
 ---
 

--- a/internal/entity/models/gitee_test.go
+++ b/internal/entity/models/gitee_test.go
@@ -210,9 +210,9 @@ func TestGiteeListModelsKeepsModelNameAfterAliasMetadataLookup(t *testing.T) {
 	if model.Name != "deepseek/deepseek-v4-pro" {
 		t.Fatalf("Name=%q, want deepseek/deepseek-v4-pro", model.Name)
 	}
-	//if model.MaxOutput == nil || *model.MaxOutput != 1048576 {
-	//	t.Fatalf("MaxOutput=%v, want 1048576", *model.MaxOutput)
-	//}
+	if model.MaxOutput == nil || *model.MaxOutput != 393216 {
+		t.Fatalf("MaxOutput=%v, want 393216", model.MaxOutput)
+	}
 	if len(model.ModelTypes) != 1 || model.ModelTypes[0] != "chat" {
 		t.Fatalf("ModelTypes=%v, want [chat]", model.ModelTypes)
 	}


### PR DESCRIPTION
## Summary

Update `conf/all_models.json`: replace legacy `max_tokens` with `content_length` + `max_output` for all 2,178 chat/vision models, with values verified against official vendor documentation.

## Changes

### Config
- **Field migration**: `max_tokens` → `content_length` + `max_output` (2,178 entries)
- **Data alignment**: Sync with PR #17836 provider configs (352 models match exactly)
- **Official values**: Correct MiniMax M2 series (mo=128000) and GLM-5.1 (cl=200000, mo=128000) per vendor docs
- **DeepSeek V4**: Fix max_output from 1048576 → 393216 (official spec: 384K)
- **New entries**: Add 129 models from provider configs that were missing

### Documentation
- **New file**: `conf/model.md` — comprehensive configuration reference
  - JSON field documentation with examples
  - Decimal vs. binary conventions per vendor (with sources)
  - Aggregator platforms list (inherit from upstream)
  - Quick reference (model_types, token rules, validation)
  - Troubleshooting guide

### Tests
- Restore `gitee_test.go` assertion for deepseek-v4-pro max_output (393216)

## Vendor Convention Reference

| Convention | Vendors |
|---|---|
| **Binary (powers of 2)** | OpenAI, Google, Meta, NVIDIA, DeepSeek, Qwen, Kimi, Mistral |
| **Decimal (powers of 10)** | Anthropic, xAI, GLM/Zhipu, MiniMax, Cohere, Baichuan, Amazon |

See `conf/model.md` for full details and source links.

