### PR TITLE
Fix: The height of the source code mode in the wiki template's Markdown editor is too small.

### DIFF
--- a/web/src/pages/user-setting/compilation-templates/edit-next/components/blueprint-section.tsx
+++ b/web/src/pages/user-setting/compilation-templates/edit-next/components/blueprint-section.tsx
@@ -59,6 +59,7 @@ export function BlueprintSection({
               name={examplePath}
               label={t('setting.example')}
               className="flex h-[50vh] min-h-0 flex-col"
+              valueClassName="flex-1 min-h-0"
             >
               {(field) => (
                 <MarkdownEditor


### PR DESCRIPTION


### Summary

Fix: The height of the source code mode in the wiki template's Markdown editor is too small.