### PR TITLE
fix(web): enlarge card '...' edit button hit area

### DIFF
--- a/web/src/components/more-button.tsx
+++ b/web/src/components/more-button.tsx
@@ -28,6 +28,9 @@ export const MoreButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
         size={size || 'icon-xs'}
         className={cn(
           'opacity-0 size-3.5 transition-all bg-transparent group-hover:bg-transparent',
+          // Keep the 14px visual size but increase the hit area with an
+          // absolutely positioned pseudo-element (14px + 8px on each side).
+          'relative after:absolute after:-inset-2 after:content-[""]',
           'group-focus-within:opacity-100 group-hover:opacity-100 aria-expanded:opacity-100',
           className,
         )}


### PR DESCRIPTION
## Problem

The '...' (more/edit) button on knowledge-base cards is very hard to click. Although `MoreButton` uses the `icon-xs` button variant (`size-6` = 24px), its own `size-3.5` class wins via tailwind-merge, shrinking the actual button box to **14×14px** — below the WCAG 24×24px minimum pointer target. The icon fills the whole button, so any click slightly off-center misses and hits the card instead.

## Fix

Keep the 14px visual size, but expand the interactive area to **30×30px** with an absolutely positioned `::after` pseudo-element (`after:-inset-2`), the same pattern already used in `ui/sidebar.tsx`. The pseudo-element belongs to the button, so clicks in the expanded ring still trigger the Radix `DropdownMenuTrigger`; card padding (`px-2.5 py-4`) fully contains the 8px expansion.

Since `MoreButton` is shared, this fixes all card types: datasets / agents / chats / searches / memories / skills / home.

## Verification

- Live-checked on `/datasets`: `getBoundingClientRect` = 14×14 while `::after` computed style has `inset: -8px`; `elementFromPoint` 7px outside the button box resolves to the button.
- Clicking in the expanded area opens the dropdown menu (Rename/Delete); `pointerdown.defaultPrevented = true` confirms no accidental card navigation.
- oxlint clean on the touched file; pre-commit hooks pass.