### PR TITLE
fix(agent): keep DSL canvas and runtime topology consistent

### DIFF
--- a/agent/dsl_migration.py
+++ b/agent/dsl_migration.py
@@ -17,7 +17,6 @@
 import copy
 import re
 
-
 # Keep all legacy chunker renames in one place so the migration rule stays readable.
 COMPONENT_RENAMES = {
     "Splitter": "TokenChunker",
@@ -30,6 +29,85 @@ NODE_TYPE_RENAMES = {
 }
 
 VARIABLE_REF_PATTERN = re.compile(r"(\{+\s*)([A-Za-z0-9:_-]+)(@[A-Za-z0-9_.-]+)(\s*\}+)")
+
+_NON_RUNTIME_COMPONENTS = {"Note", "Tool", "Placeholder"}
+_AGENT_TOP_HANDLE = "agentTop"
+_AGENT_EXCEPTION_HANDLE = "agentException"
+
+
+def _normalize_topology(dsl: dict) -> None:
+    """Make the execution topology a deterministic projection of ``graph``.
+
+    ``graph.edges`` is authoritative when a renderable graph is present.  A
+    components-only legacy DSL keeps its historical downstream topology and
+    gets a matching upstream projection.  This prevents a persisted payload
+    from rendering one route while executing another one.
+    """
+    components = dsl.get("components")
+    if not isinstance(components, dict) or not components:
+        return
+
+    component_ids = set(components)
+    graph = dsl.get("graph")
+    nodes = graph.get("nodes") if isinstance(graph, dict) else None
+    edges = graph.get("edges") if isinstance(graph, dict) else None
+
+    has_legacy_loop_item = any(
+        isinstance(component, dict) and isinstance(component.get("obj"), dict) and component["obj"].get("component_name") in {"LoopItem", "IterationItem"} for component in components.values()
+    )
+
+    if not isinstance(nodes, list) or not nodes or (has_legacy_loop_item and not edges):
+        upstream = {component_id: [] for component_id in components}
+        for source, component in components.items():
+            if not isinstance(component, dict):
+                continue
+            downstream = component.get("downstream")
+            if not isinstance(downstream, list):
+                component["downstream"] = []
+                downstream = []
+            for target in downstream:
+                if target in upstream:
+                    upstream[target].append(source)
+        for component_id, component in components.items():
+            if isinstance(component, dict):
+                component["upstream"] = upstream[component_id]
+        return
+
+    graph_node_ids = {node.get("id") for node in nodes if isinstance(node, dict) and isinstance(node.get("id"), str)}
+    bottom_subagents = {edge.get("target") for edge in edges or [] if isinstance(edge, dict) and edge.get("targetHandle") == _AGENT_TOP_HANDLE}
+    missing_components = []
+    for node in nodes:
+        if not isinstance(node, dict) or node.get("id") in component_ids:
+            continue
+        label = node.get("data", {}).get("label") if isinstance(node.get("data"), dict) else None
+        if label not in _NON_RUNTIME_COMPONENTS and node.get("id") not in bottom_subagents:
+            missing_components.append(node.get("id"))
+    missing_nodes = component_ids - graph_node_ids
+    if missing_components or missing_nodes:
+        raise ValueError(f"DSL graph/components node mismatch: missing components={sorted(str(node_id) for node_id in missing_components)}, missing graph nodes={sorted(missing_nodes)}")
+
+    expected_downstream = {component_id: [] for component_id in components}
+    expected_upstream = {component_id: [] for component_id in components}
+    for edge in edges if isinstance(edges, list) else []:
+        if not isinstance(edge, dict):
+            continue
+        source = edge.get("source")
+        target = edge.get("target")
+        if target in expected_upstream and source in component_ids:
+            expected_upstream[target].append(source)
+        if source not in expected_downstream or target not in component_ids:
+            continue
+        component = components[source]
+        obj = component.get("obj", {}) if isinstance(component, dict) else {}
+        is_agent = isinstance(obj, dict) and obj.get("component_name") == "Agent"
+        if is_agent and (edge.get("sourceHandle") == _AGENT_EXCEPTION_HANDLE or edge.get("targetHandle") == _AGENT_TOP_HANDLE or (isinstance(target, str) and target.startswith("Tool"))):
+            continue
+        expected_downstream[source].append(target)
+
+    for component_id, component in components.items():
+        if isinstance(component, dict):
+            component["downstream"] = expected_downstream[component_id]
+            component["upstream"] = expected_upstream[component_id]
 
 
 def normalize_chunker_dsl(dsl: dict) -> dict:
@@ -51,7 +129,7 @@ def normalize_chunker_dsl(dsl: dict) -> dict:
         return normalized
 
     component_id_map: dict[str, str] = {}
-    for component_id in components.keys():
+    for component_id in components:
         new_component_id = component_id
         for old_name, new_name in COMPONENT_RENAMES.items():
             prefix = f"{old_name}:"
@@ -160,5 +238,7 @@ def normalize_chunker_dsl(dsl: dict) -> dict:
     for key in ("history", "messages", "reference"):
         if key in normalized:
             normalized[key] = rewrite_value(normalized[key])
+
+    _normalize_topology(normalized)
 
     return normalized

--- a/internal/agent/dsl/normalize.go
+++ b/internal/agent/dsl/normalize.go
@@ -45,10 +45,12 @@
 //  2. If `graph.nodes` is missing but `components` is non-empty, builds
 //     a default-layout graph from the components (deterministic order,
 //     50/200/350 px column layout).
-//  3. Repairs any historically leaked runtime-only Parallel /
+//  3. Rebuilds component adjacency from graph edges. For a components-only
+//     legacy payload, preserves downstream and derives upstream from it.
+//  4. Repairs any historically leaked runtime-only Parallel /
 //     parallelNode canvas shape back to the front-end's Iteration /
 //     iterationNode protocol.
-//  4. Returns a defensive copy of the input with all transforms
+//  5. Returns a defensive copy of the input with all transforms
 //     applied. Never mutates its input.
 //
 // The function never panics on malformed input; unparseable entries are
@@ -64,6 +66,7 @@ package dsl
 import (
 	"regexp"
 	"sort"
+	"strings"
 )
 
 // componentNameIteration / componentNameIterationItem are the legacy
@@ -134,6 +137,11 @@ func normalize(dsl map[string]any, foldLegacy bool) map[string]any {
 			}
 		}
 	}
