### PR TITLE
Fix generate graph error

### DIFF
--- a/rag/advanced_rag/knowlege_compile/structure.py
+++ b/rag/advanced_rag/knowlege_compile/structure.py
@@ -1232,7 +1232,11 @@ def _struct_rebuild_doc_storage_doc(
 async def _struct_reembed_payload(payload: dict, embd_mdl):
     """Re-encode a merged payload's description with embd_mdl and return the vector."""
     text = _struct_payload_description(payload)
-    vecs = await _struct_embed(embd_mdl, [text])
+    try:
+        vecs = await _struct_embed(embd_mdl, [text])
+    except Exception:
+        logging.exception("structure merge: failed to re-embed merged payload")
+        return None
     return vecs[0] if vecs else None
 
 
@@ -1922,8 +1926,8 @@ async def _struct_local_dedup(
             )
             new_vec = await _struct_reembed_payload(merged_payload, embd_mdl)
             if new_vec is None:
-                # Re-embed failed: keep existing, drop incoming silently.
-                dropped += 1
+                # Keep both candidates when the merged row cannot be embedded.
+                kept.append(incoming)
                 continue
             rebuilt = _struct_rebuild_doc_storage_doc(
                 merged_payload,


### PR DESCRIPTION
Fix:
```
2026-08-06 16:34:51,130 ERROR    194415 status: 400, response: {"code":20015,"message":"The parameter is invalid. Please check again.","data":null}
Traceback (most recent call last):
  File "/home/lhp/qi/code/ragflow/rag/flow/base.py", line 46, in invoke
    await asyncio.wait_for(self._invoke(**kwargs), timeout=self._param.timeout)
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 507, in wait_for
    return await fut
           ^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/flow/compiler/compiler.py", line 691, in _invoke
    await _run_templates(non_tree_templates)
  File "/home/lhp/qi/code/ragflow/rag/flow/compiler/compiler.py", line 677, in _run_templates
    return await run_structure_compile_over_batches(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<10 lines>...
    )
    ^
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/runner.py", line 550, in run_structure_compile_over_batches
    await asyncio.gather(*flush_tasks)
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 304, in __step_run_and_handle_result
    result = coro.send(None)
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/runner.py", line 362, in _run_flush
    info = await merge_compiled_structures(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<15 lines>...
    )
    ^
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/structure.py", line 2905, in merge_compiled_structures
    deduped, dropped = await _struct_local_dedup_parallel(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/structure.py", line 2065, in _struct_local_dedup_parallel
    relation_results = await asyncio.gather(*(dedup_group(relation_buckets[key]) for key in relation_order))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 375, in __wakeup
    future.result()
    ~~~~~~~~~~~~~^^
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 306, in __step_run_and_handle_result
    result = coro.throw(exc)
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/structure.py", line 2035, in dedup_group
    return await _struct_local_dedup(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/structure.py", line 1923, in _struct_local_dedup
    new_vec = await _struct_reembed_payload(merged_payload, embd_mdl)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/structure.py", line 1235, in _struct_reembed_payload
    vecs = await _struct_embed(embd_mdl, [text])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/advanced_rag/knowlege_compile/_common.py", line 108, in encode
    embeddings, _ = await thread_pool_exec(embd_mdl.encode, texts)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/common/misc_utils.py", line 260, in thread_pool_exec
    return await loop.run_in_executor(executor, ctx.run, func, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/asyncio/futures.py", line 286, in __await__
    yield self  # This tells Task to wait for completion.
    ^^^^^^^^^^
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 375, in __wakeup
    future.result()
    ~~~~~~~~~~~~~^^
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/asyncio/futures.py", line 199, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/home/lhp/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/lhp/qi/code/ragflow/api/db/services/llm_service.py", line 158, in encode
    embeddings, used_tokens = self.mdl.encode(safe_texts)
                              ~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/llm/embedding_model.py", line 1023, in encode
    return self._batched_encode(texts, self._call, batch_size=16)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/llm/embedding_model.py", line 192, in _batched_encode
    embeddings, tokens = call_fn(batch)
                         ~~~~~~~^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/llm/embedding_model.py", line 1020, in _call
    return self._openai_http_embeddings(response)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/llm/embedding_model.py", line 212, in _openai_http_embeddings
    _raise_model_exception_if_failed(response)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/lhp/qi/code/ragflow/rag/llm/embedding_model.py", line 69, in _raise_model_exception_if_failed
    raise ModelException(f"status: {resp.status_code}, response: {resp.text}", retryable=False)
common.exceptions.ModelException: status: 400, response: {"code":20015,"message":"The parameter is invalid. Please check again.","data":null}
2026-08-06 16:34:52,214 INFO     194415 handle_task done for task {"id": "fb26977
```