### PR TITLE
fix(auth): strip trailing slash from OIDC issuer before discovery

### DIFF
--- a/api/apps/auth/oidc.py
+++ b/api/apps/auth/oidc.py
@@ -100,9 +100,12 @@ class OIDCClient(OAuthClient):
     def _load_oidc_metadata(issuer):
         """
         Load OIDC metadata from `/.well-known/openid-configuration`.
+
+        A configured issuer may carry a trailing slash, which would produce a
+        double slash in the discovery URL and a 404 on most providers.
         """
         try:
-            metadata_url = f"{issuer}/.well-known/openid-configuration"
+            metadata_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
             response = sync_request("GET", metadata_url, timeout=7)
             response.raise_for_status()
             return response.json()

--- a/test/testcases/test_web_api/test_auth_app/test_oidc_client_unit.py
+++ b/test/testcases/test_web_api/test_auth_app/test_oidc_client_unit.py
@@ -202,6 +202,21 @@ def test_load_oidc_metadata_success_and_wraps_failure(monkeypatch):
 
 
 @pytest.mark.p2
+def test_load_oidc_metadata_strips_trailing_slash_from_issuer(monkeypatch):
+    _, oidc_module = _load_auth_modules(monkeypatch)
+
+    calls = {}
+
+    def _ok_sync_request(method, url, timeout):
+        calls["url"] = url
+        return _FakeResponse(_metadata("https://issuer.example"))
+
+    monkeypatch.setattr(oidc_module, "sync_request", _ok_sync_request)
+    oidc_module.OIDCClient._load_oidc_metadata("https://issuer.example/")
+    assert calls["url"] == "https://issuer.example/.well-known/openid-configuration"
+
+
+@pytest.mark.p2
 def test_parse_id_token_success_and_error(monkeypatch):
     _, oidc_module = _load_auth_modules(monkeypatch)
     client = _make_client(monkeypatch, oidc_module)


### PR DESCRIPTION
### Summary

OIDC discovery builds its URL as `f"{issuer}/.well-known/openid-configuration"`. Providers whose issuer carries a trailing slash therefore get asked for a URL with a double slash in it, which 404s. authentik is one of them: its issuer is `https://auth.example.com/application/o/<app>/`, so the request goes to `.../o/<app>//.well-known/openid-configuration` and login fails right at the start with `Failed to fetch OIDC metadata`.

Stripping trailing slashes off the issuer before joining the well-known path is enough. The `issuer` used later for ID token validation still comes from the discovery document itself, so nothing else about the flow changes.
