### PR TITLE
fix(db): make negative GET_LOCK timeouts work on MariaDB

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -972,7 +972,11 @@ class MysqlDatabaseLock:
     def __init__(self, lock_name, timeout=10, db=None):
         self.lock_name = lock_name
         timeout = int(timeout)
-        self.timeout = timeout if timeout >= 0 else self.BLOCKING_TIMEOUT
+        if timeout < 0:
+            logging.debug("Normalizing negative advisory-lock timeout to %d seconds", self.BLOCKING_TIMEOUT)
+            self.timeout = self.BLOCKING_TIMEOUT
+        else:
+            self.timeout = timeout
         self.db = db if db else DB
 
     @with_retry(max_retries=3, retry_delay=1.0)

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -966,9 +966,15 @@ class GaussDBDatabaseLock(PostgresDatabaseLock):
 
 
 class MysqlDatabaseLock:
+    # MySQL treats a negative GET_LOCK() timeout as "wait forever", MariaDB does
+    # not: it returns NULL with a warning instead of waiting. Callers asking to
+    # block get this finite wait so both servers actually acquire the lock.
+    BLOCKING_TIMEOUT = 60
+
     def __init__(self, lock_name, timeout=10, db=None):
         self.lock_name = lock_name
-        self.timeout = int(timeout)
+        timeout = int(timeout)
+        self.timeout = timeout if timeout >= 0 else self.BLOCKING_TIMEOUT
         self.db = db if db else DB
 
     @with_retry(max_retries=3, retry_delay=1.0)

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -966,9 +966,7 @@ class GaussDBDatabaseLock(PostgresDatabaseLock):
 
 
 class MysqlDatabaseLock:
-    # MySQL treats a negative GET_LOCK() timeout as "wait forever", MariaDB does
-    # not: it returns NULL with a warning instead of waiting. Callers asking to
-    # block get this finite wait so both servers actually acquire the lock.
+    # Finite wait used for negative advisory-lock timeouts.
     BLOCKING_TIMEOUT = 60
 
     def __init__(self, lock_name, timeout=10, db=None):

--- a/test/unit_test/api/db/test_mysql_database_lock.py
+++ b/test/unit_test/api/db/test_mysql_database_lock.py
@@ -1,5 +1,5 @@
 """
-Tests for MySQL/MariaDB advisory lock timeouts.
+Tests for MySQL advisory lock timeouts.
 """
 
 import pytest
@@ -8,8 +8,7 @@ from api.db.db_models import MysqlDatabaseLock
 
 
 class TestMysqlDatabaseLockTimeout:
-    """MariaDB returns NULL for a negative GET_LOCK() timeout, so negative
-    timeouts have to be turned into a finite wait."""
+    """Negative advisory-lock timeouts use a finite wait."""
 
     @pytest.mark.parametrize("timeout", [-1, -60])
     def test_negative_timeout_falls_back_to_blocking_timeout(self, timeout):

--- a/test/unit_test/api/db/test_mysql_database_lock.py
+++ b/test/unit_test/api/db/test_mysql_database_lock.py
@@ -1,0 +1,22 @@
+"""
+Tests for MySQL/MariaDB advisory lock timeouts.
+"""
+
+import pytest
+
+from api.db.db_models import MysqlDatabaseLock
+
+
+class TestMysqlDatabaseLockTimeout:
+    """MariaDB returns NULL for a negative GET_LOCK() timeout, so negative
+    timeouts have to be turned into a finite wait."""
+
+    @pytest.mark.parametrize("timeout", [-1, -60])
+    def test_negative_timeout_falls_back_to_blocking_timeout(self, timeout):
+        lock = MysqlDatabaseLock("unit_test_lock", timeout)
+        assert lock.timeout == MysqlDatabaseLock.BLOCKING_TIMEOUT
+
+    @pytest.mark.parametrize("timeout", [0, 10, 60])
+    def test_non_negative_timeout_is_preserved(self, timeout):
+        lock = MysqlDatabaseLock("unit_test_lock", timeout)
+        assert lock.timeout == timeout


### PR DESCRIPTION
### Summary

`TaskService.get_ongoing_doc_name()` and `TaskService.update_progress()` acquire their lock with `DB.lock(..., -1)`, meaning "wait until the lock is free". MySQL does that, MariaDB does not: since 5.5.45 / 10.0.21 / 10.1.7 a negative `GET_LOCK()` timeout returns NULL and raises a warning instead of waiting (MDEV-4017). `MysqlDatabaseLock.lock()` then gets a value that is neither 0 nor 1, raises "failed to acquire lock", and gives up after the three retries.

On MariaDB this means progress updates fail for the whole lifetime of a task, so documents sit in the UI at whatever percentage they last reached even though parsing and indexing finished. I hit this running RAGFlow against MariaDB 11.8.

The fix turns a negative timeout into a finite 60 second wait inside `MysqlDatabaseLock`, which both servers accept. Callers keep expressing "block until available", and the equivalent PostgreSQL and GaussDB work on the same `-1` semantics (#16346, #18506) is untouched. Non-negative timeouts keep their current behaviour.
