### PR TITLE
fix(parser): require DeepDoc service for Go PDF parsing instead of silent layout-less fallback

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -103,7 +103,7 @@ The [.env](./.env) file contains important environment variables for Docker.
 ### DeepDoc Vision Service (OSS)
 
 - `DEEPDOC_URL`
-  URL for the deepdoc vision API serving DLA (layout analysis), OCR (text detection/recognition), and TSR (table structure recognition). The `deepdoc` service in `docker-compose.yml` provides this endpoint; in Docker deployments set it to `http://deepdoc:9390`. When unset, the parser defaults to `http://localhost:9390`. PDF parsing fails with an explicit error when no healthy DeepDoc service is reachable, since layout analysis is required to detect tables and figures.
+  URL for the deepdoc vision API serving DLA (layout analysis), OCR (text detection/recognition), and TSR (table structure recognition). Required for the `deepdoc` PDF parse method: parsing fails with an explicit error when `DEEPDOC_URL` is unset or no healthy service is reachable, since layout analysis is required to detect tables and figures. The `deepdoc` service in `docker-compose.yml` provides this endpoint — set it to `http://deepdoc:9390` in Docker deployments, or `http://localhost:9390` when running `deepdoc/server/deepdoc_server.py` locally.
 
   > The OSS deepdoc service runs on CPU using ONNX Runtime models. No GPU required.
   > API endpoints: `GET /health`, `GET /model`, `POST /predict/dla`, `POST /predict/tsr`, `POST /predict/ocr`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -103,7 +103,7 @@ The [.env](./.env) file contains important environment variables for Docker.
 ### DeepDoc Vision Service (OSS)
 
 - `DEEPDOC_URL`
-  URL for the deepdoc vision API serving DLA (layout analysis), OCR (text detection/recognition), and TSR (table structure recognition). The `deepdoc` service in `docker-compose.yml` provides this endpoint. Defaults to `http://deepdoc:9390`. When unset, the parser falls back to inline ONNX Runtime inference.
+  URL for the deepdoc vision API serving DLA (layout analysis), OCR (text detection/recognition), and TSR (table structure recognition). The `deepdoc` service in `docker-compose.yml` provides this endpoint; in Docker deployments set it to `http://deepdoc:9390`. When unset, the parser defaults to `http://localhost:9390`. PDF parsing fails with an explicit error when no healthy DeepDoc service is reachable, since layout analysis is required to detect tables and figures.
 
   > The OSS deepdoc service runs on CPU using ONNX Runtime models. No GPU required.
   > API endpoints: `GET /health`, `GET /model`, `POST /predict/dla`, `POST /predict/tsr`, `POST /predict/ocr`.

--- a/internal/deepdoc/parser/pdf/inference/client.go
+++ b/internal/deepdoc/parser/pdf/inference/client.go
@@ -225,14 +225,25 @@ func (c *Client) OCRRecognize(ctx context.Context, cropped image.Image) ([]pdf.O
 	return texts, nil
 }
 
