### PR TITLE
Fix: Links to wiki content accessed via the version view are not clickable.

### DIFF
--- a/web/src/pages/dataset/compilation/hooks/use-wiki-detail-content.ts
+++ b/web/src/pages/dataset/compilation/hooks/use-wiki-detail-content.ts
@@ -103,7 +103,6 @@ export function useWikiDetailContent({
 
   const handleMarkdownLinkClick = useCallback(
     (pageType: WikiPageType, slug: string) => {
-      if (isVersionView) return;
       if (currentEntry?.slug === slug && currentEntry?.pageType === pageType)
         return;
 
@@ -125,7 +124,6 @@ export function useWikiDetailContent({
     [
       push,
       onSelectArtifact,
-      isVersionView,
       currentEntry,
       pageData,
       updateCurrentTitle,


### PR DESCRIPTION


### Summary

Fix: Links to wiki content accessed via the version view are not clickable.
