### PR TITLE
fix(ingestion): derive QA chunk IDs from content_with_weight to stop chunk collapse

### DIFF
--- a/internal/common/format.go
+++ b/internal/common/format.go
@@ -188,3 +188,18 @@ func IsValidString(v interface{}) bool {
 func ChunkID(docID, text string) string {
 	return fmt.Sprintf("%016x", xxhash.Sum64String(text+docID))
 }
+
+// ChunkIDForChunk derives the deterministic id of a chunk map using the same
+// hash input as Python: content_with_weight when present, falling back to
+// text otherwise (Python hashes content_with_weight after renaming text to
+// it — rag/svr/task_executor.py). Chunkers that emit only
+// content_with_weight (e.g. QAChunker) must not be keyed on the absent
+// "text" key: that would collapse every chunk of a document onto the same
+// id and silently overwrite all but one chunk at index time.
+func ChunkIDForChunk(docID string, ck map[string]any) string {
+	content, _ := ck["content_with_weight"].(string)
+	if content == "" {
+		content, _ = ck["text"].(string)
+	}
+	return ChunkID(docID, content)
+}

--- a/internal/common/format.go
+++ b/internal/common/format.go
@@ -191,8 +191,11 @@ func ChunkID(docID, text string) string {
 
 // ChunkIDForChunk derives the deterministic id of a chunk map using the same
 // hash input as Python: content_with_weight when present, falling back to
-// text otherwise (Python hashes content_with_weight after renaming text to
-// it — rag/svr/task_executor.py). Chunkers that emit only
+// text otherwise. Both Python id sites in rag/svr/task_executor.py hash the
+// same chunk content: build_chunks→upload_to_minio hashes
+// content_with_weight directly, while the run_dataflow pipeline hashes
+// ck["text"] and only afterwards renames text to content_with_weight.
+// Chunkers that emit only
 // content_with_weight (e.g. QAChunker) must not be keyed on the absent
 // "text" key: that would collapse every chunk of a document onto the same
 // id and silently overwrite all but one chunk at index time.

--- a/internal/common/format_test.go
+++ b/internal/common/format_test.go
@@ -75,3 +75,29 @@ func TestBaseModelName(t *testing.T) {
 		})
 	}
 }
+func TestChunkIDForChunk(t *testing.T) {
+	t.Run("prefers content_with_weight", func(t *testing.T) {
+		ck := map[string]any{"content_with_weight": "cww", "text": "plain"}
+		if got, want := ChunkIDForChunk("doc-1", ck), ChunkID("doc-1", "cww"); got != want {
+			t.Fatalf("ChunkIDForChunk = %q, want %q", got, want)
+		}
+	})
+	t.Run("falls back to text", func(t *testing.T) {
+		ck := map[string]any{"text": "plain"}
+		if got, want := ChunkIDForChunk("doc-1", ck), ChunkID("doc-1", "plain"); got != want {
+			t.Fatalf("ChunkIDForChunk = %q, want %q", got, want)
+		}
+	})
+	t.Run("empty content hashes empty string", func(t *testing.T) {
+		ck := map[string]any{}
+		if got, want := ChunkIDForChunk("doc-1", ck), ChunkID("doc-1", ""); got != want {
+			t.Fatalf("ChunkIDForChunk = %q, want %q", got, want)
+		}
+	})
+	t.Run("non-string content_with_weight falls back to text", func(t *testing.T) {
+		ck := map[string]any{"content_with_weight": 42, "text": "plain"}
+		if got, want := ChunkIDForChunk("doc-1", ck), ChunkID("doc-1", "plain"); got != want {
+			t.Fatalf("ChunkIDForChunk = %q, want %q", got, want)
+		}
+	})
+}

--- a/internal/ingestion/component/chunker/qa.go
+++ b/internal/ingestion/component/chunker/qa.go
@@ -22,6 +22,13 @@
 //   - HTML (xlsx/xls)  → table-based Q&A (first two columns)
 //   - JSON (pdf, docx) → delimiter-based on structured text sections
 //
+// Raw-text QA formats (txt, md/markdown/mdx) are re-parsed from the
+// original file bytes re-acquired from storage: the upstream Parser
+// shreds text into sentence fragments (split at ！？。；) and markdown
+// into blocks, which destroys the line/heading question/answer pairing.
+// This mirrors Python qa.py, which always parses the raw file bytes for
+// these formats.
+//
 // Every Q&A pair becomes a single chunk with content_with_weight
 // formatted as "Question: {q}\tAnswer: {a}".
 package chunker
