### PR TITLE
test(chunker): pin current applyChildrenDelimText behavior (#17876 partial coverage)

### DIFF
--- a/internal/ingestion/component/chunker/token.go
+++ b/internal/ingestion/component/chunker/token.go
@@ -1491,14 +1491,16 @@ func applyChildrenDelimText(docs []schema.ChunkDoc, pattern *regexp.Regexp) []sc
 			// Preserve any incoming Mom so that a chunk flowing into this
 			// path with an explicit parent-context (e.g. from a prior
 			// delimiter branch) keeps that lineage. Fall back to the
-			// current chunk's text only when no Mom was set.
+			// current chunk's text (with the leading "\n" stripped, the
+			// historical default the function used before this PR) only
+			// when no Mom was set.
 			// Mirrors `applyChildrenDelim`, which takes the parent as an
 			// explicit `seg` argument. Regression for #17876.
 			mom := d.Mom
 			if mom == "" {
-				mom = t
+				mom = strings.TrimPrefix(t, "\n")
 			}
-			out = append(out, schema.ChunkDoc{Text: child, Mom: mom}) (fix(chunker): preserve incoming Mom in applyChildrenDelimText)
+			out = append(out, schema.ChunkDoc{Text: child, Mom: mom})
 		}
 	}
 	return out

--- a/internal/ingestion/component/chunker/token.go
+++ b/internal/ingestion/component/chunker/token.go
@@ -1488,7 +1488,17 @@ func applyChildrenDelimText(docs []schema.ChunkDoc, pattern *regexp.Regexp) []sc
 			if strings.TrimSpace(child) == "" {
 				continue
 			}
-			out = append(out, schema.ChunkDoc{Text: child, Mom: strings.TrimPrefix(t, "\n")})
+			// Preserve any incoming Mom so that a chunk flowing into this
+			// path with an explicit parent-context (e.g. from a prior
+			// delimiter branch) keeps that lineage. Fall back to the
+			// current chunk's text only when no Mom was set.
+			// Mirrors `applyChildrenDelim`, which takes the parent as an
+			// explicit `seg` argument. Regression for #17876.
+			mom := d.Mom
+			if mom == "" {
+				mom = t
+			}
+			out = append(out, schema.ChunkDoc{Text: child, Mom: mom}) (fix(chunker): preserve incoming Mom in applyChildrenDelimText)
 		}
 	}
 	return out

--- a/internal/ingestion/component/chunker/token.go
+++ b/internal/ingestion/component/chunker/token.go
@@ -1488,19 +1488,7 @@ func applyChildrenDelimText(docs []schema.ChunkDoc, pattern *regexp.Regexp) []sc
 			if strings.TrimSpace(child) == "" {
 				continue
 			}
-			// Preserve any incoming Mom so that a chunk flowing into this
-			// path with an explicit parent-context (e.g. from a prior
-			// delimiter branch) keeps that lineage. Fall back to the
-			// current chunk's text (with the leading "\n" stripped, the
-			// historical default the function used before this PR) only
-			// when no Mom was set.
-			// Mirrors `applyChildrenDelim`, which takes the parent as an
-			// explicit `seg` argument. Regression for #17876.
-			mom := d.Mom
-			if mom == "" {
-				mom = strings.TrimPrefix(t, "\n")
-			}
-			out = append(out, schema.ChunkDoc{Text: child, Mom: mom})
+			out = append(out, schema.ChunkDoc{Text: child, Mom: strings.TrimPrefix(t, "\n")})
 		}
 	}
 	return out

--- a/internal/ingestion/component/chunker/token_test.go
+++ b/internal/ingestion/component/chunker/token_test.go
@@ -784,3 +784,62 @@ func TestApplyChildrenDelimText_NilPatternIsNoop(t *testing.T) {
 		t.Errorf("input mutated under nil pattern: %+v", out[0])
 	}
 }
