### PR TITLE
fix(migration): index volume must match the configured DOC_ENGINE

### DIFF
--- a/docker/migration.sh
+++ b/docker/migration.sh
@@ -9,11 +9,22 @@
 set -e  # Exit on any error
 # Instead, we'll handle errors manually for better debugging experience
 
+# Source the index-volume resolver. Sourced here so the rest of the
+# script can use ``get_index_volume_for_engine`` without re-defining it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./migration_volumes.sh
+source "${SCRIPT_DIR}/migration_volumes.sh"
+
 # Default values
 DEFAULT_BACKUP_FOLDER="backup"
 DEFAULT_PROJECT_NAME="docker"
-VOLUME_BASES=("mysql_data" "minio_data" "redis_data" "esdata01")
-BACKUP_FILES=("mysql_backup.tar.gz" "minio_backup.tar.gz" "redis_backup.tar.gz" "es_backup.tar.gz")
+# Index volume is engine-specific; see get_index_volume_for_engine in
+# migration_volumes.sh. VOLUME_BASES and BACKUP_FILES are populated from
+# the configured DOC_ENGINE in main(), after the env is read.
+VOLUME_BASES=("mysql_data" "minio_data" "redis_data")
+BACKUP_FILES=("mysql_backup.tar.gz" "minio_backup.tar.gz" "redis_backup.tar.gz")
+INDEX_VOL_BASE=""
+INDEX_BACKUP_FILE=""
 
 # Build volume names from project name and base names
 build_volume_names() {
@@ -54,7 +65,17 @@ show_help() {
     echo "  - ${DEFAULT_PROJECT_NAME}_mysql_data     (MySQL database)"
     echo "  - ${DEFAULT_PROJECT_NAME}_minio_data     (MinIO object storage)"
     echo "  - ${DEFAULT_PROJECT_NAME}_redis_data     (Redis cache)"
-    echo "  - ${DEFAULT_PROJECT_NAME}_esdata01       (Elasticsearch indices)"
+    echo "  - <index volume>                       (DOC_ENGINE indices; see below)"
+    echo ""
+    echo "INDEX VOLUME BY DOC_ENGINE:"
+    echo "  elasticsearch -> ${DEFAULT_PROJECT_NAME}_esdata01       (file: es_backup.tar.gz)"
+    echo "  opensearch     -> ${DEFAULT_PROJECT_NAME}_osdata01       (file: os_backup.tar.gz)"
+    echo "  infinity       -> ${DEFAULT_PROJECT_NAME}_infinity_data  (file: infinity_backup.tar.gz)"
+    echo "  serenedb       -> ${DEFAULT_PROJECT_NAME}_serenedb_data  (file: serenedb_backup.tar.gz)"
+    echo "  oceanbase / seekdb use bind mounts; index backup is not supported by this script."
+    echo ""
+    echo "DOC_ENGINE is read from the environment (default: elasticsearch). To back up"
+    echo "an Infinity deployment, run e.g.  DOC_ENGINE=infinity $0 backup  ."
     echo ""
     echo "NOTE:"
     echo "  If you started RAGFlow with 'docker compose -p myproject up', the volume"
@@ -314,6 +335,27 @@ main() {
                 ;;
         esac
     done
+
+    # Read DOC_ENGINE from the environment, default elasticsearch. The
+    # index volume and backup file are engine-specific; the other three
+    # (mysql, minio, redis) are engine-independent.
+    DOC_ENGINE="${DOC_ENGINE:-elasticsearch}"
+    local index_spec
+    index_spec="$(get_index_volume_for_engine "$DOC_ENGINE")"
+    if [ -n "$index_spec" ]; then
+        INDEX_VOL_BASE="${index_spec%% *}"
+        INDEX_BACKUP_FILE="${index_spec##* }"
+        VOLUME_BASES=("mysql_data" "minio_data" "redis_data" "$INDEX_VOL_BASE")
+        BACKUP_FILES=("mysql_backup.tar.gz" "minio_backup.tar.gz" "redis_backup.tar.gz" "$INDEX_BACKUP_FILE")
+    else
+        # oceanbase / seekdb: bind-mounted, not a named volume. Skip the
+        # index backup and warn the user that restore will not include
+        # the index data. (Backup files and volumes are aligned so the
+        # restore gate at line ~228 does not complain about a missing
+        # es_backup.tar.gz on these engines.)
+        echo "ℹ️  DOC_ENGINE=$DOC_ENGINE uses bind mounts; index backup is not supported by this script."
+        echo "   Copy docker/oceanbase/data (or docker/seekdb/data) separately to back up the index."
+    fi
 
     # Build volume names based on project name
     build_volume_names

--- a/docker/migration_volumes.sh
+++ b/docker/migration_volumes.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Helper for docker/migration.sh: maps DOC_ENGINE to the index volume and
+# backup-file name, and reports engines that the migration script cannot
+# back up (oceanbase / seekdb use bind mounts, not named volumes).
+#
+# Sourced by both docker/migration.sh (the runtime) and the pytest test
+# test/unit_test/deploy/test_migration_volumes.py (the regression guard).
+# Keep this file's API stable: the test reads the function output as
+# "<volume_base> <backup_file>" (space-separated) and treats an empty
+# stdout as "engine not supported by this script".
+
+# Echoes "<volume_base> <backup_file>" for named-volume engines, or
+# nothing for engines that the migration script cannot back up.
+get_index_volume_for_engine() {
+    local engine="${1:-elasticsearch}"
+    case "$engine" in
+        elasticsearch) echo "esdata01 es_backup.tar.gz" ;;
+        opensearch)     echo "osdata01 os_backup.tar.gz" ;;
+        infinity)       echo "infinity_data infinity_backup.tar.gz" ;;
+        serenedb)       echo "serenedb_data serenedb_backup.tar.gz" ;;
+        oceanbase)      return 0 ;;  # bind mount, skipped
+        seekdb)         return 0 ;;  # bind mount, skipped
+        *)              echo "esdata01 es_backup.tar.gz" ;;  # default fallback
+    esac
+}

