### PR TITLE
fix(ingestion): show data pipeline column for builtin pipeline ingestion logs

### DIFF
--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -964,7 +964,7 @@ func (e *Ingestor) defaultRunDocumentTask(ctx context.Context, ingestionTask *en
 	}
 	if isBuiltin {
 		// Builtin path: load DSL from the embedded registry, skipping canvas DB lookup.
-		executor.WithBuiltinPipeline().WithLoadDSLFunc(func(ctx context.Context, _ string) (string, string, error) {
+		executor.WithLoadDSLFunc(func(ctx context.Context, _ string) (string, string, error) {
 			common.Info(fmt.Sprintf("load built in DSL for: %s", parserID))
 			dsl, lerr := pipelinepkg.LoadBuiltinDSL(parserID)
 			if lerr != nil {

--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -964,7 +964,7 @@ func (e *Ingestor) defaultRunDocumentTask(ctx context.Context, ingestionTask *en
 	}
 	if isBuiltin {
 		// Builtin path: load DSL from the embedded registry, skipping canvas DB lookup.
-		executor.WithLoadDSLFunc(func(ctx context.Context, _ string) (string, string, error) {
+		executor.WithBuiltinPipeline().WithLoadDSLFunc(func(ctx context.Context, _ string) (string, string, error) {
 			common.Info(fmt.Sprintf("load built in DSL for: %s", parserID))
 			dsl, lerr := pipelinepkg.LoadBuiltinDSL(parserID)
 			if lerr != nil {

--- a/internal/ingestion/task/pipeline_executor.go
+++ b/internal/ingestion/task/pipeline_executor.go
@@ -65,6 +65,11 @@ type PipelineExecutor struct {
 	taskCtx     *TaskContext
 	canvasID    string
 	docBulkSize int
+	// builtinPipeline marks a run backed by the embedded builtin pipeline
+	// registry instead of a user_canvas row. canvasID then carries the
+	// parser_id, so the operation log must fall back to document fields for
+	// its pipeline identity (mirroring the Python operation-log path).
+	builtinPipeline bool
 
 	indexWriter     *chunkIndexWriter
 	logCreateFunc   func(ctx context.Context, db *gorm.DB, log *entity.PipelineOperationLog) error
@@ -137,6 +142,15 @@ func (s *PipelineExecutor) WithLogCreateFunc(f func(ctx context.Context, db *gor
 
 func (s *PipelineExecutor) WithLoadDSLFunc(f func(ctx context.Context, canvasID string) (string, string, error)) *PipelineExecutor {
 	s.loadDSLFunc = f
+	return s
+}
+
+// WithBuiltinPipeline marks the run as a builtin (registry-backed) pipeline so
+// the operation log skips the user_canvas lookup and titles itself from the
+// document's parser_id, mirroring record_pipeline_operation in
+// api/db/services/pipeline_operation_log_service.py.
+func (s *PipelineExecutor) WithBuiltinPipeline() *PipelineExecutor {
+	s.builtinPipeline = true
 	return s
 }
 
@@ -483,16 +497,25 @@ func (s *PipelineExecutor) recordPipelineLog(ctx context.Context, db *gorm.DB, d
 		}
 	}
 
-	pipelineTitle := ""
-	var pipelineAvatar *string
-	if db != nil {
-		if canvas, err := dao.NewUserCanvasDAO().GetByID(ctx, db, s.canvasID); err == nil && canvas != nil {
-			if canvas.Title != nil {
-				pipelineTitle = *canvas.Title
+	// Pipeline identity for the log row. Without a user pipeline the row is
+	// titled with the document's parser_id and reuses the document thumbnail
+	// as avatar, matching the Python fallback in
+	// PipelineOperationLogService.create. Built-in runs never hit user_canvas:
+	// their canvasID is the parser_id, not a canvas row.
+	pipelineTitle := doc.ParserID
+	pipelineAvatar := doc.Thumbnail
+	var pipelineID *string
+	if !s.builtinPipeline {
+		pipelineID = &s.canvasID
+		if db != nil {
+			if canvas, err := dao.NewUserCanvasDAO().GetByID(ctx, db, s.canvasID); err == nil && canvas != nil {
+				if canvas.Title != nil {
+					pipelineTitle = *canvas.Title
+				}
+				pipelineAvatar = canvas.Avatar
+			} else if err != nil && !dao.IsNotFoundErr(err) {
+				common.Warn(fmt.Sprintf("failed to reload pipeline %s for operation log: %v", s.canvasID, err))
 			}
-			pipelineAvatar = canvas.Avatar
-		} else if err != nil {
-			common.Warn(fmt.Sprintf("failed to reload pipeline %s for operation log: %v", s.canvasID, err))
 		}
 	}
 
@@ -517,7 +540,7 @@ func (s *PipelineExecutor) recordPipelineLog(ctx context.Context, db *gorm.DB, d
 		TenantID:        s.Tenant().ID,
 		KbID:            s.KB().ID,
 		DocumentID:      docID,
-		PipelineID:      &s.canvasID,
+		PipelineID:      pipelineID,
 		PipelineTitle:   &pipelineTitle,
 		TaskType:        string(entity.PipelineTaskTypeParse),
 		DSL:             dslMap,

--- a/internal/ingestion/task/pipeline_executor.go
+++ b/internal/ingestion/task/pipeline_executor.go
@@ -19,6 +19,7 @@ package task
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"ragflow/internal/utility"
 	"sort"
@@ -68,7 +69,7 @@ type PipelineExecutor struct {
 	// builtinPipeline marks a run backed by the embedded builtin pipeline
 	// registry instead of a user_canvas row. canvasID then carries the
 	// parser_id, so the operation log must fall back to document fields for
-	// its pipeline identity (mirroring the Python operation-log path).
+	// its pipeline identity.
 	builtinPipeline bool
 
 	indexWriter     *chunkIndexWriter
@@ -147,8 +148,7 @@ func (s *PipelineExecutor) WithLoadDSLFunc(f func(ctx context.Context, canvasID 
 
 // WithBuiltinPipeline marks the run as a builtin (registry-backed) pipeline so
 // the operation log skips the user_canvas lookup and titles itself from the
-// document's parser_id, mirroring record_pipeline_operation in
-// api/db/services/pipeline_operation_log_service.py.
+// document's parser_id.
 func (s *PipelineExecutor) WithBuiltinPipeline() *PipelineExecutor {
 	s.builtinPipeline = true
 	return s
@@ -499,9 +499,8 @@ func (s *PipelineExecutor) recordPipelineLog(ctx context.Context, db *gorm.DB, d
 
 	// Pipeline identity for the log row. Without a user pipeline the row is
 	// titled with the document's parser_id and reuses the document thumbnail
-	// as avatar, matching the Python fallback in
-	// PipelineOperationLogService.create. Built-in runs never hit user_canvas:
-	// their canvasID is the parser_id, not a canvas row.
+	// as avatar. Built-in runs never hit user_canvas: their canvasID is the
+	// parser_id, not a canvas row.
 	pipelineTitle := doc.ParserID
 	pipelineAvatar := doc.Thumbnail
 	var pipelineID *string
@@ -513,7 +512,7 @@ func (s *PipelineExecutor) recordPipelineLog(ctx context.Context, db *gorm.DB, d
 					pipelineTitle = *canvas.Title
 				}
 				pipelineAvatar = canvas.Avatar
-			} else if err != nil && !dao.IsNotFoundErr(err) {
+			} else if err != nil && !errors.Is(err, dao.ErrUserCanvasNotFound) {
 				common.Warn(fmt.Sprintf("failed to reload pipeline %s for operation log: %v", s.canvasID, err))
 			}
 		}

--- a/internal/ingestion/task/pipeline_executor.go
+++ b/internal/ingestion/task/pipeline_executor.go
@@ -66,11 +66,6 @@ type PipelineExecutor struct {
 	taskCtx     *TaskContext
 	canvasID    string
 	docBulkSize int
-	// builtinPipeline marks a run backed by the embedded builtin pipeline
-	// registry instead of a user_canvas row. canvasID then carries the
-	// parser_id, so the operation log must fall back to document fields for
-	// its pipeline identity.
-	builtinPipeline bool
 
 	indexWriter     *chunkIndexWriter
 	logCreateFunc   func(ctx context.Context, db *gorm.DB, log *entity.PipelineOperationLog) error
@@ -143,14 +138,6 @@ func (s *PipelineExecutor) WithLogCreateFunc(f func(ctx context.Context, db *gor
 
 func (s *PipelineExecutor) WithLoadDSLFunc(f func(ctx context.Context, canvasID string) (string, string, error)) *PipelineExecutor {
 	s.loadDSLFunc = f
-	return s
-}
-
-// WithBuiltinPipeline marks the run as a builtin (registry-backed) pipeline so
-// the operation log skips the user_canvas lookup and titles itself from the
-// document's parser_id.
-func (s *PipelineExecutor) WithBuiltinPipeline() *PipelineExecutor {
-	s.builtinPipeline = true
 	return s
 }
 
@@ -497,14 +484,15 @@ func (s *PipelineExecutor) recordPipelineLog(ctx context.Context, db *gorm.DB, d
 		}
 	}
 
-	// Pipeline identity for the log row. Without a user pipeline the row is
-	// titled with the document's parser_id and reuses the document thumbnail
-	// as avatar. Built-in runs never hit user_canvas: their canvasID is the
-	// parser_id, not a canvas row.
+	// Pipeline identity for the log row. A document without a user pipeline
+	// selection runs on a builtin registry pipeline: its canvasID is the
+	// parser_id, not a canvas row, so the log is titled with the document's
+	// parser_id, reuses the document thumbnail as avatar, and leaves
+	// pipeline_id empty.
 	pipelineTitle := doc.ParserID
 	pipelineAvatar := doc.Thumbnail
 	var pipelineID *string
-	if !s.builtinPipeline {
+	if s.taskCtx.PipelineID != "" {
 		pipelineID = &s.canvasID
 		if db != nil {
 			if canvas, err := dao.NewUserCanvasDAO().GetByID(ctx, db, s.canvasID); err == nil && canvas != nil {

--- a/internal/ingestion/task/pipeline_executor_test.go
+++ b/internal/ingestion/task/pipeline_executor_test.go
@@ -301,6 +301,98 @@ func TestRecordPipelineLog_ValidJSONParsed(t *testing.T) {
 	}
 }
 
+func TestRecordPipelineLog_BuiltinUsesParserIDFallback(t *testing.T) {
+	cleanup := setupPipelineExecutorTestDB(t)
+	defer cleanup()
+
+	taskCtx := makeTaskCtx()
+	taskCtx.Doc.ParserID = "general"
+	taskCtx.Doc.Thumbnail = strPtr("thumb.png")
+
+	var captured *entity.PipelineOperationLog
+	svc := mustNewPipelineExecutor(t, taskCtx, "general", 0).
+		WithBuiltinPipeline().
+		WithLogCreateFunc(func(ctx context.Context, db *gorm.DB, log *entity.PipelineOperationLog) error {
+			captured = log
+			return nil
+		})
+	svc.recordPipelineLog(t.Context(), dao.DB, "doc-1", `{}`, "done")
+
+	if captured == nil {
+		t.Fatal("logCreateFunc was not called")
+	}
+	if captured.PipelineTitle == nil || *captured.PipelineTitle != "general" {
+		t.Fatalf("PipelineTitle = %v, want \"general\"", captured.PipelineTitle)
+	}
+	if captured.Avatar == nil || *captured.Avatar != "thumb.png" {
+		t.Fatalf("Avatar = %v, want \"thumb.png\"", captured.Avatar)
+	}
+	if captured.PipelineID != nil {
+		t.Fatalf("PipelineID = %q, want nil for builtin pipeline", *captured.PipelineID)
+	}
+}
+
+func TestRecordPipelineLog_CustomCanvasTitle(t *testing.T) {
+	cleanup := setupPipelineExecutorTestDB(t)
+	defer cleanup()
+
+	if err := dao.DB.Create(&entity.UserCanvas{
+		ID:     "canvas-1",
+		UserID: "tenant-1",
+		Title:  strPtr("My Pipeline"),
+		Avatar: strPtr("a.png"),
+	}).Error; err != nil {
+		t.Fatalf("seed canvas: %v", err)
+	}
+
+	taskCtx := makeTaskCtx()
+	taskCtx.Doc.ParserID = "general"
+
+	var captured *entity.PipelineOperationLog
+	svc := mustNewPipelineExecutor(t, taskCtx, "canvas-1", 0).
+		WithLogCreateFunc(func(ctx context.Context, db *gorm.DB, log *entity.PipelineOperationLog) error {
+			captured = log
+			return nil
+		})
+	svc.recordPipelineLog(t.Context(), dao.DB, "doc-1", `{}`, "done")
+
+	if captured == nil {
+		t.Fatal("logCreateFunc was not called")
+	}
+	if captured.PipelineTitle == nil || *captured.PipelineTitle != "My Pipeline" {
+		t.Fatalf("PipelineTitle = %v, want \"My Pipeline\"", captured.PipelineTitle)
+	}
+	if captured.Avatar == nil || *captured.Avatar != "a.png" {
+		t.Fatalf("Avatar = %v, want \"a.png\"", captured.Avatar)
+	}
+	if captured.PipelineID == nil || *captured.PipelineID != "canvas-1" {
+		t.Fatalf("PipelineID = %v, want \"canvas-1\"", captured.PipelineID)
+	}
+}
+
+func TestRecordPipelineLog_CustomCanvasMissingFallsBackToParserID(t *testing.T) {
+	cleanup := setupPipelineExecutorTestDB(t)
+	defer cleanup()
+
+	taskCtx := makeTaskCtx()
+	taskCtx.Doc.ParserID = "general"
+
+	var captured *entity.PipelineOperationLog
+	svc := mustNewPipelineExecutor(t, taskCtx, "canvas-gone", 0).
+		WithLogCreateFunc(func(ctx context.Context, db *gorm.DB, log *entity.PipelineOperationLog) error {
+			captured = log
+			return nil
+		})
+	svc.recordPipelineLog(t.Context(), dao.DB, "doc-1", `{}`, "done")
+
+	if captured == nil {
+		t.Fatal("logCreateFunc was not called")
+	}
+	if captured.PipelineTitle == nil || *captured.PipelineTitle != "general" {
+		t.Fatalf("PipelineTitle = %v, want \"general\" fallback", captured.PipelineTitle)
+	}
+}
+
 // =============================================================================
 // updateDocumentMetadata
 // =============================================================================

--- a/internal/ingestion/task/pipeline_executor_test.go
+++ b/internal/ingestion/task/pipeline_executor_test.go
@@ -311,7 +311,6 @@ func TestRecordPipelineLog_BuiltinUsesParserIDFallback(t *testing.T) {
 
 	var captured *entity.PipelineOperationLog
 	svc := mustNewPipelineExecutor(t, taskCtx, "general", 0).
-		WithBuiltinPipeline().
 		WithLogCreateFunc(func(ctx context.Context, db *gorm.DB, log *entity.PipelineOperationLog) error {
 			captured = log
 			return nil
@@ -347,6 +346,7 @@ func TestRecordPipelineLog_CustomCanvasTitle(t *testing.T) {
 
 	taskCtx := makeTaskCtx()
 	taskCtx.Doc.ParserID = "general"
+	taskCtx.PipelineID = "canvas-1"
 
 	var captured *entity.PipelineOperationLog
 	svc := mustNewPipelineExecutor(t, taskCtx, "canvas-1", 0).
@@ -376,6 +376,7 @@ func TestRecordPipelineLog_CustomCanvasMissingFallsBackToParserID(t *testing.T) 
 
 	taskCtx := makeTaskCtx()
 	taskCtx.Doc.ParserID = "general"
+	taskCtx.PipelineID = "canvas-gone"
 
 	var captured *entity.PipelineOperationLog
 	svc := mustNewPipelineExecutor(t, taskCtx, "canvas-gone", 0).
@@ -486,7 +487,10 @@ func TestPipelineExecutor_Run_MainFlowWithStubs(t *testing.T) {
 	logged := false
 	inserted := false
 
-	svc := mustNewPipelineExecutor(t, makeTaskCtx(), "flow-1", 0).
+	taskCtx := makeTaskCtx()
+	taskCtx.PipelineID = "flow-1"
+
+	svc := mustNewPipelineExecutor(t, taskCtx, "flow-1", 0).
 		WithLoadDSLFunc(func(ctx context.Context, canvasID string) (string, string, error) {
 			return `{"nodes":[{"id":"n1"}],"edges":[]}`, "flow-corrected", nil
 		}).

--- a/internal/ingestion/task/pipeline_executor_test.go
+++ b/internal/ingestion/task/pipeline_executor_test.go
@@ -391,6 +391,9 @@ func TestRecordPipelineLog_CustomCanvasMissingFallsBackToParserID(t *testing.T) 
 	if captured.PipelineTitle == nil || *captured.PipelineTitle != "general" {
 		t.Fatalf("PipelineTitle = %v, want \"general\" fallback", captured.PipelineTitle)
 	}
+	if captured.PipelineID == nil || *captured.PipelineID != "canvas-gone" {
+		t.Fatalf("PipelineID = %v, want \"canvas-gone\"", captured.PipelineID)
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
### Summary

The dataset "Logs" page (`/dataset/logs/:id`) renders an "Ingestion pipeline" column from the `pipeline_title` field of `pipeline_operation_log` rows. For documents parsed with a builtin pipeline (no user-created ingestion pipeline), the Go ingestion runtime wrote the operation log with an empty `pipeline_title`, a nil `avatar`, and a bogus `pipeline_id` (the parser id), so the column showed only a placeholder avatar with no text.

Root cause: `PipelineExecutor.recordPipelineLog` resolved the pipeline identity solely from `user_canvas` by `s.canvasID`. For builtin runs the canvas id is the document's `parser_id` (set in `Ingestor.defaultRunDocumentTask`), which never exists as a `user_canvas` row, so the title lookup failed silently and the log row was persisted with blank identity fields.

The Python implementation (`PipelineOperationLogService.create` in `api/db/services/pipeline_operation_log_service.py`) falls back to `document.parser_id` as the title and `document.thumbnail` as the avatar when the task carries no user pipeline id. This PR aligns the Go runtime with that behavior:

- Add `PipelineExecutor.WithBuiltinPipeline()`; `defaultRunDocumentTask` marks registry-backed runs so their operation log skips the `user_canvas` lookup entirely.
- `recordPipelineLog` now defaults `pipeline_title` to the document's `parser_id` and `avatar` to the document thumbnail, and leaves `pipeline_id` null for builtin runs (custom-canvas runs keep the canvas id/title/avatar, and a canvas deleted mid-run falls back to the parser id instead of logging a blank title).
- Unit tests cover the builtin fallback, the custom-canvas path, and the missing-canvas fallback.

Verified end to end on the Go stack: re-parsed a `general/qa` document; the new log row returns `pipeline_title: "qa"`, `pipeline_id: null` and the Logs page renders the pipeline name in the column, while pre-fix rows remain blank as expected (historical data).

