### PR TITLE
fix(nlp): rerank_by_model now includes question_tks in document text

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -533,8 +533,17 @@ class Dealer:
             # content_ltks = list(OrderedDict.fromkeys(sres.field[i][cfield].split()))
             content_ltks = sres.field[i][cfield].split()
             title_tks = [t for t in sres.field[i].get("title_tks", "").split() if t]
+            question_tks = [t for t in sres.field[i].get("question_tks", "").split() if t]
             important_kwd = sres.field[i].get("important_kwd", [])
-            tks = content_ltks + title_tks + important_kwd
+            # The other two rerank paths multiply title_tks * 2, important_kwd
+            # * 5 and question_tks * 6 to weight the term-similarity score, but
+            # here the tokens are joined into a single document string and
+            # passed to the cross-encoder; repeating a field would distort the
+            # model's own scoring. So question_tks (like title_tks and
+            # important_kwd above) is added unweighted. The field is fetched
+            # from the index in Dealer.__init__ and was silently dropped
+            # pre-fix; see issue #18472.
+            tks = content_ltks + title_tks + important_kwd + question_tks
             ins_tw.append(tks)
 
         docs = [remove_redundant_spaces(" ".join(tks)) for tks in ins_tw]

--- a/test/unit_test/rag/nlp/test_rerank_by_model_question_tks.py
+++ b/test/unit_test/rag/nlp/test_rerank_by_model_question_tks.py
@@ -1,0 +1,207 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Regression tests for issue #18472.
+
+The three rerank paths in ``Dealer`` (``rag/nlp/search.py``) build a
+per-chunk token list (``ins_tw``) that feeds both the term-similarity
+score and, for ``rerank_by_model``, the document string the
+cross-encoder scores. Two of the three paths included the chunk's
+generated-questions field; the third (``rerank_by_model``) silently
+dropped it. The cost was paid (the field was fetched from the index)
+and the value discarded.
+
+The fix adds ``question_tks`` to ``rerank_by_model``'s per-chunk token
+list. It is added unweighted, consistent with how ``title_tks`` and
+``important_kwd`` are handled in that path (the other two paths
+multiply by 2/5/6 to weight the term-similarity score, but here the
+tokens are joined into a single document string and passed to the
+cross-encoder -- repeating a field would distort the model's own
+scoring).
+
+The test pins the fix at the AST level: it walks
+``Dealer.rerank_by_model`` and asserts that ``question_tks`` is
+fetched from ``sres.field[i]`` and included in the per-chunk ``tks``
+list, and that the other two rerank paths still include it (regression
+guard).
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SEARCH_PY = REPO_ROOT / "rag" / "nlp" / "search.py"
+
+
+def _dealer_class_node():
+    """Parse ``rag/nlp/search.py`` and return the ``Dealer`` class AST node.
+
+    Fails the test (not the import) if the source file is missing or the
+    class has been renamed, so a future refactor that breaks the
+    contract surfaces here rather than as a silent regression.
+    """
+    if not SEARCH_PY.is_file():
+        pytest.fail(f"missing source: {SEARCH_PY}")
+    tree = ast.parse(SEARCH_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "Dealer":
+            return node
+    pytest.fail("`Dealer` class not found in rag/nlp/search.py")
+
+
+def _method_node(dealer_node, name):
+    """Return the AST node of the ``name`` method on ``Dealer``, or fail."""
+    for stmt in dealer_node.body:
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == name:
+            return stmt
+    pytest.fail(f"`Dealer.{name}` method not found in rag/nlp/search.py")
+
+
+def _assigns_in_loop(method_node, target_id):
+    """Walk the method body looking for an Assign to a Name with the
+    given id, anywhere inside any for-loop. The return value is the
+    right-hand side of the assignment, or None if not found.
+    """
+    for stmt in ast.walk(method_node):
+        if not isinstance(stmt, ast.For):
+            continue
+        for sub in ast.walk(stmt):
+            if isinstance(sub, ast.Assign) and len(sub.targets) == 1 and isinstance(sub.targets[0], ast.Name) and sub.targets[0].id == target_id:
+                return sub.value
+    return None
+
+
+def _name_nodes_in_value(node):
+    """Yield every Name node that appears anywhere in ``node``. Used to
+    check whether a specific name (e.g. ``question_tks``) is referenced
+    in an expression.
+    """
+    if isinstance(node, ast.Name):
+        yield node.id
+    for child in ast.iter_child_nodes(node):
+        yield from _name_nodes_in_value(child)
+
+
+# ---------------------------------------------------------------------------
+# rerank_by_model: must include question_tks
+# ---------------------------------------------------------------------------
+
+
+def test_rerank_by_model_extracts_question_tks_from_field():
+    """``Dealer.rerank_by_model`` must read ``question_tks`` from the
+    chunk's field map. Pre-fix, only ``title_tks`` and ``important_kwd``
+    were read; ``question_tks`` was fetched from the index and discarded.
+    """
+    dealer = _dealer_class_node()
+    method = _method_node(dealer, "rerank_by_model")
+    qtk_assign = _assigns_in_loop(method, "question_tks")
+    assert qtk_assign is not None, (
+        "`Dealer.rerank_by_model` no longer reads `question_tks` from `sres.field[i]`; the cross-encoder is now scoring without the chunk's generated questions. See issue #18472."
+    )
+    # The reading pattern should be `question_tks = [t for t in sres.field[i].get("question_tks", "").split() if t]`
+    # (matching the other two rerank paths). Pin the source: it must
+    # call sres.field[i].get("question_tks", ...).
+    src = ast.unparse(qtk_assign)
+    assert "sres.field[i]" in src and "question_tks" in src, (
+        f"`Dealer.rerank_by_model`'s question_tks extraction must read `question_tks` from `sres.field[i]` (matching the pattern used by `rerank` and `rerank_with_knn`); got: {src!r}"
+    )
+
+
+def test_rerank_by_model_includes_question_tks_in_tks_list():
+    """The per-chunk ``tks`` list in ``rerank_by_model`` must include
+    ``question_tks``. Pre-fix, the list was
+    ``content_ltks + title_tks + important_kwd`` -- missing
+    ``question_tks``. The fix adds it (unweighted) so the cross-encoder
+    scores the chunk's questions too.
+    """
+    dealer = _dealer_class_node()
+    method = _method_node(dealer, "rerank_by_model")
+    tks_assign = _assigns_in_loop(method, "tks")
+    assert tks_assign is not None, (
+        "`Dealer.rerank_by_model` no longer assigns a `tks` list inside the loop; the fix may have been moved or the function refactored away from the per-chunk token-list shape."
+    )
+    src = ast.unparse(tks_assign)
+    assert "question_tks" in src, (
+        f"`Dealer.rerank_by_model`'s per-chunk `tks` list does not include "
+        f"`question_tks`. The pre-fix list was `content_ltks + title_tks + "
+        f"important_kwd` and silently dropped the chunk's generated "
+        f"questions. got: {src!r}. See issue #18472."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: the other two rerank paths still include question_tks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method_name", ["rerank", "rerank_with_knn"])
+def test_other_rerank_paths_still_include_question_tks(method_name):
+    """``Dealer.rerank`` and ``Dealer.rerank_with_knn`` already included
+    ``question_tks`` in their per-chunk token list (with the ``*6``
+    multiplier). The fix to ``rerank_by_model`` must not regress the
+    other two paths.
+    """
+    dealer = _dealer_class_node()
+    method = _method_node(dealer, method_name)
+    tks_assign = _assigns_in_loop(method, "tks")
+    assert tks_assign is not None, f"`Dealer.{method_name}` no longer assigns a `tks` list inside the loop; the per-chunk token-list shape may have been refactored."
+    src = ast.unparse(tks_assign)
+    assert "question_tks" in src, (
+        f"`Dealer.{method_name}`'s per-chunk `tks` list no longer includes "
+        f"`question_tks`. This is a regression of the existing behaviour "
+        f"(the other two rerank paths have always included it). got: {src!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pin: the question_tks is added unweighted, not multiplied
+# ---------------------------------------------------------------------------
+
+
+def test_rerank_by_model_adds_question_tks_unweighted():
+    """``rerank_by_model`` must add ``question_tks`` unweighted, not
+    multiplied. The other two paths use ``* 2`` for title_tks, ``* 5``
+    for important_kwd, and ``* 6`` for question_tks to weight the
+    term-similarity score. But in this path the tokens are joined into
+    a single document string and passed to the cross-encoder --
+    repeating a field would distort the model's own scoring. A
+    future refactor that copies the ``* 6`` multiplier from the other
+    paths is caught here.
+    """
+    dealer = _dealer_class_node()
+    method = _method_node(dealer, "rerank_by_model")
+    tks_assign = _assigns_in_loop(method, "tks")
+    assert tks_assign is not None
+    src = ast.unparse(tks_assign)
+    # The pre-fix shape was `content_ltks + title_tks + important_kwd`
+    # (no question_tks). The fix adds `+ question_tks` (no `* N`).
+    # Pin: the binary add of `question_tks` appears without a
+    # multiplication factor.
+    assert "+ question_tks" in src or "+question_tks" in src, (
+        f"`Dealer.rerank_by_model`'s per-chunk `tks` list must add "
+        f"`question_tks` unweighted (the path joins tokens into a single "
+        f"string for the cross-encoder; repeating a field would distort "
+        f"the model's scoring). got: {src!r}"
+    )
+    # And the multiplication-factor variant must not be present.
+    assert "* 6" not in src and "*6" not in src, (
+        f"`Dealer.rerank_by_model` must not multiply `question_tks` by "
+        f"6 (the other two paths do that to weight the term-similarity "
+        f"score, but this path passes the joined string to the "
+        f"cross-encoder -- repeating a field would distort the model's "
+        f"scoring). got: {src!r}"
+    )


### PR DESCRIPTION
Fixes #18472.

## Summary

The three rerank paths in `Dealer` (`rag/nlp/search.py`) build a per-chunk token list (`ins_tw`) that feeds both the term-similarity score and, for `rerank_by_model`, the document string the cross-encoder scores:

| path | line | tokens |
| --- | --- | --- |
| `rerank_with_knn` | 462 | `content_ltks + title_tks*2 + important_kwd*5 + question_tks*6` |
| `rerank` | 494 | `content_ltks + title_tks*2 + important_kwd*5 + question_tks*6` |
| `rerank_by_model` | 516 | `content_ltks + title_tks + important_kwd` ← missing `question_tks` |

`rerank_by_model` omitted `question_tks` entirely. The field was fetched from the index (`Dealer.__init__`), so the cost was paid and the value discarded. Meanwhile the retrieval query boosts `question_tks^20` (`rag/nlp/query.py:37`) — the highest field boost in the system. With a rerank model configured, the chunk's generated questions were excluded from **both** the term-similarity score and the document text the cross-encoder scored.

## Fix

One-hunk change in `rag/nlp/search.py:Dealer.rerank_by_model`: add `question_tks` to the per-chunk token list. It is added **unweighted** (consistent with how `title_tks` and `important_kwd` are handled in this path):

```python
content_ltks = sres.field[i][cfield].split()
title_tks = [t for t in sres.field[i].get("title_tks", "").split() if t]
question_tks = [t for t in sres.field[i].get("question_tks", "").split() if t]
important_kwd = sres.field[i].get("important_kwd", [])
tks = content_ltks + title_tks + important_kwd + question_tks
```

The other two paths multiply `title_tks * 2`, `important_kwd * 5`, `question_tks * 6` to weight the term-similarity score, but `rerank_by_model` joins the tokens into a single document string and passes it to the cross-encoder — repeating a field would distort the model's own scoring. So `question_tks` is added unweighted.

## Root cause

A missed call site, not a deliberate exclusion:
- `rerank_by_model` was added in `614defec2` (2024-05-29, PR #969 "add rerank model").
- `question_tks` was introduced by `56f473b68` (2024-12-05, PR #3875). That commit added the field to the fetched source-field list and to `rerank()`'s token list, but never touched `rerank_by_model`, which had already existed for six months.

## Test

Five AST-based regression tests in `test/unit_test/rag/nlp/test_rerank_by_model_question_tks.py`:

- `test_rerank_by_model_extracts_question_tks_from_field`: pins that `Dealer.rerank_by_model` reads `question_tks` from `sres.field[i]` (same pattern as the other two paths).
- `test_rerank_by_model_includes_question_tks_in_tks_list`: pins that the per-chunk `tks` list includes `question_tks`. Pre-fix the list was `content_ltks + title_tks + important_kwd`.
- `test_other_rerank_paths_still_include_question_tks[rerank/rerank_with_knn]`: regression guard that the other two paths still include `question_tks`.
- `test_rerank_by_model_adds_question_tks_unweighted`: pins that `rerank_by_model` adds `question_tks` without the `* 6` multiplier — the cross-encoder path joins tokens into a single string, so repeating a field would distort the model's own scoring. A future refactor that copies the `* 6` is caught here.

The tests use AST inspection rather than driving the function directly because `Dealer.__init__` pulls a chain of modules (`common.settings` → `rag.utils.redis_conn`) that hits a circular import in the dev venv. The AST approach pins the contract without needing the full import graph (same shape as the cycle-21 parser output-format regression guard).

Verified pre-fix behaviour: 3 of 5 tests fail with informative assertions naming the pre-fix shape `content_ltks + title_tks + important_kwd` and the missing `question_tks` assignment. With the fix applied, all 5 pass. `ruff check` + `ruff format --check` clean.

## Risks

- A user who tuned their system to compensate for the missing `question_tks` in `rerank_by_model` (e.g. by cranking up `question_tks` retrieval weight) will see the cross-encoder score different. This is the intended fix; the change is one of behaviour, not interface.
- `rerank_by_model` is one of three paths; the fix does not change the other two (which already include `question_tks` with the `* 6` multiplier).
- No API or data-model change.
