### PR TITLE
fix(web): keep single-chat SSE stream alive across route changes

### DIFF
--- a/web/src/pages/next-chats/chat-stream/constants.ts
+++ b/web/src/pages/next-chats/chat-stream/constants.ts
@@ -1,0 +1,21 @@
+// Maximum number of idle chat sessions kept in the streaming store. Sessions
+// that are streaming, or the one currently being acted on, are never evicted.
+export const MaxCachedChatSessions = 10;
+
+// Stable id prefix for the seeded prologue message, so re-seeding the same
+// conversation is idempotent under React StrictMode's double effects.
+export const PrologueMessageIdPrefix = 'prologue_';
+
+// Minimum gap between two store writes while a stream is running. SSE chunks
+// arrive far faster than markdown can be re-rendered, and every write copies the
+// message list and re-renders the message item, so coalescing them cuts the cost
+// without any visible change to how the answer grows. The final chunk always
+// flushes immediately.
+export const AnswerFlushIntervalMs = 60;
+
+// Redux DevTools keeps a full state snapshot per action. Streaming dispatches one
+// action per chunk, each carrying the whole accumulated answer, so recording it
+// makes a long answer quadratically expensive to produce — and it keeps costing
+// after the chat page unmounts, which is what makes navigating away mid-answer
+// feel slow. Flip to true only while debugging the store.
+export const EnableChatStreamDevtools = false;

--- a/web/src/pages/next-chats/chat-stream/run-stream.ts
+++ b/web/src/pages/next-chats/chat-stream/run-stream.ts
@@ -1,0 +1,132 @@
+/**
+ * Module-level SSE driver. Deliberately not a hook: it must keep running (and
+ * keep writing into the store) after the chat page unmounts, so that navigating
+ * away mid-answer and back shows the stream still in progress.
+ */
+import { IMessage } from '@/interfaces/database/chat';
+import {
+  CompletionChunk,
+  parseCompletionEventStream,
+  readJsonSafely,
+  requestChatCompletionStream,
+} from '@/services/chat-completion-stream';
+import { AnswerFlushIntervalMs } from './constants';
+import { useChatStreamStore } from './store';
+import { mergeAnswerChunk } from './utils';
+
+export type RunChatCompletionStreamParams = {
+  conversationId: string;
+  chatId?: string;
+  messages: IMessage[];
+  enableThinking?: string;
+  enableInternet?: boolean;
+};
+
+export type RunChatCompletionStreamResult = {
+  ok: boolean;
+  aborted: boolean;
+};
+
+export async function runChatCompletionStream({
+  conversationId,
+  chatId,
+  messages,
+  enableThinking,
+  enableInternet,
+}: RunChatCompletionStreamParams): Promise<RunChatCompletionStreamResult> {
+  const { beginStream, applyAnswer, endStream } = useChatStreamStore.getState();
+
+  const controller = new AbortController();
+  if (!beginStream(conversationId, controller)) {
+    return { ok: false, aborted: false };
+  }
+
+  // Kept local rather than read back from the store: it must stay immune to
+  // concurrent mutations of the message list, and mergeAnswerChunk's
+  // `startsWith` / think-marker behaviour depends on the raw accumulated text
+  // rather than on the rendered message content.
+  let accumulatedAnswer = '';
+  let aborted = false;
+  let ok = true;
+
+  // Chunks arrive faster than the UI can use them, so they're coalesced into a
+  // single store write per AnswerFlushIntervalMs. Fields are merged rather than
+  // replaced so a `reference` or `prompt` that arrived on a skipped chunk isn't
+  // lost; the buffer resets on each flush, matching the legacy "newest chunk
+  // wins" semantics across flush windows.
+  let pendingChunk: CompletionChunk | undefined;
+  let lastFlushAt = 0;
+
+  const flushAnswer = () => {
+    if (!pendingChunk) return;
+    applyAnswer(conversationId, {
+      ...pendingChunk,
+      answer: accumulatedAnswer,
+      conversationId,
+    });
+    pendingChunk = undefined;
+    lastFlushAt = Date.now();
+  };
+
+  try {
+    const response = await requestChatCompletionStream(
+      {
+        chatId,
+        sessionId: conversationId,
+        messages,
+        enableThinking,
+        enableInternet,
+      },
+      controller.signal,
+    );
+
+    // Clone before the body is consumed: an error response carries a JSON
+    // body, which is how a failed completion is detected. On a successful SSE
+    // response this parse simply fails and yields undefined.
+    const errorBodyPromise = readJsonSafely(response.clone());
+
+    try {
+      for await (const chunk of parseCompletionEventStream(response)) {
+        accumulatedAnswer = mergeAnswerChunk(accumulatedAnswer, chunk);
+        pendingChunk = pendingChunk ? { ...pendingChunk, ...chunk } : chunk;
+
+        // The first chunk flushes immediately (lastFlushAt is 0), so the empty
+        // placeholder is replaced without waiting out an interval.
+        if (chunk.final || Date.now() - lastFlushAt >= AnswerFlushIntervalMs) {
+          flushAnswer();
+        }
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        aborted = true;
+      } else {
+        throw error;
+      }
+    }
+
+    // A healthy stream body isn't valid JSON, so errorBody stays undefined and
+    // the request counts as successful. A parseable body means the endpoint
+    // answered with an error envelope instead of a stream.
+    const errorBody = await errorBodyPromise;
+    if (
+      !aborted &&
+      errorBody !== undefined &&
+      (response.status !== 200 || errorBody.code !== 0)
+    ) {
+      ok = false;
+    }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      aborted = true;
+    } else {
+      ok = false;
+    }
+  } finally {
+    // Whatever was buffered must land, including on abort: a stopped answer
+    // keeps the text produced up to that point.
+    flushAnswer();
+    endStream(conversationId);
+  }
+
+  return { ok, aborted };
+}

