### PR TITLE
fix: correct Tongyi-Qianwen international endpoint typo (compatible-model -> compatible-mode)

### DIFF
--- a/api/apps/services/provider_api_service.py
+++ b/api/apps/services/provider_api_service.py
@@ -90,7 +90,7 @@ def list_providers(tenant_id: str, all_available: bool = False):
             if factory_info["name"].lower() == "siliconflow":
                 provider["url"]["intl"] = factory_info_map.get("siliconflow_intl", {}).get("url", "https://api.siliconflow.com/v1")
             elif factory_info["name"] == "Tongyi-Qianwen":
-                provider["url"]["intl"] = "https://dashscope-intl.aliyuncs.com/compatible-model/v1"
+                provider["url"]["intl"] = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
             providers.append(provider)
         providers.sort(key=lambda x: (factory_rank_mapping.get(x["name"]), x["name"]))
         return True, providers
@@ -113,7 +113,7 @@ def list_providers(tenant_id: str, all_available: bool = False):
             if factory_info["name"].lower() == "siliconflow":
                 provider["url"]["intl"] = factory_info_map.get("siliconflow_intl", {}).get("url", "https://api.siliconflow.com/v1")
             elif factory_info["name"] == "Tongyi-Qianwen":
-                provider["url"]["intl"] = "https://dashscope-intl.aliyuncs.com/compatible-model/v1"
+                provider["url"]["intl"] = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
             providers.append(provider)
     providers.sort(key=lambda x: (factory_rank_mapping.get(x["name"]), x["name"]))
     return True, providers


### PR DESCRIPTION
## Summary
- `api/apps/services/provider_api_service.py` hardcoded the DashScope international base URL for Tongyi-Qianwen as `.../compatible-model/v1` instead of `.../compatible-mode/v1`, in two places (`list_providers`, lines ~93 and ~116).
- Every other reference to this DashScope path in the repo (`conf/llm_factories.json`, `rag/llm/__init__.py`, Go agent components, and every locale's help text under `web/src/locales/*.ts`) correctly uses `compatible-mode`. Confirmed via a repo-wide grep before fixing — these two lines were the only occurrences of the typo.

## Impact
Selecting the international region for Tongyi-Qianwen in **Settings > Model Providers** sends every model verification request to the wrong (nonexistent) path, so DashScope returns a 404 for every single model, and the whole "save provider" flow fails.

## Verification
Reproduced against a real DashScope account:
1. Configured Tongyi-Qianwen with the international endpoint in a local RAGFlow instance; save failed, backend logs showed `litellm.NotFoundError: NotFoundError: DashscopeException - Error code: 404` repeated for every model tested.
2. Found the typo via repo-wide grep for `compatible-mode`/`compatible-model`.
3. Confirmed the account/API key itself was valid by calling the correct endpoint directly:
   ```
   curl -X POST "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions" \
     -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"qwen-plus","messages":[{"role":"user","content":"hi"}]}'
   ```
   → returned a normal chat completion.
4. Fixed the two lines, restarted the backend, confirmed the corrected URL is what the running process serves.

## Test plan
- [x] Repo-wide grep confirms `compatible-mode` is now used consistently everywhere this DashScope path appears
- [x] Manually verified against a real DashScope international-region API key (see above)
- [ ] No automated test added (this is a hardcoded string constant with no existing test coverage for this code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)