### PR TITLE
fix(deepdoc): apply 0.4 garbage gate in LayoutRecognizer.forward

### DIFF
--- a/deepdoc/vision/layout_recognizer.py
+++ b/deepdoc/vision/layout_recognizer.py
@@ -93,8 +93,7 @@ class LayoutRecognizer(Recognizer):
                     "bottom": b["bbox"][-1] / scale_factor,
                     "page_number": pn,
                 }
-                for b in lts
-                if float(b["score"]) >= 0.4 or b["type"] not in self.garbage_layouts
+                for b in self._filter_garbage_layouts(lts)
             ]
             lts = self.sort_Y_firstly(lts, np.mean([lt["bottom"] - lt["top"] for lt in lts]) / 2)
             lts = self.layouts_cleanup(bxs, lts)
@@ -168,8 +167,23 @@ class LayoutRecognizer(Recognizer):
         ocr_res = [b for b in ocr_res if b["text"].strip() not in garbag_set]
         return ocr_res, page_layout
 
+    def _filter_garbage_layouts(self, boxes, score_thr=0.4):
+        """Drop garbage-layout boxes (footer/header/reference) below ``score_thr``.
+
+        Mirrors the gate applied in ``__call__`` (layout_recognizer.py:97 and
+        :379) so that every consumer of ``forward`` — notably the
+        ``/predict/dla`` HTTP endpoint served by ``DLAAdapter`` — receives
+        Python-production-aligned output instead of raw low-confidence garbage
+        boxes. Non-garbage boxes are always kept regardless of score.
+        """
+        return [b for b in boxes if float(b["score"]) >= score_thr or b["type"] not in self.garbage_layouts]
+
     def forward(self, image_list, thr=0.7, batch_size=16):
-        return super().__call__(image_list, thr, batch_size)
+        layouts = super().__call__(image_list, thr, batch_size)
+        # Apply the 0.4 garbage gate so forward output matches __call__; the
+        # /predict/dla endpoint otherwise returns unfiltered low-confidence
+        # garbage (see _filter_garbage_layouts).
+        return [self._filter_garbage_layouts(page_boxes) for page_boxes in layouts]
 
 
 class LayoutRecognizer4YOLOv10(LayoutRecognizer):

