### PR TITLE
fix(nlp): load term weight resources as UTF-8

### DIFF
--- a/rag/nlp/term_weight.py
+++ b/rag/nlp/term_weight.py
@@ -64,7 +64,7 @@ class Dealer:
 
         def load_dict(fnm):
             res = {}
-            with open(fnm, "r") as f:
+            with open(fnm, "r", encoding="utf-8") as f:
                 while True:
                     line = f.readline()
                     if not line:
@@ -85,7 +85,7 @@ class Dealer:
         fnm = os.path.join(get_project_base_directory(), "rag/res")
         self.ne, self.df = {}, {}
         try:
-            with open(os.path.join(fnm, "ner.json"), "r") as f:
+            with open(os.path.join(fnm, "ner.json"), "r", encoding="utf-8") as f:
                 self.ne = json.load(f)
         except Exception:
             logging.warning("Load ner.json FAIL!")

--- a/test/unit_test/rag/nlp/test_term_weight.py
+++ b/test/unit_test/rag/nlp/test_term_weight.py
@@ -1,0 +1,42 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import builtins
+from pathlib import Path
+
+from rag.nlp import term_weight
+
+
+def test_dealer_loads_resource_files_as_utf8(monkeypatch, tmp_path):
+    resource_dir = tmp_path / "rag" / "res"
+    resource_dir.mkdir(parents=True)
+    (resource_dir / "ner.json").write_text('{"北京": "loca"}', encoding="utf-8")
+    (resource_dir / "term.freq").write_text("café\t42\n", encoding="utf-8")
+
+    monkeypatch.setattr(term_weight, "get_project_base_directory", lambda: str(tmp_path))
+    real_open = builtins.open
+
+    def require_explicit_utf8(file, *args, **kwargs):
+        if Path(file).parent == resource_dir:
+            assert kwargs.get("encoding") == "utf-8"
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", require_explicit_utf8)
+
+    dealer = term_weight.Dealer()
+
+    assert dealer.ne == {"北京": "loca"}
+    assert dealer.df == {"café": 42}

--- a/test/unit_test/rag/nlp/test_term_weight.py
+++ b/test/unit_test/rag/nlp/test_term_weight.py
@@ -21,15 +21,17 @@ from rag.nlp import term_weight
 
 
 def test_dealer_loads_resource_files_as_utf8(monkeypatch, tmp_path):
+    """Load non-ASCII term-weight resources with an explicit UTF-8 encoding."""
     resource_dir = tmp_path / "rag" / "res"
     resource_dir.mkdir(parents=True)
-    (resource_dir / "ner.json").write_text('{"北京": "loca"}', encoding="utf-8")
-    (resource_dir / "term.freq").write_text("café\t42\n", encoding="utf-8")
+    (resource_dir / "ner.json").write_text('{"\u5317\u4eac": "loca"}', encoding="utf-8")
+    (resource_dir / "term.freq").write_text("caf\u00e9\t42\n", encoding="utf-8")
 
     monkeypatch.setattr(term_weight, "get_project_base_directory", lambda: str(tmp_path))
     real_open = builtins.open
 
     def require_explicit_utf8(file, *args, **kwargs):
+        """Reject resource reads that rely on the platform default encoding."""
         if Path(file).parent == resource_dir:
             assert kwargs.get("encoding") == "utf-8"
         return real_open(file, *args, **kwargs)
@@ -38,5 +40,5 @@ def test_dealer_loads_resource_files_as_utf8(monkeypatch, tmp_path):
 
     dealer = term_weight.Dealer()
 
-    assert dealer.ne == {"北京": "loca"}
-    assert dealer.df == {"café": 42}
+    assert dealer.ne == {"\u5317\u4eac": "loca"}
+    assert dealer.df == {"caf\u00e9": 42}


### PR DESCRIPTION
### What problem does this PR solve?

RAGFlow's NLP resource loader opens `ner.json` and `term.freq` with the platform default encoding. On Windows systems whose default encoding is GBK/CP936, the UTF-8 `ner.json` raises `UnicodeDecodeError`; the broad fallback then silently leaves the named-entity dictionary empty. A UTF-8 `term.freq` would fail for the same reason.

This was reproduced on Windows with Python 3.13. The existing `rag/res/ner.json` could not be loaded until an explicit encoding was supplied.

### What is changed?

- Open both NLP resource files explicitly as UTF-8.
- Add a regression test using Chinese and accented Latin entries, with a guard that requires an explicit UTF-8 encoding.

This is related to #18414 but intentionally does not close it; the missing-frequency fallback needs a separate retrieval-design decision.

### Test

```text
python -m pytest test/unit_test/rag/nlp/test_term_weight.py -q --basetemp .pytest-tmp
1 passed
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)