### PR TITLE
fix: align wiki graph and dataset logs

### DIFF
--- a/internal/ingestion/knowledge_compile/dataset_log.go
+++ b/internal/ingestion/knowledge_compile/dataset_log.go
@@ -1,0 +1,138 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package knowledge_compile
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"ragflow/internal/common"
+	"ragflow/internal/entity"
+)
+
+const datasetLogDocumentID = "graph_raptor_x"
+
+// Dataset ingestion logs use the status values exposed by the Python API and
+// consumed by the shared frontend. The Go scheduler uses a different set of
+// internal terminal names, so translate them at the persistence boundary.
+func datasetLogOperationStatus(status string) string {
+	switch status {
+	case common.COMPLETED:
+		return "DONE"
+	case common.FAILED:
+		return "FAIL"
+	case common.STOPPED, common.STOPPING:
+		return "CANCEL"
+	default:
+		return status
+	}
+}
+
+func datasetCompileLogID(claimToken string) string {
+	sum := sha256.Sum256([]byte("wiki-dataset-log\x00" + claimToken))
+	return hex.EncodeToString(sum[:16])
+}
+
+func startDatasetCompileLog(ctx context.Context, tenantID, datasetID, claimToken string, entries []BacklogEntry) error {
+	if kcDB == nil || claimToken == "" {
+		return nil
+	}
+	now := time.Now()
+	status := "1"
+	message := timestampProgressMessage(fmt.Sprintf("Created automatic Wiki dataset task for %d document event(s)", len(entries)))
+	entryData := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		entryData = append(entryData, map[string]any{
+			"doc_id":     entry.DocID,
+			"event_type": entry.EventType,
+			"variants":   entry.Variants,
+		})
+	}
+	log := entity.PipelineOperationLog{
+		ID:              datasetCompileLogID(claimToken),
+		DocumentID:      datasetLogDocumentID,
+		TenantID:        tenantID,
+		KbID:            datasetID,
+		ParserID:        "wiki",
+		DocumentName:    "Wiki",
+		DocumentSuffix:  "",
+		DocumentType:    "dataset",
+		SourceFrom:      "knowledgebase",
+		Progress:        0,
+		ProgressMsg:     &message,
+		ProcessBeginAt:  &now,
+		DSL:             entity.JSONMap{"entries": entryData},
+		TaskType:        string(entity.PipelineTaskTypeWiki),
+		OperationStatus: common.RUNNING,
+		Status:          &status,
+	}
+	return kcDB.WithContext(ctx).Where("id = ?", log.ID).FirstOrCreate(&log).Error
+}
+
+func updateDatasetCompileLog(ctx context.Context, claimToken string, progress float64, message string) error {
+	if kcDB == nil || claimToken == "" {
+		return nil
+	}
+	logID := datasetCompileLogID(claimToken)
+	var log entity.PipelineOperationLog
+	if err := kcDB.WithContext(ctx).Where("id = ?", logID).First(&log).Error; err != nil {
+		return err
+	}
+	progressMessage := ""
+	if log.ProgressMsg != nil {
+		progressMessage = *log.ProgressMsg
+	}
+	progressMessage = appendProgressMessage(progressMessage, timestampProgressMessage(message))
+	duration := log.ProcessDuration
+	if log.ProcessBeginAt != nil {
+		duration = max(0, time.Since(*log.ProcessBeginAt).Seconds())
+	}
+	return kcDB.WithContext(ctx).Model(&entity.PipelineOperationLog{}).Where("id = ?", logID).Updates(map[string]any{
+		"progress":         progress,
+		"progress_msg":     progressMessage,
+		"process_duration": duration,
+		"operation_status": common.RUNNING,
+	}).Error
+}
+
+func finishDatasetCompileLog(ctx context.Context, claimToken, operationStatus, message string, progress float64) error {
+	if kcDB == nil || claimToken == "" {
+		return nil
+	}
+	logID := datasetCompileLogID(claimToken)
+	var log entity.PipelineOperationLog
+	if err := kcDB.WithContext(ctx).Where("id = ?", logID).First(&log).Error; err != nil {
+		return err
+	}
+	progressMessage := ""
+	if log.ProgressMsg != nil {
+		progressMessage = *log.ProgressMsg
+	}
+	progressMessage = appendProgressMessage(progressMessage, timestampProgressMessage(message))
+	duration := log.ProcessDuration
+	if log.ProcessBeginAt != nil {
+		duration = max(0, time.Since(*log.ProcessBeginAt).Seconds())
+	}
+	return kcDB.WithContext(ctx).Model(&entity.PipelineOperationLog{}).Where("id = ?", logID).Updates(map[string]any{
+		"progress":         progress,
+		"progress_msg":     progressMessage,
+		"process_duration": duration,
+		"operation_status": datasetLogOperationStatus(operationStatus),
+	}).Error
+}

