### PR TITLE
fix(build): name the compiler the check requires, and the option that failed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -503,7 +503,7 @@ Build script for RAGFlow Go server with C++ bindings.
 OPTIONS:
     --all, -a       Build everything (C++ library + Go server) [default]
     --cpp, -c       Build only C++ static library
-    --cpp-test      Build C++ test executable (requires --cpp first)
+    --cpp-test      Build C++ test executable (builds the C++ library if needed)
     --go, -g        Build only Go server (requires C++ library to be built)
     --test, -t      Run Go unit tests (no build tag). Sets up the CGO env and
                     native static libs (office_oxide/pdfium/pdf_oxide) needed to
@@ -539,8 +539,8 @@ EXAMPLES:
 
 DEPENDENCIES:
     - cmake >= 4.0
-    - go >= 1.24
-    - clang++ with C++17/23 support
+    - go >= 1.26.4
+    - clang++ with C++20 support
     - office_oxide native library (download with: uv run python3 ragflow_deps/download_go_deps.py)
     - lld (Linux only): sudo apt install lld-20 && sudo ln -s /usr/bin/ld.lld-20 /usr/bin/ld.lld
     - pcre2 development files

--- a/build.sh
+++ b/build.sh
@@ -540,7 +540,7 @@ EXAMPLES:
 DEPENDENCIES:
     - cmake >= 4.0
     - go >= 1.24
-    - g++ with C++17/23 support
+    - clang++ with C++17/23 support
     - office_oxide native library (download with: uv run python3 ragflow_deps/download_go_deps.py)
     - lld (Linux only): sudo apt install lld-20 && sudo ln -s /usr/bin/ld.lld-20 /usr/bin/ld.lld
     - pcre2 development files
@@ -636,7 +636,7 @@ main() {
             echo "Binary: $RAGFLOW_SERVER_BINARY, $RAGFLOW_CLI_BINARY"
             ;;
         *)
-            echo -e "${RED}Unknown option: $1${NC}"
+            echo -e "${RED}Unknown option: ${args[0]}${NC}"
             show_help
             exit 1
             ;;


### PR DESCRIPTION
### Summary

`build.sh`'s help text has drifted from the script and the build it drives. This makes the five statements it gets wrong agree with the code, and fixes one error message that named the wrong flag.

**The documented compiler is not the one the check requires.** `DEPENDENCIES` listed `g++`, but `check_cpp_deps` only probes `clang++` and exits when it is missing — `g++` is never checked. Corrected the doc rather than widening the check, because the C++ path is clang-only in practice: `internal/development.md` prescribes `clang-20` and `lld-20`, CI builds inside `infiniflow/infinity_builder:ubuntu22_clang20`, and the Linux link step statically links pdfium's Clang-built `libc++.a`/`libc++abi.a` with `--allow-multiple-definition`. Accepting `g++` would advertise a configuration nothing exercises.

**The documented C++ standard is not the one the targets set.** All three targets in `internal/binding/cpp/CMakeLists.txt` set `CXX_STANDARD 20`, overriding the file-level `set(CMAKE_CXX_STANDARD 23)`. The `C++17/23` in the help matches neither.

**The documented Go version is below the required one.** `go.mod` requires `go 1.26.4`; the help said `>= 1.24`, which refuses to build under `GOTOOLCHAIN=local`.

**`--cpp-test` does not require `--cpp` first.** `build_cpp_test` runs `cmake` itself when the build directory is missing, and `rag_analyzer_c_test` links `rag_tokenizer_c_api`, so the library is built as a target dependency.

**The unknown-option error blamed the wrong flag.** `main` consumes `--strip`/`-s` into `STRIP_SYMBOLS` and builds a filtered `args` array, then dispatches on `"${args[0]:-}"` — but the `*)` branch printed `$1`, the first argument the script received:

```
$ ./build.sh --strip --bogus     # before
Unknown option: --strip

$ ./build.sh --strip --bogus     # after
Unknown option: --bogus
```

`--strip` is valid and had already been applied; the message pointed at the one flag that worked.

Two things noticed and deliberately left alone. The help prints `$0` literally rather than the script name — that follows from the quoted `<< 'EOF'` delimiter, which the comment above it says is chosen so backticks and `$var` in the help body stay literal, so it looks like a deliberate trade-off. And the `--strip`/`-s` prefilter consumes those flags even after `--`, which the dispatcher otherwise honors as end-of-options; it is near-unreachable in practice, so it seemed out of scope here.
