### PR TITLE
test(token_chunker): drop unsupported chunk_token_size=0 case from delimiter-mode test

### DIFF
--- a/rag/flow/tests/test_token_chunker.py
+++ b/rag/flow/tests/test_token_chunker.py
@@ -426,10 +426,10 @@ def test_json_delimiter_mode_consecutive_delimiter_keeps_boundary():
         assert all("##" not in t for t in texts)
 
 
-def test_text_delimiter_mode_zero_or_one_no_atom_split():
-    # chunk_token_size=0/1 must not atom-split delimiter segments into 1-token
+def test_text_delimiter_mode_one_no_atom_split():
+    # chunk_token_size=1 must not atom-split delimiter segments into 1-token
     # chunks; the delimiter path produces delimiter-boundary chunks regardless of cap.
-    for module, chunker in _build_json_chunker({"delimiter_mode": "delimiter", "delimiters": ["`|`"]}):
+    for _module, chunker in _build_json_chunker({"delimiter_mode": "delimiter", "delimiters": ["`|`"]}):
         # text path: delimiter_mode is delimiter but a custom delimiter is
         # present, so the delimiter branch (_split_text_by_pattern) is used.
         kwargs = {
@@ -437,9 +437,9 @@ def test_text_delimiter_mode_zero_or_one_no_atom_split():
             "output_format": "text",
             "text": "aaa|bbb|ccc",
         }
-        for chunk_token_size in (0, 1):
-            setattr(chunker._param, "chunk_token_size", chunk_token_size)
-            asyncio.run(chunker._invoke(**kwargs))
-            chunks = chunker._outputs["chunks"]
-            texts = [c["text"] for c in chunks]
-            assert texts == ["aaa", "bbb", "ccc"], f"chunk_token_size={chunk_token_size} atom-split a delimiter segment: {texts}"
+        chunk_token_size = 1
+        setattr(chunker._param, "chunk_token_size", chunk_token_size)
+        asyncio.run(chunker._invoke(**kwargs))
+        chunks = chunker._outputs["chunks"]
+        texts = [c["text"] for c in chunks]
+        assert texts == ["aaa", "bbb", "ccc"], f"chunk_token_size={chunk_token_size} atom-split a delimiter segment: {texts}"


### PR DESCRIPTION
## Summary
Remove the `chunk_token_size=0` iteration from the token-chunker delimiter-mode test.

`TokenChunkerParam.check()` requires a positive `chunk_token_size`, so the zero-cap case is not a supported configuration. The test previously bypassed that validation with `setattr`, and because the delimiter path splits on the pattern regardless of cap, the `0` and `1` cases produce identical output — making the `0` iteration a dead test of unsupported behavior (flagged by CodeRabbit on #17979).

Changes:
- Keep only the valid `chunk_token_size=1` case (flattened from the loop).
- Rename the unused loop variable `module` -> `_module`.
- Rename the test to `test_text_delimiter_mode_one_no_atom_split` to reflect the remaining scope.

Per repo guideline "remove dead tests".

## Test plan
- `pytest rag/flow/tests/test_token_chunker.py` - renamed test still passes.
