### PR TITLE
fix(web): keep multi-select options in their declared order while searching

### DIFF
--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -46,6 +46,16 @@ export type MultiSelectGroupOptionType = {
   options: MultiSelectOptionType[];
 };
 
+/**
+ * cmdk's default filter scores matches fuzzily and re-sorts the list by
+ * score, which shuffles options out of their declared order as the user
+ * types. A plain substring match scores every hit equally, so cmdk's
+ * stable sort leaves the original order intact.
+ */
+function filterBySubstring(value: string, search: string) {
+  return value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+}
+
 function MultiCommandItem({
   option,
   isSelected,
@@ -458,7 +468,11 @@ export const MultiSelect = React.forwardRef<
           onFocusOutside={(event) => event.preventDefault()}
           data-testid={popoverTestId}
         >
-          <Command className="p-5 pb-8" shouldFilter={shouldFilter}>
+          <Command
+            className="p-5 pb-8"
+            shouldFilter={shouldFilter}
+            filter={filterBySubstring}
+          >
             {((options && options.length > 0) || onSearchChange) && (
               <CommandInput
                 placeholder={t('common.search') + '...'}


### PR DESCRIPTION
### Summary

fix(web): keep multi-select options in their declared order while searching

cmdk's default filter scores matches fuzzily and re-sorts the list by score, so typing in the search box shuffled the options. Score every substring hit equally instead — cmdk's sort is stable, so the declared order survives, and substring matching is closer to what users expect.
