### PR TITLE
fix(web): keep reasoning and internet options when regenerating an answer

### DIFF
--- a/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
+++ b/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
@@ -57,7 +57,7 @@ import {
   UseSendSingleMessageParameter,
 } from '../../hooks/use-send-single-message';
 import { useUploadFile } from '../../hooks/use-upload-file';
-import { buildMessageItemReference } from '../../utils';
+import { buildMessageItemReference, resolveResendOptions } from '../../utils';
 import { useAddChatBox } from '../use-add-box';
 import { useShowInternet } from '../use-show-internet';
 
@@ -134,6 +134,11 @@ const ChatCard = forwardRef(function ChatCard(
 
   const llmId = useWatch({ control: form.control, name: 'llm_id' });
 
+  // Regenerate is triggered from the transcript, which has no access to the
+  // input box's thinking / internet toggles. Remember what the last send used so
+  // a retry keeps the same options instead of silently dropping them.
+  const lastSendOptionsRef = useRef<NextMessageInputOnPressEnterParameter>({});
+
   // Regenerate within this card: reuse the card's own message state and
   // resend with the card's model settings (llm_id, temperature, ...).
   const sendCardMessage = useCallback(
@@ -141,6 +146,7 @@ const ChatCard = forwardRef(function ChatCard(
       sendMessage({
         message,
         messages,
+        ...resolveResendOptions(lastSendOptionsRef.current),
         ...form.getValues(),
         storeHistoryMessages: false,
         omitSessionId: true,
@@ -200,13 +206,15 @@ const ChatCard = forwardRef(function ChatCard(
 
   useImperativeHandle(
     ref,
-    (): HandlePressEnterType => (params) =>
-      handlePressEnter({
+    (): HandlePressEnterType => (params) => {
+      lastSendOptionsRef.current = params;
+      return handlePressEnter({
         ...params,
         ...form.getValues(),
         storeHistoryMessages: false,
         omitSessionId: true,
-      }),
+      });
+    },
   );
 
   useEffect(() => {

--- a/web/src/pages/next-chats/hooks/use-send-chat-message.ts
+++ b/web/src/pages/next-chats/hooks/use-send-chat-message.ts
@@ -20,6 +20,7 @@ import {
   useChatStreamStore,
   useIsChatStreaming,
 } from '../chat-stream/store';
+import { resolveResendOptions } from '../utils';
 import { useCreateConversationBeforeSendMessage } from './use-chat-url';
 import { useFindPrologueFromDialogList } from './use-select-conversation-list';
 import { useUploadFile } from './use-upload-file';
@@ -88,6 +89,11 @@ export const useSendMessage = () => {
   );
   const stopStream = useChatStreamStore((state) => state.stopStream);
 
+  // The regenerate button lives in the transcript, which has no access to the
+  // input box's thinking / internet toggles. Remember what the last send used
+  // so a retry keeps the same options instead of silently dropping them.
+  const lastSendOptionsRef = useRef<NextMessageInputOnPressEnterParameter>({});
+
   const sendMessage = useCallback(
     async ({
       message,
@@ -101,6 +107,8 @@ export const useSendMessage = () => {
       messages?: IMessage[];
     } & NextMessageInputOnPressEnterParameter) => {
       const sessionId = currentConversationId ?? conversationId;
+
+      lastSendOptionsRef.current = { enableInternet, enableThinking };
 
       const { ok, aborted } = await runChatCompletionStream({
         conversationId: sessionId,
@@ -157,7 +165,10 @@ export const useSendMessage = () => {
       };
 
       appendQuestion(conversationId, questionMessage);
-      sendMessage({ message: questionMessage });
+      sendMessage({
+        message: questionMessage,
+        ...resolveResendOptions(lastSendOptionsRef.current),
+      });
     },
     [conversationId, isStreaming, appendQuestion, sendMessage],
   );

--- a/web/src/pages/next-chats/utils.ts
+++ b/web/src/pages/next-chats/utils.ts
@@ -1,10 +1,30 @@
+import { NextMessageInputOnPressEnterParameter } from '@/components/message-input/next';
 import { EmptyConversationId, MessageType } from '@/constants/chat';
 import {
   IConversation,
   IMessage,
   IReference,
 } from '@/interfaces/database/chat';
+import storage from '@/utils/authorization-util';
 import { isEmpty } from 'lodash';
+
+/**
+ * Regenerate is triggered from the transcript, which has no access to the input
+ * box's thinking / internet toggles, so callers replay the options of their last
+ * send. A view that hasn't sent anything yet has no record: fall back to the
+ * input box's own defaults — it re-reads the persisted thinking level and starts
+ * with internet off, so both stay in sync after a remount.
+ */
+export function resolveResendOptions(
+  lastSendOptions: NextMessageInputOnPressEnterParameter,
+): NextMessageInputOnPressEnterParameter {
+  const {
+    enableThinking = storage.getThinkingLevel(),
+    enableInternet = false,
+  } = lastSendOptions;
+
+  return { enableThinking, enableInternet };
+}
 
 export const isConversationIdExist = (conversationId: string) => {
   return conversationId !== EmptyConversationId && conversationId !== '';


### PR DESCRIPTION
### Summary

fix(web): keep reasoning and internet options when regenerating an answer

The regenerate button lives in the transcript, which cannot reach the
thinking / internet toggles held as local state inside NextMessageInput,
so both single and multi-model chat resent the question without the
`reasoning` and `internet` parameters. Each view now remembers the
options of its last send and replays them, falling back to the input
box's own defaults (persisted thinking level, internet off) so a freshly
mounted view stays in sync with the visible toggles.

