### PR TITLE
Fix: Clicking the confirm button on the WikiCommitModal does not validate the form.

### DIFF
--- a/web/src/pages/dataset/compilation/hooks/use-commit-artifact.ts
+++ b/web/src/pages/dataset/compilation/hooks/use-commit-artifact.ts
@@ -44,10 +44,6 @@ export function useCommitArtifact({
     setIsOpen(true);
   }, [form]);
 
-  const close = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
   const handleConfirm = useCallback(
     async (values: CommitFormValues) => {
       if (!pageType || !slug) return;
@@ -72,7 +68,7 @@ export function useCommitArtifact({
   return {
     isOpen,
     open,
-    close,
+    setIsOpen,
     form,
     handleConfirm,
     isUpdating,

--- a/web/src/pages/dataset/compilation/hooks/use-wiki-detail-content.ts
+++ b/web/src/pages/dataset/compilation/hooks/use-wiki-detail-content.ts
@@ -160,7 +160,7 @@ export function useWikiDetailContent({
     }
   }, [handleMarkAsSaved, isVersionView, onSelectVersion]);
 
-  const { isOpen, open, close, form, handleConfirm, isUpdating } =
+  const { isOpen, open, setIsOpen, form, handleConfirm, isUpdating } =
     useCommitArtifact({
       editedContent,
       pageType: currentEntry?.pageType ?? selectedArtifact?.page_type ?? '',
@@ -207,7 +207,7 @@ export function useWikiDetailContent({
     referenceDocuments,
     isOpen,
     open,
-    close,
+    setIsOpen,
     form,
     handleConfirm,
     isUpdating,

--- a/web/src/pages/dataset/compilation/wiki-detail-content.tsx
+++ b/web/src/pages/dataset/compilation/wiki-detail-content.tsx
@@ -38,7 +38,7 @@ export function WikiDetailContent({
     isDirty,
     isOpen,
     open,
-    close,
+    setIsOpen,
     form,
     handleConfirm,
     isUpdating,
@@ -95,7 +95,7 @@ export function WikiDetailContent({
 
           <WikiCommitModal
             open={isOpen}
-            onOpenChange={close}
+            onOpenChange={setIsOpen}
             form={form}
             onConfirm={handleConfirm}
             loading={isUpdating}


### PR DESCRIPTION

### Summary
Fix: Clicking the confirm button on the WikiCommitModal does not validate the form.