### PR TITLE
test(task): expect 1 chunk after #17739 global merge

### DIFF
--- a/internal/ingestion/task/pipeline_real_integration_test.go
+++ b/internal/ingestion/task/pipeline_real_integration_test.go
@@ -123,8 +123,8 @@ func TestPipelineExecutor_Run_RealCanvasDSL_UsesGeneralPipeline(t *testing.T) {
 	if len(inserted) != 1 {
 		t.Fatalf("insert calls = %d, want 1", len(inserted))
 	}
-	if len(inserted[0]) != 2 {
-		t.Fatalf("inserted chunk count = %d, want 2", len(inserted[0]))
+	if len(inserted[0]) != 1 {
+		t.Fatalf("inserted chunk count = %d, want 1", len(inserted[0]))
 	}
 	for i, ck := range inserted[0] {
 		if got := ck["doc_id"]; got != docID {
@@ -354,8 +354,8 @@ func TestRunPipeline_RealPipelineOutput_ProducesIndexFields(t *testing.T) {
 		t.Fatalf("insert calls = %d, want 1", len(inserted))
 	}
 	chunks := inserted[0]
-	if len(chunks) != 2 {
-		t.Fatalf("inserted chunk count = %d, want 2", len(chunks))
+	if len(chunks) != 1 {
+		t.Fatalf("inserted chunk count = %d, want 1", len(chunks))
 	}
 	for i, ck := range chunks {
 		if got := ck["doc_id"]; got != docID {


### PR DESCRIPTION
Two real-pipeline integration tests asserted exactly 2 chunks. After #17739 (JSON path merges globally, keeping over-budget items whole), the Go TokenChunker collapses adjacent text across items into one global token budget, so these pipelines now emit 1 chunk. The `want 2` expectation was stale.

- TestPipelineExecutor_Run_RealCanvasDSL_UsesGeneralPipeline
- TestRunPipeline_RealPipelineOutput_ProducesIndexFields

Unchanged per-chunk checks (content_with_weight non-empty, doc_id match, ltks) still guard correctness.

Related: #17739 (root cause), #17835 (chunker OVER_CAP alignment).
