### PR TITLE
add nats and clickhouse expose port in docker compose

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -190,12 +190,24 @@ REDIS_PORT=6379
 REDIS_PASSWORD=infini_rag_flow
 
 NATS_HOST=nats
+# Port used by RAGFlow's Go services to connect to NATS inside the container network.
+# Do NOT change this unless you also change `nats.port` in conf/service_conf.yaml.template.
 NATS_PORT=4222
+# Host-side port that maps to the NATS container port 4222. Change this to avoid
+# clashing with a port already used on the host machine. This ONLY affects the
+# published host port and is never read by RAGFlow's internal services.
+EXPOSE_NATS_PORT=4222
 
 # The hostname where the ClickHouse service is exposed
 CLICKHOUSE_HOST=clickhouse
-# The port used to expose the ClickHouse native TCP service
+# Native TCP port used by RAGFlow's Go services to connect to ClickHouse inside
+# the container network. Do NOT change this unless you also change `clickhouse.port`
+# in conf/service_conf.yaml.template.
 CLICKHOUSE_TCP_PORT=9900
+# Host-side port that maps to the ClickHouse container native TCP port 9000. Change
+# this to avoid clashing with a port already used on the host machine. This ONLY
+# affects the published host port and is never read by RAGFlow's internal services.
+EXPOSE_CLICKHOUSE_TCP_PORT=9900
 # The port used to expose the ClickHouse HTTP service
 CLICKHOUSE_HTTP_PORT=8123
 # The username for ClickHouse

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -296,7 +296,7 @@ services:
       - ragflow-go
     image: nats:2.14.2
     ports:
-      - ${NATS_PORT:-4222}:4222
+      - ${EXPOSE_NATS_PORT:-4222}:4222
       - "8222:8222"
     volumes:
       - nats_data:/data
@@ -376,7 +376,7 @@ services:
       - clickhouse_data:/var/lib/clickhouse
       - ./init-clickhouse.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
-      - ${CLICKHOUSE_TCP_PORT:-9900}:9000
+      - ${EXPOSE_CLICKHOUSE_TCP_PORT:-9900}:9000
       - ${CLICKHOUSE_HTTP_PORT:-8123}:8123
     env_file: .env
     environment:


### PR DESCRIPTION
add nats and clickhouse expose port in docker-compose-base.yml and .env file,avoid service port name conflict