+
+	// Keep runtime adjacency as a deterministic projection of the canvas
+	// topology. For components-only payloads, preserve the historical
+	// downstream authority and rebuild upstream from it.
+	reconcileTopology(out)
 
 	// (3) Repair any historically leaked runtime-only Parallel /
 	// parallelNode view back to the front-end's Iteration /
@@ -292,6 +300,77 @@ func graphHasNodes(dsl map[string]any) bool {
 		return false
 	}
 	return len(nodes) > 0
+}
+
+func reconcileTopology(dsl map[string]any) {
+	components, _ := dsl["components"].(map[string]any)
+	if len(components) == 0 {
+		return
+	}
+
+	downstream := make(map[string][]string, len(components))
+	upstream := make(map[string][]string, len(components))
+	for id := range components {
+		downstream[id] = []string{}
+		upstream[id] = []string{}
+	}
+
+	graph, _ := dsl["graph"].(map[string]any)
+	edges, _ := graph["edges"].([]any)
+	legacyLoopItem := false
+	for _, raw := range components {
+		component, _ := raw.(map[string]any)
+		name, _, _ := extractComponent(component)
+		if name == componentNameLoopItem || name == componentNameIterationItem {
+			legacyLoopItem = true
+			break
+		}
+	}
+	if !graphHasNodes(dsl) || (legacyLoopItem && len(edges) == 0) {
+		for source, raw := range components {
+			component, _ := raw.(map[string]any)
+			for _, target := range toStringSlice(component["downstream"]) {
+				downstream[source] = append(downstream[source], target)
+				if _, ok := upstream[target]; ok {
+					upstream[target] = append(upstream[target], source)
+				}
+			}
+		}
+	} else {
+		for _, raw := range edges {
+			edge, _ := raw.(map[string]any)
+			if edge == nil {
+				continue
+			}
+			source, _ := edge["source"].(string)
+			target, _ := edge["target"].(string)
+			if _, sourceOK := components[source]; !sourceOK {
+				continue
+			}
+			if _, targetOK := components[target]; !targetOK {
+				continue
+			}
+			upstream[target] = append(upstream[target], source)
+
+			component, _ := components[source].(map[string]any)
+			name, _, _ := extractComponent(component)
+			sourceHandle, _ := edge["sourceHandle"].(string)
+			targetHandle, _ := edge["targetHandle"].(string)
+			if name == "Agent" && (sourceHandle == "agentException" || targetHandle == "agentTop" || strings.HasPrefix(target, "Tool")) {
+				continue
+			}
+			downstream[source] = append(downstream[source], target)
+		}
+	}
+
+	for id, raw := range components {
+		component, _ := raw.(map[string]any)
+		if component == nil {
+			continue
+		}
+		component["downstream"] = stringsToAny(downstream[id])
+		component["upstream"] = stringsToAny(upstream[id])
+	}
 }
 
 // buildGraphFromComponents converts the `components` block into

