### PR TITLE
feat(component): add shared message-fit package

### DIFF
--- a/internal/component/messagefit/messagefit.go
+++ b/internal/component/messagefit/messagefit.go
@@ -1,0 +1,143 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (License); you may not
+//  use this file except in compliance with the License. You may obtain a
+//  copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+
+// Package messagefit trims a message list so its total token count fits
+// within a budget. It mirrors Python's rag/prompts/generator.py:message_fit_in.
+//
+// The package is shared by the agent canvas LLM component and the ingestion
+// Extractor component. Callers convert their message type to []Message,
+// call Fit, then write the results back.
+package messagefit
+
+import (
+	"ragflow/internal/tokenizer"
+)
+
+// Message is the minimal representation the fitter needs. Both the agent's
+// schema.Message and ingestion's eschema.Message convert to this.
+type Message struct {
+	// Role is "system", "user", "assistant", etc. Only "system" receives
+	// special treatment during fitting.
+	Role string
+	// Content is the text content that may be truncated.
+	Content string
+}
+
+// Fit trims msgs so its total token count fits within maxTokens.
+//
+// Strategy (mirrors Python's message_fit_in):
+//  1. If everything fits, return as-is.
+//  2. Keep all system messages + the last non-system message, drop the
+//     rest; if that fits, return.
+//  3. If still over, trim proportionally:
+//     - System dominates (>80% of tokens) → preserve the last message,
+//     give remaining budget to system.
+//     - Otherwise → preserve system, give remaining budget to last.
+//     - Single message → trim to maxTokens directly.
+//
+// maxTokens <= 0 is treated as 8192 (Python's default).
+// Returns the token count after fitting. msgs is modified in place:
+// entries that were dropped have their Content set to "".
+func Fit(msgs []Message, maxTokens int) int {
+	if maxTokens <= 0 {
+		maxTokens = 8192
+	}
+	if len(msgs) == 0 {
+		return 0
+	}
+
+	// Step 1: everything fits.
+	if total := countTokens(msgs); total < maxTokens {
+		return total
+	}
+
+	// Step 2: keep all system + last non-system.
+	kept := make([]int, 0, len(msgs))
+	lastNonSystem := -1
+	for i := range msgs {
+		if msgs[i].Role == "system" {
+			kept = append(kept, i)
+		} else {
+			lastNonSystem = i
+		}
+	}
+	if lastNonSystem >= 0 {
+		kept = append(kept, lastNonSystem)
+	}
+	if len(kept) == 0 {
+		return 0
+	}
+
+	keptMsgs := make([]Message, len(kept))
+	for i, idx := range kept {
+		keptMsgs[i] = msgs[idx]
+	}
+	if total := countTokens(keptMsgs); total < maxTokens {
+		// Zero out the dropped entries so the caller can filter them.
+		zeroDropped(msgs, kept)
+		return total
+	}
+
+	// Step 3: trim proportionally.
+	if len(kept) == 1 {
+		msgs[kept[0]].Content = tokenizer.TrimContentToTokenLimit(msgs[kept[0]].Content, maxTokens)
+		zeroDropped(msgs, kept)
+		return countTokens(msgs[kept[0] : kept[0]+1])
+	}
+
+	sysIdx := kept[0]
+	lastIdx := kept[len(kept)-1]
+	ll := tokenizer.NumTokensFromString(msgs[sysIdx].Content)
+	ll2 := tokenizer.NumTokensFromString(msgs[lastIdx].Content)
+	total := ll + ll2
+	if total <= 0 {
+		zeroDropped(msgs, kept)
+		return 0
+	}
+
+	if float64(ll)/float64(total) > 0.8 {
+		preserved := min(ll2, maxTokens)
+		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, preserved)
+		msgs[sysIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[sysIdx].Content, max(0, maxTokens-preserved))
+	} else {
+		preserved := min(ll, maxTokens)
+		msgs[sysIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[sysIdx].Content, preserved)
+		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, max(0, maxTokens-preserved))
+	}
+	zeroDropped(msgs, kept)
+	return countTokensMulti(msgs, kept)
+}
+
+func countTokens(msgs []Message) int {
+	total := 0
+	for i := range msgs {
+		total += tokenizer.NumTokensFromString(msgs[i].Content)
+	}
+	return total
+}
+
+func countTokensMulti(msgs []Message, indices []int) int {
+	total := 0
+	for _, i := range indices {
+		total += tokenizer.NumTokensFromString(msgs[i].Content)
+	}
+	return total
+}
+
+// zeroDropped sets Content to "" for every index in msgs that is not in kept.
+func zeroDropped(msgs []Message, kept []int) {
+	keptSet := make(map[int]struct{}, len(kept))
+	for _, i := range kept {
+		keptSet[i] = struct{}{}
+	}
+	for i := range msgs {
+		if _, ok := keptSet[i]; !ok {
+			msgs[i].Content = ""
+		}
+	}
+}

