### PR TITLE
fix: clean up wiki blueprint default instruction text

### DIFF
--- a/api/db/init_data/compilation_templates/wiki.yaml
+++ b/api/db/init_data/compilation_templates/wiki.yaml
@@ -9,7 +9,7 @@ config:
       - 2. Sections with H2 headings, each starting with prose before sub-bullets.
       - 3. Bold key terms on first use; link them with [[ ]] wikilinks.
       - 4. Examples or implications where the source provides them.
-      - 5. ## See also section at the end with wikilinks to highly related pages(less than 12).\n
+      - 5. End with a "## See also" section listing wikilinks to highly related pages (less than 12).
   example: |
       - Page structure could be as following: (Not provided)
   entity:

--- a/api/db/init_data/compilation_templates/wiki/general.yaml
+++ b/api/db/init_data/compilation_templates/wiki/general.yaml
@@ -5,6 +5,6 @@ instruction: |
     - 2. Sections with H2 headings, each starting with prose before sub-bullets.
     - 3. Bold key terms on first use; link them with [[ ]] wikilinks.
     - 4. Examples or implications where the source provides them.
-    - 5. ## See also section at the end with wikilinks to highly related pages(less than 12).\n
+    - 5. End with a "## See also" section listing wikilinks to highly related pages (less than 12).
 example: |
     - (Not provided)

--- a/rag/advanced_rag/knowlege_compile/wiki.py
+++ b/rag/advanced_rag/knowlege_compile/wiki.py
@@ -2611,7 +2611,7 @@ WIKI_TEMPLATE_EXAMPLE = (
     "   Put every heading on its own line and separate every paragraph with a blank line.\n"
     "3. Bold key terms on first use; link them with [[ ]] wikilinks.\n"
     "4. Examples or implications where the source provides them.\n"
-    "5. ## See also section at the end with wikilinks to highly related pages(less than 12).\n\n"
+    '5. End with a "## See also" section listing wikilinks to highly related pages (less than 12).\n\n'
     "Page structure could be as following:\n(Not provided)"
 )
 


### PR DESCRIPTION
### Summary

The default instruction text for the custom wiki blueprint (operator-wiki) contained a stray markdown heading marker (`##`) in the middle of a sentence and a literal `\n` (in YAML block scalars it is not escaped, so it was rendered verbatim in the UI):

```
5. ## See also section at the end with wikilinks to highly related pages(less than 12).\n
```

This PR fixes the line to read cleanly in all three places where the default text lives:

- `api/db/init_data/compilation_templates/wiki/general.yaml` — the preset served (filesystem-fresh) to the frontend for the Custom blueprint
- `api/db/init_data/compilation_templates/wiki.yaml` — the built-in wiki template `example`
- `rag/advanced_rag/knowlege_compile/wiki.py` — the `WIKI_TEMPLATE_EXAMPLE` fallback

Fixed text:

```
5. End with a "## See also" section listing wikilinks to highly related pages (less than 12).
```

Also normalized the missing space before the parenthesis.