### PR TITLE
Fix: New sessions will automatically carry over messages from the previous session by default.

### DIFF
--- a/web/src/pages/next-chats/chat/index.tsx
+++ b/web/src/pages/next-chats/chat/index.tsx
@@ -53,6 +53,9 @@ export default function Chat() {
         if (!isEmpty(conversation)) {
           setCurrentConversation(conversation);
         }
+      } else {
+        // New session: clear previous session's messages so they don't leak in.
+        setCurrentConversation({} as IClientConversation);
       }
     },
     [fetchSessionManually],


### PR DESCRIPTION
### Summary

Fix: New sessions will automatically carry over messages from the previous session by default.