--- a/internal/ingestion/knowledge_compile/dataset_log_test.go
+++ b/internal/ingestion/knowledge_compile/dataset_log_test.go
@@ -1,0 +1,50 @@
+package knowledge_compile
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"ragflow/internal/common"
+	"ragflow/internal/entity"
+)
+
+func TestDatasetCompileLogLifecycle(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:dataset-log?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&entity.PipelineOperationLog{}); err != nil {
+		t.Fatalf("migrate pipeline log: %v", err)
+	}
+	oldDB := kcDB
+	kcDB = db
+	t.Cleanup(func() { kcDB = oldDB })
+
+	entries := []BacklogEntry{{DocID: "doc-1", EventType: string(EventTypeCompleted), Variants: []string{"wiki"}}}
+	if err := startDatasetCompileLog(t.Context(), "tenant-1", "kb-1", "claim-1", entries); err != nil {
+		t.Fatalf("start dataset log: %v", err)
+	}
+	if err := updateDatasetCompileLog(t.Context(), "claim-1", 0.5, "Comparing Wiki contributions: 2 affected page(s)"); err != nil {
+		t.Fatalf("update dataset log: %v", err)
+	}
+	if err := finishDatasetCompileLog(t.Context(), "claim-1", common.COMPLETED, "Wiki dataset compilation completed", 1); err != nil {
+		t.Fatalf("finish dataset log: %v", err)
+	}
+
+	var log entity.PipelineOperationLog
+	if err := db.Where("id = ?", datasetCompileLogID("claim-1")).First(&log).Error; err != nil {
+		t.Fatalf("load dataset log: %v", err)
+	}
+	if log.DocumentID != datasetLogDocumentID || log.TaskType != string(entity.PipelineTaskTypeWiki) {
+		t.Fatalf("unexpected dataset log identity: %+v", log)
+	}
+	if log.OperationStatus != "DONE" || log.Progress != 1 {
+		t.Fatalf("unexpected final state: status=%s progress=%v", log.OperationStatus, log.Progress)
+	}
+	if log.ProgressMsg == nil || !strings.Contains(*log.ProgressMsg, "2 affected page(s)") || !strings.Contains(*log.ProgressMsg, "completed") {
+		t.Fatalf("progress messages were not persisted: %v", log.ProgressMsg)
+	}
+}

