### PR TITLE
fix(deepdoc): sanitize MinerU table HTML before emitting to the table chunker

### DIFF
--- a/deepdoc/parser/mineru_parser.py
+++ b/deepdoc/parser/mineru_parser.py
@@ -906,6 +906,14 @@ class MinerUParser(RAGFlowPdfParser):
                 if not text.strip():
                     self.logger.warning("[MinerU] Empty table content at page_idx=%s; using fallback text.", output.get("page_idx"))
                     text = "FAILED TO PARSE TABLE"
+                else:
+                    # MinerU returns table_body as an HTML fragment (`<table><tr><td>...</td></tr>...`).
+                    # Without sanitization the literal tag markup ends up in the
+                    # chunk's `content_with_weight` field, which `tokenize_table`
+                    # stores verbatim and the user then sees as "garbled" table
+                    # content. The sections path (line 872) already sanitizes
+                    # when `table_enable=False`; the tables path was missed.
+                    text = self._sanitize_section_text(text)
                 tables.append(((None, text), positions))
                 continue
 

--- a/test/unit_test/deepdoc/parser/test_mineru_parser.py
+++ b/test/unit_test/deepdoc/parser/test_mineru_parser.py
@@ -161,6 +161,72 @@ def test_transfer_to_sections_only_sanitizes_tables(monkeypatch, output, expecte
     assert sections[0][0] == expected
 
 
+def test_transfer_to_tables_sanitizes_html_table_body(monkeypatch):
+    """Regression for #17298.
+
+    The tables path used to emit MinerU's raw ``table_body`` HTML fragment
+    (``<table><tr><td>...</td></tr></table>``) verbatim into the chunk's
+    ``content_with_weight`` field. The user then saw the literal HTML tag
+    markup as "garbled" table content in the knowledge base. The sections
+    path already sanitizes when ``table_enable=False``; the tables path
+    must do the same so the chunked table content is human-readable.
+    """
+    module = _load_mineru_parser(monkeypatch)
+    parser = module.MinerUParser()
+    outputs = [
+        {
+            "type": module.MinerUContentType.TABLE,
+            "table_body": "<table><tr><td rowspan=1 colspan=1></td><td rowspan=1 colspan=1>WEY</td><td rowspan=1 colspan=1>B1</td></tr><tr><td rowspan=1 colspan=1>tA</td><td rowspan=1 colspan=1>AAJEERI</td><td rowspan=1 colspan=1>EPZ$</td></tr></table>",
+            "table_caption": [],
+            "table_footnote": [],
+            "page_idx": 0,
+            "bbox": (0, 0, 1, 1),
+        },
+        {
+            "type": module.MinerUContentType.TABLE,
+            "table_body": "<table><tr><td>name</td><td>value</td></tr><tr><td>alpha</td><td>1</td></tr></table>",
+            "table_caption": ["cell-level table"],
+            "table_footnote": [],
+            "page_idx": 1,
+            "bbox": (2, 3, 4, 5),
+        },
+    ]
+
+    media = parser._transfer_to_tables(outputs)
+
+    # HTML tags are removed; cell text is preserved (rows are newline-separated,
+    # cells within a row are concatenated without a separator — `_sanitize_section_text`
+    # is intentionally minimal and does not invent inter-cell whitespace).
+    assert media[0][0] == (None, "WEYB1\ntAAAJEERIEPZ$")
+    # Caption is appended after the sanitized body; a blank line separates the
+    # closing </table> newline from the appended caption.
+    assert media[1][0] == (None, "namevalue\nalpha1\n\ncell-level table")
+
+
+def test_transfer_to_tables_does_not_strip_plain_text_tables(monkeypatch):
+    """Plain-text table content (no HTML markup) must pass through unchanged.
+
+    Sanitization only strips HTML tags and HTML entities; it does not
+    alter plain text. This keeps the contract for non-HTML tables.
+    """
+    module = _load_mineru_parser(monkeypatch)
+    parser = module.MinerUParser()
+    outputs = [
+        {
+            "type": module.MinerUContentType.TABLE,
+            "table_body": "plain text table content",
+            "table_caption": [],
+            "table_footnote": [],
+            "page_idx": 0,
+            "bbox": (0, 0, 1, 1),
+        },
+    ]
+
+    media = parser._transfer_to_tables(outputs)
+
+    assert media[0][0] == (None, "plain text table content")
+
+
 @pytest.mark.p1
 @pytest.mark.parametrize("transfer", ["sections", "tables"])
 def test_empty_table_fallback_is_logged(monkeypatch, caplog, transfer):
@@ -278,7 +344,7 @@ def test_transfer_to_tables_emits_ordered_typed_media(monkeypatch, tmp_path):
     media = parser._transfer_to_tables(outputs)
 
     assert len(media) == 3
-    assert media[0][0] == (None, "<table><tr><td>first</td></tr></table>")
+    assert media[0][0] == (None, "first")
     assert media[2][0] == (None, "second table")
     image, texts = media[1][0]
     image_path.unlink()


### PR DESCRIPTION
## Summary

`MinerUParser._transfer_to_tables` emitted the model's raw `table_body` HTML fragment (`<table><tr><td>...</td></tr></table>`) verbatim into the table tuple. `tokenize_table` stored that string in the chunk's `content_with_weight` field, so the user saw the literal HTML tag markup as "garbled" table content in the knowledge base.

Refs #17298.

## Root cause

Two code paths consume MinerU's `table_body`:

1. `_transfer_to_sections` (line 872) already sanitizes the HTML when `table_enable=False` — that path is fine.
2. `_transfer_to_tables` (line 905) had no sanitization. The raw HTML went straight to the table tuple.

The two paths were inconsistent, and the table tuple path was the one most users hit (the default `table_enable=True` keeps tables as separate media chunks).

## Fix

`deepdoc/parser/mineru_parser.py`: call `self._sanitize_section_text(text)` on the assembled `body + caption + footnote` in the table branch of `_transfer_to_tables`, mirroring the sections path.

The sanitizer:

- unescapes HTML entities (`html.unescape`)
- converts `<br>`, `</p>`, `</div>`, `</li>`, `</tr>`, `</h*>`, `</table>`, `</caption>` to newlines
- strips remaining tags
- collapses whitespace

The user gets readable plain text instead of raw HTML. Plain-text table content (no markup) is unchanged — the sanitizer only strips tags and entities.

## Test

Three test changes in `test/unit_test/deepdoc/parser/test_mineru_parser.py`:

- `test_transfer_to_tables_emits_ordered_typed_media` — the expected text now matches the sanitized plain-text output (`first`) instead of the raw HTML fragment. Pins the fix's behavior change.
- `test_transfer_to_tables_sanitizes_html_table_body` — new regression test for #17298. Verifies that a complex multi-row table with `rowspan`/`colspan` attributes is sanitized to row-separated cell text, and that the caption is appended after the sanitized body.
- `test_transfer_to_tables_does_not_strip_plain_text_tables` — guards the contract that plain-text table content (no HTML markup) passes through unchanged.

Verified pre-fix behavior: the new sanitization test fails on the pre-fix code because the raw HTML would be emitted unchanged. The updated `emits_ordered_typed_media` test also fails on the pre-fix code because it expected the raw HTML and the new contract expects sanitized text.

30/30 tests in `test_mineru_parser.py` pass. ruff check + ruff format --check clean.

## Why a smaller change

The reported chunk content in #17298 also shows garbled cell text (random strings like `WEY`, `AAJEERI`, `EPZ$`) which is a MinerU model output issue, not a RAGFlow rendering issue. That part needs a model-side fix. This PR addresses the part RAGFlow controls: the chunk rendering, which was emitting raw HTML tags in the chunk's `content_with_weight` field.
