### PR TITLE
fix(memory): normalize invalid extraction timestamps

### DIFF
--- a/api/db/joint_services/memory_message_service.py
+++ b/api/db/joint_services/memory_message_service.py
@@ -194,8 +194,8 @@ async def extract_by_llm(
         return [
             {
                 "content": extracted_content["content"],
-                "valid_at": format_iso_8601_to_ymd_hms(extracted_content["valid_at"]),
-                "invalid_at": format_iso_8601_to_ymd_hms(extracted_content["invalid_at"]) if extracted_content.get("invalid_at") else "",
+                "valid_at": format_iso_8601_to_ymd_hms(extracted_content.get("valid_at", ""), fallback=conversation_time),
+                "invalid_at": format_iso_8601_to_ymd_hms(extracted_content["invalid_at"], fallback="") if extracted_content.get("invalid_at") else "",
                 "message_type": message_type,
             }
             for message_type, extracted_content_list in res_json.items()

--- a/common/time_utils.py
+++ b/common/time_utils.py
@@ -129,12 +129,14 @@ def delta_seconds(date_string: str):
     return (datetime.datetime.now() - dt).total_seconds()
 
 
-def format_iso_8601_to_ymd_hms(time_str: str) -> str:
+def format_iso_8601_to_ymd_hms(time_str: str, fallback: str | None = None) -> str:
     """
     Convert ISO 8601 formatted string to "YYYY-MM-DD HH:MM:SS" format.
 
     Args:
         time_str: ISO 8601 date string (e.g. "2024-01-01T12:00:00Z")
+        fallback: Value to return when ``time_str`` cannot be parsed. When omitted,
+            the original input is returned for backward compatibility.
 
     Returns:
         str: Date string in "YYYY-MM-DD HH:MM:SS" format
@@ -148,6 +150,6 @@ def format_iso_8601_to_ymd_hms(time_str: str) -> str:
     try:
         dt = parser.isoparse(time_str)
         return dt.strftime("%Y-%m-%d %H:%M:%S")
-    except Exception as e:
-        logging.error(str(e))
-        return time_str
+    except (TypeError, ValueError, OverflowError) as e:
+        logging.error("Failed to parse ISO 8601 timestamp %r: %s", time_str, e)
+        return time_str if fallback is None else fallback

--- a/common/time_utils.py
+++ b/common/time_utils.py
@@ -136,7 +136,7 @@ def format_iso_8601_to_ymd_hms(time_str: str, fallback: str | None = None) -> st
     Args:
         time_str: ISO 8601 date string (e.g. "2024-01-01T12:00:00Z")
         fallback: Value to return when ``time_str`` cannot be parsed. When omitted,
-            the original input is returned for backward compatibility.
+            the original input is returned.
 
     Returns:
         str: Date string in "YYYY-MM-DD HH:MM:SS" format

--- a/test/unit_test/api/db/joint_services/test_memory_message_timestamp_normalization.py
+++ b/test/unit_test/api/db/joint_services/test_memory_message_timestamp_normalization.py
@@ -1,0 +1,56 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.db.joint_services import memory_message_service
+
+
+@pytest.mark.p1
+async def test_extract_by_llm_replaces_invalid_timestamps(monkeypatch):
+    llm = SimpleNamespace(async_chat=AsyncMock(return_value="response"))
+    extracted = {
+        "semantic": [
+            {
+                "content": "A timeless fact",
+                "valid_at": "not-a-date",
+                "invalid_at": "also-not-a-date",
+            }
+        ]
+    }
+
+    monkeypatch.setattr(memory_message_service, "current_timestamp", lambda: 1)
+    monkeypatch.setattr(memory_message_service, "timestamp_to_date", lambda _timestamp: "2026-08-18 12:00:00")
+    monkeypatch.setattr(memory_message_service, "resolve_model_config", lambda *_args: SimpleNamespace())
+    monkeypatch.setattr(memory_message_service, "LLMBundle", lambda *_args: nullcontext(llm))
+    monkeypatch.setattr(memory_message_service, "get_json_result_from_llm_response", lambda _response: extracted)
+
+    result = await memory_message_service.extract_by_llm(
+        tenant_id="tenant-1",
+        tenant_llm_id=None,
+        extract_conf={},
+        memory_type=["semantic"],
+        user_input="Remember this",
+        agent_response="I will remember it",
+        llm_id="model-1",
+    )
+
+    assert result[0]["valid_at"] == "2026-08-18 12:00:00"
+    assert result[0]["invalid_at"] == ""

--- a/test/unit_test/common/test_time_utils.py
+++ b/test/unit_test/common/test_time_utils.py
@@ -711,3 +711,11 @@ class TestFormatIso8601ToYmdHms:
     def test_invalid_string_returns_original(self):
         """Unparseable input is returned unchanged."""
         assert format_iso_8601_to_ymd_hms("not-a-date") == "not-a-date"
+
+    def test_invalid_string_uses_explicit_fallback(self, caplog):
+        """Callers can prevent invalid timestamps from being written through."""
+        with caplog.at_level("ERROR"):
+            result = format_iso_8601_to_ymd_hms("not-a-date", fallback="2026-08-18 12:00:00")
+
+        assert result == "2026-08-18 12:00:00"
+        assert "not-a-date" in caplog.text


### PR DESCRIPTION
## Summary

- allow ISO 8601 normalization callers to provide an explicit fallback while preserving the existing default behavior
- use the extraction conversation time when `valid_at` is missing or invalid
- clear an invalid optional `invalid_at` instead of writing an unparseable value
- include the rejected timestamp value in the error log

This addresses the timestamp write-through portion of #18415. It is intentionally separate from #18462, which fixes the semantic output prompt.

## Testing

- `test_memory_message_timestamp_normalization.py`: 1 passed in the isolated service import harness
- `test_time_utils.py -k FormatIso8601ToYmdHms`: 6 passed
- verified the service regression test fails before the call-site fallbacks and passes after the fix
- `ruff check` passed for the new service regression test
- `ruff format --check` passed for the changed implementation and new test files
- `python -m py_compile` passed for all changed Python files