### PR TITLE
fix: preserve blocking GaussDB advisory locks

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -936,9 +936,14 @@ class GaussDBDatabaseLock(PostgresDatabaseLock):
 
     def __init__(self, lock_name, timeout=10, db=None):
         super().__init__(lock_name, timeout=timeout, db=db)
-        self.timeout = max(float(timeout), 0.0)
+        self.timeout = float(timeout)
 
     def lock(self):
+        if self.timeout < 0:
+            cursor = self.db.execute_sql("SELECT pg_advisory_lock(%s)", (self.lock_id,))
+            cursor.fetchone()
+            return True
+
         deadline = time.monotonic() + self.timeout
         while True:
             cursor = self.db.execute_sql("SELECT pg_try_advisory_lock(%s)", (self.lock_id,))

--- a/test/unit_test/api/db/test_gaussdb_peewee.py
+++ b/test/unit_test/api/db/test_gaussdb_peewee.py
@@ -385,6 +385,24 @@ class TestGaussDBDatabase:
         assert GaussDBDatabaseLock("init_database_tables", timeout=1.0, db=db).lock()
         assert sleeps == [0.1, 0.1]
 
+    def test_gaussdb_lock_waits_indefinitely_with_blocking_lock(self):
+        db = SequenceLockDB([None])
+        lock = GaussDBDatabaseLock("update_progress", timeout=-1, db=db)
+
+        assert lock.lock()
+        assert lock.timeout == -1
+        assert db.calls == [("SELECT pg_advisory_lock(%s)", (lock.lock_id,))]
+
+    def test_gaussdb_lock_timeout_zero_only_tries_once(self, monkeypatch):
+        monkeypatch.setattr(db_models.time, "monotonic", lambda: 30.0)
+        db = SequenceLockDB([False])
+        lock = GaussDBDatabaseLock("update_progress", timeout=0, db=db)
+
+        with pytest.raises(Exception, match="acquire gaussdb lock update_progress timeout"):
+            lock.lock()
+
+        assert db.calls == [("SELECT pg_try_advisory_lock(%s)", (lock.lock_id,))]
+
     def test_gaussdb_lock_stops_at_timeout(self, monkeypatch):
         now = [20.0]
         monkeypatch.setattr(db_models.time, "monotonic", lambda: now[0])


### PR DESCRIPTION
## Background

`TaskService.update_progress()` uses `DB.lock("update_progress", -1)` to serialize task progress writes. A negative timeout is intended to wait until the lock becomes available.

With GaussDB metadata storage, a worker could finish parsing and indexing while the final progress update failed to acquire the advisory lock. The document then remained in the UI as `Running` at a stale percentage (reproduced at 10%) even though the task had already finished.

## Root cause

`GaussDBDatabaseLock.__init__()` clamped every negative timeout to `0.0`. Therefore `timeout=-1` became an immediate `pg_try_advisory_lock()` attempt. If another connection held the lock at that moment, it raised a timeout instead of waiting.

## Fix

- Preserve the signed timeout value.
- Use blocking `pg_advisory_lock()` for negative timeouts.
- Keep the existing polling and timeout behavior for zero and positive values.
- Add regression coverage for negative blocking semantics and zero-timeout one-shot semantics.

## Compatibility

The change is limited to `GaussDBDatabaseLock`. MySQL, PostgreSQL, OceanBase, and GaussDB calls with non-negative timeouts retain their existing behavior.

## Validation

- Reproduced and verified through the Dataset UI with both the metadata database and document engine set to GaussDB.
- Canceled the stale task and reparsed the same PDF from the UI; progress moved from 10% to 80% and then completed with 4 chunks.
- The worker logged `Task done (113.64s)` with no `update_progress` lock timeout.
- Focused advisory-lock semantics, Ruff formatting, stable Ruff checks, and Python syntax checks passed.