### PR TITLE
feat: rename agent log export button to export current page

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -2476,6 +2476,7 @@ Example: Virtual Hosted Style`,
       pleaseUploadAtLeastOneFile: 'Please upload at least one file',
     },
     flow: {
+      exportCurrentPage: 'Export current page',
       preprocess: {
         preprocess: 'Preprocess',
         mainContent: 'Main content',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -2116,6 +2116,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取实体和关系
       pleaseUploadAtLeastOneFile: '请上传至少一个文件',
     },
     flow: {
+      exportCurrentPage: '导出当页',
       preprocess: {
         preprocess: '预处理',
         mainContent: '主内容',

--- a/web/src/pages/agents/agent-log-page.tsx
+++ b/web/src/pages/agents/agent-log-page.tsx
@@ -273,7 +273,7 @@ const AgentLogPage: React.FC = () => {
           <div className="flex justify-end space-x-2 mb-4 text-foreground">
             <div className="flex items-center space-x-2">
               <Button onClick={onExportClick} loading={exportLoading}>
-                {t('flow.export')}
+                {t('flow.exportCurrentPage')}
               </Button>
               <span>{`${t('flow.id')}/${t('flow.logTitle')}`}</span>
               <SearchInput


### PR DESCRIPTION
### Summary

feat: rename agent log export button to export current page

Change the export button text in the agent log page from the generic 'export' to 'export current page' to clarify that only the current page of logs is exported. Add new i18n key flow.exportCurrentPage to zh.ts and en.ts.
