### PR TITLE
fix(tokenizer): consume summary for embedding to align with Python

### DIFF
--- a/internal/ingestion/component/tokenizer.go
+++ b/internal/ingestion/component/tokenizer.go
@@ -390,16 +390,24 @@ func (c *TokenizerComponent) embedChunks(ctx context.Context, tenantID, kbID, em
 		return nil, 0, fmt.Errorf("tokenizer: embedding requested but encoder resolution returned nil")
 	}
 
+	// Prefer summary for embedding (mirrors Python task_executor.py:858: questions > summary > text).
 	texts := make([]string, 0, len(chunks))
 	pairs := make([]int, 0, len(chunks))
 	for i, ck := range chunks {
-		raw := concatFields(ck, c.param.Fields)
+		var raw string
+		if q := strings.TrimSpace(ck.Questions); q != "" {
+			raw = q
+		} else if s := strings.TrimSpace(ck.Summary); s != "" {
+			raw = s
+		} else {
+			raw = concatFields(ck, c.param.Fields)
+		}
 		txt := htmlTableRE.ReplaceAllString(raw, " ")
 		txt = strings.TrimSpace(txt)
-		trunc := truncateForEmbedding(txt, embedder.MaxTokens())
 		if txt == "" {
 			continue
 		}
+		trunc := truncateForEmbedding(txt, embedder.MaxTokens())
 		texts = append(texts, trunc)
 		pairs = append(pairs, i)
 	}

--- a/internal/ingestion/component/tokenizer_unit_test.go
+++ b/internal/ingestion/component/tokenizer_unit_test.go
@@ -814,3 +814,152 @@ func TestTextPayloadToChunks_B1B2(t *testing.T) {
 }
 
 func ptr(s string) *string { return &s }
