### PR TITLE
fix: show filtered session count in session list header

### DIFF
--- a/web/src/pages/agent/explore/components/session-list.tsx
+++ b/web/src/pages/agent/explore/components/session-list.tsx
@@ -32,7 +32,9 @@ export function SessionList({
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <h2 className="text-base font-bold">{t('explore.sessions')}</h2>
-          <span className="text-xs text-text-secondary">{sessions.length}</span>
+          <span className="text-xs text-text-secondary">
+            {filteredData.length}
+          </span>
         </div>
         <Button variant="ghost" size="icon" onClick={addTemporarySession}>
           <Plus className="h-4 w-4" />


### PR DESCRIPTION
### Summary

fix: show filtered session count in session list header

The session list header displayed the total session count regardless of any active filter, which was misleading when filtering was applied. Use filteredData.length instead of sessions.length so the count reflects the currently filtered results.
