### PR TITLE
fix: split wiki template instruction and example

### DIFF
--- a/api/apps/restful_apis/compilation_template_api.py
+++ b/api/apps/restful_apis/compilation_template_api.py
@@ -61,7 +61,7 @@ def list_wiki_presets() -> Response:
     ``api/db/init_data/compilation_templates/wiki/*.yaml``.
 
     Each entry carries ``id`` (filename stem) + ``topic`` +
-    ``instruction`` + ``page_example`` so the artifact-template editor
+    ``instruction`` + ``example`` so the artifact-template editor
     can pre-fill its "Page-structure example" / "Global rules" fields
     from a canned skeleton. Filesystem-fresh per request; no DB seed.
     """

--- a/api/db/init_data/compilation_templates/wiki.yaml
+++ b/api/db/init_data/compilation_templates/wiki.yaml
@@ -3,13 +3,14 @@ display_name: Wiki — Graph-based wiki
 config:
   kind: wiki
   plan: yes
-  example: |
+  instruction: |
       - Each page must be a proper encyclopedic article, NOT a flat bullet list:
       - 1. Opening paragraph (2-4 sentences defining what this is). No heading.
       - 2. Sections with H2 headings, each starting with prose before sub-bullets.
       - 3. Bold key terms on first use; link them with [[ ]] wikilinks.
       - 4. Examples or implications where the source provides them.
       - 5. ## See also section at the end with wikilinks to highly related pages(less than 12).\n
+  example: |
       - Page structure could be as following: (Not provided)
   entity:
     description: >-

--- a/api/db/init_data/compilation_templates/wiki/brand.yaml
+++ b/api/db/init_data/compilation_templates/wiki/brand.yaml
@@ -1,8 +1,8 @@
 instruction: |
     - Each page must be a proper encyclopedic article, NOT a flat bullet list:
-    - 1. Take prefix ">" or "-" in the "page_example" as instructions to generate the content.
+    - 1. Take prefix ">" or "-" in the "example" as instructions to generate the content.
     - 2. Sections with H2 headings, each starting with prose before sub-bullets.
-page_example: |
+example: |
     # Tone of voice
 
     ## Principles
@@ -39,9 +39,8 @@ page_example: |
 
     ## Dos & Dont's
     |We say  👍|	We don't say  🙅|
-    | :--- | :---: | 
+    | :--- | :---: |
     |Example|	Example|
     |Example|	Example|
 
 topic: marketing
-      

--- a/api/db/init_data/compilation_templates/wiki/engineering.yaml
+++ b/api/db/init_data/compilation_templates/wiki/engineering.yaml
@@ -1,9 +1,9 @@
 
 instruction: |
     - Each page must be a proper encyclopedic article, NOT a flat bullet list:
-    - 1. Take prefix ">" or "-" in the "page_example" as instructions to generate the content.
+    - 1. Take prefix ">" or "-" in the "example" as instructions to generate the content.
     - 2. Sections with H2 headings, each starting with prose before sub-bullets.
-page_example: |
+example: |
     # Secret feature(Title)
 
     ## Background & research
@@ -17,7 +17,7 @@ page_example: |
     - List goals
     - KPIs
     - What success looks like
-    
+
     ## Hypothesis
     > If we achieve/enable X, then user behavior Y changes in this way leading to positive metrics Z.
 
@@ -32,7 +32,7 @@ page_example: |
     - Requirements
     - Future evolutions
     - Out of scope
-    
+
     ## Designs and assets
     > Add any necessary figma project link, hi-fi mockups, SVGs, font files, images, prototypes...
 

--- a/api/db/init_data/compilation_templates/wiki/general.yaml
+++ b/api/db/init_data/compilation_templates/wiki/general.yaml
@@ -6,5 +6,5 @@ instruction: |
     - 3. Bold key terms on first use; link them with [[ ]] wikilinks.
     - 4. Examples or implications where the source provides them.
     - 5. ## See also section at the end with wikilinks to highly related pages(less than 12).\n
-page_example: |
+example: |
     - (Not provided)

--- a/api/db/init_data/compilation_templates/wiki/market.yaml
+++ b/api/db/init_data/compilation_templates/wiki/market.yaml
@@ -1,9 +1,9 @@
 
 instruction: |
     - Each page must be a proper encyclopedic article, NOT a flat bullet list:
-    - 1. Take prefix ">" or "-" in the "page_example" as instructions to generate the content.
+    - 1. Take prefix ">" or "-" in the "example" as instructions to generate the content.
     - 2. Sections with H2 headings, each starting with prose before sub-bullets.
-page_example: |
+example: |
     # Competitor analysis(title)
 
     ## Analysis strengths/weaknesses

--- a/api/db/init_data/compilation_templates/wiki/product.yaml
+++ b/api/db/init_data/compilation_templates/wiki/product.yaml
@@ -1,8 +1,8 @@
 instruction: |
     - Each page must be a proper encyclopedic article, NOT a flat bullet list:
-    - 1. Take prefix ">" or "-" in the "page_example" as instructions to generate the content.
+    - 1. Take prefix ">" or "-" in the "example" as instructions to generate the content.
     - 2. Sections with H2 headings, each starting with prose before sub-bullets.
-page_example: |
+example: |
     # Onboarding flow update
     ## Background & research
     summary(example): 40% of new users aren't activating. By reviewing our onboarding flow we'll help teams better understand the value of the product and activate faster on Slite.

--- a/api/db/init_data/compilation_templates/wiki/user_interview.yaml
+++ b/api/db/init_data/compilation_templates/wiki/user_interview.yaml
@@ -1,8 +1,8 @@
 instruction: |
     - Each page must be a proper encyclopedic article, NOT a flat bullet list:
-    - 1. Take prefix ">" or "-" in the "page_example" as instructions to generate the content.
+    - 1. Take prefix ">" or "-" in the "example" as instructions to generate the content.
     - 2. Sections with H2 headings, each starting with prose before sub-bullets.
-page_example: |
+example: |
     # User interview
     ## Takeaways
     - The team is still unaware about features x, y, z

--- a/api/db/services/compilation_template_service.py
+++ b/api/db/services/compilation_template_service.py
@@ -233,7 +233,7 @@ class CompilationTemplateService(CommonService):
         ``api/db/init_data/compilation_templates/wiki/*.yaml``.
 
         Each file contributes one preset dict with ``topic`` /
-        ``instruction`` / ``page_example`` fields (plus ``id`` derived
+        ``instruction`` / ``example`` fields (plus ``id`` derived
         from the filename stem so the frontend can key list items
         even when several presets share the same ``topic`` — which is
         by design; the UI groups presets by topic).
@@ -278,7 +278,7 @@ class CompilationTemplateService(CommonService):
                     "id": os.path.splitext(filename)[0],
                     "topic": str(doc.get("topic") or "").strip(),
                     "instruction": str(doc.get("instruction") or ""),
-                    "page_example": str(doc.get("page_example") or ""),
+                    "example": str(doc.get("example") or ""),
                 }
             )
         return presets

--- a/rag/advanced_rag/knowlege_compile/wiki.py
+++ b/rag/advanced_rag/knowlege_compile/wiki.py
@@ -2628,7 +2628,9 @@ WIKI_REFINE_WRITER_SYSTEM_TEMPLATE = (
     "- Prose that just rephrases what was already said.\n\n"
     "# Language\n"
     "Write in the SAME LANGUAGE as the source text. Never translate content.\n\n"
-    "# Page structure — CRITICAL\n"
+    "# Additional writing instructions — CRITICAL\n"
+    "{template_instruction}\n\n"
+    "# Page structure example — CRITICAL\n"
     "{template_example}\n\n"
     "# What NOT to do\n"
     "- Do NOT dump raw bullet points from the source as the entire content.\n"
@@ -2646,18 +2648,20 @@ WIKI_REFINE_WRITER_SYSTEM_TEMPLATE = (
 )
 
 
-def _build_refine_writer_system(example: str | None) -> str:
-    """Return the writer system prompt with the configured page-structure
-    example (or ``WIKI_TEMPLATE_EXAMPLE`` when ``example`` is empty /
-    whitespace-only). Used by the REFINE phase to let each compilation
-    template override just the page-structure section.
+def _build_refine_writer_system(instruction: str | None = None, page_example: str | None = None) -> str:
+    """Return the writer system prompt with separate instruction and page
+    example overrides. Empty values use the built-in defaults.
 
     The default-filled form is also exposed as
     ``WIKI_REFINE_WRITER_SYSTEM`` for callers that don't have an
     override to apply.
     """
-    body = (example or "").strip() or WIKI_TEMPLATE_EXAMPLE
-    return WIKI_REFINE_WRITER_SYSTEM_TEMPLATE.format(template_example=body)
+    instruction_body = (instruction or "").strip() or "Follow the page structure and writing requirements below."
+    example_body = (page_example or "").strip() or WIKI_TEMPLATE_EXAMPLE
+    return WIKI_REFINE_WRITER_SYSTEM_TEMPLATE.format(
+        template_instruction=instruction_body,
+        template_example=example_body,
+    )
 
 
 WIKI_REFINE_WRITER_SYSTEM = _build_refine_writer_system(None)
@@ -3261,13 +3265,15 @@ async def _wiki_write_page_simple(
     all_plan_slugs: list[str],
     chat_mdl,
     llm_timeout: int,
+    instruction: Optional[str] = None,
+    page_example: Optional[str] = None,
     example: Optional[str] = None,
 ) -> str:
     """Single LLM call → markdown content.
 
-    ``example`` is the per-template ``parser_config.example`` override
-    for the writer's page-structure section. Falsy / whitespace-only
-    values fall through to ``WIKI_TEMPLATE_EXAMPLE``.
+    ``instruction`` and ``page_example`` are the separate per-template
+    writer overrides. ``example`` is retained as a fallback for callers
+    using the older combined configuration field.
     """
     own_slug = plan_item.get("slug") or ""
     available = [s for s in all_plan_slugs if s and s != own_slug]
@@ -3292,7 +3298,10 @@ async def _wiki_write_page_simple(
 
     content = await _wiki_chat_text(
         chat_mdl,
-        _build_refine_writer_system(example),
+        _build_refine_writer_system(
+            instruction=instruction,
+            page_example=page_example or example,
+        ),
         user_prompt,
         temperature=0.15,
         llm_timeout=llm_timeout,
@@ -3532,6 +3541,8 @@ async def wiki_refine_from_plan(
     merge_shrink_threshold: float = WIKI_MERGE_BODY_SHRINK_THRESHOLD,
     force_rerun: bool = False,
     callback: Optional[Callable] = None,
+    instruction: Optional[str] = None,
+    page_example: Optional[str] = None,
     example: Optional[str] = None,
 ) -> list[dict]:
     """Phase 4 (REFINE) — KB-scoped.
@@ -3726,6 +3737,8 @@ async def wiki_refine_from_plan(
                     all_plan_slugs,
                     chat_mdl,
                     llm_timeout,
+                    instruction=instruction,
+                    page_example=page_example,
                     example=example,
                 )
                 if not content_md_raw:

--- a/rag/svr/task_executor_refactor/dataset_wiki_generator.py
+++ b/rag/svr/task_executor_refactor/dataset_wiki_generator.py
@@ -1283,12 +1283,15 @@ async def run_wiki(
 
     # ``kb_chat_llm_id`` is captured from the first eligible template and
     # used as the canonical chat model for KB-wide REDUCE/PLAN/REFINE.
-    # ``kb_writer_example`` follows the same first-template-wins rule.
+    # Writer instructions and page examples follow the same first-template-
+    # wins rule.
     first_parser_cfg = resolved_eligible[0][2]
     first_parser_cfg = first_parser_cfg if isinstance(first_parser_cfg, dict) else {}
     kb_chat_llm_id: Optional[str] = (first_parser_cfg.get("llm_id") or "").strip() or None
-    first_example = first_parser_cfg.get("example")
-    kb_writer_example: Optional[str] = first_example if isinstance(first_example, str) and first_example.strip() else None
+    first_instruction = first_parser_cfg.get("instruction")
+    first_page_example = first_parser_cfg.get("example")
+    kb_writer_instruction: Optional[str] = first_instruction if isinstance(first_instruction, str) and first_instruction.strip() else None
+    kb_writer_page_example: Optional[str] = first_page_example if isinstance(first_page_example, str) and first_page_example.strip() else None
     map_llm_pool = LLMCallPool(WIKI_MAP_LLM_POOL_SIZE, max_pending=WIKI_MAP_MAX_PENDING)
     n_docs = len(resolved_eligible)
     map_queue: asyncio.Queue = asyncio.Queue(maxsize=WIKI_MAP_QUEUE_SIZE)
@@ -1456,7 +1459,8 @@ async def run_wiki(
             kb_id=ctx.kb_id,
             max_workers=WIKI_REFINE_WORKERS,
             callback=_stage_cb("[wiki REFINE]"),
-            example=kb_writer_example,
+            instruction=kb_writer_instruction,
+            page_example=kb_writer_page_example,
         )
     except Exception:
         logging.exception("wiki: REDUCE/PLAN/REFINE failed for kb %s", ctx.kb_id)

--- a/web/src/interfaces/database/compilation-template.ts
+++ b/web/src/interfaces/database/compilation-template.ts
@@ -74,5 +74,5 @@ export interface IWikiPreset {
   id: string;
   topic: string;
   instruction: string;
-  page_example: string;
+  example: string;
 }

--- a/web/src/lib/editor/raw-markdown-editor.tsx
+++ b/web/src/lib/editor/raw-markdown-editor.tsx
@@ -3,14 +3,19 @@
  * Theme follows the app's Nimbalyst theme system.
  */
 
