### PR TITLE
fix(go): parse PPTX one chunk per slide

### DIFF
--- a/internal/parser/parser/docx_ir.go
+++ b/internal/parser/parser/docx_ir.go
@@ -15,10 +15,12 @@
 //
 
 // Package parser: this file holds the pure-Go office_oxide IR data
-// model and JSON helpers for DOCX. It is intentionally cgo-free so
-// that postprocessing (docx_postprocess.go) and unit tests run
-// without the office_oxide native library. The cgo boundary lives
-// entirely in docx_parser.go (officeOxide.OpenFromBytes).
+// model and JSON helpers shared by the DOCX and presentation parsers.
+// It is intentionally cgo-free so that postprocessing
+// (docx_postprocess.go), per-slide section building (pptx_ir.go), and
+// unit tests run without the office_oxide native library. The cgo
+// boundary lives in docx_parser.go / pptx_parser.go
+// (officeOxide.OpenFromBytes).
 
 package parser
 
@@ -55,6 +57,7 @@ type docxIRElement struct {
 	Level   int              `json:"level"`   // heading level (1-6) or list nesting level
 	Style   string           `json:"style"`   // Word style name (e.g. "Normal", "Heading 1")
 	Content json.RawMessage  `json:"content"` // rich text runs or block-level content; decoded per type
+	Text    string           `json:"text"`    // payload of a bare "text" block; not part of the current IR schema
 	Data    []byte           `json:"data"`    // raw image bytes (for "image" type)
 	Rows    []docxIRRow      `json:"rows"`    // table rows
 	Ordered bool             `json:"ordered"` // true=numbered list, false=bullet list (for "list" type)
@@ -93,7 +96,7 @@ type docxIRList struct {
 }
 
 type docxIRRun struct {
-	Type    string          `json:"type"` // "text", "image"
+	Type    string          `json:"type"` // "text", "line_break", "image"
 	Text    string          `json:"text"`
 	Content []docxIRElement `json:"content"` // nested elements (used in table cells)
 }
@@ -106,11 +109,17 @@ type docxIRCell struct {
 	Content []docxIRElement `json:"content"` // nested paragraphs inside table cell
 }
 
+// joinDOCXIRRuns concatenates inline runs into plain text. Hard line
+// breaks become newlines so multi-line text keeps its line structure;
+// non-text payloads (e.g. inline images) contribute no characters.
 func joinDOCXIRRuns(runs []docxIRRun) string {
 	var b strings.Builder
 	for _, r := range runs {
-		if r.Type == "text" {
+		switch r.Type {
+		case "text":
 			b.WriteString(r.Text)
+		case "line_break":
+			b.WriteByte('\n')
 		}
 	}
 	return b.String()
@@ -193,14 +202,19 @@ func docxIRTableToHTML(el docxIRElement) string {
 }
 
 // docxElementText returns the plain-text rendering of any supported
-// IR element type. Used by extractDOCXFiguresFromIR so that tables,
-// lists, and text boxes contribute to image surrounding context
-// instead of becoming empty flatBlocks (which would drop adjacent
-// VLM context). Returns "" for image and unknown types.
+// IR element type. Used by buildPPTXJSONSections to flatten one slide
+// section, and by extractDOCXFiguresFromIR so that tables, lists, and
+// text boxes contribute to image surrounding context instead of
+// becoming empty flatBlocks (which would drop adjacent VLM context).
+// A bare "text" block is not part of the current IR schema, but is
+// passed through so its payload is never silently dropped. Returns ""
+// for image and unknown types.
 func docxElementText(el docxIRElement) string {
 	switch el.Type {
 	case "paragraph", "heading":
 		return joinDOCXIRRuns(el.contentRuns())
+	case "text":
+		return el.Text
 	case "table":
 		var lines []string
 		for _, row := range el.Rows {

--- a/internal/parser/parser/docx_ir_test.go
+++ b/internal/parser/parser/docx_ir_test.go
@@ -65,6 +65,19 @@ func TestJoinDOCXIRRuns(t *testing.T) {
 	}
 }
 
+// TestJoinDOCXIRRuns_LineBreak pins that a hard line break inline run
+// renders as a newline instead of being dropped.
+func TestJoinDOCXIRRuns_LineBreak(t *testing.T) {
+	runs := []docxIRRun{
+		{Type: "text", Text: "before"},
+		{Type: "line_break"},
+		{Type: "text", Text: "after"},
+	}
+	if got := joinDOCXIRRuns(runs); got != "before\nafter" {
+		t.Fatalf("joinDOCXIRRuns = %q, want %q", got, "before\nafter")
+	}
+}
+
 // TestExtractDOCXFiguresFromIR verifies the image-figure context
 // extraction: an image block carries the immediately surrounding text
 // as ContextAbove / ContextBelow / Marker. Pure-Go, runs under !cgo.

--- a/internal/parser/parser/ppt_parser_cgo_test.go
+++ b/internal/parser/parser/ppt_parser_cgo_test.go
@@ -99,8 +99,8 @@ func TestPPTXParser_ParseWithResult_MultiSlide_CGO(t *testing.T) {
 }
 
 // TestPPTXParser_ParseWithResult_EmptySlide_CGO verifies that a slide
-// without extractable text still yields its own JSON item (empty text),
-// matching the python parser which appends one text per slide.
+// without extractable text still yields its own JSON item with an
+// empty text field, so slide numbering stays aligned with the deck.
 func TestPPTXParser_ParseWithResult_EmptySlide_CGO(t *testing.T) {
 	ctx := t.Context()
 	p := NewPPTXParser()

--- a/internal/parser/parser/ppt_parser_cgo_test.go
+++ b/internal/parser/parser/ppt_parser_cgo_test.go
@@ -50,6 +50,88 @@ func TestPPTXParser_ParseWithResult_CGO(t *testing.T) {
 	}
 }
 
+// TestPPTXParser_ParseWithResult_MultiSlide_CGO is the regression test
+// for the one-chunk-per-slide contract: a multi-slide deck must emit
+// one JSON item per slide, each carrying that slide's text only.
+// office_oxide's PlainText concatenates slides without a delimiter, so
+// splitting must come from the structured IR sections.
+func TestPPTXParser_ParseWithResult_MultiSlide_CGO(t *testing.T) {
+	ctx := t.Context()
+	p := NewPPTXParser()
+
+	w := officeOxide.NewPptxWriter()
+	s1 := w.AddSlide()
+	w.SetSlideTitle(s1, "Slide One Title")
+	w.AddSlideText(s1, "First slide body about the Alpha topic.")
+	s2 := w.AddSlide()
+	w.SetSlideTitle(s2, "Slide Two Title")
+	w.AddSlideText(s2, "Second slide body about the Beta topic.")
+	data, err := w.ToBytes()
+	if err != nil {
+		t.Fatalf("PptxWriter.ToBytes: %v", err)
+	}
+
+	res := p.ParseWithResult(ctx, "deck.pptx", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if len(res.JSON) != 2 {
+		t.Fatalf("JSON items = %d, want 2 (one per slide): %#v", len(res.JSON), res.JSON)
+	}
+	for i, want := range []struct {
+		text     string
+		slideNum int
+	}{
+		{"Slide One Title\nFirst slide body about the Alpha topic.", 1},
+		{"Slide Two Title\nSecond slide body about the Beta topic.", 2},
+	} {
+		it := res.JSON[i]
+		if got := it["text"]; got != want.text {
+			t.Errorf("item %d text = %q, want %q", i, got, want.text)
+		}
+		if got := it["slide_number"]; got != want.slideNum {
+			t.Errorf("item %d slide_number = %v, want %d", i, got, want.slideNum)
+		}
+		if got := it["doc_type_kwd"]; got != "text" {
+			t.Errorf("item %d doc_type_kwd = %v, want text", i, got)
+		}
+	}
+}
+
+// TestPPTXParser_ParseWithResult_EmptySlide_CGO verifies that a slide
+// without extractable text still yields its own JSON item (empty text),
+// matching the python parser which appends one text per slide.
+func TestPPTXParser_ParseWithResult_EmptySlide_CGO(t *testing.T) {
+	ctx := t.Context()
+	p := NewPPTXParser()
+
+	w := officeOxide.NewPptxWriter()
+	s1 := w.AddSlide()
+	w.SetSlideTitle(s1, "Only Title")
+	w.AddSlide() // empty slide
+	s3 := w.AddSlide()
+	w.SetSlideTitle(s3, "Third Title")
+	w.AddSlideText(s3, "Third body.")
+	data, err := w.ToBytes()
+	if err != nil {
+		t.Fatalf("PptxWriter.ToBytes: %v", err)
+	}
+
+	res := p.ParseWithResult(ctx, "deck.pptx", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if len(res.JSON) != 3 {
+		t.Fatalf("JSON items = %d, want 3 (one per slide): %#v", len(res.JSON), res.JSON)
+	}
+	if got := res.JSON[1]["text"]; got != "" {
+		t.Errorf("empty slide text = %q, want empty", got)
+	}
+	if got := res.JSON[1]["slide_number"]; got != 2 {
+		t.Errorf("empty slide slide_number = %v, want 2", got)
+	}
+}
+
 // TestPPTParser_ParseWithResult_CGO verifies that PPTParser
 // delegates correctly to PPTXParser{format:"ppt"} and produces
 // output with File["format"] = "ppt".

--- a/internal/parser/parser/pptx_ir.go
+++ b/internal/parser/parser/pptx_ir.go
@@ -43,6 +43,9 @@ func buildPPTXJSONSections(irJSON string) ([]map[string]any, error) {
 	for i, sec := range ir.Sections {
 		var lines []string
 		for _, el := range sec.Elements {
+			// Trim each line and drop blank ones: consecutive hard line
+			// breaks collapse to a single newline, so exactly one newline
+			// survives between two non-empty lines.
 			for _, line := range strings.Split(docxElementText(el), "\n") {
 				if line = strings.TrimSpace(line); line != "" {
 					lines = append(lines, line)
@@ -56,4 +59,16 @@ func buildPPTXJSONSections(irJSON string) ([]map[string]any, error) {
 		})
 	}
 	return items, nil
+}
+
+// itemsFromPlainText wraps whole-document plain text as a single JSON
+// item. It salvages a still-readable deck when the structured IR cannot
+// be used (IR serialization failure or a sectionless IR); a document
+// without extractable text yields an empty, non-nil item slice.
+func itemsFromPlainText(text string) []map[string]any {
+	items := []map[string]any{}
+	if trimmed := strings.TrimSpace(text); trimmed != "" {
+		items = append(items, map[string]any{"text": trimmed, "doc_type_kwd": "text"})
+	}
+	return items
 }

--- a/internal/parser/parser/pptx_ir.go
+++ b/internal/parser/parser/pptx_ir.go
@@ -1,0 +1,59 @@
+//
+// Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// buildPPTXJSONSections converts office_oxide presentation IR JSON into
+// one JSON item per slide. The IR carries exactly one section per slide,
+// so section index + 1 is the slide number. Per-slide text is flattened
+// with the shared IR walker (docxElementText), which covers paragraphs,
+// headings, text boxes, tables, and (nested) lists.
+//
+// A slide without extractable text (blank layout, image-only) still
+// yields an item with an empty text field, so slide_number stays
+// aligned with the source deck.
+//
+// Pure Go (no cgo) so the IR → items transform is unit-testable without
+// the office_oxide native library.
+func buildPPTXJSONSections(irJSON string) ([]map[string]any, error) {
+	var ir docxIRDocument
+	if err := json.Unmarshal([]byte(irJSON), &ir); err != nil {
+		return nil, fmt.Errorf("presentation ir-json decode: %w", err)
+	}
+	items := make([]map[string]any, 0, len(ir.Sections))
+	for i, sec := range ir.Sections {
+		var lines []string
+		for _, el := range sec.Elements {
+			for _, line := range strings.Split(docxElementText(el), "\n") {
+				if line = strings.TrimSpace(line); line != "" {
+					lines = append(lines, line)
+				}
+			}
+		}
+		items = append(items, map[string]any{
+			"text":         strings.Join(lines, "\n"),
+			"doc_type_kwd": "text",
+			"slide_number": i + 1,
+		})
+	}
+	return items, nil
+}

--- a/internal/parser/parser/pptx_ir_test.go
+++ b/internal/parser/parser/pptx_ir_test.go
@@ -1,0 +1,120 @@
+package parser
+
+import "testing"
+
+// TestBuildPPTXJSONSections feeds office_oxide presentation IR JSON
+// directly into buildPPTXJSONSections and asserts one JSON item per
+// slide (section), including empty slides. Pure Go, runs under !cgo.
+func TestBuildPPTXJSONSections(t *testing.T) {
+	tests := []struct {
+		name      string
+		irJSON    string
+		wantTexts []string // one entry per expected slide item
+		wantErr   bool
+	}{
+		{
+			name: "multi slide paragraphs",
+			irJSON: `{"sections":[
+				{"elements":[{"type":"paragraph","content":[{"type":"text","text":"Slide One"}]}]},
+				{"elements":[{"type":"paragraph","content":[{"type":"text","text":"Slide Two"}]}]}
+			]}`,
+			wantTexts: []string{"Slide One", "Slide Two"},
+		},
+		{
+			name: "empty slide retained",
+			irJSON: `{"sections":[
+				{"elements":[{"type":"paragraph","content":[{"type":"text","text":"First"}]}]},
+				{"elements":[]},
+				{"elements":[{"type":"paragraph","content":[{"type":"text","text":"Third"}]}]}
+			]}`,
+			wantTexts: []string{"First", "", "Third"},
+		},
+		{
+			name: "bullet list with nested sub-list",
+			irJSON: `{"sections":[{"elements":[
+				{"type":"paragraph","content":[{"type":"text","text":"Agenda"}]},
+				{"type":"list","items":[
+					{"content":[{"type":"paragraph","content":[{"type":"text","text":"First point"}]}]},
+					{"content":[{"type":"paragraph","content":[{"type":"text","text":"Second point"}]}],
+					 "nested":{"items":[{"content":[{"type":"paragraph","content":[{"type":"text","text":"Sub point"}]}]}]}}
+				]}
+			]}]}`,
+			wantTexts: []string{"Agenda\nFirst point\nSecond point\nSub point"},
+		},
+		{
+			name: "table cells",
+			irJSON: `{"sections":[{"elements":[
+				{"type":"table","rows":[
+					{"cells":[
+						{"content":[{"type":"paragraph","content":[{"type":"text","text":"H1"}]}]},
+						{"content":[{"type":"paragraph","content":[{"type":"text","text":"H2"}]}]}
+					]},
+					{"cells":[
+						{"content":[{"type":"paragraph","content":[{"type":"text","text":"a"}]}]},
+						{"content":[{"type":"paragraph","content":[{"type":"text","text":"b"}]}]}
+					]}
+				]}
+			]}]}`,
+			wantTexts: []string{"H1\nH2\na\nb"},
+		},
+		{
+			name: "hard line break keeps newline",
+			irJSON: `{"sections":[{"elements":[
+				{"type":"paragraph","content":[
+					{"type":"text","text":"before"},
+					{"type":"line_break"},
+					{"type":"text","text":"after"}
+				]}
+			]}]}`,
+			wantTexts: []string{"before\nafter"},
+		},
+		{
+			name:      "bare text block passes through",
+			irJSON:    `{"sections":[{"elements":[{"type":"text","text":"loose text"}]}]}`,
+			wantTexts: []string{"loose text"},
+		},
+		{
+			name:      "image-only slide yields empty text",
+			irJSON:    `{"sections":[{"elements":[{"type":"image","data":"aGVsbG8="}]}]}`,
+			wantTexts: []string{""},
+		},
+		{
+			name:    "invalid JSON",
+			irJSON:  "{not json",
+			wantErr: true,
+		},
+		{
+			name:      "no sections yields no items",
+			irJSON:    `{"sections":[]}`,
+			wantTexts: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items, err := buildPPTXJSONSections(tt.irJSON)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("buildPPTXJSONSections: want error, got items %+v", items)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildPPTXJSONSections: %v", err)
+			}
+			if len(items) != len(tt.wantTexts) {
+				t.Fatalf("items = %d, want %d: %+v", len(items), len(tt.wantTexts), items)
+			}
+			for i, want := range tt.wantTexts {
+				if got := items[i]["text"]; got != want {
+					t.Errorf("item %d text = %q, want %q", i, got, want)
+				}
+				if got := items[i]["slide_number"]; got != i+1 {
+					t.Errorf("item %d slide_number = %v, want %d", i, got, i+1)
+				}
+				if got := items[i]["doc_type_kwd"]; got != "text" {
+					t.Errorf("item %d doc_type_kwd = %v, want text", i, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/parser/parser/pptx_ir_test.go
+++ b/internal/parser/parser/pptx_ir_test.go
@@ -69,6 +69,22 @@ func TestBuildPPTXJSONSections(t *testing.T) {
 			wantTexts: []string{"before\nafter"},
 		},
 		{
+			// Regression: two consecutive breaks must collapse to exactly
+			// one newline - not zero, and not a preserved blank line. Blank
+			// lines are dropped, keeping one newline between two non-empty
+			// lines.
+			name: "consecutive hard line breaks collapse to one newline",
+			irJSON: `{"sections":[{"elements":[
+				{"type":"paragraph","content":[
+					{"type":"text","text":"before"},
+					{"type":"line_break"},
+					{"type":"line_break"},
+					{"type":"text","text":"after"}
+				]}
+			]}]}`,
+			wantTexts: []string{"before\nafter"},
+		},
+		{
 			name:      "bare text block passes through",
 			irJSON:    `{"sections":[{"elements":[{"type":"text","text":"loose text"}]}]}`,
 			wantTexts: []string{"loose text"},
@@ -116,5 +132,19 @@ func TestBuildPPTXJSONSections(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestItemsFromPlainText pins the whole-document plain-text salvage used
+// when the structured IR is unusable: non-empty text becomes a single
+// trimmed item; blank text yields an empty, non-nil slice.
+func TestItemsFromPlainText(t *testing.T) {
+	items := itemsFromPlainText("  whole deck text  ")
+	if len(items) != 1 || items[0]["text"] != "whole deck text" || items[0]["doc_type_kwd"] != "text" {
+		t.Fatalf("items = %+v, want a single trimmed text item", items)
+	}
+	items = itemsFromPlainText("   ")
+	if items == nil || len(items) != 0 {
+		t.Fatalf("items = %+v, want an empty non-nil slice", items)
 	}
 }

--- a/internal/parser/parser/pptx_parser.go
+++ b/internal/parser/parser/pptx_parser.go
@@ -118,7 +118,20 @@ func (p *PPTXParser) ParseWithResult(ctx context.Context, filename string, data 
 	// IR, which carries one section per slide.
 	irJSON, err := doc.ToIRJSON()
 	if err != nil {
-		return ParseResult{Err: fmt.Errorf("presentation ir-json: %w", err)}
+		// Salvage path: the document opened but its structured IR could
+		// not be serialized. Fall back to whole-document plain text
+		// (worst case: the entire deck as one chunk) so a still-readable
+		// deck yields content instead of a hard parse error. The original
+		// IR error is surfaced only when plain text fails too.
+		text, perr := doc.PlainText()
+		if perr != nil {
+			return ParseResult{Err: fmt.Errorf("presentation ir-json: %w", err)}
+		}
+		return ParseResult{
+			OutputFormat: "json",
+			File:         map[string]any{"name": filename, "format": p.format},
+			JSON:         itemsFromPlainText(text),
+		}
 	}
 	items, err := buildPPTXJSONSections(irJSON)
 	if err != nil {
@@ -132,9 +145,7 @@ func (p *PPTXParser) ParseWithResult(ctx context.Context, filename string, data 
 		if perr != nil {
 			return ParseResult{Err: fmt.Errorf("presentation plain-text: %w", perr)}
 		}
-		if trimmed := strings.TrimSpace(text); trimmed != "" {
-			items = append(items, map[string]any{"text": trimmed, "doc_type_kwd": "text"})
-		}
+		items = itemsFromPlainText(text)
 	}
 
 	return ParseResult{

--- a/internal/parser/parser/pptx_parser.go
+++ b/internal/parser/parser/pptx_parser.go
@@ -20,6 +20,7 @@ package parser
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -113,27 +114,42 @@ func (p *PPTXParser) ParseWithResult(ctx context.Context, filename string, data 
 	}
 	defer doc.Close()
 
-	text, err := doc.PlainText()
+	// office_oxide's PlainText renders slides back-to-back with no page
+	// delimiter, so per-slide splitting must go through the structured
+	// IR, which carries one section per slide. This mirrors the python
+	// RAGFlowPptParser, which iterates slides and yields one text per
+	// slide ("Every page will be treated as a chunk").
+	irJSON, err := doc.ToIRJSON()
 	if err != nil {
-		return ParseResult{Err: fmt.Errorf("pptx plain-text: %w", err)}
+		return ParseResult{Err: fmt.Errorf("presentation ir-json: %w", err)}
+	}
+	var ir presentationIR
+	if err := json.Unmarshal([]byte(irJSON), &ir); err != nil {
+		return ParseResult{Err: fmt.Errorf("presentation ir-json decode: %w", err)}
 	}
 
-	// Split on form-feed (the python TxtParser convention used by
-	// RAGFlow's slide parser) — each block becomes a JSON item.
-	var items []map[string]any
-	for i, raw := range strings.Split(text, "\f") {
-		trimmed := strings.TrimSpace(raw)
-		if trimmed == "" {
-			continue
-		}
+	// One JSON item per slide, including slides without extractable
+	// text — the python parser likewise appends one (possibly empty)
+	// text per slide.
+	items := make([]map[string]any, 0, len(ir.Sections))
+	for i, sec := range ir.Sections {
 		items = append(items, map[string]any{
-			"text":         trimmed,
+			"text":         sec.text(),
 			"doc_type_kwd": "text",
 			"slide_number": i + 1,
 		})
 	}
-	if items == nil {
-		items = []map[string]any{{"text": strings.TrimSpace(text), "doc_type_kwd": "text"}}
+	if len(items) == 0 {
+		// A deck whose IR carries no sections at all: keep the
+		// whole-document text as a single item so a still-readable
+		// file yields one chunk instead of none.
+		text, perr := doc.PlainText()
+		if perr != nil {
+			return ParseResult{Err: fmt.Errorf("presentation plain-text: %w", perr)}
+		}
+		if trimmed := strings.TrimSpace(text); trimmed != "" {
+			items = append(items, map[string]any{"text": trimmed, "doc_type_kwd": "text"})
+		}
 	}
 
 	return ParseResult{
@@ -141,4 +157,88 @@ func (p *PPTXParser) ParseWithResult(ctx context.Context, filename string, data 
 		File:         map[string]any{"name": filename, "format": p.format},
 		JSON:         items,
 	}
+}
+
+// ── office_oxide presentation IR ─────────────────────────────────────
+// Subset of the office_oxide IR JSON schema needed to recover per-slide
+// plain text. Each slide is one section whose elements are block nodes
+// (headings, paragraphs, text boxes, tables, images); block nodes nest
+// (a text box contains paragraphs) and leaf "text" runs carry the
+// characters.
+
+type presentationIR struct {
+	Sections []irSection `json:"sections"`
+}
+
+type irSection struct {
+	Elements []irNode `json:"elements"`
+}
+
+type irNode struct {
+	Type    string   `json:"type"`
+	Text    string   `json:"text"`
+	Content []irNode `json:"content"`
+	Rows    []irRow  `json:"rows"`
+}
+
+type irRow struct {
+	Cells []irCell `json:"cells"`
+}
+
+type irCell struct {
+	Content []irNode `json:"content"`
+}
+
+// text flattens the slide's IR elements into plain text, one line per
+// paragraph-level block — the same shape the python parser produces by
+// joining per-shape texts with "\n".
+func (s irSection) text() string {
+	var lines []string
+	for _, el := range s.Elements {
+		lines = append(lines, irBlockLines(el)...)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// irBlockLines returns one entry per paragraph-level block under n.
+// Leaf text runs concatenate into the enclosing block's line; tables
+// yield one line per row with cells joined by "; ".
+func irBlockLines(n irNode) []string {
+	if len(n.Rows) > 0 {
+		lines := make([]string, 0, len(n.Rows))
+		for _, row := range n.Rows {
+			cells := make([]string, 0, len(row.Cells))
+			for _, cell := range row.Cells {
+				var parts []string
+				for _, el := range cell.Content {
+					parts = append(parts, irBlockLines(el)...)
+				}
+				cells = append(cells, strings.Join(parts, " "))
+			}
+			lines = append(lines, strings.Join(cells, "; "))
+		}
+		return lines
+	}
+	runsOnly := true
+	for _, c := range n.Content {
+		if c.Type != "text" {
+			runsOnly = false
+			break
+		}
+	}
+	if runsOnly {
+		var b strings.Builder
+		for _, c := range n.Content {
+			b.WriteString(c.Text)
+		}
+		if s := strings.TrimSpace(b.String()); s != "" {
+			return []string{s}
+		}
+		return nil
+	}
+	var lines []string
+	for _, c := range n.Content {
+		lines = append(lines, irBlockLines(c)...)
+	}
+	return lines
 }

--- a/internal/parser/parser/pptx_parser.go
+++ b/internal/parser/parser/pptx_parser.go
@@ -20,7 +20,6 @@ package parser
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -116,28 +115,14 @@ func (p *PPTXParser) ParseWithResult(ctx context.Context, filename string, data 
 
 	// office_oxide's PlainText renders slides back-to-back with no page
 	// delimiter, so per-slide splitting must go through the structured
-	// IR, which carries one section per slide. This mirrors the python
-	// RAGFlowPptParser, which iterates slides and yields one text per
-	// slide ("Every page will be treated as a chunk").
+	// IR, which carries one section per slide.
 	irJSON, err := doc.ToIRJSON()
 	if err != nil {
 		return ParseResult{Err: fmt.Errorf("presentation ir-json: %w", err)}
 	}
-	var ir presentationIR
-	if err := json.Unmarshal([]byte(irJSON), &ir); err != nil {
-		return ParseResult{Err: fmt.Errorf("presentation ir-json decode: %w", err)}
-	}
-
-	// One JSON item per slide, including slides without extractable
-	// text — the python parser likewise appends one (possibly empty)
-	// text per slide.
-	items := make([]map[string]any, 0, len(ir.Sections))
-	for i, sec := range ir.Sections {
-		items = append(items, map[string]any{
-			"text":         sec.text(),
-			"doc_type_kwd": "text",
-			"slide_number": i + 1,
-		})
+	items, err := buildPPTXJSONSections(irJSON)
+	if err != nil {
+		return ParseResult{Err: err}
 	}
 	if len(items) == 0 {
 		// A deck whose IR carries no sections at all: keep the
@@ -157,88 +142,4 @@ func (p *PPTXParser) ParseWithResult(ctx context.Context, filename string, data 
 		File:         map[string]any{"name": filename, "format": p.format},
 		JSON:         items,
 	}
-}
-
-// ── office_oxide presentation IR ─────────────────────────────────────
-// Subset of the office_oxide IR JSON schema needed to recover per-slide
-// plain text. Each slide is one section whose elements are block nodes
-// (headings, paragraphs, text boxes, tables, images); block nodes nest
-// (a text box contains paragraphs) and leaf "text" runs carry the
-// characters.
-
-type presentationIR struct {
-	Sections []irSection `json:"sections"`
-}
-
-type irSection struct {
-	Elements []irNode `json:"elements"`
-}
-
-type irNode struct {
-	Type    string   `json:"type"`
-	Text    string   `json:"text"`
-	Content []irNode `json:"content"`
-	Rows    []irRow  `json:"rows"`
-}
-
-type irRow struct {
-	Cells []irCell `json:"cells"`
-}
-
-type irCell struct {
-	Content []irNode `json:"content"`
-}
-
-// text flattens the slide's IR elements into plain text, one line per
-// paragraph-level block — the same shape the python parser produces by
-// joining per-shape texts with "\n".
-func (s irSection) text() string {
-	var lines []string
-	for _, el := range s.Elements {
-		lines = append(lines, irBlockLines(el)...)
-	}
-	return strings.Join(lines, "\n")
-}
-
-// irBlockLines returns one entry per paragraph-level block under n.
-// Leaf text runs concatenate into the enclosing block's line; tables
-// yield one line per row with cells joined by "; ".
-func irBlockLines(n irNode) []string {
-	if len(n.Rows) > 0 {
-		lines := make([]string, 0, len(n.Rows))
-		for _, row := range n.Rows {
-			cells := make([]string, 0, len(row.Cells))
-			for _, cell := range row.Cells {
-				var parts []string
-				for _, el := range cell.Content {
-					parts = append(parts, irBlockLines(el)...)
-				}
-				cells = append(cells, strings.Join(parts, " "))
-			}
-			lines = append(lines, strings.Join(cells, "; "))
-		}
-		return lines
-	}
-	runsOnly := true
-	for _, c := range n.Content {
-		if c.Type != "text" {
-			runsOnly = false
-			break
-		}
-	}
-	if runsOnly {
-		var b strings.Builder
-		for _, c := range n.Content {
-			b.WriteString(c.Text)
-		}
-		if s := strings.TrimSpace(b.String()); s != "" {
-			return []string{s}
-		}
-		return nil
-	}
-	var lines []string
-	for _, c := range n.Content {
-		lines = append(lines, irBlockLines(c)...)
-	}
-	return lines
 }


### PR DESCRIPTION
## Problem

In Go parse mode, a PPTX deck with multiple slides produced exactly **1 chunk** instead of one chunk per slide. E.g. a 2-page deck (titles 'Slide One' / 'Slide Two') yielded a single merged chunk containing both slides' text.

Root cause: `PPTXParser.ParseWithResult` called office_oxide's `PlainText()`, which renders slides back-to-back **without any page delimiter**, and then split on form-feed (`\f`). With no `\f` present, all slides collapsed into a single JSON item → one chunk.

## Fix

Derive per-slide text from office_oxide's structured IR (`ToIRJSON`), which carries **one section per slide**. `ParseWithResult` now emits one JSON item per slide, each with its own `text`, `doc_type_kwd: text`, and `slide_number` — mirroring the python `RAGFlowPptParser` contract ('Every page will be treated as a chunk'). Slides without extractable text still yield their own (empty) item, matching python's one-entry-per-slide behavior. A zero-section IR falls back to the whole-document `PlainText` so a readable file still yields one chunk instead of none.

## Testing

- New CGO regression tests in `ppt_parser_cgo_test.go`:
  - `TestPPTXParser_ParseWithResult_MultiSlide_CGO`: 2-slide deck → 2 JSON items with correct per-slide text and `slide_number` (1, 2).
  - `TestPPTXParser_ParseWithResult_EmptySlide_CGO`: 3-slide deck with empty middle slide → 3 items, middle one with empty text and `slide_number`=2.
- `bash build.sh --test ./internal/parser/...` — all pass.
- E2E: created a Presentation-mode dataset via the Go API, uploaded a 2-slide `.pptx`, parsed → `chunk_count = 2`, one chunk per slide ('Slide One Title…' / 'Slide Two Title…').