### PR TITLE
fix(web): add tooltip to web search toggle in chat input box

### DIFF
--- a/web/src/components/message-input/next.tsx
+++ b/web/src/components/message-input/next.tsx
@@ -30,6 +30,11 @@ import {
 } from '@/components/file-upload';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { CircleStop, Globe, Paperclip, Send, Upload, X } from 'lucide-react';
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -357,16 +362,24 @@ export function NextMessageInput({
             )}
 
             {showInternet && (
-              <Button
-                type="button"
-                variant={enableInternet ? 'accent' : 'transparent'}
-                size="icon-xs"
-                className="border-0"
-                onClick={handleInternetToggle}
-                data-testid="chat-detail-internet-toggle"
-              >
-                <Globe />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant={enableInternet ? 'accent' : 'transparent'}
+                    size="icon-xs"
+                    className="border-0"
+                    onClick={handleInternetToggle}
+                    data-testid="chat-detail-internet-toggle"
+                  >
+                    <Globe />
+                    <span className="sr-only">{t('chat.webSearch')}</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{t('chat.webSearch')}</p>
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
 

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1249,6 +1249,7 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       tavilyApiKeyTip:
         'If an API Key is correctly set here, Tavily-based web searches will be used to supplement dataset retrieval.',
       tavilyApiKeyMessage: 'Please enter your Tavily API Key',
+      webSearch: 'Web search',
       webSearchProvider: 'Web search provider',
       webSearchProviderTip:
         'Select the service used when Internet search is enabled.',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1137,6 +1137,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
       tavilyApiKeyTip:
         '如果 API 密钥设置正确，它将利用 Tavily 进行网络搜索作为知识库的补充。',
       tavilyApiKeyMessage: '请输入你的 Tavily API Key',
+      webSearch: '网络搜索',
       webSearchProvider: '网络搜索服务',
       webSearchProviderTip: '选择启用联网搜索时使用的搜索服务。',
       webSearchProviderPlaceholder: '请选择网络搜索服务',


### PR DESCRIPTION
### Summary

**Reported issue:** in a multi-model ("Multiple models") chat, Firefox showed one more button in the input box than Chrome, with no indication of what the extra button does.

**Investigation (reproduced locally with real Chrome + Firefox against the same backend):**

- The extra button is the **web-search (internet) toggle** — the globe icon, `data-testid="chat-detail-internet-toggle"`.
- Its visibility is gated purely by the assistant's `prompt_config.tavily_api_key` (`web/src/pages/next-chats/chat/use-show-internet.ts`), **not** by the browser.
- Parity matrix of input-box controls, verified in both browsers:

  | Assistant config | Chrome | Firefox |
  |---|---|---|
  | with Tavily key | 5 controls (globe shown) | 5 controls (globe shown) |
  | without Tavily key | 4 controls | 4 controls |

  → Chrome and Firefox render identically; the reporter was comparing two different assistants in the two browser windows.

**Actual defect:** the globe button had no tooltip, label, or accessible name, so users could not tell what it is or why it appears for some assistants — which caused the confusion.

**Fix:**

- Wrap the web-search toggle in a `Tooltip` showing "Web search" (`chat.webSearch`, en + zh), following the same pattern as the neighbouring thinking toggle.
- Add an `sr-only` text inside the button so it has an accessible name.

**Verification:**

- Chrome (dev-tools MCP) and Firefox (Playwright) both show the toggle with the "Web search" tooltip on hover; the parity matrix above was re-checked after the change.
- `oxlint` on touched files: no new findings.
- `tsc --noEmit`: error count identical to base (pre-existing errors only).
- `npx jest src/pages/next-chats/chat/use-show-internet.test.ts`: 8/8 pass.
