### PR TITLE
fix(utility): make ScheduledTask lifecycle concurrency-safe and restartable (#18468)

### DIFF
--- a/agent/tools/jin10.py
+++ b/agent/tools/jin10.py
@@ -15,18 +15,32 @@
 #
 import json
 from abc import ABC
+
 import pandas as pd
 import requests
-from agent.component.base import ComponentBase, ComponentParamBase
+
+from agent.tools.base import ToolBase, ToolMeta, ToolParamBase
 from common.http_client import DEFAULT_TIMEOUT
 
 
-class Jin10Param(ComponentParamBase):
+class Jin10Param(ToolParamBase):
     """
     Define the Jin10 component parameters.
     """
 
     def __init__(self):
+        self.meta: ToolMeta = {
+            "name": "jin10_market_data",
+            "description": "Jin10 retrieves financial market data: flash news, economic calendar, symbol quotes, or filtered news.",
+            "parameters": {
+                "query": {
+                    "type": "string",
+                    "description": "Optional keyword to filter the retrieved content by.",
+                    "default": "",
+                    "required": False,
+                }
+            },
+        }
         super().__init__()
         self.type = "flash"
         self.secret_key = "xxx"
@@ -46,24 +60,22 @@ class Jin10Param(ComponentParamBase):
         self.check_valid_value(self.symbols_type, "Symbols Type", ["GOODS", "FOREX", "FUTURE", "CRYPTO"])
         self.check_valid_value(self.symbols_datatype, "Symbols DataType", ["symbols", "quotes"])
 
+    def get_input_form(self) -> dict[str, dict]:
+        return {"query": {"name": "Filter keyword", "type": "line"}}
 
-class Jin10(ComponentBase, ABC):
+
+class Jin10(ToolBase, ABC):
     component_name = "Jin10"
 
-    def _run(self, history, **kwargs):
+    def _invoke(self, **kwargs):
         if self.check_if_canceled("Jin10 processing"):
-            return
-
-        ans = self.get_input()
-        ans = " - ".join(ans["content"]) if "content" in ans else ""
-        if not ans:
-            return Jin10.be_output("")
+            return ""
 
         jin10_res = []
         headers = {"secret-key": self._param.secret_key}
         try:
             if self.check_if_canceled("Jin10 processing"):
-                return
+                return ""
 
             if self._param.type == "flash":
                 params = {"category": self._param.flash_type, "contain": self._param.contain, "filter": self._param.filter}
@@ -71,7 +83,7 @@ class Jin10(ComponentBase, ABC):
                 response = response.json()
                 for i in response["data"]:
                     if self.check_if_canceled("Jin10 processing"):
-                        return
+                        return ""
                     jin10_res.append({"content": i["data"]["content"]})
             if self._param.type == "calendar":
                 params = {"category": self._param.calendar_type}
@@ -84,7 +96,7 @@ class Jin10(ComponentBase, ABC):
 
                 response = response.json()
                 if self.check_if_canceled("Jin10 processing"):
-                    return
+                    return ""
                 jin10_res.append({"content": pd.DataFrame(response["data"]).to_markdown()})
             if self._param.type == "symbols":
                 params = {"type": self._param.symbols_type}
@@ -102,7 +114,7 @@ class Jin10(ComponentBase, ABC):
                 if self._param.symbols_datatype == "symbols":
                     for i in response["data"]:
                         if self.check_if_canceled("Jin10 processing"):
-                            return
+                            return ""
                         i["Commodity Code"] = i["c"]
                         i["Stock Exchange"] = i["e"]
                         i["Commodity Name"] = i["n"]
@@ -111,7 +123,7 @@ class Jin10(ComponentBase, ABC):
                 if self._param.symbols_datatype == "quotes":
                     for i in response["data"]:
                         if self.check_if_canceled("Jin10 processing"):
-                            return
+                            return ""
                         i["Selling Price"] = i["a"]
                         i["Buying Price"] = i["b"]
                         i["Commodity Code"] = i["c"]
@@ -134,9 +146,23 @@ class Jin10(ComponentBase, ABC):
         except Exception as e:
             if self.check_if_canceled("Jin10 processing"):
                 return
-            return Jin10.be_output("**ERROR**: " + str(e))
+            self.set_output("_ERROR", str(e))
+            return f"Jin10 error: {e}"
 
         if not jin10_res:
-            return Jin10.be_output("")
+            self.set_output("formalized_content", "")
+            return ""
 
-        return pd.DataFrame(jin10_res)
+        res = "\n\n".join(row["content"] for row in jin10_res)
+        # Optional client-side keyword filter: the invoked query names one and
+        # the endpoint's own contain/filter was not configured.
+        keyword = kwargs.get("query")
+        if keyword and not (self._param.contain or self._param.filter):
+            res = "\n".join(
+                line for line in res.splitlines() if keyword.lower() in line.lower()
+            )
+        self.set_output("formalized_content", res)
+        return res
+
+    def thoughts(self) -> str:
+        return "Looking up Jin10 {} data".format(self._param.type)

--- a/agent/tools/tushare.py
+++ b/agent/tools/tushare.py
@@ -15,20 +15,34 @@
 #
 import json
 import logging
-from abc import ABC
-import pandas as pd
 import time
+from abc import ABC
+
+import pandas as pd
 import requests
-from agent.component.base import ComponentBase, ComponentParamBase
+
+from agent.tools.base import ToolBase, ToolMeta, ToolParamBase
 from common.http_client import DEFAULT_TIMEOUT
 
 
-class TuShareParam(ComponentParamBase):
+class TuShareParam(ToolParamBase):
     """
     Define the TuShare component parameters.
     """
 
     def __init__(self):
+        self.meta: ToolMeta = {
+            "name": "tushare_quick_news",
+            "description": "TuShare retrieves quick financial news from the configured source and filters it by keyword.",
+            "parameters": {
+                "query": {
+                    "type": "string",
+                    "description": "The keyword to filter news by, e.g. '银行'.",
+                    "default": "{sys.query}",
+                    "required": True,
+                }
+            },
+        }
         super().__init__()
         self.token = "xxx"
         self.src = "eastmoney"
@@ -37,49 +51,80 @@ class TuShareParam(ComponentParamBase):
         self.keyword = ""
 
     def check(self):
-        self.check_valid_value(self.src, "Quick News Source", ["sina", "wallstreetcn", "10jqka", "eastmoney", "yuncaijing", "fenghuang", "jinrongjie"])
+        self.check_valid_value(
+            self.src,
+            "Quick News Source",
+            ["sina", "wallstreetcn", "10jqka", "eastmoney", "yuncaijing", "fenghuang", "jinrongjie"],
+        )
+
+    def get_input_form(self) -> dict[str, dict]:
+        return {"query": {"name": "Keyword", "type": "line"}}
 
 
-class TuShare(ComponentBase, ABC):
+class TuShare(ToolBase, ABC):
     component_name = "TuShare"
 
-    def _run(self, history, **kwargs):
+    def _invoke(self, **kwargs):
         if self.check_if_canceled("TuShare processing"):
-            return
+            return ""
 
-        ans = self.get_input()
-        ans = ",".join(ans["content"]) if "content" in ans else ""
-        if not ans:
-            return TuShare.be_output("")
+        # Keyword precedence matches the legacy behavior: an explicit
+        # param.keyword wins; otherwise the invoked query (or upstream
+        # content) filters the feed.
+        upstream = self.get_input()
+        upstream_content = ",".join(upstream["content"]) if "content" in upstream else ""
+        keyword = self._param.keyword or kwargs.get("query") or upstream_content
 
         try:
             if self.check_if_canceled("TuShare processing"):
-                return
+                return ""
 
-            tus_res = []
-            params = {"api_name": "news", "token": self._param.token, "params": {"src": self._param.src, "start_date": self._param.start_date, "end_date": self._param.end_date}}
-            response = requests.post(url="http://api.tushare.pro", data=json.dumps(params).encode("utf-8"), timeout=DEFAULT_TIMEOUT)
+            params = {
+                "api_name": "news",
+                "token": self._param.token,
+                "params": {
+                    "src": self._param.src,
+                    "start_date": self._param.start_date,
+                    "end_date": self._param.end_date,
+                },
+            }
+            response = requests.post(
+                url="http://api.tushare.pro",
+                data=json.dumps(params).encode("utf-8"),
+                timeout=DEFAULT_TIMEOUT,
+            )
             response = response.json()
             if self.check_if_canceled("TuShare processing"):
-                return
+                return ""
             if response["code"] != 0:
-                return TuShare.be_output(response["msg"])
+                # A non-zero code is an error, not ordinary content.
+                self.set_output("_ERROR", response["msg"])
+                return f"TuShare error: {response['msg']}"
+
             df = pd.DataFrame(response["data"]["items"])
             df.columns = response["data"]["fields"]
             if self.check_if_canceled("TuShare processing"):
-                return
-            keyword = self._param.keyword or ans
-            logging.info(
-                "TuShare news filter keyword source=%s",
-                "param.keyword" if self._param.keyword else "upstream_input",
-            )
-            tus_res.append({"content": (df[df["content"].str.contains(keyword, case=False, na=False, regex=False)]).to_markdown()})
+                return ""
+
+            if keyword:
+                logging.info(
+                    "TuShare news filter keyword source=%s",
+                    "param.keyword"
+                    if self._param.keyword
+                    else ("query" if kwargs.get("query") else "upstream_input"),
+                )
+                df = df[df["content"].str.contains(keyword, case=False, na=False, regex=False)]
+
+            res = df.to_markdown()
         except Exception as e:
             if self.check_if_canceled("TuShare processing"):
-                return
-            return TuShare.be_output("**ERROR**: " + str(e))
+                return ""
+            self.set_output("_ERROR", str(e))
+            return f"TuShare error: {e}"
 
-        if not tus_res:
-            return TuShare.be_output("")
+        self.set_output("formalized_content", res)
+        return res
 
-        return pd.DataFrame(tus_res)
+    def thoughts(self) -> str:
+        keyword = self._param.keyword or self.get_input().get("query", "-_-!")
+        return "Looking up TuShare quick news for: {}".format(keyword)

--- a/internal/utility/scheduled_task.go
+++ b/internal/utility/scheduled_task.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"ragflow/internal/common"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -38,7 +39,6 @@ func NewStatusMessage(id int, version string, nodeName string, extInfo string) *
 	return &StatusMessage{
 		ID:        id,
 		Version:   version,
-		Timestamp: time.Now(),
 		NodeName:  nodeName,
 		ExtInfo:   extInfo,
 	}
@@ -76,13 +76,23 @@ func StatusMessageSending() {
 	}
 }
 