--- a/internal/agent/dsl/normalize_test.go
+++ b/internal/agent/dsl/normalize_test.go
@@ -703,3 +703,55 @@ func equalStringSlices(a, b []string) bool {
 	}
 	return true
 }
+
+func TestNormalizeForCanvasGraphOverridesConflictingComponentTopology(t *testing.T) {
+	in := map[string]any{
+		"components": map[string]any{
+			"begin":   map[string]any{"obj": map[string]any{"component_name": "Begin"}, "downstream": []any{"load"}, "upstream": []any{}},
+			"quality": map[string]any{"obj": map[string]any{"component_name": "Message"}, "downstream": []any{}, "upstream": []any{}},
+			"load":    map[string]any{"obj": map[string]any{"component_name": "Message"}, "downstream": []any{}, "upstream": []any{"begin"}},
+		},
+		"graph": map[string]any{
+			"nodes": []any{
+				map[string]any{"id": "begin"},
+				map[string]any{"id": "quality"},
+				map[string]any{"id": "load"},
+			},
+			"edges": []any{
+				map[string]any{"source": "begin", "target": "quality"},
+				map[string]any{"source": "quality", "target": "load"},
+			},
+		},
+	}
+
+	out := NormalizeForCanvas(in)
+	components := out["components"].(map[string]any)
+	begin := components["begin"].(map[string]any)
+	quality := components["quality"].(map[string]any)
+	load := components["load"].(map[string]any)
+	if got := stringSliceAny(begin["downstream"].([]any)); !equalStringSlices(got, []string{"quality"}) {
+		t.Fatalf("begin downstream = %v, want [quality]", got)
+	}
+	if got := stringSliceAny(quality["upstream"].([]any)); !equalStringSlices(got, []string{"begin"}) {
+		t.Fatalf("quality upstream = %v, want [begin]", got)
+	}
+	if got := stringSliceAny(load["upstream"].([]any)); !equalStringSlices(got, []string{"quality"}) {
+		t.Fatalf("load upstream = %v, want [quality]", got)
+	}
+}
+
+func TestNormalizeForCanvasComponentsOnlyRebuildsUpstream(t *testing.T) {
+	in := map[string]any{
+		"components": map[string]any{
+			"begin":  map[string]any{"obj": map[string]any{"component_name": "Begin"}, "downstream": []any{"middle"}, "upstream": []any{"wrong"}},
+			"middle": map[string]any{"obj": map[string]any{"component_name": "Message"}, "downstream": []any{}, "upstream": []any{}},
+		},
+	}
+
+	out := NormalizeForCanvas(in)
+	components := out["components"].(map[string]any)
+	middle := components["middle"].(map[string]any)
+	if got := stringSliceAny(middle["upstream"].([]any)); !equalStringSlices(got, []string{"begin"}) {
+		t.Fatalf("middle upstream = %v, want [begin]", got)
+	}
+}

