### PR TITLE
fix: update Tongyi Qianwen API key URL to bailian console

### DIFF
--- a/web/src/constants/llm.ts
+++ b/web/src/constants/llm.ts
@@ -225,7 +225,8 @@ export const APIMapUrl = {
   [LLMFactory.Gemini]: 'https://aistudio.google.com/app/apikey',
   [LLMFactory.DeepSeek]: 'https://platform.deepseek.com/api_keys',
   [LLMFactory.Moonshot]: 'https://platform.moonshot.cn/console/api-keys',
-  [LLMFactory.TongYiQianWen]: 'https://dashscope.console.aliyun.com/apiKey',
+  [LLMFactory.TongYiQianWen]:
+    'https://bailian.console.aliyun.com/?tab=model#/api-key',
   [LLMFactory.ZhipuAI]: 'https://open.bigmodel.cn/usercenter/apikeys',
   [LLMFactory.XAI]: 'https://x.ai/api/',
   [LLMFactory.HuggingFace]: 'https://huggingface.co/settings/tokens',


### PR DESCRIPTION
## Problem
The 'API Key' link on the Tongyi-Qianwen model provider card (Settings -> Model providers) pointed to `https://dashscope.console.aliyun.com/apiKey`, a domain that is now offline (DNS/endpoint retired), so users following the link land on a dead page.

## Root cause
Alibaba Cloud migrated DashScope / Model Studio API key management to the Bailian console. The frontend constant `APIMapUrl[LLMFactory.TongYiQianWen]` in `web/src/constants/llm.ts` still referenced the retired `dashscope.console.aliyun.com` domain.

## Fix
Updated `APIMapUrl[LLMFactory.TongYiQianWen]` to `https://bailian.console.aliyun.com/?tab=model#/api-key`.

## Verification
- Greped the whole repo: the dead domain existed only in `web/src/constants/llm.ts`.
- Ran the app, Settings -> Model providers -> Tongyi-Qianwen: the API Key link now renders `https://bailian.console.aliyun.com/?tab=model#/api-key`.
- oxlint / oxfmt pre-commit hooks pass.