### PR TITLE
fix(search): do not jump to previous search results on empty query

### DIFF
--- a/web/src/pages/next-search/search-home.tsx
+++ b/web/src/pages/next-search/search-home.tsx
@@ -19,8 +19,9 @@ import message from '@/components/ui/message';
 import { useAutoResizeTextarea } from '@/hooks/use-auto-resize-textarea';
 import { IUserInfo } from '@/interfaces/database/user-setting';
 import { cn } from '@/lib/utils';
+import { isEmpty, trim } from 'lodash';
 import { Search } from 'lucide-react';
-import { Dispatch, SetStateAction, useRef } from 'react';
+import { Dispatch, SetStateAction, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import './index.less';
 import { RAGFlowLogo } from './ragflow-logo';
@@ -47,6 +48,19 @@ export default function SearchHome({
   const searchInputRef = useRef<HTMLTextAreaElement>(null);
 
   const isMultiLine = useAutoResizeTextarea(searchInputRef, searchText);
+
+  const handleStartSearch = useCallback(() => {
+    if (canSearch === false) {
+      message.warning(t('search.chooseDataset'));
+      return;
+    }
+    // Do not enter the searching view with an empty question: it would render
+    // the previous search's stale results from the mutation cache.
+    if (isEmpty(trim(searchText))) {
+      return;
+    }
+    setIsSearching(!isSearching);
+  }, [canSearch, isSearching, searchText, setIsSearching, t]);
 
   return (
     <section className="relative w-full flex transition-all justify-center items-center mt-[15vh]">
@@ -85,11 +99,7 @@ export default function SearchHome({
                     !e.nativeEvent.isComposing
                   ) {
                     e.preventDefault();
-                    if (canSearch === false) {
-                      message.warning(t('search.chooseDataset'));
-                      return;
-                    }
-                    setIsSearching(!isSearching);
+                    handleStartSearch();
                   }
                 }}
                 onChange={(e) => {
@@ -106,13 +116,7 @@ export default function SearchHome({
                   'absolute right-3 flex size-9 items-center justify-center rounded-full bg-text-primary text-bg-base shadow transition-opacity hover:opacity-90',
                   isMultiLine ? 'bottom-3' : 'top-1/2 -translate-y-1/2',
                 )}
-                onClick={() => {
-                  if (canSearch === false) {
-                    message.warning(t('search.chooseDataset'));
-                    return;
-                  }
-                  setIsSearching(!isSearching);
-                }}
+                onClick={handleStartSearch}
               >
                 <Search size={18} />
               </button>


### PR DESCRIPTION
### Summary

On the embedded (share) search page opened in a new tab, after asking a question and returning to the home screen via the RAGFlow logo, clicking the search button with an **empty** search box navigated back to the previous search's result view instead of staying on the home screen.

**Root cause:** `SearchHome` triggers `setIsSearching(true)` from both the search button and the Enter key without checking whether the query is empty. When the searching view remounts with an empty `searchText`:

- `useSearching`'s effect skips `sendQuestion` because `searchText` is empty, so no new retrieval is fired;
- but the chunk list is rendered unconditionally from `useSelectTestingResult()`, which reads the global TanStack mutation cache (`mutationKey: ['testChunk']`) and still holds the previous search's results.

The result: the view shows the last search record even though the input is empty.

**Fix:** extract a shared `handleStartSearch` handler in `web/src/pages/next-search/search-home.tsx` and make it a no-op when the trimmed query is empty. This covers both entry points (button click and Enter) and both surfaces that render `SearchHome`: the shared search page (`/search/share`) and the internal search page (`/search/:id`).

**Verification (browser, end-to-end):**

- Before the fix, reproduced on `/search/<id>`: search a question → click the RAGFlow logo (back to home, empty box) → click Search with the empty box → the home screen disappeared and the previous searching view was restored.
- After the fix, on both the internal search page and the share page (`/search/share?...` opened in a new tab): clicking Search or pressing Enter with an empty or whitespace-only box stays on the home screen; entering a query still starts the search normally. In this environment the test KBs returned no matching chunks, so the restored view showed the previous search's empty-result state; rendering of stale chunk content follows from the same code path (`chunks?.length > 0` renders from the mutation cache with no empty-query guard).
