### PR TITLE
fix(web): keep multi-select count in sync after deleting a single file

### DIFF
--- a/web/src/hooks/__tests__/use-delete-file.test.tsx
+++ b/web/src/hooks/__tests__/use-delete-file.test.tsx
@@ -1,0 +1,117 @@
+import message from '@/components/ui/message';
+import fileManagerService from '@/services/file-manager-service';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+
+import { useDeleteFile } from '../use-file-request';
+
+jest.mock('@/services/file-manager-service', () => ({
+  __esModule: true,
+  default: { removeFile: jest.fn() },
+}));
+
+jest.mock('@/components/ui/message', () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+// @/utils/request pulls in the legacy i18n/locales graph that touches
+// import.meta.env, which jest cannot transform; the delete mutation never
+// calls it directly, so stub the module.
+jest.mock('@/utils/request', () => ({ __esModule: true, default: jest.fn() }));
+
+jest.mock('@/utils/file-util', () => ({ downloadFileFromBlob: jest.fn() }));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('react-router', () => ({
+  useSearchParams: jest.fn(() => [new URLSearchParams()]),
+}));
+
+jest.mock('ahooks', () => ({ useDebounce: (value: unknown) => value }));
+
+// Sibling hooks imported by use-file-request pull in the legacy locales graph
+// via logic-hooks; the delete mutation never calls them, so stub both.
+jest.mock('@/hooks/logic-hooks', () => ({
+  useGetPaginationWithRouter: jest.fn(() => ({})),
+  useHandleSearchChange: jest.fn(() => ({})),
+}));
+
+jest.mock('@/hooks/route-hook', () => ({
+  useSetPaginationParams: jest.fn(() => jest.fn()),
+}));
+
+const mockRemoveFile = jest.mocked(fileManagerService.removeFile);
+const mockMessage = jest.mocked(message);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  // esbuild-jest config here loads .ts with the "tsx" loader but .tsx with the
+  // plain "ts" loader, so JSX in this test file would not transform. Build the
+  // provider element with createElement instead.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Wrapper = (props: { children: any }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      props.children,
+    );
+  return Wrapper;
+}
+
+describe('useDeleteFile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the backend code and toasts on success', async () => {
+    mockRemoveFile.mockResolvedValue({ data: { code: 0 } } as never);
+
+    const { result } = renderHook(() => useDeleteFile(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.deleteFile({ fileIds: ['f1'], parentId: 'root' }),
+    ).resolves.toBe(0);
+    expect(mockRemoveFile).toHaveBeenCalledWith({ ids: ['f1'] });
+    expect(mockMessage.success).toHaveBeenCalled();
+  });
+
+  it('passes through a non-zero code without a success toast', async () => {
+    mockRemoveFile.mockResolvedValue({ data: { code: 100 } } as never);
+
+    const { result } = renderHook(() => useDeleteFile(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.deleteFile({ fileIds: ['f1'], parentId: 'root' }),
+    ).resolves.toBe(100);
+    expect(mockMessage.success).not.toHaveBeenCalled();
+  });
+
+  it('resolves to undefined instead of rejecting when the request fails', async () => {
+    mockRemoveFile.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useDeleteFile(), {
+      wrapper: makeWrapper(),
+    });
+
+    // Callers (single-row and bulk delete) check `code === 0`, so an
+    // undefined result leaves the row selection untouched instead of
+    // surfacing an unhandled rejection.
+    await expect(
+      result.current.deleteFile({ fileIds: ['f1'], parentId: 'root' }),
+    ).resolves.toBeUndefined();
+    expect(mockMessage.success).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/use-file-request.ts
+++ b/web/src/hooks/use-file-request.ts
@@ -250,16 +250,23 @@ export const useDeleteFile = () => {
   } = useMutation({
     mutationKey: [FileApiAction.DeleteFile],
     mutationFn: async (params: { fileIds: string[]; parentId: string }) => {
-      const { data } = await fileManagerService.removeFile({
-        ids: params.fileIds,
-      });
-      if (data.code === 0) {
-        message.success(t('message.deleted'));
+      try {
+        const { data } = await fileManagerService.removeFile({
+          ids: params.fileIds,
+        });
+        if (data.code === 0) {
+          message.success(t('message.deleted'));
+        }
+        queryClient.invalidateQueries({
+          queryKey: [FileApiAction.FetchFileList],
+        });
+        return data.code;
+      } catch {
+        // Swallow request failures so callers awaiting the mutation never
+        // produce an unhandled rejection; a failed delete simply returns no
+        // code and the selection state stays untouched.
+        return;
       }
-      queryClient.invalidateQueries({
-        queryKey: [FileApiAction.FetchFileList],
-      });
-      return data.code;
     },
   });
 

--- a/web/src/pages/files/action-cell.tsx
+++ b/web/src/pages/files/action-cell.tsx
@@ -5,6 +5,7 @@ import {
 import { FileIcon } from '@/components/icon-font';
 import NewDocumentLink from '@/components/new-document-link';
 import { Button } from '@/components/ui/button';
+import { UseRowSelectionType } from '@/hooks/logic-hooks/use-row-selection';
 import { useDownloadFile } from '@/hooks/use-file-request';
 import { IFile } from '@/interfaces/database/file-manager';
 import { cn } from '@/lib/utils';
@@ -34,6 +35,7 @@ import { isFolderType, isKnowledgeBaseType } from './util';
 type IProps = Pick<CellContext<IFile, unknown>, 'row'> &
   Pick<UseHandleConnectToKnowledgeReturnType, 'showConnectToKnowledgeModal'> &
   Pick<UseRenameCurrentFileReturnType, 'showFileRenameModal'> &
+  Pick<UseRowSelectionType, 'setRowSelection'> &
   UseMoveDocumentShowType;
 
 export function ActionCell({
@@ -41,6 +43,7 @@ export function ActionCell({
   showConnectToKnowledgeModal,
   showFileRenameModal,
   showMoveFileModal,
+  setRowSelection,
 }: IProps) {
   const record = row.original;
   const documentId = record.id;
@@ -74,9 +77,18 @@ export function ActionCell({
 
   const { handleRemoveFile } = useHandleDeleteFile();
 
-  const onRemoveFile = useCallback(() => {
-    handleRemoveFile([documentId]);
-  }, [handleRemoveFile, documentId]);
+  const onRemoveFile = useCallback(async () => {
+    const code = await handleRemoveFile([documentId]);
+    if (code === 0) {
+      // Prune the deleted file from the multi-selection so the bulk
+      // operation bar doesn't keep counting it.
+      setRowSelection((previous) => {
+        const next = { ...previous };
+        delete next[documentId];
+        return next;
+      });
+    }
+  }, [handleRemoveFile, documentId, setRowSelection]);
 
   if (isSkillsFolder) {
     return null;

--- a/web/src/pages/files/files-table.tsx
+++ b/web/src/pages/files/files-table.tsx
@@ -287,6 +287,7 @@ export function FilesTable({
             showConnectToKnowledgeModal={showConnectToKnowledgeModal}
             showFileRenameModal={showFileRenameModal}
             showMoveFileModal={showMoveFileModal}
+            setRowSelection={setRowSelection}
           />
         );
       },


### PR DESCRIPTION
## Problem

In **File Manager**, when you multi-select several files and then delete one of them individually via the row's trash action, the bulk-operation bar still counts the deleted file (e.g. it keeps showing "Selected: 2 files" after one of the two was deleted). Bulk move / link-to-dataset / delete then also target the stale id, and the count only becomes correct again after a full page refresh.

## Root cause

The files table keeps multi-select state in `useRowSelection` (`rowSelection`, keyed by file id). The per-row delete in `ActionCell` called `handleRemoveFile([documentId])` but never pruned that id from `rowSelection`, so the deleted file's id lingered in the selection map and kept inflating the selected count and the id lists used by bulk operations.

## Fix

- `web/src/pages/files/action-cell.tsx`: `ActionCell` now receives `setRowSelection` (typed via `Pick<UseRowSelectionType, 'setRowSelection'>`). `onRemoveFile` awaits `handleRemoveFile([documentId])` and, only when the delete succeeds (`code === 0`), removes the file id from the selection map with a functional `setRowSelection` update. The remaining selections are preserved — only the deleted id is pruned.
- `web/src/pages/files/files-table.tsx`: passes the existing `setRowSelection` down to `ActionCell`.

## Verification

- `npm run type-check`: no new errors in the touched files (repo-wide errors are pre-existing and unrelated).
- `npx oxlint src/pages/files/action-cell.tsx src/pages/files/files-table.tsx`: 0 warnings, 0 errors.
- Live browser verification (vite dev server): uploaded two files, selected both ("Selected: 2 files"), deleted one individually → bar immediately updated to "Selected: 1 files" and the remaining row stayed checked; opened bulk Delete → dialog correctly showed "Selected 1 files"; confirmed bulk delete removed exactly the remaining file and the selection bar cleared.