--- a/test/unit_test/agent/test_dsl_topology_consistency.py
+++ b/test/unit_test/agent/test_dsl_topology_consistency.py
@@ -1,0 +1,195 @@
+import copy
+
+import pytest
+
+from agent.dsl_migration import normalize_chunker_dsl
+
+
+def _component(name, downstream=None, upstream=None):
+    component = {"obj": {"component_name": name, "params": {}}}
+    if downstream is not None:
+        component["downstream"] = downstream
+    if upstream is not None:
+        component["upstream"] = upstream
+    return component
+
+
+def _node(component_id, label):
+    return {"id": component_id, "data": {"label": label, "name": label, "form": {}}}
+
+
+def test_graph_edges_replace_conflicting_runtime_topology():
+    dsl = {
+        "components": {
+            "begin": _component("Begin", ["load"], []),
+            "quality": _component("Quality", [], []),
+            "load": _component("Message", [], ["begin"]),
+        },
+        "graph": {
+            "nodes": [_node("begin", "Begin"), _node("quality", "Quality"), _node("load", "Message")],
+            "edges": [
+                {"source": "begin", "target": "quality"},
+                {"source": "quality", "target": "load"},
+            ],
+        },
+    }
+
+    normalized = normalize_chunker_dsl(dsl)
+
+    assert normalized["components"]["begin"]["downstream"] == ["quality"]
+    assert normalized["components"]["quality"]["upstream"] == ["begin"]
+    assert normalized["components"]["quality"]["downstream"] == ["load"]
+    assert normalized["components"]["load"]["upstream"] == ["quality"]
+    assert dsl["components"]["begin"]["downstream"] == ["load"]
+
+
+def test_components_only_dsl_derives_upstream_from_historical_downstream():
+    dsl = {
+        "components": {
+            "begin": _component("Begin", ["quality"]),
+            "quality": _component("Quality", ["load"]),
+            "load": _component("Message", []),
+        }
+    }
+
+    normalized = normalize_chunker_dsl(dsl)
+
+    assert normalized["components"]["begin"]["upstream"] == []
+    assert normalized["components"]["quality"]["upstream"] == ["begin"]
+    assert normalized["components"]["load"]["upstream"] == ["quality"]
+
+
+def test_graph_projection_preserves_duplicates_branches_cycles_and_isolated_nodes():
+    dsl = {
+        "components": {
+            "begin": _component("Begin"),
+            "branch": _component("Switch"),
+            "loop": _component("Loop"),
+            "iteration": _component("Iteration"),
+            "load": _component("Message"),
+            "isolated": _component("Message"),
+        },
+        "graph": {
+            "nodes": [
+                _node("begin", "Begin"),
+                _node("branch", "Switch"),
+                _node("loop", "Loop"),
+                _node("iteration", "Iteration"),
+                _node("load", "Message"),
+                _node("isolated", "Message"),
+            ],
+            "edges": [
+                {"source": "begin", "target": "branch"},
+                {"source": "branch", "target": "loop", "sourceHandle": "case-a"},
+                {"source": "branch", "target": "iteration", "sourceHandle": "case-b"},
+                {"source": "loop", "target": "load"},
+                {"source": "iteration", "target": "load"},
+                {"source": "iteration", "target": "load"},
+                {"source": "loop", "target": "loop"},
+            ],
+        },
+    }
+
+    normalized = normalize_chunker_dsl(dsl)["components"]
+
+    assert normalized["branch"]["downstream"] == ["loop", "iteration"]
+    assert normalized["load"]["upstream"] == ["loop", "iteration", "iteration"]
+    assert normalized["loop"]["upstream"] == ["branch", "loop"]
+    assert normalized["isolated"]["upstream"] == []
+    assert normalized["isolated"]["downstream"] == []
+
+
+def test_agent_control_edges_keep_frontend_runtime_projection_rules():
+    dsl = {
+        "components": {
+            "begin": _component("Begin"),
+            "agent": _component("Agent"),
+            "fallback": _component("Message"),
+        },
+        "graph": {
+            "nodes": [
+                _node("begin", "Begin"),
+                _node("agent", "Agent"),
+                _node("subagent", "Agent"),
+                _node("tool", "Tool"),
+                _node("fallback", "Message"),
+                _node("note", "Note"),
+            ],
+            "edges": [
+                {"source": "begin", "target": "agent"},
+                {"source": "agent", "target": "subagent", "targetHandle": "agentTop"},
+                {"source": "agent", "target": "tool"},
+                {"source": "agent", "target": "fallback", "sourceHandle": "agentException"},
+            ],
+        },
+    }
+
+    normalized = normalize_chunker_dsl(dsl)["components"]
+
+    assert normalized["agent"]["downstream"] == []
+    assert normalized["fallback"]["upstream"] == ["agent"]
+
+
+def test_executable_graph_node_without_component_is_rejected():
+    dsl = {
+        "components": {"begin": _component("Begin")},
+        "graph": {
+            "nodes": [_node("begin", "Begin"), _node("quality", "Quality")],
+            "edges": [{"source": "begin", "target": "quality"}],
+        },
+    }
+
+    with pytest.raises(ValueError, match="missing components=.*quality"):
+        normalize_chunker_dsl(dsl)
+
+
+def test_component_without_graph_node_is_rejected():
+    dsl = {
+        "components": {"begin": _component("Begin"), "hidden": _component("Message")},
+        "graph": {"nodes": [_node("begin", "Begin")], "edges": []},
+    }
+
+    with pytest.raises(ValueError, match="missing graph nodes=.*hidden"):
+        normalize_chunker_dsl(dsl)
+
+
+def test_legacy_component_rename_happens_before_topology_projection():
+    dsl = {
+        "components": {
+            "begin": _component("Begin", ["Splitter:1"], []),
+            "Splitter:1": _component("Splitter", [], ["begin"]),
+        },
+        "graph": {
+            "nodes": [_node("begin", "Begin"), _node("Splitter:1", "Splitter")],
+            "edges": [{"source": "begin", "target": "Splitter:1"}],
+        },
+    }
+
+    normalized = normalize_chunker_dsl(copy.deepcopy(dsl))
+
+    assert normalized["components"]["begin"]["downstream"] == ["TokenChunker:1"]
+    assert normalized["components"]["TokenChunker:1"]["upstream"] == ["begin"]
+
+
+def test_legacy_iteration_with_empty_graph_edges_keeps_runtime_body_links():
+    dsl = {
+        "components": {
+            "iteration": _component("Iteration", ["item"]),
+            "item": _component("IterationItem", ["body"]),
+            "body": _component("Message", []),
+        },
+        "graph": {
+            "nodes": [
+                _node("iteration", "Iteration"),
+                _node("item", "IterationItem"),
+                _node("body", "Message"),
+            ],
+            "edges": [],
+        },
+    }
+
+    normalized = normalize_chunker_dsl(dsl)["components"]
+
+    assert normalized["iteration"]["downstream"] == ["item"]
+    assert normalized["item"]["upstream"] == ["iteration"]
+    assert normalized["body"]["upstream"] == ["item"]


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #18352.

