### PR TITLE
docs: fix broken PaddleOCR serving link in FAQ

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -724,7 +724,7 @@ This method uses PaddleOCR's official API service with an access token.
 This method allows you to deploy your own PaddleOCR service and use it without an access token.
 
 **Step 1: Deploy PaddleOCR Service**
-Follow the [PaddleOCR serving documentation](https://www.paddleocr.ai/latest/en/version3.x/deployment/serving.html) to deploy your own service. For layout parsing, you can use an endpoint like:
+Follow the [PaddleOCR serving documentation](https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/serving/serving.html) to deploy your own service. For layout parsing, you can use an endpoint like:
 
 ```bash
 http://localhost:8080/layout-parsing


### PR DESCRIPTION
The PaddleOCR serving docs moved, so the link in the FAQ currently 404s:

`https://www.paddleocr.ai/latest/en/version3.x/deployment/serving.html` -> 404

Updated to where the page lives now:

`https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/serving/serving.html`

Found while following the "Deploy PaddleOCR Service" steps in the FAQ.