### PR TITLE
fix(router): accept share (beta) token on agent upload and attachment download

### DIFF
--- a/internal/router/agent_routes.go
+++ b/internal/router/agent_routes.go
@@ -57,9 +57,14 @@ func RegisterAgentRoutes(g *gin.RouterGroup, h *handler.AgentHandler) {
 
 	// File operations.
 	g.GET("/download", h.DownloadAgentFile)
-	g.GET("/attachments/:attachment_id/download", h.DownloadAttachment)
 	g.GET("/attachments/:attachment_id/preview", h.PreviewAttachment)
-	g.POST("/:canvas_id/upload", h.UploadAgentFile)
+	// POST /:canvas_id/upload and GET /attachments/:attachment_id/download
+	// accept the public share (beta) token used by the embedded/shared agent
+	// page, so they are registered on the beta-auth group in router.go
+	// instead of this JWT-only group. Mirrors python
+	// @login_required(auth_types=[AUTH_JWT, AUTH_API, AUTH_BETA]) on
+	// upload_agent_file (agent_api.py:990) and download_attachment
+	// (agent_api.py:2666).
 
 	// Component introspection + debug.
 	g.GET("/:canvas_id/components/:component_id/input-form", h.GetComponentInputForm)

--- a/internal/router/agent_routes.go
+++ b/internal/router/agent_routes.go
@@ -58,13 +58,6 @@ func RegisterAgentRoutes(g *gin.RouterGroup, h *handler.AgentHandler) {
 	// File operations.
 	g.GET("/download", h.DownloadAgentFile)
 	g.GET("/attachments/:attachment_id/preview", h.PreviewAttachment)
-	// POST /:canvas_id/upload and GET /attachments/:attachment_id/download
-	// accept the public share (beta) token used by the embedded/shared agent
-	// page, so they are registered on the beta-auth group in router.go
-	// instead of this JWT-only group. Mirrors python
-	// @login_required(auth_types=[AUTH_JWT, AUTH_API, AUTH_BETA]) on
-	// upload_agent_file (agent_api.py:990) and download_attachment
-	// (agent_api.py:2666).
 
 	// Component introspection + debug.
 	g.GET("/:canvas_id/components/:component_id/input-form", h.GetComponentInputForm)

--- a/internal/router/agent_routes_test.go
+++ b/internal/router/agent_routes_test.go
@@ -17,12 +17,14 @@
 package router
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 
+	"ragflow/internal/common"
 	"ragflow/internal/handler"
 )
 
@@ -88,4 +90,71 @@ func TestAgentSessionCancelRouteRegistered(t *testing.T) {
 	if w.Code == http.StatusNotFound {
 		t.Fatal("POST /api/v1/tasks/:session_id/cancel was not registered")
 	}
+}
+
+// TestAgentUploadAndAttachmentDownloadOnBetaAuth pins the wiring of the
+// two agent endpoints that python declares with
+// @login_required(auth_types=[AUTH_JWT, AUTH_API, AUTH_BETA])
+// (api/apps/restful_apis/agent_api.py upload_agent_file / download_attachment).
+// They serve the embedded/shared agent page, whose only credential is the
+// share (beta) APIToken, so Router.Setup must register them on the
+// beta-auth group — NOT on the JWT-only authorized group. With no
+// Authorization header the beta middleware answers HTTP 200 + code 102
+// ("Authorization is not valid!"), while the JWT-only AuthMiddleware
+// answers a bare HTTP 401 — which is exactly what makes the embedded
+// page redirect to /login after an upload attempt (reported issue).
+func TestAgentUploadAndAttachmentDownloadOnBetaAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	r := &Router{
+		authHandler:  handler.NewAuthHandler(),
+		agentHandler: &handler.AgentHandler{},
+	}
+	r.Setup(engine)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"agent file upload", http.MethodPost, "/api/v1/agents/canvas-1/upload"},
+		{"agent attachment download", http.MethodGet, "/api/v1/agents/attachments/att-1/download"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			engine.ServeHTTP(resp, req)
+
+			if resp.Code == http.StatusNotFound {
+				t.Fatalf("%s %s returned 404; route is not registered", tt.method, tt.path)
+			}
+			var body struct {
+				Code common.ErrorCode `json:"code"`
+			}
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("failed to decode response body: %v", err)
+			}
+			if resp.Code != http.StatusOK || body.Code != common.CodeDataError {
+				t.Fatalf("status=%d body=%s; want beta auth middleware to handle the route (HTTP 200 + code %d)", resp.Code, resp.Body.String(), common.CodeDataError)
+			}
+		})
+	}
+
+	// Parity pin: attachments preview stays JWT-only in python
+	// (plain @login_required, agent_api.py:2656), so it must keep
+	// answering 401 from the authorized group when unauthenticated.
+	t.Run("agent attachment preview stays JWT-only", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/attachments/att-1/preview", nil)
+		engine.ServeHTTP(resp, req)
+
+		if resp.Code == http.StatusNotFound {
+			t.Fatal("GET /api/v1/agents/attachments/:attachment_id/preview was not registered")
+		}
+		if resp.Code != http.StatusUnauthorized {
+			t.Fatalf("status=%d body=%s; want the JWT-only AuthMiddleware to keep guarding the preview route", resp.Code, resp.Body.String())
+		}
+	})
 }

