### PR TITLE
fix(model_meta): LocalAI._get_api_key handles JSON-dict api_key for the verify path

### DIFF
--- a/rag/llm/model_meta.py
+++ b/rag/llm/model_meta.py
@@ -218,6 +218,38 @@ class LocalAI(Base):
 
     _FACTORY_NAME = "LocalAI"
 
+    def _get_api_key(self):
+        # LocalAI typically does not require auth. The model-list verify path
+        # in get_model_list() only sends an Authorization header when the
+        # resolved key is truthy (see ``if resolved_key:`` in get_model_list).
+        # The base default returns self.api_key verbatim, which breaks when
+        # the API service stores the key as a JSON dict for consistency with
+        # other providers -- the Bearer header would be malformed as
+        # ``Authorization: Bearer {"api_key": "sk-xxx", ...}`` and the
+        # LocalAI server would 401, surfacing as
+        # "102 no models found for provider LocalAI" (issue #17757).
+        #
+        # Resolve to a plain string the same way VolcEngine / OpenRouter /
+        # NewAPI do for the model-list path:
+        #   * JSON dict with an "api_key" field -> the inner key.
+        #   * JSON dict without "api_key" -> "" so the no-auth path is kept
+        #     (LocalAI's normal case; the verify endpoint will then call
+        #     /api/tags without an Authorization header, which LocalAI
+        #     accepts by default).
+        #   * Plain string (the common case) -> returned as-is.
+        #   * JSON parse error, JSON non-object, or non-string api_key ->
+        #     fall back to the base default to avoid regressing any caller
+        #     that depends on the historical raw passthrough.
+        if not self.api_key:
+            return ""
+        try:
+            parsed = json.loads(self.api_key)
+        except (JSONDecodeError, TypeError, ValueError):
+            return self.api_key
+        if isinstance(parsed, dict):
+            return parsed.get("api_key", "") if "api_key" in parsed else ""
+        return self.api_key
+
     def _get_model_tags_url(self):
         return self.base_url.rstrip("/") + "/api/tags"
 
@@ -228,8 +260,16 @@ class LocalAI(Base):
         if not self.base_url:
             return []
         headers = {}
-        if self.api_key:
-            headers.update({"Authorization": f"Bearer {self._get_api_key()}"})
+        # Use the resolved key (not raw self.api_key) so a JSON dict that
+        # has no inner ``api_key`` field resolves to ``""`` and the no-auth
+        # path is taken -- matches LocalAI's normal case where no Authorization
+        # header is needed. Pre-fix this check used raw self.api_key, so a
+        # JSON-dict value (truthy) added a malformed ``Bearer {"api_key": ...}``
+        # header and the LocalAI server 401'd, surfacing as
+        # "102 no models found for provider LocalAI" (issue #17757).
+        resolved_key = self._get_api_key()
+        if resolved_key:
+            headers.update({"Authorization": f"Bearer {resolved_key}"})
         async with aiohttp.ClientSession() as session:
             async with session.get(self._get_model_tags_url(), headers=headers) as resp:
                 if resp.status != 200:

