### PR TITLE
fix(ingestion): key metadata LLM cache by resolved model (D25)

### DIFF
--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -536,8 +536,15 @@ type extractorInputs struct {
 	llmID        string
 	systemPrompt string
 	prompt       string
-	lang         string
-	chunks       []map[string]any
+	// cacheModel is the model identity used to key the metadata LLM cache,
+	// resolved once per Invoke in runAutoExtractions (D25). When llm_id is
+	// empty it holds the tenant default chat model ref so the key keeps a
+	// real model identity instead of an empty segment (which would collide
+	// across tenants and go stale after the default model changes). Empty
+	// elsewhere falls back to llmID in runEnableMetadata.
+	cacheModel string
+	lang       string
+	chunks     []map[string]any
 	// temperature overrides the LLM temperature for this call. A
 	// nil value leaves the request's Temperature unset so the model
 	// (or the chat-model default) decides, matching Python's generic
@@ -823,6 +830,13 @@ func (c *ExtractorComponent) runAutoExtractions(ctx context.Context, db *gorm.DB
 	if c.Param.AutoKeywords == 0 && c.Param.AutoQuestions == 0 && c.Param.EnableMetadata == 0 {
 		return nil
 	}
+	// Resolve the metadata cache key model once per invocation, not per
+	// chunk (D25): every chunk job shares the same llm_id / tenant context,
+	// so a per-chunk resolve would fan N identical tenant queries through
+	// the pool workers. Only pay it when metadata extraction actually runs.
+	if c.Param.EnableMetadata > 0 && len(c.Param.Metadata) > 0 {
+		in.cacheModel = resolveMetadataCacheModel(ctx, db, in.llmID)
+	}
 	futs := make([]utility.WorkerPoolFuture[extractorJob, struct{}], 0, len(in.chunks))
 	for i, ck := range in.chunks {
 		i, ck := i, ck
@@ -919,8 +933,14 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 	// repeated runs / identical chunks don't re-pay the LLM call.
 	// Best-effort: a missing Redis client or any cache error falls through to
 	// a live call instead of failing the extraction.
+	// cacheModel is populated per-invocation in runAutoExtractions; direct
+	// callers (tests) leave it empty, in which case the raw llmID is used.
+	keyModel := in.cacheModel
+	if keyModel == "" {
+		keyModel = in.llmID
+	}
 	var parsed map[string]any
-	if cached, hit := getMetadataLLMCache(ctx, in.llmID, schemaStr, chunkText); hit {
+	if cached, hit := getMetadataLLMCache(ctx, keyModel, schemaStr, chunkText); hit {
 		parsed = cached
 	} else {
 		metaTemp := extractorTemperature
@@ -940,7 +960,7 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 			// empty result rather than failing the chunk.
 			return nil
 		}
-		setMetadataLLMCache(ctx, in.llmID, schemaStr, chunkText, parsed)
+		setMetadataLLMCache(ctx, keyModel, schemaStr, chunkText, parsed)
 	}
 	// Merge into the chunk metadata map, preserving existing keys.
 	var meta map[string]any
@@ -960,6 +980,38 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 	}
 	ck["metadata"] = meta
 	return nil
+}
+
+// resolveMetadataCacheModel returns the model identity to key the metadata
+// LLM cache on. A bare llm_id ("") means "tenant default chat model" — the
+// live call resolves it through resolveExtractorChatDefaultConfig — but the
+// raw empty string must not be hashed into the key: Python keys on the
+// resolved chat_mdl.llm_name (task_executor.py:540/547), so an empty model
+// segment would collide across tenants and go stale for 24h after the tenant
+// default model changes (D25). Non-empty llm_id passes through unchanged,
+// preserving the exact cache behavior of the ingestion path.
+// Returns "" only in the degenerate case (no tenant context / no default
+// model) where the extraction call would have no model to run anyway.
+func resolveMetadataCacheModel(ctx context.Context, db *gorm.DB, llmID string) string {
+	if llmID != "" {
+		return llmID
+	}
+	if db == nil {
+		db = dao.DB
+	}
+	if db == nil {
+		return ""
+	}
+	state, _, err := runtime.GetStateFromContext[*runtime.CanvasState](ctx)
+	if err != nil || state == nil {
+		return ""
+	}
+	tidVal, _ := state.GetGlobal("tenant_id")
+	tid, _ := tidVal.(string)
+	if tid == "" {
+		return ""
+	}
+	return defaultChatModelRef(ctx, db, tid)
 }
 
 // metadataLLMCacheTTL mirrors Python get_llm_cache/set_llm_cache 24h TTL.

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -986,7 +986,7 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 // LLM cache on. A bare llm_id ("") means "tenant default chat model" — the
 // live call resolves it through resolveExtractorChatDefaultConfig — but the
 // raw empty string must not be hashed into the key: Python keys on the
-// resolved chat_mdl.llm_name (task_executor.py:540/547), so an empty model
+// resolved chat_mdl.llm_name (task_executor.py:543/550), so an empty model
 // segment would collide across tenants and go stale for 24h after the tenant
 // default model changes (D25). Non-empty llm_id passes through unchanged,
 // preserving the exact cache behavior of the ingestion path.

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -959,6 +959,48 @@ func TestExtractorComponent_runEnableMetadata_DegradesGracefully(t *testing.T) {
 	}
 }
 
