### PR TITLE
fix(web): always show copy button on floating chat widget replies

### DIFF
--- a/web/src/components/floating-chat-widget.tsx
+++ b/web/src/components/floating-chat-widget.tsx
@@ -625,7 +625,7 @@ const FloatingChatWidget = () => {
                   className={`flex ${message.role === MessageType.User ? 'justify-end' : 'justify-start'}`}
                 >
                   <div
-                    className={`group max-w-[280px] px-4 py-2 rounded-2xl ${
+                    className={`max-w-[280px] px-4 py-2 rounded-2xl ${
                       message.role === MessageType.User
                         ? 'text-white rounded-br-md'
                         : 'rounded-bl-md'
@@ -658,10 +658,7 @@ const FloatingChatWidget = () => {
                           }
                           clickDocumentButton={clickDocumentButton}
                         />
-                        <div
-                          className="flex justify-end opacity-0 transition-opacity group-hover:opacity-100"
-                          role="toolbar"
-                        >
+                        <div className="flex justify-end" role="toolbar">
                           <CopyToClipboard
                             text={removeThinkSection(message.content)}
                             className="border-0"
@@ -840,7 +837,7 @@ const FloatingChatWidget = () => {
                     className={`flex ${message.role === MessageType.User ? 'justify-end' : 'justify-start'}`}
                   >
                     <div
-                      className={`group max-w-[280px] px-4 py-2 rounded-2xl ${
+                      className={`max-w-[280px] px-4 py-2 rounded-2xl ${
                         message.role === MessageType.User
                           ? 'text-white rounded-br-md'
                           : 'rounded-bl-md'
@@ -873,10 +870,7 @@ const FloatingChatWidget = () => {
                             }
                             clickDocumentButton={clickDocumentButton}
                           />
-                          <div
-                            className="flex justify-end opacity-0 transition-opacity group-hover:opacity-100"
-                            role="toolbar"
-                          >
+                          <div className="flex justify-end" role="toolbar">
                             <CopyToClipboard
                               text={removeThinkSection(message.content)}
                               className="border-0"


### PR DESCRIPTION
### Summary

The embeddable floating chat widget (`/chats/widget`) showed no copy button on assistant replies, even though the main chat page always exposes one.

Root cause: the per-message `CopyToClipboard` toolbar in `web/src/components/floating-chat-widget.tsx` was rendered with `opacity-0 transition-opacity group-hover:opacity-100` in both `window` and `full` modes. The button therefore only appeared while the pointer hovered the message bubble:

- at rest the widget looks like it has no copy button at all (matches the reported screenshot);
- on touch devices the button can never appear because there is no hover state;
- the affordance is effectively undiscoverable inside a small embedded widget.

Fix: remove the hover-only visibility gating so the copy toolbar is always shown under assistant messages in both `window` and `full` render modes, and drop the now-unused `group` marker class on the message bubbles. This matches the main chat page, where the assistant action buttons (copy/read/like) are always visible.

### Validation

- Reproduced on a locally deployed widget (`/chats/widget?shared_id=...`): toolbar existed in the DOM but `opacity: 0` without hover; after the fix `opacity: 1` at rest in both `window` and `full` modes.
- Clicked the button in the browser: tooltip flips to "Copied" and the icon switches to a check mark.
- `npx oxlint` on the changed file: 0 warnings/errors; `tsc --noEmit` error count unchanged vs. baseline (219 pre-existing, none in the touched file).