--- a/test/unit_test/deploy/test_migration_volumes.py
+++ b/test/unit_test/deploy/test_migration_volumes.py
@@ -1,0 +1,182 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Regression tests for issue #18628.
+
+``docker/migration.sh`` had a hardcoded ``VOLUME_BASES=("mysql_data" "minio_data"
+"redis_data" "esdata01")`` and matching ``BACKUP_FILES`` list. The fourth
+entry (``esdata01`` / ``es_backup.tar.gz``) only matches the default
+``DOC_ENGINE=elasticsearch``; for ``opensearch``, ``infinity`` or
+``serenedb`` the script silently skipped the index volume (because the
+named volume did not exist), printed "Backup completed successfully!" and
+produced a backup set the same script then refused to restore ("Missing
+backup files: es_backup.tar.gz").
+
+The fix reads ``DOC_ENGINE`` from the environment and selects the
+correct index volume / backup file per engine via
+``get_index_volume_for_engine`` in ``docker/migration_volumes.sh``.
+
+These tests source the helper in a sub-bash and pin the mapping for
+every engine (including the bind-mount engines that return empty output
+because the migration script cannot back up their index data).
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATION_VOLUMES_SH = REPO_ROOT / "docker" / "migration_volumes.sh"
+MIGRATION_SH = REPO_ROOT / "docker" / "migration.sh"
+
+
+def _call_get_index_volume(engine: str) -> str:
+    """Source ``migration_volumes.sh`` in a sub-bash and call
+    ``get_index_volume_for_engine`` for the given DOC_ENGINE.
+    Returns the function's stdout (with trailing whitespace stripped).
+    """
+    if not MIGRATION_VOLUMES_SH.is_file():
+        pytest.fail(f"missing helper: {MIGRATION_VOLUMES_SH}")
+    out = subprocess.run(
+        ["bash", "-c", f'source "{MIGRATION_VOLUMES_SH}" && get_index_volume_for_engine "{engine}"'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def _call_migration_help() -> str:
+    """Run ``migration.sh help`` and return stdout.
+
+    The script's ``main()`` calls ``check_docker`` before any
+    operation-dispatch, so this test requires Docker to be available.
+    Skip if not -- the per-engine mapping tests above already cover the
+    helper function in isolation.
+    """
+    if not MIGRATION_SH.is_file():
+        pytest.fail(f"missing script: {MIGRATION_SH}")
+    if shutil.which("bash") is None:
+        pytest.skip("bash is not available on this platform")
+    if shutil.which("docker") is None or subprocess.run(["docker", "info"], capture_output=True, text=True, check=False).returncode != 0:
+        pytest.skip("Docker is not available; migration.sh's main() calls check_docker first")
+    out = subprocess.run(
+        ["bash", str(MIGRATION_SH), "help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return out.stdout + out.stderr
+
+
+# ---------------------------------------------------------------------------
+# Per-engine volume mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("engine", "expected_volume_base", "expected_backup_file"),
+    [
+        ("elasticsearch", "esdata01", "es_backup.tar.gz"),
+        ("opensearch", "osdata01", "os_backup.tar.gz"),
+        ("infinity", "infinity_data", "infinity_backup.tar.gz"),
+        ("serenedb", "serenedb_data", "serenedb_backup.tar.gz"),
+    ],
+)
+def test_named_volume_engines_pick_correct_volume_and_file(engine, expected_volume_base, expected_backup_file):
+    """For every engine that uses a named Docker volume, the function
+    returns the correct ``<volume_base> <backup_file>`` pair.
+    """
+    out = _call_get_index_volume(engine)
+    parts = out.split()
+    assert parts == [expected_volume_base, expected_backup_file], f"DOC_ENGINE={engine!r} should map to {expected_volume_base!r} / {expected_backup_file!r}; got {out!r}"
+
+
+@pytest.mark.parametrize("engine", ["oceanbase", "seekdb"])
+def test_bind_mount_engines_return_empty(engine):
+    """oceanbase and seekdb use bind mounts (not named volumes), so the
+    migration script cannot back up the index data. The function returns
+    empty stdout so the script drops the index entry from its
+    VOLUME_BASES / BACKUP_FILES arrays and the restore gate does not
+    complain about a missing es_backup.tar.gz.
+    """
+    out = _call_get_index_volume(engine)
+    assert out == "", f"DOC_ENGINE={engine!r} uses bind mounts and the migration script should not attempt an index backup; got {out!r}"
+
+
+def test_unknown_engine_falls_back_to_elasticsearch():
+    """An unrecognised DOC_ENGINE value falls back to the elasticsearch
+    mapping (the historical default) so a typo does not silently disable
+    the index backup.
+    """
+    out = _call_get_index_volume("totally-unknown-engine")
+    parts = out.split()
+    assert parts == ["esdata01", "es_backup.tar.gz"]
+
+
+def test_default_engine_is_elasticsearch():
+    """The function defaults to the elasticsearch mapping when called
+    with no argument (mirrors the script's ``${DOC_ENGINE:-elasticsearch}``
+    default).
+    """
+    out = subprocess.run(
+        ["bash", "-c", f'source "{MIGRATION_VOLUMES_SH}" && get_index_volume_for_engine'],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert out.split() == ["esdata01", "es_backup.tar.gz"]
+
+
+# ---------------------------------------------------------------------------
+# migration.sh integration
+# ---------------------------------------------------------------------------
+
+
+def test_migration_sh_help_documents_per_engine_index_volume():
+    """The script's ``help`` output must document the per-DOC_ENGINE
+    index volume mapping so a user running with DOC_ENGINE=infinity
+    knows the right volume / backup file name.
+    """
+    help_text = _call_migration_help()
+    assert "INDEX VOLUME BY DOC_ENGINE" in help_text
+    for engine, vol_base, backup_file in [
+        ("elasticsearch", "esdata01", "es_backup.tar.gz"),
+        ("opensearch", "osdata01", "os_backup.tar.gz"),
+        ("infinity", "infinity_data", "infinity_backup.tar.gz"),
+        ("serenedb", "serenedb_data", "serenedb_backup.tar.gz"),
+    ]:
+        assert vol_base in help_text, f"help text must mention {vol_base} for DOC_ENGINE={engine}; got: {help_text!r}"
+        assert backup_file in help_text, f"help text must mention {backup_file} for DOC_ENGINE={engine}; got: {help_text!r}"
+    assert "oceanbase" in help_text
+    assert "seekdb" in help_text
+    assert "bind mount" in help_text
+
+
+def test_migration_sh_help_no_longer_advertises_esdata01_universally():
+    """Regression guard: pre-fix, the help text listed ``esdata01`` as
+    *the* index volume for every deployment, with no mention of the
+    per-engine mapping. The fix replaces that line with a pointer to the
+    INDEX VOLUME BY DOC_ENGINE table. This test pins that change so a
+    future "fix-up" of the help text does not silently regress.
+    """
+    help_text = _call_migration_help()
+    # The bare line "docker_esdata01       (Elasticsearch indices)" is
+    # the pre-fix universal line. The new help text uses "<index volume>"
+    # in the volume summary and a per-engine table instead.
+    assert "esdata01       (Elasticsearch indices)" not in help_text
+    assert "<index volume>" in help_text


### PR DESCRIPTION
Fixes #18628.

## Summary

`docker/migration.sh` had a hardcoded `VOLUME_BASES=("mysql_data" "minio_data" "redis_data" "esdata01")` and matching `BACKUP_FILES` list. The fourth entry (`esdata01` / `es_backup.tar.gz`) only matches the default `DOC_ENGINE=elasticsearch`; for `opensearch`, `infinity` or `serenedb` the named volume does not exist, the script prints the volume-skip warning and "Backup completed successfully!", and produces a backup set the same script then refuses to restore ("Missing backup files: es_backup.tar.gz").

## Fix

Reads `DOC_ENGINE` from the environment (default `elasticsearch`) and selects the correct index volume / backup file per engine via `get_index_volume_for_engine` in the new `docker/migration_volumes.sh` helper:

| `DOC_ENGINE` | index volume | backup file |
| --- | --- | --- |
| `elasticsearch` | `esdata01` | `es_backup.tar.gz` |
| `opensearch` | `osdata01` | `os_backup.tar.gz` |
| `infinity` | `infinity_data` | `infinity_backup.tar.gz` |
| `serenedb` | `serenedb_data` | `serenedb_backup.tar.gz` |
| `oceanbase` / `seekdb` | (skipped) | (skipped) |
| (unknown) | `esdata01` (fallback) | `es_backup.tar.gz` (fallback) |

`oceanbase` and `seekdb` use bind mounts (`./oceanbase/data:/root/ob` and the seekdb equivalent in `docker-compose-base.yml`), not named volumes, so the script cannot back up the index data. The function returns empty stdout for those engines and the script drops the index entry from its arrays — `VOLUME_BASES` has 3 entries (mysql, minio, redis) and the restore gate at the missing-files check does not complain about a phantom `es_backup.tar.gz`. The script prints a single-line warning so a user with a bind-mount engine knows to copy `docker/oceanbase/data` separately.

`docker/migration_volumes.sh` is a pure helper sourced by both the script and the test. The fix does not change the three engine-independent entries (`mysql_data`, `minio_data`, `redis_data`).

## Test

Ten regression tests in `test/unit_test/deploy/test_migration_volumes.py`:

- parametrized over 4 named-volume engines: `get_index_volume_for_engine` returns the correct `<volume_base> <backup_file>` pair.
- parametrized over 2 bind-mount engines (`oceanbase`, `seekdb`): function returns empty stdout so the script drops the index entry.
- unknown engine falls back to elasticsearch.
- default (no argument) maps to elasticsearch.
- 2 integration tests on the script's `help` output (Docker-gated, skipped when Docker is not available): the help text documents the per-engine mapping, and the pre-fix universal "docker_esdata01 (Elasticsearch indices)" line is gone.

Verified pre-fix behaviour: with the helper file removed, all 8 unit tests fail with `missing helper: docker/migration_volumes.sh`. With the fix applied, 8 tests pass and 2 are Docker-gated. `bash -n` validates both shell scripts. ruff check + format clean.

## Risks

- `DOC_ENGINE` is read from the environment. A user who upgrades and continues to set `DOC_ENGINE=elasticsearch` (the default) sees no change in behaviour.
- A user who sets `DOC_ENGINE` to a value the helper does not know (`DOC_ENGINE=customengine`) falls back to the elasticsearch mapping — the same volume is checked, and if the user has not actually set up elasticsearch, the existing skip warning fires. The fallback is intentional: a typo should not silently disable the index backup.
- The `oceanbase` / `seekdb` skip path is a behaviour change. A user on those engines now sees a clear "index backup is not supported by this script" warning instead of a misleading "Backup completed successfully!" message. The script's help text documents the limitation.

## Related

`docker/.env` line 21: `DOC_ENGINE=${DOC_ENGINE:-elasticsearch}`. The script now honours this same env convention. The `infinity` / `serenedb` / `opensearch` / `oceanbase` / `seekdb` branches are pre-existing in `docker-compose-base.yml` (lines 124-161) and `.env`.
