### PR TITLE
chore(rag/app): remove stray debug print() calls

### DIFF
--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -1133,9 +1133,7 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
         callback(0.1, "Start to parse.")
         sections = TxtParser()(filename, binary, parser_config.get("chunk_token_num", 128), parser_config.get("delimiter", "\n!?;。；！？"))
         sections = _normalize_section_text_for_rtl_presentation_forms(sections)
-        print("\n", "-" * 150, "\n")
-        print(sections)
-        print("\n", "-" * 150, "\n")
+        logging.info("TxtParser produced %d sections for %s", len(sections), filename)
         callback(0.8, "Finish parsing.")
 
     elif re.search(r"\.(md|markdown|mdx)$", filename, re.IGNORECASE):

--- a/rag/app/presentation.py
+++ b/rag/app/presentation.py
@@ -87,7 +87,7 @@ class Pdf(PdfParser):
                 # pn_index in tbls is absolute page number
                 current_page_num = int(pn_index) + 1
             except Exception as e:
-                print(f"Error parsing position: {e}")
+                logging.warning(f"Error parsing position in {filename}: {e}")
                 continue
 
             if not (from_page < current_page_num <= to_page + from_page):


### PR DESCRIPTION
chore(rag/app): remove stray debug print() calls

Two hot-path debug print() calls were leaking content/error text to
stdout in production code paths.

* rag/app/naive.py: TxtParser branch in chunk() was printing the entire
  parsed sections list (formatted via repr()) wrapped in 150-char banner
  lines. For large text documents (e.g. a 1000+-page book ingest) this
  dumped tens of thousands of lines per ingest into the docker logs.
  Replaced with a structured
  `logging.info("TxtParser produced %d sections for %s", len(sections),
  filename)` so the parse count is still observable without the content
  leak.

* rag/app/presentation.py: Pdf.position parsing had a debug
  `print(f"Error parsing position: {e}")` inside an except clause in the
  ingest hot path. Replaced with
  `logging.warning(f"Error parsing position in {filename}: {e}")` to
  match the file's existing logging pattern and add filename context.

Both call sites already had logging imported; no new imports added.
logging was used throughout the surrounding code in the same
logging.{info,warning,error}(...) style.
