### PR TITLE
Fix: Prevent the tool operator from being dragged and connected by other operators.

### DIFF
--- a/web/src/pages/agent/canvas/node/tool-node.tsx
+++ b/web/src/pages/agent/canvas/node/tool-node.tsx
@@ -41,6 +41,7 @@ function InnerToolNode({
         isConnectable={isConnectable}
         isConnectableStart={false}
         className="!bg-accent-primary !size-2"
+        isConnectableEnd={false}
       />
 
       <NodeCollapsible items={[tools, mcpList]}>


### PR DESCRIPTION


### Summary

Fix: Prevent the tool operator from being dragged and connected by other operators.