### PR TITLE
Fix HTML parser treating an empty upload as a missing binary

### DIFF
--- a/deepdoc/parser/html_parser.py
+++ b/deepdoc/parser/html_parser.py
@@ -36,7 +36,7 @@ TITLE_TAGS = {"h1": "#", "h2": "##", "h3": "###", "h4": "####", "h5": "#####", "
 
 class RAGFlowHtmlParser:
     def __call__(self, fnm, binary=None, chunk_token_num=512):
-        if binary:
+        if binary is not None:
             encoding = find_codec(binary)
             txt = binary.decode(encoding, errors="ignore")
         else:


### PR DESCRIPTION
### What problem does this PR solve?

`RAGFlowHtmlParser.__call__` chose the binary branch with `if binary:`, which is falsy for an empty `bytes` object as well as for `None`. A zero-byte `.html` upload therefore fell through to the file-path branch and called `open(fnm, ...)`.

Every caller passes a logical file name alongside the payload (`HtmlParser()(filename, binary)` in `rag/app/book.py`, `laws.py`, `naive.py`, `one.py`, and `rag/flow/parser/parser.py`), not a path that exists on disk, so that branch raises instead of parsing the empty document.

Verified against the parser on current main:

```
before:  normal upload -> OK, 1 section(s): ['hello']
         0-byte upload -> FileNotFoundError: [Errno 2] No such file or directory: 'page.html'

after:   normal upload -> OK, 1 section(s): ['hello']
         0-byte upload -> OK, 0 section(s): []
```

The two sibling decode sites already use the `None` check: `deepdoc/parser/utils.py` in `get_text`, and `deepdoc/parser/epub_parser.py`, which additionally raises an explicit "Empty EPUB binary payload" error for this case.

`find_codec(b"")` is safe: `chardet.detect` returns confidence 0, the codec loop decodes the empty payload on its first candidate, and `b"".decode(..., errors="ignore")` gives `""`, which `parser_txt` accepts.

Non-empty payloads take the same path as before, so there is no behaviour change for normal uploads.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
