### PR TITLE
fix: publish wiki event when document is deleted

### DIFF
--- a/internal/ingestion/knowledge_compile/service.go
+++ b/internal/ingestion/knowledge_compile/service.go
@@ -100,6 +100,16 @@ func SetModelConfig(llmID, embedding string) {
 	defaultEmbedding = embedding
 }
 
+// InitializePublisher installs the process-wide publisher used by document
+// lifecycle events. API processes publish events but do not own the dataset
+// consumer, so they need this producer-only initialization without starting a
+// worker.
+func InitializePublisher(db *gorm.DB, mq engine.MessageQueue) {
+	if defaultPublisher == nil {
+		SetScheduler(newScheduler(db, mq, generateHolder(), 2*time.Minute))
+	}
+}
+
 // defaultDeduperFactory resolves the per-tenant LLM deps and builds the
 // KB-scoped deduper. On any failure it returns an error so the caller falls
 // back to the noop deduper (merged products are still written, just without

--- a/internal/ingestion/knowledge_compile/service.go
+++ b/internal/ingestion/knowledge_compile/service.go
@@ -100,6 +100,13 @@ func SetModelConfig(llmID, embedding string) {
 	defaultEmbedding = embedding
 }
 
+// NewPublisher creates a process-local publisher backed by the shared dataset
+// scheduling row. It does not start a consumer; API processes use it to append
+// document events for the ingestor-owned workers to consume.
+func NewPublisher(db *gorm.DB, mq engine.MessageQueue) Publisher {
+	return newScheduler(db, mq, generateHolder(), 2*time.Minute)
+}
+
 // defaultDeduperFactory resolves the per-tenant LLM deps and builds the
 // KB-scoped deduper. On any failure it returns an error so the caller falls
 // back to the noop deduper (merged products are still written, just without

--- a/internal/ingestion/knowledge_compile/service.go
+++ b/internal/ingestion/knowledge_compile/service.go
@@ -100,13 +100,6 @@ func SetModelConfig(llmID, embedding string) {
 	defaultEmbedding = embedding
 }
 
-// NewPublisher creates a process-local publisher backed by the shared dataset
-// scheduling row. It does not start a consumer; API processes use it to append
-// document events for the ingestor-owned workers to consume.
-func NewPublisher(db *gorm.DB, mq engine.MessageQueue) Publisher {
-	return newScheduler(db, mq, generateHolder(), 2*time.Minute)
-}
-
 // defaultDeduperFactory resolves the per-tenant LLM deps and builds the
 // KB-scoped deduper. On any failure it returns an error so the caller falls
 // back to the noop deduper (merged products are still written, just without

--- a/internal/service/document/document.go
+++ b/internal/service/document/document.go
@@ -26,6 +26,7 @@ import (
 
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
+	"ragflow/internal/ingestion/knowledge_compile"
 )
 
 // DocumentService document service
@@ -49,6 +50,10 @@ func NewDocumentService() *DocumentService {
 	publisher := service.NewMessageQueueTaskPublisher()
 	ingestionTaskSvc := service.NewIngestionTaskService()
 	ingestionTaskSvc.SetTaskPublisher(publisher)
+	// Document deletion is handled by the API process, while the dataset-level
+	// consumer is owned by the ingestor. Register the shared publisher here so
+	// knowledge_compile.PublishDeleted is effective in API processes as well.
+	knowledge_compile.InitializePublisher(dao.DB, engine.GetMessageQueueEngine())
 	return &DocumentService{
 		documentDAO:         dao.NewDocumentDAO(),
 		ingestionTaskDAO:    dao.NewIngestionTaskDAO(),

--- a/internal/service/document/document.go
+++ b/internal/service/document/document.go
@@ -26,7 +26,6 @@ import (
 
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
-	"ragflow/internal/ingestion/knowledge_compile"
 )
 
 // DocumentService document service
@@ -43,7 +42,6 @@ type DocumentService struct {
 	fileDAO             *dao.FileDAO
 	canvasDAO           *dao.UserCanvasDAO
 	api4ConvDAO         *dao.API4ConversationDAO
-	wikiPublisher       knowledge_compile.Publisher
 }
 
 // NewDocumentService create document service
@@ -64,7 +62,6 @@ func NewDocumentService() *DocumentService {
 		fileDAO:             dao.NewFileDAO(),
 		canvasDAO:           dao.NewUserCanvasDAO(),
 		api4ConvDAO:         dao.NewAPI4ConversationDAO(),
-		wikiPublisher:       knowledge_compile.NewPublisher(dao.DB, engine.GetMessageQueueEngine()),
 	}
 }
 

--- a/internal/service/document/document.go
+++ b/internal/service/document/document.go
@@ -26,6 +26,7 @@ import (
 
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
+	"ragflow/internal/ingestion/knowledge_compile"
 )
 
 // DocumentService document service
@@ -42,6 +43,7 @@ type DocumentService struct {
 	fileDAO             *dao.FileDAO
 	canvasDAO           *dao.UserCanvasDAO
 	api4ConvDAO         *dao.API4ConversationDAO
+	wikiPublisher       knowledge_compile.Publisher
 }
 
 // NewDocumentService create document service
@@ -62,6 +64,7 @@ func NewDocumentService() *DocumentService {
 		fileDAO:             dao.NewFileDAO(),
 		canvasDAO:           dao.NewUserCanvasDAO(),
 		api4ConvDAO:         dao.NewAPI4ConversationDAO(),
+		wikiPublisher:       knowledge_compile.NewPublisher(dao.DB, engine.GetMessageQueueEngine()),
 	}
 }
 

