### PR TITLE
fix(web): preserve leading whitespace in chunk card content

### DIFF
--- a/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-card/index.tsx
+++ b/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-card/index.tsx
@@ -128,11 +128,10 @@ const ChunkCard = ({
         >
           <div
             dangerouslySetInnerHTML={{
-              __html: sanitizeHtmlWithImagesAsText(item.content_with_weight).trim(),
+              __html: sanitizeHtmlWithImagesAsText(item.content_with_weight),
             }}
             className={classNames(
-              // Keep whitespaces?
-              'text-wrap break-words whitespace-pre',
+              'whitespace-pre-wrap break-words',
               textMode === ChunkTextMode.Ellipse && 'line-clamp-3',
             )}
           />


### PR DESCRIPTION
### Problem

Manually added chunks in an empty document may start with spaces, but the chunk list card trimmed the content before rendering, so the leading whitespace was invisible in the chunk list even though it is stored and returned by the backend API as-is.

### Root cause

`web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-card/index.tsx` called `.trim()` on the sanitized chunk content, and rendered it with `whitespace-pre`, which does not wrap long lines.

### Fix

- Drop the `.trim()` so the original content (including leading spaces) is rendered as returned by the API.
- Render with `whitespace-pre-wrap break-words` so whitespace is preserved while long lines still wrap.

The retrieval testing page (`dataset/testing/testing-result.tsx`) already renders `content_with_weight` with `whitespace-pre-wrap`, so it is unaffected.

### Verification

- Reproduced with a manually added chunk whose content starts with 4 spaces: leading spaces are now visible in the chunk list (DOM confirms `whitespace-pre-wrap` and preserved leading spaces in `textContent`).
- Retrieval testing displays the same chunk with leading spaces intact.
- `oxlint` and `oxfmt` pass on the changed file; no new type-check errors introduced (remaining `tsc --noEmit` errors are pre-existing on main).