### PR TITLE
Remove three no-op self-assignments

### DIFF
--- a/api/db/services/conversation_service.py
+++ b/api/db/services/conversation_service.py
@@ -333,7 +333,6 @@ async def async_iframe_completion(dialog_id, question, session_id=None, stream=T
         yield "data:" + json.dumps({"code": 0, "message": "", "data": True}, ensure_ascii=False) + "\n\n"
         return
     else:
-        session_id = session_id
         e, conv = API4ConversationService.get_by_id(session_id)
         assert e, "Session not found!"
         assert conv.dialog_id == dialog_id, "Session does not belong to this dialog"

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -114,8 +114,6 @@ def _normalize_section_text_for_rtl_presentation_forms(sections):
 
 
 def by_deepdoc(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang="Chinese", callback=None, pdf_cls=None, **kwargs):
-    callback = callback
-    binary = binary
     pdf_parser = pdf_cls() if pdf_cls else Pdf()
     sections, tables = pdf_parser(filename if not binary else binary, from_page=from_page, to_page=to_page, callback=callback)
 


### PR DESCRIPTION
### Summary

Was reading through `by_deepdoc` and the first two lines rebind the parameters to themselves, so they do nothing at all. Same thing in the `else` arm of `async_iframe_completion`. There is a fourth one in `rag/nlp/__init__.py` where `poss = poss` sits under `if isinstance(poss, list)`, and I left that alone on purpose: the branch has to stay so it does not fall through to the `elif`, so removing the line there is a different change than removing it here.