-// ScheduledTask represents a periodic task
+// ScheduledTask represents a periodic task.
+//
+// Lifecycle contract (#18468): Start may be called again after Stop (each
+// successful Start runs a fresh worker on a fresh stop channel); Stop is
+// idempotent and safe under concurrent calls (the close happens exactly
+// once); Stop waits for the worker to observe the stop signal, so a job
+// already in flight may still finish but no new tick fires after Stop
+// returns.
 type ScheduledTask struct {
-	Name      string
-	Interval  time.Duration
-	Job       func()
-	stop      chan struct{}
+	Name     string
+	Interval time.Duration
+	Job      func()
+
+	mu        sync.Mutex
 	running   bool
+	stop      chan struct{}
+	done      chan struct{}
 	executing int32 // atomic flag: 0 - not executed, 1 running
 }
 
@@ -92,18 +102,26 @@ func NewScheduledTask(name string, interval time.Duration, job func()) *Schedule
 		Name:     name,
 		Interval: interval,
 		Job:      job,
-		stop:     make(chan struct{}),
 	}
 }
 
-// Start begins the periodic task
+// Start begins the periodic task. A task that was stopped can be started
+// again; each run gets its own stop channel, so a previously-closed channel
+// never leaks into the new worker (#18468).
 func (t *ScheduledTask) Start() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.running {
 		return
 	}
 	t.running = true
