### PR TITLE
Fix ragflow server hung after parsing a big file

### DIFF
--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -58,17 +58,19 @@ def update_progress():
     redis_lock = RedisDistributedLock("update_progress", lock_value=lock_value, timeout=60)
     logging.info(f"update_progress lock_value: {lock_value}")
     while not stop_event.is_set():
+        acquired = False
         try:
-            if redis_lock.acquire():
+            acquired = redis_lock.acquire()
+            if acquired:
                 DocumentService.update_progress()
-                redis_lock.release()
         except Exception:
             logging.exception("update_progress exception")
         finally:
-            try:
-                redis_lock.release()
-            except Exception:
-                logging.exception("update_progress exception")
+            if acquired:
+                try:
+                    redis_lock.release()
+                except Exception:
+                    logging.exception("update_progress exception")
             stop_event.wait(6)
 
 

--- a/rag/utils/redis_conn.py
+++ b/rag/utils/redis_conn.py
@@ -514,7 +514,12 @@ class RedisDB:
         Do following atomically:
         Delete a key if its value is equals to the given one, do nothing otherwise.
         """
-        return bool(self.lua_delete_if_equal(keys=[key], args=[expected_value], client=self.REDIS))
+        try:
+            return bool(self.lua_delete_if_equal(keys=[key], args=[expected_value], client=self.REDIS))
+        except Exception as e:
+            logging.warning("RedisDB.delete_if_equal got exception: %s", str(e))
+            self.__open__()
+        return False
 
     def delete(self, key) -> bool:
         try:
@@ -537,15 +542,21 @@ class RedisDistributedLock:
         else:
             self.lock_value = str(uuid.uuid4())
         self.timeout = timeout
+        self.blocking_timeout = blocking_timeout
         self.lock = Lock(REDIS_CONN.REDIS, lock_key, timeout=timeout, blocking_timeout=blocking_timeout)
+
+    def _refresh_lock(self):
+        self.lock = Lock(REDIS_CONN.REDIS, self.lock_key, timeout=self.timeout, blocking_timeout=self.blocking_timeout)
 
     def acquire(self):
         REDIS_CONN.delete_if_equal(self.lock_key, self.lock_value)
+        self._refresh_lock()
         return self.lock.acquire(token=self.lock_value)
 
     async def spin_acquire(self):
         REDIS_CONN.delete_if_equal(self.lock_key, self.lock_value)
         while True:
+            self._refresh_lock()
             if self.lock.acquire(token=self.lock_value):
                 break
             await asyncio.sleep(10)


### PR DESCRIPTION
Fix:

```
[2026-08-06 11:28:11 +0800] [184365] [INFO] 127.0.0.1:37924 GET /api/v1/datasets/1793b408914611f1bff291ff2a1d387d/documents 1.1 200 3026 244753
2026-08-06 11:45:26,618 ERROR    184365 update_progress exception
Traceback (most recent call last):
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/_parsers/socket.py", line 65, in _read_from_socket
    data = self._sock.recv(socket_read_size)
TimeoutError: [Errno 110] Connection timed out
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/lhp/qi/code/ragflow/api/ragflow_server.py", line 62, in update_progress
    if redis_lock.acquire():
       ~~~~~~~~~~~~~~~~~~^^
  File "/home/lhp/qi/code/ragflow/rag/utils/redis_conn.py", line 543, in acquire
    REDIS_CONN.delete_if_equal(self.lock_key, self.lock_value)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/utils/redis_conn.py", line 517, in delete_if_equal
    return bool(self.lua_delete_if_equal(keys=[key], args=[expected_value], client=self.REDIS))
                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/commands/core.py", line 6356, in call
    return client.evalsha(self.sha, len(keys), *args)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/commands/core.py", line 5730, in evalsha
    return self._evalsha("EVALSHA", sha, numkeys, *keys_and_args)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/commands/core.py", line 5714, in _evalsha
    return self.execute_command(command, sha, numkeys, *keys_and_args)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/client.py", line 570, in execute_command
    response = conn.retry.call_with_retry(
        lambda: self._send_command_parse_response(
    ...<2 lines>...
        lambda error: self._disconnect_raise(conn, error),
    )
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/retry.py", line 65, in call_with_retry
    fail(error)
    ~~~~^^^^^^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/client.py", line 574, in <lambda>
    lambda error: self._disconnect_raise(conn, error),
                  ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/client.py", line 556, in _disconnect_raise
    raise error
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/retry.py", line 62, in call_with_retry
    return do()
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/client.py", line 571, in <lambda>
    lambda: self._send_command_parse_response(
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        conn, command_name, *args, **options
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/client.py", line 543, in _send_command_parse_response
    return self.parse_response(conn, command_name, **options)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/client.py", line 590, in parse_response
    response = connection.read_response()
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/connection.py", line 546, in read_response
    response = self._parser.read_response(disable_decoding=disable_decoding)
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/_parsers/resp2.py", line 15, in read_response
    result = self._read_response(disable_decoding=disable_decoding)
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/_parsers/resp2.py", line 25, in _read_response
    raw = self._buffer.readline()
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/_parsers/socket.py", line 115, in readline
    self._read_from_socket()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/lhp/qi/code/ragflow/.venv/lib/python3.13/site-packages/valkey/_parsers/socket.py", line 78, in _read_from_socket
    raise TimeoutError("Timeout reading from socket")
valkey.exceptions.TimeoutError: Timeout reading from socket
```