### PR TITLE
fix(go): sort provider model instances by creation time

### DIFF
--- a/internal/dao/tenant_model_instance.go
+++ b/internal/dao/tenant_model_instance.go
@@ -55,7 +55,10 @@ func (dao *TenantModelInstanceDAO) Create(ctx context.Context, db *gorm.DB, inst
 
 func (dao *TenantModelInstanceDAO) GetAllInstancesByProviderID(ctx context.Context, db *gorm.DB, providerID string) ([]*entity.TenantModelInstance, error) {
 	var instances []*entity.TenantModelInstance
-	err := db.WithContext(ctx).Where("provider_id = ?", providerID).Find(&instances).Error
+	// Newest instance first. Mirrors Python's provider_api_service
+	// list_provider_instances, which sorts by create_time desc so the list
+	// follows creation order instead of the random-token primary key order.
+	err := db.WithContext(ctx).Where("provider_id = ?", providerID).Order("create_time DESC").Find(&instances).Error
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dao/tenant_model_instance_test.go
+++ b/internal/dao/tenant_model_instance_test.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/glebarez/sqlite"
@@ -49,6 +50,10 @@ func TestTenantModelInstanceDAOGetAllInstancesByProviderIDOrdersByCreateTimeDesc
 	var names []string
 	for _, instance := range instances {
 		names = append(names, instance.InstanceName)
+	}
+	// Pin the provider filter explicitly: the provider-2 row must be absent.
+	if slices.Contains(names, "other") {
+		t.Fatalf("expected only provider-1 instances, got %v", names)
 	}
 	want := []string{"newest", "middle", "oldest"}
 	if len(names) != len(want) {

--- a/internal/dao/tenant_model_instance_test.go
+++ b/internal/dao/tenant_model_instance_test.go
@@ -1,0 +1,62 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"ragflow/internal/entity"
+)
+
+func setupTenantModelInstanceDAOTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	if err = db.AutoMigrate(&entity.TenantModelInstance{}); err != nil {
+		t.Fatalf("failed to migrate tenant_model_instance: %v", err)
+	}
+	return db
+}
+
+func seedTenantModelInstance(t *testing.T, db *gorm.DB, instance *entity.TenantModelInstance) {
+	t.Helper()
+	if err := db.Create(instance).Error; err != nil {
+		t.Fatalf("failed to seed tenant model instance: %v", err)
+	}
+}
+
+// The random-token primary keys make the storage order unrelated to creation
+// time, so the DAO must sort by create_time explicitly (mirroring Python's
+// list_provider_instances).
+func TestTenantModelInstanceDAOGetAllInstancesByProviderIDOrdersByCreateTimeDesc(t *testing.T) {
+	db := setupTenantModelInstanceDAOTestDB(t)
+
+	mkTime := func(v int64) *int64 { return &v }
+	// Inserted so that primary-key order differs from creation order.
+	seedTenantModelInstance(t, db, &entity.TenantModelInstance{ID: "c-instance-middle", InstanceName: "middle", ProviderID: "provider-1", APIKey: "k", BaseModel: entity.BaseModel{CreateTime: mkTime(2000)}})
+	seedTenantModelInstance(t, db, &entity.TenantModelInstance{ID: "a-instance-oldest", InstanceName: "oldest", ProviderID: "provider-1", APIKey: "k", BaseModel: entity.BaseModel{CreateTime: mkTime(1000)}})
+	seedTenantModelInstance(t, db, &entity.TenantModelInstance{ID: "b-instance-newest", InstanceName: "newest", ProviderID: "provider-1", APIKey: "k", BaseModel: entity.BaseModel{CreateTime: mkTime(3000)}})
+	seedTenantModelInstance(t, db, &entity.TenantModelInstance{ID: "d-other-provider", InstanceName: "other", ProviderID: "provider-2", APIKey: "k", BaseModel: entity.BaseModel{CreateTime: mkTime(4000)}})
+
+	instances, err := NewTenantModelInstanceDAO().GetAllInstancesByProviderID(t.Context(), db, "provider-1")
+	if err != nil {
+		t.Fatalf("failed to list instances: %v", err)
+	}
+
+	var names []string
+	for _, instance := range instances {
+		names = append(names, instance.InstanceName)
+	}
+	want := []string{"newest", "middle", "oldest"}
+	if len(names) != len(want) {
+		t.Fatalf("expected %d instances, got %v", len(want), names)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("expected instance order %v, got %v", want, names)
+		}
+	}
+}


### PR DESCRIPTION
### Summary

The model providers page showed a tenant's model instances in an arbitrary
order instead of following their creation time.

**Background.** The web UI (`/user-setting/model`) renders a provider's
instances in the exact order returned by
`GET /v1/providers/<name>/instances`. On the Python API,
`provider_api_service.list_provider_instances` already sorts instances by
`create_time` desc (established by #16999, newest instance first). The Go
port of the same endpoint (`TenantModelInstanceDAO.GetAllInstancesByProviderID`)
never mirrored that: it issues a plain `Find` without any `ORDER BY`, and
`tenant_model_instance` rows are clustered on a random 32-char token primary
key, so MySQL returns them in an order unrelated to creation time. Example
from a live deployment: Tongyi-Qianwen instances created as
`350234` (07-22) → `asdasdasdasdasd` (08-07) were listed as
`["asdasdasdasdasd", "350234"]` (primary-key order).

**Fix.** Add `ORDER BY create_time DESC` to
`TenantModelInstanceDAO.GetAllInstancesByProviderID` so the Go API matches
the Python behavior (newest instance first). All callers of this DAO method
either render the list or iterate over every row, so the explicit ordering is
safe for all of them.

**Test.** New DAO unit test
`TestTenantModelInstanceDAOGetAllInstancesByProviderIDOrdersByCreateTimeDesc`
seeds three instances whose primary-key order differs from their creation
order (in-memory SQLite) and asserts the returned order is newest-first.
Verified `bash build.sh --test ./internal/dao/...` and
`bash build.sh --test ./internal/service/...` pass, and re-checked the live
endpoint after rebuild: `OpenAI-API-Compatible` now returns
`["mock-local", "111111111"]` (created 08-14 → 08-07, previously flipped).
