### PR TITLE
deepdoc: expose real OCR rec score and use it for Go layer-2 rotation

### DIFF
--- a/deepdoc/server/adapters/ocr_adapter.py
+++ b/deepdoc/server/adapters/ocr_adapter.py
@@ -15,9 +15,6 @@ from deepdoc.vision.ocr import OCR
 
 logger = logging.getLogger(__name__)
 
-# Confidence fill value — OSS recognize_batch does not return confidence scores.
-_CONFIDENCE_FILL = 1.0
-
 
 class OCRAdapter:
     """Calls OCR.detect() and OCR.recognize_batch(), converts to wire format."""
@@ -83,10 +80,12 @@ class OCRAdapter:
 
         img = self._decode_bgr(image_data)
 
-        # OCR.recognize_batch() returns List[str]; single cropped image → list of 1 image
-        texts = self._ocr.recognize_batch([img])
+        # OCR.recognize_batch_with_score() returns List[(text, score)] so the
+        # client can do score-based layer-2 rotation selection. The score is
+        # the real recognition confidence (previously a constant 1.0 fill).
+        scored = self._ocr.recognize_batch_with_score([img])
 
-        items = [[text, _CONFIDENCE_FILL] for text in texts]
+        items = [[text, score] for text, score in scored]
 
         # 4-level nesting matching Go [][][][]any:
         # batch → page → items list → pair [text, confidence]

--- a/deepdoc/vision/ocr.py
+++ b/deepdoc/vision/ocr.py
@@ -162,7 +162,6 @@ class TextRecognizer:
         return padding_im
 
     def resize_norm_img_vl(self, img, image_shape):
-
         imgC, imgH, imgW = image_shape
         img = img[:, :, ::-1]  # bgr2rgb
         resized_image = cv2.resize(img, (imgW, imgH), interpolation=cv2.INTER_LINEAR)
@@ -197,7 +196,6 @@ class TextRecognizer:
         return np.reshape(img_black, (c, row, col)).astype(np.float32)
 
     def srn_other_inputs(self, image_shape, num_heads, max_text_length):
-
         imgC, imgH, imgW = image_shape
         feature_dim = int((imgH / 8) * (imgW / 8))
 
@@ -281,7 +279,6 @@ class TextRecognizer:
         return img
 
     def resize_norm_img_svtr(self, img, image_shape):
-
         imgC, imgH, imgW = image_shape
         resized_image = cv2.resize(img, (imgW, imgH), interpolation=cv2.INTER_LINEAR)
         resized_image = resized_image.astype("float32")
@@ -291,7 +288,6 @@ class TextRecognizer:
         return resized_image
 
     def resize_norm_img_abinet(self, img, image_shape):
-
         imgC, imgH, imgW = image_shape
 
         resized_image = cv2.resize(img, (imgW, imgH), interpolation=cv2.INTER_LINEAR)
@@ -307,7 +303,6 @@ class TextRecognizer:
         return resized_image
 
     def norm_img_can(self, img, image_shape):
-
         img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)  # CAN only predict gray scale image
 
         if self.rec_image_shape[0] == 1:
@@ -640,6 +635,27 @@ class OCR:
                 text = ""
             texts.append(text)
         return texts
+
+    def recognize_batch_with_score(self, img_list, device_id: int | None = None):
+        """Like recognize_batch but keeps the per-item recognition score.
+
+        Returns a list of (text, score) tuples. Text below drop_score is
+        blanked, matching recognize_batch, but the score is preserved so the
+        caller (the OCR HTTP adapter) can surface it for score-based layer-2
+        rotation selection. Adding this method instead of changing
+        recognize_batch keeps the in-process __ocr path (pdf_parser.py) on the
+        original text-only contract.
+        """
+        if device_id is None:
+            device_id = 0
+        rec_res, elapse = self.text_recognizer[device_id](img_list)
+        out = []
+        for i in range(len(rec_res)):
+            text, score = rec_res[i]
+            if score < self.drop_score:
+                text = ""
+            out.append((text, score))
+        return out
 
     def __call__(self, img, device_id=0, cls=True):
         time_dict = {"det": 0, "rec": 0, "cls": 0, "all": 0}

