### PR TITLE
fix(web): refetch agent logs when Reset does not change the query

### DIFF
--- a/web/src/pages/agents/agent-log-page.test.tsx
+++ b/web/src/pages/agents/agent-log-page.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AgentLogPage from './agent-log-page';
+
+const mockRefetch = jest.fn();
+const mockFetchAgentLog = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('react-router', () => ({
+  useParams: () => ({ id: 'agent-1' }),
+}));
+
+jest.mock('@/hooks/logic-hooks/navigate-hooks', () => ({
+  useNavigatePage: () => ({
+    navigateToAgents: jest.fn(),
+    navigateToAgent: () => jest.fn(),
+  }),
+}));
+
+jest.mock('../agent/hooks/use-fetch-data', () => ({
+  useFetchDataOnMount: () => ({
+    flowDetail: { title: 'Agent' },
+  }),
+}));
+
+jest.mock('@/hooks/use-agent-request', () => ({
+  useFetchAgentLog: (searchParams: unknown) => {
+    mockFetchAgentLog(searchParams);
+    return {
+      data: { sessions: [], total: 0 },
+      loading: false,
+      refetch: mockRefetch,
+    };
+  },
+}));
+
+jest.mock('./hooks/use-export-agent-log', () => ({
+  useExportAgentLogToCSV: () => ({
+    handleExport: jest.fn(),
+    loading: false,
+  }),
+}));
+
+jest.mock('@/components/page-header', () => ({
+  PageHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock('@/components/ui/breadcrumb', () => ({
+  Breadcrumb: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BreadcrumbItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BreadcrumbLink: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  BreadcrumbList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BreadcrumbPage: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  BreadcrumbSeparator: () => null,
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    loading: _loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean }) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/ui/input', () => ({
+  SearchInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}));
+
+jest.mock('@/components/ui/ragflow-pagination', () => ({
+  RAGFlowPagination: ({
+    current,
+    pageSize,
+    onChange,
+  }: {
+    current: number;
+    pageSize: number;
+    onChange: (page: number, pageSize: number) => void;
+  }) => (
+    <div>
+      <span data-testid="pagination-state">{`${current}:${pageSize}`}</span>
+      <button type="button" onClick={() => onChange(1, 25)}>
+        change page size
+      </button>
+      <button type="button" onClick={() => onChange(3, 25)}>
+        change page
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/ui/range-picker', () => ({
+  DatePickerWithRange: () => null,
+}));
+
+jest.mock('@/components/ui/spin', () => ({
+  Spin: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../../components/ui/table', () => ({
+  Table: ({ children }: { children: React.ReactNode }) => (
+    <table>{children}</table>
+  ),
+  TableBody: ({ children }: { children: React.ReactNode }) => (
+    <tbody>{children}</tbody>
+  ),
+  TableCell: ({
+    children,
+    ...props
+  }: React.TdHTMLAttributes<HTMLTableCellElement>) => (
+    <td {...props}>{children}</td>
+  ),
+  TableHead: ({
+    children,
+    ...props
+  }: React.ThHTMLAttributes<HTMLTableCellElement>) => (
+    <th {...props}>{children}</th>
+  ),
+  TableHeader: ({ children }: { children: React.ReactNode }) => (
+    <thead>{children}</thead>
+  ),
+  TableRow: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLTableRowElement>) => (
+    <tr {...props}>{children}</tr>
+  ),
+}));
+
+jest.mock('./agent-log-detail-modal', () => ({
+  AgentLogDetailModal: () => null,
+}));
+
+describe('AgentLogPage reset', () => {
+  beforeEach(() => {
+    mockRefetch.mockClear();
+    mockFetchAgentLog.mockClear();
+  });
+
+  it('refetches logs when Reset is clicked with the default query already active', () => {
+    render(<AgentLogPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.reset' }));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns to page 1 on Reset without dropping the current page size', async () => {
+    render(<AgentLogPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'change page size' }));
+    fireEvent.click(screen.getByRole('button', { name: 'change page' }));
+
+    expect(screen.getByTestId('pagination-state').textContent).toBe('3:25');
+
+    mockFetchAgentLog.mockClear();
+    mockRefetch.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'common.reset' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pagination-state').textContent).toBe('1:25');
+      expect(mockFetchAgentLog).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page: 1,
+          page_size: 25,
+          orderby: 'create_time',
+          desc: false,
+          keywords: '',
+        }),
+      );
+    });
+    expect(mockRefetch).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/agents/agent-log-page.tsx
+++ b/web/src/pages/agents/agent-log-page.tsx
@@ -220,9 +220,27 @@ const AgentLogPage: React.FC = () => {
   };
 
   const handleReset = () => {
-    setSearchParams({ ...init, page_size: pagination.pageSize });
+    const resetParams = { ...init, page_size: pagination.pageSize };
+    const alreadyReset =
+      searchParams.keywords === resetParams.keywords &&
+      searchParams.from_date?.valueOf() === resetParams.from_date.valueOf() &&
+      searchParams.to_date?.valueOf() === resetParams.to_date.valueOf() &&
+      searchParams.orderby === resetParams.orderby &&
+      searchParams.desc === resetParams.desc &&
+      searchParams.page === resetParams.page &&
+      searchParams.page_size === resetParams.page_size;
+
     setKeywords(init.keywords);
     setCurrentDate({ from: init.from_date, to: init.to_date });
+    setSortConfig({ orderby: init.orderby, desc: Boolean(init.desc) });
+    setPagination((previous) => ({
+      ...previous,
+      current: init.page,
+    }));
+    setSearchParams(resetParams);
+    if (alreadyReset) {
+      refetch();
+    }
   };
 
   const [openModal, setOpenModal] = useState(false);


### PR DESCRIPTION
### Summary

Fixes #17050.

PR #18087 already restores the default query on Reset while preserving page_size. When that target already matches the active query, React Query keeps the same key and sends no request, so the Reset button looks dead (no network, no UI change).

This follows the Search button's same-params path: call refetch() when the query is unchanged. If the query does change, Reset still returns to page 1 and default sort without dropping the current page size.

### Verification

- npx jest src/pages/agents/agent-log-page.test.tsx --no-coverage
  - Reset on the default query calls refetch()
  - Reset from page 3 / size 25 returns to page 1 and keeps size 25