### PR TITLE
fix(settings): fail hard when RAGFLOW_CRYPTO_ENABLED=true and config is broken

### DIFF
--- a/common/settings.py
+++ b/common/settings.py
@@ -218,6 +218,42 @@ class StorageFactory:
         return cls.storage_mapping[storage]()
 
 
+def _init_crypto_storage(storage_impl, *, crypto_enabled, algorithm, crypto_key):
+    """Wrap ``storage_impl`` in ``EncryptedStorageWrapper`` when requested.
+
+    When ``crypto_enabled=True`` the operator explicitly asked for encryption
+    at rest. A failure to initialize (missing key, unsupported algorithm,
+    broken wrapper) MUST fail hard: this function re-raises the underlying
+    exception after logging at CRITICAL level. Silently falling back to
+    the plaintext wrapper would write every document to object storage in
+    the clear while the operator's logs only show a single ``logging.error``
+    line — there is no health check, no metric, no startup banner that
+    distinguishes "encrypting" from "silently not encrypting".
+
+    When ``crypto_enabled=False`` the plaintext ``storage_impl`` is returned
+    unchanged.
+    """
+    if not crypto_enabled:
+        return storage_impl
+    from rag.utils.encrypted_storage import create_encrypted_storage
+
+    try:
+        return create_encrypted_storage(
+            storage_impl,
+            algorithm=algorithm,
+            key=crypto_key,
+            encryption_enabled=crypto_enabled,
+        )
+    except Exception as e:
+        logging.critical(
+            f"RAGFLOW_CRYPTO_ENABLED=true but encrypted storage init failed: {e}. "
+            f"Refusing to fall back to plaintext — every document would land on disk unencrypted. "
+            f"Check RAGFLOW_CRYPTO_KEY (must be set, non-empty) and RAGFLOW_CRYPTO_ALGORITHM "
+            f"(must be one of: aes-128-cbc, aes-256-cbc, sm4-cbc) and restart."
+        )
+        raise
+
+
 def init_settings():
     global DATABASE_TYPE, DATABASE
     DATABASE_TYPE = os.getenv("DB_TYPE", "mysql")
@@ -362,20 +398,21 @@ def init_settings():
     # Define crypto settings
     crypto_enabled = os.environ.get("RAGFLOW_CRYPTO_ENABLED", "false").lower() == "true"
 
-    # Check if encryption is enabled
-    if crypto_enabled:
-        try:
-            from rag.utils.encrypted_storage import create_encrypted_storage
-
-            algorithm = os.environ.get("RAGFLOW_CRYPTO_ALGORITHM", "aes-256-cbc")
-            crypto_key = os.environ.get("RAGFLOW_CRYPTO_KEY")
-
-            STORAGE_IMPL = create_encrypted_storage(storage_impl, algorithm=algorithm, key=crypto_key, encryption_enabled=crypto_enabled)
-        except Exception as e:
-            logging.error(f"Failed to initialize encrypted storage: {e}")
-            STORAGE_IMPL = storage_impl
-    else:
-        STORAGE_IMPL = storage_impl
+    # Check if encryption is enabled.
+    #
+    # When RAGFLOW_CRYPTO_ENABLED=true the operator explicitly asked for
+    # encryption at rest. A failure to initialize (missing key, unsupported
+    # algorithm, broken wrapper) MUST fail hard: the server refuses to
+    # start, and the operator sees the failure on the console. Silently
+    # falling back to the plaintext wrapper would write every document to
+    # object storage in the clear while the operator's logs only show
+    # ``Failed to initialize encrypted storage: ...``. There is no health
+    # check, no metric and no startup banner that distinguishes "encrypting"
+    # from "silently not encrypting", so a silent fallback can persist
+    # undetected for the lifetime of the deployment.
+    algorithm = os.environ.get("RAGFLOW_CRYPTO_ALGORITHM", "aes-256-cbc")
+    crypto_key = os.environ.get("RAGFLOW_CRYPTO_KEY")
+    STORAGE_IMPL = _init_crypto_storage(storage_impl, crypto_enabled=crypto_enabled, algorithm=algorithm, crypto_key=crypto_key)
 
     global retriever, kg_retriever
     retriever = search.Dealer(docStoreConn)

