### PR TITLE
fix(agent): close MCP sessions wrapped in MCPToolBinding

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -168,17 +168,20 @@ class Graph:
             logging.exception(e)
 
     def close(self):
-        from common.mcp_tool_call_conn import MCPToolCallSession
+        from common.mcp_tool_call_conn import MCPToolBinding, MCPToolCallSession
 
         seen = set()
         for cpn in self.components.values():
             obj = cpn.get("obj")
             if obj and hasattr(obj, "tools"):
                 for tool in obj.tools.values():
-                    if isinstance(tool, MCPToolCallSession) and id(tool) not in seen:
-                        seen.add(id(tool))
+                    session = tool if isinstance(tool, MCPToolCallSession) else (
+                        tool.session if isinstance(tool, MCPToolBinding) else None
+                    )
+                    if isinstance(session, MCPToolCallSession) and id(session) not in seen:
+                        seen.add(id(session))
                         try:
-                            tool.close_sync(timeout=3)
+                            session.close_sync(timeout=3)
                         except Exception:
                             pass
 

--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -183,7 +183,7 @@ class Graph:
                         try:
                             session.close_sync(timeout=3)
                         except Exception:
-                            pass
+                            logging.exception("Error closing MCP session for server %s", session._mcp_server.id)
 
     @staticmethod
     def _get_component_name(dsl, cid):


### PR DESCRIPTION
## What problem does this PR solve?

`Graph.close()` was added in #13295 to fix #12962, but it only checks `isinstance(tool, MCPToolCallSession)`. Since #14217, MCP sessions are stored wrapped in the `MCPToolBinding` dataclass (`self.tools[indexed_name] = MCPToolBinding(tool_call_session, tnm)`), so the check always returns `False` and `close_sync()` is never invoked.

Each `MCPToolCallSession` spawns its own event-loop thread (`ThreadPoolExecutor(max_workers=1)` + `run_forever`). Sessions created for every agent run with MCP tools are therefore never closed, so threads and connections accumulate over time — after several hours the container exhausts its resources (thousands of PIDs) and hangs.

## Solution

In `Graph.close()`, unwrap `MCPToolBinding` and close the inner session:

```python
session = tool if isinstance(tool, MCPToolCallSession) else (
    tool.session if isinstance(tool, MCPToolBinding) else None
)
if isinstance(session, MCPToolCallSession) and id(session) not in seen:
    seen.add(id(session))
    session.close_sync(timeout=3)
```

Only `agent/canvas.py` is changed.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)