### PR TITLE
fix(deepdoc): surface empty page-batch results from VisionParser through the task callback

### DIFF
--- a/deepdoc/parser/pdf_parser.py
+++ b/deepdoc/parser/pdf_parser.py
@@ -2118,7 +2118,15 @@ class VisionParser(RAGFlowPdfParser):
 
         all_docs = []
 
-        for idx, img_binary in enumerate(self.page_images or []):
+        # If `__images__` failed (pdfplumber exception path), `self.page_images`
+        # is None and the loop below silently returns no chunks. Surface the
+        # failure through the callback so the user sees a useful message in
+        # the task log instead of a generic "No chunk built from …".
+        if not self.page_images:
+            callback(-1, "VisionParser could not rasterize the PDF page batch; check server logs for the pdfplumber exception.")
+            return all_docs, []
+
+        for idx, img_binary in enumerate(self.page_images):
             pdf_page_num = from_page + idx  # 0-based
             if pdf_page_num < start_page or pdf_page_num >= end_page:
                 continue
@@ -2138,6 +2146,20 @@ class VisionParser(RAGFlowPdfParser):
             if text:
                 width, height = self.page_images[idx].size
                 all_docs.append((text, f"@@{pdf_page_num + 1}\t{0.0:.1f}\t{width / zoomin:.1f}\t{0.0:.1f}\t{height / zoomin:.1f}##"))
+
+        # If the vision model produced no output for any page in the batch,
+        # log a clear warning so the user can distinguish "no images on these
+        # pages" from "vision model returned nothing for the configured
+        # layout_recognizer". This is the silent-failure mode behind #17173
+        # (qwen-VL returning empty for page batches 2+ while the first batch
+        # succeeded).
+        if not all_docs and self.page_images:
+            callback(
+                1.0,
+                f"VisionParser processed {len(self.page_images)} page(s) "
+                f"(pages {from_page + 1}-{min(to_page, total_pdf_pages)}) but the vision model returned no text. "
+                f"Check the configured layout_recognizer model configuration.",
+            )
         return all_docs, []
 
 

