### PR TITLE
Fix empty Markdown document parsing

### DIFF
--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -837,7 +837,7 @@ class Markdown(MarkdownParser):
 
     def __call__(self, filename, binary=None, separate_tables=True, delimiter=None, return_section_images=False):
         """Parse markdown into text sections and optional standalone table chunks."""
-        if binary:
+        if binary is not None:
             encoding = find_codec(binary)
             txt = binary.decode(encoding, errors="ignore")
         else:

--- a/test/unit_test/rag/app/test_markdown_image_ssrf.py
+++ b/test/unit_test/rag/app/test_markdown_image_ssrf.py
@@ -92,6 +92,21 @@ def parser(naive_module):
 
 
 @pytest.mark.p1
+def test_parses_empty_binary_without_opening_filename(parser):
+    with patch("builtins.open") as open_file:
+        sections, tables, section_images = parser(
+            "empty-document.md",
+            binary=b"",
+            return_section_images=True,
+        )
+
+    open_file.assert_not_called()
+    assert sections == []
+    assert tables == []
+    assert section_images == []
+
+
+@pytest.mark.p1
 def test_blocks_internal_url_without_fetching(parser):
     """A markdown image pointing at an internal host must never be requested."""
     with (


### PR DESCRIPTION
## Summary
- treat empty Markdown binaries as in-memory content instead of local file paths
- add a regression test ensuring empty content does not access the filesystem

## Testing
- python -m py_compile rag/app/naive.py test/unit_test/rag/app/test_markdown_image_ssrf.py
- Targeted pytest could not run because the local environment lacks pytest and dependency resolution is blocked by an authenticated Gitee dependency.