### PR TITLE
fix: prevent empty-model warning modal from staying open after OK

### DIFF
--- a/web/src/hooks/use-warn-empty-model.tsx
+++ b/web/src/hooks/use-warn-empty-model.tsx
@@ -5,6 +5,8 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigatePage } from './logic-hooks/navigate-hooks';
 
+let isWarningVisible = false;
+
 export const useWarnEmptyModel = (
   showEmptyModelWarn: boolean,
   embdId?: string,
@@ -19,12 +21,14 @@ export const useWarnEmptyModel = (
     if (
       showEmptyModelWarn &&
       !warnedRef.current &&
+      !isWarningVisible &&
       !loading &&
       (isEmpty(embdId) || isEmpty(llmId)) &&
       typeof embdId === 'string' &&
       typeof llmId === 'string'
     ) {
       warnedRef.current = true;
+      isWarningVisible = true;
       Modal.warning({
         title: t('common.warn'),
         content: (
@@ -37,6 +41,7 @@ export const useWarnEmptyModel = (
         closable: false,
         showCancel: false,
         onOk() {
+          isWarningVisible = false;
           navigateToModelSetting();
         },
       });


### PR DESCRIPTION
### Summary

fix: prevent empty-model warning modal from staying open after OK

useWarnEmptyModel is invoked from multiple hooks (useFetchTenantInfo via useSelectParserList, and useFetchDefaultModelDictionary), each with its own warnedRef. Two instances could both fire Modal.warning(), stacking two static modals; onOk only destroys the top one, so the bottom one stays open and looks like the dialog never closed.

Add a module-level isWarningVisible guard so only one warning modal exists at a time, and reset it on dismissal.