+
+// TestApplyChildrenDelimText_FallbackStripsLeadingNewline verifies that
+// when no incoming Mom is set, the fallback Mom uses
+// strings.TrimPrefix(t, "\n") — i.e. it strips a single leading newline
+// from the current chunk's text. The historical default this PR
+// preserves; if a child path forgets to strip, JSON-keyed SQL
+// downstream could see an extra leading "\n" in the Mom value.
+func TestApplyChildrenDelimText_FallbackStripsLeadingNewline(t *testing.T) {
+	docs := []schema.ChunkDoc{
+		{Text: "\nalpha. beta. gamma"},
+	}
+	pattern := regexp.MustCompile(`\. `)
+
+	out := applyChildrenDelimText(docs, pattern)
+	if len(out) != 3 {
+		t.Fatalf("want 3 children, got %d", len(out))
+	}
+	for i, c := range out {
+		// Each child Mom must be the text-path parent segment with
+		// the leading "\n" stripped, NOT the raw text-with-newline.
+		if c.Mom != "alpha. beta. gamma" {
+			t.Errorf("child %d: Mom=%q, want %q (leading newline must be stripped)",
+				i, c.Mom, "alpha. beta. gamma")
+		}
+	}
+}
+
+// TestApplyChildrenDelim_SymmetryWithTextPath verifies that the JSON
+// branch (applyChildrenDelim, which takes an explicit seg argument) and
+// the text branch (applyChildrenDelimText, which falls back to the
+// current chunk's text) produce equivalent Mom values for equivalent
+// input. Regression for #17876.
+func TestApplyChildrenDelim_SymmetryWithTextPath(t *testing.T) {
+	pattern := regexp.MustCompile(`\. `)
+
+	// JSON path: caller supplies the explicit parent segment via the
+	// seg argument. Mirrors how upstream delimiter branches call
+	// applyChildrenDelim.
+	jsonOut := applyChildrenDelim(
+		[]schema.ChunkDoc{{Text: "alpha. beta. gamma"}},
+		pattern,
+		"\nalpha. beta. gamma", // seg = TrimPrefix(d.Text, "\n")
+	)
+	// Text path: no explicit seg; falls back to TrimPrefix(d.Text, "\n").
+	textOut := applyChildrenDelimText(
+		[]schema.ChunkDoc{{Text: "\nalpha. beta. gamma"}},
+		pattern,
+	)
+
+	if len(jsonOut) != 3 || len(textOut) != 3 {
+		t.Fatalf("expected 3 children each; json=%d text=%d", len(jsonOut), len(textOut))
+	}
+	for i := range jsonOut {
+		if jsonOut[i].Mom != textOut[i].Mom {
+			t.Errorf("child %d: json Mom=%q != text Mom=%q (branches must agree)",
+				i, jsonOut[i].Mom, textOut[i].Mom)
+		}
+	}
+}

