### PR TITLE
feat(chat): self-check contradictory prompt/dataset settings (#5703)

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1116,6 +1116,8 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
         - **When information is unavailable**: Your response must contain this exact sentence: "The answer you are looking for is not found in the dataset!"
         - **Always consider** the entire conversation history.`,
       systemMessage: 'Please input!',
+      knowledgePlaceholderMessage:
+        'Datasets are selected but the {knowledge} placeholder is missing from the system prompt, so retrieved content cannot be injected. Add {knowledge} to the system prompt or remove the datasets.',
       systemTip:
         'Your prompts or instructions for the LLM, including but not limited to its role, the desired length, tone, and language of its answers. If your model has native support for reasoning, you can add //no_thinking add the prompt to stop reasoning.',
       topN: 'Top N',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1008,6 +1008,8 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
         {knowledge}
         以上是知识库。`,
       systemMessage: '请输入',
+      knowledgePlaceholderMessage:
+        '已选择知识库但系统提示词中缺少 {knowledge} 占位符，检索到的内容将无法注入。请在系统提示词中添加 {knowledge}，或移除已选择的知识库。',
       systemTip:
         '当LLM回答问题时，你需要LLM遵循的说明，比如角色设计、答案长度和答案语言等。如果您的模型原生支持在问答中推理，可以通过 //no_thinking 关闭自动推理。',
       topN: 'Top N',

--- a/web/src/pages/next-chats/chat/app-settings/use-chat-setting-schema.tsx
+++ b/web/src/pages/next-chats/chat/app-settings/use-chat-setting-schema.tsx
@@ -11,7 +11,8 @@ import {
 import { topnSchema } from '@/components/top-n-item';
 import { WebSearchProvider } from '@/constants/chat';
 import { useTranslate } from '@/hooks/common-hooks';
-import { z } from 'zod';
+import { z, ZodIssueCode } from 'zod';
+import { chatPromptKbIssues } from './validate-chat-prompt';
 
 export function useChatSettingSchema() {
   const { t } = useTranslate('chat');
@@ -47,23 +48,33 @@ export function useChatSettingSchema() {
       .optional(),
   });
 
-  const formSchema = z.object({
-    name: z.string().min(1, { message: t('assistantNameMessage') }),
-    icon: z.string(),
-    description: z.string().optional(),
-    dataset_ids: z.array(z.string()).min(0, {
-      message: t('knowledgeBasesMessage'),
-    }),
-    prompt_config: promptConfigSchema,
-    ...rerankFormSchema,
-    llm_setting: z.object(LlmSettingFieldSchema),
-    ...LlmSettingEnabledSchema,
-    llm_id: z.string().optional(),
-    ...vectorSimilarityWeightSchema,
-    ...similarityThresholdSchema,
-    ...topnSchema,
-    ...MetadataFilterSchema,
-  });
+  const formSchema = z
+    .object({
+      name: z.string().min(1, { message: t('assistantNameMessage') }),
+      icon: z.string(),
+      description: z.string().optional(),
+      dataset_ids: z.array(z.string()).min(0, {
+        message: t('knowledgeBasesMessage'),
+      }),
+      prompt_config: promptConfigSchema,
+      ...rerankFormSchema,
+      llm_setting: z.object(LlmSettingFieldSchema),
+      ...LlmSettingEnabledSchema,
+      llm_id: z.string().optional(),
+      ...vectorSimilarityWeightSchema,
+      ...similarityThresholdSchema,
+      ...topnSchema,
+      ...MetadataFilterSchema,
+    })
+    .superRefine((value, ctx) => {
+      for (const issue of chatPromptKbIssues(value, t)) {
+        ctx.addIssue({
+          code: ZodIssueCode.custom,
+          path: issue.path,
+          message: issue.message,
+        });
+      }
+    });
 
   return formSchema;
 }

--- a/web/src/pages/next-chats/chat/app-settings/validate-chat-prompt.test.ts
+++ b/web/src/pages/next-chats/chat/app-settings/validate-chat-prompt.test.ts
@@ -1,0 +1,79 @@
+import { chatPromptKbIssues } from './validate-chat-prompt';
+
+const t = (key: string) => key;
+
+describe('chatPromptKbIssues', () => {
+  it('flags a system prompt missing {knowledge} when datasets are selected', () => {
+    const issues = chatPromptKbIssues(
+      { dataset_ids: ['kb1'], prompt_config: { system: 'answer the question' } },
+      t,
+    );
+    expect(issues).toContainEqual({
+      path: ['prompt_config', 'system'],
+      message: 'knowledgePlaceholderMessage',
+    });
+  });
+
+  it('does not flag when {knowledge} is present in the system prompt', () => {
+    const issues = chatPromptKbIssues(
+      {
+        dataset_ids: ['kb1'],
+        prompt_config: { system: 'answer using {knowledge}' },
+      },
+      t,
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('does not flag an empty system prompt (min(1) covers that instead)', () => {
+    const issues = chatPromptKbIssues(
+      { dataset_ids: ['kb1'], prompt_config: { system: '' } },
+      t,
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('flags a non-empty empty_response when no dataset is selected', () => {
+    const issues = chatPromptKbIssues(
+      {
+        dataset_ids: [],
+        prompt_config: { system: '{knowledge}', empty_response: 'nothing found' },
+      },
+      t,
+    );
+    expect(issues).toContainEqual({
+      path: ['prompt_config', 'empty_response'],
+      message: 'emptyResponseMessage',
+    });
+  });
+
+  it('does not flag an empty empty_response when no dataset is selected', () => {
+    const issues = chatPromptKbIssues(
+      { dataset_ids: [], prompt_config: { system: 'x', empty_response: '' } },
+      t,
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('does not flag empty_response when datasets are selected', () => {
+    const issues = chatPromptKbIssues(
+      {
+        dataset_ids: ['kb1'],
+        prompt_config: { system: '{knowledge}', empty_response: 'none' },
+      },
+      t,
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('ignores a whitespace-only empty_response', () => {
+    const issues = chatPromptKbIssues(
+      {
+        dataset_ids: [],
+        prompt_config: { system: 'x', empty_response: '   ' },
+      },
+      t,
+    );
+    expect(issues).toEqual([]);
+  });
+});

--- a/web/src/pages/next-chats/chat/app-settings/validate-chat-prompt.ts
+++ b/web/src/pages/next-chats/chat/app-settings/validate-chat-prompt.ts
@@ -1,0 +1,42 @@
+export type ChatPromptKbIssue = {
+  path: string[];
+  message: string;
+};
+
+export type ChatPromptKbValue = {
+  dataset_ids?: string[];
+  prompt_config?: {
+    system?: string;
+    empty_response?: string;
+  };
+};
+
+export function chatPromptKbIssues(
+  value: ChatPromptKbValue,
+  t: (key: string) => string,
+): ChatPromptKbIssue[] {
+  const system = value?.prompt_config?.system ?? '';
+  const emptyResponse = value?.prompt_config?.empty_response ?? '';
+  const datasetIds = value?.dataset_ids ?? [];
+  const issues: ChatPromptKbIssue[] = [];
+
+  if (
+    datasetIds.length > 0 &&
+    system.trim() !== '' &&
+    !system.includes('{knowledge}')
+  ) {
+    issues.push({
+      path: ['prompt_config', 'system'],
+      message: t('knowledgePlaceholderMessage'),
+    });
+  }
+
+  if (datasetIds.length === 0 && emptyResponse.trim() !== '') {
+    issues.push({
+      path: ['prompt_config', 'empty_response'],
+      message: t('emptyResponseMessage'),
+    });
+  }
+
+  return issues;
+}


### PR DESCRIPTION
## Summary

Closes #5703.

Users who delete the hardcoded `{knowledge}` placeholder from the system prompt while datasets are selected can still retrieve the right chunks, but the assistant answers as if nothing were found — because the retrieved content has nowhere to be injected. Likewise, a non-empty *empty response* with **no** dataset selected fires on every turn (nothing can ever be retrieved). This PR adds a save-time self-check that prompts the user about both contradictory configurations, as requested in the issue.

## Change

A zod `superRefine` cross-field validation on the chat-assistant settings form schema (`use-chat-setting-schema.tsx`) flags two contradictory settings when the user clicks **Save**:

1. **Datasets selected but `{knowledge}` missing from `prompt_config.system`** — retrieved content cannot be injected. (issue case 1)
2. **No dataset selected but `prompt_config.empty_response` is non-empty** — it would trigger on every turn. (issue case 2)

Both target fields already render `<FormMessage />`, so the messages surface inline automatically (no extra UI wiring needed). React-hook-form's default `onSubmit` mode means these only appear after a save attempt — not naggy while typing.

### Why frontend-only / why not the commented-out backend checks
The backend already has these checks written but **disabled** (`chat_api.py:360-366` `_validate_prompt_config` and the `{knowledge}`-vs-no-dataset block at `:638-643`/`:729-733`). Re-enabling them as hard blocks on PUT/PATCH risks rejecting **existing** misconfigured dialogs on unrelated updates. The issue frames this as a user-facing prompt ("users will be prompted when they try to save"), which is exactly what the zod validation provides, with no regression risk for existing configs.

### i18n
- Reuses the already-prepared-but-unused `emptyResponseMessage` key (present in en/zh + 10 other locales).
- Adds a new `knowledgePlaceholderMessage` key to `en.ts` and `zh.ts` only (per the frontend i18n convention; other locales fall back to en).

## Test plan

- [x] `npx jest src/pages/next-chats/chat/app-settings/validate-chat-prompt.test.ts --no-coverage` — 7 new unit tests pass.
- [x] `npx oxlint` on the three changed TS files — 0 warnings, 0 errors.
- [x] `npm run type-check` — no new errors in changed files (pre-existing project TS errors are unrelated).
- Manual: select datasets + delete `{knowledge}` from the system prompt → Save shows the inline warning on the system prompt field; clear datasets + type an empty response → Save shows the inline warning on the empty-response field.

### New tests (`validate-chat-prompt.test.ts`)
The cross-field rules live in a pure helper (`chatPromptKbIssues`) so they are unit-tested without the hook/i18n harness, matching the existing `use-show-internet.test.ts` pattern. Coverage: missing `{knowledge}` with datasets, present `{knowledge}` (no issue), empty system (handled by `min(1)`), non-empty empty_response with no dataset, empty empty_response (no issue), empty_response with datasets (no issue), whitespace-only empty_response (no issue).