### PR TITLE
fix(rag): flatten include_parsing_status counts onto the dataset entry

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -477,7 +477,16 @@ def list_datasets(tenant_id: str, args: dict):
         user_dict = user_map.get(kb["tenant_id"], {})
         kb.update({"nickname": user_dict.get("nickname", ""), "tenant_avatar": user_dict.get("avatar", "")})
         if status_by_kb:
-            kb["parsing_status"] = status_by_kb.get(kb["id"], {})
+            # Spread the per-status counts onto the dataset entry so
+            # callers see them at the same nesting level as `name`,
+            # `parser_id`, `document_count` etc. (matches the documented
+            # `include_parsing_status` response contract). Previously this
+            # was nested under a synthetic `parsing_status` key — the
+            # extra wrapping meant the documented top-level fields
+            # (`unstart_count`, `running_count`, `cancel_count`,
+            # `done_count`, `fail_count`) never appeared on the wire.
+            # Regression for #17595.
+            kb.update(status_by_kb.get(kb["id"], {}))
         response_data_list.append(remap_dictionary_keys(kb))
 
     embed_model_names = get_composite_model_name_by_ids([m["embedding_model"] for m in response_data_list])

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -478,14 +478,12 @@ def list_datasets(tenant_id: str, args: dict):
         kb.update({"nickname": user_dict.get("nickname", ""), "tenant_avatar": user_dict.get("avatar", "")})
         if status_by_kb:
             # Spread the per-status counts onto the dataset entry so
-            # callers see them at the same nesting level as `name`,
-            # `parser_id`, `document_count` etc. (matches the documented
-            # `include_parsing_status` response contract). Previously this
-            # was nested under a synthetic `parsing_status` key — the
-            # extra wrapping meant the documented top-level fields
+            # they appear at the same nesting level as `name`,
+            # `parser_id`, `document_count`, etc. The counts
             # (`unstart_count`, `running_count`, `cancel_count`,
-            # `done_count`, `fail_count`) never appeared on the wire.
-            # Regression for #17595.
+            # `done_count`, `fail_count`) are top-level fields on the
+            # dataset entry rather than nested under a synthetic
+            # `parsing_status` key.
             kb.update(status_by_kb.get(kb["id"], {}))
         response_data_list.append(remap_dictionary_keys(kb))
 

--- a/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
+++ b/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
@@ -260,6 +260,7 @@ def test_list_datasets_with_include_parsing_status_true_attaches_counts(monkeypa
     assert by_id["kb-a"]["unstart_count"] == 3
     assert by_id["kb-a"]["running_count"] == 1
     assert by_id["kb-a"]["done_count"] == 7
+    assert by_id["kb-a"]["fail_count"] == 2
     assert by_id["kb-b"]["cancel_count"] == 1
     assert by_id["kb-b"]["done_count"] == 4
 

--- a/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
+++ b/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
@@ -250,10 +250,18 @@ def test_list_datasets_with_include_parsing_status_true_attaches_counts(monkeypa
 
     assert ok is True
     parsing_status_mock.assert_called_once_with(["kb-a", "kb-b"])
-    assert "parsing_status" in payload["data"][0]
+    # The fix for #17595 spreads the counts onto the dataset entry
+    # directly (matches the documented `include_parsing_status` response
+    # contract) instead of nesting them under a synthetic `parsing_status`
+    # key. Each count lives at the same nesting level as `name`,
+    # `parser_id`, `document_count` etc.
+    assert "parsing_status" not in payload["data"][0]
     by_id = {r["id"]: r for r in payload["data"]}
-    assert by_id["kb-a"]["parsing_status"] == status_by_kb["kb-a"]
-    assert by_id["kb-b"]["parsing_status"] == status_by_kb["kb-b"]
+    assert by_id["kb-a"]["unstart_count"] == 3
+    assert by_id["kb-a"]["running_count"] == 1
+    assert by_id["kb-a"]["done_count"] == 7
+    assert by_id["kb-b"]["cancel_count"] == 1
+    assert by_id["kb-b"]["done_count"] == 4
 
 
 def test_list_datasets_with_include_parsing_status_string_true(monkeypatch):


### PR DESCRIPTION
Fixes #17595

api/apps/services/dataset_api_service.py:list_datasets nested the per-status counts returned by DocumentService.get_parsing_status_by_kb_ids under a synthetic parsing_status key on the dataset entry. The documented response contract puts those counts at the same level as name, parser_id, document_count, etc., so callers reading the docs see a field that doesn't actually exist on the wire and the fields they expect never arrive.

Switch to a plain kb.update(status_by_kb.get(kb.id, {})) so the counts surface directly on the dataset entry (unstart_count, running_count, cancel_count, done_count, fail_count).

Update test_list_datasets_with_include_parsing_status_true_attaches_counts:
- previous assertion by_id['kb-a']['parsing_status'] == status_by_kb['kb-a'] no longer holds (parsing_status key is gone). Replace with assertions on the individual top-level count fields. The other existing tests that assert 'parsing_status' not in record keep passing (no parsing_status key is set when the flag is off, and none is set when the helper returned an empty dict).