--- a/internal/ingestion/component/chunker/token_test.go
+++ b/internal/ingestion/component/chunker/token_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -725,5 +726,61 @@ func TestMergeByTokenSize_OversizeDropsBlankLines(t *testing.T) {
 	}
 	if got := joined.String(); strings.Contains(got, "\n\n") {
 		t.Errorf("blank line survived in oversize path (Python drops it): got chunk text %q, want no blank line (\\n\\n)", got)
+	}
+}
+
+// TestApplyChildrenDelimText_DefaultsMomToCurrentChunk verifies that when an
+// incoming chunk has no Mom, the children fall back to the current chunk's
+// text (the historical behaviour preserved by the fix for #17876).
+func TestApplyChildrenDelimText_DefaultsMomToCurrentChunk(t *testing.T) {
+	docs := []schema.ChunkDoc{
+		{Text: "alpha. beta. gamma"},
+	}
+	pattern := regexp.MustCompile(`\. `)
+
+	out := applyChildrenDelimText(docs, pattern)
+	if len(out) != 3 {
+		t.Fatalf("want 3 children, got %d", len(out))
+	}
+	for i, c := range out {
+		if c.Mom != "alpha. beta. gamma" {
+			t.Errorf("child %d: Mom=%q, want %q", i, c.Mom, "alpha. beta. gamma")
+		}
+	}
+}
+
+// TestApplyChildrenDelimText_PreservesIncomingMom verifies that when a chunk
+// already has a non-empty Mom (e.g. set by an upstream delimiter branch),
+// applyChildrenDelimText forwards it to its children instead of clobbering
+// it with the current chunk's text. Regression for #17876.
+func TestApplyChildrenDelimText_PreservesIncomingMom(t *testing.T) {
+	docs := []schema.ChunkDoc{
+		{Text: "alpha. beta. gamma", Mom: "parent-segment-from-prior-branch"},
+	}
+	pattern := regexp.MustCompile(`\. `)
+
+	out := applyChildrenDelimText(docs, pattern)
+	if len(out) != 3 {
+		t.Fatalf("want 3 children, got %d", len(out))
+	}
+	for i, c := range out {
+		if c.Mom != "parent-segment-from-prior-branch" {
+			t.Errorf("child %d: Mom=%q, want preserved %q", i, c.Mom, "parent-segment-from-prior-branch")
+		}
+	}
+}
+
+// TestApplyChildrenDelimText_NilPatternIsNoop verifies the early return so
+// callers that pass a nil pattern don't accidentally clear Mom.
+func TestApplyChildrenDelimText_NilPatternIsNoop(t *testing.T) {
+	docs := []schema.ChunkDoc{
+		{Text: "alpha. beta", Mom: "kept"},
+	}
+	out := applyChildrenDelimText(docs, nil)
+	if len(out) != 1 {
+		t.Fatalf("want 1 chunk unchanged, got %d", len(out))
+	}
+	if out[0].Mom != "kept" || out[0].Text != "alpha. beta" {
+		t.Errorf("input mutated under nil pattern: %+v", out[0])
 	}
 }

--- a/internal/ingestion/component/chunker/token_test.go
+++ b/internal/ingestion/component/chunker/token_test.go
@@ -749,26 +749,11 @@ func TestApplyChildrenDelimText_DefaultsMomToCurrentChunk(t *testing.T) {
 	}
 }
 
-// TestApplyChildrenDelimText_PreservesIncomingMom verifies that when a chunk
-// already has a non-empty Mom (e.g. set by an upstream delimiter branch),
-// applyChildrenDelimText forwards it to its children instead of clobbering
-// it with the current chunk's text. Regression for #17876.
-func TestApplyChildrenDelimText_PreservesIncomingMom(t *testing.T) {
-	docs := []schema.ChunkDoc{
-		{Text: "alpha. beta. gamma", Mom: "parent-segment-from-prior-branch"},
-	}
-	pattern := regexp.MustCompile(`\. `)
-
-	out := applyChildrenDelimText(docs, pattern)
-	if len(out) != 3 {
-		t.Fatalf("want 3 children, got %d", len(out))
-	}
-	for i, c := range out {
-		if c.Mom != "parent-segment-from-prior-branch" {
-			t.Errorf("child %d: Mom=%q, want preserved %q", i, c.Mom, "parent-segment-from-prior-branch")
-		}
-	}
-}
+// TestApplyChildrenDelimText_PreservesIncomingMom REMOVED: per the
+// #17876 review, no current caller of applyChildrenDelimText ever
+// sets an incoming Mom — the production code's "preserve Mom"
+// branch is unreachable. The real fix is merge-granularity alignment
+// (see #17876 for the open follow-up).
 
 // TestApplyChildrenDelimText_NilPatternIsNoop verifies the early return so
 // callers that pass a nil pattern don't accidentally clear Mom.
@@ -811,35 +796,9 @@ func TestApplyChildrenDelimText_FallbackStripsLeadingNewline(t *testing.T) {
 	}
 }
 
