### PR TITLE
Replace pgsty/minio image with pgsty/silo

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -233,7 +233,7 @@ services:
     restart: unless-stopped
 
   minio:
-    image: pgsty/minio:RELEASE.2026-03-25T00-00-00Z
+    image: pgsty/silo:RELEASE.2026-08-06T00-00-00Z
     command: ["server", "--console-address", ":9001", "/data"]
     ports:
       - ${MINIO_PORT}:9000

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -395,7 +395,7 @@ tail -f ragflow/docker/ragflow-logs/*.log
    5bc45806b680   infiniflow/ragflow:latest     "./entrypoint.sh"        11 hours ago   Up 11 hours               0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp, 0.0.0.0:9380->9380/tcp, :::9380->9380/tcp   docker-ragflow-cpu-1
    91220e3285dd   docker.elastic.co/elasticsearch/elasticsearch:8.11.3   "/bin/tini -- /usr/l…"   11 hours ago   Up 11 hours (healthy)     9300/tcp, 0.0.0.0:9200->9200/tcp, :::9200->9200/tcp           ragflow-es-01
    d8c86f06c56b   mysql:5.7.18        "docker-entrypoint.s…"   7 days ago     Up 16 seconds (healthy)   0.0.0.0:3306->3306/tcp, :::3306->3306/tcp     ragflow-mysql
-   cd29bcb254bc   pgsty/minio:RELEASE.2026-03-25T00-00-00Z               "/usr/bin/docker-ent…"   2 weeks ago    Up 11 hours      0.0.0.0:9001->9001/tcp, :::9001->9001/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp     ragflow-minio
+   cd29bcb254bc   pgsty/silo:RELEASE.2026-08-06T00-00-00Z                "/usr/bin/docker-ent…"   2 weeks ago    Up 11 hours      0.0.0.0:9001->9001/tcp, :::9001->9001/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp     ragflow-minio
    ```
 
 2. Follow [this document](./guides/run_health_check.md) to check the health status of the Elasticsearch service.
@@ -470,7 +470,7 @@ Yes, we do. See the Python files under the **rag/app** folder.
    *The status of a healthy Elasticsearch component should look as follows:*
 
    ```bash
-   cd29bcb254bc   pgsty/minio:RELEASE.2026-03-25T00-00-00Z               "/usr/bin/docker-ent…"   2 weeks ago    Up 11 hours      0.0.0.0:9001->9001/tcp, :::9001->9001/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp     ragflow-minio
+   cd29bcb254bc   pgsty/silo:RELEASE.2026-08-06T00-00-00Z                "/usr/bin/docker-ent…"   2 weeks ago    Up 11 hours      0.0.0.0:9001->9001/tcp, :::9001->9001/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp     ragflow-minio
    ```
 
 2. Follow [this document](./guides/run_health_check.md) to check the health status of the Elasticsearch service.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -193,8 +193,8 @@ opensearch:
 minio:
   enabled: true
   image:
-    repository: pgsty/minio
-    tag: RELEASE.2026-03-25T00-00-00Z
+    repository: pgsty/silo
+    tag: RELEASE.2026-08-06T00-00-00Z
     pullPolicy: IfNotPresent
     pullSecrets: []
   storage:


### PR DESCRIPTION
### Summary

Closes #18019.

Pigsty renamed its community MinIO fork from `pgsty/minio` to `pgsty/silo` on 2026-08-06 ([announcement in the repo README](https://github.com/pgsty/silo#readme)). `pgsty/minio` is frozen at `RELEASE.2026-08-04T00-00-00Z` — all further releases, including security fixes, ship as `pgsty/silo`. RAGFlow still pins the old name, so it is now parked on an image that no longer gets updates.

This PR repoints the three places that reference the image and bumps to `RELEASE.2026-08-06T00-00-00Z`, the first release published under the new name:

| File | Change |
| --- | --- |
| `docker/docker-compose-base.yml` | `image:` for the `minio` service |
| `helm/values.yaml` | `minio.image.repository` + `.tag` (kept in sync with compose, per #16322) |
| `docs/faq.mdx` | the two sample `docker ps` outputs |

`docs/release_notes.md` also mentions `pgsty/minio`, but that is the historical note for the release that introduced it, so it is left alone.

### Why this is a drop-in swap

The rename touches delivery surfaces only — Silo's compatibility policy keeps the S3 API, the `MINIO_*` variables, the `/minio/*` routes, the `x-minio-*` headers and the on-disk format (including `.minio.sys`) unchanged. Concretely, for the three things this compose service depends on:

1. **`command:` is unchanged.** The server binary is renamed `minio` → `silo` with no `minio` alias installed, but the entrypoint is still `/usr/bin/docker-entrypoint.sh` and it now translates the legacy argv:

   ```sh
   case "${1:-}" in
       "")                          set -- silo ;;
       minio)             shift;    set -- silo "$@" ;;
       silo)                        ;;
       -*|server|fmt-gen|healthcheck) set -- silo "$@" ;;
   esac
   ```

   So both the compose form (`server --console-address :9001 /data`) and the Helm form (`server --console-address=:9001 /data`) keep working untouched.

2. **The healthcheck is unchanged.** `/minio/health/live` is still served, and `curl` is still present in the image, so `test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]` needs no edit.

3. **Existing `minio_data` volumes keep working.** The on-disk format is identical, so an upgrading user's data is picked up in place — no migration, no re-upload.

Multi-arch coverage is the same as before (`linux/amd64` + `linux/arm64`).

<details>
<summary><b>Proof of working</b> (click to expand)</summary>

#### 1. Upgrade path: data written by `pgsty/minio` is served by `pgsty/silo` from the same volume

Started the **unmodified** compose service, wrote an object through the same `minio` Python SDK calls `rag/utils/minio_conn.py` makes (`list_buckets` / `bucket_exists` / `make_bucket` / `put_object` / `stat_object` / `get_object` / `copy_object` / `list_objects` / `get_presigned_url` / `remove_object`):

```console
$ docker compose -p silotest -f docker-compose-base.yml up -d minio   # pgsty/minio:RELEASE.2026-03-25T00-00-00Z
$ python s3_check.py write
[write] endpoint=127.0.0.1:9000 bucket=ragflow-kb-compat expected_sha256=1d082065173617d2...
[write] list_buckets      -> []
[write] make_bucket       -> created ragflow-kb-compat
[write] put_object        -> etag=33d155c79249de54dee3afd9df2864fe size=59392
[write] stat_object       -> size=59392 etag=33d155c79249de54dee3afd9df2864fe modified=2026-08-13 10:21:21+00:00
[write] get_object        -> sha256 OK (1d082065173617d2...)
[write] copy_object       -> OK
[write] list_objects      -> ['chunk/doc-0001.bin', 'chunk/doc-0001.copy.bin']
[write] presigned_url     -> http://127.0.0.1:9000/ragflow-kb-compat/chunk/doc-0001.bin?<signature len=256>
[write] remove_object     -> removed chunk/doc-0001.copy.bin
[write] ALL S3 OPERATIONS PASSED
```

Then applied this PR's diff and recreated the service **on the same `minio_data` volume**:

```console
$ docker compose -p silotest -f docker-compose-base.yml stop minio
$ git apply <this PR>
$ docker compose -p silotest -f docker-compose-base.yml up -d minio
 Container silotest-minio-1  Recreated
 Container silotest-minio-1  Started

$ docker compose -p silotest logs minio | tail
minio-1  | Silo Object Storage Server
minio-1  | Copyright: 2015-2025 MinIO, Inc.
minio-1  | Modifications: Copyright 2025-2026 PGSTY
minio-1  | License: GNU AGPLv3 - https://www.gnu.org/licenses/agpl-3.0.html
minio-1  | Version: RELEASE.2026-08-06T00-00-00Z (go1.26.5 linux/amd64)
minio-1  |
minio-1  | API: http://172.22.0.2:9000  http://127.0.0.1:9000
minio-1  | WebUI: http://172.22.0.2:9001 http://127.0.0.1:9001
```

The pre-existing bucket and object are intact — **same etag, same `last_modified`** as written by the old image:

```console
$ python s3_check.py read
[read] endpoint=127.0.0.1:9000 bucket=ragflow-kb-compat expected_sha256=1d082065173617d2...
[read] list_buckets      -> ['ragflow-kb-compat']
[read] stat_object       -> size=59392 etag=33d155c79249de54dee3afd9df2864fe modified=2026-08-13 10:21:21+00:00
[read] get_object        -> sha256 OK (1d082065173617d2...)
[read] copy_object       -> OK
[read] list_objects      -> ['chunk/doc-0001.bin', 'chunk/doc-0001.copy.bin']
[read] presigned_url     -> http://127.0.0.1:9000/ragflow-kb-compat/chunk/doc-0001.bin?<signature len=256>
[read] remove_object     -> removed chunk/doc-0001.copy.bin
[read] ALL S3 OPERATIONS PASSED
```

On-disk format carried over untouched:

```console
$ docker exec silotest-minio-1 sh -c 'ls /data && cat /data/.minio.sys/format.json'
ragflow-kb-compat
{"version":"1","format":"xl-single","id":"de59c359-...","xl":{"version":"3",...}}
```

#### 2. Compose healthcheck passes unmodified

```console
$ docker ps
pgsty/silo:RELEASE.2026-08-06T00-00-00Z  "/usr/bin/docker-ent…"  Up 3 minutes (healthy)  0.0.0.0:9000-9001->9000-9001/tcp  silotest-minio-1

$ docker exec silotest-minio-1 curl -f http://localhost:9000/minio/health/live   # exactly what compose runs
HTTP 200
$ curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9000/minio/health/cluster
200
$ curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9001    # console
200

$ docker exec silotest-minio-1 silo --version
silo version RELEASE.2026-08-06T00-00-00Z (commit-id=3be10fcc1a44f6620ded0bd303461f9d688cca23)
Runtime: go1.26.5 linux/amd64
License: GNU AGPLv3 - https://www.gnu.org/licenses/agpl-3.0.html
```

#### 3. Helm chart renders and lints, and its arg form works against the new image

```console
$ helm template ragflow ./helm | grep -A1 'name: minio'
      - name: minio
        image: pgsty/silo:RELEASE.2026-08-06T00-00-00Z

$ helm lint ./helm
1 chart(s) linted, 0 chart(s) failed

$ docker run -d pgsty/silo:RELEASE.2026-08-06T00-00-00Z server --console-address=:9001 /data
$ curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1:19000/minio/health/live   # S3
200
$ curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1:19001                     # console
200
```

#### 4. Multi-arch parity retained

```console
$ docker manifest inspect pgsty/silo:RELEASE.2026-08-06T00-00-00Z
  linux/amd64  sha256:da1284931914c3de5...
  linux/arm64  sha256:2c00469c7b3b95371...
```

</details>

> [!NOTE]
> @AlphaRex-pixel was assigned this issue on Aug 10 and no PR had been opened yet when I put this together — happy to close this in favour of theirs if they have work in flight.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
