### PR TITLE
fix(knowledge-base): display embedding model friendly name in datasetlabel

### DIFF
--- a/web/src/components/knowledge-base-item.tsx
+++ b/web/src/components/knowledge-base-item.tsx
@@ -97,7 +97,13 @@ export function useDisableDifferenceEmbeddingDataset(name: string) {
         suffix: (
           <section className="flex gap-2">
             <DatasetLabel text={item.nickname} />
-            <DatasetLabel text={item.embedding_model} />
+            <DatasetLabel
+              text={
+                item.embedding_model_name
+                  ? item.embedding_model_name
+                  : item.embedding_model
+              }
+            />
           </section>
         ),
         value: item.id,

--- a/web/src/interfaces/database/dataset.ts
+++ b/web/src/interfaces/database/dataset.ts
@@ -22,6 +22,7 @@ export interface IDataset {
   description?: string;
   document_count: number;
   embedding_model: string;
+  embedding_model_name?: string;
   size?: number;
   graphrag_task_finish_at: string;
   graphrag_task_id: Nullable<string>;


### PR DESCRIPTION
### Summary

fix(knowledge-base): display embedding model friendly name in datasetlabel

  Show `embedding_model_name` instead of the internal `embedding_model`
  identifier in the dataset selector label when available, falling back to
  `embedding_model` for backward compatibility. This surfaces a
  human-readable model name (e.g. "BGE-large-zh") rather than the raw
  model ID to users picking a dataset.
