### PR TITLE
fix(web): resize the mind map graph when its container changes size

### DIFF
--- a/web/src/components/indented-tree/indented-tree.tsx
+++ b/web/src/components/indented-tree/indented-tree.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Graph as G6Graph, treeToGraphData } from '@antv/g6';
+import { useSize } from 'ahooks';
 import { useEffect, useMemo, useRef } from 'react';
 
 const assignIds = (node: any, parentId: string = '', index = 0) => {
@@ -46,6 +47,9 @@ export const IndentedTree = (props: GraphProps) => {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const graphRef = useRef<G6Graph>();
+  const size = useSize(containerRef);
+  const width = size?.width;
+  const height = size?.height;
 
   const options = useMemo(
     () => ({
@@ -122,6 +126,20 @@ export const IndentedTree = (props: GraphProps) => {
       .then(() => onRender?.(graph))
       .catch((error) => console.debug(error));
   }, [options, data, onRender]);
+
+  // G6 sizes its canvas at creation time, so the graph must be resized and
+  // re-fitted whenever the container (window / sheet) changes size.
+  useEffect(() => {
+    const graph = graphRef.current;
+
+    if (!graph || graph.destroyed || !width || !height) return;
+
+    const [canvasWidth, canvasHeight] = graph.getSize();
+    if (canvasWidth === width && canvasHeight === height) return;
+
+    graph.resize(width, height);
+    graph.fitView().catch((error: unknown) => console.debug(error));
+  }, [width, height]);
 
   return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />;
 };


### PR DESCRIPTION
### Summary

fix(web): resize the mind map graph when its container changes size

G6 measures the container once at construction and never re-reads it, so the mind map canvas kept its initial pixel size while the sheet height tracks the viewport, clipping content or leaving blank space on window resize. The built-in `autoResize` only registers in the Graph constructor, and `autoFit: 'view'` only runs during `render()`, so neither covered this.

Observe the container and re-run `resize()` + `fitView()`, matching the existing MindMapG6Graph pattern.