+// TestResolveMetadataCacheModel_NonEmptyShortCircuits pins that a non-empty
+// llm_id is returned unchanged (D25): the ingestion path always injects
+// llm_id, so its cache key must not be perturbed by the tenant-default
+// resolution. This is the guard that keeps the fix from touching the hot path.
+func TestResolveMetadataCacheModel_NonEmptyShortCircuits(t *testing.T) {
+	got := resolveMetadataCacheModel(t.Context(), nil, "model-uuid")
+	if got != "model-uuid" {
+		t.Fatalf("resolveMetadataCacheModel(non-empty) = %q, want the input unchanged", got)
+	}
+}
+
+// TestResolveMetadataCacheModel_EmptyNoState_ReturnsEmpty pins the safe
+// degenerate path (D25): with no CanvasState / tenant context the resolver
+// must return "" rather than panic or invent a model — the same case that
+// would leave the extraction with no model to call anyway.
+func TestResolveMetadataCacheModel_EmptyNoState_ReturnsEmpty(t *testing.T) {
+	if got := resolveMetadataCacheModel(t.Context(), nil, ""); got != "" {
+		t.Fatalf("resolveMetadataCacheModel(empty, no state) = %q, want empty", got)
+	}
+}
+
+// TestExtractorComponent_runEnableMetadata_UsesCacheModel verifies the
+// per-invocation cache model identity (populated by runAutoExtractions) is
+// consumed by the metadata path without breaking extraction: a cacheModel that
+// differs from llmID must still produce a normal extraction (D25).
+func TestExtractorComponent_runEnableMetadata_UsesCacheModel(t *testing.T) {
+	withStubChatInvoker(t, stubResponse{Content: `{"category":"finance"}`})
+	c := newMetadataExtractor(common.MetadataFieldDef{Key: "category", Type: "string"})
+	ck := map[string]any{}
+	if err := c.runEnableMetadata(t.Context(), nil,
+		extractorInputs{llmID: "m", cacheModel: "tenant-default-ref"}, ck, "chunk text"); err != nil {
+		t.Fatalf("runEnableMetadata: %v", err)
+	}
+	meta, ok := ck["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("ck[metadata] missing or wrong type: %T", ck["metadata"])
+	}
+	if meta["category"] != "finance" {
+		t.Errorf("metadata = %v, want category=finance", meta)
+	}
+}
+
 // TestExtractorComponent_runEnableMetadata_CrossChunkUnion simulates two chunks
 // whose extraction returns overlapping list values for the same key. Aggregating
 // the chunk metadata maps with utility.UpdateMetadataTo (as mergeChunkMetadata

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -1001,6 +1001,109 @@ func TestExtractorComponent_runEnableMetadata_UsesCacheModel(t *testing.T) {
 	}
 }
 