--- a/test/unit_test/deepdoc/parser/test_vision_parser_empty_page_batch.py
+++ b/test/unit_test/deepdoc/parser/test_vision_parser_empty_page_batch.py
@@ -1,0 +1,243 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Regression tests for ``VisionParser.__call__`` empty-page-batch handling
+in ``deepdoc/parser/pdf_parser.py``.
+
+Issue: infiniflow/ragflow#17173.
+
+When the user sets the PDF parser to a vision model (e.g. "qwen" series),
+``by_plaintext`` dispatches to ``VisionParser`` via the layout_recognizer
+fallback. Pre-fix, two failure modes were both silent:
+
+1. ``VisionParser.__images__`` fails (pdfplumber exception path), so
+   ``self.page_images`` is ``None`` and the loop iterates 0 times. The
+   user sees "No chunk built from …" with no hint that rasterization
+   failed.
+2. Rasterization succeeds but the vision model returns empty text for
+   every page in the batch. The user again sees "No chunk built
+   from …" with no hint that the vision model is misconfigured or
+   returning empty.
+
+The fix surfaces both cases through the task callback so the user sees
+a clear, actionable message in the task log instead of the generic
+"No chunk built from …" line.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _load_pdf_parser(monkeypatch):
+    _stub_module(monkeypatch, "pdfplumber")
+    _stub_module(monkeypatch, "pypdf", PdfReader=object)
+    _stub_module(monkeypatch, "huggingface_hub", snapshot_download=lambda **_kwargs: "")
+    _stub_module(monkeypatch, "xgboost", Booster=_AcceptAllArgs)
+    _stub_module(monkeypatch, "sklearn")
+    _stub_module(monkeypatch, "sklearn.cluster", KMeans=object)
+    _stub_module(monkeypatch, "sklearn.metrics", silhouette_score=lambda *_a, **_k: 0)
+
+    common_mod = _stub_module(monkeypatch, "common")
+    common_mod.__path__ = [str(REPO_ROOT / "common")]
+    _stub_module(monkeypatch, "common.constants", MAXIMUM_PAGE_NUMBER=1024)
+    _stub_module(monkeypatch, "common.file_utils", get_project_base_directory=lambda: str(REPO_ROOT))
+    _stub_module(monkeypatch, "common.settings", PARALLEL_DEVICES=1)
+    _stub_module(monkeypatch, "common.misc_utils", thread_pool_exec=lambda fn, *args, **kwargs: fn(*args, **kwargs))
+
+    deepdoc_mod = _stub_module(monkeypatch, "deepdoc")
+    deepdoc_mod.__path__ = [str(REPO_ROOT / "deepdoc")]
+    _stub_module(monkeypatch, "deepdoc.parser")
+    _stub_module(monkeypatch, "deepdoc.parser.utils", extract_pdf_outlines=lambda *_a, **_k: [])
+    _stub_module(
+        monkeypatch,
+        "deepdoc.vision",
+        OCR=_AcceptAllArgs,
+        AscendLayoutRecognizer=_AcceptAllArgs,
+        LayoutRecognizer=_AcceptAllArgs,
+        Recognizer=_FakeRecognizer,
+        TableStructureRecognizer=_FakeTSR,
+    )
+
+    rag_mod = _stub_module(monkeypatch, "rag")
+    rag_mod.__path__ = [str(REPO_ROOT / "rag")]
+    _stub_module(monkeypatch, "rag.nlp", rag_tokenizer=SimpleNamespace(tokenize=lambda text: text))
+    prompts_mod = _stub_module(monkeypatch, "rag.prompts")
+    prompts_mod.__path__ = [str(REPO_ROOT / "rag" / "prompts")]
+    _stub_module(monkeypatch, "rag.prompts.generator", vision_llm_describe_prompt=lambda **_kwargs: "describe prompt")
+    # Pre-populate rag.app.picture so the lazy `from rag.app.picture import
+    # vision_llm_chunk` in VisionParser.__call__ resolves to a mock without
+    # pulling in rag.app.picture's own dependency chain (PipelineTaskType,
+    # settings, etc.). Each test sets monkeypatch-style state on this module
+    # via `setattr(sys.modules["rag.app.picture"], "vision_llm_chunk", fn)`.
+    _stub_module(monkeypatch, "rag.app")
+    picture_mod = _stub_module(monkeypatch, "rag.app.picture")
+    picture_mod.vision_llm_chunk = lambda **_kwargs: ""
+    rag_mod.app = ModuleType("rag.app")
+    rag_mod.app.picture = picture_mod
+
+    module_name = "test_vision_parser_unit_module"
+    module_path = REPO_ROOT / "deepdoc" / "parser" / "pdf_parser.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stub_module(monkeypatch, name, **attrs):
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+class _FakeRecognizer:
+    @staticmethod
+    def sort_Y_firstly(arr, _threshold):
+        return sorted(arr, key=lambda item: (item["top"], item["x0"]))
+
+    @staticmethod
+    def layouts_cleanup(_boxes, layouts, _far=2, _thr=0.7):
+        return layouts
+
+
+class _FakeTSR:
+    @staticmethod
+    def is_caption(_bx):
+        return False
+
+
+class _AcceptAllArgs:
+    """Stub that accepts any args/kwargs for instantiation, attribute
+    access, and call. Used for the heavy classes (LayoutRecognizer,
+    AscendLayoutRecognizer, OCR, xgboost.Booster) that the parser
+    instantiates with constructor args and then exercises via method
+    calls during init. The empty-batch control flow under test never
+    touches these methods, so the stub just needs to not raise.
+    """
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def __getattr__(self, _name):
+        return _AcceptAllArgs()
+
+    def __call__(self, *_args, **_kwargs):
+        return _AcceptAllArgs()
+
+
+def _make_vision_parser(pdf_parser_module, vision_model=None):
+    return pdf_parser_module.VisionParser(vision_model=vision_model or MagicMock())
+
+
+def test_vision_parser_warns_when_images_rasterization_fails(monkeypatch):
+    """Regression for #17173 (silence on rasterization failure).
+
+    When ``__images__`` fails (pdfplumber exception path),
+    ``self.page_images`` is None. Pre-fix, the loop iterates 0 times
+    and returns an empty list silently. The fix surfaces the failure
+    through the callback with progress=-1 + a clear message naming
+    rasterization, so the user sees a useful hint in the task log.
+    """
+    module = _load_pdf_parser(monkeypatch)
+    parser = _make_vision_parser(module)
+    parser.page_images = None  # simulate the __images__ failure path
+    parser.total_page = 12
+
+    callback_messages = []
+
+    def cb(prog, msg):
+        callback_messages.append((prog, msg))
+
+    docs, tbls = parser("test.pdf", from_page=0, to_page=12, callback=cb)
+
+    assert docs == []
+    assert tbls == []
+    assert any("could not rasterize" in msg for _, msg in callback_messages), f"expected a clear rasterization-failure callback, got {callback_messages!r}"
+    assert any(prog == -1 for prog, _ in callback_messages), f"expected progress=-1 to flag the failure, got {callback_messages!r}"
+
+
+def test_vision_parser_warns_when_vision_model_returns_empty(monkeypatch):
+    """Regression for #17173 (silence on empty vision model output).
+
+    The first page batch in the issue produced 12 chunks; subsequent
+    batches returned 0 chunks. The fix surfaces the empty-batch case
+    through the callback with a clear message naming the configured
+    layout_recognizer model, so the user can distinguish "no images on
+    these pages" from "vision model returned nothing".
+    """
+    module = _load_pdf_parser(monkeypatch)
+    parser = _make_vision_parser(module)
+    # Skip __images__ (the real one would need pdfplumber); inject
+    # 3 mock page images directly. The loop only needs `img_binary`
+    # to be truthy and the page image to have a .size tuple.
+    parser.__images__ = lambda **_kwargs: None
+    mock_image = MagicMock()
+    mock_image.size = (612, 792)
+    parser.page_images = [mock_image, mock_image, mock_image]
+    parser.total_page = 12
+
+    # Force picture_vision_llm_chunk to return empty for every page.
+    sys.modules["rag.app.picture"].vision_llm_chunk = lambda **_kwargs: ""
+
+    callback_messages = []
+
+    def cb(prog, msg):
+        callback_messages.append((prog, msg))
+
+    docs, tbls = parser("test.pdf", from_page=0, to_page=3, callback=cb)
+
+    assert docs == []
+    assert tbls == []
+    assert any("vision model returned no text" in msg for _, msg in callback_messages), f"expected a clear empty-output callback, got {callback_messages!r}"
+
+
+def test_vision_parser_does_not_warn_when_some_pages_succeed(monkeypatch):
+    """Regression guard: the empty-batch warning must NOT fire when at
+    least one page in the batch produced text. Only fire when ALL pages
+    returned empty.
+    """
+    module = _load_pdf_parser(monkeypatch)
+    parser = _make_vision_parser(module)
+    parser.__images__ = lambda **_kwargs: None
+    mock_image = MagicMock()
+    mock_image.size = (612, 792)
+    parser.page_images = [mock_image, mock_image, mock_image]
+    parser.total_page = 12
+
+    # First page returns text; subsequent pages return empty.
+    responses = iter(["page 1 text", "", ""])
+
+    def fake_vision_llm_chunk(**_kwargs):
+        return next(responses)
+
+    sys.modules["rag.app.picture"].vision_llm_chunk = fake_vision_llm_chunk
+
+    callback_messages = []
+
+    def cb(prog, msg):
+        callback_messages.append((prog, msg))
+
+    docs, _ = parser("test.pdf", from_page=0, to_page=3, callback=cb)
+
+    assert len(docs) == 1
+    assert not any("vision model returned no text" in msg for _, msg in callback_messages), f"empty-batch warning fired even though page 1 succeeded: {callback_messages!r}"


