### PR TITLE
fix(memory): persist memory valid_at/forget_at as server-local time instead of UTC

### DIFF
--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -847,7 +847,10 @@ func (s *MemoryService) ForgetMessage(ctx context.Context, userID string, memory
 		return errors.New("message store is not initialized")
 	}
 
-	now := time.Now().UTC()
+	// Python forget_message stamps timestamp_to_date(current_timestamp()):
+	// server-local wall clock, not UTC. forget_at_flt below is a Unix
+	// millisecond value and therefore zone-independent.
+	now := time.Now()
 	forgetTime := now.Format("2006-01-02 15:04:05")
 	messageDocID := fmt.Sprintf("%s_%d", memoryID, messageID)
 	updates := map[string]interface{}{

--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -847,10 +847,9 @@ func (s *MemoryService) ForgetMessage(ctx context.Context, userID string, memory
 		return errors.New("message store is not initialized")
 	}
 
-	// Python forget_message stamps timestamp_to_date(current_timestamp()):
-	// server-local wall clock, not UTC. forget_at_flt below is a Unix
-	// millisecond value and therefore zone-independent.
-	now := time.Now()
+	// forget_at is stamped as server-local wall clock, not UTC. forget_at_flt
+	// below is a Unix millisecond value and therefore zone-independent.
+	now := memoryNow()
 	forgetTime := now.Format("2006-01-02 15:04:05")
 	messageDocID := fmt.Sprintf("%s_%d", memoryID, messageID)
 	updates := map[string]interface{}{

--- a/internal/service/memory_extractor.go
+++ b/internal/service/memory_extractor.go
@@ -51,8 +51,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// memoryTimeLayout is the storage format for valid_at / invalid_at,
-// matching timestamp_to_date on the Python side.
+// memoryTimeLayout is the storage format for valid_at / invalid_at, matching
+// timestamp_to_date on the Python side: a server-local wall-clock string
+// ("YYYY-MM-DD HH:MM:SS"), never UTC-shifted.
 const memoryTimeLayout = "2006-01-02 15:04:05"
 
 // ErrMemoryTaskTerminal marks a memory-task failure that already has a durable
@@ -147,7 +148,9 @@ func (s *MemoryMessageService) saveExtractedToMemory(ctx context.Context, memory
 	}
 	s.updateTaskProgress(ctx, taskID, 0.5, fmt.Sprintf("Extracted %d messages from raw dialogue.", len(extracted)))
 
-	now := time.Now().UTC()
+	// Python conversation_time = timestamp_to_date(current_timestamp()):
+	// server-local wall clock, not UTC.
+	now := time.Now()
 	messages := make([]map[string]any, 0, len(extracted))
 	for _, item := range extracted {
 		messages = append(messages, buildExtractedMessage(generateRawMessageID(ctx), sourceID, memoryID, msg, item, now))
@@ -172,7 +175,7 @@ func (s *MemoryMessageService) extractByLLM(ctx context.Context, mem *CreateMemo
 	}
 
 	conversation := fmt.Sprintf("User Input: %s\nAgent Response: %s", msg.UserInput, msg.AgentResponse)
-	now := time.Now().UTC().Format(memoryTimeLayout)
+	now := time.Now().Format(memoryTimeLayout)
 	messages := []models.Message{{Role: "system", Content: systemPrompt}}
 	if mem.UserPrompt != nil && strings.TrimSpace(*mem.UserPrompt) != "" {
 		messages = append(messages,
@@ -277,18 +280,21 @@ func parseMemoryExtraction(answer string, extractTypes []string) []extractedMemo
 }
 
 // formatMemoryTime normalizes an LLM-supplied timestamp (ISO 8601 or
-// already-formatted) into memoryTimeLayout. Unparseable or empty input
-// falls back to the supplied time.
+// already-formatted) into memoryTimeLayout. The parsed timestamp keeps its
+// own wall clock (no zone conversion), matching Python
+// format_iso_8601_to_ymd_hms. Unparseable or empty input falls back to the
+// supplied time formatted in its own location (server-local when callers
+// pass time.Now()).
 func formatMemoryTime(value string, fallback time.Time) string {
 	v := strings.TrimSpace(value)
 	if v != "" {
 		for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02 15:04:05", "2006-01-02"} {
 			if t, err := time.Parse(layout, v); err == nil {
-				return t.UTC().Format(memoryTimeLayout)
+				return t.Format(memoryTimeLayout)
 			}
 		}
 	}
-	return fallback.UTC().Format(memoryTimeLayout)
+	return fallback.Format(memoryTimeLayout)
 }
 
 // updateTaskProgress stamps and persists task progress, mirroring

--- a/internal/service/memory_extractor.go
+++ b/internal/service/memory_extractor.go
@@ -51,10 +51,14 @@ import (
 	"gorm.io/gorm"
 )
 
-// memoryTimeLayout is the storage format for valid_at / invalid_at, matching
-// timestamp_to_date on the Python side: a server-local wall-clock string
-// ("YYYY-MM-DD HH:MM:SS"), never UTC-shifted.
+// memoryTimeLayout is the storage format for valid_at / invalid_at: a
+// server-local wall-clock string ("YYYY-MM-DD HH:MM:SS"), never UTC-shifted.
 const memoryTimeLayout = "2006-01-02 15:04:05"
+
+// memoryNow is the wall clock behind every memory timestamp. Tests pin it
+// to a fixed instant in a fixed location so the server-local assertions are
+// deterministic on any host, including UTC CI runners.
+var memoryNow = time.Now
 
 // ErrMemoryTaskTerminal marks a memory-task failure that already has a durable
 // terminal outcome (task row absent, or progress already persisted as failed),
@@ -148,9 +152,8 @@ func (s *MemoryMessageService) saveExtractedToMemory(ctx context.Context, memory
 	}
 	s.updateTaskProgress(ctx, taskID, 0.5, fmt.Sprintf("Extracted %d messages from raw dialogue.", len(extracted)))
 
-	// Python conversation_time = timestamp_to_date(current_timestamp()):
-	// server-local wall clock, not UTC.
-	now := time.Now()
+	// conversation_time is stamped as server-local wall clock, not UTC.
+	now := memoryNow()
 	messages := make([]map[string]any, 0, len(extracted))
 	for _, item := range extracted {
 		messages = append(messages, buildExtractedMessage(generateRawMessageID(ctx), sourceID, memoryID, msg, item, now))
@@ -175,7 +178,7 @@ func (s *MemoryMessageService) extractByLLM(ctx context.Context, mem *CreateMemo
 	}
 
 	conversation := fmt.Sprintf("User Input: %s\nAgent Response: %s", msg.UserInput, msg.AgentResponse)
-	now := time.Now().Format(memoryTimeLayout)
+	now := memoryNow().Format(memoryTimeLayout)
 	messages := []models.Message{{Role: "system", Content: systemPrompt}}
 	if mem.UserPrompt != nil && strings.TrimSpace(*mem.UserPrompt) != "" {
 		messages = append(messages,
@@ -281,10 +284,9 @@ func parseMemoryExtraction(answer string, extractTypes []string) []extractedMemo
 
 // formatMemoryTime normalizes an LLM-supplied timestamp (ISO 8601 or
 // already-formatted) into memoryTimeLayout. The parsed timestamp keeps its
-// own wall clock (no zone conversion), matching Python
-// format_iso_8601_to_ymd_hms. Unparseable or empty input falls back to the
-// supplied time formatted in its own location (server-local when callers
-// pass time.Now()).
+// own wall clock (no zone conversion). Unparseable or empty input falls
+// back to the supplied time formatted in its own location (server-local
+// when callers pass time.Now()).
 func formatMemoryTime(value string, fallback time.Time) string {
 	v := strings.TrimSpace(value)
 	if v != "" {

--- a/internal/service/memory_extractor_test.go
+++ b/internal/service/memory_extractor_test.go
@@ -24,6 +24,15 @@ import (
 	"time"
 )
 
+// pinMemoryNow fixes the memory wall clock at the given instant for the
+// duration of a test, restoring it afterwards.
+func pinMemoryNow(t *testing.T, instant time.Time) {
+	t.Helper()
+	orig := memoryNow
+	memoryNow = func() time.Time { return instant }
+	t.Cleanup(func() { memoryNow = orig })
+}
+
 // TestFormatMemoryTimeKeepsParsedWallClock: an offset-bearing or
 // Z-suffixed ISO timestamp must keep its own wall clock — never be
 // converted to UTC the way time.Time.UTC would.
@@ -35,6 +44,7 @@ func TestFormatMemoryTimeKeepsParsedWallClock(t *testing.T) {
 		want  string
 	}{
 		{name: "offset iso", value: "2026-08-20T10:05:00+08:00", want: "2026-08-20 10:05:00"},
+		{name: "offset iso with fractional seconds", value: "2026-08-20T10:05:00.123+08:00", want: "2026-08-20 10:05:00"},
 		{name: "zulu iso", value: "2026-08-20T02:05:00Z", want: "2026-08-20 02:05:00"},
 		{name: "naive iso", value: "2026-08-20T10:05:00", want: "2026-08-20 10:05:00"},
 		{name: "storage layout", value: "2026-08-20 10:05:00", want: "2026-08-20 10:05:00"},

--- a/internal/service/memory_extractor_test.go
+++ b/internal/service/memory_extractor_test.go
@@ -1,0 +1,85 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// memory_extractor_test.go — timezone-semantics tests for the memory
+// extractor's timestamp handling (valid_at / invalid_at persistence).
+
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFormatMemoryTimeKeepsParsedWallClock: an offset-bearing or
+// Z-suffixed ISO timestamp must keep its own wall clock — never be
+// converted to UTC the way time.Time.UTC would.
+func TestFormatMemoryTimeKeepsParsedWallClock(t *testing.T) {
+	fallback := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "offset iso", value: "2026-08-20T10:05:00+08:00", want: "2026-08-20 10:05:00"},
+		{name: "zulu iso", value: "2026-08-20T02:05:00Z", want: "2026-08-20 02:05:00"},
+		{name: "naive iso", value: "2026-08-20T10:05:00", want: "2026-08-20 10:05:00"},
+		{name: "storage layout", value: "2026-08-20 10:05:00", want: "2026-08-20 10:05:00"},
+		{name: "date only", value: "2026-08-20", want: "2026-08-20 00:00:00"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := formatMemoryTime(test.value, fallback); got != test.want {
+				t.Fatalf("formatMemoryTime(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+// TestFormatMemoryTimeFallbackKeepsFallbackLocation: empty or unparseable
+// input falls back to the supplied time formatted in its own location, so
+// callers passing time.Now() persist server-local wall clock.
+func TestFormatMemoryTimeFallbackKeepsFallbackLocation(t *testing.T) {
+	fallback := time.Date(2026, 8, 20, 10, 5, 0, 0, time.FixedZone("UTC+8", 8*3600))
+	for _, value := range []string{"", "   ", "not a timestamp"} {
+		if got := formatMemoryTime(value, fallback); got != "2026-08-20 10:05:00" {
+			t.Fatalf("formatMemoryTime(%q) = %q, want fallback wall clock %q", value, got, "2026-08-20 10:05:00")
+		}
+	}
+}
+
+// TestBuildExtractedMessageValidAtSemantics: extracted messages persist the
+// LLM-supplied wall clock as-is and fall back to the (server-local) now.
+func TestBuildExtractedMessageValidAtSemantics(t *testing.T) {
+	msg := MemoryMessage{UserID: "u1", AgentID: "a1", SessionID: "s1"}
+	now := time.Date(2026, 8, 20, 10, 5, 0, 0, time.Local)
+
+	withLLMTime := buildExtractedMessage(8, 42, "mem-1", msg, extractedMemory{
+		MessageType: "fact",
+		Content:     "likes coffee",
+		ValidAt:     "2026-08-20T10:05:00+08:00",
+	}, now)
+	if got := withLLMTime["valid_at"]; got != "2026-08-20 10:05:00" {
+		t.Fatalf("valid_at = %v, want LLM wall clock %q", got, "2026-08-20 10:05:00")
+	}
+
+	fallbackOnly := buildExtractedMessage(9, 42, "mem-1", msg, extractedMemory{
+		MessageType: "fact",
+		Content:     "likes coffee",
+	}, now)
+	if got := fallbackOnly["valid_at"]; got != now.Format(memoryTimeLayout) {
+		t.Fatalf("valid_at = %v, want fallback %q", got, now.Format(memoryTimeLayout))
+	}
+}

--- a/internal/service/memory_message_service.go
+++ b/internal/service/memory_message_service.go
@@ -214,9 +214,8 @@ func buildRawMessage(
 		"agent_id":     msg.AgentID,
 		"session_id":   msg.SessionID,
 		"content":      content,
-		// valid_at mirrors Python timestamp_to_date(current_timestamp()):
-		// server-local wall clock, not UTC.
-		"valid_at":   time.Now().Format(memoryTimeLayout),
+		// valid_at is stamped as server-local wall clock, not UTC.
+		"valid_at":   memoryNow().Format(memoryTimeLayout),
 		"invalid_at": nil,
 		"forget_at":  nil,
 		"status":     true,

--- a/internal/service/memory_message_service.go
+++ b/internal/service/memory_message_service.go
@@ -214,10 +214,12 @@ func buildRawMessage(
 		"agent_id":     msg.AgentID,
 		"session_id":   msg.SessionID,
 		"content":      content,
-		"valid_at":     time.Now().UTC().Format("2006-01-02 15:04:05"),
-		"invalid_at":   nil,
-		"forget_at":    nil,
-		"status":       true,
+		// valid_at mirrors Python timestamp_to_date(current_timestamp()):
+		// server-local wall clock, not UTC.
+		"valid_at":   time.Now().Format(memoryTimeLayout),
+		"invalid_at": nil,
+		"forget_at":  nil,
+		"status":     true,
 	}
 }
 

--- a/internal/service/memory_message_service_test.go
+++ b/internal/service/memory_message_service_test.go
@@ -69,10 +69,13 @@ func TestQueueSaveToMemoryTask_MissingAgentID(t *testing.T) {
 }
 
 // TestBuildRawMessage_ValidAtServerLocal: valid_at is stamped as a
-// server-local wall-clock string (Python timestamp_to_date semantics), not
-// UTC — otherwise memories asked at 10:05 local show up as 02:05.
+// server-local wall-clock string, not UTC — otherwise memories asked at
+// 10:05 local show up as 02:05. The clock is pinned to a fixed instant in a
+// fixed non-UTC location so the assertion holds on any host, including UTC
+// CI runners.
 func TestBuildRawMessage_ValidAtServerLocal(t *testing.T) {
-	before := time.Now()
+	pinMemoryNow(t, time.Date(2026, 8, 20, 10, 5, 0, 0, time.FixedZone("UTC+8", 8*3600)))
+
 	raw := buildRawMessage(42, "mem-1", MemoryMessage{
 		UserID:        "u1",
 		AgentID:       "a1",
@@ -80,18 +83,13 @@ func TestBuildRawMessage_ValidAtServerLocal(t *testing.T) {
 		UserInput:     "hi",
 		AgentResponse: "hello",
 	})
-	after := time.Now()
 
 	got, ok := raw["valid_at"].(string)
 	if !ok {
 		t.Fatalf("valid_at = %#v, want string", raw["valid_at"])
 	}
-	stamped, err := time.ParseInLocation(memoryTimeLayout, got, time.Local)
-	if err != nil {
-		t.Fatalf("valid_at %q does not parse as %q: %v", got, memoryTimeLayout, err)
-	}
-	if stamped.Before(before.Add(-2*time.Second)) || stamped.After(after.Add(2*time.Second)) {
-		t.Fatalf("valid_at %q parses as %v, want server-local time in [%v, %v]", got, stamped, before, after)
+	if want := "2026-08-20 10:05:00"; got != want {
+		t.Fatalf("valid_at = %q, want server-local wall clock %q (UTC-shifted would be %q)", got, want, "2026-08-20 02:05:00")
 	}
 }
 

--- a/internal/service/memory_message_service_test.go
+++ b/internal/service/memory_message_service_test.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestQueueSaveToMemoryTask_NilService: a nil receiver surfaces
@@ -64,6 +65,33 @@ func TestQueueSaveToMemoryTask_MissingAgentID(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "AgentID") {
 		t.Errorf("error = %v, want AgentID-required error", err)
+	}
+}
+
+// TestBuildRawMessage_ValidAtServerLocal: valid_at is stamped as a
+// server-local wall-clock string (Python timestamp_to_date semantics), not
+// UTC — otherwise memories asked at 10:05 local show up as 02:05.
+func TestBuildRawMessage_ValidAtServerLocal(t *testing.T) {
+	before := time.Now()
+	raw := buildRawMessage(42, "mem-1", MemoryMessage{
+		UserID:        "u1",
+		AgentID:       "a1",
+		SessionID:     "s1",
+		UserInput:     "hi",
+		AgentResponse: "hello",
+	})
+	after := time.Now()
+
+	got, ok := raw["valid_at"].(string)
+	if !ok {
+		t.Fatalf("valid_at = %#v, want string", raw["valid_at"])
+	}
+	stamped, err := time.ParseInLocation(memoryTimeLayout, got, time.Local)
+	if err != nil {
+		t.Fatalf("valid_at %q does not parse as %q: %v", got, memoryTimeLayout, err)
+	}
+	if stamped.Before(before.Add(-2*time.Second)) || stamped.After(after.Add(2*time.Second)) {
+		t.Fatalf("valid_at %q parses as %v, want server-local time in [%v, %v]", got, stamped, before, after)
 	}
 }
 

--- a/internal/service/memory_message_test.go
+++ b/internal/service/memory_message_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
@@ -171,6 +172,16 @@ func TestForgetMessageKeepsCompanionFieldForNonOceanBaseEngines(t *testing.T) {
 			}
 			if forgetAt, ok := docEngine.updateValue["forget_at"].(string); !ok || forgetAt == "" {
 				t.Fatalf("forget_at = %#v, want non-empty string", docEngine.updateValue["forget_at"])
+			} else {
+				// forget_at must be a server-local wall-clock string, matching
+				// Python timestamp_to_date — not a UTC-shifted one.
+				stamped, err := time.ParseInLocation(memoryTimeLayout, forgetAt, time.Local)
+				if err != nil {
+					t.Fatalf("forget_at %q does not parse as %q: %v", forgetAt, memoryTimeLayout, err)
+				}
+				if delta := time.Since(stamped); delta > 2*time.Minute || delta < -2*time.Minute {
+					t.Fatalf("forget_at %q parses as %v, want server-local now (±2min)", forgetAt, stamped)
+				}
 			}
 			_, hasCompanion := docEngine.updateValue["forget_at_flt"]
 			if hasCompanion != test.wantForgetAtCompanion {

--- a/internal/service/memory_message_test.go
+++ b/internal/service/memory_message_test.go
@@ -133,6 +133,12 @@ func setupMemoryMessageTestDB(t *testing.T) {
 func TestForgetMessageKeepsCompanionFieldForNonOceanBaseEngines(t *testing.T) {
 	setupMemoryMessageTestDB(t)
 
+	// Pin the clock to a fixed instant in a fixed non-UTC location so the
+	// server-local assertions below hold on any host, including UTC CI
+	// runners.
+	pinned := time.Date(2026, 8, 20, 10, 5, 0, 0, time.FixedZone("UTC+8", 8*3600))
+	pinMemoryNow(t, pinned)
+
 	if err := dao.DB.Create(&entity.Memory{
 		ID:          "memory-1",
 		Name:        "Test memory",
@@ -172,20 +178,17 @@ func TestForgetMessageKeepsCompanionFieldForNonOceanBaseEngines(t *testing.T) {
 			}
 			if forgetAt, ok := docEngine.updateValue["forget_at"].(string); !ok || forgetAt == "" {
 				t.Fatalf("forget_at = %#v, want non-empty string", docEngine.updateValue["forget_at"])
-			} else {
-				// forget_at must be a server-local wall-clock string, matching
-				// Python timestamp_to_date — not a UTC-shifted one.
-				stamped, err := time.ParseInLocation(memoryTimeLayout, forgetAt, time.Local)
-				if err != nil {
-					t.Fatalf("forget_at %q does not parse as %q: %v", forgetAt, memoryTimeLayout, err)
-				}
-				if delta := time.Since(stamped); delta > 2*time.Minute || delta < -2*time.Minute {
-					t.Fatalf("forget_at %q parses as %v, want server-local now (±2min)", forgetAt, stamped)
-				}
+			} else if want := "2026-08-20 10:05:00"; forgetAt != want {
+				// forget_at must be the server-local wall clock, not a
+				// UTC-shifted one (which would be "2026-08-20 02:05:00").
+				t.Fatalf("forget_at = %q, want server-local wall clock %q", forgetAt, want)
 			}
-			_, hasCompanion := docEngine.updateValue["forget_at_flt"]
+			companion, hasCompanion := docEngine.updateValue["forget_at_flt"]
 			if hasCompanion != test.wantForgetAtCompanion {
 				t.Fatalf("forget_at_flt present = %t, want %t", hasCompanion, test.wantForgetAtCompanion)
+			}
+			if hasCompanion && companion != pinned.UnixMilli() {
+				t.Fatalf("forget_at_flt = %v, want Unix milliseconds of the stamped instant %d", companion, pinned.UnixMilli())
 			}
 		})
 	}


### PR DESCRIPTION
### Summary

The Memory → Messages page showed a "Valid date" (`valid_at`) that was exactly 8 hours behind the real conversation time on a UTC+8 server: a memory message asked around 10:05 local time was listed as `2026-08-20 02:05`. The same applied to extracted-memory timestamps and the "Forget at" (`forget_at`) stamp.

Root cause: the Go memory port wrote these timestamps as **UTC** wall-clock strings, while the Python implementation it ports stores **server-local** wall-clock strings:

- Python `queue_save_to_memory_task` / `forget_message` / `extract_by_llm` stamp `timestamp_to_date(current_timestamp())`, and `common/time_utils.timestamp_to_date` renders with `time.localtime`.
- Python `format_iso_8601_to_ymd_hms` keeps the parsed ISO timestamp's own wall clock (no zone conversion).
- The frontend renders `valid_at` verbatim (`web/src/pages/memory/memory-message/message-table.tsx`), so the stored wall clock is exactly what users see.

Fix (Go side, `internal/service`):

- `buildRawMessage`: stamp `valid_at` with `time.Now()` (server-local) instead of `time.Now().UTC()`.
- `formatMemoryTime`: keep the parsed timestamp's own wall clock (no `.UTC()` conversion, matching `format_iso_8601_to_ymd_hms`) and format the fallback in its own location.
- Memory extractor: the prompt's conversation/current time and the extracted-message `valid_at` fallback now use local time.
- `ForgetMessage`: stamp `forget_at` as a local wall-clock string; `forget_at_flt` remains a zone-independent Unix-millisecond value.

Recall paths only use `exists` filters and ordering on these fields (no wall-clock range boundary against "now"), so aligning storage with Python cannot change recall semantics.

Tests (`internal/service`, run via `bash build.sh --test ./internal/service/...`):

- `TestBuildRawMessage_ValidAtServerLocal` — raw `valid_at` parses as server-local now (fails on the old UTC-shifted code).
- `TestFormatMemoryTimeKeepsParsedWallClock` / `TestFormatMemoryTimeFallbackKeepsFallbackLocation` — ISO wall clock preserved, fallback keeps its location.
- `TestBuildExtractedMessageValidAtSemantics` — extracted `valid_at` uses the LLM value as-is or the local fallback.
- Extended `TestForgetMessageKeepsCompanionFieldForNonOceanBaseEngines` — `forget_at` parses as server-local now (±2 min).

Verification boundary: an end-to-end write through the running Go server was attempted via the Messages API, but the local environment's embedding provider key is invalid (SILICONFLOW 401 "Token is invalid"), so no new memory row could be persisted. Verification therefore relies on line-by-line alignment with the Python implementation plus the unit tests above (the regression test was confirmed to fail when the UTC behavior is temporarily restored).
