### PR TITLE
fix: route TokenChunker delimiter_mode "one" to OneChunker in Go ingestion

### DIFF
--- a/internal/ingestion/component/chunker/common.go
+++ b/internal/ingestion/component/chunker/common.go
@@ -36,6 +36,12 @@ import (
 func newChunkerByName(name string, params map[string]any) (runtime.Component, error) {
 	switch name {
 	case ComponentNameTokenChunker:
+		// The DSL contract (shared by the web UI and the Python runtime)
+		// expresses single-chunk mode as TokenChunker delimiter_mode "one";
+		// in Go that behaviour lives in the OneChunker component.
+		if mode, _ := params["delimiter_mode"].(string); mode == "one" {
+			return NewOneChunker(params)
+		}
 		return NewTokenChunker(params)
 	case ComponentNameTitleChunker:
 		return NewTitleChunker(params)

--- a/internal/ingestion/component/chunker/one_test.go
+++ b/internal/ingestion/component/chunker/one_test.go
@@ -39,6 +39,20 @@ func oneChunksOf(t *testing.T, inputs map[string]any) []map[string]any {
 	return chunks
 }
 
+// TestNewChunkerByName_TokenChunkerOneMode pins the DSL-contract
+// translation: a TokenChunker component whose delimiter_mode is "one"
+// (what the web UI and the Python runtime emit) must build a
+// OneChunker, not fail schema validation.
+func TestNewChunkerByName_TokenChunkerOneMode(t *testing.T) {
+	comp, err := newChunkerByName(ComponentNameTokenChunker, map[string]any{"delimiter_mode": "one"})
+	if err != nil {
+		t.Fatalf("newChunkerByName: %v", err)
+	}
+	if _, ok := comp.(*OneChunkerComponent); !ok {
+		t.Fatalf("component type = %T, want *OneChunkerComponent", comp)
+	}
+}
+
 // TestOneChunker_Text emits exactly one chunk for a text payload,
 // faithful to rag/app/one.py (whole file = one chunk).
 func TestOneChunker_Text(t *testing.T) {


### PR DESCRIPTION
### Summary

The DSL contract shared by the web UI and the Python runtime expresses single-chunk mode as a `TokenChunker` node with `delimiter_mode: "one"`. In Go that behaviour lives in the separate `OneChunker` component, and `TokenChunkerParam.Validate` only accepts `token_size` / `delimiter`. As a result, a knowledge base configured with the **One** method failed at canvas compile time:

```
factory: TokenChunker: schema: field "delimiter_mode" has invalid value "one"
```

and the ingestor kept retrying the failed task indefinitely (the file appeared to be "parsing forever").

**Fix**: translate the contract at the single chunker factory entry point (`newChunkerByName` in `internal/ingestion/component/chunker/common.go`) — a `TokenChunker` component whose `delimiter_mode` is `"one"` now builds a `OneChunker`. This keeps one implementation path (no duplicated chunking logic), preserves the DSL node id (progress/log counting unaffected), and fixes both the ingestion pipeline and the agent canvas paths since they share the same registry factory. The strict constructor-level validation on `TokenChunker` is unchanged.

Adds a regression test (`TestNewChunkerByName_TokenChunkerOneMode`) pinning the translation. `bash build.sh --test ./internal/ingestion/component/chunker/...` passes.