--- a/web/src/pages/next-chats/chat-stream/store.ts
+++ b/web/src/pages/next-chats/chat-stream/store.ts
@@ -1,0 +1,432 @@
+/**
+ * Module-level store for the single-chat SSE stream.
+ *
+ * The message list, the streaming flag and the AbortController live here rather
+ * than in component state so an in-flight stream survives unmounting
+ * `/chat/:id`. The reader loop (see run-stream.ts) writes straight into this
+ * store, so navigating away and back re-subscribes to a stream that never
+ * stopped.
+ */
+import { IAnswer, IMessage } from '@/interfaces/database/chat';
+import { MessageType } from '@/constants/chat';
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { MaxCachedChatSessions, EnableChatStreamDevtools } from './constants';
+import {
+  buildAssistantMessageFromAnswer,
+  buildPrologueMessageId,
+  buildQuestionAndPlaceholder,
+  mergeLocalFiles,
+} from './utils';
+
+export type ChatStreamSession = {
+  chatId: string;
+  messages: IMessage[];
+  isStreaming: boolean;
+  abortController?: AbortController;
+  // Text of a question whose stream failed. Held per session because the
+  // failure can land while the user is on another conversation or page, where
+  // restoring the input box directly would either be a no-op or type into the
+  // wrong session's input.
+  pendingInput?: string;
+  lastActiveAt: number;
+};
+
+export type ChatStreamState = {
+  sessions: Record<string, ChatStreamSession>;
+
+  ensureSession(conversationId: string, chatId: string): void;
+  seedPrologue(conversationId: string, chatId: string, prologue: string): void;
+  hydrateFromServer(conversationId: string, messages: IMessage[]): void;
+  appendQuestion(conversationId: string, message: IMessage): void;
+  beginStream(conversationId: string, controller: AbortController): boolean;
+  applyAnswer(conversationId: string, answer: IAnswer): void;
+  failStream(conversationId: string, pendingInput: string): void;
+  consumePendingInput(conversationId: string): void;
+  removeMessageById(conversationId: string, messageId: string): void;
+  truncateAfterMessage(conversationId: string, messageId: string): void;
+  endStream(conversationId: string): void;
+  stopStream(conversationId: string): void;
+  removeSessions(conversationIds: string[]): void;
+};
+
+function createSession(chatId: string): ChatStreamSession {
+  return {
+    chatId,
+    messages: [],
+    isStreaming: false,
+    lastActiveAt: Date.now(),
+  };
+}
+
+/**
+ * Drops the least recently used idle sessions once the cache exceeds
+ * MaxCachedChatSessions. Never evicts a streaming session or the session being
+ * acted on. Only called from actions that can create a new entry — never from
+ * the per-chunk hot path.
+ */
+function evictIdleSessions(
+  sessions: Record<string, ChatStreamSession>,
+  protectedId: string,
+): Record<string, ChatStreamSession> {
+  const ids = Object.keys(sessions);
+  if (ids.length <= MaxCachedChatSessions) return sessions;
+
+  const evictable = ids
+    .filter((id) => id !== protectedId && !sessions[id].isStreaming)
+    .sort((a, b) => sessions[a].lastActiveAt - sessions[b].lastActiveAt);
+
+  const removeCount = ids.length - MaxCachedChatSessions;
+  const next = { ...sessions };
+  evictable.slice(0, removeCount).forEach((id) => {
+    delete next[id];
+  });
+  return next;
+}
+
+export const useChatStreamStore = create<ChatStreamState>()(
+  devtools(
+    (set, get) => ({
+      sessions: {},
+
+      ensureSession: (conversationId, chatId) => {
+        if (!conversationId) return;
+        if (get().sessions[conversationId]) return;
+        set(
+          (state) => ({
+            sessions: evictIdleSessions(
+              {
+                ...state.sessions,
+                [conversationId]: createSession(chatId),
+              },
+              conversationId,
+            ),
+          }),
+          false,
+          'ensureSession',
+        );
+      },
+
+      seedPrologue: (conversationId, chatId, prologue) => {
+        if (!conversationId) return;
+        const session = get().sessions[conversationId];
+        // Idempotent: a session that already holds messages (a seeded prologue
+        // under StrictMode's double effect, or a real exchange) is left alone.
+        if (session && session.messages.length > 0) return;
+
+        const prologueMessage: IMessage = {
+          role: MessageType.Assistant,
+          content: prologue,
+          id: buildPrologueMessageId(conversationId),
+          conversationId,
+        };
+
+        set(
+          (state) => ({
+            sessions: evictIdleSessions(
+              {
+                ...state.sessions,
+                [conversationId]: {
+                  ...(state.sessions[conversationId] ?? createSession(chatId)),
+                  messages: [prologueMessage],
+                  lastActiveAt: Date.now(),
+                },
+              },
+              conversationId,
+            ),
+          }),
+          false,
+          'seedPrologue',
+        );
+      },
+
+      hydrateFromServer: (conversationId, messages) => {
+        if (!conversationId) return;
+        const session = get().sessions[conversationId];
+        // A stream in flight owns the list: the answer it is building hasn't
+        // been persisted yet, so anything the server returns is behind.
+        if (session?.isStreaming) return;
+        // Otherwise compare lengths instead of latching authority to the local
+        // list forever. A shorter server list is a stale snapshot taken before
+        // the latest exchange was persisted — accepting it would truncate a
+        // just-finished answer (the pre-existing race). An equal or longer list
+        // is at least as new as what we hold, and it carries the real message
+        // ids, references and prompts that the SSE payload lacks, plus any
+        // exchange added from another tab.
+        if (session && messages.length < session.messages.length) return;
+
+        set(
+          (state) => {
+            const previous = state.sessions[conversationId];
+            return {
+              sessions: evictIdleSessions(
+                {
+                  ...state.sessions,
+                  [conversationId]: {
+                    ...(previous ?? createSession('')),
+                    messages: mergeLocalFiles(
+                      messages,
+                      previous?.messages ?? [],
+                    ),
+                    lastActiveAt: Date.now(),
+                  },
+                },
+                conversationId,
+              ),
+            };
+          },
+          false,
+          'hydrateFromServer',
+        );
+      },
+
+      appendQuestion: (conversationId, message) => {
+        if (!conversationId) return;
+        set(
+          (state) => {
+            const previous =
+              state.sessions[conversationId] ?? createSession('');
+            return {
+              sessions: evictIdleSessions(
+                {
+                  ...state.sessions,
+                  [conversationId]: {
+                    ...previous,
+                    messages: [
+                      ...previous.messages,
+                      ...buildQuestionAndPlaceholder(message),
+                    ],
+                    lastActiveAt: Date.now(),
+                  },
+                },
+                conversationId,
+              ),
+            };
+          },
+          false,
+          'appendQuestion',
+        );
+      },
+
+      beginStream: (conversationId, controller) => {
+        if (!conversationId) return false;
+        // Guard against a duplicate start (StrictMode, double submit).
+        if (get().sessions[conversationId]?.isStreaming) return false;
+
+        set(
+          (state) => {
+            const previous =
+              state.sessions[conversationId] ?? createSession('');
+            return {
+              sessions: {
+                ...state.sessions,
+                [conversationId]: {
+                  ...previous,
+                  isStreaming: true,
+                  abortController: controller,
+                  lastActiveAt: Date.now(),
+                },
+              },
+            };
+          },
+          false,
+          'beginStream',
+        );
+        return true;
+      },
+
+      applyAnswer: (conversationId, answer) => {
+        if (!conversationId) return;
+        set(
+          (state) => {
+            const previous = state.sessions[conversationId];
+            if (!previous) return state;
+            return {
+              sessions: {
+                ...state.sessions,
+                [conversationId]: {
+                  ...previous,
+                  messages: [
+                    ...previous.messages.slice(0, -1),
+                    buildAssistantMessageFromAnswer(answer),
+                  ],
+                  lastActiveAt: Date.now(),
+                },
+              },
+            };
+          },
+          false,
+          'applyAnswer',
+        );
+      },
+
+      // Drops the failed question/placeholder pair and parks the question text
+      // on the session so it can be handed back to the input box whenever the
+      // user is (or returns to) this conversation.
+      failStream: (conversationId, pendingInput) => {
+        if (!conversationId) return;
+        set(
+          (state) => {
+            const previous = state.sessions[conversationId];
+            if (!previous) return state;
+            return {
+              sessions: {
+                ...state.sessions,
+                [conversationId]: {
+                  ...previous,
+                  messages: previous.messages.slice(0, -2),
+                  pendingInput,
+                },
+              },
+            };
+          },
+          false,
+          'failStream',
+        );
+      },
+
+      consumePendingInput: (conversationId) => {
+        if (!conversationId) return;
+        set(
+          (state) => {
+            const previous = state.sessions[conversationId];
+            if (!previous?.pendingInput) return state;
+            return {
+              sessions: {
+                ...state.sessions,
+                [conversationId]: { ...previous, pendingInput: undefined },
+              },
+            };
+          },
+          false,
+          'consumePendingInput',
+        );
+      },
+
+      removeMessageById: (conversationId, messageId) => {
+        if (!conversationId) return;
+        set(
+          (state) => {
+            const previous = state.sessions[conversationId];
+            if (!previous) return state;
+            return {
+              sessions: {
+                ...state.sessions,
+                [conversationId]: {
+                  ...previous,
+                  messages: previous.messages.filter((x) => x.id !== messageId),
+                },
+              },
+            };
+          },
+          false,
+          'removeMessageById',
+        );
+      },
+
+      truncateAfterMessage: (conversationId, messageId) => {
+        if (!conversationId) return;
+        set(
+          (state) => {
+            const previous = state.sessions[conversationId];
+            if (!previous) return state;
+
+            const index = previous.messages.findIndex(
+              (x) => x.id === messageId,
+            );
+            if (index === -1) return state;
+
+            const kept = previous.messages.slice(0, index + 2);
+            const latest = kept.at(-1);
+            const messages = latest
+              ? [
+                  ...kept.slice(0, -1),
+                  {
+                    ...latest,
+                    content: '',
+                    reference: undefined,
+                    prompt: undefined,
+                  },
+                ]
+              : kept;
+
+            return {
+              sessions: {
+                ...state.sessions,
+                [conversationId]: { ...previous, messages },
+              },
+            };
+          },
+          false,
+          'truncateAfterMessage',
+        );
+      },
+
+      endStream: (conversationId) => {
+        if (!conversationId) return;
+        set(
+          (state) => {
+            const previous = state.sessions[conversationId];
+            if (!previous) return state;
+            return {
+              sessions: {
+                ...state.sessions,
+                [conversationId]: {
+                  ...previous,
+                  isStreaming: false,
+                  abortController: undefined,
+                },
+              },
+            };
+          },
+          false,
+          'endStream',
+        );
+      },
+
+      stopStream: (conversationId) => {
+        if (!conversationId) return;
+        get().sessions[conversationId]?.abortController?.abort();
+      },
+
+      removeSessions: (conversationIds) => {
+        if (conversationIds.length === 0) return;
+        set(
+          (state) => {
+            const sessions = { ...state.sessions };
+            conversationIds.forEach((id) => {
+              sessions[id]?.abortController?.abort();
+              delete sessions[id];
+            });
+            return { sessions };
+          },
+          false,
+          'removeSessions',
+        );
+      },
+    }),
+    { name: 'chat-stream', enabled: EnableChatStreamDevtools },
+  ),
+);
+
+// Shared empty array so a session-less selector keeps returning the same
+// reference and doesn't trigger re-renders.
+const EmptyMessages: IMessage[] = [];
+
+export function useChatStreamMessages(conversationId: string) {
+  return useChatStreamStore(
+    (state) => state.sessions[conversationId]?.messages ?? EmptyMessages,
+  );
+}
+
+export function useIsChatStreaming(conversationId: string) {
+  return useChatStreamStore(
+    (state) => state.sessions[conversationId]?.isStreaming ?? false,
+  );
+}
+
+export function useChatPendingInput(conversationId: string) {
+  return useChatStreamStore(
+    (state) => state.sessions[conversationId]?.pendingInput,
+  );
+}

