### PR TITLE
fix(web): pass pdf.js cMap/standard font URLs so CID-font PDFs render in preview

### DIFF
--- a/web/src/components/document-preview/pdf-preview.tsx
+++ b/web/src/components/document-preview/pdf-preview.tsx
@@ -33,6 +33,7 @@ import { getAuthorization } from '@/utils/authorization-util';
 import { useCatchDocumentError } from './hooks';
 type PdfLoaderProps = React.ComponentProps<typeof PdfLoader> & {
   httpHeaders?: Record<string, string>;
+  standardFontDataUrl?: string;
 };
 
 const Loader = PdfLoader as React.ComponentType<PdfLoaderProps>;
@@ -100,6 +101,9 @@ const PdfPreview = ({
           </div>
         }
         workerSrc="/pdfjs-dist/pdf.worker.min.js"
+        cMapUrl="/pdfjs-dist/cmaps/"
+        cMapPacked={true}
+        standardFontDataUrl="/pdfjs-dist/standard_fonts/"
         errorMessage={<FileError>{error}</FileError>}
       >
         {(pdfDocument) => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -160,6 +160,14 @@ export default defineConfig(({ mode }) => {
             src: 'node_modules/monaco-editor/min/vs/',
             dest: './',
           },
+          {
+            src: 'node_modules/pdfjs-dist/cmaps/',
+            dest: 'pdfjs-dist/',
+          },
+          {
+            src: 'node_modules/pdfjs-dist/standard_fonts/',
+            dest: 'pdfjs-dist/',
+          },
         ],
       }),
       createHtmlPlugin({


### PR DESCRIPTION
## What
Knowledge-base PDF preview renders **blank pages** for PDFs that use built-in CID fonts (very common for CJK documents, e.g. the Tencent PDF in #8813). The canvas paints nothing and the text layer stays empty.

## Root cause
`PdfLoader` (react-pdf-highlighter / pdf.js) was used without `cMapUrl` / `cMapPacked` / `standardFontDataUrl`. pdf.js therefore could not load the required CMaps (`UniGB-UCS2-H`, etc.) and standard font data, failing with console warnings:

```
Warning: CMapReaderFactory not initialized, using default CMapReaderFactory
```

For CID-keyed fonts this means glyphs cannot be resolved, so pages render empty even though the document parses fine.

## Fix
- `web/vite.config.ts`: copy `pdfjs-dist/cmaps/` and `pdfjs-dist/standard_fonts/` into the already-served `public/pdfjs-dist/` directory via the existing `viteStaticCopy` setup (same mechanism already used for `pdf.worker.min.js`).
- `web/src/components/document-preview/pdf-preview.tsx`: pass `cMapUrl="/pdfjs-dist/cmaps/"`, `cMapPacked={true}` and `standardFontDataUrl="/pdfjs-dist/standard_fonts/"` to `PdfLoader` (and extend the local `PdfLoaderProps` type with `standardFontDataUrl`, which react-pdf-highlighter's typings don't expose).

12 lines added, 0 removed.

## Verification (dev server, knowledge-base document preview)
Reproduced with a CJK CID-font PDF (\u56fd\u5bcc\u8bba / Wealth of Nations, Chinese) uploaded to a knowledge base:

| | Before (props removed) | After (this PR) |
|---|---|---|
| textLayer text length | `0` | full Chinese text of the page |
| canvas | 2 blank canvases | 2 canvases with glyphs painted |
| console | `CMapReaderFactory not initialized` warnings | no pdf.js warnings/errors |

With the fix, the text layer contains the complete selectable Chinese text (e.g. \u7b2c\u4e00\u7bc7 \u8bba\u52b3\u52a8\u751f\u4ea7\u529b\u589e\u8fdb\u7684\u539f\u56e0...) and the page visually renders all characters; both `cmaps/` and `standard_fonts/` are served with HTTP 200 under `/pdfjs-dist/`.

## Notes
- Relates to #8813 (same symptom; this fixes the CID-font path for the current preview component).
- Type-check: 223 pre-existing repo-wide `tsc` errors, **none introduced by this change** (the 2 `TS6133` hits in `pdf-preview.tsx` are pre-existing unused callback params untouched by this diff). `oxlint` on the touched files: 0 warnings, 0 errors.
