### PR TITLE
fix(web): show queued memory extraction tasks as pending instead of failed

### DIFF
--- a/web/src/pages/memory/memory-message/message-table.tsx
+++ b/web/src/pages/memory/memory-message/message-table.tsx
@@ -70,8 +70,10 @@ function getTaskStatus(progress: number) {
     return RunningStatus.DONE;
   } else if (progress > 0 && progress < 1) {
     return RunningStatus.RUNNING;
-  } else {
+  } else if (progress < 0) {
     return RunningStatus.FAIL;
+  } else {
+    return RunningStatus.UNSTART;
   }
 }
 
@@ -291,6 +293,7 @@ export function MemoryTable({
                   'bg-state-success': taskStatus === RunningStatus.DONE,
                   'bg-state-error': taskStatus === RunningStatus.FAIL,
                   'bg-state-warning': taskStatus === RunningStatus.RUNNING,
+                  'bg-text-secondary': taskStatus === RunningStatus.UNSTART,
                 })}
               />
             </Button>


### PR DESCRIPTION
## Problem

In the Memory → Messages page, memory extraction tasks that are stuck in the queue show a **Failed** status in the Action column, and clicking the status dot opens an **empty** process-log popup.

## Root cause

Queued extraction tasks are created with `progress = 0` and no `progress_msg`. `getTaskStatus` in `web/src/pages/memory/memory-message/message-table.tsx` mapped any `progress <= 0` to `RunningStatus.FAIL`, so queued tasks were rendered as Failed. Since there is no progress message yet, the log popup has nothing to show.

Genuine failures are written by the extractor with `progress = -1` together with an error message (`internal/service/memory_extractor.go`), so they always have details in the popup.

## Fix

- `progress < 0` → `RunningStatus.FAIL` (real failures, with error message)
- `progress == 0` → `RunningStatus.UNSTART` (queued, renders a neutral dot and a Pending label from the existing `RunningStatusMap`)

## Verification

Verified locally against a memory with queued extraction tasks: the Action column now shows a neutral status dot, and clicking it shows Status: **Pending** instead of Failed.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)