--- a/web/src/pages/next-chats/chat-stream/utils.ts
+++ b/web/src/pages/next-chats/chat-stream/utils.ts
@@ -1,0 +1,97 @@
+import { MessageType } from '@/constants/chat';
+import { IAnswer, IMessage } from '@/interfaces/database/chat';
+import { buildMessageUuid } from '@/utils/chat';
+import { omit } from 'lodash';
+import { CompletionChunk } from '@/services/chat-completion-stream';
+import { PrologueMessageIdPrefix } from './constants';
+
+/**
+ * Accumulates a streamed answer chunk onto the previously accumulated text.
+ * Ported verbatim from the legacy `setAnswer` reducer in
+ * `useSendMessageWithSse` (src/hooks/logic-hooks.ts) to preserve behaviour:
+ * the final chunk is skipped only when earlier chunks exist (single-shot
+ * answers arrive with `final: true` only), a chunk that already contains the
+ * previous text replaces it instead of being appended, and think markers are
+ * injected inline.
+ */
+export function mergeAnswerChunk(
+  previousAnswer: string,
+  chunk: CompletionChunk,
+): string {
+  const currentAnswer = chunk.final && previousAnswer ? '' : chunk.answer || '';
+
+  let nextAnswer: string;
+  if (previousAnswer && currentAnswer.startsWith(previousAnswer)) {
+    nextAnswer = currentAnswer;
+  } else {
+    nextAnswer = previousAnswer + currentAnswer;
+  }
+
+  if (chunk.start_to_think === true) {
+    nextAnswer = nextAnswer + '<think>';
+  }
+
+  if (chunk.end_to_think === true) {
+    nextAnswer = nextAnswer + '</think>';
+  }
+
+  return nextAnswer;
+}
+
+/** Builds the assistant message that replaces the trailing placeholder. */
+export function buildAssistantMessageFromAnswer(answer: IAnswer): IMessage {
+  return {
+    role: MessageType.Assistant,
+    content: answer.answer,
+    reference: answer.reference,
+    id: buildMessageUuid({ id: answer.id, role: MessageType.Assistant }),
+    prompt: answer.prompt,
+    audio_binary: answer.audio_binary,
+    ...omit(answer, 'reference'),
+  } as IMessage;
+}
+
+/**
+ * Builds the user question plus the empty assistant placeholder that the
+ * streamed answer will progressively fill in.
+ */
+export function buildQuestionAndPlaceholder(message: IMessage): IMessage[] {
+  return [
+    {
+      ...message,
+      id: buildMessageUuid(message),
+    },
+    {
+      role: MessageType.Assistant,
+      content: '',
+      conversationId: message.conversationId,
+      id: buildMessageUuid({ ...message, role: MessageType.Assistant }),
+    } as IMessage,
+  ];
+}
+
+/**
+ * Server messages don't carry the locally uploaded `File` instances. Re-attach
+ * them by message id so attachments survive a server refresh.
+ */
+export function mergeLocalFiles(
+  serverMessages: IMessage[],
+  localMessages: IMessage[],
+): IMessage[] {
+  const filesMap = new Map(
+    localMessages.filter((x) => x.files?.length).map((x) => [x.id, x.files]),
+  );
+
+  if (filesMap.size === 0) {
+    return serverMessages;
+  }
+
+  return serverMessages.map((x) => ({
+    ...x,
+    files: filesMap.get(x.id) ?? x.files,
+  }));
+}
+
+export function buildPrologueMessageId(conversationId: string) {
+  return `${PrologueMessageIdPrefix}${conversationId}`;
+}

