### PR TITLE
fix(search): fix layout clipping when search page is not fullscreen

### DIFF
--- a/web/src/pages/next-search/index.tsx
+++ b/web/src/pages/next-search/index.tsx
@@ -50,11 +50,11 @@ export default function SearchPage() {
 
   return (
     <section
-      className="size-full flex-1 relative px-5 pb-5 flex pt-4 overflow-x-auto"
+      className="size-full flex-1 relative px-5 pb-5 flex pt-4"
       data-testid="search-detail"
     >
-      <div className="flex gap-3 w-full bg-bg-base border-0.5 border-border-button min-w-[1280px] ">
-        <div className="flex-1 min-w-0">
+      <div className="flex gap-3 flex-1 min-w-0 bg-bg-base border-0.5 border-border-button">
+        <div className="flex-1 min-w-0 overflow-hidden">
           {!isSearching && (
             <div className="animate-fade-in-down">
               <SearchHome
@@ -82,6 +82,7 @@ export default function SearchPage() {
           <SearchSetting
             open={openSetting}
             setOpen={setOpenSetting}
+            className="shrink-0 max-w-full"
             data={SearchData as ISearchAppDetailProps}
           />
         )}
@@ -89,7 +90,7 @@ export default function SearchPage() {
 
       <Button
         variant="transparent"
-        className="bg-bg-card ml-5"
+        className="bg-bg-card ml-5 shrink-0"
         onClick={() => setOpenSetting(!openSetting)}
       >
         <Settings className="text-text-secondary" />

--- a/web/src/pages/next-search/index.tsx
+++ b/web/src/pages/next-search/index.tsx
@@ -56,7 +56,7 @@ export default function SearchPage() {
       <div className="flex gap-3 flex-1 min-w-0 bg-bg-base border-0.5 border-border-button">
         <div className="flex-1 min-w-0 overflow-hidden">
           {!isSearching && (
-            <div className="animate-fade-in-down">
+            <div className="animate-fade-in-down h-full overflow-x-hidden overflow-y-auto">
               <SearchHome
                 setIsSearching={setIsSearching}
                 isSearching={isSearching}

--- a/web/src/pages/next-search/search-home.tsx
+++ b/web/src/pages/next-search/search-home.tsx
@@ -50,7 +50,7 @@ export default function SearchHome({
 
   return (
     <section className="relative w-full flex transition-all justify-center items-center mt-[15vh]">
-      <div className="relative z-10 px-8 pt-8 flex  text-transparent flex-col justify-center items-center w-[780px]">
+      <div className="relative z-10 px-8 pt-8 flex  text-transparent flex-col justify-center items-center w-full max-w-[780px]">
         <RAGFlowLogo showEmbedIcon={showEmbedLogo}></RAGFlowLogo>
         <div className="rounded-lg  text-primary text-xl sticky flex justify-center w-full transform scale-100 mt-8 p-6 min-h-[240px] border">
           {!isSearching && <Spotlight className="z-0" />}


### PR DESCRIPTION
### Summary

When the search page (`/search/:id`) is opened in a non-fullscreen window, the layout breaks visually: a horizontal scrollbar appears, the settings gear is pushed outside the viewport, and focusing the search input auto-scrolls the container so the panel border and logo are cut through at the viewport edge (the "穿模"/clipping reported in the issue).

Root cause: #18050 added `overflow-x-auto` on the page section and a `min-w-[1280px]` floor on the content panel to protect against squeezed layouts. However, the settings gear button sits *after* that min-width panel in the same flex row, so at viewport widths below ~1382px the row always overflows: the panel is pinned at 1280px, the gear lands beyond the right edge (measured at x=1320-1362 in a 1100px viewport), and the scroll container gets auto-scrolled when the textarea receives focus.

This PR removes the hard floor and fixes the real squeeze source instead:

- `web/src/pages/next-search/index.tsx`
  - Drop `overflow-x-auto` from the section and `min-w-[1280px]` from the panel; the panel is now `flex-1 min-w-0` so it fills the remaining space and can shrink.
  - The settings gear button gets `shrink-0` so it always stays visible next to the panel.
  - The settings panel gets `shrink-0 max-w-full` so it never exceeds the bordered panel, and the main area gets `overflow-hidden` so its content can never bleed across the settings divider at very narrow widths.
- `web/src/pages/next-search/search-home.tsx`
  - The home card container changes from a fixed `w-[780px]` to `w-full max-w-[780px]`, so it shrinks gracefully on narrow windows instead of overflowing the panel border (the layout squeeze that #18050's min-width was papering over). This also benefits the embedded/share page, which renders this component at arbitrary widths.

Verification (DOM-measured in the browser against a real search app with retrieval + AI summary):

| width | state | before | after |
|---|---|---|---|
| 1100 | home | h-scroll, gear off-screen (x=1320) | no h-scroll, gear visible |
| 1100 | searching | h-scroll, auto-scroll clipped logo, mind-map button off-screen | all elements in view, results render normally |
| 1100 | settings open | gear pushed out of viewport (x=1100-1142) | no overflow, settings inside panel border |
| 700 | settings open | n/a (horizontal scroll) | no bleed across the settings divider (hit-test verified) |
| 1920 | home / settings open | OK | OK — geometry unchanged, no regression |

No unit tests cover these layout classes; `npm run type-check` reports no new errors for the touched files, and oxlint passes on both. The Playwright e2e selectors (`[data-testid='search-detail']`) are unchanged.
