### PR TITLE
fix(deps): bump Werkzeug to 3.1.8 to fix intermittent multipart CRLF corruption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ dependencies = [
     "qianfan==0.4.6",
     "quart-auth==0.11.0",
     "quart-cors==0.8.0",
+    # Werkzeug 3.1.5 can prepend \r\n to multipart file bodies when TCP chunks
+    # split at part headers (https://github.com/pallets/werkzeug/issues/3088);
+    # fixed in >=3.1.7. Pin so uv.lock cannot resolve back to the buggy release.
+    "werkzeug>=3.1.7,<4",
     "ranx==0.3.20",
     "readability-lxml>=0.8.4,<1.0.0",
     "replicate==0.31.0",

--- a/uv.lock
+++ b/uv.lock
@@ -8166,6 +8166,7 @@ dependencies = [
     { name = "webdav4" },
     { name = "webdriver-manager" },
     { name = "wechatpy" },
+    { name = "werkzeug" },
     { name = "wikipedia" },
     { name = "word2number" },
     { name = "xgboost" },
@@ -8322,6 +8323,7 @@ requires-dist = [
     { name = "webdav4", specifier = ">=0.10.0,<0.11.0" },
     { name = "webdriver-manager", specifier = "==4.0.1" },
     { name = "wechatpy", specifier = ">=1.8.18" },
+    { name = "werkzeug", specifier = ">=3.1.7,<4" },
     { name = "wikipedia", specifier = "==1.4.0" },
     { name = "word2number", specifier = "==1.1" },
     { name = "xgboost", specifier = "==1.6.0" },
@@ -9919,14 +9921,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.5"
+version = "3.1.8"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `werkzeug>=3.1.7,<4` and refresh `uv.lock` to **3.1.8**.
- Fixes intermittent corruption of uploaded file bodies: when TCP segments split right after multipart part headers, Werkzeug **3.1.5** can include a leading `\r\n` in the file content ([pallets/werkzeug#3088](https://github.com/pallets/werkzeug/issues/3088); fixed in 3.1.7).
- In RAGFlow this commonly breaks `.xlsx` parsing: ZIP/OOXML magic (`PK\x03\x04`) no longer matches, the Excel parser falls back to CSV, then fails with UTF-8 decode errors such as `invalid start/continuation byte`.

## Reproduction notes
- Observed with Quart + Hypercorn receiving `multipart/form-data` document uploads.
- Symptom is intermittent and size-dependent on chunk boundaries (`file size == expected + 2`, head bytes `0d0a504b...`).
- Same payload often succeeds on retry when segment boundaries differ.

## Test plan
- [ ] `uv sync --frozen` installs Werkzeug 3.1.8
- [ ] Upload `.xlsx` documents repeatedly (10+ times) via `/api/v1/datasets/{id}/documents` and confirm stored object head remains `504b0304` (no leading `\r\n`)
- [ ] Confirm previously failing xlsx files parse without `Failed to parse CSV and convert to Excel Workbook: ... utf-8 ...`


Made with [Cursor](https://cursor.com)