### PR TITLE
fix(web): style think/retrieving blocks in floating chat widget

### DIFF
--- a/web/src/components/floating-chat-widget-markdown.module.less
+++ b/web/src/components/floating-chat-widget-markdown.module.less
@@ -59,6 +59,32 @@
     line-height: 1.6;
   }
 
+  :global(details.think),
+  :global(details.retrieving) {
+    padding-inline-start: 0px;
+    margin-bottom: 10px;
+    font-size: 12px;
+    color: rgb(var(--text-secondary));
+
+    summary {
+      cursor: pointer;
+      font-weight: 500;
+      user-select: none;
+      color: var(--text-secondary);
+      &:hover {
+        color: rgb(var(--text-secondary));
+      }
+    }
+  }
+
+  :global(details.think) {
+    border-inline-start: 2px solid var(--border-default);
+  }
+
+  :global(details.retrieving) {
+    border-inline-start: 2px solid var(--border-button);
+  }
+
   /* Enhanced image styles */
   img,
   .ant-image,

--- a/web/src/components/floating-chat-widget-markdown.tsx
+++ b/web/src/components/floating-chat-widget-markdown.tsx
@@ -317,7 +317,7 @@ const FloatingChatWidgetMarkdown = ({
   const dir = getDirAttribute(content.replace(citationMarkerReg, ''));
 
   return (
-    <div className="floating-chat-widget" dir={dir}>
+    <div className={styles['floating-chat-widget']} dir={dir}>
       <Markdown
         rehypePlugins={[rehypeRaw, rehypeWrapReference, rehypeKatex]}
         remarkPlugins={MarkdownRemarkPlugins}


### PR DESCRIPTION
### Summary

fix(web): style think/retrieving blocks in floating chat widget

The widget markdown wrapper referenced the class name as a plain string while the stylesheet is a CSS module, so the hashed class never matched and none of the rules applied. Bind the wrapper to the module class and add details.think / details.retrieving rules so reasoning blocks are visually distinct from the answer body, matching next-markdown-content.