@@ -32,6 +39,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"log/slog"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -40,6 +49,7 @@ import (
 	"gorm.io/gorm"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/ingestion/component"
 	"ragflow/internal/ingestion/component/schema"
 	"ragflow/internal/tokenizer"
 )
@@ -83,10 +93,10 @@ func (c *QAChunkerComponent) Inputs() map[string]string { return ChunkerInputs }
 func (c *QAChunkerComponent) Outputs() map[string]string { return ChunkerOutputs }
 
 func (c *QAChunkerComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[string]any) (map[string]any, error) {
-	return c.invoke(ctx, inputs)
+	return c.invoke(ctx, db, inputs)
 }
 
-func (c *QAChunkerComponent) invoke(_ context.Context, inputs map[string]any) (map[string]any, error) {
+func (c *QAChunkerComponent) invoke(ctx context.Context, db *gorm.DB, inputs map[string]any) (map[string]any, error) {
 	if inputs == nil {
 		return emptyOutputs(), nil
 	}
@@ -107,19 +117,7 @@ func (c *QAChunkerComponent) invoke(_ context.Context, inputs map[string]any) (m
 		qPrefix, aPrefix = "Question: ", "Answer: "
 	}
 
-	var qaPairs []qaPair
-	var isMarkdown bool
-	switch upstream.OutputFormat {
-	case schema.PayloadFormatHTML:
-		qaPairs = extractQATable(stringPtrVal(upstream.HTMLResult))
-	case schema.PayloadFormatMarkdown:
-		qaPairs = extractQAMarkdown(stringPtrVal(upstream.MarkdownResult))
-		isMarkdown = true
-	case schema.PayloadFormatText:
-		qaPairs = extractQAText(stringPtrVal(upstream.TextResult))
-	default:
-		qaPairs = extractQAJSON(upstream.JSONResult)
-	}
+	qaPairs, isMarkdown := extractQAPairs(ctx, db, upstream)
 
 	chunks := make([]schema.ChunkDoc, 0, len(qaPairs))
 	lang, _ := inputs["lang"].(string)
@@ -156,6 +154,89 @@ func (c *QAChunkerComponent) invoke(_ context.Context, inputs map[string]any) (m
 	}
 
 	return chunkOutputs(chunks), nil
+}
+
+// extractQAPairs selects the Q&A extraction strategy. Raw-text QA
+// formats (txt, md/markdown/mdx) are parsed from the original file
+// bytes re-acquired from storage — the upstream Parser shreds them
+// past the point where question/answer pairing survives (mirrors
+// Python qa.py, which always reads the raw file for these formats).
+// When no storage reference is present (unit tests, canvas runs
+// without a File upstream), the upstream payload is used as-is.
+func extractQAPairs(ctx context.Context, db *gorm.DB, upstream schema.ChunkerFromUpstream) ([]qaPair, bool) {
+	if isRawTextQAFile(upstream.Name) {
+		raw, err := reacquireQARawText(ctx, db, upstream)
+		if err != nil {
+			slog.Warn("QAChunker: re-acquire raw source failed; falling back to upstream payload",
+				"name", upstream.Name, "err", err)
+		} else if raw != "" {
+			if isMarkdownQAFile(upstream.Name) {
+				return extractQAMarkdown(raw), true
+			}
+			return extractQAText(raw), false
+		}
+	}
+	return extractQAPairsFromPayload(upstream)
+}
+
+func extractQAPairsFromPayload(upstream schema.ChunkerFromUpstream) ([]qaPair, bool) {
+	switch upstream.OutputFormat {
+	case schema.PayloadFormatHTML:
+		return extractQATable(stringPtrVal(upstream.HTMLResult)), false
+	case schema.PayloadFormatMarkdown:
+		return extractQAMarkdown(stringPtrVal(upstream.MarkdownResult)), true
+	case schema.PayloadFormatText:
+		return extractQAText(stringPtrVal(upstream.TextResult)), false
+	default:
+		return extractQAJSON(upstream.JSONResult), false
+	}
+}
+
+// isRawTextQAFile reports whether name is a QA format parsed from raw
+// file text, mirroring the Python qa.py extension branches
+// (txt → delimiter-based, md/markdown/mdx → heading-based).
+func isRawTextQAFile(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".txt", ".md", ".markdown", ".mdx":
+		return true
+	}
+	return false
+}
+
+func isMarkdownQAFile(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".md", ".markdown", ".mdx":
+		return true
+	}
+	return false
+}
+
+// reacquireQARawText re-reads the source document bytes from storage
+// using the same resolution as the PDF crop path (explicit bucket/path
+// first, then doc_id-driven resolution). It returns ("", nil) when no
+// storage reference is present so callers fall back to the upstream
+// payload.
+func reacquireQARawText(ctx context.Context, db *gorm.DB, upstream schema.ChunkerFromUpstream) (string, error) {
+	var data []byte
+	var err error
+	switch {
+	case upstream.Bucket != "" && upstream.Path != "":
+		data, err = component.FetchBinary(ctx, upstream.Bucket, upstream.Path)
+	case upstream.DocID != "":
+		var ref *component.DocumentStorageRef
+		ref, err = component.ResolveDocumentStorage(ctx, db, upstream.DocID)
+		if err == nil && ref != nil {
+			data, err = component.FetchBinary(ctx, ref.Bucket, ref.Path)
+		}
+	default:
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	// Strip a UTF-8 BOM so the first question does not start with U+FEFF
+	// (Python get_text strips it via codec detection).
+	return strings.TrimPrefix(string(data), "\ufeff"), nil
 }
 
 func renderMarkdown(s string) string {

--- a/internal/ingestion/component/chunker/qa.go
+++ b/internal/ingestion/component/chunker/qa.go
@@ -34,18 +34,25 @@
 package chunker
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"html"
+	"io"
 	"log/slog"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/parser"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 	"gorm.io/gorm"
 
 	"ragflow/internal/agent/runtime"
@@ -93,10 +100,6 @@ func (c *QAChunkerComponent) Inputs() map[string]string { return ChunkerInputs }
 func (c *QAChunkerComponent) Outputs() map[string]string { return ChunkerOutputs }
 
 func (c *QAChunkerComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[string]any) (map[string]any, error) {
-	return c.invoke(ctx, db, inputs)
-}
-
-func (c *QAChunkerComponent) invoke(ctx context.Context, db *gorm.DB, inputs map[string]any) (map[string]any, error) {
 	if inputs == nil {
 		return emptyOutputs(), nil
 	}
@@ -234,9 +237,50 @@ func reacquireQARawText(ctx context.Context, db *gorm.DB, upstream schema.Chunke
 	if err != nil {
 		return "", err
 	}
-	// Strip a UTF-8 BOM so the first question does not start with U+FEFF
-	// (Python get_text strips it via codec detection).
-	return strings.TrimPrefix(string(data), "\ufeff"), nil
+	return decodeQARawText(data), nil
+}
+
+// decodeQARawText decodes raw QA file bytes to text, mirroring Python
+// get_text/find_codec (deepdoc/parser/utils.py, rag/nlp/__init__.py):
+// UTF-16 is honored only with a leading BOM (Python's utf_16 codec also
+// requires one), valid UTF-8 is used as-is, and anything else is decoded as
+// GB18030, a superset of GBK/GB2312 — the encodings chardet realistically
+// reports for CJK text. A leading U+FEFF is stripped so the first question
+// never starts with the BOM. Undecodable input falls back to the raw bytes
+// (Python decodes with errors="ignore", equally lossy).
+func decodeQARawText(data []byte) string {
+	switch {
+	case bytes.HasPrefix(data, []byte{0xFF, 0xFE}):
+		if s, ok := decodeQACharset(data[2:], unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)); ok {
+			return strings.TrimPrefix(s, "\ufeff")
+		}
+	case bytes.HasPrefix(data, []byte{0xFE, 0xFF}):
+		if s, ok := decodeQACharset(data[2:], unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)); ok {
+			return strings.TrimPrefix(s, "\ufeff")
+		}
+	case utf8.Valid(data):
+		return strings.TrimPrefix(string(data), "\ufeff")
+	default:
+		if s, ok := decodeQACharset(data, simplifiedchinese.GB18030); ok {
+			return strings.TrimPrefix(s, "\ufeff")
+		}
+	}
+	return strings.TrimPrefix(string(data), "\ufeff")
+}
+
+// decodeQACharset decodes data with enc, rejecting output that contains
+// replacement characters (the same acceptance rule as the email parser's
+// decodeTransform).
+func decodeQACharset(data []byte, enc encoding.Encoding) (string, bool) {
+	decoded, err := io.ReadAll(transform.NewReader(bytes.NewReader(data), enc.NewDecoder()))
+	if err != nil {
+		return "", false
+	}
+	s := string(decoded)
+	if strings.ContainsRune(s, '\ufffd') {
+		return "", false
+	}
+	return s, true
 }
 
 func renderMarkdown(s string) string {

--- a/internal/ingestion/component/chunker/qa_test.go
+++ b/internal/ingestion/component/chunker/qa_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/common"
+	"ragflow/internal/ingestion/component"
+	"ragflow/internal/storage"
 )
 
 func TestQAChunker_Registered(t *testing.T) {
@@ -285,5 +288,286 @@ func TestQAChunker_MarkdownRendersHTML(t *testing.T) {
 	if !strings.Contains(cww, "<strong>bold</strong>") &&
 		!strings.Contains(cww, "<b>bold</b>") {
 		t.Fatalf("markdown not rendered to HTML: %q", cww)
+	}
+}
+
+// withQAMemoryStorage swaps the global storage factory for an
+// in-memory backend and restores it on cleanup. Mirrors
+// withMemoryStorage in internal/ingestion/component/file_test.go.
+func withQAMemoryStorage(t *testing.T) *storage.MemoryStorage {
+	t.Helper()
+	factory := storage.GetStorageFactory()
+	prev := factory.GetStorage()
+	ms := storage.NewMemoryStorage().(*storage.MemoryStorage)
+	factory.SetStorage(ms)
+	t.Cleanup(func() { factory.SetStorage(prev) })
+	return ms
+}
+
+// TestQAChunker_TxtReacquiresRawFromStorage is the regression test for
+// txt QA files producing zero chunks: the upstream text parser shreds
+// tab-separated Q&A lines into delimiter-less fragments, so the chunker
+// must re-read the raw file bytes from storage (mirrors Python qa.py).
+func TestQAChunker_TxtReacquiresRawFromStorage(t *testing.T) {
+	ms := withQAMemoryStorage(t)
+	ctx := context.Background()
+	raw := "What is Go?\tGo is a programming language.\nWhat is Rust?\tRust is a systems language.\n"
+	if err := ms.Put(ctx, "kb-1", "qa.txt", []byte(raw)); err != nil {
+		t.Fatal(err)
+	}
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "qa.txt",
+		"output_format": "json",
+		// What the shredded upstream payload looks like: no delimiter
+		// survives in any fragment, so JSON extraction yields nothing.
+		"json": []map[string]any{
+			{"text": "What is Go?"},
+			{"text": " Go is a programming language."},
+			{"text": "What is Rust?"},
+			{"text": " Rust is a systems language."},
+		},
+		"bucket": "kb-1",
+		"path":   "qa.txt",
+	}
+	out, err := comp.Invoke(ctx, nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	if msg, ok := out["_ERROR"]; ok {
+		t.Fatalf("unexpected _ERROR: %v", msg)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	cww, _ := chunks[0]["content_with_weight"].(string)
+	if want := "Question: What is Go?\tAnswer: Go is a programming language."; cww != want {
+		t.Fatalf("unexpected content: %q, want %q", cww, want)
+	}
+}
+
+// TestQAChunker_TxtReacquiresRawViaDocID covers the doc_id-driven
+// storage resolution path (no explicit bucket/path on the wire).
+func TestQAChunker_TxtReacquiresRawViaDocID(t *testing.T) {
+	ms := withQAMemoryStorage(t)
+	ctx := context.Background()
+	if err := ms.Put(ctx, "kb-1", "loc/qa.txt", []byte("Q1\tA1\n")); err != nil {
+		t.Fatal(err)
+	}
+	prev := component.ResolveDocumentStorageOverride
+	component.ResolveDocumentStorageOverride = func(docID string) (*component.DocumentStorageRef, error) {
+		if docID != "doc-1" {
+			t.Errorf("unexpected doc_id: %q", docID)
+		}
+		return &component.DocumentStorageRef{Bucket: "kb-1", Path: "loc/qa.txt"}, nil
+	}
+	t.Cleanup(func() { component.ResolveDocumentStorageOverride = prev })
+
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "qa.txt",
+		"output_format": "json",
+		"json":          []map[string]any{{"text": "Q1"}},
+		"doc_id":        "doc-1",
+	}
+	out, err := comp.Invoke(ctx, nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	cww, _ := chunks[0]["content_with_weight"].(string)
+	if want := "Question: Q1\tAnswer: A1"; cww != want {
+		t.Fatalf("unexpected content: %q, want %q", cww, want)
+	}
+}
+
+// TestQAChunker_MarkdownReacquiresRawFromStorage covers heading-based
+// md QA files: block-split markdown items carry no delimiter, so the
+// raw file must be re-read (Python qa.py md branch).
+func TestQAChunker_MarkdownReacquiresRawFromStorage(t *testing.T) {
+	ms := withQAMemoryStorage(t)
+	ctx := context.Background()
+	raw := "# What is Go?\nGo is a **programming** language.\n\n# What is Rust?\nRust is a systems language.\n"
+	if err := ms.Put(ctx, "kb-1", "qa.md", []byte(raw)); err != nil {
+		t.Fatal(err)
+	}
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "qa.md",
+		"output_format": "json",
+		"json": []map[string]any{
+			{"text": "What is Go?"},
+			{"text": "Go is a **programming** language."},
+		},
+		"bucket": "kb-1",
+		"path":   "qa.md",
+	}
+	out, err := comp.Invoke(ctx, nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	cww, _ := chunks[0]["content_with_weight"].(string)
+	if !strings.Contains(cww, "Question: What is Go?") {
+		t.Fatalf("unexpected content: %q", cww)
+	}
+	if !strings.Contains(cww, "<strong>programming</strong>") &&
+		!strings.Contains(cww, "<b>programming</b>") {
+		t.Fatalf("markdown answer not rendered to HTML: %q", cww)
+	}
+}
+
+// TestQAChunker_TxtNoStorageRefFallsBackToPayload verifies that a txt
+// input without any storage reference keeps the pre-existing payload
+// behavior (direct-fed canvas runs, unit tests).
+func TestQAChunker_TxtNoStorageRefFallsBackToPayload(t *testing.T) {
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "qa.txt",
+		"output_format": "json",
+		"json":          []map[string]any{{"text": "What is Go?\tGo is a programming language."}},
+	}
+	out, err := comp.Invoke(context.Background(), nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	if msg, ok := out["_ERROR"]; ok {
+		t.Fatalf("unexpected _ERROR: %v", msg)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+}
+
+// TestQAChunker_TxtStorageFailureFallsBackToPayload verifies that a
+// storage read failure degrades to the upstream payload with a warning
+// rather than failing the component.
+func TestQAChunker_TxtStorageFailureFallsBackToPayload(t *testing.T) {
+	withQAMemoryStorage(t) // object intentionally absent
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "qa.txt",
+		"output_format": "json",
+		"json":          []map[string]any{{"text": "What is Go?\tGo is a programming language."}},
+		"bucket":        "kb-1",
+		"path":          "missing.txt",
+	}
+	out, err := comp.Invoke(context.Background(), nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	if msg, ok := out["_ERROR"]; ok {
+		t.Fatalf("unexpected _ERROR: %v", msg)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+}
+
+// TestQAChunker_TxtReacquireStripsBOM verifies a UTF-8 BOM does not
+// leak into the first question.
+func TestQAChunker_TxtReacquireStripsBOM(t *testing.T) {
+	ms := withQAMemoryStorage(t)
+	ctx := context.Background()
+	if err := ms.Put(ctx, "kb-1", "qa.txt", []byte("\ufeffQ1\tA1\n")); err != nil {
+		t.Fatal(err)
+	}
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "qa.txt",
+		"output_format": "json",
+		"json":          []map[string]any{{"text": "Q1"}},
+		"bucket":        "kb-1",
+		"path":          "qa.txt",
+	}
+	out, err := comp.Invoke(ctx, nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	cww, _ := chunks[0]["content_with_weight"].(string)
+	if want := "Question: Q1\tAnswer: A1"; cww != want {
+		t.Fatalf("unexpected content: %q, want %q", cww, want)
+	}
+}
+
+// TestQAChunker_DecoratorAssignsDistinctIDs pins the chunk-id regression
+// where the registration decorator hashed ck["text"] — absent on QA chunks
+// (they carry content_with_weight) — collapsing every QA chunk of a
+// document onto the same id, so all but one chunk were silently
+// overwritten at index time.
+func TestQAChunker_DecoratorAssignsDistinctIDs(t *testing.T) {
+	ms := withQAMemoryStorage(t)
+	ctx := context.Background()
+	raw := "What is Go?\tGo is a programming language.\nWhat is Rust?\tRust is a systems language.\n"
+	if err := ms.Put(ctx, testKBID, "qa.txt", []byte(raw)); err != nil {
+		t.Fatal(err)
+	}
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decorated := &imageUploadDecorator{inner: comp}
+	inputs := map[string]any{
+		"name":          "qa.txt",
+		"kb_id":         testKBID,
+		"doc_id":        testDocID,
+		"output_format": "json",
+		"json":          []map[string]any{{"text": "What is Go?"}}, // shredded upstream payload; raw bytes win
+		"bucket":        testKBID,
+		"path":          "qa.txt",
+	}
+	out, err := decorated.Invoke(ctx, nil, inputs)
+	if err != nil {
+		t.Fatalf("decorated Invoke: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	seen := map[string]bool{}
+	for i, ck := range chunks {
+		id, _ := ck["id"].(string)
+		if id == "" {
+			t.Fatalf("chunk %d has empty id", i)
+		}
+		if seen[id] {
+			t.Fatalf("chunk %d duplicates id %q — chunks would overwrite each other", i, id)
+		}
+		seen[id] = true
+		cww, _ := ck["content_with_weight"].(string)
+		if want := common.ChunkID(testDocID, cww); id != want {
+			t.Errorf("chunk %d id = %q, want %q (xxhash of content_with_weight)", i, id, want)
+		}
 	}
 }

--- a/internal/ingestion/component/chunker/qa_test.go
+++ b/internal/ingestion/component/chunker/qa_test.go
@@ -521,6 +521,92 @@ func TestQAChunker_TxtReacquireStripsBOM(t *testing.T) {
 	}
 }
 
+// TestQAChunker_TxtReacquireDecodesGBK verifies that a GBK-encoded qa.txt
+// is decoded instead of collapsing into U+FFFD replacement characters
+// (mirrors Python find_codec: utf-8 fails, then gbk/gb18030 succeeds;
+// GB18030 is a superset of GBK/GB2312, so one decoder covers all three).
+func TestQAChunker_TxtReacquireDecodesGBK(t *testing.T) {
+	ms := withQAMemoryStorage(t)
+	ctx := context.Background()
+	// "中文问题一\t中文回答一\n" encoded in GBK.
+	gbk := []byte{0xd6, 0xd0, 0xce, 0xc4, 0xce, 0xca, 0xcc, 0xe2, 0xd2, 0xbb, 0x09, 0xd6, 0xd0, 0xce, 0xc4, 0xbb, 0xd8, 0xb4, 0xf0, 0xd2, 0xbb, 0x0a}
+	if err := ms.Put(ctx, "kb-1", "qa.txt", gbk); err != nil {
+		t.Fatal(err)
+	}
+	comp, err := NewQAChunker(map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "qa.txt",
+		"output_format": "json",
+		"json":          []map[string]any{{"text": "shredded fragment"}},
+		"bucket":        "kb-1",
+		"path":          "qa.txt",
+	}
+	out, err := comp.Invoke(ctx, nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	if msg, ok := out["_ERROR"]; ok {
+		t.Fatalf("unexpected _ERROR: %v", msg)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	cww, _ := chunks[0]["content_with_weight"].(string)
+	if want := "问题：中文问题一\t回答：中文回答一"; cww != want {
+		t.Fatalf("unexpected content: %q, want %q", cww, want)
+	}
+}
+
+// TestQAChunker_TxtReacquireDecodesUTF16 covers UTF-16LE/BE qa.txt files
+// with a BOM: they must be decoded instead of producing replacement
+// characters and NULs (Python's utf_16 codec likewise requires the BOM).
+func TestQAChunker_TxtReacquireDecodesUTF16(t *testing.T) {
+	// "Q1\tA1\n" encoded in UTF-16 with a leading BOM.
+	cases := map[string][]byte{
+		"le": {0xff, 0xfe, 0x51, 0x00, 0x31, 0x00, 0x09, 0x00, 0x41, 0x00, 0x31, 0x00, 0x0a, 0x00},
+		"be": {0xfe, 0xff, 0x00, 0x51, 0x00, 0x31, 0x00, 0x09, 0x00, 0x41, 0x00, 0x31, 0x00, 0x0a},
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			ms := withQAMemoryStorage(t)
+			ctx := context.Background()
+			if err := ms.Put(ctx, "kb-1", "qa.txt", data); err != nil {
+				t.Fatal(err)
+			}
+			comp, err := NewQAChunker(map[string]any{"lang": "english"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			inputs := map[string]any{
+				"name":          "qa.txt",
+				"output_format": "json",
+				"json":          []map[string]any{{"text": "Q1"}},
+				"bucket":        "kb-1",
+				"path":          "qa.txt",
+			}
+			out, err := comp.Invoke(ctx, nil, inputs)
+			if err != nil {
+				t.Fatalf("Invoke failed: %v", err)
+			}
+			if msg, ok := out["_ERROR"]; ok {
+				t.Fatalf("unexpected _ERROR: %v", msg)
+			}
+			chunks, _ := out["chunks"].([]map[string]any)
+			if len(chunks) != 1 {
+				t.Fatalf("expected 1 chunk, got %d", len(chunks))
+			}
+			cww, _ := chunks[0]["content_with_weight"].(string)
+			if want := "Question: Q1\tAnswer: A1"; cww != want {
+				t.Fatalf("unexpected content: %q, want %q", cww, want)
+			}
+		})
+	}
+}
+
 // TestQAChunker_DecoratorAssignsDistinctIDs pins the chunk-id regression
 // where the registration decorator hashed ck["text"] — absent on QA chunks
 // (they carry content_with_weight) — collapsing every QA chunk of a

--- a/internal/ingestion/component/chunker/register.go
+++ b/internal/ingestion/component/chunker/register.go
@@ -73,13 +73,13 @@ func (d *imageUploadDecorator) Invoke(ctx context.Context, db *gorm.DB, inputs m
 	}
 	kbID, docID := resolveImageUploadContext(ctx, inputs)
 
-	// Compute and write the deterministic chunk id (component.ChunkID) for
-	// every chunk. This happens here — before any upload — so uploadChunkImage
+	// Compute and write the deterministic chunk id for every chunk from its
+	// content (content_with_weight, else text) — the same hash input Python
+	// uses. This happens here — before any upload — so uploadChunkImage
 	// can read ck["id"] without deriving it itself. Downstream, the persist
 	// stage reuses the same formula as a fallback when ck["id"] is absent.
 	for _, ck := range chunks {
-		text, _ := ck["text"].(string)
-		ck["id"] = common.ChunkID(docID, text)
+		ck["id"] = common.ChunkIDForChunk(docID, ck)
 	}
 
 	// kb_id is empty only in canvas debug (dry-run) mode; production ingestion

--- a/internal/ingestion/component/chunker/testdata/parity/known_diffs.json
+++ b/internal/ingestion/component/chunker/testdata/parity/known_diffs.json
@@ -8,7 +8,7 @@
       "applies_to": ["*"],
       "fields": ["id"],
       "permanent": true,
-      "reason": "register.go MustRegisterChunker wraps every chunker in imageUploadDecorator, which writes ck[\"id\"] = common.ChunkID(doc_id, text) before any image upload so uploadChunkImage and the persist stage share one chunk identity. Python derives chunk ids outside the chunker, so its _finalize_json_chunks output has no id."
+      "reason": "register.go MustRegisterChunker wraps every chunker in imageUploadDecorator, which writes ck[\"id\"] = common.ChunkIDForChunk(doc_id, ck) — hashing content_with_weight (falling back to text) — before any image upload so uploadChunkImage and the persist stage share one chunk identity. Python derives chunk ids outside the chunker, so its _finalize_json_chunks output has no id."
     },
     {
       "id": "go-only-token-metadata",

--- a/internal/ingestion/task/indexdoc/process.go
+++ b/internal/ingestion/task/indexdoc/process.go
@@ -55,12 +55,11 @@ func GetEmbeddingTokenConsumption(output map[string]any) int {
 }
 
 // ProcessChunksForPipeline mutates chunks into the pre-index structure used by
-// the pipeline and returns merged metadata. It returns an error if a chunk's
-// "text" field is present but not a string: that is an upstream contract
-// violation (the chunker/parser must emit string text), and continuing would
-// collapse every such chunk onto the same empty-text ChunkID, silently
-// overwriting each other in the index. The caller fails the task so the
-// violation surfaces instead of corrupting the index.
+// the pipeline and returns merged metadata. Chunks missing an "id" get one
+// derived from their content (content_with_weight, else text) via
+// common.ChunkIDForChunk — the same hash input Python uses — so chunks that
+// carry only content_with_weight (e.g. QAChunker output) still receive
+// distinct ids instead of collapsing onto one empty-text id.
 //
 // Note: kb_id is intentionally NOT stamped here. It is an index-physical
 // concern owned by the search engine at the write boundary (ES chunk.go
@@ -86,8 +85,7 @@ func ProcessChunksForPipeline(
 		ck["create_timestamp_flt"] = timestamp
 
 		if _, exists := ck["id"]; !exists {
-			text, _ := ck["text"].(string)
-			ck["id"] = common.ChunkID(docID, text)
+			ck["id"] = common.ChunkIDForChunk(docID, ck)
 		}
 
 		cleanupConsumedChunkFields(ck)

--- a/internal/ingestion/task/indexdoc/process_test.go
+++ b/internal/ingestion/task/indexdoc/process_test.go
@@ -3,6 +3,8 @@ package indexdoc
 import (
 	"testing"
 	"time"
+
+	"ragflow/internal/common"
 )
 
 // =============================================================================
@@ -459,5 +461,32 @@ func TestCleanupConsumedChunkFields_ImportantKwdDropsEmptyParts(t *testing.T) {
 	want := []string{"a", "b"}
 	if len(kwd) != len(want) || kwd[0] != "a" || kwd[1] != "b" {
 		t.Fatalf("executor important_kwd = %v, want %v (empty parts dropped)", kwd, want)
+	}
+}
+
+// TestProcessChunksForPipeline_DistinctIDsFromContentWithWeight pins the id
+// fallback for chunks that carry only content_with_weight (e.g. QAChunker
+// output): ids must be derived from the content, not from the absent "text"
+// key, or every chunk of a document collapses onto one id and all but one
+// are overwritten at index time.
+func TestProcessChunksForPipeline_DistinctIDsFromContentWithWeight(t *testing.T) {
+	chunks := []map[string]any{
+		{"content_with_weight": "Question: Q1\tAnswer: A1"},
+		{"content_with_weight": "Question: Q2\tAnswer: A2"},
+	}
+	_, err := ProcessChunksForPipeline(chunks, "doc-1", "qa.txt", time.Now())
+	if err != nil {
+		t.Fatalf("ProcessChunksForPipeline: %v", err)
+	}
+	id0, _ := chunks[0]["id"].(string)
+	id1, _ := chunks[1]["id"].(string)
+	if id0 == "" || id1 == "" {
+		t.Fatalf("ids should be non-empty, got %q and %q", id0, id1)
+	}
+	if id0 == id1 {
+		t.Fatalf("ids must differ for distinct content, both = %q", id0)
+	}
+	if want := common.ChunkID("doc-1", "Question: Q1\tAnswer: A1"); id0 != want {
+		t.Errorf("id0 = %q, want %q", id0, want)
 	}
 }


### PR DESCRIPTION
## Problem

Uploading a tab-separated `qa.txt` (question<TAB>answer per line) into a
knowledge base with the **QA** parser indexed only **1 chunk** no matter how
many QA pairs the file contained. The same happened for heading-based
`qa.md` files.

## Root cause

The Go QA chunker emits chunks that only carry `content_with_weight`
(`问题:...\t回答:...`) and never set the `text` key. The
`imageUploadDecorator` in `internal/ingestion/component/chunker/register.go`
assigned chunk ids via `common.ChunkID(docID, ck["text"])`, which hashed an
**empty string** for every QA chunk. All chunks of a document therefore
collapsed onto the same id and silently overwrote each other when persisted
to the doc store — only the last pair survived.

## Fix

Add `common.ChunkIDForChunk(docID, ck)` in `internal/common/format.go`,
which hashes `content_with_weight` first and falls back to `text`, and use
it at both id-assignment sites:

- the ID decorator in `register.go` (before image upload, so
  `uploadChunkImage` and the persist stage share one chunk identity);
- the persist fallback in `internal/ingestion/task/indexdoc/process.go`
  (when `ck["id"]` is absent).

The parity `known_diffs.json` reason text is updated to reference
`ChunkIDForChunk`.

## Tests

- `internal/common/format_test.go` — `TestChunkIDForChunk`: prefers
  `content_with_weight`, falls back to `text`, handles empty/non-string
  values.
- `internal/ingestion/component/chunker/qa_test.go` —
  `TestQAChunker_DecoratorAssignsDistinctIDs`: runs the registered QA
  chunker over a 2-pair `qa.txt` from in-memory storage and asserts 2
  chunks with distinct ids equal to `common.ChunkID(docID,
  content_with_weight)`.
- `internal/ingestion/task/indexdoc/process_test.go` —
  `TestProcessChunksForPipeline_DistinctIDsFromContentWithWeight`: asserts
  the persist fallback assigns distinct ids to
  `content_with_weight`-only chunks.

`bash build.sh --test ./internal/ingestion/...` passes across all
subtrees; `bash build.sh --go` builds clean.

## End-to-end verification

Against a full local stack (Go API + web UI + ES + MySQL):

- Re-parsed a 2-pair `qa.txt`: `chunk_num` 1 → **2**; ES index now holds
  2 documents with distinct `_id`s, one per QA pair.
- Uploaded and parsed a 2-pair `qa.md`: `chunk_num` = **2**, 2 distinct
  ES documents.
- Re-parsing remains stable (idempotent 2 chunks).
