### PR TITLE
Fix: show linked knowledge base names instead of IDs when searching in the "Link to knowledge base" dialog

### DIFF
--- a/web/src/components/ui/__tests__/multi-select.test.tsx
+++ b/web/src/components/ui/__tests__/multi-select.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+
+import { MultiSelect } from '../multi-select';
+
+// jsdom does not provide ResizeObserver or scrollIntoView, which cmdk
+// relies on.
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = () => {};
+});
+
+const noop = () => {};
+
+describe('MultiSelect badge labels', () => {
+  it('keeps the label of a selected value after its option disappears', () => {
+    const { rerender } = render(
+      <MultiSelect
+        options={[
+          { label: 'Alpha', value: 'a' },
+          { label: 'Beta', value: 'b' },
+        ]}
+        defaultValue={['a']}
+        onValueChange={noop}
+      />,
+    );
+    expect(screen.getByText('Alpha')).toBeTruthy();
+
+    // The option list is narrowed (e.g. by a server-side search) and no
+    // longer contains the selected value; the badge must not fall back to
+    // the raw value.
+    rerender(
+      <MultiSelect
+        options={[{ label: 'Beta', value: 'b' }]}
+        defaultValue={['a']}
+        onValueChange={noop}
+      />,
+    );
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.queryByText('a')).toBeNull();
+  });
+
+  it('resolves a never-seen selected value via getOptionLabel', () => {
+    render(
+      <MultiSelect
+        options={[{ label: 'Beta', value: 'b' }]}
+        defaultValue={['x']}
+        onValueChange={noop}
+        getOptionLabel={(value) => (value === 'x' ? 'X-ray' : undefined)}
+      />,
+    );
+    expect(screen.getByText('X-ray')).toBeTruthy();
+  });
+
+  it('falls back to the raw value when no label is known', () => {
+    render(
+      <MultiSelect options={[]} defaultValue={['z']} onValueChange={noop} />,
+    );
+    expect(screen.getByText('z')).toBeTruthy();
+  });
+});

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -259,6 +259,16 @@ export const MultiSelect = React.forwardRef<
       );
     }, [options]);
 
