### PR TITLE
docs(api): fix agent list filter parameter

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -5509,14 +5509,14 @@ Failure:
 
 ### List agents
 
-**GET** `/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&name={agent_name}&id={agent_id}`
+**GET** `/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&keywords={keywords}`
 
 Lists agents.
 
 #### Request
 
 - Method: GET
-- URL: `/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&title={agent_name}&id={agent_id}`
+- URL: `/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&keywords={keywords}`
 - Headers:
   - `'Authorization: Bearer <YOUR_API_KEY>'`
 
@@ -5524,7 +5524,7 @@ Lists agents.
 
 ```bash
 curl --request GET \
-     --url http://{address}/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&title={agent_name}&id={agent_id} \
+     --url http://{address}/api/v1/agents?page={page}&page_size={page_size}&orderby={orderby}&desc={desc}&keywords={keywords} \
      --header 'Authorization: Bearer <YOUR_API_KEY>'
 ```
 
@@ -5540,10 +5540,8 @@ curl --request GET \
   - `update_time`
 - `desc`: (*Filter parameter*), `boolean`
   Indicates whether the retrieved agents should be sorted in descending order. Defaults to `true`.
-- `id`: (*Filter parameter*), `string`
-  The ID of the agent to retrieve.
-- `title`: (*Filter parameter*), `string`
-  The name of the agent to retrieve.
+- `keywords`: (*Filter parameter*), `string`
+  A case-insensitive substring used to filter agents by title.
 
 #### Response
 

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -5541,7 +5541,7 @@ curl --request GET \
 - `desc`: (*Filter parameter*), `boolean`
   Indicates whether the retrieved agents should be sorted in descending order. Defaults to `true`.
 - `keywords`: (*Filter parameter*), `string`
-  A case-insensitive substring used to filter agents by title.
+  Filters agent titles using a case-insensitive substring. When compilation template groups are included in the response, it also filters their names.
 
 #### Response
 


### PR DESCRIPTION
### Summary

Correct the documented filter for `GET /api/v1/agents`.

The API reference mixed `name`, `title`, and `id` across the endpoint signature, URL, example, and parameter list. Neither runtime reads those parameters for agent listing. Both implementations use `keywords`:

- Python: `request.args.get("keywords", "")`
- Go: `c.Query("keywords")`

The documented URL and parameter list now use `keywords`, described as the case-insensitive substring filter applied to agent titles.

### Verification

- Confirmed the Python handler passes `keywords` to `UserCanvasService.get_by_tenant_ids`, which filters `UserCanvas.title`.
- Confirmed the Go handler declares and reads the `keywords` query parameter.
- Confirmed no stale `name`, `title`, or `id` filters remain in the documented List agents endpoint.
- `git diff --check`

### Scope

Documentation only; runtime behavior is unchanged.