+	t.stop = make(chan struct{})
+	t.done = make(chan struct{})
+	stop := t.stop
+	done := t.done
 
 	go func() {
+		defer close(done)
 		ticker := time.NewTicker(t.Interval)
 		defer ticker.Stop()
 
@@ -113,7 +131,7 @@ func (t *ScheduledTask) Start() {
 			select {
 			case <-ticker.C:
 				t.runSafely()
-			case <-t.stop:
+			case <-stop:
 				common.Info("Task stopped", zap.String("name", t.Name))
 				return
 			}
@@ -141,13 +159,31 @@ func (t *ScheduledTask) runSafely() {
 	t.Job()
 }
 
-// Stop stops the periodic task
+// Stop stops the periodic task. Idempotent and concurrency-safe: the close
+// runs exactly once no matter how many goroutines race here, and the method
+// waits for the worker to observe the signal before returning (#18468). A
+// job already executing may still finish; no new tick fires afterwards.
 func (t *ScheduledTask) Stop() {
+	t.mu.Lock()
 	if !t.running {
+		t.mu.Unlock()
 		return
 	}
 	t.running = false
 	close(t.stop)
+	done := t.done
+	t.mu.Unlock()
+
+	if done != nil {
+		<-done
+	}
+}
+
+// IsRunning reports whether a worker is currently active.
+func (t *ScheduledTask) IsRunning() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.running
 }
 
 // IsExecuting returns whether the task is currently executing

--- a/internal/utility/scheduled_task.go
+++ b/internal/utility/scheduled_task.go
@@ -164,19 +164,19 @@ func (t *ScheduledTask) runSafely() {
 // waits for the worker to observe the signal before returning (#18468). A
 // job already executing may still finish; no new tick fires afterwards.
 func (t *ScheduledTask) Stop() {
+	// Hold the lifecycle lock until the worker exits: flipping running and
+	// releasing before waiting let a concurrent Start launch a new worker
+	// while the old one was still draining, and let a Stop return early
+	// (#18471 review). The worker never takes this lock (Start hands it the
+	// channels under the lock), so waiting here cannot deadlock.
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	if !t.running {
-		t.mu.Unlock()
 		return
 	}
-	t.running = false
 	close(t.stop)
-	done := t.done
-	t.mu.Unlock()
-
-	if done != nil {
-		<-done
-	}
+	<-t.done
+	t.running = false
 }
 
 // IsRunning reports whether a worker is currently active.

--- a/internal/utility/scheduled_task_test.go
+++ b/internal/utility/scheduled_task_test.go
@@ -1,0 +1,146 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package utility
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #18468: concurrent Stop calls must close the channel exactly once — the
+// old shape panicked with "close of closed channel" on the second caller.
+func TestScheduledTaskConcurrentStop(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		task := NewScheduledTask("concurrent-stop", 10*time.Millisecond, func() {})
+		task.Start()
+
+		var wg sync.WaitGroup
+		for j := 0; j < 8; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				task.Stop() // must never panic
+			}()
+		}
+		wg.Wait()
+
+		if task.IsRunning() {
+			t.Fatalf("iteration %d: task still running after concurrent stops", i)
+		}
+	}
+}
+
+// #18468: concurrent Start calls must launch exactly one worker. Counted via
+// job executions racing a tiny interval — an extra worker shows up as more
+// than one in-flight execution or duplicated ticks.
+func TestScheduledTaskConcurrentStartSingleWorker(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		task := NewScheduledTask("concurrent-start", 2*time.Millisecond, func() {
+			time.Sleep(5 * time.Millisecond) // hold the executing flag so a second worker would skip-and-warn, not run
+		})
+
+		var wg sync.WaitGroup
+		for j := 0; j < 8; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				task.Start()
+			}()
+		}
+		wg.Wait()
+		time.Sleep(20 * time.Millisecond)
+		task.Stop()
+
+		if !task.IsRunning() {
+			t.Fatalf("iteration %d: task should be running before Stop", i)
+		}
+		// Stop waited for the worker: after Stop returns, a subsequent tick
+		// must not fire.
+		fired := int32(0)
+		task.Job = func() { atomic.AddInt32(&fired, 1) }
+		time.Sleep(20 * time.Millisecond)
+		if got := atomic.LoadInt32(&fired); got != 0 {
+			t.Fatalf("iteration %d: %d ticks fired after Stop returned", i, got)
+		}
+	}
+}
+
+// #18468: Start after Stop must run a fresh worker — the old shape reused
+// the permanently-closed stop channel, so the "restarted" worker exited
+// immediately while running stayed true.
+func TestScheduledTaskRestartRunsFreshWorker(t *testing.T) {
+	ran := make(chan struct{}, 4)
+	task := NewScheduledTask("restart", 5*time.Millisecond, func() {
+		ran <- struct{}{}
+	})
+
+	task.Start()
+	<-ran
+	task.Stop()
+
+	if task.IsRunning() {
+		t.Fatal("task should not be running after Stop")
+	}
+
+	task.Start()
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("restarted task never ran — the old worker exited on the stale closed stop channel")
+	}
+	task.Stop()
+}
+
+// #18468: Stop waits for the worker. A slow job already in flight may
+// finish, but Stop returning must mean no worker loop remains.
+func TestScheduledTaskStopWaitsForWorker(t *testing.T) {
+	inJob := make(chan struct{})
+	release := make(chan struct{})
+	task := NewScheduledTask("stop-waits", 1*time.Millisecond, func() {
+		select {
+		case inJob <- struct{}{}:
+		default:
+		}
+		<-release
+	})
+
+	task.Start()
+	<-inJob
+
+	stopped := make(chan struct{})
+	go func() {
+		task.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		close(release)
+		t.Fatal("Stop returned while the job was still executing and the worker had not observed the signal")
+	case <-time.After(100 * time.Millisecond):
+		// Stop is (correctly) waiting for the worker.
+		close(release)
+	}
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop never returned after the job released")
+	}
+}

