### PR TITLE
docs: document the tenant_id parameter in resume parsing

### DIFF
--- a/rag/app/resume.py
+++ b/rag/app/resume.py
@@ -1045,6 +1045,7 @@ def _call_llm(prompt: str, tenant_id, lang: str) -> Optional[dict]:
 
     Args:
         prompt: User prompt
+        tenant_id: Tenant ID used to build the LLMBundle that serves the request
         lang: Language
     Returns:
         Parsed dictionary, or None on failure
@@ -1295,6 +1296,7 @@ def parse_with_llm(indexed_text: str, lines: list[str], tenant_id, lang: str) ->
     Args:
         indexed_text: Line-indexed resume text
         lines: List of original line texts (for index-based extraction)
+        tenant_id: Tenant ID used to resolve the chat model for each subtask
         lang: Language
     Returns:
         Merged structured resume dictionary, or None on failure
@@ -2072,6 +2074,7 @@ def parse_resume(filename: str, binary: bytes, tenant_id, lang: str = "Chinese")
     Args:
         filename: File name
         binary: File binary content
+        tenant_id: Tenant ID forwarded to the LLM extraction stage
         lang: Language, default "Chinese"
     Returns:
         (resume, lines, line_positions) tuple:


### PR DESCRIPTION
Second ragflow PR (#17639 merged 2026-07-31). Docstrings only, no behavior change.

## What's wrong

Three functions in `rag/app/resume.py` document every parameter **except** `tenant_id` — and
`tenant_id` is the one that decides which tenant's chat model serves the request, so it is the least
guessable of the set:

| Function | Args section lists | Omits | What `tenant_id` actually does there |
|---|---|---|---|
| `_call_llm` (`:1037`) | `prompt`, `lang` | `tenant_id` | `:1057` `LLMBundle(tenant_id, LLMType.CHAT, lang=lang)` — it selects the model |
| `parse_with_llm` (`:1285`) | `indexed_text`, `lines`, `lang` | `tenant_id` | `:1305-1308` forwards it to all four parallel extraction subtasks |
| `parse_resume` (`:2062`) | `filename`, `binary`, `lang` | `tenant_id` | `:2078` forwards it to `parse_with_llm` |

Each docstring is otherwise complete, so the omission reads as an oversight from when `tenant_id`
was threaded through, not as a deliberate style choice.

I traced each one to the line that uses the value rather than paraphrasing the parameter name —
that is where "selects the tenant's chat model" comes from (`_call_llm` → `LLMBundle(..., LLMType.CHAT)`),
not from the name looking like a tenant id.

## Deliberately not touched

`chunk()` (`:2479`) also takes `tenant_id` and its Args section does not list it separately — **but
that one is intentional and I left it alone.** Its `**kwargs` entry reads:

```
**kwargs: Other parameters (parser_config, kb_id, tenant_id, etc.)
```

so the author folded `tenant_id` into the kwargs description. My scanner flagged it; reading the
docstring showed the flag was wrong. Changing it would be a style argument, not a defect fix.

## Validation

```
$ python3 -c "import ast; ast.parse(open('rag/app/resume.py').read())"   # parses clean
$ ruff check rag/app/resume.py --line-length 200                          # 0 findings on this file
```

Ruff output is byte-identical before and after the change (verified by stashing the diff and
re-running), so nothing here introduces a lint finding. The one >200-char line in this file
(`:1980`) is pre-existing and untouched.

`git diff --stat`: `rag/app/resume.py | 3 +++` — three added lines, no deletions.

---

🤖 Written with [Claude Code](https://claude.com/claude-code). Each site was opened and read, and
each description was checked against the line that consumes the value.
