### PR TITLE
chore(wiki): remove stray debug print

### DIFF
--- a/rag/advanced_rag/knowlege_compile/wiki.py
+++ b/rag/advanced_rag/knowlege_compile/wiki.py
@@ -2995,7 +2995,6 @@ async def _wiki_build_source_context(
 
     chunk_map = await _wiki_load_chunks_by_id(chunk_ids, tenant_id, kb_id)
     if not chunk_map:
-        print("chunk_map::::::::::::::", chunk_ids, tenant_id, kb_id, flush=True)
         return "(source chunks could not be loaded)"
 
     parts: list[str] = []


### PR DESCRIPTION
### Summary

Remove a stray `print()` from the Wiki source-context fallback.

When evidence chunk IDs cannot be resolved, the fallback currently writes the
chunk IDs, tenant ID, and knowledge-base ID directly to stdout before returning
the existing user-facing fallback text. This bypasses structured logging and
adds internal identifiers to container output.

The change only removes that debug output. The fallback return value and Wiki
generation control flow remain unchanged.

### Validation

- Exact-function stdout harness:
  - `origin/main@99110c2df`: failed because stdout was non-empty
  - this commit: passed with the same fallback result and empty stdout
- Ruff `T201`: 1 finding before, 0 after
- `python -m py_compile rag/advanced_rag/knowlege_compile/wiki.py`
- `ruff format --check rag/advanced_rag/knowlege_compile/wiki.py`
- `git diff --check`

proof: sufficient
