### PR TITLE
fix(web): replace ambiguous compilation page title with interpolated wording

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -555,7 +555,7 @@ Example: A 1 KB message with 1024-dim embedding uses ~9 KB. The 5 MB default lim
       selectArtifact: 'Select an item from the contents to view details',
       searchEntity: 'Search entity',
       sourceDocuments: 'Source documents',
-      compilationTitleSuffix: "' dataset",
+      compilationTitle: '{{name}} compilation',
       name: 'Name',
       namePlaceholder: 'Please input name!',
       doc: 'Docs',

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -397,7 +397,7 @@ export default {
       directoryRulePlaceholder: '入力してください',
       selectArtifact: 'ナビゲーションから項目を選択すると詳細が表示されます',
       sourceDocuments: 'ソースドキュメント',
-      compilationTitleSuffix: 'のデータセット',
+      compilationTitle: '{{name}}のコンパイル',
       noTestResultsForRuned:
         '関連する結果が見つかりませんでした。クエリまたはパラメータを調整してください。',
       noTestResultsForNotRuned:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -500,7 +500,7 @@ export default {
       selectArtifact: '从目录中选择一个条目以查看详情',
       searchEntity: '搜索实体',
       sourceDocuments: '来源文档',
-      compilationTitleSuffix: '的数据集',
+      compilationTitle: '{{name}} 编译',
       files: '个文件',
       name: '名称',
       namePlaceholder: '请输入名称',

--- a/web/src/pages/dataset/compilation/index.tsx
+++ b/web/src/pages/dataset/compilation/index.tsx
@@ -51,8 +51,9 @@ export default function Compilation() {
               className="size-10 rounded-lg"
             />
             <h2 className="text-xl font-medium text-text-primary">
-              {knowledgeBase?.name}
-              {t('knowledgeDetails.compilationTitleSuffix')}
+              {t('knowledgeDetails.compilationTitle', {
+                name: knowledgeBase?.name,
+              })}
             </h2>
           </div>
 


### PR DESCRIPTION
### Summary

The knowledge base **Compilation** page title was built by concatenating the knowledge base name with a suffix ('的数据集' / "' dataset" / 'のデータセット'), e.g. `redream的数据集` / `redream' dataset`. This reads awkwardly and is ambiguous: it is unclear whether 'dataset' refers to the knowledge base itself or a dataset within it.

This PR replaces the suffix concatenation with an interpolated i18n title that matches the sidebar tab label and removes the ambiguity:

- zh: `{{name}} 编译`
- en: `{{name}} compilation`
- ja: `{{name}}のコンパイル`

Changes:
- `web/src/pages/dataset/compilation/index.tsx`: render the title via `t('knowledgeDetails.compilationTitle', { name })` instead of name + suffix concatenation.
- `web/src/locales/{zh,en,ja}.ts`: replace `compilationTitleSuffix` with `compilationTitle`.