### PR TITLE
fix(parser): stop treating legacy DOC files as DOCX

### DIFF
--- a/rag/app/manual.py
+++ b/rag/app/manual.py
@@ -306,6 +306,8 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
         if table_ctx or image_ctx:
             attach_media_context(res, table_ctx, image_ctx)
         return res
+    elif re.search(r"\.doc$", filename, re.IGNORECASE):
+        raise NotImplementedError("Legacy .doc files are not supported by the Manual parser. Please convert the file to .docx or PDF.")
     else:
         raise NotImplementedError("file type not supported yet(pdf and docx supported)")
 

--- a/rag/app/manual.py
+++ b/rag/app/manual.py
@@ -283,7 +283,7 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
             res[0]["__outline__"] = [{"title": title, "depth": depth} for title, depth, *_ in pdf_parser.outlines]
         return res
 
-    elif re.search(r"\.docx?$", filename, re.IGNORECASE):
+    elif re.search(r"\.docx$", filename, re.IGNORECASE):
         docx_parser = Docx()
         ti_list, tbls = docx_parser(filename, binary, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, callback=callback)
         tbls = vision_figure_parser_docx_wrapper(

--- a/test/unit_test/rag/app/test_manual.py
+++ b/test/unit_test/rag/app/test_manual.py
@@ -1,0 +1,47 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _file_routing_patterns():
+    tree = ast.parse((REPO_ROOT / "rag/app/manual.py").read_text())
+    return [
+        node.args[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "re"
+        and node.func.attr == "search"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ]
+
+
+@pytest.mark.p1
+@pytest.mark.parametrize("filename", ["legacy.doc", "legacy.DOC"])
+def test_legacy_doc_has_no_manual_parser_route(filename):
+    patterns = _file_routing_patterns()
+
+    assert any(re.search(pattern, "document.docx", re.IGNORECASE) for pattern in patterns)
+    assert not any(re.search(pattern, filename, re.IGNORECASE) for pattern in patterns)

--- a/test/unit_test/rag/app/test_manual.py
+++ b/test/unit_test/rag/app/test_manual.py
@@ -44,10 +44,9 @@ def _file_routes():
 def test_legacy_doc_is_rejected_with_conversion_guidance(filename):
     routes = _file_routes()
 
-    assert any(re.search(pattern, "document.docx", re.IGNORECASE) for pattern, _ in routes)
+    assert any(pattern == r"\.docx$" for pattern, _ in routes)
     doc_route = next(node for pattern, node in routes if re.search(pattern, filename, re.IGNORECASE))
     error = next(node for node in doc_route.body if isinstance(node, ast.Raise))
     message = error.exc.args[0].value
 
-    assert ".docx" in message
-    assert "convert" in message.lower()
+    assert message == "Legacy .doc files are not supported by the Manual parser. Please convert the file to .docx or PDF."

--- a/test/unit_test/rag/app/test_manual.py
+++ b/test/unit_test/rag/app/test_manual.py
@@ -22,26 +22,32 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
-def _file_routing_patterns():
+def _file_routes():
     tree = ast.parse((REPO_ROOT / "rag/app/manual.py").read_text())
     return [
-        node.args[0].value
+        (node.test.args[0].value, node)
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == "re"
-        and node.func.attr == "search"
-        and node.args
-        and isinstance(node.args[0], ast.Constant)
-        and isinstance(node.args[0].value, str)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Call)
+        and isinstance(node.test.func, ast.Attribute)
+        and isinstance(node.test.func.value, ast.Name)
+        and node.test.func.value.id == "re"
+        and node.test.func.attr == "search"
+        and node.test.args
+        and isinstance(node.test.args[0], ast.Constant)
+        and isinstance(node.test.args[0].value, str)
     ]
 
 
 @pytest.mark.p1
 @pytest.mark.parametrize("filename", ["legacy.doc", "legacy.DOC"])
-def test_legacy_doc_has_no_manual_parser_route(filename):
-    patterns = _file_routing_patterns()
+def test_legacy_doc_is_rejected_with_conversion_guidance(filename):
+    routes = _file_routes()
 
-    assert any(re.search(pattern, "document.docx", re.IGNORECASE) for pattern in patterns)
-    assert not any(re.search(pattern, filename, re.IGNORECASE) for pattern in patterns)
+    assert any(re.search(pattern, "document.docx", re.IGNORECASE) for pattern, _ in routes)
+    doc_route = next(node for pattern, node in routes if re.search(pattern, filename, re.IGNORECASE))
+    error = next(node for node in doc_route.body if isinstance(node, ast.Raise))
+    message = error.exc.args[0].value
+
+    assert ".docx" in message
+    assert "convert" in message.lower()


### PR DESCRIPTION
Fixes #18621

### What problem does this PR solve?

The Manual parser uses `re.search(r"\.docx?$", filename, re.IGNORECASE)` to select its DOCX parsing path.

Because `x` is optional, this expression matches both `.doc` and `.docx` files. Both formats are consequently passed to `python-docx.Document()`.

Legacy `.doc` files are OLE/CFB compound documents, while `.docx` files are Office Open XML ZIP packages. `python-docx` only supports DOCX packages, so parsing a real legacy DOC file fails with an internal `BadZipFile` or OPC-related exception.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

### Changes

- Restrict the Manual parser's DOCX branch to `.docx` files.
- Keep legacy `.doc` files unsupported by the Manual parser and return actionable guidance to convert them to `.docx` or PDF.
- Add regression coverage for lowercase and uppercase legacy DOC filenames, including the conversion guidance, while confirming that DOCX remains routed.

### Test plan

- [x] `uv run pytest -q test/unit_test/rag/app/test_manual.py`
- [x] `uv run ruff check rag/app/manual.py test/unit_test/rag/app/test_manual.py`