+// TestResolveMetadataCacheModel_EmptyWithPinnedDefault verifies the core D25
+// fix path: an empty llm_id resolves to the tenant's pinned default chat
+// model (tenant_model UUID) when CanvasState carries tenant_id — the identity
+// that must be hashed into the cache key instead of an empty segment.
+func TestResolveMetadataCacheModel_EmptyWithPinnedDefault(t *testing.T) {
+	db := openExtractorContextTestDB(t)
+	seedExtractorContextModel(t, db, "0123456789abcdef0123456789abcdef")
+	ctx := extractorStateCtx(t, "tenant-1")
+
+	if got := resolveMetadataCacheModel(ctx, db, ""); got != "0123456789abcdef0123456789abcdef" {
+		t.Fatalf("resolveMetadataCacheModel(empty, pinned default) = %q, want the tenant_model UUID", got)
+	}
+}
+
+// TestResolveMetadataCacheModel_EmptyWithCompositeDefault verifies the D25
+// fix path for a tenant whose default chat model is the composite
+// "model@provider" ref (no tenant_model pinned).
+func TestResolveMetadataCacheModel_EmptyWithCompositeDefault(t *testing.T) {
+	db := openExtractorContextTestDB(t)
+	seedExtractorContextModel(t, db, "")
+	ctx := extractorStateCtx(t, "tenant-1")
+
+	if got := resolveMetadataCacheModel(ctx, db, ""); got != "gpt-4o@openai" {
+		t.Fatalf("resolveMetadataCacheModel(empty, composite default) = %q, want gpt-4o@openai", got)
+	}
+}
+
+// TestResolveMetadataCacheModel_CrossTenantDefaultsDiffer pins the D25
+// isolation guarantee at the resolver level: two tenants with different
+// default chat models resolve to different cache model refs, so identical
+// chunk text + schema can no longer collide on one Redis key.
+func TestResolveMetadataCacheModel_CrossTenantDefaultsDiffer(t *testing.T) {
+	db := openExtractorContextTestDB(t)
+	seedExtractorContextModel(t, db, "0123456789abcdef0123456789abcdef")
+	// Second tenant with a different composite default (no tenant_model pinned).
+	status := "1"
+	if err := db.Create(&entity.Tenant{ID: "tenant-2", LLMID: "claude-3@anthropic", Status: &status}).Error; err != nil {
+		t.Fatalf("create second tenant: %v", err)
+	}
+	ctxA := extractorStateCtx(t, "tenant-1")
+	ctxB := extractorStateCtx(t, "tenant-2")
+
+	refA := resolveMetadataCacheModel(ctxA, db, "")
+	refB := resolveMetadataCacheModel(ctxB, db, "")
+	if refA == "" || refB == "" {
+		t.Fatalf("both tenants must resolve a default model, got refA=%q refB=%q", refA, refB)
+	}
+	if refA == refB {
+		t.Fatalf("tenants with different defaults must resolve different refs, both = %q", refA)
+	}
+}
+
+// TestResolveMetadataCacheModel_EmptyNoDefaultModel pins the fallback when a
+// tenant has no default chat model at all: the resolver returns "" and
+// runEnableMetadata falls back to the raw llm_id (pre-D25 behavior) rather
+// than inventing a model — matching the live call, which would have no model
+// to run either.
+func TestResolveMetadataCacheModel_EmptyNoDefaultModel(t *testing.T) {
+	db := openExtractorContextTestDB(t)
+	status := "1"
+	if err := db.Create(&entity.Tenant{ID: "tenant-1", LLMID: "", Status: &status}).Error; err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	ctx := extractorStateCtx(t, "tenant-1")
+
+	if got := resolveMetadataCacheModel(ctx, db, ""); got != "" {
+		t.Fatalf("resolveMetadataCacheModel(empty, no default model) = %q, want empty", got)
+	}
+}
+
+// TestMetadataLLMCacheKey_ModelIsolation pins the D25 cache-key contract at
+// the key level: the model segment must isolate entries, so a resolved model
+// ref produces a different key than another ref or than the empty pre-fix
+// segment, while identical inputs stay deterministic. get/setMetadataLLMCache
+// are thin wrappers around this key, so the isolation holds for both cache
+// reads and writes.
+func TestMetadataLLMCacheKey_ModelIsolation(t *testing.T) {
+	const (
+		schema = `{"type":"object","properties":{"category":{"type":"string"}}}`
+		text   = "identical chunk text across tenants"
+	)
+
+	keyA := metadataLLMCacheKey("tenant-a-default-ref", schema, text)
+	keyB := metadataLLMCacheKey("tenant-b-default-ref", schema, text)
+	if keyA == keyB {
+		t.Fatalf("different model refs must not share a cache key (D25 cross-tenant collision): both %q", keyA)
+	}
+	if got := metadataLLMCacheKey("", schema, text); got == keyA {
+		t.Fatalf("empty model segment (pre-D25) must differ from resolved ref key %q", keyA)
+	}
+	// Determinism: same model + text + schema always hashes identically.
+	if got := metadataLLMCacheKey("tenant-a-default-ref", schema, text); got != keyA {
+		t.Fatalf("cache key not deterministic: %q vs %q", got, keyA)
+	}
+	// Text and schema remain key dimensions too.
+	if got := metadataLLMCacheKey("tenant-a-default-ref", schema, text+" extra"); got == keyA {
+		t.Fatalf("different chunk text must not share a cache key")
+	}
+	if got := metadataLLMCacheKey("tenant-a-default-ref", schema+" extra", text); got == keyA {
+		t.Fatalf("different schema must not share a cache key")
+	}
+}
+
 // TestExtractorComponent_runEnableMetadata_CrossChunkUnion simulates two chunks
 // whose extraction returns overlapping list values for the same key. Aggregating
 // the chunk metadata maps with utility.UpdateMetadataTo (as mergeChunkMetadata


