### PR TITLE
fix: hide resume parser option

### DIFF
--- a/web/src/pages/dataset/dataset-setting/hooks.ts
+++ b/web/src/pages/dataset/dataset-setting/hooks.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import { formSchema } from './form-schema';
 
 // The value that does not need to be displayed in the analysis method Select
-const HiddenFields = ['email', 'picture', 'audio'];
+const HiddenFields = ['email', 'picture', 'audio', 'resume'];
 
 export function useSelectChunkMethodList() {
   const parserList = useSelectParserList();


### PR DESCRIPTION
### What problem does this PR solve?

Hide the Resume parser from the knowledge base chunking method selector because it is not intended to be user-selectable there.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)