### PR TITLE
fix(parser): make PDF "remove TOC" and "remove header/footer" options work without DeepDoc inference

### DIFF
--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	deepdoctype "ragflow/internal/deepdoc/parser/type"
 )
@@ -15,6 +16,33 @@ import (
 // exact token, so a composite label like "page-footer" is also stripped.
 var pdfHeaderFooterPattern = regexp.MustCompile(`(?i)header|footer|number`)
 var pdfTOCTitlePattern = regexp.MustCompile(`(?i)^(contents|目录|目次|table of contents|致谢|acknowledge)$`)
+
+// TOC entry patterns: dot leaders or wide whitespace followed by a trailing
+// page number, e.g. "Chapter One .............. 2" or "Chapter One    2".
+var (
+	pdfTOCDotLeaderPattern    = regexp.MustCompile(`(\.|…|·){3,}\s*\d{1,5}\s*$`)
+	pdfTOCTrailingPagePattern = regexp.MustCompile(`\s{2,}\d{1,5}\s*$`)
+	pdfTOCEntryNumberPattern  = regexp.MustCompile(`^\d+(\.\d+)*[\s\.、]`)
+)
+
+// isPDFTOCEntry reports whether a line still looks like a table-of-contents
+// entry (title text plus a trailing page number). Used to consume the whole
+// contiguous run of entries after the TOC title instead of only the first.
+func isPDFTOCEntry(text string) bool {
+	t := strings.TrimSpace(text)
+	if len(t) < 4 || len(t) > 200 {
+		return false
+	}
+	if !pdfTOCDotLeaderPattern.MatchString(t) && !pdfTOCTrailingPagePattern.MatchString(t) {
+		return false
+	}
+	for _, r := range t {
+		if unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return pdfTOCEntryNumberPattern.MatchString(t)
+}
 
 type pdfPostProcessOptions struct {
 	outputFormat       string
@@ -40,6 +68,7 @@ func applyPDFPostProcess(result *deepdoctype.ParseResult, opts pdfPostProcessOpt
 	normalizePDFLayoutTypes(result)
 	if opts.removeHeaderFooter {
 		filterPDFHeaderFooter(result)
+		removePDFRunningHeaderFooter(result)
 	}
 	assignPDFDocTypeKeywords(result, opts.flattenMediaToText)
 }
@@ -58,6 +87,122 @@ func filterPDFHeaderFooter(result *deepdoctype.ParseResult) {
 	filtered := result.Sections[:0]
 	for _, s := range result.Sections {
 		if pdfHeaderFooterPattern.MatchString(strings.TrimSpace(s.LayoutType)) {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	result.Sections = filtered
+}
+
+const (
+	// pdfHeaderZoneRatio / pdfFooterZoneRatio bound the page zones where
+	// running headers/footers live: sections sitting entirely in the top
+	// or bottom fraction of a page are candidates.
+	pdfHeaderZoneRatio = 0.10
+	pdfFooterZoneRatio = 0.90
+	// pdfMinPagesForHeaderFooter guards against false positives on short
+	// documents: cross-page repetition only means "running header/footer"
+	// when the document has enough pages.
+	pdfMinPagesForHeaderFooter = 3
+)
+
+var pdfRunningDigitPattern = regexp.MustCompile(`\d+`)
+
+// normalizePDFRunningText collapses whitespace and replaces digit runs so
+// that per-page variants of the same running header/footer ("- 2 -",
+// "- 3 -", "Page 4 of 9") share one comparison key.
+func normalizePDFRunningText(text string) string {
+	t := strings.Join(strings.Fields(text), " ")
+	t = pdfRunningDigitPattern.ReplaceAllString(t, "#")
+	return strings.ToLower(strings.TrimSpace(t))
+}
+
+// removePDFRunningHeaderFooter drops sections whose normalized text repeats
+// in the same page zone (top 10% or bottom 10%) on at least half of the
+// document's pages — running headers, footers, and page numbers. The
+// layout-type filter above only works when a DeepDoc inference service
+// (DEEPDOC_URL) types header/footer regions; in default deployments there
+// is none, every section stays "text", and 页眉页脚 removal silently does
+// nothing. This positional frequency pass makes the option work without an
+// inference service. Repetition — not position alone — is the guard that
+// keeps genuine body text: a section must recur on >= max(2, pages/2) pages
+// in the same zone to be removed.
+func removePDFRunningHeaderFooter(result *deepdoctype.ParseResult) {
+	sections := result.Sections
+	if len(sections) == 0 || len(result.PageHeight) == 0 {
+		return
+	}
+	pageSet := make(map[int]struct{}, len(result.PageHeight))
+	for i := range sections {
+		if len(sections[i].Positions) == 0 || len(sections[i].Positions[0].PageNumbers) == 0 {
+			continue
+		}
+		pageSet[sections[i].Positions[0].PageNumbers[0]] = struct{}{}
+	}
+	numPages := len(pageSet)
+	if numPages < pdfMinPagesForHeaderFooter {
+		return
+	}
+	type zoneKey struct {
+		header bool
+		text   string
+	}
+	keyPages := make(map[zoneKey]map[int]struct{})
+	keySections := make(map[zoneKey][]int)
+	for i := range sections {
+		s := &sections[i]
+		if layout := strings.TrimSpace(s.LayoutType); layout != "" && layout != deepdoctype.LayoutTypeText {
+			continue
+		}
+		if len(s.Positions) == 0 || len(s.Positions[0].PageNumbers) == 0 {
+			continue
+		}
+		page := s.Positions[0].PageNumbers[0]
+		pageHeight := result.PageHeight[page]
+		if pageHeight <= 0 {
+			continue
+		}
+		top, bottom := s.Positions[0].Top, s.Positions[0].Bottom
+		if bottom <= top {
+			continue
+		}
+		var isHeader, isFooter bool
+		switch {
+		case top <= pageHeight*pdfHeaderZoneRatio && bottom <= pageHeight*0.5:
+			isHeader = true
+		case bottom >= pageHeight*pdfFooterZoneRatio && top >= pageHeight*0.5:
+			isFooter = true
+		}
+		if !isHeader && !isFooter {
+			continue
+		}
+		norm := normalizePDFRunningText(s.Text)
+		if norm == "" {
+			continue
+		}
+		key := zoneKey{header: isHeader, text: norm}
+		if keyPages[key] == nil {
+			keyPages[key] = make(map[int]struct{})
+		}
+		keyPages[key][page] = struct{}{}
+		keySections[key] = append(keySections[key], i)
+	}
+	drop := make(map[int]struct{})
+	for key, pages := range keyPages {
+		n := len(pages)
+		if n < 2 || n*2 < numPages {
+			continue
+		}
+		for _, i := range keySections[key] {
+			drop[i] = struct{}{}
+		}
+	}
+	if len(drop) == 0 {
+		return
+	}
+	filtered := sections[:0]
+	for i, s := range sections {
+		if _, ok := drop[i]; ok {
 			continue
 		}
 		filtered = append(filtered, s)
@@ -167,6 +312,21 @@ func removePDFTOC(result *deepdoctype.ParseResult) {
 		sections = append(sections[:i], sections[i+1:]...)
 		if i >= len(sections) || prefix == "" {
 			break
+		}
+		// Consume the remaining contiguous TOC entries (dot leaders or a
+		// trailing page number). Python's remove_contents_table stops at the
+		// first line sharing the first entry's 3-byte prefix, which leaves
+		// most of the table behind whenever every entry shares that prefix
+		// (e.g. "Chapter One ...", "Chapter Two ...", ...). When entries were
+		// consumed this way, skip the legacy prefix scan and resume the title
+		// scan; otherwise fall back to it for pattern-less TOCs.
+		removedEntries := 0
+		for i < len(sections) && isPDFTOCEntry(sections[i].Text) {
+			sections = append(sections[:i], sections[i+1:]...)
+			removedEntries++
+		}
+		if removedEntries > 0 {
+			continue
 		}
 		for j := i; j < len(sections) && j < i+128; j++ {
 			if !strings.HasPrefix(sectionText(sections[j]), prefix) {

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -313,6 +313,16 @@ func removePDFTOC(result *deepdoctype.ParseResult) {
 		if i >= len(sections) || prefix == "" {
 			break
 		}
+		// The first entry is formatted (leader run plus page number): the
+		// table is entry-shaped and the prefix scan below must not run —
+		// with a single formatted entry that scan would delete body text up
+		// to the next line sharing the entry's prefix. Drop the entry and
+		// resume the title scan; filterPDFTOCEntries removes the remaining
+		// entry lines.
+		if isPDFTOCEntrySection(sectionText(sections[i])) {
+			sections = append(sections[:i], sections[i+1:]...)
+			continue
+		}
 		sections = append(sections[:i], sections[i+1:]...)
 		if i >= len(sections) || prefix == "" {
 			break

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -124,7 +124,9 @@ func normalizePDFRunningText(text string) string {
 
 // removePDFRunningHeaderFooter drops sections whose normalized text repeats
 // in the same page zone (top 10% or bottom 10%) on at least half of the
-// document's pages — running headers, footers, and page numbers. The
+// document's pages — running headers, footers, and page numbers. Every
+// rendered page counts toward the total, including blank or image-only
+// pages that produced no sections. The
 // layout-type filter above only works when a DeepDoc inference service
 // (DEEPDOC_URL) types header/footer regions; in default deployments there
 // is none, every section stays "text", and 页眉页脚 removal silently does
@@ -137,14 +139,7 @@ func removePDFRunningHeaderFooter(result *deepdoctype.ParseResult) {
 	if len(sections) == 0 || len(result.PageHeight) == 0 {
 		return
 	}
-	pageSet := make(map[int]struct{}, len(result.PageHeight))
-	for i := range sections {
-		if len(sections[i].Positions) == 0 || len(sections[i].Positions[0].PageNumbers) == 0 {
-			continue
-		}
-		pageSet[sections[i].Positions[0].PageNumbers[0]] = struct{}{}
-	}
-	numPages := len(pageSet)
+	numPages := len(result.PageHeight)
 	if numPages < pdfMinPagesForHeaderFooter {
 		return
 	}
@@ -173,9 +168,9 @@ func removePDFRunningHeaderFooter(result *deepdoctype.ParseResult) {
 		}
 		var isHeader, isFooter bool
 		switch {
-		case top <= pageHeight*pdfHeaderZoneRatio && bottom <= pageHeight*0.5:
+		case bottom <= pageHeight*pdfHeaderZoneRatio:
 			isHeader = true
-		case bottom >= pageHeight*pdfFooterZoneRatio && top >= pageHeight*0.5:
+		case top >= pageHeight*pdfFooterZoneRatio:
 			isFooter = true
 		}
 		if !isHeader && !isFooter {

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -73,6 +73,7 @@ func applyPDFPostProcess(result *deepdoctype.ParseResult, opts pdfPostProcessOpt
 	normalizePDFLayoutTypes(result)
 	if opts.removeHeaderFooter {
 		filterPDFHeaderFooter(result)
+		removePDFRunningHeaderFooter(result)
 	}
 	assignPDFDocTypeKeywords(result, opts.flattenMediaToText)
 }
@@ -91,6 +92,122 @@ func filterPDFHeaderFooter(result *deepdoctype.ParseResult) {
 	filtered := result.Sections[:0]
 	for _, s := range result.Sections {
 		if pdfHeaderFooterPattern.MatchString(strings.TrimSpace(s.LayoutType)) {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	result.Sections = filtered
+}
+
+const (
+	// pdfHeaderZoneRatio / pdfFooterZoneRatio bound the page zones where
+	// running headers/footers live: sections sitting entirely in the top
+	// or bottom fraction of a page are candidates.
+	pdfHeaderZoneRatio = 0.10
+	pdfFooterZoneRatio = 0.90
+	// pdfMinPagesForHeaderFooter guards against false positives on short
+	// documents: cross-page repetition only means "running header/footer"
+	// when the document has enough pages.
+	pdfMinPagesForHeaderFooter = 3
+)
+
+var pdfRunningDigitPattern = regexp.MustCompile(`\d+`)
+
+// normalizePDFRunningText collapses whitespace and replaces digit runs so
+// that per-page variants of the same running header/footer ("- 2 -",
+// "- 3 -", "Page 4 of 9") share one comparison key.
+func normalizePDFRunningText(text string) string {
+	t := strings.Join(strings.Fields(text), " ")
+	t = pdfRunningDigitPattern.ReplaceAllString(t, "#")
+	return strings.ToLower(strings.TrimSpace(t))
+}
+
+// removePDFRunningHeaderFooter drops sections whose normalized text repeats
+// in the same page zone (top 10% or bottom 10%) on at least half of the
+// document's pages — running headers, footers, and page numbers. The
+// layout-type filter above only works when a DeepDoc inference service
+// (DEEPDOC_URL) types header/footer regions; in default deployments there
+// is none, every section stays "text", and 页眉页脚 removal silently does
+// nothing. This positional frequency pass makes the option work without an
+// inference service. Repetition — not position alone — is the guard that
+// keeps genuine body text: a section must recur on >= max(2, pages/2) pages
+// in the same zone to be removed.
+func removePDFRunningHeaderFooter(result *deepdoctype.ParseResult) {
+	sections := result.Sections
+	if len(sections) == 0 || len(result.PageHeight) == 0 {
+		return
+	}
+	pageSet := make(map[int]struct{}, len(result.PageHeight))
+	for i := range sections {
+		if len(sections[i].Positions) == 0 || len(sections[i].Positions[0].PageNumbers) == 0 {
+			continue
+		}
+		pageSet[sections[i].Positions[0].PageNumbers[0]] = struct{}{}
+	}
+	numPages := len(pageSet)
+	if numPages < pdfMinPagesForHeaderFooter {
+		return
+	}
+	type zoneKey struct {
+		header bool
+		text   string
+	}
+	keyPages := make(map[zoneKey]map[int]struct{})
+	keySections := make(map[zoneKey][]int)
+	for i := range sections {
+		s := &sections[i]
+		if layout := strings.TrimSpace(s.LayoutType); layout != "" && layout != deepdoctype.LayoutTypeText {
+			continue
+		}
+		if len(s.Positions) == 0 || len(s.Positions[0].PageNumbers) == 0 {
+			continue
+		}
+		page := s.Positions[0].PageNumbers[0]
+		pageHeight := result.PageHeight[page]
+		if pageHeight <= 0 {
+			continue
+		}
+		top, bottom := s.Positions[0].Top, s.Positions[0].Bottom
+		if bottom <= top {
+			continue
+		}
+		var isHeader, isFooter bool
+		switch {
+		case top <= pageHeight*pdfHeaderZoneRatio && bottom <= pageHeight*0.5:
+			isHeader = true
+		case bottom >= pageHeight*pdfFooterZoneRatio && top >= pageHeight*0.5:
+			isFooter = true
+		}
+		if !isHeader && !isFooter {
+			continue
+		}
+		norm := normalizePDFRunningText(s.Text)
+		if norm == "" {
+			continue
+		}
+		key := zoneKey{header: isHeader, text: norm}
+		if keyPages[key] == nil {
+			keyPages[key] = make(map[int]struct{})
+		}
+		keyPages[key][page] = struct{}{}
+		keySections[key] = append(keySections[key], i)
+	}
+	drop := make(map[int]struct{})
+	for key, pages := range keyPages {
+		n := len(pages)
+		if n < 2 || n*2 < numPages {
+			continue
+		}
+		for _, i := range keySections[key] {
+			drop[i] = struct{}{}
+		}
+	}
+	if len(drop) == 0 {
+		return
+	}
+	filtered := sections[:0]
+	for i, s := range sections {
+		if _, ok := drop[i]; ok {
 			continue
 		}
 		filtered = append(filtered, s)

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -119,7 +119,9 @@ func normalizePDFRunningText(text string) string {
 
 // removePDFRunningHeaderFooter drops sections whose normalized text repeats
 // in the same page zone (top 10% or bottom 10%) on at least half of the
-// document's pages — running headers, footers, and page numbers. The
+// document's pages — running headers, footers, and page numbers. Every
+// rendered page counts toward the total, including blank or image-only
+// pages that produced no sections. The
 // layout-type filter above only works when a DeepDoc inference service
 // (DEEPDOC_URL) types header/footer regions; in default deployments there
 // is none, every section stays "text", and 页眉页脚 removal silently does
@@ -132,14 +134,7 @@ func removePDFRunningHeaderFooter(result *deepdoctype.ParseResult) {
 	if len(sections) == 0 || len(result.PageHeight) == 0 {
 		return
 	}
-	pageSet := make(map[int]struct{}, len(result.PageHeight))
-	for i := range sections {
-		if len(sections[i].Positions) == 0 || len(sections[i].Positions[0].PageNumbers) == 0 {
-			continue
-		}
-		pageSet[sections[i].Positions[0].PageNumbers[0]] = struct{}{}
-	}
-	numPages := len(pageSet)
+	numPages := len(result.PageHeight)
 	if numPages < pdfMinPagesForHeaderFooter {
 		return
 	}
@@ -168,9 +163,9 @@ func removePDFRunningHeaderFooter(result *deepdoctype.ParseResult) {
 		}
 		var isHeader, isFooter bool
 		switch {
-		case top <= pageHeight*pdfHeaderZoneRatio && bottom <= pageHeight*0.5:
+		case bottom <= pageHeight*pdfHeaderZoneRatio:
 			isHeader = true
-		case bottom >= pageHeight*pdfFooterZoneRatio && top >= pageHeight*0.5:
+		case top >= pageHeight*pdfFooterZoneRatio:
 			isFooter = true
 		}
 		if !isHeader && !isFooter {
@@ -314,12 +309,10 @@ func removePDFTOC(result *deepdoctype.ParseResult) {
 			break
 		}
 		// Consume the remaining contiguous TOC entries (dot leaders or a
-		// trailing page number). Python's remove_contents_table stops at the
-		// first line sharing the first entry's 3-byte prefix, which leaves
-		// most of the table behind whenever every entry shares that prefix
-		// (e.g. "Chapter One ...", "Chapter Two ...", ...). When entries were
-		// consumed this way, skip the legacy prefix scan and resume the title
-		// scan; otherwise fall back to it for pattern-less TOCs.
+		// trailing page number). When entries were consumed this way,
+		// resume the title scan; otherwise run the prefix scan below,
+		// which cuts everything up to the first line sharing the first
+		// entry's 3-byte prefix and so handles pattern-less TOCs.
 		removedEntries := 0
 		for i < len(sections) && isPDFTOCEntry(sections[i].Text) {
 			sections = append(sections[:i], sections[i+1:]...)

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -157,10 +157,10 @@ func TestApplyPDFPostProcess_RemoveTOCRemovesAllDotLeaderEntries(t *testing.T) {
 	}
 }
 
-func TestApplyPDFPostProcess_RemoveTOCLegacyPrefixScanWithoutEntryPattern(t *testing.T) {
-	// Pattern-less TOC entries keep the legacy python-parity behavior: title
-	// and first entry go, then everything up to the first line sharing the
-	// first entry's prefix (the real body heading).
+func TestApplyPDFPostProcess_RemoveTOCPrefixScanWithoutEntryPattern(t *testing.T) {
+	// Pattern-less TOC entries take the prefix scan: title and first entry
+	// go, then everything up to the first line sharing the first entry's
+	// prefix (the real body heading).
 	result := &deepdoctype.ParseResult{
 		Sections: []deepdoctype.Section{
 			{Text: "Contents"},
@@ -254,6 +254,74 @@ func TestApplyPDFPostProcess_RunningHeaderFooterSkipsShortDocuments(t *testing.T
 	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
 	if len(result.Sections) != 4 {
 		t.Fatalf("len(Sections) = %d, want 4 (2-page doc must not be touched)", len(result.Sections))
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterCountsAllRenderedPages(t *testing.T) {
+	const pageHeight = 842.0
+	// Pages 3 and 4 are blank or image-only: they produced no sections but
+	// still count toward the page total. A candidate repeated on 2 of the 5
+	// rendered pages occurs on fewer than half of the document's pages and
+	// must survive.
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight, 3: pageHeight, 4: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("Chapter One Introduction", "", 0, 72, 206, 88, 100),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body text one.", "", 1, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 21, 30),
+			makePDFSection("Body text two.", "", 2, 72, 374, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 5 {
+		t.Fatalf("len(Sections) = %d, want 5 (2 of 5 rendered pages is below the repetition threshold)", len(result.Sections))
+	}
+
+	// The same header on 3 of the 5 rendered pages meets the threshold and
+	// is removed even though two pages contributed no sections.
+	result = &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight, 3: pageHeight, 4: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 0, 72, 210, 21, 30),
+			makePDFSection("Body text one.", "", 0, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body text two.", "", 1, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 21, 30),
+			makePDFSection("Body text three.", "", 2, 72, 367, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 3 {
+		t.Fatalf("len(Sections) = %d, want 3 (running header removed on 3 of 5 rendered pages)", len(result.Sections))
+	}
+	for _, s := range result.Sections {
+		if strings.Contains(s.Text, "CONFIDENTIAL") {
+			t.Fatalf("running header survived: %q", s.Text)
+		}
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterRequiresFullZone(t *testing.T) {
+	const pageHeight = 842.0
+	// A section that merely starts in the top 10% but extends past it
+	// (bottom 200 > 842*0.10) is body content, not a header candidate —
+	// even when it repeats on every page. Same for a section that ends in
+	// the bottom 10% but starts above it (top 700 < 842*0.90).
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 0, 72, 210, 40, 200),
+			makePDFSection("Long legal disclaimer note", "", 0, 72, 363, 700, 800),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 40, 200),
+			makePDFSection("Long legal disclaimer note", "", 1, 72, 363, 700, 800),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 40, 200),
+			makePDFSection("Long legal disclaimer note", "", 2, 72, 363, 700, 800),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 6 {
+		t.Fatalf("len(Sections) = %d, want 6 (sections crossing the zone boundary must survive)", len(result.Sections))
 	}
 }
 

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -163,6 +163,36 @@ func TestApplyPDFPostProcess_RemoveTOCPrefixScanWithoutEntryPattern(t *testing.T
 	}
 }
 
+func TestApplyPDFPostProcess_RemoveTOCSingleFormattedEntryKeepsBody(t *testing.T) {
+	// Only the first entry after the TOC title is formatted. It must count
+	// as a consumed entry so the prefix scan never runs: that scan would
+	// otherwise delete every line up to the next "Cha"-prefixed heading
+	// ("Chapter Two"), dropping the body text between the TOC and it.
+	result := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "Contents"},
+			{Text: "Chapter One ..... 2"},
+			{Text: "Body A"},
+			{Text: "Body B"},
+			{Text: "Chapter Two"},
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeTOC: true})
+	var kept []string
+	for _, s := range result.Sections {
+		kept = append(kept, s.Text)
+	}
+	want := []string{"Body A", "Body B", "Chapter Two"}
+	if len(kept) != len(want) {
+		t.Fatalf("kept = %v, want %v", kept, want)
+	}
+	for i := range want {
+		if kept[i] != want[i] {
+			t.Fatalf("kept = %v, want %v", kept, want)
+		}
+	}
+}
+
 func TestApplyPDFPostProcess_RemoveRunningHeaderFooterWithoutDLA(t *testing.T) {
 	const pageHeight = 842.0
 	result := &deepdoctype.ParseResult{
@@ -299,6 +329,46 @@ func TestApplyPDFPostProcess_RunningHeaderFooterRequiresFullZone(t *testing.T) {
 	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
 	if len(result.Sections) != 6 {
 		t.Fatalf("len(Sections) = %d, want 6 (sections crossing the zone boundary must survive)", len(result.Sections))
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterNeedsRepetitionNotPosition(t *testing.T) {
+	const pageHeight = 842.0
+	// Body blocks sitting fully inside the top 10% of every page but never
+	// repeating: position alone must not remove them — the guard requires
+	// the same normalized text on >= half of the rendered pages.
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight, 3: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("Quarterly results summary", "", 0, 72, 300, 21, 60),
+			makePDFSection("Ordinary body text on page zero.", "", 0, 72, 363, 124, 136),
+			makePDFSection("Annual meeting minutes", "", 1, 72, 300, 21, 60),
+			makePDFSection("Ordinary body text on page one.", "", 1, 72, 363, 124, 136),
+			makePDFSection("Risk assessment overview", "", 2, 72, 300, 21, 60),
+			makePDFSection("Ordinary body text on page two.", "", 2, 72, 363, 124, 136),
+			makePDFSection("Compliance audit findings", "", 3, 72, 300, 21, 60),
+			makePDFSection("Ordinary body text on page three.", "", 3, 72, 363, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 8 {
+		t.Fatalf("len(Sections) = %d, want 8 (in-zone but non-repeating text must survive)", len(result.Sections))
+	}
+
+	// Repetition counts distinct pages, not occurrences: the same text
+	// twice on one page still covers a single page of the document.
+	result = &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("Repeated block", "", 0, 72, 300, 21, 40),
+			makePDFSection("Repeated block", "", 0, 72, 300, 45, 64),
+			makePDFSection("Body text page one.", "", 1, 72, 363, 124, 136),
+			makePDFSection("Body text page two.", "", 2, 72, 363, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 4 {
+		t.Fatalf("len(Sections) = %d, want 4 (two occurrences on one page count as one page)", len(result.Sections))
 	}
 }
 

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	deepdoctype "ragflow/internal/deepdoc/parser/type"
@@ -95,6 +96,164 @@ func TestApplyPDFPostProcess_HeaderFooterFilteringIsOptional(t *testing.T) {
 	}
 	if got, want := result.Sections[0].Text, "body"; got != want {
 		t.Fatalf("remaining section = %q, want %q", got, want)
+	}
+}
+
+func TestIsPDFTOCEntry(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"Chapter One Introduction .............. 2", true},
+		{"Chapter Two Methods ................... 3", true},
+		{"1.1 Overview ……… 12", true},
+		{"Preface    7", true},
+		{"3.2 Methods ..... 15", true},
+		{"Chapter One Introduction", false}, // body heading: no page number
+		{"Page 3 of 10", false},             // no letters before number
+		{"- 2 -", false},                    // page-number footer, not a TOC entry
+		{"See the results in 2024.", false}, // single space before number
+		{"abc", false},                      // too short
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isPDFTOCEntry(c.text); got != c.want {
+			t.Errorf("isPDFTOCEntry(%q) = %v, want %v", c.text, got, c.want)
+		}
+	}
+}
+
+func TestApplyPDFPostProcess_RemoveTOCRemovesAllDotLeaderEntries(t *testing.T) {
+	result := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "Contents"},
+			{Text: "Chapter One Introduction .............. 2"},
+			{Text: "Chapter Two Methods ................... 3"},
+			{Text: "Chapter Three Results ................. 4"},
+			{Text: "Chapter One Introduction"},
+			{Text: "Body text that must survive parsing."},
+			{Text: "Chapter Two Methods"},
+			{Text: "More body text."},
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeTOC: true})
+	var kept []string
+	for _, s := range result.Sections {
+		kept = append(kept, s.Text)
+	}
+	want := []string{
+		"Chapter One Introduction",
+		"Body text that must survive parsing.",
+		"Chapter Two Methods",
+		"More body text.",
+	}
+	if len(kept) != len(want) {
+		t.Fatalf("kept = %v, want %v", kept, want)
+	}
+	for i := range want {
+		if kept[i] != want[i] {
+			t.Fatalf("kept = %v, want %v", kept, want)
+		}
+	}
+}
+
+func TestApplyPDFPostProcess_RemoveTOCLegacyPrefixScanWithoutEntryPattern(t *testing.T) {
+	// Pattern-less TOC entries keep the legacy python-parity behavior: title
+	// and first entry go, then everything up to the first line sharing the
+	// first entry's prefix (the real body heading).
+	result := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "Contents"},
+			{Text: "1. Introduction"},
+			{Text: "2. Background"},
+			{Text: "1. Introduction"},
+			{Text: "Body text."},
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeTOC: true})
+	var kept []string
+	for _, s := range result.Sections {
+		kept = append(kept, s.Text)
+	}
+	want := []string{"1. Introduction", "Body text."}
+	if len(kept) != len(want) {
+		t.Fatalf("kept = %v, want %v", kept, want)
+	}
+	for i := range want {
+		if kept[i] != want[i] {
+			t.Fatalf("kept = %v, want %v", kept, want)
+		}
+	}
+}
+
+func TestApplyPDFPostProcess_RemoveRunningHeaderFooterWithoutDLA(t *testing.T) {
+	const pageHeight = 842.0
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight, 3: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("Contents", "", 0, 72, 158, 40, 60),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Chapter One Introduction", "", 1, 72, 206, 88, 100),
+			makePDFSection("Body text one.", "", 1, 72, 363, 124, 136),
+			makePDFSection("- 2 -", "", 1, 289, 305, 807, 817),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 21, 30),
+			makePDFSection("Chapter Two Methods", "", 2, 72, 190, 88, 100),
+			makePDFSection("Body text two.", "", 2, 72, 374, 124, 136),
+			makePDFSection("- 3 -", "", 2, 289, 305, 807, 817),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 3, 72, 210, 21, 30),
+			makePDFSection("Chapter Three Results", "", 3, 72, 192, 88, 100),
+			makePDFSection("Body text three.", "", 3, 72, 367, 124, 136),
+			makePDFSection("- 4 -", "", 3, 289, 305, 807, 817),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	for _, s := range result.Sections {
+		if strings.Contains(s.Text, "CONFIDENTIAL") {
+			t.Fatalf("running header survived: %q", s.Text)
+		}
+		if strings.HasPrefix(strings.TrimSpace(s.Text), "- ") {
+			t.Fatalf("page-number footer survived: %q", s.Text)
+		}
+	}
+	if len(result.Sections) != 7 {
+		t.Fatalf("len(Sections) = %d, want 7 (body content preserved)", len(result.Sections))
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterKeepsUniqueZoneText(t *testing.T) {
+	const pageHeight = 842.0
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight},
+		Sections: []deepdoctype.Section{
+			// Different top-of-page text on every page: not a running header.
+			makePDFSection("Unique top line one", "", 0, 72, 210, 21, 30),
+			makePDFSection("Body one.", "", 0, 72, 363, 124, 136),
+			makePDFSection("Unique top line two", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body two.", "", 1, 72, 363, 124, 136),
+			makePDFSection("Unique top line three", "", 2, 72, 210, 21, 30),
+			makePDFSection("Body three.", "", 2, 72, 363, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 6 {
+		t.Fatalf("len(Sections) = %d, want 6 (unique zone text must survive)", len(result.Sections))
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterSkipsShortDocuments(t *testing.T) {
+	const pageHeight = 842.0
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 0, 72, 210, 21, 30),
+			makePDFSection("Body one.", "", 0, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body two.", "", 1, 72, 363, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 4 {
+		t.Fatalf("len(Sections) = %d, want 4 (2-page doc must not be touched)", len(result.Sections))
 	}
 }
 

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	deepdoctype "ragflow/internal/deepdoc/parser/type"
@@ -96,6 +97,140 @@ func TestApplyPDFPostProcess_HeaderFooterFilteringIsOptional(t *testing.T) {
 	}
 	if got, want := result.Sections[0].Text, "body"; got != want {
 		t.Fatalf("remaining section = %q, want %q", got, want)
+	}
+}
+
+func TestApplyPDFPostProcess_RemoveTOCRemovesAllDotLeaderEntries(t *testing.T) {
+	result := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "Contents"},
+			{Text: "Chapter One Introduction .............. 2"},
+			{Text: "Chapter Two Methods ................... 3"},
+			{Text: "Chapter Three Results ................. 4"},
+			{Text: "Chapter One Introduction"},
+			{Text: "Body text that must survive parsing."},
+			{Text: "Chapter Two Methods"},
+			{Text: "More body text."},
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeTOC: true})
+	var kept []string
+	for _, s := range result.Sections {
+		kept = append(kept, s.Text)
+	}
+	want := []string{
+		"Chapter One Introduction",
+		"Body text that must survive parsing.",
+		"Chapter Two Methods",
+		"More body text.",
+	}
+	if len(kept) != len(want) {
+		t.Fatalf("kept = %v, want %v", kept, want)
+	}
+	for i := range want {
+		if kept[i] != want[i] {
+			t.Fatalf("kept = %v, want %v", kept, want)
+		}
+	}
+}
+
+func TestApplyPDFPostProcess_RemoveTOCLegacyPrefixScanWithoutEntryPattern(t *testing.T) {
+	// Pattern-less TOC entries keep the legacy python-parity behavior: title
+	// and first entry go, then everything up to the first line sharing the
+	// first entry's prefix (the real body heading).
+	result := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "Contents"},
+			{Text: "1. Introduction"},
+			{Text: "2. Background"},
+			{Text: "1. Introduction"},
+			{Text: "Body text."},
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeTOC: true})
+	var kept []string
+	for _, s := range result.Sections {
+		kept = append(kept, s.Text)
+	}
+	want := []string{"1. Introduction", "Body text."}
+	if len(kept) != len(want) {
+		t.Fatalf("kept = %v, want %v", kept, want)
+	}
+	for i := range want {
+		if kept[i] != want[i] {
+			t.Fatalf("kept = %v, want %v", kept, want)
+		}
+	}
+}
+
+func TestApplyPDFPostProcess_RemoveRunningHeaderFooterWithoutDLA(t *testing.T) {
+	const pageHeight = 842.0
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight, 3: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("Contents", "", 0, 72, 158, 40, 60),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Chapter One Introduction", "", 1, 72, 206, 88, 100),
+			makePDFSection("Body text one.", "", 1, 72, 363, 124, 136),
+			makePDFSection("- 2 -", "", 1, 289, 305, 807, 817),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 21, 30),
+			makePDFSection("Chapter Two Methods", "", 2, 72, 190, 88, 100),
+			makePDFSection("Body text two.", "", 2, 72, 374, 124, 136),
+			makePDFSection("- 3 -", "", 2, 289, 305, 807, 817),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 3, 72, 210, 21, 30),
+			makePDFSection("Chapter Three Results", "", 3, 72, 192, 88, 100),
+			makePDFSection("Body text three.", "", 3, 72, 367, 124, 136),
+			makePDFSection("- 4 -", "", 3, 289, 305, 807, 817),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	for _, s := range result.Sections {
+		if strings.Contains(s.Text, "CONFIDENTIAL") {
+			t.Fatalf("running header survived: %q", s.Text)
+		}
+		if strings.HasPrefix(strings.TrimSpace(s.Text), "- ") {
+			t.Fatalf("page-number footer survived: %q", s.Text)
+		}
+	}
+	if len(result.Sections) != 7 {
+		t.Fatalf("len(Sections) = %d, want 7 (body content preserved)", len(result.Sections))
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterKeepsUniqueZoneText(t *testing.T) {
+	const pageHeight = 842.0
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight},
+		Sections: []deepdoctype.Section{
+			// Different top-of-page text on every page: not a running header.
+			makePDFSection("Unique top line one", "", 0, 72, 210, 21, 30),
+			makePDFSection("Body one.", "", 0, 72, 363, 124, 136),
+			makePDFSection("Unique top line two", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body two.", "", 1, 72, 363, 124, 136),
+			makePDFSection("Unique top line three", "", 2, 72, 210, 21, 30),
+			makePDFSection("Body three.", "", 2, 72, 363, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 6 {
+		t.Fatalf("len(Sections) = %d, want 6 (unique zone text must survive)", len(result.Sections))
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterSkipsShortDocuments(t *testing.T) {
+	const pageHeight = 842.0
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 0, 72, 210, 21, 30),
+			makePDFSection("Body one.", "", 0, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body two.", "", 1, 72, 363, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 4 {
+		t.Fatalf("len(Sections) = %d, want 4 (2-page doc must not be touched)", len(result.Sections))
 	}
 }
 

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -134,10 +134,10 @@ func TestApplyPDFPostProcess_RemoveTOCRemovesAllDotLeaderEntries(t *testing.T) {
 	}
 }
 
-func TestApplyPDFPostProcess_RemoveTOCLegacyPrefixScanWithoutEntryPattern(t *testing.T) {
-	// Pattern-less TOC entries keep the legacy python-parity behavior: title
-	// and first entry go, then everything up to the first line sharing the
-	// first entry's prefix (the real body heading).
+func TestApplyPDFPostProcess_RemoveTOCPrefixScanWithoutEntryPattern(t *testing.T) {
+	// Pattern-less TOC entries take the prefix scan: title and first entry
+	// go, then everything up to the first line sharing the first entry's
+	// prefix (the real body heading).
 	result := &deepdoctype.ParseResult{
 		Sections: []deepdoctype.Section{
 			{Text: "Contents"},
@@ -231,6 +231,74 @@ func TestApplyPDFPostProcess_RunningHeaderFooterSkipsShortDocuments(t *testing.T
 	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
 	if len(result.Sections) != 4 {
 		t.Fatalf("len(Sections) = %d, want 4 (2-page doc must not be touched)", len(result.Sections))
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterCountsAllRenderedPages(t *testing.T) {
+	const pageHeight = 842.0
+	// Pages 3 and 4 are blank or image-only: they produced no sections but
+	// still count toward the page total. A candidate repeated on 2 of the 5
+	// rendered pages occurs on fewer than half of the document's pages and
+	// must survive.
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight, 3: pageHeight, 4: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("Chapter One Introduction", "", 0, 72, 206, 88, 100),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body text one.", "", 1, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 21, 30),
+			makePDFSection("Body text two.", "", 2, 72, 374, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 5 {
+		t.Fatalf("len(Sections) = %d, want 5 (2 of 5 rendered pages is below the repetition threshold)", len(result.Sections))
+	}
+
+	// The same header on 3 of the 5 rendered pages meets the threshold and
+	// is removed even though two pages contributed no sections.
+	result = &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight, 3: pageHeight, 4: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 0, 72, 210, 21, 30),
+			makePDFSection("Body text one.", "", 0, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 21, 30),
+			makePDFSection("Body text two.", "", 1, 72, 363, 124, 136),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 21, 30),
+			makePDFSection("Body text three.", "", 2, 72, 367, 124, 136),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 3 {
+		t.Fatalf("len(Sections) = %d, want 3 (running header removed on 3 of 5 rendered pages)", len(result.Sections))
+	}
+	for _, s := range result.Sections {
+		if strings.Contains(s.Text, "CONFIDENTIAL") {
+			t.Fatalf("running header survived: %q", s.Text)
+		}
+	}
+}
+
+func TestApplyPDFPostProcess_RunningHeaderFooterRequiresFullZone(t *testing.T) {
+	const pageHeight = 842.0
+	// A section that merely starts in the top 10% but extends past it
+	// (bottom 200 > 842*0.10) is body content, not a header candidate —
+	// even when it repeats on every page. Same for a section that ends in
+	// the bottom 10% but starts above it (top 700 < 842*0.90).
+	result := &deepdoctype.ParseResult{
+		PageHeight: map[int]float64{0: pageHeight, 1: pageHeight, 2: pageHeight},
+		Sections: []deepdoctype.Section{
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 0, 72, 210, 40, 200),
+			makePDFSection("Long legal disclaimer note", "", 0, 72, 363, 700, 800),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 1, 72, 210, 40, 200),
+			makePDFSection("Long legal disclaimer note", "", 1, 72, 363, 700, 800),
+			makePDFSection("CONFIDENTIAL DRAFT HEADER", "", 2, 72, 210, 40, 200),
+			makePDFSection("Long legal disclaimer note", "", 2, 72, 363, 700, 800),
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeHeaderFooter: true})
+	if len(result.Sections) != 6 {
+		t.Fatalf("len(Sections) = %d, want 6 (sections crossing the zone boundary must survive)", len(result.Sections))
 	}
 }
 


### PR DESCRIPTION
### Summary

The PDF knowledge-base options **"remove table of contents"** (`removeTOC`) and **"remove header/footer"** (`removeHeaderFooter`) silently did nothing for most PDFs. This PR fixes both paths in the Go parser (`internal/parser/parser/pdf_postprocess.go`).

### Background / Root cause

Two independent bugs:

1. **TOC removal kept almost the whole table.**
   `removePDFTOC` inherited a Python parity quirk (`rag/nlp/__init__.py remove_contents_table`): after removing the TOC title it removed only the *first* entry, then scanned forward for a line sharing that entry's 3-byte prefix to stop at. When every TOC entry shares the same prefix (the common case — "Chapter One Introduction ...... 2", "Chapter Two Methods ...... 3", ...), the first body heading matches only at its position, but the scan hit later TOC entries first, or stopped immediately — in practice only the title and one entry were removed, and the remaining entries leaked into chunks.

2. **Header/footer removal was a no-op without a DeepDoc inference service.**
   `filterPDFHeaderFooter` only dropped sections whose `LayoutType` matched `header|footer|number`. Those layout types come from the DeepDoc inference service (`DEEPDOC_URL`). In default deployments there is no such service, every section stays `text`, and the option removed nothing at all — while the UI happily let users enable it.

### Fix

- **TOC**: after the title and first entry, consume the whole contiguous run of lines that still look like TOC entries via `isPDFTOCEntry` — dot leaders or ≥2 spaces followed by a trailing page number (`Chapter One .............. 2`, `Preface    7`, `1.1 Overview ……… 12`), requiring letter content so page-number-only footers are never mistaken for entries. When no entries match, the legacy prefix-scan fallback is preserved for pattern-less TOCs.
- **Header/footer**: added `removePDFRunningHeaderFooter`, which runs after the layout-type filter whenever `removeHeaderFooter` is on. It drops sections that:
  - sit entirely in the top 10% (header) or bottom 10% (footer) of their page (PDF point space, using `PageHeight`),
  - have a digit-normalized text (digits → `#`, so `- 2 -`, `- 3 -`, `Page 4 of 9` share a key) that repeats in the **same zone** on at least `max(2, pages/2)` pages,
  - and the document has at least 3 pages, and the section has no non-`text` layout type.
  
  Repetition across pages — not position alone — is the guard that keeps genuine body text; unique top-of-page lines survive.

### Tests

New unit tests in `pdf_postprocess_test.go`:

- `TestIsPDFTOCEntry` — pattern table (dot leaders, trailing page numbers, negative cases for body headings and page-number footers).
- `TestApplyPDFPostProcess_RemoveTOCRemovesAllDotLeaderEntries` — whole TOC table removed, body headings kept.
- `TestApplyPDFPostProcess_RemoveTOCLegacyPrefixScanWithoutEntryPattern` — pattern-less TOC keeps legacy behavior.
- `TestApplyPDFPostProcess_RemoveRunningHeaderFooterWithoutDLA` — running header + page-number footers removed with all sections typed `text` (no inference service), body preserved.
- `TestApplyPDFPostProcess_RunningHeaderFooterKeepsUniqueZoneText` — no false positives on unique top-of-page text.
- `TestApplyPDFPostProcess_RunningHeaderFooterSkipsShortDocuments` — 2-page documents untouched.

`bash build.sh --test ./internal/parser/...` passes.

### End-to-end verification

Verified against a local instance (Go ingestor + ES):

- Repro PDF: 4 pages, TOC page ("Contents" + 3 dot-leader entries), running `CONFIDENTIAL DRAFT HEADER` on pages 2–4, `- N -` page-number footers.
- Before: chunks contained TOC entries, headers, and footers with both options enabled.
- After: re-parsed with both options enabled → the single chunk contains only chapter headings and body paragraphs; ES query confirms no `Contents`/TOC entries/`CONFIDENTIAL DRAFT HEADER`/`- N -` remain.

Verification boundary: verified with the default deployment (no DeepDoc inference service). With `DEEPDOC_URL` configured, the pre-existing layout-type filter still applies first and this positional pass only acts on what remains.
