### PR TITLE
fix(web): make chat attachment images click-to-zoomable

### DIFF
--- a/web/src/components/next-message-item/__tests__/utils.test.ts
+++ b/web/src/components/next-message-item/__tests__/utils.test.ts
@@ -1,0 +1,66 @@
+import { UploadResponseDataType } from '@/interfaces/database/chat';
+import { IDocumentInfo } from '@/interfaces/database/document';
+import { getFileMimeType, isImageFile } from '../utils';
+
+describe('getFileMimeType', () => {
+  it('uses the browser-provided type for local File objects', () => {
+    const file = new File(['x'], 'photo.png', { type: 'image/png' });
+    expect(getFileMimeType(file)).toBe('image/png');
+  });
+
+  it('reads mime_type from uploaded file metadata', () => {
+    const file = {
+      name: 'photo.webp',
+      mime_type: 'image/webp',
+    } as UploadResponseDataType;
+    expect(getFileMimeType(file)).toBe('image/webp');
+  });
+
+  it('returns an empty string when no MIME metadata exists', () => {
+    const file = { name: 'scan.png' } as IDocumentInfo;
+    expect(getFileMimeType(file)).toBe('');
+  });
+});
+
+describe('isImageFile', () => {
+  it('detects images by MIME type', () => {
+    const file = new File(['x'], 'photo', { type: 'image/png' });
+    expect(isImageFile(file)).toBe(true);
+  });
+
+  it('falls back to the filename extension when MIME metadata is missing', () => {
+    const file = new File(['x'], 'photo.png', { type: '' });
+    expect(isImageFile(file)).toBe(true);
+  });
+
+  it('matches extensions case-insensitively', () => {
+    const file = { name: 'diagram.SVG' } as IDocumentInfo;
+    expect(isImageFile(file)).toBe(true);
+  });
+
+  it('detects uploaded files through their mime_type', () => {
+    const file = {
+      name: 'photo.avif',
+      mime_type: 'image/avif',
+    } as UploadResponseDataType;
+    expect(isImageFile(file)).toBe(true);
+  });
+
+  it('lets explicit MIME metadata win over the filename extension', () => {
+    const file = {
+      name: 'fake.png',
+      mime_type: 'application/pdf',
+    } as UploadResponseDataType;
+    expect(isImageFile(file)).toBe(false);
+  });
+
+  it('passes non-image files through as non-image', () => {
+    expect(
+      isImageFile(new File(['x'], 'notes.txt', { type: 'text/plain' })),
+    ).toBe(false);
+    expect(isImageFile({ name: 'report.docx' } as IDocumentInfo)).toBe(false);
+    expect(isImageFile(new File(['x'], 'archive.bin', { type: '' }))).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/components/next-message-item/uploaded-message-files.tsx
+++ b/web/src/components/next-message-item/uploaded-message-files.tsx
@@ -16,14 +16,100 @@
 
 import { UploadResponseDataType } from '@/interfaces/database/chat';
 import { IDocumentInfo } from '@/interfaces/database/document';
+import api from '@/utils/api';
 import { getExtension } from '@/utils/document-util';
 import { formatBytes } from '@/utils/file-util';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
+import { PhotoProvider, PhotoView } from 'react-photo-view';
 import FileIcon from '../file-icon';
+import { useAuthenticatedImageUrl } from '../image';
 import SvgIcon from '../svg-icon';
 
 interface IProps {
   files?: File[] | IDocumentInfo[] | UploadResponseDataType[];
+}
+
+const ImageExtensions = [
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'svg',
+  'ico',
+  'avif',
+];
+
+function getFileMimeType(
+  file: File | IDocumentInfo | UploadResponseDataType,
+): string {
+  if (file instanceof File) {
+    return file.type;
+  }
+  if ('mime_type' in file && typeof file.mime_type === 'string') {
+    return file.mime_type;
+  }
+  return '';
+}
+
+function isImageFile(
+  file: File | IDocumentInfo | UploadResponseDataType,
+): boolean {
+  const mimeType = getFileMimeType(file);
+  if (mimeType) {
+    return mimeType.startsWith('image/');
+  }
+  return ImageExtensions.includes(getExtension(file.name));
+}
+
+// Zoomable thumbnail for files already uploaded to the server: chat uploads
+// are stored as blobs in the per-user downloads bucket (no file/document
+// row), so the raw content is fetched through the authenticated attachment
+// preview endpoint and displayed in a lightbox (react-photo-view) on click.
+function UploadedFileImage({
+  id,
+  name,
+  mimeType,
+}: {
+  id: string;
+  name: string;
+  mimeType?: string;
+}) {
+  const src = useAuthenticatedImageUrl(
+    id
+      ? api.getAttachmentFilePreview({ docId: id, filename: name, mimeType })
+      : null,
+  );
+
+  if (!src) {
+    return <FileIcon id={id} name={name}></FileIcon>;
+  }
+
+  return (
+    <PhotoView src={src}>
+      <img
+        src={src}
+        alt={name}
+        className="size-10 object-cover cursor-zoom-in"
+      />
+    </PhotoView>
+  );
+}
+
+// Zoomable thumbnail for local files that have not been sent yet.
+function LocalFileImage({ file, name }: { file: File; name: string }) {
+  const objectUrl = useMemo(() => URL.createObjectURL(file), [file]);
+
+  return (
+    <PhotoView src={objectUrl}>
+      <img
+        src={objectUrl}
+        alt={name}
+        className="size-10 object-cover cursor-zoom-in"
+      />
+    </PhotoView>
+  );
 }
 
 type NameWidgetType = {
@@ -47,36 +133,43 @@ function NameWidget({ name, size }: NameWidgetType) {
 }
 export function InnerUploadedMessageFiles({ files = [] }: IProps) {
   return (
-    <section className="flex gap-2 pt-2 flex-wrap">
-      {files?.map((file, idx) => {
-        const name = file.name;
-        const isFile = file instanceof File;
+    <PhotoProvider>
+      <section className="flex gap-2 pt-2 flex-wrap">
+        {files?.map((file, idx) => {
+          const name = file.name;
+          const isFile = file instanceof File;
+          const isImage = isImageFile(file);
 
-        return (
-          <div key={idx} className="flex gap-1 border rounded-md p-1.5">
-            {!isFile ? (
-              <FileIcon id={file.id} name={name}></FileIcon>
-            ) : file.type.startsWith('image/') ? (
-              <img
-                src={URL.createObjectURL(file)}
-                alt={name}
-                className="size-10 object-cover"
-              />
-            ) : (
-              <SvgIcon
-                name={`file-icon/${getExtension(name)}`}
-                width={24}
-              ></SvgIcon>
-            )}
-            <NameWidget
-              name={name}
-              size={file.size}
-              id={isFile ? undefined : file.id}
-            ></NameWidget>
-          </div>
-        );
-      })}
-    </section>
+          return (
+            <div key={idx} className="flex gap-1 border rounded-md p-1.5">
+              {isImage ? (
+                isFile ? (
+                  <LocalFileImage file={file} name={name}></LocalFileImage>
+                ) : (
+                  <UploadedFileImage
+                    id={file.id}
+                    name={name}
+                    mimeType={getFileMimeType(file)}
+                  ></UploadedFileImage>
+                )
+              ) : !isFile ? (
+                <FileIcon id={file.id} name={name}></FileIcon>
+              ) : (
+                <SvgIcon
+                  name={`file-icon/${getExtension(name)}`}
+                  width={24}
+                ></SvgIcon>
+              )}
+              <NameWidget
+                name={name}
+                size={file.size}
+                id={isFile ? undefined : file.id}
+              ></NameWidget>
+            </div>
+          );
+        })}
+      </section>
+    </PhotoProvider>
   );
 }
 

--- a/web/src/components/next-message-item/uploaded-message-files.tsx
+++ b/web/src/components/next-message-item/uploaded-message-files.tsx
@@ -19,48 +19,15 @@ import { IDocumentInfo } from '@/interfaces/database/document';
 import api from '@/utils/api';
 import { getExtension } from '@/utils/document-util';
 import { formatBytes } from '@/utils/file-util';
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { PhotoProvider, PhotoView } from 'react-photo-view';
 import FileIcon from '../file-icon';
 import { useAuthenticatedImageUrl } from '../image';
 import SvgIcon from '../svg-icon';
+import { getFileMimeType, isImageFile } from './utils';
 
 interface IProps {
   files?: File[] | IDocumentInfo[] | UploadResponseDataType[];
-}
-
-const ImageExtensions = [
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'bmp',
-  'webp',
-  'svg',
-  'ico',
-  'avif',
-];
-
-function getFileMimeType(
-  file: File | IDocumentInfo | UploadResponseDataType,
-): string {
-  if (file instanceof File) {
-    return file.type;
-  }
-  if ('mime_type' in file && typeof file.mime_type === 'string') {
-    return file.mime_type;
-  }
-  return '';
-}
-
-function isImageFile(
-  file: File | IDocumentInfo | UploadResponseDataType,
-): boolean {
-  const mimeType = getFileMimeType(file);
-  if (mimeType) {
-    return mimeType.startsWith('image/');
-  }
-  return ImageExtensions.includes(getExtension(file.name));
 }
 
 // Zoomable thumbnail for files already uploaded to the server: chat uploads
@@ -99,7 +66,17 @@ function UploadedFileImage({
 
 // Zoomable thumbnail for local files that have not been sent yet.
 function LocalFileImage({ file, name }: { file: File; name: string }) {
-  const objectUrl = useMemo(() => URL.createObjectURL(file), [file]);
+  const [objectUrl, setObjectUrl] = useState('');
+
+  useEffect(() => {
+    const url = URL.createObjectURL(file);
+    setObjectUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  if (!objectUrl) {
+    return null;
+  }
 
   return (
     <PhotoView src={objectUrl}>

--- a/web/src/components/next-message-item/utils.ts
+++ b/web/src/components/next-message-item/utils.ts
@@ -14,7 +14,10 @@
  *  limitations under the License.
  */
 
+import { UploadResponseDataType } from '@/interfaces/database/chat';
+import { IDocumentInfo } from '@/interfaces/database/document';
 import { currentReg, parseCitationIndex } from '@/utils/chat';
+import { getExtension } from '@/utils/document-util';
 
 export const extractNumbersFromMessageContent = (content: string) => {
   const matches = content?.match(currentReg);
@@ -30,3 +33,37 @@ export const extractNumbersFromMessageContent = (content: string) => {
   }
   return [];
 };
+
+const ImageExtensions = [
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'svg',
+  'ico',
+  'avif',
+];
+
+export function getFileMimeType(
+  file: File | IDocumentInfo | UploadResponseDataType,
+): string {
+  if (file instanceof File) {
+    return file.type;
+  }
+  if ('mime_type' in file && typeof file.mime_type === 'string') {
+    return file.mime_type;
+  }
+  return '';
+}
+
+export function isImageFile(
+  file: File | IDocumentInfo | UploadResponseDataType,
+): boolean {
+  const mimeType = getFileMimeType(file);
+  if (mimeType) {
+    return mimeType.startsWith('image/');
+  }
+  return ImageExtensions.includes(getExtension(file.name));
+}


### PR DESCRIPTION
### Summary

Images attached to chat messages were rendered as plain 40px thumbnails with no way to view them at full size.

This PR wraps image attachments in `react-photo-view` (already used elsewhere in the app) so clicking a thumbnail opens a zoomable lightbox, while non-image files keep the existing open-in-new-tab behavior.

Two details worth noting:

- Image detection now works for all three file shapes this component receives (`File`, `IDocumentInfo`, `UploadResponseDataType`) via `isImageFile()`/`getFileMimeType()` helpers, falling back to the extension when no MIME type is available.
- Server-stored chat uploads are kept as blobs in the per-user downloads bucket with **no `document`/`file` table row**, so the document image endpoint cannot serve them. Their thumbnails are therefore fetched through the authenticated agents attachment preview endpoint (`getAttachmentFilePreview`, with `responseType: blob` via the existing `useAuthenticatedImageUrl` hook) and rendered from an object URL; a `FileIcon` is shown while loading.

Verified end-to-end in the browser: clicking a chat image attachment opens the lightbox with the fully decoded image (2035×1593 PNG), zoom/rotate controls work, and non-image attachments are unaffected.