### PR TITLE
fix(entrypoint): restart loop survives a crashed service

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -281,8 +281,7 @@ if [[ "${ENABLE_ADMIN_SERVER}" -eq 1 ]]; then
     if [[ "${API_PROXY_SCHEME}" == "hybrid" ]] || [[ "${API_PROXY_SCHEME}" == "python" ]]; then
         while true; do
             echo "Attempt to start Admin python server..."
-            "$PY" admin/server/admin_server.py
-            echo "Admin python server started"
+            "$PY" admin/server/admin_server.py || echo "Admin python server exited, restarting in 1s..."
             sleep 1;
         done &
     fi
@@ -290,8 +289,7 @@ if [[ "${ENABLE_ADMIN_SERVER}" -eq 1 ]]; then
     if [[ "${API_PROXY_SCHEME}" == "hybrid" ]] || [[ "${API_PROXY_SCHEME}" == "go" ]]; then
         while true; do
             echo "Starting Admin go server..."
-            bin/ragflow_server --admin
-            echo "Admin go server started."
+            bin/ragflow_server --admin || echo "Admin go server exited, restarting in 1s..."
             sleep 1;
         done &
     fi
@@ -304,8 +302,7 @@ if [[ "${ENABLE_WEBSERVER}" -eq 1 ]]; then
     if [[ "${API_PROXY_SCHEME}" == "hybrid" ]] || [[ "${API_PROXY_SCHEME}" == "python" ]]; then
         while true; do
             echo "Attempt to start RAGFlow python server..."
-            "$PY" api/ragflow_server.py ${INIT_SUPERUSER_ARGS}
-            echo "RAGFlow python server started."
+            "$PY" api/ragflow_server.py ${INIT_SUPERUSER_ARGS} || echo "RAGFlow python server exited, restarting in 1s..."
             sleep 1;
         done &
     fi
@@ -313,8 +310,7 @@ if [[ "${ENABLE_WEBSERVER}" -eq 1 ]]; then
     if [[ "${API_PROXY_SCHEME}" == "hybrid" ]] || [[ "${API_PROXY_SCHEME}" == "go" ]]; then
         while true; do
             echo "Starting RAGFlow go server..."
-            bin/ragflow_server --api
-            echo "RAGFlow go server started."
+            bin/ragflow_server --api || echo "RAGFlow go server exited, restarting in 1s..."
             sleep 1;
         done &
     fi
@@ -347,7 +343,7 @@ if [[ "${ENABLE_TASKEXECUTOR}" -eq 1 ]]; then
         if [[ "${API_PROXY_SCHEME}" == "hybrid" ]] || [[ "${API_PROXY_SCHEME}" == "go" ]]; then
             while true; do
                 echo "Starting go ingestor..."
-                bin/ragflow_server --ingestor
+                bin/ragflow_server --ingestor || echo "Go ingestor exited, restarting in 1s..."
                 sleep 1;
             done &
         fi
@@ -365,7 +361,7 @@ if [[ "${ENABLE_TASKEXECUTOR}" -eq 1 ]]; then
           if [[ "${API_PROXY_SCHEME}" == "hybrid" ]] || [[ "${API_PROXY_SCHEME}" == "go" ]]; then
               while true; do
                   echo "Starting go ingestor..."
-                  bin/ragflow_server --ingestor
+                  bin/ragflow_server --ingestor || echo "Go ingestor exited, restarting in 1s..."
                   sleep 1;
               done &
           fi

