### PR TITLE
fix(mcp): preserve nonempty custom header values

### DIFF
--- a/common/mcp_tool_call_conn.py
+++ b/common/mcp_tool_call_conn.py
@@ -73,8 +73,13 @@ class MCPToolCallSession(ToolCallSession):
         for h, v in raw_headers.items():
             nh = Template(h).safe_substitute(self._server_variables)
             nv = Template(v).safe_substitute(self._server_variables)
-            if nh.strip() and nv.strip().strip("Bearer"):
+            stripped_name = nh.strip()
+            stripped_value = nv.strip()
+            empty_authorization = stripped_name.lower() == "authorization" and stripped_value.lower() == "bearer"
+            if stripped_name and stripped_value and not empty_authorization:
                 headers[nh] = nv
+            else:
+                logging.debug("Rejected MCP header during validation")
 
         for h, v in custom_header.items():
             nh = Template(h).safe_substitute(custom_header)

--- a/test/unit_test/common/test_mcp_tool_call_conn_headers.py
+++ b/test/unit_test/common/test_mcp_tool_call_conn_headers.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+import pytest
+
+from common.constants import MCPServerType
+from common.mcp_tool_call_conn import MCPToolCallSession
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _ClientSession:
+    def __init__(self, *_streams):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def initialize(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_mcp_session_preserves_nonempty_header_values(monkeypatch):
+    captured = {}
+
+    def fake_sse_client(url, headers):
+        captured["url"] = url
+        captured["headers"] = headers
+        return _AsyncContext(("read", "write"))
+
+    session = MCPToolCallSession.__new__(MCPToolCallSession)
+    session._mcp_server = SimpleNamespace(
+        id="server-1",
+        url="https://mcp.example/sse",
+        headers={
+            "X-Api-Key": "Bear",
+            "X-Environment": "Bearer",
+            "Authorization": "Bearer ",
+        },
+        server_type=MCPServerType.SSE,
+    )
+    session._server_variables = {}
+    session._custom_header = None
+
+    async def process_tasks(_client_session, _error_message=None):
+        return None
+
+    session._process_mcp_tasks = process_tasks
+
+    monkeypatch.setattr("common.mcp_tool_call_conn.sse_client", fake_sse_client)
+    monkeypatch.setattr("common.mcp_tool_call_conn.ClientSession", _ClientSession)
+
+    await session._mcp_server_loop()
+
+    assert captured["headers"] == {
+        "X-Api-Key": "Bear",
+        "X-Environment": "Bearer",
+    }


### PR DESCRIPTION
### Summary

Preserve non-empty MCP header values instead of treating `"Bearer"` as a set of characters to strip.

Python's `str.strip(chars)` removes any combination of those characters from both ends, so values such as `X-Api-Key: Bear` were silently omitted. The new condition filters blank values and only the empty authorization placeholder `Authorization: Bearer`; non-authorization values remain unchanged, including the literal `Bearer`.

### Verification

- On current `main`, the focused SSE regression test failed because the captured headers were `{}` instead of containing `X-Api-Key: Bear`.
- After the fix: `1 passed`.
- Ruff `B005` check on the source: passed.
- Full Ruff check on the test: passed.
- Ruff format and `git diff --check`: passed.

### Scope

- Production: `common/mcp_tool_call_conn.py` (`+6/-1`).
- Regression test: `test/unit_test/common/test_mcp_tool_call_conn_headers.py` (`+70`).
- Header substitution and transport behavior are unchanged.