### PR TITLE
fix(web): confirm selected MultiSelect option on Enter instead of deselecting

### DIFF
--- a/web/src/components/ui/__tests__/multi-select.test.tsx
+++ b/web/src/components/ui/__tests__/multi-select.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MultiSelect } from '../multi-select';
+
+beforeAll(() => {
+  // jsdom does not implement these browser APIs used by cmdk/radix.
+  Element.prototype.scrollIntoView = jest.fn();
+  (globalThis as Record<string, unknown>).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const options = [
+  { label: 'Chat', value: 'chat' },
+  { label: 'VLM', value: 'vlm' },
+  { label: 'OCR', value: 'ocr' },
+];
+
+function renderOpenedMultiSelect(onValueChange = jest.fn()) {
+  const utils = render(
+    <MultiSelect
+      options={options}
+      defaultValue={['chat', 'vlm']}
+      onValueChange={onValueChange}
+      placeholder="Model type"
+    />,
+  );
+
+  fireEvent.click(
+    utils.container.querySelector('button') as HTMLButtonElement,
+  );
+
+  const root = document.querySelector('[cmdk-root]') as HTMLElement;
+  expect(root).not.toBeNull();
+
+  const input = root.querySelector('[cmdk-input]') as HTMLInputElement;
+  const items = () =>
+    Array.from(root.querySelectorAll<HTMLElement>('[cmdk-item]'));
+  const itemByText = (text: string) => {
+    const item = items().find((element) =>
+      element.textContent?.includes(text),
+    );
+    expect(item).toBeDefined();
+    return item as HTMLElement;
+  };
+
+  // (Select all), Chat, VLM, OCR, Clear, Close
+  expect(items()).toHaveLength(6);
+
+  return { onValueChange, input, items, itemByText };
+}
+
+function pressArrowDown(input: HTMLElement, times: number) {
+  for (let index = 0; index < times; index++) {
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+  }
+}
+
+describe('MultiSelect keyboard interaction', () => {
+  it('keeps an already-selected option selected and closes the dropdown on Enter', () => {
+    const onValueChange = jest.fn();
+    const { input, itemByText } = renderOpenedMultiSelect(onValueChange);
+
+    pressArrowDown(input, 1); // (Select all) -> Chat
+    expect(itemByText('Chat')).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(document.querySelector('[cmdk-root]')).toBeNull();
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+  });
+
+  it('selects an unselected highlighted option on Enter and keeps the dropdown open', () => {
+    const onValueChange = jest.fn();
+    const { input, itemByText } = renderOpenedMultiSelect(onValueChange);
+
+    pressArrowDown(input, 3); // (Select all) -> Chat -> VLM -> OCR
+    expect(itemByText('OCR')).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onValueChange).toHaveBeenCalledWith(['chat', 'vlm', 'ocr']);
+    expect(document.querySelector('[cmdk-root]')).not.toBeNull();
+  });
+
+  it('toggles all options on Enter while (Select all) is highlighted', () => {
+    const onValueChange = jest.fn();
+    const { input, items } = renderOpenedMultiSelect(onValueChange);
+
+    // The first item is (Select all), auto-highlighted when the dropdown opens.
+    expect(items()[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange.mock.calls[0][0].slice().sort()).toEqual([
+      'chat',
+      'ocr',
+      'vlm',
+    ]);
+    expect(document.querySelector('[cmdk-root]')).not.toBeNull();
+  });
+
+  it('deselects a selected option on click and keeps the dropdown open', () => {
+    const onValueChange = jest.fn();
+    const { itemByText } = renderOpenedMultiSelect(onValueChange);
+
+    fireEvent.click(itemByText('Chat'));
+
+    expect(onValueChange).toHaveBeenCalledWith(['vlm']);
+    expect(document.querySelector('[cmdk-root]')).not.toBeNull();
+  });
+});

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -65,6 +65,7 @@ function MultiCommandItem({
         toggleOption(option.value);
       }}
       data-testid={optionTestId}
+      data-option-value={option.value}
       className={cn('cursor-pointer', {
         'cursor-not-allowed text-text-disabled': option.disabled,
       })}
@@ -281,7 +282,26 @@ export const MultiSelect = React.forwardRef<
       event: React.KeyboardEvent<HTMLInputElement>,
     ) => {
       if (event.key === 'Enter') {
-        setIsPopoverOpen(true);
+        if (!isPopoverOpen) {
+          setIsPopoverOpen(true);
+          return;
+        }
+        // cmdk's default Enter handling toggles the highlighted option, which
+        // deselects one that is already selected. Treat Enter on an
+        // already-selected option as confirmation instead: keep the selection
+        // and close the dropdown. Other items (unselected options, select
+        // all, clear, close) keep cmdk's default Enter handling.
+        const highlightedItem = event.currentTarget
+          .closest('[cmdk-root]')
+          ?.querySelector('[cmdk-item][aria-selected="true"]');
+        const optionValue =
+          highlightedItem instanceof HTMLElement
+            ? highlightedItem.dataset.optionValue
+            : undefined;
+        if (optionValue && selectedValues.includes(optionValue)) {
+          event.preventDefault();
+          setIsPopoverOpen(false);
+        }
       } else if (event.key === 'Backspace' && !event.currentTarget.value) {
         const newSelectedValues = [...selectedValues];
         const removableIndex = [...newSelectedValues]

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -281,6 +281,9 @@ export const MultiSelect = React.forwardRef<
     const handleInputKeyDown = (
       event: React.KeyboardEvent<HTMLInputElement>,
     ) => {
+      // Read currentTarget synchronously: React clears it once the handler
+      // returns, so it must be captured before any deferred access.
+      const input = event.currentTarget;
       if (event.key === 'Enter') {
         if (!isPopoverOpen) {
           setIsPopoverOpen(true);
@@ -291,7 +294,7 @@ export const MultiSelect = React.forwardRef<
         // already-selected option as confirmation instead: keep the selection
         // and close the dropdown. Other items (unselected options, select
         // all, clear, close) keep cmdk's default Enter handling.
-        const highlightedItem = event.currentTarget
+        const highlightedItem = input
           .closest('[cmdk-root]')
           ?.querySelector('[cmdk-item][aria-selected="true"]');
         const optionValue =
@@ -302,7 +305,7 @@ export const MultiSelect = React.forwardRef<
           event.preventDefault();
           setIsPopoverOpen(false);
         }
-      } else if (event.key === 'Backspace' && !event.currentTarget.value) {
+      } else if (event.key === 'Backspace' && !input.value) {
         const newSelectedValues = [...selectedValues];
         const removableIndex = [...newSelectedValues]
           .reverse()


### PR DESCRIPTION
### Summary

In the cmdk-based `MultiSelect` component (`web/src/components/ui/multi-select.tsx`), pressing Enter while an already-selected option was highlighted deselected that option. cmdk's root keydown handler dispatches a select event for the highlighted item on Enter, and the component's `onSelect` toggles the option — so keyboard users confirming a dropdown choice (e.g. the model type in the Edit model dialog at `/user-setting/model`) accidentally removed it.

Enter on an already-selected option is now treated as confirmation instead of a toggle:

- Each option's `CommandItem` carries a `data-option-value` attribute so the highlighted item can be mapped back to its option value.
- In the search input's `onKeyDown`, when the dropdown is open and the highlighted item is an already-selected option, the handler calls `preventDefault()` (cmdk checks `defaultPrevented` before dispatching its own Enter selection) and closes the dropdown, leaving the selection unchanged.

Behavior that is intentionally preserved:

- Enter on an unselected option still selects it and keeps the dropdown open.
- Enter on (Select all)/Clear/Close keeps cmdk's default handling.
- Clicking a selected option still deselects it.

### Test plan

- New unit tests in `web/src/components/ui/__tests__/multi-select.test.tsx` (4 cases: Enter on a selected option closes the dropdown without changing the selection; Enter on an unselected option selects it and keeps the dropdown open; Enter on (Select all) toggles all options; clicking a selected option deselects it) — all pass via `npx jest src/components/ui/__tests__/multi-select.test.tsx`.
- `npx oxlint` on the touched files is clean; `tsc --noEmit` reports no errors in the touched files (only pre-existing errors in unrelated files).
- Manually verified in the browser on the Edit model dialog (`glm-4.6v-Flash`): Enter on the highlighted, already-selected "Chat" closes the dropdown with "Chat" still selected; Enter on unselected "Embedding" selects it and keeps the dropdown open; clicking the selected "Chat" deselects it.
