### PR TITLE
Fix: Editing a document slice requires showing the wiki's update button

### DIFF
--- a/web/src/interfaces/database/dataset.ts
+++ b/web/src/interfaces/database/dataset.ts
@@ -279,8 +279,10 @@ export interface IArtifactGraphEntity {
 export interface IArtifactAlteration {
   removed: number;
   newly_uploaded: number;
+  changed: number;
   removed_doc_ids: string[];
   newly_uploaded_doc_ids: string[];
+  changed_doc_ids: string[];
   involved_doc_ids: string[];
   eligible_doc_ids: string[];
 }

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -467,7 +467,7 @@ Example: A 1 KB message with 1024-dim embedding uses ~9 KB. The 5 MB default lim
         'Are you sure you want to clear all wiki pages in this dataset? This action cannot be undone.',
       update: 'Update',
       updateTooltip:
-        '{{newlyUploaded}} new, {{removed}} removed documents found. Click to compile and merge into current Wiki.',
+        '{{newlyUploaded}} new, {{removed}} removed, {{changed}} changed documents found. Click to compile and merge into current Wiki.',
       updateSheetTitle: 'Update Wiki',
       updateStructureSheetTitle: 'Update {{name}}',
       updateStructureTooltip:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -421,7 +421,7 @@ export default {
         '确定要清空该数据集下的所有 Wiki 页面吗？此操作无法撤销。',
       update: '更新',
       updateTooltip:
-        '发现 {{newlyUploaded}} 个新文档，{{removed}} 个已移除文档。点击编译并合并到当前 Wiki。',
+        '发现 {{newlyUploaded}} 个新文档，{{removed}} 个已移除文档，{{changed}} 个已变更文档。点击编译并合并到当前 Wiki。',
       updateSheetTitle: '更新 Wiki',
       updateStructureSheetTitle: '更新{{name}}',
       updateStructureTooltip:

--- a/web/src/pages/dataset/compilation/llm-wiki-view.tsx
+++ b/web/src/pages/dataset/compilation/llm-wiki-view.tsx
@@ -10,6 +10,7 @@ import {
   useTraceRunData,
 } from '@/hooks/use-dataset-generate';
 import {
+  ArtifactAlterationKeys,
   ArtifactKeys,
   ArtifactTopicKeys,
   useFetchArtifactTopicList,
@@ -46,6 +47,9 @@ export function LlmWikiView() {
   const [updateSheetOpen, setUpdateSheetOpen] = useState(false);
 
   const handleRunEnd = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: ArtifactAlterationKeys.detail(id!, 'wiki'),
+    });
     queryClient.invalidateQueries({
       queryKey: ArtifactKeys.listByDataset(id!),
     });

--- a/web/src/pages/dataset/compilation/update-button.tsx
+++ b/web/src/pages/dataset/compilation/update-button.tsx
@@ -21,6 +21,7 @@ type CompilationUpdateButtonProps = {
   hasChanges: boolean;
   newlyUploaded: number;
   removed: number;
+  changed?: number;
   loading: boolean;
   tooltip: string;
   onClick: () => void;
@@ -32,6 +33,7 @@ export function CompilationUpdateButton({
   hasChanges,
   newlyUploaded,
   removed,
+  changed = 0,
   loading,
   tooltip,
   onClick,
@@ -73,6 +75,11 @@ export function CompilationUpdateButton({
                 {removed > 0 && (
                   <Badge variant="destructive" className="ml-1">
                     {removed}
+                  </Badge>
+                )}
+                {changed > 0 && (
+                  <Badge variant="secondary" className="ml-1">
+                    {changed}
                   </Badge>
                 )}
                 <WandSparkles />

--- a/web/src/pages/dataset/compilation/wiki-left-panel/hooks/use-wiki-update.ts
+++ b/web/src/pages/dataset/compilation/wiki-left-panel/hooks/use-wiki-update.ts
@@ -15,7 +15,8 @@ export function useWikiUpdate({ onUpdate }: UseWikiUpdateOptions = {}) {
 
   const newlyUploaded = data?.newly_uploaded ?? 0;
   const removed = data?.removed ?? 0;
-  const hasChanges = newlyUploaded > 0 || removed > 0;
+  const changed = data?.changed ?? 0;
+  const hasChanges = newlyUploaded > 0 || removed > 0 || changed > 0;
 
   const handleUpdate = useCallback(async () => {
     const result = await runArtifactIndex();
@@ -28,6 +29,7 @@ export function useWikiUpdate({ onUpdate }: UseWikiUpdateOptions = {}) {
     hasChanges,
     newlyUploaded,
     removed,
+    changed,
     handleUpdate,
     loading: queryLoading || mutationLoading,
   };

--- a/web/src/pages/dataset/compilation/wiki-left-panel/index.tsx
+++ b/web/src/pages/dataset/compilation/wiki-left-panel/index.tsx
@@ -49,6 +49,7 @@ export function WikiLeftPanel({
     hasChanges,
     newlyUploaded,
     removed,
+    changed,
     handleUpdate,
     loading: updateLoading,
   } = useWikiUpdate();
@@ -72,12 +73,14 @@ export function WikiLeftPanel({
           hasChanges={hasChanges}
           newlyUploaded={newlyUploaded}
           removed={removed}
+          changed={changed}
           loading={updateLoading}
           tooltip={t('knowledgeDetails.updateTooltip', {
             newlyUploaded,
             removed,
+            changed,
             defaultValue:
-              '{{newlyUploaded}} new, {{removed}} removed documents found. Click to compile and merge into current Wiki.',
+              '{{newlyUploaded}} new, {{removed}} removed, {{changed}} changed documents found. Click to compile and merge into current Wiki.',
           })}
           onClick={handleUpdateClick}
         />


### PR DESCRIPTION
### Summary

Fix: Editing a document slice requires showing the wiki's update button