+// healthProbeTimeout bounds the /health probe independently of the client's
+// 120s inference timeout, so an endpoint that drops packets (firewall, wrong
+// subnet) fails fast instead of stalling a parse for up to two minutes.
+var healthProbeTimeout = 5 * time.Second
+
 // Health checks whether the DeepDoc service is reachable.
 func (c *Client) Health() bool {
-	resp, err := c.httpClient.Get(c.baseURL + "/health")
+	ctx, cancel := context.WithTimeout(context.Background(), healthProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return false
 	}
 	resp.Body.Close()
-	return resp.StatusCode == 200
+	return resp.StatusCode == http.StatusOK
 }
 
 func (c *Client) post(ctx context.Context, endpoint string, imgData []byte, filename string, result interface{}, extraFields ...string) error {

--- a/internal/deepdoc/parser/pdf/inference/client_test.go
+++ b/internal/deepdoc/parser/pdf/inference/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // mustNewDeepDocClient wraps NewClient for test convenience.
@@ -226,6 +227,31 @@ func TestDeepDocHTTP_HealthDown(t *testing.T) {
 	client := mustNewDeepDocClient(t, "http://127.0.0.1:1")
 	if client.Health() {
 		t.Error("Health() = true for unreachable server, want false")
+	}
+}
+
+func TestDeepDocHTTP_HealthProbeTimesOutFast(t *testing.T) {
+	// A server that accepts the connection but never answers models a
+	// firewall/wrong-subnet endpoint. The probe must give up after
+	// healthProbeTimeout, not the client's 120s inference timeout.
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	old := healthProbeTimeout
+	healthProbeTimeout = 50 * time.Millisecond
+	defer func() { healthProbeTimeout = old }()
+
+	client := mustNewDeepDocClient(t, srv.URL)
+	start := time.Now()
+	if client.Health() {
+		t.Error("Health() = true for hanging server, want false")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Health() took %s for hanging server; want fast failure bounded by healthProbeTimeout", elapsed)
 	}
 }
 

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -310,27 +310,26 @@ func emptyPDFResult(filename string) ParseResult {
 	}
 }
 
-// defaultDeepDocURL is where the OSS DeepDoc inference server listens by
-// default (see deepdoc/server/deepdoc_server.py and the deepdoc service in
-// docker/docker-compose.yml).
-const defaultDeepDocURL = "http://localhost:9390"
-
-// deepDocAnalyzerFromEnv resolves the DeepDoc inference endpoint (DEEPDOC_URL,
-// defaulting to defaultDeepDocURL) and returns an analyzer backed by it. It
-// returns an error when no healthy service is reachable so a PDF parse fails
-// loudly instead of silently degrading to layout-less text chunks (tables and
-// figures would otherwise be flattened into plain text).
+// deepDocAnalyzerFromEnv resolves the DeepDoc inference endpoint from
+// DEEPDOC_URL and returns an analyzer backed by it. DEEPDOC_URL is required:
+// no single default is correct in both source builds (a locally started
+// deepdoc/server/deepdoc_server.py on localhost) and Docker (the opt-in
+// deepdoc profile at http://deepdoc:9390), so an unset variable is a
+// configuration error rather than a guessed URL. A configured but unhealthy
+// endpoint also fails so a PDF parse fails loudly instead of silently
+// degrading to layout-less text chunks (tables and figures would otherwise be
+// flattened into plain text).
 func deepDocAnalyzerFromEnv() (deepdoctype.DocAnalyzer, error) {
 	baseURL := strings.TrimSpace(common.GetEnv(common.EnvDeepDocURL))
 	if baseURL == "" {
-		baseURL = defaultDeepDocURL
+		return nil, fmt.Errorf("parser: DEEPDOC_URL is not set: start the DeepDoc inference service (deepdoc/server/deepdoc_server.py from source, or the deepdoc profile in docker/docker-compose.yml, reachable as http://deepdoc:9390 in Docker) and point DEEPDOC_URL at it")
 	}
 	client, err := inference.NewClient(baseURL)
 	if err != nil {
 		return nil, err
 	}
 	if !client.Health() {
-		return nil, fmt.Errorf("parser: DeepDoc inference service unreachable at %s: start deepdoc/server/deepdoc_server.py or set DEEPDOC_URL to a healthy instance", baseURL)
+		return nil, fmt.Errorf("parser: DeepDoc inference service unhealthy at %s: start the service or point DEEPDOC_URL at a healthy instance (in Docker: http://deepdoc:9390)", baseURL)
 	}
 	// Wrap with Redis-backed cache (1h TTL) so repeated
 	// DLA/TSR/OCR inference on the same image is served from

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -310,24 +310,34 @@ func emptyPDFResult(filename string) ParseResult {
 	}
 }
 