--- a/internal/router/agent_routes_test.go
+++ b/internal/router/agent_routes_test.go
@@ -17,6 +17,7 @@
 package router
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -92,17 +93,12 @@ func TestAgentSessionCancelRouteRegistered(t *testing.T) {
 	}
 }
 
-// TestAgentUploadAndAttachmentDownloadOnBetaAuth pins the wiring of the
-// two agent endpoints that python declares with
-// @login_required(auth_types=[AUTH_JWT, AUTH_API, AUTH_BETA])
-// (api/apps/restful_apis/agent_api.py upload_agent_file / download_attachment).
-// They serve the embedded/shared agent page, whose only credential is the
-// share (beta) APIToken, so Router.Setup must register them on the
-// beta-auth group — NOT on the JWT-only authorized group. With no
-// Authorization header the beta middleware answers HTTP 200 + code 102
-// ("Authorization is not valid!"), while the JWT-only AuthMiddleware
-// answers a bare HTTP 401 — which is exactly what makes the embedded
-// page redirect to /login after an upload attempt (reported issue).
+// TestAgentUploadAndAttachmentDownloadOnBetaAuth pins the auth wiring of
+// the agent file upload and attachment-download routes: the embedded
+// agent page holds only a share (beta) token, so both must sit on the
+// beta-auth group. Unauthenticated, its middleware answers HTTP 200 +
+// code 102 instead of the bare 401 the JWT-only AuthMiddleware would
+// return, which is what bounced the embedded page to /login.
 func TestAgentUploadAndAttachmentDownloadOnBetaAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -124,7 +120,7 @@ func TestAgentUploadAndAttachmentDownloadOnBetaAuth(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := httptest.NewRecorder()
-			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req := httptest.NewRequestWithContext(context.Background(), tt.method, tt.path, nil)
 			engine.ServeHTTP(resp, req)
 
 			if resp.Code == http.StatusNotFound {
@@ -142,12 +138,9 @@ func TestAgentUploadAndAttachmentDownloadOnBetaAuth(t *testing.T) {
 		})
 	}
 
