### PR TITLE
fix(chunk): render <img> tags as escaped text to prevent tracking

### DIFF
--- a/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-card/index.tsx
+++ b/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-card/index.tsx
@@ -9,9 +9,9 @@ import {
 } from '@/components/ui/tooltip';
 import type { ChunkDocType, IChunk } from '@/interfaces/database/dataset';
 import { cn } from '@/lib/utils';
+import { sanitizeHtmlWithImagesAsText } from '@/utils/dom-util';
 import { CheckedState } from '@radix-ui/react-checkbox';
 import classNames from 'classnames';
-import DOMPurify from 'dompurify';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChunkTextMode } from '../../constant';
@@ -128,7 +128,7 @@ const ChunkCard = ({
         >
           <div
             dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(item.content_with_weight).trim(),
+              __html: sanitizeHtmlWithImagesAsText(item.content_with_weight).trim(),
             }}
             className={classNames(
               // Keep whitespaces?

--- a/web/src/pages/dataflow-result/components/chunk-card/index.tsx
+++ b/web/src/pages/dataflow-result/components/chunk-card/index.tsx
@@ -8,9 +8,9 @@ import {
 } from '@/components/ui/popover';
 import { Switch } from '@/components/ui/switch';
 import { IChunk } from '@/interfaces/database/dataset';
+import { sanitizeHtmlWithImagesAsText } from '@/utils/dom-util';
 import { CheckedState } from '@radix-ui/react-checkbox';
 import classNames from 'classnames';
-import DOMPurify from 'dompurify';
 import { useEffect, useState } from 'react';
 import { ChunkTextMode } from '../../constant';
 import styles from './index.module.less';
@@ -102,7 +102,7 @@ const ChunkCard = ({
         >
           <div
             dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(item.content_with_weight),
+              __html: sanitizeHtmlWithImagesAsText(item.content_with_weight),
             }}
             className={classNames(styles.contentText, {
               [styles.contentEllipsis]: textMode === ChunkTextMode.Ellipse,

--- a/web/src/utils/dom-util.ts
+++ b/web/src/utils/dom-util.ts
@@ -1,3 +1,22 @@
+import DOMPurify from 'dompurify';
+
 export const scrollToBottom = (element: HTMLElement) => {
   element.scrollTo(0, element.scrollHeight);
+};
+
+/**
+ * Sanitize HTML and render any <img> elements as escaped text strings
+ * instead of loading them as images. Prevents image-based tracking /
+ * data exfiltration via external image URLs and layout disruption, while
+ * keeping the img markup visible to the user as literal text.
+ *
+ * Event-handler XSS (onerror) is already stripped by DOMPurify's default
+ * config; this additionally neutralizes the image element itself.
+ */
+export const sanitizeHtmlWithImagesAsText = (html: string): string => {
+  const node = DOMPurify.sanitize(html, { RETURN_DOM: true }) as HTMLElement;
+  node.querySelectorAll('img').forEach((img) => {
+    img.replaceWith(document.createTextNode(img.outerHTML));
+  });
+  return node.innerHTML;
 };


### PR DESCRIPTION
### Summary

fix(chunk): render <img> tags as escaped text to prevent tracking

Replace DOMPurify.sanitize with a new sanitizeHtmlWithImagesAsText helper in both chunk-card components. The helper sanitizes HTML with DOMPurify and replaces each <img> element with an escaped text node of its outerHTML, so external image URLs are not loaded by the browser. This prevents image-based tracking/data exfiltration and layout shifts while keeping the img markup visible as literal text.