-import type { OnChange, OnMount } from '@monaco-editor/react';
-import Editor from '@monaco-editor/react';
+import Editor, {
+  loader,
+  type OnChange,
+  type OnMount,
+} from '@monaco-editor/react';
 import { Eye } from 'lucide-react';
 import type { editor as monacoEditor } from 'monaco-editor';
 import type { JSX } from 'react';
 import { useEffect, useRef } from 'react';
 
 import { useTheme } from '@/components/theme-provider';
+
+loader.config({ paths: { vs: '/vs' } });
 
 interface Props {
   content: string;

--- a/web/src/pages/user-setting/compilation-templates/create-next/components/blueprints-step.tsx
+++ b/web/src/pages/user-setting/compilation-templates/create-next/components/blueprints-step.tsx
@@ -72,14 +72,14 @@ export function BlueprintsStep({
 
   const instructionPath =
     `templates.${selectedTemplateIndex}.config.instruction` as const;
-  const pageExamplePath =
-    `templates.${selectedTemplateIndex}.config.page_example` as const;
+  const examplePath =
+    `templates.${selectedTemplateIndex}.config.example` as const;
   const useBlueprintPath =
     `templates.${selectedTemplateIndex}.config.use_blueprint` as const;
 
-  const pageExample = useWatch({
+  const example = useWatch({
     control: form.control,
-    name: pageExamplePath,
+    name: examplePath,
   });
 
   const instruction = useWatch({
@@ -100,7 +100,7 @@ export function BlueprintsStep({
     return selectedItem?.name ?? '';
   }, [treeData, selectedItemId]);
 
-  const hasTemplateData = Boolean(selectedItemId || instruction || pageExample);
+  const hasTemplateData = Boolean(selectedItemId || instruction || example);
 
   const handleSelect = useCallback(
     (item?: TreeDataItem) => {
@@ -113,11 +113,11 @@ export function BlueprintsStep({
       form.setValue(instructionPath, preset.instruction, {
         shouldValidate: false,
       });
-      form.setValue(pageExamplePath, preset.page_example, {
+      form.setValue(examplePath, preset.example, {
         shouldValidate: false,
       });
     },
-    [form, instructionPath, pageExamplePath],
+    [form, instructionPath, examplePath],
   );
 
   const handleToggleBlueprint = useCallback(
@@ -128,11 +128,11 @@ export function BlueprintsStep({
     [form, useBlueprintPath],
   );
 
-  const handlePageExampleChange = useCallback(
+  const handleExampleChange = useCallback(
     (value: string) => {
-      form.setValue(pageExamplePath, value, { shouldValidate: false });
+      form.setValue(examplePath, value, { shouldValidate: false });
     },
-    [form, pageExamplePath],
+    [form, examplePath],
   );
 
   return (
@@ -175,8 +175,8 @@ export function BlueprintsStep({
 
               <div className="flex-1 min-h-0 flex flex-col">
                 <MarkdownEditor
-                  content={String(pageExample ?? '')}
-                  onChange={handlePageExampleChange}
+                  content={String(example ?? '')}
+                  onChange={handleExampleChange}
                 />
               </div>
             </div>

--- a/web/src/pages/user-setting/compilation-templates/create-next/constant.ts
+++ b/web/src/pages/user-setting/compilation-templates/create-next/constant.ts
@@ -20,7 +20,6 @@ export const DefaultTemplateValues: TemplateSchemaType = {
     global_rules: '',
     example: '',
     instruction: '',
-    page_example: '',
     use_blueprint: false,
     plan: true,
     rechunk: false,

--- a/web/src/pages/user-setting/compilation-templates/create-next/utils.ts
+++ b/web/src/pages/user-setting/compilation-templates/create-next/utils.ts
@@ -20,20 +20,6 @@ import {
   SectionPriority,
 } from './constant';
 
-export const splitExampleToBlueprintFields = (
-  example: string,
-): { instruction: string; page_example: string } => {
-  const trimmed = example.trim();
-  const separatorIndex = trimmed.indexOf('\n\n');
-  if (separatorIndex === -1) {
-    return { instruction: trimmed, page_example: '' };
-  }
-  return {
-    instruction: trimmed.slice(0, separatorIndex).trim(),
-    page_example: trimmed.slice(separatorIndex + 2).trim(),
-  };
-};
-
 export const getFieldKeyOrder = (keys: string[]): string[] => {
   const sortedKeys = [...keys].sort();
   return (
@@ -52,7 +38,6 @@ export const isConfigMetaKey = (key: string) =>
     'global_rules',
     'example',
     'instruction',
-    'page_example',
     'synthesis',
     'use_blueprint',
     'plan',
@@ -85,6 +70,10 @@ export const buildConfigFromBuiltin = (
   kind: string,
   llmId: string,
 ): TemplateSchemaType['config'] => {
+  const instruction =
+    typeof builtinTemplate.config?.instruction === 'string'
+      ? builtinTemplate.config.instruction
+      : '';
   const example =
     typeof builtinTemplate.config?.example === 'string'
       ? builtinTemplate.config.example
@@ -108,7 +97,8 @@ export const buildConfigFromBuiltin = (
         }
       : {}),
     use_blueprint:
-      kind === CompilationTemplateKind.Artifacts && example.length > 0,
+      kind === CompilationTemplateKind.Artifacts &&
+      (instruction.length > 0 || example.length > 0),
     plan:
       typeof builtinTemplate.config?.plan === 'boolean'
         ? builtinTemplate.config.plan
@@ -124,11 +114,12 @@ export const buildConfigFromBuiltin = (
       : {}),
   };
 
-  if (kind === CompilationTemplateKind.Artifacts && example.length > 0) {
-    const { instruction, page_example } =
-      splitExampleToBlueprintFields(example);
+  if (
+    kind === CompilationTemplateKind.Artifacts &&
+    (instruction.length > 0 || example.length > 0)
+  ) {
     sections.instruction = instruction;
-    sections.page_example = page_example;
+    sections.example = example;
   }
 
   if (kind === CompilationTemplateKind.Tree) {
@@ -160,12 +151,18 @@ export const transformDetailToForm = (
   detail: ICompilationTemplate,
 ): TemplateSchemaType => {
   const config = detail.config ?? {};
-  const example = typeof config.example === 'string' ? config.example : '';
+  const storedInstruction =
+    typeof config.instruction === 'string' ? config.instruction : '';
+  const storedExample =
+    typeof config.example === 'string' ? config.example : '';
+  const hasBlueprintContent = Boolean(
+    storedInstruction.trim() || storedExample.trim(),
+  );
   const base: TemplateSchemaType['config'] = {
     kind: config.kind ?? '',
     llm_id: config.llm_id ?? '',
     global_rules: config.global_rules ?? '',
-    example: typeof config.example === 'string' ? config.example : '',
+    example: storedExample,
     ...(typeof config.synthesis === 'object' && config.synthesis !== null
       ? {
           synthesis:
@@ -173,7 +170,7 @@ export const transformDetailToForm = (
         }
       : {}),
     use_blueprint:
-      detail.kind === CompilationTemplateKind.Artifacts && example.length > 0,
+      detail.kind === CompilationTemplateKind.Artifacts && hasBlueprintContent,
     plan: typeof config.plan === 'boolean' ? config.plan : true,
     ...(detail.kind !== CompilationTemplateKind.Tree
       ? {
@@ -186,11 +183,12 @@ export const transformDetailToForm = (
       : {}),
   };
 
-  if (detail.kind === CompilationTemplateKind.Artifacts && example.length > 0) {
-    const { instruction, page_example } =
-      splitExampleToBlueprintFields(example);
-    base.instruction = instruction;
-    base.page_example = page_example;
+  if (
+    detail.kind === CompilationTemplateKind.Artifacts &&
+    hasBlueprintContent
+  ) {
+    base.instruction = storedInstruction;
+    base.example = storedExample;
   }
 
   if (detail.kind === CompilationTemplateKind.Tree) {
@@ -254,7 +252,7 @@ export const transformTemplateToPayload = (template: TemplateSchemaType) => {
 
   Object.entries(template.config).forEach(([key, value]) => {
     if (key === 'kind' || key === 'llm_id') return;
-    if (key === 'instruction' || key === 'page_example') return;
+    if (key === 'example' || key === 'instruction') return;
     if (key === 'synthesis') {
       config[key] = value as ICompilationTemplateConfigRequest[string];
       return;
@@ -274,9 +272,11 @@ export const transformTemplateToPayload = (template: TemplateSchemaType) => {
   if (template.kind === CompilationTemplateKind.Artifacts) {
     if (template.config.use_blueprint) {
       const instruction = String(template.config.instruction ?? '').trim();
-      const pageExample = String(template.config.page_example ?? '').trim();
-      config.example = [instruction, pageExample].filter(Boolean).join('\n\n');
+      const example = String(template.config.example ?? '').trim();
+      config.instruction = instruction;
+      config.example = example;
     } else {
+      config.instruction = '';
       config.example = '';
     }
   }

--- a/web/src/pages/user-setting/compilation-templates/edit-next/components/blueprint-section.tsx
+++ b/web/src/pages/user-setting/compilation-templates/edit-next/components/blueprint-section.tsx
@@ -29,8 +29,8 @@ export function BlueprintSection({
     options,
     handleSelect,
     instructionPath,
-    pageExample,
-    handlePageExampleChange,
+    example,
+    handleExampleChange,
   } = useBlueprintSelection({ form, selectedTemplateIndex, presets, builtins });
 
   if (presets.length === 0) {
@@ -63,8 +63,8 @@ export function BlueprintSection({
 
             <div className="flex h-[50vh] min-h-0 flex-col">
               <MarkdownEditor
-                content={String(pageExample ?? '')}
-                onChange={handlePageExampleChange}
+                content={String(example ?? '')}
+                onChange={handleExampleChange}
               />
             </div>
           </div>

--- a/web/src/pages/user-setting/compilation-templates/edit-next/constant.ts
+++ b/web/src/pages/user-setting/compilation-templates/edit-next/constant.ts
@@ -20,7 +20,6 @@ export const DefaultTemplateValues: TemplateSchemaType = {
     global_rules: '',
     example: '',
     instruction: '',
-    page_example: '',
     use_blueprint: false,
     plan: true,
     rechunk: false,

--- a/web/src/pages/user-setting/compilation-templates/edit-next/hooks/use-blueprint-selection.ts
+++ b/web/src/pages/user-setting/compilation-templates/edit-next/hooks/use-blueprint-selection.ts
@@ -9,7 +9,6 @@ import { UseFormReturn, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import { FormSchemaType } from '../schema';
-import { splitExampleToBlueprintFields } from '../utils';
 
 export const CustomBlueprintValue = '__custom__';
 
@@ -23,10 +22,10 @@ type UseBlueprintSelectionParams = {
 const isSameBlueprintContent = (
   preset: IWikiPreset,
   instruction: string,
-  pageExample: string,
+  example: string,
 ) =>
   preset.instruction.trim() === instruction.trim() &&
-  preset.page_example.trim() === pageExample.trim();
+  preset.example.trim() === example.trim();
 
 export function useBlueprintSelection({
   form,
@@ -40,8 +39,8 @@ export function useBlueprintSelection({
   const kindPath = `templates.${selectedTemplateIndex}.kind` as const;
   const instructionPath =
     `templates.${selectedTemplateIndex}.config.instruction` as const;
-  const pageExamplePath =
-    `templates.${selectedTemplateIndex}.config.page_example` as const;
+  const examplePath =
+    `templates.${selectedTemplateIndex}.config.example` as const;
   const useBlueprintPath =
     `templates.${selectedTemplateIndex}.config.use_blueprint` as const;
 
@@ -53,21 +52,21 @@ export function useBlueprintSelection({
     control: form.control,
     name: instructionPath,
   });
-  const pageExample = useWatch({
+  const example = useWatch({
     control: form.control,
-    name: pageExamplePath,
+    name: examplePath,
   });
 
   const matchedPresetId = useMemo(() => {
     const currentInstruction = String(instruction ?? '');
-    const currentPageExample = String(pageExample ?? '');
-    if (!currentInstruction.trim() && !currentPageExample.trim()) {
+    const currentExample = String(example ?? '');
+    if (!currentInstruction.trim() && !currentExample.trim()) {
       return undefined;
     }
     return presets.find((preset) =>
-      isSameBlueprintContent(preset, currentInstruction, currentPageExample),
+      isSameBlueprintContent(preset, currentInstruction, currentExample),
     )?.id;
-  }, [instruction, pageExample, presets]);
+  }, [instruction, example, presets]);
 
   const selectedValue =
     explicitValue ?? matchedPresetId ?? CustomBlueprintValue;
@@ -92,18 +91,18 @@ export function useBlueprintSelection({
         const builtinTemplate = builtins.find(
           (template) => template.kind === kind,
         );
-        const example =
+        const defaultInstruction =
+          typeof builtinTemplate?.config?.instruction === 'string'
+            ? builtinTemplate.config.instruction
+            : '';
+        const defaultPageExample =
           typeof builtinTemplate?.config?.example === 'string'
             ? builtinTemplate.config.example
             : '';
-        const {
-          instruction: defaultInstruction,
-          page_example: defaultPageExample,
-        } = splitExampleToBlueprintFields(example);
         form.setValue(instructionPath, defaultInstruction, {
           shouldValidate: false,
         });
-        form.setValue(pageExamplePath, defaultPageExample, {
+        form.setValue(examplePath, defaultPageExample, {
           shouldValidate: false,
         });
       } else {
@@ -112,7 +111,7 @@ export function useBlueprintSelection({
         form.setValue(instructionPath, preset.instruction, {
           shouldValidate: false,
         });
-        form.setValue(pageExamplePath, preset.page_example, {
+        form.setValue(examplePath, preset.example, {
           shouldValidate: false,
         });
       }
@@ -124,18 +123,18 @@ export function useBlueprintSelection({
       form,
       instructionPath,
       kind,
-      pageExamplePath,
+      examplePath,
       presets,
       selectedValue,
       useBlueprintPath,
     ],
   );
 
-  const handlePageExampleChange = useCallback(
+  const handleExampleChange = useCallback(
     (value: string) => {
-      form.setValue(pageExamplePath, value, { shouldValidate: false });
+      form.setValue(examplePath, value, { shouldValidate: false });
     },
-    [form, pageExamplePath],
+    [form, examplePath],
   );
 
   return {
@@ -143,7 +142,7 @@ export function useBlueprintSelection({
     options,
     handleSelect,
     instructionPath,
-    pageExample,
-    handlePageExampleChange,
+    example,
+    handleExampleChange,
   };
 }

--- a/web/src/pages/user-setting/compilation-templates/edit-next/utils.ts
+++ b/web/src/pages/user-setting/compilation-templates/edit-next/utils.ts
@@ -19,20 +19,6 @@ import {
   SectionPriority,
 } from './constant';
 
-export const splitExampleToBlueprintFields = (
-  example: string,
-): { instruction: string; page_example: string } => {
-  const trimmed = example.trim();
-  const separatorIndex = trimmed.indexOf('\n\n');
-  if (separatorIndex === -1) {
-    return { instruction: trimmed, page_example: '' };
-  }
-  return {
-    instruction: trimmed.slice(0, separatorIndex).trim(),
-    page_example: trimmed.slice(separatorIndex + 2).trim(),
-  };
-};
-
 export const getFieldKeyOrder = (keys: string[]): string[] => {
   const sortedKeys = [...keys].sort();
   return (
@@ -48,7 +34,6 @@ export const isConfigMetaKey = (key: string) =>
     'global_rules',
     'example',
     'instruction',
-    'page_example',
     'synthesis',
     'use_blueprint',
     'plan',
@@ -81,6 +66,10 @@ export const buildConfigFromBuiltin = (
   kind: string,
   llmId: string,
 ): TemplateSchemaType['config'] => {
+  const instruction =
+    typeof builtinTemplate.config?.instruction === 'string'
+      ? builtinTemplate.config.instruction
+      : '';
   const example =
     typeof builtinTemplate.config?.example === 'string'
       ? builtinTemplate.config.example
@@ -104,7 +93,8 @@ export const buildConfigFromBuiltin = (
         }
       : {}),
     use_blueprint:
-      kind === CompilationTemplateKind.Artifacts && example.length > 0,
+      kind === CompilationTemplateKind.Artifacts &&
+      (instruction.length > 0 || example.length > 0),
     plan:
       typeof builtinTemplate.config?.plan === 'boolean'
         ? builtinTemplate.config.plan
@@ -120,11 +110,12 @@ export const buildConfigFromBuiltin = (
       : {}),
   };
 
-  if (kind === CompilationTemplateKind.Artifacts && example.length > 0) {
-    const { instruction, page_example } =
-      splitExampleToBlueprintFields(example);
+  if (
+    kind === CompilationTemplateKind.Artifacts &&
+    (instruction.length > 0 || example.length > 0)
+  ) {
     sections.instruction = instruction;
-    sections.page_example = page_example;
+    sections.example = example;
   }
 
   if (kind === CompilationTemplateKind.Tree) {
@@ -156,12 +147,18 @@ export const transformDetailToForm = (
   detail: ICompilationTemplate,
 ): TemplateSchemaType => {
   const config = detail.config ?? {};
-  const example = typeof config.example === 'string' ? config.example : '';
+  const storedInstruction =
+    typeof config.instruction === 'string' ? config.instruction : '';
+  const storedExample =
+    typeof config.example === 'string' ? config.example : '';
+  const hasBlueprintContent = Boolean(
+    storedInstruction.trim() || storedExample.trim(),
+  );
   const base: TemplateSchemaType['config'] = {
     kind: config.kind ?? '',
     llm_id: config.llm_id ?? '',
     global_rules: config.global_rules ?? '',
-    example: typeof config.example === 'string' ? config.example : '',
+    example: storedExample,
     ...(typeof config.synthesis === 'object' && config.synthesis !== null
       ? {
           synthesis:
@@ -169,7 +166,7 @@ export const transformDetailToForm = (
         }
       : {}),
     use_blueprint:
-      detail.kind === CompilationTemplateKind.Artifacts && example.length > 0,
+      detail.kind === CompilationTemplateKind.Artifacts && hasBlueprintContent,
     plan: typeof config.plan === 'boolean' ? config.plan : true,
     ...(detail.kind !== CompilationTemplateKind.Tree
       ? {
@@ -182,11 +179,12 @@ export const transformDetailToForm = (
       : {}),
   };
 
-  if (detail.kind === CompilationTemplateKind.Artifacts && example.length > 0) {
-    const { instruction, page_example } =
-      splitExampleToBlueprintFields(example);
-    base.instruction = instruction;
-    base.page_example = page_example;
+  if (
+    detail.kind === CompilationTemplateKind.Artifacts &&
+    hasBlueprintContent
+  ) {
+    base.instruction = storedInstruction;
+    base.example = storedExample;
   }
 
   if (detail.kind === CompilationTemplateKind.Tree) {
@@ -250,7 +248,7 @@ export const transformTemplateToPayload = (template: TemplateSchemaType) => {
 
   Object.entries(template.config).forEach(([key, value]) => {
     if (key === 'kind' || key === 'llm_id') return;
-    if (key === 'instruction' || key === 'page_example') return;
+    if (key === 'example' || key === 'instruction') return;
     if (key === 'synthesis') {
       config[key] = value as ICompilationTemplateConfigRequest[string];
       return;
@@ -270,9 +268,11 @@ export const transformTemplateToPayload = (template: TemplateSchemaType) => {
   if (template.kind === CompilationTemplateKind.Artifacts) {
     if (template.config.use_blueprint) {
       const instruction = String(template.config.instruction ?? '').trim();
-      const pageExample = String(template.config.page_example ?? '').trim();
-      config.example = [instruction, pageExample].filter(Boolean).join('\n\n');
+      const example = String(template.config.example ?? '').trim();
+      config.instruction = instruction;
+      config.example = example;
     } else {
+      config.instruction = '';
       config.example = '';
     }
   }


### PR DESCRIPTION
### What problem does this PR solve?

Separate Wiki template instructions from page examples across the backend, frontend, preset files, and Wiki generation flow.

Also configure the raw Markdown editor to use the local Monaco loader consistently.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)