### PR TITLE
fix: keep loading indicator on streaming assistant message in agent chat

### DIFF
--- a/web/src/pages/agent/chat/box.tsx
+++ b/web/src/pages/agent/chat/box.tsx
@@ -107,8 +107,7 @@ function AgentChatBox() {
                   loading={
                     message.role === MessageType.Assistant &&
                     sendLoading &&
-                    derivedMessages.length - 1 === i &&
-                    !message.content
+                    derivedMessages.length - 1 === i
                   }
                   key={buildMessageUuidWithRole(message)}
                   nickname={userInfo.nickname}


### PR DESCRIPTION
### Summary

fix: keep loading indicator on streaming assistant message in agent chat

The last assistant message dropped its loading state as soon as the first content chunk arrived, so the spinner vanished while the answer was still streaming. Tie the indicator to sendLoading only.
