### PR TITLE
fix: clear existing volume before restore

### DIFF
--- a/docker/migration.sh
+++ b/docker/migration.sh
@@ -274,7 +274,10 @@ perform_restore() {
             echo "  📋 Creating Docker volume: $volume"
             docker volume create "$volume"
         else
-            echo "  📋 Using existing Docker volume: $volume"
+            echo "  📋 Clearing existing Docker volume: $volume"
+            docker run --rm \
+                -v "$volume":/target \
+                alpine sh -c "find /target -mindepth 1 -delete"
         fi
 
         # Restore data


### PR DESCRIPTION
## What does this PR do?

Clear the contents of an existing Docker volume before restoring backup data.

Currently, `migration.sh restore` extracts the backup archive directly into an existing volume. `tar xzf` overwrites files that exist in the archive, but it does not remove files that exist only in the target volume.

As a result, restoring into an existing volume performs a merge instead of an exact restore.

This can cause problems for stateful services such as MySQL. In my case, stale InnoDB redo log files remained after restore and caused MySQL to fail during startup with errors such as:

```text
[ERROR] [InnoDB] Missing redo log file
[ERROR] [InnoDB] Plugin initialization aborted with error Generic error
[ERROR] Failed to initialize DD Storage Engine
[ERROR] Data Dictionary initialization failed
[ERROR] Aborting