### PR TITLE
fix(llm): isolate bundle generation config

### DIFF
--- a/api/db/services/llm_service.py
+++ b/api/db/services/llm_service.py
@@ -430,7 +430,8 @@ class LLMBundle(LLM4Tenant):
         threading.Thread(target=worker, daemon=True).start()
         return queue
 
-    async def async_chat(self, system: str, history: list, gen_conf: dict = {}, **kwargs):
+    async def async_chat(self, system: str, history: list, gen_conf: dict | None = None, **kwargs):
+        gen_conf = dict(gen_conf or {})
         if self.is_tools and hasattr(self.mdl, "async_chat_with_tools"):
             base_fn = self.mdl.async_chat_with_tools
         elif hasattr(self.mdl, "async_chat"):
@@ -471,7 +472,8 @@ class LLMBundle(LLM4Tenant):
 
         return txt
 
-    async def async_chat_streamly(self, system: str, history: list, gen_conf: dict = {}, **kwargs):
+    async def async_chat_streamly(self, system: str, history: list, gen_conf: dict | None = None, **kwargs):
+        gen_conf = dict(gen_conf or {})
         total_tokens = 0
         ans = ""
         _bundle_is_tools = self.is_tools
@@ -521,7 +523,8 @@ class LLMBundle(LLM4Tenant):
                 generation.end()
             return
 
-    async def async_chat_streamly_delta(self, system: str, history: list, gen_conf: dict = {}, **kwargs):
+    async def async_chat_streamly_delta(self, system: str, history: list, gen_conf: dict | None = None, **kwargs):
+        gen_conf = dict(gen_conf or {})
         total_tokens = 0
         ans = ""
         if self.is_tools and getattr(self.mdl, "is_tools", False) and hasattr(self.mdl, "async_chat_streamly_with_tools"):

--- a/test/unit_test/api/db/services/test_llm_bundle_gen_conf.py
+++ b/test/unit_test/api/db/services/test_llm_bundle_gen_conf.py
@@ -7,30 +7,59 @@ from api.db.services import llm_service
 
 class _MutatingChatModel:
     def __init__(self):
-        self.received = []
+        self.chat_received = []
+        self.stream_received = []
 
     async def async_chat(self, _system, _history, gen_conf):
-        self.received.append(dict(gen_conf))
+        self.chat_received.append(dict(gen_conf))
         gen_conf["provider_mutation"] = True
         return "ok", 0
 
+    async def async_chat_streamly(self, _system, _history, gen_conf):
+        self.stream_received.append(dict(gen_conf))
+        gen_conf["provider_mutation"] = True
+        yield "ok"
 
-@pytest.mark.asyncio
-async def test_async_chat_default_gen_conf_is_isolated_between_calls(monkeypatch):
-    model = _MutatingChatModel()
+
+def _bundle(model):
     bundle = llm_service.LLMBundle.__new__(llm_service.LLMBundle)
     bundle.mdl = model
     bundle.is_tools = False
     bundle.langfuse = None
     bundle.verbose_tool_use = False
     bundle.model_config = {"llm_name": "fake"}
+    return bundle
+
+
+@pytest.mark.asyncio
+async def test_async_chat_default_gen_conf_is_isolated_between_calls(monkeypatch):
+    model = _MutatingChatModel()
+    bundle = _bundle(model)
 
     monkeypatch.setattr(llm_service, "record_run_token_usage", lambda *_args: None)
 
     await bundle.async_chat("", [])
     await bundle.async_chat("", [])
 
