### PR TITLE
fix(web): enable client pagination in admin user detail tables

### DIFF
--- a/web/src/pages/admin/user-detail.tsx
+++ b/web/src/pages/admin/user-detail.tsx
@@ -9,6 +9,7 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
@@ -130,6 +131,7 @@ function UserDatasetTable(props: {
 
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
 
     enableSorting: false,
   });
@@ -237,6 +239,7 @@ function UserAgentTable(props: { data?: AdminService.ListUserAgentItem[] }) {
 
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
 
     enableSorting: false,
   });


### PR DESCRIPTION
### Summary

fix(web): enable client pagination in admin user detail tables

The dataset and agent tables render pagination controls but never registered the pagination row model, so every row was shown at once.