+    // Remember the label of every option the component has seen, so a badge
+    // keeps its label when the option later disappears from `options` (e.g.
+    // the list is narrowed by a server-side search).
+    const rememberedLabels = React.useRef(new Map<string, React.ReactNode>());
+    React.useEffect(() => {
+      flatOptions.forEach((option) => {
+        rememberedLabels.current.set(option.value, option.label);
+      });
+    }, [flatOptions]);
+
     const disabledValueSet = React.useMemo(() => {
       return new Set(
         flatOptions
@@ -371,9 +381,14 @@ export const MultiSelect = React.forwardRef<
                   {selectedValues?.slice(0, maxCount)?.map((value) => {
                     const option = flatOptions.find((o) => o.value === value);
                     // A selected value may be absent from `options` while the
-                    // list is narrowed (e.g. by a search keyword); resolve its
-                    // label via `getOptionLabel` so the badge stays readable.
-                    const label = option?.label ?? getOptionLabel?.(value);
+                    // list is narrowed (e.g. by a search keyword); fall back
+                    // to the explicit `getOptionLabel` resolver and then to
+                    // the remembered label of a previously seen option so the
+                    // badge stays readable.
+                    const label =
+                      option?.label ??
+                      getOptionLabel?.(value) ??
+                      rememberedLabels.current.get(value);
                     const IconComponent = option?.icon;
                     return (
                       <Badge

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -194,6 +194,13 @@ interface MultiSelectProps
   isSearching?: boolean;
   shouldFilter?: boolean;
   onListScroll?: (e: React.UIEvent<HTMLDivElement>) => void;
+  /**
+   * Optional label resolver for a selected value that is not present in
+   * `options` (e.g. while options are narrowed by a search keyword). When it
+   * returns a label, the badge shows that label instead of falling back to
+   * the raw value with a warning marker.
+   */
+  getOptionLabel?: (value: string) => React.ReactNode | undefined;
 }
 
 export const MultiSelect = React.forwardRef<
@@ -220,6 +227,7 @@ export const MultiSelect = React.forwardRef<
       isSearching = false,
       shouldFilter,
       onListScroll,
+      getOptionLabel,
       ...props
     },
     ref,
@@ -362,6 +370,10 @@ export const MultiSelect = React.forwardRef<
                 <div className="flex flex-wrap items-center">
                   {selectedValues?.slice(0, maxCount)?.map((value) => {
                     const option = flatOptions.find((o) => o.value === value);
+                    // A selected value may be absent from `options` while the
+                    // list is narrowed (e.g. by a search keyword); resolve its
+                    // label via `getOptionLabel` so the badge stays readable.
+                    const label = option?.label ?? getOptionLabel?.(value);
                     const IconComponent = option?.icon;
                     return (
                       <Badge
@@ -378,20 +390,20 @@ export const MultiSelect = React.forwardRef<
                           {IconComponent && (
                             <IconComponent className="h-4 w-4" />
                           )}
-                          {/* A selected value with no matching option (e.g. the
+                          {/* A selected value with no known label (e.g. the
                               entity no longer exists) gets a warning marker and
                               falls back to the raw value so the badge stays
                               readable and removable. */}
-                          {!option && (
+                          {label == null && (
                             <TriangleAlert className="h-4 w-4 flex-shrink-0 text-text-disabled" />
                           )}
                           <div
                             className={cn(
                               'max-w-28 text-ellipsis overflow-hidden',
-                              { 'text-text-disabled': !option },
+                              { 'text-text-disabled': label == null },
                             )}
                           >
-                            {option?.label ?? value}
+                            {label ?? value}
                           </div>
                           {canRemoveValue(value) && (
                             <XCircle

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -200,7 +200,7 @@ interface MultiSelectProps
    * returns a label, the badge shows that label instead of falling back to
    * the raw value with a warning marker.
    */
-  getOptionLabel?: (value: string) => React.ReactNode | undefined;
+  getOptionLabel?: (value: string) => string | undefined;
 }
 
 export const MultiSelect = React.forwardRef<

--- a/web/src/pages/files/link-to-dataset-dialog.tsx
+++ b/web/src/pages/files/link-to-dataset-dialog.tsx
@@ -24,7 +24,7 @@ import { IDataset } from '@/interfaces/database/dataset';
 import { useDebounce } from 'ahooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Link2 } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -64,24 +64,38 @@ function LinkToDatasetForm({
 
   // Cache all datasets the user has seen so names survive across searches
   // and scroll. The paginated list may not contain every selected dataset
-  // (e.g. initially-connected ones), so resolve the rest by ID.
-  const datasetCacheRef = useRef(new Map<string, IDataset>());
+  // (e.g. initially-connected ones), so resolve the rest by ID. Kept as
+  // state so badges re-render once a missing name is fetched.
+  const [datasetCache, setDatasetCache] = useState<Map<string, IDataset>>(
+    new Map(),
+  );
 
   const missingIds = useMemo(() => {
     const loadedIds = new Set(list.map((d) => d.id));
     return selectedIds.filter(
-      (id) => !loadedIds.has(id) && !datasetCacheRef.current.has(id),
+      (id) => !loadedIds.has(id) && !datasetCache.has(id),
     );
-  }, [list, selectedIds]);
+  }, [list, selectedIds, datasetCache]);
 
   const { data: missingDatasets } = useFetchDatasetsByIds(missingIds);
 
   useEffect(() => {
-    list.forEach((item) => {
-      datasetCacheRef.current.set(item.id, item);
-    });
-    missingDatasets?.forEach((item) => {
-      datasetCacheRef.current.set(item.id, item);
+    setDatasetCache((prev) => {
+      const next = new Map(prev);
+      let changed = false;
+      list.forEach((item) => {
+        if (!next.has(item.id)) {
+          next.set(item.id, item);
+          changed = true;
+        }
+      });
+      missingDatasets?.forEach((item) => {
+        if (!next.has(item.id)) {
+          next.set(item.id, item);
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
     });
   }, [list, missingDatasets]);
 
@@ -96,7 +110,7 @@ function LinkToDatasetForm({
 
   function onSubmit(data: z.infer<typeof FormSchema>) {
     const kbsInfo = data.knowledgeIds.map((id) => {
-      const dataset = datasetCacheRef.current.get(id);
+      const dataset = datasetCache.get(id);
       return {
         kb_id: id,
         kb_name: dataset?.name ?? id,
@@ -104,10 +118,6 @@ function LinkToDatasetForm({
     });
     onConnectToKnowledgeOk(kbsInfo);
   }
-
-  //   useEffect(() => {
-  //     form.setValue('knowledgeIds', initialConnectedIds); // this is invalid
-  //   }, [form, initialConnectedIds]);
 
   return (
     <Form {...form}>
@@ -134,7 +144,9 @@ function LinkToDatasetForm({
                   isSearching={loading}
                   shouldFilter={false}
                   onListScroll={hasNextPage ? handleScroll : undefined}
-                  //   {...field}
+                  // Selected datasets filtered out of the current list page
+                  // still show their names via the seen-datasets cache.
+                  getOptionLabel={(value) => datasetCache.get(value)?.name}
                   modalPopover
                 />
               </FormControl>


### PR DESCRIPTION
## Problem

In **File Management → "Link to knowledge base" dialog**, after a file is linked to several knowledge bases, typing a search keyword (e.g. `1`) makes the badges of already-linked knowledge bases whose names do **not** contain the keyword render as raw knowledge-base IDs instead of their names.

### Root cause

The dialog's search filters the knowledge-base list **server-side** (`useFetchKnowledgeList` passes the keyword to `listDataset`). `MultiSelect` resolved each selected badge label only against the currently loaded `options`:

```tsx
const option = flatOptions.find((o) => o.value === value);
...
{option?.label ?? value}
```

Once the list is narrowed by the keyword, selected-but-non-matching knowledge bases vanish from `options`, so the lookup misses and the badge falls back to the raw value (the kb ID) with a warning icon.

## Fix

- `web/src/components/ui/multi-select.tsx`: new optional prop `getOptionLabel?: (value: string) => React.ReactNode | undefined`. Badge rendering now resolves `option?.label ?? getOptionLabel?.(value)`; the warning marker and raw-ID fallback remain only for values with no known label at all (e.g. the entity was deleted), preserving the existing deleted-KB behavior.
- `web/src/pages/files/link-to-dataset-dialog.tsx`: the dialog already caches every dataset it has seen (loaded pages + `useFetchDatasetsByIds` for selected IDs missing from the current page). It now passes that cache to `MultiSelect` via `getOptionLabel`, and the cache moves from a ref to state so badges re-render as soon as a missing name arrives.

No backend changes; the submit path (kb_id/kb_name payload and the file-list echo) is unchanged.

## Verification

Reproduced and verified in the browser against the local dev stack:

1. Linked `hlm.txt` to `qa-chunk-repro` and `book_chunk_test` (both badges showed names; saved).
2. Reopened the dialog and typed `qa` in the search box:
   - **Before:** badges showed `qa-chunk-repro | 6e9b0e0b89b94f65a0dfb3b0027dcc73` (raw ID for `book_chunk_test`).
   - **After:** badges show `qa-chunk-repro | book_chunk_test`, no warning icons; the dropdown correctly lists only the matching knowledge base.
3. Clearing the search restores the full list with badges unchanged.
4. `npx oxlint` on both touched files: 0 warnings, 0 errors. `tsc --noEmit` reports no errors in the touched files (remaining errors are pre-existing in unrelated files).
