### PR TITLE
refa: remove document graph snapshot payload

### DIFF
--- a/rag/advanced_rag/knowlege_compile/structure.py
+++ b/rag/advanced_rag/knowlege_compile/structure.py
@@ -2396,7 +2396,6 @@ async def _struct_upsert_graph_json(
     row_id = _struct_graph_row_id(doc_id, compile_kwd, compilation_template_id)
     row = {
         "id": row_id,
-        "content_with_weight": json.dumps(graph, ensure_ascii=False),
         "compile_kwd": compile_kwd,
         "knowledge_graph_kwd": "graph",
         "doc_id": doc_id,


### PR DESCRIPTION
### What problem does this PR solve?

Remove the redundant full document-level graph JSON payload from structure graph metadata rows. Entity and relation rows remain the source of truth, while the graph row is retained for template discovery.

### Type of change

- [x] Refactor (no functional change)