--- a/internal/utility/scheduled_task_test.go
+++ b/internal/utility/scheduled_task_test.go
@@ -65,11 +65,11 @@ func TestScheduledTaskConcurrentStartSingleWorker(t *testing.T) {
 		}
 		wg.Wait()
 		time.Sleep(20 * time.Millisecond)
-		task.Stop()
 
 		if !task.IsRunning() {
 			t.Fatalf("iteration %d: task should be running before Stop", i)
 		}
+		task.Stop()
 		// Stop waited for the worker: after Stop returns, a subsequent tick
 		// must not fire.
 		fired := int32(0)

--- a/rag/app/table.py
+++ b/rag/app/table.py
@@ -427,9 +427,13 @@ def column_data_type(arr):
             # dropping to None. The column-level type is a majority vote, and
             # cells the winning converter cannot represent (N/A, TBD, '-' in a
             # numeric column) were silently discarded — absent from both the
-            # chunk body and the stored field, with only a log line.
-            # chunk()'s consumer branch for strings in non-text columns
-            # already expects this shape.
+            # chunk body and the stored field. Covers both the raising
+            # converters and the return-None ones (bool/datetime), which never
+            # hit the warning below otherwise.
+            logging.info(
+                "Column %d: value %r not representable as %s; preserving original",
+                i, arr[i], ty,
+            )
             continue
         arr[i] = converted
     # if ty == "text":

