### PR TITLE
Fix(mcp): reset bulk selection after delete and mode switch

### DIFF
--- a/web/src/pages/user-setting/mcp/index.tsx
+++ b/web/src/pages/user-setting/mcp/index.tsx
@@ -39,6 +39,7 @@ export default function McpServer() {
     handleDelete,
     handleExportMcp,
     handleSelectAll,
+    resetSelection,
   } = useBulkOperateMCP(data.mcp_servers);
   const { t } = useTranslation();
   const {
@@ -60,7 +61,8 @@ export default function McpServer() {
 
   const switchSelectionMode = useCallback(() => {
     setSelectionMode((prev) => !prev);
-  }, []);
+    resetSelection();
+  }, [resetSelection]);
 
   return (
     <ProfileSettingWrapperCard

--- a/web/src/pages/user-setting/mcp/use-bulk-operate-mcp.tsx
+++ b/web/src/pages/user-setting/mcp/use-bulk-operate-mcp.tsx
@@ -11,9 +11,16 @@ export function useBulkOperateMCP(mcpList: IMcpServer[]) {
   const { deleteMcpServer } = useDeleteMcpServer();
   const { handleExportMcpJson } = useExportMcp();
 
-  const handleDelete = useCallback(() => {
-    deleteMcpServer(selectedList);
-  }, [deleteMcpServer, selectedList]);
+  const resetSelection = useCallback(() => {
+    setSelectedList([]);
+  }, []);
+
+  const handleDelete = useCallback(async () => {
+    const ret = await deleteMcpServer(selectedList);
+    if (ret.code === 0) {
+      resetSelection();
+    }
+  }, [deleteMcpServer, selectedList, resetSelection]);
 
   const handleSelectChange = useCallback((id: string, checked: boolean) => {
     setSelectedList((list) => {
@@ -50,6 +57,7 @@ export function useBulkOperateMCP(mcpList: IMcpServer[]) {
     handleDelete,
     handleExportMcp: handleExportMcpJson(selectedList),
     handleSelectAll,
+    resetSelection,
   };
 }
 

--- a/web/src/pages/user-setting/mcp/use-bulk-operate-mcp.tsx
+++ b/web/src/pages/user-setting/mcp/use-bulk-operate-mcp.tsx
@@ -16,11 +16,14 @@ export function useBulkOperateMCP(mcpList: IMcpServer[]) {
   }, []);
 
   const handleDelete = useCallback(async () => {
-    const ret = await deleteMcpServer(selectedList);
+    const deletedIds = selectedList;
+    const ret = await deleteMcpServer(deletedIds);
     if (ret.code === 0) {
-      resetSelection();
+      setSelectedList((list) =>
+        list.filter((id) => !deletedIds.includes(id)),
+      );
     }
-  }, [deleteMcpServer, selectedList, resetSelection]);
+  }, [deleteMcpServer, selectedList]);
 
   const handleSelectChange = useCallback((id: string, checked: boolean) => {
     setSelectedList((list) => {


### PR DESCRIPTION
### Summary

Fix stale bulk selection state on the MCP server settings page (User Settings -> MCP).

Previously, the `selectedList` state in `useBulkOperateMCP` was never reset:

1. After a successful bulk delete, the list refreshed via react-query invalidation, but the deleted IDs remained in `selectedList`, so the "Selected N" count still showed the old number.
2. Toggling "Bulk Manage" / "Exit Bulk Manage" only flipped `isSelectionMode` without clearing the selection, so re-entering bulk manage mode showed a stale "Selected N" count even with nothing checked.

Changes:

- `use-bulk-operate-mcp.tsx`: `handleDelete` now awaits the delete mutation and clears the selection on success (`code === 0`); a new `resetSelection` helper is exposed.
- `index.tsx`: `switchSelectionMode` calls `resetSelection` so entering/exiting bulk manage mode always starts with an empty selection.