### PR TITLE
docs(harness): fix AgentCore import aliases in examples

### DIFF
--- a/internal/harness/README.md
+++ b/internal/harness/README.md
@@ -87,7 +87,7 @@ package main
 
 import (
     "context"
-    "ragflow/internal/harness/core"
+    agentcore "ragflow/internal/harness/core"
     "ragflow/internal/harness/core/schema"
 )
 
@@ -1068,7 +1068,7 @@ builder.AddNodeWithOptions("risky_node", nodeFunc, harness.NodeOptions{
 
 ```go
 import (
-    "ragflow/internal/harness/core"
+    agentcore "ragflow/internal/harness/core"
     "ragflow/internal/harness/core/middlewares/filesystem"
     "ragflow/internal/harness/core/middlewares/summarization"
     "ragflow/internal/harness/core/middlewares/subagent"


### PR DESCRIPTION
### Summary

Fix two Harness README examples by aliasing `ragflow/internal/harness/core` as `agentcore`.

Both examples call `agentcore.*`, while Go derives the imported package name as `core`. The current snippets therefore produce `undefined: agentcore` and an unused import.

Validation:

- Confirmed both affected blocks now have the explicit alias
- Confirmed no unaliased imports remain
- `git diff --check`