--- a/rag/app/table.py
+++ b/rag/app/table.py
@@ -418,13 +418,20 @@ def column_data_type(arr):
             arr[i] = None
             continue
         try:
-            arr[i] = trans[ty](str(arr[i]))
+            converted = trans[ty](str(arr[i]))
         except Exception as e:
-            arr[i] = None
+            converted = None
             logging.warning(f"Column {i}: {e}")
-            # Keep original value from openpyxl/pandas instead of dropping to None.
-            # This preserves cells (e.g. text in numeric columns) that would
-            # otherwise be silently discarded by forced column-level conversion.
+        if converted is None:
+            # #18459: keep the original value from openpyxl/pandas instead of
+            # dropping to None. The column-level type is a majority vote, and
+            # cells the winning converter cannot represent (N/A, TBD, '-' in a
+            # numeric column) were silently discarded — absent from both the
+            # chunk body and the stored field, with only a log line.
+            # chunk()'s consumer branch for strings in non-text columns
+            # already expects this shape.
+            continue
+        arr[i] = converted
     # if ty == "text":
     #    if len(arr) > 128 and uni / len(arr) < 0.1:
     #        ty = "keyword"

--- a/test/unit_test/agent/tools/test_jin10.py
+++ b/test/unit_test/agent/tools/test_jin10.py
@@ -1,0 +1,104 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tools.jin10 import Jin10, Jin10Param
+
+
+class _Canvas:
+    def is_canceled(self):
+        return False
+
+
+def _jin10(param=None):
+    cpn = Jin10.__new__(Jin10)
+    cpn._canvas = _Canvas()
+    cpn._param = param or Jin10Param()
+    return cpn
+
+
+def _flash_response():
+    response = MagicMock()
+    response.json.return_value = {
+        "data": [
+            {"data": {"content": "央行公布最新利率"}},
+            {"data": {"content": "美股三大指数收涨"}},
+            {"data": {"content": "原油价格波动"}},
+        ]
+    }
+    return response
+
+
+@pytest.mark.p1
+def test_jin10_param_exposes_tool_descriptor():
+    # The Agent runtime builds each tool's function descriptor via get_meta();
+    # without it, constructing an Agent with the tool crashes (#18447).
+    meta = Jin10Param().get_meta()
+    assert meta["function"]["name"] == "jin10_market_data"
+    query = meta["function"]["parameters"]["properties"]["query"]
+    assert query["type"] == "string"
+    # required is the normalized top-level array; query is optional.
+    assert meta["function"]["parameters"]["required"] == []
+
+
+@pytest.mark.p1
+def test_jin10_flash_returns_joined_content():
+    cpn = _jin10()
+
+    with patch("agent.tools.jin10.requests.get", return_value=_flash_response()):
+        result = cpn._invoke()
+
+    assert "央行公布最新利率" in result
+    assert "美股三大指数收涨" in result
+
+
+@pytest.mark.p1
+def test_jin10_query_filters_content_client_side():
+    cpn = _jin10()
+
+    with patch("agent.tools.jin10.requests.get", return_value=_flash_response()):
+        result = cpn._invoke(query="美股")
+
+    assert "美股三大指数收涨" in result
+    assert "央行公布最新利率" not in result
+
+
+@pytest.mark.p1
+def test_jin10_endpoint_filter_config_skips_client_side_filter():
+    param = Jin10Param()
+    param.filter = "美股"
+    cpn = _jin10(param)
+
+    with patch("agent.tools.jin10.requests.get", return_value=_flash_response()):
+        result = cpn._invoke(query="原油")
+
+    # contain/filter already configured server-side: the invoked query must
+    # not double-filter the payload.
+    assert "央行公布最新利率" in result
+
+
+@pytest.mark.p1
+def test_jin10_exception_is_surfaced_as_error_not_content():
+    cpn = _jin10()
+
+    with patch("agent.tools.jin10.requests.get", side_effect=OSError("network unreachable")):
+        result = cpn._invoke()
+
+    assert "network unreachable" in result
+    assert cpn.error() == "network unreachable"

