### PR TITLE
fix(model_meta): Ollama._get_api_key handles JSON-dict api_key for the verify path

### DIFF
--- a/rag/llm/model_meta.py
+++ b/rag/llm/model_meta.py
@@ -122,6 +122,39 @@ class VolcEngine(Base):
 class Ollama(Base):
     _FACTORY_NAME = "Ollama"
 
+    def _get_api_key(self):
+        # Ollama typically does not require auth. The model-list verify path
+        # in get_model_list() only sends an Authorization header when the
+        # resolved key is truthy (see ``if resolved_key:`` in get_model_list).
+        # The base default returns self.api_key verbatim, which breaks when
+        # the API service stores the key as a JSON dict for consistency with
+        # other providers -- the Bearer header would be malformed as
+        # ``Authorization: Bearer {"api_key": "sk-xxx", ...}``. Ollama does
+        # not validate the token and accepts the malformed Bearer, but
+        # downstream Ollama setups that do validate (e.g. behind an
+        # authenticating reverse proxy) would reject it.
+        #
+        # Resolve to a plain string the same way LocalAI / VolcEngine /
+        # OpenRouter / NewAPI do for the model-list path:
+        #   * JSON dict with an "api_key" field -> the inner key.
+        #   * JSON dict without "api_key" -> "" so the no-auth path is kept
+        #     (Ollama's normal case; the verify endpoint will then call
+        #     /api/tags without an Authorization header, which Ollama
+        #     accepts by default).
+        #   * Plain string (the common case) -> returned as-is.
+        #   * JSON parse error, JSON non-object, or non-string api_key ->
+        #     fall back to the base default to avoid regressing any caller
+        #     that depends on the historical raw passthrough.
+        if not self.api_key:
+            return ""
+        try:
+            parsed = json.loads(self.api_key)
+        except (JSONDecodeError, TypeError, ValueError):
+            return self.api_key
+        if isinstance(parsed, dict):
+            return parsed.get("api_key", "") if "api_key" in parsed else ""
+        return self.api_key
+
     def _get_model_tags_url(self):
         return self.base_url.rstrip("/") + "/api/tags"
 
@@ -132,8 +165,15 @@ class Ollama(Base):
         if not self.base_url:
             return []
         headers = {}
-        if self.api_key:
-            headers.update({"Authorization": f"Bearer {self._get_api_key()}"})
+        # Use the resolved key (not raw self.api_key) so a JSON dict that
+        # has no inner ``api_key`` field resolves to ``""`` and the no-auth
+        # path is taken -- matches Ollama's normal case where no Authorization
+        # header is needed. Pre-fix this check used raw self.api_key, so a
+        # JSON-dict value (truthy) added a malformed ``Bearer {"api_key": ...}``
+        # header.
+        resolved_key = self._get_api_key()
+        if resolved_key:
+            headers.update({"Authorization": f"Bearer {resolved_key}"})
         async with aiohttp.ClientSession() as session:
             async with session.get(self._get_model_tags_url(), headers=headers) as resp:
                 if resp.status != 200:

