### PR TITLE
feat(web): pin the current user to the top of admin user list

### DIFF
--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -449,8 +449,27 @@ function AdminUserManagement() {
     ],
   );
 
+  // Pin the current user to the top of the list
+  const orderedUsersList = useMemo(() => {
+    if (!usersList) {
+      return EMPTY_DATA;
+    }
+
+    const currentUserIndex = usersList.findIndex(
+      (user) => user.email === userInfo?.email,
+    );
+
+    if (currentUserIndex <= 0) {
+      return usersList;
+    }
+
+    const rest = usersList.filter((_, index) => index !== currentUserIndex);
+
+    return [usersList[currentUserIndex], ...rest];
+  }, [usersList, userInfo?.email]);
+
   const table = useReactTable({
-    data: usersList ?? EMPTY_DATA,
+    data: orderedUsersList,
     columns: columnDefs,
 
     globalFilterFn,


### PR DESCRIPTION
### Summary

feat(web): pin the current user to the top of admin user list

Admins most often act on their own account first, so surface it without scrolling or searching. Ordering the data rather than using row pinning keeps the row inside the existing search, filter, and pagination flow.