### PR TITLE
fix: preserve empty chat fields on GaussDB

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -1442,8 +1442,8 @@ class Dialog(DataBaseModel):
     id = CharField(max_length=32, primary_key=True)
     tenant_id = CharField(max_length=32, null=False, index=True)
     name = CharField(max_length=255, null=True, help_text="dialog application name", index=True)
-    description = TextField(null=True, help_text="Dialog description")
-    icon = TextField(null=True, help_text="icon base64 string")
+    description = EmptyStringTextField(null=True, help_text="Dialog description")
+    icon = EmptyStringTextField(null=True, help_text="icon base64 string")
     language = CharField(max_length=32, null=True, default="Chinese" if "zh_CN" in os.getenv("LANG", "") else "English", help_text="English|Chinese", index=True)
     # Map application-level empty chat/reranker model IDs to storage NULL in the
     # field instead of handling None throughout the business code.

--- a/test/unit_test/api/db/test_gaussdb_user_flow.py
+++ b/test/unit_test/api/db/test_gaussdb_user_flow.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[4]
 HELPER_DIR = Path(__file__).resolve().parent
 
@@ -37,6 +36,7 @@ stub_settings_import_dependencies()
         text=True,
         capture_output=True,
         timeout=timeout,
+        check=False,
     )
     assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     return result
@@ -75,6 +75,8 @@ print("gaussdb-adapter-ok")
 
 
 def test_gaussdb_empty_string_compatible_fields_are_nullable_only_for_gaussdb():
+    """Verify empty-string field behavior across supported metadata databases."""
+
     gaussdb_result = run_isolated_flow(
         """
 from api.db.db_models import API4Conversation, Dialog, File, Knowledgebase, Memory, SyncLogs, SystemSettings, Task, Tenant, User, UserCanvas
@@ -88,6 +90,8 @@ fields = [
     Tenant.rerank_id,
     File.source_type,
     Knowledgebase.embd_id,
+    Dialog.description,
+    Dialog.icon,
     Dialog.llm_id,
     Dialog.rerank_id,
     Memory.embd_id,
@@ -146,6 +150,8 @@ fields = [
     (Tenant.rerank_id, False),
     (File.source_type, False),
     (Knowledgebase.embd_id, False),
+    (Dialog.description, True),
+    (Dialog.icon, True),
     (Dialog.llm_id, False),
     (Dialog.rerank_id, False),
     (Memory.embd_id, False),
@@ -163,6 +169,9 @@ for field, expected_null in fields:
     assert field.null is expected_null
     assert field.db_value("") == ""
 
+for field in (Dialog.description, Dialog.icon):
+    assert field.python_value(None) is None
+
 assert Task.chunk_ids.field_type == "LONGTEXT"
 sql, params = File.select().where(File.source_type == "").sql()
 assert "IS NULL" not in sql
@@ -175,6 +184,38 @@ print("mysql-nullability-ok")
         },
     )
     assert "mysql-nullability-ok" in mysql_result.stdout
+
+    postgres_result = run_isolated_flow(
+        """
+from common import config_utils
+
+config_utils.CONFIGS["postgres"] = {
+    "name": "rag_flow",
+    "user": "rag_flow",
+    "password": "test-password",
+    "host": "postgres.local",
+    "port": 5432,
+    "max_connections": 1,
+    "stale_timeout": 30,
+}
+from api.db.db_models import Dialog
+
+for field in (Dialog.description, Dialog.icon):
+    assert field.null is True
+    assert field.db_value("") == ""
+    assert field.python_value(None) is None
+
+sql, params = Dialog.select().where(Dialog.icon == "").sql()
+assert "IS NULL" not in sql
+assert "LENGTH" not in sql
+assert params == [""]
+print("postgres-empty-string-behavior-ok")
+""",
+        {
+            "DB_TYPE": "postgres",
+        },
+    )
+    assert "postgres-empty-string-behavior-ok" in postgres_result.stdout
 
 
 def test_live_gaussdb_init_lock_and_user_crud_flow():


### PR DESCRIPTION
### Summary

On A/ORA-compatible GaussDB, empty strings are stored as `NULL`. A newly created Chat leaves `Dialog.icon` and `Dialog.description` empty, so reading the record returned `null`. Chat settings then rejected both optional fields with `Expected string, received null`.

This PR changes those two fields to the existing `EmptyStringTextField`. GaussDB may keep storing `NULL`, while the ORM/API restores the application-level empty string expected by the frontend.

### Compatibility

MySQL and PostgreSQL behavior is unchanged: outside compatible GaussDB, `EmptyStringTextField` retains normal Peewee `TextField` conversion and the existing nullable schema. No database migration is required because both columns are already nullable.

### Tests

- Added focused coverage for GaussDB, MySQL, and PostgreSQL empty-string/null conversion.
- Verified against a live GaussDB deployment: raw `(NULL, NULL)` values are returned by the ORM as `("", "")`.
- Targeted test passed: `test_gaussdb_empty_string_compatible_fields_are_nullable_only_for_gaussdb`.

### Symptom

<img width="622" height="263" alt="Chat settings validation error" src="https://github.com/user-attachments/assets/5420f0d0-8fc8-43b2-bd3e-1ca91021299b" />
