### PR TITLE
docs: fix Docker installation link in Korean README

### DIFF
--- a/README_ko.md
+++ b/README_ko.md
@@ -138,7 +138,7 @@
 - [gVisor](https://gvisor.dev/docs/user_guide/install/): RAGFlow의 코드 실행기(샌드박스) 기능을 사용하려는 경우에만 필요합니다.
 
 > [!TIP]
-> 로컬 머신(Windows, Mac, Linux)에 Docker가 설치되지 않은 경우, [Docker 엔진 설치](<(https://docs.docker.com/engine/install/)>)를 참조하세요.
+> 로컬 머신(Windows, Mac, Linux)에 Docker가 설치되지 않은 경우, [Docker 엔진 설치](https://docs.docker.com/engine/install/)를 참조하세요.
 
 ### 🚀 서버 시작하기
 


### PR DESCRIPTION
### Summary

Fix the malformed Markdown destination in `README_ko.md` so the Korean setup instructions link to Docker's official Engine installation guide.

Validation:

- `git diff --check`
- Confirmed the malformed link is absent and the corrected link occurs once.
- Verified `https://docs.docker.com/engine/install/` returns HTTP 200.