### PR TITLE
fix(memory): honor custom extraction prompts

### DIFF
--- a/api/db/joint_services/memory_message_service.py
+++ b/api/db/joint_services/memory_message_service.py
@@ -60,6 +60,8 @@ async def save_to_memory(memory_id: str, message_dict: dict):
             get_memory_type_human(memory.memory_type),
             message_dict.get("user_input", ""),
             message_dict.get("agent_response", ""),
+            system_prompt=memory.system_prompt,
+            user_prompt=memory.user_prompt,
             llm_id=memory.llm_id,
         )
         if memory.memory_type != MemoryType.RAW.value
@@ -124,6 +126,8 @@ async def save_extracted_to_memory_only(memory_id: str, message_dict, source_mes
         get_memory_type_human(memory.memory_type),
         message_dict.get("user_input", ""),
         message_dict.get("agent_response", ""),
+        system_prompt=memory.system_prompt,
+        user_prompt=memory.user_prompt,
         task_id=task_id,
         llm_id=memory.llm_id,
     )

--- a/test/unit_test/api/db/joint_services/test_memory_message_service.py
+++ b/test/unit_test/api/db/joint_services/test_memory_message_service.py
@@ -1,0 +1,82 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.db.joint_services import memory_message_service
+from common.constants import MemoryType
+
+
+def make_memory():
+    return SimpleNamespace(
+        id="memory-1",
+        tenant_id="tenant-1",
+        tenant_llm_id="tenant-llm-1",
+        temperature=0.2,
+        memory_type=MemoryType.SEMANTIC.value,
+        llm_id="model-1",
+        system_prompt="Custom system prompt",
+        user_prompt="Custom user prompt",
+    )
+
+
+def make_message():
+    return {
+        "user_id": "user-1",
+        "agent_id": "agent-1",
+        "session_id": "session-1",
+        "user_input": "Remember this",
+        "agent_response": "I will remember it",
+    }
+
+
+def assert_custom_prompts_forwarded(extract_by_llm):
+    extract_by_llm.assert_awaited_once()
+    assert extract_by_llm.await_args.kwargs["system_prompt"] == "Custom system prompt"
+    assert extract_by_llm.await_args.kwargs["user_prompt"] == "Custom user prompt"
+
+
+@pytest.mark.p1
+async def test_save_to_memory_forwards_custom_extraction_prompts(monkeypatch):
+    memory = make_memory()
+    extract_by_llm = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(memory_message_service.MemoryService, "get_by_memory_id", lambda _memory_id: memory)
+    monkeypatch.setattr(memory_message_service, "extract_by_llm", extract_by_llm)
+    monkeypatch.setattr(memory_message_service.REDIS_CONN, "generate_auto_increment_id", lambda **_kwargs: 1)
+    monkeypatch.setattr(memory_message_service, "embed_and_save", AsyncMock(return_value=(True, "Message saved successfully.")))
+
+    result = await memory_message_service.save_to_memory(memory.id, make_message())
+
+    assert result == (True, "Message saved successfully.")
+    assert_custom_prompts_forwarded(extract_by_llm)
+
+
+@pytest.mark.p1
+async def test_save_extracted_to_memory_only_forwards_custom_extraction_prompts(monkeypatch):
+    memory = make_memory()
+    extract_by_llm = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(memory_message_service.MemoryService, "get_by_memory_id", lambda _memory_id: memory)
+    monkeypatch.setattr(memory_message_service, "extract_by_llm", extract_by_llm)
+
+    result = await memory_message_service.save_extracted_to_memory_only(memory.id, make_message(), source_message_id=1)
+
+    assert result == (True, "No memory extracted from raw message.")
+    assert_custom_prompts_forwarded(extract_by_llm)


### PR DESCRIPTION
### Summary

- Forward each memory's stored system_prompt and user_prompt to extract_by_llm.
- Cover both immediate save and queued extraction paths with focused regression tests.
- Preserve the existing default-prompt fallback when stored prompts are empty.

Fixes #18413.

### Testing

- Added two async regression tests covering both call sites.
- Verified both tests fail before the fix and pass after it.
- Ruff check and format validation pass for the changed test and files.