### PR TITLE
fix(llm): disable DeepSeek V4 thinking by default via extra_body

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -335,7 +335,7 @@ class Canvas(Graph):
             "sys.conversation_turns": 0,
             "sys.files": [],
             "sys.history": [],
-            "sys.date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            "sys.date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
         self.variables = {}
         # Aggregated provider token usage (prompt/completion/total) across every LLM
@@ -354,7 +354,7 @@ class Canvas(Graph):
             if "sys.history" not in self.globals:
                 self.globals["sys.history"] = []
             if "sys.date" not in self.globals:
-                self.globals["sys.date"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                self.globals["sys.date"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         else:
             self.globals = {
                 "sys.query": "",
@@ -362,7 +362,7 @@ class Canvas(Graph):
                 "sys.conversation_turns": 0,
                 "sys.files": [],
                 "sys.history": [],
-                "sys.date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+                "sys.date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             }
         if "variables" in self.dsl:
             self.variables = self.dsl["variables"]
@@ -468,7 +468,7 @@ class Canvas(Graph):
             reset_llm_request_context(_req_ctx_token)
 
     async def _run_impl(self, **kwargs):
-        self.globals["sys.date"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        self.globals["sys.date"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         st = time.perf_counter()
         self._loop = asyncio.get_running_loop()
         self.message_id = get_uuid()

--- a/internal/agent/runtime/state.go
+++ b/internal/agent/runtime/state.go
@@ -95,7 +95,7 @@ func NewCanvasState(runID, taskID string) *CanvasState {
 	return s
 }
 
-// EnsureSysDate fills sys.date with the current UTC timestamp when it
+// EnsureSysDate fills sys.date with the current local timestamp when it
 // is missing or blank. Python canvas initializes the same variable with
 // "%Y-%m-%d %H:%M:%S"; keep that wire format for DSL compatibility.
 func (s *CanvasState) EnsureSysDate() {
@@ -110,7 +110,7 @@ func (s *CanvasState) EnsureSysDate() {
 	if v, ok := s.Sys["date"]; ok && strings.TrimSpace(fmt.Sprint(v)) != "" {
 		return
 	}
-	s.Sys["date"] = time.Now().UTC().Format("2006-01-02 15:04:05")
+	s.Sys["date"] = time.Now().Format("2006-01-02 15:04:05")
 }
 
 // init registers CanvasState with eino's internal type registry so

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -163,7 +163,12 @@ def _apply_model_family_policies(
         return sanitized_gen_conf, sanitized_kwargs
 
     if backend == "litellm":
-        if provider in {SupportedLiteLLMProvider.OpenAI, SupportedLiteLLMProvider.Azure_OpenAI} and "gpt-5" in model_name_lower:
+        if provider == SupportedLiteLLMProvider.DeepSeek:
+            _pop_thinking_controls()
+            sanitized_gen_conf.pop("reasoning_effort", None)
+            sanitized_kwargs.pop("reasoning_effort", None)
+            _merge_extra_body(sanitized_gen_conf, {"thinking": {"type": thinking_type or "disabled"}})
+        elif provider in {SupportedLiteLLMProvider.OpenAI, SupportedLiteLLMProvider.Azure_OpenAI} and "gpt-5" in model_name_lower:
             for key in ("temperature", "top_p", "logprobs", "top_logprobs"):
                 sanitized_gen_conf.pop(key, None)
                 sanitized_kwargs.pop(key, None)

--- a/test/unit_test/rag/llm/test_chat_model_thinking_policy.py
+++ b/test/unit_test/rag/llm/test_chat_model_thinking_policy.py
@@ -134,6 +134,43 @@ def test_glm_thinking_maps_to_zhipu_payload():
     assert gen_conf["thinking"] == {"type": "enabled"}
 
 
+def test_deepseek_thinking_disabled_via_extra_body():
+    # litellm 1.82.x DeepSeek transformation drops `thinking` from the top
+    # level (only {"type": "enabled"} survives) and rejects reasoning_effort
+    # alongside thinking: disabled. The toggle must be carried in extra_body
+    # and any reasoning_effort stripped. When unspecified, default to disabled.
+    for gen_input in (
+        {"thinking": "disabled", "reasoning_effort": "high"},
+        {"thinking": "default"},
+        {"temperature": 0.5},
+    ):
+        gen_conf, kwargs = _apply_model_family_policies(
+            "deepseek-v4-flash",
+            backend="litellm",
+            provider=SupportedLiteLLMProvider.DeepSeek,
+            gen_conf=dict(gen_input),
+            request_kwargs={},
+        )
+        assert kwargs == {}
+        assert "thinking" not in gen_conf
+        assert "reasoning_effort" not in gen_conf
+        assert gen_conf["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+def test_deepseek_thinking_enabled_via_extra_body():
+    gen_conf, kwargs = _apply_model_family_policies(
+        "deepseek-v4-flash",
+        backend="litellm",
+        provider=SupportedLiteLLMProvider.DeepSeek,
+        gen_conf={"thinking": "enabled"},
+        request_kwargs={},
+    )
+
+    assert kwargs == {}
+    assert "thinking" not in gen_conf
+    assert gen_conf["extra_body"]["thinking"] == {"type": "enabled"}
+
+
 def test_litellm_provider_body_fields_move_to_extra_body_before_drop_params():
     completion_args = {
         "model": "kimi-latest",


### PR DESCRIPTION
## Summary
- Disable DeepSeek V4 thinking (chain-of-thought) by default.
- litellm 1.82.x drops `thinking: disabled`; carry the toggle through `extra_body.thinking.type` and strip `reasoning_effort` to avoid the 400.
- Use local timezone for agent `sys.date` instead of UTC.

Reference: https://api-docs.deepseek.com/guides/thinking_mode
