### PR TITLE
fix(web): preserve entire subtree of title-matching nodes in TreeSelect filter

### DIFF
--- a/web/src/components/tree-select.tsx
+++ b/web/src/components/tree-select.tsx
@@ -145,11 +145,18 @@ export const TreeSelect = forwardRef<HTMLButtonElement, TreeSelectProps>(
           const titleMatch = node.title
             .toLowerCase()
             .includes(term.toLowerCase());
+          // A matching parent keeps its entire subtree so its children stay
+          // visible; otherwise only branches containing matching descendants
+          // are kept.
+          if (titleMatch) {
+            acc.push(node);
+            return acc;
+          }
           const filteredChildren = node.children
             ? filterTree(node.children, term)
             : undefined;
-          if (titleMatch || filteredChildren?.length) {
-            acc.push({ ...node, children: filteredChildren ?? node.children });
+          if (filteredChildren?.length) {
+            acc.push({ ...node, children: filteredChildren });
           }
           return acc;
         }, []);


### PR DESCRIPTION
### Summary

fix(web): preserve entire subtree of title-matching nodes in TreeSelect filter

  ## Problem

  When filtering the `TreeSelect` tree, a parent node whose title matched the
  search term was re-attached with its *filtered* children. Since `filterTree`
  only keeps matching branches, all non-matching children of a matched parent
  disappeared from the dropdown, even though the parent itself matched.

  ## Change

  - In `filterTree` inside `web/src/components/tree-select.tsx`, short-circuit when a node's title matches the search term: push the node as-is, keeping its original children and entire subtree visible.
  - Nodes whose titles do not match are still kept only when they contain matching descendants, and their subtree continues to be filtered as before.