### PR DESCRIPTION
## Summary

The metadata extraction LLM cache key was built from the **raw** `llm_id` parameter. An empty `llm_id` (legal: means "use the tenant default chat model") hashed an empty model segment into the key, so the cache could not tell which model produced a result:

- **Cross-tenant collision**: with an empty model segment, every tenant with identical chunk text + schema shared one Redis key (`kc:meta:`), so tenant B could hit tenant A's extraction.
- **Stale after default-model change**: switching the tenant default model kept serving the old model's result for the 24h TTL.

Python has no such bug — it keys on the resolved `chat_mdl.llm_name` (`task_executor.py:543/550`). After this fix the Go cache key carries a real model identity whenever one is resolvable, matching Python's semantics.

## Change

- New `resolveMetadataCacheModel`: when `llm_id` is empty, resolves the tenant default chat model ref (reusing `defaultChatModelRef`); non-empty `llm_id` passes through unchanged.
- `runAutoExtractions` resolves it **once per Invoke** (not per chunk) and carries it in `extractorInputs.cacheModel`.
- `runEnableMetadata` uses `cacheModel` (fallback to `llmID`) for both cache read and write, keeping them symmetric.

Non-empty `llm_id` path (ingestion main line) is behavior-identical; existing cache entries are untouched. Note: when a tenant's default is a composite `model@provider` ref, tenants sharing the same resolved default model still share a key — the same behavior as Python keying on `llm_name`.

## Tests

`bash build.sh --test ./internal/ingestion/component/` — package passes. New tests:

- `TestResolveMetadataCacheModel_NonEmptyShortCircuits` — non-empty `llm_id` passes through unchanged
- `TestResolveMetadataCacheModel_EmptyNoState_ReturnsEmpty` — safe degenerate path (no canvas state / tenant)
- `TestResolveMetadataCacheModel_EmptyWithPinnedDefault` / `TestResolveMetadataCacheModel_EmptyWithCompositeDefault` — empty `llm_id` resolves the pinned tenant_model UUID / composite `model@provider` default
- `TestResolveMetadataCacheModel_CrossTenantDefaultsDiffer` — tenants with different defaults resolve to different refs
- `TestResolveMetadataCacheModel_EmptyNoDefaultModel` — no default model → falls back to pre-fix behavior
- `TestMetadataLLMCacheKey_ModelIsolation` — distinct models / empty-vs-resolved refs produce distinct keys; deterministic; text/schema stay key dimensions
- `TestExtractorComponent_runEnableMetadata_UsesCacheModel` — per-invocation `cacheModel` is consumed without breaking extraction
