### PR TITLE
fix: allow recreating deleted template groups

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -1183,7 +1183,6 @@ class CompilationTemplateGroup(DataBaseModel):
 
     class Meta:
         db_table = "compilation_template_group"
-        indexes = ((("tenant_id", "name", "status"), True),)
 
 
 class Search(DataBaseModel):
@@ -1825,6 +1824,9 @@ def migrate_db():
         ("compilation_template", "compilationtemplate_tenant_id_name_is_builtin_status"),
         ("compilation_template", "compilation_template_tenant_id_name_is_builtin_status"),
         ("compilation_template", "idx_compilation_template_tenant_id_name_is_builtin_status"),
+        ("compilation_template_group", "compilationtemplategroup_tenant_id_name_status"),
+        ("compilation_template_group", "compilation_template_group_tenant_id_name_status"),
+        ("compilation_template_group", "idx_compilation_template_group_tenant_id_name_status"),
     ]
     for table_name, index_name in legacy_indexes:
         try:


### PR DESCRIPTION
### What problem does this PR solve?

Fix duplicate-key errors when deleting and recreating compilation template groups with the same name.

- Remove the obsolete `(tenant_id, name, status)` unique index.
- Drop legacy versions of the index during database migration.
- Keep duplicate-name validation for active groups.
- Allow reusing names from invalidated groups.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)