### PR TITLE
fix(web): widen max_tokens number input in LLM settings popover

### DIFF
--- a/web/src/components/llm-setting-items/next.tsx
+++ b/web/src/components/llm-setting-items/next.tsx
@@ -246,7 +246,7 @@ export function LlmSettingFieldItems({
         <SliderInputSwitchFormField
           name={getFieldWithPrefix('max_tokens')}
           checkName="maxTokensEnabled"
-          numberInputClassName="w-20"
+          numberInputClassName="w-24 shrink-0"
           label="maxTokens"
           max={128000}
           min={0}


### PR DESCRIPTION
## Problem

In the Agent component's LLM settings popover, the **Max_Tokens** number input is too narrow: its width is set via `numberInputClassName="w-20"` (80px), and because the field row is a flex container (`flex items-center gap-4 justify-between`, ~254px wide) the default `flex-shrink: 1` shrinks the wrapper even further (measured ~53.86px). As a result, large values such as `128000` (the max) are visually truncated.

## Fix

Change the Max_Tokens field's `numberInputClassName` from `w-20` to `w-24 shrink-0` in `web/src/components/llm-setting-items/next.tsx`:

- `w-24` widens the input to 96px so 6-digit values fit;
- `shrink-0` prevents the flex parent from shrinking it back down (`w-24` alone still computed to ~53.86px).

## Verification

Verified in browser against a local instance (agent with model glm-4.6v-Flash):

- Input wrapper now computes to exactly **96px**;
- `128000` is fully visible (`scrollWidth 94 <= clientWidth 94`);
- 7-digit intermediate values (~66px text width) also fit.

| Before | After |
|---|---|
| `128000` truncated in ~54px input | `128000` fully visible in 96px input |