### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/internal/agent/tool/agentic_search.go
+++ b/internal/agent/tool/agentic_search.go
@@ -173,14 +173,14 @@ func splitKeywords(keywords string) []string {
 		return nil
 	}
 	kwds := make([]string, 0, 8)
-	for _, k := range strings.Split(keywords, ",") {
+	for k := range strings.SplitSeq(keywords, ",") {
 		if k = strings.TrimSpace(k); k != "" {
 			kwds = append(kwds, strings.ToLower(k))
 		}
 	}
 	if len(kwds) < 3 {
 		words := make([]string, 0, 8)
-		for _, w := range strings.Split(keywords, " ") {
+		for w := range strings.SplitSeq(keywords, " ") {
 			if w = strings.TrimSpace(w); w != "" {
 				words = append(words, strings.ToLower(w))
 			}

--- a/internal/agent/tool/duckduckgo.go
+++ b/internal/agent/tool/duckduckgo.go
@@ -513,7 +513,7 @@ func hasClassToken(n *xhtml.Node, want string) bool {
 		if a.Key != "class" {
 			continue
 		}
-		for _, token := range strings.Fields(a.Val) {
+		for token := range strings.FieldsSeq(a.Val) {
 			if token == want {
 				return true
 			}

--- a/internal/deepdoc/parser/pdf/table/table_cells.go
+++ b/internal/deepdoc/parser/pdf/table/table_cells.go
@@ -224,8 +224,8 @@ func simpleTokenCount(text string) int {
 		}
 	}
 	// Also count space-separated words.
-	words := strings.Fields(text)
-	for _, w := range words {
+	words := strings.FieldsSeq(text)
+	for w := range words {
 		if !containsCJK(w) {
 			count++
 		}

--- a/internal/deepdoc/parser/pdf/util/position.go
+++ b/internal/deepdoc/parser/pdf/util/position.go
@@ -45,7 +45,7 @@ func ExtractPositions(text string) []pdf.Position {
 
 		// Parse page range
 		var pageNums []int
-		for _, p := range strings.Split(parts[0], "-") {
+		for p := range strings.SplitSeq(parts[0], "-") {
 			n, err := strconv.Atoi(p)
 			if err != nil {
 				slog.Warn("ExtractPositions: invalid page number in tag", "tag", tag, "part", p, "err", err)

--- a/internal/engine/elasticsearch/chunk.go
+++ b/internal/engine/elasticsearch/chunk.go
@@ -2148,7 +2148,7 @@ func (e *Engine) GetAggregation(chunks []map[string]interface{}, fieldName strin
 			if fieldName == "tag_kwd" && strings.Contains(valueStr, "###") {
 				separator = "###"
 			}
-			for _, tag := range strings.Split(valueStr, separator) {
+			for tag := range strings.SplitSeq(valueStr, separator) {
 				countElasticsearchAggregationTag(tagCounts, tag)
 			}
 			continue

--- a/internal/engine/elasticsearch/meta_filter.go
+++ b/internal/engine/elasticsearch/meta_filter.go
@@ -482,8 +482,8 @@ func csvOrList(value interface{}, flt map[string]interface{}) []interface{} {
 			}
 		} else {
 			// Comma-separated
-			parts := strings.Split(v, ",")
-			for _, p := range parts {
+			parts := strings.SplitSeq(v, ",")
+			for p := range parts {
 				trimmed := strings.TrimSpace(p)
 				if trimmed != "" {
 					members = append(members, strings.ToLower(trimmed))

--- a/internal/engine/infinity/chunk.go
+++ b/internal/engine/infinity/chunk.go
@@ -1814,7 +1814,7 @@ func (e *Engine) GetAggregation(chunks []map[string]interface{}, fieldName strin
 			var tags []string
 			// Split by "###" for tag_kwd field
 			if fieldName == "tag_kwd" && strings.Contains(valueStr, "###") {
-				for _, tag := range strings.Split(valueStr, "###") {
+				for tag := range strings.SplitSeq(valueStr, "###") {
 					tag = strings.TrimSpace(tag)
 					if tag != "" {
 						tags = append(tags, tag)
@@ -1822,7 +1822,7 @@ func (e *Engine) GetAggregation(chunks []map[string]interface{}, fieldName strin
 				}
 			} else {
 				// Fallback to comma separation
-				for _, tag := range strings.Split(valueStr, ",") {
+				for tag := range strings.SplitSeq(valueStr, ",") {
 					tag = strings.TrimSpace(tag)
 					if tag != "" {
 						tags = append(tags, tag)

--- a/internal/engine/infinity/meta_filter.go
+++ b/internal/engine/infinity/meta_filter.go
@@ -385,8 +385,8 @@ func csvOrList(value interface{}, flt map[string]interface{}) []interface{} {
 				members = parsed
 			}
 		} else {
-			parts := strings.Split(v, ",")
-			for _, p := range parts {
+			parts := strings.SplitSeq(v, ",")
+			for p := range parts {
 				trimmed := strings.TrimSpace(p)
 				if trimmed != "" {
 					members = append(members, strings.ToLower(trimmed))

--- a/internal/engine/infinity/sql.go
+++ b/internal/engine/infinity/sql.go
@@ -84,7 +84,7 @@ func loadFieldMapping(mappingFileName string) (aliasToActual map[string]string, 
 			continue
 		}
 		var firstAlias string
-		for _, raw := range strings.Split(info.Comment, ",") {
+		for raw := range strings.SplitSeq(info.Comment, ",") {
 			alias := strings.TrimSpace(raw)
 			if alias == "" {
 				continue
@@ -216,7 +216,7 @@ func parsePsqlTable(output string) *psqlResult {
 		return res
 	}
 
-	for _, raw := range strings.Split(lines[0], "|") {
+	for raw := range strings.SplitSeq(lines[0], "|") {
 		if col := strings.TrimSpace(raw); col != "" {
 			res.Columns = append(res.Columns, col)
 		}

--- a/internal/engine/serenedb/common.go
+++ b/internal/engine/serenedb/common.go
@@ -197,7 +197,7 @@ func stripESQuery(matchingText string) string {
 	txt = esSyntaxRe.ReplaceAllString(txt, " ")
 	seen := map[string]struct{}{}
 	var out []string
-	for _, t := range strings.Fields(txt) {
+	for t := range strings.FieldsSeq(txt) {
 		if _, ok := seen[t]; ok {
 			continue
 		}

--- a/internal/harness/core/middlewares/filesystem/filesystem.go
+++ b/internal/harness/core/middlewares/filesystem/filesystem.go
@@ -253,7 +253,7 @@ func formatGrepResult(result, outputMode string) (string, error) {
 		return fmt.Sprintf("%d matches", lines), nil
 	case "files":
 		unique := make(map[string]bool)
-		for _, line := range strings.Split(result, "\n") {
+		for line := range strings.SplitSeq(result, "\n") {
 			if line == "" {
 				continue
 			}

--- a/internal/harness/core/middlewares/skill/skill.go
+++ b/internal/harness/core/middlewares/skill/skill.go
@@ -160,7 +160,7 @@ func parseSkill(content string) *Config {
 		if len(parts) == 2 {
 			front := strings.TrimSpace(parts[0])
 			body := strings.TrimSpace(parts[1])
-			for _, line := range strings.Split(front, "\n") {
+			for line := range strings.SplitSeq(front, "\n") {
 				line = strings.TrimSpace(line)
 				if strings.HasPrefix(line, "name:") {
 					cfg.Name = strings.TrimSpace(line[5:])

--- a/internal/harness/core/middlewares/summarization/compactor.go
+++ b/internal/harness/core/middlewares/summarization/compactor.go
@@ -295,13 +295,13 @@ func ApplySupersede(msgs []*schema.Message) []*schema.Message {
 }
 
 func extractFilePath(content string) string {
-	lines := strings.Split(content, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(content, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "/") || strings.HasPrefix(line, "./") ||
 			strings.HasPrefix(line, "../") || strings.Contains(line, "/") {
-			parts := strings.Fields(line)
-			for _, p := range parts {
+			parts := strings.FieldsSeq(line)
+			for p := range parts {
 				if strings.Contains(p, ".") || strings.Contains(p, "/") {
 					return p
 				}

--- a/internal/harness/graph/graph/state.go
+++ b/internal/harness/graph/graph/state.go
@@ -117,8 +117,8 @@ func parseAnnotation(tag string) (*Annotation, error) {
 		Metadata: make(map[string]interface{}),
 	}
 
-	pairs := strings.Split(tag, ",")
-	for _, pair := range pairs {
+	pairs := strings.SplitSeq(tag, ",")
+	for pair := range pairs {
 		kv := strings.SplitN(pair, "=", 2)
 		if len(kv) != 2 {
 			// Could be a boolean flag

--- a/internal/ingestion/component/knowledge_compiler/wiki/page.go
+++ b/internal/ingestion/component/knowledge_compiler/wiki/page.go
@@ -109,7 +109,7 @@ func ParseOutline(md string) []Section {
 			current = nil
 		}
 	}
-	for _, line := range strings.Split(md, "\n") {
+	for line := range strings.SplitSeq(md, "\n") {
 		trimmed := strings.TrimRight(line, "\r")
 		if lvl := headingLevel(trimmed); lvl > 0 {
 			flush()
@@ -275,7 +275,7 @@ func buildWikiPageProducts(tenantID, docID string, pages []wikiPageResult) []com
 
 // firstHeading returns the first Markdown "# "-prefixed line, trimmed.
 func firstHeading(md string) string {
-	for _, line := range strings.Split(md, "\n") {
+	for line := range strings.SplitSeq(md, "\n") {
 		s := strings.TrimSpace(line)
 		if strings.HasPrefix(s, "# ") {
 			return strings.TrimSpace(strings.TrimPrefix(s, "# "))
@@ -286,7 +286,7 @@ func firstHeading(md string) string {
 
 // firstParagraph returns the first non-empty, non-heading line, capped.
 func firstParagraph(md string) string {
-	for _, line := range strings.Split(md, "\n") {
+	for line := range strings.SplitSeq(md, "\n") {
 		s := strings.TrimSpace(line)
 		if s == "" || strings.HasPrefix(s, "#") {
 			continue

--- a/internal/ingestion/component/knowledge_compiler/wiki/wiki.go
+++ b/internal/ingestion/component/knowledge_compiler/wiki/wiki.go
@@ -1182,7 +1182,7 @@ func wikiMarkdownDropsContent(mergedMD, sourceMD string) bool {
 }
 
 func wikiMarkdownTitle(md string) string {
-	for _, line := range strings.Split(md, "\n") {
+	for line := range strings.SplitSeq(md, "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "# ") {
 			return strings.TrimSpace(strings.TrimPrefix(line, "# "))

--- a/internal/service/nlp/reranker.go
+++ b/internal/service/nlp/reranker.go
@@ -536,7 +536,7 @@ func extractContentTokens(fields map[string]interface{}, cfield string) []string
 	// Split by whitespace to get individual tokens
 	seen := make(map[string]bool)
 	var result []string
-	for _, t := range strings.Fields(v) {
+	for t := range strings.FieldsSeq(v) {
 		if !seen[t] {
 			seen[t] = true
 			result = append(result, t)
@@ -553,7 +553,7 @@ func extractTitleTokens(fields map[string]interface{}) []string {
 	}
 	// NOTE: Do NOT call RemoveRedundantSpaces here - it removes spaces between Chinese chars
 	var result []string
-	for _, t := range strings.Fields(v) {
+	for t := range strings.FieldsSeq(v) {
 		if t != "" {
 			result = append(result, t)
 		}
@@ -568,7 +568,7 @@ func extractQuestionTokens(fields map[string]interface{}) []string {
 		return []string{}
 	}
 	var result []string
-	for _, t := range strings.Fields(v) {
+	for t := range strings.FieldsSeq(v) {
 		if t != "" {
 			result = append(result, t)
 		}

--- a/internal/service/nlp/retrieval.go
+++ b/internal/service/nlp/retrieval.go
@@ -731,7 +731,7 @@ func (s *RetrievalService) Search(ctx context.Context, req *RetrievalSearchReque
 		for _, k := range keywords {
 			kwds[k] = struct{}{}
 			fgToken, _ := tokenizer.FineGrainedTokenize(k)
-			for _, kk := range strings.Fields(fgToken) {
+			for kk := range strings.FieldsSeq(fgToken) {
 				if len(kk) < 2 {
 					continue
 				}
@@ -1079,7 +1079,7 @@ func (s *RetrievalService) PruneDeletedChunks(ctx context.Context, result *Retri
 func buildIndexNames(tenantIDs []string) []string {
 	var indexNames []string
 	for _, tid := range tenantIDs {
-		for _, part := range strings.Split(tid, ",") {
+		for part := range strings.SplitSeq(tid, ",") {
 			part = strings.TrimSpace(part)
 			if part != "" {
 				indexNames = append(indexNames, fmt.Sprintf("ragflow_%s", part))

--- a/internal/service/nlp/term_weight.go
+++ b/internal/service/nlp/term_weight.go
@@ -134,7 +134,7 @@ func (d *TermWeightDealer) Pretoken(txt string, num bool, stpwd bool) []string {
 		tokenized = txt
 	}
 
-	for _, t := range strings.Fields(tokenized) {
+	for t := range strings.FieldsSeq(tokenized) {
 		tk := t
 		// Check stop words
 		if stpwd {
@@ -258,7 +258,7 @@ func (d *TermWeightDealer) Split(txt string) []string {
 	txt = regexp.MustCompile("[ \\t]+").ReplaceAllString(txt, " ")
 	txt = strings.TrimSpace(txt)
 
-	for _, t := range strings.Split(txt, " ") {
+	for t := range strings.SplitSeq(txt, " ") {
 		t = strings.TrimSpace(t)
 		if t == "" {
 			continue

--- a/internal/syncer/connector/google_drive.go
+++ b/internal/syncer/connector/google_drive.go
@@ -1240,7 +1240,7 @@ func (c *GoogleDriveConnector) effectiveIncludeSharedWithMe() bool {
 
 func splitCommaList(value string) []string {
 	values := []string{}
-	for _, part := range strings.Split(value, ",") {
+	for part := range strings.SplitSeq(value, ",") {
 		part = strings.TrimSpace(part)
 		if part != "" {
 			values = append(values, part)


### PR DESCRIPTION
### Summary

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901
