### PR TITLE
Refine agentic research

### DIFF
--- a/internal/agent/harness/planner.go
+++ b/internal/agent/harness/planner.go
@@ -34,6 +34,17 @@ import (
 // instructions; the Go planner selects by question_type.
 const decomposePrompt = `Break down the research question into %d atomic claims (facts or sub-questions).
 
+CRITICAL — Enumeration questions:
+These questions ask for a complete set of items. The grounding context may mention some candidate names as partial evidence — never turn every name you see into a verification claim. Each decomposed claim must be a discovery query that searches for the full collection, NOT a yes/no verification of individual candidates.
+
+EXAMPLE of WRONG decomposition for "Which cities have hosted the Olympic Games?":
+  ❌ "London hosted the Olympic Games"  (verification form, presupposes the answer)
+  ❌ "Tokyo hosted the Olympic Games"
+
+EXAMPLE of CORRECT decomposition:
+  ✅ "Complete list of all host cities of the Olympic Games"
+  ✅ "Olympic Games host cities across all editions"
+
 Question: %s
 
 Detail level: %s

--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -33,8 +33,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import re
 import logging
+import re
 from typing import Any, TypedDict
 
 from langgraph.graph import END, START, StateGraph
@@ -150,30 +150,6 @@ async def _split_think_stream(stream):
 # ── Graph construction ──
 
 
-def _merge_result_into_kbinfos(tools, result: dict) -> None:
-    """Merge a search result's chunks/doc_aggs into ``tools.kbinfos``, deduped.
-
-    Mirrors the orchestrators' merge so seed evidence and orchestrator evidence
-    share one deduplicated pool.
-    """
-    if not result or not result.get("chunks"):
-        return
-    kb = tools.kbinfos
-    seen = {c.get("chunk_id") or c.get("id") or id(c) for c in kb.get("chunks", [])}
-    for c in result.get("chunks", []):
-        k = c.get("chunk_id") or c.get("id") or id(c)
-        if k in seen:
-            continue
-        seen.add(k)
-        kb.setdefault("chunks", []).append(c)
-    dseen = {d.get("doc_id") for d in kb.get("doc_aggs", [])}
-    for d in result.get("doc_aggs", []):
-        if d.get("doc_id") in dseen:
-            continue
-        dseen.add(d.get("doc_id"))
-        kb.setdefault("doc_aggs", []).append(d)
-
-
 def build_agentic_graph(tools, token_queue: asyncio.Queue, gen_conf: dict | None = None):
     """Compile the 4-node agentic-search graph."""
     answer_conf = dict(gen_conf) if gen_conf else {"temperature": 0.3}
@@ -207,8 +183,9 @@ def build_agentic_graph(tools, token_queue: asyncio.Queue, gen_conf: dict | None
 
         Only runs for decomposition modes (direct/low mode retrieves in
         orchestrator_loop anyway, so we skip the duplicate search). The result
-        is narrowed by keywords inside ``hybrid_search`` and merged into the
-        shared citation pool so it also enriches the final answer.
+        is narrowed by keywords inside ``hybrid_search``. Seed chunks are only
+        used to ground the planner — they are NOT merged into the citation pool;
+        only chunks retrieved by claim-level searches become evidence.
         """
         route = state.get("route")
         if not route or not getattr(route, "requires_decomposition", False):
@@ -227,8 +204,7 @@ def build_agentic_graph(tools, token_queue: asyncio.Queue, gen_conf: dict | None
             return {"seed_chunks": []}
 
         chunks = result.get("chunks", []) or []
-        _merge_result_into_kbinfos(tools, result)
-        _LOG.info("[Preliminary search] First look found %d passage(s); %d gathered so far.", len(chunks), len(tools.kbinfos.get("chunks", [])))
+        _LOG.info("[Preliminary search] First look found %d passage(s) (for planner grounding only — not merged into evidence pool).", len(chunks))
         return {"seed_chunks": chunks}
 
     # ── Node: planner ──
@@ -251,7 +227,7 @@ def build_agentic_graph(tools, token_queue: asyncio.Queue, gen_conf: dict | None
         abstain = state.get("abstain", False)
         empty_result = state.get("empty_result", False)
 
-        _note = " — partial answer, some gaps remain" if partial else (" — not enough evidence to answer" if abstain else "")
+        _note = " — not enough evidence to answer" if abstain else (" — partial answer, some gaps remain" if partial else "")
         _LOG.info('[Composing the answer] Writing the final answer to "%s" from %d gathered passage(s)%s.', _snip(question), len(kbinfos["chunks"]), _note)
 
         tools.kbinfos = kbinfos

--- a/rag/advanced_rag/harness/orchestrator/agentic.py
+++ b/rag/advanced_rag/harness/orchestrator/agentic.py
@@ -3,18 +3,18 @@
 import asyncio
 import logging
 
-from rag.advanced_rag.harness.types import (
-    ClaimTarget,
-    AgentResult,
-    OrchestratorContext,
-)
+from rag.advanced_rag.harness.agent import research_agent_loop
 from rag.advanced_rag.harness.config import get_mode
 from rag.advanced_rag.harness.pipeline import Pipeline
-from rag.advanced_rag.harness.agent import research_agent_loop
 from rag.advanced_rag.harness.sufficiency import (
-    cross_check_claim,
     compute_fusion_score,
+    cross_check_claim,
     route_sufficiency_verdict,
+)
+from rag.advanced_rag.harness.types import (
+    AgentResult,
+    ClaimTarget,
+    OrchestratorContext,
 )
 
 _LOG = logging.getLogger(__name__)
@@ -143,10 +143,11 @@ async def agentic_research(state: dict, tools) -> dict:
         if action == "ANSWER_PARTIAL":
             return _finalize(ctx, tools, partial=True)
         if action == "ABSTAIN":
-            if getattr(tools, "text_attachments_content", ""):
-                return {"verdict": verdict.__dict__, "kbinfos": tools.kbinfos}
-            tools.kbinfos["chunks"] = []
-            return {"verdict": verdict.__dict__, "abstain": True}
+            # ABSTAIN means the model does not know the answer and should not
+            # fabricate one. Evidence is preserved in kbinfos but the
+            # formalize_answer node will surface "I cannot answer" instead of
+            # generating from unreliable evidence.
+            return _finalize(ctx, tools, partial=True, fallback=True, abstain=True)
         if action == "REPLAN":
             # Ultra: re-plan on low score
             from rag.advanced_rag.harness.planner import planner_node
@@ -178,7 +179,7 @@ async def _run_claim_research(
         )
     except asyncio.CancelledError:
         raise
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOG.warning(
             '[Agentic research] Gave up on "%s" — it took longer than %ss.',
             _snip(claim.description),
@@ -214,12 +215,13 @@ async def _run_claim_research(
     return result
 
 
-def _finalize(ctx: OrchestratorContext, tools, partial: bool = False, fallback: bool = False) -> dict:
+def _finalize(ctx: OrchestratorContext, tools, partial: bool = False, fallback: bool = False, abstain: bool = False) -> dict:
     """Merge agent results into kbinfos and return."""
     _merge_agent_results(ctx, tools)
     return {
         "verdict": ctx.verdict.__dict__ if ctx.verdict else None,
         "partial_answer": partial or fallback,
+        "abstain": abstain,
         "kbinfos": tools.kbinfos,
     }
 
@@ -306,8 +308,8 @@ async def _add_template_group_compilations(comps: set[str], parser_config: dict,
     if not tenant_id:
         return
     try:
-        from common.misc_utils import thread_pool_exec
         from api.db.services.compilation_template_group_service import CompilationTemplateGroupService
+        from common.misc_utils import thread_pool_exec
         from rag.svr.task_executor_refactor.chunk_post_processor import (
             _parser_config_compilation_template_group_ids,
         )

--- a/rag/advanced_rag/harness/planner.py
+++ b/rag/advanced_rag/harness/planner.py
@@ -5,14 +5,14 @@ import logging
 import re
 
 from rag.advanced_rag.agentic_rag_graph import _snip
-from rag.advanced_rag.harness.types import ClaimTarget, WorkflowPlan, RouteDecision
 from rag.advanced_rag.harness.config import get_mode
 from rag.advanced_rag.harness.prompts.decompose_prompts import (
-    DECOMPOSE_FACTUAL,
     DECOMPOSE_COMPARATIVE,
-    DECOMPOSE_PROCEDURAL,
     DECOMPOSE_EXPLORATORY,
+    DECOMPOSE_FACTUAL,
+    DECOMPOSE_PROCEDURAL,
 )
+from rag.advanced_rag.harness.types import ClaimTarget, RouteDecision, WorkflowPlan
 
 _LOG = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ async def planner_node(state: dict, tools) -> dict:
         _LOG.warning("planner: no route found, using defaults")
         return _default_plan(state.get("question", ""))
 
-    _LOG.info("[Planner] Working out how to research this %s question: \"%s\"", route.question_type, _snip(route.question))
+    _LOG.info('[Planner] Working out how to research this %s question: "%s"', route.question_type, _snip(route.question))
     if not route.requires_decomposition:
         # Direct mode: single coarse claim
         return _direct_plan(route.question)
@@ -68,6 +68,12 @@ async def planner_node(state: dict, tools) -> dict:
         )
         system, user = prompt.split("Output format", 1)
         system = system.strip()
+        system += (
+            "\n\nWrite every claim description in the SAME LANGUAGE as the user's "
+            "question. If the question is in Chinese, all descriptions MUST be in "
+            "Chinese, using native entity names. If the question is in English, use "
+            "English. Never mix languages in descriptions."
+        )
         user = "Output format" + user
         msg = await tools._fit_messages(system, user)
         ans = await tools.chat_mdl.async_chat(msg[0]["content"], msg[1:], {"temperature": 0.2})

--- a/rag/advanced_rag/harness/prompts/decompose_prompts.py
+++ b/rag/advanced_rag/harness/prompts/decompose_prompts.py
@@ -16,12 +16,27 @@ Detail level: {detail_level}
 Preliminary retrieved context for this question (use it to ground each claim in what the corpus actually contains; do not invent facts it cannot support):
 {retrieved}
 
+For enumeration questions, use discovery queries that search for the full set, not verification claims for individual candidates.
+
 Output format (JSON):
+
+Enumeration question — CORRECT example (discovery query, searches the full set):
 {{
     "claims": [
         {{
             "claim_id": "c1",
-            "description": "The year Apple acquired Beats",
+            "description": "Complete list of all Olympic host cities",
+            "priority": 1
+        }}
+    ]
+}}
+
+Non-enumeration factual question — decompose into atomic fact queries:
+{{
+    "claims": [
+        {{
+            "claim_id": "c1",
+            "description": "The year Apple acquired Beets",
             "priority": 1
         }}
     ]

--- a/rag/advanced_rag/harness/prompts/route_prompt.py
+++ b/rag/advanced_rag/harness/prompts/route_prompt.py
@@ -7,13 +7,24 @@ Question: {question}
 Analyze it across these dimensions:
 1. Question type: factual / comparative / analytical / procedural / exploratory / verification / summarization.
 2. Whether it needs decomposition into atomic facts, meaning whether multiple independent pieces of information must be retrieved separately before answering: true/false.
+   - REQUIRES decomposition (true): open-ended list/enumeration questions (who, what kinds, which people, list all, 谁, 哪些), multi-entity comparisons, multi-step procedures, analytical questions spanning domains, questions whose answer has no single concise fact but requires gathering many independent facts.
+   - Does NOT require decomposition (false): simple fact lookups (single person's birth year, definition of one term), yes/no verifications against a known fact, summarization of a single document or event.
 3. Suggested knowledge compilation tool: null (none) / toc (document table of contents) / graph (knowledge graph) / wiki (compiled domain knowledge).
+
+Examples:
+
+Q: "曹操是谁？" (Who is Cao Cao?) → factual, single entity → NO decomposition
+Q: "曹操认识谁？" (Who did Cao Cao know?) → exploratory open-ended list → NEEDS decomposition (many independent relationship facts)
+Q: "秦始皇和汉武帝谁更伟大？" (Who was greater, Qin Shi Huang or Han Wudi?) → comparative → NEEDS decomposition
+Q: "光合作用的过程是什么？" (What is the process of photosynthesis?) → procedural, but single process → NO decomposition (OR: NEEDS decomposition if the KB spans many domains)
+Q: "2024年诺贝尔物理学奖得主是谁？" (Who won the 2024 Nobel Prize in Physics?) → factual, single fact → NO decomposition
+Q: "有哪些方法可以降低胆固醇？" (What are the methods to lower cholesterol?) → exploratory list → NEEDS decomposition
 
 Output format (JSON):
 {{
-    "question_type": "comparative",
+    "question_type": "exploratory",
     "requires_decomposition": true,
-    "suggests_compilation": null,
-    "reasoning": "This is a comparative question, so it needs to be decomposed into two independent facts and one comparison relation."
+    "suggests_compilation": "graph",
+    "reasoning": "Open-ended question about a person's relationships. Many independent facts must be gathered, so decomposition is required. A knowledge graph compilation tool may help."
 }}
 """

--- a/rag/advanced_rag/harness/sufficiency.py
+++ b/rag/advanced_rag/harness/sufficiency.py
@@ -2,13 +2,13 @@
 
 import logging
 
+from rag.advanced_rag.harness.config import get_mode
 from rag.advanced_rag.harness.types import (
     AgentResult,
     ClaimCrossCheckResult,
-    SufficiencyVerdict,
     ExecutionStrategy,
+    SufficiencyVerdict,
 )
-from rag.advanced_rag.harness.config import get_mode
 
 _LOG = logging.getLogger(__name__)
 
@@ -58,19 +58,41 @@ def cross_check_claim(agent_result: AgentResult, all_chunks: dict) -> ClaimCross
         text = chunk.get("content_with_weight", chunk.get("text", ""))
         text_lower = text.lower()
 
-        for num in numbers:
-            if str(num) not in text_lower:
-                mismatches.append(f"number {num} not found in chunk {eid}")
-            else:
-                matches.append(f"number {num} found in chunk {eid}")
+        # For Chinese (and other non-English) content: if the chunk itself
+        # contains no Arabic digits, skipping number-based cross-check is
+        # correct — the chunk is pure classical text and matching LLM-
+        # synthesized years/numbers against it would produce false negatives.
+        chunk_has_digits = bool(re.search(r"\d", text_lower))
+
+        if chunk_has_digits or entities:
+            for num in numbers:
+                if str(num) not in text_lower:
+                    mismatches.append(f"number {num} not found in chunk {eid}")
+                else:
+                    matches.append(f"number {num} found in chunk {eid}")
 
         for ent in entities:
             if ent.lower() not in text_lower:
                 mismatches.append(f"entity '{ent}' not found in chunk {eid}")
 
     total = len(matches) + len(mismatches)
-    cross_score = len(matches) / max(total, 1) if total > 0 else 0.0
-    cross_passed = len(mismatches) < len(matches) * 0.5
+    # When no extractable entities or numbers exist to cross-check against
+    # (common for Chinese text), treat as passed — nothing falsified the claim.
+    if total == 0:
+        cross_passed = True
+        cross_score = 1.0
+    else:
+        # When the report contains numbers but evidence chunks are primarily
+        # Chinese (no extractable English named-entities), the number-matching
+        # heuristic is unreliable — the LLM may synthesize dates or counts that
+        # the raw chunks do not contain verbatim.  Treat lightly: any match at
+        # all still passes; zero matches is a soft fail, not a hard one.
+        if entities:
+            cross_score = len(matches) / total
+            cross_passed = len(mismatches) < len(matches) * 0.5
+        else:
+            cross_passed = len(matches) > 0
+            cross_score = len(matches) / max(total, 1)
 
     return ClaimCrossCheckResult(
         claim_id=agent_result.claim_id,
@@ -113,14 +135,16 @@ def compute_fusion_score(
     has_conflicts = any(len(r.mismatches) > 0 for r in cross_check_results)
 
     # 5-way verdict
-    if has_conflicts and fusion_score < mode.partial_threshold:
+    # UNANSWERABLE first: when no claim passed cross-check at all,
+    # treat as truly unanswerable (not "conflicting").
+    if cross_check_results and not any(r.cross_check_passed for r in cross_check_results):
+        status = "UNANSWERABLE"
+    elif has_conflicts and fusion_score < mode.partial_threshold:
         status = "CONFLICTING"
     elif fusion_score >= mode.sufficiency_threshold:
         status = "SUFFICIENT"
     elif fusion_score >= mode.partial_threshold:
         status = "USEFUL_BUT_INCOMPLETE"
-    elif not any(r.cross_check_passed for r in cross_check_results):
-        status = "UNANSWERABLE"
     else:
         status = "INSUFFICIENT"
 

--- a/rag/advanced_rag/harness/tools/search.py
+++ b/rag/advanced_rag/harness/tools/search.py
@@ -1,9 +1,11 @@
 """Search tools: hybrid, vector, BM25, web, structured."""
 
+import hashlib
 import logging
 import re
-import hashlib
+
 from common import settings
+
 from .navigation import _kg_scopes
 
 _LOG = logging.getLogger(__name__)
@@ -127,12 +129,15 @@ def _narrow_by_keywords(chunks: list[dict], keywords: str) -> list[dict]:
     kwds = [k.strip().lower() for k in (keywords or "").split(",") if k.strip()]
     if not kwds or not chunks:
         return chunks
-    if len(kwds) < 3:
-        kwds = [k.strip().lower() for k in (keywords or "").split(" ") if k.strip()]
-        _kwds = []
-        for i in range(len(kwds) - 1):
-            _kwds.append(kwds[i] + " " + kwds[i + 1])
-        kwds = _kwds
+    if 1 < len(kwds) < 3:
+        space_kwds = [k.strip().lower() for k in (keywords or "").split(" ") if k.strip()]
+        if len(space_kwds) > len(kwds):
+            kwds = space_kwds
+        else:
+            _kwds = []
+            for i in range(len(kwds) - 1):
+                _kwds.append(kwds[i] + " " + kwds[i + 1])
+            kwds = _kwds
 
     scored = [(ck, _narrow_content(ck.get("content_with_weight") or ck.get("content") or "", kwds)) for ck in chunks]
     out: list[dict] = []


### PR DESCRIPTION
### Summary

Refine agentic search — fixes critical correctness bugs and improves planning/decomposition quality in the agentic RAG pipeline.

**Bug fixes**
ABSTAIN path was dead code → now correctly surfaces "I cannot answer"

agentic.py: _finalize now accepts abstain parameter, ABSTAIN path passes abstain=True → formalize_answer abstain branch (line 215) is reachable. Previously ABSTAIN silently became a normal partial answer using unreliable evidence. FALLBACK_LLM is unaffected.
agentic_rag_graph.py: log _note priority fixed — abstain now checked before partial.
Single-keyword search zeroed out all results

search.py: len(kwds) < 3 → 1 < len(kwds) < 3. A single keyword (e.g. "颜良") previously entered else → range(0) → kwds=[] → all chunks dropped. Now single-keyword queries are preserved as-is.
UNANSWERABLE misclassified as CONFLICTING, Chinese NER false negatives

sufficiency.py: UNANSWERABLE check moved before CONFLICTING. total == 0 (no extractable entities/numbers from Chinese text) now passes instead of scoring 0.
Chinese-only chunks with no English entities now use lenient matching (any digit match passes).
Preliminary search polluted final answer citations

agentic_rag_graph.py: removed _merge_result_into_kbinfos(). Seed chunks from preliminary search are only stored in state["seed_chunks"] for planner grounding — never merged into the shared citation pool.

**Quality improvements**

Route classifier (route_prompt.py): added explicit decomposition conditions + 6 bilingual examples → "曹操认识谁？" now correctly routes exploratory → decompose.

Decomposition prompt (decompose_prompts.py): enumeration questions now use a single discovery query instead of per-candidate verification → avoids claim collapse for questions like "who did X know?".

Language alignment (planner.py): runtime instruction forces claim descriptions to match the user's question language.

Go planner parity (planner.go): enumeration guidance and WRONG/CORRECT examples aligned with Python side.