--- a/internal/component/messagefit/messagefit.go
+++ b/internal/component/messagefit/messagefit.go
@@ -30,14 +30,17 @@ type Message struct {
 
 // Fit trims msgs so its total token count fits within maxTokens.
 //
-// Strategy (mirrors Python's message_fit_in):
+// Strategy (mirrors Python's message_fit_in, with two deliberate tweaks:
+// an exact budget match counts as fitting, and the system share is spread
+// across every retained system message instead of only the first):
 //  1. If everything fits, return as-is.
 //  2. Keep all system messages + the last non-system message, drop the
 //     rest; if that fits, return.
 //  3. If still over, trim proportionally:
 //     - System dominates (>80% of tokens) → preserve the last message,
-//     give remaining budget to system.
-//     - Otherwise → preserve system, give remaining budget to last.
+//     give the remaining budget to the system messages.
+//     - Otherwise → preserve the system messages, give the remaining
+//     budget to the last.
 //     - Single message → trim to maxTokens directly.
 //
 // maxTokens <= 0 is treated as 8192 (Python's default).
@@ -51,8 +54,8 @@ func Fit(msgs []Message, maxTokens int) int {
 		return 0
 	}
 
-	// Step 1: everything fits.
-	if total := countTokens(msgs); total < maxTokens {
+	// Step 1: everything fits (an exact budget match counts as fitting).
+	if total := countTokens(msgs); total <= maxTokens {
 		return total
 	}
 
@@ -77,7 +80,7 @@ func Fit(msgs []Message, maxTokens int) int {
 	for i, idx := range kept {
 		keptMsgs[i] = msgs[idx]
 	}
-	if total := countTokens(keptMsgs); total < maxTokens {
+	if total := countTokens(keptMsgs); total <= maxTokens {
 		// Zero out the dropped entries so the caller can filter them.
 		zeroDropped(msgs, kept)
 		return total
@@ -90,9 +93,14 @@ func Fit(msgs []Message, maxTokens int) int {
 		return countTokens(msgs[kept[0] : kept[0]+1])
 	}
 
-	sysIdx := kept[0]
+	// kept[:len(kept)-1] are the retained system messages; the last entry
+	// is the final non-system message.
+	sysIdxs := kept[:len(kept)-1]
 	lastIdx := kept[len(kept)-1]
-	ll := tokenizer.NumTokensFromString(msgs[sysIdx].Content)
+	ll := 0
+	for _, idx := range sysIdxs {
+		ll += tokenizer.NumTokensFromString(msgs[idx].Content)
+	}
 	ll2 := tokenizer.NumTokensFromString(msgs[lastIdx].Content)
 	total := ll + ll2
 	if total <= 0 {
@@ -101,16 +109,54 @@ func Fit(msgs []Message, maxTokens int) int {
 	}
 
 	if float64(ll)/float64(total) > 0.8 {
+		// System dominates: preserve the last message and give the
+		// remaining budget to the system messages.
 		preserved := min(ll2, maxTokens)
 		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, preserved)
-		msgs[sysIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[sysIdx].Content, max(0, maxTokens-preserved))
+		trimSystems(msgs, sysIdxs, max(0, maxTokens-preserved))
 	} else {
 		preserved := min(ll, maxTokens)
-		msgs[sysIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[sysIdx].Content, preserved)
+		trimSystems(msgs, sysIdxs, preserved)
 		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, max(0, maxTokens-preserved))
 	}
 	zeroDropped(msgs, kept)
 	return countTokensMulti(msgs, kept)
+}
+
+// trimSystems trims each retained system message so their combined token
+// count fits within budget. The budget is allocated in proportion to each
+// message's original token count, with the last message taking any remainder
+// so the total never exceeds budget.
+func trimSystems(msgs []Message, sysIdxs []int, budget int) {
+	if len(sysIdxs) == 0 {
+		return
+	}
+	if budget <= 0 {
+		for _, idx := range sysIdxs {
+			msgs[idx].Content = ""
+		}
+		return
+	}
+	total := 0
+	for _, idx := range sysIdxs {
+		total += tokenizer.NumTokensFromString(msgs[idx].Content)
+	}
+	if total <= 0 {
+		return
+	}
+	remaining := budget
+	for i, idx := range sysIdxs {
+		limit := remaining
+		if i < len(sysIdxs)-1 {
+			tokens := tokenizer.NumTokensFromString(msgs[idx].Content)
+			limit = int(float64(budget) * float64(tokens) / float64(total))
+			if limit > remaining {
+				limit = remaining
+			}
+		}
+		msgs[idx].Content = tokenizer.TrimContentToTokenLimit(msgs[idx].Content, limit)
+		remaining -= tokenizer.NumTokensFromString(msgs[idx].Content)
+	}
 }
 
 func countTokens(msgs []Message) int {

--- a/internal/component/messagefit/messagefit.go
+++ b/internal/component/messagefit/messagefit.go
@@ -10,11 +10,13 @@
 // within a budget. It mirrors Python's rag/prompts/generator.py:message_fit_in.
 //
 // The package is shared by the agent canvas LLM component and the ingestion
-// Extractor component. Callers convert their message type to []Message,
-// call Fit, then write the results back.
+// Extractor component. Callers convert their message type to []Message, call
+// Fit, and send the returned kept messages (at keptIdx into the input).
 package messagefit
 
 import (
+	"slices"
+
 	"ragflow/internal/tokenizer"
 )
 
@@ -28,10 +30,17 @@ type Message struct {
 	Content string
 }
 
-// Fit trims msgs so its total token count fits within budget. budget is the
+// Fit trims msgs so the kept messages fit within budget. budget is the
 // caller-chosen token ceiling for the whole conversation — the agent LLM and
 // ingestion Extractor both pass the chat model's context window
 // (content_length), not the generation cap (max_output).
+//
+// It returns the kept messages in original order (trimmed when necessary),
+// their original indices into msgs, and the kept messages' total token count.
+// msgs itself is never modified, and dropped entries are simply absent from
+// kept/keptIdx — no empty-content sentinel is used. A message that is kept but
+// trimmed to empty (e.g. the system share collapses to 0 when the last message
+// alone fills the budget) is still reported as kept, mirroring Python.
 //
 // Strategy (mirrors Python's message_fit_in, with two deliberate tweaks:
 // an exact budget match counts as fitting, and the system share is spread
@@ -47,126 +56,121 @@ type Message struct {
 //     - Single message → trim to budget directly.
 //
 // budget <= 0 is treated as 8192 (Python's default).
-// Returns the token count after fitting. msgs is modified in place:
-// entries that were dropped have their Content set to "".
-func Fit(msgs []Message, budget int) int {
+func Fit(msgs []Message, budget int) (kept []Message, keptIdx []int, count int) {
 	if budget <= 0 {
 		budget = 8192
 	}
 	if len(msgs) == 0 {
-		return 0
+		return nil, nil, 0
 	}
 
 	// Step 1: everything fits (an exact budget match counts as fitting).
 	if total := countTokens(msgs); total <= budget {
-		return total
+		kept = slices.Clone(msgs)
+		keptIdx = make([]int, len(msgs))
+		for i := range keptIdx {
+			keptIdx[i] = i
+		}
+		return kept, keptIdx, total
 	}
 
 	// Step 2: keep all system + last non-system.
-	kept := make([]int, 0, len(msgs))
+	kept = make([]Message, 0, len(msgs))
+	keptIdx = make([]int, 0, len(msgs))
 	lastNonSystem := -1
 	for i := range msgs {
 		if msgs[i].Role == "system" {
-			kept = append(kept, i)
+			kept = append(kept, msgs[i])
+			keptIdx = append(keptIdx, i)
 		} else {
 			lastNonSystem = i
 		}
 	}
 	if lastNonSystem >= 0 {
-		kept = append(kept, lastNonSystem)
+		kept = append(kept, msgs[lastNonSystem])
+		keptIdx = append(keptIdx, lastNonSystem)
 	}
 	if len(kept) == 0 {
-		return 0
+		return nil, nil, 0
 	}
-
-	keptMsgs := make([]Message, len(kept))
-	for i, idx := range kept {
-		keptMsgs[i] = msgs[idx]
-	}
-	if total := countTokens(keptMsgs); total <= budget {
-		// Zero out the dropped entries so the caller can filter them.
-		zeroDropped(msgs, kept)
-		return total
+	if total := countTokens(kept); total <= budget {
+		return kept, keptIdx, total
 	}
 
 	// Step 3: trim proportionally.
 	if len(kept) == 1 {
-		msgs[kept[0]].Content = tokenizer.TrimContentToTokenLimit(msgs[kept[0]].Content, budget)
-		zeroDropped(msgs, kept)
-		return countTokens(msgs[kept[0] : kept[0]+1])
+		kept[0].Content = tokenizer.TrimContentToTokenLimit(kept[0].Content, budget)
+		return kept, keptIdx, countTokens(kept)
 	}
 
 	// Only system messages were retained (no non-system message): spread the
 	// whole budget across every retained system message.
 	if lastNonSystem < 0 {
-		trimSystems(msgs, kept, budget)
-		zeroDropped(msgs, kept)
-		return countTokensMulti(msgs, kept)
+		trimSystems(kept, budget)
+		return kept, keptIdx, countTokens(kept)
 	}
 
 	// kept[:len(kept)-1] are the retained system messages; the last entry
 	// is the final non-system message.
-	sysIdxs := kept[:len(kept)-1]
-	lastIdx := kept[len(kept)-1]
+	sys := kept[:len(kept)-1]
+	last := &kept[len(kept)-1]
 	ll := 0
-	for _, idx := range sysIdxs {
-		ll += tokenizer.NumTokensFromString(msgs[idx].Content)
+	for i := range sys {
+		ll += tokenizer.NumTokensFromString(sys[i].Content)
 	}
-	ll2 := tokenizer.NumTokensFromString(msgs[lastIdx].Content)
+	ll2 := tokenizer.NumTokensFromString(last.Content)
 	total := ll + ll2
 	if total <= 0 {
-		zeroDropped(msgs, kept)
-		return 0
+		return kept, keptIdx, 0
 	}
 
 	if float64(ll)/float64(total) > 0.8 {
 		// System dominates: preserve the last message and give the
 		// remaining budget to the system messages.
 		preserved := min(ll2, budget)
-		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, preserved)
-		trimSystems(msgs, sysIdxs, max(0, budget-preserved))
+		last.Content = tokenizer.TrimContentToTokenLimit(last.Content, preserved)
+		trimSystems(sys, max(0, budget-preserved))
 	} else {
 		preserved := min(ll, budget)
-		trimSystems(msgs, sysIdxs, preserved)
-		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, max(0, budget-preserved))
+		trimSystems(sys, preserved)
+		last.Content = tokenizer.TrimContentToTokenLimit(last.Content, max(0, budget-preserved))
 	}
-	zeroDropped(msgs, kept)
-	return countTokensMulti(msgs, kept)
+	return kept, keptIdx, countTokens(kept)
 }
 
-// trimSystems trims each retained system message so their combined token
-// count fits within budget. The budget is allocated in proportion to each
-// message's original token count, with the last message taking any remainder
-// so the total never exceeds budget.
-func trimSystems(msgs []Message, sysIdxs []int, budget int) {
-	if len(sysIdxs) == 0 {
+// trimSystems trims each system message so their combined token count fits
+// within budget. The budget is allocated in proportion to each message's
+// original token count, with the last message taking any remainder so the
+// total never exceeds budget.
+func trimSystems(sys []Message, budget int) {
+	if len(sys) == 0 {
 		return
 	}
 	if budget <= 0 {
-		for _, idx := range sysIdxs {
-			msgs[idx].Content = ""
+		for i := range sys {
+			sys[i].Content = ""
 		}
 		return
 	}
 	total := 0
-	for _, idx := range sysIdxs {
-		total += tokenizer.NumTokensFromString(msgs[idx].Content)
+	for i := range sys {
+		total += tokenizer.NumTokensFromString(sys[i].Content)
 	}
 	if total <= 0 {
 		return
 	}
 	remaining := budget
-	for i, idx := range sysIdxs {
+	for i := range sys {
 		limit := remaining
-		if i < len(sysIdxs)-1 {
-			tokens := tokenizer.NumTokensFromString(msgs[idx].Content)
+		if i < len(sys)-1 {
+			tokens := tokenizer.NumTokensFromString(sys[i].Content)
 			limit = int(float64(budget) * float64(tokens) / float64(total))
 			if limit > remaining {
 				limit = remaining
 			}
 		}
-		msgs[idx].Content = tokenizer.TrimContentToTokenLimit(msgs[idx].Content, limit)
-		remaining -= tokenizer.NumTokensFromString(msgs[idx].Content)
+		sys[i].Content = tokenizer.TrimContentToTokenLimit(sys[i].Content, limit)
+		remaining -= tokenizer.NumTokensFromString(sys[i].Content)
 	}
 }
 
@@ -176,25 +180,4 @@ func countTokens(msgs []Message) int {
 		total += tokenizer.NumTokensFromString(msgs[i].Content)
 	}
 	return total
-}
-
-func countTokensMulti(msgs []Message, indices []int) int {
-	total := 0
-	for _, i := range indices {
-		total += tokenizer.NumTokensFromString(msgs[i].Content)
-	}
-	return total
-}
-
-// zeroDropped sets Content to "" for every index in msgs that is not in kept.
-func zeroDropped(msgs []Message, kept []int) {
-	keptSet := make(map[int]struct{}, len(kept))
-	for _, i := range kept {
-		keptSet[i] = struct{}{}
-	}
-	for i := range msgs {
-		if _, ok := keptSet[i]; !ok {
-			msgs[i].Content = ""
-		}
-	}
 }

--- a/internal/component/messagefit/messagefit.go
+++ b/internal/component/messagefit/messagefit.go
@@ -28,7 +28,10 @@ type Message struct {
 	Content string
 }
 
-// Fit trims msgs so its total token count fits within maxTokens.
+// Fit trims msgs so its total token count fits within budget. budget is the
+// caller-chosen token ceiling for the whole conversation — the agent LLM and
+// ingestion Extractor both pass the chat model's context window
+// (content_length), not the generation cap (max_output).
 //
 // Strategy (mirrors Python's message_fit_in, with two deliberate tweaks:
 // an exact budget match counts as fitting, and the system share is spread
@@ -41,21 +44,21 @@ type Message struct {
 //     give the remaining budget to the system messages.
 //     - Otherwise → preserve the system messages, give the remaining
 //     budget to the last.
-//     - Single message → trim to maxTokens directly.
+//     - Single message → trim to budget directly.
 //
-// maxTokens <= 0 is treated as 8192 (Python's default).
+// budget <= 0 is treated as 8192 (Python's default).
 // Returns the token count after fitting. msgs is modified in place:
 // entries that were dropped have their Content set to "".
-func Fit(msgs []Message, maxTokens int) int {
-	if maxTokens <= 0 {
-		maxTokens = 8192
+func Fit(msgs []Message, budget int) int {
+	if budget <= 0 {
+		budget = 8192
 	}
 	if len(msgs) == 0 {
 		return 0
 	}
 
 	// Step 1: everything fits (an exact budget match counts as fitting).
-	if total := countTokens(msgs); total <= maxTokens {
+	if total := countTokens(msgs); total <= budget {
 		return total
 	}
 
@@ -80,7 +83,7 @@ func Fit(msgs []Message, maxTokens int) int {
 	for i, idx := range kept {
 		keptMsgs[i] = msgs[idx]
 	}
-	if total := countTokens(keptMsgs); total <= maxTokens {
+	if total := countTokens(keptMsgs); total <= budget {
 		// Zero out the dropped entries so the caller can filter them.
 		zeroDropped(msgs, kept)
 		return total
@@ -88,9 +91,17 @@ func Fit(msgs []Message, maxTokens int) int {
 
 	// Step 3: trim proportionally.
 	if len(kept) == 1 {
-		msgs[kept[0]].Content = tokenizer.TrimContentToTokenLimit(msgs[kept[0]].Content, maxTokens)
+		msgs[kept[0]].Content = tokenizer.TrimContentToTokenLimit(msgs[kept[0]].Content, budget)
 		zeroDropped(msgs, kept)
 		return countTokens(msgs[kept[0] : kept[0]+1])
+	}
+
+	// Only system messages were retained (no non-system message): spread the
+	// whole budget across every retained system message.
+	if lastNonSystem < 0 {
+		trimSystems(msgs, kept, budget)
+		zeroDropped(msgs, kept)
+		return countTokensMulti(msgs, kept)
 	}
 
 	// kept[:len(kept)-1] are the retained system messages; the last entry
@@ -111,13 +122,13 @@ func Fit(msgs []Message, maxTokens int) int {
 	if float64(ll)/float64(total) > 0.8 {
 		// System dominates: preserve the last message and give the
 		// remaining budget to the system messages.
-		preserved := min(ll2, maxTokens)
+		preserved := min(ll2, budget)
 		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, preserved)
-		trimSystems(msgs, sysIdxs, max(0, maxTokens-preserved))
+		trimSystems(msgs, sysIdxs, max(0, budget-preserved))
 	} else {
-		preserved := min(ll, maxTokens)
+		preserved := min(ll, budget)
 		trimSystems(msgs, sysIdxs, preserved)
-		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, max(0, maxTokens-preserved))
+		msgs[lastIdx].Content = tokenizer.TrimContentToTokenLimit(msgs[lastIdx].Content, max(0, budget-preserved))
 	}
 	zeroDropped(msgs, kept)
 	return countTokensMulti(msgs, kept)

--- a/internal/component/messagefit/messagefit_test.go
+++ b/internal/component/messagefit/messagefit_test.go
@@ -92,7 +92,12 @@ func TestFit_SystemOnlyMessages(t *testing.T) {
 	if total > budget {
 		t.Errorf("fitted total %d exceeds budget %d", total, budget)
 	}
-	if len(msgs[0].Content) >= len(sys1) || len(msgs[1].Content) >= len(sys2) {
+	fitted0 := tokenizer.NumTokensFromString(msgs[0].Content)
+	fitted1 := tokenizer.NumTokensFromString(msgs[1].Content)
+	if fitted0 == 0 || fitted1 == 0 {
+		t.Errorf("a system message was emptied by fitting: %+v", msgs)
+	}
+	if fitted0 >= tokenizer.NumTokensFromString(sys1) || fitted1 >= tokenizer.NumTokensFromString(sys2) {
 		t.Errorf("system messages not trimmed: %+v", msgs)
 	}
 }
@@ -123,7 +128,12 @@ func TestFit_TrimsAllSystemMessages(t *testing.T) {
 	if total > budget {
 		t.Errorf("fitted total %d exceeds budget %d", total, budget)
 	}
-	if len(msgs[0].Content) >= len(sys1) || len(msgs[1].Content) >= len(sys2) {
+	fitted0 := tokenizer.NumTokensFromString(msgs[0].Content)
+	fitted1 := tokenizer.NumTokensFromString(msgs[1].Content)
+	if fitted0 == 0 || fitted1 == 0 {
+		t.Errorf("a system message was emptied by fitting: %+v", msgs)
+	}
+	if fitted0 >= tokenizer.NumTokensFromString(sys1) || fitted1 >= tokenizer.NumTokensFromString(sys2) {
 		t.Errorf("system messages not trimmed: %+v", msgs)
 	}
 }

--- a/internal/component/messagefit/messagefit_test.go
+++ b/internal/component/messagefit/messagefit_test.go
@@ -7,16 +7,6 @@ import (
 	"ragflow/internal/tokenizer"
 )
 
-func countMessages(msgs []Message) int {
-	total := 0
-	for _, m := range msgs {
-		if m.Content != "" {
-			total += len(m.Content) // rough proxy; not token-accurate
-		}
-	}
-	return total
-}
-
 func TestFit_AllFits(t *testing.T) {
 	msgs := []Message{
 		{Role: "system", Content: "hello"},

--- a/internal/component/messagefit/messagefit_test.go
+++ b/internal/component/messagefit/messagefit_test.go
@@ -1,6 +1,7 @@
 package messagefit
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -12,13 +13,30 @@ func TestFit_AllFits(t *testing.T) {
 		{Role: "system", Content: "hello"},
 		{Role: "user", Content: "world"},
 	}
-	got := Fit(msgs, 100000)
-	if got == 0 {
-		t.Errorf("Fit returned 0, want > 0")
+	kept, keptIdx, count := Fit(msgs, 100000)
+	if count == 0 {
+		t.Errorf("Fit returned count 0, want > 0")
 	}
-	// Nothing should be dropped.
-	if msgs[0].Content != "hello" || msgs[1].Content != "world" {
-		t.Errorf("messages modified when they fit: %+v", msgs)
+	if len(kept) != 2 || !slices.Equal(keptIdx, []int{0, 1}) {
+		t.Fatalf("got kept=%+v keptIdx=%v, want both messages", kept, keptIdx)
+	}
+	if kept[0].Content != "hello" || kept[1].Content != "world" {
+		t.Errorf("messages modified when they fit: %+v", kept)
+	}
+}
+
+// TestFit_DoesNotMutateInput verifies the non-mutating contract: Fit never
+// rewrites msgs, so a caller cannot accidentally send emptied entries.
+func TestFit_DoesNotMutateInput(t *testing.T) {
+	orig := []Message{
+		{Role: "system", Content: strings.Repeat("s ", 500)},
+		{Role: "user", Content: strings.Repeat("u ", 500)},
+		{Role: "user", Content: "last"},
+	}
+	msgs := slices.Clone(orig)
+	Fit(msgs, 100)
+	if !slices.Equal(msgs, orig) {
+		t.Fatalf("Fit mutated its input:\n got %+v\nwant %+v", msgs, orig)
 	}
 }
 
@@ -35,37 +53,52 @@ func TestFit_Step2_DropsMiddle(t *testing.T) {
 	}
 	budget := tokenizer.NumTokensFromString(sysContent) + tokenizer.NumTokensFromString(last)
 
-	if got := Fit(msgs, budget); got == 0 {
-		t.Fatalf("Fit returned 0, want > 0")
+	kept, keptIdx, count := Fit(msgs, budget)
+	if count == 0 {
+		t.Fatalf("Fit returned count 0, want > 0")
 	}
-	if msgs[1].Content != "" {
-		t.Errorf("middle message not cleared: %q", msgs[1].Content)
+	if !slices.Equal(keptIdx, []int{0, 2}) {
+		t.Fatalf("keptIdx = %v, want [0 2] (middle dropped)", keptIdx)
 	}
-	if msgs[0].Content != sysContent || msgs[2].Content != last {
-		t.Errorf("retained messages modified: %+v", msgs)
+	if kept[0].Content != sysContent || kept[1].Content != last {
+		t.Errorf("retained messages modified: %+v", kept)
 	}
 }
 
-// TestFit_ExactBudget verifies that a total exactly equal to the budget
-// counts as fitting: nothing is dropped or trimmed.
 func TestFit_ExactBudget(t *testing.T) {
+	// A total exactly equal to the budget counts as fitting.
 	msgs := []Message{
 		{Role: "system", Content: "abc"},
 		{Role: "user", Content: "def"},
 	}
 	budget := tokenizer.NumTokensFromString("abc") + tokenizer.NumTokensFromString("def")
 
-	if got := Fit(msgs, budget); got == 0 {
-		t.Fatalf("Fit returned 0, want > 0")
+	kept, keptIdx, _ := Fit(msgs, budget)
+	if len(kept) != 2 || !slices.Equal(keptIdx, []int{0, 1}) {
+		t.Fatalf("got kept=%+v keptIdx=%v, want both messages kept", kept, keptIdx)
 	}
-	if msgs[0].Content != "abc" || msgs[1].Content != "def" {
-		t.Errorf("messages modified at exact budget: %+v", msgs)
+	if kept[0].Content != "abc" || kept[1].Content != "def" {
+		t.Errorf("messages modified at exact budget: %+v", kept)
 	}
 }
 
-// TestFit_SystemOnlyMessages verifies that when only system messages are
-// retained (no non-system message), the whole budget is spread across every
-// retained system message and the total never exceeds it.
+// TestFit_NoSystem_KeepsOnlyLast locks the Python-parity behavior: without a
+// system message, Step 2 keeps only the last non-system message.
+func TestFit_NoSystem_KeepsOnlyLast(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: strings.Repeat("a ", 300)},
+		{Role: "assistant", Content: strings.Repeat("b ", 300)},
+		{Role: "user", Content: "last"},
+	}
+	kept, keptIdx, _ := Fit(msgs, 100)
+	if !slices.Equal(keptIdx, []int{2}) {
+		t.Fatalf("keptIdx = %v, want [2] (only the last user kept)", keptIdx)
+	}
+	if len(kept) != 1 || kept[0].Content != "last" {
+		t.Fatalf("kept = %+v, want the last user message", kept)
+	}
+}
+
 func TestFit_SystemOnlyMessages(t *testing.T) {
 	sys1 := strings.Repeat("s ", 800)
 	sys2 := strings.Repeat("t ", 200)
@@ -75,28 +108,29 @@ func TestFit_SystemOnlyMessages(t *testing.T) {
 	}
 	const budget = 500
 
-	if got := Fit(msgs, budget); got == 0 {
-		t.Fatalf("Fit returned 0, want > 0")
+	kept, keptIdx, count := Fit(msgs, budget)
+	if count == 0 {
+		t.Fatalf("Fit returned count 0, want > 0")
 	}
-	total := tokenizer.NumTokensFromString(msgs[0].Content) + tokenizer.NumTokensFromString(msgs[1].Content)
+	if len(kept) != 2 || !slices.Equal(keptIdx, []int{0, 1}) {
+		t.Fatalf("got kept=%+v keptIdx=%v, want both systems", kept, keptIdx)
+	}
+	total := tokenizer.NumTokensFromString(kept[0].Content) + tokenizer.NumTokensFromString(kept[1].Content)
 	if total > budget {
 		t.Errorf("fitted total %d exceeds budget %d", total, budget)
 	}
-	fitted0 := tokenizer.NumTokensFromString(msgs[0].Content)
-	fitted1 := tokenizer.NumTokensFromString(msgs[1].Content)
+	fitted0 := tokenizer.NumTokensFromString(kept[0].Content)
+	fitted1 := tokenizer.NumTokensFromString(kept[1].Content)
 	if fitted0 == 0 || fitted1 == 0 {
-		t.Errorf("a system message was emptied by fitting: %+v", msgs)
+		t.Errorf("a system message was emptied by fitting: %+v", kept)
 	}
 	if fitted0 >= tokenizer.NumTokensFromString(sys1) || fitted1 >= tokenizer.NumTokensFromString(sys2) {
-		t.Errorf("system messages not trimmed: %+v", msgs)
+		t.Errorf("system messages not trimmed: %+v", kept)
 	}
 }
 
-// TestFit_TrimsAllSystemMessages verifies that the system budget is spread
-// across every retained system message, not just the first one, so the final
-// total never exceeds the budget.
 func TestFit_TrimsAllSystemMessages(t *testing.T) {
-	sys1 := strings.Repeat("s ", 800) // dominates the token count
+	sys1 := strings.Repeat("s ", 800)
 	sys2 := strings.Repeat("t ", 200)
 	last := "last"
 	msgs := []Message{
@@ -106,60 +140,116 @@ func TestFit_TrimsAllSystemMessages(t *testing.T) {
 	}
 	const budget = 500
 
-	if got := Fit(msgs, budget); got == 0 {
-		t.Fatalf("Fit returned 0, want > 0")
+	kept, keptIdx, count := Fit(msgs, budget)
+	if count == 0 {
+		t.Fatalf("Fit returned count 0, want > 0")
 	}
-	if msgs[2].Content != last {
-		t.Errorf("last user message not preserved: %q", msgs[2].Content)
+	if !slices.Equal(keptIdx, []int{0, 1, 2}) {
+		t.Fatalf("keptIdx = %v, want [0 1 2]", keptIdx)
 	}
-	total := tokenizer.NumTokensFromString(msgs[0].Content) +
-		tokenizer.NumTokensFromString(msgs[1].Content) +
-		tokenizer.NumTokensFromString(msgs[2].Content)
+	if kept[2].Content != last {
+		t.Errorf("last user message not preserved: %q", kept[2].Content)
+	}
+	total := tokenizer.NumTokensFromString(kept[0].Content) +
+		tokenizer.NumTokensFromString(kept[1].Content) +
+		tokenizer.NumTokensFromString(kept[2].Content)
 	if total > budget {
 		t.Errorf("fitted total %d exceeds budget %d", total, budget)
 	}
-	fitted0 := tokenizer.NumTokensFromString(msgs[0].Content)
-	fitted1 := tokenizer.NumTokensFromString(msgs[1].Content)
+	fitted0 := tokenizer.NumTokensFromString(kept[0].Content)
+	fitted1 := tokenizer.NumTokensFromString(kept[1].Content)
 	if fitted0 == 0 || fitted1 == 0 {
-		t.Errorf("a system message was emptied by fitting: %+v", msgs)
+		t.Errorf("a system message was emptied by fitting: %+v", kept)
 	}
 	if fitted0 >= tokenizer.NumTokensFromString(sys1) || fitted1 >= tokenizer.NumTokensFromString(sys2) {
-		t.Errorf("system messages not trimmed: %+v", msgs)
+		t.Errorf("system messages not trimmed: %+v", kept)
 	}
 }
 
 func TestFit_Step3_SystemDominates(t *testing.T) {
 	// System takes >80% of tokens → preserve user, trim system.
-	sysContent := strings.Repeat("a ", 800)  // ~1600 tokens
-	userContent := strings.Repeat("b ", 100) // ~200 tokens
+	sysContent := strings.Repeat("a ", 800)  // dominates
+	userContent := strings.Repeat("b ", 100) // small, fits entirely
 	msgs := []Message{
 		{Role: "system", Content: sysContent},
 		{Role: "user", Content: userContent},
 	}
-	got := Fit(msgs, 500)
-	if got == 0 {
-		t.Errorf("Fit returned 0, want > 0")
+	const budget = 500
+
+	kept, keptIdx, count := Fit(msgs, budget)
+	if count == 0 {
+		t.Fatalf("Fit returned count 0, want > 0")
 	}
-	// System should have been trimmed, user preserved.
-	if len(msgs[0].Content) >= len(sysContent) {
-		t.Errorf("system not trimmed: got %d want < %d", len(msgs[0].Content), len(sysContent))
+	if count > budget {
+		t.Errorf("fitted total %d exceeds budget %d", count, budget)
+	}
+	if !slices.Equal(keptIdx, []int{0, 1}) {
+		t.Fatalf("keptIdx = %v, want [0 1]", keptIdx)
+	}
+	// User preserved verbatim; system trimmed.
+	if tokenizer.NumTokensFromString(kept[1].Content) != tokenizer.NumTokensFromString(userContent) {
+		t.Errorf("user message not preserved: %+v", kept)
+	}
+	if tokenizer.NumTokensFromString(kept[0].Content) >= tokenizer.NumTokensFromString(sysContent) {
+		t.Errorf("system not trimmed: %+v", kept)
 	}
 }
 
 func TestFit_Step3_UserDominates(t *testing.T) {
 	// User takes >20% → preserve system, trim user.
-	sysContent := strings.Repeat("a ", 200)
-	userContent := strings.Repeat("b ", 800)
+	sysContent := strings.Repeat("a ", 150)  // small, fits entirely
+	userContent := strings.Repeat("b ", 800) // dominates
 	msgs := []Message{
 		{Role: "system", Content: sysContent},
 		{Role: "user", Content: userContent},
 	}
-	got := Fit(msgs, 500)
-	if got == 0 {
-		t.Errorf("Fit returned 0, want > 0")
+	const budget = 500
+
+	kept, keptIdx, count := Fit(msgs, budget)
+	if count == 0 {
+		t.Fatalf("Fit returned count 0, want > 0")
 	}
-	if len(msgs[1].Content) >= len(userContent) {
-		t.Errorf("user not trimmed: got %d want < %d", len(msgs[1].Content), len(userContent))
+	if count > budget {
+		t.Errorf("fitted total %d exceeds budget %d", count, budget)
+	}
+	if !slices.Equal(keptIdx, []int{0, 1}) {
+		t.Fatalf("keptIdx = %v, want [0 1]", keptIdx)
+	}
+	// System preserved verbatim; user trimmed.
+	if tokenizer.NumTokensFromString(kept[0].Content) != tokenizer.NumTokensFromString(sysContent) {
+		t.Errorf("system message not preserved: %+v", kept)
+	}
+	if tokenizer.NumTokensFromString(kept[1].Content) >= tokenizer.NumTokensFromString(userContent) {
+		t.Errorf("user not trimmed: %+v", kept)
+	}
+}
+
+// TestFit_Step3_BudgetFilledByLast locks the boundary where the last message
+// alone fills the budget (preserved == budget): the system share collapses to
+// 0, so every retained system message is kept but trimmed to empty — it must
+// NOT be reported as dropped. Python's message_fit_in retains the system entry
+// with content "" in this case too.
+func TestFit_Step3_BudgetFilledByLast(t *testing.T) {
+	sysContent := strings.Repeat("a ", 3000) // dominates (>80% of tokens)
+	userContent := strings.Repeat("b ", 600) // alone exceeds the budget
+	msgs := []Message{
+		{Role: "system", Content: sysContent},
+		{Role: "user", Content: userContent},
+	}
+	const budget = 500
+
+	kept, keptIdx, count := Fit(msgs, budget)
+	if !slices.Equal(keptIdx, []int{0, 1}) {
+		t.Fatalf("keptIdx = %v, want [0 1] (both messages still kept)", keptIdx)
+	}
+	if count > budget {
+		t.Errorf("fitted total %d exceeds budget %d", count, budget)
+	}
+	if kept[0].Content != "" {
+		t.Errorf("system message not trimmed to empty when the last message fills the budget: %+v", kept)
+	}
+	if tokenizer.NumTokensFromString(kept[1].Content) > budget {
+		t.Errorf("user message exceeds budget after trim: %+v", kept)
 	}
 }
 
@@ -167,37 +257,41 @@ func TestFit_SingleMessage(t *testing.T) {
 	msgs := []Message{
 		{Role: "system", Content: strings.Repeat("x ", 1000)},
 	}
-	got := Fit(msgs, 100)
-	if got == 0 {
-		t.Errorf("Fit returned 0, want > 0")
+	kept, keptIdx, count := Fit(msgs, 100)
+	if count == 0 {
+		t.Fatalf("Fit returned count 0, want > 0")
 	}
-	if len(msgs[0].Content) >= 1000 {
-		t.Errorf("single message not trimmed: got %d", len(msgs[0].Content))
+	if !slices.Equal(keptIdx, []int{0}) {
+		t.Fatalf("keptIdx = %v, want [0]", keptIdx)
+	}
+	if tokenizer.NumTokensFromString(kept[0].Content) > 100 {
+		t.Errorf("single message not trimmed: %+v", kept)
 	}
 }
 
-func TestFit_ZeroMaxTokens(t *testing.T) {
-	// maxTokens <= 0 should use 8192 default and not panic.
+func TestFit_ZeroBudget(t *testing.T) {
+	// budget <= 0 should use 8192 default and not panic.
 	msgs := []Message{
 		{Role: "system", Content: "hello"},
 		{Role: "user", Content: "world"},
 	}
-	got := Fit(msgs, 0)
-	if got == 0 {
-		t.Errorf("Fit returned 0, want > 0")
+	kept, keptIdx, count := Fit(msgs, 0)
+	if count == 0 {
+		t.Fatalf("Fit returned count 0, want > 0")
 	}
-	if msgs[0].Content != "hello" || msgs[1].Content != "world" {
-		t.Errorf("messages modified with default budget: %+v", msgs)
+	if len(kept) != 2 || !slices.Equal(keptIdx, []int{0, 1}) {
+		t.Fatalf("got kept=%+v keptIdx=%v, want both messages", kept, keptIdx)
+	}
+	if kept[0].Content != "hello" || kept[1].Content != "world" {
+		t.Errorf("messages modified with default budget: %+v", kept)
 	}
 }
 
 func TestFit_Empty(t *testing.T) {
-	got := Fit(nil, 1000)
-	if got != 0 {
-		t.Errorf("Fit on nil = %d, want 0", got)
+	if kept, keptIdx, count := Fit(nil, 1000); kept != nil || keptIdx != nil || count != 0 {
+		t.Errorf("Fit(nil) = %v, %v, %d; want nil, nil, 0", kept, keptIdx, count)
 	}
-	got = Fit([]Message{}, 1000)
-	if got != 0 {
-		t.Errorf("Fit on empty = %d, want 0", got)
+	if kept, keptIdx, count := Fit([]Message{}, 1000); len(kept) != 0 || len(keptIdx) != 0 || count != 0 {
+		t.Errorf("Fit(empty) = %v, %v, %d; want 0, 0, 0", kept, keptIdx, count)
 	}
 }

--- a/internal/component/messagefit/messagefit_test.go
+++ b/internal/component/messagefit/messagefit_test.go
@@ -73,6 +73,30 @@ func TestFit_ExactBudget(t *testing.T) {
 	}
 }
 
+// TestFit_SystemOnlyMessages verifies that when only system messages are
+// retained (no non-system message), the whole budget is spread across every
+// retained system message and the total never exceeds it.
+func TestFit_SystemOnlyMessages(t *testing.T) {
+	sys1 := strings.Repeat("s ", 800)
+	sys2 := strings.Repeat("t ", 200)
+	msgs := []Message{
+		{Role: "system", Content: sys1},
+		{Role: "system", Content: sys2},
+	}
+	const budget = 500
+
+	if got := Fit(msgs, budget); got == 0 {
+		t.Fatalf("Fit returned 0, want > 0")
+	}
+	total := tokenizer.NumTokensFromString(msgs[0].Content) + tokenizer.NumTokensFromString(msgs[1].Content)
+	if total > budget {
+		t.Errorf("fitted total %d exceeds budget %d", total, budget)
+	}
+	if len(msgs[0].Content) >= len(sys1) || len(msgs[1].Content) >= len(sys2) {
+		t.Errorf("system messages not trimmed: %+v", msgs)
+	}
+}
+
 // TestFit_TrimsAllSystemMessages verifies that the system budget is spread
 // across every retained system message, not just the first one, so the final
 // total never exceeds the budget.

--- a/internal/component/messagefit/messagefit_test.go
+++ b/internal/component/messagefit/messagefit_test.go
@@ -1,0 +1,135 @@
+package messagefit
+
+import (
+	"strings"
+	"testing"
+)
+
+func countMessages(msgs []Message) int {
+	total := 0
+	for _, m := range msgs {
+		if m.Content != "" {
+			total += len(m.Content) // rough proxy; not token-accurate
+		}
+	}
+	return total
+}
+
+func TestFit_AllFits(t *testing.T) {
+	msgs := []Message{
+		{Role: "system", Content: "hello"},
+		{Role: "user", Content: "world"},
+	}
+	got := Fit(msgs, 100000)
+	if got == 0 {
+		t.Errorf("Fit returned 0, want > 0")
+	}
+	// Nothing should be dropped.
+	if msgs[0].Content != "hello" || msgs[1].Content != "world" {
+		t.Errorf("messages modified when they fit: %+v", msgs)
+	}
+}
+
+func TestFit_Step2_DropsMiddle(t *testing.T) {
+	// Three system + one user in the middle + last user. With a tight
+	// budget that fits system + last user, the middle user is dropped.
+	long := strings.Repeat("x ", 500) // ~1000 tokens
+	short := "y"
+	msgs := []Message{
+		{Role: "system", Content: long},
+		{Role: "user", Content: short},
+		{Role: "user", Content: long},
+	}
+	// Budget that fits system + last but not all three.
+	budget := len(long)/2 + len(long)/2 + 100 // rough
+	_ = budget
+	// Use a very tight budget to force step 3.
+	got := Fit(msgs, 50)
+	if got == 0 {
+		t.Errorf("Fit returned 0, want > 0")
+	}
+	// After fitting, at least the last message should be kept (non-empty).
+	foundLast := false
+	for _, m := range msgs {
+		if m.Content != "" {
+			foundLast = true
+		}
+	}
+	if !foundLast {
+		t.Errorf("all messages empty after fit: %+v", msgs)
+	}
+}
+
+func TestFit_Step3_SystemDominates(t *testing.T) {
+	// System takes >80% of tokens → preserve user, trim system.
+	sysContent := strings.Repeat("a ", 800)  // ~1600 tokens
+	userContent := strings.Repeat("b ", 100) // ~200 tokens
+	msgs := []Message{
+		{Role: "system", Content: sysContent},
+		{Role: "user", Content: userContent},
+	}
+	got := Fit(msgs, 500)
+	if got == 0 {
+		t.Errorf("Fit returned 0, want > 0")
+	}
+	// System should have been trimmed, user preserved.
+	if len(msgs[0].Content) >= len(sysContent) {
+		t.Errorf("system not trimmed: got %d want < %d", len(msgs[0].Content), len(sysContent))
+	}
+}
+
+func TestFit_Step3_UserDominates(t *testing.T) {
+	// User takes >20% → preserve system, trim user.
+	sysContent := strings.Repeat("a ", 200)
+	userContent := strings.Repeat("b ", 800)
+	msgs := []Message{
+		{Role: "system", Content: sysContent},
+		{Role: "user", Content: userContent},
+	}
+	got := Fit(msgs, 500)
+	if got == 0 {
+		t.Errorf("Fit returned 0, want > 0")
+	}
+	if len(msgs[1].Content) >= len(userContent) {
+		t.Errorf("user not trimmed: got %d want < %d", len(msgs[1].Content), len(userContent))
+	}
+}
+
+func TestFit_SingleMessage(t *testing.T) {
+	msgs := []Message{
+		{Role: "system", Content: strings.Repeat("x ", 1000)},
+	}
+	got := Fit(msgs, 100)
+	if got == 0 {
+		t.Errorf("Fit returned 0, want > 0")
+	}
+	if len(msgs[0].Content) >= 1000 {
+		t.Errorf("single message not trimmed: got %d", len(msgs[0].Content))
+	}
+}
+
+func TestFit_ZeroMaxTokens(t *testing.T) {
+	// maxTokens <= 0 should use 8192 default and not panic.
+	msgs := []Message{
+		{Role: "system", Content: "hello"},
+		{Role: "user", Content: "world"},
+	}
+	got := Fit(msgs, 0)
+	if got == 0 {
+		t.Errorf("Fit returned 0, want > 0")
+	}
+	if msgs[0].Content != "hello" || msgs[1].Content != "world" {
+		t.Errorf("messages modified with default budget: %+v", msgs)
+	}
+}
+
+func TestFit_Empty(t *testing.T) {
+	got := Fit(nil, 1000)
+	if got != 0 {
+		t.Errorf("Fit on nil = %d, want 0", got)
+	}
+	got = Fit([]Message{}, 1000)
+	if got != 0 {
+		t.Errorf("Fit on empty = %d, want 0", got)
+	}
+}

--- a/internal/component/messagefit/messagefit_test.go
+++ b/internal/component/messagefit/messagefit_test.go
@@ -3,6 +3,8 @@ package messagefit
 import (
 	"strings"
 	"testing"
+
+	"ragflow/internal/tokenizer"
 )
 
 func countMessages(msgs []Message) int {
@@ -31,32 +33,74 @@ func TestFit_AllFits(t *testing.T) {
 }
 
 func TestFit_Step2_DropsMiddle(t *testing.T) {
-	// Three system + one user in the middle + last user. With a tight
-	// budget that fits system + last user, the middle user is dropped.
-	long := strings.Repeat("x ", 500) // ~1000 tokens
-	short := "y"
+	// system + last user fit within the budget, but all three together do
+	// not, so Step 2 drops the middle user and keeps system + last intact.
+	sysContent := strings.Repeat("x ", 200)
+	middle := "middle"
+	last := "last"
 	msgs := []Message{
-		{Role: "system", Content: long},
-		{Role: "user", Content: short},
-		{Role: "user", Content: long},
+		{Role: "system", Content: sysContent},
+		{Role: "user", Content: middle},
+		{Role: "user", Content: last},
 	}
-	// Budget that fits system + last but not all three.
-	budget := len(long)/2 + len(long)/2 + 100 // rough
-	_ = budget
-	// Use a very tight budget to force step 3.
-	got := Fit(msgs, 50)
-	if got == 0 {
-		t.Errorf("Fit returned 0, want > 0")
+	budget := tokenizer.NumTokensFromString(sysContent) + tokenizer.NumTokensFromString(last)
+
+	if got := Fit(msgs, budget); got == 0 {
+		t.Fatalf("Fit returned 0, want > 0")
 	}
-	// After fitting, at least the last message should be kept (non-empty).
-	foundLast := false
-	for _, m := range msgs {
-		if m.Content != "" {
-			foundLast = true
-		}
+	if msgs[1].Content != "" {
+		t.Errorf("middle message not cleared: %q", msgs[1].Content)
 	}
-	if !foundLast {
-		t.Errorf("all messages empty after fit: %+v", msgs)
+	if msgs[0].Content != sysContent || msgs[2].Content != last {
+		t.Errorf("retained messages modified: %+v", msgs)
+	}
+}
+
+// TestFit_ExactBudget verifies that a total exactly equal to the budget
+// counts as fitting: nothing is dropped or trimmed.
+func TestFit_ExactBudget(t *testing.T) {
+	msgs := []Message{
+		{Role: "system", Content: "abc"},
+		{Role: "user", Content: "def"},
+	}
+	budget := tokenizer.NumTokensFromString("abc") + tokenizer.NumTokensFromString("def")
+
+	if got := Fit(msgs, budget); got == 0 {
+		t.Fatalf("Fit returned 0, want > 0")
+	}
+	if msgs[0].Content != "abc" || msgs[1].Content != "def" {
+		t.Errorf("messages modified at exact budget: %+v", msgs)
+	}
+}
+
+// TestFit_TrimsAllSystemMessages verifies that the system budget is spread
+// across every retained system message, not just the first one, so the final
+// total never exceeds the budget.
+func TestFit_TrimsAllSystemMessages(t *testing.T) {
+	sys1 := strings.Repeat("s ", 800) // dominates the token count
+	sys2 := strings.Repeat("t ", 200)
+	last := "last"
+	msgs := []Message{
+		{Role: "system", Content: sys1},
+		{Role: "system", Content: sys2},
+		{Role: "user", Content: last},
+	}
+	const budget = 500
+
+	if got := Fit(msgs, budget); got == 0 {
+		t.Fatalf("Fit returned 0, want > 0")
+	}
+	if msgs[2].Content != last {
+		t.Errorf("last user message not preserved: %q", msgs[2].Content)
+	}
+	total := tokenizer.NumTokensFromString(msgs[0].Content) +
+		tokenizer.NumTokensFromString(msgs[1].Content) +
+		tokenizer.NumTokensFromString(msgs[2].Content)
+	if total > budget {
+		t.Errorf("fitted total %d exceeds budget %d", total, budget)
+	}
+	if len(msgs[0].Content) >= len(sys1) || len(msgs[1].Content) >= len(sys2) {
+		t.Errorf("system messages not trimmed: %+v", msgs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Extract the `message_fit_in` trimming strategy (mirroring Python's `rag/prompts/generator.py`) into a shared Go package `internal/component/messagefit`.

## Why

The agent LLM component and the ingestion Extractor component both need to trim prompts to the model's context window before calling the provider. Each previously did (or would do) this with its own copy of the logic. This PR adds the shared primitive; follow-up PRs wire it into the agent LLM component (#18092) and the ingestion Extractor/tagger (#18095).

## Changes

- New package `internal/component/messagefit` with `Message` and `Fit`.
- `Fit` is non-mutating and returns the trimmed result explicitly:
  `Fit(msgs []Message, budget int) (kept []Message, keptIdx []int, count int)`.
  No empty-content sentinel is used — dropped entries are simply absent from
  `kept`/`keptIdx`, and a message kept but trimmed to empty (e.g. the system
  share collapses to 0 when the last message alone fills the budget) is still
  reported as kept, mirroring Python.
- `Fit` implements the same three-step strategy as Python's `message_fit_in`:
  1. everything fits → return as-is
  2. keep all system messages + last non-system message
  3. proportional trim (system-dominant vs otherwise), single-message trim
- Unit tests covering each branch (all-fit, middle-drop, no-system list,
  system-only, both Step-3 branches with token-budget assertions, the
  budget-filled-by-last boundary, single message, zero budget, empty input)
  plus a test that the input slice is never mutated.

## Testing

- `bash build.sh --test ./internal/component/messagefit/...` passes.
- Rebased onto latest `main` (`a0e091e75`).

## Note

This PR is the shared foundation and only delivers value once the consumer
PRs land: #18092 / #18093 (agent LLM fitting) and #18095 (ingestion
Extractor/tagger fitting), together with the shared model-context resolver
#18106. It is intentionally prepared first so the consumers can rebase onto
it.