### PR TITLE
fix(connector): honor configured S3-compatible bucket type

### DIFF
--- a/common/data_source/__init__.py
+++ b/common/data_source/__init__.py
@@ -111,7 +111,7 @@ def build_connector_for_source(source: str, config: dict[str, Any]) -> Any:
     if connector_cls is None:
         raise ConnectorValidationError(f"Unsupported data source type: {source}")
     if connector_cls is BlobStorageConnector:
-        return connector_cls.build_connector(config, bucket_type=source)
+        return connector_cls.build_connector(config, bucket_type=config.get("bucket_type") or source)
     if connector_cls is RDBMSConnector:
         return connector_cls.build_connector(config, db_type=source)
     return connector_cls.build_connector(config)

--- a/test/unit_test/common/test_data_source_factory.py
+++ b/test/unit_test/common/test_data_source_factory.py
@@ -1,0 +1,54 @@
+"""Tests for data-source connector construction."""
+
+import pytest
+
+from common import settings  # noqa: F401 - initialize shared settings before connector imports
+from common.constants import FileSource
+from common.data_source import BlobStorageConnector, build_connector_for_source
+
+
+def test_s3_connector_uses_configured_compatible_bucket_type(monkeypatch):
+    captured = {}
+    expected = object()
+
+    def build_connector(config, *, bucket_type):
+        captured["config"] = config
+        captured["bucket_type"] = bucket_type
+        return expected
+
+    monkeypatch.setattr(BlobStorageConnector, "build_connector", build_connector)
+    config = {"bucket_name": "database", "bucket_type": "s3_compatible"}
+
+    connector = build_connector_for_source(FileSource.S3, config)
+
+    assert connector is expected
+    assert captured == {"config": config, "bucket_type": "s3_compatible"}
+
+
+def test_s3_connector_defaults_bucket_type_to_source(monkeypatch):
+    captured = {}
+
+    def build_connector(_config, *, bucket_type):
+        captured["bucket_type"] = bucket_type
+        return object()
+
+    monkeypatch.setattr(BlobStorageConnector, "build_connector", build_connector)
+
+    build_connector_for_source(FileSource.S3, {"bucket_name": "database"})
+
+    assert captured["bucket_type"] == FileSource.S3
+
+
+@pytest.mark.parametrize("configured_bucket_type", [None, ""])
+def test_s3_connector_defaults_empty_bucket_type_to_source(monkeypatch, configured_bucket_type):
+    captured = {}
+
+    def build_connector(_config, *, bucket_type):
+        captured["bucket_type"] = bucket_type
+        return object()
+
+    monkeypatch.setattr(BlobStorageConnector, "build_connector", build_connector)
+
+    build_connector_for_source(FileSource.S3, {"bucket_name": "database", "bucket_type": configured_bucket_type})
+
+    assert captured["bucket_type"] == FileSource.S3


### PR DESCRIPTION
### Summary

Honor `config["bucket_type"]` when constructing blob-storage connectors.

Previously, `build_connector_for_source()` always passed the source type to `BlobStorageConnector`. An S3 data source configured with `bucket_type: s3_compatible` was therefore constructed as Amazon S3, causing it to use the wrong credential validation and client setup.

This change uses the configured bucket type when present and falls back to the source type when it is missing or empty.

### Verification

- Added unit coverage for a configured `s3_compatible` bucket type.
- Added unit coverage for missing, `None`, and empty bucket-type fallbacks.
- `python3 -m py_compile common/data_source/__init__.py test/unit_test/common/test_data_source_factory.py`
- `git diff --check`