### PR TITLE
  feat: add more file type preview support in document viewer

### DIFF
--- a/web/src/constants/common.ts
+++ b/web/src/constants/common.ts
@@ -199,6 +199,9 @@ export const ExceptiveType = [
   'docx',
   'md',
   'mdx',
+  'txt',
+  'csv',
+  'pptx',
   ...Images,
 ];
 

--- a/web/src/pages/document-viewer/index.tsx
+++ b/web/src/pages/document-viewer/index.tsx
@@ -16,6 +16,7 @@ import PdfPreview from '@/components/document-preview/pdf-preview';
 import { PptPreviewer } from '@/components/document-preview/ppt-preview';
 import { TxtPreviewer } from '@/components/document-preview/txt-preview';
 import { previewHtmlFile } from '@/utils/file-util';
+import CSVFileViewer from '@/components/document-preview/csv-preview';
 // import styles from './index.less';
 
 // TODO: The interface returns an incorrect content-type for the SVG.
@@ -55,6 +56,11 @@ const DocumentViewer = () => {
       )}
       {(ext === 'xlsx' || ext === 'xls') && (
         <ExcelCsvPreviewer url={api}></ExcelCsvPreviewer>
+      )}
+      {ext === 'csv' && (
+        <section className="m-1">
+          <CSVFileViewer url={api} />
+        </section>
       )}
 
       {ext === 'docx' && <DocPreviewer url={api}></DocPreviewer>}


### PR DESCRIPTION
### Summary

  feat: add more file type preview support in document viewer
 
 Add 'txt', 'csv', and 'pptx' to the ExceptiveType list so they are recognized
  as previewable file types. Render CSV files through the dedicated CSVFileViewer
  component in the document viewer, separate from the existing Excel/CSV ExcelCsvPreviewer
  which was previously handling CSVs as a spreadsheet.
