### PR TITLE
fix(ingestion): shallow-copy chunk maps so Extractor writes don't mutate upstream

### DIFF
--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -606,9 +606,10 @@ func extractorChunkInputOrder(inputs map[string]any) []string {
 // extractorChunkList coerces v into a []map[string]any of chunk maps. Each
 // chunk map is shallow-copied so the Extractor's writes (field_name result,
 // important_kwd/question_kwd/metadata, tag_fea) land on a private copy and do
-// not mutate the upstream chunk maps the pipeline passed in — mirroring
-// Python's deepcopy(args[k]) at extractor.py:87. Nested values (maps/slices
-// inside a chunk) remain shared references; only the top-level map is copied.
+// not mutate the upstream chunk maps the pipeline passed in. This mirrors the
+// caller-data isolation Python gets via deepcopy at extractor.py:87, but only
+// for the top-level map — nested values (maps/slices inside a chunk) remain
+// shared references.
 func extractorChunkList(v any) ([]map[string]any, bool) {
 	clone := func(m map[string]any) map[string]any {
 		cp := make(map[string]any, len(m))

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -603,10 +603,27 @@ func extractorChunkInputOrder(inputs map[string]any) []string {
 	return order
 }
 
+// extractorChunkList coerces v into a []map[string]any of chunk maps. Each
+// chunk map is shallow-copied so the Extractor's writes (field_name result,
+// important_kwd/question_kwd/metadata, tag_fea) land on a private copy and do
+// not mutate the upstream chunk maps the pipeline passed in — mirroring
+// Python's deepcopy(args[k]) at extractor.py:87. Nested values (maps/slices
+// inside a chunk) remain shared references; only the top-level map is copied.
 func extractorChunkList(v any) ([]map[string]any, bool) {
+	clone := func(m map[string]any) map[string]any {
+		cp := make(map[string]any, len(m))
+		for k, val := range m {
+			cp[k] = val
+		}
+		return cp
+	}
 	switch list := v.(type) {
 	case []map[string]any:
-		return list, true
+		out := make([]map[string]any, 0, len(list))
+		for _, m := range list {
+			out = append(out, clone(m))
+		}
+		return out, true
 	case []any:
 		out := make([]map[string]any, 0, len(list))
 		for _, item := range list {
@@ -614,7 +631,7 @@ func extractorChunkList(v any) ([]map[string]any, bool) {
 			if !ok {
 				continue
 			}
-			out = append(out, m)
+			out = append(out, clone(m))
 		}
 		return out, true
 	default:

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -117,6 +117,47 @@ func TestExtractorComponent_Registered(t *testing.T) {
 	}
 }
 
+// TestExtractorComponent_Invoke_DoesNotMutateUpstream verifies that the
+// Extractor writes to shallow copies of the input chunk maps rather than
+// mutating the maps the caller passed in (mirrors Python's
+// deepcopy(args[k]) at extractor.py:87). Both the field_name result and the
+// auto keyword/question/metadata writes must land on the copy, leaving the
+// upstream chunks untouched.
+func TestExtractorComponent_Invoke_DoesNotMutateUpstream(t *testing.T) {
+	withStubChatInvoker(t,
+		stubResponse{Content: "extracted summary"},
+		stubResponse{Content: "kw1,kw2"},
+	)
+
+	c := &ExtractorComponent{Param: schema.ExtractorParam{
+		FieldName:     "summary",
+		AutoKeywords:  2,
+		LLMID:         "gpt-4o-mini",
+		Prompt:        "Extract:",
+		SystemPrompt:  "",
+	}}
+	upstream := []map[string]any{
+		{"text": "doc one"},
+		{"text": "doc two"},
+	}
+	if _, err := c.Invoke(t.Context(), nil, map[string]any{
+		"chunks": upstream,
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	// Upstream chunk maps must not have been mutated by the Extractor:
+	// no field_name key, no important_kwd key.
+	for i, ck := range upstream {
+		if _, has := ck["summary"]; has {
+			t.Errorf("upstream chunk[%d] was mutated: got key %q", i, "summary")
+		}
+		if _, has := ck["important_kwd"]; has {
+			t.Errorf("upstream chunk[%d] was mutated: got key %q", i, "important_kwd")
+		}
+	}
+}
+
 // TestExtractorComponent_Invoke_HappyPath covers the per-chunk
 // fan-out: two chunks in → two LLM calls → each chunk enriched
 // with the field_name key.

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -118,11 +118,12 @@ func TestExtractorComponent_Registered(t *testing.T) {
 }
 
 // TestExtractorComponent_Invoke_DoesNotMutateUpstream verifies that the
-// Extractor writes to shallow copies of the input chunk maps rather than
-// mutating the maps the caller passed in (mirrors Python's
-// deepcopy(args[k]) at extractor.py:87). Both the field_name result and the
-// auto keyword/question/metadata writes must land on the copy, leaving the
-// upstream chunks untouched.
+// Extractor writes to shallow copies of the input chunk maps (top-level map
+// isolation): the returned chunks carry the field_name result and the auto
+// keyword writes, while the upstream maps the caller passed in stay untouched.
+// The positive assertions on the returned chunks make the test fail if
+// extraction is skipped — a no-op that only leaves upstream unmutated would
+// otherwise pass.
 func TestExtractorComponent_Invoke_DoesNotMutateUpstream(t *testing.T) {
 	withStubChatInvoker(t,
 		stubResponse{Content: "extracted summary"},
@@ -130,20 +131,37 @@ func TestExtractorComponent_Invoke_DoesNotMutateUpstream(t *testing.T) {
 	)
 
 	c := &ExtractorComponent{Param: schema.ExtractorParam{
-		FieldName:     "summary",
-		AutoKeywords:  2,
-		LLMID:         "gpt-4o-mini",
-		Prompt:        "Extract:",
-		SystemPrompt:  "",
+		FieldName:    "summary",
+		AutoKeywords: 2,
+		LLMID:        "gpt-4o-mini",
+		Prompt:       "Extract:",
+		SystemPrompt: "",
 	}}
 	upstream := []map[string]any{
 		{"text": "doc one"},
 		{"text": "doc two"},
 	}
-	if _, err := c.Invoke(t.Context(), nil, map[string]any{
+	out, err := c.Invoke(t.Context(), nil, map[string]any{
 		"chunks": upstream,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Invoke: %v", err)
+	}
+
+	// The returned chunks are the Extractor's private copies: they must
+	// carry the field_name result and the auto-keyword writes. Absence
+	// here means extraction was skipped, not that isolation worked.
+	chunks, ok := out["chunks"].([]map[string]any)
+	if !ok {
+		t.Fatalf("chunks key missing or wrong shape: %T", out["chunks"])
+	}
+	for i, ck := range chunks {
+		if _, has := ck["summary"]; !has {
+			t.Errorf("returned chunk[%d] is missing %q", i, "summary")
+		}
+		if _, has := ck["important_kwd"]; !has {
+			t.Errorf("returned chunk[%d] is missing %q", i, "important_kwd")
+		}
 	}
 
 	// Upstream chunk maps must not have been mutated by the Extractor:


### PR DESCRIPTION
## Summary

`extractorChunkList` returned the upstream `[]map[string]any` slice directly (and shared each chunk map by reference for the `[]any` branch). As a result, the Extractor's writes during `Invoke` — the `field_name` extraction result, `important_kwd`/`question_kwd`/`metadata`, and `tag_fea` — landed on the **caller's chunk maps**, mutating data the upstream pipeline still holds.

Python avoids this with `deepcopy(args[k])` at `extractor.py:87`.

## Fix

Shallow-copy each chunk map in `extractorChunkList` so the Extractor works on private top-level maps and upstream chunks stay untouched. Nested values (maps/slices inside a chunk) remain shared references — a deeper copy is out of scope for this parity fix (documented in the comment).

## Tests

Added `TestExtractorComponent_Invoke_DoesNotMutateUpstream`, asserting neither the `field_name` key nor the auto-keyword key appears on the caller's chunk maps after `Invoke`. All `internal/ingestion/component` tests pass via `build.sh --test`.