--- a/deepdoc/vision/test_ocr_score.py
+++ b/deepdoc/vision/test_ocr_score.py
@@ -1,0 +1,74 @@
+"""Offline unit tests for score-bearing OCR recognition.
+
+These bypass model loading by constructing OCR / OCRAdapter via
+object.__new__ and injecting fake recognizers, so they run without the
+DeepDoc weights. They verify:
+- recognize_batch_with_score returns (text, score) tuples,
+- text below drop_score is blanked while the score is preserved,
+- the original recognize_batch (text-only) contract is unchanged,
+- OCRAdapter.recognize surfaces the real score instead of a 1.0 fill.
+"""
+
+import unittest
+
+from deepdoc.server.adapters.ocr_adapter import OCRAdapter
+from deepdoc.vision.ocr import OCR
+
+
+class FakeRecognizer:
+    """Callable stand-in for OCR.text_recognizer[device_id].
+
+    results is a list of recognizer outputs, one per call; each output is a
+    list of (text, score) tuples as produced by TextRecognizer.__call__.
+    """
+
+    def __init__(self, results):
+        self._results = results
+        self.calls = 0
+
+    def __call__(self, img_list):
+        res = self._results[self.calls]
+        self.calls += 1
+        return res, 0.0
+
+
+def make_ocr(results, drop_score=0.5):
+    ocr = object.__new__(OCR)
+    ocr.text_recognizer = [FakeRecognizer(results)]
+    ocr.drop_score = drop_score
+    return ocr
+
+
+class TestRecognizeBatchWithScore(unittest.TestCase):
+    def test_returns_score_tuples(self):
+        ocr = make_ocr([[["hello", 0.92]]])
+        self.assertEqual(ocr.recognize_batch_with_score(["img"]), [("hello", 0.92)])
+
+    def test_blanks_below_drop_score_keeps_score(self):
+        ocr = make_ocr([[["garble", 0.10]]], drop_score=0.5)
+        # text is blanked by drop_score, but the score is preserved for
+        # layer-2 selection.
+        self.assertEqual(ocr.recognize_batch_with_score(["img"]), [("", 0.10)])
+
+    def test_original_recognize_batch_unchanged(self):
+        # The in-process __ocr path keeps its text-only contract.
+        ocr = make_ocr([[["hello", 0.92]]])
+        self.assertEqual(ocr.recognize_batch(["img"]), ["hello"])
+
+
+class TestOCRAdapterScore(unittest.TestCase):
+    def test_recognize_surfaces_real_score(self):
+        adapter = object.__new__(OCRAdapter)
+
+        class FakeOCR:
+            def recognize_batch_with_score(self, imgs):
+                return [("world", 0.88)]
+
+        adapter._ocr = FakeOCR()
+        adapter._decode_bgr = lambda data: "img"
+        out = adapter.recognize(b"fake")
+        self.assertEqual(out, {"output": [[[["world", 0.88]]]]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/internal/deepdoc/parser/pdf/parser_ocr.go
+++ b/internal/deepdoc/parser/pdf/parser_ocr.go
@@ -38,7 +38,7 @@ func (p *Parser) ocrDetectAndRecognize(ctx context.Context, pageImg image.Image,
 			continue
 		}
 		cropped := util.FastCrop(pageImg, x0, y0, x1, y1)
-		texts, recErr := p.inferOCRRecognize(ctx, doc, cropped)
+		texts, recErr := p.ocrRecognizeWithRotation(ctx, doc, cropped)
 		if recErr != nil {
 			slog.Warn(logLabel+" OCR recognize failed", "page", pageNum, "err", recErr)
 			continue
@@ -77,6 +77,61 @@ func (p *Parser) ocrDetectAndRecognize(ctx context.Context, pageImg image.Image,
 		}
 	}
 	return result
+}
+
+// ocrRecognizeWithRotation recognizes a single cropped text region, applying
+// layer-2 rotation selection (PaddleOCR-style) for tall, narrow crops.
+//
+// Layer 2 (rotation selection): when a crop's height is at least 1.5x its
+// width, the text is most likely a vertical line. PaddleOCR's recognizer is
+// trained on horizontal text, so a vertical line only reads cleanly after a
+// 90° rotation. We recognize the crop at 0°, CW90°, and CCW90° and keep the
+// orientation with the highest recognition score. The crop is emitted with its
+// ORIGINAL bounding box; only the recognized text is effectively rotated. This
+// matches Python's get_rotate_crop_image → _rotate_select behavior on the
+// in-process __ocr path, which also selects by recognition score.
+//
+// The DeepDoc rec service now surfaces the real recognition score (previously
+// a constant 1.0), so Go can pick the orientation by score exactly like
+// Python. (Layer 1, the perspective de-skew, is a separate concern handled at
+// crop time.)
+func (p *Parser) ocrRecognizeWithRotation(ctx context.Context, doc pdf.DocAnalyzer, cropped image.Image) ([]pdf.OCRText, error) {
+	b := cropped.Bounds()
+	// Short / wide crops are already horizontal — no rotation needed.
+	if float64(b.Dy()) < 1.5*float64(b.Dx()) {
+		return p.inferOCRRecognize(ctx, doc, cropped)
+	}
+	candidates := []image.Image{
+		cropped,
+		util.RotateImageCW(cropped, 90),  // CW90°
+		util.RotateImageCW(cropped, 270), // CCW90°
+	}
+	var best []pdf.OCRText
+	bestScore := -1.0
+	for _, c := range candidates {
+		texts, err := p.inferOCRRecognize(ctx, doc, c)
+		if err != nil {
+			return nil, err
+		}
+		if s := ocrBestScore(texts); s > bestScore {
+			bestScore = s
+			best = texts
+		}
+	}
+	return best, nil
+}
+
+// ocrBestScore is the layer-2 orientation score: the highest recognition
+// confidence among recognized items. The correctly oriented line reads with a
+// high confidence; a mis-rotated line reads with a low one.
+func ocrBestScore(texts []pdf.OCRText) float64 {
+	best := 0.0
+	for _, t := range texts {
+		if t.Confidence > best {
+			best = t.Confidence
+		}
+	}
+	return best
 }
 
 // ocrMergeChars runs full-page detect on a page that has embedded chars,

--- a/internal/deepdoc/parser/pdf/parser_ocr_rotate_integration_test.go
+++ b/internal/deepdoc/parser/pdf/parser_ocr_rotate_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package pdf
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"image"
+	"os"
+	"strings"
+	"testing"
+
+	_ "image/jpeg"
+
+	"ragflow/internal/deepdoc/parser/pdf/inference"
+	"ragflow/internal/deepdoc/parser/pdf/util"
+)
+
+// layer2CropB64 is a vertical (tall, h/w ~= 4.5) "RAGFlow" text crop, embedded
+// as a JPEG so the test stays self-contained without committing a binary into
+// the gitignored testdata/ directory. The crop is unreadable at 0 deg but reads
+// cleanly once rotated upright (CW90), which is exactly what layer-2 must pick.
+const layer2CropB64 = "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAEEADkDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigAorz34m/EuT4dXGjH+zFvob7zvMHm+WybNmMHBH8Z/Ks/Rfj74M1Pal5Jd6ZKeD9ph3Jn2ZM/mQKAPUqKztL17SNci8zStTs71cZP2eZXx9QDx+NaNABRRRQAUUUUAcB8T/AIZj4iwadt1T7DNYebszD5ivv2ZzyMfcH514frHwD8a6bua0itNSjHObaYK2P919v5DNe2fFP4lyfDuDTRBpiXs1/wCbtLzFFj2bOoAOc7/UdK8XufjH8RvFNwbXSAYWb/ljploXfH1O5vyxQBwGoaHr3hu4Vr/Tr/TpVPyvJE0fP+y3f8K9N+DXjzxTe/EDStEvNburrTrgSiSK4bzD8sTsMM2WGCo6Gs+H4V/E7xfKs+rC4UE5Euq3ZJH/AAHLMPyr0r4efA+Xwh4ks9fvtbS4ubYPtt4ISEyyMhyxOTwx7CgD2OiiigAooooA4L4mfDSL4iwaeDqb2M1j5vlkQiRW37c5GR/cHfvXjGofAfxzok32nSLi2vGTlHtbgwyj/vrGPwJr1/4rfEu4+HkGmC102K8mv/N2tLKVWPZs6gD5s7/UdK8L1j44+OdW3LHqMWnxN/BZQhf/AB5ssPzoAs/8Jt8V/AxVdSl1NIQcY1KDzUb2EjDJ/Bq9E+G/xu1LxZ4psfD+p6RapLdCTFzbyMoXbGz/AHDnOduOo618/wAlxrvie+Akl1HVbtugZnnc/Tqa9Y+EHw28WaX480vXtR0iSzsLcSl2uGVX+aJ1GEzu6sOooA+lKKKKACiiigDg/iN8NIviJcaQbjU3s4bDztyxxB2k37OhJwMbPQ9aq6L8D/A+kbWk0+TUZV/jvZS//jowv5itf4j+OrfwF4aa/aNZr2ZvKtICeHfGcn/ZA5P4DvXyfr/jjxL4munn1TWLqUMciFZCkS+wQcD+dAH2tY6dY6ZbiCws7e0hHSOCJY1/ICrNfCGn69q+kzrPp2p3lrIpyGhmZf5HmvpH4OfFe48XM+ha4yHVoo/MinVQouEHXIHAYdeOo+hoA9eooooAKKKKAPmr9pK8kfxbpFiSfKhsTMo/2nkYH/0AV3vwu+Fvhi28HaZqmoaZbajf31uly8l0gkVA43BVU8DAI5xnOfoOY/aR8PzudI8QxIWhRWtJ2H8HO5PwOXH5etcp4F+OOreEdHh0i70+PU7KAYgzKYpI1/u7sEEDtx+OMUAe+6z8MvBut2UltP4fsYCwwJrSFYZEPqGUDp75HtXzL4Pil8M/GnTbGOXe9rrH2IyAfeBkMTH8QTXd6z+0lf3NlJDpGgxWc7LgTz3HnbPcLtAz9SR7Vx/we0W78SfFCxun3yJZyG+uZm55HK5PqXI/X0oA+vKKKKACiivFfHnxwv8Awf401DQYdFtrmO18vErzMpbdGr9AP9rFAHsGpabZ6xp0+n6hbpcWk67JYnHDD/PftXhWv/s3F7p5fD+tokLHIgvUOU/4GvX/AL5/OqP/AA0rqn/Qu2f/AH/b/Cj/AIaV1T/oXbP/AL/t/hQAzTv2bNYedf7T12xhhzybZHlY/wDfQWvb/B/gvR/BGk/YNJhYbyGmnkOZJm9WP8gOBXif/DSuqf8AQu2f/f8Ab/Cuj8B/HC/8YeNNP0GbRba2juvMzKkzMV2xs/Qj/ZxQB7VRRRQAV5B42+Bg8Y+L77Xv+EiNp9q8v9x9i8zbtjVPveYM5256d69fryD4q/FvV/AXii20uwsLG4ilsluC84fcGLuuOGHHyCgDn/8AhmUf9Dcf/Bd/9to/4ZlH/Q3H/wAF3/22vbPDmpS6z4X0nVJkRJb2yhuHRM7VZ0DEDPbmvNv+F5Rf8LA/4RT+wH3f2p/Zv2n7WMZ83y9+3Z+OM/jQBzn/AAzKP+huP/gu/wDttdB4J+Bg8HeL7HXv+EiN39l8z9x9i8vdujZPveYcY3Z6dq9fooAKKKKACvmD9o7/AJKHp/8A2Co//RstfT9fMH7R3/JQ9P8A+wVH/wCjZaAPf/An/JPPDX/YKtf/AEUtfMH/ADcL/wBzX/7d1Ppnxw8Y6TpVnptrJYi3tIEgi3W+TtRQoyc8nArjP+Egvv8AhK/+EkzH/aH277fnb8vm79/T03dqAPuuivlL/hoDxx/z00//AMBv/r11fw1+MHirxT8QNL0bUnszaXPm+YI4NrfLE7DBz6qKAPoKiiigArzf4gfCKz8f69Bqtxq09o8VqtsI44gwIDM2ck/7f6V6RXK+MfiFoPgY2i6zLMHutxjWGPecLjJPPHUUAebf8M1aZ/0Md3/4Dr/jR/wzVpn/AEMd3/4Dr/jXrXhfxNY+LtFTV9NS4FpI7IjTx7C204JA9M5H4GuL+Ivxfj+H/iC30p9Ea+M1qtz5gufLxl3XGNp/uZz70Acz/wAM1aZ/0Md3/wCA6/41u+DvgfY+D/FVlr0OtXNzJa78RPCqhtyMnUH/AGs/hXNf8NMQf9CrJ/4Hj/43XZfDn4u2nj/VrrTf7MbT7iGHzkDTiTzFzhv4RjGR+ftQB6TRRRQAV8qftA6i158S2tS3yWVpFEB6Fsuf/Qx+VfVdfIvxyheL4taq7A4ljgdfp5SL/NTQB9R+FtJj0LwppWlxqALa1jjOO7bRuP4nJ/Gvnf8AaO/5KHp//YKj/wDRstfRvh/VoNe8Pafqts4aK6gSQEHoSOR9Qcg/SsXxP8N/C/jDUo9Q1uxknuY4RArLO6YQFmAwpA6saAPCNH/Z/wBd1nQ9P1SHV9OjivbaO4RHD7lDqGAOB15rB+GUtx4a+MemWsx2yJePYzAdCW3Rkf8AfWD+FfWtpbWeiaPBaQ4hsrG3WNN7ZCRouBkn0A6mvkPQLsa38brG/tgdl1r63KjH8Jn3/wAqAPsiiiigArwX9onwhNcR2Xiq0iLrAn2a82j7q5JR/pkkE+6171Uc8EN1byW9xEksMqlHjdQVZTwQQeooA+PPAvxT1/wIrW1oY7vTnbc1pcZ2g9ypHKn9PavS0/aYh8rL+FX8zHQXwx+fl1L4t/Z1hurmS68LahHahzn7Hd7ii/7rjJA9iD9a4dvgD45WXYILFl/vi6GP5Z/SgCDxv8aPEHjGyk02OKLTdNk4khgYs8g9Gc9R7ADPfNbX7P3hCfUvFLeJJ4iLLTlZYmI4eZhjA9cKST6ErWt4a/ZwuTcJN4l1WFYQcm3scszexdgMfgD9a960vSrHRNMg07TbaO2tIF2xxIOAP6nuSeTQBcooooAKKK8y+Jvxdj8AahDpcGlNeX01uLhXeTZEilmUZxkk5Q8cduaAPTa5fxH8RPCvhUMuqaxAtwv/AC7RHzJc+m1ckfjgV8v+JPi14x8Tb47jVXtbZv8Al3sv3SY9CR8xH1JrA0Twrr3iWby9H0q6vDnBeNDsU+7n5R+JoA9h8SftH3Em+Hw1pCwr0FzfHc34IpwD9SfpWF8MvGXiLxT8Y9DfWdXubpc3BERbbGp8iTogwo/KvP8ATPDzy+OrPw3qW6GR9TSwufLYEoTKI2weQSOfUV9Y+Ffhb4U8H3Md5ptgz30YIW7uJC8gyCDj+EcEjgDrQB2VFFFABXzB+0d/yULT/wDsFR/+jZa+n6oaroul65am11XT7a9h/uTxh8e4z0PuKAPi/wAJ+IrHw5qX2m+8O6frKZHyXe75f93kr+amvozwx8c/BepRRWtx5miSABVjnj/dD2DLwB9QtZ3iT9njw/qG+bQryfS5jyIn/fRfqdw/M/SvIfEnwd8ZeG98j6ab+1X/AJb2JMox7rjcPxGKAEgnhuvj7HcW8qSwy+KA8ckbBldTdZBBHBBHevsOvge1urnTdQgu7Z2huraVZI3A5R1OQee4Ir3r4VfGLxL4h8Xaf4d1hbW6juRJ/pIj2SqVjZ/4flP3cdB1oA9+ooooAKKK5T4geOrLwD4f/tG5jNxcSv5dtbK20yPjPJ7KB1P09aAOror5Xn/aE8aSXJkiTTYY88RLbkjHuS2f1r1X4efGbT/FOn3o1tYdNvrCA3ExVj5UkQ+8y55BHGV5PIxnsAdh4i8B+GPFSt/a+kW80xH+vUbJR/wNcH8DxXneifC7w/4K+KuiXWn+JFMxM2zTLnDTMDDIMgr2HJ5A6dSa4vxv8fdY1aWWz8NKdMsclRcEAzyD19E/Dn3rn/gzNPd/GXRrieWSaVzcNJJIxZmPkSckmgD67ooooAK+a/2kr2R/Fej2BY+XDYmYD3d2B/8ARYr6Ur5g/aO/5KHp/wD2Co//AEbLQBd8F/AJfEHhez1jU9ZltXvIxNFDDCG2oeVJJPORg4x3rzrx14Qu/APiebR5brz0aISRTICnmxtnqM8cggjJ6V6v4d/aB0jRfDOlaVLol9JJZWcNuzrIgDFECkj24rzb4o+N7Xx94mttVtLSa1jis1tykrAkkO7Z47fOPyoA6b4b/BK48W2EOtazdNZaXKcxRxAGWZQcZyeFHocEn06Gvojw54Q0HwlafZ9F06G2BGHkAzJJ/vOeT/KvGfDnx/0bQ/DGlaU+iXrvZWkVuzo6AMyoFJH1IzXX+EPjfpfi/wAU2ehW2kXlvLdb9skjqVXajPzj2XFAHqVFFFABXiHxk+GXiXxn4vtNR0a3gkt47BIGMk6od4kkY8H2YV7fRQB8m/8AChfHf/Pnaf8AgUtH/ChfHf8Az52n/gUtfWVFAHyb/wAKF8d/8+dp/wCBS11nwz+Efi3wx8QtL1jU7a2Szt/N8xkuFYjdE6jge7CvoaigAooooAKKKKACiiigAooooAKKKKAP/9k="
+
+// TestOCRRecognizeWithRotation_Live verifies layer-2 rotation selection
+// end-to-end against a running DeepDoc rec service. It sends a vertical
+// (tall, h/w >= 1.5) text crop at 0/CW90/CCW90 and asserts the orientation
+// with the highest REAL recognition confidence reads the vertical text
+// correctly — i.e. the Go path now does score-based selection (matching
+// Python's get_rotate_crop_image) instead of the old constant-1.0 fallback.
+//
+// Requires a live rec service (DEEPDOC_URL, default http://localhost:9390).
+// Run with: build.sh --test-integration ./internal/deepdoc/parser/pdf/
+func TestOCRRecognizeWithRotation_Live(t *testing.T) {
+	url := os.Getenv("DEEPDOC_URL")
+	if url == "" {
+		url = "http://localhost:9390"
+	}
+	client, err := inference.NewClient(url)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if !client.Health() {
+		t.Skip("deepdoc rec service not healthy; set DEEPDOC_URL")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(layer2CropB64)
+	if err != nil {
+		t.Fatalf("decode embedded crop: %v", err)
+	}
+	crop, _, err := image.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("decode crop: %v", err)
+	}
+
+	cands := map[string]image.Image{
+		"0":     crop,
+		"CW90":  util.RotateImageCW(crop, 90),
+		"CCW90": util.RotateImageCW(crop, 270),
+	}
+	scores := map[string]float64{}
+	texts := map[string]string{}
+	best, bestConf, bestText := "", -1.0, ""
+	for name, im := range cands {
+		rec, recErr := client.OCRRecognize(context.Background(), im)
+		if recErr != nil {
+			t.Fatalf("rec %s: %v", name, recErr)
+		}
+		c, txt := 0.0, ""
+		if len(rec) > 0 {
+			c, txt = rec[0].Confidence, rec[0].Text
+		}
+		scores[name], texts[name] = c, txt
+		if c > bestConf {
+			bestConf, best, bestText = c, name, txt
+		}
+	}
+
+	// The rec service must surface REAL scores, not the old constant 1.0 fill.
+	realScore := false
+	for _, c := range scores {
+		if c != 1.0 {
+			realScore = true
+		}
+	}
+	if !realScore {
+		t.Fatalf("rec service returned constant 1.0; real score not surfaced: %v", scores)
+	}
+
+	// Layer 2 must find an upright orientation that reads the vertical text.
+	if bestConf < 0.8 {
+		t.Fatalf("best orientation confidence too low (%.3f); layer-2 failed: %v", bestConf, scores)
+	}
+	if !strings.Contains(strings.ToUpper(bestText), "RAG") {
+		t.Fatalf("best orientation did not read the vertical text; got %q (scores=%v)", bestText, scores)
+	}
+	// 0° (as-is vertical) must score strictly worse than the best — proving
+	// layer 2 actually does work rather than always trusting 0°.
+	if scores["0"] >= bestConf {
+		t.Fatalf("0° orientation scored >= best; layer-2 selection not effective: %v", scores)
+	}
+	t.Logf("layer-2 selected %s (conf=%.3f, text=%q); scores=%v", best, bestConf, bestText, scores)
+}