-    assert model.received == [{}, {}]
+    assert model.chat_received == [{}, {}]
+
+
+@pytest.mark.parametrize("method_name", ["async_chat_streamly", "async_chat_streamly_delta"])
+@pytest.mark.asyncio
+async def test_streaming_gen_conf_is_isolated_and_does_not_mutate_caller(method_name, monkeypatch):
+    model = _MutatingChatModel()
+    bundle = _bundle(model)
+    caller_conf = {"temperature": 0.3}
+
+    monkeypatch.setattr(llm_service, "record_run_token_usage", lambda *_args: None)
+
+    async for _ in getattr(bundle, method_name)("", []):
+        pass
+    async for _ in getattr(bundle, method_name)("", [], caller_conf):
+        pass
+
+    assert model.stream_received == [{}, {"temperature": 0.3}]
+    assert caller_conf == {"temperature": 0.3}
 
 
 @pytest.mark.parametrize(

--- a/test/unit_test/api/db/services/test_llm_bundle_gen_conf.py
+++ b/test/unit_test/api/db/services/test_llm_bundle_gen_conf.py
@@ -1,8 +1,11 @@
 import inspect
+import logging
 
 import pytest
 
 from api.db.services import llm_service
+
+LOGGER = logging.getLogger(__name__)
 
 
 class _MutatingChatModel:
@@ -12,11 +15,13 @@ class _MutatingChatModel:
 
     async def async_chat(self, _system, _history, gen_conf):
         self.chat_received.append(dict(gen_conf))
+        LOGGER.debug("Mutating provider generation config in async_chat")
         gen_conf["provider_mutation"] = True
         return "ok", 0
 
     async def async_chat_streamly(self, _system, _history, gen_conf):
         self.stream_received.append(dict(gen_conf))
+        LOGGER.debug("Mutating provider generation config in async_chat_streamly")
         gen_conf["provider_mutation"] = True
         yield "ok"
 
@@ -35,13 +40,16 @@ def _bundle(model):
 async def test_async_chat_default_gen_conf_is_isolated_between_calls(monkeypatch):
     model = _MutatingChatModel()
     bundle = _bundle(model)
+    caller_conf = {"temperature": 0.3}
 
     monkeypatch.setattr(llm_service, "record_run_token_usage", lambda *_args: None)
 
     await bundle.async_chat("", [])
     await bundle.async_chat("", [])
+    await bundle.async_chat("", [], caller_conf)
 
-    assert model.chat_received == [{}, {}]
+    assert model.chat_received == [{}, {}, {"temperature": 0.3}]
+    assert caller_conf == {"temperature": 0.3}
 
 
 @pytest.mark.parametrize("method_name", ["async_chat_streamly", "async_chat_streamly_delta"])
@@ -55,10 +63,12 @@ async def test_streaming_gen_conf_is_isolated_and_does_not_mutate_caller(method_
 
     async for _ in getattr(bundle, method_name)("", []):
         pass
+    async for _ in getattr(bundle, method_name)("", []):
+        pass
     async for _ in getattr(bundle, method_name)("", [], caller_conf):
         pass
 
-    assert model.stream_received == [{}, {"temperature": 0.3}]
+    assert model.stream_received == [{}, {}, {"temperature": 0.3}]
     assert caller_conf == {"temperature": 0.3}
 
 

--- a/test/unit_test/api/db/services/test_llm_bundle_gen_conf.py
+++ b/test/unit_test/api/db/services/test_llm_bundle_gen_conf.py
@@ -1,0 +1,43 @@
+import inspect
+
+import pytest
+
+from api.db.services import llm_service
+
+
+class _MutatingChatModel:
+    def __init__(self):
+        self.received = []
+
+    async def async_chat(self, _system, _history, gen_conf):
+        self.received.append(dict(gen_conf))
+        gen_conf["provider_mutation"] = True
+        return "ok", 0
+
+
+@pytest.mark.asyncio
+async def test_async_chat_default_gen_conf_is_isolated_between_calls(monkeypatch):
+    model = _MutatingChatModel()
+    bundle = llm_service.LLMBundle.__new__(llm_service.LLMBundle)
+    bundle.mdl = model
+    bundle.is_tools = False
+    bundle.langfuse = None
+    bundle.verbose_tool_use = False
+    bundle.model_config = {"llm_name": "fake"}
+
+    monkeypatch.setattr(llm_service, "record_run_token_usage", lambda *_args: None)
+
+    await bundle.async_chat("", [])
+    await bundle.async_chat("", [])
+
+    assert model.received == [{}, {}]
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["async_chat", "async_chat_streamly", "async_chat_streamly_delta"],
+)
+def test_llm_bundle_gen_conf_defaults_to_none(method_name):
+    parameter = inspect.signature(getattr(llm_service.LLMBundle, method_name)).parameters["gen_conf"]
+
+    assert parameter.default is None


### PR DESCRIPTION
### Review scope

- Production diff: `llm_service.py` (`+6/-3`).
- Regression evidence: `test_llm_bundle_gen_conf.py` (`+82/-0`, 3 focused isolation contracts).
- The API-default change and tests are intentionally atomic; the tests prove both cross-call isolation and caller-dictionary immutability.

### Summary

Isolate generation configuration dictionaries at the `LLMBundle` async chat boundary.

The three async chat entry points used `gen_conf={}` as a default. Python creates that dictionary once, so a provider that mutates the configuration can leak state into later requests that omit `gen_conf`. Caller-provided dictionaries were also passed through directly and could be modified by the provider.

The methods now default to `None` and create a shallow dictionary copy for every call:

- `async_chat`
- `async_chat_streamly`
- `async_chat_streamly_delta`

### Verification

- Added a behavioral regression test with a provider that mutates `gen_conf`.
- Before the fix, the second call received `provider_mutation=True`.
- Added signature checks for all three entry points.
- Before the fix: `4 failed`.
- After the fix: the new tests and existing provider-layer mutable-default guard pass (`7 passed`).
- Ruff `B006`/undefined-name checks, test Ruff, format, and `git diff --check`: passed.

### Scope

Generation settings and provider dispatch behavior are unchanged. The only behavioral difference is that provider-side mutations no longer escape the current call.