### PR TITLE
 Fix: applying model config in one multi-chat card no longer overrides sibling cards

### DIFF
--- a/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
+++ b/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
@@ -138,7 +138,13 @@ const ChatCard = forwardRef(function ChatCard(
   // resend with the card's model settings (llm_id, temperature, ...).
   const sendCardMessage = useCallback(
     ({ message, messages }: { message: IMessage; messages?: IMessage[] }) =>
-      sendMessage({ message, messages, ...form.getValues(), storeHistoryMessages: false, omitSessionId: true }),
+      sendMessage({
+        message,
+        messages,
+        ...form.getValues(),
+        storeHistoryMessages: false,
+        omitSessionId: true,
+      }),
     [sendMessage, form],
   );
 
@@ -152,9 +158,22 @@ const ChatCard = forwardRef(function ChatCard(
   const { data: currentDialog } = useFetchChat();
   const findLlmByUuid = useFindLlmByUuid();
 
+  // Each card must keep its own independently selected model after the initial
+  // sync. Without this guard, clicking "Apply" in one card patches the dialog
+  // (which invalidates [FetchChat] and refetches currentDialog), and the
+  // changed currentDialog.llm_id would then overwrite every other card's
+  // llm_id via this effect. Sync only when dialogId changes (initial load or
+  // conversation switch), not when currentDialog.llm_id changes due to Apply.
+  const syncedDialogIdRef = useRef<string | undefined>(undefined);
   useLayoutEffect(() => {
-    form.setValue('llm_id', currentDialog?.llm_id || '');
-  }, [currentDialog?.llm_id, form]);
+    if (
+      syncedDialogIdRef.current !== dialogId &&
+      currentDialog?.llm_id
+    ) {
+      form.setValue('llm_id', currentDialog.llm_id);
+      syncedDialogIdRef.current = dialogId;
+    }
+  }, [currentDialog?.llm_id, dialogId, form]);
 
   const isLatestChat = idx === chatBoxIds.length - 1;
 
@@ -170,6 +189,7 @@ const ChatCard = forwardRef(function ChatCard(
       params: {
         ...currentDialog,
         llm_id: llmId,
+        tenant_llm_id: llmId,
         llm_setting: {
           ...omit(values, 'llm_id'),
           model_type: findLlmByUuid(llmId)?.model_type || 'chat',
@@ -181,7 +201,12 @@ const ChatCard = forwardRef(function ChatCard(
   useImperativeHandle(
     ref,
     (): HandlePressEnterType => (params) =>
-      handlePressEnter({ ...params, ...form.getValues(), storeHistoryMessages: false, omitSessionId: true }),
+      handlePressEnter({
+        ...params,
+        ...form.getValues(),
+        storeHistoryMessages: false,
+        omitSessionId: true,
+      }),
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

Fix: applying model config in one multi-chat card no longer overrides sibling cards

  In the multi-model chat view, each ChatCard holds its own `useForm`
  instance so users can compare different models side by side. However,
  the `useLayoutEffect` that synced `llm_id` from `currentDialog` re-ran
  whenever `currentDialog.llm_id` changed. Since `currentDialog` is shared
  across all cards, clicking "Apply" in one card triggered `patchChat` ->
  `invalidateQueries([FetchChat])` -> refetch, and the resulting
  `currentDialog.llm_id` update then reset every other card's `llm_id`
  form value to the patched value, destroying the per-card model selection.

  Fix: gate the sync with a `syncedDialogIdRef` so each card only picks up
  `currentDialog.llm_id` once per `dialogId` (initial load or conversation
  switch). Subsequent `currentDialog.llm_id` changes driven by Apply no
  longer leak into sibling cards.

  Also pass `tenant_llm_id` alongside `llm_id` when patching the dialog so
  the tenant-level model binding stays consistent with the applied config.