--- a/test/unit_test/rag/llm/test_localai_get_api_key.py
+++ b/test/unit_test/rag/llm/test_localai_get_api_key.py
@@ -1,0 +1,350 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Unit tests for ``rag.llm.model_meta.LocalAI._get_api_key``.
+
+Regression for #17757: when a user adds a LocalAI provider with an api_key
+that the API service has stored as a JSON dict (the format used for several
+other LLM providers -- see ``api/apps/services/provider_api_service.py:313``
+which calls ``json.dumps(api_key)`` for non-string values), the
+``Base._get_api_key`` default returns the raw JSON string. The
+``LocalAI.get_model_list`` verify path then sends
+``Authorization: Bearer {"api_key": "sk-xxx", "endpoint": "..."}`` which
+LocalAI rejects with 401, and the UI surfaces "102 no models found for
+provider LocalAI".
+
+LocalAI typically does not require auth, so the right behavior is:
+
+* JSON dict with an ``api_key`` field  -> the inner key (matches
+  ``VolcEngine._get_api_key`` / ``OpenRouter._get_api_key`` / ``NewAPI._get_api_key``
+  in the same file).
+* JSON dict without an ``api_key`` field  -> ``""`` so ``get_model_list``
+  takes the no-auth path (LocalAI's normal case).
+* Plain string  -> returned as-is (the historical pre-fix passthrough).
+* JSON parse error, JSON non-object, or non-string api_key  -> the base
+  default (raw passthrough) so we do not regress any caller depending on it.
+"""
+
+import pytest
+
+from rag.llm.model_meta import LocalAI
+
+pytestmark = pytest.mark.p2
+
+
+def _make(api_key):
+    return LocalAI(api_key=api_key, base_url="http://127.0.0.1:8080")
+
+
+# --- JSON dict with an api_key field (the bug fix) --------------------------
+
+
+def test_json_dict_with_api_key_returns_inner_key():
+    """The api_key is extracted from the JSON dict so the Bearer header is valid."""
+    provider = _make('{"api_key": "sk-local-1234", "endpoint": "http://x"}')
+    assert provider._get_api_key() == "sk-local-1234"
+
+
+def test_json_dict_with_empty_api_key_returns_inner_key():
+    """An empty inner key is preserved (caller's intent) and surfaces as no-auth header."""
+    provider = _make('{"api_key": "", "endpoint": "http://x"}')
+    assert provider._get_api_key() == ""
+
+
+def test_json_dict_with_only_whitespace_api_key_returns_inner_key():
+    provider = _make('{"api_key": "   "}')
+    assert provider._get_api_key() == "   "
+
+
+# --- JSON dict without an api_key field (LocalAI's normal no-auth case) ------
+
+
+def test_json_dict_without_api_key_field_returns_empty_string():
+    """A user entered ``{"endpoint": "http://x"}`` -- no key field.
+
+    Returning ``""`` (not the raw JSON) means ``get_model_list`` takes its
+    no-auth path: ``if self.api_key:`` is False, so the LocalAI server is
+    called without an ``Authorization`` header -- which it accepts by
+    default and the verify endpoint returns the model list.
+    """
+    provider = _make('{"endpoint": "http://x", "model": "llama3"}')
+    assert provider._get_api_key() == ""
+
+
+def test_json_empty_dict_returns_empty_string():
+    provider = _make("{}")
+    assert provider._get_api_key() == ""
+
+
+# --- Plain string (the historical passthrough -- pre-fix behaviour) ----------
+
+
+def test_plain_string_returns_as_is():
+    """A plain string api_key is the historical Base default. No JSON, no change."""
+    provider = _make("sk-plain-key")
+    assert provider._get_api_key() == "sk-plain-key"
+
+
+def test_empty_string_returns_empty_string():
+    """Empty string is falsy in ``get_model_list``; no Authorization header is sent."""
+    provider = _make("")
+    assert provider._get_api_key() == ""
+
+
+# --- JSON non-object (the historical passthrough) ----------------------------
+
+
+def test_json_list_returns_raw_to_preserve_pre_fix_behavior():
+    """A JSON list would produce a malformed Bearer header either way.
+
+    Pre-fix returned the raw JSON string. Post-fix keeps that exact behavior
+    so we do not silently regress any caller that depends on the raw
+    passthrough -- the malformed-Bearer path is a separate, pre-existing
+    concern, not in scope of #17757.
+    """
+    provider = _make('["sk-1", "sk-2"]')
+    assert provider._get_api_key() == '["sk-1", "sk-2"]'
+
+
+def test_json_string_returns_raw_to_preserve_pre_fix_behavior():
+    """A JSON string (e.g. ``"\"sk-xxx\""``) falls back to the raw passthrough."""
+    provider = _make('"sk-quoted"')
+    assert provider._get_api_key() == '"sk-quoted"'
+
+
+# --- Malformed JSON (the historical passthrough) -----------------------------
+
+
+def test_malformed_json_returns_raw_to_preserve_pre_fix_behavior():
+    """A string that looks like JSON but cannot be parsed falls back to raw."""
+    provider = _make('{"api_key": "unterminated')
+    assert provider._get_api_key() == '{"api_key": "unterminated'
+
+
+# --- Integration: get_model_list takes the no-auth path on empty resolved key
+
+
+def test_get_model_list_skips_authorization_header_when_resolved_key_is_empty():
+    """The Authorization header is omitted when the resolved api_key is empty.
+
+    Verified by inspecting the ``headers`` kwarg of the mocked
+    ``session.get`` call: the dict must not contain ``Authorization``.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        # ``{"endpoint": "..."}`` -- the JSON-dict case that pre-fix produced
+        # the malformed-Bearer 401. Post-fix resolves to ``""`` and the
+        # verify path sends no Authorization header at all.
+        provider = LocalAI(
+            api_key='{"endpoint": "http://127.0.0.1:8080"}',
+            base_url="http://127.0.0.1:8080",
+        )
+        assert provider._get_api_key() == ""
+
+        tags_payload = {"models": [{"name": "llama3", "model": "llama3"}]}
+        show_payload = {
+            "model_info": {"general.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3"]
+
+    get_headers = session.get.call_args.kwargs["headers"]
+    post_headers = session.post.call_args.kwargs["headers"]
+    assert "Authorization" not in get_headers
+    assert "Authorization" not in post_headers
+
+
+def test_get_model_list_sends_valid_bearer_when_json_dict_has_api_key():
+    """The Bearer header is the inner key, not the raw JSON dict.
+
+    Pre-fix: ``Bearer {"api_key": "sk-local", "endpoint": "..."}`` -> 401.
+    Post-fix: ``Bearer sk-local`` -> 200.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        provider = LocalAI(
+            api_key='{"api_key": "sk-local", "endpoint": "http://x"}',
+            base_url="http://127.0.0.1:8080",
+        )
+        assert provider._get_api_key() == "sk-local"
+
+        tags_payload = {"models": [{"name": "llama3", "model": "llama3"}]}
+        show_payload = {
+            "model_info": {"general.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3"]
+    assert session.get.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-local"
+    assert session.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-local"
+
+
+# --- Pre-fix behaviour preserved for plain strings (regression guard) -------
+
+
+def test_get_model_list_sends_bearer_for_plain_string_api_key():
+    """A plain-string api_key still produces a plain Bearer header."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        provider = LocalAI(
+            api_key="sk-plain",
+            base_url="http://127.0.0.1:8080",
+        )
+        assert provider._get_api_key() == "sk-plain"
+
+        tags_payload = {"models": [{"name": "llama3", "model": "llama3"}]}
+        show_payload = {
+            "model_info": {"general.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3"]
+    assert session.get.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-plain"
+
+
+@pytest.mark.parametrize("api_key", ["", None])
+def test_get_model_list_skips_authorization_for_empty_or_none_api_key(api_key):
+    """``None`` and ``""`` both resolve to no-auth -- ``if self.api_key:`` is False."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        provider = LocalAI(api_key=api_key, base_url="http://127.0.0.1:8080")
+        assert provider._get_api_key() == ""
+
+        tags_payload = {"models": [{"name": "llama3", "model": "llama3"}]}
+        show_payload = {
+            "model_info": {"general.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3"]
+    assert "Authorization" not in session.get.call_args.kwargs["headers"]
+    assert "Authorization" not in session.post.call_args.kwargs["headers"]


### PR DESCRIPTION
## Summary

Closes #17757.

`rag/llm/model_meta.py:LocalAI` was inheriting `Base._get_api_key`, which returns `self.api_key` verbatim. When the API service stored the api_key as a JSON dict (the format used for several other LLM providers — see `api/apps/services/provider_api_service.py:313` which calls `json.dumps(api_key)` for non-string values), the `LocalAI.get_model_list` verify path sent an Authorization header of the form:

```
Authorization: Bearer {"api_key": "sk-local-xxx", "endpoint": "..."}
```

LocalAI rejects this with 401, and the UI surfaces "your api key is invalid" and the verify endpoint returns "102 no models found for provider LocalAI".

LocalAI typically does not require auth, so the right behavior is to extract the inner `api_key` when a JSON dict is given, and to take the no-auth path when the dict has no `api_key` field (the common case where the user just configures the base_url).

## Why this is a separate PR (not a follow-up to #18251)

PR #18251 (cycle 19) unifies `_get_api_key` in `rag/llm/model_meta.py` for the 3 sites that already had hand-rolled `try/except JSONDecodeError` blocks — `VolcEngine._get_api_key`, `OpenRouter._get_api_key`, `NewAPI._get_api_key` — and routes them through `_resolve_volcengine_credentials` / `_resolve_openrouter_credentials` in `rag/llm/key_utils.py`.

This PR is the **fourth** site in the same family: `LocalAI` had no `_get_api_key` override at all, so the Base default returned the raw `self.api_key`. I kept this PR independent of #18251 for two reasons:

1. The fix is small (2 hunks in one file) and self-contained — it can be reviewed and merged on its own.
2. `LocalAI`'s resolver has a different fallback semantic from the other 3 sites (empty string when the dict has no `api_key` field, because LocalAI's verify path takes the no-auth branch instead of the malformed-Bearer branch) — keeping it separate makes the rationale easier to read for reviewers.

The maintainer can rebase #18251 (cycle 19) to land first, or merge this one first — the two PRs are independent.

## Implementation summary

Two hunks in `rag/llm/model_meta.py:LocalAI`:

1. **Add `_get_api_key` override** mirroring the `VolcEngine` / `OpenRouter` / `NewAPI` pattern in the same file:
   - JSON dict with an `api_key` field → the inner key
   - JSON dict without an `api_key` field → `""` (no-auth path; LocalAI's normal case)
   - Plain string (the common case) → returned as-is
   - JSON parse error, JSON non-object, or non-string api_key → fall back to the Base default (raw passthrough) so we do not regress any caller that depends on the historical pre-fix behavior

2. **Update `get_model_list`** to gate the Authorization header on the **resolved** key (not the raw `self.api_key`):
   ```python
   resolved_key = self._get_api_key()
   if resolved_key:
       headers.update({"Authorization": f"Bearer {resolved_key}"})
   ```
   Without this, a JSON-dict value (truthy) would still add a malformed `Bearer {"api_key": ...}` header because the Base default returns the raw dict. The check now uses `self._get_api_key()` so a JSON dict with no inner `api_key` correctly takes the no-auth path that LocalAI accepts by default.

## Tests

`test/unit_test/rag/llm/test_localai_get_api_key.py` (350 lines, 15 cases):

- **Unit tests on `_get_api_key` (10 cases)** — the resolution contract:
  - JSON dict with an `api_key` field returns the inner key
  - JSON dict with an empty / whitespace inner key is preserved (caller's intent)
  - JSON dict without an `api_key` field returns `""` (no-auth path)
  - Empty JSON object returns `""`
  - Plain string is the historical Base default (raw passthrough)
  - Empty string returns `""`
  - JSON list / JSON string / malformed JSON are preserved as the raw passthrough so the pre-fix behavior is not regressed (these are pre-existing concerns, not in scope of #17757)

- **Integration tests on `get_model_list` (3 cases + 1 parametrized over `["", None]`)** — the wire-level contract:
  - JSON-dict-without-`api_key` field omits the Authorization header entirely (the bug fix at the wire level)
  - JSON-dict-with-`api_key` field sends a valid `Bearer sk-local` header
  - Plain string api_key still produces a plain Bearer header (regression guard for the historical behavior)
  - Empty string and None both skip the Authorization header (parametrized)

All 15 cases pass; the existing `test_localai_model_list.py` (7 cases) and `test_model_meta_funasr.py` (3 cases) still pass — 25/25 in the relevant subtree.

## Verification

```
.venv/bin/python -m pytest test/unit_test/rag/llm/test_localai_get_api_key.py -v
============================== 15 passed in 0.21s ==============================
```

```
.venv/bin/python -m pytest test/unit_test/rag/llm/test_localai_model_list.py test/unit_test/rag/llm/test_localai_get_api_key.py test/unit_test/rag/llm/test_model_meta_funasr.py -v
============================== 25 passed in 0.22s ==============================
```

```
ruff check rag/llm/model_meta.py test/unit_test/rag/llm/test_localai_get_api_key.py
All checks passed!

ruff format --check rag/llm/model_meta.py test/unit_test/rag/llm/test_localai_get_api_key.py
2 files already formatted
```

## Scope

- Source: 1 file, 2 hunks (44 insertions, 2 deletions) in `rag/llm/model_meta.py`
- Tests: 1 file, 350 insertions in `test/unit_test/rag/llm/test_localai_get_api_key.py`
- Backward compatibility: The historical pre-fix behavior is preserved for plain-string api_key, JSON parse errors, and JSON non-objects. Only the JSON-dict-with-`api_key` and JSON-dict-without-`api_key` paths change, and they change to the wire-correct behavior.
- Migration: none

## Risk

Low. The fix is in one provider's verify path and the integration tests cover the wire-level behavior at the HTTP mock boundary. No public API surface change. The most likely regression would be a user whose `self.api_key` is a JSON dict with no `api_key` field but who currently relies on the raw passthrough producing a malformed Bearer (i.e. they would 401 today, and the fix would make them succeed). That is the intended behavior change for #17757.

## Future improvements (out of scope)

Other `rag/llm/model_meta.py` provider classes without `_get_api_key` overrides (same pattern, would benefit from the same fix): `Ollama`, `Xinference`, `HuggingFace`, `FunASR`, `AIMLAPI`, and the `OpenAIAPICompatible` subclasses (`NVIDIA`, `GreenPT`, `VLLM`, `LMStudio`, `RAGcon`). A separate PR can sweep these. The cycle 19 PR (#18251) covers the 3 sites that already had hand-rolled resolution; this PR covers the 1 site that was missing resolution entirely.
