### PR TITLE
fix(agent): sanitize Excel output sheet names

### DIFF
--- a/agent/component/excel_processor.py
+++ b/agent/component/excel_processor.py
@@ -348,7 +348,7 @@ class ExcelProcessor(ComponentBase, ABC):
                     for sheet_name, df in dfs.items():
                         # Sanitize sheet name (max 31 chars, no special or reserved names)
                         original_name = str(sheet_name)
-                        normalized_name = re.sub(r"[\\/*?:\[\]]", "_", original_name).strip("'")
+                        normalized_name = re.sub(r"[\x00-\x08\x0B\x0C\x0E-\x1F\\/*?:\[\]]", "_", original_name).strip("'")
                         if normalized_name.casefold() == "history":
                             normalized_name = f"{normalized_name}_"
                         base_name = normalized_name[:31] or "Sheet"

--- a/agent/component/excel_processor.py
+++ b/agent/component/excel_processor.py
@@ -23,6 +23,7 @@ Supports multiple Excel file inputs, data transformation, and Excel output gener
 
 import logging
 import os
+import re
 from abc import ABC
 from io import BytesIO
 
@@ -341,10 +342,32 @@ class ExcelProcessor(ComponentBase, ABC):
                 # Excel output
                 excel_io = BytesIO()
                 with pd.ExcelWriter(excel_io, engine="openpyxl") as writer:
+                    used_sheet_names = set()
+                    normalized_sheet_count = 0
+                    deduplicated_sheet_count = 0
                     for sheet_name, df in dfs.items():
-                        # Sanitize sheet name (max 31 chars, no special chars)
-                        safe_name = sheet_name[:31].replace("/", "_").replace("\\", "_")
+                        # Sanitize sheet name (max 31 chars, no special or reserved names)
+                        original_name = str(sheet_name)
+                        normalized_name = re.sub(r"[\\/*?:\[\]]", "_", original_name).strip("'")
+                        if normalized_name.casefold() == "history":
+                            normalized_name = f"{normalized_name}_"
+                        base_name = normalized_name[:31] or "Sheet"
+                        normalized_sheet_count += base_name != original_name
+                        safe_name = base_name
+                        counter = 2
+                        if safe_name.casefold() in used_sheet_names:
+                            deduplicated_sheet_count += 1
+                        while safe_name.casefold() in used_sheet_names:
+                            suffix = f"_{counter}"
+                            safe_name = f"{base_name[: 31 - len(suffix)]}{suffix}"
+                            counter += 1
+                        used_sheet_names.add(safe_name.casefold())
                         df.to_excel(writer, sheet_name=safe_name, index=False)
+                logging.info(
+                    "ExcelProcessor: Normalized %d sheet name(s) and deduplicated %d",
+                    normalized_sheet_count,
+                    deduplicated_sheet_count,
+                )
                 excel_io.seek(0)
                 binary_content = excel_io.read()
                 filename = f"{self._param.output_filename}.xlsx"

--- a/test/unit_test/agent/component/test_excel_processor_output.py
+++ b/test/unit_test/agent/component/test_excel_processor_output.py
@@ -101,12 +101,15 @@ def test_output_excel_sanitizes_and_deduplicates_sheet_names(monkeypatch):
     }
     assert stored["tenant_id"] == "tenant-1"
     workbook = openpyxl.load_workbook(BytesIO(stored["data"]), read_only=True)
-    assert workbook.sheetnames == [
-        "Q1_ Sales",
-        "Q1_ Sales_2",
-        "Sales",
-        "History_",
-        "Sheet",
-        "A" * 31,
-        "Nul_Name",
-    ]
+    try:
+        assert workbook.sheetnames == [
+            "Q1_ Sales",
+            "Q1_ Sales_2",
+            "Sales",
+            "History_",
+            "Sheet",
+            "A" * 31,
+            "Nul_Name",
+        ]
+    finally:
+        workbook.close()

