### PR TITLE
fix: make ScheduledTask lifecycle concurrency-safe

### DIFF
--- a/internal/utility/scheduled_task.go
+++ b/internal/utility/scheduled_task.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"ragflow/internal/common"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -82,6 +83,7 @@ type ScheduledTask struct {
 	Interval  time.Duration
 	Job       func()
 	stop      chan struct{}
+	mu        sync.Mutex
 	running   bool
 	executing int32 // atomic flag: 0 - not executed, 1 running
 }
@@ -92,18 +94,22 @@ func NewScheduledTask(name string, interval time.Duration, job func()) *Schedule
 		Name:     name,
 		Interval: interval,
 		Job:      job,
-		stop:     make(chan struct{}),
 	}
 }
 
 // Start begins the periodic task
 func (t *ScheduledTask) Start() {
+	t.mu.Lock()
 	if t.running {
+		t.mu.Unlock()
 		return
 	}
+	stop := make(chan struct{})
+	t.stop = stop
 	t.running = true
+	t.mu.Unlock()
 
-	go func() {
+	go func(stop <-chan struct{}) {
 		ticker := time.NewTicker(t.Interval)
 		defer ticker.Stop()
 
@@ -113,12 +119,12 @@ func (t *ScheduledTask) Start() {
 			select {
 			case <-ticker.C:
 				t.runSafely()
-			case <-t.stop:
+			case <-stop:
 				common.Info("Task stopped", zap.String("name", t.Name))
 				return
 			}
 		}
-	}()
+	}(stop)
 }
 
 // runSafely executes the job with panic recovery and prevents overlap
@@ -143,11 +149,15 @@ func (t *ScheduledTask) runSafely() {
 
 // Stop stops the periodic task
 func (t *ScheduledTask) Stop() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if !t.running {
 		return
 	}
 	t.running = false
 	close(t.stop)
+	t.stop = nil
 }
 
 // IsExecuting returns whether the task is currently executing

--- a/internal/utility/scheduled_task_test.go
+++ b/internal/utility/scheduled_task_test.go
@@ -1,0 +1,134 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package utility
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestScheduledTaskConcurrentStart(t *testing.T) {
+	task := NewScheduledTask("concurrent start", time.Hour, func() {})
+	t.Cleanup(task.Stop)
+
+	const callers = 64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			task.Start()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	task.mu.Lock()
+	running := task.running
+	stop := task.stop
+	task.mu.Unlock()
+	if !running || stop == nil {
+		t.Fatal("concurrent Start calls did not leave the task running")
+	}
+}
+
+func TestScheduledTaskConcurrentStopIsIdempotent(t *testing.T) {
+	task := NewScheduledTask("concurrent stop", time.Hour, func() {})
+	task.Start()
+
+	const callers = 64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			task.Stop()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	task.Stop()
+
+	task.mu.Lock()
+	running := task.running
+	stop := task.stop
+	task.mu.Unlock()
+	if running || stop != nil {
+		t.Fatal("concurrent Stop calls did not leave the task stopped")
+	}
+}
+
+func TestScheduledTaskCanRestart(t *testing.T) {
+	var runs atomic.Int32
+	task := NewScheduledTask("restart", time.Millisecond, func() {
+		runs.Add(1)
+	})
+	t.Cleanup(task.Stop)
+
+	task.Start()
+	firstStop := scheduledTaskStopChannel(task)
+	waitForScheduledTaskRuns(t, &runs, 1)
+	task.Stop()
+
+	task.Start()
+	secondStop := scheduledTaskStopChannel(task)
+	if firstStop == secondStop {
+		t.Fatal("Start reused the closed stop channel")
+	}
+	select {
+	case <-secondStop:
+		t.Fatal("restart created an already-closed stop channel")
+	default:
+	}
+
+	previousRuns := runs.Load()
+	waitForScheduledTaskRuns(t, &runs, previousRuns+1)
+}
+
+func scheduledTaskStopChannel(task *ScheduledTask) chan struct{} {
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	return task.stop
+}
+
+func waitForScheduledTaskRuns(t *testing.T, runs *atomic.Int32, want int32) {
+	t.Helper()
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if runs.Load() >= want {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("scheduled task ran %d times; want at least %d", runs.Load(), want)
+		case <-ticker.C:
+		}
+	}
+}


### PR DESCRIPTION
### Summary

Make `ScheduledTask.Start()` and `ScheduledTask.Stop()` safe under concurrent calls.

Fixes https://github.com/infiniflow/ragflow/issues/18468

### Changes

- Protect lifecycle state with a mutex.
- Make `Stop()` idempotent to prevent closing the stop channel more than once.
- Create a new stop channel for each successful `Start()`.
- Capture the per-run stop channel in the worker goroutine.
- Prevent concurrent `Start()` calls from launching duplicate workers.
- Add tests for concurrent Start/Stop calls and restart behavior.

### Testing

- `go test -race ./internal/utility`
- `bash build.sh --test ./internal/utility`