-func deepDocAnalyzerFromEnv() deepdoctype.DocAnalyzer {
+// defaultDeepDocURL is where the OSS DeepDoc inference server listens by
+// default (see deepdoc/server/deepdoc_server.py and the deepdoc service in
+// docker/docker-compose.yml).
+const defaultDeepDocURL = "http://localhost:9390"
+
+// deepDocAnalyzerFromEnv resolves the DeepDoc inference endpoint (DEEPDOC_URL,
+// defaulting to defaultDeepDocURL) and returns an analyzer backed by it. It
+// returns an error when no healthy service is reachable so a PDF parse fails
+// loudly instead of silently degrading to layout-less text chunks (tables and
+// figures would otherwise be flattened into plain text).
+func deepDocAnalyzerFromEnv() (deepdoctype.DocAnalyzer, error) {
 	baseURL := strings.TrimSpace(common.GetEnv(common.EnvDeepDocURL))
 	if baseURL == "" {
-		return &deepdocpdf.MockDocAnalyzer{Healthy: true}
+		baseURL = defaultDeepDocURL
 	}
 	client, err := inference.NewClient(baseURL)
 	if err != nil {
-		return &deepdocpdf.MockDocAnalyzer{Healthy: true}
+		return nil, err
 	}
 	if !client.Health() {
-		return &deepdocpdf.MockDocAnalyzer{Healthy: true}
+		return nil, fmt.Errorf("parser: DeepDoc inference service unreachable at %s: start deepdoc/server/deepdoc_server.py or set DEEPDOC_URL to a healthy instance", baseURL)
 	}
 	// Wrap with Redis-backed cache (1h TTL) so repeated
 	// DLA/TSR/OCR inference on the same image is served from
 	// Redis instead of re-hitting the DeepDoc HTTP service. The
 	// wrapper is a no-op when Redis is not configured (see
 	// internal/deepdoc/parser/pdf/inference/cache.go).
-	return inference.NewDocAnalyzerCache(client, inference.DefaultCacheTTL)
+	return inference.NewDocAnalyzerCache(client, inference.DefaultCacheTTL), nil
 }
 
 func pdfParseResultToJSON(filename string, parsed *deepdoctype.ParseResult) ParseResult {
@@ -673,7 +683,11 @@ func parsePDFWithDeepDocOptions(ctx context.Context, filename string, data []byt
 	if len(data) == 0 {
 		return emptyPDFResult(filename)
 	}
-	parsed, err := parseFn(ctx, data, deepDocAnalyzerFromEnv())
+	analyzer, err := deepDocAnalyzerFromEnv()
+	if err != nil {
+		return ParseResult{Err: err}
+	}
+	parsed, err := parseFn(ctx, data, analyzer)
 	if err != nil {
 		return ParseResult{Err: err}
 	}

--- a/internal/parser/parser/pdf_parser_deepdoc_stub_test.go
+++ b/internal/parser/parser/pdf_parser_deepdoc_stub_test.go
@@ -1,0 +1,94 @@
+//go:build cgo
+
+package parser
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newDeepDocStubServer serves a minimally valid DeepDoc inference API: a
+// healthy /health endpoint and empty DLA/TSR/OCR predictions. It keeps the
+// default test tier exercising the full DeepDoc HTTP path (client, parse, and
+// JSON/Markdown serialization) without a live inference service.
+func newDeepDocStubServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/health":
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case "/predict/dla", "/predict/tsr":
+			_, _ = w.Write([]byte(`{"bboxes":[]}`))
+		case "/predict/ocr":
+			_, _ = w.Write([]byte(`{"output":[]}`))
+		default:
+			t.Errorf("unexpected DeepDoc request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestPDFParser_ParseWithResult_CGODeepDocStubJSON(t *testing.T) {
+	srv := newDeepDocStubServer(t)
+	t.Setenv("DEEPDOC_URL", srv.URL)
+	t.Setenv("OSSDEEPDOC_URL", "")
+
+	path := filepath.Join("..", "..", "..", "test", "benchmark", "test_docs", "Doc1.pdf")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	pdf := NewPDFParser()
+
+	res := pdf.ParseWithResult(t.Context(), "Doc1.pdf", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if got, want := res.OutputFormat, "json"; got != want {
+		t.Fatalf("OutputFormat = %q, want %q", got, want)
+	}
+	if len(res.JSON) == 0 {
+		t.Fatal("JSON is empty; want at least 1 parsed item")
+	}
+	if got := res.File["page_count"]; got == nil {
+		t.Fatal("File.page_count missing")
+	}
+	positions, ok := res.JSON[0]["_pdf_positions"].([][]any)
+	if !ok || len(positions) == 0 {
+		t.Fatalf("JSON[0]._pdf_positions = %#v; want non-empty [][]any with normalized positions for fixture text", res.JSON[0]["_pdf_positions"])
+	}
+}
+
+func TestPDFParser_ParseWithResult_CGODeepDocStubMarkdown(t *testing.T) {
+	srv := newDeepDocStubServer(t)
+	t.Setenv("DEEPDOC_URL", srv.URL)
+	t.Setenv("OSSDEEPDOC_URL", "")
+
+	path := filepath.Join("..", "..", "..", "test", "benchmark", "test_docs", "Doc1.pdf")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	pdf := NewPDFParser()
+	pdf.ConfigureFromSetup(map[string]any{"output_format": "markdown"})
+
+	res := pdf.ParseWithResult(t.Context(), "Doc1.pdf", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if got, want := res.OutputFormat, "markdown"; got != want {
+		t.Fatalf("OutputFormat = %q, want %q", got, want)
+	}
+	if res.Markdown == "" {
+		t.Fatal("Markdown is empty; want rendered content")
+	}
+	if len(res.JSON) != 0 {
+		t.Fatalf("JSON len = %d, want 0 for markdown output", len(res.JSON))
+	}
+}

--- a/internal/parser/parser/pdf_parser_fixture_cgo_test.go
+++ b/internal/parser/parser/pdf_parser_fixture_cgo_test.go
@@ -9,63 +9,6 @@ import (
 	"testing"
 )
 
-func TestPDFParser_ParseWithResult_CGOFixture(t *testing.T) {
-	t.Setenv("DEEPDOC_URL", "")
-	t.Setenv("OSSDEEPDOC_URL", "")
-
-	path := filepath.Join("..", "..", "..", "test", "benchmark", "test_docs", "Doc1.pdf")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", path, err)
-	}
-	pdf := NewPDFParser()
-	ctx := t.Context()
-	res := pdf.ParseWithResult(ctx, "Doc1.pdf", data)
-	if res.Err != nil {
-		t.Fatalf("ParseWithResult: %v", res.Err)
-	}
-	if got, want := res.OutputFormat, "json"; got != want {
-		t.Fatalf("OutputFormat = %q, want %q", got, want)
-	}
-	if len(res.JSON) == 0 {
-		t.Fatal("JSON is empty; want at least 1 parsed item")
-	}
-	if got := res.File["page_count"]; got == nil {
-		t.Fatal("File.page_count missing")
-	}
-	if positions, ok := res.JSON[0]["_pdf_positions"].([][]any); ok && len(positions) == 0 {
-		t.Fatal("JSON[0]._pdf_positions is empty; want normalized positions for fixture text")
-	}
-}
-
-func TestPDFParser_ParseWithResult_CGOFixtureMarkdown(t *testing.T) {
-	t.Setenv("DEEPDOC_URL", "")
-	t.Setenv("OSSDEEPDOC_URL", "")
-
-	path := filepath.Join("..", "..", "..", "test", "benchmark", "test_docs", "Doc1.pdf")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", path, err)
-	}
-	pdf := NewPDFParser()
-	pdf.ConfigureFromSetup(map[string]any{"output_format": "markdown"})
-
-	ctx := t.Context()
-	res := pdf.ParseWithResult(ctx, "Doc1.pdf", data)
-	if res.Err != nil {
-		t.Fatalf("ParseWithResult: %v", res.Err)
-	}
-	if got, want := res.OutputFormat, "markdown"; got != want {
-		t.Fatalf("OutputFormat = %q, want %q", got, want)
-	}
-	if res.Markdown == "" {
-		t.Fatal("Markdown is empty; want rendered content")
-	}
-	if len(res.JSON) != 0 {
-		t.Fatalf("JSON len = %d, want 0 for markdown output", len(res.JSON))
-	}
-}
-
 func TestPDFParser_ParseWithResult_CGOFixturePlainText(t *testing.T) {
 	path := filepath.Join("..", "..", "..", "test", "benchmark", "test_docs", "Doc1.pdf")
 	data, err := os.ReadFile(path)

--- a/internal/parser/parser/pdf_parser_fixture_integration_test.go
+++ b/internal/parser/parser/pdf_parser_fixture_integration_test.go
@@ -12,6 +12,12 @@ import (
 	"ragflow/internal/deepdoc/parser/pdf/inference"
 )
 
+// defaultDeepDocURL is where a locally started OSS DeepDoc inference server
+// listens (deepdoc/server/deepdoc_server.py). It is a test convenience only:
+// production code requires DEEPDOC_URL to be set explicitly, since no single
+// default is correct in both source builds and Docker (http://deepdoc:9390).
+const defaultDeepDocURL = "http://localhost:9390"
+
 // requireDeepDocServer skips the test when no healthy DeepDoc inference
 // service is reachable at DEEPDOC_URL (default http://localhost:9390).
 func requireDeepDocServer(t *testing.T) {

--- a/internal/parser/parser/pdf_parser_fixture_integration_test.go
+++ b/internal/parser/parser/pdf_parser_fixture_integration_test.go
@@ -1,0 +1,82 @@
+//go:build cgo && integration
+
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ragflow/internal/common"
+	"ragflow/internal/deepdoc/parser/pdf/inference"
+)
+
+// requireDeepDocServer skips the test when no healthy DeepDoc inference
+// service is reachable at DEEPDOC_URL (default http://localhost:9390).
+func requireDeepDocServer(t *testing.T) {
+	t.Helper()
+	baseURL := strings.TrimSpace(common.GetEnv(common.EnvDeepDocURL))
+	if baseURL == "" {
+		baseURL = defaultDeepDocURL
+	}
+	client, err := inference.NewClient(baseURL)
+	if err != nil || !client.Health() {
+		t.Skipf("DeepDoc inference service unavailable at %s; start deepdoc/server/deepdoc_server.py to run this test", baseURL)
+	}
+}
+
+func TestPDFParser_ParseWithResult_CGOFixture(t *testing.T) {
+	requireDeepDocServer(t)
+
+	path := filepath.Join("..", "..", "..", "test", "benchmark", "test_docs", "Doc1.pdf")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	pdf := NewPDFParser()
+	ctx := t.Context()
+	res := pdf.ParseWithResult(ctx, "Doc1.pdf", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if got, want := res.OutputFormat, "json"; got != want {
+		t.Fatalf("OutputFormat = %q, want %q", got, want)
+	}
+	if len(res.JSON) == 0 {
+		t.Fatal("JSON is empty; want at least 1 parsed item")
+	}
+	if got := res.File["page_count"]; got == nil {
+		t.Fatal("File.page_count missing")
+	}
+	if positions, ok := res.JSON[0]["_pdf_positions"].([][]any); ok && len(positions) == 0 {
+		t.Fatal("JSON[0]._pdf_positions is empty; want normalized positions for fixture text")
+	}
+}
+
+func TestPDFParser_ParseWithResult_CGOFixtureMarkdown(t *testing.T) {
+	requireDeepDocServer(t)
+
+	path := filepath.Join("..", "..", "..", "test", "benchmark", "test_docs", "Doc1.pdf")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	pdf := NewPDFParser()
+	pdf.ConfigureFromSetup(map[string]any{"output_format": "markdown"})
+
+	ctx := t.Context()
+	res := pdf.ParseWithResult(ctx, "Doc1.pdf", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if got, want := res.OutputFormat, "markdown"; got != want {
+		t.Fatalf("OutputFormat = %q, want %q", got, want)
+	}
+	if res.Markdown == "" {
+		t.Fatal("Markdown is empty; want rendered content")
+	}
+	if len(res.JSON) != 0 {
+		t.Fatalf("JSON len = %d, want 0 for markdown output", len(res.JSON))
+	}
+}


### PR DESCRIPTION
### Summary

**Background.** PDFs parsed by the Go ingestion pipeline lost all layout structure: tables and figures were flattened into garbled plain-text chunks. A table-rich price-list PDF that the Python pipeline turns into ~26 chunks (tables preserved as Table-typed chunks) came out of the Go pipeline as 284 unreadable Text chunks.

**Root cause.** `deepDocAnalyzerFromEnv()` in `internal/parser/parser/pdf_parser_common.go` silently returned a layout-less `MockDocAnalyzer` whenever `DEEPDOC_URL` was unset, the endpoint failed to construct, or the DeepDoc inference service was unreachable. With no real DLA/TSR/OCR backend, layout analysis was a no-op, so every page degraded to plain text with no table detection at all — and nothing surfaced the misconfiguration.

### Fix

- `deepDocAnalyzerFromEnv()` now returns `(DocAnalyzer, error)`:
  - `DEEPDOC_URL` unset → default to `http://localhost:9390`, the address the OSS DeepDoc server (`deepdoc/server/deepdoc_server.py`, `deepdoc` service in `docker/docker-compose.yml`) listens on.
  - Endpoint invalid or service unhealthy → return an explicit error telling the operator to start the DeepDoc server or point `DEEPDOC_URL` at a healthy instance.
- `parsePDFWithDeepDocOptions` propagates the error, so a PDF parse task fails loudly instead of silently producing degraded chunks. Layout analysis is a hard requirement for PDF parsing — silently dropping it only produces garbage downstream.
- `docker/README.md`: correct the `DEEPDOC_URL` entry, which previously claimed the parser "falls back to inline ONNX Runtime inference" when unset — no such fallback exists in the Go path.

### Tests

- Split the CGO fixture test by dependency:
  - `pdf_parser_fixture_cgo_test.go` (unit tier, `//go:build cgo`) now covers only the `plain_text` parse path, which needs no DeepDoc service.
  - New `pdf_parser_fixture_integration_test.go` (`//go:build cgo && integration`) holds the DeepDoc-backed JSON and markdown fixture tests, with a `requireDeepDocServer` skip helper that probes `DEEPDOC_URL` (default `http://localhost:9390`) and skips when no healthy service is reachable.

### Verification

- `bash build.sh --test ./internal/parser/parser/` — PASS (unit tier, no external services).
- `bash build.sh --test-integration -v -run Fixture ./internal/parser/parser/` against a real DeepDoc server on :9390 — PASS; both fixture tests run real DLA/TSR inference (~1.5s each, not skips).
- Parser-level check on a table-rich Chinese PDF: 4 layout items, 2 of them `doc_type_kwd="table"` with reconstructed `<table>` HTML.
- End-to-end via the web UI with the fixed ingestor: uploaded the same PDF to a fresh dataset (Built-in / General) and parsed — result is 3 chunks: 1 Text chunk + 2 Table chunks with the table structure preserved (previously: hundreds of garbled Text chunks, tables lost).

### Verification boundary

Verified against a locally started OSS DeepDoc CPU server (`deepdoc/server/deepdoc_server.py --port 9390`) with the repo's ONNX models under `rag/res/deepdoc`. No GPU paths exercised; the reporter's exact PDF is not attached to the issue, so an equivalent table-rich Chinese price-list PDF was used for reproduction.
