### PR TITLE
fix(web): give each provider instance card its own surface

### DIFF
--- a/web/src/pages/user-setting/setting-model/instance-card/components/draft-mode-card.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/components/draft-mode-card.tsx
@@ -59,7 +59,7 @@ export function DraftModeCard({
   );
 
   return (
-    <div className="px-2 py-3 flex flex-col gap-4">
+    <div className="px-5 py-3 flex flex-col gap-4 bg-bg-card rounded-xl ">
       <InstanceNameSection
         draftName={draftName}
         setDraftName={setDraftName}

--- a/web/src/pages/user-setting/setting-model/instance-card/components/saved-mode-card.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/components/saved-mode-card.tsx
@@ -37,6 +37,7 @@ import { useTranslation } from 'react-i18next';
 import { DRAFT_INSTANCE_SENTINEL, SavedModeCardProps } from '../interface';
 import { ModelsSection } from '../models-section';
 import VerifyButton from '../verify-button';
+import { cn } from '@/lib/utils';
 
 /**
  * The saved (non-draft) variant of the provider instance card.
@@ -128,11 +129,17 @@ export function SavedModeCard({
   const displayName = editedInstanceName || instanceName;
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="bg-bg-card px-5 py-3 rounded-xl"
+    >
       <CollapsibleTrigger asChild>
-        <div className="flex items-center gap-1 w-full mb-5">
+        <div
+          className={cn('flex items-center gap-1 w-full ', open ? 'mb-5' : '')}
+        >
           <div
-            className="group w-[calc(100%-40px)] flex items-center flex-1 gap-2 px-2 py-1 cursor-pointer bg-bg-card rounded-md"
+            className="group w-[calc(100%-40px)] flex items-center flex-1 gap-2 cursor-pointer rounded-md"
             data-testid="instance-name-row"
           >
             <Button
@@ -163,7 +170,10 @@ export function SavedModeCard({
               />
             ) : (
               <div
-                className="text-sm font-medium truncate overflow-hidden flex-1 cursor-text"
+                className={cn(
+                  'text-sm font-medium truncate overflow-hidden flex-1 cursor-text hover:text-text-primary',
+                  open ? 'text-text-primary' : 'text-text-secondary',
+                )}
                 onDoubleClick={(e) => {
                   e.stopPropagation();
                   // startRename();

--- a/web/src/pages/user-setting/setting-model/instance-card/provider-instance-card.tsx
+++ b/web/src/pages/user-setting/setting-model/instance-card/provider-instance-card.tsx
@@ -212,7 +212,7 @@ const GenericProviderInstanceCard = forwardRef<
 
   return (
     <div
-      className="border-b border-border-button mb-5 pb-5"
+      className="mb-5 pb-5"
       data-testid={`instance-card-${instance.instance_name || 'draft'}`}
     >
       {isDraft ? (


### PR DESCRIPTION
### Summary

fix(web): give each provider instance card its own surface

Instance cards were separated only by a bottom border, so the draft and saved variants read as one continuous list rather than distinct cards. Move the card surface onto each variant, and dim the collapsed instance name so the open one stands out.
