### PR TITLE
fix: clear stale tenant model ids

### DIFF
--- a/web/src/utils/llm-util.ts
+++ b/web/src/utils/llm-util.ts
@@ -199,17 +199,26 @@ export function addTenantParams(data: any, url?: string): any {
     return data;
   }
 
-  const llmList = getCachedLlmList();
-  if (!llmList) return data;
-
   // Handle arrays
   if (Array.isArray(data)) {
     return data.map((item) => addTenantParams(item, url));
   }
 
   const newData = { ...data };
+  const llmList = getCachedLlmList();
 
-  // Iterate through model parameters and add corresponding tenant parameters
+  // Clear the paired tenant ID when a model selection is explicitly cleared.
+  for (const [paramName, tenantParamName] of Object.entries(modelParamMap)) {
+    if (
+      Object.hasOwn(newData, paramName) &&
+      (newData[paramName] === '' || newData[paramName] == null)
+    ) {
+      newData[tenantParamName] = null;
+    }
+  }
+
+  if (!llmList) return newData;
+
   for (const [paramName, tenantParamName] of Object.entries(modelParamMap)) {
     if (newData[paramName]) {
       try {

--- a/web/src/utils/tests/llm-util.test.ts
+++ b/web/src/utils/tests/llm-util.test.ts
@@ -1,4 +1,5 @@
 import {
+  addTenantParams,
   buildModelValue,
   getEmbeddingBaseName,
   parseModelUuid,
@@ -158,5 +159,31 @@ describe('getEmbeddingBaseName — dataset co-selection grouping', () => {
   test('empty and undefined values produce an empty base name', () => {
     expect(getEmbeddingBaseName('')).toBe('');
     expect(getEmbeddingBaseName(undefined)).toBe('');
+  });
+});
+
+describe('addTenantParams — clearing model selections', () => {
+  test('clears a stale tenant rerank model id when rerank is explicitly cleared', () => {
+    expect(
+      addTenantParams(
+        {
+          rerank_id: '',
+          tenant_rerank_id: 'stale-tenant-model-id',
+        },
+        '/api/v1/chats/chat-id',
+      ),
+    ).toEqual({
+      rerank_id: '',
+      tenant_rerank_id: null,
+    });
+  });
+
+  test('preserves the tenant rerank model id when rerank is not part of the request', () => {
+    expect(
+      addTenantParams(
+        { tenant_rerank_id: 'existing-tenant-model-id' },
+        '/api/v1/chats/chat-id',
+      ),
+    ).toEqual({ tenant_rerank_id: 'existing-tenant-model-id' });
   });
 });


### PR DESCRIPTION
### Summary

Clear the paired tenant model ID when a model selection is explicitly cleared in a whitelisted API request.

Chat settings currently merge the fetched chat object into the update payload. Clearing the rerank selector sets `rerank_id` to an empty string, but the previously fetched `tenant_rerank_id` remains in the payload. The backend then resolves that stale tenant model ID back into the rerank model name, so reranking stays enabled after the user saves the cleared selection.

This change makes `addTenantParams` set the paired `tenant_*_id` to `null` when the corresponding model field is explicitly `""`, `null`, or `undefined`. Requests that omit the model field continue to preserve an existing tenant model ID.

### User impact

Users can clear the rerank model in chat settings without the previous tenant-scoped model ID silently restoring it. The same synchronization rule applies to other model selectors handled by `addTenantParams`.

### Validation

- `npm test -- --runInBand src/utils/tests/llm-util.test.ts` (20 tests passed)
- `npx oxlint src/utils/llm-util.ts src/utils/tests/llm-util.test.ts`
- `npx oxfmt --check src/utils/llm-util.ts src/utils/tests/llm-util.test.ts`
- `git diff --check`
