### PR TITLE
fix: use updated RAPTOR options for skill generation

### DIFF
--- a/rag/svr/task_executor_refactor/dataset_skill_generator.py
+++ b/rag/svr/task_executor_refactor/dataset_skill_generator.py
@@ -366,9 +366,10 @@ async def run_corpus2skill(
         llm_model=chat_mdl,
         embd_model=embedding_model,
         prompt="Please write a concise summary of the following texts:\n{cluster_content}",
-        max_token=256,
-        threshold=0.1,
+        max_token=512,
         max_errors=3,
+        clustering_threshold=0.3,
+        clustering_ratio=0.5,
     )
 
     # ---- Phase 1: per-doc summaries.


### PR DESCRIPTION
### What problem does this PR solve?

Skill generation still passed the removed `threshold` argument to the RAPTOR constructor, causing a runtime `TypeError`.

This PR updates skill generation to use the current RAPTOR options and minimum supported token limit.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
