### PR TITLE
fix(web): seed new conversation from server prologue before appending question

### DIFF
--- a/web/src/pages/next-chats/hooks/use-send-chat-message.ts
+++ b/web/src/pages/next-chats/hooks/use-send-chat-message.ts
@@ -7,6 +7,7 @@ import {
 } from '@/hooks/logic-hooks';
 import { useGetChatSearchParams } from '@/hooks/use-chat-request';
 import { IMessage } from '@/interfaces/database/chat';
+import { buildMessageListWithUuid } from '@/utils/chat';
 import notification from '@/utils/notification';
 import { trim } from 'lodash';
 import { useCallback, useEffect, useRef } from 'react';
@@ -198,14 +199,21 @@ export const useSendMessage = () => {
         conversationId: targetConversationId,
       };
 
+      // A brand new conversation is persisted under a server-generated id, so
+      // the prologue seeded on the temporary id doesn't carry over. Seed the
+      // real session from the server's list (which holds just the prologue)
+      // BEFORE appending the question — hydrating afterwards would pass the
+      // authority check (not streaming yet) and wipe the question and
+      // placeholder that were just appended.
+      if (currentMessages.length > 0) {
+        hydrateFromServer(
+          targetConversationId,
+          buildMessageListWithUuid(currentMessages),
+        );
+      }
+
       // Route the question to the conversation it was asked in, not whichever
       // is currently displayed.
-      //
-      // Do NOT hydrate from currentMessages here. For a freshly created
-      // conversation the server only returns the seeded prologue, which
-      // seedPrologue has already put in the store — and hydrating now would
-      // pass the authority check (not streaming yet) and wipe the question and
-      // placeholder that were just appended.
       appendQuestion(targetConversationId, questionMessage);
 
       setValue('');
@@ -243,6 +251,7 @@ export const useSendMessage = () => {
       isStreaming,
       createConversationBeforeSendMessage,
       appendQuestion,
+      hydrateFromServer,
       files,
       clearFiles,
       setValue,


### PR DESCRIPTION
### Summary

fix(web): seed new conversation from server prologue before appending question

A freshly created conversation is persisted under a server-generated id, so the prologue seeded on the temporary id never carries over and the first answer rendered without it. Hydrate the real session id from the server list before appending the question, so the ordering doesn't trip the streaming authority check and wipe the just-appended question and placeholder.
