### PR TITLE
fix(tests): expect default date prompt parameter

### DIFF
--- a/test/testcases/test_sdk_api/test_chat_assistant_management/test_create_chat_assistant.py
+++ b/test/testcases/test_sdk_api/test_chat_assistant_management/test_create_chat_assistant.py
@@ -185,7 +185,8 @@ class TestChatAssistantCreate:
         else:
             chat_assistant = client.create_chat(name="prompt_test", dataset_ids=[dataset.id], prompt_config=prompt_config)
             for k, v in prompt_config.items():
-                assert getattr(chat_assistant.prompt_config, k) == v
+                expected = [{"key": "date", "optional": True}] if k == "parameters" and not v else v
+                assert getattr(chat_assistant.prompt_config, k) == expected
 
 
 class TestChatAssistantCreate2:


### PR DESCRIPTION
### Summary

Align the SDK chat-assistant P3 assertion with the default optional `date` prompt parameter added by #17430.

The scheduled P3 run failed in both Elasticsearch and Infinity because the test still expected an explicitly empty `parameters` list to remain empty. Chat creation now intentionally appends:

```json
{"key": "date", "optional": true}
```

The input case remains `parameters: []`; only its expected response changes. All other prompt-config cases keep their existing exact comparisons.

### Verification

- Scheduled P3 baseline failed at the same `prompt_config21` case in Elasticsearch and Infinity: https://github.com/infiniflow/ragflow/actions/runs/31197060660
- Exact test-method harness:
  - Before the fix: `AssertionError`.
  - After the fix: passed.
- `uv run python -m py_compile test/testcases/test_sdk_api/test_chat_assistant_management/test_create_chat_assistant.py`: passed.
- Ruff format and `git diff --check`: passed.
- Ruff baseline comparison: the same pre-existing `I001` on `main` and this PR.

### CI note

Two unrelated Go failures have been isolated during reruns: first a syncer cancellation race (`context canceled` versus `interrupted (9)`), then an Infinity runner NATS port collision (`address already in use`). In the latter run, both Python matrices and Elasticsearch Go passed. Because fork PR authors cannot rerun upstream Actions jobs, the unchanged commit was amended to trigger a fresh matrix.

### Scope

One test file, `+2/-1`; no production behavior changes.