### PR TITLE
docs: fix broken sandbox link in quickstart

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -32,7 +32,7 @@ If you are on an ARM platform, follow [this guide](./develop/build_docker_image.
 - Disk &ge; 50 GB;
 - Docker &ge; 24.0.0 & Docker Compose &ge; v2.26.1;
 - Python &ge; 3.13;
-- [gVisor](https://gvisor.dev/docs/user_guide/install/): Required only if you intend to use the code executor ([sandbox](https://github.com/infiniflow/ragflow/tree/main/sandbox)) feature of RAGFlow.
+- [gVisor](https://gvisor.dev/docs/user_guide/install/): Required only if you intend to use the code executor ([sandbox](https://github.com/infiniflow/ragflow/tree/main/agent/sandbox)) feature of RAGFlow.
 
 :::tip NOTE
 If you have not installed Docker on your local machine (Windows, Mac, or Linux), see [Install Docker Engine](https://docs.docker.com/engine/install/).


### PR DESCRIPTION
## What

The quickstart guide references the code executor **sandbox** feature and links to `/tree/main/sandbox`, but the sandbox now lives at `agent/sandbox` (contains `executor_manager`, `providers/`, `result_protocol.py`, etc.). The current link 404s.

```diff
- [sandbox](https://github.com/infiniflow/ragflow/tree/main/sandbox)
+ [sandbox](https://github.com/infiniflow/ragflow/tree/main/agent/sandbox)
```

Verified the target directory exists on `main`. Docs-only change.