--- a/test/unit_test/common/test_settings_crypto_init.py
+++ b/test/unit_test/common/test_settings_crypto_init.py
@@ -1,0 +1,300 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Unit tests for ``common.settings._init_crypto_storage``.
+
+Closes the security gap reported in issue #17752: when
+``RAGFLOW_CRYPTO_ENABLED=true`` and the crypto configuration is broken
+(missing ``RAGFLOW_CRYPTO_KEY``, unsupported ``RAGFLOW_CRYPTO_ALGORITHM``,
+broken wrapper), the original code in ``init_settings()`` caught every
+exception from ``create_encrypted_storage()``, logged it once at ERROR
+level, and silently fell back to the **plaintext** storage impl. The
+operator's data ended up on disk unencrypted, with no health check, no
+metric and no startup banner that distinguished "encrypting" from
+"silently not encrypting".
+
+The fix: extract the crypto init into ``_init_crypto_storage`` and have
+it re-raise the underlying exception after a CRITICAL log line that
+names the misconfigured env vars. Plaintext fallback only happens when
+``crypto_enabled=False`` (the operator opted out).
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from common.settings import _init_crypto_storage
+
+
+@pytest.fixture
+def storage_impl():
+    """A sentinel for the underlying plaintext storage impl."""
+    return object()
+
+
+# ---------------------------------------------------------------------------
+# crypto_enabled=False — plaintext path (unchanged behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestDisabled:
+    """When the operator did NOT request encryption, the plaintext impl is
+    returned unchanged regardless of the other arguments. No wrapper is
+    ever created, so the operator's misconfigurations (missing KEY, bad
+    ALGORITHM) are silently ignored — which is correct, because the
+    operator opted out.
+    """
+
+    def test_returns_plaintext_unchanged(self, storage_impl):
+        result = _init_crypto_storage(
+            storage_impl,
+            crypto_enabled=False,
+            algorithm="aes-256-cbc",
+            crypto_key="unused",
+        )
+        assert result is storage_impl
+
+    def test_never_creates_wrapper(self, storage_impl):
+        with patch("rag.utils.encrypted_storage.create_encrypted_storage") as mock_create:
+            _init_crypto_storage(
+                storage_impl,
+                crypto_enabled=False,
+                algorithm="aes-256-cbc",
+                crypto_key="some-key",
+            )
+        mock_create.assert_not_called()
+
+    def test_works_with_none_key_and_bad_algorithm(self, storage_impl):
+        # crypto_enabled=False short-circuits before any validation, so a
+        # None key or unsupported algorithm is fine here.
+        result = _init_crypto_storage(
+            storage_impl,
+            crypto_enabled=False,
+            algorithm="bogus-algorithm",
+            crypto_key=None,
+        )
+        assert result is storage_impl
+
+
+# ---------------------------------------------------------------------------
+# crypto_enabled=True — wrapper path
+# ---------------------------------------------------------------------------
+
+
+class TestEnabledHappyPath:
+    """When crypto is enabled and the config is valid, the wrapper is
+    created with the supplied algorithm and key. ``create_encrypted_storage``
+    receives the exact (algorithm, key, encryption_enabled) we passed.
+    """
+
+    def test_returns_wrapper(self, storage_impl):
+        wrapper = object()
+        with patch("rag.utils.encrypted_storage.create_encrypted_storage", return_value=wrapper) as mock_create:
+            result = _init_crypto_storage(
+                storage_impl,
+                crypto_enabled=True,
+                algorithm="aes-256-cbc",
+                crypto_key="my-key",
+            )
+        assert result is wrapper
+        mock_create.assert_called_once_with(
+            storage_impl,
+            algorithm="aes-256-cbc",
+            key="my-key",
+            encryption_enabled=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# crypto_enabled=True + broken config — must FAIL HARD (the bug)
+# ---------------------------------------------------------------------------
+
+
+class TestEnabledFailsHard:
+    """When crypto is enabled and the wrapper init fails for any reason,
+    the original exception MUST propagate. The plaintext ``storage_impl``
+    must NEVER be returned, because that is the security failure mode
+    described in #17752.
+    """
+
+    def test_missing_key_raises_value_error(self, storage_impl):
+        # CryptoUtil("aes-256-cbc", key=None) raises ValueError at __init__
+        # because the key derivation requires a non-empty key. The wrapper
+        # therefore fails to construct, and the plaintext fallback MUST NOT
+        # happen.
+        with pytest.raises(ValueError):
+            _init_crypto_storage(
+                storage_impl,
+                crypto_enabled=True,
+                algorithm="aes-256-cbc",
+                crypto_key=None,
+            )
+
+    def test_empty_key_raises_value_error(self, storage_impl):
+        with pytest.raises(ValueError):
+            _init_crypto_storage(
+                storage_impl,
+                crypto_enabled=True,
+                algorithm="aes-256-cbc",
+                crypto_key="",
+            )
+
+    def test_unsupported_algorithm_raises_value_error(self, storage_impl):
+        with pytest.raises(ValueError):
+            _init_crypto_storage(
+                storage_impl,
+                crypto_enabled=True,
+                algorithm="aes256-cbc",  # missing hyphen — typo case from the issue
+                crypto_key="my-key",
+            )
+
+    def test_wrapper_constructor_exception_propagates(self, storage_impl):
+        # Simulate any non-ValueError failure (e.g. AttributeError from a
+        # broken storage_impl, ImportError from a bad wrapper). The
+        # helper must re-raise unchanged, not fall back.
+        with patch(
+            "rag.utils.encrypted_storage.create_encrypted_storage",
+            side_effect=AttributeError("Storage implementation missing required method: put"),
+        ):
+            with pytest.raises(AttributeError, match="missing required method"):
+                _init_crypto_storage(
+                    storage_impl,
+                    crypto_enabled=True,
+                    algorithm="aes-256-cbc",
+                    crypto_key="my-key",
+                )
+
+    def test_plaintext_is_never_returned_on_failure(self, storage_impl):
+        # The bug's core failure mode: ``storage_impl`` (plaintext) leaks
+        # through as the active STORAGE_IMPL. Pin that this can never
+        # happen — every failure must raise, and the caller never sees
+        # ``storage_impl`` as a result.
+        with patch(
+            "rag.utils.encrypted_storage.create_encrypted_storage",
+            side_effect=RuntimeError("anything"),
+        ):
+            with pytest.raises(RuntimeError):
+                result = _init_crypto_storage(
+                    storage_impl,
+                    crypto_enabled=True,
+                    algorithm="aes-256-cbc",
+                    crypto_key="my-key",
+                )
+                # ``result`` is never bound because the helper raises; this
+                # assertion is for documentation only.
+                assert result is not storage_impl  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL log line — the operator's only signal
+# ---------------------------------------------------------------------------
+
+
+class TestCriticalLogging:
+    """The fix logs at CRITICAL level before re-raising, naming the
+    misconfigured env vars. The previous behavior logged once at ERROR
+    level and moved on — operators reading the log had no way to tell
+    "encryption failed at startup" from any other transient ERROR.
+    """
+
+    def test_logs_critical_on_failure(self, storage_impl, caplog):
+        with caplog.at_level(logging.CRITICAL, logger="common.settings"):
+            with patch(
+                "rag.utils.encrypted_storage.create_encrypted_storage",
+                side_effect=ValueError("bad key"),
+            ):
+                with pytest.raises(ValueError):
+                    _init_crypto_storage(
+                        storage_impl,
+                        crypto_enabled=True,
+                        algorithm="aes-256-cbc",
+                        crypto_key="my-key",
+                    )
+        critical = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+        assert critical, "expected a CRITICAL log line on crypto init failure"
+        msg = critical[0].getMessage()
+        # The error message must name the env vars so the operator knows
+        # what to check.
+        assert "RAGFLOW_CRYPTO_KEY" in msg
+        assert "RAGFLOW_CRYPTO_ALGORITHM" in msg
+        # It must also explain WHY the server refuses to start, so the
+        # operator doesn't think this is a recoverable warning.
+        assert "plaintext" in msg.lower()
+        assert "refus" in msg.lower()  # refuse / refusing / refused
+
+    def test_does_not_log_when_disabled(self, storage_impl, caplog):
+        # crypto_enabled=False is a normal path; no warning, no critical.
+        with caplog.at_level(logging.CRITICAL, logger="common.settings"):
+            _init_crypto_storage(
+                storage_impl,
+                crypto_enabled=False,
+                algorithm="aes-256-cbc",
+                crypto_key=None,
+            )
+        assert [r for r in caplog.records if r.levelno == logging.CRITICAL] == []
+
+    def test_does_not_log_when_init_succeeds(self, storage_impl, caplog):
+        with caplog.at_level(logging.CRITICAL, logger="common.settings"):
+            with patch("rag.utils.encrypted_storage.create_encrypted_storage", return_value=object()):
+                _init_crypto_storage(
+                    storage_impl,
+                    crypto_enabled=True,
+                    algorithm="aes-256-cbc",
+                    crypto_key="my-key",
+                )
+        assert [r for r in caplog.records if r.levelno == logging.CRITICAL] == []
+
+
+# ---------------------------------------------------------------------------
+# Original exception is preserved (not wrapped, not swallowed)
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionPreserved:
+    """The re-raised exception must be the SAME exception that the wrapper
+    raised, not a wrapper, not a different type, and not the CRITICAL log's
+    string. Operators reading the traceback need to see ``ValueError: bad
+    key`` or ``AttributeError: missing method: put`` — whatever the wrapper
+    actually said — to know what to fix.
+    """
+
+    def test_value_error_passes_through_unchanged(self, storage_impl):
+        sentinel = ValueError("specific reason")
+        with patch("rag.utils.encrypted_storage.create_encrypted_storage", side_effect=sentinel):
+            with pytest.raises(ValueError) as exc_info:
+                _init_crypto_storage(
+                    storage_impl,
+                    crypto_enabled=True,
+                    algorithm="aes-256-cbc",
+                    crypto_key="my-key",
+                )
+        assert exc_info.value is sentinel  # identity, not just type
+
+    def test_attribute_error_passes_through_unchanged(self, storage_impl):
+        sentinel = AttributeError("Storage implementation missing required method: put")
+        with patch("rag.utils.encrypted_storage.create_encrypted_storage", side_effect=sentinel):
+            with pytest.raises(AttributeError) as exc_info:
+                _init_crypto_storage(
+                    storage_impl,
+                    crypto_enabled=True,
+                    algorithm="aes-256-cbc",
+                    crypto_key="my-key",
+                )
+        assert exc_info.value is sentinel
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #17752 — `RAGFLOW_CRYPTO_ENABLED=true` silently falls back to **unencrypted** storage when the crypto configuration is broken (missing `RAGFLOW_CRYPTO_KEY`, unsupported `RAGFLOW_CRYPTO_ALGORITHM`, broken wrapper). The operator asked for encryption at rest; the deployment runs in the clear; nothing surfaces the mismatch.

The original code in `common/settings.py:init_settings()` was:

```python
if crypto_enabled:
    try:
        ...
        STORAGE_IMPL = create_encrypted_storage(storage_impl, ...)
    except Exception as e:
        logging.error(f"Failed to initialize encrypted storage: {e}")
        STORAGE_IMPL = storage_impl   # <-- silent plaintext fallback
```

A single `logging.error` is the only signal. There is no health check, no startup banner, no metric, and `BaseCrypto.decrypt()` deliberately returns plaintext unchanged when the magic header is missing — so the silent fallback can persist undetected for the lifetime of the cluster.

## What this PR fixes

Three real-world misconfigurations (all one-character mistakes in `docker/.env`, where the variables ship commented out):

| config | result | on-disk |
| --- | --- | --- |
| `ENABLED=true`, `KEY=my-key` | wrapped | encrypted |
| `ENABLED=true`, `KEY` line still commented out | **falls back** (pre-fix) → **fails hard** (post-fix) | plaintext (pre-fix), no startup (post-fix) |
| `ENABLED=true`, `KEY=my-key`, `ALGORITHM=aes256-cbc` (missing hyphen) | **falls back** (pre-fix) → **fails hard** (post-fix) | plaintext (pre-fix), no startup (post-fix) |
| `ENABLED=true`, `KEY=` (empty) | **falls back** (pre-fix) → **fails hard** (post-fix) | plaintext (pre-fix), no startup (post-fix) |

The fix extracts the crypto init into `_init_crypto_storage(storage_impl, *, crypto_enabled, algorithm, crypto_key)` and has it re-raise the underlying exception after a `logging.critical(...)` line that names both `RAGFLOW_CRYPTO_KEY` and `RAGFLOW_CRYPTO_ALGORITHM` and lists the supported algorithms. The plaintext `storage_impl` is returned **only** when `crypto_enabled=False` (the operator opted out). When the operator opted in and the config is broken, the server refuses to start.

## Design decisions

- **Fail hard, not silently fall back.** The issue's title is unambiguous: silent fallback is the security failure. The fix re-raises.
- **`logging.critical` instead of `logging.error`.** The pre-fix code used `logging.error` — operators reading the log had no way to tell "encryption failed at startup" from any other transient ERROR. CRITICAL is visible in startup banners, alerting systems, and operator eyeballs.
- **Re-raise the original exception unchanged.** Operators reading the traceback need to see `ValueError: bad key` or `AttributeError: missing method: put` — whatever the wrapper actually said — to know what to fix. Wrapping or stringifying would lose the diagnostic. The test file pins this with `exc_info.value is sentinel` (identity, not just type).
- **Extract a helper instead of testing `init_settings()` directly.** `init_settings()` has ~150 lines of side effects (database, ES, message queue, etc.). The helper has clear inputs and outputs and is unit-testable in isolation.
- **Do not change the `crypto_enabled=False` path.** The plaintext storage impl is the correct, intended behavior when the operator opted out. Only the opted-in-but-broken path is changed.
- **No new dependencies, no new config knobs.** The fix uses `logging.critical` (already in the stdlib) and `raise` (already Python). The error message lists the supported algorithms so operators don't have to read the source to learn them.

## Files changed

- `common/settings.py` — extract `_init_crypto_storage()`; `init_settings()` calls it instead of inlining the try/except (51 +/− 14)
- `test/unit_test/common/test_settings_crypto_init.py` — 14 unit tests across 5 classes (300 +)

## Testing performed

- `pytest test/unit_test/common/test_settings_crypto_init.py` — 14/14 pass
- `ruff check common/settings.py test/unit_test/common/test_settings_crypto_init.py` — clean
- `ruff format --check` on both — clean
- `python3 -c "import ast; ast.parse(...)"` on `settings.py` — clean
- Module imports cleanly: `from common.settings import _init_crypto_storage; ...`

The 5 test classes:

1. `TestDisabled` (3 cases) — `crypto_enabled=False` short-circuits before any validation. Plaintext is returned unchanged; `create_encrypted_storage` is never called; even `None` key and bogus algorithm are fine.
2. `TestEnabledHappyPath` (1) — `crypto_enabled=True` with a valid config returns the wrapper, called with the exact `(algorithm, key, encryption_enabled)` the caller passed.
3. `TestEnabledFailsHard` (5) — every failure mode (None key, empty key, unsupported algorithm, generic `AttributeError`) MUST propagate. The plaintext `storage_impl` is never returned on failure.
4. `TestCriticalLogging` (3) — the fix logs at CRITICAL level (not ERROR) before re-raising, and the message names both `RAGFLOW_CRYPTO_KEY` and `RAGFLOW_CRYPTO_ALGORITHM`. No CRITICAL log on disabled or happy paths.
5. `TestExceptionPreserved` (2) — the re-raised exception is the same object the wrapper raised (identity, not just type).

## Backward compatibility

- **Behavior change is the bug fix.** The pre-fix behavior of "silently fall back to plaintext when crypto is requested but broken" is the security failure. Operators who relied on that fallback were already losing data confidentiality without knowing it.
- **The error message is actionable.** `Check RAGFLOW_CRYPTO_KEY (must be set, non-empty) and RAGFLOW_CRYPTO_ALGORITHM (must be one of: aes-128-cbc, aes-256-cbc, sm4-cbc) and restart.` — operators reading the failure can fix it in 30 seconds.
- **No config schema change.** Same env vars, same defaults, same `init_settings()` signature.

## Out of scope

- The DB-persistence companion issue #17265 (encrypt `connector.config` at rest) is a different, larger fix and is not addressed here.
- The `BaseCrypto.decrypt()` passthrough behavior is intentional (lets you enable encryption over an existing bucket) and is preserved.
- A startup health-check endpoint that surfaces the encryption state is a good follow-up but is out of scope for this PR.

## Linked issues

- Closes #17752
