### PR TITLE
fix(web): agent explore streaming answer leaking into the switched-to session

### DIFF
--- a/web/src/pages/agent/chat/use-send-agent-message.test.tsx
+++ b/web/src/pages/agent/chat/use-send-agent-message.test.tsx
@@ -1,0 +1,169 @@
+import { act, renderHook } from '@testing-library/react';
+import { MessageEventType } from '@/hooks/use-send-message';
+import { MessageType } from '@/constants/chat';
+import { useSendAgentMessage } from './use-send-agent-message';
+
+let mockAnswerList: any[] = [];
+let mockDone = true;
+const mockSend = jest.fn();
+const mockAddNewestOneAnswer = jest.fn();
+
+jest.mock('@/hooks/use-send-message', () => ({
+  // Mirrors the real MessageEventType enum; the real module cannot be
+  // requireActual'd here because it pulls in eventsource-parser's
+  // TransformStream, which jsdom does not provide.
+  MessageEventType: {
+    WorkflowStarted: 'workflow_started',
+    NodeStarted: 'node_started',
+    NodeFinished: 'node_finished',
+    Message: 'message',
+    MessageEnd: 'message_end',
+    WorkflowFinished: 'workflow_finished',
+    UserInputs: 'user_inputs',
+    WaitingForUser: 'waiting_for_user',
+    NodeLogs: 'node_logs',
+  },
+  useSendMessageBySSE: () => ({
+    send: mockSend,
+    answerList: mockAnswerList,
+    done: mockDone,
+    setDone: jest.fn(),
+    resetAnswerList: jest.fn(),
+    stopOutputMessage: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/logic-hooks', () => ({
+  // Fully mocked: the real module imports eventsource-parser, which needs
+  // TransformStream (unavailable in jsdom).
+  useHandleMessageInputChange: () => ({
+    handleInputChange: jest.fn(),
+    value: '',
+    setValue: jest.fn(),
+  }),
+  useSelectDerivedMessages: () => ({
+    derivedMessages: [],
+    setDerivedMessages: jest.fn(),
+    scrollRef: { current: null },
+    messageContainerRef: { current: null },
+    removeLatestMessage: jest.fn(),
+    removeMessageById: jest.fn(),
+    addNewestOneQuestion: jest.fn(),
+    addNewestOneAnswer: mockAddNewestOneAnswer,
+    removeAllMessages: jest.fn(),
+    removeAllMessagesExceptFirst: jest.fn(),
+    scrollToBottom: jest.fn(),
+    addPrologue: jest.fn(),
+  }),
+}));
+
+jest.mock('react-router', () => ({
+  useParams: () => ({}),
+  useSearchParams: () => [new URLSearchParams(), jest.fn()],
+}));
+
+jest.mock('../hooks/use-get-begin-query', () => ({
+  useIsTaskMode: () => false,
+  useSelectBeginNodeDataInputs: () => [],
+}));
+
+const messageFrame = (sessionId: string, content: string) => ({
+  event: MessageEventType.Message,
+  data: { content, session_id: sessionId },
+  message_id: 'message-1',
+  session_id: sessionId,
+});
+
+const renderSendAgentMessage = (activeSessionId: string | undefined) =>
+  renderHook(
+    (props: { activeSessionId: string | undefined }) =>
+      useSendAgentMessage({ activeSessionId: props.activeSessionId }),
+    { initialProps: { activeSessionId } },
+  );
+
+describe('useSendAgentMessage session-scoped stream gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAnswerList = [];
+    mockDone = true;
+  });
+
+  it('does not apply frames whose session_id differs from activeSessionId', () => {
+    const { rerender } = renderSendAgentMessage('session-b');
+    mockAnswerList = [messageFrame('session-a', 'hello')];
+    rerender({ activeSessionId: 'session-b' });
+    expect(mockAddNewestOneAnswer).not.toHaveBeenCalled();
+  });
+
+  it('applies frames whose session_id matches activeSessionId', () => {
+    const { rerender } = renderSendAgentMessage('session-a');
+    mockAnswerList = [messageFrame('session-a', 'hello')];
+    rerender({ activeSessionId: 'session-a' });
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledTimes(1);
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'message-1', answer: 'hello' }),
+    );
+  });
+
+  it('keeps applying frames that carry no session id', () => {
+    const { rerender } = renderSendAgentMessage('');
+    mockAnswerList = [
+      {
+        event: MessageEventType.Message,
+        data: { content: 'legacy frame' },
+        message_id: 'message-2',
+      },
+    ];
+    rerender({ activeSessionId: '' });
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledTimes(1);
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'message-2', answer: 'legacy frame' }),
+    );
+  });
+
+  it('replays the streamed answer when switching back to the stream session', () => {
+    const { rerender } = renderSendAgentMessage('session-b');
+    mockAnswerList = [messageFrame('session-a', 'hello')];
+    rerender({ activeSessionId: 'session-b' });
+    expect(mockAddNewestOneAnswer).not.toHaveBeenCalled();
+
+    // A -> B -> A: the accumulated answer is re-applied without a new frame.
+    rerender({ activeSessionId: 'session-a' });
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-applies the streamed answer after external hydration replaced the list', async () => {
+    const { result, rerender } = renderSendAgentMessage('session-a');
+    mockAnswerList = [messageFrame('session-a', 'hello')];
+    rerender({ activeSessionId: 'session-a' });
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledTimes(1);
+
+    // SessionChat hydrates persisted messages and asks for a re-apply.
+    await act(async () => {
+      result.current.reapplyStreamedAnswer();
+    });
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledTimes(2);
+  });
+
+  it('still applies frames when no activeSessionId is provided', () => {
+    const { rerender } = renderSendAgentMessage(undefined);
+    mockAnswerList = [messageFrame('session-a', 'hello')];
+    rerender({ activeSessionId: undefined });
+    expect(mockAddNewestOneAnswer).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the session a request is sent to before the first frame', async () => {
+    mockSend.mockResolvedValue({
+      response: { ok: true, status: 200 },
+      data: { code: 0 },
+    });
+    const { result } = renderSendAgentMessage('session-new');
+    await act(async () => {
+      await result.current.sendMessage({
+        message: { id: 'q1', content: 'hi', role: MessageType.User },
+        exploreSessionId: 'session-new',
+      });
+    });
+    expect(result.current.requestedSessionId).toBe('session-new');
+  });
+});