--- a/test/unit_test/rag/llm/test_ollama_get_api_key.py
+++ b/test/unit_test/rag/llm/test_ollama_get_api_key.py
@@ -1,0 +1,355 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Unit tests for ``rag.llm.model_meta.Ollama._get_api_key``.
+
+Same shape as the LocalAI JSON-decode fix (PR #18314, closes #17757):
+Ollama was inheriting ``Base._get_api_key`` (returns ``self.api_key`` verbatim)
+and using the raw ``self.api_key`` truthiness in ``get_model_list`` to gate
+the ``Authorization`` header. When the API service stored the api_key as a
+JSON dict (the format ``api/apps/services/provider_api_service.py:313``
+produces for non-string values via ``json.dumps(api_key)``), the verify
+path would have sent ``Authorization: Bearer {"api_key": "sk-xxx", "endpoint": "..."}``
+to the Ollama server.
+
+Ollama does not validate the bearer (it accepts malformed Bearer headers
+silently), so the user-facing symptom is mild compared to LocalAI's 401
+behavior, but downstream setups that front Ollama with an authenticating
+reverse proxy would reject the malformed token. The same defensive
+resolution rule from cycle 22 applies:
+
+  * JSON dict with an ``api_key`` field  -> the inner key
+  * JSON dict without an ``api_key`` field  -> ``""`` (no-auth path;
+    matches Ollama's normal case where no Authorization header is needed)
+  * Plain string  -> returned as-is (the historical pre-fix passthrough)
+  * JSON parse error, JSON non-object, or non-string api_key  -> the base
+    default (raw passthrough) so we do not regress any caller depending on it
+"""
+
+import pytest
+
+from rag.llm.model_meta import Ollama
+
+pytestmark = pytest.mark.p2
+
+
+def _make(api_key):
+    return Ollama(api_key=api_key, base_url="http://127.0.0.1:11434")
+
+
+# --- JSON dict with an api_key field (the bug fix) --------------------------
+
+
+def test_json_dict_with_api_key_returns_inner_key():
+    provider = _make('{"api_key": "sk-ollama-1234", "endpoint": "http://x"}')
+    assert provider._get_api_key() == "sk-ollama-1234"
+
+
+def test_json_dict_with_empty_api_key_returns_inner_key():
+    provider = _make('{"api_key": "", "endpoint": "http://x"}')
+    assert provider._get_api_key() == ""
+
+
+def test_json_dict_with_only_whitespace_api_key_returns_inner_key():
+    provider = _make('{"api_key": "   "}')
+    assert provider._get_api_key() == "   "
+
+
+# --- JSON dict without an api_key field (Ollama's normal no-auth case) ------
+
+
+def test_json_dict_without_api_key_field_returns_empty_string():
+    """A user entered ``{"endpoint": "http://x"}`` -- no key field.
+
+    Returning ``""`` (not the raw JSON) means ``get_model_list`` takes its
+    no-auth path: ``if resolved_key:`` is False, so the Ollama server is
+    called without an ``Authorization`` header -- which Ollama accepts by
+    default and the verify endpoint returns the model list.
+    """
+    provider = _make('{"endpoint": "http://x", "model": "llama3"}')
+    assert provider._get_api_key() == ""
+
+
+def test_json_empty_dict_returns_empty_string():
+    provider = _make("{}")
+    assert provider._get_api_key() == ""
+
+
+# --- Plain string (the historical passthrough -- pre-fix behaviour) ----------
+
+
+def test_plain_string_returns_as_is():
+    provider = _make("sk-plain-key")
+    assert provider._get_api_key() == "sk-plain-key"
+
+
+def test_empty_string_returns_empty_string():
+    provider = _make("")
+    assert provider._get_api_key() == ""
+
+
+# --- JSON non-object (the historical passthrough) ----------------------------
+
+
+def test_json_list_returns_raw_to_preserve_pre_fix_behavior():
+    """Pre-fix returned the raw JSON string. Post-fix keeps that exact behavior
+    so we do not silently regress any caller that depends on the raw
+    passthrough -- Ollama does not validate the bearer so a malformed
+    Bearer is silently accepted, but the pre-fix behavior is preserved.
+    """
+    provider = _make('["sk-1", "sk-2"]')
+    assert provider._get_api_key() == '["sk-1", "sk-2"]'
+
+
+def test_json_string_returns_raw_to_preserve_pre_fix_behavior():
+    provider = _make('"sk-quoted"')
+    assert provider._get_api_key() == '"sk-quoted"'
+
+
+# --- Malformed JSON (the historical passthrough) -----------------------------
+
+
+def test_malformed_json_returns_raw_to_preserve_pre_fix_behavior():
+    provider = _make('{"api_key": "unterminated')
+    assert provider._get_api_key() == '{"api_key": "unterminated'
+
+
+# --- Integration: get_model_list takes the no-auth path on empty resolved key
+
+
+def test_get_model_list_skips_authorization_header_when_resolved_key_is_empty():
+    """The Authorization header is omitted when the resolved api_key is empty.
+
+    Verified by inspecting the ``headers`` kwarg of the mocked
+    ``session.get`` / ``session.post`` calls: the dict must not contain
+    ``Authorization``.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        provider = Ollama(
+            api_key='{"endpoint": "http://127.0.0.1:11434"}',
+            base_url="http://127.0.0.1:11434",
+        )
+        assert provider._get_api_key() == ""
+
+        tags_payload = {
+            "models": [
+                {"name": "llama3:latest", "model": "llama3:latest"},
+            ]
+        }
+        show_payload = {
+            "model_info": {"llama.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3:latest"]
+
+    get_headers = session.get.call_args.kwargs["headers"]
+    post_headers = session.post.call_args.kwargs["headers"]
+    assert "Authorization" not in get_headers
+    assert "Authorization" not in post_headers
+
+
+def test_get_model_list_sends_valid_bearer_when_json_dict_has_api_key():
+    """The Bearer header is the inner key, not the raw JSON dict.
+
+    Pre-fix: ``Bearer {"api_key": "sk-ollama", "endpoint": "..."}``.
+    Post-fix: ``Bearer sk-ollama``.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        provider = Ollama(
+            api_key='{"api_key": "sk-ollama", "endpoint": "http://x"}',
+            base_url="http://127.0.0.1:11434",
+        )
+        assert provider._get_api_key() == "sk-ollama"
+
+        tags_payload = {
+            "models": [
+                {"name": "llama3:latest", "model": "llama3:latest"},
+            ]
+        }
+        show_payload = {
+            "model_info": {"llama.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3:latest"]
+    assert session.get.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-ollama"
+    assert session.post.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-ollama"
+
+
+# --- Pre-fix behaviour preserved for plain strings (regression guard) -------
+
+
+def test_get_model_list_sends_bearer_for_plain_string_api_key():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        provider = Ollama(
+            api_key="sk-plain",
+            base_url="http://127.0.0.1:11434",
+        )
+        assert provider._get_api_key() == "sk-plain"
+
+        tags_payload = {
+            "models": [
+                {"name": "llama3:latest", "model": "llama3:latest"},
+            ]
+        }
+        show_payload = {
+            "model_info": {"llama.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3:latest"]
+    assert session.get.call_args.kwargs["headers"]["Authorization"] == "Bearer sk-plain"
+
+
+@pytest.mark.parametrize("api_key", ["", None])
+def test_get_model_list_skips_authorization_for_empty_or_none_api_key(api_key):
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    async def _run():
+        provider = Ollama(api_key=api_key, base_url="http://127.0.0.1:11434")
+        assert provider._get_api_key() == ""
+
+        tags_payload = {
+            "models": [
+                {"name": "llama3:latest", "model": "llama3:latest"},
+            ]
+        }
+        show_payload = {
+            "model_info": {"llama.context_length": 8192},
+            "capabilities": ["completion"],
+        }
+
+        def _mock_resp(payload, status=200):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=payload)
+            return resp
+
+        tags_resp = _mock_resp(tags_payload)
+        show_resp = _mock_resp(show_payload)
+        wrapper = MagicMock()
+        wrapper.__aenter__ = AsyncMock(return_value=tags_resp)
+        wrapper.__aexit__ = AsyncMock(return_value=None)
+        show_wrapper = MagicMock()
+        show_wrapper.__aenter__ = AsyncMock(return_value=show_resp)
+        show_wrapper.__aexit__ = AsyncMock(return_value=None)
+
+        session = MagicMock()
+        session.get.return_value = wrapper
+        session.post.return_value = show_wrapper
+        session_cls = MagicMock()
+        session_cls.__aenter__ = AsyncMock(return_value=session)
+        session_cls.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session_cls):
+            return await provider.get_model_list(), session
+
+    import asyncio
+
+    models, session = asyncio.run(_run())
+    assert [m["name"] for m in models] == ["llama3:latest"]
+    assert "Authorization" not in session.get.call_args.kwargs["headers"]
+    assert "Authorization" not in session.post.call_args.kwargs["headers"]


### PR DESCRIPTION
## Summary

5th site in the `rag/llm/model_meta.py` JSON-decode family — same shape as PR #18251 (cycle 19, VolcEngine / OpenRouter / NewAPI unification) and PR #18314 (cycle 22, LocalAI).

`rag/llm/model_meta.py:Ollama` was inheriting `Base._get_api_key`, which returns `self.api_key` verbatim. When the API service stored the api_key as a JSON dict (the format used for several other LLM providers — see `api/apps/services/provider_api_service.py:313` which calls `json.dumps(api_key)` for non-string values), `Ollama.get_model_list` sent an Authorization header of the form:

```
Authorization: Bearer {"api_key": "sk-ollama-xxx", "endpoint": "..."}
```

Ollama does not validate the bearer (it accepts malformed Bearer headers silently), so the user-facing symptom is mild compared to LocalAI's 401 behavior, but downstream setups that front Ollama with an authenticating reverse proxy would reject the malformed token. The fix is the same defensive resolution rule as cycle 22.

## Why this is a separate PR (not a follow-up to #18314)

PR #18314 (cycle 22, LocalAI) closed #17757. The 4 sites in the model_meta JSON-decode family are now: VolcEngine / OpenRouter / NewAPI (cycle 19 #18251) + LocalAI (cycle 22 #18314) + Ollama (this PR). The remaining 5 sites without `_get_api_key` overrides (`Xinference`, `HuggingFace`, `FunASR`, `AIMLAPI`, plus the `OpenAIAPICompatible` subclasses `NVIDIA` / `GreenPT` / `VLLM` / `LMStudio` / `RAGcon` which all share `Base._get_raw_model_list`) have the same missing-resolution pattern; future cycles can sweep them. The maintainer can merge this one independently of #18314 and #18251.

## Implementation summary

Two hunks in `rag/llm/model_meta.py:Ollama`:

1. **Add `_get_api_key` override** mirroring the `VolcEngine` / `OpenRouter` / `NewAPI` / `LocalAI` pattern:
   - JSON dict with an `api_key` field → the inner key
   - JSON dict without an `api_key` field → `""` (no-auth path; Ollama's normal case)
   - Plain string (the common case) → returned as-is
   - JSON parse error, JSON non-object, or non-string api_key → fall back to the Base default (raw passthrough) so the pre-fix behavior is preserved

2. **Update `get_model_list`** to gate the Authorization header on the **resolved** key (not the raw `self.api_key`):
   ```python
   resolved_key = self._get_api_key()
   if resolved_key:
       headers.update({"Authorization": f"Bearer {resolved_key}"})
   ```
   Without this, a JSON-dict value (truthy) would still add a malformed `Bearer {"api_key": ...}` header because the Base default returns the raw dict.

## Tests

`test/unit_test/rag/llm/test_ollama_get_api_key.py` (355 lines, 15 cases) — mirrors the cycle 22 `test_localai_get_api_key.py` pattern:

- **Unit tests on `_get_api_key` (10 cases)** — the resolution contract:
  - JSON dict with an `api_key` field returns the inner key
  - JSON dict with an empty / whitespace inner key is preserved (caller's intent)
  - JSON dict without an `api_key` field returns `""` (no-auth path)
  - Empty JSON object returns `""`
  - Plain string is the historical Base default (raw passthrough)
  - Empty string returns `""`
  - JSON list / JSON string / malformed JSON are preserved as the raw passthrough so the pre-fix behavior is not regressed

- **Integration tests on `get_model_list` (3 cases + 1 parametrized over `["", None]`)** — the wire-level Bearer contract:
  - JSON-dict-without-`api_key` field omits the Authorization header entirely
  - JSON-dict-with-`api_key` field sends a valid `Bearer sk-ollama` header
  - Plain string api_key still produces a plain Bearer header (regression guard)
  - Empty string and None both skip the Authorization header (parametrized)

Ollama-specific test fixture notes: Ollama's `/api/tags` returns `{"models": [{"name": <name>}, ...]}` (no `:latest` tag stripping, no separate `model` field), and the `/api/show` response uses `"{family}.context_length"` (not `"general.context_length"` like LocalAI), so the test fixtures use the Ollama-specific shape.

## Verification

```
.venv/bin/python -m pytest test/unit_test/rag/llm/test_ollama_get_api_key.py -v
============================== 15 passed in 0.24s ==============================
```

```
.venv/bin/python -m pytest test/unit_test/rag/llm/test_ollama_get_api_key.py test/unit_test/rag/llm/test_model_meta_funasr.py -v
============================== 18 passed in 0.20s ==============================
```

```
ruff check rag/llm/model_meta.py test/unit_test/rag/llm/test_ollama_get_api_key.py
All checks passed!

ruff format --check rag/llm/model_meta.py test/unit_test/rag/llm/test_ollama_get_api_key.py
2 files already formatted
```

## Scope

- Source: 1 file, 2 hunks (44 insertions, 2 deletions) in `rag/llm/model_meta.py`
- Tests: 1 file, 355 insertions in `test/unit_test/rag/llm/test_ollama_get_api_key.py`
- Backward compatibility: The historical pre-fix behavior is preserved for plain-string api_key, JSON parse errors, and JSON non-objects. Only the JSON-dict-with-`api_key` and JSON-dict-without-`api_key` paths change, and they change to the wire-correct behavior.
- Migration: none

## Risk

Low. The fix is in one provider's verify path and the integration tests cover the wire-level behavior at the HTTP mock boundary. No public API surface change. The most likely regression would be a user whose `self.api_key` is a JSON dict with no `api_key` field but who currently relies on the raw passthrough producing a malformed Bearer (i.e. they would have an unusable auth header today because Ollama doesn't validate it; the fix would make them succeed). That is the intended behavior change for the family of bugs this PR addresses.

## Future improvements (out of scope)

5 more providers in `rag/llm/model_meta.py` without `_get_api_key` overrides: `Xinference`, `HuggingFace`, `FunASR`, `AIMLAPI`, plus the `OpenAIAPICompatible` subclasses `NVIDIA` / `GreenPT` / `VLLM` / `LMStudio` / `RAGcon`. The `OpenAIAPICompatible` subclasses all share `Base._get_raw_model_list` (which always sends the Bearer) — fixing the base class would fix 5 sites at once but with broader risk surface. The per-provider approach matches cycle 19 / cycle 22 / this PR and lets the maintainer merge each independently.