-	// Parity pin: attachments preview stays JWT-only in python
-	// (plain @login_required, agent_api.py:2656), so it must keep
-	// answering 401 from the authorized group when unauthenticated.
 	t.Run("agent attachment preview stays JWT-only", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/attachments/att-1/preview", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/agents/attachments/att-1/preview", nil)
 		engine.ServeHTTP(resp, req)
 
 		if resp.Code == http.StatusNotFound {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -222,14 +222,6 @@ func (r *Router) Setup(engine *gin.Engine) {
 		apiBetaAuth.GET("/documents/images/:image_id", r.documentHandler.GetDocumentImage)
 		apiBetaAuth.GET("/thumbnails", r.documentHandler.GetThumbnail)
 
-		// Agent upload + attachment download also serve the embedded/shared
-		// agent page, whose only credential is the share (beta) APIToken
-		// passed as the ?auth= query param. Python declares both endpoints
-		// with @login_required(auth_types=[AUTH_JWT, AUTH_API, AUTH_BETA])
-		// (api/apps/restful_apis/agent_api.py:990 upload_agent_file,
-		// :2666 download_attachment); BetaAuthMiddleware resolves the same
-		// three credential kinds (session JWT → API token → beta token), so
-		// the routes stay usable from the logged-in console as well.
 		apiBetaAuth.POST("/agents/:canvas_id/upload", r.agentHandler.UploadAgentFile)
 		apiBetaAuth.GET("/agents/attachments/:attachment_id/download", r.agentHandler.DownloadAttachment)
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -222,6 +222,17 @@ func (r *Router) Setup(engine *gin.Engine) {
 		apiBetaAuth.GET("/documents/images/:image_id", r.documentHandler.GetDocumentImage)
 		apiBetaAuth.GET("/thumbnails", r.documentHandler.GetThumbnail)
 
+		// Agent upload + attachment download also serve the embedded/shared
+		// agent page, whose only credential is the share (beta) APIToken
+		// passed as the ?auth= query param. Python declares both endpoints
+		// with @login_required(auth_types=[AUTH_JWT, AUTH_API, AUTH_BETA])
+		// (api/apps/restful_apis/agent_api.py:990 upload_agent_file,
+		// :2666 download_attachment); BetaAuthMiddleware resolves the same
+		// three credential kinds (session JWT → API token → beta token), so
+		// the routes stay usable from the logged-in console as well.
+		apiBetaAuth.POST("/agents/:canvas_id/upload", r.agentHandler.UploadAgentFile)
+		apiBetaAuth.GET("/agents/attachments/:attachment_id/download", r.agentHandler.DownloadAttachment)
+
 		// MCP server endpoint — exposes RAGFlow capabilities as MCP tools.
 		// Uses BetaAuthMiddleware to resolve the user from the
 		// Authorization header.


### PR DESCRIPTION
### Summary

Uploading an attachment on an **embedded/shared agent page** fails and the page is redirected to the login page (reported against the Go API).

**Root cause.** The embed URL (`/agent/share?shared_id=<canvas id>&auth=<beta token>`) carries no user session; the only credential is the share (beta) APIToken, which the web client sends as `Authorization: Bearer <beta>` (`web/src/utils/authorization-util.ts: getAuthorization()`). The shared page uploads through `POST /api/v1/agents/<canvas id>/upload` (`web/src/hooks/use-agent-request.ts: useUploadAgentFileWithProgress`).

Python implements this endpoint with `@login_required(auth_types=[AUTH_JWT, AUTH_API, AUTH_BETA])` (`api/apps/restful_apis/agent_api.py:990`), so the beta token authenticates and the upload succeeds. The Go router instead registered `POST /api/v1/agents/:canvas_id/upload` inside the `authorized` group guarded by `AuthMiddleware`, which only accepts a session JWT or a regular API token. A beta token therefore produced `HTTP 401 "Invalid access token"`, and the web client's 401 interceptor (`web/src/utils/request.ts`) calls `redirectToLogin()` — the reported "jump to login page". `GET /api/v1/agents/attachments/:attachment_id/download` (used to fetch the uploaded attachment from the embed page) has the same python decorator (`agent_api.py:2666`) and the same defect.

**Fix.** Register both endpoints on the `apiBetaAuth` group (router.go), whose `BetaAuthMiddleware` resolves exactly the same three credential kinds as python's `[AUTH_JWT, AUTH_API, AUTH_BETA]` (session JWT → API token → beta token). This mirrors how the other mixed-auth endpoints (`/documents/:id/preview`, `/documents/images/:image_id`, `/thumbnails`) were already ported. `GET /api/v1/agents/attachments/:attachment_id/preview` keeps plain `@login_required` in python and therefore stays on the JWT-only authorized group. Both handlers only read the `user` context key, which `BetaAuthMiddleware` sets, so no handler changes are needed.

**Verification.**
- New regression test `TestAgentUploadAndAttachmentDownloadOnBetaAuth` (internal/router) pins: upload + attachment download are served by the beta middleware (HTTP 200 + code 102 envelope when unauthenticated, not a bare 401) and the preview route stays JWT-only. Full package passes: `bash build.sh --test ./internal/router/...`.
- Live A/B probe against the running backends with a valid beta token: before the fix, Go returned `HTTP 401 {"code":401,"message":"Invalid access token"}` while python returned `HTTP 200 {"code":103,"message":"Make sure you have permission to access the agent."}` (beta auth accepted; 103 because the probe token's tenant does not own the probe canvas). After the fix the Go API returns the same python envelope.
- Boundary: full browser end-to-end reproduction on the embed page was not possible in this environment because console login (`1@1.com`) is currently blocked by an environment data issue (the stored password hash does not match the UI's base64-wrapped password convention; the same browser login fails identically against the python backend), and minting a fresh share token requires console login. The evidence above (python parity, controlled live A/B on the auth boundary, router regression tests) pins the root cause and the fix instead.
