### PR TITLE
fix(agent): bound crawler response bodies to 4 MiB

### DIFF
--- a/internal/agent/tool/crawler.go
+++ b/internal/agent/tool/crawler.go
@@ -35,6 +35,8 @@ const crawlerToolName = "web_crawler"
 
 const crawlerToolDescription = "Crawls a web page and returns its extracted text content and links."
 
+const maxCrawlerResponseBytes = 4 << 20
+
 // crawlerArgs is the JSON shape the model sends in. query is the
 // Python-compatible argument name; url is accepted for older Go
 // callers. max_depth and max_pages are accepted for API symmetry with
@@ -205,10 +207,14 @@ func (c *CrawlerTool) InvokableRun(ctx context.Context, argumentsInJSON string, 
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxCrawlerResponseBytes+1))
 	if err != nil {
 		return crawlerStubResult(crawlerResult{URL: targetURL, Status: resp.StatusCode, Error: "read body: " + err.Error()}),
 			fmt.Errorf("crawler: read body: %w", err)
+	}
+	if len(body) > maxCrawlerResponseBytes {
+		err = errors.New("crawler: response too large")
+		return crawlerStubResult(crawlerResult{URL: targetURL, Status: resp.StatusCode, Error: err.Error()}), err
 	}
 
 	page, err := extractPage(body)

--- a/internal/agent/tool/crawler_test.go
+++ b/internal/agent/tool/crawler_test.go
@@ -103,6 +103,38 @@ func TestCrawler_FetchesAndExtractsText(t *testing.T) {
 	}
 }
 
+func TestCrawler_RejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", maxCrawlerResponseBytes+1)))
+	}))
+	defer srv.Close()
+
+	loopbackResolver := func(rawURL string) (string, net.IP, error) {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return "", nil, err
+		}
+		host := u.Hostname()
+		return host, net.ParseIP(host), nil
+	}
+	c := NewCrawlerTool().WithResolver(loopbackResolver)
+	out, err := c.InvokableRun(ctx, `{"query":`+jsonString(srv.URL)+`}`)
+	if err == nil || !strings.Contains(err.Error(), "response too large") {
+		t.Fatalf("err = %v, want response too large", err)
+	}
+
+	var got crawlerResult
+	if jerr := json.Unmarshal([]byte(out), &got); jerr != nil {
+		t.Fatalf("output is not valid JSON: %v (raw=%s)", jerr, out)
+	}
+	if !strings.Contains(got.Error, "response too large") {
+		t.Fatalf("_ERROR = %q, want response too large", got.Error)
+	}
+}
+
 func TestCrawler_RejectsMaxDepthGreaterThanZero(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()


### PR DESCRIPTION
### Summary

The Go web crawler currently reads the full upstream response with `io.ReadAll` before parsing it. A large or streaming page can therefore grow memory usage across the response buffer, HTML DOM, extracted text, and model-facing JSON.

This change:
- caps the decompressed response body at 4 MiB with `io.LimitReader(limit + 1)`;
- returns the existing structured `_ERROR` together with a Go error before HTML parsing when the response exceeds the limit;
- adds a local `httptest` regression for a 4 MiB + 1 byte response.

The 4 MiB budget follows the existing AkShare tool convention.

#16165 touches the same files as part of a larger harness refactor, while its current head retains the same unbounded read. This guard is independent of that refactor.

### Testing

- `CGO_ENABLED=0 go test ./internal/agent/tool -run '^TestCrawler_' -count=1`
- `CGO_ENABLED=0 go vet ./internal/agent/tool`
- `gofmt -d internal/agent/tool/crawler.go internal/agent/tool/crawler_test.go`
- `git diff --check`