--- a/web/src/pages/agent/chat/use-send-agent-message.ts
+++ b/web/src/pages/agent/chat/use-send-agent-message.ts
@@ -263,6 +263,22 @@ export const useSendAgentMessage = ({
   // Session that owns the in-flight stream; every SSE frame carries the
   // session_id it belongs to.
   const streamSessionId = firstAnswer?.session_id;
+  // Session the pending request was sent to. It is known before the first
+  // SSE frame arrives, so the stream can already be attributed to its
+  // session during connection setup.
+  const [requestedSessionId, setRequestedSessionId] = useState<
+    string | null | undefined
+  >();
+  // Bumped when derivedMessages is replaced externally (Explore hydrates
+  // persisted messages when a session is re-selected) while a stream
+  // owned by the displayed session is in flight, so the streamed answer
+  // is re-applied on top of the hydrated history — the effect below
+  // otherwise only re-runs when a new frame arrives.
+  const [streamReplayToken, setStreamReplayToken] = useState(0);
+  const reapplyStreamedAnswer = useCallback(
+    () => setStreamReplayToken((token) => token + 1),
+    [],
+  );
   const messageId = useMemo(() => {
     return firstAnswer?.message_id;
   }, [firstAnswer]);
@@ -337,6 +353,10 @@ export const useSendAgentMessage = ({
         // The hook keeps its own session cache for streamed replies, but that cache
         // can lag behind when the user switches sessions in Explore.
         params.session_id = exploreSessionId || sessionId;
+        // Remember the owner before the first frame arrives so
+        // connection-setup loading states are attributed to the right
+        // session.
+        setRequestedSessionId((exploreSessionId || sessionId) ?? null);
         if (releaseMode) {
           params.release = releaseMode;
         }
@@ -388,6 +408,7 @@ export const useSendAgentMessage = ({
           .join('<br/>'),
         role: MessageType.User,
       });
+      setRequestedSessionId(sessionId ?? null);
       await send({
         ...body,
         ...(isShared ? {} : { agent_id: agentId }),
@@ -514,7 +535,13 @@ export const useSendAgentMessage = ({
         });
       }
     }
-  }, [activeSessionId, answerList, addNewestOneAnswer, streamSessionId]);
+  }, [
+    activeSessionId,
+    answerList,
+    addNewestOneAnswer,
+    streamSessionId,
+    streamReplayToken,
+  ]);
 
   useEffect(() => {
     if (isTaskMode) {
@@ -568,5 +595,7 @@ export const useSendAgentMessage = ({
     setDerivedMessages,
     addPrologue,
     streamSessionId,
+    requestedSessionId,
+    reapplyStreamedAnswer,
   };
 };

--- a/web/src/pages/agent/chat/use-send-agent-message.ts
+++ b/web/src/pages/agent/chat/use-send-agent-message.ts
@@ -236,6 +236,7 @@ export const useSendAgentMessage = ({
   refetch,
   isTaskMode: isTask,
   releaseMode,
+  activeSessionId,
 }: {
   url?: string;
   addEventList?: (data: IEventList, messageId: string) => void;
@@ -244,6 +245,13 @@ export const useSendAgentMessage = ({
   refetch?: () => void;
   isTaskMode?: boolean;
   releaseMode?: string | null;
+  /**
+   * Session the page is currently displaying. When provided, streamed
+   * frames that belong to another session are not written into the
+   * displayed message list (the user may switch sessions in Explore
+   * while an answer is still streaming).
+   */
+  activeSessionId?: string;
 }) => {
   const { id: agentId } = useParams();
   const { handleInputChange, value, setValue } = useHandleMessageInputChange();
@@ -252,6 +260,9 @@ export const useSendAgentMessage = ({
   const { send, answerList, done, stopOutputMessage, resetAnswerList } =
     useSendMessageBySSE(url || api.agentChatCompletion);
   const firstAnswer = answerList[0];
+  // Session that owns the in-flight stream; every SSE frame carries the
+  // session_id it belongs to.
+  const streamSessionId = firstAnswer?.session_id;
   const messageId = useMemo(() => {
     return firstAnswer?.message_id;
   }, [firstAnswer]);
@@ -461,6 +472,16 @@ export const useSendAgentMessage = ({
   }, [sendMessageInTaskMode]);
 
   useEffect(() => {
+    // The stream belongs to the session it was started in. If the user has
+    // switched to a different session while the answer is streaming, do not
+    // write the incoming frames into the message list being displayed.
+    if (
+      activeSessionId !== undefined &&
+      streamSessionId !== undefined &&
+      streamSessionId !== activeSessionId
+    ) {
+      return;
+    }
     const { content, id, attachment, audio_binary, downloads } =
       findMessageFromList(answerList);
     const inputAnswer = findInputFromList(answerList);
@@ -493,7 +514,7 @@ export const useSendAgentMessage = ({
         });
       }
     }
-  }, [answerList, addNewestOneAnswer]);
+  }, [activeSessionId, answerList, addNewestOneAnswer, streamSessionId]);
 
   useEffect(() => {
     if (isTaskMode) {
@@ -546,5 +567,6 @@ export const useSendAgentMessage = ({
     removeFile,
     setDerivedMessages,
     addPrologue,
+    streamSessionId,
   };
 };

--- a/web/src/pages/agent/explore/components/session-chat.tsx
+++ b/web/src/pages/agent/explore/components/session-chat.tsx
@@ -50,12 +50,17 @@ export function SessionChat({ session }: SessionChatProps) {
     beginInputs,
     shouldShowParameterDialog,
     setDerivedMessages,
+    streamSessionId,
   } = useSendSessionMessage();
 
   const { buildInputList, handleOk, isWaiting } = useAwaitComponentData({
     derivedMessages,
     sendFormMessage,
   });
+  // An in-flight stream only renders a loading state on the session it
+  // belongs to, not on whichever session the user switched to.
+  const isStreamingActiveSession =
+    sendLoading && (streamSessionId ? streamSessionId === sessionId : true);
   const hasActiveSession = Boolean(
     sessionId || isNew || hasLocalMessageRef.current,
   );
@@ -141,7 +146,7 @@ export function SessionChat({ session }: SessionChatProps) {
                     <MessageItem
                       loading={
                         message.role === MessageType.Assistant &&
-                        sendLoading &&
+                        isStreamingActiveSession &&
                         derivedMessages.length - 1 === i
                       }
                       key={buildMessageUuidWithRole(message)}
@@ -159,7 +164,7 @@ export function SessionChat({ session }: SessionChatProps) {
                       clickDocumentButton={clickDocumentButton}
                       index={i}
                       showLikeButton={false}
-                      sendLoading={sendLoading}
+                      sendLoading={isStreamingActiveSession}
                       showLog={false}
                     >
                       {hasUserFillUpInputs &&

--- a/web/src/pages/agent/explore/components/session-chat.tsx
+++ b/web/src/pages/agent/explore/components/session-chat.tsx
@@ -51,6 +51,8 @@ export function SessionChat({ session }: SessionChatProps) {
     shouldShowParameterDialog,
     setDerivedMessages,
     streamSessionId,
+    requestedSessionId,
+    reapplyStreamedAnswer,
   } = useSendSessionMessage();
 
   const { buildInputList, handleOk, isWaiting } = useAwaitComponentData({
@@ -58,9 +60,14 @@ export function SessionChat({ session }: SessionChatProps) {
     sendFormMessage,
   });
   // An in-flight stream only renders a loading state on the session it
-  // belongs to, not on whichever session the user switched to.
+  // belongs to, not on whichever session the user switched to. Before the
+  // first SSE frame arrives the frame-carried session id is unknown, so
+  // fall back to the session the request was sent to; only when neither
+  // is known is the stream treated as belonging to the displayed session.
+  const streamOwnerSessionId = streamSessionId ?? requestedSessionId;
   const isStreamingActiveSession =
-    sendLoading && (streamSessionId ? streamSessionId === sessionId : true);
+    sendLoading &&
+    (streamOwnerSessionId ? streamOwnerSessionId === sessionId : true);
   const hasActiveSession = Boolean(
     sessionId || isNew || hasLocalMessageRef.current,
   );
@@ -98,6 +105,24 @@ export function SessionChat({ session }: SessionChatProps) {
       setDerivedMessages(messages as IMessage[]);
     }
   }, [session?.id, session?.message, sessionId, setDerivedMessages]);
+
+  // Hydrating persisted messages replaces the streamed view, and the
+  // persisted list cannot contain the answer that is still being
+  // generated. When a stream owned by this session is in flight, ask the
+  // send-message hook to re-apply the streamed answer on top of the
+  // hydrated history — its replay effect only re-runs when a new frame
+  // arrives, which can take a long time or never happen (the stream may
+  // have finished while another session was displayed).
+  useEffect(() => {
+    if (isStreamingActiveSession) {
+      reapplyStreamedAnswer();
+    }
+  }, [
+    session?.message,
+    sessionId,
+    isStreamingActiveSession,
+    reapplyStreamedAnswer,
+  ]);
 
   useEffect(() => {
     if (!sessionId && !isNew && !hasLocalMessageRef.current && !sendLoading) {
@@ -200,6 +225,10 @@ export function SessionChat({ session }: SessionChatProps) {
           </div>
         )}
         <section className="p-4">
+          {/* The SSE stream and its message state are shared by every
+              session of this canvas, so the input stays disabled while any
+              session is streaming: a second concurrent stream would
+              interleave its frames into the same answer list. */}
           <NextMessageInput
             value={value}
             sendLoading={sendLoading}

--- a/web/src/pages/agent/explore/hooks/use-send-session-message.ts
+++ b/web/src/pages/agent/explore/hooks/use-send-session-message.ts
@@ -63,6 +63,9 @@ export const useSendSessionMessage = () => {
     ...chatLogic
   } = useSendAgentMessage({
     beginParams,
+    // Gate streamed output so a stream started in another session never
+    // renders into the session the user switched to.
+    activeSessionId: sessionId ?? '',
   });
 
   const handleParametersOk = useCallback(


### PR DESCRIPTION
### Summary

In agent **Explore**, asking a model and switching to another session (chat box) while the answer was still streaming caused the streaming answer to be rendered inside the session the user had just switched to.

**Root cause.** The Explore page mounts `SessionChat` once per canvas; `useSendAgentMessage` therefore keeps one SSE `answerList` and one `derivedMessages` list shared by every session. The effect that folds streamed frames into the message list (`web/src/pages/agent/chat/use-send-agent-message.ts`) appended unconditionally, so after a session switch the in-flight frames of session A were written into the message list of the currently displayed session B. The global `sendLoading` also made the last assistant message of session B show a streaming indicator.

**Fix.** Every agent SSE frame already carries the `session_id` it belongs to (see the frame contract in `internal/agent/canvas/runner.go`), so ownership is known on the client:

- `useSendAgentMessage` accepts an optional `activeSessionId` (the session the page is currently displaying) and skips the streamed-answer append when the stream's `session_id` differs from it. It also exposes `streamSessionId` so callers can scope streaming UI.
- The Explore hook (`use-send-session-message.ts`) passes the URL session id as `activeSessionId`.
- `session-chat.tsx` shows the per-message streaming loading state only when the in-flight stream belongs to the displayed session.

Behavior after the fix: switching sessions mid-answer keeps each session's message list clean; switching back to the streaming session resumes rendering the answer there; the answer is still persisted to its own session by the backend. Canvas debug chat and shared-agent chat are unchanged (they pass no `activeSessionId`, so the gate is inactive).

**Verification.** Reproduced in the browser (dev services): asked for a long essay in session A, switched to session B mid-stream — pre-fix, session B showed session A's growing essay (~27k chars); post-fix, session B shows only its own history while the stream keeps running (confirmed by switching back and watching it continue in A). `jest src/pages/agent` passes (12 suites / 79 tests); `tsc --noEmit` shows no new errors in the touched files (remaining errors are pre-existing on main).