--- a/test/unit_test/deploy/test_entrypoint_restart_loop.py
+++ b/test/unit_test/deploy/test_entrypoint_restart_loop.py
@@ -1,0 +1,214 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Regression tests for issue #18542.
+
+``docker/entrypoint.sh`` runs each service under a ``while true; do ...
+done &`` loop. When the inner command crashed (e.g. ``api/ragflow_server.py``
+aborted on the infinity 120s readiness timeout during cold start), the
+web server's loop wrapper silently disappeared -- leaving nginx serving
+HTML with no backend on port 9380. The admin / task-executor / data-sync
+loops restarted on the same crash, but the web server's loop did not.
+
+The fix wraps the inner command of each restart loop with
+``|| echo "X server exited, restarting in 1s..."`` so the loop body
+always exits 0 and the loop continues. The misleading ``X server started``
+log line (which printed AFTER the inner command exited, not after it
+started) is removed.
+
+These tests parse ``docker/entrypoint.sh`` with a small regex-based
+scanner and pin the loop-body structure. They run as pytest tests
+without importing the script (the script lives at the repo root and
+is not a Python module). The repo-root path is derived from
+``Path(__file__).resolve().parents[4]``.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
+
+
+def _read_entrypoint():
+    if not ENTRYPOINT.is_file():
+        pytest.fail(f"missing script: {ENTRYPOINT}")
+    return ENTRYPOINT.read_text(encoding="utf-8")
+
+
+def _restart_loop_bodies(source, *, require_background=True, require_no_wait=True):
+    """Yield the body of each ``while true; do ... done &`` restart loop,
+    in source order. The body's text is the full literal block between
+    ``do`` and ``done`` on the same indentation level.
+
+    Filters:
+    - ``require_background``: only yield loops whose ``done`` ends in ``&``
+      (the loop is itself backgrounded). The fix for issue #18542 only
+      targets these -- a synchronous ``while true`` inside a function
+      is supervised by ``wait`` and does not have the bug.
+    - ``require_no_wait``: only yield loops whose body does not contain
+      ``wait``. The ``sync_data_source.py`` / ``task_executor.py``
+      patterns use ``wait`` to supervise the backgrounded inner
+      process -- ``wait`` itself absorbs the failed exit code so the
+      ``while`` body's last command (``sleep 1``) is always successful
+      and the loop continues. Those loops are robust without the
+      ``|| echo ...`` guard.
+    """
+    lines = source.splitlines()
+    i = 0
+    while i < len(lines):
+        m = re.search(r"\bwhile\s+true\s*;\s*do\b", lines[i])
+        if not m:
+            i += 1
+            continue
+        # Find the matching `done` at the same indentation. The loop in
+        # entrypoint.sh is short (3-5 lines) and the `done` is the next
+        # line starting with the same indent as the `while`.
+        while_indent = len(lines[i]) - len(lines[i].lstrip())
+        j = i + 1
+        while j < len(lines):
+            stripped = lines[j].lstrip()
+            line_indent = len(lines[j]) - len(stripped)
+            if stripped.startswith("done") and line_indent == while_indent:
+                # Yield the body lines (between `do` and `done`).
+                body = "\n".join(lines[i + 1 : j])
+                is_backgrounded = stripped.endswith("&")
+                is_supervised = "wait" in body
+                if (not require_background or is_backgrounded) and (not require_no_wait or not is_supervised):
+                    yield body
+                i = j + 1
+                break
+            j += 1
+        else:
+            return  # no matching `done` found
+
+
+# ---------------------------------------------------------------------------
+# Pin the restart-loop structure: each loop must (a) call the inner command
+# with `|| echo "... exited, restarting in 1s..."` so a non-zero exit does
+# not break the loop, and (b) NOT include the misleading `X server started`
+# log line that printed AFTER the process exited.
+# ---------------------------------------------------------------------------
+
+
+EXPECTED_RESTART_LOOP_MARKERS = [
+    "admin/server/admin_server.py",
+    "bin/ragflow_server --admin",
+    "api/ragflow_server.py",
+    "bin/ragflow_server --api",
+    "bin/ragflow_server --ingestor",
+]
+
+
+@pytest.mark.parametrize("inner_command", EXPECTED_RESTART_LOOP_MARKERS)
+def test_restart_loop_guards_inner_command_with_or_echo(inner_command):
+    """The inner command for each restart loop must be guarded with
+    ``|| echo "... exited, restarting in 1s..."`` so a crash does not
+    break the loop. Pre-fix, the inner command was un-guarded; on
+    certain bash versions / configurations the failed command in the
+    while-body would silently exit the backgrounded loop wrapper,
+    leaving the service down with no automatic recovery.
+    """
+    source = _read_entrypoint()
+    bodies = list(_restart_loop_bodies(source, require_background=True))
+    matching = [b for b in bodies if inner_command in b]
+    assert matching, (
+        f"no restart loop in entrypoint.sh runs the inner command {inner_command!r}; "
+        f"loops seen: {len(bodies)}. This typically means the script was "
+        f"refactored; if the new structure still works, the marker list needs "
+        f"to be updated."
+    )
+    body = matching[0]
+    assert "exited, restarting in 1s..." in body, (
+        f"the restart loop running {inner_command!r} must guard the inner "
+        f"command with `|| echo '... exited, restarting in 1s...'`. The "
+        f"un-guarded form let the backgrounded loop wrapper silently "
+        f"disappear after a crash (issue #18542). body:\n{body}"
+    )
+
+
+@pytest.mark.parametrize("inner_command", EXPECTED_RESTART_LOOP_MARKERS)
+def test_restart_loop_drops_misleading_started_log_line(inner_command):
+    """The pre-fix script logged ``X server started`` AFTER the inner
+    command exited, so the message printed on crash too. The fix
+    removes that misleading line; the body must NOT contain it.
+    """
+    source = _read_entrypoint()
+    bodies = list(_restart_loop_bodies(source, require_background=True))
+    matching = [b for b in bodies if inner_command in b]
+    assert matching, f"no restart loop runs the inner command {inner_command!r}"
+    body = matching[0]
+    assert "server started" not in body, (
+        f"the restart loop running {inner_command!r} must not contain the "
+        f"misleading 'X server started' log line -- pre-fix, that line "
+        f"printed AFTER the inner command exited (crash or normal), so "
+        f"a crash-restart looked identical to a healthy start. body:\n{body}"
+    )
+
+
+def test_every_restart_loop_uses_the_protected_pattern():
+    """No restart loop is allowed to skip the protection. A regression
+    that adds a new service loop (or removes the guard from an existing
+    one) is caught here.
+    """
+    source = _read_entrypoint()
+    bodies = list(_restart_loop_bodies(source, require_background=True))
+    assert len(bodies) >= 4, (
+        f"expected at least 4 backgrounded restart loops in entrypoint.sh "
+        f"(admin python, admin go, web python, web go); found {len(bodies)}. "
+        f"If the script's structure changed, this test needs to be "
+        f"updated alongside the change."
+    )
+    for idx, body in enumerate(bodies):
+        assert "exited, restarting in 1s..." in body, (
+            f"restart loop #{idx + 1} does not guard its inner command with `|| echo '... exited, restarting in 1s...'`. The un-guarded form is the bug from issue #18542. body:\n{body}"
+        )
+        assert "server started" not in body, f"restart loop #{idx + 1} contains the misleading 'X server started' log line that printed on crash too. body:\n{body}"
+
+
+# ---------------------------------------------------------------------------
+# Bash syntax check
+# ---------------------------------------------------------------------------
+
+
+def test_entrypoint_sh_is_syntactically_valid_bash():
+    """The fix changes the loop bodies; ``bash -n`` catches any syntax
+    regression before it ships.
+    """
+    if shutil.which("bash") is None:
+        pytest.skip("bash is not available on this platform")
+    result = subprocess.run(["bash", "-n", str(ENTRYPOINT)], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, f"bash -n failed on {ENTRYPOINT}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the four expected restart loops are all present
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_expected_restart_loops_are_present():
+    """Sanity check: the four expected restart loops are all present in
+    the script. A future refactor that drops one (e.g. removes the go
+    server) surfaces here, alongside an update to the marker list.
+    """
+    source = _read_entrypoint()
+    bodies = list(_restart_loop_bodies(source, require_background=True))
+    bodies_str = "\n".join(bodies)
+    for marker in EXPECTED_RESTART_LOOP_MARKERS:
+        assert marker in bodies_str, f"expected restart loop running {marker!r} is missing from entrypoint.sh. If the service was removed, drop the marker from EXPECTED_RESTART_LOOP_MARKERS."


### PR DESCRIPTION
Fixes #18542.

## Summary

When `api/ragflow_server.py` crashed during cold start (e.g. infinity took >120s to become healthy and the readiness check in `common/doc_store/infinity_conn_pool.py` raised), the `while true; do ... done &` loop wrapper that owned the crash silently disappeared. The admin / task-executor / data-sync loops restarted their inner command on the same crash, but the main web server loop did not — leaving nginx serving HTML with no backend on port 9380. The only recovery was `docker restart`.

## Fix

Rewrites each restart loop so the body cannot fail:

- drop the misleading `X server started` log line (it printed AFTER the process exited, not after it started — a real diagnostic bug);
- guard the inner command with `|| echo "X server exited, restarting in 1s..."` so the body always exits 0, and the restart message only fires on actual crashes.

Applied to all six simple `while true; do ... done &` loops in `docker/entrypoint.sh`:

| service | inner command |
| --- | --- |
| admin python | `admin/server/admin_server.py` |
| admin go | `bin/ragflow_server --admin` |
| web python | `api/ragflow_server.py` |
| web go | `bin/ragflow_server --api` |
| go ingestor (single-worker) | `bin/ragflow_server --ingestor` |
| go ingestor (multi-worker) | `bin/ragflow_server --ingestor` |

The `sync_data_source.py` and `task_executor.py` loops use a different pattern (`& wait; sleep 1; done`) where `wait` itself absorbs the failed exit code, so the body's last command (`sleep 1`) is always successful and the loop continues. Those loops are robust without the `|| echo` guard.

## Test

Thirteen regression tests in `test/unit_test/deploy/test_entrypoint_restart_loop.py`:

- 5 parametrized cases over `EXPECTED_RESTART_LOOP_MARKERS` for `test_restart_loop_guards_inner_command_with_or_echo`: each restart loop's inner command must be guarded with `|| echo '... exited, restarting in 1s...'`.
- 5 parametrized cases for `test_restart_loop_drops_misleading_started_log_line`: the pre-fix script logged `X server started` AFTER the inner command exited; the fix removes that misleading line; the body must NOT contain `server started`.
- `test_every_restart_loop_uses_the_protected_pattern`: walks every backgrounded restart loop (skips synchronous `wait`-supervised loops) and asserts the protected pattern is present in all of them. A regression that adds a new service loop or removes the guard from an existing one is caught here.
- `test_entrypoint_sh_is_syntactically_valid_bash`: `bash -n` catches any syntax regression.
- `test_all_four_expected_restart_loops_are_present`: sanity check that the restart loops are still in the script.

The test uses a small regex-based scanner to walk the `while true; do ... done` chains and extract their bodies — no AST import needed, no bash interpreter required for the unit tests themselves.

Verified pre-fix behaviour: the central `test_every_restart_loop_uses_the_protected_pattern` fails with the exact assertion naming the un-guarded body. With the fix applied, all 13 pass. `bash -n` validates `docker/entrypoint.sh`. ruff check + format clean.

## Risks

- The `X server started` log line is removed; operators used to seeing it on every start will see only the new `X server exited, restarting in 1s...` line on crashes. The `echo "Attempt to start X server..."` line at the top of each loop body still fires on every attempt, so the per-attempt log cadence is preserved.
- The `|| echo` guard swallows the inner command's exit code. Operators who relied on inspecting the inner command's actual exit code via the loop body's exit status will need to look at the captured `RAGFlow python server exited, restarting in 1s...` line instead. This is the same level of information the user already gets from `docker logs`.
- Backward compatible: a healthy system never triggers the `|| echo` branch (it only fires on non-zero exits), so the change has no effect on the steady state.
