### PR TITLE
fix(web): exclude <think> reasoning blocks from copied answer

### DIFF
--- a/web/src/components/message-item/group-button.tsx
+++ b/web/src/components/message-item/group-button.tsx
@@ -24,6 +24,7 @@ import {
 import { useSetModalState } from '@/hooks/common-hooks';
 import { IRemoveMessageById } from '@/hooks/logic-hooks';
 import { cn } from '@/lib/utils';
+import { removeThinkSection } from '@/utils/chat';
 import {
   LucidePauseCircle,
   LucideRefreshCw,
@@ -32,7 +33,7 @@ import {
   LucideTrash2,
   LucideVolume2,
 } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import FeedbackDialog from '../feedback-dialog';
 import { PromptDialog } from '../prompt-dialog';
@@ -66,6 +67,8 @@ export const AssistantGroupButton = ({
   const { t } = useTranslation();
   const { handleRead, ref, isPlaying } = useSpeech(content, audioBinary);
 
+  const copyText = useMemo(() => removeThinkSection(content), [content]);
+
   const handleLike = useCallback(() => {
     onFeedbackOk({ thumbup: true });
   }, [onFeedbackOk]);
@@ -77,7 +80,7 @@ export const AssistantGroupButton = ({
         role="toolbar"
       >
         <CopyToClipboard
-          text={content}
+          text={copyText}
           className="border-0"
           size="icon-xs"
           avoidButtonWrapper

--- a/web/src/components/next-message-item/group-button.tsx
+++ b/web/src/components/next-message-item/group-button.tsx
@@ -25,6 +25,7 @@ import { useSetModalState } from '@/hooks/common-hooks';
 import { IRemoveMessageById } from '@/hooks/logic-hooks';
 import { AgentChatContext } from '@/pages/agent/context';
 import { downloadAgentFile } from '@/services/file-manager-service';
+import { removeThinkSection } from '@/utils/chat';
 import { downloadFileFromBlob } from '@/utils/file-util';
 import {
   DeleteOutlined,
@@ -35,7 +36,7 @@ import {
   SyncOutlined,
 } from '@ant-design/icons';
 import { Download, NotebookText } from 'lucide-react';
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import FeedbackDialog from '../feedback-dialog';
 import { PromptDialog } from '../prompt-dialog';
@@ -85,6 +86,8 @@ export const AssistantGroupButton = ({
 
   const { showLogSheet } = useContext(AgentChatContext);
 
+  const copyText = useMemo(() => removeThinkSection(content), [content]);
+
   const handleShowLogSheet = useCallback(() => {
     showLogSheet(messageId);
   }, [messageId, showLogSheet]);
@@ -99,7 +102,7 @@ export const AssistantGroupButton = ({
       >
         <ToggleGroupItem value="a">
           <CopyToClipboard
-            text={content}
+            text={copyText}
             className="border-none hover:!bg-transparent"
             avoidButtonWrapper
           ></CopyToClipboard>

--- a/web/src/utils/chat.ts
+++ b/web/src/utils/chat.ts
@@ -108,6 +108,15 @@ export function replaceThinkToSection(
   return result;
 }
 
+// Strip <think> reasoning blocks so only the answer text remains.
+// The second replace handles a streaming message whose block is still unclosed.
+export function removeThinkSection(text: string = '') {
+  return text
+    .replace(/<think>[\s\S]*?<\/think>/g, '')
+    .replace(/<think>[\s\S]*$/, '')
+    .trim();
+}
+
 export function replaceRetrievingToSection(text: string = '') {
   const pattern = /<retrieving>([\s\S]*?)<\/retrieving>/g;
 


### PR DESCRIPTION
Copying an assistant message handed over the raw content, so the model's reasoning block came along with the answer. Strip it via a shared removeThinkSection helper, which also tolerates an unclosed block while the message is still streaming.

### Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._
