### PR TITLE
fix(compilation-template): emit wiki presets with the contracted "example" key

### DIFF
--- a/internal/service/compilation_template_service.go
+++ b/internal/service/compilation_template_service.go
@@ -96,7 +96,7 @@ type WikiPreset struct {
 	ID          string `json:"id"`
 	Topic       string `json:"topic"`
 	Instruction string `json:"instruction"`
-	PageExample string `json:"page_example"`
+	Example     string `json:"example"`
 }
 
 // CompilationTemplateService implements the read-side compilation template
@@ -175,7 +175,7 @@ func (s *CompilationTemplateService) LoadWikiPresets() ([]*WikiPreset, error) {
 			ID:          strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())),
 			Topic:       strings.TrimSpace(yamlStr(doc["topic"])),
 			Instruction: yamlStr(doc["instruction"]),
-			PageExample: yamlStr(doc["page_example"]),
+			Example:     yamlStr(doc["example"]),
 		})
 	}
 	return presets, nil

--- a/internal/service/compilation_template_service_test.go
+++ b/internal/service/compilation_template_service_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"ragflow/internal/entity"
@@ -65,5 +67,56 @@ func TestValidateTemplatePayload_AcceptsJSONMapConfig(t *testing.T) {
 	bad["config"] = "not-a-map"
 	if err := ValidateTemplatePayload(bad, true); err == nil {
 		t.Fatal("non-map config should be rejected")
+	}
+}
+
+// TestLoadWikiPresets_FrontendContract pins the Python API contract of
+// /v1/compilation-templates/wiki-presets: every preset must expose the
+// "example" JSON key filled from the yaml "example" key. The Go port once
+// emitted "page_example" while reading a yaml key that does not exist, so
+// the frontend received undefined for preset.example and the "Add template"
+// page crashed with "TypeError: Cannot read properties of undefined
+// (reading 'trim')" as soon as the Wiki kind was selected.
+func TestLoadWikiPresets_FrontendContract(t *testing.T) {
+	// LoadWikiPresets resolves the preset directory from the working
+	// directory, so run from the repo root where the data files live.
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err = os.Chdir("../.."); err != nil {
+		t.Fatalf("chdir to repo root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	svc := NewCompilationTemplateService()
+	presets, err := svc.LoadWikiPresets()
+	if err != nil {
+		t.Fatalf("LoadWikiPresets: %v", err)
+	}
+	if len(presets) == 0 {
+		t.Fatal("expected wiki presets to load from api/db/init_data")
+	}
+	for _, preset := range presets {
+		if preset.Instruction == "" {
+			t.Errorf("preset %q: empty instruction", preset.ID)
+		}
+		if preset.Example == "" {
+			t.Errorf("preset %q: empty example (yaml key mismatch?)", preset.ID)
+		}
+		blob, merr := json.Marshal(preset)
+		if merr != nil {
+			t.Fatalf("marshal preset %q: %v", preset.ID, merr)
+		}
+		var decoded map[string]interface{}
+		if uerr := json.Unmarshal(blob, &decoded); uerr != nil {
+			t.Fatalf("unmarshal preset %q: %v", preset.ID, uerr)
+		}
+		if _, ok := decoded["example"]; !ok {
+			t.Errorf("preset %q: JSON payload missing \"example\" key: %s", preset.ID, blob)
+		}
+		if _, ok := decoded["page_example"]; ok {
+			t.Errorf("preset %q: stale \"page_example\" key in JSON payload: %s", preset.ID, blob)
+		}
 	}
 }


### PR DESCRIPTION
### Summary

On the Go API stack, creating a compilation template ("Add template" page) and selecting the **Wiki** kind crashed the whole page with:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

**Root cause.** The Go port of `GET /v1/compilation-templates/wiki-presets` (`internal/service/compilation_template_service.go`) diverged from the Python implementation (`api/db/services/compilation_template_service.py:load_wiki_presets_from_files`):

- The `WikiPreset` struct serialized the page example under the JSON key `page_example`, while the Python API and the frontend `IWikiPreset` contract both use `example`.
- The loader also read the yaml key `doc["page_example"]`, which does not exist in `api/db/init_data/compilation_templates/wiki/*.yaml` (the files use `example`), so the value was always empty anyway.

Selecting Wiki makes the frontend render the blueprint section, whose preset matching calls `preset.example.trim()`. With the Go payload `preset.example` was `undefined`, so the call threw and the page-level error boundary replaced the whole form.

**Fix.** Align the Go payload with the Python contract: rename the field/JSON tag to `example` and read `doc["example"]` from the yaml files. No frontend change is needed — the frontend already matches the Python contract.

**Test.** Added `TestLoadWikiPresets_FrontendContract` (unit tier) which loads the real preset files and pins the contract: every preset must have non-empty `instruction`/`example` and the marshaled JSON must expose `example` (and must not reintroduce `page_example`).

**Verification.**
- `bash build.sh --test -run 'TestLoadWikiPresets|TestValidateTemplatePayload' ./internal/service/` → ok
- End-to-end on the running Go stack (response header `x-api-source: go`): before the fix, selecting Wiki reproduced the exact crash from the report; after the fix the API returns the `example` field with real content and the page renders the Wiki mode / Entity / Relation / Claim / Concept configuration normally.