Agent DSL stores both a React-Flow topology (`graph.edges`) and runtime adjacency (`components[*].upstream/downstream`). Direct API/import payloads could make them disagree. The UI then displayed one route while Python and Go executed another, allowing an intermediate validation/quality/security node to be bypassed.

Reproduction before this change:

- `graph.edges`: `begin -> quality -> load`
- `components`: `begin -> load`
- rendered path: `begin -> quality -> load`
- Python runtime path: `begin -> load`

## What is changed?

- Treat `graph.edges` as the canonical topology whenever a renderable graph exists.
- Rebuild both runtime `downstream` and `upstream` adjacency in the Python migration boundary and Go DSL normalization boundary.
- For components-only historical DSL, preserve the historical Python runtime authority (`downstream`) and deterministically derive `upstream`.
- Reject Python DSLs whose executable graph node set differs from the component set, while allowing Note/Tool/Placeholder nodes and bottom sub-agent view nodes.
- Preserve frontend Agent control-edge rules (tool, sub-agent, and exception edges).
- Preserve legacy Loop/IterationItem DSLs whose historical graph has no edges.
- Preserve edge order, branches, duplicate edges, cycles, and isolated nodes deterministically.

The regular web save path already derives components from graph; this closes the direct API, import/migration, persisted-row, and Go runtime gaps.

## Tests

- `8 passed` — focused Python topology regression suite
- `ruff check` — passed
- `ruff format --check` — passed
- Go `internal/agent/dsl` sources and tests copied unchanged into an isolated Go 1.22 module: passed (`ok dsltest`)
- `bash build.sh --test ./internal/agent/dsl` was attempted but the local environment lacks the required `office_oxide` native archive. A subsequent project-native Go test attempt could not finish downloading the required Go 1.26.4 toolchain; CI should run the repository-native package test.
- Repository has no `.pre-commit-config.yaml`, so no pre-commit hook suite was available.