### PR TITLE
feat(cli): add sync logs listing commands for the user CLI

### DIFF
--- a/internal/cli/README.md
+++ b/internal/cli/README.md
@@ -150,8 +150,8 @@ LIST DATASETS;
 DROP DATASET 'my_dataset';
 
 -- Data sync logs
-LIST SYNC LOGS;
-LIST DATASET 'my_dataset' SYNC LOGS;
+LIST SYNC_LOGS;
+LIST DATASET 'my_dataset' SYNC_LOGS;
 
 -- Model configuration
 SET DEFAULT LLM 'gpt-4';

--- a/internal/cli/README.md
+++ b/internal/cli/README.md
@@ -149,6 +149,10 @@ CREATE DATASET 'my_dataset' WITH EMBEDDING 'text-embedding-ada-002' PARSER 'naiv
 LIST DATASETS;
 DROP DATASET 'my_dataset';
 
+-- Data sync logs
+LIST SYNC LOGS;
+LIST DATASET 'my_dataset' SYNC LOGS;
+
 -- Model configuration
 SET DEFAULT LLM 'gpt-4';
 SET DEFAULT EMBEDDING 'text-embedding-ada-002';

--- a/internal/cli/cli_http.go
+++ b/internal/cli/cli_http.go
@@ -484,6 +484,8 @@ func (c *CLI) ExecuteUserCommand(cmd *Command) (ResponseIf, error) {
 		return c.APIStopIngestionCommand(cmd)
 	case "api_list_ingestion_tasks":
 		return c.APIListIngestionTasks(cmd)
+	case "api_list_sync_logs":
+		return c.APIListSyncLogsCommand(cmd)
 	case "api_remove_task":
 		return c.APIRemoveTaskCommand(cmd)
 	case "user_parse_local_file_command":

--- a/internal/cli/lexer.go
+++ b/internal/cli/lexer.go
@@ -411,6 +411,8 @@ func (l *Lexer) lookupIdent(ident string) Token {
 		return Token{Type: TokenAsync, Value: ident}
 	case "SYNC":
 		return Token{Type: TokenSync, Value: ident}
+	case "SYNC_LOGS":
+		return Token{Type: TokenSyncLogs, Value: ident}
 	case "BENCHMARK":
 		return Token{Type: TokenBenchmark, Value: ident}
 	case "PING":

--- a/internal/cli/response.go
+++ b/internal/cli/response.go
@@ -213,6 +213,42 @@ func (r *ListDocumentsResponse) PrintOut() {
 	}
 }
 
+type ListSyncLogsResponse struct {
+	Code         int                    `json:"code"`
+	Data         map[string]interface{} `json:"data"`
+	Message      string                 `json:"message"`
+	Duration     float64
+	OutputFormat OutputFormat
+}
+
+func (r *ListSyncLogsResponse) Type() string {
+	return "list_sync_logs"
+}
+
+func (r *ListSyncLogsResponse) TimeCost() float64 {
+	return r.Duration
+}
+
+func (r *ListSyncLogsResponse) SetOutputFormat(format OutputFormat) {
+	r.OutputFormat = format
+}
+
+func (r *ListSyncLogsResponse) PrintOut() {
+	if r.Code == 0 {
+		total := r.Data["total"].(float64)
+		fmt.Printf("Total: %0.0f\n", total)
+		logs := r.Data["logs"].([]interface{})
+		table := make([]map[string]interface{}, 0)
+		for _, log := range logs {
+			table = append(table, log.(map[string]interface{}))
+		}
+		PrintTableSimpleByFormat(table, r.OutputFormat)
+	} else {
+		fmt.Println("ERROR")
+		fmt.Printf("%d, %s\n", r.Code, r.Message)
+	}
+}
+
 type ListAgentsResponse struct {
 	Code         int                    `json:"code"`
 	Data         map[string]interface{} `json:"data"`

--- a/internal/cli/types.go
+++ b/internal/cli/types.go
@@ -129,6 +129,7 @@ const (
 	TokenDimension
 	TokenAsync
 	TokenSync
+	TokenSyncLogs
 	TokenBenchmark
 	TokenPing
 	TokenToken

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -3493,8 +3493,18 @@ func (c *CLI) APIListSyncLogsCommand(cmd *Command) (ResponseIf, error) {
 	}
 
 	url := "/connectors/sync_logs"
+	query := netUrl.Values{}
 	if datasetID != "" {
-		url = fmt.Sprintf("/connectors/sync_logs?dataset_id=%s", netUrl.QueryEscape(datasetID))
+		query.Set("dataset_id", datasetID)
+	}
+	if page, ok := cmd.Params["page"].(int); ok {
+		query.Set("page", fmt.Sprintf("%d", page))
+	}
+	if pageSize, ok := cmd.Params["page_size"].(int); ok {
+		query.Set("page_size", fmt.Sprintf("%d", pageSize))
+	}
+	if encoded := query.Encode(); encoded != "" {
+		url += "?" + encoded
 	}
 
 	resp, err := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].Request("GET", url, "web", nil, nil)

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -3467,6 +3467,50 @@ func (c *CLI) APIListIngestionTasks(cmd *Command) (ResponseIf, error) {
 	return HandleCommonResponse(resp, "list ingestion tasks")
 }
 
+// APIListSyncLogsCommand lists sync logs (user mode).
+// LIST SYNC LOGS; lists the sync logs of all datasets, and
+// LIST DATASET 'dataset_name' SYNC LOGS; follows the ingestion-tasks pattern.
+func (c *CLI) APIListSyncLogsCommand(cmd *Command) (ResponseIf, error) {
+	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
+		return nil, fmt.Errorf("API key not set. Please login first")
+	}
+
+	if c.Config.CLIMode != APIMode {
+		return nil, fmt.Errorf("this command is only allowed in USER mode")
+	}
+
+	datasetID, ok := cmd.Params["dataset_id"].(*string)
+	if !ok {
+		datasetID = nil
+	}
+
+	url := "/sync_logs"
+	if datasetID != nil && *datasetID != "" {
+		url = fmt.Sprintf("/sync_logs?dataset_id=%s", *datasetID)
+	}
+
+	resp, err := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].Request("GET", url, "web", nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sync logs: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to list sync logs: HTTP %d, body: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	var result ListSyncLogsResponse
+	if err = json.Unmarshal(resp.Body, &result); err != nil {
+		return nil, fmt.Errorf("list sync logs failed: invalid JSON (%w)", err)
+	}
+
+	if result.Code != 0 {
+		return nil, fmt.Errorf("%s", result.Message)
+	}
+	result.Duration = resp.Duration
+
+	return &result, nil
+}
+
 // APIShowLogLevelCommand sets the log level for the system.
 func (c *CLI) APIShowLogLevelCommand(cmd *Command) (ResponseIf, error) {
 	if c.Config.CLIMode != APIMode {

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -3497,11 +3497,19 @@ func (c *CLI) APIListSyncLogsCommand(cmd *Command) (ResponseIf, error) {
 	if datasetID != "" {
 		query.Set("dataset_id", datasetID)
 	}
-	if page, ok := cmd.Params["page"].(int); ok {
+	page, hasPage := cmd.Params["page"].(int)
+	pageSize, hasPageSize := cmd.Params["page_size"].(int)
+	switch {
+	case hasPage && hasPageSize:
 		query.Set("page", fmt.Sprintf("%d", page))
-	}
-	if pageSize, ok := cmd.Params["page_size"].(int); ok {
 		query.Set("page_size", fmt.Sprintf("%d", pageSize))
+	case hasPage:
+		query.Set("page", fmt.Sprintf("%d", page))
+	case hasPageSize:
+		query.Set("page_size", fmt.Sprintf("%d", pageSize))
+	default:
+		// No pagination requested: ask the API for every matching row.
+		query.Set("page_size", "0")
 	}
 	if encoded := query.Encode(); encoded != "" {
 		url += "?" + encoded

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -3492,9 +3492,9 @@ func (c *CLI) APIListSyncLogsCommand(cmd *Command) (ResponseIf, error) {
 		datasetID = id
 	}
 
-	url := "/sync_logs"
+	url := "/connectors/sync_logs"
 	if datasetID != "" {
-		url = fmt.Sprintf("/sync_logs?dataset_id=%s", netUrl.QueryEscape(datasetID))
+		url = fmt.Sprintf("/connectors/sync_logs?dataset_id=%s", netUrl.QueryEscape(datasetID))
 	}
 
 	resp, err := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].Request("GET", url, "web", nil, nil)

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -3468,8 +3468,8 @@ func (c *CLI) APIListIngestionTasks(cmd *Command) (ResponseIf, error) {
 }
 
 // APIListSyncLogsCommand lists sync logs (user mode).
-// LIST SYNC LOGS; lists the sync logs of all datasets.
-// LIST SYNC LOGS FROM 'dataset_id'; and LIST DATASET 'dataset_name' SYNC LOGS;
+// LIST SYNC_LOGS; lists the sync logs of all datasets.
+// LIST SYNC_LOGS FROM 'dataset_id'; and LIST DATASET 'dataset_name' SYNC_LOGS;
 // restrict the listing to one dataset.
 func (c *CLI) APIListSyncLogsCommand(cmd *Command) (ResponseIf, error) {
 	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {

--- a/internal/cli/user_command.go
+++ b/internal/cli/user_command.go
@@ -3468,8 +3468,9 @@ func (c *CLI) APIListIngestionTasks(cmd *Command) (ResponseIf, error) {
 }
 
 // APIListSyncLogsCommand lists sync logs (user mode).
-// LIST SYNC LOGS; lists the sync logs of all datasets, and
-// LIST DATASET 'dataset_name' SYNC LOGS; follows the ingestion-tasks pattern.
+// LIST SYNC LOGS; lists the sync logs of all datasets.
+// LIST SYNC LOGS FROM 'dataset_id'; and LIST DATASET 'dataset_name' SYNC LOGS;
+// restrict the listing to one dataset.
 func (c *CLI) APIListSyncLogsCommand(cmd *Command) (ResponseIf, error) {
 	if c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].APIKey == nil && c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].LoginToken == nil {
 		return nil, fmt.Errorf("API key not set. Please login first")
@@ -3479,14 +3480,21 @@ func (c *CLI) APIListSyncLogsCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("this command is only allowed in USER mode")
 	}
 
-	datasetID, ok := cmd.Params["dataset_id"].(*string)
-	if !ok {
-		datasetID = nil
+	datasetID := ""
+	if rawID, ok := cmd.Params["dataset_id"].(string); ok {
+		datasetID = strings.TrimSpace(rawID)
+	}
+	if datasetName, ok := cmd.Params["dataset_name"].(string); ok && datasetName != "" {
+		id, err := c.getDatasetID(datasetName)
+		if err != nil {
+			return nil, err
+		}
+		datasetID = id
 	}
 
 	url := "/sync_logs"
-	if datasetID != nil && *datasetID != "" {
-		url = fmt.Sprintf("/sync_logs?dataset_id=%s", *datasetID)
+	if datasetID != "" {
+		url = fmt.Sprintf("/sync_logs?dataset_id=%s", netUrl.QueryEscape(datasetID))
 	}
 
 	resp, err := c.APIServerClientMap[c.Config.APIClientConfig.CurrentAPIServer].Request("GET", url, "web", nil, nil)

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -248,6 +248,7 @@ func (p *Parser) parseAPIListDatasetIngestionTasks(datasetName string) (*Command
 
 // LIST SYNC LOGS;
 // LIST SYNC LOGS FROM 'dataset_id'
+// LIST SYNC LOGS [FROM 'dataset_id'] WITH PAGE 2 PAGE_SIZE 50
 func (p *Parser) parseAPIListSyncLogs() (*Command, error) {
 	p.nextToken() // consume SYNC
 
@@ -266,6 +267,11 @@ func (p *Parser) parseAPIListSyncLogs() (*Command, error) {
 			return nil, err
 		}
 		cmd.Params["dataset_id"] = datasetID
+		p.nextToken() // move past the dataset id
+	}
+
+	if err := p.parseSyncLogsWithOptions(cmd); err != nil {
+		return nil, err
 	}
 
 	// Semicolon is optional
@@ -275,7 +281,7 @@ func (p *Parser) parseAPIListSyncLogs() (*Command, error) {
 	return cmd, nil
 }
 
-// LIST DATASET 'dataset_name' SYNC LOGS;
+// LIST DATASET 'dataset_name' SYNC LOGS [WITH PAGE 2 PAGE_SIZE 50];
 func (p *Parser) parseAPIListDatasetSyncLogs(datasetName string) (*Command, error) {
 	p.nextToken() // consume SYNC
 
@@ -283,14 +289,61 @@ func (p *Parser) parseAPIListDatasetSyncLogs(datasetName string) (*Command, erro
 		return nil, fmt.Errorf("expected LOGS")
 	}
 
+	p.nextToken() // consume LOGS
+
+	cmd := NewCommand("api_list_sync_logs")
+	cmd.Params["dataset_name"] = datasetName
+
+	if err := p.parseSyncLogsWithOptions(cmd); err != nil {
+		return nil, err
+	}
+
 	// Semicolon is optional
 	if p.curToken.Type == TokenSemicolon {
 		p.nextToken()
 	}
-
-	cmd := NewCommand("api_list_sync_logs")
-	cmd.Params["dataset_name"] = datasetName
 	return cmd, nil
+}
+
+// parseSyncLogsWithOptions parses the optional WITH clause of the sync logs
+// listing commands. Only PAGE and PAGE_SIZE are accepted, both as integers,
+// mirroring the search command's space-separated WITH syntax.
+func (p *Parser) parseSyncLogsWithOptions(cmd *Command) error {
+	if p.curToken.Type != TokenWith && !(p.curToken.Type == TokenIdentifier && strings.EqualFold(p.curToken.Value, "with")) {
+		return nil
+	}
+	p.nextToken() // consume WITH
+
+	for p.curToken.Type != TokenEOF && p.curToken.Type != TokenSemicolon {
+		if p.curToken.Type == TokenComma {
+			return fmt.Errorf("syntax error: WITH options must be space-separated, not comma-separated")
+		}
+		if p.curToken.Type != TokenIdentifier {
+			break
+		}
+		paramName := strings.ToLower(p.curToken.Value)
+		p.nextToken()
+
+		if p.curToken.Type != TokenInteger {
+			if p.curToken.Type == TokenEOF || p.curToken.Type == TokenSemicolon {
+				return fmt.Errorf("WITH option %q is missing a value", paramName)
+			}
+			return fmt.Errorf("WITH option %q must be an integer, got %s", paramName, tokenTypeDescription(p.curToken.Type, p.curToken))
+		}
+		value, err := p.parseNumber()
+		if err != nil {
+			return err
+		}
+		p.nextToken()
+
+		switch paramName {
+		case "page", "page_size":
+			cmd.Params[paramName] = value
+		default:
+			return fmt.Errorf("unknown WITH option %q", paramName)
+		}
+	}
+	return nil
 }
 
 func (p *Parser) parseAPIListAgents() (*Command, error) {

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -151,6 +151,8 @@ func (p *Parser) parseAPIListCommands() (*Command, error) {
 		return p.parseAPIListAllModels()
 	case TokenIngestion:
 		return p.parseAPIListIngestionTasks()
+	case TokenSync:
+		return p.parseAPIListSyncLogs()
 	case TokenDefault:
 		return p.parseAPIListDefaultModels()
 	case TokenAvailable:
@@ -194,6 +196,8 @@ func (p *Parser) parseAPIListDatasetCommands() (*Command, error) {
 		return p.parseAPIListDatasetFiles(datasetID)
 	case TokenIngestion:
 		return p.parseAPIListDatasetIngestionTasks(datasetID)
+	case TokenSync:
+		return p.parseAPIListDatasetSyncLogs(datasetID)
 	default:
 		return nil, fmt.Errorf("unknown LIST target: %s", p.curToken.Value)
 	}
@@ -238,6 +242,53 @@ func (p *Parser) parseAPIListDatasetIngestionTasks(datasetName string) (*Command
 	}
 
 	cmd := NewCommand("api_list_ingestion_tasks")
+	cmd.Params["dataset_name"] = datasetName
+	return cmd, nil
+}
+
+// LIST SYNC LOGS;
+// LIST SYNC LOGS FROM 'dataset_id'
+func (p *Parser) parseAPIListSyncLogs() (*Command, error) {
+	p.nextToken() // consume SYNC
+
+	if p.curToken.Type != TokenLogs {
+		return nil, fmt.Errorf("expected LOGS")
+	}
+
+	p.nextToken() // consume LOGS
+
+	cmd := NewCommand("api_list_sync_logs")
+
+	if p.curToken.Type == TokenFrom {
+		p.nextToken()
+		datasetID, err := p.parseQuotedString()
+		if err != nil {
+			return nil, err
+		}
+		cmd.Params["dataset_id"] = datasetID
+	}
+
+	// Semicolon is optional
+	if p.curToken.Type == TokenSemicolon {
+		p.nextToken()
+	}
+	return cmd, nil
+}
+
+// LIST DATASET 'dataset_name' SYNC LOGS;
+func (p *Parser) parseAPIListDatasetSyncLogs(datasetName string) (*Command, error) {
+	p.nextToken() // consume SYNC
+
+	if p.curToken.Type != TokenLogs {
+		return nil, fmt.Errorf("expected LOGS")
+	}
+
+	// Semicolon is optional
+	if p.curToken.Type == TokenSemicolon {
+		p.nextToken()
+	}
+
+	cmd := NewCommand("api_list_sync_logs")
 	cmd.Params["dataset_name"] = datasetName
 	return cmd, nil
 }

--- a/internal/cli/user_parser.go
+++ b/internal/cli/user_parser.go
@@ -151,7 +151,7 @@ func (p *Parser) parseAPIListCommands() (*Command, error) {
 		return p.parseAPIListAllModels()
 	case TokenIngestion:
 		return p.parseAPIListIngestionTasks()
-	case TokenSync:
+	case TokenSyncLogs:
 		return p.parseAPIListSyncLogs()
 	case TokenDefault:
 		return p.parseAPIListDefaultModels()
@@ -196,7 +196,7 @@ func (p *Parser) parseAPIListDatasetCommands() (*Command, error) {
 		return p.parseAPIListDatasetFiles(datasetID)
 	case TokenIngestion:
 		return p.parseAPIListDatasetIngestionTasks(datasetID)
-	case TokenSync:
+	case TokenSyncLogs:
 		return p.parseAPIListDatasetSyncLogs(datasetID)
 	default:
 		return nil, fmt.Errorf("unknown LIST target: %s", p.curToken.Value)
@@ -246,17 +246,11 @@ func (p *Parser) parseAPIListDatasetIngestionTasks(datasetName string) (*Command
 	return cmd, nil
 }
 
-// LIST SYNC LOGS;
-// LIST SYNC LOGS FROM 'dataset_id'
-// LIST SYNC LOGS [FROM 'dataset_id'] WITH PAGE 2 PAGE_SIZE 50
+// LIST SYNC_LOGS;
+// LIST SYNC_LOGS FROM 'dataset_id'
+// LIST SYNC_LOGS [FROM 'dataset_id'] WITH PAGE 2 PAGE_SIZE 50
 func (p *Parser) parseAPIListSyncLogs() (*Command, error) {
-	p.nextToken() // consume SYNC
-
-	if p.curToken.Type != TokenLogs {
-		return nil, fmt.Errorf("expected LOGS")
-	}
-
-	p.nextToken() // consume LOGS
+	p.nextToken() // consume SYNC_LOGS
 
 	cmd := NewCommand("api_list_sync_logs")
 
@@ -281,15 +275,9 @@ func (p *Parser) parseAPIListSyncLogs() (*Command, error) {
 	return cmd, nil
 }
 
-// LIST DATASET 'dataset_name' SYNC LOGS [WITH PAGE 2 PAGE_SIZE 50];
+// LIST DATASET 'dataset_name' SYNC_LOGS [WITH PAGE 2 PAGE_SIZE 50];
 func (p *Parser) parseAPIListDatasetSyncLogs(datasetName string) (*Command, error) {
-	p.nextToken() // consume SYNC
-
-	if p.curToken.Type != TokenLogs {
-		return nil, fmt.Errorf("expected LOGS")
-	}
-
-	p.nextToken() // consume LOGS
+	p.nextToken() // consume SYNC_LOGS
 
 	cmd := NewCommand("api_list_sync_logs")
 	cmd.Params["dataset_name"] = datasetName

--- a/internal/cli/user_parser_test.go
+++ b/internal/cli/user_parser_test.go
@@ -179,16 +179,16 @@ func TestParseListSyncLogs(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:  "LIST SYNC LOGS",
-			input: "LIST SYNC LOGS;",
+			name:  "LIST SYNC_LOGS",
+			input: "LIST SYNC_LOGS;",
 			expected: &Command{
 				Type:   "api_list_sync_logs",
 				Params: map[string]interface{}{},
 			},
 		},
 		{
-			name:  "LIST SYNC LOGS FROM dataset_id",
-			input: "LIST SYNC LOGS FROM 'kb-1';",
+			name:  "LIST SYNC_LOGS FROM dataset_id",
+			input: "LIST SYNC_LOGS FROM 'kb-1';",
 			expected: &Command{
 				Type: "api_list_sync_logs",
 				Params: map[string]interface{}{
@@ -197,8 +197,8 @@ func TestParseListSyncLogs(t *testing.T) {
 			},
 		},
 		{
-			name:  "LIST DATASET name SYNC LOGS",
-			input: "LIST DATASET 'my dataset' SYNC LOGS;",
+			name:  "LIST DATASET name SYNC_LOGS",
+			input: "LIST DATASET 'my dataset' SYNC_LOGS;",
 			expected: &Command{
 				Type: "api_list_sync_logs",
 				Params: map[string]interface{}{
@@ -207,8 +207,8 @@ func TestParseListSyncLogs(t *testing.T) {
 			},
 		},
 		{
-			name:  "LIST SYNC LOGS WITH page and page_size",
-			input: "LIST SYNC LOGS WITH PAGE 2 PAGE_SIZE 50;",
+			name:  "LIST SYNC_LOGS WITH page and page_size",
+			input: "LIST SYNC_LOGS WITH PAGE 2 PAGE_SIZE 50;",
 			expected: &Command{
 				Type: "api_list_sync_logs",
 				Params: map[string]interface{}{
@@ -218,8 +218,8 @@ func TestParseListSyncLogs(t *testing.T) {
 			},
 		},
 		{
-			name:  "LIST SYNC LOGS FROM dataset_id WITH page",
-			input: "LIST SYNC LOGS FROM 'kb-1' WITH PAGE 3;",
+			name:  "LIST SYNC_LOGS FROM dataset_id WITH page",
+			input: "LIST SYNC_LOGS FROM 'kb-1' WITH PAGE 3;",
 			expected: &Command{
 				Type: "api_list_sync_logs",
 				Params: map[string]interface{}{
@@ -229,8 +229,8 @@ func TestParseListSyncLogs(t *testing.T) {
 			},
 		},
 		{
-			name:  "LIST DATASET name SYNC LOGS WITH page_size",
-			input: "LIST DATASET 'my dataset' SYNC LOGS WITH PAGE_SIZE 20;",
+			name:  "LIST DATASET name SYNC_LOGS WITH page_size",
+			input: "LIST DATASET 'my dataset' SYNC_LOGS WITH PAGE_SIZE 20;",
 			expected: &Command{
 				Type: "api_list_sync_logs",
 				Params: map[string]interface{}{
@@ -241,17 +241,17 @@ func TestParseListSyncLogs(t *testing.T) {
 		},
 		{
 			name:    "unknown WITH option",
-			input:   "LIST SYNC LOGS WITH FOO 1;",
+			input:   "LIST SYNC_LOGS WITH FOO 1;",
 			wantErr: true,
 		},
 		{
 			name:    "non-integer WITH option",
-			input:   "LIST SYNC LOGS WITH PAGE 'x';",
+			input:   "LIST SYNC_LOGS WITH PAGE 'x';",
 			wantErr: true,
 		},
 		{
 			name:    "comma-separated WITH options",
-			input:   "LIST SYNC LOGS WITH PAGE 2, PAGE_SIZE 50;",
+			input:   "LIST SYNC_LOGS WITH PAGE 2, PAGE_SIZE 50;",
 			wantErr: true,
 		},
 	}

--- a/internal/cli/user_parser_test.go
+++ b/internal/cli/user_parser_test.go
@@ -170,3 +170,66 @@ func TestParseAddModelWithDimensions(t *testing.T) {
 		})
 	}
 }
+
+func TestParseListSyncLogs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *Command
+	}{
+		{
+			name:  "LIST SYNC LOGS",
+			input: "LIST SYNC LOGS;",
+			expected: &Command{
+				Type:   "api_list_sync_logs",
+				Params: map[string]interface{}{},
+			},
+		},
+		{
+			name:  "LIST SYNC LOGS FROM dataset_id",
+			input: "LIST SYNC LOGS FROM 'kb-1';",
+			expected: &Command{
+				Type: "api_list_sync_logs",
+				Params: map[string]interface{}{
+					"dataset_id": "kb-1",
+				},
+			},
+		},
+		{
+			name:  "LIST DATASET name SYNC LOGS",
+			input: "LIST DATASET 'my dataset' SYNC LOGS;",
+			expected: &Command{
+				Type: "api_list_sync_logs",
+				Params: map[string]interface{}{
+					"dataset_name": "my dataset",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			cmd, err := p.Parse(APIMode)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+
+			if cmd.Type != tt.expected.Type {
+				t.Errorf("Command Type = %v, expected = %v", cmd.Type, tt.expected.Type)
+			}
+
+			gotDatasetID, _ := cmd.Params["dataset_id"].(string)
+			expectedDatasetID, _ := tt.expected.Params["dataset_id"].(string)
+			if gotDatasetID != expectedDatasetID {
+				t.Errorf("dataset_id = %v, expected = %v", gotDatasetID, expectedDatasetID)
+			}
+
+			gotDatasetName, _ := cmd.Params["dataset_name"].(string)
+			expectedDatasetName, _ := tt.expected.Params["dataset_name"].(string)
+			if gotDatasetName != expectedDatasetName {
+				t.Errorf("dataset_name = %v, expected = %v", gotDatasetName, expectedDatasetName)
+			}
+		})
+	}
+}

--- a/internal/cli/user_parser_test.go
+++ b/internal/cli/user_parser_test.go
@@ -176,6 +176,7 @@ func TestParseListSyncLogs(t *testing.T) {
 		name     string
 		input    string
 		expected *Command
+		wantErr  bool
 	}{
 		{
 			name:  "LIST SYNC LOGS",
@@ -205,12 +206,66 @@ func TestParseListSyncLogs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "LIST SYNC LOGS WITH page and page_size",
+			input: "LIST SYNC LOGS WITH PAGE 2 PAGE_SIZE 50;",
+			expected: &Command{
+				Type: "api_list_sync_logs",
+				Params: map[string]interface{}{
+					"page":      2,
+					"page_size": 50,
+				},
+			},
+		},
+		{
+			name:  "LIST SYNC LOGS FROM dataset_id WITH page",
+			input: "LIST SYNC LOGS FROM 'kb-1' WITH PAGE 3;",
+			expected: &Command{
+				Type: "api_list_sync_logs",
+				Params: map[string]interface{}{
+					"dataset_id": "kb-1",
+					"page":       3,
+				},
+			},
+		},
+		{
+			name:  "LIST DATASET name SYNC LOGS WITH page_size",
+			input: "LIST DATASET 'my dataset' SYNC LOGS WITH PAGE_SIZE 20;",
+			expected: &Command{
+				Type: "api_list_sync_logs",
+				Params: map[string]interface{}{
+					"dataset_name": "my dataset",
+					"page_size":    20,
+				},
+			},
+		},
+		{
+			name:    "unknown WITH option",
+			input:   "LIST SYNC LOGS WITH FOO 1;",
+			wantErr: true,
+		},
+		{
+			name:    "non-integer WITH option",
+			input:   "LIST SYNC LOGS WITH PAGE 'x';",
+			wantErr: true,
+		},
+		{
+			name:    "comma-separated WITH options",
+			input:   "LIST SYNC LOGS WITH PAGE 2, PAGE_SIZE 50;",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewParser(tt.input)
 			cmd, err := p.Parse(APIMode)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse() error = nil, want error")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("Parse() error = %v", err)
 			}
@@ -229,6 +284,18 @@ func TestParseListSyncLogs(t *testing.T) {
 			expectedDatasetName, _ := tt.expected.Params["dataset_name"].(string)
 			if gotDatasetName != expectedDatasetName {
 				t.Errorf("dataset_name = %v, expected = %v", gotDatasetName, expectedDatasetName)
+			}
+
+			gotPage, _ := cmd.Params["page"].(int)
+			expectedPage, _ := tt.expected.Params["page"].(int)
+			if gotPage != expectedPage {
+				t.Errorf("page = %v, expected = %v", gotPage, expectedPage)
+			}
+
+			gotPageSize, _ := cmd.Params["page_size"].(int)
+			expectedPageSize, _ := tt.expected.Params["page_size"].(int)
+			if gotPageSize != expectedPageSize {
+				t.Errorf("page_size = %v, expected = %v", gotPageSize, expectedPageSize)
 			}
 		})
 	}

--- a/internal/dao/connector.go
+++ b/internal/dao/connector.go
@@ -517,7 +517,7 @@ func (dao *ConnectorDAO) ListLogs(ctx context.Context, db *gorm.DB, tenantIDs []
 	}
 
 	var logs []*entity.ConnectorSyncLog
-	err := baseQuery.
+	query := baseQuery.
 		Select(
 			"sync_logs.id",
 			"sync_logs.connector_id",
@@ -536,10 +536,11 @@ func (dao *ConnectorDAO) ListLogs(ctx context.Context, db *gorm.DB, tenantIDs []
 			"sync_logs.status",
 		).
 		Distinct().
-		Order("sync_logs.update_date DESC").
-		Offset(offset).
-		Limit(limit).
-		Scan(&logs).Error
+		Order("sync_logs.update_date DESC")
+	if limit > 0 {
+		query = query.Offset(offset).Limit(limit)
+	}
+	err := query.Scan(&logs).Error
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/dao/connector.go
+++ b/internal/dao/connector.go
@@ -497,3 +497,52 @@ func (dao *ConnectorDAO) ListLogsByConnectorID(ctx context.Context, db *gorm.DB,
 
 	return logs, total, nil
 }
+
+// ListLogs lists sync logs for the given tenant IDs with pagination.
+// When datasetID is non-empty, only logs of that dataset are returned.
+func (dao *ConnectorDAO) ListLogs(ctx context.Context, db *gorm.DB, tenantIDs []string, datasetID string, offset, limit int) ([]*entity.ConnectorSyncLog, int64, error) {
+	baseQuery := db.WithContext(ctx).Model(&entity.SyncLogs{}).
+		Joins("JOIN connector ON sync_logs.connector_id = connector.id").
+		Joins("JOIN connector2kb ON sync_logs.connector_id = connector2kb.connector_id AND sync_logs.kb_id = connector2kb.kb_id").
+		Joins("JOIN knowledgebase ON sync_logs.kb_id = knowledgebase.id").
+		Where("connector.tenant_id IN ?", tenantIDs)
+
+	if datasetID != "" {
+		baseQuery = baseQuery.Where("sync_logs.kb_id = ?", datasetID)
+	}
+
+	var total int64
+	if err := baseQuery.Distinct("sync_logs.id").Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var logs []*entity.ConnectorSyncLog
+	err := baseQuery.
+		Select(
+			"sync_logs.id",
+			"sync_logs.connector_id",
+			"sync_logs.task_type",
+			"sync_logs.kb_id",
+			"sync_logs.update_date",
+			"sync_logs.new_docs_indexed",
+			"sync_logs.total_docs_indexed",
+			"sync_logs.docs_removed_from_index",
+			"sync_logs.error_msg",
+			"sync_logs.error_count",
+			"sync_logs.time_started",
+			"connector.refresh_freq AS refresh_freq",
+			"connector.prune_freq AS prune_freq",
+			"knowledgebase.name AS kb_name",
+			"sync_logs.status",
+		).
+		Distinct().
+		Order("sync_logs.update_date DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&logs).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return logs, total, nil
+}

--- a/internal/handler/connector.go
+++ b/internal/handler/connector.go
@@ -36,6 +36,7 @@ type connectorServiceIface interface {
 	CreateConnector(ctx context.Context, userID string, req *service.CreateConnectorRequest) (*entity.Connector, error)
 	GetConnector(ctx context.Context, connectorID, userID string) (*entity.Connector, common.ErrorCode, error)
 	ListLog(ctx context.Context, connectorID, userID string, page, pageSize int) ([]*entity.ConnectorSyncLog, int64, common.ErrorCode, error)
+	ListLogs(ctx context.Context, userID, datasetID string, page, pageSize int) ([]*entity.ConnectorSyncLog, int64, common.ErrorCode, error)
 	DeleteConnector(ctx context.Context, connectorID, userID string) (bool, common.ErrorCode, error)
 	RebuildConnector(ctx context.Context, connectorID, userID, kbID string) (bool, common.ErrorCode, error)
 	TestConnector(ctx context.Context, connectorID, userID string) error
@@ -223,6 +224,59 @@ func (h *ConnectorHandler) ListLogs(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	logs, total, code, err := h.connectorService.ListLog(ctx, c.Param("connector_id"), user.ID, page, pageSize)
+	if err != nil {
+		common.ErrorWithCode(c, code, err.Error())
+		return
+	}
+	if logs == nil {
+		logs = []*entity.ConnectorSyncLog{}
+	}
+
+	common.SuccessWithData(c, gin.H{"total": total, "logs": logs}, "success")
+}
+
+// ListSyncLogs handles GET /api/v1/sync_logs.
+// Lists sync logs for the current user; when dataset_id is provided, only
+// the logs of that dataset are returned.
+// @Summary list sync logs
+// @Description list sync logs for the current user, optionally filtered by dataset_id
+// @Tags connector
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/sync_logs [get]
+func (h *ConnectorHandler) ListSyncLogs(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		common.ErrorWithCode(c, errorCode, errorMessage)
+		return
+	}
+
+	page := 1
+	if rawPage := strings.TrimSpace(c.DefaultQuery("page", "1")); rawPage != "" {
+		parsedPage, err := strconv.Atoi(rawPage)
+		if err != nil {
+			common.ErrorWithCode(c, common.CodeArgumentError, "page must be an integer")
+			return
+		}
+		page = parsedPage
+	}
+
+	pageSize := 15
+	if rawPageSize := strings.TrimSpace(c.DefaultQuery("page_size", "15")); rawPageSize != "" {
+		parsedPageSize, err := strconv.Atoi(rawPageSize)
+		if err != nil {
+			common.ErrorWithCode(c, common.CodeArgumentError, "page_size must be an integer")
+			return
+		}
+		pageSize = parsedPageSize
+	}
+
+	datasetID := strings.TrimSpace(c.Query("dataset_id"))
+
+	ctx := c.Request.Context()
+
+	logs, total, code, err := h.connectorService.ListLogs(ctx, user.ID, datasetID, page, pageSize)
 	if err != nil {
 		common.ErrorWithCode(c, code, err.Error())
 		return

--- a/internal/handler/connector.go
+++ b/internal/handler/connector.go
@@ -254,28 +254,21 @@ func (h *ConnectorHandler) ListSyncLogs(c *gin.Context) {
 
 	page := 1
 	pageSize := 15
-	rawPage := strings.TrimSpace(c.Query("page"))
-	rawPageSize := strings.TrimSpace(c.Query("page_size"))
-	if rawPage == "" && rawPageSize == "" {
-		// No pagination requested: pageSize == 0 means list everything.
-		pageSize = 0
-	} else {
-		if rawPage != "" {
-			parsedPage, err := strconv.Atoi(rawPage)
-			if err != nil {
-				common.ErrorWithCode(c, common.CodeArgumentError, "page must be an integer")
-				return
-			}
-			page = parsedPage
+	if rawPage := strings.TrimSpace(c.Query("page")); rawPage != "" {
+		parsedPage, err := strconv.Atoi(rawPage)
+		if err != nil {
+			common.ErrorWithCode(c, common.CodeArgumentError, "page must be an integer")
+			return
 		}
-		if rawPageSize != "" {
-			parsedPageSize, err := strconv.Atoi(rawPageSize)
-			if err != nil {
-				common.ErrorWithCode(c, common.CodeArgumentError, "page_size must be an integer")
-				return
-			}
-			pageSize = parsedPageSize
+		page = parsedPage
+	}
+	if rawPageSize := strings.TrimSpace(c.Query("page_size")); rawPageSize != "" {
+		parsedPageSize, err := strconv.Atoi(rawPageSize)
+		if err != nil {
+			common.ErrorWithCode(c, common.CodeArgumentError, "page_size must be an integer")
+			return
 		}
+		pageSize = parsedPageSize
 	}
 
 	datasetID := strings.TrimSpace(c.Query("dataset_id"))

--- a/internal/handler/connector.go
+++ b/internal/handler/connector.go
@@ -253,23 +253,29 @@ func (h *ConnectorHandler) ListSyncLogs(c *gin.Context) {
 	}
 
 	page := 1
-	if rawPage := strings.TrimSpace(c.DefaultQuery("page", "1")); rawPage != "" {
-		parsedPage, err := strconv.Atoi(rawPage)
-		if err != nil {
-			common.ErrorWithCode(c, common.CodeArgumentError, "page must be an integer")
-			return
-		}
-		page = parsedPage
-	}
-
 	pageSize := 15
-	if rawPageSize := strings.TrimSpace(c.DefaultQuery("page_size", "15")); rawPageSize != "" {
-		parsedPageSize, err := strconv.Atoi(rawPageSize)
-		if err != nil {
-			common.ErrorWithCode(c, common.CodeArgumentError, "page_size must be an integer")
-			return
+	rawPage := strings.TrimSpace(c.Query("page"))
+	rawPageSize := strings.TrimSpace(c.Query("page_size"))
+	if rawPage == "" && rawPageSize == "" {
+		// No pagination requested: pageSize == 0 means list everything.
+		pageSize = 0
+	} else {
+		if rawPage != "" {
+			parsedPage, err := strconv.Atoi(rawPage)
+			if err != nil {
+				common.ErrorWithCode(c, common.CodeArgumentError, "page must be an integer")
+				return
+			}
+			page = parsedPage
 		}
-		pageSize = parsedPageSize
+		if rawPageSize != "" {
+			parsedPageSize, err := strconv.Atoi(rawPageSize)
+			if err != nil {
+				common.ErrorWithCode(c, common.CodeArgumentError, "page_size must be an integer")
+				return
+			}
+			pageSize = parsedPageSize
+		}
 	}
 
 	datasetID := strings.TrimSpace(c.Query("dataset_id"))

--- a/internal/handler/connector.go
+++ b/internal/handler/connector.go
@@ -235,7 +235,7 @@ func (h *ConnectorHandler) ListLogs(c *gin.Context) {
 	common.SuccessWithData(c, gin.H{"total": total, "logs": logs}, "success")
 }
 
-// ListSyncLogs handles GET /api/v1/sync_logs.
+// ListSyncLogs handles GET /api/v1/connectors/sync_logs.
 // Lists sync logs for the current user; when dataset_id is provided, only
 // the logs of that dataset are returned.
 // @Summary list sync logs
@@ -244,7 +244,7 @@ func (h *ConnectorHandler) ListLogs(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Success 200 {object} map[string]interface{}
-// @Router /api/v1/sync_logs [get]
+// @Router /api/v1/connectors/sync_logs [get]
 func (h *ConnectorHandler) ListSyncLogs(c *gin.Context) {
 	user, errorCode, errorMessage := GetUser(c)
 	if errorCode != common.CodeSuccess {

--- a/internal/handler/connector_test.go
+++ b/internal/handler/connector_test.go
@@ -24,6 +24,12 @@ type fakeConnectorService struct {
 	code      common.ErrorCode
 	err       error
 	html      string
+	capture   *logListCapture
+}
+
+type logListCapture struct {
+	page     int
+	pageSize int
 }
 
 func (s fakeConnectorService) ListConnectors(context.Context, string) (*service.ListConnectorsResponse, error) {
@@ -105,9 +111,13 @@ func (s fakeConnectorService) ListLog(context.Context, string, string, int, int)
 	return s.logs, s.total, common.CodeSuccess, nil
 }
 
-func (s fakeConnectorService) ListLogs(context.Context, string, string, int, int) ([]*entity.ConnectorSyncLog, int64, common.ErrorCode, error) {
+func (s fakeConnectorService) ListLogs(_ context.Context, _, _ string, page, pageSize int) ([]*entity.ConnectorSyncLog, int64, common.ErrorCode, error) {
 	if s.err != nil {
 		return nil, 0, s.code, s.err
+	}
+	if s.capture != nil {
+		s.capture.page = page
+		s.capture.pageSize = pageSize
 	}
 	return s.logs, s.total, common.CodeSuccess, nil
 }
@@ -446,6 +456,96 @@ func TestConnectorHandlerListLogs(t *testing.T) {
 				logs := data["logs"].([]interface{})
 				if len(logs) != tt.wantLogs {
 					t.Fatalf("logs=%v body=%v", logs, body)
+				}
+			}
+		})
+	}
+}
+
+func TestConnectorHandlerListSyncLogs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		query        string
+		wantCode     common.ErrorCode
+		wantMsg      string
+		wantPage     int
+		wantPageSize int
+	}{
+		{
+			name:         "no pagination params lists all",
+			query:        "",
+			wantCode:     common.CodeSuccess,
+			wantPage:     1,
+			wantPageSize: 0,
+		},
+		{
+			name:         "page only defaults page_size",
+			query:        "?page=3",
+			wantCode:     common.CodeSuccess,
+			wantPage:     3,
+			wantPageSize: 15,
+		},
+		{
+			name:         "page_size only defaults page",
+			query:        "?page_size=50",
+			wantCode:     common.CodeSuccess,
+			wantPage:     1,
+			wantPageSize: 50,
+		},
+		{
+			name:         "both params",
+			query:        "?page=2&page_size=10",
+			wantCode:     common.CodeSuccess,
+			wantPage:     2,
+			wantPageSize: 10,
+		},
+		{
+			name:     "bad page",
+			query:    "?page=abc",
+			wantCode: common.CodeArgumentError,
+			wantMsg:  "page must be an integer",
+		},
+		{
+			name:     "bad page_size",
+			query:    "?page_size=xyz",
+			wantCode: common.CodeArgumentError,
+			wantMsg:  "page_size must be an integer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := &logListCapture{}
+			h := &ConnectorHandler{connectorService: fakeConnectorService{
+				logs:    []*entity.ConnectorSyncLog{{ID: "log-1"}},
+				total:   1,
+				capture: capture,
+			}}
+			router := gin.New()
+			router.GET("/api/v1/connectors/sync_logs", func(c *gin.Context) {
+				c.Set("user", &entity.User{ID: "tenant-1"})
+				h.ListSyncLogs(c)
+			})
+
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/connectors/sync_logs"+tt.query, nil)
+			router.ServeHTTP(resp, req)
+
+			var body map[string]interface{}
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if body["code"] != float64(tt.wantCode) {
+				t.Fatalf("code=%v body=%v", body["code"], body)
+			}
+			if tt.wantMsg != "" && body["message"] != tt.wantMsg {
+				t.Fatalf("message=%v body=%v", body["message"], body)
+			}
+			if tt.wantCode == common.CodeSuccess {
+				if capture.page != tt.wantPage || capture.pageSize != tt.wantPageSize {
+					t.Fatalf("service called with page=%d page_size=%d, want %d/%d", capture.page, capture.pageSize, tt.wantPage, tt.wantPageSize)
 				}
 			}
 		})

--- a/internal/handler/connector_test.go
+++ b/internal/handler/connector_test.go
@@ -474,11 +474,11 @@ func TestConnectorHandlerListSyncLogs(t *testing.T) {
 		wantPageSize int
 	}{
 		{
-			name:         "no pagination params lists all",
+			name:         "no pagination params uses defaults",
 			query:        "",
 			wantCode:     common.CodeSuccess,
 			wantPage:     1,
-			wantPageSize: 0,
+			wantPageSize: 15,
 		},
 		{
 			name:         "page only defaults page_size",

--- a/internal/handler/connector_test.go
+++ b/internal/handler/connector_test.go
@@ -105,6 +105,13 @@ func (s fakeConnectorService) ListLog(context.Context, string, string, int, int)
 	return s.logs, s.total, common.CodeSuccess, nil
 }
 
+func (s fakeConnectorService) ListLogs(context.Context, string, string, int, int) ([]*entity.ConnectorSyncLog, int64, common.ErrorCode, error) {
+	if s.err != nil {
+		return nil, 0, s.code, s.err
+	}
+	return s.logs, s.total, common.CodeSuccess, nil
+}
+
 func (s fakeConnectorService) DeleteConnector(context.Context, string, string) (bool, common.ErrorCode, error) {
 	if s.err != nil {
 		return false, s.code, s.err

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -638,6 +638,9 @@ func (r *Router) Setup(engine *gin.Engine) {
 				connectors.POST("/:connector_id/test", r.connectorHandler.TestConnector)
 			}
 
+			// Sync logs for the current user, optionally filtered by dataset.
+			v1.GET("/sync_logs", r.connectorHandler.ListSyncLogs)
+
 			// MCP server routes.
 			mcp := v1.Group("/mcp")
 			{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -626,6 +626,8 @@ func (r *Router) Setup(engine *gin.Engine) {
 			{
 				connectors.GET("", r.connectorHandler.ListConnectors)
 				connectors.POST("", r.connectorHandler.CreateConnector)
+				// Sync logs for the current user, optionally filtered by dataset.
+				connectors.GET("/sync_logs", r.connectorHandler.ListSyncLogs)
 				connectors.POST("/google/oauth/web/start", r.connectorHandler.StartGoogleWebOAuth)
 				connectors.POST("/google/oauth/web/result", r.connectorHandler.PollGoogleWebOAuthResult)
 				connectors.POST("/box/oauth/web/start", r.connectorHandler.StartBoxWebOAuth)
@@ -637,9 +639,6 @@ func (r *Router) Setup(engine *gin.Engine) {
 				connectors.POST("/:connector_id/rebuild", r.connectorHandler.RebuildConnector)
 				connectors.POST("/:connector_id/test", r.connectorHandler.TestConnector)
 			}
-
-			// Sync logs for the current user, optionally filtered by dataset.
-			v1.GET("/sync_logs", r.connectorHandler.ListSyncLogs)
 
 			// MCP server routes.
 			mcp := v1.Group("/mcp")

--- a/internal/service/connector.go
+++ b/internal/service/connector.go
@@ -1100,15 +1100,21 @@ func (s *ConnectorService) ListLogs(ctx context.Context, userID, datasetID strin
 	}
 	tenantIDs = append(tenantIDs, userID)
 
-	if page < 1 {
-		page = 1
+	offset, limit := 0, pageSize
+	if pageSize <= 0 {
+		// pageSize == 0 means no pagination: return every matching row.
+		limit = 0
+	} else {
+		if page < 1 {
+			page = 1
+		}
+		if pageSize > 100 {
+			limit = 15
+		}
+		offset = (page - 1) * limit
 	}
-	if pageSize <= 0 || pageSize > 100 {
-		pageSize = 15
-	}
-	offset := (page - 1) * pageSize
 
-	logs, total, err := s.connectorDAO.ListLogs(ctx, dao.DB, tenantIDs, datasetID, offset, pageSize)
+	logs, total, err := s.connectorDAO.ListLogs(ctx, dao.DB, tenantIDs, datasetID, offset, limit)
 	if err != nil {
 		return nil, 0, common.CodeServerError, fmt.Errorf("failed to fetch sync logs: %w", err)
 	}

--- a/internal/service/connector.go
+++ b/internal/service/connector.go
@@ -1086,6 +1086,38 @@ func (s *ConnectorService) ListLog(ctx context.Context, connectorID, userID stri
 	return logs, total, common.CodeSuccess, nil
 }
 
+// ListLogs lists sync logs for the current user with pagination.
+// When datasetID is non-empty, only logs of that dataset are returned.
+func (s *ConnectorService) ListLogs(ctx context.Context, userID, datasetID string, page, pageSize int) ([]*entity.ConnectorSyncLog, int64, common.ErrorCode, error) {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return nil, 0, common.CodeDataError, fmt.Errorf("user_id is required")
+	}
+
+	tenantIDs, err := s.userTenantDAO.GetTenantIDsByUserID(ctx, dao.DB, userID)
+	if err != nil {
+		return nil, 0, common.CodeServerError, err
+	}
+	tenantIDs = append(tenantIDs, userID)
+
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 15
+	}
+	offset := (page - 1) * pageSize
+
+	logs, total, err := s.connectorDAO.ListLogs(ctx, dao.DB, tenantIDs, datasetID, offset, pageSize)
+	if err != nil {
+		return nil, 0, common.CodeServerError, fmt.Errorf("failed to fetch sync logs: %w", err)
+	}
+	if logs == nil {
+		logs = []*entity.ConnectorSyncLog{}
+	}
+	return logs, total, common.CodeSuccess, nil
+}
+
 func (s *ConnectorService) StartBoxWebOAuth(ctx context.Context, userID string, req *StartBoxWebOAuthRequest) (*StartBoxWebOAuthResponse, common.ErrorCode, error) {
 	var clientID, clientSecret, redirectURI string
 	if req != nil {

--- a/internal/service/connector_logs_test.go
+++ b/internal/service/connector_logs_test.go
@@ -1,0 +1,114 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"ragflow/internal/common"
+	"ragflow/internal/dao"
+	"ragflow/internal/entity"
+)
+
+func TestListLogsPaginationModes(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	if err := db.AutoMigrate(&entity.Connector{}, &entity.Connector2Kb{}, &entity.Knowledgebase{}, &entity.SyncLogs{}); err != nil {
+		t.Fatalf("migrate connector tables: %v", err)
+	}
+
+	if err := db.Create(&entity.Connector{
+		ID:          "conn-1",
+		TenantID:    "user-1",
+		Name:        "conn-1",
+		Source:      "rss",
+		InputType:   "poll",
+		Config:      entity.JSONMap{},
+		Status:      string(entity.TaskStatusDone),
+		RefreshFreq: 5,
+		PruneFreq:   5,
+		TimeoutSecs: 60,
+	}).Error; err != nil {
+		t.Fatalf("insert connector: %v", err)
+	}
+	if err := db.Create(&entity.Knowledgebase{
+		ID:        "kb-1",
+		TenantID:  "user-1",
+		Name:      "kb-1",
+		CreatedBy: "user-1",
+		EmbdID:    "embd",
+	}).Error; err != nil {
+		t.Fatalf("insert kb: %v", err)
+	}
+	if err := db.Create(&entity.Connector2Kb{
+		ID:          "conn-1-kb-1",
+		ConnectorID: "conn-1",
+		KbID:        "kb-1",
+		AutoParse:   "1",
+	}).Error; err != nil {
+		t.Fatalf("insert connector2kb: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := db.Create(&entity.SyncLogs{
+			ID:          fmt.Sprintf("task-%d", i),
+			ConnectorID: "conn-1",
+			KbID:        "kb-1",
+			TaskType:    dao.TaskTypeSync,
+			Status:      dao.SyncStatusDone,
+			ErrorMsg:    "",
+		}).Error; err != nil {
+			t.Fatalf("insert sync log %d: %v", i, err)
+		}
+	}
+
+	svc := NewConnectorService()
+	ctx := context.Background()
+
+	all, total, code, err := svc.ListLogs(ctx, "user-1", "", 1, 0)
+	if err != nil || code != common.CodeSuccess {
+		t.Fatalf("ListLogs(all): code=%v err=%v", code, err)
+	}
+	if total != 5 || len(all) != 5 {
+		t.Fatalf("ListLogs(all) = total %d len %d, want 5/5", total, len(all))
+	}
+
+	first, total, code, err := svc.ListLogs(ctx, "user-1", "", 1, 2)
+	if err != nil || code != common.CodeSuccess {
+		t.Fatalf("ListLogs(page): code=%v err=%v", code, err)
+	}
+	if total != 5 || len(first) != 2 {
+		t.Fatalf("ListLogs(page) = total %d len %d, want 5/2", total, len(first))
+	}
+
+	second, total, code, err := svc.ListLogs(ctx, "user-1", "", 2, 2)
+	if err != nil || code != common.CodeSuccess {
+		t.Fatalf("ListLogs(page2): code=%v err=%v", code, err)
+	}
+	if total != 5 || len(second) != 2 {
+		t.Fatalf("ListLogs(page2) = total %d len %d, want 5/2", total, len(second))
+	}
+
+	normalized, total, code, err := svc.ListLogs(ctx, "user-1", "", 0, 101)
+	if err != nil || code != common.CodeSuccess {
+		t.Fatalf("ListLogs(normalize): code=%v err=%v", code, err)
+	}
+	if total != 5 || len(normalized) != 5 {
+		t.Fatalf("ListLogs(normalize) = total %d len %d, want 5/5", total, len(normalized))
+	}
+}

--- a/internal/syncer/scheduler.go
+++ b/internal/syncer/scheduler.go
@@ -165,7 +165,6 @@ func (s *Scheduler) queueAvailable() int {
 
 // publishStartupTasks scan DB for first time run
 func (s *Scheduler) publishStartupTasks(ctx context.Context) error {
-	// TODO restores running tasks during syncer startup.
 	if err := s.taskService.RecoverRunning(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary
```
RAGFlow(api/default)> LIST SYNC LOGS WITH PAGE_SIZE 2 PAGE 2;
Total: 764
+----------------------------------+-------------------------+-------------+-----------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+
| connector_id                     | docs_removed_from_index | error_count | error_msg | id                               | kb_id                            | kb_name | new_docs_indexed | prune_freq | refresh_freq | status | task_type | time_started        | total_docs_indexed | update_date         |
+----------------------------------+-------------------------+-------------+-----------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |           | fb55b5f1fb754475834cd9eac8b52054 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:45 | 16                 | 2026-08-13 09:49:46 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |           | 3cad779d7d2e4efb8d8d2dbf05d45653 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:42 | 16                 | 2026-08-13 09:49:43 |
+----------------------------------+-------------------------+-------------+-----------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+

```
```
RAGFlow(api/default)> LIST SYNC LOGS;
Total: 764
+----------------------------------+-------------------------+-------------+--------------------------------------------------------------------------------------------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+
| connector_id                     | docs_removed_from_index | error_count | error_msg                                                                                  | id                               | kb_id                            | kb_name | new_docs_indexed | prune_freq | refresh_freq | status | task_type | time_started        | total_docs_indexed | update_date         |
+----------------------------------+-------------------------+-------------+--------------------------------------------------------------------------------------------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 1           | sync task failed: failed to fetch URL: Get "https://xxxxxxxxxxxx/rss.xml": EOF             | 87592e5623fc4284bf69b9290f322718 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 4      | sync      | 2026-08-13 09:49:48 | 16                 | 2026-08-13 09:51:01 |
| 570138201cf44e1180711f1ebdf8492f | 0                       | 1           | sync task failed: failed to fetch URL: Get "https://www.ruanyifeng.com/blog/atom.xml": EOF | 456adbbf21a147af99adfce4405abd99 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 1            | 4      | sync      | 2026-08-13 09:50:00 | 3                  | 2026-08-13 09:50:18 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | fb55b5f1fb754475834cd9eac8b52054 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:45 | 16                 | 2026-08-13 09:49:46 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 3cad779d7d2e4efb8d8d2dbf05d45653 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:42 | 16                 | 2026-08-13 09:49:43 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | dd09320aa5b34d6cbcfa7b03ede68c4a | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:36 | 16                 | 2026-08-13 09:49:38 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | afbcee73240f420ca1997e6506f387fb | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:33 | 16                 | 2026-08-13 09:49:34 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 7d018146a0f14a25b7263d5980fdc30f | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:30 | 16                 | 2026-08-13 09:49:32 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 520e0d6f421e40628ab541fc4fee1a69 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:27 | 16                 | 2026-08-13 09:49:28 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 3d3ce49825de4ef99642e7994ae954e3 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:21 | 16                 | 2026-08-13 09:49:22 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 1c511f9b4a7c425fb30a956589ca56fa | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:18 | 16                 | 2026-08-13 09:49:19 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | b9ab73c3f48c4f47a84fd55b542b32b4 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:15 | 16                 | 2026-08-13 09:49:16 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | db0cad90a7744d758b24d2e3d3828963 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:12 | 16                 | 2026-08-13 09:49:13 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | a501eadb2cce452187f3c86431352c70 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:08 | 16                 | 2026-08-13 09:49:10 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | b4265a3b7baf4466a525b91a9fe21b71 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:03 | 16                 | 2026-08-13 09:49:05 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | a6ad590931c046dda5fc3222b4010c06 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:00 | 16                 | 2026-08-13 09:49:02 |
......
+----------------------------------+-------------------------+-------------+--------------------------------------------------------------------------------------------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+

```
list all logs
```
RAGFlow(api/default)> LIST DATASET 'test' SYNC LOGS;
Total: 764
+----------------------------------+-------------------------+-------------+--------------------------------------------------------------------------------------------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+
| connector_id                     | docs_removed_from_index | error_count | error_msg                                                                                  | id                               | kb_id                            | kb_name | new_docs_indexed | prune_freq | refresh_freq | status | task_type | time_started        | total_docs_indexed | update_date         |
+----------------------------------+-------------------------+-------------+--------------------------------------------------------------------------------------------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 1           | sync task failed: failed to fetch URL: Get "https://xxxxxxxxxxxx/rss.xml": EOF             | 87592e5623fc4284bf69b9290f322718 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 4      | sync      | 2026-08-13 09:49:48 | 16                 | 2026-08-13 09:51:01 |
| 570138201cf44e1180711f1ebdf8492f | 0                       | 1           | sync task failed: failed to fetch URL: Get "https://www.ruanyifeng.com/blog/atom.xml": EOF | 456adbbf21a147af99adfce4405abd99 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 1            | 4      | sync      | 2026-08-13 09:50:00 | 3                  | 2026-08-13 09:50:18 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | fb55b5f1fb754475834cd9eac8b52054 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:45 | 16                 | 2026-08-13 09:49:46 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 3cad779d7d2e4efb8d8d2dbf05d45653 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:42 | 16                 | 2026-08-13 09:49:43 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | dd09320aa5b34d6cbcfa7b03ede68c4a | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:36 | 16                 | 2026-08-13 09:49:38 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | afbcee73240f420ca1997e6506f387fb | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:33 | 16                 | 2026-08-13 09:49:34 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 7d018146a0f14a25b7263d5980fdc30f | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:30 | 16                 | 2026-08-13 09:49:32 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 520e0d6f421e40628ab541fc4fee1a69 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:27 | 16                 | 2026-08-13 09:49:28 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 3d3ce49825de4ef99642e7994ae954e3 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:21 | 16                 | 2026-08-13 09:49:22 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | 1c511f9b4a7c425fb30a956589ca56fa | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:18 | 16                 | 2026-08-13 09:49:19 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | b9ab73c3f48c4f47a84fd55b542b32b4 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:15 | 16                 | 2026-08-13 09:49:16 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | db0cad90a7744d758b24d2e3d3828963 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:12 | 16                 | 2026-08-13 09:49:13 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | a501eadb2cce452187f3c86431352c70 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:08 | 16                 | 2026-08-13 09:49:10 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | b4265a3b7baf4466a525b91a9fe21b71 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:03 | 16                 | 2026-08-13 09:49:05 |
| 02b5b14183884445bd55ad6b9d322204 | 0                       | 0           |                                                                                            | a6ad590931c046dda5fc3222b4010c06 | 0e6e28e65b7044e58070e0e4252319a6 | test    | 0                | 5          | 0            | 3      | sync      | 2026-08-13 09:49:00 | 16                 | 2026-08-13 09:49:02 |
......
+----------------------------------+-------------------------+-------------+--------------------------------------------------------------------------------------------+----------------------------------+----------------------------------+---------+------------------+------------+--------------+--------+-----------+---------------------+--------------------+---------------------+
```
