### PR TITLE
fix: exclude compiled artifacts from chunk lists

### DIFF
--- a/internal/service/chunk/chunk.go
+++ b/internal/service/chunk/chunk.go
@@ -882,7 +882,8 @@ func (s *ChunkService) List(ctx context.Context, req *service.ListChunksRequest,
 			"available_int",
 		},
 		Filter: map[string]interface{}{
-			"doc_id": req.DocID,
+			"doc_id":   req.DocID,
+			"must_not": map[string]interface{}{"exists": "compile_kwd"},
 		},
 	}
 

--- a/internal/service/chunk/chunk_test.go
+++ b/internal/service/chunk/chunk_test.go
@@ -405,6 +405,10 @@ func TestListBuildsMatchTextExprForKeywords(t *testing.T) {
 	if got := engine.searchReq.Filter["doc_id"]; got != documentID {
 		t.Fatalf("doc_id filter = %#v, want %q", got, documentID)
 	}
+	mustNot, ok := engine.searchReq.Filter["must_not"].(map[string]interface{})
+	if !ok || mustNot["exists"] != "compile_kwd" {
+		t.Fatalf("must_not filter = %#v, want compile_kwd existence exclusion", engine.searchReq.Filter["must_not"])
+	}
 	if slices.Contains(engine.searchReq.SelectFields, "content") {
 		t.Fatalf("SelectFields = %#v, should not request content with content_with_weight", engine.searchReq.SelectFields)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

The Go document chunks API included Wiki pages, sections, and other compiled artifacts in ordinary chunk lists. This PR excludes chunks containing `compile_kwd`, aligning the Go behavior, pagination, and total count with the Python implementation.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)