### PR TITLE
fix(web): prevent column shift in data source log table

### DIFF
--- a/web/src/pages/user-setting/data-source/data-source-detail-page/log-table.tsx
+++ b/web/src/pages/user-setting/data-source/data-source-detail-page/log-table.tsx
@@ -113,6 +113,7 @@ const columns = ({
     {
       accessorKey: 'update_date',
       header: t('setting.timeStarted'),
+      meta: { headerClassName: 'w-44' },
       cell: ({ row }) => (
         <div className="flex items-center gap-2 text-text-primary">
           {row.original.update_date
@@ -124,6 +125,7 @@ const columns = ({
     {
       accessorKey: 'status',
       header: t('knowledgeDetails.status'),
+      meta: { headerClassName: 'w-28' },
       cell: ({ row }) => (
         <FileStatusBadge
           status={row.original.status as RunningStatus}
@@ -135,6 +137,7 @@ const columns = ({
     {
       accessorKey: 'kb_name',
       header: t('knowledgeDetails.dataset'),
+      meta: { headerClassName: 'w-1/4' },
       cell: ({ row }) => {
         return (
           <div
@@ -148,7 +151,7 @@ const columns = ({
               name={row.original.kb_name}
               className="size-4"
             />
-            {row.original.kb_name}
+            <span className="truncate">{row.original.kb_name}</span>
           </div>
         );
       },
@@ -156,6 +159,7 @@ const columns = ({
     {
       accessorKey: 'task_type',
       header: 'Task Type',
+      meta: { headerClassName: 'w-28' },
       cell: ({ row }) => row.original.task_type || 'sync',
     },
     {
@@ -234,12 +238,15 @@ export const DataSourceLogsTable = ({
     // <div className="w-full h-[calc(100vh-360px)]">
     //   <Table rootClassName="max-h-[calc(100vh-380px)]">
     <div className="w-full">
-      <Table>
+      <Table className="table-fixed">
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
+                <TableHead
+                  key={header.id}
+                  className={header.column.columnDef.meta?.headerClassName}
+                >
                   {flexRender(
                     header.column.columnDef.header,
                     header.getContext(),


### PR DESCRIPTION
### Summary

In the data source detail log table (Knowledge Base -> Data Source -> Settings), the Summary column contains a live countdown (e.g. `Task starts in 59s`). The table used the browser's auto layout, so whenever the seconds value changed digit count (e.g. `59s` -> `9s`), the content width changed and the browser redistributed all column widths, causing the Summary column (and the whole table) to visibly shift back and forth every second. The existing `tabular-nums` class only keeps digits of the same count aligned and cannot prevent width changes when the digit count changes.

This PR fixes the layout shift by:

- Switching the table to a fixed layout (`table-fixed`) so column widths no longer depend on cell content.
- Assigning explicit widths to the first four columns via the existing `meta.headerClassName` mechanism (Time Started `w-44`, Status `w-28`, Dataset `w-1/4`, Task Type `w-28`), leaving Summary to take the remaining space.
- Adding `truncate` to the dataset name so long names do not overflow under the fixed layout.