### PR TITLE
fix(web): align Go chunk method dropdown order with Python parser_ids

### DIFF
--- a/web/src/hooks/use-user-setting-request.tsx
+++ b/web/src/hooks/use-user-setting-request.tsx
@@ -194,7 +194,36 @@ export const useSelectParserList = (): Array<{
           const translated = t(key);
           return translated !== key ? translated : title;
         };
-        return pipelineList.map((item) => ({
+        // Order the Go pipeline catalog the same way as the Python
+        // backend's parser_ids (settings.PARSERS), so the chunk-method
+        // dropdown lists commonly used methods first. The Python "naive"
+        // slot corresponds to the Go "general" pipeline. Go-only pipelines
+        // (e.g. knowledge_compiler) keep their API order at the end.
+        const pythonParserOrder = [
+          'general', // "naive" in Python parser_ids
+          'qa',
+          'resume',
+          'manual',
+          'table',
+          'paper',
+          'book',
+          'laws',
+          'presentation',
+          'picture',
+          'one',
+          'audio',
+          'email',
+          'tag',
+        ];
+        const order = new Map(
+          pythonParserOrder.map((id, index) => [id, index]),
+        );
+        const sortedList = [...pipelineList].sort(
+          (a, b) =>
+            (order.get(a.id) ?? pythonParserOrder.length) -
+            (order.get(b.id) ?? pythonParserOrder.length),
+        );
+        return sortedList.map((item) => ({
           value: item.id,
           label: labelFromAPI(item.id, item.title),
         }));


### PR DESCRIPTION
### Summary

In Go backend mode, the chunk method dropdown in the knowledge-base creation dialog lists methods in alphabetical order (Audio, Book, Email, General, ...) because `GET /api/v1/pipelines?type=builtin` returns the registry sorted by id. The Python backend instead orders methods via `settings.PARSERS`, with commonly used methods listed first.

This PR sorts the Go pipeline catalog on the front end (`useSelectParserList`) to match the Python `parser_ids` order: general (naive), qa, resume, manual, table, paper, book, laws, presentation, picture, one, audio, email, tag. Go-only pipelines such as `knowledge_compiler` keep their API order at the end.

This is a display-order-only change; the Go API contract and its error messages are untouched.