### PR TITLE
fix: pack heading-less book text runs into token-bounded chunks

### DIFF
--- a/internal/ingestion/component/chunker/group.go
+++ b/internal/ingestion/component/chunker/group.go
@@ -54,13 +54,11 @@ import (
 
 const ComponentNameGroupTitleChunker = "GroupTitleChunker"
 
-// MIN_GROUP_TOKENS / MAX_GROUP_TOKENS mirror the python constants in
-// group_chunker.py:22-23. They drive the merge heuristic for adjacent
-// text records.
-const (
-	minGroupTokens = 32
-	maxGroupTokens = 1024
-)
+// minGroupTokens mirrors MIN_GROUP_TOKENS (group_chunker.py:22): very
+// small chunks are allowed to absorb the next record regardless of
+// section change. The merge ceiling is the configurable chunk_token_cap
+// (group_chunker.py:90), not a fixed constant.
+const minGroupTokens = 32
 
 // resolveTargetLevel mirrors common.py:resolve_target_level: pick the
 // n-th smallest heading level from the per-line `levels` vector.
@@ -242,9 +240,14 @@ func groupRecords(records []lineRecord, secIDs []int, p *titleChunkerParam) [][]
 			continue
 		}
 		tokenCount := tokenizer.NumTokensFromString(text)
+		// Merge ceiling mirrors group_chunker.py:90: the configurable
+		// chunk_token_cap (0/negative disables the ceiling). The post-build
+		// enforceTitleTokenCap stays the single hard guarantee for any
+		// residual over-cap chunk.
+		mergeCeilingOK := p.ChunkTokenCap <= 0 || tkCnt < p.ChunkTokenCap
 		shouldMerge := len(currentGroup) > 0 &&
 			currentGroup[0].isText() &&
