### PR TITLE
security: remove leaked OAuth credentials and stop logging user secrets

### DIFF
--- a/api/apps/restful_apis/connector_api.py
+++ b/api/apps/restful_apis/connector_api.py
@@ -338,7 +338,6 @@ async def start_google_web_oauth():
 
     try:
         credentials = _load_credentials(raw_credentials)
-        print(credentials)
     except ValueError as exc:
         return get_json_result(code=RetCode.ARGUMENT_ERROR, message=str(exc))
 

--- a/common/data_source/box_connector.py
+++ b/common/data_source/box_connector.py
@@ -186,7 +186,7 @@ class BoxConnector(LoadConnector, PollConnector):
 # app = Flask(__name__)
 
 # AUTH = BoxOAuth(
-#     OAuthConfig(client_id="8suvn9ik7qezsq2dub0ye6ubox61081z", client_secret="QScvhLgBcZrb2ck1QP1ovkutpRhI2QcN")
+#     OAuthConfig(client_id="<your-client-id>", client_secret="<your-client-secret>")
 # )
 
 


### PR DESCRIPTION
## What this PR does
- `common/data_source/box_connector.py`: a commented-out `BoxOAuth` example embedded a real-looking `client_id` / `client_secret`. Even disabled, committed secrets must be treated as compromised and rotated by their owner; the example now uses placeholders.
- `api/apps/restful_apis/connector_api.py`: `start_google_web_oauth` printed the full parsed credentials dict (including `client_secret`) to stdout before caching it in Redis, so user-supplied secrets landed in container / log-aggregation logs. Dropped the `print`.

## Verification
- `python -m py_compile` on both files.
- No behaviour change apart from the removed logging and the placeholder swap.