### PR TITLE
fix: restore document query cache matching

### DIFF
--- a/web/src/hooks/__tests__/use-document-request-query-keys.test.ts
+++ b/web/src/hooks/__tests__/use-document-request-query-keys.test.ts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { partialMatchKey } from '@tanstack/query-core';
+import { DocumentKeys } from '../document-query-keys';
+
+describe('DocumentKeys', () => {
+  it('matches parameterized document lists with the list prefix', () => {
+    const actual = DocumentKeys.list(
+      'keyword',
+      { current: 1, pageSize: 30 },
+      { run: ['1'] },
+    );
+
+    expect(partialMatchKey(actual, DocumentKeys.all())).toBe(true);
+  });
+
+  it('matches parameterized document filters with the filter prefix', () => {
+    const actual = DocumentKeys.filter('keyword', 'dataset-id');
+
+    expect(partialMatchKey(actual, DocumentKeys.allFilters())).toBe(true);
+  });
+});

--- a/web/src/hooks/document-query-keys.ts
+++ b/web/src/hooks/document-query-keys.ts
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export const enum DocumentApiAction {
+  UploadDocument = 'uploadDocument',
+  FetchDocumentList = 'fetchDocumentList',
+  UpdateDocumentStatus = 'updateDocumentStatus',
+  RunDocumentByIds = 'runDocumentByIds',
+  RemoveDocument = 'removeDocument',
+  SaveDocumentName = 'saveDocumentName',
+  SetDocumentParser = 'setDocumentParser',
+  SetDocumentMeta = 'setDocumentMeta',
+  FetchDocumentFilter = 'fetchDocumentFilter',
+  CreateDocument = 'createDocument',
+  FetchDocumentThumbnails = 'fetchDocumentThumbnails',
+  ParseDocument = 'parseDocument',
+}
+
+export const DocumentKeys = {
+  all: () => [DocumentApiAction.FetchDocumentList] as const,
+  list: (searchString: string, pagination: unknown, filter: unknown) =>
+    [...DocumentKeys.all(), searchString, pagination, filter] as const,
+  allFilters: () => [DocumentApiAction.FetchDocumentFilter] as const,
+  filter: (searchString: string, knowledgeId?: string) =>
+    [...DocumentKeys.allFilters(), searchString, knowledgeId] as const,
+  thumbnails: (ids: string[]) =>
+    [DocumentApiAction.FetchDocumentThumbnails, ids] as const,
+  byIds: (ids: string[]) =>
+    [DocumentApiAction.FetchDocumentList, 'byIds', ids] as const,
+};

--- a/web/src/hooks/use-document-request.ts
+++ b/web/src/hooks/use-document-request.ts
@@ -70,42 +70,14 @@ import {
   useSetPaginationParams,
 } from './route-hook';
 import { KnowledgeApiAction } from './use-knowledge-request';
+import { DocumentApiAction, DocumentKeys } from './document-query-keys';
 
-export const enum DocumentApiAction {
-  UploadDocument = 'uploadDocument',
-  FetchDocumentList = 'fetchDocumentList',
-  UpdateDocumentStatus = 'updateDocumentStatus',
-  RunDocumentByIds = 'runDocumentByIds',
-  RemoveDocument = 'removeDocument',
-  SaveDocumentName = 'saveDocumentName',
-  SetDocumentParser = 'setDocumentParser',
-  SetDocumentMeta = 'setDocumentMeta',
-  FetchDocumentFilter = 'fetchDocumentFilter',
-  CreateDocument = 'createDocument',
-  FetchDocumentThumbnails = 'fetchDocumentThumbnails',
-  ParseDocument = 'parseDocument',
-}
+export { DocumentApiAction, DocumentKeys } from './document-query-keys';
 
 export const enum DocumentStructureApiAction {
   FetchDocumentStructureGraph = 'fetchDocumentStructureGraph',
   DeleteDocumentStructureGraph = 'deleteDocumentStructureGraph',
 }
-
-const DocumentKeys = {
-  list: (searchString?: string, pagination?: unknown, filter?: unknown) =>
-    [
-      DocumentApiAction.FetchDocumentList,
-      searchString,
-      pagination,
-      filter,
-    ] as const,
-  filter: (searchString?: string, knowledgeId?: string) =>
-    [DocumentApiAction.FetchDocumentFilter, searchString, knowledgeId] as const,
-  thumbnails: (ids: string[]) =>
-    [DocumentApiAction.FetchDocumentThumbnails, ids] as const,
-  byIds: (ids: string[]) =>
-    [DocumentApiAction.FetchDocumentList, 'byIds', ids] as const,
-};
 
 const documentIngestInFlight = new Map<string, Promise<unknown>>();
 
@@ -161,7 +133,7 @@ export const useUploadDocument = () => {
 
         if (code === 0 || code === 500) {
           queryClient.invalidateQueries({
-            queryKey: DocumentKeys.list(),
+            queryKey: DocumentKeys.all(),
           });
         }
         return ret;
@@ -238,7 +210,7 @@ export const useFetchDocumentList = (loop = true) => {
       );
       if (ret.data.code === 0) {
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.filter(),
+          queryKey: DocumentKeys.allFilters(),
         });
         return ret.data.data;
       }
@@ -382,7 +354,7 @@ export const useSetDocumentStatus = () => {
       if (data.code === 0) {
         message.success(i18n.t('message.modified'));
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.list(),
+          queryKey: DocumentKeys.all(),
         });
       }
       return data;
@@ -416,7 +388,7 @@ export const useRunDocument = () => {
         queryClient.setQueriesData<{
           docs: IDocumentInfo[];
           total: number;
-        }>({ queryKey: DocumentKeys.list() }, (current) => {
+        }>({ queryKey: DocumentKeys.all() }, (current) => {
           if (!current) {
             return current;
           }
@@ -439,7 +411,7 @@ export const useRunDocument = () => {
       }
       if (run !== 1) {
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.list(),
+          queryKey: DocumentKeys.all(),
         });
       }
       const ret = await kbService.documentIngest({
@@ -455,13 +427,13 @@ export const useRunDocument = () => {
         // polling again.
         if (run !== 1) {
           queryClient.invalidateQueries({
-            queryKey: DocumentKeys.list(),
+            queryKey: DocumentKeys.all(),
           });
         }
         message.success(i18n.t('message.operated'));
       } else {
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.list(),
+          queryKey: DocumentKeys.all(),
         });
       }
 
@@ -469,7 +441,7 @@ export const useRunDocument = () => {
     },
     onError: () => {
       queryClient.invalidateQueries({
-        queryKey: DocumentKeys.list(),
+        queryKey: DocumentKeys.all(),
       });
     },
   });
@@ -521,7 +493,7 @@ export const useRemoveDocument = () => {
       if (data.code === 0) {
         message.success(i18n.t('message.deleted'));
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.list(),
+          queryKey: DocumentKeys.all(),
         });
       }
       return data.code;
@@ -555,7 +527,7 @@ export const useSaveDocumentName = () => {
       if (data.code === 0) {
         message.success(i18n.t('message.renamed'));
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.list(),
+          queryKey: DocumentKeys.all(),
         });
       }
       return data.code;
@@ -607,7 +579,7 @@ export const useSetDocumentParser = () => {
       );
       if (data.code === 0) {
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.list(),
+          queryKey: DocumentKeys.all(),
         });
 
         message.success(i18n.t('message.modified'));
@@ -672,7 +644,7 @@ export const useSetDocumentPipelineParser = () => {
       );
       if (data.code === 0) {
         queryClient.invalidateQueries({
-          queryKey: DocumentKeys.list(),
+          queryKey: DocumentKeys.all(),
         });
 
         message.success(i18n.t('message.modified'));
@@ -702,7 +674,7 @@ export const useSetDocumentMeta = () => {
 
         if (data?.code === 0) {
           queryClient.invalidateQueries({
-            queryKey: DocumentKeys.list(),
+            queryKey: DocumentKeys.all(),
           });
 
           message.success(i18n.t('message.modified'));
@@ -736,7 +708,7 @@ export const useCreateDocument = () => {
       if (data.code === 0) {
         if (page === 1) {
           queryClient.invalidateQueries({
-            queryKey: DocumentKeys.list(),
+            queryKey: DocumentKeys.all(),
           });
         } else {
           setPaginationParams(); // fetch document list


### PR DESCRIPTION
### What problem does this PR solve?

Fixes document query cache matching after the query key factory refactor. Prefix operations previously generated keys with trailing `undefined` values, causing `invalidateQueries` and optimistic `setQueriesData` updates to miss parameterized document list and filter queries.

This PR introduces explicit prefix keys and adds regression tests using TanStack Query’s actual partial matching behavior.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)