-			(tkCnt < minGroupTokens || (tkCnt < maxGroupTokens && secID == lastSID))
+			(tkCnt < minGroupTokens || (mergeCeilingOK && secID == lastSID))
 		if shouldMerge {
 			currentGroup = append(currentGroup, rec)
 			tkCnt += tokenCount

--- a/internal/ingestion/component/chunker/hierarchy.go
+++ b/internal/ingestion/component/chunker/hierarchy.go
@@ -34,6 +34,12 @@
 //     `include_heading_content` and the python leaf-only rule: when
 //     include_heading_content is false, only leaf nodes emit.
 //
+//   - Deliberate divergence from the python pipeline: when a text run
+//     has no detectable heading levels (resolve_target_level → None),
+//     the run is packed into token-bounded groups (group variant
+//     budget) instead of one giant chunk, matching the classic
+//     rag/app/book.py naive_merge fallback.
+//
 //   - No PDF-position / deepdoc awareness; structured chunk inputs
 //     use the same dfs over text records.
 package chunker
@@ -195,12 +201,17 @@ func invokeHierarchy(parentCtx context.Context, db *gorm.DB, inputs map[string]a
 		}
 		targetLevel := resolveTargetLevel(textLevels, h)
 		if targetLevel == 0 {
-			// resolve_target_level returned None (no heading levels in
-			// the run): emit the whole run as a single group, exactly
-			// like python's `record_groups.append(text_records.copy())`.
-			runCopy := make([]lineRecord, len(textRun))
-			copy(runCopy, textRun)
-			recordGroups = append(recordGroups, runCopy)
+			// resolve_target_level returned None: no line in the run
+			// matched a heading pattern. Emitting the whole run as one
+			// group (python pipeline's `record_groups.append(
+			// text_records.copy())`) collapses a heading-less book —
+			// e.g. a plain-prose txt or a PDF without bookmarks — into
+			// a single chunk and breaks retrieval. The classic python
+			// book chunker (rag/app/book.py) falls back to token-bounded
+			// naive_merge in exactly this case, so mirror that fallback
+			// here by packing the run with the same token budget the
+			// group variant uses (minGroupTokens/maxGroupTokens).
+			recordGroups = append(recordGroups, groupRecords(textRun, make([]int, len(textRun)), p)...)
 		} else {
 			indexed := make([]indexedLine, len(textRun))
 			for j := range textRun {

--- a/internal/ingestion/component/chunker/hierarchy.go
+++ b/internal/ingestion/component/chunker/hierarchy.go
@@ -38,7 +38,10 @@
 //     has no detectable heading levels (resolve_target_level → None),
 //     the run is packed into token-bounded groups (group variant
 //     budget) instead of one giant chunk, matching the classic
-//     rag/app/book.py naive_merge fallback.
+//     rag/app/book.py naive_merge fallback. When NO run in the document
+//     yields a heading, root_chunk_as_heading is suppressed too: with
+//     no heading anywhere there is no root heading, and the rewrite
+//     would drop the leading body chunk.
 //
 //   - No PDF-position / deepdoc awareness; structured chunk inputs
 //     use the same dfs over text records.
@@ -190,6 +193,7 @@ func invokeHierarchy(parentCtx context.Context, db *gorm.DB, inputs map[string]a
 	var recordGroups [][]lineRecord
 	var textRun []lineRecord
 	var textLevels []int
+	sawHeading := false
 
 	flush := func() {
 		if len(textRun) == 0 {
@@ -209,10 +213,12 @@ func invokeHierarchy(parentCtx context.Context, db *gorm.DB, inputs map[string]a
 			// a single chunk and breaks retrieval. The classic python
 			// book chunker (rag/app/book.py) falls back to token-bounded
 			// naive_merge in exactly this case, so mirror that fallback
-			// here by packing the run with the same token budget the
-			// group variant uses (minGroupTokens/maxGroupTokens).
+			// here by packing the run with the same budget the group
+			// variant uses (minGroupTokens + the configurable
+			// chunk_token_cap merge ceiling).
 			recordGroups = append(recordGroups, groupRecords(textRun, make([]int, len(textRun)), p)...)
 		} else {
+			sawHeading = true
 			indexed := make([]indexedLine, len(textRun))
 			for j := range textRun {
 				indexed[j] = indexedLine{level: textLevels[j], index: j}
@@ -251,7 +257,19 @@ func invokeHierarchy(parentCtx context.Context, db *gorm.DB, inputs map[string]a
 		zap.Int("record_groups", len(recordGroups)),
 	)
 
-	chunks := buildChunksFromRecordGroups(recordGroups, p, isPlainTextFormat(inputs))
+	// A document whose text runs all missed heading detection has no root
+	// heading: every emitted chunk is plain body prose, so the
+	// root-as-heading rewrite would drop the leading body chunk and
+	// prepend its text to the rest. Suppress the rewrite for that case
+	// only; a document with any detected heading keeps the python
+	// behavior unchanged.
+	chunkParam := p
+	if p.RootChunkAsHeading && !sawHeading {
+		np := *p
+		np.RootChunkAsHeading = false
+		chunkParam = &np
+	}
+	chunks := buildChunksFromRecordGroups(recordGroups, chunkParam, isPlainTextFormat(inputs))
 	// Enforce the title-family token ceiling (chunk_token_cap) right after
 	// build_chunks and BEFORE the on-demand crop, mirroring Python's
 	// invoke() order (build -> cap -> set_chunks).

--- a/internal/ingestion/component/chunker/hierarchy_test.go
+++ b/internal/ingestion/component/chunker/hierarchy_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/tokenizer"
 )
 
 func TestHierarchyTitleChunker_Registered(t *testing.T) {
@@ -530,5 +531,81 @@ func TestHierarchyTitleChunker_ConsecutiveNonTextOrder(t *testing.T) {
 	}
 	if !(iA < iB && iB < iBody) {
 		t.Errorf("non-text order wrong: imgA=%d imgB=%d body=%d, want imgA<imgB<body", iA, iB, iBody)
+	}
+}
+
+// TestHierarchyTitleChunker_NoHeadingsTokenFallback pins the
+// heading-less fallback: when no line matches a heading pattern
+// (resolve_target_level → None), the run must be packed into
+// token-bounded chunks instead of collapsing into a single chunk
+// (classic rag/app/book.py naive_merge fallback).
+func TestHierarchyTitleChunker_NoHeadingsTokenFallback(t *testing.T) {
+	c, err := NewHierarchyTitleChunker(map[string]any{
+		"hierarchy":               5,
+		"levels":                  [][]string{{`^# `}},
+		"include_heading_content": true,
+	})
+	if err != nil {
+		t.Fatalf("NewHierarchyTitleChunker: %v", err)
+	}
+	// Plain-prose book with 第N回-style markers that no configured
+	// heading family matches — mirrors the reported 红楼梦 txt case.
+	line := "第一回 " + strings.Repeat("红尘滚滚正文段落", 10)
+	var b strings.Builder
+	for i := 0; i < 120; i++ {
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	out, err := c.Invoke(t.Context(), nil, map[string]any{
+		"name": "hlm.txt",
+		"text": b.String(),
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) < 2 {
+		t.Fatalf("heading-less book collapsed into %d chunk(s), want >= 2", len(chunks))
+	}
+	lineTokens := tokenizer.NumTokensFromString(line)
+	var all strings.Builder
+	for i, ck := range chunks {
+		text, _ := ck["text"].(string)
+		if text == "" {
+			t.Errorf("chunk[%d] text is empty", i)
+		}
+		if got := tokenizer.NumTokensFromString(text); got > maxGroupTokens+lineTokens {
+			t.Errorf("chunk[%d] tokens = %d, want <= %d (budget + one-line overshoot)", i, got, maxGroupTokens+lineTokens)
+		}
+		all.WriteString(text)
+	}
+	if !strings.Contains(all.String(), "第一回") {
+		t.Error("merged chunk text lost content")
+	}
+}
+
+// TestHierarchyTitleChunker_NoHeadingsSmallDoc pins that a short
+// heading-less document still yields exactly one chunk.
+func TestHierarchyTitleChunker_NoHeadingsSmallDoc(t *testing.T) {
+	c, err := NewHierarchyTitleChunker(map[string]any{
+		"hierarchy": 5,
+		"levels":    [][]string{{`^# `}},
+	})
+	if err != nil {
+		t.Fatalf("NewHierarchyTitleChunker: %v", err)
+	}
+	out, err := c.Invoke(t.Context(), nil, map[string]any{
+		"name": "note.txt",
+		"text": "只是几行普通正文\n没有任何标题结构\n内容很短",
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("chunks = %d, want 1 for a short heading-less doc", len(chunks))
+	}
+	if text, _ := chunks[0]["text"].(string); !strings.Contains(text, "没有任何标题结构") {
+		t.Errorf("chunk text = %q, want it to contain the body", text)
 	}
 }

--- a/internal/ingestion/component/chunker/hierarchy_test.go
+++ b/internal/ingestion/component/chunker/hierarchy_test.go
@@ -550,15 +550,10 @@ func TestHierarchyTitleChunker_NoHeadingsTokenFallback(t *testing.T) {
 	}
 	// Plain-prose book with 第N回-style markers that no configured
 	// heading family matches — mirrors the reported 红楼梦 txt case.
-	line := "第一回 " + strings.Repeat("红尘滚滚正文段落", 10)
-	var b strings.Builder
-	for i := 0; i < 120; i++ {
-		b.WriteString(line)
-		b.WriteString("\n")
-	}
+	src := headingLessProse(120)
 	out, err := c.Invoke(t.Context(), nil, map[string]any{
 		"name": "hlm.txt",
-		"text": b.String(),
+		"text": src,
 	})
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
@@ -567,20 +562,35 @@ func TestHierarchyTitleChunker_NoHeadingsTokenFallback(t *testing.T) {
 	if len(chunks) < 2 {
 		t.Fatalf("heading-less book collapsed into %d chunk(s), want >= 2", len(chunks))
 	}
-	lineTokens := tokenizer.NumTokensFromString(line)
+	// chunk_token_cap defaults to 512 and is the hard ceiling on every
+	// emitted text chunk (enforceTitleTokenCap).
+	const capTokens = 512
 	var all strings.Builder
 	for i, ck := range chunks {
 		text, _ := ck["text"].(string)
 		if text == "" {
 			t.Errorf("chunk[%d] text is empty", i)
 		}
-		if got := tokenizer.NumTokensFromString(text); got > maxGroupTokens+lineTokens {
-			t.Errorf("chunk[%d] tokens = %d, want <= %d (budget + one-line overshoot)", i, got, maxGroupTokens+lineTokens)
+		if got := tokenizer.NumTokensFromString(text); got > capTokens {
+			t.Errorf("chunk[%d] tokens = %d, want <= %d (chunk_token_cap hard ceiling)", i, got, capTokens)
 		}
 		all.WriteString(text)
 	}
-	if !strings.Contains(all.String(), "第一回") {
-		t.Error("merged chunk text lost content")
+	// Full content preservation: the concatenated chunk text must
+	// reproduce the source text (whitespace-normalized), in order and
+	// with every repeated occurrence intact.
+	assertNormalizedTextEqual(t, all.String(), src)
+}
+
+// assertNormalizedTextEqual fails the test when got and want differ
+// after whitespace normalization, i.e. when chunking dropped,
+// duplicated, or reordered any source content.
+func assertNormalizedTextEqual(t *testing.T, got, want string) {
+	t.Helper()
+	g := strings.Join(strings.Fields(got), "")
+	w := strings.Join(strings.Fields(want), "")
+	if g != w {
+		t.Errorf("chunk text does not preserve the source content: got %d bytes, want %d bytes", len(g), len(w))
 	}
 }
 
@@ -605,7 +615,87 @@ func TestHierarchyTitleChunker_NoHeadingsSmallDoc(t *testing.T) {
 	if len(chunks) != 1 {
 		t.Fatalf("chunks = %d, want 1 for a short heading-less doc", len(chunks))
 	}
-	if text, _ := chunks[0]["text"].(string); !strings.Contains(text, "没有任何标题结构") {
-		t.Errorf("chunk text = %q, want it to contain the body", text)
+	text, _ := chunks[0]["text"].(string)
+	assertNormalizedTextEqual(t, text, "只是几行普通正文\n没有任何标题结构\n内容很短")
+}
+
+// headingLessProse returns n identical plain-prose lines whose 第N回-style
+// marker matches no configured heading family (the reported 红楼梦 txt case).
+func headingLessProse(n int) string {
+	line := "第一回 " + strings.Repeat("红尘滚滚正文段落", 10)
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString(line)
+		b.WriteString("\n")
 	}
+	return b.String()
+}
+
+// TestHierarchyTitleChunker_NoHeadingsRootChunkAsHeading pins that
+// root_chunk_as_heading does not drop the leading body chunk when the
+// whole document is heading-less: with no heading anywhere there is no
+// root heading, so every body chunk must be preserved (wangq8 review).
+func TestHierarchyTitleChunker_NoHeadingsRootChunkAsHeading(t *testing.T) {
+	c, err := NewHierarchyTitleChunker(map[string]any{
+		"hierarchy":             5,
+		"levels":                [][]string{{`^# `}},
+		"root_chunk_as_heading": true,
+	})
+	if err != nil {
+		t.Fatalf("NewHierarchyTitleChunker: %v", err)
+	}
+	src := headingLessProse(40)
+	out, err := c.Invoke(t.Context(), nil, map[string]any{
+		"name": "hlm.txt",
+		"text": src,
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) < 2 {
+		t.Fatalf("heading-less book collapsed into %d chunk(s), want >= 2", len(chunks))
+	}
+	var all strings.Builder
+	for _, ck := range chunks {
+		text, _ := ck["text"].(string)
+		all.WriteString(text)
+	}
+	assertNormalizedTextEqual(t, all.String(), src)
+}
+
+// TestHierarchyTitleChunker_NoHeadingsConfigurableCap pins that the
+// heading-less fallback budget follows the configurable chunk_token_cap
+// (xugangqiang review): with a 128-token cap every emitted chunk stays
+// within it and the content is fully preserved.
+func TestHierarchyTitleChunker_NoHeadingsConfigurableCap(t *testing.T) {
+	c, err := NewHierarchyTitleChunker(map[string]any{
+		"hierarchy":       5,
+		"levels":          [][]string{{`^# `}},
+		"chunk_token_cap": 128,
+	})
+	if err != nil {
+		t.Fatalf("NewHierarchyTitleChunker: %v", err)
+	}
+	src := headingLessProse(40)
+	out, err := c.Invoke(t.Context(), nil, map[string]any{
+		"name": "hlm.txt",
+		"text": src,
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) < 2 {
+		t.Fatalf("heading-less book collapsed into %d chunk(s), want >= 2", len(chunks))
+	}
+	var all strings.Builder
+	for i, ck := range chunks {
+		text, _ := ck["text"].(string)
+		if got := tokenizer.NumTokensFromString(text); got > 128 {
+			t.Errorf("chunk[%d] tokens = %d, want <= 128 (configured chunk_token_cap)", i, got)
+		}
+		all.WriteString(text)
+	}
+	assertNormalizedTextEqual(t, all.String(), src)
 }


### PR DESCRIPTION
### Summary

Book (hierarchy) chunking collapsed a heading-less book into exactly **1 chunk**: when no line in a text run matched a heading pattern, `resolveTargetLevel` returns none and the Go hierarchy chunker emitted the whole run as a single record group (mirroring the python pipeline's `record_groups.append(text_records.copy())`). A 49 KB novel txt (`第N回`-style markers not covered by the configured heading families) or a PDF without bookmarks therefore indexed as one giant chunk, breaking retrieval.

The classic python book chunker (`rag/app/book.py`) falls back to token-bounded `naive_merge` in exactly this case. This PR mirrors that fallback in the Go hierarchy chunker: when the run has no detectable heading levels, it is packed with the same token budget the group variant uses (`minGroupTokens`/`maxGroupTokens`) instead of one oversized group.

### Verification

- Unit: `bash build.sh --test ./internal/ingestion/component/chunker/...` — new regression tests `TestHierarchyTitleChunker_NoHeadingsTokenFallback` (long heading-less book → multiple budget-bounded chunks, no content loss) and `TestHierarchyTitleChunker_NoHeadingsSmallDoc` (short doc still yields exactly 1 chunk); full package green.
- E2E on a local build: re-parsed the reproducing 49 KB `hlm_test.txt` with chunk method **Book** — chunk count went from **1 → 17**, parse status DONE.

### Notes

- Deliberate divergence from the python *pipeline* hierarchy chunker (which keeps the single-chunk behavior); aligns with the classic `rag/app/book.py` product behavior and with the Go group variant, which already bounds chunks by token budget.
