### PR TITLE
fix(rerank): set NvidiaRerank base_url for all models

### DIFF
--- a/rag/llm/rerank_model.py
+++ b/rag/llm/rerank_model.py
@@ -202,6 +202,12 @@ class NvidiaRerank(Base):
             base_url = "https://ai.api.nvidia.com/v1/retrieval/nvidia/"
         self.model_name = model_name
 
+        # Default to NVIDIA's generic reranking endpoint. base_url used to be
+        # assigned only inside the two model-specific branches below, so any
+        # other model left the attribute unset and raised AttributeError on the
+        # first _compute_rank() call.
+        self.base_url = urljoin(base_url, "reranking")
+
         if self.model_name == "nvidia/nv-rerankqa-mistral-4b-v3":
             self.base_url = urljoin(base_url, "nv-rerankqa-mistral-4b-v3/reranking")
 


### PR DESCRIPTION
### What problem does this PR solve?

`NvidiaRerank.__init__` only assigned `self.base_url` inside two model-specific
`if` branches:

```python
if self.model_name == "nvidia/nv-rerankqa-mistral-4b-v3":
    self.base_url = urljoin(base_url, "nv-rerankqa-mistral-4b-v3/reranking")
if self.model_name == "nvidia/rerank-qa-mistral-4b":
    self.base_url = urljoin(base_url, "reranking")
```

Any other NVIDIA rerank model therefore left the attribute unset, and the first
`_compute_rank()` call died with `AttributeError: 'NvidiaRerank' object has no
attribute 'base_url'`.

This is reachable in normal use: `conf/llm_factories.json` ships no NVIDIA
rerank entries at all, so every NVIDIA rerank model has to be added by hand,
and any name other than those two hardcoded strings crashes.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Fix

Default `self.base_url` to NVIDIA's generic `<base>/reranking` endpoint before
the model-specific branches, so unknown models get a working endpoint instead
of an unset attribute.

Behaviour is unchanged for both previously-handled models: `rerank-qa-mistral-4b`
already used the generic endpoint, and `nv-rerankqa-mistral-4b-v3` still
overrides with its own path.

### Test plan

- [x] Instantiating `NvidiaRerank` with an arbitrary model name no longer
      raises `AttributeError` on first use.
- [x] Both previously-hardcoded model names resolve to the same URLs as before.
- [ ] Live scoring against NVIDIA's endpoint (needs an NVIDIA API key; both
      endpoints return `403 Authorization failed` without one).