-// TestApplyChildrenDelim_SymmetryWithTextPath verifies that the JSON
-// branch (applyChildrenDelim, which takes an explicit seg argument) and
-// the text branch (applyChildrenDelimText, which falls back to the
-// current chunk's text) produce equivalent Mom values for equivalent
-// input. Regression for #17876.
-func TestApplyChildrenDelim_SymmetryWithTextPath(t *testing.T) {
-	pattern := regexp.MustCompile(`\. `)
-
-	// JSON path: caller supplies the explicit parent segment via the
-	// seg argument. Mirrors how upstream delimiter branches call
-	// applyChildrenDelim.
-	jsonOut := applyChildrenDelim(
-		[]schema.ChunkDoc{{Text: "alpha. beta. gamma"}},
-		pattern,
-		"\nalpha. beta. gamma", // seg = TrimPrefix(d.Text, "\n")
-	)
-	// Text path: no explicit seg; falls back to TrimPrefix(d.Text, "\n").
-	textOut := applyChildrenDelimText(
-		[]schema.ChunkDoc{{Text: "\nalpha. beta. gamma"}},
-		pattern,
-	)
-
-	if len(jsonOut) != 3 || len(textOut) != 3 {
-		t.Fatalf("expected 3 children each; json=%d text=%d", len(jsonOut), len(textOut))
-	}
-	for i := range jsonOut {
-		if jsonOut[i].Mom != textOut[i].Mom {
-			t.Errorf("child %d: json Mom=%q != text Mom=%q (branches must agree)",
-				i, jsonOut[i].Mom, textOut[i].Mom)
-		}
-	}
-}
+// TestApplyChildrenDelim_SymmetryWithTextPath REMOVED: it called
+// applyChildrenDelim, which doesn't exist anywhere in the repo
+// (verified via code search). The symmetry check was useful in
+// principle but the missing function makes it a compile error.
+// Per the #17876 review, the real fix is merge-granularity alignment,
+// which lives in a separate PR.

--- a/internal/ingestion/component/chunker/token_test.go
+++ b/internal/ingestion/component/chunker/token_test.go
@@ -749,11 +749,40 @@ func TestApplyChildrenDelimText_DefaultsMomToCurrentChunk(t *testing.T) {
 	}
 }
 
-// TestApplyChildrenDelimText_PreservesIncomingMom REMOVED: per the
-// #17876 review, no current caller of applyChildrenDelimText ever
-// sets an incoming Mom — the production code's "preserve Mom"
-// branch is unreachable. The real fix is merge-granularity alignment
-// (see #17876 for the open follow-up).
+// TestApplyChildrenDelimText_OverwritesIncomingMom documents the
+// CURRENT behaviour: when a chunk flowing into applyChildrenDelimText
+// already has a non-empty Mom, the function OVERWRITES it with
+// TrimPrefix(d.Text, "\n") of the current chunk's text. This is
+// the divergence that #17876 item 2 (multi-chunk text-path Mom
+// granularity) is tracking. Once the merge-granularity fix lands,
+// this test should be updated (or the PreservesIncomingMom version
+// added back).
+func TestApplyChildrenDelimText_OverwritesIncomingMom(t *testing.T) {
+	docs := []schema.ChunkDoc{
+		{Text: "alpha. beta. gamma", Mom: "incoming-mom-from-upstream"},
+	}
+	pattern := regexp.MustCompile(`\. `)
+
+	out := applyChildrenDelimText(docs, pattern)
+	if len(out) != 3 {
+		t.Fatalf("want 3 children, got %d", len(out))
+	}
+	for i, c := range out {
+		// Children must NOT carry the incoming Mom; the function
+		// overwrites it with TrimPrefix(d.Text, "\n") of the current
+		// chunk's text. This pins the current behavior; a future
+		// merge-granularity fix should update this test (or the test
+		// itself flips to assert the new preserved Mom behavior).
+		if c.Mom == "incoming-mom-from-upstream" {
+			t.Errorf("child %d: Mom=%q, expected overwrite to %q (not preserved)",
+				i, c.Mom, "alpha. beta. gamma")
+		}
+		if c.Mom != "alpha. beta. gamma" {
+			t.Errorf("child %d: Mom=%q, want %q (TrimPrefix(d.Text, \"\\n\"))",
+				i, c.Mom, "alpha. beta. gamma")
+		}
+	}
+}
 
 // TestApplyChildrenDelimText_NilPatternIsNoop verifies the early return so
 // callers that pass a nil pattern don't accidentally clear Mom.
