### PR TITLE
Fix QA Excel parser dropping rows whose answer is a zero value

### DIFF
--- a/rag/app/qa.py
+++ b/rag/app/qa.py
@@ -50,7 +50,7 @@ class Excel(ExcelParser):
             for i, r in enumerate(rows):
                 q, a = "", ""
                 for cell in r:
-                    if not cell.value:
+                    if cell.value is None or str(cell.value).strip() == "":
                         continue
                     if not q:
                         q = str(cell.value)

--- a/rag/app/qa.py
+++ b/rag/app/qa.py
@@ -50,6 +50,7 @@ class Excel(ExcelParser):
             for i, r in enumerate(rows):
                 q, a = "", ""
                 for cell in r:
+                    # A 0, 0.0, or False answer is falsy but is real content.
                     if cell.value is None or str(cell.value).strip() == "":
                         continue
                     if not q:

--- a/test/unit_test/rag/app/test_qa_excel.py
+++ b/test/unit_test/rag/app/test_qa_excel.py
@@ -1,0 +1,100 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from __future__ import annotations
+
+import warnings
+from io import BytesIO
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message=".*pkg_resources is deprecated.*", category=UserWarning)
+    import pkg_resources  # noqa: F401 - stabilize xgboost import during collection
+
+import pytest
+from openpyxl import Workbook
+
+from rag.app import qa
+
+
+def _noop_callback(*_args, **_kwargs):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _stub_rag_tokenizer(monkeypatch):
+    def fake_tokenize(text):
+        return str(text)
+
+    monkeypatch.setattr("rag.nlp.rag_tokenizer.tokenize", fake_tokenize)
+    monkeypatch.setattr("rag.nlp.rag_tokenizer.fine_grained_tokenize", fake_tokenize)
+
+
+@pytest.mark.p2
+def test_excel_keeps_zero_valued_answers():
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["plain question", "plain answer"])
+    ws.append(["how many retries", 0])
+    ws.append(["what is the delta", 0.0])
+    ws.append(["is it enabled", False])
+    ws.append(["count of rows", 7])
+    binary = BytesIO()
+    wb.save(binary)
+    messages = []
+
+    def record_callback(_progress, message):
+        messages.append(message)
+
+    chunks = qa.chunk(
+        "qa.xlsx",
+        binary=binary.getvalue(),
+        lang="English",
+        callback=record_callback,
+    )
+
+    assert len(chunks) == 5
+    assert [chunk["content_with_weight"] for chunk in chunks] == [
+        "Question: plain question\tAnswer: plain answer",
+        "Question: how many retries\tAnswer: 0",
+        "Question: what is the delta\tAnswer: 0",
+        "Question: is it enabled\tAnswer: False",
+        "Question: count of rows\tAnswer: 7",
+    ]
+    assert not any("failure" in message for message in messages)
+
+
+@pytest.mark.p2
+def test_excel_drops_whitespace_only_cells():
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["valid question", "valid answer"])
+    ws.append(["   ", "ignored answer"])
+    binary = BytesIO()
+    wb.save(binary)
+    messages = []
+
+    def record_callback(_progress, message):
+        messages.append(message)
+
+    chunks = qa.chunk(
+        "qa.xlsx",
+        binary=binary.getvalue(),
+        lang="English",
+        callback=record_callback,
+    )
+
+    assert len(chunks) == 1
+    assert any("failure" in message for message in messages)


### PR DESCRIPTION
### What problem does this PR solve?

The Excel branch of the QA parser drops any row whose answer is a zero value.

`rag/app/qa.py` skipped cells with `if not cell.value`, which is falsy for `0`, `0.0` and `False` as well as for genuinely empty cells. When the answer column held one of those, `a` stayed empty, the row failed the `q and a` check and was appended to `fails` - so it was silently discarded from the index rather than surfaced as content.

Reproduced with a 5-row sheet (openpyxl, unmodified parser loop):

```
before:  2/5 pairs extracted, dropped rows [2, 3, 4]
after:   5/5 pairs extracted, dropped rows []
```

The three lost rows had answers `0` (int), `0.0` (float) and `False` (bool). Text and non-zero numeric answers give the same result before and after, which is why this is easy to miss. The new condition changes two other cases. See "Other behaviour changes" below.

`deepdoc/parser/excel_parser.py` already hit this exact problem and fixed it in #16287 ("keep zero-valued cells when building Excel text chunks"). This ports the same test to the QA parser, which was the only remaining `if not cell.value` in `rag/app/` or `deepdoc/`.

`rag/app/tag.py` does `from rag.app.qa import Excel` and instantiates it, so tag parsing was dropping the same rows.

### Other behaviour changes

The new condition tests for `None` and for an empty string after `strip()`. This changes two more cases. I measured both against the real parser.

**1. Whitespace-only cells are now skipped.** A cell that holds only spaces was truthy before, so it became a question or an answer.

| row | before | after |
|---|---|---|
| `("   ", "answer under a blank question")` | kept, with a blank question | dropped, counted in `fails` |
| `("question with a blank answer", "   ")` | kept, with a blank answer | dropped, counted in `fails` |

A blank question is not a question. The row now shows in the failure line instead of the index. `test_excel_drops_whitespace_only_cells` locks this in.

**2. A leading zero-valued column changes the pair.** The parser takes the first two non-empty cells as the question and the answer.

| row | before | after |
|---|---|---|
| `[0, "Q", "A"]` | `("Q", "A")` | `("0", "Q")` |
| `[5, "Q", "A"]` | `("5", "Q")` | `("5", "Q")` |

The second row is the control. Any leading ID column already broke the pair, so this limit is not new. The `0` case was correct before only because the bug skipped the cell. I did not add a test for this case. A test would lock in `("0", "Q")`, which is not the output we want. A correct fix needs a header row or a column count, and that is out of scope here.

### Test

`test/unit_test/rag/app/test_qa_excel.py` is new. It follows the conventions of the sibling `test/unit_test/rag/app/test_qa_csv.py`. It builds the sheet with openpyxl and calls `qa.chunk` with a `.xlsx` name, so it drives the real parser path.

With the one-line fix reverted and the test kept:

```
FAILED test_excel_keeps_zero_valued_answers - AssertionError: assert 2 == 5
FAILED test_excel_drops_whitespace_only_cells - AssertionError: assert 2 == 1
2 failed
```

With the fix:

```
2 passed
```

`test_qa_csv.py` still gives 4 passed. `ruff check` passes on both changed files.

Note for a local run: `pytest test/unit_test/rag/app/` fails to collect four files, including the pre-existing `test_one.py` and `test_qa_csv.py`, with `ImportError: cannot import name 'PlainParser' from 'deepdoc.parser.pdf_parser'`. This comes from the stub in `test/unit_test/rag/conftest.py` and is not related to this change. I ran the tests with `--noconftest`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
