### PR TITLE
fix(web): surface the validation error when a metadata value save is blocked

### DIFF
--- a/web/src/pages/dataset/components/metedata/hooks/use-manage-values-modal.ts
+++ b/web/src/pages/dataset/components/metedata/hooks/use-manage-values-modal.ts
@@ -6,6 +6,7 @@ import {
   metadataValueTypeEnum,
 } from '../constant';
 import { IManageValuesProps, IMetaDataTableData } from '../interface';
+import message from '@/components/ui/message';
 
 export const useManageValues = (props: IManageValuesProps) => {
   const {
@@ -115,6 +116,7 @@ export const useManageValues = (props: IManageValuesProps) => {
 
   const handleSave = useCallback(() => {
     if (type === MetadataType.Setting && valueError.field) {
+      message.error(valueError.field);
       return;
     }
     if (isAddValueMode) {


### PR DESCRIPTION
### Summary

fix(web): surface the validation error when a metadata value save is blocked

Confirming with an invalid field returned silently, so the modal stayed open with no explanation. Show the existing field error as a toast.
