### PR TITLE
fix(dataset): shrink table height when bulk operate bar is visible

### DIFF
--- a/web/src/pages/dataset/dataset/dataset-table.tsx
+++ b/web/src/pages/dataset/dataset/dataset-table.tsx
@@ -47,6 +47,7 @@ export type DatasetTableProps = Pick<
 > &
   Pick<UseRowSelectionType, 'rowSelection' | 'setRowSelection'> & {
     showManageMetadataModal: (config: ShowManageMetadataModalProps) => void;
+    bulkOperateBarVisible?: boolean;
   };
 
 export function DatasetTable({
@@ -56,6 +57,7 @@ export function DatasetTable({
   rowSelection,
   setRowSelection,
   showManageMetadataModal,
+  bulkOperateBarVisible = false,
 }: DatasetTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -130,7 +132,13 @@ export function DatasetTable({
 
   return (
     <div className="w-full">
-      <Table rootClassName="max-h-[calc(100vh-280px)]">
+      <Table
+        rootClassName={
+          bulkOperateBarVisible
+            ? 'max-h-[calc(100vh-320px)]'
+            : 'max-h-[calc(100vh-280px)]'
+        }
+      >
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>

--- a/web/src/pages/dataset/dataset/index.tsx
+++ b/web/src/pages/dataset/dataset/index.tsx
@@ -195,6 +195,7 @@ export default function Dataset() {
           setRowSelection={setRowSelection}
           showManageMetadataModal={showManageMetadataModal}
           loading={loading}
+          bulkOperateBarVisible={!rowSelectionIsEmpty}
         />
 
         {documentUploadVisible && (


### PR DESCRIPTION
### Summary

fix(dataset): shrink table height when bulk operate bar is visible

When rows are selected, the BulkOperateBar appears in the CardHeader and pushes content down, but the DatasetTable's max height stayed at calc(100vh-280px), causing the table body to overlap with the absolutely-positioned RAGFlowPagination at the bottom.

Add a `bulkOperateBarVisible` prop to DatasetTable that shrinks the table max height to calc(100vh-320px) when the bulk bar is visible, keeping the pagination clear of the table rows.
