### PR TITLE
fix: allow OpenAI-API-Compatible models as tenant default models

### DIFF
--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -449,17 +449,6 @@ func ptrStringValue(s *string) string {
 	return *s
 }
 
-func factoryModelTypeName(modelType string) string {
-	switch modelType {
-	case "image2text":
-		return "vision"
-	case "speech2text":
-		return "asr"
-	default:
-		return modelType
-	}
-}
-
 // GetDefaultModelName returns the full default model ID for a tenant and model type
 // Format: modelName@instanceName@providerName or modelName@providerName
 // Returns empty string if no default model is set
@@ -537,17 +526,10 @@ func (s *TenantService) GetModelInfo(ctx context.Context, tenantID string, defau
 		return nil, nil, nil, false, err
 	}
 
-	// Validate that the factory model supports this model type.
-	modelSchema, err := dao.GetModelProviderManager().GetModelByName(providerName, modelName)
-	if err != nil {
-		return nil, nil, nil, false, err
-	}
-	factoryModelType := factoryModelTypeName(modelType)
-	if !modelSchema.ModelTypeMap[factoryModelType] {
-		return nil, nil, nil, false, fmt.Errorf("model %s isn't a %s model", modelName, modelType)
-	}
-
-	// Check if the model exists and is active.
+	// Check if the model exists and is active. The tenant_model row is the
+	// source of truth here — providers with an empty factory catalog (e.g.
+	// OpenAI-API-Compatible, whose models are user-defined) cannot be
+	// validated against the catalog. Mirrors Python's _get_model_info.
 	modelEntity, err := s.modelDAO.GetModelByProviderIDAndInstanceIDAndModelName(ctx, dao.DB, modelProvider.ID, modelInstance.ID, modelName)
 	if err != nil {
 		if !dao.IsNotFoundErr(err) {


### PR DESCRIPTION
### Summary

Models added via the **OpenAI-API-Compatible** provider could not be kept as tenant default models (LLM/Embedding/Rerank/etc.) on the Go backend: selecting one in the *Set Default Model* page appeared to save, but the field showed up empty again on reload.

Root cause: `TenantService.GetModelInfo` (used by `ListTenantDefaultModels`, i.e. `GET /api/v1/models/default`) validated the saved default model against the factory model catalog via `GetModelByName`. OpenAI-API-Compatible ships an empty catalog (`conf/models/openai-api-compatible.json` has `"models": []`) because its models are entirely user-defined, so the lookup always failed and `ListTenantDefaultModels` silently dropped the entry (`if err == nil` guard).

Fix: drop the factory-catalog validation in `GetModelInfo` and rely on the `tenant_model` row (exists + active) as the source of truth — this matches the Python backend's `_get_model_info` behavior, which performs no catalog check. The now-unused `factoryModelTypeName` helper is removed as well.

Verified: `bash build.sh --test ./internal/service/...` passes.