### PR TITLE
fix(show_env): keep git errors out of the environment report

### DIFF
--- a/show_env.sh
+++ b/show_env.sh
@@ -17,12 +17,16 @@ get_distro_info() {
 
 # get Git repository name
 git_repo_name=''
-if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
-    if git_toplevel=$(git rev-parse --show-toplevel 2>/dev/null); then
-        git_repo_name=$(basename "$git_toplevel")
-    else
-        git_repo_name="(Can't get repo name)"
-    fi
+if git_toplevel=$(git rev-parse --show-toplevel 2>/dev/null); then
+    git_repo_name=$(basename "$git_toplevel")
+elif git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null); then
+    # Inside .git, or in a bare repo: there is no work tree to name, but this is
+    # still a repository. A ".git" directory is named by its parent; a bare one
+    # names itself.
+    case "$git_dir" in
+        */.git) git_repo_name=$(basename "$(dirname "$git_dir")") ;;
+        *) git_repo_name=$(basename "$git_dir") ;;
+    esac
 else
     git_repo_name="It is NOT a Git repo"
 fi

--- a/show_env.sh
+++ b/show_env.sh
@@ -17,9 +17,10 @@ get_distro_info() {
 
 # get Git repository name
 git_repo_name=''
-if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-    git_repo_name=$(basename "$(git rev-parse --show-toplevel)")
-    if [ $? -ne 0 ]; then
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
+    if git_toplevel=$(git rev-parse --show-toplevel 2>/dev/null); then
+        git_repo_name=$(basename "$git_toplevel")
+    else
         git_repo_name="(Can't get repo name)"
     fi
 else
@@ -47,7 +48,7 @@ python_version=$(python3 --version 2>&1 || python --version 2>&1 || echo "Python
 echo "Current Repository: $git_repo_name"
 
 # get Commit ID
-git_version=$(git log -1 --pretty=format:'%h')
+git_version=$(git log -1 --pretty=format:'%h' 2>/dev/null)
 
 if [ -z "$git_version" ]; then
     echo "Commit Id: The current directory is not a Git repository, or the Git command is not installed."

--- a/show_env.sh
+++ b/show_env.sh
@@ -27,7 +27,11 @@ elif git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null); then
     if [ "$(git rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
         git_repo_name=$(basename "$git_dir")
     else
-        git_repo_name=$(basename "$(dirname "$git_dir")")
+        # A linked worktree's git dir lives under .git/worktrees, so the main
+        # repository is found through the common dir. That is reported relative
+        # to the git dir (plain "." inside .git), hence resolving it here.
+        git_common=$(cd "$git_dir" && cd "$(git rev-parse --git-common-dir)" && pwd)
+        git_repo_name=$(basename "$(dirname "$git_common")")
     fi
 else
     git_repo_name="It is NOT a Git repo"

--- a/show_env.sh
+++ b/show_env.sh
@@ -21,12 +21,14 @@ if git_toplevel=$(git rev-parse --show-toplevel 2>/dev/null); then
     git_repo_name=$(basename "$git_toplevel")
 elif git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null); then
     # Inside .git, or in a bare repo: there is no work tree to name, but this is
-    # still a repository. A ".git" directory is named by its parent; a bare one
-    # names itself.
-    case "$git_dir" in
-        */.git) git_repo_name=$(basename "$(dirname "$git_dir")") ;;
-        *) git_repo_name=$(basename "$git_dir") ;;
-    esac
+    # still a repository. Ask git whether it is bare rather than reading the
+    # path, since a bare repo may itself be called ".git". A bare repository
+    # names itself; otherwise the git directory's parent is the repository.
+    if [ "$(git rev-parse --is-bare-repository 2>/dev/null)" = "true" ]; then
+        git_repo_name=$(basename "$git_dir")
+    else
+        git_repo_name=$(basename "$(dirname "$git_dir")")
+    fi
 else
     git_repo_name="It is NOT a Git repo"
 fi


### PR DESCRIPTION
### Summary

`show_env.sh` exists to produce a clean environment report to paste into an issue. Run outside a work tree it printed a raw git error into the middle of it.

Before, from a directory that is not a repository:

```
Current Repository: It is NOT a Git repo
fatal: not a git repository (or any of the parent directories): .git
Commit Id: The current directory is not a Git repository, or the Git command is not installed.
```

The two surrounding lines already report the condition politely; only `git log -1` was missing the `2>/dev/null` its neighbours have. After:

```
Current Repository: It is NOT a Git repo
Commit Id: The current directory is not a Git repository, or the Git command is not installed.
```

**The repo-name guard could also never fire.** It was:

```sh
git_repo_name=$(basename "$(git rev-parse --show-toplevel)")
if [ $? -ne 0 ]; then
    git_repo_name="(Can't get repo name)"
fi
```

`$?` there is `basename`'s status, and `basename` given one argument does not fail — so `(Can't get repo name)` was unreachable. Meanwhile the case it guards is reachable: inside `.git`, `git rev-parse --is-inside-work-tree` exits 0 and prints `false`, so the outer test passed on exit status alone, `--show-toplevel` then failed, and the name came out empty. The condition now compares the output rather than the status, and `--show-toplevel` is captured and tested on its own.

Verified in three states — inside the work tree (`Current Repository: ragflow`), inside `.git` (`It is NOT a Git repo`, no error text), and outside any repository (clean, as above).
