### PR TITLE
fix: handle map result in auto keyword/question extraction

### DIFF
--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -751,7 +751,17 @@ func (c *ExtractorComponent) runAutoKeywords(ctx context.Context, db *gorm.DB, i
 	if err != nil {
 		return err
 	}
-	resultStr, _ := result.(string)
+	resultStr, ok := result.(string)
+	if !ok {
+		if m, isMap := result.(map[string]any); isMap {
+			if kw, exists := m["keywords"]; exists {
+				resultStr = fmt.Sprintf("%v", kw)
+			} else {
+				b, _ := json.Marshal(m)
+				resultStr = string(b)
+			}
+		}
+	}
 	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil
@@ -787,7 +797,17 @@ func (c *ExtractorComponent) runAutoQuestions(ctx context.Context, db *gorm.DB, 
 	if err != nil {
 		return err
 	}
-	resultStr, _ := result.(string)
+	resultStr, ok := result.(string)
+	if !ok {
+		if m, isMap := result.(map[string]any); isMap {
+			if q, exists := m["questions"]; exists {
+				resultStr = fmt.Sprintf("%v", q)
+			} else {
+				b, _ := json.Marshal(m)
+				resultStr = string(b)
+			}
+		}
+	}
 	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -753,14 +753,7 @@ func (c *ExtractorComponent) runAutoKeywords(ctx context.Context, db *gorm.DB, i
 	}
 	resultStr, ok := result.(string)
 	if !ok {
-		if m, isMap := result.(map[string]any); isMap {
-			if kw, exists := m["keywords"]; exists {
-				resultStr = fmt.Sprintf("%v", kw)
-			} else {
-				b, _ := json.Marshal(m)
-				resultStr = string(b)
-			}
-		}
+		resultStr = formatStructuredExtraction(result, "keywords", ",")
 	}
 	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
@@ -799,14 +792,7 @@ func (c *ExtractorComponent) runAutoQuestions(ctx context.Context, db *gorm.DB, 
 	}
 	resultStr, ok := result.(string)
 	if !ok {
-		if m, isMap := result.(map[string]any); isMap {
-			if q, exists := m["questions"]; exists {
-				resultStr = fmt.Sprintf("%v", q)
-			} else {
-				b, _ := json.Marshal(m)
-				resultStr = string(b)
-			}
-		}
+		resultStr = formatStructuredExtraction(result, "questions", "\n")
 	}
 	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
@@ -1058,6 +1044,31 @@ func cleanExtractionResult(s string) string {
 		return ""
 	}
 	return s
+}
+
+func formatStructuredExtraction(result any, field, separator string) string {
+	m, ok := result.(map[string]any)
+	if !ok {
+		return ""
+	}
+	value, exists := m[field]
+	if !exists {
+		b, _ := json.Marshal(m)
+		return string(b)
+	}
+	if value == nil {
+		return ""
+	}
+	if values, ok := value.([]any); ok {
+		parts := make([]string, 0, len(values))
+		for _, item := range values {
+			if item != nil {
+				parts = append(parts, fmt.Sprint(item))
+			}
+		}
+		return strings.Join(parts, separator)
+	}
+	return fmt.Sprint(value)
 }
 
 // splitKeywords splits a comma-delimited keyword string.

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -848,6 +848,30 @@ func TestCleanExtractionResult(t *testing.T) {
 	}
 }
 
+func TestFormatStructuredExtraction(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    any
+		field     string
+		separator string
+		want      string
+	}{
+		{name: "object field", result: map[string]any{"keywords": "k1,k2"}, field: "keywords", separator: ",", want: "k1,k2"},
+		{name: "keyword array", result: map[string]any{"keywords": []any{"k1", "k2"}}, field: "keywords", separator: ",", want: "k1,k2"},
+		{name: "question array", result: map[string]any{"questions": []any{"q1", "q2"}}, field: "questions", separator: "\n", want: "q1\nq2"},
+		{name: "null field", result: map[string]any{"keywords": nil}, field: "keywords", separator: ",", want: ""},
+		{name: "string response", result: "k1,k2", field: "keywords", separator: ",", want: ""},
+		{name: "object fallback", result: map[string]any{"other": "value"}, field: "keywords", separator: ",", want: `{"other":"value"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatStructuredExtraction(tt.result, tt.field, tt.separator); got != tt.want {
+				t.Errorf("formatStructuredExtraction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // newMetadataExtractor returns an ExtractorComponent wired for doc-level
 // metadata extraction with the given field definitions.
 func newMetadataExtractor(fields ...common.MetadataFieldDef) *ExtractorComponent {


### PR DESCRIPTION
## Summary

Fix automatic keyword and question extraction when the LLM response is decoded by `call()` as `map[string]any` instead of a string.

## Problem

`runAutoKeywords` and `runAutoQuestions` used a non-checked type assertion:

```go
resultStr, _ := result.(string)
```

When `call()` returned a map for valid JSON content, the assertion failed and the extraction result was silently discarded. Additionally, formatting structured array fields with `fmt.Sprintf("%v")` converted values such as `["k1", "k2"]` to `[k1 k2]` and `null` to `<nil>`, which could break downstream parsing.

## Changes

- Check the result type before using it as a string.
- Extract the `keywords` field for automatic keyword extraction.
- Extract the `questions` field for automatic question extraction.
- Normalize keyword arrays as comma-separated text.
- Normalize question arrays as newline-separated text.
- Treat null field values as empty results.
- Fall back to JSON marshaling for other map-shaped responses.
- Preserve existing behavior for string responses and empty results.

## Testing

- Added focused tests for object, array, null, and string responses.
- Verified with `./build.sh --test -run ^TestFormatStructuredExtraction ./internal/ingestion/component`.
- Verified the diff with `git diff --check`.
