### PR TITLE
docs(ingestion): correct stale parser-component scope comment

### DIFF
--- a/internal/ingestion/component/parser.go
+++ b/internal/ingestion/component/parser.go
@@ -44,18 +44,21 @@
 //   - The Python component dispatches to 13 file-format branches
 //     (pdf, Markdown, text&code, html, spreadsheet, slides, doc,
 //     docx, image, audio, video, email, epub) — see parser.py
-//     function_map at line ~1273. The Go counterparts in
-//     internal/parser/parser/ are SKELETONS that print to
-//     stdout and return nil. The cgo-gated office variants
-//     (docx, doc, ppt, pptx, xls, xlsx) call office_oxide but
-//     discard the result.
+//     function_map at line ~1273. The Go port is LANDed and LIVE
+//     in production for the families the ingestor claims (see
+//     cmd/ragflow_server.go: Ingestor.supportedTypes =
+//     ["pdf","docx","txt"]); those run their real parsers,
+//     including the cgo-gated office variants via office_oxide.
+//     Families not yet ported fall through to the raw-text path
+//     below rather than printing skeletons.
 //
-//   - Until the parser package returns real data, the Go Parser
-//     component uses a "raw text" fallback: it treats the input
-//     binary as UTF-8 and slices it into 1 page (or N pages
-//     when the upstream signals a page boundary with a literal
+//   - For any family NOT yet ported (its Go parser returns no real
+//     data), the component uses a "raw text" fallback: it treats
+//     the input binary as UTF-8 and slices it into 1 page (or N
+//     pages when the upstream signals a page boundary with a literal
 //     "\f" form feed). This is the conservative, observable
-//     behaviour until the real format dispatch lands.
+//     behaviour for UNPORTED families only; ported families run
+//     their real parsers.
 //
 //   - The Python side's "image2id" pipeline (parser.py:1317-1329)
 //     that uploads embedded images to MinIO is not replicated —


### PR DESCRIPTION
## Summary
Correct the stale SCOPE comment in `internal/ingestion/component/parser.go` that claimed all Go parser counterparts are skeletons printing to stdout and returning nil.

## What changed
- The parser package is no longer skeleton-only. `pdf`/`docx`/`txt` run their real parsers (including the cgo-gated office variants via `office_oxide`), matching the ingestor's supported types in `cmd/ragflow_server.go` (`ingestion.NewIngestor(..., []string{"pdf", "docx", "txt"})`).
- The comment now states that ported families run their real parsers, and only **UNPORTED** families fall through to the raw-text path — instead of claiming every Go counterpart is a skeleton.

## Verification
- `cmd/ragflow_server.go:567` wires the ingestor with `[]string{"pdf", "docx", "txt"}` (reference added to the comment).
- `internal/parser/parser/` contains real implementations (`text_parser.go`, `markdown_parser.go`, `html_parser.go`, `docx_parser.go`, etc.), not stdout-printing stubs.
- Docs-only change; no logic touched. Pre-commit hooks (gofmt / check-json / etc.) pass.

## Test plan
None required — comment-only change. Build/`gofmt` clean.

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy)