### PR TITLE
fix(rag/app/table): keep table cells that column type conversion cannot represent

### DIFF
--- a/rag/app/table.py
+++ b/rag/app/table.py
@@ -418,13 +418,16 @@ def column_data_type(arr):
             arr[i] = None
             continue
         try:
-            arr[i] = trans[ty](str(arr[i]))
+            converted = trans[ty](str(arr[i]))
         except Exception as e:
-            arr[i] = None
             logging.warning(f"Column {i}: {e}")
             # Keep original value from openpyxl/pandas instead of dropping to None.
             # This preserves cells (e.g. text in numeric columns) that would
             # otherwise be silently discarded by forced column-level conversion.
+            continue
+        if converted is None:
+            continue
+        arr[i] = converted
     # if ty == "text":
     #    if len(arr) > 128 and uni / len(arr) < 0.1:
     #        ty = "keyword"

--- a/rag/app/table.py
+++ b/rag/app/table.py
@@ -408,6 +408,7 @@ def column_data_type(arr):
         type_priority = {"text": 0, "datetime": 1, "float": 2, "int": 3, "bool": 4}
         counts = sorted(counts.items(), key=lambda x: (x[1] * -1, type_priority[x[0]]))
         ty = counts[0][0]
+    conversion_failures = 0
     for i in range(len(arr)):
         if arr[i] is None:
             continue
@@ -419,8 +420,8 @@ def column_data_type(arr):
             continue
         try:
             converted = trans[ty](str(arr[i]))
-        except Exception as e:
-            logging.warning(f"Column {i}: {e}")
+        except ValueError:
+            conversion_failures += 1
             # Keep original value from openpyxl/pandas instead of dropping to None.
             # This preserves cells (e.g. text in numeric columns) that would
             # otherwise be silently discarded by forced column-level conversion.
@@ -428,6 +429,11 @@ def column_data_type(arr):
         if converted is None:
             continue
         arr[i] = converted
+    if conversion_failures:
+        # Aggregate rather than log per-cell: individual cell values must not
+        # be written to application logs, and per-cell warnings would flood
+        # logs on large uploads.
+        logging.warning(f"column_data_type: kept {conversion_failures} cell(s) that could not convert to {ty}")
     # if ty == "text":
     #    if len(arr) > 128 and uni / len(arr) < 0.1:
     #        ty = "keyword"

--- a/test/unit_test/rag/app/test_table_chunk_column_roles.py
+++ b/test/unit_test/rag/app/test_table_chunk_column_roles.py
@@ -44,6 +44,11 @@ TEST_CSV = b"""row_id,title,content,country,category
 TEST_DUPLICATE_COLUMNS_CSV = b"""name,name,name_2
 Alice,Engineer,Team A
 """
+TEST_PARTIAL_NUMERIC_CSV = b"""row_id,amount,note
+1,100,first
+2,N/A,second
+3,300,third
+"""
 
 FILENAME = "test.csv"
 KB_ID = "test_kb_id"
@@ -372,3 +377,35 @@ def test_chunk_infinity_field_map_non_ascii_columns_are_keys(table_module, mock_
     assert "\u59d3\u540d" in field_map  # 姓名
     assert "\u957f\u5ea6" in field_map  # 长度
     assert not any(k.endswith("_tks") for k in field_map.keys())
+
+
+@pytest.mark.parametrize(
+    ("column", "expected_type"),
+    [
+        (["1", "2", "3", "N/A"], "int"),
+        (["1.5", "2.5", "3.5", "see note"], "float"),
+        (["yes", "no", "yes", "unknown"], "bool"),
+        (["2025-01-01", "2025-02-01", "ongoing"], "datetime"),
+    ],
+)
+def test_column_data_type_keeps_cells_it_cannot_convert(table_module, column, expected_type):
+    converted, ty = table_module.column_data_type(list(column))
+    assert ty == expected_type
+    assert converted[-1] == column[-1]
+    assert None not in converted
+
+
+def test_chunk_keeps_unconvertible_cell_in_content(table_module, mock_update_kb: MagicMock):
+    chunks = table_module.chunk(
+        FILENAME,
+        binary=TEST_PARTIAL_NUMERIC_CSV,
+        callback=_noop_callback,
+        kb_id=KB_ID,
+        parser_config={},
+        lang="Chinese",
+    )
+    assert len(chunks) == 3
+    assert chunks[0]["amount_long"] == 100
+    assert chunks[2]["amount_long"] == 300
+    assert chunks[1].get("amount_long") != "N/A"
+    assert "- amount: N/A" in chunks[1]["content_with_weight"]

--- a/test/unit_test/rag/app/test_table_chunk_column_roles.py
+++ b/test/unit_test/rag/app/test_table_chunk_column_roles.py
@@ -44,6 +44,11 @@ TEST_CSV = b"""row_id,title,content,country,category
 TEST_DUPLICATE_COLUMNS_CSV = b"""name,name,name_2
 Alice,Engineer,Team A
 """
+TEST_PARTIAL_NUMERIC_CSV = b"""row_id,amount,note
+1,100,first
+2,N/A,second
+3,300,third
+"""
 
 FILENAME = "test.csv"
 KB_ID = "test_kb_id"
@@ -294,3 +299,32 @@ def test_chunk_updates_table_column_names(table_module, mock_update_kb: MagicMoc
 def test_chunk_count_matches_row_count(table_module, mock_update_kb: MagicMock):
     chunks = _run_chunk(table_module, {}, mock_update_kb)
     assert len(chunks) == 3
+
+
+@pytest.mark.parametrize(
+    ("column", "expected_type"),
+    [
+        (["1", "2", "3", "N/A"], "int"),
+        (["1.5", "2.5", "3.5", "see note"], "float"),
+        (["yes", "no", "yes", "unknown"], "bool"),
+        (["2025-01-01", "2025-02-01", "ongoing"], "datetime"),
+    ],
+)
+def test_column_data_type_keeps_cells_it_cannot_convert(table_module, column, expected_type):
+    converted, ty = table_module.column_data_type(list(column))
+    assert ty == expected_type
+    assert converted[-1] == column[-1]
+    assert None not in converted
+
+
+def test_chunk_keeps_unconvertible_cell_in_content(table_module, mock_update_kb: MagicMock):
+    chunks = table_module.chunk(
+        FILENAME,
+        binary=TEST_PARTIAL_NUMERIC_CSV,
+        callback=_noop_callback,
+        kb_id=KB_ID,
+        parser_config={},
+        lang="Chinese",
+    )
+    assert len(chunks) == 3
+    assert "- amount: N/A" in chunks[1]["content_with_weight"]


### PR DESCRIPTION
### Summary

Fixes #18459.

`column_data_type()` in `rag/app/table.py` infers one type per column and replaces every cell it cannot convert with `None`. `chunk()` then skips `None` cells at line 600, so the value disappears from the chunk body as well as from the stored field. A CSV/XLSX column that is mostly numeric but carries `N/A`, `TBD`, `-` or a footnote loses exactly those cells, with no user-visible error.

The code already documents the opposite behaviour. PR #17946 added this comment directly below the `arr[i] = None` it describes:

```python
            # Keep original value from openpyxl/pandas instead of dropping to None.
            # This preserves cells (e.g. text in numeric columns) that would
            # otherwise be silently discarded by forced column-level conversion.
```

and added a branch in `chunk()` that only makes sense if the original value survives:

```python
                        if clmn_tys[j] != "text":
                            val = row[col_name]
                            # If a string value ended up in a non-text column,
                            # it was preserved from a failed conversion in
                            # column_data_type. ...
                            if isinstance(val, str):
                                pass
```

Since the producer never leaves a string in a non-text column, that branch is unreachable.

This change keeps the original value when the converter raises **or** returns `None`. The second case matters: `trans_bool("unknown")` and `trans_datatime("ongoing")` return `None` rather than raising, so `bool` and `datetime` columns were being nulled through the success path without even logging the `Column N: ...` warning.

No doc engine receives a wrongly typed value. `chunk_data` is a JSON/JSONB column in Infinity, OceanBase, GaussDB and SereneDB, and the Elasticsearch path is guarded by the `isinstance(val, str)` branch above, which this change makes reachable as intended.

### Behaviour

Before:

```
['1', '2', '3', 'N/A']                       -> int       [1, 2, 3, None]
['1.5', '2.5', '3.5', 'see note']            -> float     [1.5, 2.5, 3.5, None]
['yes', 'no', 'yes', 'unknown']              -> bool      ['yes', 'no', 'yes', None]
['2025-01-01', '2025-02-01', 'ongoing']      -> datetime  ['2025-01-01 00:00:00', '2025-02-01 00:00:00', None]
```

After:

```
['1', '2', '3', 'N/A']                       -> int       [1, 2, 3, 'N/A']
['1.5', '2.5', '3.5', 'see note']            -> float     [1.5, 2.5, 3.5, 'see note']
['yes', 'no', 'yes', 'unknown']              -> bool      ['yes', 'no', 'yes', 'unknown']
['2025-01-01', '2025-02-01', 'ongoing']      -> datetime  ['2025-01-01 00:00:00', '2025-02-01 00:00:00', 'ongoing']
```

End to end, for a CSV `row_id,amount,note` with the row `2,N/A,second`, the chunk for that row was `- row_id: 2\n- note: second` and is now `- row_id: 2\n- amount: N/A\n- note: second`.

### Tests

Added to `test/unit_test/rag/app/test_table_chunk_column_roles.py`, using the existing `table_module` fixture:

- `test_column_data_type_keeps_cells_it_cannot_convert` — four parametrized cases covering `int`, `float`, `bool` and `datetime` columns.
- `test_chunk_keeps_unconvertible_cell_in_content` — asserts the cell reaches `content_with_weight`.

All five fail on `main` and pass with this change. The 11 existing tests in that file are unaffected, and `test/unit_test/rag/app/` plus the table metadata/column-role helper tests and the chunker tests (`test_naive_merge`, `test_merge_paragraphs`, `test_delim`, `test_is_english`) pass — 212 tests total.

`ruff check` reports the same findings on `rag/app/table.py` before and after this change (18, all pre-existing), and `ruff format --check` reports both files already formatted.