@@ -796,9 +825,9 @@ func TestApplyChildrenDelimText_FallbackStripsLeadingNewline(t *testing.T) {
 	}
 }
 
-// TestApplyChildrenDelim_SymmetryWithTextPath REMOVED: it called
-// applyChildrenDelim, which doesn't exist anywhere in the repo
-// (verified via code search). The symmetry check was useful in
-// principle but the missing function makes it a compile error.
-// Per the #17876 review, the real fix is merge-granularity alignment,
-// which lives in a separate PR.
+// TestApplyChildrenDelim_SymmetryWithTextPath was dropped because it
+// referenced applyChildrenDelim, a function that does not exist in
+// the current Go chunker — only applyChildrenDelimText exists. The
+// missing function makes the test a compile error, so the symmetry
+// check has to live in a follow-up that introduces the JSON-side
+// helper too.

--- a/internal/ingestion/component/chunker/token_test.go
+++ b/internal/ingestion/component/chunker/token_test.go
@@ -824,10 +824,3 @@ func TestApplyChildrenDelimText_FallbackStripsLeadingNewline(t *testing.T) {
 		}
 	}
 }
-
-// TestApplyChildrenDelim_SymmetryWithTextPath was dropped because it
-// referenced applyChildrenDelim, a function that does not exist in
-// the current Go chunker — only applyChildrenDelimText exists. The
-// missing function makes the test a compile error, so the symmetry
-// check has to live in a follow-up that introduces the JSON-side
-// helper too.


### PR DESCRIPTION
Adds four regression tests for `applyChildrenDelimText` in `internal/ingestion/component/chunker/token.go`. No production code change.

## What this PR covers

The Go chunker's text-path helper `applyChildrenDelimText` has three behaviors worth pinning down so a future refactor doesn't regress them silently:

1. **`applyChildrenDelimText_DefaultsMomToCurrentChunk`** — when no `Mom` is set on the incoming chunk, every child carries the parent segment text (with leading `\n` stripped) as its `Mom`.
2. **`applyChildrenDelimText_NilPatternIsNoop`** — `pattern == nil` returns the input slice verbatim without dropping `Mom` on any element.
3. **`applyChildrenDelimText_FallbackStripsLeadingNewline`** — when no `Mom` is set, the fallback `Mom` uses `strings.TrimPrefix(t, "\n")`. A leading newline on the current chunk's text must be stripped (JSON-keyed SQL downstream breaks if a stray `\n` leaks through).
4. **`applyChildrenDelimText_OverwritesIncomingMom`** (new this rev) — documents the **current** behavior: when a chunk flowing into `applyChildrenDelimText` already has a non-empty `Mom`, the function **overwrites** it with `TrimPrefix(d.Text, "\n")` of the current chunk's text. This is the divergence that #17876 item 2 (multi-chunk text-path Mom granularity) is tracking — once the merge-granularity fix lands, this test should be updated (or the PreservesIncomingMom version added back).

## Out of scope (kept in #17876)

This PR does **not** address the core #17876 problem. The real divergence is that Branch A in the Go chunker sets `Mom` to the token-merged chunk while Python sets `Mom` to the `naive_merge` segment `c` (different granularity/boundaries). That's a separate fix in the parity harness and should land in its own PR. #17876 stays open for that work.

## Test gap closed

- Replaced the REMOVED comment stubs (which violated code hygiene per @xugangqiang's review) with a real test that records the current behavior.
- Removed the symmetry test that called `applyChildrenDelim` (a function that does not exist in the repo — would have been a compile error).
- Added `TestApplyChildrenDelimText_OverwritesIncomingMom` as a NEGATIVE test that pins the current overwrite behavior, so the future fix is forced to explicitly flip this assertion (and document the change in the test's docstring).

## Verification

```
$ gofmt -l internal/ingestion/component/chunker/*.go
(no output)
```

`go build ./internal/ingestion/component/chunker` clean (full `go test ./...` blocked locally by the same `office_oxide.h` cgo transitive dep as in previous PRs — unrelated to this change).
