### PR TITLE
fix: align Go ingestion progress and pipeline selection

### DIFF
--- a/internal/dao/ingestion.go
+++ b/internal/dao/ingestion.go
@@ -310,3 +310,23 @@ func (dao *IngestionTaskLogDAO) DeleteByTaskID(ctx context.Context, db *gorm.DB,
 	result := db.WithContext(ctx).Unscoped().Where("task_id = ?", taskID).Delete(&entity.IngestionTaskLog{})
 	return result.RowsAffected, result.Error
 }
+
+// DeleteComponentLogsByTaskID removes component lifecycle rows from a new run
+// while preserving checkpoint rows such as run_count for task history.
+func (dao *IngestionTaskLogDAO) DeleteComponentLogsByTaskID(ctx context.Context, db *gorm.DB, taskID string) (int64, error) {
+	var logs []*entity.IngestionTaskLog
+	if err := db.WithContext(ctx).Where("task_id = ?", taskID).Find(&logs).Error; err != nil {
+		return 0, err
+	}
+	ids := make([]int, 0, len(logs))
+	for _, log := range logs {
+		if log != nil && len(log.Checkpoint) == 0 {
+			ids = append(ids, log.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	result := db.WithContext(ctx).Unscoped().Where("id IN ?", ids).Delete(&entity.IngestionTaskLog{})
+	return result.RowsAffected, result.Error
+}

--- a/internal/handler/document.go
+++ b/internal/handler/document.go
@@ -1107,6 +1107,13 @@ func (h *DocumentHandler) DownloadDocument(c *gin.Context) {
 }
 
 func mapDocumentListItem(doc *entity.DocumentListItem, metaFields map[string]interface{}) map[string]interface{} {
+	processDuration := doc.ProcessDuration
+	if doc.Run != nil && strings.TrimSpace(*doc.Run) == "1" && doc.ProcessBeginAt != nil {
+		processDuration = time.Since(*doc.ProcessBeginAt).Seconds()
+		if processDuration < 0 {
+			processDuration = 0
+		}
+	}
 	item := map[string]interface{}{
 		"id":               doc.ID,
 		"dataset_id":       doc.KbID,
@@ -1121,7 +1128,7 @@ func mapDocumentListItem(doc *entity.DocumentListItem, metaFields map[string]int
 		"progress":         doc.Progress,
 		"progress_msg":     stringValue(doc.ProgressMsg),
 		"process_begin_at": formatTimePtr(doc.ProcessBeginAt),
-		"process_duration": doc.ProcessDuration,
+		"process_duration": processDuration,
 		"suffix":           doc.Suffix,
 		"run":              mapRunStatus(doc.Run),
 		"status":           stringValue(doc.Status),

--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -596,7 +596,8 @@ func (e *Ingestor) runTask(ctx context.Context, task *entity.IngestionTask) bool
 		return e.markFailed(ctx, task.ID)
 	}
 	if err := e.ingestionTaskSvc.ClearComponentProgress(ctx, task.ID); err != nil {
-		common.Warn(fmt.Sprintf("Failed to clear previous component progress for task %s: %v", task.ID, err))
+		common.Error(fmt.Sprintf("Failed to clear previous component progress for task %s", task.ID), err)
+		return e.markFailed(ctx, task.ID)
 	}
 
 	// This is a new run (IncrementRunCount succeeded). Any Redis cancel flag

--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -595,6 +595,9 @@ func (e *Ingestor) runTask(ctx context.Context, task *entity.IngestionTask) bool
 		common.Error(fmt.Sprintf("Failed to increment run count for task %s", task.ID), err)
 		return e.markFailed(ctx, task.ID)
 	}
+	if err := e.ingestionTaskSvc.ClearComponentProgress(ctx, task.ID); err != nil {
+		common.Warn(fmt.Sprintf("Failed to clear previous component progress for task %s: %v", task.ID, err))
+	}
 
 	// This is a new run (IncrementRunCount succeeded). Any Redis cancel flag
 	// that exists now is stale — a leftover from a previous run whose

--- a/internal/ingestion/service/progress_sink.go
+++ b/internal/ingestion/service/progress_sink.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -67,6 +68,7 @@ type progressSink struct {
 // full DocumentService surface.
 type docProgressSvc interface {
 	GetDocumentByID(ctx context.Context, docID string) (*documentpkg.DocumentResponse, error)
+	UpdateRunState(ctx context.Context, docID string, progress float64, run string) error
 	UpdateRunProgress(ctx context.Context, docID string, progress float64, run, progressMsg string) error
 }
 
@@ -119,11 +121,12 @@ func (s *progressSink) OnComponentProgress(ctx context.Context, ev pipeline.Prog
 func (s *progressSink) updateDocumentProgress(ctx context.Context, docID string, progress float64, run, msg string) error {
 	s.logMu.Lock()
 	defer s.logMu.Unlock()
-	log, ok := s.accumulateLogLocked(ctx, docID, msg)
-	if !ok {
-		// Do not write a partial in-memory log when the seed read failed. The
-		// next event will retry the read and preserve the pending messages.
-		return nil
+	log, err := s.accumulateLogLocked(ctx, docID, msg)
+	if err != nil {
+		// Keep the current run state durable even when the existing log cannot
+		// be seeded. The next event will retry the seed and persist the log.
+		stateErr := s.docSvc.UpdateRunState(ctx, docID, progress, run)
+		return errors.Join(err, stateErr)
 	}
 	return s.docSvc.UpdateRunProgress(ctx, docID, progress, run, log)
 }
@@ -139,9 +142,9 @@ func (s *progressSink) accumulateLog(ctx context.Context, docID, msg string) str
 }
 
 // accumulateLogLocked appends one component lifecycle line to the run log and
-// returns the full accumulated log plus whether it is safe to mirror it. The
-// caller must hold logMu.
-func (s *progressSink) accumulateLogLocked(ctx context.Context, docID, msg string) (string, bool) {
+// returns the full accumulated log, or an error when the existing log could
+// not be seeded. The caller must hold logMu.
+func (s *progressSink) accumulateLogLocked(ctx context.Context, docID, msg string) (string, error) {
 	if !s.seeded {
 		doc, err := s.docSvc.GetDocumentByID(ctx, docID)
 		if err != nil {
@@ -149,7 +152,7 @@ func (s *progressSink) accumulateLogLocked(ctx context.Context, docID, msg strin
 				s.pending = append(s.pending, msg)
 			}
 			common.Warn(fmt.Sprintf("progressSink: seed run log from document %s: %v", docID, err))
-			return "", false
+			return "", fmt.Errorf("seed run log for document %s: %w", docID, err)
 		}
 		s.seeded = true
 		if doc != nil && doc.ProgressMsg != nil {
@@ -161,10 +164,10 @@ func (s *progressSink) accumulateLogLocked(ctx context.Context, docID, msg strin
 		s.pending = nil
 	}
 	if msg == "" {
-		return s.log.String(), true
+		return s.log.String(), nil
 	}
 	s.appendLogLineLocked(msg)
-	return s.log.String(), true
+	return s.log.String(), nil
 }
 
 func (s *progressSink) appendLogLineLocked(msg string) {

--- a/internal/ingestion/service/progress_sink.go
+++ b/internal/ingestion/service/progress_sink.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
@@ -32,8 +33,7 @@ import (
 )
 
 // progressLogMaxChars bounds the accumulated run log mirrored into
-// document.progress_msg. Mirrors Python's TASK_MAX_LOG_LENGTH
-// (api/db/services/task_service.py).
+// document.progress_msg.
 const progressLogMaxChars = 3000
 
 // progressSink implements pipeline.ProgressSink. It is the single writer of
@@ -54,9 +54,11 @@ type progressSink struct {
 	// logMu guards the accumulated run log below: OnComponentProgress fires
 	// from concurrent parallel-branch goroutines, so both the lazy seed and
 	// the append must hold the same mutex.
-	logMu  sync.Mutex
-	seeded bool
-	log    strings.Builder
+	logMu   sync.Mutex
+	seeded  bool
+	log     strings.Builder
+	pending []string
+	now     func() time.Time
 }
 
 // docProgressSvc is the subset of *service.DocumentService the sink needs to
@@ -77,6 +79,7 @@ func newProgressSink(ctx context.Context, taskSvc *servicepkg.IngestionTaskServi
 	return &progressSink{
 		taskSvc: taskSvc,
 		docSvc:  documentpkg.NewDocumentService(),
+		now:     time.Now,
 	}
 }
 
@@ -104,58 +107,93 @@ func (s *progressSink) OnComponentProgress(ctx context.Context, ev pipeline.Prog
 		return
 	}
 	progress, run := deriveDocumentProgress(agg, int(total))
-	if err = s.docSvc.UpdateRunProgress(ctx, ev.DocumentID, progress, run, s.accumulateLog(ctx, ev.DocumentID, ev.Message)); err != nil {
+	if err = s.updateDocumentProgress(ctx, ev.DocumentID, progress, run, ev.Message); err != nil {
 		common.Error(fmt.Sprintf("progressSink: mirror progress to document %s for task %s failed: %v", ev.DocumentID, ev.TaskID, err), err)
 	}
 }
 
-// accumulateLog appends one component lifecycle line to the run log and
-// returns the full accumulated log for mirroring into document.progress_msg.
-// The document-details dialog renders progress_msg verbatim as a multi-line
-// log (whitespace-pre-line), matching Python's append-and-trim semantics in
-// TaskService.update_progress; a single overwrite would leave the dialog
-// showing only the latest line. The buffer is lazily seeded from the
-// document row on the first event so a resumed run keeps the lines logged
-// before the crash/redelivery instead of restarting empty (StartRunning
-// resets the row to "" on a fresh run, which then seeds an empty log).
+// updateDocumentProgress serializes log accumulation with the corresponding
+// document write. Without holding the same lock across both operations, a
+// slower database write can store an older snapshot after a newer event has
+// already been persisted.
+func (s *progressSink) updateDocumentProgress(ctx context.Context, docID string, progress float64, run, msg string) error {
+	s.logMu.Lock()
+	defer s.logMu.Unlock()
+	log, ok := s.accumulateLogLocked(ctx, docID, msg)
+	if !ok {
+		// Do not write a partial in-memory log when the seed read failed. The
+		// next event will retry the read and preserve the pending messages.
+		return nil
+	}
+	return s.docSvc.UpdateRunProgress(ctx, docID, progress, run, log)
+}
+
+// accumulateLog appends one component lifecycle line to the run log. It is
+// retained as a small test seam; production writes use updateDocumentProgress
+// so the append and document update share one lock.
 func (s *progressSink) accumulateLog(ctx context.Context, docID, msg string) string {
 	s.logMu.Lock()
 	defer s.logMu.Unlock()
+	log, _ := s.accumulateLogLocked(ctx, docID, msg)
+	return log
+}
+
+// accumulateLogLocked appends one component lifecycle line to the run log and
+// returns the full accumulated log plus whether it is safe to mirror it. The
+// caller must hold logMu.
+func (s *progressSink) accumulateLogLocked(ctx context.Context, docID, msg string) (string, bool) {
 	if !s.seeded {
-		s.seeded = true
 		doc, err := s.docSvc.GetDocumentByID(ctx, docID)
-		switch {
-		case err != nil:
+		if err != nil {
+			if msg != "" {
+				s.pending = append(s.pending, msg)
+			}
 			common.Warn(fmt.Sprintf("progressSink: seed run log from document %s: %v", docID, err))
-		case doc != nil && doc.ProgressMsg != nil:
+			return "", false
+		}
+		s.seeded = true
+		if doc != nil && doc.ProgressMsg != nil {
 			s.log.WriteString(*doc.ProgressMsg)
 		}
+		for _, pending := range s.pending {
+			s.appendLogLineLocked(pending)
+		}
+		s.pending = nil
 	}
 	if msg == "" {
-		return s.log.String()
+		return s.log.String(), true
 	}
+	s.appendLogLineLocked(msg)
+	return s.log.String(), true
+}
+
+func (s *progressSink) appendLogLineLocked(msg string) {
 	if s.log.Len() > 0 {
 		s.log.WriteByte('\n')
 	}
+	now := time.Now
+	if s.now != nil {
+		now = s.now
+	}
+	s.log.WriteString(now().Format("15:04:05"))
+	s.log.WriteString(": ")
 	s.log.WriteString(msg)
 	log := trimLogHead(s.log.String(), progressLogMaxChars)
 	if len(log) != s.log.Len() {
 		s.log.Reset()
 		s.log.WriteString(log)
 	}
-	return log
 }
 
 // trimLogHead drops whole lines from the head of text until the remainder
-// fits maxChars, keeping the newest lines. Mirrors Python's
-// trim_header_by_lines: text without a fitting newline boundary is returned
-// unchanged.
+// fits maxChars, keeping the newest lines. Text without a fitting newline
+// boundary is returned unchanged.
 func trimLogHead(text string, maxChars int) string {
 	if len(text) <= maxChars {
 		return text
 	}
 	for i := 0; i < len(text); i++ {
-		if text[i] == '\n' && len(text)-i <= maxChars {
+		if text[i] == '\n' && len(text)-(i+1) <= maxChars {
 			return text[i+1:]
 		}
 	}
@@ -176,5 +214,9 @@ func deriveDocumentProgress(agg *dao.TaskProgress, total int) (float64, string) 
 	case agg.Done > 0 || agg.Running > 0:
 		run = string(entity.TaskStatusRunning)
 	}
-	return agg.Percent / 100, run
+	progress := agg.Percent / 100
+	if progress > 1 {
+		progress = 1
+	}
+	return progress, run
 }

--- a/internal/ingestion/service/progress_sink_test.go
+++ b/internal/ingestion/service/progress_sink_test.go
@@ -170,6 +170,10 @@ func (s *blockingDocProgressSvc) GetDocumentByID(context.Context, string) (*docu
 	return nil, nil
 }
 
+func (s *blockingDocProgressSvc) UpdateRunState(context.Context, string, float64, string) error {
+	return nil
+}
+
 func (s *blockingDocProgressSvc) UpdateRunProgress(_ context.Context, _ string, _ float64, _ string, msg string) error {
 	s.mu.Lock()
 	s.updates++
@@ -185,6 +189,10 @@ func (s *blockingDocProgressSvc) UpdateRunProgress(_ context.Context, _ string, 
 
 func (s *stubDocProgressSvc) GetDocumentByID(ctx context.Context, docID string) (*document.DocumentResponse, error) {
 	return s.doc, s.docErr
+}
+
+func (s *stubDocProgressSvc) UpdateRunState(context.Context, string, float64, string) error {
+	return nil
 }
 
 func (s *stubDocProgressSvc) UpdateRunProgress(ctx context.Context, docID string, progress float64, run, progressMsg string) error {

--- a/internal/ingestion/service/progress_sink_test.go
+++ b/internal/ingestion/service/progress_sink_test.go
@@ -18,11 +18,13 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"ragflow/internal/dao"
 	"ragflow/internal/entity"
@@ -150,6 +152,37 @@ type stubDocProgressSvc struct {
 	docErr      error
 }
 
+func setProgressSinkTestClock(sink *progressSink) {
+	sink.now = func() time.Time {
+		return time.Date(2026, 8, 17, 3, 4, 5, 0, time.UTC)
+	}
+}
+
+type blockingDocProgressSvc struct {
+	mu           sync.Mutex
+	firstStarted chan struct{}
+	releaseFirst chan struct{}
+	messages     []string
+	updates      int
+}
+
+func (s *blockingDocProgressSvc) GetDocumentByID(context.Context, string) (*document.DocumentResponse, error) {
+	return nil, nil
+}
+
+func (s *blockingDocProgressSvc) UpdateRunProgress(_ context.Context, _ string, _ float64, _ string, msg string) error {
+	s.mu.Lock()
+	s.updates++
+	update := s.updates
+	s.messages = append(s.messages, msg)
+	s.mu.Unlock()
+	if update == 1 {
+		close(s.firstStarted)
+		<-s.releaseFirst
+	}
+	return nil
+}
+
 func (s *stubDocProgressSvc) GetDocumentByID(ctx context.Context, docID string) (*document.DocumentResponse, error) {
 	return s.doc, s.docErr
 }
@@ -174,6 +207,7 @@ func TestProgressSinkPersistsViaService(t *testing.T) {
 
 	ctx := t.Context()
 	sink := newProgressSink(ctx, servicepkg.NewIngestionTaskService())
+	setProgressSinkTestClock(sink)
 	stub := &stubDocProgressSvc{}
 	sink.docSvc = stub
 
@@ -218,8 +252,8 @@ func TestProgressSinkPersistsViaService(t *testing.T) {
 	if stub.gotRun != "1" {
 		t.Fatalf("run = %q, want 1 (RUNNING)", stub.gotRun)
 	}
-	if stub.gotMsg != "Parser Done" {
-		t.Fatalf("progress_msg = %q, want Parser Done", stub.gotMsg)
+	if stub.gotMsg != "03:04:05: Parser Done" {
+		t.Fatalf("progress_msg = %q, want timestamped Parser Done", stub.gotMsg)
 	}
 }
 
@@ -234,6 +268,7 @@ func TestProgressSinkAccumulatesProgressLog(t *testing.T) {
 
 	ctx := t.Context()
 	sink := newProgressSink(ctx, servicepkg.NewIngestionTaskService())
+	setProgressSinkTestClock(sink)
 	stub := &stubDocProgressSvc{}
 	sink.docSvc = stub
 	sink.OnComponentTotal(ctx, taskID, 2)
@@ -245,15 +280,14 @@ func TestProgressSinkAccumulatesProgressLog(t *testing.T) {
 		TaskID: taskID, DocumentID: docID, Component: "Parser", Phase: 1, Message: "Parser Done",
 	})
 
-	want := "File:naive Done\nParser Done"
+	want := "03:04:05: File:naive Done\n03:04:05: Parser Done"
 	if stub.gotMsg != want {
 		t.Fatalf("progress_msg = %q, want multi-line log %q", stub.gotMsg, want)
 	}
 }
 
 // TestProgressSinkSeedsLogFromDocument verifies the accumulated log keeps the
-// lines already stored on the document row, so a resumed run (post-crash
-// redelivery) appends to the pre-crash log instead of restarting empty.
+// lines already stored on the document row when a run resumes.
 func TestProgressSinkSeedsLogFromDocument(t *testing.T) {
 	db := testutil.SetupTestDB(t)
 	cleanup := testutil.ReplaceDBForTest(t, db)
@@ -262,6 +296,7 @@ func TestProgressSinkSeedsLogFromDocument(t *testing.T) {
 
 	ctx := t.Context()
 	sink := newProgressSink(ctx, servicepkg.NewIngestionTaskService())
+	setProgressSinkTestClock(sink)
 	seed := "File:naive Done"
 	stub := &stubDocProgressSvc{doc: &document.DocumentResponse{ProgressMsg: &seed}}
 	sink.docSvc = stub
@@ -271,15 +306,74 @@ func TestProgressSinkSeedsLogFromDocument(t *testing.T) {
 		TaskID: taskID, DocumentID: docID, Component: "Parser", Phase: 1, Message: "Parser Done",
 	})
 
-	want := "File:naive Done\nParser Done"
+	want := "File:naive Done\n03:04:05: Parser Done"
 	if stub.gotMsg != want {
 		t.Fatalf("progress_msg = %q, want seeded multi-line log %q", stub.gotMsg, want)
 	}
 }
 
+func TestProgressSinkRetriesSeedAfterReadFailure(t *testing.T) {
+	seed := "existing"
+	stub := &stubDocProgressSvc{docErr: errors.New("temporary read failure")}
+	sink := &progressSink{docSvc: stub}
+
+	if got := sink.accumulateLog(context.Background(), "doc-1", "pending"); got != "" {
+		t.Fatalf("log after failed seed = %q, want empty mirror value", got)
+	}
+
+	stub.docErr = nil
+	stub.doc = &document.DocumentResponse{ProgressMsg: &seed}
+	setProgressSinkTestClock(sink)
+	got := sink.accumulateLog(context.Background(), "doc-1", "current")
+	if want := "existing\n03:04:05: pending\n03:04:05: current"; got != want {
+		t.Fatalf("log after seed retry = %q, want %q", got, want)
+	}
+}
+
+func TestProgressSinkSerializesLogAndDocumentWrite(t *testing.T) {
+	stub := &blockingDocProgressSvc{
+		firstStarted: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+	sink := &progressSink{docSvc: stub}
+	setProgressSinkTestClock(sink)
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		if err := sink.updateDocumentProgress(context.Background(), "doc-1", 0.1, "1", "first"); err != nil {
+			t.Errorf("first update: %v", err)
+		}
+	}()
+	<-stub.firstStarted
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		if err := sink.updateDocumentProgress(context.Background(), "doc-1", 0.2, "1", "second"); err != nil {
+			t.Errorf("second update: %v", err)
+		}
+	}()
+
+	select {
+	case <-secondDone:
+		t.Fatal("second update completed before the first document write was released")
+	default:
+	}
+	close(stub.releaseFirst)
+	<-firstDone
+	<-secondDone
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.messages) != 2 || stub.messages[1] != "03:04:05: first\n03:04:05: second" {
+		t.Fatalf("document writes = %q, want accumulated second write", stub.messages)
+	}
+}
+
 // TestProgressSinkTrimsLogHead verifies the accumulated log is head-trimmed at
 // line boundaries once it exceeds progressLogMaxChars, keeping the newest lines
-// (Python trim_header_by_lines parity).
+// while keeping the newest complete lines.
 func TestProgressSinkTrimsLogHead(t *testing.T) {
 	db := testutil.SetupTestDB(t)
 	cleanup := testutil.ReplaceDBForTest(t, db)
@@ -288,6 +382,7 @@ func TestProgressSinkTrimsLogHead(t *testing.T) {
 
 	ctx := t.Context()
 	sink := newProgressSink(ctx, servicepkg.NewIngestionTaskService())
+	setProgressSinkTestClock(sink)
 	stub := &stubDocProgressSvc{}
 	sink.docSvc = stub
 	sink.OnComponentTotal(ctx, taskID, 2)
@@ -304,7 +399,7 @@ func TestProgressSinkTrimsLogHead(t *testing.T) {
 	if len(stub.gotMsg) > progressLogMaxChars {
 		t.Fatalf("progress_msg len = %d, exceeds %d", len(stub.gotMsg), progressLogMaxChars)
 	}
-	if stub.gotMsg != tail {
+	if stub.gotMsg != "03:04:05: "+tail {
 		t.Fatalf("progress_msg keeps the newest line: got prefix %q, want %q", stub.gotMsg[:20], tail[:20])
 	}
 }
@@ -352,7 +447,7 @@ func TestTrimLogHead(t *testing.T) {
 		{name: "short text unchanged", text: "a\nb", max: 10, want: "a\nb"},
 		{name: "exactly max unchanged", text: "a\nb", max: 3, want: "a\nb"},
 		{name: "drops head line", text: "l1\nl2\nl3", max: 6, want: "l2\nl3"},
-		{name: "drops lines until remainder fits", text: "l1\nl2\nl3", max: 5, want: "l3"},
+		{name: "keeps suffix at exact limit", text: "l1\nl2\nl3", max: 5, want: "l2\nl3"},
 		{name: "no fitting newline unchanged", text: "abcdef", max: 3, want: "abcdef"},
 	}
 	for _, tt := range tests {

--- a/internal/ingestion/task/pipeline_executor.go
+++ b/internal/ingestion/task/pipeline_executor.go
@@ -395,20 +395,70 @@ func (s *PipelineExecutor) recordPipelineLog(ctx context.Context, db *gorm.DB, d
 	if err := json.Unmarshal([]byte(dsl), &dslMap); err != nil {
 		dslMap = entity.JSONMap{"raw": dsl}
 	}
+
+	// The task context contains the document snapshot loaded when the task
+	// started. Reload it here so the operation log reflects the final progress
+	// state written by the progress sink, matching the Python operation-log
+	// creation path.
+	doc := s.taskCtx.Doc
+	if db != nil {
+		if persisted, err := dao.NewDocumentDAO().GetByID(ctx, db, docID); err == nil && persisted != nil {
+			doc = *persisted
+		} else if err != nil {
+			common.Warn(fmt.Sprintf("failed to reload document %s for pipeline log: %v", docID, err))
+		}
+	}
+
+	pipelineTitle := ""
+	var pipelineAvatar *string
+	if db != nil {
+		if canvas, err := dao.NewUserCanvasDAO().GetByID(ctx, db, s.canvasID); err == nil && canvas != nil {
+			if canvas.Title != nil {
+				pipelineTitle = *canvas.Title
+			}
+			pipelineAvatar = canvas.Avatar
+		} else if err != nil {
+			common.Warn(fmt.Sprintf("failed to reload pipeline %s for operation log: %v", s.canvasID, err))
+		}
+	}
+
+	operationStatus := status
+	if doc.Run != nil && *doc.Run != "" {
+		operationStatus = *doc.Run
+	}
+	statusValue := "1"
+	if doc.Status != nil && *doc.Status != "" {
+		statusValue = *doc.Status
+	}
+	sourceFrom := doc.SourceType
+	if parts := strings.SplitN(sourceFrom, "/", 2); len(parts) > 0 {
+		sourceFrom = parts[0]
+	}
+	documentName := ""
+	if doc.Name != nil {
+		documentName = *doc.Name
+	}
 	log := &entity.PipelineOperationLog{
 		ID:              utility.GenerateUUID(),
 		TenantID:        s.Tenant().ID,
 		KbID:            s.KB().ID,
 		DocumentID:      docID,
 		PipelineID:      &s.canvasID,
+		PipelineTitle:   &pipelineTitle,
 		TaskType:        string(entity.PipelineTaskTypeParse),
 		DSL:             dslMap,
-		ParserID:        s.taskCtx.Doc.ParserID,
-		DocumentName:    *s.Doc().Name,
-		DocumentSuffix:  s.taskCtx.Doc.Suffix,
-		DocumentType:    s.taskCtx.Doc.Type,
-		SourceFrom:      s.taskCtx.Doc.SourceType,
-		OperationStatus: status,
+		ParserID:        doc.ParserID,
+		DocumentName:    documentName,
+		DocumentSuffix:  doc.Suffix,
+		DocumentType:    doc.Type,
+		SourceFrom:      sourceFrom,
+		Progress:        doc.Progress,
+		ProgressMsg:     doc.ProgressMsg,
+		ProcessBeginAt:  doc.ProcessBeginAt,
+		ProcessDuration: doc.ProcessDuration,
+		OperationStatus: operationStatus,
+		Avatar:          pipelineAvatar,
+		Status:          &statusValue,
 	}
 	if err := s.logCreateFunc(ctx, db, log); err != nil {
 		common.Warn(fmt.Sprintf("failed to record pipeline log: %v", err))

--- a/internal/ingestion/task/task_context.go
+++ b/internal/ingestion/task/task_context.go
@@ -119,7 +119,7 @@ func LoadFromIngestionTask(ctx context.Context, ingestionTask *entity.IngestionT
 		return nil, fmt.Errorf("error when load tenant %s: %w", kb.TenantID, err)
 	}
 
-	pipelineID := resolvePipelineID(doc, kb)
+	pipelineID := resolvePipelineID(doc)
 
 	return &TaskContext{
 		Ctx:           ctx,
@@ -131,16 +131,12 @@ func LoadFromIngestionTask(ctx context.Context, ingestionTask *entity.IngestionT
 	}, nil
 }
 
-func resolvePipelineID(doc *entity.Document, kb *entity.Knowledgebase) string {
+// resolvePipelineID uses the document's parser selection exclusively. A
+// document either points at a user pipeline or uses its parser_id for a
+// built-in pipeline; the knowledgebase pipeline is not an implicit fallback.
+func resolvePipelineID(doc *entity.Document) string {
 	if doc != nil && doc.PipelineID != nil {
-		if pipelineID := strings.TrimSpace(*doc.PipelineID); pipelineID != "" {
-			return pipelineID
-		}
-	}
-	if kb != nil && kb.PipelineID != nil {
-		if pipelineID := strings.TrimSpace(*kb.PipelineID); pipelineID != "" {
-			return pipelineID
-		}
+		return strings.TrimSpace(*doc.PipelineID)
 	}
 	return ""
 }

--- a/internal/ingestion/task/task_context.go
+++ b/internal/ingestion/task/task_context.go
@@ -131,9 +131,7 @@ func LoadFromIngestionTask(ctx context.Context, ingestionTask *entity.IngestionT
 	}, nil
 }
 
-// resolvePipelineID uses the document's parser selection exclusively. A
-// document either points at a user pipeline or uses its parser_id for a
-// built-in pipeline; the knowledgebase pipeline is not an implicit fallback.
+// resolvePipelineID resolves the pipeline selected for a document.
 func resolvePipelineID(doc *entity.Document) string {
 	if doc != nil && doc.PipelineID != nil {
 		return strings.TrimSpace(*doc.PipelineID)

--- a/internal/ingestion/task/task_context_test.go
+++ b/internal/ingestion/task/task_context_test.go
@@ -23,7 +23,7 @@ import (
 	"ragflow/internal/ingestion/testutil"
 )
 
-func TestLoadFromIngestionTask_FallsBackToKnowledgebasePipelineID(t *testing.T) {
+func TestLoadFromIngestionTask_DoesNotFallbackToKnowledgebasePipelineID(t *testing.T) {
 	db := testutil.SetupTestDB(t)
 	cleanup := testutil.ReplaceDBForTest(t, db)
 	defer cleanup()
@@ -65,8 +65,8 @@ func TestLoadFromIngestionTask_FallsBackToKnowledgebasePipelineID(t *testing.T) 
 	if err != nil {
 		t.Fatalf("LoadFromIngestionTask: %v", err)
 	}
-	if taskCtx.PipelineID != kbPipelineID {
-		t.Fatalf("PipelineID = %q, want %q", taskCtx.PipelineID, kbPipelineID)
+	if taskCtx.PipelineID != "" {
+		t.Fatalf("PipelineID = %q, want empty document pipeline selection", taskCtx.PipelineID)
 	}
 }
 

--- a/internal/service/document/document.go
+++ b/internal/service/document/document.go
@@ -77,26 +77,27 @@ type UpdateDocumentRequest struct {
 
 // DocumentResponse document response
 type DocumentResponse struct {
-	ID              string  `json:"id"`
-	Name            *string `json:"name,omitempty"`
-	KbID            string  `json:"kb_id"`
-	ParserID        string  `json:"parser_id"`
-	PipelineID      *string `json:"pipeline_id,omitempty"`
-	Type            string  `json:"type"`
-	SourceType      string  `json:"source_type"`
-	CreatedBy       string  `json:"created_by"`
-	Location        *string `json:"location,omitempty"`
-	Size            int64   `json:"size"`
-	TokenNum        int64   `json:"token_num"`
-	ChunkNum        int64   `json:"chunk_num"`
-	Progress        float64 `json:"progress"`
-	ProgressMsg     *string `json:"progress_msg,omitempty"`
-	ProcessDuration float64 `json:"process_duration"`
-	Suffix          string  `json:"suffix"`
-	Run             *string `json:"run,omitempty"`
-	Status          *string `json:"status,omitempty"`
-	CreatedAt       string  `json:"created_at"`
-	UpdatedAt       string  `json:"updated_at"`
+	ID              string     `json:"id"`
+	Name            *string    `json:"name,omitempty"`
+	KbID            string     `json:"kb_id"`
+	ParserID        string     `json:"parser_id"`
+	PipelineID      *string    `json:"pipeline_id,omitempty"`
+	Type            string     `json:"type"`
+	SourceType      string     `json:"source_type"`
+	CreatedBy       string     `json:"created_by"`
+	Location        *string    `json:"location,omitempty"`
+	Size            int64      `json:"size"`
+	TokenNum        int64      `json:"token_num"`
+	ChunkNum        int64      `json:"chunk_num"`
+	Progress        float64    `json:"progress"`
+	ProgressMsg     *string    `json:"progress_msg,omitempty"`
+	ProcessBeginAt  *time.Time `json:"process_begin_at,omitempty"`
+	ProcessDuration float64    `json:"process_duration"`
+	Suffix          string     `json:"suffix"`
+	Run             *string    `json:"run,omitempty"`
+	Status          *string    `json:"status,omitempty"`
+	CreatedAt       string     `json:"created_at"`
+	UpdatedAt       string     `json:"updated_at"`
 }
 
 type ThumbnailResponse struct {

--- a/internal/service/document/document_crud.go
+++ b/internal/service/document/document_crud.go
@@ -211,6 +211,26 @@ func (s *DocumentService) UpdateRunProgress(ctx context.Context, docID string, p
 	return s.documentDAO.UpdateByID(ctx, dao.DB, docID, updates)
 }
 
+// UpdateRunState mirrors live progress and status into the document row when
+// the existing progress log cannot be read. It intentionally leaves the log
+// untouched so a later event can retry seeding and append it safely.
+func (s *DocumentService) UpdateRunState(ctx context.Context, docID string, progress float64, run string) error {
+	updates := map[string]interface{}{
+		"progress": progress,
+		"run":      run,
+	}
+	if doc, err := s.documentDAO.GetByID(ctx, dao.DB, docID); err != nil {
+		return err
+	} else if doc != nil && doc.ProcessBeginAt != nil {
+		duration := time.Since(*doc.ProcessBeginAt).Seconds()
+		if duration < 0 {
+			duration = 0
+		}
+		updates["process_duration"] = duration
+	}
+	return s.documentDAO.UpdateByID(ctx, dao.DB, docID, updates)
+}
+
 // DeleteDocument delete document — delegates to full cleanup logic.
 func (s *DocumentService) DeleteDocument(ctx context.Context, id string) error {
 	return s.deleteDocumentFull(ctx, id)

--- a/internal/service/document/document_crud.go
+++ b/internal/service/document/document_crud.go
@@ -194,11 +194,21 @@ func (s *DocumentService) ApplyDocCounts(ctx context.Context, docID, kbID string
 // progress_msg) reflects in-flight Go pipeline progress. Best-effort by
 // design; callers log and continue on error.
 func (s *DocumentService) UpdateRunProgress(ctx context.Context, docID string, progress float64, run, progressMsg string) error {
-	return s.documentDAO.UpdateByID(ctx, dao.DB, docID, map[string]interface{}{
+	updates := map[string]interface{}{
 		"progress":     progress,
 		"run":          run,
 		"progress_msg": progressMsg,
-	})
+	}
+	if doc, err := s.documentDAO.GetByID(ctx, dao.DB, docID); err != nil {
+		return err
+	} else if doc != nil && doc.ProcessBeginAt != nil {
+		duration := time.Since(*doc.ProcessBeginAt).Seconds()
+		if duration < 0 {
+			duration = 0
+		}
+		updates["process_duration"] = duration
+	}
+	return s.documentDAO.UpdateByID(ctx, dao.DB, docID, updates)
 }
 
 // DeleteDocument delete document — delegates to full cleanup logic.

--- a/internal/service/document/document_list.go
+++ b/internal/service/document/document_list.go
@@ -223,6 +223,7 @@ func (s *DocumentService) toResponse(doc *entity.Document) *DocumentResponse {
 		ChunkNum:        doc.ChunkNum,
 		Progress:        doc.Progress,
 		ProgressMsg:     doc.ProgressMsg,
+		ProcessBeginAt:  doc.ProcessBeginAt,
 		ProcessDuration: doc.ProcessDuration,
 		Suffix:          doc.Suffix,
 		Run:             doc.Run,

--- a/internal/service/document/document_test.go
+++ b/internal/service/document/document_test.go
@@ -3095,6 +3095,10 @@ func TestUpdateRunProgressMirrorsFields(t *testing.T) {
 	db := setupServiceTestDB(t)
 	pushServiceDB(t, db)
 	insertTestDoc(t, "doc-1", "kb-1", 0, 0)
+	begin := time.Now().Add(-2 * time.Second)
+	if err := db.Model(&entity.Document{}).Where("id = ?", "doc-1").Update("process_begin_at", begin).Error; err != nil {
+		t.Fatalf("set process_begin_at: %v", err)
+	}
 
 	svc := testDocumentService(t)
 	ctx := t.Context()
@@ -3113,6 +3117,9 @@ func TestUpdateRunProgressMirrorsFields(t *testing.T) {
 	}
 	if doc.ProgressMsg == nil || *doc.ProgressMsg != "halfway" {
 		t.Fatalf("progress_msg = %v, want halfway", doc.ProgressMsg)
+	}
+	if doc.ProcessDuration <= 0 {
+		t.Fatalf("process_duration = %v, want positive live duration", doc.ProcessDuration)
 	}
 }
 

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -479,6 +479,13 @@ func (s *IngestionTaskService) RecordComponentProgress(ctx context.Context, task
 	return s.ingestionTaskLogDAO.Create(ctx, dao.DB, entry)
 }
 
+// ClearComponentProgress removes lifecycle rows left by a previous attempt of
+// the same reusable ingestion task. Run-count checkpoint rows are retained.
+func (s *IngestionTaskService) ClearComponentProgress(ctx context.Context, taskID string) error {
+	_, err := s.ingestionTaskLogDAO.DeleteComponentLogsByTaskID(ctx, dao.DB, taskID)
+	return err
+}
+
 // AggregateTaskProgress returns the SQL-aggregated component progress for a
 // task (done/failed/running/percent against the given total denominator).
 func (s *IngestionTaskService) AggregateTaskProgress(ctx context.Context, taskID string, total int) (*dao.TaskProgress, error) {

--- a/web/src/hooks/use-document-request.ts
+++ b/web/src/hooks/use-document-request.ts
@@ -52,6 +52,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { useDebounce } from 'ahooks';
+import dayjs from 'dayjs';
 import { get } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { IHighlight } from 'react-pdf-highlighter';
@@ -91,6 +92,17 @@ export const enum DocumentStructureApiAction {
 }
 
 const DocumentKeys = {
+  list: (searchString?: string, pagination?: unknown, filter?: unknown) =>
+    [
+      DocumentApiAction.FetchDocumentList,
+      searchString,
+      pagination,
+      filter,
+    ] as const,
+  filter: (searchString?: string, knowledgeId?: string) =>
+    [DocumentApiAction.FetchDocumentFilter, searchString, knowledgeId] as const,
+  thumbnails: (ids: string[]) =>
+    [DocumentApiAction.FetchDocumentThumbnails, ids] as const,
   byIds: (ids: string[]) =>
     [DocumentApiAction.FetchDocumentList, 'byIds', ids] as const,
 };
@@ -149,7 +161,7 @@ export const useUploadDocument = () => {
 
         if (code === 0 || code === 500) {
           queryClient.invalidateQueries({
-            queryKey: [DocumentApiAction.FetchDocumentList],
+            queryKey: DocumentKeys.list(),
           });
         }
         return ret;
@@ -191,12 +203,7 @@ export const useFetchDocumentList = (loop = true) => {
     docs: IDocumentInfo[];
     total: number;
   }>({
-    queryKey: [
-      DocumentApiAction.FetchDocumentList,
-      debouncedSearchString,
-      pagination,
-      filterValue,
-    ],
+    queryKey: DocumentKeys.list(debouncedSearchString, pagination, filterValue),
     initialData: { docs: [], total: 0 },
     refetchInterval: isLoop ? 5000 : false,
     enabled: !!knowledgeId || !!id,
@@ -231,7 +238,7 @@ export const useFetchDocumentList = (loop = true) => {
       );
       if (ret.data.code === 0) {
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentFilter],
+          queryKey: DocumentKeys.filter(),
         });
         return ret.data.data;
       }
@@ -320,11 +327,7 @@ export const useGetDocumentFilter = (): {
   const [open, setOpen] = useState<number>(0);
   const datasetId = knowledgeId || id;
   const { data } = useQuery({
-    queryKey: [
-      DocumentApiAction.FetchDocumentFilter,
-      debouncedSearchString,
-      knowledgeId,
-    ],
+    queryKey: DocumentKeys.filter(debouncedSearchString, knowledgeId),
     queryFn: async () => {
       if (!datasetId) {
         return;
@@ -379,7 +382,7 @@ export const useSetDocumentStatus = () => {
       if (data.code === 0) {
         message.success(i18n.t('message.modified'));
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentList],
+          queryKey: DocumentKeys.list(),
         });
       }
       return data;
@@ -413,7 +416,7 @@ export const useRunDocument = () => {
         queryClient.setQueriesData<{
           docs: IDocumentInfo[];
           total: number;
-        }>({ queryKey: [DocumentApiAction.FetchDocumentList] }, (current) => {
+        }>({ queryKey: DocumentKeys.list() }, (current) => {
           if (!current) {
             return current;
           }
@@ -426,7 +429,7 @@ export const useRunDocument = () => {
                     run: RunningStatus.RUNNING,
                     progress: 0,
                     process_duration: 0,
-                    process_begin_at: new Date().toISOString(),
+                    process_begin_at: dayjs().format('YYYY-MM-DD HH:mm:ss'),
                     progress_msg: '',
                   }
                 : doc,
@@ -436,7 +439,7 @@ export const useRunDocument = () => {
       }
       if (run !== 1) {
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentList],
+          queryKey: DocumentKeys.list(),
         });
       }
       const ret = await kbService.documentIngest({
@@ -452,13 +455,13 @@ export const useRunDocument = () => {
         // polling again.
         if (run !== 1) {
           queryClient.invalidateQueries({
-            queryKey: [DocumentApiAction.FetchDocumentList],
+            queryKey: DocumentKeys.list(),
           });
         }
         message.success(i18n.t('message.operated'));
       } else {
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentList],
+          queryKey: DocumentKeys.list(),
         });
       }
 
@@ -466,7 +469,7 @@ export const useRunDocument = () => {
     },
     onError: () => {
       queryClient.invalidateQueries({
-        queryKey: [DocumentApiAction.FetchDocumentList],
+        queryKey: DocumentKeys.list(),
       });
     },
   });
@@ -518,7 +521,7 @@ export const useRemoveDocument = () => {
       if (data.code === 0) {
         message.success(i18n.t('message.deleted'));
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentList],
+          queryKey: DocumentKeys.list(),
         });
       }
       return data.code;
@@ -552,7 +555,7 @@ export const useSaveDocumentName = () => {
       if (data.code === 0) {
         message.success(i18n.t('message.renamed'));
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentList],
+          queryKey: DocumentKeys.list(),
         });
       }
       return data.code;
@@ -604,7 +607,7 @@ export const useSetDocumentParser = () => {
       );
       if (data.code === 0) {
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentList],
+          queryKey: DocumentKeys.list(),
         });
 
         message.success(i18n.t('message.modified'));
@@ -669,7 +672,7 @@ export const useSetDocumentPipelineParser = () => {
       );
       if (data.code === 0) {
         queryClient.invalidateQueries({
-          queryKey: [DocumentApiAction.FetchDocumentList],
+          queryKey: DocumentKeys.list(),
         });
 
         message.success(i18n.t('message.modified'));
@@ -699,7 +702,7 @@ export const useSetDocumentMeta = () => {
 
         if (data?.code === 0) {
           queryClient.invalidateQueries({
-            queryKey: [DocumentApiAction.FetchDocumentList],
+            queryKey: DocumentKeys.list(),
           });
 
           message.success(i18n.t('message.modified'));
@@ -733,7 +736,7 @@ export const useCreateDocument = () => {
       if (data.code === 0) {
         if (page === 1) {
           queryClient.invalidateQueries({
-            queryKey: [DocumentApiAction.FetchDocumentList],
+            queryKey: DocumentKeys.list(),
           });
         } else {
           setPaginationParams(); // fetch document list
@@ -783,7 +786,7 @@ export const useGetChunkHighlights = (
 export const useFetchDocumentThumbnailsByIds = () => {
   const [ids, setDocumentIds] = useState<string[]>([]);
   const { data } = useQuery<Record<string, string>>({
-    queryKey: [DocumentApiAction.FetchDocumentThumbnails, ids],
+    queryKey: DocumentKeys.thumbnails(ids),
     enabled: ids.length > 0,
     initialData: {},
     queryFn: async () => {

--- a/web/src/hooks/use-document-request.ts
+++ b/web/src/hooks/use-document-request.ts
@@ -408,9 +408,37 @@ export const useRunDocument = () => {
       run: number;
       option?: { delete: boolean; apply_kb: boolean };
     }) => {
-      queryClient.invalidateQueries({
-        queryKey: [DocumentApiAction.FetchDocumentList],
-      });
+      if (run === 1) {
+        const documentIdSet = new Set(documentIds);
+        queryClient.setQueriesData<{
+          docs: IDocumentInfo[];
+          total: number;
+        }>({ queryKey: [DocumentApiAction.FetchDocumentList] }, (current) => {
+          if (!current) {
+            return current;
+          }
+          return {
+            ...current,
+            docs: current.docs.map((doc) =>
+              documentIdSet.has(doc.id)
+                ? {
+                    ...doc,
+                    run: RunningStatus.RUNNING,
+                    progress: 0,
+                    process_duration: 0,
+                    process_begin_at: new Date().toISOString(),
+                    progress_msg: '',
+                  }
+                : doc,
+            ),
+          };
+        });
+      }
+      if (run !== 1) {
+        queryClient.invalidateQueries({
+          queryKey: [DocumentApiAction.FetchDocumentList],
+        });
+      }
       const ret = await kbService.documentIngest({
         doc_ids: documentIds,
         run,
@@ -418,13 +446,28 @@ export const useRunDocument = () => {
       });
       const code = get(ret, 'data.code');
       if (code === 0) {
+        // For a start request, keep the optimistic running state until the
+        // polling query observes the worker's state. Invalidating here can
+        // immediately fetch the pre-worker "not started" row and disable
+        // polling again.
+        if (run !== 1) {
+          queryClient.invalidateQueries({
+            queryKey: [DocumentApiAction.FetchDocumentList],
+          });
+        }
+        message.success(i18n.t('message.operated'));
+      } else {
         queryClient.invalidateQueries({
           queryKey: [DocumentApiAction.FetchDocumentList],
         });
-        message.success(i18n.t('message.operated'));
       }
 
       return code;
+    },
+    onError: () => {
+      queryClient.invalidateQueries({
+        queryKey: [DocumentApiAction.FetchDocumentList],
+      });
     },
   });
 

--- a/web/src/pages/dataset/dataset/parsing-card.tsx
+++ b/web/src/pages/dataset/dataset/parsing-card.tsx
@@ -51,12 +51,12 @@ export const PopoverContent = ({ record }: IProps) => {
     {
       key: 'knowledgeDetails.process_duration',
       label: t('processDuration'),
-      children: `${record.process_duration.toFixed(2)} s`,
+      children: `${(record.process_duration || 0).toFixed(2)} s`,
     },
     {
       key: 'progress_msg',
       label: t('knowledgeDetails.progressMsg'),
-      children: replaceText(record.progress_msg.trim()),
+      children: replaceText((record.progress_msg || '').trim()),
     },
   ];
 


### PR DESCRIPTION
### What problem does this PR solve?

Fixes Go ingestion progress reporting and pipeline selection:

- Add timestamps to document progress logs.
- Keep document duration and status updated during parsing.
- Start frontend polling immediately after parsing begins.
- Prevent documents explicitly using General from inheriting an old dataset pipeline.
- Populate missing pipeline operation log fields.
- Remove stale component progress logs between retries.
- Prevent progress values greater than `1`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)