+
+func TestTokenizer_Embedding_PrefersSummaryOverText(t *testing.T) {
+	_, stub := withStubEmbedder(t, 4)
+	comp, err := NewTokenizerComponentWithResolver(map[string]any{
+		"search_method": []any{"embedding"},
+	}, func(_ context.Context, _, _, _ string) (Embedder, error) { return stub, nil })
+	if err != nil {
+		t.Fatalf("NewTokenizerComponentWithResolver: %v", err)
+	}
+	c := comp.(*TokenizerComponent)
+
+	_, err = c.Invoke(context.Background(), nil, map[string]any{
+		"kb_id":         "kb-1",
+		"name":          "doc.pdf",
+		"output_format": "chunks",
+		"chunks": []map[string]any{
+			{"text": "original text that should be ignored", "summary": "concise summary for embedding"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if len(stub.callInputs) < 2 {
+		t.Fatalf("expected 2 embed calls (title + content), got %d", len(stub.callInputs))
+	}
+	got := stub.callInputs[1][0]
+	if got != "concise summary for embedding" {
+		t.Errorf("embedding text = %q, want summary", got)
+	}
+}
+
+func TestTokenizer_Embedding_WhitespaceSummaryFallsBackToText(t *testing.T) {
+	_, stub := withStubEmbedder(t, 4)
+	comp, err := NewTokenizerComponentWithResolver(map[string]any{
+		"search_method": []any{"embedding"},
+	}, func(_ context.Context, _, _, _ string) (Embedder, error) { return stub, nil })
+	if err != nil {
+		t.Fatalf("NewTokenizerComponentWithResolver: %v", err)
+	}
+	c := comp.(*TokenizerComponent)
+
+	_, err = c.Invoke(context.Background(), nil, map[string]any{
+		"kb_id":         "kb-1",
+		"name":          "doc.pdf",
+		"output_format": "chunks",
+		"chunks": []map[string]any{
+			{"text": "fallback text", "summary": "   "},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if len(stub.callInputs) < 2 {
+		t.Fatalf("expected 2 embed calls, got %d", len(stub.callInputs))
+	}
+	got := stub.callInputs[1][0]
+	if got != "fallback text" {
+		t.Errorf("whitespace summary should fallback to text, got %q", got)
+	}
+}
+
+func TestTokenizer_Embedding_PrefersQuestionsOverSummary(t *testing.T) {
+	_, stub := withStubEmbedder(t, 4)
+	comp, err := NewTokenizerComponentWithResolver(map[string]any{
+		"search_method": []any{"embedding"},
+	}, func(_ context.Context, _, _, _ string) (Embedder, error) { return stub, nil })
+	if err != nil {
+		t.Fatalf("NewTokenizerComponentWithResolver: %v", err)
+	}
+	c := comp.(*TokenizerComponent)
+
+	_, err = c.Invoke(context.Background(), nil, map[string]any{
+		"kb_id":         "kb-1",
+		"name":          "doc.pdf",
+		"output_format": "chunks",
+		"chunks": []map[string]any{
+			{"text": "text", "summary": "summary", "questions": "what is ragflow?"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if len(stub.callInputs) < 2 {
+		t.Fatalf("expected 2 embed calls, got %d", len(stub.callInputs))
+	}
+	got := stub.callInputs[1][0]
+	if got != "what is ragflow?" {
+		t.Errorf("questions should take priority over summary, got %q", got)
+	}
+}
+
+func TestTokenizer_Embedding_FallsBackToTextWhenNoSummary(t *testing.T) {
+	_, stub := withStubEmbedder(t, 4)
+	comp, err := NewTokenizerComponentWithResolver(map[string]any{
+		"search_method": []any{"embedding"},
+	}, func(_ context.Context, _, _, _ string) (Embedder, error) { return stub, nil })
+	if err != nil {
+		t.Fatalf("NewTokenizerComponentWithResolver: %v", err)
+	}
+	c := comp.(*TokenizerComponent)
+
+	_, err = c.Invoke(context.Background(), nil, map[string]any{
+		"kb_id":         "kb-1",
+		"name":          "doc.pdf",
+		"output_format": "chunks",
+		"chunks": []map[string]any{
+			{"text": "plain text only"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if len(stub.callInputs) < 2 {
+		t.Fatalf("expected 2 embed calls, got %d", len(stub.callInputs))
+	}
+	got := stub.callInputs[1][0]
+	if got != "plain text only" {
+		t.Errorf("expected text fallback, got %q", got)
+	}
+}
+
+func TestTokenizer_Embedding_WhitespaceQuestionsFallsBackToSummary(t *testing.T) {
+	_, stub := withStubEmbedder(t, 4)
+	comp, err := NewTokenizerComponentWithResolver(map[string]any{
+		"search_method": []any{"embedding"},
+	}, func(_ context.Context, _, _, _ string) (Embedder, error) { return stub, nil })
+	if err != nil {
+		t.Fatalf("NewTokenizerComponentWithResolver: %v", err)
+	}
+	c := comp.(*TokenizerComponent)
+	_, err = c.Invoke(context.Background(), nil, map[string]any{
+		"kb_id":         "kb-1",
+		"name":          "doc.pdf",
+		"output_format": "chunks",
+		"chunks": []map[string]any{
+			{"text": "text", "summary": "summary value", "questions": "   "},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if len(stub.callInputs) < 2 {
+		t.Fatalf("expected 2 embed calls, got %d", len(stub.callInputs))
+	}
+	got := stub.callInputs[1][0]
+	if got != "summary value" {
+		t.Errorf("whitespace questions should fallback to summary, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Full-text already consumes `summary` for `content_ltks` (`tokenizer.go:tokenizeChunks` mirrors `rag/flow/tokenizer/tokenizer.py:155`), but vector search still used `text` only (`Tokenizer.fields=[\"text\"]`). When `Summary.Enabled=true`, keyword search hit summary while vector search hit raw text — inconsistent with Python `task_executor.py:858` / `embedding_utils.py:103` (`questions > summary > text`).

This PR aligns Go with Python: `embedChunks` now prefers `questions > summary > text` (whitespace-only summary treated as absent — Go intentional, unlike Python truthy check). `summary` remains a transient field: consumed for both `content_ltks` and vector, then deleted in `indexdoc/process.go:cleanupConsumedChunkFields` — `content_with_weight=text` for display, `content_ltks` + vector from summary for retrieval. No schema/template change (`fields` stays ``[\"text\"]``).

## Changes
- `internal/ingestion/component/tokenizer.go:embedChunks`: priority `questions > summary > text`, with whitespace guard
- `internal/ingestion/component/tokenizer.go:tokenizeChunks` + `internal/ingestion/task/indexdoc/process.go:cleanupConsumedChunkFields`: document `display=text, retrieval=summary` contract and Python parity

## Behavior
- `Summary.Enabled=false` (default): no change
- `Summary.Enabled=true` with `embedding` + `full_text`: both retrieval paths use summary; existing docs keep old text-based vectors until re-ingest

## Verification
- `bash build.sh --test ./internal/ingestion/component -- -run TestTokenizer` ok
- `bash build.sh --test ./internal/ingestion/task/indexdoc` ok