--- a/web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx
+++ b/web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx
@@ -18,22 +18,16 @@ import { buildMessageItemReference } from '../../utils';
 import { useShowInternet } from '../use-show-internet';
 
 interface IProps {
-  controller: AbortController;
-  stopOutputMessage(): void;
   conversation: IClientConversation;
 }
 
-export function SingleChatBox({
-  controller,
-  stopOutputMessage,
-  conversation,
-}: IProps) {
+export function SingleChatBox({ conversation }: IProps) {
   const {
     value,
     scrollRef,
     messageContainerRef,
     sendLoading,
-    derivedMessages,
+    messages,
     isUploading,
     handleInputChange,
     handlePressEnter,
@@ -41,9 +35,9 @@ export function SingleChatBox({
     removeMessageById,
     handleUploadFile,
     removeFile,
-    setDerivedMessages,
-    activeStreamsRef,
-  } = useSendMessage(controller);
+    hydrateFromServer,
+    stopOutputMessage,
+  } = useSendMessage();
   const { data: userInfo } = useFetchUserInfo();
   const { data: currentDialog } = useFetchChat();
   const { createConversationBeforeUploadDocument } =
@@ -57,56 +51,27 @@ export function SingleChatBox({
   const showInternet = useShowInternet();
 
   useEffect(() => {
-    // Don't let backend data overwrite local streaming state while SSE is
-    // in-flight for this conversation. The server hasn't persisted the latest
-    // answer yet, and applying conversation.messages would discard the
-    // in-progress answer.
-    if (activeStreamsRef.current.has(conversationId)) return;
-
     // Skip when the conversation prop is stale — its id doesn't match the
     // URL's current conversationId. This happens during a switch (e.g.
     // clicking "+" to create a new session): child effects fire before the
     // parent's clear/load effect, so for one render the prop still holds the
     // previous conversation's messages. Applying them here would leak the old
     // conversation's content into the newly switched (or new) conversation.
-    // The cache + prologue logic in useSelectNextMessages handles restoring
-    // or seeding messages for the new conversationId.
     if (conversation?.id && conversation.id !== conversationId) return;
 
     const messages = conversation?.messages;
     if (Array.isArray(messages)) {
-      setDerivedMessages((prevMessages) => {
-        // Preserve uploaded file objects from local state that the server doesn't
-        // persist (e.g. File instances). Build a map of message id → files from
-        // the current local state so they survive when server data is applied.
-        const filesMap = new Map(
-          prevMessages
-            .filter((m) => m.files?.length)
-            .map((m) => [m.id, m.files]),
-        );
-        if (filesMap.size === 0) {
-          return messages;
-        }
-        return messages.map((m) => ({
-          ...m,
-          files: filesMap.get(m.id) ?? m.files,
-        }));
-      });
+      // hydrateFromServer is a no-op while a stream is in flight, and rejects a
+      // server list shorter than the local one, so it can never truncate an
+      // answer the server hasn't persisted yet.
+      hydrateFromServer(conversationId, messages);
     }
   }, [
     conversation?.messages,
     conversation?.id,
     conversationId,
-    setDerivedMessages,
-    activeStreamsRef,
+    hydrateFromServer,
   ]);
-
-  useEffect(() => {
-    // Clear the message list after deleting the conversation.
-    if (conversationId === '') {
-      setDerivedMessages([]);
-    }
-  }, [conversationId, setDerivedMessages]);
 
   return (
     <section className="flex flex-col h-full gap-4">
@@ -115,12 +80,12 @@ export function SingleChatBox({
         className="p-5 flex-1 overflow-auto min-h-0 scrollbar-auto"
       >
         <div className="w-full pr-5">
-          {derivedMessages?.map((message, i) => (
+          {messages?.map((message, i) => (
             <MessageItem
               loading={
                 message.role === MessageType.Assistant &&
                 sendLoading &&
-                derivedMessages.length - 1 === i
+                messages.length - 1 === i
               }
               key={buildMessageUuidWithRole(message)}
               item={message}
@@ -129,7 +94,7 @@ export function SingleChatBox({
               avatarDialog={currentDialog.icon}
               reference={buildMessageItemReference(
                 {
-                  messages: derivedMessages,
+                  messages,
                   reference: conversation.reference,
                 },
                 message,

--- a/web/src/pages/next-chats/chat/conversation-dropdown.tsx
+++ b/web/src/pages/next-chats/chat/conversation-dropdown.tsx
@@ -13,6 +13,7 @@ import { IConversation } from '@/interfaces/database/chat';
 import { Trash2 } from 'lucide-react';
 import { MouseEventHandler, PropsWithChildren, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useChatStreamStore } from '../chat-stream/store';
 import { useChatUrlParams } from '../hooks/use-chat-url';
 
 export function ConversationDropdown({
@@ -27,17 +28,22 @@ export function ConversationDropdown({
   const { setConversationBoth } = useChatUrlParams();
   const { removeSessions } = useRemoveSessions();
   const { conversationId, isNew } = useGetChatSearchParams();
+  const removeStreamSessions = useChatStreamStore(
+    (state) => state.removeSessions,
+  );
 
   const handleDelete: MouseEventHandler<HTMLDivElement> =
     useCallback(async () => {
       if (isNew === 'true' && removeTemporaryConversation) {
         removeTemporaryConversation(conversation.id);
+        removeStreamSessions([conversation.id]);
         if (conversationId === conversation.id) {
           setConversationBoth('', '');
         }
       } else {
         const code = await removeSessions([conversation.id]);
         if (code === 0) {
+          removeStreamSessions([conversation.id]);
           setConversationBoth('', '');
         }
       }
@@ -46,6 +52,7 @@ export function ConversationDropdown({
       conversationId,
       isNew,
       removeSessions,
+      removeStreamSessions,
       removeTemporaryConversation,
       setConversationBoth,
     ]);

--- a/web/src/pages/next-chats/chat/index.tsx
+++ b/web/src/pages/next-chats/chat/index.tsx
@@ -136,11 +136,7 @@ export default function Chat() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="flex-1 p-0 min-h-0">
-                  <SingleChatBox
-                    controller={controller}
-                    stopOutputMessage={stopOutputMessage}
-                    conversation={currentConversation}
-                  />
+                  <SingleChatBox conversation={currentConversation} />
                 </CardContent>
               </Card>
 

--- a/web/src/pages/next-chats/chat/sessions.tsx
+++ b/web/src/pages/next-chats/chat/sessions.tsx
@@ -30,6 +30,7 @@ import {
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
+import { useChatStreamStore } from '../chat-stream/store';
 import { useChatUrlParams } from '../hooks/use-chat-url';
 import { useHandleClickConversationCard } from '../hooks/use-click-card';
 import { useSelectDerivedConversationList } from '../hooks/use-select-conversation-list';
@@ -53,6 +54,9 @@ export function Sessions({ handleConversationCardClick }: SessionProps) {
   const { removeSessions } = useRemoveSessions();
   const { setConversationBoth } = useChatUrlParams();
   const { conversationId } = useGetChatSearchParams();
+  const removeStreamSessions = useChatStreamStore(
+    (state) => state.removeSessions,
+  );
 
   // Selection mode state
   const [selectionMode, setSelectionMode] = useState(false);
@@ -118,10 +122,12 @@ export function Sessions({ handleConversationCardClick }: SessionProps) {
       conversationList.filter((item) => item.is_new).map((item) => item.id),
     );
     const persistedIds: string[] = [];
+    const removedTemporaryIds: string[] = [];
 
     visibleSelectedIds.forEach((id) => {
       if (temporaryIdSet.has(id)) {
         removeTemporaryConversation(id);
+        removedTemporaryIds.push(id);
       } else {
         persistedIds.push(id);
       }
@@ -131,6 +137,13 @@ export function Sessions({ handleConversationCardClick }: SessionProps) {
     if (persistedIds.length > 0) {
       removeCode = await removeSessions(persistedIds);
     }
+
+    // Purge the streaming store for every id that actually went away, aborting
+    // any in-flight stream so it can't keep writing into a dead session.
+    removeStreamSessions([
+      ...removedTemporaryIds,
+      ...(removeCode === 0 ? persistedIds : []),
+    ]);
 
     if (currentConversationDeleted && conversationId) {
       const currentIsTemporary = temporaryIdSet.has(conversationId);
@@ -148,6 +161,7 @@ export function Sessions({ handleConversationCardClick }: SessionProps) {
     setConversationBoth,
     removeTemporaryConversation,
     removeSessions,
+    removeStreamSessions,
     exitSelectionMode,
   ]);
 

--- a/web/src/pages/next-chats/hooks/use-send-chat-message.ts
+++ b/web/src/pages/next-chats/hooks/use-send-chat-message.ts
@@ -3,167 +3,99 @@ import { MessageType } from '@/constants/chat';
 import {
   useHandleMessageInputChange,
   useRegenerateMessage,
-  useSelectDerivedMessages,
-  useSendMessageWithSse,
+  useScrollToBottom,
 } from '@/hooks/logic-hooks';
 import { useGetChatSearchParams } from '@/hooks/use-chat-request';
-import { IAnswer, IMessage } from '@/interfaces/database/chat';
-import api from '@/utils/api';
-import { buildMessageUuid } from '@/utils/chat';
-import { omit, trim } from 'lodash';
+import { IMessage } from '@/interfaces/database/chat';
+import notification from '@/utils/notification';
+import { trim } from 'lodash';
 import { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { v4 as uuid } from 'uuid';
+import { runChatCompletionStream } from '../chat-stream/run-stream';
+import {
+  useChatPendingInput,
+  useChatStreamMessages,
+  useChatStreamStore,
+  useIsChatStreaming,
+} from '../chat-stream/store';
 import { useCreateConversationBeforeSendMessage } from './use-chat-url';
 import { useFindPrologueFromDialogList } from './use-select-conversation-list';
 import { useUploadFile } from './use-upload-file';
 
-// Append an answer to a messages array (mirrors addNewestAnswer logic in
-// useSelectDerivedMessages) for updating a background conversation's cache
-// without touching the currently displayed derivedMessages.
-function appendAnswerToMessages(
-  messages: IMessage[],
-  answer: IAnswer,
-): IMessage[] {
-  return [
-    ...(messages.slice(0, -1) ?? []),
-    {
-      role: MessageType.Assistant,
-      content: answer.answer,
-      reference: answer.reference,
-      id: buildMessageUuid({ id: answer.id, role: MessageType.Assistant }),
-      prompt: answer.prompt,
-      audio_binary: answer.audio_binary,
-      ...omit(answer, 'reference'),
-    },
-  ];
-}
-
-// Append a user question + empty assistant placeholder to a messages array
-// (mirrors addNewestQuestion logic) for updating a background conversation's
-// cache when the user asks a question right before switching conversations.
-function appendQuestionToMessages(
-  messages: IMessage[],
-  message: IMessage,
-): IMessage[] {
-  return [
-    ...messages,
-    {
-      ...message,
-      id: buildMessageUuid(message),
-    },
-    {
-      role: MessageType.Assistant,
-      content: '',
-      conversationId: message.conversationId,
-      id: buildMessageUuid({ ...message, role: MessageType.Assistant }),
-    },
-  ];
-}
-
-export const useSelectNextMessages = () => {
-  const {
-    scrollRef,
-    messageContainerRef,
-    setDerivedMessages,
-    derivedMessages,
-    addNewestAnswer,
-    addNewestQuestion,
-    removeLatestMessage,
-    removeMessageById,
-    removeMessagesAfterCurrentMessage,
-  } = useSelectDerivedMessages();
-  const { isNew, conversationId } = useGetChatSearchParams();
+/**
+ * Subscribes to the current conversation's entry in the chat stream store and
+ * seeds the prologue for a brand new session. Because the store lives at module
+ * level, an in-flight stream keeps updating it while this page is unmounted, so
+ * switching back re-attaches to the still-running stream.
+ */
+export const useCurrentChatSession = () => {
+  const { conversationId, isNew } = useGetChatSearchParams();
   const { id: dialogId } = useParams();
   const prologue = useFindPrologueFromDialogList();
 
-  // Per-conversation message cache so switching conversations preserves the
-  // local derivedMessages (including in-flight SSE answers) instead of wiping
-  // them. Keyed by conversationId.
-  const messagesCacheRef = useRef<Record<string, IMessage[]>>({});
-  // Tracks conversations with an in-flight SSE stream so the backend sync
-  // effect in SingleChatBox can avoid overwriting local streaming state.
-  const activeStreamsRef = useRef<Set<string>>(new Set());
-  // Tracks which conversationId the current derivedMessages belongs to, so
-  // the cache-write effect doesn't mistakenly write the previous conversation's
-  // messages into the newly switched conversation's cache entry during the
-  // render where conversationId has changed but derivedMessages hasn't yet.
-  const messagesConversationIdRef = useRef(conversationId);
+  const messages = useChatStreamMessages(conversationId);
+  const isStreaming = useIsChatStreaming(conversationId);
 
-  // On conversation switch, restore cached messages (or start empty).
-  useEffect(() => {
-    messagesConversationIdRef.current = conversationId;
-    const cached = messagesCacheRef.current[conversationId];
-    setDerivedMessages(cached ?? []);
-  }, [conversationId, setDerivedMessages]);
+  const messageContainerRef = useRef<HTMLDivElement>(null);
+  const { scrollRef } = useScrollToBottom(messages, messageContainerRef);
 
-  const addPrologue = useCallback(() => {
-    if (dialogId !== '' && isNew === 'true') {
-      const nextMessage = {
-        role: MessageType.Assistant,
-        content: prologue,
-        id: uuid(),
-        conversationId: conversationId,
-      } as IMessage;
-
-      setDerivedMessages([nextMessage]);
-    }
-  }, [conversationId, dialogId, isNew, prologue, setDerivedMessages]);
+  const ensureSession = useChatStreamStore((state) => state.ensureSession);
+  const seedPrologue = useChatStreamStore((state) => state.seedPrologue);
 
   useEffect(() => {
-    addPrologue();
-  }, [addPrologue]);
+    if (!conversationId) return;
+    ensureSession(conversationId, dialogId ?? '');
+  }, [conversationId, dialogId, ensureSession]);
 
-  // Persist current derivedMessages back into the cache for the conversation
-  // they actually belong to (not necessarily the URL's current conversationId
-  // during a switch).
   useEffect(() => {
-    messagesCacheRef.current[messagesConversationIdRef.current] = derivedMessages;
-  }, [derivedMessages]);
+    if (!conversationId || isNew !== 'true') return;
+    seedPrologue(conversationId, dialogId ?? '', prologue ?? '');
+  }, [conversationId, dialogId, isNew, prologue, seedPrologue]);
 
   return {
+    messages,
+    isStreaming,
     scrollRef,
     messageContainerRef,
-    derivedMessages,
-    addNewestAnswer,
-    addNewestQuestion,
-    removeLatestMessage,
-    removeMessageById,
-    removeMessagesAfterCurrentMessage,
-    setDerivedMessages,
-    messagesCacheRef,
-    activeStreamsRef,
   };
 };
 
-export const useSendMessage = (controller: AbortController) => {
-  const { conversationId, isNew } = useGetChatSearchParams();
+export const useSendMessage = () => {
+  const { conversationId } = useGetChatSearchParams();
+  const { t } = useTranslation();
   const { handleInputChange, value, setValue } = useHandleMessageInputChange();
 
   const { handleUploadFile, isUploading, removeFile, files, clearFiles } =
     useUploadFile();
 
   const { id: chatId } = useParams();
-  const { send, answer, done } = useSendMessageWithSse();
-  const {
-    scrollRef,
-    messageContainerRef,
-    derivedMessages,
-    addNewestAnswer,
-    addNewestQuestion,
-    removeLatestMessage,
-    removeMessageById,
-    removeMessagesAfterCurrentMessage,
-    setDerivedMessages,
-    messagesCacheRef,
-    activeStreamsRef,
-  } = useSelectNextMessages();
+  const { messages, isStreaming, scrollRef, messageContainerRef } =
+    useCurrentChatSession();
+
+  const appendQuestion = useChatStreamStore((state) => state.appendQuestion);
+  const failStream = useChatStreamStore((state) => state.failStream);
+  const consumePendingInput = useChatStreamStore(
+    (state) => state.consumePendingInput,
+  );
+  const pendingInput = useChatPendingInput(conversationId);
+  const removeMessageFromStore = useChatStreamStore(
+    (state) => state.removeMessageById,
+  );
+  const truncateAfterMessage = useChatStreamStore(
+    (state) => state.truncateAfterMessage,
+  );
+  const hydrateFromServer = useChatStreamStore(
+    (state) => state.hydrateFromServer,
+  );
+  const stopStream = useChatStreamStore((state) => state.stopStream);
 
   const sendMessage = useCallback(
     async ({
       message,
       currentConversationId,
-      messages,
+      messages: explicitMessages,
       enableInternet,
       enableThinking,
     }: {
@@ -172,52 +104,58 @@ export const useSendMessage = (controller: AbortController) => {
       messages?: IMessage[];
     } & NextMessageInputOnPressEnterParameter) => {
       const sessionId = currentConversationId ?? conversationId;
-      activeStreamsRef.current.add(sessionId);
-      try {
-        const res = await send(
-          api.completionUrl,
-          {
-            chat_id: chatId,
-            session_id: sessionId,
-            // An explicitly provided list is authoritative, even when empty
-            // (e.g. regenerating the first question must truncate history).
-            messages: [
-              ...(Array.isArray(messages) ? messages : (derivedMessages ?? [])),
-              message,
-            ],
-            pass_all_history_messages: true,
-            reasoning: Number(enableThinking),
-            internet: enableInternet,
-          },
-          controller,
-        );
 
-        if (res && (res?.response.status !== 200 || res?.data?.code !== 0)) {
-          // cancel loading
-          setValue(message.content);
-          console.info('removeLatestMessage111');
-          removeLatestMessage();
-        }
-      } finally {
-        activeStreamsRef.current.delete(sessionId);
+      const { ok, aborted } = await runChatCompletionStream({
+        conversationId: sessionId,
+        chatId,
+        // An explicitly provided list is authoritative, even when empty
+        // (e.g. regenerating the first question must truncate history).
+        messages: [
+          ...(Array.isArray(explicitMessages) ? explicitMessages : messages),
+          message,
+        ],
+        enableThinking,
+        enableInternet,
+      });
+
+      if (!ok && !aborted) {
+        // The failure can land long after the page unmounted or after the user
+        // switched conversations, so don't write to the input box here: park the
+        // text on the failing session instead, and tell the user something went
+        // wrong wherever they currently are.
+        failStream(sessionId, message.content);
+        notification.error({ message: t('message.requestError') });
       }
     },
-    [
-      derivedMessages,
-      conversationId,
-      chatId,
-      removeLatestMessage,
-      setValue,
-      send,
-      controller,
-      activeStreamsRef,
-    ],
+    [conversationId, chatId, messages, failStream, t],
+  );
+
+  // Hand a failed question back to the input box, but only once the box is
+  // empty so a message the user is currently typing is never clobbered.
+  useEffect(() => {
+    if (!pendingInput || trim(value) !== '') return;
+    consumePendingInput(conversationId);
+    setValue(pendingInput);
+  }, [pendingInput, value, conversationId, consumePendingInput, setValue]);
+
+  const removeMessagesAfterCurrentMessage = useCallback(
+    (messageId: string) => {
+      truncateAfterMessage(conversationId, messageId);
+    },
+    [conversationId, truncateAfterMessage],
+  );
+
+  const removeMessageById = useCallback(
+    (messageId: string) => {
+      removeMessageFromStore(conversationId, messageId);
+    },
+    [conversationId, removeMessageFromStore],
   );
 
   const { regenerateMessage } = useRegenerateMessage({
     removeMessagesAfterCurrentMessage,
     sendMessage,
-    messages: derivedMessages,
+    messages,
   });
 
   const { createConversationBeforeSendMessage } =
@@ -228,7 +166,7 @@ export const useSendMessage = (controller: AbortController) => {
       enableThinking,
       enableInternet,
     }: NextMessageInputOnPressEnterParameter) => {
-      if (trim(value) === '' || !done) return;
+      if (trim(value) === '' || isStreaming) return;
 
       const data = await createConversationBeforeSendMessage(value);
 
@@ -238,44 +176,54 @@ export const useSendMessage = (controller: AbortController) => {
 
       const { targetConversationId, currentMessages } = data;
 
+      // The await above can span a conversation switch, and the target session
+      // may already have a stream running.
+      if (
+        useChatStreamStore.getState().sessions[targetConversationId]
+          ?.isStreaming
+      ) {
+        return;
+      }
+
       const id = uuid();
 
-      const questionMessage = {
+      // useUploadFile tracks files as loosely typed records; narrow once here.
+      const attachedFiles = files as IMessage['files'];
+
+      const questionMessage: IMessage = {
         content: value,
-        files: files,
+        files: attachedFiles,
         id,
         role: MessageType.User,
         conversationId: targetConversationId,
       };
-      // The await on createConversationBeforeSendMessage above can span a
-      // conversation switch. Route the question to the conversation it was
-      // asked in, not whichever is currently displayed.
-      if (targetConversationId === conversationId) {
-        addNewestQuestion(questionMessage);
-      } else {
-        const cached = messagesCacheRef.current[targetConversationId] ?? [];
-        messagesCacheRef.current[targetConversationId] =
-          appendQuestionToMessages(cached, questionMessage);
-      }
 
-      if (done) {
-        setValue('');
-        sendMessage({
-          currentConversationId: targetConversationId,
-          // For an existing conversation currentMessages is empty; fall back
-          // to derivedMessages instead of sending an empty history.
-          messages: currentMessages.length > 0 ? currentMessages : undefined,
-          message: {
-            id,
-            content: value.trim(),
-            role: MessageType.User,
-            files,
-            conversationId: targetConversationId,
-          },
-          enableInternet,
-          enableThinking,
-        });
-      }
+      // Route the question to the conversation it was asked in, not whichever
+      // is currently displayed.
+      //
+      // Do NOT hydrate from currentMessages here. For a freshly created
+      // conversation the server only returns the seeded prologue, which
+      // seedPrologue has already put in the store — and hydrating now would
+      // pass the authority check (not streaming yet) and wipe the question and
+      // placeholder that were just appended.
+      appendQuestion(targetConversationId, questionMessage);
+
+      setValue('');
+      sendMessage({
+        currentConversationId: targetConversationId,
+        // For an existing conversation currentMessages is empty; fall back to
+        // the store's message list instead of sending an empty history.
+        messages: currentMessages.length > 0 ? currentMessages : undefined,
+        message: {
+          id,
+          content: value.trim(),
+          role: MessageType.User,
+          files: attachedFiles,
+          conversationId: targetConversationId,
+        },
+        enableInternet,
+        enableThinking,
+      });
 
       clearFiles();
 
@@ -292,38 +240,20 @@ export const useSendMessage = (controller: AbortController) => {
     },
     [
       value,
-      done,
+      isStreaming,
       createConversationBeforeSendMessage,
-      addNewestQuestion,
+      appendQuestion,
       files,
       clearFiles,
       setValue,
       sendMessage,
       messageContainerRef,
-      conversationId,
-      messagesCacheRef,
     ],
   );
 
-  useEffect(() => {
-    //  #1289
-    if (!answer.answer || isNew === 'true') return;
-    // Route the answer to the conversation it belongs to. answer.conversationId
-    // comes from the request body's session_id (set in useSendMessageWithSse.send),
-    // NOT from the URL, so it stays correct even after switching conversations.
-    // This prevents a background stream's answer from leaking into the currently
-    // displayed conversation, and keeps the background conversation's cache
-    // updating so switching back shows the streamed answer.
-    const targetId = answer.conversationId;
-    if (!targetId) return;
-    if (targetId === conversationId) {
-      addNewestAnswer(answer);
-    } else {
-      const cached = messagesCacheRef.current[targetId] ?? [];
-      messagesCacheRef.current[targetId] =
-        appendAnswerToMessages(cached, answer);
-    }
-  }, [answer, addNewestAnswer, conversationId, isNew, messagesCacheRef]);
+  const stopOutputMessage = useCallback(() => {
+    stopStream(conversationId);
+  }, [conversationId, stopStream]);
 
   return {
     handlePressEnter,
@@ -331,16 +261,15 @@ export const useSendMessage = (controller: AbortController) => {
     value,
     setValue,
     regenerateMessage,
-    sendLoading: !done,
+    sendLoading: isStreaming,
     scrollRef,
     messageContainerRef,
-    derivedMessages,
+    messages,
     removeMessageById,
     handleUploadFile,
     isUploading,
     removeFile,
-    setDerivedMessages,
-    messagesCacheRef,
-    activeStreamsRef,
+    hydrateFromServer,
+    stopOutputMessage,
   };
 };

--- a/web/src/services/chat-completion-stream.ts
+++ b/web/src/services/chat-completion-stream.ts
@@ -1,0 +1,113 @@
+/**
+ * Chat completion SSE streaming.
+ *
+ * NOTE on the network layering convention (see web/CLAUDE.md): this file
+ * deliberately uses the native `fetch` API instead of the shared axios instance
+ * in `@/utils/next-request`. Streaming requires access to the raw
+ * `Response.body` `ReadableStream`, which axios cannot expose in the browser.
+ * This mirrors the pre-existing SSE approach in `useSendMessageWithSse`
+ * (`src/hooks/logic-hooks.ts`), but keeps `api.completionUrl` and the parsing
+ * loop out of the hook layer.
+ */
+import { Authorization } from '@/constants/authorization';
+import { ResponseType } from '@/interfaces/database/base';
+import { IMessage } from '@/interfaces/database/chat';
+import api from '@/utils/api';
+import { getAuthorization } from '@/utils/authorization-util';
+import { EventSourceParserStream } from 'eventsource-parser/stream';
+
+export type ChatCompletionStreamParams = {
+  chatId?: string;
+  sessionId: string;
+  messages: IMessage[];
+  enableThinking?: string;
+  enableInternet?: boolean;
+};
+
+export type CompletionChunk = {
+  answer?: string;
+  final?: boolean;
+  start_to_think?: boolean;
+  end_to_think?: boolean;
+  [key: string]: any;
+};
+
+export function requestChatCompletionStream(
+  { chatId, sessionId, messages, enableThinking, enableInternet }: ChatCompletionStreamParams,
+  signal: AbortSignal,
+) {
+  return fetch(api.completionUrl, {
+    method: 'POST',
+    headers: {
+      [Authorization]: getAuthorization(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      chat_id: chatId,
+      session_id: sessionId,
+      messages,
+      pass_all_history_messages: true,
+      reasoning: Number(enableThinking),
+      internet: enableInternet,
+    }),
+    signal,
+  });
+}
+
+/**
+ * Yields each parsed SSE payload's `data` field. Terminates on stream end and
+ * on any reader error; an AbortError is rethrown so the caller can distinguish
+ * user cancellation from a genuine failure.
+ */
+export async function* parseCompletionEventStream(
+  response: Response,
+): AsyncGenerator<CompletionChunk> {
+  const reader = response.body
+    ?.pipeThrough(new TextDecoderStream())
+    .pipeThrough(new EventSourceParserStream())
+    .getReader();
+
+  if (!reader) return;
+
+  // oxlint-disable-next-line no-constant-condition
+  while (true) {
+    let chunk: Awaited<ReturnType<typeof reader.read>>;
+    try {
+      chunk = await reader.read();
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error;
+      }
+      // Any other reader failure means the stream is unusable. Unlike the
+      // legacy loop in logic-hooks.ts, break out instead of spinning forever.
+      break;
+    }
+
+    if (chunk.done) break;
+
+    let payload: any;
+    try {
+      payload = JSON.parse(chunk.value?.data || '');
+    } catch {
+      // Swallow malformed SSE payloads, matching existing behaviour.
+      continue;
+    }
+
+    const data = payload?.data;
+    // The backend signals termination with a boolean `data` field.
+    if (typeof data === 'boolean') continue;
+
+    yield data as CompletionChunk;
+  }
+}
+
+/** Reads the response body as JSON without throwing on a non-JSON body. */
+export async function readJsonSafely(
+  response: Response,
+): Promise<ResponseType | undefined> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
### Summary

fix(web): keep single-chat SSE stream alive across route changes

Asking a question and navigating away mid-answer lost the stream: the answer bubble came back empty or frozen, and the real answer only appeared once the backend had finished and the session was refetched.

All SSE state lived in component-local state and refs, so unmounting /chat/:id destroyed it. The fetch and reader loop already survived the unmount, but every chunk was written into a dead setState and silently discarded, and on return a fresh hook found an empty cache while the server had not persisted the answer yet.

Hoist the message list, the streaming flag and the AbortController into a module-level Zustand store keyed by conversation id, and move the reader loop into a plain module-level async function that writes into that store. Components become pure subscribers, so unmounting no longer touches the stream.

Scope is the single-chat path only; useSendMessageWithSse and the multi-model path are untouched. Recovery across a hard reload is out of scope, since the browser kills the request.

Also on this path:
- a server response resolving right after a stream ends can no longer truncate the finished answer (message-count comparison in hydrateFromServer), while still letting real message ids, references and out-of-band updates through
- a failed stream parks the question text on its own session instead of typing it into whichever input happens to be mounted, and now raises a notification instead of failing silently
- chunks are coalesced into one store write per 60ms and the store no longer records every chunk into Redux DevTools, which is what made navigating away mid-answer feel slow
- a non-abort reader error breaks out of the parse loop instead of spinning forever