### PR TITLE
fix(agentic-rag): enforce bound dataset scope in retrieval tools

### DIFF
--- a/internal/agentic_rag/helper.go
+++ b/internal/agentic_rag/helper.go
@@ -23,6 +23,26 @@ import (
 	"ragflow/internal/agent/runtime"
 )
 
+// resolveDatasetScope keeps model-provided dataset ids within the
+// conversation's server-bound scope. An omitted request uses the full bound
+// scope; an explicit request must be a subset of it.
+func resolveDatasetScope(bound, requested []string) ([]string, error) {
+	if len(requested) == 0 {
+		return bound, nil
+	}
+
+	allowed := make(map[string]struct{}, len(bound))
+	for _, id := range bound {
+		allowed[id] = struct{}{}
+	}
+	for _, id := range requested {
+		if _, ok := allowed[id]; !ok {
+			return nil, fmt.Errorf("dataset_id %q is outside the conversation's bound scope", id)
+		}
+	}
+	return requested, nil
+}
+
 // clampFloat01 clamps a float into [0, 1], used for similarity weights the model
 // may supply out of range.
 func clampFloat01(v float64) float64 {

--- a/internal/agentic_rag/tool_grep_chunks.go
+++ b/internal/agentic_rag/tool_grep_chunks.go
@@ -141,13 +141,16 @@ func (g *GrepChunksTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 		return "", fmt.Errorf("grep_chunks: invalid regex %q: %w", query, err)
 	}
 
-	svc := runtime.GetGrepService()
-	tenantID := g.tenantID
-	datasetIDs := args.DatasetIDs
+	datasetIDs, err := resolveDatasetScope(g.datasetIDs, args.DatasetIDs)
+	if err != nil {
+		return "", fmt.Errorf("grep_chunks: %w", err)
+	}
 	if len(datasetIDs) == 0 {
-		datasetIDs = g.datasetIDs
+		return formatGrepResults(query, nil, re), nil
 	}
 
+	svc := runtime.GetGrepService()
+	tenantID := g.tenantID
 	chunks, err := svc.Grep(ctx, runtime.GrepRequest{
 		Pattern:      query,
 		DatasetIDs:   datasetIDs,

--- a/internal/agentic_rag/tool_list_chunks.go
+++ b/internal/agentic_rag/tool_list_chunks.go
@@ -34,9 +34,9 @@ import (
 
 // listChunksToolName is the constrained deep-read runtime. It pages through ALL
 // chunks of exactly ONE document in reading order (chunk_index) within an
-// offset/limit range. The document is scoped by doc_id (authoritative and
-// unique — it can only belong to one dataset), and each returned chunk carries
-// its owning dataset_id in the output.
+// offset/limit range. The document id is resolved within the conversation's
+// server-bound dataset scope, and each returned chunk carries its owning
+// dataset_id in the output.
 const listChunksToolName = "list_chunks"
 
 const listChunksToolDescription = `Read the FULL original text of ONE dataset document in reading order (Deep Read).
@@ -144,23 +144,23 @@ func (l *ListChunksTool) InvokableRun(ctx context.Context, argumentsInJSON strin
 	}
 	offset := max(args.Offset, 0)
 
-	svc := runtime.GetGrepService()
 	tenantID := l.tenantID
+	if tenantID == "" || len(l.datasetIDs) == 0 {
+		return chunksXMLEmpty(), nil
+	}
+
+	svc := runtime.GetGrepService()
 	dr, ok := svc.(deepReadService)
-	if svc == nil || tenantID == "" {
+	if svc == nil {
 		return chunksXMLEmpty(), nil
 	}
 	if !ok {
 		return "", fmt.Errorf("list_chunks: configured grep service does not support deep read")
 	}
 
-	// Deep reads scope purely by doc_id. The doc_id comes from grep_chunks /
-	// search_chunks, which are already constrained to the conversation's dataset
-	// scope, so no extra dataset filter is needed here; DatasetIDs is left nil
-	// (optional) and the document is located by its unique doc_id alone.
 	chunks, err := dr.ListByDocIDs(ctx, runtime.GrepRequest{
 		DocScope:     []string{docID},
-		DatasetIDs:   nil,
+		DatasetIDs:   l.datasetIDs,
 		Limit:        limit,
 		Offset:       offset,
 		Sort:         grepChunksSortFields, // doc_id, page_num_int, chunk_order_int

--- a/internal/agentic_rag/tool_search_chunks.go
+++ b/internal/agentic_rag/tool_search_chunks.go
@@ -185,8 +185,12 @@ func (k *SearchChunksTool) InvokableRun(ctx context.Context, argumentsInJSON str
 	if args.KeywordsSimilarityWeight != nil {
 		weight = clampFloat01(*args.KeywordsSimilarityWeight)
 	}
+	datasetIDs, err := resolveDatasetScope(k.datasetIDs, args.DatasetIDs)
+	if err != nil {
+		return "", fmt.Errorf("search_chunks: %w", err)
+	}
 	if len(args.DatasetIDs) > 10 {
-		args.DatasetIDs = args.DatasetIDs[:10]
+		datasetIDs = datasetIDs[:10]
 	}
 	if len(args.DocScope) > 10 {
 		args.DocScope = args.DocScope[:10]
@@ -194,10 +198,6 @@ func (k *SearchChunksTool) InvokableRun(ctx context.Context, argumentsInJSON str
 
 	svc := runtime.GetRetrievalService()
 	tenantID := k.tenantID
-	datasetIDs := args.DatasetIDs
-	if len(datasetIDs) == 0 {
-		datasetIDs = k.datasetIDs
-	}
 	if svc == nil || tenantID == "" || len(datasetIDs) == 0 {
 		return searchResultsXMLEmpty(), nil
 	}

--- a/internal/agentic_rag/tools_test.go
+++ b/internal/agentic_rag/tools_test.go
@@ -21,15 +21,77 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"gorm.io/gorm"
+
 	"ragflow/internal/agent/runtime"
 	"ragflow/internal/engine"
 	enginetypes "ragflow/internal/engine/types"
 )
+
+type scopeRecordingGrepService struct {
+	grepRequests []runtime.GrepRequest
+	listRequests []runtime.GrepRequest
+}
+
+func (s *scopeRecordingGrepService) Grep(_ context.Context, req runtime.GrepRequest) ([]runtime.RetrievalChunk, error) {
+	s.grepRequests = append(s.grepRequests, req)
+	return nil, nil
+}
+
+func (s *scopeRecordingGrepService) ListByDocIDs(_ context.Context, req runtime.GrepRequest) ([]runtime.RetrievalChunk, error) {
+	s.listRequests = append(s.listRequests, req)
+	return nil, nil
+}
+
+type scopeRecordingRetrievalService struct {
+	requests []runtime.RetrievalRequest
+}
+
+func (s *scopeRecordingRetrievalService) Search(_ context.Context, _ *gorm.DB, req runtime.RetrievalRequest) ([]runtime.RetrievalChunk, error) {
+	s.requests = append(s.requests, req)
+	return nil, nil
+}
+
+func TestResolveDatasetScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		bound     []string
+		requested []string
+		want      []string
+		wantErr   string
+	}{
+		{name: "omitted uses bound scope", bound: []string{"kb-1", "kb-2"}, want: []string{"kb-1", "kb-2"}},
+		{name: "bound subset", bound: []string{"kb-1", "kb-2"}, requested: []string{"kb-2"}, want: []string{"kb-2"}},
+		{name: "outside scope", bound: []string{"kb-1"}, requested: []string{"kb-2"}, wantErr: "kb-2"},
+		{name: "mixed scope", bound: []string{"kb-1"}, requested: []string{"kb-1", "kb-2"}, wantErr: "kb-2"},
+		{name: "empty bound rejects request", requested: []string{"kb-1"}, wantErr: "kb-1"},
+		{name: "empty bound and request", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveDatasetScope(tt.bound, tt.requested)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveDatasetScope error = %v, want one containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveDatasetScope: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("resolveDatasetScope = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 // mustJSONString marshals v to a compact JSON string, failing the test on error.
 func mustJSONString(t *testing.T, v interface{}) string {
@@ -145,6 +207,137 @@ func TestSearchChunksTool_EmptyQueries(t *testing.T) {
 	_, err := NewSearchChunksTool("", nil).InvokableRun(context.Background(), `{"queries":[]}`)
 	if err == nil {
 		t.Fatal("expected error for empty queries")
+	}
+}
+
+func TestRetrievalTools_RejectDatasetScopeExpansion(t *testing.T) {
+	t.Run("grep_chunks", func(t *testing.T) {
+		svc := &scopeRecordingGrepService{}
+		previous := runtime.GetGrepService()
+		runtime.SetGrepService(svc)
+		t.Cleanup(func() { runtime.SetGrepService(previous) })
+
+		_, err := NewGrepChunksTool("tenant", []string{"kb-allowed"}).InvokableRun(
+			context.Background(), `{"query":"term","dataset_ids":["kb-outside"]}`,
+		)
+		if err == nil || !strings.Contains(err.Error(), "kb-outside") {
+			t.Fatalf("expected an error naming the out-of-scope dataset, got %v", err)
+		}
+		if len(svc.grepRequests) != 0 {
+			t.Fatalf("out-of-scope grep reached the backend %d times", len(svc.grepRequests))
+		}
+	})
+
+	t.Run("search_chunks", func(t *testing.T) {
+		svc := &scopeRecordingRetrievalService{}
+		previous := runtime.GetRetrievalService()
+		runtime.SetRetrievalService(svc)
+		t.Cleanup(func() { runtime.SetRetrievalService(previous) })
+
+		_, err := NewSearchChunksTool("tenant", []string{"kb-allowed"}).InvokableRun(
+			context.Background(), `{"queries":["question"],"dataset_ids":["kb-outside"]}`,
+		)
+		if err == nil || !strings.Contains(err.Error(), "kb-outside") {
+			t.Fatalf("expected an error naming the out-of-scope dataset, got %v", err)
+		}
+		if len(svc.requests) != 0 {
+			t.Fatalf("out-of-scope search reached the backend %d times", len(svc.requests))
+		}
+
+		overLimit := make([]string, 10)
+		for i := range overLimit {
+			overLimit[i] = "kb-allowed"
+		}
+		overLimit = append(overLimit, "kb-outside")
+		arguments := mustJSONString(t, searchChunksArgs{Queries: []string{"question"}, DatasetIDs: overLimit})
+		_, err = NewSearchChunksTool("tenant", []string{"kb-allowed"}).InvokableRun(context.Background(), arguments)
+		if err == nil || !strings.Contains(err.Error(), "kb-outside") {
+			t.Fatalf("expected validation before the input cap, got %v", err)
+		}
+		if len(svc.requests) != 0 {
+			t.Fatalf("out-of-scope search reached the backend %d times", len(svc.requests))
+		}
+	})
+}
+
+func TestRetrievalTools_ApplyResolvedDatasetScope(t *testing.T) {
+	grepSvc := &scopeRecordingGrepService{}
+	previousGrep := runtime.GetGrepService()
+	runtime.SetGrepService(grepSvc)
+	t.Cleanup(func() { runtime.SetGrepService(previousGrep) })
+
+	_, err := NewGrepChunksTool("tenant", []string{"kb-1", "kb-2"}).InvokableRun(
+		context.Background(), `{"query":"term"}`,
+	)
+	if err != nil {
+		t.Fatalf("grep_chunks: %v", err)
+	}
+	if len(grepSvc.grepRequests) != 1 || !slices.Equal(grepSvc.grepRequests[0].DatasetIDs, []string{"kb-1", "kb-2"}) {
+		t.Fatalf("grep scope = %v, want [kb-1 kb-2]", grepSvc.grepRequests)
+	}
+
+	searchSvc := &scopeRecordingRetrievalService{}
+	previousRetrieval := runtime.GetRetrievalService()
+	runtime.SetRetrievalService(searchSvc)
+	t.Cleanup(func() { runtime.SetRetrievalService(previousRetrieval) })
+
+	_, err = NewSearchChunksTool("tenant", []string{"kb-1", "kb-2"}).InvokableRun(
+		context.Background(), `{"queries":["question"],"dataset_ids":["kb-2"]}`,
+	)
+	if err != nil {
+		t.Fatalf("search_chunks: %v", err)
+	}
+	if len(searchSvc.requests) != 1 || !slices.Equal(searchSvc.requests[0].DatasetIDs, []string{"kb-2"}) {
+		t.Fatalf("search scope = %v, want [kb-2]", searchSvc.requests)
+	}
+}
+
+func TestListChunksTool_ForwardsBoundDatasetScope(t *testing.T) {
+	svc := &scopeRecordingGrepService{}
+	previous := runtime.GetGrepService()
+	runtime.SetGrepService(svc)
+	t.Cleanup(func() { runtime.SetGrepService(previous) })
+
+	_, err := NewListChunksTool("tenant", []string{"kb-1", "kb-2"}).InvokableRun(
+		context.Background(), `{"doc_id":"doc-1"}`,
+	)
+	if err != nil {
+		t.Fatalf("InvokableRun: %v", err)
+	}
+	if len(svc.listRequests) != 1 {
+		t.Fatalf("deep-read backend calls = %d, want 1", len(svc.listRequests))
+	}
+	if got := strings.Join(svc.listRequests[0].DatasetIDs, ","); got != "kb-1,kb-2" {
+		t.Fatalf("deep-read dataset scope = %q, want %q", got, "kb-1,kb-2")
+	}
+}
+
+func TestRetrievalTools_EmptyBoundScopeSkipsBackends(t *testing.T) {
+	grepSvc := &scopeRecordingGrepService{}
+	previousGrep := runtime.GetGrepService()
+	runtime.SetGrepService(grepSvc)
+	t.Cleanup(func() { runtime.SetGrepService(previousGrep) })
+
+	searchSvc := &scopeRecordingRetrievalService{}
+	previousRetrieval := runtime.GetRetrievalService()
+	runtime.SetRetrievalService(searchSvc)
+	t.Cleanup(func() { runtime.SetRetrievalService(previousRetrieval) })
+
+	if _, err := NewGrepChunksTool("tenant", nil).InvokableRun(context.Background(), `{"query":"term"}`); err != nil {
+		t.Fatalf("grep_chunks empty scope: %v", err)
+	}
+	if _, err := NewSearchChunksTool("tenant", nil).InvokableRun(context.Background(), `{"queries":["question"]}`); err != nil {
+		t.Fatalf("search_chunks empty scope: %v", err)
+	}
+	if _, err := NewListChunksTool("tenant", nil).InvokableRun(context.Background(), `{"doc_id":"doc-1"}`); err != nil {
+		t.Fatalf("list_chunks empty scope: %v", err)
+	}
+
+	if len(grepSvc.grepRequests) != 0 || len(grepSvc.listRequests) != 0 {
+		t.Fatalf("empty bound scope reached grep backend: grep=%d deep-read=%d", len(grepSvc.grepRequests), len(grepSvc.listRequests))
+	}
+	if len(searchSvc.requests) != 0 {
+		t.Fatalf("empty bound scope reached search backend %d times", len(searchSvc.requests))
 	}
 }
 


### PR DESCRIPTION
### Summary

Follow-up to #18654.

Keep Agentic RAG retrieval within the conversation's server-bound dataset scope.

- Validate model-provided `dataset_ids` as a subset before `grep_chunks` and
  `search_chunks` reach retrieval backends.
- Return empty results without backend access when the bound scope is empty.
- Forward the bound scope to `list_chunks` deep reads.
- Add regression coverage for omitted scopes, valid subsets, out-of-scope
  rejection, validation before the 10-item cap, empty scopes, and deep-read
  forwarding.

Out-of-scope IDs return a clear error so the agent can correct its tool call.

Related review findings:

- https://github.com/infiniflow/ragflow/pull/18654#discussion_r3837569551
- https://github.com/infiniflow/ragflow/pull/18654#discussion_r3837992009

### Validation

- `CGO_ENABLED=0 go test -count=1 -cover ./internal/agentic_rag`
  - passed, 68.9% package coverage
- `CGO_ENABLED=0 go test -count=5 -shuffle=on -run 'TestResolveDatasetScope|TestRetrievalTools_|TestListChunksTool_ForwardsBoundDatasetScope' ./internal/agentic_rag`
  - passed
- `CGO_ENABLED=0 go vet ./internal/agentic_rag`
  - passed
- `gofmt -d` and `git diff --check`
  - passed

The repository `build.sh --test` command is pending CI because the local
Windows checkout does not contain the required `office_oxide` static library.