### PR TITLE
fix: prevent stale loading state on previous agent chat reply

### DIFF
--- a/web/src/pages/agent/chat/box.tsx
+++ b/web/src/pages/agent/chat/box.tsx
@@ -107,7 +107,8 @@ function AgentChatBox() {
                   loading={
                     message.role === MessageType.Assistant &&
                     sendLoading &&
-                    derivedMessages.length - 1 === i
+                    derivedMessages.length - 1 === i &&
+                    !message.content
                   }
                   key={buildMessageUuidWithRole(message)}
                   nickname={userInfo.nickname}
@@ -118,7 +119,7 @@ function AgentChatBox() {
                   clickDocumentButton={clickDocumentButton}
                   index={i}
                   showLikeButton={false}
-                  sendLoading={sendLoading}
+                  sendLoading={sendLoading && derivedMessages.length - 1 === i}
                 >
                   {message.role === MessageType.Assistant &&
                     derivedMessages.length - 1 === i && (


### PR DESCRIPTION
### Summary

fix: prevent stale loading state on previous agent chat reply

`sendLoading` (= !done) is global — when a new conversation's stream starts it flips to true, and any assistant message matching `derivedMessages.length - 1 === i` lights up the loading indicator, including the previous conversation's reply.

- Gate the `loading` prop on `!message.content` so a reply that already has content never shows the loading state.
- Scope the `sendLoading` prop passed to MessageItem to the last message only, so LoadingDots (keyed on `sendLoading && isEmpty(content)`) doesn't render on historical replies either.
