### PR TITLE
fix(web): scope answer loading placeholder to the last message

### DIFF
--- a/web/src/components/markdown-content/index.tsx
+++ b/web/src/components/markdown-content/index.tsx
@@ -142,7 +142,7 @@ const MarkdownContent = ({
     });
 
     // let text = content;
-    if (text === '') {
+    if (text === '' && loading) {
       text = t('chat.searching');
     }
     const nextText = replaceTextByOldReg(text);

--- a/web/src/components/message-item/index.tsx
+++ b/web/src/components/message-item/index.tsx
@@ -51,6 +51,7 @@ interface IProps extends Partial<IRemoveMessageById>, IRegenerateMessage {
   index: number;
   showLikeButton?: boolean;
   showLoudspeaker?: boolean;
+  isLast?: boolean;
 }
 
 const MessageItem = ({
@@ -68,6 +69,7 @@ const MessageItem = ({
   showLoudspeaker = true,
   visibleAvatar = true,
   nickname,
+  isLast = false,
 }: IProps) => {
   const { theme } = useTheme();
   const isAssistant = item.role === MessageType.Assistant;
@@ -164,7 +166,7 @@ const MessageItem = ({
                   { '!bg-bg-card': !isAssistant },
                 )}
               >
-                {sendLoading && isEmpty(messageContent) ? (
+                {sendLoading && isLast && isEmpty(messageContent) ? (
                   <LoadingDots className="text-text-secondary" />
                 ) : (
                   <MarkdownContent

--- a/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
+++ b/web/src/pages/next-chats/chat/chat-box/next-multiple-chat-box.tsx
@@ -304,6 +304,7 @@ const ChatCard = forwardRef(function ChatCard(
                   reference={messageReferences.get(message) ?? EmptyReference}
                   // clickDocumentButton={clickDocumentButton}
                   index={i}
+                  isLast={i === derivedMessages.length - 1}
                   removeMessageById={removeMessageById}
                   regenerateMessage={regenerateMessage}
                   sendLoading={sendLoading}

--- a/web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx
+++ b/web/src/pages/next-chats/chat/chat-box/single-chat-box.tsx
@@ -101,6 +101,7 @@ export function SingleChatBox({ conversation }: IProps) {
               reference={messageReferences.get(message) ?? EmptyReference}
               clickDocumentButton={clickDocumentButton}
               index={i}
+              isLast={i === messages.length - 1}
               removeMessageById={removeMessageById}
               regenerateMessage={regenerateMessage}
               sendLoading={sendLoading}

--- a/web/src/pages/next-chats/share/index.tsx
+++ b/web/src/pages/next-chats/share/index.tsx
@@ -88,6 +88,7 @@ const ChatContainer = () => {
                       derivedMessages?.length - 1 === i
                     }
                     index={i}
+                    isLast={i === derivedMessages.length - 1}
                     clickDocumentButton={clickDocumentButton}
                     showLikeButton={false}
                     showLoudspeaker={false}


### PR DESCRIPTION
### Summary

fix(web): scope answer loading placeholder to the last message

While a new answer is streaming, every assistant message with empty content rendered the loading dots and the "searching" placeholder, so historical empty answers flickered as if they were regenerating. Pass `isLast` down to MessageItem and only show the placeholder for the message actually being generated.
