### PR TITLE
docs(harness): fix package documentation link

### DIFF
--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -51,7 +51,7 @@
 //	})
 //
 // For more examples and documentation, visit:
-// https://ragflow/internal/harness
+// https://github.com/infiniflow/ragflow/tree/main/internal/harness
 package harness
 
 import (


### PR DESCRIPTION
### What

Replace the invalid Harness package documentation URL with the current GitHub directory.

### Why

The existing `https://ragflow/internal/harness` hostname cannot be resolved, so readers cannot reach the Harness documentation from the package docs.

### Validation

- Confirmed `internal/harness` exists through the GitHub Contents API
- `git diff --check`