### PR TITLE
fix(models): infer model types on catalog miss so Qwen VLMs show LLM+VLM tags

### DIFF
--- a/internal/entity/models/base_model.go
+++ b/internal/entity/models/base_model.go
@@ -383,6 +383,11 @@ func ParseSSEStreamTolerant[T any](r io.Reader, onEvent func(event T) error) (do
 
 // ParseListModel Parse model list. Empty/whitespace IDs are skipped so
 // upstream typos do not surface as blank entries in the UI.
+//
+// Entries the catalog cannot type fall back to name-based inference
+// (InferModelTypes), mirroring Python's
+// OpenAIAPICompatible._format_model_list (rag/llm/model_meta.py) so remote
+// entries never surface type-less.
 func ParseListModel(modelList ModelList) []ListModelResponse {
 	var models []ListModelResponse
 	pm := GetProviderManager()
@@ -405,7 +410,18 @@ func ParseListModel(modelList ModelList) []ListModelResponse {
 			modelResponse.MaxOutput = modelEntity.MaxOutput
 			modelResponse.ModelTypes = modelEntity.ModelTypes
 			modelResponse.Thinking = modelEntity.Thinking
-			modelResponse.Dimensions = modelEntity.Dimensions
+		}
+
+		// The provider-list merge treats remote entries as authoritative
+		// (internal/handler/providers.go) and the instance save path
+		// persists whatever types this list carries, so a catalog miss
+		// must not leave ModelTypes empty — the UI renders type-less
+		// models with an LLM-only badge. Infer types from the model name
+		// (vision models like qwen-vl-plus keep their VLM tag even before
+		// the catalog knows them); InferModelTypes always returns at
+		// least ["chat"].
+		if len(modelResponse.ModelTypes) == 0 {
+			modelResponse.ModelTypes = InferModelTypes(modelName)
 		}
 
 		models = append(models, modelResponse)

--- a/internal/entity/models/base_model_test.go
+++ b/internal/entity/models/base_model_test.go
@@ -1,0 +1,83 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+import (
+	"slices"
+	"testing"
+)
+
+// ParseListModel feeds the provider-model list endpoint whose merge treats
+// remote entries as authoritative: every returned entry must carry non-empty
+// model types. Catalog hits keep the catalog types; catalog misses fall back
+// to name-based inference (defaulting to chat), mirroring Python's
+// OpenAIAPICompatible._format_model_list.
+func TestParseListModelAssignsModelTypes(t *testing.T) {
+	dir, restore := setupProviderTestDir(t, "aliyun.json")
+	defer restore()
+
+	if err := InitProviderManager(dir); err != nil {
+		t.Fatalf("InitProviderManager: %v", err)
+	}
+
+	got := ParseListModel(ModelList{Models: []ModelListItem{
+		{ID: "qwen3-vl-plus"},             // catalog hit: chat+vision+ocr
+		{ID: "qwen-vl-plus"},              // catalog hit: chat+vision
+		{ID: "qwen3-vl-flash-2099-01-01"}, // miss: future dated variant -> inferred
+		{ID: "gpt-4o-2099-01-01"},         // miss -> inferred
+		{ID: "text-embedding-v4"},         // miss -> inferred
+		{ID: "qwen3-reranker-2099"},       // miss -> inferred
+		{ID: "some-unknown-model"},        // miss -> default chat
+		{ID: " qwen-vl-max-2099-01-01 "},  // trimmed, miss -> inferred
+		{ID: " "},                         // skipped
+	}})
+
+	want := map[string][]string{
+		"qwen3-vl-plus":             {"chat", "vision", "ocr"}, // catalog wins over inference
+		"qwen-vl-plus":              {"chat", "vision"},
+		"qwen3-vl-flash-2099-01-01": {"chat", "vision"},
+		"gpt-4o-2099-01-01":         {"chat", "vision"},
+		"text-embedding-v4":         {"embedding"},
+		"qwen3-reranker-2099":       {"rerank"},
+		"some-unknown-model":        {"chat"},
+		"qwen-vl-max-2099-01-01":    {"chat", "vision"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("ParseListModel returned %d entries, want %d (blank IDs skipped)", len(got), len(want))
+	}
+
+	for _, m := range got {
+		wantTypes, ok := want[m.Name]
+		if !ok {
+			t.Fatalf("unexpected entry %q in result", m.Name)
+		}
+		if !slices.Equal(m.ModelTypes, wantTypes) {
+			t.Errorf("model %q: ModelTypes = %v, want %v", m.Name, m.ModelTypes, wantTypes)
+		}
+	}
+
+	// Catalog metadata still flows through on a hit (qwen3-vl-plus declares
+	// max_output 8192 in conf/all_models.json).
+	for _, m := range got {
+		if m.Name == "qwen3-vl-plus" {
+			if m.MaxOutput == nil || *m.MaxOutput != 8192 {
+				t.Errorf("qwen3-vl-plus: MaxOutput = %v, want 8192", m.MaxOutput)
+			}
+		}
+	}
+}

--- a/internal/entity/models/gitee_test.go
+++ b/internal/entity/models/gitee_test.go
@@ -184,8 +184,10 @@ func TestGiteeListModelsMapsAllDeepSeekAliasesToModelMetadata(t *testing.T) {
 	if unknown.MaxOutput != nil {
 		t.Fatalf("unknown.MaxOutput=%v, want nil", *unknown.MaxOutput)
 	}
-	if len(unknown.ModelTypes) != 0 {
-		t.Fatalf("unknown.ModelTypes=%v, want empty", unknown.ModelTypes)
+	// Catalog misses fall back to name-based inference, which defaults to
+	// chat — remote entries must never surface type-less.
+	if len(unknown.ModelTypes) != 1 || unknown.ModelTypes[0] != "chat" {
+		t.Fatalf("unknown.ModelTypes=%v, want [chat]", unknown.ModelTypes)
 	}
 }
 


### PR DESCRIPTION
## Problem

Qwen vision-language models (e.g. `qwen-vl-plus`, `qwen3-vl-flash`) listed under an Aliyun (OpenAI-compatible) provider showed only the **LLM** tag, while the Python version shows **LLM + VLM**.

## Root cause

- Go `ParseListModel` (`internal/entity/models/base_model.go`) enriches remote `/models` entries only from the static catalog (`conf/all_models.json`). On a catalog miss — non-exact names/aliases like `qwen-vl-plus`, `qwen3-vl-flash`, or dated variants such as `qwen-vl-plus-2025-01-25` — the entry carried **empty `ModelTypes`**.
- The provider-list handler (`internal/handler/providers.go`) treats remote entries as authoritative: on a name match the remote entry **wholesale replaces** the static one, erasing the static entry's types.
- The instance save path persists whatever types the list carries, and the frontend defaults empty types to a chat-only badge — so vision models rendered as LLM-only.
- Python's equivalent (`rag/llm/model_meta.py`, `OpenAIAPICompatible._format_model_list`) always derives types from name hints and defaults to `["chat"]`, which is why the Python UI shows LLM + VLM.

## Fix

`ParseListModel` now falls back to `InferModelTypes(name)` when the catalog cannot type an entry, mirroring Python semantics:

- vision names (`qwen-vl…`, `gpt-4o…`, `glm-4v…`, …) → `chat` + `vision`
- embedding/rerank names → their own types
- unknown names → `chat` (never type-less again)

Catalog hits keep catalog types (precedence preserved). Also removed a duplicated `Dimensions` assignment in the same function.

## Tests

- `internal/entity/models/base_model_test.go` (new): catalog hits keep catalog types (`qwen3-vl-plus` → `chat+vision+ocr`), catalog misses infer types (`qwen3-vl-flash-2099-01-01`, `gpt-4o-2099-01-01` → `chat+vision`; `text-embedding-v4` → `embedding`; `qwen3-reranker-2099` → `rerank`; unknown → `chat`), blank IDs still skipped, catalog metadata still flows.
- `internal/entity/models/gitee_test.go`: updated the assertion that locked in the old type-less catalog-miss behavior.

## Verification

- `bash build.sh --test ./internal/entity/models/... ./internal/handler/... ./internal/service/...` — all pass.
- E2E (live UI, rebuilt services):
  - Live **List models** fetch against Tongyi-Qianwen returns `qwen3-vl-plus` with `model_types: ["vision","chat"]` (previously empty) — server-side fix path confirmed.
  - Against a stub OpenAI-compatible endpoint (`/v1/models`) added as a VLLM instance, the model settings page rendered: `qwen-vl-plus` → **LLM + VLM**, `qwen3-vl-flash-2099-01-01` → **LLM + VLM** (catalog-miss dated variant, proves the `InferModelTypes` fallback), `my-plain-model` → **LLM** only, `bge-m3-stub` → **Embedding**.
  - Screenshot: `vlm-tags-e2e-final.png` (stub instance and stub server removed after verification).
