### PR TITLE
fix(web): merge Token/Delimiter chunker tabs into one in TokenChunker

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -784,7 +784,7 @@ Example: A 1 KB message with 1024-dim embedding uses ~9 KB. The 5 MB default lim
       permissionsTip:
         "If it is set to 'Team', all your team members will be able to manage the dataset.",
       chunkTokenNumberTip:
-        'It kind of sets the token threshold for a creating a chunk. A segment with fewer tokens than this threshold will be combined with the following segments until the token count exceeds the threshold, at which point a chunk is created. No new chunk is created unless a delimiter is encountered, even if the threshold is exceeded.',
+        'Maximum number of tokens per chunk. Delimiters are always respected as hard boundaries: the chunker never breaks a delimiter. Adjacent pieces below the limit are merged greedily until the next piece would exceed the limit, at which point a new chunk begins. A single piece that already exceeds the limit is kept intact rather than split.',
       chunkMethod: 'Chunking method',
       chunkMethodTip: 'View the tips on the right.',
       upload: 'Upload',
@@ -2567,9 +2567,13 @@ Best for: Documents with flowing, contextually connected content — such as boo
       space: 'Space',
       delimiters: 'Delimiters',
       one: 'One',
+      chunkingStrategy: 'Chunking strategy',
+      tokenDelimiter: 'Token - Delimiter',
+      tokenDelimiterTip:
+        'Text is first split at every delimiter (newlines and any custom delimiters), which are always treated as hard chunk boundaries. Adjacent pieces are then grouped up to the recommended chunk size; a piece larger than that size is kept whole and never split. Choose "One" to keep the entire input as a single chunk.',
       oneChunkTitle: 'Note',
       oneChunkDescription:
-        'All parsed sections will be merged in order into a single chunk.',
+        'All parsed content is merged in order and returned as a single chunk.',
       flattenMediaToText: 'Disable vision model',
       flattenMediaToTextTip:
         'Treat image and table sections as plain text and skip vision enhancement.',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -717,7 +717,7 @@ export default {
       permissionsTip:
         '如果把知识库权限设为“团队”，则所有团队成员都可以操作该知识库。',
       chunkTokenNumberTip:
-        '建议的生成文本块的 token 数阈值。如果切分得到的小文本段 token 数达不到这一阈值就会不断与之后的文本段合并，直至再合并下一个文本段会超过这一阈值为止，此时产生一个最终文本块。如果系统在切分文本段时始终没有遇到文本分段标识符，即便文本段 token 数已经超过这一阈值，系统也不会生成新文本块。',
+        '每个 chunk 的最大 token 数。分隔符始终被视为硬性边界：分块器不会在分隔符处断开。低于上限的相邻片段会被贪心合并，直到下一片会使块超过上限时才开始新块；单个已超限的片段将保持完整而不被拆分。',
       chunkMethod: '切片方法',
       chunkMethodTip: '说明位于右侧。',
       upload: '上传',
@@ -2213,9 +2213,13 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       space: '空格',
       delimiters: '分隔符',
       one: 'One',
+      chunkingStrategy: '分块策略',
+      tokenDelimiter: 'Token - 分隔符',
+      tokenDelimiterTip:
+        '文本会先按每个分隔符（换行符及自定义分隔符）切分，分隔符始终作为硬性分块边界。相邻片段会被贪心合并，直到加入下一片会超过建议块大小为止，此时开始新块；单个片段若已超过该大小则保持完整、不再拆分。选择“One”可将整个输入作为单个块。',
       oneChunkTitle: 'Note',
       oneChunkDescription:
-        '所有解析后的 sections 会按原始顺序合并为 1 个 chunk。',
+        '所有解析后的内容会按原始顺序合并，作为单个 chunk 返回。',
       flattenMediaToText: '禁用视觉模型',
       flattenMediaToTextTip: '将图片和表格区块按普通文本处理，并跳过视觉增强。',
       merge: '合并',

--- a/web/src/pages/agent/constant/pipeline.tsx
+++ b/web/src/pages/agent/constant/pipeline.tsx
@@ -262,7 +262,7 @@ export const initialTokenChunkerValues = {
   outputs: {
     chunks: { type: 'Array<Object>', value: [] },
   },
-  delimiter_mode: 'token_size',
+  delimiter_mode: 'token_delimiter',
   chunk_token_size: 512,
   overlapped_percent: 0,
   delimiters: [{ value: '\n' }],

--- a/web/src/pages/agent/form/token-chunker-form/index.tsx
+++ b/web/src/pages/agent/form/token-chunker-form/index.tsx
@@ -37,7 +37,7 @@ export const FormSchema = z.object({
     }),
   ),
   overlapped_percent: z.number(),
-  delimiter_mode: z.enum(['token_size', 'delimiter', 'one']).optional(),
+  delimiter_mode: z.enum(['token_delimiter', 'one']).optional(),
 });
 
 export type TokenChunkerFormSchemaType = z.infer<typeof FormSchema>;
