### PR TITLE
fix(wiki): preserve template models without pipelines

### DIFF
--- a/rag/svr/task_executor_refactor/dataset_wiki_generator.py
+++ b/rag/svr/task_executor_refactor/dataset_wiki_generator.py
@@ -262,17 +262,23 @@ def _pipeline_compiler_llm_id(pipeline_id: str) -> str | None:
     return None
 
 
-def _validate_wiki_eligible_docs(eligible: list[tuple[dict, str]]) -> dict[str, str | None]:
-    """Validate one Wiki template and return each doc's pipeline chat model."""
+def _validate_wiki_eligible_docs(eligible: list[tuple[dict, str]], tenant_id: str) -> dict[str, str | None]:
+    """Validate one Wiki template and return each document's chat model."""
+    from api.db.services.compilation_template_service import CompilationTemplateService
+
     template_ids = {template_id for _, template_id in eligible}
     if len(template_ids) > 1:
         raise ValueError("Eligible Wiki documents must use the same template")
     pipeline_chat_llm_ids: dict[str, str | None] = {}
-    for doc, _ in eligible:
+    for doc, template_id in eligible:
         doc_id = str(doc.get("id") or "")
         pipeline_id = (doc.get("pipeline_id") or "").strip()
         if not pipeline_id:
-            raise ValueError(f"Wiki document {doc_id} must use a pipeline")
+            template = CompilationTemplateService.get_saved(template_id, tenant_id)
+            config = (template.get("config") or {}) if template else {}
+            llm_id = config.get("llm_id") if isinstance(config, dict) else None
+            pipeline_chat_llm_ids[doc_id] = llm_id.strip() if isinstance(llm_id, str) and llm_id.strip() else None
+            continue
         pipeline_chat_llm_ids[doc_id] = _pipeline_compiler_llm_id(pipeline_id)
     return pipeline_chat_llm_ids
 
