### PR TITLE
Fix: go switch user from superuser to normal user error

### DIFF
--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -272,7 +272,7 @@ func (h *Handler) CreateUser(c *gin.Context) {
 func getUserName(c *gin.Context) (string, error) {
 	username := c.Param("username")
 	if username == "" {
-		err := errors.New("Username is required")
+		err := errors.New("username is required")
 		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
 		return "", err
 	}
@@ -467,7 +467,7 @@ func (h *Handler) DeleteUserAPIToken(c *gin.Context) {
 		return
 	}
 	key := c.Param("token")
-	if username == "" || key == "" {
+	if key == "" {
 		common.ErrorWithCode(c, common.CodeBadRequest, "Username and key are required")
 		return
 	}

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -270,14 +270,10 @@ func (h *Handler) CreateUser(c *gin.Context) {
 }
 
 func getUserName(c *gin.Context) (string, error) {
-	encodedUsername := c.Param("username")
-	username, err := common.DecodeFromBase64(encodedUsername)
-	if err != nil {
-		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
-		return "", err
-	}
+	username := c.Param("username")
 	if username == "" {
-		common.ErrorWithCode(c, common.CodeBadRequest, "Username is required")
+		err := errors.New("Username is required")
+		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
 		return "", err
 	}
 	return username, nil
@@ -466,10 +462,8 @@ func (h *Handler) GenerateUserAPIToken(c *gin.Context) {
 
 // DeleteUserAPIToken handle delete user API key
 func (h *Handler) DeleteUserAPIToken(c *gin.Context) {
-	encodedUsername := c.Param("username")
-	username, err := common.DecodeFromBase64(encodedUsername)
+	username, err := getUserName(c)
 	if err != nil {
-		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
 		return
 	}
 	key := c.Param("token")

--- a/internal/admin/handler_ee.go
+++ b/internal/admin/handler_ee.go
@@ -1740,7 +1740,7 @@ func (h *Handler) DeleteUserAPIKey(c *gin.Context) {
 		return
 	}
 	key := c.Param("key")
-	if username == "" || key == "" {
+	if key == "" {
 		common.ErrorWithCode(c, common.CodeBadRequest, "Username and key are required")
 		return
 	}

--- a/internal/admin/handler_ee.go
+++ b/internal/admin/handler_ee.go
@@ -1203,14 +1203,8 @@ func (h *Handler) ListUserProviders(c *gin.Context) {
 
 // ListUserProviderInstances handle show user provider instances
 func (h *Handler) ListUserProviderInstances(c *gin.Context) {
-	encodedUsername := c.Param("username")
-	userName, err := common.DecodeFromBase64(encodedUsername)
+	userName, err := getUserName(c)
 	if err != nil {
-		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
-		return
-	}
-	if userName == "" {
-		common.ErrorWithCode(c, common.CodeBadRequest, "Username is required")
 		return
 	}
 
@@ -1232,14 +1226,8 @@ func (h *Handler) ListUserProviderInstances(c *gin.Context) {
 
 // ListUserProviderInstanceModels handle show user provider instance models
 func (h *Handler) ListUserProviderInstanceModels(c *gin.Context) {
-	encodedUsername := c.Param("username")
-	userName, err := common.DecodeFromBase64(encodedUsername)
+	userName, err := getUserName(c)
 	if err != nil {
-		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
-		return
-	}
-	if userName == "" {
-		common.ErrorWithCode(c, common.CodeBadRequest, "Username is required")
 		return
 	}
 
@@ -1267,14 +1255,8 @@ func (h *Handler) ListUserProviderInstanceModels(c *gin.Context) {
 
 // ListUserDefaultModels handle show user default models
 func (h *Handler) ListUserDefaultModels(c *gin.Context) {
-	encodedUsername := c.Param("username")
-	userName, err := common.DecodeFromBase64(encodedUsername)
+	userName, err := getUserName(c)
 	if err != nil {
-		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
-		return
-	}
-	if userName == "" {
-		common.ErrorWithCode(c, common.CodeBadRequest, "Username is required")
 		return
 	}
 	ctx := c.Request.Context()
@@ -1735,10 +1717,8 @@ func (h *Handler) PurgeUsersData(c *gin.Context) {
 
 // GenerateUserAPIKey handle create tenant API key
 func (h *Handler) GenerateUserAPIKey(c *gin.Context) {
-	encodedUsername := c.Param("username")
-	username, err := common.DecodeFromBase64(encodedUsername)
+	username, err := getUserName(c)
 	if err != nil {
-		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
 		return
 	}
 
@@ -1755,10 +1735,8 @@ func (h *Handler) GenerateUserAPIKey(c *gin.Context) {
 
 // DeleteUserAPIKey handle delete user API key
 func (h *Handler) DeleteUserAPIKey(c *gin.Context) {
-	encodedUsername := c.Param("username")
-	username, err := common.DecodeFromBase64(encodedUsername)
+	username, err := getUserName(c)
 	if err != nil {
-		common.ErrorWithCode(c, common.CodeBadRequest, err.Error())
 		return
 	}
 	key := c.Param("key")

--- a/internal/cli/admin_command.go
+++ b/internal/cli/admin_command.go
@@ -274,7 +274,7 @@ func (c *CLI) AdminGrantUserAdminCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/admin", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("PUT", apiURL, "admin", nil, nil)
@@ -296,7 +296,7 @@ func (c *CLI) AdminRevokeUserAdminCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/admin", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("DELETE", apiURL, "admin", nil, nil)
@@ -452,7 +452,7 @@ func (c *CLI) AdminCreateUserAPIKeyCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 
 	apiURL := fmt.Sprintf("/admin/users/%s/keys", encodedUserName)
 
@@ -507,7 +507,7 @@ func (c *CLI) AdminActivateUser(cmd *Command) (ResponseIf, error) {
 		"activate_status": activateStatus,
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/activate", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("PUT", apiURL, "admin", nil, payload)
@@ -549,7 +549,7 @@ func (c *CLI) AdminAlterUserPassword(cmd *Command) (ResponseIf, error) {
 		"new_password": encryptedPassword,
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/password", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("PUT", apiURL, "admin", nil, payload)
@@ -1003,7 +1003,7 @@ func (c *CLI) AdminDropUserCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("DELETE", apiURL, "admin", nil, nil)
@@ -1030,7 +1030,7 @@ func (c *CLI) AdminDropUserAPIKeyCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("api_key not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/keys/%s", encodedUserName, apiKey)
 
 	resp, err := c.AdminServerClient.Request("DELETE", apiURL, "admin", nil, nil)
@@ -1059,7 +1059,7 @@ func (c *CLI) ListUserDatasets(cmd *Command) (ResponseIf, error) {
 		iterations = val
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/datasets", encodedUserName)
 
 	if iterations > 1 {
@@ -1110,7 +1110,7 @@ func (c *CLI) ShowUserPermission(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/permission", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -1412,7 +1412,7 @@ func (c *CLI) AdminShowUserCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -1480,7 +1480,7 @@ func (c *CLI) AdminShowUserActivityCommand(cmd *Command) (ResponseIf, error) {
 		"email": email,
 	}
 
-	encodedUserName := common.EncodeToBase64(email)
+	encodedUserName := url.PathEscape(email)
 	apiURL := fmt.Sprintf("/admin/users/%s/activity", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, payload)
@@ -1501,7 +1501,7 @@ func (c *CLI) AdminShowUserSummaryCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/summary", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -1546,7 +1546,7 @@ func (c *CLI) AdminShowUserDatasetCommand(cmd *Command) (ResponseIf, error) {
 		"dataset": dataset,
 	}
 
-	encodedUserName := common.EncodeToBase64(email)
+	encodedUserName := url.PathEscape(email)
 	apiURL := fmt.Sprintf("/admin/users/%s/dataset", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, payload)
@@ -1568,7 +1568,7 @@ func (c *CLI) AdminShowUserStorageCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(email)
+	encodedUserName := url.PathEscape(email)
 	apiURL := fmt.Sprintf("/admin/users/%s/storage", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -1604,7 +1604,7 @@ func (c *CLI) AdminShowUserQuotaCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(email)
+	encodedUserName := url.PathEscape(email)
 	apiURL := fmt.Sprintf("/admin/users/%s/quota", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -1640,7 +1640,7 @@ func (c *CLI) AdminShowUserIndexCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(email)
+	encodedUserName := url.PathEscape(email)
 	apiURL := fmt.Sprintf("/admin/users/%s/index", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -1676,7 +1676,7 @@ func (c *CLI) AdminShowUserPermissionCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(email)
+	encodedUserName := url.PathEscape(email)
 	apiURL := fmt.Sprintf("/admin/users/%s/permission", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2204,7 +2204,7 @@ func (c *CLI) AdminPurgeUserCommand(cmd *Command) (ResponseIf, error) {
 		"preview": preview,
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/data", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("DELETE", apiURL, "admin", nil, payload)
@@ -2321,7 +2321,7 @@ func (c *CLI) AdminListUserDatasetsCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/datasets", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2342,7 +2342,7 @@ func (c *CLI) AdminListUserAgentsCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/agents", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2363,7 +2363,7 @@ func (c *CLI) AdminListUserChatsCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/chats", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2385,7 +2385,7 @@ func (c *CLI) AdminListUserSearchesCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/searches", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2407,7 +2407,7 @@ func (c *CLI) AdminListUserModelsCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/models", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2429,7 +2429,7 @@ func (c *CLI) AdminListUserFilesCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/files", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2451,7 +2451,7 @@ func (c *CLI) AdminListUserKeysCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/keys", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2496,7 +2496,7 @@ func (c *CLI) AdminListUserProvidersCommand(cmd *Command) (ResponseIf, error) {
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/providers", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2523,7 +2523,7 @@ func (c *CLI) AdminListUserProviderInstancesCommand(cmd *Command) (ResponseIf, e
 		return nil, fmt.Errorf("provider_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/providers/%s/instances", encodedUserName, providerName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2553,7 +2553,7 @@ func (c *CLI) AdminListUserProviderInstanceModelsCommand(cmd *Command) (Response
 		return nil, fmt.Errorf("instance_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/providers/%s/instances/%s/models", encodedUserName, providerName, instanceName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)
@@ -2575,7 +2575,7 @@ func (c *CLI) AdminListUserDefaultModelsCommand(cmd *Command) (ResponseIf, error
 		return nil, fmt.Errorf("user_name not provided")
 	}
 
-	encodedUserName := common.EncodeToBase64(userName)
+	encodedUserName := url.PathEscape(userName)
 	apiURL := fmt.Sprintf("/admin/users/%s/default-models", encodedUserName)
 
 	resp, err := c.AdminServerClient.Request("GET", apiURL, "admin", nil, nil)

--- a/internal/entity/models/ollama_test.go
+++ b/internal/entity/models/ollama_test.go
@@ -88,7 +88,7 @@ func TestOllamaChatMapsMultimodalImages(t *testing.T) {
 			return
 		}
 		assertOllamaMultimodalRequest(t, body, false)
-		_, _ = io.WriteString(w, `{"message":{"content":"ok","thinking":""}}`)
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}]}`)
 	}))
 	defer srv.Close()
 
@@ -118,7 +118,7 @@ func TestOllamaStreamingChatMapsMultimodalImages(t *testing.T) {
 			return
 		}
 		assertOllamaMultimodalRequest(t, body, true)
-		_, _ = io.WriteString(w, "{\"message\":{\"content\":\"ok\"},\"done\":false}\n{\"done\":true}\n")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
 	}))
 	defer srv.Close()
 

--- a/internal/entity/models/ollama_test.go
+++ b/internal/entity/models/ollama_test.go
@@ -88,7 +88,7 @@ func TestOllamaChatMapsMultimodalImages(t *testing.T) {
 			return
 		}
 		assertOllamaMultimodalRequest(t, body, false)
-		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"ok"}}]}`)
+		_, _ = io.WriteString(w, `{"message":{"content":"ok","thinking":""}}`)
 	}))
 	defer srv.Close()
 
@@ -118,7 +118,7 @@ func TestOllamaStreamingChatMapsMultimodalImages(t *testing.T) {
 			return
 		}
 		assertOllamaMultimodalRequest(t, body, true)
-		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+		_, _ = io.WriteString(w, "{\"message\":{\"content\":\"ok\"},\"done\":false}\n{\"done\":true}\n")
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary

Fix the Go admin API returning illegal base64 data when a raw email address is used as the username path parameter, including when switching a superuser back to a normal user.

## Root cause

PR #16204 changed Go admin username path parameters to standard Base64. The web UI and Python admin client still send literal email addresses, so the Go handler attempted to Base64-decode values such as qi.wang@ragflow.ai and returned HTTP 400 before reaching the user service. Standard Base64 can also emit characters that are unsafe in URL path segments.

## Fix

- Read username route parameters directly in the Go admin handlers.
- URL-path-escape username segments generated by the Go CLI instead of Base64-encoding them.
- Use the shared username validation path in the remaining admin handlers.
- Align stale Ollama unit-test response fixtures with the OpenAI-compatible parser used by the driver.