--- a/internal/ingestion/knowledge_compile/scheduler.go
+++ b/internal/ingestion/knowledge_compile/scheduler.go
@@ -123,6 +123,9 @@ type Claimer interface {
 	// live, so a stale worker whose lease was reclaimed cannot overwrite the
 	// status of the worker that took over.
 	SetError(ctx context.Context, datasetID, token, errMsg string) error
+	// UpdateProgress records the current batch phase and progress while the
+	// claim is live. Updates from a stale worker are ignored by token.
+	UpdateProgress(ctx context.Context, datasetID, token string, progress float64, phase, message string) error
 
 	// CancelInflight drops the live claim for a dataset back into the backlog so
 	// a rewrite can start from a clean index. The token is intentionally NOT
@@ -214,7 +217,7 @@ func (s *mysqlScheduler) Provision(ctx context.Context) error {
 // each other's backlog), and the notify is always paired with the append so a
 // producer never needs a separate Notify call.
 func (s *mysqlScheduler) Publish(ctx context.Context, tenantID, datasetID, docID, eventType string, variants []string) error {
-	return s.publish(ctx, tenantID, datasetID, docID, eventType, variants)
+	return s.publishEntry(ctx, tenantID, datasetID, BacklogEntry{DocID: docID, EventType: eventType, Variants: variants})
 }
 
 // loadRow fetches the dataset scheduling row (no lock). Returns nil (no error)
@@ -231,10 +234,13 @@ func (s *mysqlScheduler) loadRow(ctx context.Context, datasetID string) (*entity
 }
 
 func (s *mysqlScheduler) publish(ctx context.Context, tenantID, datasetID, docID, eventType string, variants []string) error {
+	return s.publishEntry(ctx, tenantID, datasetID, BacklogEntry{DocID: docID, EventType: eventType, Variants: variants})
+}
+
+func (s *mysqlScheduler) publishEntry(ctx context.Context, tenantID, datasetID string, entry BacklogEntry) error {
 	if s.db == nil {
 		return nil
 	}
-	entry := BacklogEntry{DocID: docID, EventType: eventType, Variants: variants}
 	// KnowledgeCompileDataset.dataset_id is the PRIMARY KEY, so the SELECT ... FOR
 	// UPDATE below also takes an InnoDB gap lock for a not-yet-existing dataset;
 	// concurrent publishers for the same dataset serialize on that lock and the
@@ -277,8 +283,8 @@ func (s *mysqlScheduler) publish(ctx context.Context, tenantID, datasetID, docID
 	common.Info("knowledge_compile: published backlog entry",
 		zap.String("dataset_id", datasetID),
 		zap.String("tenant_id", tenantID),
-		zap.String("doc_id", docID),
-		zap.String("event_type", eventType))
+		zap.String("doc_id", entry.DocID),
+		zap.String("event_type", entry.EventType))
 	return s.notify(ctx, datasetID)
 }
 
@@ -350,6 +356,9 @@ func (s *mysqlScheduler) claimRow(ctx context.Context, tx *gorm.DB, datasetID st
 	row.ClaimExpiresAt = &exp
 	row.State = DatasetStateRunning
 	row.ErrorMsg = ""
+	row.Progress = 0
+	row.CurrentPhase = "claiming"
+	row.ProgressMsg = ""
 	if err := tx.Save(&row).Error; err != nil {
 		return ClaimResult{}, false, err
 	}
@@ -459,6 +468,62 @@ func (s *mysqlScheduler) SetError(ctx context.Context, datasetID, token, errMsg 
 			zap.String("dataset_id", datasetID))
 	}
 	return nil
+}
+
+const progressMessageMaxLength = 3000
+
+func timestampProgressMessage(message string) string {
+	if message == "" {
+		return ""
+	}
+	return time.Now().Format("15:04:05") + " " + message
+}
+
+func appendProgressMessage(previous, message string) string {
+	if message == "" {
+		return previous
+	}
+	if previous == "" {
+		if len([]rune(message)) > progressMessageMaxLength {
+			return string([]rune(message)[len([]rune(message))-progressMessageMaxLength:])
+		}
+		return message
+	}
+	joined := previous + "\n" + message
+	if len([]rune(joined)) > progressMessageMaxLength {
+		runes := []rune(joined)
+		return string(runes[len(runes)-progressMessageMaxLength:])
+	}
+	return joined
+}
+
+// UpdateProgress records a best-effort phase update for the active claim. The
+// token check prevents a worker whose lease was reclaimed from overwriting the
+// progress of the new owner.
+func (s *mysqlScheduler) UpdateProgress(ctx context.Context, datasetID, token string, progress float64, phase, message string) error {
+	if s.db == nil {
+		return nil
+	}
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var row entity.KnowledgeCompileDataset
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("dataset_id = ?", datasetID).First(&row).Error; err != nil {
+			return err
+		}
+		if row.ClaimToken != token {
+			return nil
+		}
+		row.Progress = progress
+		row.CurrentPhase = phase
+		row.ProgressMsg = appendProgressMessage(row.ProgressMsg, message)
+		return tx.Save(&row).Error
+	})
 }
 
 // CancelInflight drops the live claim for a dataset back into the backlog so a
