### PR TITLE
fix(tests): isolate token chunker imports

### DIFF
--- a/rag/flow/parser/pdf_chunk_metadata.py
+++ b/rag/flow/parser/pdf_chunk_metadata.py
@@ -22,11 +22,8 @@ import numpy as np
 import pdfplumber
 from PIL import Image
 
-from api.db.services.file2document_service import File2DocumentService
-from api.db.services.file_service import FileService
 from common import settings
 from common.misc_utils import get_uuid
-from deepdoc.parser.pdf_parser import LOCK_KEY_pdfplumber, RAGFlowPdfParser
 from rag.utils.base64_image import image2id
 
 PDF_PREVIEW_GAP = 6
@@ -47,6 +44,8 @@ def _extract_raw_positions(item):
 
     position_tag = item.get("position_tag")
     if isinstance(position_tag, str) and position_tag:
+        from deepdoc.parser.pdf_parser import RAGFlowPdfParser
+
         return [[pos[0][-1], *pos[1:]] for pos in RAGFlowPdfParser.extract_positions(position_tag)]
 
     position_int = item.get("position_int")
@@ -187,6 +186,9 @@ def finalize_pdf_chunk(chunk):
 
 
 def _fetch_source_blob(from_upstream, canvas):
+    from api.db.services.file2document_service import File2DocumentService
+    from api.db.services.file_service import FileService
+
     if canvas._doc_id:
         bucket, name = File2DocumentService.get_storage_address(doc_id=canvas._doc_id)
         return settings.STORAGE_IMPL.get(bucket, name)
@@ -196,6 +198,8 @@ def _fetch_source_blob(from_upstream, canvas):
 
 
 def _load_pdf_page_images(blob, zoom=PDF_PREVIEW_ZOOM):
+    from deepdoc.parser.pdf_parser import LOCK_KEY_pdfplumber
+
     with sys.modules[LOCK_KEY_pdfplumber]:
         with pdfplumber.open(io.BytesIO(blob)) as pdf:
             return [page.to_image(resolution=72 * zoom, antialias=True).annotated for page in pdf.pages]

--- a/test/unit_test/rag/test_flow_chunker_import.py
+++ b/test/unit_test/rag/test_flow_chunker_import.py
@@ -1,0 +1,32 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import importlib
+import sys
+
+
+def test_token_chunker_imports_without_pdf_parser_symbols(pdf_parser_stub, monkeypatch):
+    monkeypatch.delattr(pdf_parser_stub, "RAGFlowPdfParser")
+    for module_name in [
+        "rag.flow.chunker",
+        "rag.flow.chunker.token_chunker",
+        "rag.flow.parser.pdf_chunk_metadata",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    token_chunker = importlib.import_module("rag.flow.chunker.token_chunker")
+
+    assert callable(token_chunker._merge_text_chunks_by_token_size)

--- a/test/unit_test/rag/test_flow_chunker_import.py
+++ b/test/unit_test/rag/test_flow_chunker_import.py
@@ -30,3 +30,17 @@ def test_token_chunker_imports_without_pdf_parser_symbols(pdf_parser_stub, monke
     token_chunker = importlib.import_module("rag.flow.chunker.token_chunker")
 
     assert callable(token_chunker._merge_text_chunks_by_token_size)
+
+    position_tag = "@@1\t10\t20\t30\t40##"
+    extracted_tags = []
+
+    class RuntimePdfParser:
+        @staticmethod
+        def extract_positions(value):
+            extracted_tags.append(value)
+            return [([0], 10.0, 20.0, 30.0, 40.0)]
+
+    monkeypatch.setattr(pdf_parser_stub, "RAGFlowPdfParser", RuntimePdfParser, raising=False)
+
+    assert token_chunker.extract_pdf_positions({"position_tag": position_tag}) == [[1, 10.0, 20.0, 30.0, 40.0]]
+    assert extracted_tags == [position_tag]


### PR DESCRIPTION
### Review scope

- Production diff: `pdf_chunk_metadata.py` (`+7/-3`).
- Regression evidence: `test_flow_chunker_import.py` (`+46/-0`).
- The lazy imports and regression test are atomic because the defect is a cross-suite import collision.

### Summary

Fix the pytest collection conflict in #17985 by keeping PDF preview and parser
dependencies out of `pdf_chunk_metadata.py`'s module import path.

`test/unit_test/rag/conftest.py` intentionally provides a lightweight
`deepdoc.parser.pdf_parser` stub for `rag.nlp` tests. Importing TokenChunker
previously pulled in database services, `LOCK_KEY_pdfplumber`, and
`RAGFlowPdfParser` at module load time. That coupled the chunker import to the
stub's exact symbol set and failed against a partial or poisoned parser module.

This change:

- imports `FileService` and `File2DocumentService` only when a source blob is requested;
- imports `LOCK_KEY_pdfplumber` only when PDF page images are loaded;
- imports `RAGFlowPdfParser` only when a legacy `position_tag` is parsed;
- verifies TokenChunker imports when the parser stub exposes no PDF parser symbols;
- executes the `position_tag` path against the runtime parser stub and verifies the normalized coordinates.

Runtime PDF preview and position-tag behavior is unchanged; only import timing
changes.

### Follow-up

#18184 tracks the remaining root cause outside this PR: `parser.py` still has the
same eager service/parser import class, and the affected test directories still
need a stable package/import layout. This PR remains the narrow stopgap for the
TokenChunker collection failure rather than leaving that broader work implicit.

Closes #17985.

### Validation

- Strengthened import-time regression test:
  - previous PR head `c0db8016a`: `1 failed` with missing `RAGFlowPdfParser`;
  - current branch: `1 passed`.
- Runtime lazy-import regression: `position_tag` invokes the stubbed
  `RAGFlowPdfParser.extract_positions` and returns normalized PDF coordinates.
- Targeted test: `uv run pytest test/unit_test/rag/test_flow_chunker_import.py -q` (`1 passed`).
- Original combined reproduction: `25 passed`.
- Combined regression run: `26 passed`.
- `uvx ruff check test/unit_test/rag/test_flow_chunker_import.py`: passed.
- `uvx ruff format --check test/unit_test/rag/test_flow_chunker_import.py`: passed.
- Production-file Ruff baseline: the same 3 existing findings on `main` and this PR.
- `python -m py_compile`: passed.
- `git diff --check`: passed.

proof: sufficient
