### PR TITLE
fix(memory): require semantic valid_at timestamp

### DIFF
--- a/memory/utils/prompt_util.py
+++ b/memory/utils/prompt_util.py
@@ -77,7 +77,7 @@ You are an expert at analyzing conversations to extract structured memory.
         "semantic": [
             {
                 "content": "Clear factual statement",
-                "valid_at": "timestamp or empty",
+                "valid_at": "timestamp — use the conversation time when the fact has no date of its own",
                 "invalid_at": "timestamp or empty"
             }
         ]

--- a/test/unit_test/memory/utils/test_prompt_util.py
+++ b/test/unit_test/memory/utils/test_prompt_util.py
@@ -1,0 +1,24 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from memory.utils.prompt_util import PromptAssembler
+
+
+def test_semantic_output_format_requires_valid_at_timestamp():
+    prompt = PromptAssembler.assemble_system_prompt({"memory_type": ["semantic"]})
+
+    assert '"valid_at": "timestamp — use the conversation time when the fact has no date of its own"' in prompt
+    assert '"valid_at": "timestamp or empty"' not in prompt


### PR DESCRIPTION
## Summary

- require a `valid_at` timestamp in the semantic-memory output schema
- tell the extraction model to use conversation time when a fact has no date of its own
- add a regression test for the assembled semantic prompt

This addresses the deterministic prompt inconsistency reported in #18415. The invalid-timestamp fallback is intentionally left unchanged because selecting its replacement policy requires a separate design decision.

## Testing

- `uvx --from pytest --with pytest-asyncio pytest --noconftest -q test/unit_test/memory/utils/test_prompt_util.py`
- verified the regression test fails before the fix and passes after it
- `uvx ruff check test/unit_test/memory/utils/test_prompt_util.py`
- `uvx ruff format --check memory/utils/prompt_util.py test/unit_test/memory/utils/test_prompt_util.py`
- `python -m py_compile memory/utils/prompt_util.py test/unit_test/memory/utils/test_prompt_util.py`