### PR TITLE
Fix: Owner filter count not updated after deleting a dataset

### DIFF
--- a/web/src/hooks/use-knowledge-request.ts
+++ b/web/src/hooks/use-knowledge-request.ts
@@ -312,6 +312,9 @@ export const useDeleteKnowledge = () => {
         queryClient.invalidateQueries({
           queryKey: [KnowledgeApiAction.FetchKnowledgeListByPage],
         });
+        queryClient.invalidateQueries({
+          queryKey: [KnowledgeApiAction.FetchDatasetFilter],
+        });
       }
       return data?.data ?? [];
     },


### PR DESCRIPTION
### Summary

On the **Dataset list page** (`/datasets`), after deleting a knowledge base via the card menu, the count shown next to each owner in the **Owner filter** stayed stale until a manual page refresh. The dataset list itself refreshed correctly, so the filter count and the list disagreed (e.g. filter still showed 3 while the list showed Total 2).

**Root cause (frontend only):** `useDeleteKnowledge` in `web/src/hooks/use-knowledge-request.ts` only invalidated the `FetchKnowledgeListByPage` React Query key on success. The Owner filter popover reads from a separate query (`useFetchDatasetFilter`, key `FetchDatasetFilter`, `GET /api/v1/datasets?type=filter`), which was never invalidated, so the popover kept rendering the cached pre-delete counts. The backend filter SQL is correct — the issue screenshot shows only `DELETE` + list refetch requests, with no filter refetch.

**Fix:** also invalidate the `FetchDatasetFilter` query key after a successful delete, so the filter data is refetched together with the list:

```diff
         queryClient.invalidateQueries({
           queryKey: [KnowledgeApiAction.FetchKnowledgeListByPage],
         });
+        queryClient.invalidateQueries({
+          queryKey: [KnowledgeApiAction.FetchDatasetFilter],
+        });
```

**Verification (browser, against `origin/main` baseline):**

- *Before the fix*: open Owner filter (count 3 cached) → delete a dataset → network shows only `DELETE /api/v1/datasets` + list refetch, **no** `datasets?type=filter` request → popover still shows 3 while the list shows Total 2 (bug reproduced, matching the issue's network screenshot).
- *After the fix*: delete a dataset → `DELETE` + list refetch + `datasets?type=filter` refetch (response `count: 1`) → popover automatically shows the correct count 1 without any manual refresh.
- `oxlint` on the changed file: 0 warnings/errors. `tsc --noEmit`: error set identical to the unmodified tree (215 pre-existing errors elsewhere, none in the changed file).

### What problem does this PR solve?

Fixes the stale Owner filter count on the dataset list page after deleting a knowledge base; the count now updates immediately without requiring a manual page refresh.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
