### PR TITLE
fix(models): normalize catalog "vlm" model type to canonical "vision"

### DIFF
--- a/internal/entity/models/model.go
+++ b/internal/entity/models/model.go
@@ -233,6 +233,23 @@ func GetProviderManager() *ProviderManager {
 	return providerManager
 }
 
+// normalizeModelTypes maps the external model catalog's type vocabulary onto
+// the canonical names understood by entity.ModelTypeFromString, conf/models
+// provider configs, and the web UI. conf/all_models.json (synced from an
+// upstream catalog) labels vision-capable models "vlm"; every consumer of the
+// provider manager expects "vision"/"image2text". Leaving "vlm" raw leaks it
+// into provider model listings (an extra lowercase "vlm" filter category in
+// the UI) and silently maps to ModelType 0 when a tenant model is saved,
+// dropping the type.
+func normalizeModelTypes(modelTypes []string) []string {
+	for i, modelType := range modelTypes {
+		if modelType == "vlm" {
+			modelTypes[i] = "vision"
+		}
+	}
+	return modelTypes
+}
+
 // InitProviderManager creates a new ProviderManager by reading all JSON files from a directory
 func InitProviderManager(dirPath string) error {
 	var providers []Provider
@@ -285,6 +302,7 @@ func InitProviderManager(dirPath string) error {
 				model.Class = &provider.Name
 			}
 
+			model.ModelTypes = normalizeModelTypes(model.ModelTypes)
 			model.ModelTypeMap = make(map[string]bool)
 			for _, modelType := range model.ModelTypes {
 				model.ModelTypeMap[modelType] = true
@@ -319,6 +337,10 @@ func InitProviderManager(dirPath string) error {
 	var allModels AllModels
 	if err = json.Unmarshal(data, &allModels); err != nil {
 		return fmt.Errorf("error parsing JSON from file 'conf/all_models.json': %w", err)
+	}
+
+	for idx := range allModels.Models {
+		allModels.Models[idx].ModelTypes = normalizeModelTypes(allModels.Models[idx].ModelTypes)
 	}
 
 	alias2ModelIndex := make(map[string]int)

--- a/internal/entity/models/model_test.go
+++ b/internal/entity/models/model_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"ragflow/internal/entity"
 )
 
 // joinModelNames extracts model names from a ListModelResponse slice and
@@ -391,5 +393,49 @@ func TestSiliconFlowProviderConfigLoadsLatestProModels(t *testing.T) {
 	}
 	if *glm51.MaxOutput != 128000 || *glm51.ContentLength != 200000 {
 		t.Errorf("GLM-5.1 max_output=%d content_length=%d", *glm51.MaxOutput, *glm51.ContentLength)
+	}
+}
+
+// all_models.json comes from an external catalog that labels vision-capable
+// models "vlm". The provider manager must normalize that to the canonical
+// "vision" at load time: a raw "vlm" shows up as a stray lowercase filter
+// category in provider model listings, and ModelTypeFromString maps it to 0,
+// so a tenant model saved with that type loses its type entirely.
+func TestInitProviderManagerNormalizesCatalogVLModelTypes(t *testing.T) {
+	dir, restore := setupProviderTestDir(t, "siliconflow.json")
+	defer restore()
+
+	if err := InitProviderManager(dir); err != nil {
+		t.Fatalf("InitProviderManager: %v", err)
+	}
+
+	pm := GetProviderManager()
+	if pm == nil {
+		t.Fatal("provider manager is nil")
+	}
+
+	for _, model := range pm.AllModels {
+		for _, modelType := range model.ModelTypes {
+			if modelType == "vlm" {
+				t.Fatalf("catalog model %q exposes raw type %q, want normalized \"vision\"", model.Name, modelType)
+			}
+		}
+	}
+
+	// qwen/qwen3-vl-plus-2025-12-19 is declared ["chat","vlm"] in
+	// conf/all_models.json and must resolve to chat+vision.
+	model := pm.GetModelByNameOrAlias("qwen3-vl-plus-2025-12-19")
+	if model == nil {
+		t.Fatal("GetModelByNameOrAlias qwen3-vl-plus-2025-12-19: not found")
+	}
+	if len(model.ModelTypes) != 2 || model.ModelTypes[0] != "chat" || model.ModelTypes[1] != "vision" {
+		t.Errorf("qwen3-vl-plus-2025-12-19 model types=%v, want [chat vision]", model.ModelTypes)
+	}
+
+	// The normalized types must survive the save path: addModelToInstance ORs
+	// ModelTypeFromString over the type list, so "vlm" would silently drop to
+	// ModelType 0 while "vision" keeps the Image2Text bit.
+	if got := entity.ModelTypeFromStrings(model.ModelTypes); !got.Has(entity.ModelTypeImage2Text) || !got.Has(entity.ModelTypeChat) {
+		t.Errorf("qwen3-vl-plus-2025-12-19 ModelTypeFromStrings=%d, want chat|image2text bits", got)
 	}
 }


### PR DESCRIPTION
### Summary

After a provider API key is verified, clicking "模型列表" (model list) showed a stray lowercase `vlm` filter category alongside the regular `VLM` one, and after adding/saving the models the `vlm`-typed entries silently disappeared.

**Root cause.** `conf/all_models.json` is synced from an external catalog that labels vision-capable models with the type `vlm` (1020 occurrences), while the canonical model-type vocabulary used everywhere else in the repo is `vision`/`image2text` (`conf/models/*.json` provider configs, `entity.ModelTypeFromString`, and the web UI `mapModelKey`). The provider manager loaded the catalog without normalizing the vocabulary, so:

1. `GET /api/v1/providers/<name>/models` enriches remotely listed models with catalog `model_types` (`ParseListModel` → `GetModelByNameOrAlias`). After verification the panel rendered one `VLM` category (from static provider configs) plus a raw lowercase `vlm` category (from catalog-enriched remote models).
2. Saving those models ran the raw type through `entity.ModelTypeFromString("vlm")`, which returns `0`, so `addModelToInstance` stored the model with no type — after save/reload the `vlm` entries vanished from the instance model list.

**Fix.** Normalize `vlm` → `vision` once at the provider-manager load boundary (`InitProviderManager`), covering both `conf/models/*.json` entries and the `conf/all_models.json` catalog. All consumers — provider model listings, the all-models endpoint, the tenant-model save path, and UI type tags — now see a single vocabulary, so vision models are listed as `VLM`, save with the `image2text` bit set, and no longer disappear after save.

**Verification.**
- Reproduced at the data layer: `GET /api/v1/all-models` returned 3833 entries with 1020 raw `vlm` types; after the fix the endpoint returns only canonical types (`chat`/`embedding`/`asr`/`vision`/`rerank`/`tts`/`ocr`).
- New unit test `TestInitProviderManagerNormalizesCatalogVLModelTypes` asserts the catalog exposes no raw `vlm`, that `qwen3-vl-plus-2025-12-19` resolves to `[chat vision]`, and that the normalized list survives the save path (`entity.ModelTypeFromStrings` keeps the chat|image2text bits).
- `bash build.sh --test ./internal/entity/models/...` passes.
- Not verified end-to-end against a live DashScope account (no real API key available); the remote-listing path was validated through the same catalog data source plus unit tests.
