### PR TITLE
fix: align wiki graph and dataset logs

### DIFF
--- a/internal/ingestion/knowledge_compile/dataset_log.go
+++ b/internal/ingestion/knowledge_compile/dataset_log.go
@@ -28,6 +28,22 @@ import (
 
 const datasetLogDocumentID = "graph_raptor_x"
 
+// Dataset ingestion logs use the status values exposed by the Python API and
+// consumed by the shared frontend. The Go scheduler uses a different set of
+// internal terminal names, so translate them at the persistence boundary.
+func datasetLogOperationStatus(status string) string {
+	switch status {
+	case common.COMPLETED:
+		return "DONE"
+	case common.FAILED:
+		return "FAIL"
+	case common.STOPPED, common.STOPPING:
+		return "CANCEL"
+	default:
+		return status
+	}
+}
+
 func datasetCompileLogID(claimToken string) string {
 	sum := sha256.Sum256([]byte("wiki-dataset-log\x00" + claimToken))
 	return hex.EncodeToString(sum[:16])
@@ -39,7 +55,7 @@ func startDatasetCompileLog(ctx context.Context, tenantID, datasetID, claimToken
 	}
 	now := time.Now()
 	status := "1"
-	message := fmt.Sprintf("Created automatic Wiki dataset task for %d document event(s)", len(entries))
+	message := timestampProgressMessage(fmt.Sprintf("Created automatic Wiki dataset task for %d document event(s)", len(entries)))
 	entryData := make([]any, 0, len(entries))
 	for _, entry := range entries {
 		entryData = append(entryData, map[string]any{
@@ -82,7 +98,7 @@ func updateDatasetCompileLog(ctx context.Context, claimToken string, progress fl
 	if log.ProgressMsg != nil {
 		progressMessage = *log.ProgressMsg
 	}
-	progressMessage = appendProgressMessage(progressMessage, message)
+	progressMessage = appendProgressMessage(progressMessage, timestampProgressMessage(message))
 	duration := log.ProcessDuration
 	if log.ProcessBeginAt != nil {
 		duration = max(0, time.Since(*log.ProcessBeginAt).Seconds())
@@ -108,7 +124,7 @@ func finishDatasetCompileLog(ctx context.Context, claimToken, operationStatus, m
 	if log.ProgressMsg != nil {
 		progressMessage = *log.ProgressMsg
 	}
-	progressMessage = appendProgressMessage(progressMessage, message)
+	progressMessage = appendProgressMessage(progressMessage, timestampProgressMessage(message))
 	duration := log.ProcessDuration
 	if log.ProcessBeginAt != nil {
 		duration = max(0, time.Since(*log.ProcessBeginAt).Seconds())
@@ -117,6 +133,6 @@ func finishDatasetCompileLog(ctx context.Context, claimToken, operationStatus, m
 		"progress":         progress,
 		"progress_msg":     progressMessage,
 		"process_duration": duration,
-		"operation_status": operationStatus,
+		"operation_status": datasetLogOperationStatus(operationStatus),
 	}).Error
 }

--- a/internal/ingestion/knowledge_compile/dataset_log_test.go
+++ b/internal/ingestion/knowledge_compile/dataset_log_test.go
@@ -41,7 +41,7 @@ func TestDatasetCompileLogLifecycle(t *testing.T) {
 	if log.DocumentID != datasetLogDocumentID || log.TaskType != string(entity.PipelineTaskTypeWiki) {
 		t.Fatalf("unexpected dataset log identity: %+v", log)
 	}
-	if log.OperationStatus != common.COMPLETED || log.Progress != 1 {
+	if log.OperationStatus != "DONE" || log.Progress != 1 {
 		t.Fatalf("unexpected final state: status=%s progress=%v", log.OperationStatus, log.Progress)
 	}
 	if log.ProgressMsg == nil || !strings.Contains(*log.ProgressMsg, "2 affected page(s)") || !strings.Contains(*log.ProgressMsg, "completed") {

--- a/internal/ingestion/knowledge_compile/scheduler.go
+++ b/internal/ingestion/knowledge_compile/scheduler.go
@@ -472,6 +472,13 @@ func (s *mysqlScheduler) SetError(ctx context.Context, datasetID, token, errMsg 
 
 const progressMessageMaxLength = 3000
 
+func timestampProgressMessage(message string) string {
+	if message == "" {
+		return ""
+	}
+	return time.Now().Format("15:04:05") + " " + message
+}
+
 func appendProgressMessage(previous, message string) string {
 	if message == "" {
 		return previous

--- a/internal/ingestion/knowledge_compile/writer.go
+++ b/internal/ingestion/knowledge_compile/writer.go
@@ -1093,10 +1093,6 @@ func (w engineWriter) ProjectWikiGraph(ctx context.Context, tenant, kb string) e
 	if err != nil {
 		return err
 	}
-	// Telemetry: confirm how many merged wiki_page rows survived WriteMerged.
-	// If this is 0 while WriteMerged reported wiki_page:N, the merged rows are
-	// not queryable under (compile_kwd=wiki_page AND available_int=1) — point at the
-	// stored field values, not a downstream delete.
 	common.Info("knowledge_compile: ProjectWikiGraph load",
 		zap.String("kb_id", kb),
 		zap.Int("merged_wiki_pages_loaded", len(pages)))


### PR DESCRIPTION
### What problem does this PR solve?

- Resolve conflicts with the latest `upstream/main`.
- Ensure Wiki graph projection uses merged dataset-level Wiki pages.
- Align dataset log statuses with frontend expectations.
- Add timestamps to dataset Wiki progress messages.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)