### PR TITLE
fix(engine): return error instead of panic when NATS engine is uninitialized

### DIFF
--- a/internal/engine/nats/nats.go
+++ b/internal/engine/nats/nats.go
@@ -108,6 +108,10 @@ func (n *NatsEngine) Type() string {
 }
 
 func (n *NatsEngine) PublishTask(subject string, payload []byte) error {
+	if n.jetStream == nil {
+		return errors.New("NATS jetstream is nil, engine not properly initialized")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -226,6 +230,10 @@ func (n *NatsEngine) InitConsumer(subject string) error {
 	return nil
 }
 func (n *NatsEngine) GetMessages(messageCount int) ([]common.TaskHandle, error) {
+	if n.consumer == nil {
+		return nil, errors.New("NATS consumer is nil, engine not properly initialized")
+	}
+
 	resultMessages := make([]common.TaskHandle, 0)
 	messages, err := n.consumer.Fetch(messageCount, jetstream.FetchMaxWait(1*time.Second))
 	if err != nil {
@@ -238,6 +246,9 @@ func (n *NatsEngine) GetMessages(messageCount int) ([]common.TaskHandle, error) 
 }
 
 func (n *NatsEngine) CheckStatus() string {
+	if n.nc == nil {
+		return "NATS connection is nil, engine not properly initialized"
+	}
 	n.nc.Stats()
 	return n.nc.Status().String()
 }

--- a/internal/engine/nats/nats.go
+++ b/internal/engine/nats/nats.go
@@ -124,6 +124,10 @@ func (n *NatsEngine) PublishTask(subject string, payload []byte) error {
 }
 
 func (n *NatsEngine) ShowMessageQueue() (map[string]string, error) {
+	if n.jetStream == nil || n.stream == nil {
+		return nil, errors.New("NATS jetstream/stream is nil, engine not properly initialized")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	accountInfo, err := n.jetStream.AccountInfo(ctx)

--- a/internal/engine/nats/nats_uninitialized_test.go
+++ b/internal/engine/nats/nats_uninitialized_test.go
@@ -1,0 +1,29 @@
+package nats
+
+import (
+	"strings"
+	"testing"
+)
+
+// An engine whose Init failed (or was never called) must return errors from
+// its public methods instead of panicking on nil fields. Regression test for
+// the nil-deref panic at PublishTask: the server bootstrap only logs message
+// queue init failures, so a half-initialized engine stays registered
+// process-wide and every later task publish crashed the caller.
+func TestUninitializedEngineMethodsReturnErrors(t *testing.T) {
+	// Nothing listens on this port; Init() is deliberately not called so the
+	// engine keeps its zero-value (nil) connection, jetstream and consumer.
+	e := NewNatsEngine("127.0.0.1", 1)
+
+	if err := e.PublishTask("tasks.RAGFLOW", []byte("{}")); err == nil || !strings.Contains(err.Error(), "not properly initialized") {
+		t.Fatalf("PublishTask on uninitialized engine: err = %v, want 'not properly initialized'", err)
+	}
+
+	if _, err := e.GetMessages(1); err == nil || !strings.Contains(err.Error(), "not properly initialized") {
+		t.Fatalf("GetMessages on uninitialized engine: err = %v, want 'not properly initialized'", err)
+	}
+
+	if status := e.CheckStatus(); !strings.Contains(status, "not properly initialized") {
+		t.Fatalf("CheckStatus on uninitialized engine = %q, want 'not properly initialized'", status)
+	}
+}

--- a/internal/engine/nats/nats_uninitialized_test.go
+++ b/internal/engine/nats/nats_uninitialized_test.go
@@ -23,6 +23,10 @@ func TestUninitializedEngineMethodsReturnErrors(t *testing.T) {
 		t.Fatalf("GetMessages on uninitialized engine: err = %v, want 'not properly initialized'", err)
 	}
 
+	if _, err := e.ShowMessageQueue(); err == nil || !strings.Contains(err.Error(), "not properly initialized") {
+		t.Fatalf("ShowMessageQueue on uninitialized engine: err = %v, want 'not properly initialized'", err)
+	}
+
 	if status := e.CheckStatus(); !strings.Contains(status, "not properly initialized") {
 		t.Fatalf("CheckStatus on uninitialized engine = %q, want 'not properly initialized'", status)
 	}

--- a/internal/service/memory_queue_task_test.go
+++ b/internal/service/memory_queue_task_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"ragflow/internal/engine"
+	natsengine "ragflow/internal/engine/nats"
+)
+
+// queueMemoryTask is the agent-canvas memory-save publish path. When the
+// message queue engine is a NatsEngine whose Init failed at boot, publishing
+// must surface a clean error (caught by the Message component's best-effort
+// memory save) rather than panicking and failing the whole canvas run.
+func TestQueueMemoryTaskUninitializedQueueReturnsError(t *testing.T) {
+	previous := engine.GetMessageQueueEngine()
+	engine.SetMessageQueueEngine(natsengine.NewNatsEngine("127.0.0.1", 1))
+	t.Cleanup(func() { engine.SetMessageQueueEngine(previous) })
+
+	err := queueMemoryTask(
+		t.Context(),
+		"mem-1",
+		"tenant-1",
+		1,
+		map[string]any{"id": "task-1", "task_type": "memory"},
+		MemoryMessage{UserID: "u1", AgentID: "agent-1", SessionID: "s1", UserInput: "hi", AgentResponse: "hello"},
+	)
+	if err == nil {
+		t.Fatal("queueMemoryTask with uninitialized MQ engine: err = nil, want publish error")
+	}
+	if !strings.Contains(err.Error(), "not properly initialized") {
+		t.Fatalf("queueMemoryTask err = %v, want engine-not-initialized error", err)
+	}
+}


### PR DESCRIPTION
### Summary

After an agent finished answering in the canvas chat, users got a red error
dialog ending the run with:

    canvas invoke: [NodeRunError] panic error:
    runtime error: invalid memory address or nil pointer dereference
    ... ragflow/internal/engine/nats.(*NatsEngine).PublishTask nats.go:114
    ... internal/service.queueMemoryTask memory_message_service.go:380
    ... (*MemoryMessageService).QueueSaveToMemoryTask ...
    ... (*MemoryService).saveAgentMessage ...

**Root cause.** `engine.InitMessageQueue()` registers the `NatsEngine`
instance in the process-global engine slot *before* calling `Init()`, and
the server bootstrap (`cmd/ragflow_server.go`) only logs an init failure and
keeps running. When NATS is unreachable at boot (config mismatch, NATS down
during restart, etc.), the registered engine keeps a nil `jetStream`, and
`PublishTask` called `n.jetStream.Publish(...)`, panicking on every task
publish. In the agent canvas the panic happened in the memory-save path
(`saveAgentMessage` -> `QueueSaveToMemoryTask` -> `queueMemoryTask` ->
`PublishTask`), so eino's task manager recovered the panic and failed the
whole run right after the answer streamed. The same panic site also turned
document parse requests (`/api/v1/documents/ingest`) into HTTP 500s via
`MessageQueueTaskPublisher.PublishTaskMessage`.

**Fix.** Guard the engine fields that are only set by `Init()`:
- `PublishTask` returns `NATS jetstream is nil, engine not properly
  initialized` instead of dereferencing nil,
- `GetMessages` and `CheckStatus` get the same guards for their nil
  consumer / connection fields,

matching the nil checks already present in `InitConsumer` / `ListMessages`.
Consequences: the agent Message component's memory save stays best-effort as
designed (the error is surfaced under `outputs["memory_error"]`, the run
completes and the answer is fully delivered); document ingest returns a
clean error response instead of a recovered-panic 500.

**Tests.**
- `internal/engine/nats`: `TestUninitializedEngineMethodsReturnErrors` —
  PublishTask/GetMessages/CheckStatus on a never-initialized engine must
  return errors, not panic.
- `internal/service`: `TestQueueMemoryTaskUninitializedQueueReturnsError` —
  the reported agent memory-save publish path returns a clean
  engine-not-initialized error.

**Validation.**
- Reproduced locally with NATS stopped and the server restarted: uploading a
  document with "parse on creation" returned HTTP 500 and the Go log showed
  the recovered panic at `nats.go:114 PublishTask` (same frame as the
  reported stack). With the fix, the same request returns a proper error
  response and the log shows no panic.
- The agent-canvas chat path itself was not exercised end-to-end because the
  local tenant has no embedding model configured (memory save fails earlier,
  at `embedAndSave`, before reaching the publish step); that path is covered
  by the unit test on `queueMemoryTask` plus the shared `PublishTask` guard.