--- a/internal/service/document/document_crud.go
+++ b/internal/service/document/document_crud.go
@@ -342,7 +342,7 @@ func (s *DocumentService) RemoveDocumentKeepFile(ctx context.Context, docID stri
 	// the deleted document's contribution in both paths.
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancel()
-	if err := s.publishWikiDocumentDeleted(pubCtx, kb.TenantID, kb.ID, docID); err != nil {
+	if err := knowledge_compile.PublishDeleted(pubCtx, kb.TenantID, kb.ID, docID); err != nil {
 		common.Warn(fmt.Sprintf("RemoveDocumentKeepFile: publish doc_deleted for %s failed: %v", docID, err))
 	}
 	return nil
@@ -405,14 +405,15 @@ func (s *DocumentService) resolveDocAndKB(ctx context.Context, docID string) (*e
 	return doc, kb, nil
 }
 
-// deleteDocEngineData removes chunks and metadata from the document engine and
-// publishes the document deletion event for dataset-level products.
+// deleteDocEngineData removes chunks and metadata from the document engine.
+// No-op when the engine is nil.
 func (s *DocumentService) deleteDocEngineData(ctx context.Context, docID, tenantID, kbID string) {
-	if s.docEngine != nil {
-		indexName := fmt.Sprintf("ragflow_%s", tenantID)
-		if _, delErr := s.docEngine.DeleteChunks(ctx, map[string]interface{}{"doc_id": docID}, indexName, kbID); delErr != nil {
-			common.Warn(fmt.Sprintf("deleteDocEngineData: failed to delete chunks for %s: %v", docID, delErr))
-		}
+	if s.docEngine == nil {
+		return
+	}
+	indexName := fmt.Sprintf("ragflow_%s", tenantID)
+	if _, delErr := s.docEngine.DeleteChunks(ctx, map[string]interface{}{"doc_id": docID}, indexName, kbID); delErr != nil {
+		common.Warn(fmt.Sprintf("deleteDocEngineData: failed to delete chunks for %s: %v", docID, delErr))
 	}
 	// Notify the dataset-level post-processing consumer (§11) that this document's
 	// source + per-doc compiled chunks are gone. The consumer removes the
@@ -421,21 +422,14 @@ func (s *DocumentService) deleteDocEngineData(ctx context.Context, docID, tenant
 	// source/per-doc chunks, so the consumer only owns merged-product cleanup.
 	// Bound the publish with a timeout so a stalled scheduler (MySQL/NATS) can
 	// never block the document delete, which already succeeded above.
-	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	pubCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	if err := s.publishWikiDocumentDeleted(pubCtx, tenantID, kbID, docID); err != nil {
+	if err := knowledge_compile.PublishDeleted(pubCtx, tenantID, kbID, docID); err != nil {
 		common.Warn(fmt.Sprintf("deleteDocEngineData: publish doc_deleted for %s failed: %v", docID, err))
 	}
 	if s.metadataSvc != nil {
 		_ = s.DeleteDocumentAllMetadata(ctx, docID) // logs internally
 	}
-}
-
-func (s *DocumentService) publishWikiDocumentDeleted(ctx context.Context, tenantID, datasetID, docID string) error {
-	if s.wikiPublisher != nil {
-		return s.wikiPublisher.Publish(ctx, tenantID, datasetID, docID, string(knowledge_compile.EventTypeDeleted), nil)
-	}
-	return knowledge_compile.PublishDeleted(ctx, tenantID, datasetID, docID)
 }
 
 // deleteDocRecordWithCounters hard-deletes the document row and decrements the

--- a/internal/service/document/document_crud.go
+++ b/internal/service/document/document_crud.go
@@ -342,7 +342,7 @@ func (s *DocumentService) RemoveDocumentKeepFile(ctx context.Context, docID stri
 	// the deleted document's contribution in both paths.
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancel()
-	if err := knowledge_compile.PublishDeleted(pubCtx, kb.TenantID, kb.ID, docID); err != nil {
+	if err := s.publishWikiDocumentDeleted(pubCtx, kb.TenantID, kb.ID, docID); err != nil {
 		common.Warn(fmt.Sprintf("RemoveDocumentKeepFile: publish doc_deleted for %s failed: %v", docID, err))
 	}
 	return nil
@@ -405,15 +405,14 @@ func (s *DocumentService) resolveDocAndKB(ctx context.Context, docID string) (*e
 	return doc, kb, nil
 }
 
-// deleteDocEngineData removes chunks and metadata from the document engine.
-// No-op when the engine is nil.
+// deleteDocEngineData removes chunks and metadata from the document engine and
+// publishes the document deletion event for dataset-level products.
 func (s *DocumentService) deleteDocEngineData(ctx context.Context, docID, tenantID, kbID string) {
-	if s.docEngine == nil {
-		return
-	}
-	indexName := fmt.Sprintf("ragflow_%s", tenantID)
-	if _, delErr := s.docEngine.DeleteChunks(ctx, map[string]interface{}{"doc_id": docID}, indexName, kbID); delErr != nil {
-		common.Warn(fmt.Sprintf("deleteDocEngineData: failed to delete chunks for %s: %v", docID, delErr))
+	if s.docEngine != nil {
+		indexName := fmt.Sprintf("ragflow_%s", tenantID)
+		if _, delErr := s.docEngine.DeleteChunks(ctx, map[string]interface{}{"doc_id": docID}, indexName, kbID); delErr != nil {
+			common.Warn(fmt.Sprintf("deleteDocEngineData: failed to delete chunks for %s: %v", docID, delErr))
+		}
 	}
 	// Notify the dataset-level post-processing consumer (§11) that this document's
 	// source + per-doc compiled chunks are gone. The consumer removes the
@@ -422,14 +421,21 @@ func (s *DocumentService) deleteDocEngineData(ctx context.Context, docID, tenant
 	// source/per-doc chunks, so the consumer only owns merged-product cleanup.
 	// Bound the publish with a timeout so a stalled scheduler (MySQL/NATS) can
 	// never block the document delete, which already succeeded above.
-	pubCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancel()
-	if err := knowledge_compile.PublishDeleted(pubCtx, tenantID, kbID, docID); err != nil {
+	if err := s.publishWikiDocumentDeleted(pubCtx, tenantID, kbID, docID); err != nil {
 		common.Warn(fmt.Sprintf("deleteDocEngineData: publish doc_deleted for %s failed: %v", docID, err))
 	}
 	if s.metadataSvc != nil {
 		_ = s.DeleteDocumentAllMetadata(ctx, docID) // logs internally
 	}
+}
+
+func (s *DocumentService) publishWikiDocumentDeleted(ctx context.Context, tenantID, datasetID, docID string) error {
+	if s.wikiPublisher != nil {
+		return s.wikiPublisher.Publish(ctx, tenantID, datasetID, docID, string(knowledge_compile.EventTypeDeleted), nil)
+	}
+	return knowledge_compile.PublishDeleted(ctx, tenantID, datasetID, docID)
 }
 
 // deleteDocRecordWithCounters hard-deletes the document row and decrements the


### PR DESCRIPTION
### What problem does this PR solve?

Document deletion events were not published when the API process had no local Wiki publisher, so dataset-level Wiki updates were not triggered.

This change creates a process-local publisher in the document service and publishes `doc_deleted` events through the shared scheduler.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)