### PR TITLE
fix: resolve python lint errors

### DIFF
--- a/test/unit_test/agent/test_canvas_at_split.py
+++ b/test/unit_test/agent/test_canvas_at_split.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest

--- a/tools/scripts/rename_models_providers.py
+++ b/tools/scripts/rename_models_providers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Rename provider name fields in conf/models/*.json to match llm_factories.json."""
-import json, os
+import json
+import os
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 MODELS_DIR = os.path.join(REPO_ROOT, "conf", "models")


### PR DESCRIPTION
### Summary

This PR resolves a couple of minor Python code quality and styling issues in the repository, ensuring the codebase passes `ruff check` without any errors.

**Changes included:**
* **Fixed `F401` (Unused Import):** Removed the unused `types.SimpleNamespace` import in `test/unit_test/agent/test_canvas_at_split.py` to clean up the test file.
* **Fixed `E401` (Multiple Imports):** Split the multiple imports on one line (`import json, os`) into separate lines in `tools/scripts/rename_models_providers.py` to adhere to Python PEP 8 styling guidelines.

These changes were automatically generated and verified using `ruff check --fix`.
