### PR TITLE
fix(sdk): temperature default should be a float, not a 1-tuple

### DIFF
--- a/sdk/python/ragflow_sdk/modules/memory.py
+++ b/sdk/python/ragflow_sdk/modules/memory.py
@@ -32,7 +32,7 @@ class Memory(Base):
         self.description = ""
         self.memory_size = 5 * 1024 * 1024
         self.forgetting_policy = "FIFO"
-        self.temperature = (0.5,)
+        self.temperature = 0.5
         self.system_prompt = ""
         self.user_prompt = ""
         for k in list(res_dict.keys()):


### PR DESCRIPTION
### Summary

`Memory.__init__` in the Python SDK sets

```python
self.temperature = (0.5,)
```

The parentheses + trailing comma make this a one-element **tuple**, not a float. It is a trailing-comma typo:

- The server-side model stores `temperature` as a `FloatField(default=0.5)` (`api/db/db_models.py`), and `memory_api_service.update_memory` validates it with `float(...)`.
- Every other scalar default in the SDK modules is a plain scalar (e.g. `self.progress = 0.0` in `document.py`).

The tuple default is normally masked because the API response includes `temperature` and `Base._update_from_dict` overwrites the attribute, but whenever a response omits the field, `memory.temperature` leaks the tuple (e.g. `str(memory)`/`to_json()` renders `"temperature": [0.5]`, and float comparisons/`json` payloads get a list instead of a number). Fix is the scalar `0.5`, matching the server default.