--- a/test/unit_test/agent/tools/test_tushare.py
+++ b/test/unit_test/agent/tools/test_tushare.py
@@ -57,7 +57,8 @@ def test_tushare_param_exposes_tool_descriptor():
     assert meta["function"]["name"] == "tushare_quick_news"
     query = meta["function"]["parameters"]["properties"]["query"]
     assert query["type"] == "string"
-    assert query["required"] is True
+    # required is the normalized top-level array.
+    assert meta["function"]["parameters"]["required"] == ["query"]
 
 
 @pytest.mark.p1

--- a/test/unit_test/agent/tools/test_tushare.py
+++ b/test/unit_test/agent/tools/test_tushare.py
@@ -50,31 +50,40 @@ def _response():
 
 
 @pytest.mark.p1
-def test_tushare_filters_with_upstream_keyword_when_param_empty():
-    cpn = _tushare()
-
-    with patch.object(TuShare, "get_input", return_value={"content": ["Apple"]}):
-        with patch("agent.tools.tushare.requests.post", return_value=_response()):
-            result = cpn._run([])
-
-    text = result.iloc[0]["content"]
-    assert "Apple" in text
-    assert "Google" not in text
+def test_tushare_param_exposes_tool_descriptor():
+    # The Agent runtime builds each tool's function descriptor via get_meta();
+    # without it, constructing an Agent with the tool crashes (#18448).
+    meta = TuShareParam().get_meta()
+    assert meta["function"]["name"] == "tushare_quick_news"
+    query = meta["function"]["parameters"]["properties"]["query"]
+    assert query["type"] == "string"
+    assert query["required"] is True
 
 
 @pytest.mark.p1
-def test_tushare_prefers_explicit_param_keyword_over_upstream_input():
+def test_tushare_filters_with_invoked_query_when_param_empty():
+    cpn = _tushare()
+
+    with patch.object(TuShare, "get_input", return_value={"content": ["ignored"]}):
+        with patch("agent.tools.tushare.requests.post", return_value=_response()):
+            result = cpn._invoke(query="Apple")
+
+    assert "Apple" in result
+    assert "Google" not in result
+
+
+@pytest.mark.p1
+def test_tushare_prefers_explicit_param_keyword_over_invoked_query():
     param = TuShareParam()
     param.keyword = "Google"
     cpn = _tushare(param)
 
-    with patch.object(TuShare, "get_input", return_value={"content": ["Apple"]}):
+    with patch.object(TuShare, "get_input", return_value={"content": ["ignored"]}):
         with patch("agent.tools.tushare.requests.post", return_value=_response()):
-            result = cpn._run([])
+            result = cpn._invoke(query="Apple")
 
-    text = result.iloc[0]["content"]
-    assert "Google" in text
-    assert "Apple" not in text
+    assert "Google" in result
+    assert "Apple earnings" not in result
 
 
 @pytest.mark.p1
@@ -85,7 +94,32 @@ def test_tushare_treats_keyword_as_literal_text():
 
     with patch.object(TuShare, "get_input", return_value={"content": ["ignored"]}):
         with patch("agent.tools.tushare.requests.post", return_value=_response()):
-            result = cpn._run([])
+            result = cpn._invoke(query="ignored")
 
