### PR TITLE
fix(agent): keep agent chat sidebar scroll container shrinkable

### DIFF
--- a/web/src/pages/agent/chat/box.tsx
+++ b/web/src/pages/agent/chat/box.tsx
@@ -97,7 +97,10 @@ function AgentChatBox() {
   return (
     <>
       <section className="flex flex-1 flex-col px-5 min-h-0 pb-4">
-        <div className="flex-1 overflow-auto" ref={messageContainerRef}>
+        <div
+          className="flex-1 overflow-auto min-h-0"
+          ref={messageContainerRef}
+        >
           <div>
             {!sendLoading && <div data-testid="agent-run-idle" />}
             {/* <Spin spinning={sendLoading}> */}


### PR DESCRIPTION
## Problem
In the agent canvas debug chat sidebar, the streaming answer area could fail to stay anchored to the bottom because the message-list scroll container (`web/src/pages/agent/chat/box.tsx`) was a `flex-1 overflow-auto` flex item without an explicit `min-h-0`. Both sibling chat containers already carry `min-h-0` on the same pattern:

- `web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx` (line 86)
- `web/src/pages/agent/explore/components/session-chat.tsx` (line 122)

## Change
Add `min-h-0` to the scroll container class list in `box.tsx`, so the flex item is explicitly shrinkable instead of relying on `overflow:auto` zeroing its automatic minimum size, keeping the auto-scroll-to-bottom behavior stable regardless of how ancestors size the flex column.

## Verification
Ran the agent debug chat drawer against a ~6k-char streaming answer and sampled the scroll container every second: `scrollTop + clientHeight >= scrollHeight - 25` held for every sample (atBottom true), computed `min-height: 0px`, and the drawer layout is unchanged.