@@ -52,7 +52,7 @@ const TokenChunkerForm = ({
 
   const formDefaultValues = {
     ...defaultValues,
-    delimiter_mode: defaultValues.delimiter_mode || 'token_size',
+    delimiter_mode: defaultValues.delimiter_mode || 'token_delimiter',
   };
 
   const form = useForm<TokenChunkerFormSchemaType>({
@@ -83,21 +83,22 @@ const TokenChunkerForm = ({
           field={{
             name: 'delimiter_mode',
             type: FormFieldType.Segmented,
-            label: '',
+            label: t('flow.chunkingStrategy'),
+            tooltip: t('flow.tokenDelimiterTip'),
             options: [
-              { label: 'Token Size', value: 'token_size' },
-              { label: t('flow.delimiters'), value: 'delimiter' },
+              { label: t('flow.tokenDelimiter'), value: 'token_delimiter' },
               { label: t('flow.one'), value: 'one' },
             ],
           }}
         />
 
-        {delimiterMode === 'token_size' && (
+        {delimiterMode !== 'one' && (
           <>
             <SliderInputFormField
               name="chunk_token_size"
               max={2048}
               label={t('knowledgeConfiguration.chunkTokenNumber')}
+              tooltip={t('knowledgeConfiguration.chunkTokenNumberTip')}
             />
             <SliderInputFormField
               name="overlapped_percent"
@@ -112,11 +113,6 @@ const TokenChunkerForm = ({
               label={t('knowledgeConfiguration.imageTableContextWindow')}
               tooltip={t('knowledgeConfiguration.imageTableContextWindowTip')}
             />
-          </>
-        )}
-
-        {delimiterMode === 'delimiter' && (
-          <>
             <section>
               <span className="mb-2 inline-block">{t('flow.delimiters')}</span>
               <div className="space-y-4">

--- a/web/src/pages/agent/utils.ts
+++ b/web/src/pages/agent/utils.ts
@@ -347,16 +347,24 @@ export function transformTokenChunkerParams(
 ) {
   const { image_table_context_window, ...rest } = params;
   const imageTableContextWindow = Number(image_table_context_window || 0);
+  const isOne = params.delimiter_mode === 'one';
+  const delimiters = isOne
+    ? []
+    : transformObjectArrayToPureArray(params.delimiters, 'value');
+  // The form exposes a single "Token - Delimiter" tab that covers both legacy
+  // strategies. Derive the backend delimiter_mode: when the user supplies
+  // delimiters they act as hard boundaries ("delimiter"); otherwise the chunker
+  // falls back to token-size merging ("token_size").
+  const delimiterMode = isOne
+    ? 'one'
+    : delimiters.length > 0
+      ? 'delimiter'
+      : 'token_size';
   return {
     ...rest,
-    overlapped_percent:
-      params.delimiter_mode === 'one'
-        ? 0
-        : Number(params.overlapped_percent) / 100,
-    delimiters:
-      params.delimiter_mode === 'delimiter'
-        ? transformObjectArrayToPureArray(params.delimiters, 'value')
-        : [],
+    delimiter_mode: delimiterMode,
+    overlapped_percent: isOne ? 0 : Number(params.overlapped_percent) / 100,
+    delimiters,
     table_context_size: imageTableContextWindow,
     image_context_size: imageTableContextWindow,
 

--- a/web/src/utils/pipeline-operator.ts
+++ b/web/src/utils/pipeline-operator.ts
@@ -114,11 +114,11 @@ function transformTokenChunkerConfigToForm(
   const imageSize = Number(config.image_context_size ?? 0);
   result.image_table_context_window = Math.max(tableSize, imageSize);
 
-  // Derive delimiter_mode from data
-  if (config.delimiter_mode === undefined) {
-    const hasDelimiters =
-      Array.isArray(config.delimiters) && config.delimiters.length > 0;
-    result.delimiter_mode = hasDelimiters ? 'delimiter' : 'token_size';
+  // Normalize delimiter_mode to the merged form contract.
+  // The form exposes two tabs ("Token - Delimiter" and "One"); the legacy
+  // "token_size" / "delimiter" values are collapsed into "token_delimiter".
+  if (config.delimiter_mode !== 'one') {
+    result.delimiter_mode = 'token_delimiter';
   }
 
   // Derive enable_children from presence of children_delimiters


### PR DESCRIPTION
## Summary

PR #17808 (backend) made the delimiter a hard chunk boundary in both the token-size and delimiter strategies, so the two are no longer distinct on the backend. The TokenChunker frontend form still exposed three tabs — **Token Size / Delimiter / One** — which no longer matches the behavior.

This PR aligns the UI:

- Collapse the three tabs into two:
  - **Token - Delimiter**: shows the recommended chunk size, overlap, image/table context window, and the delimiter editor together.
  - **One**: keeps the entire parsed input as a single chunk.
- The form now stores a single `delimiter_mode` (`token_delimiter` / `one`) and derives the backend value on submit: `delimiter` when delimiters are supplied, otherwise `token_size`. Wire values stay compatible with both the Python and Go chunkers.
- Pipelines persisted with `delimiter_mode` `token_size` or `delimiter` are normalized to `token_delimiter` on load.

## Tooltip updates (en / zh)

- **Recommended chunk size** tooltip now describes the new semantics:
  > Maximum number of tokens per chunk. Delimiters are always respected as hard boundaries: the chunker never breaks a delimiter. Adjacent pieces below the limit are merged greedily until the next piece would exceed the limit, at which point a new chunk begins. A single piece that already exceeds the limit is kept intact rather than split.
- New **Chunking strategy** tooltip on the tab selector explains that text is split at every delimiter (hard boundary), pieces are grouped up to the chunk size, and over-limit pieces are kept whole; "One" keeps everything in a single chunk.

## Test plan

- [ ] Open an agent canvas, add a TokenChunker node, confirm only two tabs (Token - Delimiter / One) are shown.
- [ ] In "Token - Delimiter", set chunk size and add a custom delimiter; save and reopen — delimiters and size persist.
- [ ] Switch to "One" — the single-chunk note is shown; children delimiter section is hidden.
- [ ] Reload a pipeline previously saved with `delimiter_mode: token_size` / `delimiter`: it opens under the "Token - Delimiter" tab.

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy)