### PR TITLE
fix(web): hide verify button for OpenAI-API-Compatible provider

### DIFF
--- a/web/src/pages/user-setting/setting-model/instance-card/components/draft-mode-card.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/components/draft-mode-card.tsx
@@ -80,13 +80,15 @@ export function DraftModeCard({
         <AimlapiGetKeyButton onKey={handleAimlapiKey} />
       )}
 
-      <div className="pt-3">
-        <VerifyButton
-          onVerify={handleVerify}
-          isAbsolute={false}
-          formRef={formRef}
-        />
-      </div>
+      {providerName !== LLMFactory.OpenAiAPICompatible && (
+        <div className="pt-3">
+          <VerifyButton
+            onVerify={handleVerify}
+            isAbsolute={false}
+            formRef={formRef}
+          />
+        </div>
+      )}
 
       <div className="pt-3">
         <ModelsSection

--- a/web/src/pages/user-setting/setting-model/instance-card/components/saved-mode-card.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/components/saved-mode-card.tsx
@@ -23,6 +23,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
+import { LLMFactory } from '@/constants/llm';
 import { useTranslate } from '@/hooks/common-hooks';
 import { ListChevronsDownUp, ListChevronsUpDown, Trash2 } from 'lucide-react';
 import {
@@ -199,13 +200,15 @@ export function SavedModeCard({
             resetOptions={{ keepDirtyValues: true }}
           />
 
-          <div className="pt-3">
-            <VerifyButton
-              onVerify={handleVerify}
-              isAbsolute={false}
-              formRef={formRef}
-            />
-          </div>
+          {providerName !== LLMFactory.OpenAiAPICompatible && (
+            <div className="pt-3">
+              <VerifyButton
+                onVerify={handleVerify}
+                isAbsolute={false}
+                formRef={formRef}
+              />
+            </div>
+          )}
 
           {open && (
             <div className="pt-3">


### PR DESCRIPTION
### Summary

fix(web): hide verify button for OpenAI-API-Compatible provider

The OpenAI-API-Compatible provider has no provider-level credential to verify, so the verify action is meaningless there. Skip rendering the button in both draft and saved instance cards.