--- a/deepdoc/vision/test_layout_garbage_gate.py
+++ b/deepdoc/vision/test_layout_garbage_gate.py
@@ -1,0 +1,77 @@
+"""Offline unit tests for the DLA 0.4 garbage gate.
+
+LayoutRecognizer.forward (deepdoc/vision/layout_recognizer.py:171) is the
+shared model-output path used by the /predict/dla HTTP endpoint (via
+DLAAdapter). It previously applied only the detection threshold + NMS and
+returned raw low-confidence footer/header/reference boxes, diverging from
+LayoutRecognizer.__call__ which applies a 0.4 garbage gate
+(layout_recognizer.py:97 and :379). These tests pin the gate on forward
+without loading the DeepDoc weights: the recognizer is built via
+object.__new__ and the base Recognizer.__call__ that forward delegates to is
+stubbed.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from deepdoc.vision.layout_recognizer import LayoutRecognizer
+
+
+def _make_rec():
+    """Build a LayoutRecognizer without loading the ONNX model."""
+    rec = LayoutRecognizer.__new__(LayoutRecognizer)
+    rec.garbage_layouts = ["footer", "header", "reference"]
+    rec.label_list = [
+        "title",
+        "text",
+        "reference",
+        "figure",
+        "figure caption",
+        "table",
+        "table caption",
+        "table caption",
+        "equation",
+        "figure caption",
+    ]
+    return rec
+
+
+# Boxes returned by the stubbed base Recognizer.__call__ (one page).
+RAW_BOXES = [
+    {"type": "reference", "bbox": [1, 2, 3, 4], "score": 0.30},  # low-conf garbage -> dropped
+    {"type": "text", "bbox": [1, 2, 3, 4], "score": 0.10},  # low-conf non-garbage -> kept
+    {"type": "reference", "bbox": [1, 2, 3, 4], "score": 0.90},  # high-conf garbage -> kept
+    {"type": "reference", "bbox": [1, 2, 3, 4], "score": 0.40},  # boundary 0.4 -> kept
+]
+
+
+class TestFilterGarbageLayouts(unittest.TestCase):
+    def test_drops_low_conf_garbage_only(self):
+        rec = _make_rec()
+        kept = rec._filter_garbage_layouts(RAW_BOXES)
+        kept_sig = [(b["type"], b["score"]) for b in kept]
+        self.assertNotIn(("reference", 0.30), kept_sig)
+        self.assertIn(("text", 0.10), kept_sig)
+        self.assertIn(("reference", 0.90), kept_sig)
+        self.assertIn(("reference", 0.40), kept_sig)
+
+
+class TestForwardGarbageGate(unittest.TestCase):
+    def test_forward_drops_low_conf_garbage(self):
+        rec = _make_rec()
+        # Stub the base Recognizer.__call__ that forward() delegates to, so no
+        # model inference runs.
+        with patch("deepdoc.vision.recognizer.Recognizer.__call__", return_value=[RAW_BOXES]):
+            out = rec.forward([np.zeros((10, 10, 3), dtype=np.uint8)])
+        self.assertEqual(len(out), 1)
+        kept_sig = [(b["type"], b["score"]) for b in out[0]]
+        self.assertNotIn(("reference", 0.30), kept_sig)
+        self.assertIn(("text", 0.10), kept_sig)
+        self.assertIn(("reference", 0.90), kept_sig)
+        self.assertIn(("reference", 0.40), kept_sig)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`LayoutRecognizer.forward` is the shared model-output path used by the
`/predict/dla` HTTP endpoint (served by `DLAAdapter`). It previously applied
only the detection threshold + NMS and returned **raw low-confidence**
`footer`/`header`/`reference` boxes, diverging from `LayoutRecognizer.__call__`,
which applies a 0.4 garbage gate (`deepdoc/vision/layout_recognizer.py:97` and
`:379`).

This divergence was the **root cause** of the Go↔Python DLA parity gap (#3):
the Go client consumes `/predict/dla` (which calls `forward`), so it received
unfiltered low-confidence garbage while Python's own `parse_into_bboxes`
(via `__call__`) dropped it. The Go-side fix (PR #18365) added the gate at the
`Client.DLA` source as a stopgap; this PR fixes the root cause at the Python
model-output layer so every `forward` consumer — not just the Go client — gets
Python-production-aligned output.

## Changes

- Extract `_filter_garbage_layouts(boxes, score_thr=0.4)` (keeps a box when
  `score >= 0.4 or type not in garbage_layouts`) as the single source of truth.
- Apply it in `forward` (after NMS, before returning) so `/predict/dla` no longer
  emits raw low-confidence garbage.
- Reuse the same helper in `LayoutRecognizer.__call__` (CPU path), replacing the
  inline gate — behavior is identical (same predicate), removing the duplication.
- `AscendLayoutRecognizer` keeps its own inline gate (it extends the base
  `Recognizer`, not `LayoutRecognizer`); its predicate is already identical.

## Regression safety

- Python's own production path (`parse_into_bboxes` → `__call__`) is **unchanged**:
  `__call__` does not route through `forward`, and the predicate is byte-identical.
- The change only affects `forward` consumers (the `/predict/dla` endpoint). The
  Go client (`Client.DLA`) already applies the same gate, so the result is
  idempotent there.
- The gate is applied **after** NMS, matching `__call__`'s order, so NMS behavior
  is unchanged.

## Tests

Add `deepdoc/vision/test_layout_garbage_gate.py` — offline unit tests that
bypass the ONNX model via `object.__new__` and stub the base `Recognizer.__call__`
that `forward` delegates to. They pin:
- `_filter_garbage_layouts` drops low-conf garbage only (keeps low-conf non-garbage
  and high-conf garbage; boundary `0.4` is kept).
- `forward` actually applies the gate end-to-end (low-conf `reference` dropped,
  `text`/`reference` at other scores kept).

These are the TDD tests: they failed before the gate was added and pass after.

## Relation to other PRs

- Companion to the Go-side fix in PR #18365 (which added the gate at `Client.DLA`
  as a stopgap). With this Python fix, the Go gate is belt-and-suspenders.

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy)