### PR TITLE
fix(i18n): clarify selectAll label selects current page only

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1022,7 +1022,7 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       createChunk: 'Create chunk',
       editChunk: 'Edit chunk',
       bulk: 'Bulk',
-      selectAll: 'Select all',
+      selectAll: 'Select page',
       enabledSelected: 'Enable selected',
       disabledSelected: 'Disable selected',
       deleteSelected: 'Delete selected',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -920,7 +920,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       createChunk: '创建解析块',
       editChunk: '编辑解析块',
       bulk: '批量',
-      selectAll: '选择所有',
+      selectAll: '选择当前页',
       enabledSelected: '启用选定的',
       disabledSelected: '禁用选定的',
       deleteSelected: '删除选定的',


### PR DESCRIPTION
### Summary

fix(i18n): clarify selectAll label selects current page only

Rename "Select all" / "选择所有" to "Select page" / "选择当前页" in the chunk operations to accurately reflect that the action selects items on the current page, not across all pages.
