### PR TITLE
fix: skip built-in parser validation when pipeline mode is selected

### DIFF
--- a/web/src/components/chunk-method-dialog/hooks.ts
+++ b/web/src/components/chunk-method-dialog/hooks.ts
@@ -19,7 +19,7 @@ import { useCallback } from 'react';
 const hideAutoKeywords = ['qa', 'table', 'resume', 'knowledge_graph', 'tag'];
 
 export const useShowAutoKeywords = () => {
-  const showAutoKeywords = useCallback((selectedTag: string) => {
+  const showAutoKeywords = useCallback((selectedTag: string | undefined) => {
     return hideAutoKeywords.every((x) => selectedTag !== x);
   }, []);
 

--- a/web/src/components/chunk-method-dialog/index.tsx
+++ b/web/src/components/chunk-method-dialog/index.tsx
@@ -116,12 +116,7 @@ export function ChunkMethodDialog({
   const FormSchema = z
     .object({
       parseType: z.nativeEnum(ParseType),
-      parser_id: z
-        .string()
-        .min(1, {
-          message: t('common.pleaseSelect'),
-        })
-        .trim(),
+      parser_id: z.string().trim().optional(),
       pipeline_id: z.string().optional(),
       parser_config: z.object({
         task_page_size: z.coerce.number().optional(),
@@ -186,6 +181,13 @@ export function ChunkMethodDialog({
       }),
     })
     .superRefine((data, ctx) => {
+      if (data.parseType === ParseType.BuiltIn && !data.parser_id) {
+        ctx.addIssue({
+          path: ['parser_id'],
+          message: t('common.pleaseSelect'),
+          code: 'custom',
+        });
+      }
       if (data.parseType === ParseType.Pipeline && !data.pipeline_id) {
         ctx.addIssue({
           path: ['pipeline_id'],
@@ -251,6 +253,7 @@ export function ChunkMethodDialog({
     );
     const nextData = {
       ...data,
+      parser_id: data.parser_id || '',
       parser_config: {
         ...parserConfig,
         image_table_context_window: imageTableContextWindow,


### PR DESCRIPTION
### Summary

fix: skip built-in parser validation when pipeline mode is selected
