### PR TITLE
refactor(extractor): keep only system_prompt/user_prompt, drop prompts queue

### DIFF
--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -230,7 +230,7 @@ type ExtractorComponent struct {
 //	  "field_name":     string,           — optional; key the extraction lands under
 //	  "llm_id":         string,           — optional; resolves via models.NewModelFactory
 //	  "system_prompt":  string,           — optional override
-//	  "prompt":         string,           — optional user prompt
+//	  "user_prompt":    string,           — optional user prompt
 //	}
 //
 // errors here surface as canvas compile failures so a malformed
@@ -246,24 +246,9 @@ func NewExtractorComponent(params map[string]any) (runtime.Component, error) {
 		}
 		if v, ok := params["system_prompt"].(string); ok {
 			p.SystemPrompt = v
-		} else if v, ok := params["sys_prompt"].(string); ok {
-			p.SystemPrompt = v
 		}
-		if v, ok := params["prompt"].(string); ok {
-			p.Prompt = v
-		} else if v, ok := params["prompts"].(string); ok && v != "" {
-			// Python agent/component/llm.py:119-120 normalizes a bare-string
-			// prompts into [{"role":"user","content":prompts}]. Mirror that
-			// here so a front-end/template that emits prompts as a string
-			// (the graph.nodes form / dsl testdata) is not silently dropped
-			// by the .([]any) assertion on the list branch below.
-			p.Prompt = v
-		} else if promptsRaw, ok := params["prompts"].([]any); ok && len(promptsRaw) > 0 {
-			if first, ok := promptsRaw[0].(map[string]any); ok {
-				if content, ok := first["content"].(string); ok {
-					p.Prompt = content
-				}
-			}
+		if v, ok := params["user_prompt"].(string); ok {
+			p.UserPrompt = v
 		}
 		if v, ok := params["auto_keywords"]; ok {
 			p.AutoKeywords = mapInt(v)
@@ -323,7 +308,7 @@ func NewExtractorComponent(params map[string]any) (runtime.Component, error) {
 func (c *ExtractorComponent) Inputs() map[string]string {
 	return map[string]string{
 		"chunks":        "List of map[string]any from upstream Tokenizer. Each entry must carry a string 'text' (or 'content_with_weight') field. Optional — when absent the LLM is called once with the resolved args.",
-		"prompt":        "Optional user prompt template. Falls back to Param.Prompt when absent.",
+		"user_prompt":   "Optional user prompt template. Falls back to Param.UserPrompt when absent.",
 		"llm_id":        "Optional per-call LLM id override. Falls back to Param.LLMID when absent.",
 		"system_prompt": "Optional per-call system prompt override. Falls back to Param.SystemPrompt.",
 	}
@@ -535,7 +520,7 @@ type extractorInputs struct {
 	fieldName    string
 	llmID        string
 	systemPrompt string
-	prompt       string
+	userPrompt   string
 	lang         string
 	chunks       []map[string]any
 	// temperature overrides the LLM temperature for this call. A
@@ -558,7 +543,7 @@ func (c *ExtractorComponent) resolveInputs(inputs map[string]any) extractorInput
 		fieldName:    c.Param.FieldName,
 		llmID:        c.Param.LLMID,
 		systemPrompt: c.Param.SystemPrompt,
-		prompt:       c.Param.Prompt,
+		userPrompt:   c.Param.UserPrompt,
 	}
 	if inputs == nil {
 		return out
@@ -566,12 +551,10 @@ func (c *ExtractorComponent) resolveInputs(inputs map[string]any) extractorInput
 	if v, ok := inputs["llm_id"].(string); ok && v != "" {
 		out.llmID = v
 	}
-	if v, ok := inputs["prompt"].(string); ok && v != "" {
-		out.prompt = v
+	if v, ok := inputs["user_prompt"].(string); ok && v != "" {
+		out.userPrompt = v
 	}
 	if v, ok := inputs["system_prompt"].(string); ok && v != "" {
-		out.systemPrompt = v
-	} else if v, ok := inputs["sys_prompt"].(string); ok && v != "" {
 		out.systemPrompt = v
 	}
 	if v, ok := inputs["lang"].(string); ok && v != "" {
@@ -628,7 +611,7 @@ func extractorChunkList(v any) ([]map[string]any, bool) {
 //
 //	chunks         (optional, []map[string]any) — upstream chunks; each must
 //	                                            carry a string "text".
-//	prompt         (optional, string)            — overrides Param.Prompt.
+//	user_prompt    (optional, string)            — overrides Param.UserPrompt.
 //	system_prompt  (optional, string)            — overrides Param.SystemPrompt.
 //	llm_id         (optional, string)            — overrides Param.LLMID.
 //
@@ -704,7 +687,7 @@ func (c *ExtractorComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map
 			// replaced, the chunk body is already in the prompt — suppress
 			// the append to avoid duplication.
 			var subP, subS bool
-			callIn.prompt, subP = substituteChunkPlaceholders(in.prompt, ck, text)
+			callIn.userPrompt, subP = substituteChunkPlaceholders(in.userPrompt, ck, text)
 			callIn.systemPrompt, subS = substituteChunkPlaceholders(in.systemPrompt, ck, text)
 			callChunkText := text
 			if subP || subS {
@@ -745,7 +728,7 @@ func (c *ExtractorComponent) runAutoKeywords(ctx context.Context, db *gorm.DB, i
 	kwIn := extractorInputs{
 		llmID:        in.llmID,
 		systemPrompt: fmt.Sprintf(autoKeywordPrompt, c.Param.AutoKeywords, chunkText),
-		prompt:       "Output: ",
+		userPrompt:   "Output: ",
 		temperature:  &kwTemp,
 	}
 	resultStr, err := c.callText(ctx, db, kwIn, "")
@@ -780,7 +763,7 @@ func (c *ExtractorComponent) runAutoQuestions(ctx context.Context, db *gorm.DB, 
 	qIn := extractorInputs{
 		llmID:        in.llmID,
 		systemPrompt: fmt.Sprintf(autoQuestionPrompt, c.Param.AutoQuestions, chunkText),
-		prompt:       "Output: ",
+		userPrompt:   "Output: ",
 		temperature:  &qTemp,
 	}
 	resultStr, err := c.callText(ctx, db, qIn, "")
@@ -927,7 +910,7 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 		metaIn := extractorInputs{
 			llmID:        in.llmID,
 			systemPrompt: fmt.Sprintf(autoMetadataPrompt, schemaStr, chunkText),
-			prompt:       "Output: ",
+			userPrompt:   "Output: ",
 			temperature:  &metaTemp,
 		}
 		parsed, err = c.callStructured(ctx, db, metaIn, "")
@@ -1131,7 +1114,7 @@ func (c *ExtractorComponent) callRaw(ctx context.Context, db *gorm.DB, in extrac
 	if err != nil {
 		return nil, err
 	}
-	msgs := buildExtractorMessages(in.systemPrompt, in.prompt, chunkText, in.chunks)
+	msgs := buildExtractorMessages(in.systemPrompt, in.userPrompt, chunkText, in.chunks)
 	fitted, fitErr := fitExtractorMessages(ctx, db, in.llmID, msgs)
 	if fitErr != nil {
 		return nil, fitErr
@@ -1518,7 +1501,7 @@ func fitExtractorMessages(ctx context.Context, db *gorm.DB, llmID string, msgs [
 
 // buildExtractorMessages assembles system + user messages for
 // one extraction call. The user prompt is rendered as
-// "<prompt>\n\n<chunkText>" so the python behavior of
+// "<userPrompt>\n\n<chunkText>" so the python behavior of
 // substituting the chunk text into the args dict is preserved
 // without invoking a template engine.
 //
@@ -1532,12 +1515,12 @@ func fitExtractorMessages(ctx context.Context, db *gorm.DB, llmID string, msgs [
 // Substitution is opt-in: when chunks is nil/empty the placeholder
 // is left intact so a misconfigured template surfaces as a
 // clear pattern rather than silently disappearing.
-func buildExtractorMessages(system, prompt, chunkText string, chunks []map[string]any) []eschema.Message {
+func buildExtractorMessages(system, userPrompt, chunkText string, chunks []map[string]any) []eschema.Message {
 	out := make([]eschema.Message, 0, 2)
 	if system != "" {
 		out = append(out, eschema.Message{Role: eschema.System, Content: system})
 	}
-	user := prompt
+	user := userPrompt
 	if chunkText != "" {
 		if user != "" {
 			user += "\n\n"

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -131,9 +131,9 @@ func TestExtractorComponent_Invoke_HappyPath(t *testing.T) {
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "summary",
-		LLMID:     "gpt-4o-mini",
-		Prompt:    "Summarize:",
+		FieldName:  "summary",
+		LLMID:      "gpt-4o-mini",
+		UserPrompt: "Summarize:",
 	}}
 	out, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{
@@ -301,8 +301,8 @@ func TestExtractorComponent_Invoke_KeepsJSONAsString(t *testing.T) {
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "extraction",
-		Prompt:    "extract:",
+		FieldName:  "extraction",
+		UserPrompt: "extract:",
 	}}
 	out, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{"text": "doc"}}},
@@ -557,7 +557,7 @@ func TestExtractorComponent_NewExtractorComponent_Happy(t *testing.T) {
 		"field_name":    "summary",
 		"llm_id":        "openai/gpt-4o-mini",
 		"system_prompt": "You are a precise summarizer.",
-		"prompt":        "Summarize:",
+		"user_prompt":   "Summarize:",
 	})
 	if err != nil {
 		t.Fatalf("NewExtractorComponent: %v", err)
@@ -569,20 +569,51 @@ func TestExtractorComponent_NewExtractorComponent_Happy(t *testing.T) {
 	}
 }
 
-// TestNewExtractorComponent_SysPromptAlias verifies that "sys_prompt"
-// (the Python DSL name) is accepted as a fallback for SystemPrompt.
-func TestNewExtractorComponent_SysPromptAlias(t *testing.T) {
+// TestNewExtractorComponent_ParsesUserPrompt verifies that the DSL keys
+// "user_prompt" / "system_prompt" map onto the UserPrompt / SystemPrompt
+// fields. These are the only prompt keys the extractor recognizes.
+func TestNewExtractorComponent_ParsesUserPrompt(t *testing.T) {
 	withStubChatInvoker(t, stubResponse{Content: "ok"})
 	comp, err := NewExtractorComponent(map[string]any{
-		"field_name": "out",
-		"sys_prompt": "You are a Python DSL prompt.",
+		"field_name":    "out",
+		"system_prompt": "You are a precise summarizer.",
+		"user_prompt":   "Summarize:",
 	})
 	if err != nil {
 		t.Fatalf("NewExtractorComponent: %v", err)
 	}
 	ec := comp.(*ExtractorComponent)
-	if ec.Param.SystemPrompt != "You are a Python DSL prompt." {
-		t.Errorf("SystemPrompt = %q, want %q", ec.Param.SystemPrompt, "You are a Python DSL prompt.")
+	if ec.Param.SystemPrompt != "You are a precise summarizer." {
+		t.Errorf("SystemPrompt = %q, want %q", ec.Param.SystemPrompt, "You are a precise summarizer.")
+	}
+	if ec.Param.UserPrompt != "Summarize:" {
+		t.Errorf("UserPrompt = %q, want %q", ec.Param.UserPrompt, "Summarize:")
+	}
+}
+
+// TestNewExtractorComponent_IgnoresLegacyPromptKeys pins that the removed
+// prompt aliases ("sys_prompt", "prompt", and the "prompts" string/list
+// forms) are no longer read by the extractor: the two canonical fields
+// stay at their defaults even when only legacy keys are present.
+func TestNewExtractorComponent_IgnoresLegacyPromptKeys(t *testing.T) {
+	withStubChatInvoker(t, stubResponse{Content: "ok"})
+	comp, err := NewExtractorComponent(map[string]any{
+		"field_name": "out",
+		"sys_prompt": "ignored sys",
+		"prompt":     "ignored user",
+		"prompts": []any{
+			map[string]any{"content": "ignored queue", "role": "user"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+	ec := comp.(*ExtractorComponent)
+	if ec.Param.SystemPrompt != "" {
+		t.Errorf("SystemPrompt = %q, want empty (sys_prompt must be ignored)", ec.Param.SystemPrompt)
+	}
+	if ec.Param.UserPrompt != "" {
+		t.Errorf("UserPrompt = %q, want empty (prompt/prompts must be ignored)", ec.Param.UserPrompt)
 	}
 }
 
@@ -619,113 +650,6 @@ func TestNewExtractorComponent_MetadataAsAnySlice(t *testing.T) {
 	}
 	if len(ec.Param.Metadata[1].Enum) != 2 {
 		t.Errorf("Metadata[1].Enum = %#v, want 2 enum values", ec.Param.Metadata[1].Enum)
-	}
-}
-
-// TestNewExtractorComponent_PromptsArray verifies that the Python DSL
-// "prompts" array format is parsed into Param.Prompt.
-func TestNewExtractorComponent_PromptsArray(t *testing.T) {
-	withStubChatInvoker(t, stubResponse{Content: "ok"})
-	comp, err := NewExtractorComponent(map[string]any{
-		"field_name": "out",
-		"prompts": []any{
-			map[string]any{
-				"content": "Analyze: {TitleChunker:FlatMiceFix@chunks}",
-				"role":    "user",
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("NewExtractorComponent: %v", err)
-	}
-	ec := comp.(*ExtractorComponent)
-	want := "Analyze: {TitleChunker:FlatMiceFix@chunks}"
-	if ec.Param.Prompt != want {
-		t.Errorf("Prompt = %q, want %q", ec.Param.Prompt, want)
-	}
-}
-
-// TestNewExtractorComponent_PromptsArray_PromptWins verifies that
-// "prompt" (string) takes priority over "prompts" (array) when both
-// are present in the DSL params.
-func TestNewExtractorComponent_PromptsArray_PromptWins(t *testing.T) {
-	withStubChatInvoker(t, stubResponse{Content: "ok"})
-	comp, err := NewExtractorComponent(map[string]any{
-		"field_name": "out",
-		"prompt":     "Direct prompt wins.",
-		"prompts": []any{
-			map[string]any{
-				"content": "Should be ignored.",
-				"role":    "user",
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("NewExtractorComponent: %v", err)
-	}
-	ec := comp.(*ExtractorComponent)
-	if ec.Param.Prompt != "Direct prompt wins." {
-		t.Errorf("Prompt = %q, want %q", ec.Param.Prompt, "Direct prompt wins.")
-	}
-}
-
-// TestNewExtractorComponent_PromptsString verifies that a bare-string
-// "prompts" (the shape emitted by the front-end graph.nodes form and
-// the dsl/testdata templates) is normalized into Param.Prompt, mirroring
-// Python agent/component/llm.py:119-120 which coerces a string prompts
-// into [{"role":"user","content":prompts}]. Without this normalization
-// the string form is silently dropped (the .([]any) assertion fails).
-func TestNewExtractorComponent_PromptsString(t *testing.T) {
-	withStubChatInvoker(t, stubResponse{Content: "ok"})
-	comp, err := NewExtractorComponent(map[string]any{
-		"field_name": "out",
-		"prompts":    "Content: {TitleChunker:FlatMiceFix@chunks}",
-	})
-	if err != nil {
-		t.Fatalf("NewExtractorComponent: %v", err)
-	}
-	ec := comp.(*ExtractorComponent)
-	want := "Content: {TitleChunker:FlatMiceFix@chunks}"
-	if ec.Param.Prompt != want {
-		t.Errorf("Prompt = %q, want %q (string prompts should be normalized)", ec.Param.Prompt, want)
-	}
-}
-
-// TestNewExtractorComponent_PromptsString_PromptWins verifies that
-// "prompt" (string) still takes priority over a string-form "prompts"
-// when both are present, matching the prompt>prompts precedence of
-// the list-form path (TestNewExtractorComponent_PromptsArray_PromptWins).
-func TestNewExtractorComponent_PromptsString_PromptWins(t *testing.T) {
-	withStubChatInvoker(t, stubResponse{Content: "ok"})
-	comp, err := NewExtractorComponent(map[string]any{
-		"field_name": "out",
-		"prompt":     "Direct prompt wins.",
-		"prompts":    "Should be ignored.",
-	})
-	if err != nil {
-		t.Fatalf("NewExtractorComponent: %v", err)
-	}
-	ec := comp.(*ExtractorComponent)
-	if ec.Param.Prompt != "Direct prompt wins." {
-		t.Errorf("Prompt = %q, want %q", ec.Param.Prompt, "Direct prompt wins.")
-	}
-}
-
-// TestNewExtractorComponent_SystemPromptWinsOverSysPrompt verifies
-// that "system_prompt" takes priority over "sys_prompt".
-func TestNewExtractorComponent_SystemPromptWinsOverSysPrompt(t *testing.T) {
-	withStubChatInvoker(t, stubResponse{Content: "ok"})
-	comp, err := NewExtractorComponent(map[string]any{
-		"field_name":    "out",
-		"system_prompt": "system_prompt wins.",
-		"sys_prompt":    "sys_prompt ignored.",
-	})
-	if err != nil {
-		t.Fatalf("NewExtractorComponent: %v", err)
-	}
-	ec := comp.(*ExtractorComponent)
-	if ec.Param.SystemPrompt != "system_prompt wins." {
-		t.Errorf("SystemPrompt = %q, want %q", ec.Param.SystemPrompt, "system_prompt wins.")
 	}
 }
 
@@ -1474,9 +1398,9 @@ func TestExtractorComponent_Invoke_ContentWithWeightPlaceholder(t *testing.T) {
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "out",
-		Prompt:    "Weighted: {content_with_weight}",
-		LLMID:     "gpt-4o-mini",
+		FieldName:  "out",
+		UserPrompt: "Weighted: {content_with_weight}",
+		LLMID:      "gpt-4o-mini",
 	}}
 	_, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{"content_with_weight": "weighted doc"}},
@@ -1513,9 +1437,9 @@ func TestExtractorComponent_Invoke_NonContentPlaceholderKeepsChunkText(t *testin
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "out",
-		Prompt:    "Title: {title}\nExtract:",
-		LLMID:     "gpt-4o-mini",
+		FieldName:  "out",
+		UserPrompt: "Title: {title}\nExtract:",
+		LLMID:      "gpt-4o-mini",
 	}}
 	_, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{
@@ -1554,9 +1478,9 @@ func TestExtractorComponent_Invoke_UnresolvedTextPlaceholderKeepsChunkText(t *te
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "out",
-		Prompt:    "Content: {text}",
-		LLMID:     "gpt-4o-mini",
+		FieldName:  "out",
+		UserPrompt: "Content: {text}",
+		LLMID:      "gpt-4o-mini",
 	}}
 	_, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{
@@ -1592,9 +1516,9 @@ func TestExtractorComponent_Invoke_SubstitutesPlaceholders(t *testing.T) {
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "summary",
-		Prompt:    "Analyze: {text}",
-		LLMID:     "gpt-4o-mini",
+		FieldName:  "summary",
+		UserPrompt: "Analyze: {text}",
+		LLMID:      "gpt-4o-mini",
 	}}
 	_, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{"text": "the document content"}},
@@ -1634,9 +1558,9 @@ func TestExtractorComponent_Invoke_PlaceholderChunksAlias(t *testing.T) {
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "out",
-		Prompt:    "Content: {chunks}",
-		LLMID:     "gpt-4o-mini",
+		FieldName:  "out",
+		UserPrompt: "Content: {chunks}",
+		LLMID:      "gpt-4o-mini",
 	}}
 	_, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{"content_with_weight": "weighted doc"}},
@@ -1674,9 +1598,9 @@ func TestExtractorComponent_Invoke_AppendsChunkTextWhenNoPlaceholder(t *testing.
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "summary",
-		Prompt:    "Summarize the above:",
-		LLMID:     "gpt-4o-mini",
+		FieldName:  "summary",
+		UserPrompt: "Summarize the above:",
+		LLMID:      "gpt-4o-mini",
 	}}
 	_, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{"text": "the document content"}},
@@ -1710,7 +1634,7 @@ func TestExtractorComponent_Invoke_SystemPromptPlaceholderSuppressesAppend(t *te
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
 		FieldName:    "out",
-		Prompt:       "Extract:",
+		UserPrompt:   "Extract:",
 		SystemPrompt: "Context: {text}",
 		LLMID:        "gpt-4o-mini",
 	}}
@@ -1756,9 +1680,9 @@ func TestExtractorComponent_Invoke_FieldValueContainsPlaceholderSubstring(t *tes
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName: "out",
-		Prompt:    "Body: {text}\nLabel: {title}",
-		LLMID:     "gpt-4o-mini",
+		FieldName:  "out",
+		UserPrompt: "Body: {text}\nLabel: {title}",
+		LLMID:      "gpt-4o-mini",
 	}}
 	_, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{{
@@ -1867,7 +1791,7 @@ func TestExtractorComponent_CallRaw_FitsBeforeInvoke(t *testing.T) {
 
 	_, err := c.callText(t.Context(), nil, extractorInputs{
 		systemPrompt: "extract fields",
-		prompt:       "summarize",
+		userPrompt:   "summarize",
 		llmID:        "test@test",
 	}, strings.Repeat("chunk text with lots of tokens. ", 500))
 	if err != nil {
@@ -1923,7 +1847,7 @@ func TestExtractorComponent_CallRaw_CustomContextOverride(t *testing.T) {
 	c := &ExtractorComponent{}
 	_, err := c.callText(ctx, db, extractorInputs{
 		systemPrompt: "extract fields",
-		prompt:       "summarize",
+		userPrompt:   "summarize",
 		llmID:        "gpt-4o@OpenAI",
 	}, strings.Repeat("chunk text with lots of tokens. ", 500))
 	if err != nil {

--- a/internal/ingestion/component/schema/extractor.go
+++ b/internal/ingestion/component/schema/extractor.go
@@ -95,8 +95,8 @@ type ExtractorParam struct {
 	// SystemPrompt is the optional system prompt override.
 	SystemPrompt string `json:"system_prompt,omitempty"`
 
-	// Prompt is the user-side template passed to the LLM.
-	Prompt string `json:"prompt,omitempty"`
+	// UserPrompt is the user-side template passed to the LLM.
+	UserPrompt string `json:"user_prompt,omitempty"`
 
 	// AutoKeywords enables automatic keyword extraction with a fixed
 	// prompt. The value determines the top-N count.
@@ -137,7 +137,7 @@ func (ExtractorParam) Defaults() ExtractorParam {
 		FieldName:      "",
 		LLMID:          "",
 		SystemPrompt:   "",
-		Prompt:         "",
+		UserPrompt:     "",
 		AutoKeywords:   0,
 		AutoQuestions:  0,
 		AutoTags:       0,


### PR DESCRIPTION
## Summary

Refactor the ingestion **Extractor** to recognize exactly two prompt keys — `system_prompt` and `user_prompt` — and drop the `prompts` queue plus every alias (`sys_prompt`, `prompt`, and the `prompts` string/list forms). Scope is confined to `internal/ingestion/component/` (3 files).

## Changes

- `schema.ExtractorParam`: `Prompt` → `UserPrompt` (`json:"user_prompt"`); `SystemPrompt` stays `system_prompt`.
- `NewExtractorComponent` / `resolveInputs` / `Inputs()`: parse only `system_prompt` + `user_prompt`; remove the `sys_prompt` alias and the `prompt`/`prompts` (string + list) branches.
- Message building (`buildExtractorMessages`) is unchanged: `[system, user]`, chunk text appended to the user turn, `{...@chunks}` placeholder substitution on the user prompt.
- Obsolete tests protecting the removed aliases/queue are deleted; new tests pin `user_prompt` parsing and that `sys_prompt`/`prompt`/`prompts` are ignored.

## Reverted (back to main)

The earlier shared multi-message prompts design is withdrawn: the `internal/component/promptmsg` package and the LLM/Agent changes that depended on it are gone. The Agent keeps main's existing `prompts` folding support; the LLM is untouched.

## Note

The frontend extractor form still serializes `sys_prompt`/`prompts` (`web/src/utils/pipeline-operator.ts:245`); since the Go side no longer reads those keys, that form's prompt fields are inert until the frontend is updated. Frontend sync is intentionally out of scope here.