--- a/internal/deepdoc/parser/pdf/parser_ocr_rotate_test.go
+++ b/internal/deepdoc/parser/pdf/parser_ocr_rotate_test.go
@@ -1,0 +1,134 @@
+package pdf
+
+import (
+	"context"
+	"image"
+	"sync"
+	"testing"
+
+	pdf "ragflow/internal/deepdoc/parser/pdf/type"
+)
+
+// fakeRotateDoc is a DocAnalyzer whose OCRRecognize returns text and a
+// recognition score keyed on the image orientation: a "wide" image (w >= h)
+// reads as a clean coherent line with wideScore, a "tall" image (h > w) reads
+// as a low-score / garbled result with tallScore. This mirrors reality: a
+// correctly oriented horizontal line reads with high confidence, while a
+// 90°-rotated line reads with low confidence. It also counts calls so the
+// tests can assert the layer-2 fan-out (1 call for short crops, 3 for tall
+// crops) and the score-based selection outcome.
+type fakeRotateDoc struct {
+	mu        sync.Mutex
+	calls     int
+	wideText  string
+	tallText  string
+	wideScore float64
+	tallScore float64
+}
+
+func (f *fakeRotateDoc) OCRRecognize(_ context.Context, img image.Image) ([]pdf.OCRText, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	b := img.Bounds()
+	txt := f.tallText
+	score := f.tallScore
+	if b.Dx() >= b.Dy() {
+		txt = f.wideText
+		score = f.wideScore
+	}
+	if txt == "" {
+		return nil, nil
+	}
+	return []pdf.OCRText{{Text: txt, Confidence: score}}, nil
+}
+func (f *fakeRotateDoc) Health() bool { return true }
+func (f *fakeRotateDoc) DLA(context.Context, image.Image) ([]pdf.DLARegion, error) {
+	return nil, nil
+}
+func (f *fakeRotateDoc) TSR(context.Context, image.Image) ([]pdf.TSRCell, error) {
+	return nil, nil
+}
+func (f *fakeRotateDoc) OCRDetect(context.Context, image.Image) ([]pdf.OCRBox, error) {
+	return nil, nil
+}
+
+// TestOCRRecognizeWithRotation_ShortCrop_NoRotation verifies that crops whose
+// height is below 1.5x their width are recognized once at 0° with no rotation
+// fan-out — i.e. layer 2 is a no-op for the common horizontal case.
+func TestOCRRecognizeWithRotation_ShortCrop_NoRotation(t *testing.T) {
+	crop := image.NewRGBA(image.Rect(0, 0, 60, 20)) // w=60, h=20 -> ratio 0.33
+	doc := &fakeRotateDoc{wideText: "Hello", tallText: "x"}
+	p := &Parser{}
+
+	texts, err := p.ocrRecognizeWithRotation(context.Background(), doc, crop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.calls != 1 {
+		t.Fatalf("expected 1 rec call for short crop, got %d", doc.calls)
+	}
+	if len(texts) != 1 || texts[0].Text != "Hello" {
+		t.Fatalf("expected [Hello], got %+v", texts)
+	}
+}
+
+// TestOCRRecognizeWithRotation_TallCrop_PicksBestScore verifies that a tall
+// narrow crop (h/w >= 1.5) is tried at 0°, CW90°, CCW90° and the orientation
+// with the highest recognition score wins (score-based, matching Python).
+func TestOCRRecognizeWithRotation_TallCrop_PicksBestScore(t *testing.T) {
+	crop := image.NewRGBA(image.Rect(0, 0, 20, 60)) // w=20, h=60 -> ratio 3.0
+	doc := &fakeRotateDoc{wideText: "Hello world", tallText: "x", wideScore: 0.95, tallScore: 0.30}
+	p := &Parser{}
+
+	texts, err := p.ocrRecognizeWithRotation(context.Background(), doc, crop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.calls != 3 {
+		t.Fatalf("expected 3 rec calls for tall crop, got %d", doc.calls)
+	}
+	if len(texts) != 1 || texts[0].Text != "Hello world" {
+		t.Fatalf("expected best-score text [Hello world], got %+v", texts)
+	}
+}
+
+// TestOCRRecognizeWithRotation_TallCrop_TieKeepsZero verifies the stable
+// tie-break: when all three orientations yield equal score, the 0° result is
+// kept (matches Python's first-wins selection order).
+func TestOCRRecognizeWithRotation_TallCrop_TieKeepsZero(t *testing.T) {
+	crop := image.NewRGBA(image.Rect(0, 0, 20, 60)) // w=20, h=60 -> ratio 3.0
+	doc := &fakeRotateDoc{wideText: "AB", tallText: "CD", wideScore: 0.5, tallScore: 0.5}
+	p := &Parser{}
+
+	texts, err := p.ocrRecognizeWithRotation(context.Background(), doc, crop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.calls != 3 {
+		t.Fatalf("expected 3 rec calls, got %d", doc.calls)
+	}
+	if len(texts) != 1 || texts[0].Text != "CD" {
+		t.Fatalf("expected tie to keep 0° text [CD], got %+v", texts)
+	}
+}
+
+// TestOCRBestScore verifies the orientation score is the max recognition
+// confidence across items.
+func TestOCRBestScore(t *testing.T) {
+	cases := []struct {
+		name  string
+		texts []pdf.OCRText
+		want  float64
+	}{
+		{"empty", nil, 0},
+		{"single", []pdf.OCRText{{Text: "ab", Confidence: 0.9}}, 0.9},
+		{"multi", []pdf.OCRText{{Text: "ab", Confidence: 0.7}, {Text: "c", Confidence: 0.95}}, 0.95},
+		{"keeps max", []pdf.OCRText{{Text: "a", Confidence: 0.2}, {Text: "b", Confidence: 0.8}}, 0.8},
+	}
+	for _, c := range cases {
+		if got := ocrBestScore(c.texts); got != c.want {
+			t.Fatalf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The Go PDF OCR path was missing **layer-2 rotation selection** (PaddleOCR-style): for tall, narrow crops (height >= 1.5x width, i.e. vertical text lines) it only recognized at 0°, so vertical text was read as garbage.

The reason was architectural: the DeepDoc rec service previously filled recognition confidence with a constant `1.0` (`OCR.recognize_batch` discards the per-item score, and the adapter had nothing else to send). Without a usable score, the Go side could not pick the best orientation the way the in-process Python `__ocr` path does, and fell back to a text-volume heuristic.

This PR makes the rec service surface the **real recognition score** and switches the Go layer-2 selection to use it — matching Python's `get_rotate_crop_image` / `_rotate_select` behavior.

## Changes

- `deepdoc/vision/ocr.py`: add `recognize_batch_with_score` which returns `List[(text, score)]` and preserves the existing `drop_score` blanking. The original `recognize_batch` is **unchanged**, so the in-process `__ocr` path keeps its text-only contract.
- `deepdoc/server/adapters/ocr_adapter.py`: `recognize()` now returns `[[text, real_score]]` instead of `[[text, 1.0]]`, surfacing the real confidence to clients. Removed `_CONFIDENCE_FILL`.
- `internal/deepdoc/parser/pdf/parser_ocr.go`: `ocrRecognizeWithRotation` recognizes a crop at `0°/CW90°/CCW90°` (only when `h/w >= 1.5`) and keeps the orientation with the highest recognition confidence, replacing the text-volume heuristic.
- Tests: Python offline unit test for `recognize_batch_with_score` + adapter; Go unit tests asserting score-based selection.

## Verification

- Go: `build.sh --test ./internal/deepdoc/parser/pdf/` passes (short crops recognized once at 0°; tall crops tried at 3 orientations and selected by highest score; stable tie-break keeps 0°).
- Python: offline unit tests for the new method/adapter pass; `ruff` clean.
- End-to-end against the rebuilt `deepdoc_oss` image: a vertical crop (h/w = 4.56) was recognized at 0/CW90/CCW90 and the correctly oriented crop won by confidence (~0.97); both a direct service call and the Go client received the **real** (non-1.0) score and selected the upright orientation.

## Notes / no regression

- Horizontal crops (`h/w < 1.5`) are recognized once at 0° — behavior identical to before.
- The in-process Python `__ocr` path is untouched (uses the unchanged `recognize_batch`).
- `OCRText.Confidence` is never consumed as a threshold anywhere in the Go pipeline (`pdf.TextBox` carries no confidence field), so the real score triggers no downstream filtering/dropping.
- This is the **layer-2** change only. **Layer 1** (perspective de-skew / WarpCrop) is tracked separately in PR #18299.

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy)