### PR TITLE
fix(tree-select): allow collapsing parent nodes during search

### DIFF
--- a/web/src/components/tree-select.tsx
+++ b/web/src/components/tree-select.tsx
@@ -144,26 +144,32 @@ export const TreeSelect = forwardRef<HTMLButtonElement, TreeSelectProps>(
       [data, searchTerm, filterTree],
     );
 
-    const visibleExpandedIds = useMemo(() => {
-      if (!searchTerm) return expandedIds;
-      const ids = new Set<string>();
-      const walk = (nodes: TreeSelectNode[]) => {
-        for (const node of nodes) {
-          if (node.children?.length) {
-            ids.add(node.id);
-            walk(node.children);
+    // Auto-expand all matching parents when the search term changes so users
+    // can see search results. The effect only depends on searchTerm and
+    // filteredData, so a manual collapse (which updates expandedIds) won't
+    // trigger re-expansion — the user's collapse choice is respected.
+    useEffect(() => {
+      if (!searchTerm) return;
+      setExpandedIds((prev) => {
+        const next = new Set(prev);
+        const walk = (nodes: TreeSelectNode[]) => {
+          for (const node of nodes) {
+            if (node.children?.length) {
+              next.add(node.id);
+              walk(node.children);
+            }
           }
-        }
-      };
-      walk(filteredData);
-      return ids;
-    }, [searchTerm, expandedIds, filteredData]);
+        };
+        walk(filteredData);
+        return next;
+      });
+    }, [searchTerm, filteredData]);
 
     const renderTree = useCallback(
       (nodes: TreeSelectNode[], level = 0): React.ReactNode => {
         return nodes.map((node) => {
           const leaf = isLeaf(node);
-          const expanded = visibleExpandedIds.has(node.id);
+          const expanded = expandedIds.has(node.id);
           const selected = value === node.id;
 
           return (
@@ -204,7 +210,7 @@ export const TreeSelect = forwardRef<HTMLButtonElement, TreeSelectProps>(
           );
         });
       },
-      [isLeaf, visibleExpandedIds, value, handleSelect],
+      [isLeaf, expandedIds, value, handleSelect],
     );
 
     return (


### PR DESCRIPTION
### Summary

fix(tree-select): allow collapsing parent nodes during search

During search, `visibleExpandedIds` recomputed all parent IDs from `filteredData` on every render, ignoring `expandedIds`. This made `handleToggle` a no-op, so clicking a parent node to collapse it had no effect while searching.

Replace the search override with a `useEffect` that auto-expands matching parents into `expandedIds` when the search term changes. Because the effect only depends on `searchTerm`/`filteredData`, a manual collapse (which updates `expandedIds`) is preserved rather than being immediately overridden.
