### PR TITLE
fix(ingestion): mirror document run status on parse enqueue

### DIFF
--- a/internal/dao/document.go
+++ b/internal/dao/document.go
@@ -71,6 +71,18 @@ func (dao *DocumentDAO) UpdateByID(ctx context.Context, db *gorm.DB, id string, 
 	return db.WithContext(ctx).Model(&entity.Document{}).Where("id = ?", id).Updates(updates).Error
 }
 
+// UpdateByIDIfNotCancelled updates document by ID with the given fields, but
+// only when the document's run status is not CANCEL. Mirrors the WHERE clause
+// of Python's DocumentService.begin2parse: a concurrent cancel writes
+// run=CANCEL as the last step of the cancel flow, so the conditional keeps an
+// enqueue-time status mirror from overwriting a cancel that already committed.
+func (dao *DocumentDAO) UpdateByIDIfNotCancelled(ctx context.Context, db *gorm.DB, id string, updates map[string]interface{}) error {
+	return db.WithContext(ctx).Model(&entity.Document{}).
+		Where("id = ?", id).
+		Where("run IS NULL OR run <> ?", string(entity.TaskStatusCancel)).
+		Updates(updates).Error
+}
+
 // IncrementCounts atomically increments chunk_num, token_num, and process_duration for a document
 func (dao *DocumentDAO) IncrementCounts(ctx context.Context, db *gorm.DB, id string, kbID string, chunkNum int64, tokenNum int64, duration float64) error {
 	return db.WithContext(ctx).Model(&entity.Document{}).

--- a/internal/service/document/document_ingest.go
+++ b/internal/service/document/document_ingest.go
@@ -83,9 +83,8 @@ func (s *DocumentService) Ingest(ctx context.Context, userID string, req *Ingest
 		doc := vd.doc
 		kb := vd.kb
 
-		// Start parsing: delegates to the shared start-parse flow. The
-		// document run status is set by service.IngestionTaskService.StartRunning
-		// when the task transitions from CREATED, not here.
+		// Start parsing: delegates to the shared start-parse flow, which
+		// mirrors the document run status on enqueue acceptance.
 		if run == string(entity.TaskStatusRunning) {
 			if err = s.StartParseDocuments(ctx, doc, kb, userID, StartParseOptions{
 				ApplyKB:         req.ApplyKB,

--- a/internal/service/document/document_parse.go
+++ b/internal/service/document/document_parse.go
@@ -21,10 +21,11 @@ import (
 // StartParseDocuments starts parsing a document via the DSL ingestion
 // pipeline. It optionally clears prior results (RerunWithDelete), applies
 // KB config (ApplyKB), validates storage, and enqueues an ingestion task.
-// The document run status is NOT set here; service.IngestionTaskService.StartRunning
-// sets it to RUNNING when the worker picks up the task and transitions it from
-// CREATED. Extracted from Ingest so other entry points (e.g. ChunkService.Parse)
-// can reuse the same start-parse flow.
+// The document run status is mirrored to RUNNING on enqueue acceptance in
+// service.IngestionTaskService.CreateForDocuments, then re-asserted with
+// progress counter resets by service.IngestionTaskService.StartRunning when
+// the worker picks up the task. Extracted from Ingest so other entry points
+// (e.g. ChunkService.Parse) can reuse the same start-parse flow.
 func (s *DocumentService) StartParseDocuments(ctx context.Context, doc *entity.Document, kb *entity.Knowledgebase, userID string, opts StartParseOptions) error {
 	// Validate storage first so we don't clear prior results and then fail
 	// because the document can't be read, leaving the document with neither

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -116,11 +116,21 @@ func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID
 
 		// The queue accepted the task: mirror RUNNING to the document so
 		// list views flip on the next refetch instead of waiting for the
-		// worker pickup. Best-effort like the StartRunning mirror — a DB
-		// blip must not turn an accepted enqueue into an API error.
-		if err := s.documentDAO.UpdateByID(ctx, dao.DB, task.DocumentID, map[string]interface{}{
-			"run":      string(entity.TaskStatusRunning),
-			"progress": float64(0),
+		// worker pickup. Conditional on the document not being CANCEL,
+		// mirroring Python's DocumentService.begin2parse: a concurrent
+		// CancelDocParse writes run=CANCEL after RequestStop, so whichever
+		// write commits last wins and this mirror can never overwrite a
+		// committed cancel. progress_msg/process_begin_at follow
+		// begin2parse's queued state so the document does not show stale
+		// values from the previous run while waiting for worker pickup;
+		// StartRunning resets the remaining counters at pickup. Best-effort
+		// like the StartRunning mirror — a DB blip must not turn an
+		// accepted enqueue into an API error.
+		if err := s.documentDAO.UpdateByIDIfNotCancelled(ctx, dao.DB, task.DocumentID, map[string]interface{}{
+			"run":              string(entity.TaskStatusRunning),
+			"progress":         float64(0),
+			"progress_msg":     "Task is queued...",
+			"process_begin_at": time.Now(),
 		}); err != nil {
 			common.Warn(fmt.Sprintf("CreateForDocuments: mark document %s running for task %s: %v", task.DocumentID, task.ID, err))
 		}

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -114,6 +114,17 @@ func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID
 			continue
 		}
 
+		// The queue accepted the task: mirror RUNNING to the document so
+		// list views flip on the next refetch instead of waiting for the
+		// worker pickup. Best-effort like the StartRunning mirror — a DB
+		// blip must not turn an accepted enqueue into an API error.
+		if err := s.documentDAO.UpdateByID(ctx, dao.DB, task.DocumentID, map[string]interface{}{
+			"run":      string(entity.TaskStatusRunning),
+			"progress": float64(0),
+		}); err != nil {
+			common.Warn(fmt.Sprintf("CreateForDocuments: mark document %s running for task %s: %v", task.DocumentID, task.ID, err))
+		}
+
 		responses = append(responses, &ParseDocumentResponse{
 			DocumentID: docID,
 			Result:     fmt.Sprintf("task_id: %s", task.ID),

--- a/internal/service/ingestion_task_service_test.go
+++ b/internal/service/ingestion_task_service_test.go
@@ -64,8 +64,10 @@ func TestIngestionTaskServiceCreateForDocumentsMirrorsRunningToDocument(t *testi
 	pushServiceDB(t, db)
 	insertTestKB(t, "kb-1", "tenant-1", 1, 0, 0)
 	insertTestDoc(t, "doc-1", "kb-1", 0, 0)
-	if err := dao.DB.Model(&entity.Document{}).Where("id = ?", "doc-1").Update("progress", 0.42).Error; err != nil {
-		t.Fatalf("set progress: %v", err)
+	staleMsg := "Previous run failed"
+	if err := dao.DB.Model(&entity.Document{}).Where("id = ?", "doc-1").
+		Updates(map[string]interface{}{"progress": 0.42, "progress_msg": staleMsg}).Error; err != nil {
+		t.Fatalf("set stale progress: %v", err)
 	}
 
 	publisher := &recordingTaskPublisher{}
@@ -90,6 +92,55 @@ func TestIngestionTaskServiceCreateForDocumentsMirrorsRunningToDocument(t *testi
 	}
 	if doc.Progress != 0 {
 		t.Fatalf("document progress = %v, want 0 after enqueue mirror", doc.Progress)
+	}
+	if doc.ProgressMsg == nil || *doc.ProgressMsg != "Task is queued..." {
+		t.Fatalf("document progress_msg = %v, want %q after enqueue mirror", doc.ProgressMsg, "Task is queued...")
+	}
+	if doc.ProcessBeginAt == nil {
+		t.Fatal("document process_begin_at should be set by the enqueue mirror")
+	}
+}
+
+// A cancel that commits before the enqueue mirror must not be overwritten
+// back to RUNNING: CancelDocParse writes run=CANCEL as the last step of the
+// cancel flow, so the mirror's begin2parse-style conditional update skips the
+// document and both commit orders converge to CANCEL.
+func TestIngestionTaskServiceCreateForDocumentsSkipsMirrorAfterCancel(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertTestKB(t, "kb-1", "tenant-1", 1, 0, 0)
+	insertTestDoc(t, "doc-1", "kb-1", 0, 0)
+	cancelRun := string(entity.TaskStatusCancel)
+	if err := dao.DB.Model(&entity.Document{}).Where("id = ?", "doc-1").
+		Updates(map[string]interface{}{"run": cancelRun, "progress": -1.0}).Error; err != nil {
+		t.Fatalf("set cancelled state: %v", err)
+	}
+
+	publisher := &recordingTaskPublisher{}
+	svc := NewIngestionTaskService()
+	svc.taskPublisher = publisher
+
+	ctx := t.Context()
+	resp, err := svc.CreateForDocuments(ctx, "kb-1", "user-1", []string{"doc-1"})
+	if err != nil {
+		t.Fatalf("CreateForDocuments failed: %v", err)
+	}
+	if len(resp) != 1 || !strings.HasPrefix(resp[0].Result, "task_id:") {
+		t.Fatalf("unexpected responses: %+v", resp)
+	}
+	if len(publisher.messages) != 1 {
+		t.Fatalf("expected 1 published message, got %d", len(publisher.messages))
+	}
+
+	doc, err := dao.NewDocumentDAO().GetByID(ctx, db, "doc-1")
+	if err != nil {
+		t.Fatalf("reload document: %v", err)
+	}
+	if doc.Run == nil || *doc.Run != cancelRun {
+		t.Fatalf("document run = %v, want %q preserved (mirror must skip a cancelled document)", doc.Run, cancelRun)
+	}
+	if doc.Progress != -1.0 {
+		t.Fatalf("document progress = %v, want -1 preserved from the cancel", doc.Progress)
 	}
 }
 

--- a/internal/service/ingestion_task_service_test.go
+++ b/internal/service/ingestion_task_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"ragflow/internal/common"
@@ -55,6 +56,40 @@ func TestIngestionTaskServiceCreateForDocumentsPublishesTaskMessages(t *testing.
 	}
 	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.UserID != "user-1" {
 		t.Fatalf("unexpected task: %+v", task)
+	}
+}
+
+func TestIngestionTaskServiceCreateForDocumentsMirrorsRunningToDocument(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertTestKB(t, "kb-1", "tenant-1", 1, 0, 0)
+	insertTestDoc(t, "doc-1", "kb-1", 0, 0)
+	if err := dao.DB.Model(&entity.Document{}).Where("id = ?", "doc-1").Update("progress", 0.42).Error; err != nil {
+		t.Fatalf("set progress: %v", err)
+	}
+
+	publisher := &recordingTaskPublisher{}
+	svc := NewIngestionTaskService()
+	svc.taskPublisher = publisher
+
+	ctx := t.Context()
+	resp, err := svc.CreateForDocuments(ctx, "kb-1", "user-1", []string{"doc-1"})
+	if err != nil {
+		t.Fatalf("CreateForDocuments failed: %v", err)
+	}
+	if len(resp) != 1 || !strings.HasPrefix(resp[0].Result, "task_id:") {
+		t.Fatalf("unexpected responses: %+v", resp)
+	}
+
+	doc, err := dao.NewDocumentDAO().GetByID(ctx, db, "doc-1")
+	if err != nil {
+		t.Fatalf("reload document: %v", err)
+	}
+	if doc.Run == nil || *doc.Run != string(entity.TaskStatusRunning) {
+		t.Fatalf("document run = %v, want %q", doc.Run, entity.TaskStatusRunning)
+	}
+	if doc.Progress != 0 {
+		t.Fatalf("document progress = %v, want 0 after enqueue mirror", doc.Progress)
 	}
 }
 


### PR DESCRIPTION
### Summary

**Bug**: In the knowledge base document list, clicking Parse shows a success toast, but the parse button state does not change. Clicking it again fails with `failed to enqueue document ... already exists, status: RUNNING`.

**Root cause**: On a successful parse enqueue, the Go backend only flips the document's `run` status to RUNNING when the worker actually picks the task up (`IngestionTaskService.StartRunning`). The frontend invalidates and refetches the document list right after the success response, but the document still carries the stale `run` value (UNSTART/DONE), so the row keeps rendering the parse button. A second click reaches `CreateAndEnqueue`, which correctly rejects the duplicate with the "already exists" error. The stale window grows with queue backlog, since the task may sit in CREATED long before pickup.

**Fix**: Mirror `run=RUNNING` (and `progress=0`) to the document as soon as the queue accepts the task in `IngestionTaskService.CreateForDocuments` — the single funnel used by all parse entry points (UI ingest, SDK parse endpoint, connector sync re-parse, ChunkService.Parse). The mirror is best-effort (warn-only on DB error) so an accepted enqueue never turns into an API error. `StartRunning` still re-asserts the status and resets progress counters at actual worker pickup. This is symmetric with the cancel path, which already mirrors `run=CANCEL` synchronously.

**Testing**:
- New unit test `TestIngestionTaskServiceCreateForDocumentsMirrorsRunningToDocument` asserts the document is RUNNING with progress reset right after `CreateForDocuments`; full `internal/service/...`, `internal/handler`, `internal/ingestion/service` suites pass.
- Live verification: reparse of a 132-chunk PDF flips the row to the running state immediately after the confirm dialog (sampled at 400ms intervals) and transitions to success on worker completion; no "already exists" error on screen.