### PR TITLE
Fix pdf cancel at task level not document level, multiple record logs

### DIFF
--- a/api/db/services/pipeline_operation_log_service.py
+++ b/api/db/services/pipeline_operation_log_service.py
@@ -234,14 +234,36 @@ class PipelineOperationLogService(CommonService):
         log["update_time"] = timestamp
         log["update_date"] = datetime_now
         with DB.atomic():
-            Document.select(Document.id).where(Document.id == document.id).for_update().first()
-            if document_id != GRAPH_RAPTOR_FAKE_DOC_ID and process_begin_at is not None:
+            operation_status_value = operation_status.value if isinstance(operation_status, TaskStatus) else str(operation_status)
+            if document_id != GRAPH_RAPTOR_FAKE_DOC_ID and operation_status_value == TaskStatus.CANCEL.value:
+                # Serialize page-task finalizers for the same canceled document.
+                locked_document = Document.select(Document.id, Document.run, Document.update_time).where(Document.id == document.id).for_update().first()
+                if locked_document is None or locked_document.run != TaskStatus.CANCEL.value:
+                    return None
+                cancel_update_time = locked_document.update_time or timestamp
+                if locked_document.update_time is None:
+                    Document.update(update_time=cancel_update_time, update_date=datetime_now).where(Document.id == locked_document.id).execute()
+                pipeline_filter = cls.model.pipeline_id == pipeline_id if pipeline_id else (cls.model.pipeline_id.is_null(True) | (cls.model.pipeline_id == ""))
                 existing = (
                     cls.model.select()
-                    .where((cls.model.document_id == document_id) & (cls.model.pipeline_id == pipeline_id) & (cls.model.task_type == task_type) & (cls.model.process_begin_at == process_begin_at))
+                    .where(
+                        (cls.model.document_id == document_id)
+                        & pipeline_filter
+                        & (cls.model.task_type == task_type)
+                        & (cls.model.operation_status == TaskStatus.CANCEL.value)
+                        & (cls.model.create_time >= cancel_update_time)
+                    )
                     .first()
                 )
                 if existing:
+                    logging.debug(
+                        "Skip duplicate pipeline operation log document_id=%s pipeline_id=%s task_type=%s process_begin_at=%s existing_id=%s",
+                        document_id,
+                        pipeline_id,
+                        task_type,
+                        process_begin_at,
+                        existing.id,
+                    )
                     return existing
 
             obj = cls.save(**log)

--- a/api/db/services/pipeline_operation_log_service.py
+++ b/api/db/services/pipeline_operation_log_service.py
@@ -234,6 +234,16 @@ class PipelineOperationLogService(CommonService):
         log["update_time"] = timestamp
         log["update_date"] = datetime_now
         with DB.atomic():
+            Document.select(Document.id).where(Document.id == document.id).for_update().first()
+            if document_id != GRAPH_RAPTOR_FAKE_DOC_ID and process_begin_at is not None:
+                existing = (
+                    cls.model.select()
+                    .where((cls.model.document_id == document_id) & (cls.model.pipeline_id == pipeline_id) & (cls.model.task_type == task_type) & (cls.model.process_begin_at == process_begin_at))
+                    .first()
+                )
+                if existing:
+                    return existing
+
             obj = cls.save(**log)
 
             limit = int(os.getenv("PIPELINE_OPERATION_LOG_LIMIT", 1000))


### PR DESCRIPTION
Cause:
- PDFs are split into page-range tasks, normally 12 pages each.
- Cancellation immediately marks the document final.
- Each remaining page task then created its own pipeline_operation_log.
- Thus a PDF split into five tasks could produce five cancellation records.

Fix:
- Log creation is now idempotent for the same document ingestion run.
- A document-row lock prevents concurrent task finalizers from inserting duplicates.