@@ -679,14 +744,17 @@ func removeEntries(inflight, batch []BacklogEntry) []BacklogEntry {
 // ---- in-memory scheduler for tests ----
 
 type fakeRow struct {
-	tenant   string
-	backlog  []BacklogEntry
-	inflight []BacklogEntry
-	owner    string
-	token    string
-	expires  *time.Time
-	state    string
-	errorMsg string
+	tenant       string
+	backlog      []BacklogEntry
+	inflight     []BacklogEntry
+	owner        string
+	token        string
+	expires      *time.Time
+	state        string
+	errorMsg     string
+	progress     float64
+	currentPhase string
+	progressMsg  string
 	// writeMu serializes per-dataset writer side effects and rebuilds, mirroring
 	// the MySQL scheduler's WithDatasetLock row lock.
 	writeMu sync.Mutex
@@ -716,10 +784,10 @@ func (f *FakeScheduler) Provision(_ context.Context) error { return nil }
 
 // Publish appends one doc event and pushes a notify (same contract as MySQL).
 func (f *FakeScheduler) Publish(_ context.Context, tenantID, datasetID, docID, eventType string, variants []string) error {
-	return f.publish(tenantID, datasetID, docID, eventType, variants)
+	return f.publishEntry(tenantID, datasetID, BacklogEntry{DocID: docID, EventType: eventType, Variants: variants})
 }
 
-func (f *FakeScheduler) publish(tenantID, datasetID, docID, eventType string, variants []string) error {
+func (f *FakeScheduler) publishEntry(tenantID, datasetID string, entry BacklogEntry) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	r, ok := f.rows[datasetID]
@@ -730,7 +798,7 @@ func (f *FakeScheduler) publish(tenantID, datasetID, docID, eventType string, va
 	if r.tenant == "" {
 		r.tenant = tenantID
 	}
-	r.backlog = append(r.backlog, BacklogEntry{DocID: docID, EventType: eventType, Variants: variants})
+	r.backlog = append(r.backlog, entry)
 	// Mirror the MySQL scheduler: surface pending unless a worker is running.
 	if r.state != DatasetStateRunning {
 		r.state = DatasetStatePending
@@ -767,6 +835,9 @@ func (f *FakeScheduler) Claim(_ context.Context, datasetID string) (ClaimResult,
 	r.expires = &exp
 	r.state = DatasetStateRunning
 	r.errorMsg = ""
+	r.progress = 0
+	r.currentPhase = "claiming"
+	r.progressMsg = ""
 	return ClaimResult{DatasetID: datasetID, TenantID: r.tenant, Entries: batch, Token: r.token}, true, nil
 }
 
@@ -813,6 +884,25 @@ func (f *FakeScheduler) SetError(_ context.Context, datasetID, token, errMsg str
 		return nil
 	}
 	r.errorMsg = errMsg
+	return nil
+}
+
+func (f *FakeScheduler) UpdateProgress(_ context.Context, datasetID, token string, progress float64, phase, message string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.rows[datasetID]
+	if !ok || r.token != token {
+		return nil
+	}
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+	r.progress = progress
+	r.currentPhase = phase
+	r.progressMsg = appendProgressMessage(r.progressMsg, message)
 	return nil
 }
 

--- a/internal/ingestion/knowledge_compile/writer.go
+++ b/internal/ingestion/knowledge_compile/writer.go
@@ -1093,10 +1093,6 @@ func (w engineWriter) ProjectWikiGraph(ctx context.Context, tenant, kb string) e
 	if err != nil {
 		return err
 	}
-	// Telemetry: confirm how many merged wiki_page rows survived WriteMerged.
-	// If this is 0 while WriteMerged reported wiki_page:N, the merged rows are
-	// not queryable under (compile_kwd=wiki_page AND available_int=1) — point at the
-	// stored field values, not a downstream delete.
 	common.Info("knowledge_compile: ProjectWikiGraph load",
 		zap.String("kb_id", kb),
 		zap.Int("merged_wiki_pages_loaded", len(pages)))


### PR DESCRIPTION
### What problem does this PR solve?

- Make dataset Wiki graph projection use merged dataset-level Wiki pages instead of document-level pages.
- Align dataset log statuses with the frontend contract.
- Add timestamps to dataset Wiki progress messages.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)