### PR TITLE
fix: self-heal stale chunk dynamic import failures

### DIFF
--- a/docker/nginx/ragflow.conf.golang
+++ b/docker/nginx/ragflow.conf.golang
@@ -30,8 +30,16 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Cache-Control: max-age Expires
-    location ~ ^/static/(css|js|media)/ {
+    # index.html must always be revalidated: it references hashed chunks,
+    # a stale copy points at chunk files that no longer exist after upgrades.
+    location = /index.html {
+        add_header Cache-Control "no-cache" always;
+    }
+
+    # Hashed build assets: cache aggressively, and return 404 instead of
+    # falling back to index.html (HTML breaks dynamic import()).
+    location ~* \.(?:js|mjs|css|png|jpg|jpeg|gif|ico|svg|webp|woff2?|ttf|eot|map)$ {
+        try_files $uri =404;
         expires 10y;
         access_log off;
     }

--- a/web/src/components/fallback-component/index.tsx
+++ b/web/src/components/fallback-component/index.tsx
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isRouteErrorResponse, useRouteError } from 'react-router';
 
@@ -22,6 +22,15 @@ interface FallbackComponentProps {
   error?: Error;
   reset?: () => void;
 }
+
+// Chrome: "Failed to fetch dynamically imported module"
+// Firefox: "error loading dynamically imported module"
+// Safari: "Importing a module script failed"
+const DYNAMIC_IMPORT_ERROR_PATTERN =
+  /dynamically imported module|Importing a module script failed/i;
+
+const RELOAD_GUARD_KEY = 'ragflow:chunk-load-reload';
+const RELOAD_GUARD_INTERVAL = 10_000;
 
 const FallbackComponent: React.FC<FallbackComponentProps> = ({
   error: errorProp,
@@ -31,6 +40,19 @@ const FallbackComponent: React.FC<FallbackComponentProps> = ({
   const routeError = useRouteError();
   const error =
     errorProp ?? (routeError instanceof Error ? routeError : undefined);
+
+  // A failed lazy chunk usually means the app shell is stale (old index.html
+  // referencing chunk files that no longer exist). Reload once to self-heal.
+  useEffect(() => {
+    if (!error || !DYNAMIC_IMPORT_ERROR_PATTERN.test(error.message)) {
+      return;
+    }
+    const lastReload = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) || 0);
+    if (Date.now() - lastReload > RELOAD_GUARD_INTERVAL) {
+      sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+      window.location.reload();
+    }
+  }, [error]);
 
   let routeErrorDataStr = '';
   if (isRouteErrorResponse(routeError)) {


### PR DESCRIPTION
### Summary

Navigating to a lazily loaded route (e.g. Knowledge Base -> View All -> `/datasets`) can fail with `TypeError: error loading dynamically imported module`, and the error is reproducible across logout/login.

Root cause: nginx serves `index.html` without any `Cache-Control`, so browsers heuristically cache it. A stale `index.html` references hashed chunk files that no longer exist after an upgrade, and `try_files ... /index.html` serves the HTML fallback (200) for the missing `/chunk/js/*.js` request, breaking dynamic `import()`. Since logout/login are full-page navigations that reload the same stale cached shell, the error keeps reproducing.

Changes:

- **nginx (go mode, `docker/nginx/ragflow.conf.golang`)**: serve `index.html` with `Cache-Control: no-cache` so chunk references are always revalidated; return 404 for missing static assets instead of the `index.html` HTML fallback (also replaces the stale `/static/(css|js|media)/` rule, since build output actually lives under `/chunk/`, `/entry/` and `/assets/`).
- **web (`fallback-component`)**: detect dynamic import failures (Chrome/Firefox/Safari error variants) in the route error boundary and reload the page once to self-heal, guarded by a 10s `sessionStorage` timestamp to prevent reload loops.