@@ -1393,7 +1399,7 @@ async def run_wiki(
     if not eligible:
         progress(1.0, "No documents are configured for wiki compilation.")
         return
-    pipeline_chat_llm_ids = _validate_wiki_eligible_docs(eligible)
+    pipeline_chat_llm_ids = _validate_wiki_eligible_docs(eligible, ctx.tenant_id)
 
     # 3. Resolve chat models. MAP is per document, so each document uses
     # its pipeline Compiler's ``llm_id``. REDUCE / PLAN / REFINE are
@@ -1755,7 +1761,7 @@ async def run_wiki_incremental(
     if not eligible and not is_incremental:
         progress(1.0, "No enabled documents are configured for wiki compilation.")
         return
-    pipeline_chat_llm_ids = _validate_wiki_eligible_docs(eligible) if eligible else {}
+    pipeline_chat_llm_ids = _validate_wiki_eligible_docs(eligible, ctx.tenant_id) if eligible else {}
 
     # Resolve mode from the eligible documents' templates. Each eligible
     # doc resolves to a wiki template either via its own parser_config or via

--- a/rag/svr/task_executor_refactor/dataset_wiki_generator.py
+++ b/rag/svr/task_executor_refactor/dataset_wiki_generator.py
@@ -269,18 +269,29 @@ def _validate_wiki_eligible_docs(eligible: list[tuple[dict, str]], tenant_id: st
     template_ids = {template_id for _, template_id in eligible}
     if len(template_ids) > 1:
         raise ValueError("Eligible Wiki documents must use the same template")
-    pipeline_chat_llm_ids: dict[str, str | None] = {}
-    for doc, template_id in eligible:
+
+    template_chat_llm_id = None
+    if any(not (doc.get("pipeline_id") or "").strip() for doc, _ in eligible):
+        template_id = next(iter(template_ids))
+        template = CompilationTemplateService.get_saved(template_id, tenant_id)
+        config = (template.get("config") or {}) if template else {}
+        llm_id = config.get("llm_id") if isinstance(config, dict) else None
+        template_chat_llm_id = llm_id.strip() if isinstance(llm_id, str) and llm_id.strip() else None
+        logging.info(
+            "wiki: template %s chat model resolved to %s",
+            template_id,
+            template_chat_llm_id or "tenant default",
+        )
+
+    chat_llm_ids: dict[str, str | None] = {}
+    for doc, _ in eligible:
         doc_id = str(doc.get("id") or "")
         pipeline_id = (doc.get("pipeline_id") or "").strip()
         if not pipeline_id:
-            template = CompilationTemplateService.get_saved(template_id, tenant_id)
-            config = (template.get("config") or {}) if template else {}
-            llm_id = config.get("llm_id") if isinstance(config, dict) else None
-            pipeline_chat_llm_ids[doc_id] = llm_id.strip() if isinstance(llm_id, str) and llm_id.strip() else None
+            chat_llm_ids[doc_id] = template_chat_llm_id
             continue
-        pipeline_chat_llm_ids[doc_id] = _pipeline_compiler_llm_id(pipeline_id)
-    return pipeline_chat_llm_ids
+        chat_llm_ids[doc_id] = _pipeline_compiler_llm_id(pipeline_id)
+    return chat_llm_ids
 
 
 def _wiki_eligible_docs(all_docs, tenant_id: str, skip_doc_ids=None) -> list[tuple[dict, str]]:
@@ -1399,12 +1410,12 @@ async def run_wiki(
     if not eligible:
         progress(1.0, "No documents are configured for wiki compilation.")
         return
-    pipeline_chat_llm_ids = _validate_wiki_eligible_docs(eligible, ctx.tenant_id)
+    chat_llm_ids = _validate_wiki_eligible_docs(eligible, ctx.tenant_id)
 
     # 3. Resolve chat models. MAP is per document, so each document uses
-    # its pipeline Compiler's ``llm_id``. REDUCE / PLAN / REFINE are
-    # KB-wide and need exactly one model — we pick the first eligible
-    # pipeline Compiler's ``llm_id`` as the canonical KB chat model.
+    # its template or pipeline Compiler's ``llm_id``. REDUCE / PLAN / REFINE
+    # are KB-wide and need exactly one model — we pick the first eligible
+    # document's ``llm_id`` as the canonical KB chat model.
     llm_bundle_cache: dict[str, LLMBundle] = {}
 
     def _bundle_for(llm_id: str | None) -> LLMBundle:
@@ -1474,14 +1485,14 @@ async def run_wiki(
         progress(1.0, "No valid templates resolved for wiki compilation.")
         return
 
-    # ``kb_chat_llm_id`` is captured from the first eligible pipeline and
+    # ``kb_chat_llm_id`` is captured from the first eligible document and
     # used as the canonical chat model for KB-wide REDUCE/PLAN/REFINE.
     # Writer instructions and page examples follow the same first-template-
     # wins rule.
     first_doc = resolved_eligible[0][0]
     first_parser_cfg = resolved_eligible[0][2]
     first_parser_cfg = first_parser_cfg if isinstance(first_parser_cfg, dict) else {}
-    kb_chat_llm_id = pipeline_chat_llm_ids.get(str(first_doc.get("id") or ""))
+    kb_chat_llm_id = chat_llm_ids.get(str(first_doc.get("id") or ""))
     first_instruction = first_parser_cfg.get("instruction")
     first_example = first_parser_cfg.get("example")
     kb_writer_instruction: Optional[str] = first_instruction if isinstance(first_instruction, str) and first_instruction.strip() else None
@@ -1530,7 +1541,7 @@ async def run_wiki(
                 i, doc, template_id, parser_cfg, batch, batch_no = item
                 doc_id = doc["id"]
                 stats = doc_stats[i]
-                map_llm_id = pipeline_chat_llm_ids.get(str(doc_id))
+                map_llm_id = chat_llm_ids.get(str(doc_id))
                 phase1 = await wiki_map_from_chunks(
                     chunks=batch,
                     chat_mdl=map_llm_pool.wrap(
@@ -1761,7 +1772,7 @@ async def run_wiki_incremental(
     if not eligible and not is_incremental:
         progress(1.0, "No enabled documents are configured for wiki compilation.")
         return
-    pipeline_chat_llm_ids = _validate_wiki_eligible_docs(eligible, ctx.tenant_id) if eligible else {}
+    chat_llm_ids = _validate_wiki_eligible_docs(eligible, ctx.tenant_id) if eligible else {}
 
     # Resolve mode from the eligible documents' templates. Each eligible
     # doc resolves to a wiki template either via its own parser_config or via
@@ -1849,7 +1860,7 @@ async def run_wiki_incremental(
             doc_configs[d["id"]] = cfg
             if not first_template_found and isinstance(cfg, dict):
                 first_template_found = True
-                kb_chat_llm_id = pipeline_chat_llm_ids.get(str(d.get("id") or ""))
+                kb_chat_llm_id = chat_llm_ids.get(str(d.get("id") or ""))
         except Exception:
             logging.exception("wiki: config resolve failed for doc %s", d["id"])
             doc_configs[d["id"]] = {}
@@ -1877,7 +1888,7 @@ async def run_wiki_incremental(
                     return
                 _, doc, template_id, parser_cfg, batch = item
                 doc_id = doc["id"]
-                map_llm_id = pipeline_chat_llm_ids.get(str(doc_id))
+                map_llm_id = chat_llm_ids.get(str(doc_id))
 
                 result = await wiki_map_from_chunks(
                     chunks=batch,

--- a/test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py
+++ b/test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py
@@ -20,14 +20,29 @@ from rag.svr.task_executor_refactor.dataset_wiki_generator import _validate_wiki
 
 
 def test_validate_wiki_eligible_docs_uses_template_model_without_pipeline():
-    eligible = [({"id": "doc-1", "pipeline_id": ""}, "template-1")]
+    eligible = [
+        ({"id": "doc-1", "pipeline_id": ""}, "template-1"),
+        ({"id": "doc-2", "pipeline_id": ""}, "template-1"),
+    ]
 
     with patch("api.db.services.compilation_template_service.CompilationTemplateService.get_saved") as get_saved:
         get_saved.return_value = {"config": {"llm_id": "template-chat"}}
 
         result = _validate_wiki_eligible_docs(eligible, "tenant-1")
 
-    assert result == {"doc-1": "template-chat"}
+    assert result == {"doc-1": "template-chat", "doc-2": "template-chat"}
+    get_saved.assert_called_once_with("template-1", "tenant-1")
+
+
+def test_validate_wiki_eligible_docs_uses_tenant_default_without_template_model():
+    eligible = [({"id": "doc-1", "pipeline_id": ""}, "template-1")]
+
+    with patch("api.db.services.compilation_template_service.CompilationTemplateService.get_saved") as get_saved:
+        get_saved.return_value = {"config": {}}
+
+        result = _validate_wiki_eligible_docs(eligible, "tenant-1")
+
+    assert result == {"doc-1": None}
     get_saved.assert_called_once_with("template-1", "tenant-1")
 
 

--- a/test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py
+++ b/test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py
@@ -1,0 +1,41 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from unittest.mock import patch
+
+from rag.svr.task_executor_refactor.dataset_wiki_generator import _validate_wiki_eligible_docs
+
+
+def test_validate_wiki_eligible_docs_uses_template_model_without_pipeline():
+    eligible = [({"id": "doc-1", "pipeline_id": ""}, "template-1")]
+
+    with patch("api.db.services.compilation_template_service.CompilationTemplateService.get_saved") as get_saved:
+        get_saved.return_value = {"config": {"llm_id": "template-chat"}}
+
+        result = _validate_wiki_eligible_docs(eligible, "tenant-1")
+
+    assert result == {"doc-1": "template-chat"}
+    get_saved.assert_called_once_with("template-1", "tenant-1")
+
+
+def test_validate_wiki_eligible_docs_keeps_pipeline_model_resolution():
+    eligible = [({"id": "doc-1", "pipeline_id": "pipeline-1"}, "template-1")]
+
+    with patch("rag.svr.task_executor_refactor.dataset_wiki_generator._pipeline_compiler_llm_id", return_value="pipeline-chat") as pipeline_model:
+        result = _validate_wiki_eligible_docs(eligible, "tenant-1")
+
+    assert result == {"doc-1": "pipeline-chat"}
+    pipeline_model.assert_called_once_with("pipeline-1")


### PR DESCRIPTION
### Summary

The Wiki eligibility path supports documents configured directly through `parser_config`, but the model validation added in #18216 rejected those documents when `pipeline_id` was empty.

Use the selected compilation template's `llm_id` for pipeline-less documents, while keeping Compiler model resolution unchanged for pipeline-backed documents. Missing template model configuration still falls through to the existing tenant-default behavior.

### Tests

- `.venv/Scripts/python.exe -m pytest test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py -q`
- `.venv/Scripts/python.exe -m py_compile rag/svr/task_executor_refactor/dataset_wiki_generator.py test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py`
- `uvx ruff check test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py --output-format concise`
- `uvx ruff check rag/svr/task_executor_refactor/dataset_wiki_generator.py --select F821,F822,F823 --output-format concise`
- `uvx ruff format --check rag/svr/task_executor_refactor/dataset_wiki_generator.py test/unit_test/rag/svr/task_executor_refactor/test_dataset_wiki_generator.py`