### PR DESCRIPTION
## Summary

`VisionParser.__call__` silently returns an empty list when the page batch produces no usable output. The user sees only the generic "No chunk built from …" line in the task log with no hint about what went wrong.

Refs #17173 (qwen PDF parser: first page batch produces 12 chunks, subsequent batches return "No chunk built from …").

## Two silent failure modes

1. **Rasterization failure** — `VisionParser.__images__` catches pdfplumber exceptions and sets `self.page_images = None`. The loop iterates 0 times and returns an empty list. The internal `logging.exception("VisionParser __images__")` records the traceback, but the user only sees the generic "No chunk built from …" message — they have to dig into server logs to find the real cause.
2. **Empty vision model output** — rasterization succeeds but the configured vision model (e.g. qwen-VL) returns empty text for every page in the batch. The user again sees "No chunk built from …" with no hint that the vision model is misconfigured or returning empty.

## Fix

`deepdoc/parser/pdf_parser.py:VisionParser.__call__` — surface both cases through the task callback:

- If `self.page_images` is None after `__images__`, call `callback(-1, "VisionParser could not rasterize the PDF page batch; check server logs for the pdfplumber exception.")` and return.
- If the vision model returned empty text for every page in the batch, call `callback(1.0, "VisionParser processed N page(s) (pages X-Y) but the vision model returned no text. Check the configured layout_recognizer model configuration.")` and return.

The "No chunk built from …" line still fires (it's emitted by the orchestrator when chunks is empty), but now the user has a clear, actionable hint about *why* chunks is empty.

## Test

Three tests in `test/unit_test/deepdoc/parser/test_vision_parser_empty_page_batch.py`:

- `test_vision_parser_warns_when_images_rasterization_fails` — pre-fix: callback receives only "Processed" lines (or no messages at all). Post-fix: callback receives the `progress=-1` rasterization-failure message.
- `test_vision_parser_warns_when_vision_model_returns_empty` — pre-fix: callback receives "Processed: 1/3, 2/3, 3/3" but no warning. Post-fix: callback receives the "vision model returned no text" message.
- `test_vision_parser_does_not_warn_when_some_pages_succeed` — regression guard that the empty-batch warning does NOT fire when at least one page in the batch produced text.

The test loads the real `VisionParser` via `importlib.util.spec_from_file_location` with the module's heavy runtime dependencies stubbed (same pattern as `test_pdf_parser_table_coordinates.py`). The `rag.app.picture` module is pre-populated so the lazy `from rag.app.picture import vision_llm_chunk` inside `__call__` resolves to a mock without pulling in `rag.app.picture`'s own dependency chain.

3/3 tests pass on the fix. Verified pre-fix behavior: the first two tests fail (the pre-fix code emits the "Processed" progress messages without the new warnings). ruff check + ruff format --check clean.

## What's NOT fixed in this PR

The underlying root cause of the qwen-VL empty output in #17173 (why the vision model returns nothing for page batches 2+) is a model / configuration concern, not a RAGFlow rendering bug. The original behavior — "No chunk built from …" — is unchanged in the sense that the chunk list is still empty. The fix only changes the diagnostic surface so the user can see *why* the chunks are empty.

If the qwen-VL specific issue is reproducible end-to-end with a known setup, a follow-up PR could add a sanity-check or retry around the vision model call. This PR is the minimal scope: make the failure mode visible.