--- a/test/unit_test/agent/component/test_excel_processor_output.py
+++ b/test/unit_test/agent/component/test_excel_processor_output.py
@@ -1,0 +1,110 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import importlib.util
+import sys
+from io import BytesIO
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import openpyxl
+
+
+def _load_excel_processor(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[4]
+
+    class ComponentBase:
+        pass
+
+    class ComponentParamBase:
+        def __init__(self):
+            self.outputs = {}
+
+    base = ModuleType("agent.component.base")
+    base.ComponentBase = ComponentBase
+    base.ComponentParamBase = ComponentParamBase
+    monkeypatch.setitem(sys.modules, "agent.component.base", base)
+
+    file_service = ModuleType("api.db.services.file_service")
+    file_service.FileService = SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "api.db.services.file_service", file_service)
+
+    api_utils = ModuleType("api.utils.api_utils")
+    api_utils.timeout = lambda _seconds: lambda func: func
+    monkeypatch.setitem(sys.modules, "api.utils.api_utils", api_utils)
+
+    storage = SimpleNamespace(put=lambda *_args, **_kwargs: None)
+    common = ModuleType("common")
+    common.settings = SimpleNamespace(STORAGE_IMPL=storage)
+    monkeypatch.setitem(sys.modules, "common", common)
+
+    misc_utils = ModuleType("common.misc_utils")
+    misc_utils.get_uuid = lambda: "attachment-id"
+    monkeypatch.setitem(sys.modules, "common.misc_utils", misc_utils)
+
+    module_path = repo_root / "agent" / "component" / "excel_processor.py"
+    spec = importlib.util.spec_from_file_location("test_excel_processor_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "test_excel_processor_module", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_output_excel_sanitizes_and_deduplicates_sheet_names(monkeypatch):
+    module = _load_excel_processor(monkeypatch)
+    stored = {}
+    module.settings.STORAGE_IMPL.put = lambda tenant_id, doc_id, data: stored.update(tenant_id=tenant_id, doc_id=doc_id, data=data)
+
+    long_sheet_name = "A" * 40
+    data = {
+        "Q1: Sales": [{"amount": 10}],
+        "Q1/ Sales": [{"amount": 20}],
+        "'Sales'": [{"amount": 30}],
+        "History": [{"amount": 40}],
+        "": [{"amount": 50}],
+        long_sheet_name: [{"amount": 60}],
+    }
+    component = module.ExcelProcessor.__new__(module.ExcelProcessor)
+    component._canvas = SimpleNamespace(
+        _tenant_id="tenant-1",
+        get_variable_value=lambda _ref: data,
+    )
+    component._param = SimpleNamespace(
+        transform_data="source@data",
+        output_format="xlsx",
+        output_filename="quarterly",
+    )
+    component.set_input_value = lambda *_args, **_kwargs: None
+    outputs = {}
+    component.set_output = outputs.__setitem__
+
+    component._output_excel()
+
+    assert outputs["attachment"] == {
+        "doc_id": "attachment-id",
+        "format": "xlsx",
+        "file_name": "quarterly.xlsx",
+    }
+    assert stored["tenant_id"] == "tenant-1"
+    workbook = openpyxl.load_workbook(BytesIO(stored["data"]), read_only=True)
+    assert workbook.sheetnames == [
+        "Q1_ Sales",
+        "Q1_ Sales_2",
+        "Sales",
+        "History_",
+        "Sheet",
+        "A" * 31,
+    ]

--- a/test/unit_test/agent/component/test_excel_processor_output.py
+++ b/test/unit_test/agent/component/test_excel_processor_output.py
@@ -76,6 +76,7 @@ def test_output_excel_sanitizes_and_deduplicates_sheet_names(monkeypatch):
         "History": [{"amount": 40}],
         "": [{"amount": 50}],
         long_sheet_name: [{"amount": 60}],
+        "Nul\x00Name": [{"amount": 70}],
     }
     component = module.ExcelProcessor.__new__(module.ExcelProcessor)
     component._canvas = SimpleNamespace(
@@ -107,4 +108,5 @@ def test_output_excel_sanitizes_and_deduplicates_sheet_names(monkeypatch):
         "History_",
         "Sheet",
         "A" * 31,
+        "Nul_Name",
     ]


### PR DESCRIPTION
### Summary

Sanitize `ExcelProcessor` sheet names before writing XLSX output. Multi-sheet agent data can use keys such as `Q1: Sales`; openpyxl rejects `:` and the component currently turns the entire output into an error. This replaces Excel-prohibited characters and titles (including edge apostrophes and the reserved name `History`), preserves the 31-character limit and empty-name fallback, and deduplicates names case-insensitively after normalization.

The regression test writes an actual workbook from invalid, reserved, empty, overlong, and colliding names, reopens it, and verifies the normalized sheets and stored attachment.

Testing:

- `.venv/bin/python -m pytest -q --confcutdir=test/unit_test/agent/component test/unit_test/agent/component/test_excel_processor_output.py` — 1 passed
- `python3 -m ruff check agent/component/excel_processor.py test/unit_test/agent/component/test_excel_processor_output.py` — passed
- `python3 -m ruff format --check agent/component/excel_processor.py test/unit_test/agent/component/test_excel_processor_output.py` — passed
- `.venv/bin/python -m py_compile agent/component/excel_processor.py test/unit_test/agent/component/test_excel_processor_output.py` — passed

OpenAI Codex assisted with identifying the edge case and preparing the focused patch; the behavior and test results were verified locally.
