### PR TITLE
fix(web): show agent opening statement in embedded floating widget

### DIFF
--- a/web/src/components/floating-chat-widget.tsx
+++ b/web/src/components/floating-chat-widget.tsx
@@ -20,7 +20,6 @@ import { useClickDrawer } from '@/components/pdf-drawer/hooks';
 import { MessageType, SharedFrom } from '@/constants/chat';
 import { useFetchExternalAgentInputs } from '@/hooks/use-agent-request';
 import { useFetchExternalChatInfo } from '@/hooks/use-chat-request';
-import { IAnswer } from '@/interfaces/database/chat';
 import i18n, { changeLanguageAsync } from '@/locales/config';
 import { useSendNextSharedMessage } from '@/pages/agent/hooks/use-send-shared-message';
 import { removeThinkSection } from '@/utils/chat';
@@ -100,6 +99,13 @@ const normalizeWidgetFooterLink = (value: string | null) => {
 };
 
 /**
+ * Stable id for the seeded agent prologue. `addNewestOneAnswer` dedupes by
+ * message id, so a re-invoked effect (e.g. under React StrictMode) merges
+ * into the seeded message instead of appending a duplicate.
+ */
+const PROLOGUE_MESSAGE_ID = 'prologue';
+
+/**
  * Renders the embeddable floating chat widget and applies URL-driven widget settings.
  */
 const FloatingChatWidget = () => {
@@ -166,11 +172,13 @@ const FloatingChatWidget = () => {
   } = hookResult;
   const findReferenceByMessageId = (hookResult as any).findReferenceByMessageId;
   // Only the agent flow exposes these. The chat flow receives its prologue
-  // through the completions handshake instead.
-  const { addNewestOneAnswer, isTaskMode } = hookResult as {
-    addNewestOneAnswer?: (answer: IAnswer) => void;
-    isTaskMode?: boolean;
-  };
+  // through the completions handshake instead, so both stay optional here.
+  const { addNewestOneAnswer, isTaskMode } = hookResult as Partial<
+    Pick<
+      ReturnType<typeof useSendNextSharedMessage>,
+      'addNewestOneAnswer' | 'isTaskMode'
+    >
+  >;
 
   // Sync our local input with the hook's value when needed
   useEffect(() => {
@@ -195,8 +203,7 @@ const FloatingChatWidget = () => {
     if (data?.prologue) {
       addNewestOneAnswer?.({
         answer: data.prologue,
-        // Stable id so a re-invoked effect merges instead of duplicating.
-        id: 'prologue',
+        id: PROLOGUE_MESSAGE_ID,
       });
     }
   }, [isFromAgent, isTaskMode, data?.prologue, addNewestOneAnswer]);

--- a/web/src/components/floating-chat-widget.tsx
+++ b/web/src/components/floating-chat-widget.tsx
@@ -20,6 +20,7 @@ import { useClickDrawer } from '@/components/pdf-drawer/hooks';
 import { MessageType, SharedFrom } from '@/constants/chat';
 import { useFetchExternalAgentInputs } from '@/hooks/use-agent-request';
 import { useFetchExternalChatInfo } from '@/hooks/use-chat-request';
+import { IAnswer } from '@/interfaces/database/chat';
 import i18n, { changeLanguageAsync } from '@/locales/config';
 import { useSendNextSharedMessage } from '@/pages/agent/hooks/use-send-shared-message';
 import { removeThinkSection } from '@/utils/chat';
@@ -164,6 +165,12 @@ const FloatingChatWidget = () => {
     hasError,
   } = hookResult;
   const findReferenceByMessageId = (hookResult as any).findReferenceByMessageId;
+  // Only the agent flow exposes these. The chat flow receives its prologue
+  // through the completions handshake instead.
+  const { addNewestOneAnswer, isTaskMode } = hookResult as {
+    addNewestOneAnswer?: (answer: IAnswer) => void;
+    isTaskMode?: boolean;
+  };
 
   // Sync our local input with the hook's value when needed
   useEffect(() => {
@@ -175,6 +182,24 @@ const FloatingChatWidget = () => {
   const { data } = (
     isFromAgent ? useFetchExternalAgentInputs : useFetchExternalChatInfo
   )();
+
+  // Seed the agent's opening statement. The agent send hook derives the
+  // prologue from the agent canvas graph store, which is never populated on
+  // the widget page, so mirror pages/agent/share and take the prologue from
+  // the agentbots inputs endpoint instead. The chat flow already gets its
+  // prologue from the completions handshake.
+  useEffect(() => {
+    if (!isFromAgent || isTaskMode) {
+      return;
+    }
+    if (data?.prologue) {
+      addNewestOneAnswer?.({
+        answer: data.prologue,
+        // Stable id so a re-invoked effect merges instead of duplicating.
+        id: 'prologue',
+      });
+    }
+  }, [isFromAgent, isTaskMode, data?.prologue, addNewestOneAnswer]);
 
   const title = data.title;
   const displayTitle = widgetTitle || title || t('chat.chatSupport');


### PR DESCRIPTION
### Summary

An agent whose Begin component has the opening-statement switch enabled showed no opening statement (prologue) when embedded as the floating chat widget on a website, while the same agent showed it correctly on the fullscreen share page.

Root cause: the floating widget routes agent chats through `useSendNextSharedMessage` -> `useSendAgentMessage`, whose prologue seeding reads the agent canvas graph store (`useGetBeginNodePrologue`). That store is never populated on the widget page, so the prologue was silently dropped. The chat-assistant flow was unaffected because its prologue arrives from the completions handshake, and the agent share page was unaffected because it seeds the prologue from the `agentbots/<id>/inputs` response.

Fix: mirror `web/src/pages/agent/share/index.tsx` in `web/src/components/floating-chat-widget.tsx` — when the widget runs the agent flow (and not in task mode), seed the prologue returned by the agentbots inputs endpoint into the message list via the agent hook's `addNewestOneAnswer`. A stable message id keeps the seeding idempotent under React StrictMode double-invoked effects. The chat-assistant flow is untouched (the effect early-returns for non-agent embeds).

### Verification

- Reproduced pre-fix with a released conversational agent (`enablePrologue` on): the widget rendered the header but no opening message.
- Post-fix, the same widget URL renders the configured opening statement immediately.
- `npx oxlint` clean on the changed file; `npm run type-check` reports no errors for the changed file (remaining repo errors are pre-existing in unrelated files).
