### PR TITLE
fix: precompile regexes on the retrieval hot path

### DIFF
--- a/internal/service/nlp/query_builder.go
+++ b/internal/service/nlp/query_builder.go
@@ -45,6 +45,30 @@ type QueryBuilder struct {
 	synonym     *Synonym
 }
 
+// Precompiled regexes. Compiling these per-call on the retrieval hot path
+// (Go's regexp.MustCompile / regexp.MatchString has no cache) wastes a full
+// parse+compile on every token/term. All patterns below are compile-time
+// constants, so they are compiled once at package init.
+var (
+	reEngAlpha       = regexp.MustCompile(`^[a-zA-Z]+$`)
+	reSubSpecialChar = regexp.MustCompile(`([:{}/\[\]\-\*"\(\)\|\+~\^])`)
+	reStopWordsZH    = regexp.MustCompile(`(?i)是*(怎么办|什么样的|哪家|一下|那家|请问|啥样|咋样了|什么时候|何时|何地|何人|是否|是不是|多少|哪里|怎么|哪儿|怎么样|如何|哪些|是啥|啥是|啊|吗|呢|吧|咋|什么|有没有|呀|谁|哪位|哪个)是*`)
+	reStopWordsEN1   = regexp.MustCompile(`(?i)(^| )(what|who|how|which|where|why)('re|'s)? `)
+	reStopWordsEN2   = regexp.MustCompile(`(?i)(^| )('s|'re|is|are|were|was|do|does|did|don't|doesn't|didn't|has|have|be|there|you|me|your|my|mine|just|please|may|i|should|would|wouldn't|will|won't|done|go|for|with|so|the|a|an|by|i'm|it's|he's|she's|they|they're|you're|as|by|on|in|at|up|out|down|of|to|or|and|if) `)
+	reEngZhNum       = regexp.MustCompile(`([A-Za-z]+[0-9]*)([\x{4e00}-\x{9fa5}]+)`)
+	reEngZh          = regexp.MustCompile(`([A-Za-z])([\x{4e00}-\x{9fa5}]+)`)
+	reZhEngNum       = regexp.MustCompile(`([\x{4e00}-\x{9fa5}]+)([A-Za-z]+[0-9]*)`)
+	reZhEng          = regexp.MustCompile(`([\x{4e00}-\x{9fa5}]+)([A-Za-z])`)
+	reSimpleToken    = regexp.MustCompile(`^[0-9a-z\.\+#_\*-]+$`)
+	rePunct          = regexp.MustCompile(`[ :|\r\n\t,，.。?？/\` + "`" + `!！&^%()\[\]{}<>*~'"\\]+`)
+	reCleanQuote     = regexp.MustCompile(`[ \"'^]+`)
+	reSingleChar     = regexp.MustCompile(`^[a-z0-9]$`)
+	reLeadSign       = regexp.MustCompile(`^[\+\-]+`)
+	reQuerySpecial   = regexp.MustCompile(`[.^+\(\)-]`)
+	reSpecialChar    = regexp.MustCompile(`[,\.\/;'\[\]\\\` + "`" + `~!@#$%\^&\*\(\)=\+_<>\?:"\{\}\|，。；'‘’【】、！￥……（）——《》？："""-]+`)
+	reCleanTerm      = regexp.MustCompile(`[ \"']+`)
+)
+
 // InitQueryBuilder initializes the global QueryBuilder with the given wordnet directory.
 // It should be called during the initialization phase of main.go, after tokenizer.Init.
 // The wordnetDir is typically filepath.Join(tokenizer.Config.DictPath, "wordnet")
@@ -108,7 +132,7 @@ func (qb *QueryBuilder) IsChinese(line string) bool {
 	}
 	nonAlpha := 0
 	for _, f := range fields {
-		matched, _ := regexp.MatchString(`^[a-zA-Z]+$`, f)
+		matched := reEngAlpha.MatchString(f)
 		if !matched {
 			nonAlpha++
 		}
@@ -119,26 +143,25 @@ func (qb *QueryBuilder) IsChinese(line string) bool {
 // SubSpecialChar escapes special characters for use in queries.
 func (qb *QueryBuilder) SubSpecialChar(line string) string {
 	// Regex matches : { } / [ ] - * " ( ) | + ~ ^ and prepends backslash
-	re := regexp.MustCompile(`([:{}/\[\]\-\*"\(\)\|\+~\^])`)
-	return re.ReplaceAllString(line, `\$1`)
+	return reSubSpecialChar.ReplaceAllString(line, `\$1`)
 }
 
 // RmWWW removes common stop words and question words from queries.
 func (qb *QueryBuilder) RmWWW(txt string) string {
+	// Compiled regex + replacement pairs for Chinese and English stop words.
 	patterns := []struct {
-		regex string
-		repl  string
+		re   *regexp.Regexp
+		repl string
 	}{
 		// Chinese stop words
-		{`是*(怎么办|什么样的|哪家|一下|那家|请问|啥样|咋样了|什么时候|何时|何地|何人|是否|是不是|多少|哪里|怎么|哪儿|怎么样|如何|哪些|是啥|啥是|啊|吗|呢|吧|咋|什么|有没有|呀|谁|哪位|哪个)是*`, ""},
+		{reStopWordsZH, ""},
 		// English stop words (case-insensitive)
-		{`(^| )(what|who|how|which|where|why)('re|'s)? `, " "},
-		{`(^| )('s|'re|is|are|were|was|do|does|did|don't|doesn't|didn't|has|have|be|there|you|me|your|my|mine|just|please|may|i|should|would|wouldn't|will|won't|done|go|for|with|so|the|a|an|by|i'm|it's|he's|she's|they|they're|you're|as|by|on|in|at|up|out|down|of|to|or|and|if) `, " "},
+		{reStopWordsEN1, " "},
+		{reStopWordsEN2, " "},
 	}
 	original := txt
 	for _, p := range patterns {
-		re := regexp.MustCompile(`(?i)` + p.regex)
-		txt = re.ReplaceAllString(txt, p.repl)
+		txt = p.re.ReplaceAllString(txt, p.repl)
 	}
 	if txt == "" {
 		txt = original
@@ -149,20 +172,16 @@ func (qb *QueryBuilder) RmWWW(txt string) string {
 // AddSpaceBetweenEngZh adds spaces between English letters and Chinese characters to improve tokenization.
 func (qb *QueryBuilder) AddSpaceBetweenEngZh(txt string) string {
 	// (ENG/ENG+NUM) + ZH: e.g., "ABC123中文" -> "ABC123 中文"
-	re1 := regexp.MustCompile(`([A-Za-z]+[0-9]*)([\x{4e00}-\x{9fa5}]+)`)
-	txt = re1.ReplaceAllString(txt, "$1 $2")
+	txt = reEngZhNum.ReplaceAllString(txt, "$1 $2")
 
 	// ENG + ZH: e.g., "ABC中文" -> "ABC 中文"
-	re2 := regexp.MustCompile(`([A-Za-z])([\x{4e00}-\x{9fa5}]+)`)
-	txt = re2.ReplaceAllString(txt, "$1 $2")
+	txt = reEngZh.ReplaceAllString(txt, "$1 $2")
 
 	// ZH + (ENG/ENG+NUM): e.g., "中文ABC123" -> "中文 ABC123"
-	re3 := regexp.MustCompile(`([\x{4e00}-\x{9fa5}]+)([A-Za-z]+[0-9]*)`)
-	txt = re3.ReplaceAllString(txt, "$1 $2")
+	txt = reZhEngNum.ReplaceAllString(txt, "$1 $2")
 
 	// ZH + ENG: e.g., "中文ABC" -> "中文 ABC"
-	re4 := regexp.MustCompile(`([\x{4e00}-\x{9fa5}]+)([A-Za-z])`)
-	txt = re4.ReplaceAllString(txt, "$1 $2")
+	txt = reZhEng.ReplaceAllString(txt, "$1 $2")
 	return txt
 }
 
@@ -202,7 +221,7 @@ func (qb *QueryBuilder) NeedFineGrainedTokenize(tk string) bool {
 	if utf8.RuneCountInString(tk) < 3 {
 		return false
 	}
-	if matched, _ := regexp.MatchString(`^[0-9a-z\.\+#_\*-]+$`, tk); matched {
+	if reSimpleToken.MatchString(tk) {
 		return false
 	}
 	return true
@@ -228,10 +247,8 @@ func (qb *QueryBuilder) Question(txt string, tbl string, minMatch float64) (*typ
 
 	// Replace punctuation and special characters with space
 	// Reference: rag/nlp/query.py L44-48
-	// re is the regex pattern for matching punctuation and special characters.
-	re := regexp.MustCompile(`[ :|\r\n\t,，.。?？/\` + "`" + `!！&^%()\[\]{}<>*~'"\\]+`)
 	// txtCleaned is the text after removing punctuation and special characters.
-	txtCleaned := re.ReplaceAllString(txtSimplified, " ")
+	txtCleaned := rePunct.ReplaceAllString(txtSimplified, " ")
 
 	// Remove stop words
 	txtNoStopWords := qb.RmWWW(txtCleaned)
@@ -280,11 +297,11 @@ func (qb *QueryBuilder) Question(txt string, tbl string, minMatch float64) (*typ
 			w := tw.Weight
 
 			// Clean token: remove special chars
-			tk = regexp.MustCompile(`[ \"'^]+`).ReplaceAllString(tk, "")
+			tk = reCleanQuote.ReplaceAllString(tk, "")
 			// Remove single alphanumeric chars
-			tk = regexp.MustCompile(`^[a-z0-9]$`).ReplaceAllString(tk, "")
+			tk = reSingleChar.ReplaceAllString(tk, "")
 			// Remove leading +/-
-			tk = regexp.MustCompile(`^[\+\-]+`).ReplaceAllString(tk, "")
+			tk = reLeadSign.ReplaceAllString(tk, "")
 			tk = strings.TrimSpace(tk)
 
 			if tk == "" {
@@ -331,7 +348,7 @@ func (qb *QueryBuilder) Question(txt string, tbl string, minMatch float64) (*typ
 			tk := tw.tk
 			w := tw.w
 			// Skip tokens with special regex chars
-			if matched, _ := regexp.MatchString(`[.^+\(\)-]`, tk); matched {
+			if reQuerySpecial.MatchString(tk) {
 				continue
 			}
 			// Format: (token^weight synonym)
@@ -437,10 +454,8 @@ func (qb *QueryBuilder) Question(txt string, tbl string, minMatch float64) (*typ
 			// Clean special characters from sm
 			// cleanSm holds cleaned fine‑grained tokens with special characters removed.
 			var cleanSm []string
-			// specialCharRe is the regex pattern for matching special characters.
-			specialCharRe := regexp.MustCompile(`[,\.\/;'\[\]\\\` + "`" + `~!@#$%\^&\*\(\)=\+_<>\?:"\{\}\|，。；'‘’【】、！￥……（）——《》？："""-]+`)
 			for _, m := range sm {
-				m = specialCharRe.ReplaceAllString(m, "")
+				m = reSpecialChar.ReplaceAllString(m, "")
 				m = qb.SubSpecialChar(m)
 				if len([]rune(m)) > 1 {
 					cleanSm = append(cleanSm, m)
@@ -451,7 +466,7 @@ func (qb *QueryBuilder) Question(txt string, tbl string, minMatch float64) (*typ
 			// Add to keywords if under limit
 			if len(keywords) < 32 {
 				// cleanTk is the term with quotes and spaces removed.
-				cleanTk := regexp.MustCompile(`[ \"']+`).ReplaceAllString(term, "")
+				cleanTk := reCleanTerm.ReplaceAllString(term, "")
 				if cleanTk != "" {
 					keywords = append(keywords, cleanTk)
 				}


### PR DESCRIPTION
## Summary

`regexp.MustCompile` / `regexp.MatchString` have **no cache** in Go — every call performs a full parse+compile of the pattern. The fulltext query builder compiled the same 17 patterns from scratch on **every** invocation of the retrieval hot path (tokenize → query build), paying a fresh regexp parse+compile per token/term.

This hoists all patterns into package-level `var`s compiled **once at package init**, and references them from every call site. **Zero logic change** — every pattern string is byte-identical to before.

## Hot-path call chain affected

- `IsChinese` / `SubSpecialChar` / `RmWWW` (repeatedly called per token in `TextSplitter` tokenization)
- `AddSpaceBetweenEngZh` (×4) / `NeedFineGrainedTokenize`
- `Question` cleaning (`rePunct`)
- token cleaning (`reCleanQuote` / `reSingleChar` / `reLeadSign`)
- `query` special-char / `specialCharRe` / `cleanTk`

These run per-token/per-query in the retrieval pipeline (see callers in `nlp/retrieval.go`, `nlp/reranker.go`, `memory.go`, `tag.go`).

## Impact

- Removes ~17 redundant regexp parse+compile per token/query from the hot path.
- Go's regexp compile is not cached and is measurably more expensive than the `match` itself for short patterns.

## Testing

Patterns are byte-identical to the originals (verified against `HEAD`). CI `go test` covers compilation.