### PR TITLE
fix: align shared search result total

### DIFF
--- a/api/apps/restful_apis/bot_api.py
+++ b/api/apps/restful_apis/bot_api.py
@@ -462,6 +462,7 @@ async def retrieval_test_embedded(tenant_id=None):
             enrich_chunks_with_document_metadata(ranks["chunks"], metadata_fields)
 
         ranks["labels"] = labels
+        ranks["total"] = len(ranks["chunks"])
 
         return get_json_result(data=ranks)
 


### PR DESCRIPTION
### What problem does this PR solve?

Align the shared search retrieval API's `total` with the number of chunks actually returned, ensuring consistent result counts between shared and regular search pages.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)