### PR TITLE
fix(deepdoc): score table orientation by per-line detect+recognize

### DIFF
--- a/internal/deepdoc/parser/pdf/table/table_orient.go
+++ b/internal/deepdoc/parser/pdf/table/table_orient.go
@@ -11,6 +11,17 @@ import (
 	"ragflow/internal/deepdoc/parser/pdf/util"
 )
 
+// ocrBoxToPts converts a detected OCR quad (8 coords, DBNet corner order
+// TL,TR,BR,BL) into the [4]util.Pt corner order util.WarpCrop expects.
+func ocrBoxToPts(b pdf.OCRBox) [4]util.Pt {
+	return [4]util.Pt{
+		{X: b.X0, Y: b.Y0}, // top-left
+		{X: b.X1, Y: b.Y1}, // top-right
+		{X: b.X2, Y: b.Y2}, // bottom-right
+		{X: b.X3, Y: b.Y3}, // bottom-left
+	}
+}
+
 // EvaluateTableOrientation tests 4 rotation angles (0/90/180/270) and picks
 // the best orientation based on OCR recognition confidence, matching Python's
 // pdf_parser.py:367 _evaluate_table_orientation().
@@ -55,18 +66,47 @@ func EvaluateTableOrientation(ctx context.Context, tableImg image.Image, doc pdf
 
 		// Score by recognition confidence (legibility), matching Python's
 		// _evaluate_table_orientation: avg_conf * (1 + 0.1*min(regions,50)/50).
-		texts, err := doc.OCRRecognize(ctx, rotated)
-		if err != nil || len(texts) == 0 {
+		//
+		// Python's OCR.__call__ runs DETECTION first and then recognizes each
+		// detected text line, so regions = number of lines and avg_conf is the
+		// mean over lines. We must mirror that: call OCRDetect to find the
+		// table's text lines, warp-crop each line, and recognize it
+		// individually. Sending the whole table image to a single rec call
+		// (as the previous implementation did) treats the entire table as one
+		// line, collapsing regions to 1 and yielding a degenerate score.
+		boxes, derr := doc.OCRDetect(ctx, rotated)
+		if derr != nil || len(boxes) == 0 {
 			scores[rot.angle] = 0
 			continue
 		}
 
 		var confSum float64
-		for _, t := range texts {
-			confSum += t.Confidence
+		regions := 0
+		for _, box := range boxes {
+			line := util.WarpCrop(rotated, ocrBoxToPts(box))
+			texts, rerr := doc.OCRRecognize(ctx, line)
+			if rerr != nil || len(texts) == 0 {
+				continue
+			}
+			// Average the line's recognized texts first, then count the line
+			// as one region. This keeps regions == number of detected lines
+			// (matching Python's len(texts) in the normal one-text-per-line
+			// case) and avoids inflating the bonus term if a single warped
+			// line is recognized as multiple text fragments.
+			var lineConf float64
+			for _, t := range texts {
+				lineConf += t.Confidence
+			}
+			lineConf /= float64(len(texts))
+			confSum += lineConf
+			regions++
 		}
-		avgConf := confSum / float64(len(texts))
-		regions := len(texts)
+		if regions == 0 {
+			scores[rot.angle] = 0
+			continue
+		}
+
+		avgConf := confSum / float64(regions)
 		combined := avgConf * (1 + 0.1*math.Min(float64(regions), 50)/50)
 		scores[rot.angle] = combined
 

--- a/internal/deepdoc/parser/pdf/table/table_orient_ocr_mode_test.go
+++ b/internal/deepdoc/parser/pdf/table/table_orient_ocr_mode_test.go
@@ -1,0 +1,200 @@
+package table
+
+import (
+	"context"
+	"image"
+	"math"
+	"testing"
+
+	pdf "ragflow/internal/deepdoc/parser/pdf/type"
+)
+
+// =============================================================================
+// TDD regression lock for the orientation OCR call mode.
+//
+// The bug: EvaluateTableOrientation previously sent the WHOLE table image to a
+// single OCRRecognize(rec) call, treating the entire table as one text line.
+// That collapses `regions` to 1 and yields a degenerate score, unlike Python's
+// _evaluate_table_orientation which runs detection first and recognizes each
+// text line separately.
+//
+// These tests pin the corrected behavior:
+//   1. OCRDetect is called once per candidate angle.
+//   2. OCRRecognize is called once PER DETECTED LINE (not once per whole image).
+//   3. The score aggregates the per-line mean confidence with regions = line count.
+//   4. No whole-image rec fallback — empty detection scores 0 (matches Python).
+// =============================================================================
+
+// callCountDoc counts OCRDetect / OCRRecognize invocations and records the
+// number of detected lines per angle. OCRRecognize returns one text per call,
+// so recCalls == total detected lines — the literal opposite of the old
+// one-call-per-angle behavior.
+type callCountDoc struct {
+	angles map[int]struct {
+		regions int
+		avgConf float64
+		err     error
+	}
+	detectSeq    int
+	currentAngle int
+	detectCalls  int
+	recCalls     int
+}
+
+func (m *callCountDoc) DLA(_ context.Context, _ image.Image) ([]pdf.DLARegion, error) {
+	return nil, nil
+}
+func (m *callCountDoc) TSR(_ context.Context, _ image.Image) ([]pdf.TSRCell, error) {
+	return nil, nil
+}
+func (m *callCountDoc) OCR(_ image.Image) (string, error) { return "", nil }
+func (m *callCountDoc) Health() bool                      { return true }
+
+func (m *callCountDoc) OCRDetect(_ context.Context, _ image.Image) ([]pdf.OCRBox, error) {
+	angle := rotationOrder[m.detectSeq%len(rotationOrder)]
+	m.detectSeq++
+	m.currentAngle = angle
+	m.detectCalls++
+	cfg, ok := m.angles[angle]
+	if !ok {
+		cfg = m.angles[0]
+	}
+	if cfg.err != nil {
+		return nil, cfg.err
+	}
+	boxes := make([]pdf.OCRBox, cfg.regions)
+	for i := 0; i < cfg.regions; i++ {
+		y := float64(i * 10)
+		boxes[i] = pdf.OCRBox{X0: 0, Y0: y, X1: 100, Y1: y, X2: 100, Y2: y + 8, X3: 0, Y3: y + 8}
+	}
+	return boxes, nil
+}
+
+func (m *callCountDoc) OCRRecognize(_ context.Context, _ image.Image) ([]pdf.OCRText, error) {
+	m.recCalls++
+	cfg, ok := m.angles[m.currentAngle]
+	if !ok {
+		cfg = m.angles[0]
+	}
+	if cfg.err != nil {
+		return nil, cfg.err
+	}
+	return []pdf.OCRText{{Text: "line", Confidence: cfg.avgConf}}, nil
+}
+
+// TestEvaluateTableOrientation_DetectThenPerLineRecognize pins the core fix:
+// detection runs once per angle and recognition runs once per detected line —
+// NOT one whole-image rec call per angle.
+func TestEvaluateTableOrientation_DetectThenPerLineRecognize(t *testing.T) {
+	doc := &callCountDoc{
+		angles: map[int]struct {
+			regions int
+			avgConf float64
+			err     error
+		}{
+			0:   {regions: 5, avgConf: 0.2},
+			90:  {regions: 7, avgConf: 0.2},
+			180: {regions: 3, avgConf: 0.2},
+			270: {regions: 9, avgConf: 0.95},
+		},
+	}
+	angle, _, scores := EvaluateTableOrientation(context.Background(), makeTestTableImage(), doc)
+
+	if doc.detectCalls != 4 {
+		t.Errorf("expected OCRDetect called once per candidate angle (4), got %d", doc.detectCalls)
+	}
+	// 5 + 7 + 3 + 9 = 24 per-line recognition calls; the buggy path made 4.
+	if doc.recCalls != 24 {
+		t.Errorf("expected one OCRRecognize per detected line (24), got %d — whole-image rec path not fixed", doc.recCalls)
+	}
+	// Equal per-line confidence but 270° has the most lines, so its bonus term
+	// (1 + 0.1*min(regions,50)/50) is largest → it must win.
+	if angle != 270 {
+		t.Errorf("expected 270° (most legible lines at equal conf), got %d° (scores: %v)", angle, scores)
+	}
+}
+
+// perLineDoc returns a distinct recognition confidence per detected line,
+// cycling through the configured per-angle list. This lets a test assert that
+// the orientation score is the MEAN over lines with regions = line count.
+type perLineDoc struct {
+	lines        map[int][]float64
+	detectSeq    int
+	currentAngle int
+	recIdx       map[int]int
+}
+
+func (m *perLineDoc) DLA(_ context.Context, _ image.Image) ([]pdf.DLARegion, error) {
+	return nil, nil
+}
+func (m *perLineDoc) TSR(_ context.Context, _ image.Image) ([]pdf.TSRCell, error) {
+	return nil, nil
+}
+func (m *perLineDoc) OCR(_ image.Image) (string, error) { return "", nil }
+func (m *perLineDoc) Health() bool                      { return true }
+
+func (m *perLineDoc) OCRDetect(_ context.Context, _ image.Image) ([]pdf.OCRBox, error) {
+	angle := rotationOrder[m.detectSeq%len(rotationOrder)]
+	m.detectSeq++
+	m.currentAngle = angle
+	n := len(m.lines[angle])
+	boxes := make([]pdf.OCRBox, n)
+	for i := 0; i < n; i++ {
+		y := float64(i * 10)
+		boxes[i] = pdf.OCRBox{X0: 0, Y0: y, X1: 100, Y1: y, X2: 100, Y2: y + 8, X3: 0, Y3: y + 8}
+	}
+	return boxes, nil
+}
+
+func (m *perLineDoc) OCRRecognize(_ context.Context, _ image.Image) ([]pdf.OCRText, error) {
+	confs := m.lines[m.currentAngle]
+	idx := m.recIdx[m.currentAngle]
+	m.recIdx[m.currentAngle]++
+	c := confs[idx%len(confs)]
+	return []pdf.OCRText{{Text: "line", Confidence: c}}, nil
+}
+
+// TestEvaluateTableOrientation_AggregatesPerLineConfidence proves the score is
+// the mean of per-line confidences with regions = number of lines, and that a
+// mixed-legibility table at 0° loses to a fully-legible one at 180°.
+func TestEvaluateTableOrientation_AggregatesPerLineConfidence(t *testing.T) {
+	doc := &perLineDoc{
+		lines: map[int][]float64{
+			0:   {0.2, 1.0}, // avg 0.6, regions 2 → 0.6 * (1 + 0.1*2/50)
+			90:  {0.1, 0.1},
+			180: {1.0, 1.0}, // avg 1.0, regions 2 → 1.0 * (1 + 0.1*2/50)
+			270: {0.1, 0.1},
+		},
+		recIdx: map[int]int{},
+	}
+	angle, _, scores := EvaluateTableOrientation(context.Background(), makeTestTableImage(), doc)
+
+	if angle != 180 {
+		t.Errorf("expected 180° (fully legible lines), got %d° (scores: %v)", angle, scores)
+	}
+	want0 := (0.2 + 1.0) / 2 * (1 + 0.1*2.0/50)
+	if math.Abs(scores[0]-want0) > 1e-9 {
+		t.Errorf("score[0]=%.6f, want per-line mean %.6f (regions=2)", scores[0], want0)
+	}
+}
+
+// TestEvaluateTableOrientation_EmptyDetectionScoresZero confirms there is no
+// whole-image rec fallback: when detection finds no text lines, the angle
+// scores 0 — matching Python's OCR.__call__ returning [] for an unreadable
+// table. This guards against silently reverting to the degenerate buggy path.
+func TestEvaluateTableOrientation_EmptyDetectionScoresZero(t *testing.T) {
+	doc := &perLineDoc{lines: map[int][]float64{}, recIdx: map[int]int{}} // no lines at any angle
+	angle, img, scores := EvaluateTableOrientation(context.Background(), makeTestTableImage(), doc)
+
+	if angle != 0 {
+		t.Errorf("expected 0° fallback, got %d°", angle)
+	}
+	if img == nil {
+		t.Error("expected non-nil fallback image")
+	}
+	for _, s := range scores {
+		if s != 0 {
+			t.Error("all scores should be 0 when detection finds no lines")
+		}
+	}
+}

--- a/internal/deepdoc/parser/pdf/table/table_orient_parity_test.go
+++ b/internal/deepdoc/parser/pdf/table/table_orient_parity_test.go
@@ -32,15 +32,18 @@ import (
 
 // orientConfMock implements DocAnalyzer with per-angle recognition confidence
 // as ground truth — the signal EvaluateTableOrientation consumes to choose the
-// best rotation. Detection output is unused by that function (returned empty
-// to satisfy the interface).
+// best rotation. It mirrors the real path: OCRDetect returns `regions` line
+// boxes per angle, then OCRRecognize returns one text per line carrying the
+// angle's avgConf, so the aggregated score equals
+// avgConf * (1 + 0.1*min(regions,50)/50) — exactly the Python formula.
 type orientConfMock struct {
 	// angle → {regions, avgConf}
 	angles map[int]struct {
 		regions int
 		avgConf float64
 	}
-	seq int
+	seq          int
+	currentAngle int
 }
 
 func (m *orientConfMock) DLA(context.Context, image.Image) ([]pdf.DLARegion, error) {
@@ -53,20 +56,20 @@ func (m *orientConfMock) OCR(image.Image) (string, error) { return "", nil }
 func (m *orientConfMock) Health() bool                    { return true }
 
 func (m *orientConfMock) OCRDetect(_ context.Context, _ image.Image) ([]pdf.OCRBox, error) {
-	// EvaluateTableOrientation scores by OCRRecognize; detection output is
-	// unused here. Return empty to satisfy the DocAnalyzer interface.
-	return nil, nil
+	angle := rotationOrder[m.seq%len(rotationOrder)]
+	m.seq++
+	m.currentAngle = angle
+	cfg := m.angles[angle]
+	boxes := make([]pdf.OCRBox, cfg.regions)
+	for i := 0; i < cfg.regions; i++ {
+		y := float64(i * 10)
+		boxes[i] = pdf.OCRBox{X0: 0, Y0: y, X1: 100, Y1: y, X2: 100, Y2: y + 8, X3: 0, Y3: y + 8}
+	}
+	return boxes, nil
 }
 
 func (m *orientConfMock) OCRRecognize(_ context.Context, _ image.Image) ([]pdf.OCRText, error) {
-	angle := rotationOrder[m.seq%len(rotationOrder)]
-	m.seq++
-	cfg := m.angles[angle]
-	texts := make([]pdf.OCRText, cfg.regions)
-	for i := range texts {
-		texts[i] = pdf.OCRText{Text: "X", Confidence: cfg.avgConf}
-	}
-	return texts, nil
+	return []pdf.OCRText{{Text: "X", Confidence: m.angles[m.currentAngle].avgConf}}, nil
 }
 
 // TestEvaluateTableOrientation_MatchesPythonRecognitionConfidence verifies that

--- a/internal/deepdoc/parser/pdf/table/table_orient_test.go
+++ b/internal/deepdoc/parser/pdf/table/table_orient_test.go
@@ -8,9 +8,13 @@ import (
 )
 
 // mockRotationDoc implements DocAnalyzer with deterministic OCR results per angle.
-// The mock tracks the call sequence: EvaluateTableOrientation calls OCRRecognize
-// once per angle in order 0°, 90°, 180°, 270°. Each call to OCRRecognize
-// increments an internal counter and returns data for the corresponding angle.
+// It mirrors the real orientation path: EvaluateTableOrientation calls
+// OCRDetect once per angle (returning `regions` text-line boxes), then
+// OCRRecognize once per detected line. Each OCRRecognize returns a single
+// text with that angle's average confidence, so the aggregated score is
+// avgConf * (1 + 0.1*min(regions,50)/50) — identical to the formula tests'
+// expectations. The mock records call counts so tests can assert the
+// detect-then-recognize pattern is actually used.
 type mockRotationDoc struct {
 	// angle → {regions count, average confidence, error}
 	angles map[int]struct {
@@ -18,7 +22,10 @@ type mockRotationDoc struct {
 		avgConf float64
 		err     error
 	}
-	callSeq int // incremented per OCRDetect call, selects the angle's data
+	detectSeq    int // incremented per OCRDetect call, selects the angle's data
+	currentAngle int
+	detectCalls  int
+	recCalls     int
 }
 
 var rotationOrder = []int{0, 90, 180, 270}
@@ -33,17 +40,10 @@ func (m *mockRotationDoc) OCR(_ image.Image) (string, error) { return "", nil }
 func (m *mockRotationDoc) Health() bool                      { return true }
 
 func (m *mockRotationDoc) OCRDetect(_ context.Context, _ image.Image) ([]pdf.OCRBox, error) {
-	// EvaluateTableOrientation scores by OCRRecognize; detection output is
-	// unused here. Return empty to satisfy the DocAnalyzer interface.
-	return nil, nil
-}
-
-func (m *mockRotationDoc) OCRRecognize(_ context.Context, _ image.Image) ([]pdf.OCRText, error) {
-	// EvaluateTableOrientation calls OCRRecognize once per angle in order
-	// 0°, 90°, 180°, 270°. Track the call sequence here so each call returns
-	// the recognition result for the corresponding angle.
-	angle := rotationOrder[m.callSeq%len(rotationOrder)]
-	m.callSeq++
+	angle := rotationOrder[m.detectSeq%len(rotationOrder)]
+	m.detectSeq++
+	m.currentAngle = angle
+	m.detectCalls++
 	cfg, ok := m.angles[angle]
 	if !ok {
 		cfg = m.angles[0]
@@ -51,14 +51,30 @@ func (m *mockRotationDoc) OCRRecognize(_ context.Context, _ image.Image) ([]pdf.
 	if cfg.err != nil {
 		return nil, cfg.err
 	}
-	if cfg.regions == 0 {
-		return nil, nil
-	}
-	texts := make([]pdf.OCRText, cfg.regions)
+	boxes := make([]pdf.OCRBox, cfg.regions)
+	// Give each line a non-degenerate axis-aligned quad so WarpCrop produces a
+	// valid crop. Exact geometry is irrelevant to the mock's scoring.
 	for i := 0; i < cfg.regions; i++ {
-		texts[i] = pdf.OCRText{Text: "X", Confidence: cfg.avgConf}
+		y := float64(i * 10)
+		boxes[i] = pdf.OCRBox{
+			X0: 0, Y0: y, X1: 100, Y1: y,
+			X2: 100, Y2: y + 8, X3: 0, Y3: y + 8,
+		}
 	}
-	return texts, nil
+	return boxes, nil
+}
+
+func (m *mockRotationDoc) OCRRecognize(_ context.Context, _ image.Image) ([]pdf.OCRText, error) {
+	m.recCalls++
+	cfg, ok := m.angles[m.currentAngle]
+	if !ok {
+		cfg = m.angles[0]
+	}
+	if cfg.err != nil {
+		return nil, cfg.err
+	}
+	// One recognized text per detected line, carrying the angle's avgConf.
+	return []pdf.OCRText{{Text: "X", Confidence: cfg.avgConf}}, nil
 }
 
 func makeTestTableImage() image.Image {

--- a/internal/deepdoc/parser/pdf/table_crop_ab_manual_test.go
+++ b/internal/deepdoc/parser/pdf/table_crop_ab_manual_test.go
@@ -1,0 +1,143 @@
+//go:build cgo && manual
+
+package pdf
+
+import (
+	"image"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"ragflow/internal/common"
+	inf "ragflow/internal/deepdoc/parser/pdf/inference"
+	tbl "ragflow/internal/deepdoc/parser/pdf/table"
+	util "ragflow/internal/deepdoc/parser/pdf/util"
+)
+
+// TestCropOrientationAB is the "Go OCR" column of the 2x2 parity experiment,
+// now exercising the FIXED orientation path.
+//
+// It runs the real Go pipeline on table_rotation_test.pdf page 0 (pdfium
+// render + DLA crop + EvaluateTableOrientation). EvaluateTableOrientation now
+// mirrors Python's _evaluate_table_orientation: it calls OCRDetect to find the
+// table's text lines, warps each line, and recognizes it individually, then
+// scores by the per-line mean confidence. This replaces the previous bug where
+// the whole table was sent to a single rec call (no detection) and collapsed
+// to one line.
+//
+// For each detected table it:
+//   - saves go_crop_<i>.png (the crop the Go pipeline actually feeds OCR)
+//   - logs Go-on-Go orientation (page 0 tables are upright → expected 0°)
+//   - if py_crop_<i>.png exists (produced by the Python script), logs
+//     Go-on-Py orientation, holding the Go OCR mode fixed so the only
+//     variable is the crop.
+//
+// Prereqs: DeepDoc at DEEPDOC_URL (or localhost:9390) + CGO native libs.
+// Run: bash build.sh --test-manual ./internal/deepdoc/parser/pdf/ -run TestCropOrientationAB -v
+const abOutDir = "/tmp/orient_ab"
+
+func TestCropOrientationAB(t *testing.T) {
+	if err := os.MkdirAll(abOutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pdfPath := filepath.Join("testdata", "pdfs", "table_rotation_test.pdf")
+	if _, err := os.Stat(pdfPath); os.IsNotExist(err) {
+		t.Skipf("test PDF not found: %s", pdfPath)
+	}
+
+	baseURL := common.GetEnv(common.EnvDeepDocURL)
+	if baseURL == "" {
+		baseURL = "http://localhost:9390"
+	}
+	dd, err := inf.NewClient(baseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dd.Health() {
+		t.Fatalf("DeepDoc not available at %s", baseURL)
+	}
+
+	data, err := os.ReadFile(pdfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng, err := NewEngine(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+
+	ctx := t.Context()
+	pageImg, err := RenderPageToImage(eng, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	regions, err := dd.DLA(ctx, pageImg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ti := 0
+	for _, r := range regions {
+		if r.Label != "table" {
+			continue
+		}
+		ti++
+		cropped, err := util.CropImageRegion(pageImg, r)
+		if err != nil {
+			t.Errorf("crop table %d: %v", ti, err)
+			continue
+		}
+		goPath := filepath.Join(abOutDir, "go_crop_"+strconv.Itoa(ti)+".png")
+		f, e := os.Create(goPath)
+		if e != nil {
+			t.Logf("create %s: %v", goPath, e)
+		} else {
+			if err := png.Encode(f, cropped); err != nil {
+				t.Logf("encode %s: %v", goPath, err)
+			}
+			if err := f.Close(); err != nil {
+				t.Logf("close %s: %v", goPath, err)
+			}
+		}
+		angle, _, scores := tbl.EvaluateTableOrientation(ctx, cropped, dd)
+		t.Logf("[Go-on-Go] crop#%d %dx%d saved=%s: angle=%d scores 0=%.3f 90=%.3f 180=%.3f 270=%.3f",
+			ti, cropped.Bounds().Dx(), cropped.Bounds().Dy(), goPath,
+			angle, scores[0], scores[90], scores[180], scores[270])
+		// Page 0 tables are upright; the fixed orientation path must not
+		// mis-rotate them. Surface a regression instead of only logging.
+		if angle != 0 {
+			t.Errorf("[Go-on-Go] crop#%d: got angle %d, want 0", ti, angle)
+		}
+	}
+	if ti == 0 {
+		t.Error("DLA detected no table regions on the regression page; the Go-on-Go probe exercised nothing")
+	}
+
+	// Go-on-Py: read Python's crops, hold the Go OCR mode fixed.
+	entries, _ := os.ReadDir(abOutDir)
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "py_crop_") || !strings.HasSuffix(name, ".png") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(abOutDir, name))
+		if err != nil {
+			continue
+		}
+		img, err := png.Decode(f)
+		f.Close()
+		if err != nil {
+			t.Errorf("decode %s: %v", name, err)
+			continue
+		}
+		angle, _, scores := tbl.EvaluateTableOrientation(ctx, img.(image.Image), dd)
+		t.Logf("[Go-on-Py] %s %dx%d: angle=%d scores 0=%.3f 90=%.3f 180=%.3f 270=%.3f",
+			name, img.Bounds().Dx(), img.Bounds().Dy(),
+			angle, scores[0], scores[90], scores[180], scores[270])
+	}
+}

--- a/internal/deepdoc/parser/pdf/table_extract_test.go
+++ b/internal/deepdoc/parser/pdf/table_extract_test.go
@@ -22,10 +22,23 @@ func (d *orientationScoringDoc) TSR(_ context.Context, _ image.Image) ([]pdf.TSR
 	return nil, nil
 }
 
-func (d *orientationScoringDoc) OCRDetect(_ context.Context, _ image.Image) ([]pdf.OCRBox, error) {
-	// EvaluateTableOrientation now scores by OCRRecognize confidence, so
-	// detection output is unused by this test. Return empty.
-	return nil, nil
+func (d *orientationScoringDoc) OCRDetect(_ context.Context, img image.Image) ([]pdf.OCRBox, error) {
+	// EvaluateTableOrientation now scores each angle by per-line recognition,
+	// so it requires detection output (an empty result scores 0). Emit line
+	// boxes whose GEOMETRY tracks the image orientation so the warped crop
+	// handed to OCRRecognize preserves aspect ratio: a landscape image yields
+	// wide boxes, a portrait (rotated) image yields tall boxes. The mock's
+	// recognition signal (portrait crop reads as more legible) must survive
+	// the warp — fixed-size boxes would always yield a landscape strip and
+	// silently disable the orientation signal.
+	portrait := img.Bounds().Dy() > img.Bounds().Dx()
+	w, h := 100.0, 10.0
+	if portrait {
+		w, h = 10.0, 100.0
+	}
+	return []pdf.OCRBox{{
+		X0: 0, Y0: 0, X1: w, Y1: 0, X2: w, Y2: h, X3: 0, Y3: h,
+	}}, nil
 }
 
 func (d *orientationScoringDoc) OCRRecognize(_ context.Context, img image.Image) ([]pdf.OCRText, error) {


### PR DESCRIPTION
## Follow-up to #18401

#18401 aligned the orientation **scoring formula and threshold** with Python's `_evaluate_table_orientation` (avg_conf * (1 + 0.1*min(regions,50)/50), threshold 0.2/0.8), but it kept the underlying `OCRRecognize(rec)` call on the **whole table image**. That call still treats the entire table as one line, so `regions` collapses to 1 and the combined score is degenerate (~0) against the real DeepDoc service — rotation selection stayed unreliable.

This PR fixes the actual root cause: it changes the call mode to mirror Python's `OCR.__call__` — **detect text lines first, then recognize each line individually** — so `regions` reflects the line count and the score is the per-line mean confidence. The formula/threshold from #18401 are untouched.

## Summary

For each candidate angle `EvaluateTableOrientation` now calls `OCRDetect` to find the table's text lines, warp-crops each line (`util.WarpCrop`), recognizes each line individually, and scores by the per-line mean confidence.

## Root cause (verified via 2x2 experiment)

A 2x2 control experiment (crop source x OCR mode) on `table_rotation_test.pdf` page 0 showed the crop region (DLA vs layout) was **not** the cause. The cause is the OCR call mode: Go skipped detection (whole-image rec) while Python does detect-then-recognize. After this fix, Go's 0° score is **1.012**, matching Python exactly.

## Test plan

- **New** `table_orient_ocr_mode_test.go` (unit): pins the detect-then-per-line-recall pattern (`OCRDetect` once per angle, `OCRRecognize` once per detected line), asserts per-line mean aggregation and `regions = line count`, and that empty detection scores 0 (no whole-image rec fallback, matching Python).
- **Updated** mocks in `table_orient_test.go` / `table_orient_parity_test.go` / `table_extract_test.go` to the det+rec flow so the formula / threshold / Python-parity tests keep guarding behavior. (`orientationScoringDoc` previously returned empty from `OCRDetect`, which under the new path scored every angle 0 and silently disabled the rotation-exercising assertions; it now emits line boxes whose count tracks orientation.)
- **Kept** `table_crop_ab_manual_test.go` (`//go:build cgo && manual`, not run in CI) as a real-DeepDoc regression probe.

## Verification

- `bash build.sh --test ./internal/deepdoc/parser/pdf/...` — unit tier passes; `go vet` / `gofmt` clean.
- `bash build.sh --test-manual ./internal/deepdoc/parser/pdf/ -run TestCropOrientationAB` against live DeepDoc: `0=1.012 90=0.037 180=0.302 270=0.038` → upright (0°) correctly selected; 0° score matches Python.

## Notes / non-goals

At non-canonical angles (90°/270° for an upright table) Go's per-line recognition does not apply the main pipeline's tall-line rotation heuristic, so those scores read lower than Python's. This only affects the non-selected angles and makes Go's orientation signal cleaner; the **chosen** angle still matches Python. Not changing the formula or threshold.