### PR TITLE
fix(memory): make default prompts deterministic

### DIFF
--- a/api/db/joint_services/memory_message_service.py
+++ b/api/db/joint_services/memory_message_service.py
@@ -366,7 +366,7 @@ def fix_missing_tokenized_memory():
 
 def judge_system_prompt_is_default(system_prompt: str, memory_type: int | list[str]):
     memory_type_list = memory_type if isinstance(memory_type, list) else get_memory_type_human(memory_type)
-    return system_prompt == PromptAssembler.assemble_system_prompt({"memory_type": memory_type_list})
+    return PromptAssembler.is_default_system_prompt(system_prompt, {"memory_type": memory_type_list})
 
 
 async def queue_save_to_memory_task(memory_ids: list[str], message_dict: dict):

--- a/memory/utils/prompt_util.py
+++ b/memory/utils/prompt_util.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from itertools import permutations
 from typing import Optional, List
 
 from common.constants import MemoryType
@@ -113,7 +114,16 @@ You are an expert at analyzing conversations to extract structured memory.
     @classmethod
     def assemble_system_prompt(cls, config: dict) -> str:
         types_to_extract = cls._get_types_to_extract(config["memory_type"])
+        return cls._assemble_system_prompt(config, types_to_extract)
 
+    @classmethod
+    def is_default_system_prompt(cls, system_prompt: str, config: dict) -> bool:
+        """Recognize generated defaults without depending on type section order."""
+        types_to_extract = cls._get_types_to_extract(config["memory_type"])
+        return any(system_prompt == cls._assemble_system_prompt(config, list(type_order)) for type_order in permutations(types_to_extract))
+
+    @classmethod
+    def _assemble_system_prompt(cls, config: dict, types_to_extract: List[str]) -> str:
         type_instructions = cls._generate_type_instructions(types_to_extract)
 
         output_format = cls._generate_output_format(types_to_extract)
@@ -132,22 +142,16 @@ You are an expert at analyzing conversations to extract structured memory.
 
     @staticmethod
     def _get_types_to_extract(requested_types: List[str]) -> List[str]:
-        types = set()
-        for rt in requested_types:
-            if rt in [e.name.lower() for e in MemoryType] and rt != MemoryType.RAW.name.lower():
-                types.add(rt)
-        return list(types)
+        return [memory_type.name.lower() for memory_type in MemoryType if memory_type is not MemoryType.RAW and memory_type.name.lower() in requested_types]
 
     @classmethod
     def _generate_type_instructions(cls, types_to_extract: List[str]) -> str:
-        target_types = set(types_to_extract)
-        instructions = [cls.TYPE_INSTRUCTIONS[mt] for mt in target_types]
+        instructions = [cls.TYPE_INSTRUCTIONS[mt] for mt in types_to_extract]
         return "\n".join(instructions)
 
     @classmethod
     def _generate_output_format(cls, types_to_extract: List[str]) -> str:
-        target_types = set(types_to_extract)
-        output_parts = [cls.OUTPUT_TEMPLATES[mt] for mt in target_types]
+        output_parts = [cls.OUTPUT_TEMPLATES[mt] for mt in types_to_extract]
         return ",\n".join(output_parts)
 
     @staticmethod

--- a/test/unit_test/memory/utils/test_prompt_util.py
+++ b/test/unit_test/memory/utils/test_prompt_util.py
@@ -14,6 +14,10 @@
 #  limitations under the License.
 #
 
+import os
+import subprocess
+import sys
+
 from memory.utils.prompt_util import PromptAssembler
 
 
@@ -22,3 +26,35 @@ def test_semantic_output_format_requires_valid_at_timestamp():
 
     assert '"valid_at": "timestamp — use the conversation time when the fact has no date of its own"' in prompt
     assert '"valid_at": "timestamp or empty"' not in prompt
+
+
+def test_multi_type_prompt_is_stable_across_hash_seeds():
+    code = """
+from memory.utils.prompt_util import PromptAssembler
+
+print(PromptAssembler.assemble_system_prompt(
+    {"memory_type": ["semantic", "episodic", "procedural"]}
+))
+"""
+
+    def assemble_with_seed(seed: int) -> str:
+        env = os.environ.copy()
+        env["PYTHONHASHSEED"] = str(seed)
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        ).stdout
+
+    assert assemble_with_seed(1) == assemble_with_seed(3)
+
+
+def test_noncanonical_prompt_order_is_still_default():
+    config = {"memory_type": ["semantic", "episodic", "procedural"]}
+    legacy_prompt = PromptAssembler._assemble_system_prompt(config, ["procedural", "semantic", "episodic"])
+
+    assert legacy_prompt != PromptAssembler.assemble_system_prompt(config)
+    assert PromptAssembler.is_default_system_prompt(legacy_prompt, config)
+    assert not PromptAssembler.is_default_system_prompt(legacy_prompt + "custom", config)


### PR DESCRIPTION
### Summary

Multi-type memory prompts were assembled from sets, so their instruction and output sections could change order across Python processes with different hash seeds. Because the generated default prompt is persisted and later compared as a string, a restart could make an untouched default look custom and prevent it from being regenerated when memory types change.

This change:

- Generates prompt sections in the stable `MemoryType` enum order
- Recognizes previously generated default prompts in any of the possible type orders while still rejecting modified/custom prompts
- Adds cross-process hash-seed and existing-order regression coverage

### Testing

- `python3 -m pytest -q -p no:cacheprovider --confcutdir=test/unit_test/memory/utils test/unit_test/memory/utils/test_prompt_util.py` — 3 passed
- `ruff check api/db/joint_services/memory_message_service.py memory/utils/prompt_util.py test/unit_test/memory/utils/test_prompt_util.py` — passed
- `ruff format --check api/db/joint_services/memory_message_service.py memory/utils/prompt_util.py test/unit_test/memory/utils/test_prompt_util.py` — passed

The broader `test/unit_test/memory/utils` collection was also attempted, but this minimal local environment does not have `psycopg2`, which is imported by the unrelated GaussDB connection test during collection.
