### PR TITLE
fix(web): clicking anywhere in a switch setting row toggles the switch

### DIFF
--- a/web/src/components/__tests__/switch-fom-field.test.tsx
+++ b/web/src/components/__tests__/switch-fom-field.test.tsx
@@ -1,0 +1,44 @@
+import { Form } from '@/components/ui/form';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { SwitchFormField } from '../switch-fom-field';
+
+function Harness() {
+  const form = useForm({ defaultValues: { flag: false } });
+  return (
+    <TooltipProvider>
+      <Form {...form}>
+        <SwitchFormField
+          name="flag"
+          label="Enable feature"
+          tooltip="Explains the feature"
+        />
+      </Form>
+    </TooltipProvider>
+  );
+}
+
+describe('SwitchFormField', () => {
+  it('toggles the switch when the label text is clicked', () => {
+    render(<Harness />);
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).toHaveAttribute('data-state', 'unchecked');
+
+    fireEvent.click(screen.getByText('Enable feature'));
+
+    expect(switchEl).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('does not toggle the switch when the tooltip icon is clicked', () => {
+    const { container } = render(<Harness />);
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).toHaveAttribute('data-state', 'unchecked');
+
+    const icon = container.querySelector('svg.lucide');
+    expect(icon).not.toBeNull();
+    fireEvent.click(icon!);
+
+    expect(switchEl).toHaveAttribute('data-state', 'unchecked');
+  });
+});

--- a/web/src/components/switch-fom-field.tsx
+++ b/web/src/components/switch-fom-field.tsx
@@ -52,7 +52,9 @@ export function SwitchFormField({
             'justify-between': !vertical,
           })}
         >
-          <FormLabel tooltip={tooltip}>{label}</FormLabel>
+          <FormLabel className="w-fit" tooltip={tooltip}>
+            {label}
+          </FormLabel>
           <FormControl>
             <Switch
               checked={field.value}


### PR DESCRIPTION
## Problem

In settings panels such as Chat setting → Advanced settings (Show quote,
Keyword analysis, Text to speech, Multi-turn optimization), clicking
anywhere on the label row of a switch - even the empty space far to the
right of the text - toggles the switch.

### Root cause

`SwitchFormField` (`web/src/components/switch-fom-field.tsx`) renders the
`FormItem` as a flex column. As a flex item the `FormLabel` (`<label>`) is
blockified and stretched to the full container width
(`align-items: stretch`). The label remains associated with the switch
through `htmlFor`/`id`, and the browser natively forwards clicks on a
label to its labeled control. The result: the entire row acts as an
invisible switch hit area, so stray clicks in the row toggle the setting.

## Fix

One-line change in the shared component: constrain the label to its
content width with `w-fit`, so the clickable label area covers only the
text (and tooltip icon), not the whole row.

```tsx
<FormLabel className="w-fit" tooltip={tooltip}>
  {label}
</FormLabel>
```

Behavior after the fix:

- Clicking the empty area of the row no longer toggles the switch.
- Clicking the label text still toggles it (standard label semantics and
  accessibility association are preserved).
- Clicking the switch itself is unchanged.
- The horizontal variant (`vertical={false}`, e.g. compilation
  templates) is unaffected: in a row layout the label width is already
  content-based.

## Affected surfaces

All `SwitchFormField` consumers are fixed at once:

- `web/src/pages/next-chats/chat/app-settings/chat-prompt-engine.tsx`
  (Show quote / Keyword analysis / Text to speech / Multi-turn
  optimization)
- `web/src/components/embed-dialog/index.tsx` (Embed into webpage)
- `web/src/pages/user-setting/compilation-templates/edit-next/...`
- `web/src/pages/agent/form/yahoo-finance-form/index.tsx`

## Verification

- Browser (vite dev server, chat settings → Advanced settings):
  - the Show quote label box is now ~94px wide inside the 400px row and
    carries the `w-fit` class;
  - a click dispatched at the empty row area right of the text hits the
    FormItem div, not the label, and the switch state does not change;
  - a real click on the label text still toggles the switch
    (checked → unchecked).
- `npx oxlint src/components/switch-fom-field.tsx`: 0 warnings/errors.
- `npx tsc --noEmit`: no errors in the touched file (the repo has
  pre-existing errors in unrelated files).
