### PR TITLE
fix(search): pass selected pageSize when retrieving chunks on document change

### DIFF
--- a/web/src/pages/next-search/search-view.tsx
+++ b/web/src/pages/next-search/search-view.tsx
@@ -204,7 +204,9 @@ export default function SearchingView({
                   <RetrievalDocuments
                     selectedDocumentIds={selectedDocumentIds}
                     setSelectedDocumentIds={setSelectedDocumentIds}
-                    onTesting={handleTestChunk}
+                    onTesting={(vals: string[]) =>
+                      handleTestChunk(vals, 1, pageSize)
+                    }
                     setLoading={(loading: boolean) => {
                       setRetrievalLoading(loading);
                     }}


### PR DESCRIPTION
### Summary

fix(search): pass selected pageSize when retrieving chunks on document change
