### PR TITLE
Fix: The download button is displayed on the agent dialog page shared externally.

### DIFF
--- a/web/src/components/next-message-item/group-button.tsx
+++ b/web/src/components/next-message-item/group-button.tsx
@@ -128,7 +128,7 @@ export const AssistantGroupButton = ({
             </Tooltip>
           </ToggleGroupItem>
         )}
-        {!!attachment?.doc_id && !isShare && (
+        {!!attachment?.doc_id && (
           <ToggleGroupItem
             value="g"
             onClick={async () => {


### PR DESCRIPTION


### Summary

Fix: The download button is displayed on the agent dialog page shared externally.