### PR TITLE
feat: support per-model endpoint overrides for NVIDIA hosted API

### DIFF
--- a/conf/models/nvidia.json
+++ b/conf/models/nvidia.json
@@ -7,7 +7,17 @@
     "chat": "chat/completions",
     "models": "models",
     "embedding": "embeddings",
-    "rerank": "ranking"
+    "rerank": "ranking",
+    "special": [
+      {
+        "name": "meta/llama-3.2-11b-vision-instruct",
+        "url": "https://integrate.api.nvidia.com/v1/meta/llama-3.2-11b-vision-instruct"
+      },
+      {
+        "name": "meta/llama-3.2-90b-vision-instruct",
+        "url": "https://integrate.api.nvidia.com/v1/meta/llama-3.2-90b-vision-instruct"
+      }
+    ]
   },
   "class": "nvidia",
   "models": [

--- a/internal/entity/models/google_test.go
+++ b/internal/entity/models/google_test.go
@@ -314,7 +314,7 @@ func TestGoogleModelNewInstancePreservesCustomBaseURL(t *testing.T) {
 	if google.baseModel.BaseURL["default"] != customBaseURL["default"] {
 		t.Fatalf("expected base URL %q, got %q", customBaseURL["default"], google.baseModel.BaseURL["default"])
 	}
-	if google.baseModel.URLSuffix != model.baseModel.URLSuffix {
+	if !reflect.DeepEqual(google.baseModel.URLSuffix, model.baseModel.URLSuffix) {
 		t.Fatalf("expected URL suffix %v, got %v", model.baseModel.URLSuffix, google.baseModel.URLSuffix)
 	}
 }

--- a/internal/entity/models/nvidia.go
+++ b/internal/entity/models/nvidia.go
@@ -72,10 +72,11 @@ func buildNvidiaSpecialURLs(special []URLSuffixSpecial) map[string]string {
 	urls := make(map[string]string, len(special))
 	for _, entry := range special {
 		name := strings.TrimSpace(entry.Name)
-		if name == "" || strings.TrimSpace(entry.URL) == "" {
+		endpointURL := strings.TrimSpace(entry.URL)
+		if name == "" || endpointURL == "" {
 			continue
 		}
-		urls[strings.ToLower(name)] = entry.URL
+		urls[strings.ToLower(name)] = endpointURL
 	}
 	return urls
 }

--- a/internal/entity/models/nvidia.go
+++ b/internal/entity/models/nvidia.go
@@ -41,6 +41,12 @@ type NvidiaModel struct {
 	baseModel     BaseModel
 	catalogURL    string
 	hostedAPIHost string
+	// specialURLs maps a model name (lowercase) to a full endpoint URL
+	// that overrides the default base URL + suffix assembly. Populated
+	// from url_suffix.special in conf/models/nvidia.json; the hosted
+	// NVIDIA catalog exposes per-model endpoints that do not follow the
+	// standard suffix scheme (e.g. /v1/meta/llama-3.2-11b-vision-instruct).
+	specialURLs map[string]string
 }
 
 // NewNvidiaModel creates a new Nvidia model instance
@@ -53,7 +59,49 @@ func NewNvidiaModel(baseURL map[string]string, urlSuffix URLSuffix) *NvidiaModel
 		},
 		catalogURL:    nvidiaCatalogURL,
 		hostedAPIHost: nvidiaHostedAPIHost,
+		specialURLs:   buildNvidiaSpecialURLs(urlSuffix.Special),
 	}
+}
+
+// buildNvidiaSpecialURLs indexes the special endpoint list by lowercase
+// model name. Entries with an empty name or URL are skipped.
+func buildNvidiaSpecialURLs(special []URLSuffixSpecial) map[string]string {
+	if len(special) == 0 {
+		return nil
+	}
+	urls := make(map[string]string, len(special))
+	for _, entry := range special {
+		name := strings.TrimSpace(entry.Name)
+		if name == "" || strings.TrimSpace(entry.URL) == "" {
+			continue
+		}
+		urls[strings.ToLower(name)] = entry.URL
+	}
+	return urls
+}
+
+// specialURL returns the per-model endpoint override for modelName,
+// or "" when the model has no special endpoint configured.
+func (n *NvidiaModel) specialURL(modelName string) string {
+	if n.specialURLs == nil {
+		return ""
+	}
+	return n.specialURLs[strings.ToLower(strings.TrimSpace(modelName))]
+}
+
+// resolveEndpointURL returns the request URL for a model. When the
+// resolved base URL points at the NVIDIA hosted API (integrate.api.
+// nvidia.com) and the model has a special endpoint override, that full
+// URL is used verbatim. Otherwise the base URL is joined with the
+// provider's default suffix, so self-hosted NIM deployments configured
+// through a custom base URL keep using the standard suffix scheme.
+func (n *NvidiaModel) resolveEndpointURL(baseURL, modelName, defaultSuffix string) string {
+	if n.usesHostedCatalog(baseURL) {
+		if special := n.specialURL(modelName); special != "" {
+			return special
+		}
+	}
+	return fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), defaultSuffix)
 }
 
 func (n *NvidiaModel) NewInstance(baseURL map[string]string) ModelDriver {
@@ -77,7 +125,7 @@ func (n *NvidiaModel) ChatWithMessages(ctx context.Context, modelName string, me
 	if err != nil {
 		return nil, err
 	}
-	baseURL := fmt.Sprintf("%s/%s", resolvedBaseURL, n.baseModel.URLSuffix.Chat)
+	baseURL := n.resolveEndpointURL(resolvedBaseURL, modelName, n.baseModel.URLSuffix.Chat)
 	reqBody := buildRequestBody(chatModelConfig, modelName, messages, false)
 
 	if chatModelConfig != nil {
@@ -112,7 +160,7 @@ func (n *NvidiaModel) ChatStreamlyWithSender(ctx context.Context, modelName stri
 	if err != nil {
 		return err
 	}
-	baseURL := fmt.Sprintf("%s/%s", resolvedBaseURL, n.baseModel.URLSuffix.Chat)
+	baseURL := n.resolveEndpointURL(resolvedBaseURL, modelName, n.baseModel.URLSuffix.Chat)
 	reqBody := buildRequestBody(modelConfig, modelName, messages, true)
 
 	if modelConfig != nil {
@@ -157,7 +205,7 @@ func (n *NvidiaModel) Embed(ctx context.Context, modelName *string, texts []stri
 		return nil, err
 	}
 
-	baseURL := fmt.Sprintf("%s/%s", strings.TrimSuffix(resolvedBaseURL, "/"), n.baseModel.URLSuffix.Embedding)
+	baseURL := n.resolveEndpointURL(resolvedBaseURL, *modelName, n.baseModel.URLSuffix.Embedding)
 
 	reqBody := map[string]interface{}{
 		"model":           *modelName,
@@ -269,7 +317,7 @@ func (n *NvidiaModel) Rerank(ctx context.Context, modelName *string, query strin
 		return nil, err
 	}
 
-	baseURL := fmt.Sprintf("%s/%s", strings.TrimSuffix(resolvedBaseURL, "/"), n.baseModel.URLSuffix.Rerank)
+	baseURL := n.resolveEndpointURL(resolvedBaseURL, *modelName, n.baseModel.URLSuffix.Rerank)
 
 	topN := len(documents)
 	if rerankConfig != nil && rerankConfig.TopN > 0 && rerankConfig.TopN < topN {

--- a/internal/entity/models/nvidia_special_test.go
+++ b/internal/entity/models/nvidia_special_test.go
@@ -1,0 +1,170 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// nvidiaChatCompletionBody returns a minimal OpenAI-compatible chat
+// completion response accepted by HandleNonStreamingResponse.
+func nvidiaChatCompletionBody() map[string]any {
+	return map[string]any{
+		"id":    "chatcmpl-test",
+		"model": "nvidia-test",
+		"choices": []map[string]any{
+			{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "hello",
+				},
+				"finish_reason": "stop",
+			},
+		},
+	}
+}
+
+func newNvidiaSpecialModelForTest(baseURL string, special []URLSuffixSpecial) *NvidiaModel {
+	return NewNvidiaModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{
+			Chat:      "chat/completions",
+			Embedding: "embeddings",
+			Rerank:    "ranking",
+			Models:    "models",
+			Special:   special,
+		},
+	)
+}
+
+// markHostedAs pretends the httptest server is the NVIDIA hosted API so
+// the special endpoint override is honored by usesHostedCatalog.
+func markHostedAs(driver *NvidiaModel, serverURL string) {
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		panic(err)
+	}
+	driver.hostedAPIHost = parsed.Hostname()
+}
+
+func TestNvidiaSpecialChatUsesSpecialURL(t *testing.T) {
+	withSSRFBypass(t)
+	const specialPath = "/v1/meta/llama-3.2-11b-vision-instruct"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+			return
+		}
+		if r.URL.Path != specialPath {
+			t.Errorf("path = %s, want %s", r.URL.Path, specialPath)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(nvidiaChatCompletionBody())
+	}))
+	defer server.Close()
+
+	driver := newNvidiaSpecialModelForTest(server.URL, []URLSuffixSpecial{
+		{Name: "meta/llama-3.2-11b-vision-instruct", URL: server.URL + specialPath},
+	})
+	markHostedAs(driver, server.URL)
+
+	apiKey := "test-key"
+	resp, err := driver.ChatWithMessages(context.Background(), "meta/llama-3.2-11b-vision-instruct",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err != nil {
+		t.Fatalf("ChatWithMessages() error = %v", err)
+	}
+	if resp == nil || resp.Answer == nil || *resp.Answer != "hello" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestNvidiaSpecialChatFallbackDefaultSuffix(t *testing.T) {
+	withSSRFBypass(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %s, want /v1/chat/completions", r.URL.Path)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(nvidiaChatCompletionBody())
+	}))
+	defer server.Close()
+
+	// No special entries: the model must be assembled from the default
+	// base URL and the chat suffix.
+	driver := newNvidiaSpecialModelForTest(server.URL+"/v1", nil)
+
+	apiKey := "test-key"
+	resp, err := driver.ChatWithMessages(context.Background(), "meta/llama-3.3-70b-instruct",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err != nil {
+		t.Fatalf("ChatWithMessages() error = %v", err)
+	}
+	if resp == nil || resp.Answer == nil || *resp.Answer != "hello" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestNvidiaSpecialIgnoredForNonHostedBaseURL(t *testing.T) {
+	withSSRFBypass(t)
+	// hostedAPIHost stays at the real integrate.api.nvidia.com, so a
+	// self-hosted base URL must not trigger the special endpoint even
+	// when the model has an entry.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %s, want /v1/chat/completions", r.URL.Path)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(nvidiaChatCompletionBody())
+	}))
+	defer server.Close()
+
+	driver := newNvidiaSpecialModelForTest(server.URL+"/v1", []URLSuffixSpecial{
+		{Name: "meta/llama-3.2-11b-vision-instruct", URL: server.URL + "/v1/should-not-be-called"},
+	})
+
+	apiKey := "test-key"
+	_, err := driver.ChatWithMessages(context.Background(), "meta/llama-3.2-11b-vision-instruct",
+		[]Message{{Role: "user", Content: "hi"}},
+		&APIConfig{ApiKey: &apiKey}, nil, nil)
+	if err != nil {
+		t.Fatalf("ChatWithMessages() error = %v", err)
+	}
+}
+
+func TestNvidiaSpecialURLCaseInsensitive(t *testing.T) {
+	withSSRFBypass(t)
+	driver := newNvidiaSpecialModelForTest("https://integrate.api.nvidia.com/v1", []URLSuffixSpecial{
+		{Name: "META/LLAMA-3.2-11B-VISION-INSTRUCT", URL: "https://integrate.api.nvidia.com/v1/meta/llama-3.2-11b-vision-instruct"},
+	})
+
+	got := driver.specialURL("meta/llama-3.2-11b-vision-instruct")
+	want := "https://integrate.api.nvidia.com/v1/meta/llama-3.2-11b-vision-instruct"
+	if got != want {
+		t.Fatalf("specialURL() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildNvidiaSpecialURLsSkipsEmptyEntries(t *testing.T) {
+	driver := newNvidiaSpecialModelForTest("https://integrate.api.nvidia.com/v1", []URLSuffixSpecial{
+		{Name: "", URL: "https://integrate.api.nvidia.com/v1/empty-name"},
+		{Name: "meta/llama-3.2-90b-vision-instruct", URL: "  "},
+		{Name: "meta/llama-3.2-11b-vision-instruct", URL: "https://integrate.api.nvidia.com/v1/meta/llama-3.2-11b-vision-instruct"},
+	})
+
+	if got := driver.specialURL("meta/llama-3.2-11b-vision-instruct"); got == "" {
+		t.Fatalf("expected valid special URL to be indexed")
+	}
+	if got := driver.specialURL("meta/llama-3.2-90b-vision-instruct"); got != "" {
+		t.Fatalf("specialURL() = %q, want empty for blank URL", got)
+	}
+	if got := driver.specialURL(""); got != "" {
+		t.Fatalf("specialURL() = %q, want empty for blank name", got)
+	}
+}

--- a/internal/entity/models/types.go
+++ b/internal/entity/models/types.go
@@ -144,23 +144,33 @@ type ModelList struct {
 	Models []ModelListItem `json:"data"`
 }
 
+// URLSuffixSpecial maps a model name to a full endpoint URL that
+// overrides the default base URL + suffix assembly for that model.
+// Used by providers such as NVIDIA whose hosted catalog exposes
+// per-model endpoints that do not follow the standard suffix scheme.
+type URLSuffixSpecial struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
 // URLSuffix represents the URL suffixes for different API endpoints
 type URLSuffix struct {
-	Chat          string `json:"chat"`
-	AsyncChat     string `json:"async_chat"`
-	AsyncResult   string `json:"async_result"`
-	Embedding     string `json:"embedding"`
-	Rerank        string `json:"rerank"`
-	TTS           string `json:"tts"`
-	ASR           string `json:"asr"`
-	OCR           string `json:"ocr"`
-	DocumentParse string `json:"doc_parse"`
-	Models        string `json:"models"`
-	Balance       string `json:"balance"`
-	Files         string `json:"files"`
-	Status        string `json:"status"`
-	Tasks         string `json:"tasks"`
-	Task          string `json:"task"`
+	Chat          string             `json:"chat"`
+	AsyncChat     string             `json:"async_chat"`
+	AsyncResult   string             `json:"async_result"`
+	Embedding     string             `json:"embedding"`
+	Rerank        string             `json:"rerank"`
+	TTS           string             `json:"tts"`
+	ASR           string             `json:"asr"`
+	OCR           string             `json:"ocr"`
+	DocumentParse string             `json:"doc_parse"`
+	Models        string             `json:"models"`
+	Balance       string             `json:"balance"`
+	Files         string             `json:"files"`
+	Status        string             `json:"status"`
+	Tasks         string             `json:"tasks"`
+	Task          string             `json:"task"`
+	Special       []URLSuffixSpecial `json:"special"`
 }
 
 type ChatConfig struct {


### PR DESCRIPTION
NVIDIA's hosted catalog serves some models (e.g. the llama-3.2 vision models) from model-specific paths instead of /chat/completions. Add an optional "special" list under url_suffix that maps a model to a full endpoint URL; the NVIDIA driver uses it verbatim when the base URL points at the hosted API, and falls back to the standard suffix scheme otherwise so self-hosted NIM deployments are unaffected.
