### PR TITLE
fix(docker): restart python webserver after failure

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -293,8 +293,9 @@ if [[ "${ENABLE_WEBSERVER}" -eq 1 ]]; then
     if [[ "${API_PROXY_SCHEME}" == "hybrid" ]] || [[ "${API_PROXY_SCHEME}" == "python" ]]; then
         while true; do
             echo "Attempt to start RAGFlow python server..."
-            "$PY" api/ragflow_server.py ${INIT_SUPERUSER_ARGS}
-            echo "RAGFlow python server started."
+            exit_code=0
+            "$PY" api/ragflow_server.py ${INIT_SUPERUSER_ARGS} || exit_code=$?
+            echo "RAGFlow python server exited with status ${exit_code}. Restarting..."
             sleep 1;
         done &
     fi


### PR DESCRIPTION
### Summary

Fixes #18542.

When the Python API exits with a non-zero status during an Infinity cold start, `set -e` terminates the background supervisor before it can retry. Capture the exit status in an OR-list so the loop remains alive, and log the status before restarting the server.

### Verification

- `bash -n docker/entrypoint.sh`
- `shellcheck --severity=error docker/entrypoint.sh`
- Bash 5.2 behavior probe confirmed the supervisor reaches a second launch after the first command exits with status 1
