### PR TITLE
fix(mcp): isolate connector metadata caches

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -61,14 +61,13 @@ class RAGFlowConnector:
     # Keep in sync with api.utils.pagination_utils.REST_API_MAX_PAGE_SIZE.
     _REST_API_MAX_PAGE_SIZE = 100
 
-    _dataset_metadata_cache: OrderedDict[str, tuple[dict, float | int]] = OrderedDict()  # "dataset_id" -> (metadata, expiry_ts)
-    _document_metadata_cache: OrderedDict[str, tuple[list[tuple[str, dict]], float | int]] = OrderedDict()  # "dataset_id" -> ([(document_id, doc_metadata)], expiry_ts)
-
     def __init__(self, base_url: str, version="v1"):
         self.base_url = base_url
         self.version = version
         self.api_url = f"{self.base_url}/api/{self.version}"
         self._async_client = None
+        self._dataset_metadata_cache: OrderedDict[str, tuple[dict, float | int]] = OrderedDict()
+        self._document_metadata_cache: OrderedDict[str, tuple[list[tuple[str, dict]], float | int]] = OrderedDict()
 
     async def _get_client(self):
         if self._async_client is None:

--- a/test/unit_test/mcp/test_document_metadata_pagination.py
+++ b/test/unit_test/mcp/test_document_metadata_pagination.py
@@ -16,7 +16,6 @@
 
 import importlib.util
 import re
-from collections import OrderedDict
 from pathlib import Path
 
 import pytest
@@ -55,11 +54,21 @@ def mcp_server():
 
 def _fresh_connector(mcp_server):
     connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
-    # The metadata caches are class-level OrderedDicts shared across instances;
-    # shadow them per test so cases don't pollute one another.
-    connector._dataset_metadata_cache = OrderedDict()
-    connector._document_metadata_cache = OrderedDict()
     return connector
+
+
+def test_connector_instances_do_not_share_metadata_caches(mcp_server):
+    first = mcp_server.RAGFlowConnector(base_url="https://first.example")
+    second = mcp_server.RAGFlowConnector(base_url="https://second.example")
+
+    first._set_cached_dataset_metadata("same-id", {"name": "first"})
+    first._set_cached_document_metadata_by_dataset(
+        "same-id",
+        [("doc-1", {"name": "first document"})],
+    )
+
+    assert second._get_cached_dataset_metadata("same-id") is None
+    assert second._get_cached_document_metadata_by_dataset("same-id") is None
 
 
 def _stub_get(monkeypatch, connector, total, *, code=0, page_size=30, guard=100):


### PR DESCRIPTION
### Review scope

- Production diff: `mcp/server/server.py` (`+2/-3`).
- Regression evidence: `test_document_metadata_pagination.py` (`+14/-5`).
- The cache-key correction and regression coverage are intentionally atomic because isolation must be verified across connector instances.

### Summary

Scope MCP dataset and document metadata caches to each `RAGFlowConnector` instance.

The caches were class-level `OrderedDict` objects keyed only by `dataset_id`. As a result, connectors targeting different RAGFlow base URLs or credentials shared cached metadata. If two deployments used the same dataset ID, one connector could return the other deployment's dataset or document metadata until the cache expired.

The caches are now initialized in `RAGFlowConnector.__init__`, alongside the connector-specific base URL and HTTP client.

### Verification

- Added a two-connector regression test using different base URLs and the same dataset ID.
- Before the fix, the second connector read the first connector's cached dataset metadata and the test failed.
- After the fix, both dataset and document metadata caches are isolated.
- MCP metadata pagination and dataset suites: `13 passed`.
- Ruff mutable-class-default/undefined-name checks, test Ruff, format, and `git diff --check`: passed.

### Scope

Cache keys, TTL, eviction, and metadata mapping behavior are unchanged within one connector. This only changes cache ownership from process-global class state to connector-local state.