### PR TITLE
fix(memory): display embd_name with fallback to embd_id in form field

### DIFF
--- a/web/src/components/memories-form-field.tsx
+++ b/web/src/components/memories-form-field.tsx
@@ -62,7 +62,7 @@ export function useDisableDifferenceEmbeddingMemory(name: string) {
             name={item.name}
           />
         ),
-        suffix: <MemoryLabel text={item.embd_id} />,
+        suffix: <MemoryLabel text={item.embd_name || item.embd_id} />,
         value: item.id,
         disabled: item.embd_id !== selectedEmbedId && selectedEmbedId !== '',
       };

--- a/web/src/interfaces/database/memory.ts
+++ b/web/src/interfaces/database/memory.ts
@@ -9,5 +9,6 @@ export interface IMemory {
   storage_type: string;
   tenant_id: string;
   embd_id: string;
+  embd_name?: string;
   llm_id: string;
 }


### PR DESCRIPTION
### Summary

fix(memory): display embd_name with fallback to embd_id in form field

The memory form field suffix was showing the raw embedding model ID (embd_id) instead of the human-readable name. Use embd_name when available, falling back to embd_id for backward compatibility.
