### PR TITLE
fix(files): use long task pool for recursive deletion

### DIFF
--- a/api/apps/services/file_api_service.py
+++ b/api/apps/services/file_api_service.py
@@ -26,7 +26,7 @@ from api.db.services.file_service import FileService
 from api.utils.file_utils import filename_type
 from common import settings
 from common.constants import FileSource
-from common.misc_utils import get_uuid, thread_pool_exec
+from common.misc_utils import get_uuid, thread_pool_exec, thread_pool_exec_long_time
 
 
 async def upload_file(tenant_id: str, pf_id: str, file_objs: list):
@@ -450,7 +450,7 @@ async def delete_files(uid: str, file_ids: list, auth_header: str = ""):
             return False, {"success_count": success_count, "errors": errors}
         return True, {"success_count": success_count}
 
-    return await thread_pool_exec(_rm_sync)
+    return await thread_pool_exec_long_time(_rm_sync)
 
 
 async def move_files(uid: str, src_file_ids: list, dest_file_id: str = None, new_name: str = None):

--- a/test/testcases/test_http_api/test_file_app/test_file_routes.py
+++ b/test/testcases/test_http_api/test_file_app/test_file_routes.py
@@ -178,6 +178,7 @@ def _load_file_api_service(monkeypatch):
         return func(*args, **kwargs)
 
     misc_utils_mod.thread_pool_exec = thread_pool_exec
+    misc_utils_mod.thread_pool_exec_long_time = thread_pool_exec
     monkeypatch.setitem(sys.modules, "common.misc_utils", misc_utils_mod)
 
     module_path = repo_root / "api" / "apps" / "services" / "file_api_service.py"
@@ -263,6 +264,28 @@ def test_delete_files_checks_team_permission(monkeypatch):
     ok, message = _run(module.delete_files("tenant1", ["file1"]))
     assert ok is False
     assert message == {"success_count": 0, "errors": ["No authorization for file file1"]}
+
+
+@pytest.mark.p2
+def test_delete_files_uses_long_time_thread_pool(monkeypatch):
+    module = _load_file_api_service(monkeypatch)
+    calls = []
+
+    async def run_long_time(func, *args, **kwargs):
+        calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    async def fail_short_pool(*_args, **_kwargs):
+        raise AssertionError("recursive deletion must not use the short-lived executor")
+
+    monkeypatch.setattr(module, "thread_pool_exec", fail_short_pool)
+    monkeypatch.setattr(module, "thread_pool_exec_long_time", run_long_time)
+
+    ok, data = _run(module.delete_files("tenant1", ["file1"]))
+
+    assert ok is True
+    assert data == {"success_count": 1}
+    assert calls == ["_rm_sync"]
 
 
 @pytest.mark.p2


### PR DESCRIPTION
### Review scope

- Production diff: `file_api_service.py` (`+2/-2`).
- Regression evidence: `test_file_routes.py` (`+23/-0`).
- The executor selection change and cancellation test are intentionally atomic because the bug is observable only through cancellation timing.

### Summary

Run recursive file and folder deletion through `thread_pool_exec_long_time` instead of the short-lived executor.

`delete_files()` can recursively remove storage objects, document records, skill indexes, and buckets. The short-lived helper owns a temporary executor whose context manager calls `shutdown(wait=True)` when request cancellation unwinds the coroutine. A disconnected or timed-out request can therefore remain blocked until the entire recursive cleanup finishes.

The long-task helper uses the repository's shared bounded executor, allowing the Quart request task to be released while the synchronous cleanup continues. Deletion behavior, ordering, and error reporting are unchanged.

### Verification

- Added a regression test that rejects the short-lived executor and verifies recursive deletion is submitted through `thread_pool_exec_long_time`.
- Before the fix: the new test fails with `recursive deletion must not use the short-lived executor`.
- After the fix: `10 passed`.
- Ruff check on the modified test: passed.
- Ruff format check on both modified files: passed.
- `git diff --check`: passed.

### Scope

This change only selects the executor used by the existing `_rm_sync` cleanup. It does not change deletion semantics or attempt to cancel a cleanup that is already running in a worker thread.