### PR TITLE
Fix: propagate file rename to all linked knowledgebase documents

### DIFF
--- a/internal/service/file/file_folder.go
+++ b/internal/service/file/file_folder.go
@@ -510,11 +510,14 @@ func (s *FileService) MoveFiles(ctx context.Context, uid string, srcFileIDs []st
 }
 
 // renameLinkedDocuments renames every knowledgebase document linked to the
-// given file so the new name is reflected in all linked datasets.
+// given file so the new name is reflected in all linked datasets. Only the
+// document name is synced: the Python reference (_rename_linked_documents in
+// api/apps/services/file_api_service.py) updates no other denormalized field
+// on rename.
 func (s *FileService) renameLinkedDocuments(ctx context.Context, fileID, newName string) error {
 	informs, err := s.file2DocumentDAO.GetByFileID(ctx, dao.DB, fileID)
 	if err != nil {
-		return nil
+		return err
 	}
 	documentDAO := dao.NewDocumentDAO()
 	for _, inform := range informs {

--- a/internal/service/file/file_folder.go
+++ b/internal/service/file/file_folder.go
@@ -500,18 +500,32 @@ func (s *FileService) MoveFiles(ctx context.Context, uid string, srcFileIDs []st
 			return false, "Database error (File rename)!"
 		}
 
-		// Update associated document name if exists
-		informs, err := s.file2DocumentDAO.GetByFileID(ctx, dao.DB, file.ID)
-		if err == nil && len(informs) > 0 && informs[0].DocumentID != nil {
-			docID := *informs[0].DocumentID
-			documentDAO := dao.NewDocumentDAO()
-			if err = documentDAO.UpdateByID(ctx, dao.DB, docID, map[string]interface{}{"name": newName}); err != nil {
-				return false, "Database error (Document rename)!"
-			}
+		// Update names of all linked documents if any exist
+		if err = s.renameLinkedDocuments(ctx, file.ID, newName); err != nil {
+			return false, "Database error (Document rename)!"
 		}
 	}
 
 	return true, ""
+}
+
+// renameLinkedDocuments renames every knowledgebase document linked to the
+// given file so the new name is reflected in all linked datasets.
+func (s *FileService) renameLinkedDocuments(ctx context.Context, fileID, newName string) error {
+	informs, err := s.file2DocumentDAO.GetByFileID(ctx, dao.DB, fileID)
+	if err != nil {
+		return nil
+	}
+	documentDAO := dao.NewDocumentDAO()
+	for _, inform := range informs {
+		if inform.DocumentID == nil {
+			continue
+		}
+		if err := documentDAO.UpdateByID(ctx, dao.DB, *inform.DocumentID, map[string]interface{}{"name": newName}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // moveEntryRecursive recursively moves a file or folder entry
@@ -598,15 +612,10 @@ func (s *FileService) moveEntryRecursive(ctx context.Context, sourceFile *entity
 		}
 	}
 
-	// Update associated document name if renamed
+	// Update names of all linked documents if renamed
 	if overrideName != "" {
-		informs, err := s.file2DocumentDAO.GetByFileID(ctx, dao.DB, sourceFile.ID)
-		if err == nil && len(informs) > 0 && informs[0].DocumentID != nil {
-			docID := *informs[0].DocumentID
-			documentDAO := dao.NewDocumentDAO()
-			if err = documentDAO.UpdateByID(ctx, dao.DB, docID, map[string]interface{}{"name": overrideName}); err != nil {
-				return fmt.Errorf("database error (Document rename): %w", err)
-			}
+		if err := s.renameLinkedDocuments(ctx, sourceFile.ID, overrideName); err != nil {
+			return fmt.Errorf("database error (Document rename): %w", err)
 		}
 	}
 

--- a/internal/service/file/file_folder_test.go
+++ b/internal/service/file/file_folder_test.go
@@ -162,6 +162,32 @@ func TestMoveFilesRenameUpdatesAllLinkedDocuments(t *testing.T) {
 	}
 }
 
+// A failing file2document lookup must surface as an error instead of being
+// silently treated as "no links", so a rename never reports success while
+// linked documents keep stale names.
+func TestRenameLinkedDocumentsLookupErrorPropagates(t *testing.T) {
+	db := setupFolderTestDB(t)
+	insertFolderTestFile(t, "file-1", "folder-1", "old.pdf")
+
+	// Force the link lookup to fail by dropping its table.
+	if err := db.Migrator().DropTable(&entity.File2Document{}); err != nil {
+		t.Fatalf("drop file2document table: %v", err)
+	}
+
+	svc := testFileService()
+	if err := svc.renameLinkedDocuments(t.Context(), "file-1", "new.pdf"); err == nil {
+		t.Fatal("renameLinkedDocuments returned nil error on lookup failure")
+	}
+
+	ok, msg := svc.MoveFiles(t.Context(), "user-1", []string{"file-1"}, "", "new.pdf")
+	if ok {
+		t.Fatal("MoveFiles succeeded despite file2document lookup failure")
+	}
+	if !strings.Contains(msg, "Document rename") {
+		t.Fatalf("MoveFiles message = %q, want it to mention %q", msg, "Document rename")
+	}
+}
+
 // Renaming while moving into the same parent folder (no storage move) must
 // also propagate the new name to every linked document.
 func TestMoveEntryRecursiveRenameUpdatesAllLinkedDocuments(t *testing.T) {

--- a/internal/service/file/file_folder_test.go
+++ b/internal/service/file/file_folder_test.go
@@ -51,3 +51,152 @@ func TestFileService_MoveFiles_RejectsSlashInNewName(t *testing.T) {
 		t.Fatalf("MoveFiles rename = %v, %q, want slash validation error", ok, msg)
 	}
 }
+
+// setupFolderTestDB initializes an in-memory SQLite database for file folder tests.
+func setupFolderTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		TranslateError: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+
+	if err = db.AutoMigrate(
+		&entity.File{},
+		&entity.File2Document{},
+		&entity.Document{},
+	); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	orig := dao.DB
+	dao.DB = db
+	t.Cleanup(func() {
+		dao.DB = orig
+	})
+	return db
+}
+
+func insertFolderTestFile(t *testing.T, id, parentID, name string) {
+	t.Helper()
+	f := &entity.File{
+		ID:        id,
+		ParentID:  parentID,
+		TenantID:  "tenant-1",
+		CreatedBy: "user-1",
+		Name:      name,
+		Location:  sptr(name),
+		Type:      "pdf",
+	}
+	if err := dao.DB.Create(f).Error; err != nil {
+		t.Fatalf("insert test file: %v", err)
+	}
+}
+
+func insertFolderTestDocument(t *testing.T, id, kbID, name string) {
+	t.Helper()
+	doc := &entity.Document{
+		ID:           id,
+		KbID:         kbID,
+		ParserID:     "naive",
+		ParserConfig: entity.JSONMap{},
+		CreatedBy:    "user-1",
+		Name:         sptr(name),
+		Location:     sptr(name),
+		Type:         "pdf",
+		Suffix:       "pdf",
+	}
+	if err := dao.DB.Create(doc).Error; err != nil {
+		t.Fatalf("insert test document: %v", err)
+	}
+}
+
+func insertFolderTestFile2Document(t *testing.T, id, fileID, docID string) {
+	t.Helper()
+	f2d := &entity.File2Document{
+		ID:         id,
+		FileID:     &fileID,
+		DocumentID: &docID,
+	}
+	if err := dao.DB.Create(f2d).Error; err != nil {
+		t.Fatalf("insert test f2d: %v", err)
+	}
+}
+
+// Renaming a file linked to multiple datasets must propagate the new name to
+// every linked document, not just the first one.
+func TestMoveFilesRenameUpdatesAllLinkedDocuments(t *testing.T) {
+	db := setupFolderTestDB(t)
+	insertFolderTestFile(t, "file-1", "folder-1", "old.pdf")
+	insertFolderTestDocument(t, "doc-1", "kb-1", "old.pdf")
+	insertFolderTestDocument(t, "doc-2", "kb-2", "old.pdf")
+	insertFolderTestFile2Document(t, "f2d-1", "file-1", "doc-1")
+	insertFolderTestFile2Document(t, "f2d-2", "file-1", "doc-2")
+
+	svc := testFileService()
+	ctx := t.Context()
+	ok, msg := svc.MoveFiles(ctx, "user-1", []string{"file-1"}, "", "new.pdf")
+	if !ok {
+		t.Fatalf("MoveFiles failed: %s", msg)
+	}
+
+	file, err := dao.NewFileDAO().GetByID(ctx, db, "file-1")
+	if err != nil {
+		t.Fatalf("get file: %v", err)
+	}
+	if file.Name != "new.pdf" {
+		t.Fatalf("file name = %q, want %q", file.Name, "new.pdf")
+	}
+
+	documentDAO := dao.NewDocumentDAO()
+	for _, docID := range []string{"doc-1", "doc-2"} {
+		doc, err := documentDAO.GetByID(ctx, db, docID)
+		if err != nil {
+			t.Fatalf("get %s: %v", docID, err)
+		}
+		if doc.Name == nil || *doc.Name != "new.pdf" {
+			t.Fatalf("%s name = %v, want %q", docID, doc.Name, "new.pdf")
+		}
+	}
+}
+
+// Renaming while moving into the same parent folder (no storage move) must
+// also propagate the new name to every linked document.
+func TestMoveEntryRecursiveRenameUpdatesAllLinkedDocuments(t *testing.T) {
+	db := setupFolderTestDB(t)
+	insertFolderTestFile(t, "file-1", "folder-1", "old.pdf")
+	insertFolderTestDocument(t, "doc-1", "kb-1", "old.pdf")
+	insertFolderTestDocument(t, "doc-2", "kb-2", "old.pdf")
+	insertFolderTestFile2Document(t, "f2d-1", "file-1", "doc-1")
+	insertFolderTestFile2Document(t, "f2d-2", "file-1", "doc-2")
+
+	svc := testFileService()
+	ctx := t.Context()
+	destFolder, err := dao.NewFileDAO().GetByID(ctx, db, "folder-1")
+	if err != nil {
+		// folder-1 does not exist as a row; construct the minimal folder entity
+		// with the same parent id so no storage move happens.
+		destFolder = &entity.File{ID: "folder-1", Type: FileTypeFolder}
+	}
+	srcFile, err := dao.NewFileDAO().GetByID(ctx, db, "file-1")
+	if err != nil {
+		t.Fatalf("get file: %v", err)
+	}
+
+	if err = svc.moveEntryRecursive(ctx, srcFile, destFolder, "new.pdf"); err != nil {
+		t.Fatalf("moveEntryRecursive failed: %v", err)
+	}
+
+	documentDAO := dao.NewDocumentDAO()
+	for _, docID := range []string{"doc-1", "doc-2"} {
+		doc, err := documentDAO.GetByID(ctx, db, docID)
+		if err != nil {
+			t.Fatalf("get %s: %v", docID, err)
+		}
+		if doc.Name == nil || *doc.Name != "new.pdf" {
+			t.Fatalf("%s name = %v, want %q", docID, doc.Name, "new.pdf")
+		}
+	}
+}


### PR DESCRIPTION
### Summary

When a file in **File Management** is linked to multiple knowledgebases, renaming the file only updated the document name in the *first* linked dataset. The other linked datasets kept showing the old name, and the preview link on the File Management page pointed to the first linked dataset, so the rename appeared to only partially apply.

**Root cause**

Both rename paths in the Go `FileService` (`internal/service/file/file_folder.go`) looked up the file's `file2document` links but only updated `informs[0]` — the first linked document:

- `MoveFiles` (used by the rename endpoint when the file stays in the same folder)
- `moveEntryRecursive` (used when moving/renaming a file across folders)

The Python reference implementation (`api/db/services/file_service.py::_rename_linked_documents`) iterates over **all** `file2document` links and renames every linked document; the Go port only handled the first one.

**Fix**

- Extracted a `renameLinkedDocuments(ctx, fileID, newName)` helper that iterates over all `file2document` links for the file and updates every linked document's `name`.
- Both `MoveFiles` and `moveEntryRecursive` now call this helper instead of only updating `informs[0]`.

**Verification**

- New unit tests in `internal/service/file/file_folder_test.go` cover both paths: renaming a file linked to two documents now renames both documents. `bash build.sh --test ./internal/service/file/...` passes.
- End-to-end in the browser: uploaded a file, linked it to two datasets (`rename-kb-1`, `rename-kb-2`), renamed it in File Management — before the fix only the first dataset showed the new name; after rebuilding and re-walking the path, **both** datasets show the new name.
