### PR TITLE
fix(web): accept a single API key for Baidu YiYan

### DIFF
--- a/web/src/pages/user-setting/setting-model/provider-schema/field-config/provider-config-map.ts
+++ b/web/src/pages/user-setting/setting-model/provider-schema/field-config/provider-config-map.ts
@@ -340,47 +340,25 @@ export const ProviderConfigMap: Record<string, ProviderConfig> = {
         validation: { message: 'instanceNameMessage' },
       },
       {
-        name: 'yiyan_ak',
-        label: 'addyiyanAK',
-        type: FormFieldType.Text,
+        name: 'api_key',
+        label: 'apiKey',
+        type: FormFieldType.Password,
         required: true,
-        placeholder: 'yiyanAKMessage',
+        placeholder: 'apiKeyMessage',
         shouldRender: 'hideWhenInstanceExists',
-        validation: { message: 'yiyanAKMessage' },
-      },
-      {
-        name: 'yiyan_sk',
-        label: 'addyiyanSK',
-        type: FormFieldType.Text,
-        required: true,
-        placeholder: 'yiyanSKMessage',
-        shouldRender: 'hideWhenInstanceExists',
-        validation: { message: 'yiyanSKMessage' },
+        validation: { message: 'apiKeyMessage' },
       },
     ],
     verifyTransform: (values) => ({
-      apiKey: {
-        yiyan_ak: values.yiyan_ak,
-        yiyan_sk: values.yiyan_sk,
-      },
+      apiKey: values.api_key,
       modelInfo: [],
     }),
     submitTransform: (values) => ({
       instance_name: values.instance_name,
       llm_factory: LLMFactory.BaiduYiYan,
-      api_key: {
-        yiyan_ak: values.yiyan_ak,
-        yiyan_sk: values.yiyan_sk,
-      },
+      api_key: values.api_key,
       model_info: [],
     }),
-    echoTransform: (instance) => {
-      const obj = parseApiKeyAsObject(instance.api_key) ?? {};
-      return {
-        yiyan_ak: obj.yiyan_ak ?? '',
-        yiyan_sk: obj.yiyan_sk ?? '',
-      };
-    },
   },
 
   // ============ Fish Audio ============


### PR DESCRIPTION
### Summary

fix(web): accept a single API key for Baidu YiYan

The backend now allows a plain YiYan API key instead of an AK/SK pair, so the provider form no longer needs two separate credential fields.
