### PR TITLE
fix: update ZHIPU-AI API key URL to the new BigModel console

### DIFF
--- a/web/src/constants/llm.ts
+++ b/web/src/constants/llm.ts
@@ -227,7 +227,7 @@ export const APIMapUrl = {
   [LLMFactory.Moonshot]: 'https://platform.moonshot.cn/console/api-keys',
   [LLMFactory.TongYiQianWen]:
     'https://bailian.console.aliyun.com/?tab=model#/api-key',
-  [LLMFactory.ZhipuAI]: 'https://open.bigmodel.cn/usercenter/apikeys',
+  [LLMFactory.ZhipuAI]: 'https://bigmodel.cn/usercenter/proj-mgmt/apikeys',
   [LLMFactory.XAI]: 'https://x.ai/api/',
   [LLMFactory.HuggingFace]: 'https://huggingface.co/settings/tokens',
   [LLMFactory.Mistral]: 'https://console.mistral.ai/api-keys/',


### PR DESCRIPTION
### Summary

In **User Settings → Model providers**, the ZHIPU-AI entry links to the legacy API-key page `https://open.bigmodel.cn/usercenter/apikeys`. Zhipu has migrated its console: that route now renders the BigModel **404 page** (`open.bigmodel.cn/404`) for signed-in users instead of the API keys page (anonymous visitors only get bounced to the login page, which masks the breakage).

Zhipu official documentation now links the API key console at `https://bigmodel.cn/usercenter/proj-mgmt/apikeys` (verified as a valid route — it redirects anonymous users to login with `redirect=/apikey/platform`).

This PR updates `APIMapUrl[LLMFactory.ZhipuAI]` in `web/src/constants/llm.ts` to the new canonical URL, so clicking the ZHIPU-AI link from the model-provider settings lands on the real API keys console instead of a 404.

Verification: opened the link from the local model-providers page before (old URL) and after (new URL) the change; `oxlint` clean; unrelated pre-existing type-check errors untouched.