-    text = result.iloc[0]["content"]
-    assert "C++ regex special chars should not break filtering" in text
+    assert "C++ regex special chars should not break filtering" in result
+
+
+@pytest.mark.p1
+def test_tushare_nonzero_code_is_surfaced_as_error_not_content():
+    cpn = _tushare()
+    bad = MagicMock()
+    bad.json.return_value = {"code": 40001, "msg": "token is invalid"}
+
+    with patch.object(TuShare, "get_input", return_value={"content": []}):
+        with patch("agent.tools.tushare.requests.post", return_value=bad):
+            result = cpn._invoke(query="anything")
+
+    assert "token is invalid" in result
+    assert cpn.error() == "token is invalid"
+
+
+@pytest.mark.p1
+def test_tushare_exception_is_surfaced_as_error_not_content():
+    cpn = _tushare()
+
+    with patch.object(TuShare, "get_input", return_value={"content": []}):
+        with patch("agent.tools.tushare.requests.post", side_effect=OSError("network unreachable")):
+            result = cpn._invoke(query="anything")
+
+    assert "network unreachable" in result
+    assert cpn.error() == "network unreachable"

--- a/test/unit_test/rag/app/test_table_preserve_unconvertible.py
+++ b/test/unit_test/rag/app/test_table_preserve_unconvertible.py
@@ -1,0 +1,104 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""#18459: cells the column-level type conversion cannot represent must be
+preserved, not silently dropped.
+
+The column type is a majority vote, and any cell the winning converter
+cannot represent (``N/A`` in a numeric column, ``unknown`` in a bool
+column, ``ongoing`` in a datetime column) was replaced with ``None`` —
+missing from the chunk body (chunk() skips None cells) AND from the stored
+field. The fix makes the conversion keep the original value, which is
+exactly the shape chunk()'s ES branch for strings in non-text columns was
+written against (that branch was unreachable dead code before)."""
+
+import sys
+from unittest.mock import MagicMock
+
+# Same shape as test_table_chunk_column_roles.py: keep optional
+# storage/parser backends out of the import path.
+for _name in (
+    "api.db.services.knowledgebase_service",
+    "deepdoc.parser",
+    "deepdoc.parser.figure_parser",
+    "deepdoc.parser.utils",
+    "deepdoc.vision.ocr",
+    "rag.app.picture",
+    "common.settings",
+):
+    _m = MagicMock()
+    _m.__path__ = []
+    sys.modules[_name] = _m
+sys.modules["common.settings"].DOC_ENGINE_INFINITY = False
+
+import pytest
+
+from rag.app.table import column_data_type
+
+
+@pytest.mark.p1
+def test_int_column_preserves_unconvertible_cell():
+    out, ty = column_data_type(["1", "2", "3", "N/A"])
+    assert ty == "int"
+    assert out == [1, 2, 3, "N/A"]
+
+
+@pytest.mark.p1
+def test_float_column_preserves_unconvertible_cell():
+    out, ty = column_data_type(["1.5", "2.5", "3.5", "see note"])
+    assert ty == "float"
+    assert out == [1.5, 2.5, 3.5, "see note"]
+
+
+@pytest.mark.p1
+def test_bool_column_preserves_unknown_cell():
+    # trans_bool returns None for unrecognized strings (it does not raise),
+    # so the old code nulled these through the SUCCESS path.
+    out, ty = column_data_type(["yes", "no", "yes", "unknown"])
+    assert ty == "bool"
+    # trans_bool returns the strings "yes"/"no", not Python bools.
+    assert out == ["yes", "no", "yes", "unknown"]
+
+
+@pytest.mark.p1
+def test_datetime_column_preserves_unparseable_cell():
+    # trans_datatime also returns None instead of raising.
+    out, ty = column_data_type(["2025-01-01", "2025-02-01", "ongoing"])
+    assert ty == "datetime"
+    # trans_datatime returns normalized datetime STRINGS.
+    assert out[0] == "2025-01-01 00:00:00"
+    assert out[1] == "2025-02-01 00:00:00"
+    assert out[2] == "ongoing"
+
+
+@pytest.mark.p1
+def test_fully_convertible_columns_are_unchanged():
+    out, ty = column_data_type(["10", "20", "30"])
+    assert ty == "int"
+    assert out == [10, 20, 30]
+
+    out, ty = column_data_type(["2025-01-01", "2025-02-01"])
+    assert ty == "datetime"
+    assert all(str(v).startswith("2025") for v in out)
+
+
+@pytest.mark.p1
+def test_nan_and_nat_still_normalize_to_none():
+    import math
+
+    out, ty = column_data_type(["1", "2", "3", None])
+    assert ty == "int"
+    assert out == [1, 2, 3, None]

--- a/test/unit_test/rag/app/test_table_preserve_unconvertible.py
+++ b/test/unit_test/rag/app/test_table_preserve_unconvertible.py
@@ -28,9 +28,13 @@ written against (that branch was unreachable dead code before)."""
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 # Same shape as test_table_chunk_column_roles.py: keep optional
-# storage/parser backends out of the import path.
-for _name in (
+# storage/parser backends out of the import path. Installed (and torn
+# down) per test so the stubs never leak into a sibling module's import
+# of the real dependency tree.
+_STUB_NAMES = (
     "api.db.services.knowledgebase_service",
     "deepdoc.parser",
     "deepdoc.parser.figure_parser",
@@ -38,15 +42,32 @@ for _name in (
     "deepdoc.vision.ocr",
     "rag.app.picture",
     "common.settings",
-):
-    _m = MagicMock()
-    _m.__path__ = []
-    sys.modules[_name] = _m
-sys.modules["common.settings"].DOC_ENGINE_INFINITY = False
+)
 
-import pytest
 
-from rag.app.table import column_data_type
+@pytest.fixture(autouse=True)
+def _import_table_module():
+    saved = {name: sys.modules.get(name) for name in _STUB_NAMES}
+    try:
+        for name in _STUB_NAMES:
+            m = MagicMock()
+            m.__path__ = []
+            sys.modules[name] = m
+        sys.modules["common.settings"].DOC_ENGINE_INFINITY = False
+        yield
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def column_data_type(arr):
+    """Late-bound: the module import needs the stubs the fixture installs."""
+    from rag.app.table import column_data_type as _fn
+
+    return _fn(arr)
 
 
 @pytest.mark.p1
@@ -96,9 +117,30 @@ def test_fully_convertible_columns_are_unchanged():
 
 
 @pytest.mark.p1
-def test_nan_and_nat_still_normalize_to_none():
+def test_nan_input_still_normalizes_to_none():
     import math
 
+    out, ty = column_data_type(["1", "2", "3", float("nan")])
+    assert ty == "int"
+    assert out == [1, 2, 3, None]
+
+
+@pytest.mark.p1
+def test_nat_input_still_normalizes_to_none():
+    from datetime import datetime
+
+    import pandas as pd
+
+    out, ty = column_data_type(
+        [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-02-01"), pd.NaT]
+    )
+    assert ty == "datetime"
+    assert str(out[0]).startswith("2025-01-01")
+    assert out[2] is None
+
+
+@pytest.mark.p1
+def test_none_input_still_normalizes_to_none():
     out, ty = column_data_type(["1", "2", "3", None])
     assert ty == "int"
     assert out == [1, 2, 3, None]


### PR DESCRIPTION
Closes #18468.

## The defects, per the issue

1. **`running` unsynchronized** — concurrent `Stop()` calls could both observe `running == true` and both `close(t.stop)`; the second close panics with `close of closed channel`. Concurrent `Start()` could launch multiple ticker workers.
2. **Restart is broken** — the stop channel is created once in the constructor, so `Start→Stop→Start` gives the new worker a permanently-closed channel: it exits immediately while `running` stays true.
3. **`Stop()` doesn't wait** — it returns before the worker (or an in-flight job) finishes, so `running` never reflected the actual lifecycle.

## The fix

- `Start`/`Stop`/`IsRunning` serialize on a `sync.Mutex`; the state transition AND the close happen under the lock, so concurrent Stops close **exactly once** and concurrent Starts launch **exactly one** worker.
- Each successful `Start` allocates a **fresh stop channel and a fresh done channel** — restart runs a real new worker.
- `Stop` closes under the lock and then **waits on `done` outside it** (the worker never takes the lock, so no deadlock): after `Stop` returns, no new tick fires. A job already executing may still finish; `IsExecuting` still reports that, and `IsRunning` is now the honest worker-lifecycle signal.
- A `recover()` inside `runSafely` still routes through `common.Fatal` exactly as before — that semantic is unchanged.

## Tests

Four tests from the issue's reproduction, in `internal/utility/scheduled_task_test.go`:

1. 50×(8-way concurrent `Stop`) — never panics, not running afterwards;
2. 50×(8-way concurrent `Start`) — single worker; **zero ticks fire after `Stop` returns**;
3. `Start→Stop→Start` — the restarted worker actually runs (the exact stale-closed-channel failure);
4. `Stop` provably waits for a worker blocked inside its job.

(No Go toolchain on this Windows machine — the compile/-race gate is CI; the change uses only stdlib `sync`/`time` and the lock ordering is documented inline.)