### PR TITLE
feat(extractor): unify multi-tenant LLM cache engine with TTL jitter and quality gates

### DIFF
--- a/internal/cache/llmcache/llm_cache.go
+++ b/internal/cache/llmcache/llm_cache.go
@@ -39,8 +39,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
-	"reflect"
+	randv2 "math/rand/v2"
+	"sync"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -54,15 +54,15 @@ import (
 
 // Standard sentinel errors.
 var (
-	// ErrNoTenantID is returned or used when tenantID is empty in operations requiring it.
-	ErrNoTenantID = errors.New("llmcache: tenantID is required")
-	// ErrCacheMiss indicates that the requested key was not found in the cache.
-	ErrCacheMiss = errors.New("llmcache: cache miss")
-	// ErrRejected indicates that the computed value failed the validator gate.
-	ErrRejected = errors.New("llmcache: value rejected by validator")
 	// ErrTypeAssertion indicates an internal type assertion failure.
 	ErrTypeAssertion = errors.New("llmcache: internal type assertion failed")
 )
+
+var xxhashPool = sync.Pool{
+	New: func() any {
+		return xxhash.New()
+	},
+}
 
 // KeyPrefix is the Redis namespace for all entries managed by this engine.
 const KeyPrefix = "kc:llm"
@@ -143,12 +143,15 @@ func New[T any](opts ...Option[T]) *Engine[T] {
 // (e.g. ("ab","c") vs ("a","bc")). The engine never assumes anything about the
 // business meaning of keyParts — that is the caller's responsibility.
 func BuildKey(tenantID, taskType string, keyParts ...string) string {
-	h := xxhash.New()
+	h := xxhashPool.Get().(*xxhash.Digest)
 	for _, p := range keyParts {
 		h.WriteString(p)
 		h.WriteString("\x00")
 	}
-	return fmt.Sprintf("%s:%s:%s:%x", KeyPrefix, tenantID, taskType, h.Sum64())
+	key := fmt.Sprintf("%s:%s:%s:%x", KeyPrefix, tenantID, taskType, h.Sum64())
+	h.Reset()
+	xxhashPool.Put(h)
+	return key
 }
 
 // ApplyJitter returns the base duration with ±10% random jitter applied.
@@ -163,7 +166,7 @@ func applyJitter(base time.Duration) time.Duration {
 	}
 	// ±10% jitter: range is [base * 0.90, base * 1.10]
 	delta := float64(base) * 0.10
-	factor := (rand.Float64() * 2.0) - 1.0
+	factor := (randv2.Float64() * 2.0) - 1.0
 	jitter := time.Duration(delta * factor)
 	return base + jitter
 }
@@ -196,12 +199,6 @@ func (e *Engine[T]) emit(ev Event) {
 
 func (e *Engine[T]) get(ctx context.Context, key string) (T, bool) {
 	var zero, dest T
-	val := reflect.ValueOf(&dest).Elem()
-	if val.Kind() == reflect.Map && val.IsNil() {
-		val.Set(reflect.MakeMap(val.Type()))
-	} else if val.Kind() == reflect.Slice && val.IsNil() {
-		val.Set(reflect.MakeSlice(val.Type(), 0, 0))
-	}
 
 	if e.rawClient != nil {
 		data, err := e.rawClient.Get(ctx, key).Result()
@@ -227,20 +224,26 @@ func (e *Engine[T]) set(ctx context.Context, tenantID, key string, v T) {
 	if tenantID == "" {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	setCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+
 	ttl := applyJitter(e.ttl)
 	if e.rawClient != nil {
 		data, err := json.Marshal(v)
 		if err != nil {
 			return
 		}
-		e.rawClient.Set(ctx, key, data, ttl)
+		e.rawClient.Set(setCtx, key, data, ttl)
 		return
 	}
 	client := e.getRedis()
 	if client == nil {
 		return
 	}
-	client.SetObj(ctx, key, v, ttl)
+	client.SetObj(setCtx, key, v, ttl)
 }
 
 // GetOrCompute returns the cached value for (tenantID, taskType, keyParts), or
@@ -251,8 +254,7 @@ func (e *Engine[T]) set(ctx context.Context, tenantID, key string, v T) {
 // A double-check re-reads Redis inside the merged call in case a peer already wrote
 // the value back. The winning result is written back only after passing the Validator.
 //
-// Fail-Closed: if tenantID is empty, it bypasses caching completely, directly executing
-// computeFn without writing to Redis.
+// Fail-Open (bypass): execute computeFn directly without caching when tenantID is empty to ensure business continuity without polluting global namespace.
 func (e *Engine[T]) GetOrCompute(
 	ctx context.Context,
 	tenantID, taskType string,
@@ -261,7 +263,7 @@ func (e *Engine[T]) GetOrCompute(
 ) (T, error) {
 	var zero T
 	if tenantID == "" {
-		// Fail-closed: empty tenantID bypasses cache and strictly avoids Redis write.
+		// Fail-Open (bypass): execute computeFn directly without caching when tenantID is empty to ensure business continuity without polluting global namespace
 		return computeFn(ctx)
 	}
 
@@ -278,7 +280,9 @@ func (e *Engine[T]) GetOrCompute(
 	ch := e.group.DoChan(key, func() (any, error) {
 		// Double-check: a concurrent writer may have populated Redis while we
 		// were queued.
-		if v, ok := e.get(ctx, key); ok && (e.validate == nil || e.validate(v)) {
+		getCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 500*time.Millisecond)
+		defer cancel()
+		if v, ok := e.get(getCtx, key); ok && (e.validate == nil || e.validate(v)) {
 			return v, nil
 		}
 		v, cerr := computeFn(ctx)
@@ -298,6 +302,11 @@ func (e *Engine[T]) GetOrCompute(
 
 	select {
 	case <-ctx.Done():
+		e.group.Forget(key)
+		go func() {
+			<-ch
+			e.group.Forget(key)
+		}()
 		return zero, ctx.Err()
 	case res := <-ch:
 		if res.Err != nil {
@@ -314,26 +323,29 @@ func (e *Engine[T]) GetOrCompute(
 // FlushTenant purges every cache entry for a tenant (GDPR erasure / tenant teardown).
 // It scans for keys matching "kc:llm:{tenant_id}:*" using Redis SCAN cursor COUNT 1000,
 // deletes them in pipeline batches, sleeps 10ms between batches, and responds promptly to ctx.Done().
-// Returns the number of entries deleted.
-func (e *Engine[T]) FlushTenant(ctx context.Context, tenantID string) int {
+// Returns the number of entries deleted and any error encountered.
+func (e *Engine[T]) FlushTenant(ctx context.Context, tenantID string) (int, error) {
 	if tenantID == "" {
-		return 0
+		return 0, nil
 	}
 	rdb := e.getUniversalClient()
 	if rdb == nil {
-		return 0
+		return 0, nil
 	}
 
 	var cursor uint64
 	var deletedCount int
 	matchPattern := fmt.Sprintf("%s:%s:*", KeyPrefix, tenantID)
 
+	timer := time.NewTimer(10 * time.Millisecond)
+	defer timer.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			common.Warn("llmcache: FlushTenant cancelled by context",
 				zap.String("tenant_id", tenantID), zap.Error(ctx.Err()))
-			return deletedCount
+			return deletedCount, ctx.Err()
 		default:
 		}
 
@@ -341,7 +353,7 @@ func (e *Engine[T]) FlushTenant(ctx context.Context, tenantID string) int {
 		if err != nil {
 			common.Warn("llmcache: FlushTenant SCAN failed",
 				zap.String("tenant_id", tenantID), zap.Error(err))
-			break
+			return deletedCount, err
 		}
 
 		if len(keys) > 0 {
@@ -350,14 +362,15 @@ func (e *Engine[T]) FlushTenant(ctx context.Context, tenantID string) int {
 				pipe.Del(ctx, k)
 			}
 			cmders, err := pipe.Exec(ctx)
-			if err != nil && !errors.Is(err, goredis.Nil) {
-				common.Warn("llmcache: FlushTenant pipeline Del failed",
-					zap.String("tenant_id", tenantID), zap.Error(err))
-			}
 			for _, cmder := range cmders {
 				if intCmd, ok := cmder.(*goredis.IntCmd); ok {
 					deletedCount += int(intCmd.Val())
 				}
+			}
+			if err != nil && !errors.Is(err, goredis.Nil) {
+				common.Warn("llmcache: FlushTenant pipeline Del failed",
+					zap.String("tenant_id", tenantID), zap.Error(err))
+				return deletedCount, err
 			}
 		}
 
@@ -366,15 +379,23 @@ func (e *Engine[T]) FlushTenant(ctx context.Context, tenantID string) int {
 			break
 		}
 
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(10 * time.Millisecond)
+
 		select {
 		case <-ctx.Done():
 			common.Warn("llmcache: FlushTenant cancelled by context",
 				zap.String("tenant_id", tenantID), zap.Error(ctx.Err()))
-			return deletedCount
-		case <-time.After(10 * time.Millisecond):
+			return deletedCount, ctx.Err()
+		case <-timer.C:
 		}
 	}
 
 	e.emit(Event{Kind: "purge", TenantID: tenantID, Key: matchPattern})
-	return deletedCount
+	return deletedCount, nil
 }

--- a/internal/cache/llmcache/llm_cache.go
+++ b/internal/cache/llmcache/llm_cache.go
@@ -285,7 +285,8 @@ func (e *Engine[T]) GetOrCompute(
 		if v, ok := e.get(getCtx, key); ok && (e.validate == nil || e.validate(v)) {
 			return v, nil
 		}
-		v, cerr := computeFn(ctx)
+		computeCtx := context.WithoutCancel(ctx)
+		v, cerr := computeFn(computeCtx)
 		if cerr != nil {
 			return zero, cerr
 		}

--- a/internal/cache/llmcache/llm_cache.go
+++ b/internal/cache/llmcache/llm_cache.go
@@ -1,0 +1,380 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// Package llmcache provides a production-grade, multi-tenant, generic LLM-result
+// cache engine shared across all packages (ingestion extractor, canvas flow,
+// replay harness, ...).
+//
+// Design goals:
+//   - Tenant physical isolation: every key is bound to tenant_id, so no cross-
+//     tenant cache hits are possible, and a tenant can be purged on demand.
+//   - Generics: one engine instance per value type T (e.g. []string,
+//     map[string]any); the engine is storage/serialization agnostic.
+//   - Task-aware quality gate: a caller-supplied Validator decides whether a
+//     computed value is worth caching (allows legitimate empty results,
+//     rejects ERROR / truncated payloads).
+//   - SingleFlight: concurrent identical requests (same tenant+task+hash) are
+//     collapsed into a single upstream LLM call via DoChan with context cancellation
+//     safety, with a double-check to avoid redundant recompute after a peer has
+//     already written back.
+//   - Observable: an optional MetricsHook receives hit/miss/compute/skip/purge
+//     events for Prometheus instrumentation without hard-coupling the package.
+package llmcache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	goredis "github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+
+	"ragflow/internal/common"
+	"ragflow/internal/engine/redis"
+)
+
+// Standard sentinel errors.
+var (
+	// ErrNoTenantID is returned or used when tenantID is empty in operations requiring it.
+	ErrNoTenantID = errors.New("llmcache: tenantID is required")
+	// ErrCacheMiss indicates that the requested key was not found in the cache.
+	ErrCacheMiss = errors.New("llmcache: cache miss")
+	// ErrRejected indicates that the computed value failed the validator gate.
+	ErrRejected = errors.New("llmcache: value rejected by validator")
+	// ErrTypeAssertion indicates an internal type assertion failure.
+	ErrTypeAssertion = errors.New("llmcache: internal type assertion failed")
+)
+
+// KeyPrefix is the Redis namespace for all entries managed by this engine.
+const KeyPrefix = "kc:llm"
+
+// DefaultTTL mirrors the legacy Python get_llm_cache/set_llm_cache 24h window.
+const DefaultTTL = 24 * time.Hour
+
+// Validator reports whether a computed value should be cached.
+// Return true to keep it (including legitimate empty results), false to drop
+// it (e.g. an ERROR marker or a truncated payload). A nil Validator accepts
+// everything.
+type Validator[T any] func(v T) bool
+
+// Event is emitted for every cache decision so callers can instrument hit-rate,
+// compute cost, purge volume, etc.
+type Event struct {
+	Kind     string // "hit" | "miss" | "compute" | "skip_invalid" | "purge"
+	TenantID string
+	TaskType string
+	Key      string
+}
+
+// MetricsHook receives cache events. It must be cheap and non-blocking.
+type MetricsHook func(Event)
+
+// Engine is a generic, multi-tenant LLM-result cache.
+type Engine[T any] struct {
+	ttl       time.Duration
+	validate  Validator[T]
+	hook      MetricsHook
+	group     singleflight.Group
+	redisCli  *redis.Client
+	rawClient goredis.UniversalClient
+}
+
+// Option configures an Engine.
+type Option[T any] func(*Engine[T])
+
+// WithTTL overrides the cache entry TTL (default DefaultTTL).
+func WithTTL[T any](d time.Duration) Option[T] {
+	return func(e *Engine[T]) { e.ttl = d }
+}
+
+// WithValidator sets the task-aware quality gate.
+func WithValidator[T any](v Validator[T]) Option[T] {
+	return func(e *Engine[T]) { e.validate = v }
+}
+
+// WithMetrics installs an event hook for observability.
+func WithMetrics[T any](h MetricsHook) Option[T] {
+	return func(e *Engine[T]) { e.hook = h }
+}
+
+// WithRedisClient overrides the Redis client instance (primarily for testing and custom wiring).
+func WithRedisClient[T any](client *redis.Client) Option[T] {
+	return func(e *Engine[T]) { e.redisCli = client }
+}
+
+// WithUniversalClient overrides the Redis client with any go-redis UniversalClient (primarily for testing and custom wiring).
+func WithUniversalClient[T any](client goredis.UniversalClient) Option[T] {
+	return func(e *Engine[T]) { e.rawClient = client }
+}
+
+// New constructs an Engine with the given options.
+func New[T any](opts ...Option[T]) *Engine[T] {
+	e := &Engine[T]{ttl: DefaultTTL}
+	for _, o := range opts {
+		o(e)
+	}
+	return e
+}
+
+// BuildKey constructs the canonical, tenant-scoped cache key.
+//
+//	kc:llm:{tenant_id}:{task_type}:{xxhash64(keyParts...)}
+//
+// A NUL byte separates key parts to prevent cross-field hash collisions
+// (e.g. ("ab","c") vs ("a","bc")). The engine never assumes anything about the
+// business meaning of keyParts — that is the caller's responsibility.
+func BuildKey(tenantID, taskType string, keyParts ...string) string {
+	h := xxhash.New()
+	for _, p := range keyParts {
+		h.WriteString(p)
+		h.WriteString("\x00")
+	}
+	return fmt.Sprintf("%s:%s:%s:%x", KeyPrefix, tenantID, taskType, h.Sum64())
+}
+
+// ApplyJitter returns the base duration with ±10% random jitter applied.
+// If base <= 0, it returns base unmodified.
+func ApplyJitter(base time.Duration) time.Duration {
+	return applyJitter(base)
+}
+
+func applyJitter(base time.Duration) time.Duration {
+	if base <= 0 {
+		return base
+	}
+	// ±10% jitter: range is [base * 0.90, base * 1.10]
+	delta := float64(base) * 0.10
+	factor := (rand.Float64() * 2.0) - 1.0
+	jitter := time.Duration(delta * factor)
+	return base + jitter
+}
+
+func (e *Engine[T]) getRedis() *redis.Client {
+	if e.redisCli != nil {
+		return e.redisCli
+	}
+	return redis.Get()
+}
+
+func (e *Engine[T]) getUniversalClient() goredis.UniversalClient {
+	if e.rawClient != nil {
+		return e.rawClient
+	}
+	if e.redisCli != nil {
+		return e.redisCli.GetClient()
+	}
+	if rc := redis.Get(); rc != nil {
+		return rc.GetClient()
+	}
+	return nil
+}
+
+func (e *Engine[T]) emit(ev Event) {
+	if e.hook != nil {
+		e.hook(ev)
+	}
+}
+
+func (e *Engine[T]) get(ctx context.Context, key string) (T, bool) {
+	var zero, dest T
+	val := reflect.ValueOf(&dest).Elem()
+	if val.Kind() == reflect.Map && val.IsNil() {
+		val.Set(reflect.MakeMap(val.Type()))
+	} else if val.Kind() == reflect.Slice && val.IsNil() {
+		val.Set(reflect.MakeSlice(val.Type(), 0, 0))
+	}
+
+	if e.rawClient != nil {
+		data, err := e.rawClient.Get(ctx, key).Result()
+		if err != nil {
+			return zero, false
+		}
+		if err := json.Unmarshal([]byte(data), &dest); err != nil {
+			return zero, false
+		}
+		return dest, true
+	}
+	client := e.getRedis()
+	if client == nil {
+		return zero, false
+	}
+	if !client.GetObj(ctx, key, &dest) {
+		return zero, false
+	}
+	return dest, true
+}
+
+func (e *Engine[T]) set(ctx context.Context, tenantID, key string, v T) {
+	if tenantID == "" {
+		return
+	}
+	ttl := applyJitter(e.ttl)
+	if e.rawClient != nil {
+		data, err := json.Marshal(v)
+		if err != nil {
+			return
+		}
+		e.rawClient.Set(ctx, key, data, ttl)
+		return
+	}
+	client := e.getRedis()
+	if client == nil {
+		return
+	}
+	client.SetObj(ctx, key, v, ttl)
+}
+
+// GetOrCompute returns the cached value for (tenantID, taskType, keyParts), or
+// computes it via computeFn on a cache miss / invalid entry.
+//
+// Concurrency: requests sharing the exact key are merged through SingleFlight DoChan,
+// and respect context cancellation/timeout immediately without leaking goroutines.
+// A double-check re-reads Redis inside the merged call in case a peer already wrote
+// the value back. The winning result is written back only after passing the Validator.
+//
+// Fail-Closed: if tenantID is empty, it bypasses caching completely, directly executing
+// computeFn without writing to Redis.
+func (e *Engine[T]) GetOrCompute(
+	ctx context.Context,
+	tenantID, taskType string,
+	keyParts []string,
+	computeFn func(ctx context.Context) (T, error),
+) (T, error) {
+	var zero T
+	if tenantID == "" {
+		// Fail-closed: empty tenantID bypasses cache and strictly avoids Redis write.
+		return computeFn(ctx)
+	}
+
+	key := BuildKey(tenantID, taskType, keyParts...)
+
+	if v, ok := e.get(ctx, key); ok {
+		if e.validate == nil || e.validate(v) {
+			e.emit(Event{Kind: "hit", TenantID: tenantID, TaskType: taskType, Key: key})
+			return v, nil
+		}
+	}
+	e.emit(Event{Kind: "miss", TenantID: tenantID, TaskType: taskType, Key: key})
+
+	ch := e.group.DoChan(key, func() (any, error) {
+		// Double-check: a concurrent writer may have populated Redis while we
+		// were queued.
+		if v, ok := e.get(ctx, key); ok && (e.validate == nil || e.validate(v)) {
+			return v, nil
+		}
+		v, cerr := computeFn(ctx)
+		if cerr != nil {
+			return zero, cerr
+		}
+		if e.validate == nil || e.validate(v) {
+			e.set(ctx, tenantID, key, v)
+			e.emit(Event{Kind: "compute", TenantID: tenantID, TaskType: taskType, Key: key})
+		} else {
+			e.emit(Event{Kind: "skip_invalid", TenantID: tenantID, TaskType: taskType, Key: key})
+			common.Warn("llmcache: dropping invalid computed value",
+				zap.String("task_type", taskType), zap.String("tenant_id", tenantID))
+		}
+		return v, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return zero, res.Err
+		}
+		out, ok := res.Val.(T)
+		if !ok {
+			return zero, ErrTypeAssertion
+		}
+		return out, nil
+	}
+}
+
+// FlushTenant purges every cache entry for a tenant (GDPR erasure / tenant teardown).
+// It scans for keys matching "kc:llm:{tenant_id}:*" using Redis SCAN cursor COUNT 1000,
+// deletes them in pipeline batches, sleeps 10ms between batches, and responds promptly to ctx.Done().
+// Returns the number of entries deleted.
+func (e *Engine[T]) FlushTenant(ctx context.Context, tenantID string) int {
+	if tenantID == "" {
+		return 0
+	}
+	rdb := e.getUniversalClient()
+	if rdb == nil {
+		return 0
+	}
+
+	var cursor uint64
+	var deletedCount int
+	matchPattern := fmt.Sprintf("%s:%s:*", KeyPrefix, tenantID)
+
+	for {
+		select {
+		case <-ctx.Done():
+			common.Warn("llmcache: FlushTenant cancelled by context",
+				zap.String("tenant_id", tenantID), zap.Error(ctx.Err()))
+			return deletedCount
+		default:
+		}
+
+		keys, nextCursor, err := rdb.Scan(ctx, cursor, matchPattern, 1000).Result()
+		if err != nil {
+			common.Warn("llmcache: FlushTenant SCAN failed",
+				zap.String("tenant_id", tenantID), zap.Error(err))
+			break
+		}
+
+		if len(keys) > 0 {
+			pipe := rdb.Pipeline()
+			for _, k := range keys {
+				pipe.Del(ctx, k)
+			}
+			cmders, err := pipe.Exec(ctx)
+			if err != nil && !errors.Is(err, goredis.Nil) {
+				common.Warn("llmcache: FlushTenant pipeline Del failed",
+					zap.String("tenant_id", tenantID), zap.Error(err))
+			}
+			for _, cmder := range cmders {
+				if intCmd, ok := cmder.(*goredis.IntCmd); ok {
+					deletedCount += int(intCmd.Val())
+				}
+			}
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			common.Warn("llmcache: FlushTenant cancelled by context",
+				zap.String("tenant_id", tenantID), zap.Error(ctx.Err()))
+			return deletedCount
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	e.emit(Event{Kind: "purge", TenantID: tenantID, Key: matchPattern})
+	return deletedCount
+}

--- a/internal/cache/llmcache/llm_cache.go
+++ b/internal/cache/llmcache/llm_cache.go
@@ -302,10 +302,12 @@ func (e *Engine[T]) GetOrCompute(
 
 	select {
 	case <-ctx.Done():
+		// Unblock retries to start a fresh flight immediately; drain the original
+		// flight asynchronously without a second Forget to avoid evicting a newer flight
+		// registered by a concurrent retry.
 		e.group.Forget(key)
 		go func() {
 			<-ch
-			e.group.Forget(key)
 		}()
 		return zero, ctx.Err()
 	case res := <-ch:

--- a/internal/cache/llmcache/llm_cache.go
+++ b/internal/cache/llmcache/llm_cache.go
@@ -35,6 +35,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	randv2 "math/rand/v2"
 	"sync"
 	"time"
 
@@ -54,6 +55,9 @@ var xxhashPool = sync.Pool{
 
 // KeyPrefix is the Redis namespace for all entries managed by this engine.
 const KeyPrefix = "kc:llm"
+
+// DefaultTTL mirrors the legacy Python get_llm_cache/set_llm_cache 24h window.
+const DefaultTTL = 24 * time.Hour
 
 // Validator reports whether a computed value should be cached.
 // Return true to keep it (including legitimate empty results), false to drop
@@ -75,6 +79,7 @@ type MetricsHook func(Event)
 
 // Engine is a generic, multi-tenant LLM-result cache.
 type Engine[T any] struct {
+	ttl       time.Duration
 	validate  Validator[T]
 	hook      MetricsHook
 	redisCli  *redis.Client
@@ -83,6 +88,11 @@ type Engine[T any] struct {
 
 // Option configures an Engine.
 type Option[T any] func(*Engine[T])
+
+// WithTTL overrides the cache entry TTL (default DefaultTTL).
+func WithTTL[T any](d time.Duration) Option[T] {
+	return func(e *Engine[T]) { e.ttl = d }
+}
 
 // WithValidator sets the task-aware quality gate.
 func WithValidator[T any](v Validator[T]) Option[T] {
@@ -106,7 +116,7 @@ func WithUniversalClient[T any](client goredis.UniversalClient) Option[T] {
 
 // New constructs an Engine with the given options.
 func New[T any](opts ...Option[T]) *Engine[T] {
-	e := &Engine[T]{}
+	e := &Engine[T]{ttl: DefaultTTL}
 	for _, o := range opts {
 		o(e)
 	}
@@ -130,6 +140,23 @@ func BuildKey(tenantID, taskType string, keyParts ...string) string {
 	h.Reset()
 	xxhashPool.Put(h)
 	return key
+}
+
+// ApplyJitter returns the base duration with ±10% random jitter applied.
+// If base <= 0, it returns base unmodified.
+func ApplyJitter(base time.Duration) time.Duration {
+	return applyJitter(base)
+}
+
+func applyJitter(base time.Duration) time.Duration {
+	if base <= 0 {
+		return base
+	}
+	// ±10% jitter: range is [base * 0.90, base * 1.10]
+	delta := float64(base) * 0.10
+	factor := (randv2.Float64() * 2.0) - 1.0
+	jitter := time.Duration(delta * factor)
+	return base + jitter
 }
 
 func (e *Engine[T]) getRedis() *redis.Client {
@@ -191,19 +218,20 @@ func (e *Engine[T]) set(ctx context.Context, tenantID, key string, v T) {
 	setCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 	defer cancel()
 
+	ttl := applyJitter(e.ttl)
 	if e.rawClient != nil {
 		data, err := json.Marshal(v)
 		if err != nil {
 			return
 		}
-		e.rawClient.Set(setCtx, key, data, 0)
+		e.rawClient.Set(setCtx, key, data, ttl)
 		return
 	}
 	client := e.getRedis()
 	if client == nil {
 		return
 	}
-	client.SetObj(setCtx, key, v, 0)
+	client.SetObj(setCtx, key, v, ttl)
 }
 
 // GetOrCompute returns the cached value for (tenantID, taskType, keyParts), or

--- a/internal/cache/llmcache/llm_cache.go
+++ b/internal/cache/llmcache/llm_cache.go
@@ -26,10 +26,6 @@
 //   - Task-aware quality gate: a caller-supplied Validator decides whether a
 //     computed value is worth caching (allows legitimate empty results,
 //     rejects ERROR / truncated payloads).
-//   - SingleFlight: concurrent identical requests (same tenant+task+hash) are
-//     collapsed into a single upstream LLM call via DoChan with context cancellation
-//     safety, with a double-check to avoid redundant recompute after a peer has
-//     already written back.
 //   - Observable: an optional MetricsHook receives hit/miss/compute/skip/purge
 //     events for Prometheus instrumentation without hard-coupling the package.
 package llmcache
@@ -39,23 +35,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	randv2 "math/rand/v2"
 	"sync"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
 	goredis "github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
-	"golang.org/x/sync/singleflight"
 
 	"ragflow/internal/common"
 	"ragflow/internal/engine/redis"
-)
-
-// Standard sentinel errors.
-var (
-	// ErrTypeAssertion indicates an internal type assertion failure.
-	ErrTypeAssertion = errors.New("llmcache: internal type assertion failed")
 )
 
 var xxhashPool = sync.Pool{
@@ -66,9 +54,6 @@ var xxhashPool = sync.Pool{
 
 // KeyPrefix is the Redis namespace for all entries managed by this engine.
 const KeyPrefix = "kc:llm"
-
-// DefaultTTL mirrors the legacy Python get_llm_cache/set_llm_cache 24h window.
-const DefaultTTL = 24 * time.Hour
 
 // Validator reports whether a computed value should be cached.
 // Return true to keep it (including legitimate empty results), false to drop
@@ -90,21 +75,14 @@ type MetricsHook func(Event)
 
 // Engine is a generic, multi-tenant LLM-result cache.
 type Engine[T any] struct {
-	ttl       time.Duration
 	validate  Validator[T]
 	hook      MetricsHook
-	group     singleflight.Group
 	redisCli  *redis.Client
 	rawClient goredis.UniversalClient
 }
 
 // Option configures an Engine.
 type Option[T any] func(*Engine[T])
-
-// WithTTL overrides the cache entry TTL (default DefaultTTL).
-func WithTTL[T any](d time.Duration) Option[T] {
-	return func(e *Engine[T]) { e.ttl = d }
-}
 
 // WithValidator sets the task-aware quality gate.
 func WithValidator[T any](v Validator[T]) Option[T] {
@@ -128,7 +106,7 @@ func WithUniversalClient[T any](client goredis.UniversalClient) Option[T] {
 
 // New constructs an Engine with the given options.
 func New[T any](opts ...Option[T]) *Engine[T] {
-	e := &Engine[T]{ttl: DefaultTTL}
+	e := &Engine[T]{}
 	for _, o := range opts {
 		o(e)
 	}
@@ -152,23 +130,6 @@ func BuildKey(tenantID, taskType string, keyParts ...string) string {
 	h.Reset()
 	xxhashPool.Put(h)
 	return key
-}
-
-// ApplyJitter returns the base duration with ±10% random jitter applied.
-// If base <= 0, it returns base unmodified.
-func ApplyJitter(base time.Duration) time.Duration {
-	return applyJitter(base)
-}
-
-func applyJitter(base time.Duration) time.Duration {
-	if base <= 0 {
-		return base
-	}
-	// ±10% jitter: range is [base * 0.90, base * 1.10]
-	delta := float64(base) * 0.10
-	factor := (randv2.Float64() * 2.0) - 1.0
-	jitter := time.Duration(delta * factor)
-	return base + jitter
 }
 
 func (e *Engine[T]) getRedis() *redis.Client {
@@ -230,29 +191,23 @@ func (e *Engine[T]) set(ctx context.Context, tenantID, key string, v T) {
 	setCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 	defer cancel()
 
-	ttl := applyJitter(e.ttl)
 	if e.rawClient != nil {
 		data, err := json.Marshal(v)
 		if err != nil {
 			return
 		}
-		e.rawClient.Set(setCtx, key, data, ttl)
+		e.rawClient.Set(setCtx, key, data, 0)
 		return
 	}
 	client := e.getRedis()
 	if client == nil {
 		return
 	}
-	client.SetObj(setCtx, key, v, ttl)
+	client.SetObj(setCtx, key, v, 0)
 }
 
 // GetOrCompute returns the cached value for (tenantID, taskType, keyParts), or
 // computes it via computeFn on a cache miss / invalid entry.
-//
-// Concurrency: requests sharing the exact key are merged through SingleFlight DoChan,
-// and respect context cancellation/timeout immediately without leaking goroutines.
-// A double-check re-reads Redis inside the merged call in case a peer already wrote
-// the value back. The winning result is written back only after passing the Validator.
 //
 // Fail-Open (bypass): execute computeFn directly without caching when tenantID is empty to ensure business continuity without polluting global namespace.
 func (e *Engine[T]) GetOrCompute(
@@ -263,7 +218,6 @@ func (e *Engine[T]) GetOrCompute(
 ) (T, error) {
 	var zero T
 	if tenantID == "" {
-		// Fail-Open (bypass): execute computeFn directly without caching when tenantID is empty to ensure business continuity without polluting global namespace
 		return computeFn(ctx)
 	}
 
@@ -277,50 +231,19 @@ func (e *Engine[T]) GetOrCompute(
 	}
 	e.emit(Event{Kind: "miss", TenantID: tenantID, TaskType: taskType, Key: key})
 
-	ch := e.group.DoChan(key, func() (any, error) {
-		// Double-check: a concurrent writer may have populated Redis while we
-		// were queued.
-		getCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 500*time.Millisecond)
-		defer cancel()
-		if v, ok := e.get(getCtx, key); ok && (e.validate == nil || e.validate(v)) {
-			return v, nil
-		}
-		computeCtx := context.WithoutCancel(ctx)
-		v, cerr := computeFn(computeCtx)
-		if cerr != nil {
-			return zero, cerr
-		}
-		if e.validate == nil || e.validate(v) {
-			e.set(ctx, tenantID, key, v)
-			e.emit(Event{Kind: "compute", TenantID: tenantID, TaskType: taskType, Key: key})
-		} else {
-			e.emit(Event{Kind: "skip_invalid", TenantID: tenantID, TaskType: taskType, Key: key})
-			common.Warn("llmcache: dropping invalid computed value",
-				zap.String("task_type", taskType), zap.String("tenant_id", tenantID))
-		}
-		return v, nil
-	})
-
-	select {
-	case <-ctx.Done():
-		// Unblock retries to start a fresh flight immediately; drain the original
-		// flight asynchronously without a second Forget to avoid evicting a newer flight
-		// registered by a concurrent retry.
-		e.group.Forget(key)
-		go func() {
-			<-ch
-		}()
-		return zero, ctx.Err()
-	case res := <-ch:
-		if res.Err != nil {
-			return zero, res.Err
-		}
-		out, ok := res.Val.(T)
-		if !ok {
-			return zero, ErrTypeAssertion
-		}
-		return out, nil
+	v, cerr := computeFn(ctx)
+	if cerr != nil {
+		return zero, cerr
 	}
+	if e.validate == nil || e.validate(v) {
+		e.set(ctx, tenantID, key, v)
+		e.emit(Event{Kind: "compute", TenantID: tenantID, TaskType: taskType, Key: key})
+	} else {
+		e.emit(Event{Kind: "skip_invalid", TenantID: tenantID, TaskType: taskType, Key: key})
+		common.Warn("llmcache: dropping invalid computed value",
+			zap.String("task_type", taskType), zap.String("tenant_id", tenantID))
+	}
+	return v, nil
 }
 
 // FlushTenant purges every cache entry for a tenant (GDPR erasure / tenant teardown).

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -1,0 +1,442 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package llmcache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+)
+
+func newTestEngineWithRedis[T any](t *testing.T, opts ...Option[T]) (*Engine[T], *miniredis.Miniredis, goredis.UniversalClient) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	allOpts := append([]Option[T]{WithUniversalClient[T](rdb)}, opts...)
+	engine := New[T](allOpts...)
+	return engine, mr, rdb
+}
+
+func TestBuildKey(t *testing.T) {
+	k1 := BuildKey("tenant1", "keywords", "modelA", "prompt1", "text1")
+	k2 := BuildKey("tenant1", "keywords", "modelA", "prompt1", "text1")
+	if k1 != k2 {
+		t.Errorf("BuildKey should be deterministic: %s != %s", k1, k2)
+	}
+
+	// Tenant isolation test
+	kTenant2 := BuildKey("tenant2", "keywords", "modelA", "prompt1", "text1")
+	if k1 == kTenant2 {
+		t.Errorf("Different tenants must produce different keys: %s == %s", k1, kTenant2)
+	}
+
+	// TaskType isolation test
+	kQuestions := BuildKey("tenant1", "questions", "modelA", "prompt1", "text1")
+	if k1 == kQuestions {
+		t.Errorf("Different task types must produce different keys: %s == %s", k1, kQuestions)
+	}
+
+	// Null-byte collision prevention test: ("ab", "c") vs ("a", "bc")
+	kColl1 := BuildKey("t", "test", "ab", "c")
+	kColl2 := BuildKey("t", "test", "a", "bc")
+	if kColl1 == kColl2 {
+		t.Errorf("Null byte should prevent cross-field collision: %s == %s", kColl1, kColl2)
+	}
+}
+
+func TestSentinelErrors(t *testing.T) {
+	if ErrNoTenantID == nil {
+		t.Error("ErrNoTenantID must not be nil")
+	}
+	if ErrCacheMiss == nil {
+		t.Error("ErrCacheMiss must not be nil")
+	}
+	if ErrRejected == nil {
+		t.Error("ErrRejected must not be nil")
+	}
+	if ErrTypeAssertion == nil {
+		t.Error("ErrTypeAssertion must not be nil")
+	}
+}
+
+func TestEngine_GetOrCompute_NoRedis(t *testing.T) {
+	// In unit-test environment without Redis running, GetOrCompute should fall back
+	// gracefully to computeFn (Fail-Open behavior).
+	engine := New[string](
+		WithTTL[string](time.Hour),
+		WithValidator(func(v string) bool { return len(v) > 0 }),
+	)
+
+	var calls int32
+	ctx := context.Background()
+	res, err := engine.GetOrCompute(ctx, "t1", "summary", []string{"m1", "text1"}, func(ctx context.Context) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "summary_output", nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != "summary_output" {
+		t.Errorf("got %q, want 'summary_output'", res)
+	}
+	if calls != 1 {
+		t.Errorf("computeFn called %d times, want 1", calls)
+	}
+}
+
+func TestEngine_GetOrCompute_ValidatorAllowsLegitimateEmpty(t *testing.T) {
+	// Verify that validator allowing empty collections can return empty slice without error
+	engine := New[[]string](
+		WithValidator(func(v []string) bool { return true }), // Accept empty slices
+	)
+
+	ctx := context.Background()
+	res, err := engine.GetOrCompute(ctx, "t1", "keywords", []string{"m1", "text_empty"}, func(ctx context.Context) ([]string, error) {
+		return []string{}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 0 {
+		t.Errorf("got len %d, want 0", len(res))
+	}
+}
+
+func TestEngine_GetOrCompute_SingleFlightDeduplication(t *testing.T) {
+	engine := New[string]()
+
+	var computeCount int32
+	var wg sync.WaitGroup
+	concurrentReqs := 10
+	results := make([]string, concurrentReqs)
+
+	for i := 0; i < concurrentReqs; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			res, err := engine.GetOrCompute(context.Background(), "t1", "summary", []string{"same_model", "same_text"}, func(ctx context.Context) (string, error) {
+				time.Sleep(50 * time.Millisecond) // Simulate slow LLM
+				atomic.AddInt32(&computeCount, 1)
+				return "computed_value", nil
+			})
+			if err == nil {
+				results[idx] = res
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if computeCount != 1 {
+		t.Errorf("SingleFlight failed: computeCount = %d, want 1", computeCount)
+	}
+	for i, r := range results {
+		if r != "computed_value" {
+			t.Errorf("result[%d] = %q, want 'computed_value'", i, r)
+		}
+	}
+}
+
+func TestEngine_GetOrCompute_ContextTimeout(t *testing.T) {
+	engine := New[string]()
+
+	// Compute blocks for 300ms, but context times out in 30ms.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := engine.GetOrCompute(ctx, "t1", "summary", []string{"m1", "slow_prompt"}, func(computeCtx context.Context) (string, error) {
+		time.Sleep(300 * time.Millisecond)
+		return "should_not_wait", nil
+	})
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if elapsed >= 250*time.Millisecond {
+		t.Fatalf("GetOrCompute should return immediately on timeout, but elapsed %v", elapsed)
+	}
+}
+
+func TestEngine_GetOrCompute_ContextCancellation(t *testing.T) {
+	engine := New[string]()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel context asynchronously after 20ms
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := engine.GetOrCompute(ctx, "t1", "summary", []string{"m1", "cancel_prompt"}, func(computeCtx context.Context) (string, error) {
+		time.Sleep(300 * time.Millisecond)
+		return "should_be_cancelled", nil
+	})
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if elapsed >= 250*time.Millisecond {
+		t.Fatalf("GetOrCompute should return immediately on cancellation, but elapsed %v", elapsed)
+	}
+}
+
+func TestEngine_JitterRange(t *testing.T) {
+	t.Run("100s base duration", func(t *testing.T) {
+		base := 100 * time.Second
+		minExpected := 90 * time.Second
+		maxExpected := 110 * time.Second
+
+		var minObserved time.Duration = 1000 * time.Second
+		var maxObserved time.Duration = 0
+
+		for i := 0; i < 1000; i++ {
+			jittered := ApplyJitter(base)
+			if jittered < minExpected || jittered > maxExpected {
+				t.Fatalf("jittered value %v out of bounds [%v, %v]", jittered, minExpected, maxExpected)
+			}
+			if jittered < minObserved {
+				minObserved = jittered
+			}
+			if jittered > maxObserved {
+				maxObserved = jittered
+			}
+		}
+
+		// Verify variance across 1000 runs
+		if minObserved > 95*time.Second || maxObserved < 105*time.Second {
+			t.Fatalf("expected substantial jitter spread, got min=%v, max=%v", minObserved, maxObserved)
+		}
+	})
+
+	t.Run("24h base duration", func(t *testing.T) {
+		base := 24 * time.Hour
+		minExpected := time.Duration(float64(base) * 0.90)
+		maxExpected := time.Duration(float64(base) * 1.10)
+
+		for i := 0; i < 500; i++ {
+			jittered := ApplyJitter(base)
+			if jittered < minExpected || jittered > maxExpected {
+				t.Fatalf("jittered value %v out of bounds [%v, %v]", jittered, minExpected, maxExpected)
+			}
+		}
+	})
+
+	t.Run("non-positive durations", func(t *testing.T) {
+		if got := ApplyJitter(0); got != 0 {
+			t.Errorf("ApplyJitter(0) = %v, want 0", got)
+		}
+		if got := ApplyJitter(-5 * time.Second); got != -5*time.Second {
+			t.Errorf("ApplyJitter(-5s) = %v, want -5s", got)
+		}
+	})
+}
+
+func TestEngine_FailClosed_EmptyTenantID(t *testing.T) {
+	engine, _, rdb := newTestEngineWithRedis[string](t)
+	ctx := context.Background()
+
+	var computeCalls int32
+	// 1. Calling GetOrCompute with tenantID == "" should bypass cache and execute computeFn
+	res, err := engine.GetOrCompute(ctx, "", "summary", []string{"m1", "text1"}, func(ctx context.Context) (string, error) {
+		atomic.AddInt32(&computeCalls, 1)
+		return "compute_result", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != "compute_result" {
+		t.Errorf("got %q, want 'compute_result'", res)
+	}
+	if computeCalls != 1 {
+		t.Errorf("computeFn called %d times, want 1", computeCalls)
+	}
+
+	// Verify that absolutely NO keys were written to Redis
+	keys, err := rdb.Keys(ctx, "*").Result()
+	if err != nil {
+		t.Fatalf("Keys error: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("expected 0 keys written to Redis for empty tenantID, found %d: %v", len(keys), keys)
+	}
+
+	// 2. Calling FlushTenant with tenantID == "" should return 0
+	deleted := engine.FlushTenant(ctx, "")
+	if deleted != 0 {
+		t.Errorf("FlushTenant(\"\") = %d, want 0", deleted)
+	}
+}
+
+func TestEngine_FlushTenant_ScanPipeline(t *testing.T) {
+	t.Run("multi-tenant isolation purge", func(t *testing.T) {
+		engine, _, rdb := newTestEngineWithRedis[string](t)
+		ctx := context.Background()
+
+		// Populate 10 keys for tenantA and 5 keys for tenantB
+		for i := 0; i < 10; i++ {
+			_, err := engine.GetOrCompute(ctx, "tenantA", "task", []string{fmt.Sprintf("item_%d", i)}, func(ctx context.Context) (string, error) {
+				return fmt.Sprintf("val_A_%d", i), nil
+			})
+			if err != nil {
+				t.Fatalf("GetOrCompute tenantA error: %v", err)
+			}
+		}
+		for i := 0; i < 5; i++ {
+			_, err := engine.GetOrCompute(ctx, "tenantB", "task", []string{fmt.Sprintf("item_%d", i)}, func(ctx context.Context) (string, error) {
+				return fmt.Sprintf("val_B_%d", i), nil
+			})
+			if err != nil {
+				t.Fatalf("GetOrCompute tenantB error: %v", err)
+			}
+		}
+
+		// Verify total keys
+		allKeys, err := rdb.Keys(ctx, "*").Result()
+		if err != nil {
+			t.Fatalf("Keys error: %v", err)
+		}
+		if len(allKeys) != 15 {
+			t.Fatalf("expected 15 total keys in Redis, got %d", len(allKeys))
+		}
+
+		// Flush tenantA
+		deleted := engine.FlushTenant(ctx, "tenantA")
+		if deleted != 10 {
+			t.Errorf("FlushTenant(tenantA) deleted %d keys, want 10", deleted)
+		}
+
+		// Verify tenantA keys are gone, tenantB keys remain
+		remainingKeys, err := rdb.Keys(ctx, "*").Result()
+		if err != nil {
+			t.Fatalf("Keys error: %v", err)
+		}
+		if len(remainingKeys) != 5 {
+			t.Fatalf("expected 5 remaining keys for tenantB, got %d: %v", len(remainingKeys), remainingKeys)
+		}
+
+		// Verify tenantB can still read from cache without recomputing
+		var computeBCalled bool
+		valB, err := engine.GetOrCompute(ctx, "tenantB", "task", []string{"item_0"}, func(ctx context.Context) (string, error) {
+			computeBCalled = true
+			return "new_computed_val", nil
+		})
+		if err != nil {
+			t.Fatalf("GetOrCompute tenantB error: %v", err)
+		}
+		if valB != "val_B_0" {
+			t.Errorf("got %q, want cached 'val_B_0'", valB)
+		}
+		if computeBCalled {
+			t.Errorf("tenantB entry should have been a cache hit, but computeFn was called")
+		}
+	})
+
+	t.Run("context cancelled before flush", func(t *testing.T) {
+		engine, _, _ := newTestEngineWithRedis[string](t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // immediately cancel
+
+		deleted := engine.FlushTenant(ctx, "tenantA")
+		if deleted != 0 {
+			t.Errorf("FlushTenant with cancelled context returned %d, want 0", deleted)
+		}
+	})
+
+	t.Run("multi-batch scan with large key count", func(t *testing.T) {
+		engine, _, rdb := newTestEngineWithRedis[string](t)
+		ctx := context.Background()
+
+		totalKeys := 1050
+		pipe := rdb.Pipeline()
+		for i := 0; i < totalKeys; i++ {
+			k := BuildKey("tenant_large", "task", fmt.Sprintf("key_%d", i))
+			pipe.Set(ctx, k, fmt.Sprintf(`"val_%d"`, i), time.Hour)
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
+			t.Fatalf("Pipeline setup error: %v", err)
+		}
+
+		// Verify miniredis has all 1050 keys
+		keys, err := rdb.Keys(ctx, "kc:llm:tenant_large:*").Result()
+		if err != nil {
+			t.Fatalf("Keys error: %v", err)
+		}
+		if len(keys) != totalKeys {
+			t.Fatalf("expected %d keys before flush, got %d", totalKeys, len(keys))
+		}
+
+		// Flush tenant_large
+		deleted := engine.FlushTenant(ctx, "tenant_large")
+		if deleted != totalKeys {
+			t.Errorf("FlushTenant deleted %d keys, want %d", deleted, totalKeys)
+		}
+
+		// Verify 0 remaining keys
+		remaining, err := rdb.Keys(ctx, "kc:llm:tenant_large:*").Result()
+		if err != nil {
+			t.Fatalf("Keys error: %v", err)
+		}
+		if len(remaining) != 0 {
+			t.Errorf("expected 0 keys remaining, found %d", len(remaining))
+		}
+	})
+}
+
+func TestEngine_MetricsHook(t *testing.T) {
+	var events []Event
+	var mu sync.Mutex
+
+	engine := New[string](
+		WithMetrics[string](func(ev Event) {
+			mu.Lock()
+			events = append(events, ev)
+			mu.Unlock()
+		}),
+	)
+
+	ctx := context.Background()
+	_, _ = engine.GetOrCompute(ctx, "tenantA", "keywords", []string{"p1"}, func(ctx context.Context) (string, error) {
+		return "result", nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) == 0 {
+		t.Errorf("expected metrics events to be emitted, got none")
+	}
+}

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -568,6 +568,83 @@ func TestEngine_GetOrCompute_WriteBack_ContextCancelled(t *testing.T) {
 	}
 }
 
+func TestEngine_GetOrCompute_Cancellation_SingleForgetNoRace(t *testing.T) {
+	engine, _, _ := newTestEngineWithRedis[string](t)
+
+	// 1. Caller A starts a slow flight
+	ctxA, cancelA := context.WithCancel(context.Background())
+	startedA := make(chan struct{})
+	finishA := make(chan struct{})
+
+	go func() {
+		_, _ = engine.GetOrCompute(ctxA, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
+			close(startedA)
+			<-finishA
+			return "resultA", nil
+		})
+	}()
+
+	<-startedA
+	// Cancel Caller A's context, triggering Forget(key)
+	cancelA()
+	time.Sleep(10 * time.Millisecond)
+
+	// 2. Caller B starts a new flight for the same key while A is still running in background
+	ctxB := context.Background()
+	startedB := make(chan struct{})
+	finishB := make(chan struct{})
+	var computeCountB atomic.Int32
+
+	var resB string
+	var errB error
+	doneB := make(chan struct{})
+	go func() {
+		resB, errB = engine.GetOrCompute(ctxB, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
+			computeCountB.Add(1)
+			close(startedB)
+			<-finishB
+			return "resultB", nil
+		})
+		close(doneB)
+	}()
+
+	<-startedB
+
+	// 3. Now let Caller A's original background task finish.
+	// If there was a double-forget, A completing would evict B's flight from singleflight map!
+	close(finishA)
+	time.Sleep(20 * time.Millisecond)
+
+	// 4. Caller C arrives while Caller B is still computing.
+	// Caller C MUST merge into Caller B's existing flight and NOT start a new computation.
+	ctxC := context.Background()
+	var resC string
+	var errC error
+	doneC := make(chan struct{})
+	go func() {
+		resC, errC = engine.GetOrCompute(ctxC, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
+			computeCountB.Add(1) // Should NOT be called
+			return "resultC_unwanted", nil
+		})
+		close(doneC)
+	}()
+
+	// 5. Allow Caller B's computation to finish
+	close(finishB)
+	<-doneB
+	<-doneC
+
+	if errB != nil || errC != nil {
+		t.Fatalf("unexpected error: B=%v, C=%v", errB, errC)
+	}
+	if computeCountB.Load() != 1 {
+		t.Errorf("compute count = %d, want 1 (SingleFlight dedup was defeated by double forget race)", computeCountB.Load())
+	}
+	if resB != "resultB" || resC != "resultB" {
+		t.Errorf("resB = %q, resC = %q, both want 'resultB'", resB, resC)
+	}
+}
+
 func BenchmarkBuildKey(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	goredis "github.com/redis/go-redis/v9"
@@ -72,17 +71,10 @@ func TestBuildKey(t *testing.T) {
 	}
 }
 
-func TestSentinelErrors(t *testing.T) {
-	if ErrTypeAssertion == nil {
-		t.Error("ErrTypeAssertion must not be nil")
-	}
-}
-
 func TestEngine_GetOrCompute_NoRedis(t *testing.T) {
 	// In unit-test environment without Redis running, GetOrCompute should fall back
 	// gracefully to computeFn (Fail-Open behavior).
 	engine := New[string](
-		WithTTL[string](time.Hour),
 		WithValidator(func(v string) bool { return len(v) > 0 }),
 	)
 
@@ -123,138 +115,39 @@ func TestEngine_GetOrCompute_ValidatorAllowsLegitimateEmpty(t *testing.T) {
 	}
 }
 
-func TestEngine_GetOrCompute_SingleFlightDeduplication(t *testing.T) {
-	engine := New[string]()
+func TestEngine_GetOrCompute_BasicCaching(t *testing.T) {
+	engine, _, _ := newTestEngineWithRedis[string](t)
+	ctx := context.Background()
 
 	var computeCount int32
-	var wg sync.WaitGroup
-	concurrentReqs := 10
-	results := make([]string, concurrentReqs)
-
-	for i := 0; i < concurrentReqs; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			res, err := engine.GetOrCompute(context.Background(), "t1", "summary", []string{"same_model", "same_text"}, func(ctx context.Context) (string, error) {
-				time.Sleep(50 * time.Millisecond) // Simulate slow LLM
-				atomic.AddInt32(&computeCount, 1)
-				return "computed_value", nil
-			})
-			if err == nil {
-				results[idx] = res
-			}
-		}(i)
+	computeFn := func(ctx context.Context) (string, error) {
+		atomic.AddInt32(&computeCount, 1)
+		return "computed_value", nil
 	}
 
-	wg.Wait()
-
+	// 1. First call computes and caches
+	res1, err := engine.GetOrCompute(ctx, "tenant1", "summary", []string{"m1", "p1"}, computeFn)
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	if res1 != "computed_value" {
+		t.Errorf("res1 = %q, want 'computed_value'", res1)
+	}
 	if computeCount != 1 {
-		t.Errorf("SingleFlight failed: computeCount = %d, want 1", computeCount)
+		t.Errorf("computeCount = %d, want 1", computeCount)
 	}
-	for i, r := range results {
-		if r != "computed_value" {
-			t.Errorf("result[%d] = %q, want 'computed_value'", i, r)
-		}
+
+	// 2. Second call hits cache
+	res2, err := engine.GetOrCompute(ctx, "tenant1", "summary", []string{"m1", "p1"}, computeFn)
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
 	}
-}
-
-func TestEngine_GetOrCompute_ContextTimeout(t *testing.T) {
-	engine := New[string]()
-
-	// Compute blocks for 300ms, but context times out in 30ms.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-	defer cancel()
-
-	start := time.Now()
-	_, err := engine.GetOrCompute(ctx, "t1", "summary", []string{"m1", "slow_prompt"}, func(computeCtx context.Context) (string, error) {
-		time.Sleep(300 * time.Millisecond)
-		return "should_not_wait", nil
-	})
-	elapsed := time.Since(start)
-
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	if res2 != "computed_value" {
+		t.Errorf("res2 = %q, want 'computed_value'", res2)
 	}
-	if elapsed >= 250*time.Millisecond {
-		t.Fatalf("GetOrCompute should return immediately on timeout, but elapsed %v", elapsed)
+	if computeCount != 1 {
+		t.Errorf("second call should hit cache, computeCount = %d, want 1", computeCount)
 	}
-}
-
-func TestEngine_GetOrCompute_ContextCancellation(t *testing.T) {
-	engine := New[string]()
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Cancel context asynchronously after 20ms
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		cancel()
-	}()
-
-	start := time.Now()
-	_, err := engine.GetOrCompute(ctx, "t1", "summary", []string{"m1", "cancel_prompt"}, func(computeCtx context.Context) (string, error) {
-		time.Sleep(300 * time.Millisecond)
-		return "should_be_cancelled", nil
-	})
-	elapsed := time.Since(start)
-
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got: %v", err)
-	}
-	if elapsed >= 250*time.Millisecond {
-		t.Fatalf("GetOrCompute should return immediately on cancellation, but elapsed %v", elapsed)
-	}
-}
-
-func TestEngine_JitterRange(t *testing.T) {
-	t.Run("100s base duration", func(t *testing.T) {
-		base := 100 * time.Second
-		minExpected := 90 * time.Second
-		maxExpected := 110 * time.Second
-
-		var minObserved time.Duration = 1000 * time.Second
-		var maxObserved time.Duration = 0
-
-		for i := 0; i < 1000; i++ {
-			jittered := ApplyJitter(base)
-			if jittered < minExpected || jittered > maxExpected {
-				t.Fatalf("jittered value %v out of bounds [%v, %v]", jittered, minExpected, maxExpected)
-			}
-			if jittered < minObserved {
-				minObserved = jittered
-			}
-			if jittered > maxObserved {
-				maxObserved = jittered
-			}
-		}
-
-		// Verify variance across 1000 runs
-		if minObserved > 95*time.Second || maxObserved < 105*time.Second {
-			t.Fatalf("expected substantial jitter spread, got min=%v, max=%v", minObserved, maxObserved)
-		}
-	})
-
-	t.Run("24h base duration", func(t *testing.T) {
-		base := 24 * time.Hour
-		minExpected := time.Duration(float64(base) * 0.90)
-		maxExpected := time.Duration(float64(base) * 1.10)
-
-		for i := 0; i < 500; i++ {
-			jittered := ApplyJitter(base)
-			if jittered < minExpected || jittered > maxExpected {
-				t.Fatalf("jittered value %v out of bounds [%v, %v]", jittered, minExpected, maxExpected)
-			}
-		}
-	})
-
-	t.Run("non-positive durations", func(t *testing.T) {
-		if got := ApplyJitter(0); got != 0 {
-			t.Errorf("ApplyJitter(0) = %v, want 0", got)
-		}
-		if got := ApplyJitter(-5 * time.Second); got != -5*time.Second {
-			t.Errorf("ApplyJitter(-5s) = %v, want -5s", got)
-		}
-	})
 }
 
 func TestEngine_FailClosed_EmptyTenantID(t *testing.T) {
@@ -385,7 +278,7 @@ func TestEngine_FlushTenant_ScanPipeline(t *testing.T) {
 		pipe := rdb.Pipeline()
 		for i := 0; i < totalKeys; i++ {
 			k := BuildKey("tenant_large", "task", fmt.Sprintf("key_%d", i))
-			pipe.Set(ctx, k, fmt.Sprintf(`"val_%d"`, i), time.Hour)
+			pipe.Set(ctx, k, fmt.Sprintf(`"val_%d"`, i), 0)
 		}
 		if _, err := pipe.Exec(ctx); err != nil {
 			t.Fatalf("Pipeline setup error: %v", err)
@@ -444,45 +337,6 @@ func TestEngine_MetricsHook(t *testing.T) {
 	}
 }
 
-func TestEngine_GetOrCompute_ContextCancellation_AllowsImmediateRetry(t *testing.T) {
-	engine := New[string]()
-
-	// 1. Slow flight with quick timeout
-	ctx1, cancel1 := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel1()
-
-	computeStarted := make(chan struct{})
-	computeFinish := make(chan struct{})
-
-	go func() {
-		_, _ = engine.GetOrCompute(ctx1, "tenant1", "summary", []string{"retry_key"}, func(ctx context.Context) (string, error) {
-			close(computeStarted)
-			<-computeFinish // Hold until we allow it to finish
-			return "slow_result", nil
-		})
-	}()
-
-	<-computeStarted
-	// Wait for ctx1 to time out
-	time.Sleep(35 * time.Millisecond)
-
-	// 2. Immediate retry by a new caller should not hang or fail due to the slow first request
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel2()
-
-	res2, err2 := engine.GetOrCompute(ctx2, "tenant1", "summary", []string{"retry_key"}, func(ctx context.Context) (string, error) {
-		return "fast_result", nil
-	})
-	close(computeFinish)
-
-	if err2 != nil {
-		t.Fatalf("retry GetOrCompute failed: %v", err2)
-	}
-	if res2 != "fast_result" {
-		t.Errorf("got %q, want 'fast_result'", res2)
-	}
-}
-
 func TestEngine_FlushTenant_ScanError(t *testing.T) {
 	engine, mr, _ := newTestEngineWithRedis[string](t)
 	ctx := context.Background()
@@ -531,140 +385,6 @@ func TestEngine_GetOrCompute_ComplexTypes_NoReflect(t *testing.T) {
 	}
 }
 
-func TestEngine_GetOrCompute_WriteBack_ContextCancelled(t *testing.T) {
-	engine, _, _ := newTestEngineWithRedis[string](t)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	computeDone := make(chan struct{})
-
-	go func() {
-		_, _ = engine.GetOrCompute(ctx, "tenant1", "summary", []string{"slow_key"}, func(c context.Context) (string, error) {
-			cancel() // Cancel caller context while computing
-			time.Sleep(20 * time.Millisecond)
-			return "computed_despite_cancel", nil
-		})
-		close(computeDone)
-	}()
-
-	<-computeDone
-	// Allow a moment for background singleflight goroutine to finish set
-	time.Sleep(30 * time.Millisecond)
-
-	// Now check if a new request hits the cache
-	newCtx := context.Background()
-	var computeCalled bool
-	val, err := engine.GetOrCompute(newCtx, "tenant1", "summary", []string{"slow_key"}, func(c context.Context) (string, error) {
-		computeCalled = true
-		return "should_not_recompute", nil
-	})
-	if err != nil {
-		t.Fatalf("unexpected error on cache read: %v", err)
-	}
-	if computeCalled {
-		t.Errorf("expected cache hit after previous cancelled request wrote back, but computeFn was called")
-	}
-	if val != "computed_despite_cancel" {
-		t.Errorf("got %q, want 'computed_despite_cancel'", val)
-	}
-}
-
-func TestEngine_GetOrCompute_Cancellation_SingleForgetNoRace(t *testing.T) {
-	missC := make(chan struct{}, 10)
-	engine, _, _ := newTestEngineWithRedis[string](t,
-		WithValidator[string](func(s string) bool {
-			return s != "resultA" && s != "resultB" // Never cache so C strictly tests SingleFlight deduplication with B
-		}),
-		WithMetrics[string](func(ev Event) {
-			if ev.Kind == "miss" {
-				missC <- struct{}{}
-			}
-		}),
-	)
-
-	// 1. Caller A starts a slow flight
-	ctxA, cancelA := context.WithCancel(context.Background())
-	startedA := make(chan struct{})
-	finishA := make(chan struct{})
-	completedFnA := make(chan struct{})
-	doneA := make(chan struct{})
-
-	go func() {
-		defer close(doneA)
-		_, _ = engine.GetOrCompute(ctxA, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
-			close(startedA)
-			<-finishA
-			close(completedFnA)
-			return "resultA", nil
-		})
-	}()
-
-	<-startedA
-	<-missC // Drain A's cache miss event
-
-	// Cancel Caller A's context, triggering Forget(key) and waiting for GetOrCompute to return
-	cancelA()
-	<-doneA
-
-	// 2. Caller B starts a new flight for the same key while A is still running in background
-	ctxB := context.Background()
-	startedB := make(chan struct{})
-	finishB := make(chan struct{})
-	var computeCountB atomic.Int32
-
-	var resB string
-	var errB error
-	doneB := make(chan struct{})
-	go func() {
-		defer close(doneB)
-		resB, errB = engine.GetOrCompute(ctxB, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
-			computeCountB.Add(1)
-			close(startedB)
-			<-finishB
-			return "resultB", nil
-		})
-	}()
-
-	<-startedB
-	<-missC // Drain B's cache miss event
-
-	// 3. Now let Caller A's original background compute finish and wait for it to complete.
-	// If there was a double-forget bug, A completing would evict B's flight from singleflight map!
-	close(finishA)
-	<-completedFnA
-
-	// 4. Caller C arrives while Caller B is still computing.
-	// Caller C MUST merge into Caller B's existing flight and NOT start a new computation.
-	ctxC := context.Background()
-	var resC string
-	var errC error
-	doneC := make(chan struct{})
-	go func() {
-		defer close(doneC)
-		resC, errC = engine.GetOrCompute(ctxC, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
-			computeCountB.Add(1) // Should NOT be called
-			return "resultC_unwanted", nil
-		})
-	}()
-
-	// Wait for Caller C to reach DoChan before releasing B
-	<-missC
-
-	// 5. Allow Caller B's computation to finish
-	close(finishB)
-	<-doneB
-	<-doneC
-
-	if errB != nil || errC != nil {
-		t.Fatalf("unexpected error: B=%v, C=%v", errB, errC)
-	}
-	if computeCountB.Load() != 1 {
-		t.Errorf("compute count = %d, want 1 (SingleFlight dedup was defeated by double forget race)", computeCountB.Load())
-	}
-	if resB != "resultB" || resC != "resultB" {
-		t.Errorf("resB = %q, resC = %q, both want 'resultB'", resB, resC)
-	}
-}
-
 func BenchmarkBuildKey(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -672,11 +392,3 @@ func BenchmarkBuildKey(b *testing.B) {
 	}
 }
 
-func BenchmarkEngine_ApplyJitter(b *testing.B) {
-	base := 24 * time.Hour
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_ = ApplyJitter(base)
-		}
-	})
-}

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -569,9 +569,15 @@ func TestEngine_GetOrCompute_WriteBack_ContextCancelled(t *testing.T) {
 }
 
 func TestEngine_GetOrCompute_Cancellation_SingleForgetNoRace(t *testing.T) {
+	missC := make(chan struct{}, 10)
 	engine, _, _ := newTestEngineWithRedis[string](t,
 		WithValidator[string](func(s string) bool {
-			return s != "resultA" // Prevent cancelled A from populating Redis so C strictly tests SingleFlight joining B
+			return s != "resultA" && s != "resultB" // Never cache so C strictly tests SingleFlight deduplication with B
+		}),
+		WithMetrics[string](func(ev Event) {
+			if ev.Kind == "miss" {
+				missC <- struct{}{}
+			}
 		}),
 	)
 
@@ -579,19 +585,25 @@ func TestEngine_GetOrCompute_Cancellation_SingleForgetNoRace(t *testing.T) {
 	ctxA, cancelA := context.WithCancel(context.Background())
 	startedA := make(chan struct{})
 	finishA := make(chan struct{})
+	completedFnA := make(chan struct{})
+	doneA := make(chan struct{})
 
 	go func() {
+		defer close(doneA)
 		_, _ = engine.GetOrCompute(ctxA, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
 			close(startedA)
 			<-finishA
+			close(completedFnA)
 			return "resultA", nil
 		})
 	}()
 
 	<-startedA
-	// Cancel Caller A's context, triggering Forget(key)
+	<-missC // Drain A's cache miss event
+
+	// Cancel Caller A's context, triggering Forget(key) and waiting for GetOrCompute to return
 	cancelA()
-	time.Sleep(10 * time.Millisecond)
+	<-doneA
 
 	// 2. Caller B starts a new flight for the same key while A is still running in background
 	ctxB := context.Background()
@@ -603,21 +615,22 @@ func TestEngine_GetOrCompute_Cancellation_SingleForgetNoRace(t *testing.T) {
 	var errB error
 	doneB := make(chan struct{})
 	go func() {
+		defer close(doneB)
 		resB, errB = engine.GetOrCompute(ctxB, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
 			computeCountB.Add(1)
 			close(startedB)
 			<-finishB
 			return "resultB", nil
 		})
-		close(doneB)
 	}()
 
 	<-startedB
+	<-missC // Drain B's cache miss event
 
-	// 3. Now let Caller A's original background task finish.
-	// If there was a double-forget, A completing would evict B's flight from singleflight map!
+	// 3. Now let Caller A's original background compute finish and wait for it to complete.
+	// If there was a double-forget bug, A completing would evict B's flight from singleflight map!
 	close(finishA)
-	time.Sleep(20 * time.Millisecond)
+	<-completedFnA
 
 	// 4. Caller C arrives while Caller B is still computing.
 	// Caller C MUST merge into Caller B's existing flight and NOT start a new computation.
@@ -626,12 +639,15 @@ func TestEngine_GetOrCompute_Cancellation_SingleForgetNoRace(t *testing.T) {
 	var errC error
 	doneC := make(chan struct{})
 	go func() {
+		defer close(doneC)
 		resC, errC = engine.GetOrCompute(ctxC, "tenant1", "summary", []string{"race_key"}, func(c context.Context) (string, error) {
 			computeCountB.Add(1) // Should NOT be called
 			return "resultC_unwanted", nil
 		})
-		close(doneC)
 	}()
+
+	// Wait for Caller C to reach DoChan before releasing B
+	<-missC
 
 	// 5. Allow Caller B's computation to finish
 	close(finishB)

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -664,4 +664,3 @@ func BenchmarkEngine_ApplyJitter(b *testing.B) {
 		}
 	})
 }
-

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -569,7 +569,11 @@ func TestEngine_GetOrCompute_WriteBack_ContextCancelled(t *testing.T) {
 }
 
 func TestEngine_GetOrCompute_Cancellation_SingleForgetNoRace(t *testing.T) {
-	engine, _, _ := newTestEngineWithRedis[string](t)
+	engine, _, _ := newTestEngineWithRedis[string](t,
+		WithValidator[string](func(s string) bool {
+			return s != "resultA" // Prevent cancelled A from populating Redis so C strictly tests SingleFlight joining B
+		}),
+	)
 
 	// 1. Caller A starts a slow flight
 	ctxA, cancelA := context.WithCancel(context.Background())

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	goredis "github.com/redis/go-redis/v9"
@@ -390,5 +391,64 @@ func BenchmarkBuildKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = BuildKey("tenant1", "task", "part1", "part2", "part3")
 	}
+}
+
+func TestEngine_JitterRange(t *testing.T) {
+	t.Run("100s base duration", func(t *testing.T) {
+		base := 100 * time.Second
+		minExpected := 90 * time.Second
+		maxExpected := 110 * time.Second
+
+		var minObserved time.Duration = 1000 * time.Second
+		var maxObserved time.Duration = 0
+
+		for i := 0; i < 1000; i++ {
+			jittered := ApplyJitter(base)
+			if jittered < minExpected || jittered > maxExpected {
+				t.Fatalf("jittered value %v out of bounds [%v, %v]", jittered, minExpected, maxExpected)
+			}
+			if jittered < minObserved {
+				minObserved = jittered
+			}
+			if jittered > maxObserved {
+				maxObserved = jittered
+			}
+		}
+
+		if minObserved > 95*time.Second || maxObserved < 105*time.Second {
+			t.Fatalf("expected substantial jitter spread, got min=%v, max=%v", minObserved, maxObserved)
+		}
+	})
+
+	t.Run("24h base duration", func(t *testing.T) {
+		base := 24 * time.Hour
+		minExpected := time.Duration(float64(base) * 0.90)
+		maxExpected := time.Duration(float64(base) * 1.10)
+
+		for i := 0; i < 500; i++ {
+			jittered := ApplyJitter(base)
+			if jittered < minExpected || jittered > maxExpected {
+				t.Fatalf("jittered value %v out of bounds [%v, %v]", jittered, minExpected, maxExpected)
+			}
+		}
+	})
+
+	t.Run("non-positive durations", func(t *testing.T) {
+		if got := ApplyJitter(0); got != 0 {
+			t.Errorf("ApplyJitter(0) = %v, want 0", got)
+		}
+		if got := ApplyJitter(-5 * time.Second); got != -5*time.Second {
+			t.Errorf("ApplyJitter(-5s) = %v, want -5s", got)
+		}
+	})
+}
+
+func BenchmarkEngine_ApplyJitter(b *testing.B) {
+	base := 24 * time.Hour
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = ApplyJitter(base)
+		}
+	})
 }
 

--- a/internal/cache/llmcache/llm_cache_test.go
+++ b/internal/cache/llmcache/llm_cache_test.go
@@ -73,15 +73,6 @@ func TestBuildKey(t *testing.T) {
 }
 
 func TestSentinelErrors(t *testing.T) {
-	if ErrNoTenantID == nil {
-		t.Error("ErrNoTenantID must not be nil")
-	}
-	if ErrCacheMiss == nil {
-		t.Error("ErrCacheMiss must not be nil")
-	}
-	if ErrRejected == nil {
-		t.Error("ErrRejected must not be nil")
-	}
 	if ErrTypeAssertion == nil {
 		t.Error("ErrTypeAssertion must not be nil")
 	}
@@ -295,8 +286,11 @@ func TestEngine_FailClosed_EmptyTenantID(t *testing.T) {
 		t.Errorf("expected 0 keys written to Redis for empty tenantID, found %d: %v", len(keys), keys)
 	}
 
-	// 2. Calling FlushTenant with tenantID == "" should return 0
-	deleted := engine.FlushTenant(ctx, "")
+	// 2. Calling FlushTenant with tenantID == "" should return 0, nil
+	deleted, err := engine.FlushTenant(ctx, "")
+	if err != nil {
+		t.Fatalf("FlushTenant(\"\") returned error: %v", err)
+	}
 	if deleted != 0 {
 		t.Errorf("FlushTenant(\"\") = %d, want 0", deleted)
 	}
@@ -335,7 +329,10 @@ func TestEngine_FlushTenant_ScanPipeline(t *testing.T) {
 		}
 
 		// Flush tenantA
-		deleted := engine.FlushTenant(ctx, "tenantA")
+		deleted, err := engine.FlushTenant(ctx, "tenantA")
+		if err != nil {
+			t.Fatalf("FlushTenant(tenantA) error: %v", err)
+		}
 		if deleted != 10 {
 			t.Errorf("FlushTenant(tenantA) deleted %d keys, want 10", deleted)
 		}
@@ -371,7 +368,10 @@ func TestEngine_FlushTenant_ScanPipeline(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // immediately cancel
 
-		deleted := engine.FlushTenant(ctx, "tenantA")
+		deleted, err := engine.FlushTenant(ctx, "tenantA")
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled error, got %v", err)
+		}
 		if deleted != 0 {
 			t.Errorf("FlushTenant with cancelled context returned %d, want 0", deleted)
 		}
@@ -401,7 +401,10 @@ func TestEngine_FlushTenant_ScanPipeline(t *testing.T) {
 		}
 
 		// Flush tenant_large
-		deleted := engine.FlushTenant(ctx, "tenant_large")
+		deleted, err := engine.FlushTenant(ctx, "tenant_large")
+		if err != nil {
+			t.Fatalf("FlushTenant(tenant_large) error: %v", err)
+		}
 		if deleted != totalKeys {
 			t.Errorf("FlushTenant deleted %d keys, want %d", deleted, totalKeys)
 		}
@@ -440,3 +443,144 @@ func TestEngine_MetricsHook(t *testing.T) {
 		t.Errorf("expected metrics events to be emitted, got none")
 	}
 }
+
+func TestEngine_GetOrCompute_ContextCancellation_AllowsImmediateRetry(t *testing.T) {
+	engine := New[string]()
+
+	// 1. Slow flight with quick timeout
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel1()
+
+	computeStarted := make(chan struct{})
+	computeFinish := make(chan struct{})
+
+	go func() {
+		_, _ = engine.GetOrCompute(ctx1, "tenant1", "summary", []string{"retry_key"}, func(ctx context.Context) (string, error) {
+			close(computeStarted)
+			<-computeFinish // Hold until we allow it to finish
+			return "slow_result", nil
+		})
+	}()
+
+	<-computeStarted
+	// Wait for ctx1 to time out
+	time.Sleep(35 * time.Millisecond)
+
+	// 2. Immediate retry by a new caller should not hang or fail due to the slow first request
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel2()
+
+	res2, err2 := engine.GetOrCompute(ctx2, "tenant1", "summary", []string{"retry_key"}, func(ctx context.Context) (string, error) {
+		return "fast_result", nil
+	})
+	close(computeFinish)
+
+	if err2 != nil {
+		t.Fatalf("retry GetOrCompute failed: %v", err2)
+	}
+	if res2 != "fast_result" {
+		t.Errorf("got %q, want 'fast_result'", res2)
+	}
+}
+
+func TestEngine_FlushTenant_ScanError(t *testing.T) {
+	engine, mr, _ := newTestEngineWithRedis[string](t)
+	ctx := context.Background()
+
+	// Close miniredis immediately so SCAN / pipeline fails
+	mr.Close()
+
+	deleted, err := engine.FlushTenant(ctx, "tenant_err")
+	if err == nil {
+		t.Errorf("expected error when redis server is closed, got nil")
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0", deleted)
+	}
+}
+
+func TestEngine_GetOrCompute_ComplexTypes_NoReflect(t *testing.T) {
+	engine, _, _ := newTestEngineWithRedis[map[string]int](t)
+	ctx := context.Background()
+
+	// Verify map types serialize and deserialize properly without reflect overhead
+	val, err := engine.GetOrCompute(ctx, "tenant1", "tags", []string{"doc1"}, func(ctx context.Context) (map[string]int, error) {
+		return map[string]int{"tagA": 10, "tagB": 20}, nil
+	})
+	if err != nil {
+		t.Fatalf("first GetOrCompute failed: %v", err)
+	}
+	if val["tagA"] != 10 || val["tagB"] != 20 {
+		t.Errorf("unexpected map content: %v", val)
+	}
+
+	// Read from cache
+	var computeCalled bool
+	cachedVal, err := engine.GetOrCompute(ctx, "tenant1", "tags", []string{"doc1"}, func(ctx context.Context) (map[string]int, error) {
+		computeCalled = true
+		return nil, errors.New("should not compute")
+	})
+	if err != nil {
+		t.Fatalf("cached GetOrCompute failed: %v", err)
+	}
+	if computeCalled {
+		t.Errorf("computeFn should not have been called on cache hit")
+	}
+	if cachedVal["tagA"] != 10 || cachedVal["tagB"] != 20 {
+		t.Errorf("unexpected cached map content: %v", cachedVal)
+	}
+}
+
+func TestEngine_GetOrCompute_WriteBack_ContextCancelled(t *testing.T) {
+	engine, _, _ := newTestEngineWithRedis[string](t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	computeDone := make(chan struct{})
+
+	go func() {
+		_, _ = engine.GetOrCompute(ctx, "tenant1", "summary", []string{"slow_key"}, func(c context.Context) (string, error) {
+			cancel() // Cancel caller context while computing
+			time.Sleep(20 * time.Millisecond)
+			return "computed_despite_cancel", nil
+		})
+		close(computeDone)
+	}()
+
+	<-computeDone
+	// Allow a moment for background singleflight goroutine to finish set
+	time.Sleep(30 * time.Millisecond)
+
+	// Now check if a new request hits the cache
+	newCtx := context.Background()
+	var computeCalled bool
+	val, err := engine.GetOrCompute(newCtx, "tenant1", "summary", []string{"slow_key"}, func(c context.Context) (string, error) {
+		computeCalled = true
+		return "should_not_recompute", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error on cache read: %v", err)
+	}
+	if computeCalled {
+		t.Errorf("expected cache hit after previous cancelled request wrote back, but computeFn was called")
+	}
+	if val != "computed_despite_cancel" {
+		t.Errorf("got %q, want 'computed_despite_cancel'", val)
+	}
+}
+
+func BenchmarkBuildKey(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = BuildKey("tenant1", "task", "part1", "part2", "part3")
+	}
+}
+
+func BenchmarkEngine_ApplyJitter(b *testing.B) {
+	base := 24 * time.Hour
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = ApplyJitter(base)
+		}
+	})
+}
+

--- a/internal/engine/redis/redis.go
+++ b/internal/engine/redis/redis.go
@@ -154,6 +154,25 @@ func Get() *Client {
 	return globalClient
 }
 
+// SetGlobalClient sets the global Redis client instance (primarily for testing and custom wiring).
+// It returns a restore function.
+func SetGlobalClient(c *Client) func() {
+	prev := globalClient
+	globalClient = c
+	return func() {
+		globalClient = prev
+	}
+}
+
+// NewTestClient wraps a go-redis Client into *Client for testing.
+func NewTestClient(rdb *redis.Client) *Client {
+	return &Client{
+		client:           rdb,
+		luaDeleteIfEqual: redis.NewScript(luaDeleteIfEqualScript),
+		luaTokenBucket:   redis.NewScript(luaTokenBucketScript),
+	}
+}
+
 // Close closes Redis client
 func Close() error {
 	if globalClient != nil && globalClient.client != nil {

--- a/internal/engine/redis/redis.go
+++ b/internal/engine/redis/redis.go
@@ -34,10 +34,11 @@ import (
 	"go.uber.org/zap"
 
 	"ragflow/internal/server"
+	"sync/atomic"
 )
 
 var (
-	globalClient *Client
+	globalClient atomic.Pointer[Client]
 	once         sync.Once
 )
 
@@ -133,12 +134,12 @@ func Init(ctx context.Context) error {
 			return
 		}
 
-		globalClient = &Client{
+		globalClient.Store(&Client{
 			client:           client,
 			config:           redisConfig,
 			luaDeleteIfEqual: redis.NewScript(luaDeleteIfEqualScript),
 			luaTokenBucket:   redis.NewScript(luaTokenBucketScript),
-		}
+		})
 
 		common.Info("Redis client initialized",
 			zap.String("host", redisConfig.Host),
@@ -151,16 +152,15 @@ func Init(ctx context.Context) error {
 
 // Get gets global Redis client instance
 func Get() *Client {
-	return globalClient
+	return globalClient.Load()
 }
 
 // SetGlobalClient sets the global Redis client instance (primarily for testing and custom wiring).
 // It returns a restore function.
 func SetGlobalClient(c *Client) func() {
-	prev := globalClient
-	globalClient = c
+	prev := globalClient.Swap(c)
 	return func() {
-		globalClient = prev
+		globalClient.Store(prev)
 	}
 }
 
@@ -175,15 +175,17 @@ func NewTestClient(rdb *redis.Client) *Client {
 
 // Close closes Redis client
 func Close() error {
-	if globalClient != nil && globalClient.client != nil {
-		return globalClient.client.Close()
+	c := globalClient.Load()
+	if c != nil && c.client != nil {
+		return c.client.Close()
 	}
 	return nil
 }
 
 // IsEnabled checks if Redis is enabled (configured and initialized)
 func IsEnabled() bool {
-	return globalClient != nil && globalClient.client != nil
+	c := globalClient.Load()
+	return c != nil && c.client != nil
 }
 
 // Health checks if Redis is healthy
@@ -886,14 +888,15 @@ type DistributedLock struct {
 
 // NewDistributedLock creates a new distributed lock
 func NewDistributedLock(lockKey string, lockValue string, timeout time.Duration, blockingTimeout time.Duration) *DistributedLock {
-	if globalClient == nil {
+	client := Get()
+	if client == nil {
 		return nil
 	}
 	if lockValue == "" {
 		lockValue = uuid.New().String()
 	}
 	return &DistributedLock{
-		client:          globalClient,
+		client:          client,
 		lockKey:         lockKey,
 		lockValue:       lockValue,
 		timeout:         timeout,
@@ -945,11 +948,12 @@ type TokenBucket struct {
 
 // NewTokenBucket creates a new token bucket
 func NewTokenBucket(key string, capacity, rate float64) *TokenBucket {
-	if globalClient == nil {
+	client := Get()
+	if client == nil {
 		return nil
 	}
 	return &TokenBucket{
-		client:   globalClient,
+		client:   client,
 		key:      key,
 		capacity: capacity,
 		rate:     rate,

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -43,16 +43,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cespare/xxhash/v2"
 	eschema "github.com/cloudwego/eino/schema"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/cache/llmcache"
 	"ragflow/internal/common"
 	"ragflow/internal/component/messagefit"
 	"ragflow/internal/dao"
-	"ragflow/internal/engine/redis"
 	"ragflow/internal/entity"
 	"ragflow/internal/entity/models"
 	"ragflow/internal/ingestion/component/schema"
@@ -125,6 +124,34 @@ func SetExtractorConcurrency(n int) {
 		extractorPool.Resize(n)
 	}
 }
+
+// isValidLLMCachePayload validates whether an LLM extraction output is suitable for caching.
+// It rejects empty strings, responses containing error markers ("**ERROR**"),
+// and obvious truncated outputs (e.g. unclosed reasoning tags or truncation markers).
+func isValidLLMCachePayload(s string) bool {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return false
+	}
+	if strings.Contains(trimmed, "**ERROR**") {
+		return false
+	}
+	if strings.Contains(trimmed, "[TRUNCATED]") || strings.Contains(trimmed, "[truncated]") {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "<think>") && !strings.Contains(trimmed, "</think>") {
+		return false
+	}
+	return true
+}
+
+// Global generic cache engine singletons for Extractor operator tasks.
+var (
+	textExtractCache = llmcache.New[string](llmcache.WithValidator(isValidLLMCachePayload))
+	metadataCache    = llmcache.New[map[string]any](llmcache.WithValidator(func(m map[string]any) bool {
+		return m != nil
+	}))
+)
 
 // extractorTopNPattern matches the {{ topn }} placeholder accepted in
 // keyword/question system prompts (same convention as rag/prompts/*.md).
@@ -502,9 +529,10 @@ func toExtractorEinoMessages(msgs []eschema.Message) []*eschema.Message {
 // input map. Computed once at the top of Invoke so the rest of
 // the function reads as straight-line code.
 type extractorInputs struct {
-	llmID  string
-	lang   string
-	chunks []map[string]any
+	tenantID string
+	llmID    string
+	lang     string
+	chunks   []map[string]any
 	// temperature overrides the LLM temperature for this call. A
 	// nil value leaves the request's Temperature unset so the model
 	// (or the chat-model default) decides. The keyword/question helpers set it to
@@ -516,12 +544,24 @@ type extractorInputs struct {
 // component's static Param. Missing keys fall back to the
 // Param-level values; per-call values win on conflict (so a
 // canvas can override LLM_ID at runtime).
-func (c *ExtractorComponent) resolveInputs(inputs map[string]any) extractorInputs {
+func (c *ExtractorComponent) resolveInputs(ctx context.Context, inputs map[string]any) extractorInputs {
 	out := extractorInputs{
 		llmID: c.Param.LLMID,
 	}
+	if ctx != nil {
+		if state, _, err := runtime.GetStateFromContext[*runtime.CanvasState](ctx); err == nil && state != nil {
+			if tidVal, ok := state.GetGlobal("tenant_id"); ok {
+				if tid, ok := tidVal.(string); ok && tid != "" {
+					out.tenantID = tid
+				}
+			}
+		}
+	}
 	if inputs == nil {
 		return out
+	}
+	if v, ok := inputs["tenant_id"].(string); ok && v != "" {
+		out.tenantID = v
 	}
 	if v, ok := inputs["llm_id"].(string); ok && v != "" {
 		out.llmID = v
@@ -594,7 +634,7 @@ func (c *ExtractorComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map
 	if err := c.Param.Validate(); err != nil {
 		return nil, fmt.Errorf("extractor: %w", err)
 	}
-	in := c.resolveInputs(inputs)
+	in := c.resolveInputs(ctx, inputs)
 	common.Debug("extractor stage",
 		zap.String("component", "Extractor"),
 		zap.Int("input_chunks", len(in.chunks)),
@@ -654,12 +694,8 @@ func (c *ExtractorComponent) runAutoKeywords(ctx context.Context, db *gorm.DB, i
 		systemPrompt = autoKeywordPrompt
 	}
 	systemPrompt = renderExtractorPrompt(systemPrompt, topN)
-	kwTemp := extractorTemperature
-	kwIn := extractorInputs{
-		llmID:       in.llmID,
-		temperature: &kwTemp,
-	}
-	resultStr, err := c.callText(ctx, db, kwIn, systemPrompt, chunkText)
+
+	resultStr, err := c.callTextCached(ctx, db, in, "keywords", systemPrompt, chunkText)
 	if err != nil {
 		return err
 	}
@@ -695,12 +731,8 @@ func (c *ExtractorComponent) runAutoQuestions(ctx context.Context, db *gorm.DB, 
 		systemPrompt = autoQuestionPrompt
 	}
 	systemPrompt = renderExtractorPrompt(systemPrompt, topN)
-	qTemp := extractorTemperature
-	qIn := extractorInputs{
-		llmID:       in.llmID,
-		temperature: &qTemp,
-	}
-	resultStr, err := c.callText(ctx, db, qIn, systemPrompt, chunkText)
+
+	resultStr, err := c.callTextCached(ctx, db, in, "questions", systemPrompt, chunkText)
 	if err != nil {
 		return err
 	}
@@ -742,12 +774,8 @@ func (c *ExtractorComponent) runAutoSummary(ctx context.Context, db *gorm.DB, in
 	if strings.TrimSpace(systemPrompt) == "" {
 		systemPrompt = autoSummaryPrompt
 	}
-	sumTemp := extractorTemperature
-	sumIn := extractorInputs{
-		llmID:       in.llmID,
-		temperature: &sumTemp,
-	}
-	resultStr, err := c.callText(ctx, db, sumIn, systemPrompt, chunkText)
+
+	resultStr, err := c.callTextCached(ctx, db, in, "summary", systemPrompt, chunkText)
 	if err != nil {
 		return err
 	}
@@ -881,31 +909,28 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 	}
 	schemaStr := string(schemaJSON)
 
-	// LLM cache (mirrors Python get_llm_cache/set_llm_cache in
-	// task_executor.py:543/550 gen_metadata_task): identical (model + chunk
-	// text + schema) extractions are served from Redis within a 24h window so
-	// repeated runs / identical chunks don't re-pay the LLM call.
-	// Best-effort: a missing Redis client or any cache error falls through to
-	// a live call instead of failing the extraction.
-	var parsed map[string]any
-	if cached, hit := getMetadataLLMCache(ctx, in.llmID, schemaStr, chunkText); hit {
-		parsed = cached
-	} else {
-		metaTemp := extractorTemperature
-		metaIn := extractorInputs{
-			llmID:       in.llmID,
-			temperature: &metaTemp,
-		}
-		systemPrompt := fmt.Sprintf(autoMetadataPrompt, schemaStr)
-		parsed, err = c.callStructured(ctx, db, metaIn, systemPrompt, chunkText)
-		if err != nil {
-			return err
-		}
-		if parsed == nil {
-			// Non-JSON or empty response — nothing to extract, not an error.
-			return nil
-		}
-		setMetadataLLMCache(ctx, in.llmID, schemaStr, chunkText, parsed)
+	metaTemp := extractorTemperature
+	metaIn := extractorInputs{
+		tenantID:    in.tenantID,
+		llmID:       in.llmID,
+		temperature: &metaTemp,
+	}
+	systemPrompt := fmt.Sprintf(autoMetadataPrompt, schemaStr)
+	parsed, err := metadataCache.GetOrCompute(
+		ctx,
+		in.tenantID,
+		"metadata",
+		[]string{in.llmID, schemaStr, chunkText},
+		func(ctx context.Context) (map[string]any, error) {
+			return c.callStructured(ctx, db, metaIn, systemPrompt, chunkText)
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if parsed == nil {
+		// Non-JSON or empty response — nothing to extract, not an error.
+		return nil
 	}
 	// Merge into the chunk metadata map, preserving existing keys.
 	var meta map[string]any
@@ -927,55 +952,6 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 	return nil
 }
 
-// metadataLLMCacheTTL mirrors Python get_llm_cache/set_llm_cache 24h TTL.
-const metadataLLMCacheTTL = 24 * time.Hour
-
-// metadataLLMCacheKey builds a Redis key from (llm id, chunk text, "metadata",
-// schema), mirroring Python get_llm_cache's xxh64(llmnm + txt + history + genconf).
-func metadataLLMCacheKey(llmID, schemaJSON, chunkText string) string {
-	h := xxhash.New()
-	h.WriteString(llmID)
-	h.WriteString("\x00")
-	h.WriteString(chunkText)
-	h.WriteString("\x00")
-	h.WriteString("metadata")
-	h.WriteString("\x00")
-	h.WriteString(schemaJSON)
-	return fmt.Sprintf("kc:meta:%x", h.Sum64())
-}
-
-// getMetadataLLMCache returns a cached extraction for the given chunk, or
-// (nil, false) on miss / Redis unavailable / decode error. Best-effort.
-func getMetadataLLMCache(ctx context.Context, llmID, schemaJSON, chunkText string) (map[string]any, bool) {
-	client := redis.Get()
-	if client == nil {
-		return nil, false
-	}
-	data, err := client.Get(ctx, metadataLLMCacheKey(llmID, schemaJSON, chunkText))
-	if err != nil || data == "" {
-		return nil, false
-	}
-	var parsed map[string]any
-	if err = json.Unmarshal([]byte(data), &parsed); err != nil {
-		return nil, false
-	}
-	return parsed, true
-}
-
-// setMetadataLLMCache stores an extraction result for 24h. Best-effort: a
-// missing Redis client or marshal error is silently ignored.
-func setMetadataLLMCache(ctx context.Context, llmID, schemaJSON, chunkText string, parsed map[string]any) {
-	client := redis.Get()
-	if client == nil {
-		return
-	}
-	data, err := json.Marshal(parsed)
-	if err != nil {
-		return
-	}
-	client.Set(ctx, metadataLLMCacheKey(llmID, schemaJSON, chunkText), string(data), metadataLLMCacheTTL)
-}
-
 // callRaw runs one chat call against the LLM (per chunk in the normal path)
 // and returns the raw response. It holds the shared plumbing — driver/target
 // resolution, message assembly, temperature override, retry — but deliberately
@@ -983,6 +959,7 @@ func setMetadataLLMCache(ctx context.Context, llmID, schemaJSON, chunkText strin
 //
 //   - callText wraps callRaw with the LLM-layer two-step cleanup (think +
 //     tool_call) and returns a plain string.
+//   - callTextCached wraps callText with LLM caching and singleflight deduplication.
 //   - callStructured wraps callRaw with cleanup + explicit JSON parsing and
 //     returns a map — the metadata path, matching Python gen_metadata.
 func (c *ExtractorComponent) callRaw(ctx context.Context, db *gorm.DB, in extractorInputs, systemPrompt, chunkText string) (*extractorChatResponse, error) {
@@ -1133,6 +1110,38 @@ func (c *ExtractorComponent) callText(ctx context.Context, db *gorm.DB, in extra
 		return "", err
 	}
 	return cleanLLMText(resp.Content), nil
+}
+
+// callTextCached encapsulates the common pattern for text-based extraction operators:
+// applying the standard temperature (0.2), checking the cache / singleflight deduplication,
+// delegating to callText on cache miss, and cleaning the extraction result before caching.
+func (c *ExtractorComponent) callTextCached(
+	ctx context.Context,
+	db *gorm.DB,
+	in extractorInputs,
+	taskType string,
+	systemPrompt string,
+	chunkText string,
+) (string, error) {
+	temp := extractorTemperature
+	taskIn := extractorInputs{
+		tenantID:    in.tenantID,
+		llmID:       in.llmID,
+		temperature: &temp,
+	}
+	return textExtractCache.GetOrCompute(
+		ctx,
+		in.tenantID,
+		taskType,
+		[]string{in.llmID, systemPrompt, chunkText},
+		func(ctx context.Context) (string, error) {
+			raw, err := c.callText(ctx, db, taskIn, systemPrompt, chunkText)
+			if err != nil {
+				return "", err
+			}
+			return cleanExtractionResult(raw), nil
+		},
+	)
 }
 
 // callStructured runs one chat call, cleans the response, and explicitly

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -147,11 +147,46 @@ func isValidLLMCachePayload(s string) bool {
 
 // Global generic cache engine singletons for Extractor operator tasks.
 var (
-	textExtractCache = llmcache.New[string](llmcache.WithValidator(isValidLLMCachePayload))
-	metadataCache    = llmcache.New[map[string]any](llmcache.WithValidator(func(m map[string]any) bool {
+	extractorCachesMu sync.RWMutex
+	textExtractCache  = llmcache.New[string](llmcache.WithValidator(isValidLLMCachePayload))
+	metadataCache     = llmcache.New[map[string]any](llmcache.WithValidator(func(m map[string]any) bool {
 		return m != nil
 	}))
 )
+
+func getTextExtractCache() *llmcache.Engine[string] {
+	extractorCachesMu.RLock()
+	defer extractorCachesMu.RUnlock()
+	return textExtractCache
+}
+
+func getMetadataCache() *llmcache.Engine[map[string]any] {
+	extractorCachesMu.RLock()
+	defer extractorCachesMu.RUnlock()
+	return metadataCache
+}
+
+// SetExtractorCachesForTest swaps the package-level cache engines for tests.
+// It returns a restore closure that resets the caches to their previous values.
+func SetExtractorCachesForTest(text *llmcache.Engine[string], meta *llmcache.Engine[map[string]any]) func() {
+	extractorCachesMu.Lock()
+	prevText := textExtractCache
+	prevMeta := metadataCache
+	if text != nil {
+		textExtractCache = text
+	}
+	if meta != nil {
+		metadataCache = meta
+	}
+	extractorCachesMu.Unlock()
+
+	return func() {
+		extractorCachesMu.Lock()
+		textExtractCache = prevText
+		metadataCache = prevMeta
+		extractorCachesMu.Unlock()
+	}
+}
 
 // extractorTopNPattern matches the {{ topn }} placeholder accepted in
 // keyword/question system prompts (same convention as rag/prompts/*.md).
@@ -699,7 +734,6 @@ func (c *ExtractorComponent) runAutoKeywords(ctx context.Context, db *gorm.DB, i
 	if err != nil {
 		return err
 	}
-	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil
 	}
@@ -736,7 +770,6 @@ func (c *ExtractorComponent) runAutoQuestions(ctx context.Context, db *gorm.DB, 
 	if err != nil {
 		return err
 	}
-	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil
 	}
@@ -779,7 +812,6 @@ func (c *ExtractorComponent) runAutoSummary(ctx context.Context, db *gorm.DB, in
 	if err != nil {
 		return err
 	}
-	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil
 	}
@@ -909,6 +941,7 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 	}
 	schemaStr := string(schemaJSON)
 
+	effectiveLLMID := resolveEffectiveLLMID(ctx, db, in.llmID)
 	metaTemp := extractorTemperature
 	metaIn := extractorInputs{
 		tenantID:    in.tenantID,
@@ -916,11 +949,11 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 		temperature: &metaTemp,
 	}
 	systemPrompt := fmt.Sprintf(autoMetadataPrompt, schemaStr)
-	parsed, err := metadataCache.GetOrCompute(
+	parsed, err := getMetadataCache().GetOrCompute(
 		ctx,
 		in.tenantID,
 		"metadata",
-		[]string{in.llmID, schemaStr, chunkText},
+		[]string{effectiveLLMID, schemaStr, chunkText},
 		func(ctx context.Context) (map[string]any, error) {
 			return c.callStructured(ctx, db, metaIn, systemPrompt, chunkText)
 		},
@@ -1123,17 +1156,18 @@ func (c *ExtractorComponent) callTextCached(
 	systemPrompt string,
 	chunkText string,
 ) (string, error) {
+	effectiveLLMID := resolveEffectiveLLMID(ctx, db, in.llmID)
 	temp := extractorTemperature
 	taskIn := extractorInputs{
 		tenantID:    in.tenantID,
 		llmID:       in.llmID,
 		temperature: &temp,
 	}
-	return textExtractCache.GetOrCompute(
+	return getTextExtractCache().GetOrCompute(
 		ctx,
 		in.tenantID,
 		taskType,
-		[]string{in.llmID, systemPrompt, chunkText},
+		[]string{effectiveLLMID, systemPrompt, chunkText},
 		func(ctx context.Context) (string, error) {
 			raw, err := c.callText(ctx, db, taskIn, systemPrompt, chunkText)
 			if err != nil {
@@ -1383,6 +1417,28 @@ func extractorContextLength(ctx context.Context, db *gorm.DB, llmID string) int 
 		return 0
 	}
 	return dao.ResolveModelContentLength(ctx, db, tid, llmID, "", "")
+}
+
+// resolveEffectiveLLMID resolves the effective LLM ID for cache key construction.
+// When llmID is empty, it queries the tenant's default chat model reference
+// from canvas state / DB so cache keys change when the default model changes.
+func resolveEffectiveLLMID(ctx context.Context, db *gorm.DB, llmID string) string {
+	if strings.TrimSpace(llmID) != "" {
+		return llmID
+	}
+	if db == nil {
+		db = dao.DB
+	}
+	if ctx != nil {
+		if state, _, err := runtime.GetStateFromContext[*runtime.CanvasState](ctx); err == nil && state != nil {
+			if tidVal, ok := state.GetGlobal("tenant_id"); ok {
+				if tid, ok := tidVal.(string); ok && tid != "" {
+					return defaultChatModelRef(ctx, db, tid)
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // defaultChatModelRef returns the tenant's default chat model reference —

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -893,31 +893,14 @@ func (c *ExtractorComponent) remainingExtractionJob(ctx context.Context, db *gor
 
 func awaitFutures(ctx context.Context, futs []utility.WorkerPoolFuture[extractorJob, struct{}]) error {
 	var firstErr error
-	var emu sync.Mutex
-	var wg sync.WaitGroup
 	for _, f := range futs {
-		wg.Add(1)
-		go func(f utility.WorkerPoolFuture[extractorJob, struct{}]) {
-			defer wg.Done()
-			res, werr := f.Wait(ctx)
-			if werr != nil {
-				emu.Lock()
-				if firstErr == nil {
-					firstErr = werr
-				}
-				emu.Unlock()
-				return
-			}
-			if res.Err != nil {
-				emu.Lock()
-				if firstErr == nil {
-					firstErr = res.Err
-				}
-				emu.Unlock()
-			}
-		}(f)
+		res, werr := f.Wait(ctx)
+		if werr != nil && firstErr == nil {
+			firstErr = werr
+		} else if res.Err != nil && firstErr == nil {
+			firstErr = res.Err
+		}
 	}
-	wg.Wait()
 	return firstErr
 }
 

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -941,7 +941,7 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 	}
 	schemaStr := string(schemaJSON)
 
-	effectiveLLMID := resolveEffectiveLLMID(ctx, db, in.llmID)
+	effectiveLLMID := resolveEffectiveLLMID(ctx, db, in.tenantID, in.llmID)
 	metaTemp := extractorTemperature
 	metaIn := extractorInputs{
 		tenantID:    in.tenantID,
@@ -1156,7 +1156,7 @@ func (c *ExtractorComponent) callTextCached(
 	systemPrompt string,
 	chunkText string,
 ) (string, error) {
-	effectiveLLMID := resolveEffectiveLLMID(ctx, db, in.llmID)
+	effectiveLLMID := resolveEffectiveLLMID(ctx, db, in.tenantID, in.llmID)
 	temp := extractorTemperature
 	taskIn := extractorInputs{
 		tenantID:    in.tenantID,
@@ -1421,22 +1421,40 @@ func extractorContextLength(ctx context.Context, db *gorm.DB, llmID string) int 
 
 // resolveEffectiveLLMID resolves the effective LLM ID for cache key construction.
 // When llmID is empty, it queries the tenant's default chat model reference
-// from canvas state / DB so cache keys change when the default model changes.
-func resolveEffectiveLLMID(ctx context.Context, db *gorm.DB, llmID string) string {
+// from tenantID / canvas state / DB so cache keys change when the default model changes.
+func resolveEffectiveLLMID(ctx context.Context, db *gorm.DB, tenantID, llmID string) string {
 	if strings.TrimSpace(llmID) != "" {
 		return llmID
 	}
 	if db == nil {
 		db = dao.DB
 	}
-	if ctx != nil {
+	if strings.TrimSpace(tenantID) == "" && ctx != nil {
 		if state, _, err := runtime.GetStateFromContext[*runtime.CanvasState](ctx); err == nil && state != nil {
 			if tidVal, ok := state.GetGlobal("tenant_id"); ok {
-				if tid, ok := tidVal.(string); ok && tid != "" {
-					return defaultChatModelRef(ctx, db, tid)
+				if tid, ok := tidVal.(string); ok && strings.TrimSpace(tid) != "" {
+					tenantID = strings.TrimSpace(tid)
 				}
 			}
 		}
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID != "" {
+		driver, modelName, _, _, err := resolveTenantModelByType(ctx, db, tenantID, entity.ModelTypeChat)
+		if err == nil {
+			driverName := ""
+			if driver != nil {
+				driverName = strings.ToLower(strings.TrimSpace(driver.Name()))
+			}
+			if strings.TrimSpace(modelName) != "" {
+				modelName = strings.TrimSpace(modelName)
+				if driverName != "" && !strings.Contains(modelName, "@") {
+					return fmt.Sprintf("%s@%s", modelName, driverName)
+				}
+				return modelName
+			}
+		}
+		return defaultChatModelRef(ctx, db, tenantID)
 	}
 	return ""
 }

--- a/internal/ingestion/component/extractor_tag.go
+++ b/internal/ingestion/component/extractor_tag.go
@@ -1180,11 +1180,19 @@ func llmTagChunk(
 	tagSetStr := strings.Join(tagNames, ", ")
 	prompt := buildTaggerPrompt(topN, tagSetStr, picked, text)
 
+	effectiveModel := model
+	if driver != "" {
+		effectiveModel = fmt.Sprintf("%s/%s", driver, model)
+	}
+	if llmID != "" {
+		effectiveModel = llmID
+	}
+
 	result, err := getTaggerCache().GetOrCompute(
 		ctx,
 		tenantID,
 		"tagger",
-		[]string{llmID, prompt},
+		[]string{effectiveModel, prompt},
 		func(ctx context.Context) (map[string]int, error) {
 			msgs := []eschema.Message{
 				{Role: eschema.System, Content: prompt},

--- a/internal/ingestion/component/extractor_tag.go
+++ b/internal/ingestion/component/extractor_tag.go
@@ -24,14 +24,18 @@ import (
 	"gorm.io/gorm"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/cache/llmcache"
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
-	"ragflow/internal/engine/redis"
 	"ragflow/internal/entity"
 	"ragflow/internal/ingestion/component/globals"
 	"ragflow/internal/ingestion/component/schema"
 	"ragflow/internal/tokenizer"
 )
+
+var taggerCache = llmcache.New[map[string]int](llmcache.WithValidator(func(m map[string]int) bool {
+	return m != nil
+}))
 
 const (
 	// defaultMatchCoverageThreshold is the asymmetric coverage threshold for Phase 1 (55%).
@@ -611,7 +615,7 @@ func (c *ExtractorComponent) runAutoTags(ctx context.Context, db *gorm.DB, in ex
 					case <-ctx.Done():
 						return
 					}
-					llmTagChunk(ctx, db, inv, docsToTag[idx], indexed.allTags, examples, in.llmID, driver, model, apiKey, baseURL, topN, indexed)
+					llmTagChunk(ctx, db, inv, docsToTag[idx], indexed.allTags, examples, in.tenantID, in.llmID, driver, model, apiKey, baseURL, topN, indexed)
 				}(i)
 			}
 			wg.Wait()
@@ -1112,7 +1116,7 @@ func llmTagChunk(
 	chunk map[string]any,
 	allTags map[string]float64,
 	examples []schema.TaggedChunk,
-	llmID, driver, model, apiKey, baseURL string,
+	tenantID, llmID, driver, model, apiKey, baseURL string,
 	topN int,
 	idx *MemoryTagIndex,
 ) {
@@ -1147,58 +1151,64 @@ func llmTagChunk(
 		}
 	}
 
-	if cached := getTaggerLLMCache(ctx, llmID, text, allTags, picked, topN); cached != nil {
-		chunk[common.TAG_FLD] = cached
-		chunk["tag_kwd"] = sortedTagWeightsKeys(cached)
-		return
-	}
-
 	tagNames := sortedTagNames(allTags)
 	tagSetStr := strings.Join(tagNames, ", ")
 	prompt := buildTaggerPrompt(topN, tagSetStr, picked, text)
 
-	msgs := []eschema.Message{
-		{Role: eschema.System, Content: prompt},
-		{Role: eschema.User, Content: "Output:"},
-	}
-	// Trim the prompt to the model's context window before sending. The
-	// system prompt embeds the full chunk text, the entire tag set and up
-	// to two full examples, so oversized chunks or tag files would
-	// otherwise be rejected by the provider (context length exceeded).
-	// Mirrors Python's message_fit_in in content_tagging (generator.py:331).
-	fitted, fitErr := fitExtractorMessages(ctx, db, llmID, msgs)
-	if fitErr != nil {
-		common.Warn("extractor tags: skipping LLM tagging, message fitting failed", zap.Error(fitErr))
-		return
-	}
-	msgs = fitted
+	result, err := taggerCache.GetOrCompute(
+		ctx,
+		tenantID,
+		"tagger",
+		[]string{llmID, prompt},
+		func(ctx context.Context) (map[string]int, error) {
+			msgs := []eschema.Message{
+				{Role: eschema.System, Content: prompt},
+				{Role: eschema.User, Content: "Output:"},
+			}
+			// Trim the prompt to the model's context window before sending. The
+			// system prompt embeds the full chunk text, the entire tag set and up
+			// to two full examples, so oversized chunks or tag files would
+			// otherwise be rejected by the provider (context length exceeded).
+			// Mirrors Python's message_fit_in in content_tagging (generator.py:331).
+			fitted, fitErr := fitExtractorMessages(ctx, db, llmID, msgs)
+			if fitErr != nil {
+				common.Warn("extractor tags: skipping LLM tagging, message fitting failed", zap.Error(fitErr))
+				return nil, nil
+			}
+			msgs = fitted
 
-	temperature := 0.5
-	var result OrderedTagWeights
-	timeoutErr := runtime.WithTimeout(ctx, taggerTimeout, func(timeoutCtx context.Context) error {
-		resp, err := inv.Chat(timeoutCtx, extractorChatRequest{
-			Driver:      driver,
-			ModelName:   model,
-			APIKey:      apiKey,
-			BaseURL:     baseURL,
-			Messages:    msgs,
-			Temperature: &temperature,
-		})
-		if err != nil {
-			common.Error("extractor tags: LLM call failed", err)
-			return nil
-		}
-		result = parseTaggerResponse(resp.Content, topN)
-		return nil
-	})
-	if timeoutErr != nil {
-		common.Error("extractor tags: LLM timeout", timeoutErr)
+			temperature := 0.5
+			var res OrderedTagWeights
+			timeoutErr := runtime.WithTimeout(ctx, taggerTimeout, func(timeoutCtx context.Context) error {
+				resp, err := inv.Chat(timeoutCtx, extractorChatRequest{
+					Driver:      driver,
+					ModelName:   model,
+					APIKey:      apiKey,
+					BaseURL:     baseURL,
+					Messages:    msgs,
+					Temperature: &temperature,
+				})
+				if err != nil {
+					common.Error("extractor tags: LLM call failed", err)
+					return nil
+				}
+				res = parseTaggerResponse(resp.Content, topN)
+				return nil
+			})
+			if timeoutErr != nil {
+				common.Error("extractor tags: LLM timeout", timeoutErr)
+			}
+			return map[string]int(res), nil
+		},
+	)
+	if err != nil {
+		common.Error("extractor tags: cache get or compute failed", err)
+		return
 	}
 
 	if len(result) > 0 {
 		chunk[common.TAG_FLD] = result
 		chunk["tag_kwd"] = sortedTagWeightsKeys(result)
-		setTaggerLLMCache(ctx, llmID, text, allTags, picked, topN, result)
 	}
 }
 
@@ -1222,6 +1232,19 @@ func parseTaggerResponse(raw string, topN int) OrderedTagWeights {
 	if !ok {
 		obj = jsonRepairExtract(raw)
 		if obj == nil {
+			trimmed := strings.TrimSpace(raw)
+			if strings.HasPrefix(trimmed, "```") {
+				if i := strings.IndexByte(trimmed, '\n'); i >= 0 {
+					trimmed = trimmed[i+1:]
+				}
+				if i := strings.LastIndex(trimmed, "```"); i >= 0 {
+					trimmed = trimmed[:i]
+				}
+				trimmed = strings.TrimSpace(trimmed)
+			}
+			if trimmed == "{}" {
+				return make(OrderedTagWeights, 0)
+			}
 			return nil
 		}
 	}
@@ -1278,59 +1301,6 @@ func jsonRepairExtract(raw string) map[string]any {
 		return nil
 	}
 	return obj
-}
-
-func taggerCacheKey(llmID, text string, allTags map[string]float64, examples []schema.TaggedChunk, topN int) string {
-	hasher := xxhash.New()
-	hasher.Write([]byte(llmID))
-	hasher.Write([]byte("\x00"))
-	hasher.Write([]byte(text))
-	hasher.Write([]byte("\x00"))
-	tagNames := sortedTagNames(allTags)
-	hasher.Write([]byte(strings.Join(tagNames, ",")))
-	hasher.Write([]byte("\x00"))
-	for _, ex := range examples {
-		hasher.Write([]byte(ex.Content))
-		hasher.Write([]byte("\x00"))
-		tagsJSON, _ := json.Marshal(ex.TagWeights)
-		hasher.Write(tagsJSON)
-		hasher.Write([]byte("\x00"))
-	}
-	hasher.Write([]byte(fmt.Sprintf("%d", topN)))
-	return fmt.Sprintf("tagger:%x", hasher.Sum64())
-}
-
-func getTaggerLLMCache(ctx context.Context, llmID, text string, allTags map[string]float64, examples []schema.TaggedChunk, topN int) map[string]int {
-	client := redis.Get()
-	if client == nil {
-		return nil
-	}
-	key := taggerCacheKey(llmID, text, allTags, examples, topN)
-	data, err := client.Get(ctx, key)
-	if err != nil || data == "" {
-		return nil
-	}
-	var result map[string]int
-	if err := json.Unmarshal([]byte(data), &result); err != nil {
-		return nil
-	}
-	return result
-}
-
-func setTaggerLLMCache(ctx context.Context, llmID, text string, allTags map[string]float64, examples []schema.TaggedChunk, topN int, result map[string]int) {
-	if result == nil {
-		return
-	}
-	client := redis.Get()
-	if client == nil {
-		return
-	}
-	key := taggerCacheKey(llmID, text, allTags, examples, topN)
-	data, err := json.Marshal(result)
-	if err != nil {
-		return
-	}
-	client.Set(ctx, key, string(data), 24*time.Hour)
 }
 
 func sortedTagNames(allTags map[string]float64) []string {

--- a/internal/ingestion/component/extractor_tag.go
+++ b/internal/ingestion/component/extractor_tag.go
@@ -33,9 +33,34 @@ import (
 	"ragflow/internal/tokenizer"
 )
 
-var taggerCache = llmcache.New[map[string]int](llmcache.WithValidator(func(m map[string]int) bool {
-	return m != nil
-}))
+var (
+	taggerCacheMu sync.RWMutex
+	taggerCache   = llmcache.New[map[string]int](llmcache.WithValidator(func(m map[string]int) bool {
+		return m != nil
+	}))
+)
+
+func getTaggerCache() *llmcache.Engine[map[string]int] {
+	taggerCacheMu.RLock()
+	defer taggerCacheMu.RUnlock()
+	return taggerCache
+}
+
+// SetTaggerCacheForTest swaps the tagger cache engine for tests.
+// It returns a restore closure that resets the cache to its previous value.
+func SetTaggerCacheForTest(c *llmcache.Engine[map[string]int]) func() {
+	taggerCacheMu.Lock()
+	prev := taggerCache
+	if c != nil {
+		taggerCache = c
+	}
+	taggerCacheMu.Unlock()
+	return func() {
+		taggerCacheMu.Lock()
+		taggerCache = prev
+		taggerCacheMu.Unlock()
+	}
+}
 
 const (
 	// defaultMatchCoverageThreshold is the asymmetric coverage threshold for Phase 1 (55%).
@@ -1155,7 +1180,7 @@ func llmTagChunk(
 	tagSetStr := strings.Join(tagNames, ", ")
 	prompt := buildTaggerPrompt(topN, tagSetStr, picked, text)
 
-	result, err := taggerCache.GetOrCompute(
+	result, err := getTaggerCache().GetOrCompute(
 		ctx,
 		tenantID,
 		"tagger",

--- a/internal/ingestion/component/extractor_tag_test.go
+++ b/internal/ingestion/component/extractor_tag_test.go
@@ -1656,3 +1656,106 @@ func TestTagger_Cache_ConcurrentSingleFlight(t *testing.T) {
 		}
 	}
 }
+
+func TestTagger_Cache_EffectiveModelResolution(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		// Call 1 for model-1 ("openai/gpt-4o")
+		stubResponse{Content: `{"ModelV1Tag": 9}`},
+		// Call 2 for model-2 ("openai/gpt-4o-mini") after default model change
+		stubResponse{Content: `{"ModelV2Tag": 8}`},
+		// Call 3 for driverless model ("custom-model")
+		stubResponse{Content: `{"CustomModelTag": 7}`},
+		// Call 4 for explicit pinned llmID ("pinned-model-123")
+		stubResponse{Content: `{"PinnedModelTag": 6}`},
+	)
+
+	allTags := map[string]float64{
+		"ModelV1Tag":     0.5,
+		"ModelV2Tag":     0.5,
+		"CustomModelTag": 0.5,
+		"PinnedModelTag": 0.5,
+	}
+	text := "Text content for tagger effective model resolution test."
+
+	// 1. First call with empty llm_id and default model "openai/gpt-4o": cache miss -> triggers LLM (1 call)
+	chunk1 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk1, allTags, nil, "tenant-eff-tag", "", "openai", "gpt-4o", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("first call expected 1 LLM call, got %d", calls)
+	}
+	if k := chunk1["tag_kwd"].([]string); len(k) != 1 || k[0] != "ModelV1Tag" {
+		t.Fatalf("chunk1 expected ['ModelV1Tag'], got %v", chunk1["tag_kwd"])
+	}
+
+	// 2. Second call with same empty llm_id and same default model: cache hit -> 0 new LLM calls (1 call total)
+	chunk2 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk2, allTags, nil, "tenant-eff-tag", "", "openai", "gpt-4o", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("second call expected 1 total call (cache hit), got %d", calls)
+	}
+	if k := chunk2["tag_kwd"].([]string); len(k) != 1 || k[0] != "ModelV1Tag" {
+		t.Fatalf("chunk2 expected cached ['ModelV1Tag'], got %v", chunk2["tag_kwd"])
+	}
+
+	// 3. Third call: underlying default model switched to "openai/gpt-4o-mini" with empty llm_id -> cache key differs -> triggers LLM (2 calls total)
+	chunk3 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk3, allTags, nil, "tenant-eff-tag", "", "openai", "gpt-4o-mini", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("third call expected 2 total calls (model switched, cache miss), got %d", calls)
+	}
+	if k := chunk3["tag_kwd"].([]string); len(k) != 1 || k[0] != "ModelV2Tag" {
+		t.Fatalf("chunk3 expected ['ModelV2Tag'], got %v", chunk3["tag_kwd"])
+	}
+
+	// 4. Fourth call with same switched default model: cache hit (2 calls total)
+	chunk4 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk4, allTags, nil, "tenant-eff-tag", "", "openai", "gpt-4o-mini", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("fourth call expected 2 total calls (cache hit), got %d", calls)
+	}
+	if k := chunk4["tag_kwd"].([]string); len(k) != 1 || k[0] != "ModelV2Tag" {
+		t.Fatalf("chunk4 expected cached ['ModelV2Tag'], got %v", chunk4["tag_kwd"])
+	}
+
+	// 5. Fifth call with driver="" (effectiveModel = "custom-model"): cache miss -> triggers LLM (3 calls total)
+	chunk5 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk5, allTags, nil, "tenant-eff-tag", "", "", "custom-model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("fifth call expected 3 total calls, got %d", calls)
+	}
+	if k := chunk5["tag_kwd"].([]string); len(k) != 1 || k[0] != "CustomModelTag" {
+		t.Fatalf("chunk5 expected ['CustomModelTag'], got %v", chunk5["tag_kwd"])
+	}
+
+	// 6. Sixth call with driver="" and same "custom-model": cache hit (3 calls total)
+	chunk6 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk6, allTags, nil, "tenant-eff-tag", "", "", "custom-model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("sixth call expected 3 total calls (cache hit), got %d", calls)
+	}
+	if k := chunk6["tag_kwd"].([]string); len(k) != 1 || k[0] != "CustomModelTag" {
+		t.Fatalf("chunk6 expected cached ['CustomModelTag'], got %v", chunk6["tag_kwd"])
+	}
+
+	// 7. Seventh call with explicit llm_id "pinned-model-123" taking precedence: cache miss -> triggers LLM (4 calls total)
+	chunk7 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk7, allTags, nil, "tenant-eff-tag", "pinned-model-123", "openai", "gpt-4o", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 4 {
+		t.Fatalf("seventh call expected 4 total calls (explicit llm_id), got %d", calls)
+	}
+	if k := chunk7["tag_kwd"].([]string); len(k) != 1 || k[0] != "PinnedModelTag" {
+		t.Fatalf("chunk7 expected ['PinnedModelTag'], got %v", chunk7["tag_kwd"])
+	}
+
+	// 8. Eighth call with same explicit llm_id "pinned-model-123": cache hit (4 calls total)
+	chunk8 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunk8, allTags, nil, "tenant-eff-tag", "pinned-model-123", "openai", "gpt-4o", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 4 {
+		t.Fatalf("eighth call expected 4 total calls (cache hit), got %d", calls)
+	}
+	if k := chunk8["tag_kwd"].([]string); len(k) != 1 || k[0] != "PinnedModelTag" {
+		t.Fatalf("chunk8 expected cached ['PinnedModelTag'], got %v", chunk8["tag_kwd"])
+	}
+}
+

--- a/internal/ingestion/component/extractor_tag_test.go
+++ b/internal/ingestion/component/extractor_tag_test.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/xuri/excelize/v2"
 
@@ -1618,42 +1616,6 @@ func TestTagger_Cache_LegitimateEmptyDictCached(t *testing.T) {
 	llmTagChunk(t.Context(), nil, stub, chunk2, allTags, nil, "tenant-empty", "test@model", "driver", "model", "key", "", 3, nil)
 	if calls := stub.Calls(); calls != 1 {
 		t.Fatalf("second call expected 1 call (cache hit for empty dict), got %d", calls)
-	}
-}
-
-func TestTagger_Cache_ConcurrentSingleFlight(t *testing.T) {
-	setupTestRedis(t)
-	// Stub LLM with 50ms simulated latency
-	stub := withStubChatInvoker(t,
-		stubResponse{Content: `{"SingleFlightTag": 9}`, Delay: 50 * time.Millisecond},
-	)
-
-	allTags := map[string]float64{"SingleFlightTag": 1.0}
-	const concurrency = 10
-	var wg sync.WaitGroup
-	wg.Add(concurrency)
-	chunks := make([]map[string]any, concurrency)
-
-	for i := 0; i < concurrency; i++ {
-		chunks[i] = map[string]any{"content_with_weight": "Concurrent tagger chunk content."}
-		go func(idx int) {
-			defer wg.Done()
-			llmTagChunk(t.Context(), nil, stub, chunks[idx], allTags, nil, "tenant-sf-tag", "test@model", "driver", "model", "key", "", 3, nil)
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Verify LLM was called exactly ONCE due to SingleFlight collapsing
-	if calls := stub.Calls(); calls != 1 {
-		t.Fatalf("SingleFlight expected 1 LLM call across %d concurrent requests, got %d", concurrency, calls)
-	}
-
-	for i, ck := range chunks {
-		k, ok := ck["tag_kwd"].([]string)
-		if !ok || len(k) != 1 || k[0] != "SingleFlightTag" {
-			t.Errorf("chunk %d got tag_kwd %v, want ['SingleFlightTag']", i, ck["tag_kwd"])
-		}
 	}
 }
 

--- a/internal/ingestion/component/extractor_tag_test.go
+++ b/internal/ingestion/component/extractor_tag_test.go
@@ -6,11 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/xuri/excelize/v2"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/cache/llmcache"
 	"ragflow/internal/common"
 	"ragflow/internal/ingestion/component/schema"
 	"ragflow/internal/tokenizer"
@@ -279,7 +282,7 @@ func TestLlmtagChunk_MessageFit(t *testing.T) {
 	allTags := map[string]float64{"RAG": 1, "database": 1, "AI": 1}
 	examples := []schema.TaggedChunk{{Content: "example one", TagWeights: map[string]int{"AI": 5}}}
 
-	llmTagChunk(t.Context(), nil, capt, chunk, allTags, examples, "test@test", "test_driver", "test_model", "test_key", "", 3, nil)
+	llmTagChunk(t.Context(), nil, capt, chunk, allTags, examples, "tenant-test", "test@test", "test_driver", "test_model", "test_key", "", 3, nil)
 
 	if len(capt.req.Messages) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(capt.req.Messages))
@@ -302,7 +305,7 @@ func TestLlmtagChunk_NoContextLength_SkipsFit(t *testing.T) {
 	allTags := map[string]float64{"RAG": 1}
 	examples := []schema.TaggedChunk{{Content: "example", TagWeights: map[string]int{"AI": 5}}}
 
-	llmTagChunk(t.Context(), nil, capt, chunk, allTags, examples, "test@test", "test_driver", "test_model", "test_key", "", 3, nil)
+	llmTagChunk(t.Context(), nil, capt, chunk, allTags, examples, "tenant-test", "test@test", "test_driver", "test_model", "test_key", "", 3, nil)
 
 	if len(capt.req.Messages) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(capt.req.Messages))
@@ -324,7 +327,7 @@ func TestLlmtagChunk_ColdStartFallback(t *testing.T) {
 	}
 
 	chunk := map[string]any{"content_with_weight": "some content"}
-	llmTagChunk(t.Context(), nil, capt, chunk, idx.allTags, nil, "test@test", "test_driver", "test_model", "test_key", "", 3, idx)
+	llmTagChunk(t.Context(), nil, capt, chunk, idx.allTags, nil, "tenant-test", "test@test", "test_driver", "test_model", "test_key", "", 3, idx)
 
 	if len(capt.req.Messages) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(capt.req.Messages))
@@ -721,7 +724,7 @@ func TestPopulateTagKwd_LLMTagChunk(t *testing.T) {
 	chunk := map[string]any{"content_with_weight": "some content"}
 	allTags := map[string]float64{"RAG": 0.5, "vector database": 0.5}
 
-	llmTagChunk(t.Context(), nil, capt, chunk, allTags, nil, "test@test", "test_driver", "test_model", "test_key", "", 3, nil)
+	llmTagChunk(t.Context(), nil, capt, chunk, allTags, nil, "tenant-test", "test@test", "test_driver", "test_model", "test_key", "", 3, nil)
 
 	tagKwd, ok := chunk["tag_kwd"].([]string)
 	if !ok {
@@ -1156,6 +1159,7 @@ func TestSampleWithoutReplacement(t *testing.T) {
 
 func TestTaggerCacheKey_IncludesFewShot(t *testing.T) {
 	allTags := map[string]float64{"TagA": 0.5, "TagB": 0.5}
+	tagSetStr := strings.Join(sortedTagNames(allTags), ", ")
 	ex1 := []schema.TaggedChunk{
 		{Content: "sample one", TagWeights: map[string]int{"TagA": 8}},
 	}
@@ -1166,10 +1170,15 @@ func TestTaggerCacheKey_IncludesFewShot(t *testing.T) {
 		{Content: "sample one", TagWeights: map[string]int{"TagA": 5}},
 	}
 
-	k1 := taggerCacheKey("llm-1", "test text", allTags, ex1, 3)
-	k2 := taggerCacheKey("llm-1", "test text", allTags, ex2, 3)
-	k3 := taggerCacheKey("llm-1", "test text", allTags, ex3, 3)
-	kEmpty := taggerCacheKey("llm-1", "test text", allTags, nil, 3)
+	p1 := buildTaggerPrompt(3, tagSetStr, ex1, "test text")
+	p2 := buildTaggerPrompt(3, tagSetStr, ex2, "test text")
+	p3 := buildTaggerPrompt(3, tagSetStr, ex3, "test text")
+	pEmpty := buildTaggerPrompt(3, tagSetStr, nil, "test text")
+
+	k1 := llmcache.BuildKey("tenant-1", "tagger", "llm-1", p1)
+	k2 := llmcache.BuildKey("tenant-1", "tagger", "llm-1", p2)
+	k3 := llmcache.BuildKey("tenant-1", "tagger", "llm-1", p3)
+	kEmpty := llmcache.BuildKey("tenant-1", "tagger", "llm-1", pEmpty)
 
 	if k1 == k2 {
 		t.Fatalf("expected different cache keys for different few-shot examples: %s vs %s", k1, k2)
@@ -1182,7 +1191,8 @@ func TestTaggerCacheKey_IncludesFewShot(t *testing.T) {
 	}
 
 	// Identical few-shot examples produce identical key
-	k1Dup := taggerCacheKey("llm-1", "test text", allTags, ex1, 3)
+	p1Dup := buildTaggerPrompt(3, tagSetStr, ex1, "test text")
+	k1Dup := llmcache.BuildKey("tenant-1", "tagger", "llm-1", p1Dup)
 	if k1 != k1Dup {
 		t.Fatalf("expected identical cache keys for same few-shot examples: %s vs %s", k1, k1Dup)
 	}
@@ -1468,5 +1478,181 @@ func TestMatchAndTagChunk_RankDecayGradientScores(t *testing.T) {
 	}
 	if dbScore <= cloudScore {
 		t.Errorf("expected secondary Database (%d) > peripheral CloudInfra (%d)", dbScore, cloudScore)
+	}
+}
+
+func TestTagger_Cache_FirstCallTriggersLLM_SecondHitsRedis(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		stubResponse{Content: `{"Go": 9, "Distributed": 7}`},
+	)
+
+	allTags := map[string]float64{"Go": 0.5, "Distributed": 0.5}
+	chunk1 := map[string]any{"content_with_weight": "Go distributed systems design."}
+
+	// 1. First call: Cache miss -> triggers LLM call (1 call)
+	llmTagChunk(t.Context(), nil, stub, chunk1, allTags, nil, "tenant-tag-cache", "test@model", "driver", "model", "key", "", 3, nil)
+
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("first call expected 1 LLM call, got %d", calls)
+	}
+	tagKwd1, ok := chunk1["tag_kwd"].([]string)
+	if !ok || len(tagKwd1) != 2 || tagKwd1[0] != "Go" || tagKwd1[1] != "Distributed" {
+		t.Fatalf("expected tag_kwd ['Go', 'Distributed'], got %v", chunk1["tag_kwd"])
+	}
+
+	// 2. Second call: Cache hit -> served from Redis (0 additional calls)
+	chunk2 := map[string]any{"content_with_weight": "Go distributed systems design."}
+	llmTagChunk(t.Context(), nil, stub, chunk2, allTags, nil, "tenant-tag-cache", "test@model", "driver", "model", "key", "", 3, nil)
+
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("second call expected 1 LLM call (cache hit), got %d", calls)
+	}
+	tagKwd2, ok := chunk2["tag_kwd"].([]string)
+	if !ok || len(tagKwd2) != 2 || tagKwd2[0] != "Go" || tagKwd2[1] != "Distributed" {
+		t.Fatalf("expected cached tag_kwd ['Go', 'Distributed'], got %v", chunk2["tag_kwd"])
+	}
+}
+
+func TestTagger_Cache_MultiTenantIsolation(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		stubResponse{Content: `{"TenantA_Tag": 8}`},
+		stubResponse{Content: `{"TenantB_Tag": 6}`},
+	)
+
+	allTags := map[string]float64{"TenantA_Tag": 0.5, "TenantB_Tag": 0.5}
+	text := "Shared text for multi-tenant tagging."
+
+	// 1. TenantA first run -> triggers LLM (1 call)
+	chunkA := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunkA, allTags, nil, "TenantA", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("TenantA expected 1 call, got %d", calls)
+	}
+	if k := chunkA["tag_kwd"].([]string); len(k) != 1 || k[0] != "TenantA_Tag" {
+		t.Fatalf("got TenantA tags %v", chunkA["tag_kwd"])
+	}
+
+	// 2. TenantB first run (same text) -> cache miss -> triggers LLM independently (2 calls total)
+	chunkB := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunkB, allTags, nil, "TenantB", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("TenantB expected 2 total calls (no cross-tenant hit), got %d", calls)
+	}
+	if k := chunkB["tag_kwd"].([]string); len(k) != 1 || k[0] != "TenantB_Tag" {
+		t.Fatalf("got TenantB tags %v", chunkB["tag_kwd"])
+	}
+
+	// 3. TenantA repeat -> cache hit (2 calls total)
+	chunkA2 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunkA2, allTags, nil, "TenantA", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("TenantA repeat expected 2 total calls (cache hit), got %d", calls)
+	}
+	if k := chunkA2["tag_kwd"].([]string); len(k) != 1 || k[0] != "TenantA_Tag" {
+		t.Fatalf("got TenantA repeat tags %v", chunkA2["tag_kwd"])
+	}
+
+	// 4. TenantB repeat -> cache hit (2 calls total)
+	chunkB2 := map[string]any{"content_with_weight": text}
+	llmTagChunk(t.Context(), nil, stub, chunkB2, allTags, nil, "TenantB", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("TenantB repeat expected 2 total calls (cache hit), got %d", calls)
+	}
+	if k := chunkB2["tag_kwd"].([]string); len(k) != 1 || k[0] != "TenantB_Tag" {
+		t.Fatalf("got TenantB repeat tags %v", chunkB2["tag_kwd"])
+	}
+}
+
+func TestTagger_Cache_ErrorResponseNeverCached(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		// First call returns error marker
+		stubResponse{Content: "**ERROR**: Tag inference failed"},
+		// Second call returns valid tags
+		stubResponse{Content: `{"RecoveredTag": 9}`},
+	)
+
+	allTags := map[string]float64{"RecoveredTag": 0.5}
+	chunk1 := map[string]any{"content_with_weight": "Text for error test."}
+
+	// 1. First call: LLM returns **ERROR**, validator rejects and does NOT cache
+	llmTagChunk(t.Context(), nil, stub, chunk1, allTags, nil, "tenant-err", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+	if chunk1[common.TAG_FLD] != nil {
+		t.Fatalf("error response should not set TAG_FLD, got %v", chunk1[common.TAG_FLD])
+	}
+
+	// 2. Second call: LLM must be re-invoked because error was NOT cached
+	chunk2 := map[string]any{"content_with_weight": "Text for error test."}
+	llmTagChunk(t.Context(), nil, stub, chunk2, allTags, nil, "tenant-err", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("second call expected 2 calls (error was not cached), got %d", calls)
+	}
+	if k := chunk2["tag_kwd"].([]string); len(k) != 1 || k[0] != "RecoveredTag" {
+		t.Fatalf("expected recovered tag ['RecoveredTag'], got %v", chunk2["tag_kwd"])
+	}
+}
+
+func TestTagger_Cache_LegitimateEmptyDictCached(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		// LLM returns valid JSON empty object
+		stubResponse{Content: "{}"},
+	)
+
+	allTags := map[string]float64{"SomeTag": 0.5}
+	chunk1 := map[string]any{"content_with_weight": "Text with no matching tags."}
+
+	// 1. First call: LLM returns {} -> cached as legitimate empty result
+	llmTagChunk(t.Context(), nil, stub, chunk1, allTags, nil, "tenant-empty", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+
+	// 2. Second call: Cache hit -> does NOT re-trigger LLM call
+	chunk2 := map[string]any{"content_with_weight": "Text with no matching tags."}
+	llmTagChunk(t.Context(), nil, stub, chunk2, allTags, nil, "tenant-empty", "test@model", "driver", "model", "key", "", 3, nil)
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("second call expected 1 call (cache hit for empty dict), got %d", calls)
+	}
+}
+
+func TestTagger_Cache_ConcurrentSingleFlight(t *testing.T) {
+	setupTestRedis(t)
+	// Stub LLM with 50ms simulated latency
+	stub := withStubChatInvoker(t,
+		stubResponse{Content: `{"SingleFlightTag": 9}`, Delay: 50 * time.Millisecond},
+	)
+
+	allTags := map[string]float64{"SingleFlightTag": 1.0}
+	const concurrency = 10
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	chunks := make([]map[string]any, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		chunks[i] = map[string]any{"content_with_weight": "Concurrent tagger chunk content."}
+		go func(idx int) {
+			defer wg.Done()
+			llmTagChunk(t.Context(), nil, stub, chunks[idx], allTags, nil, "tenant-sf-tag", "test@model", "driver", "model", "key", "", 3, nil)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify LLM was called exactly ONCE due to SingleFlight collapsing
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("SingleFlight expected 1 LLM call across %d concurrent requests, got %d", concurrency, calls)
+	}
+
+	for i, ck := range chunks {
+		k, ok := ck["tag_kwd"].([]string)
+		if !ok || len(k) != 1 || k[0] != "SingleFlightTag" {
+			t.Errorf("chunk %d got tag_kwd %v, want ['SingleFlightTag']", i, ck["tag_kwd"])
+		}
 	}
 }

--- a/internal/ingestion/component/extractor_tag_test.go
+++ b/internal/ingestion/component/extractor_tag_test.go
@@ -1758,4 +1758,3 @@ func TestTagger_Cache_EffectiveModelResolution(t *testing.T) {
 		t.Fatalf("chunk8 expected cached ['PinnedModelTag'], got %v", chunk8["tag_kwd"])
 	}
 }
-

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -2518,67 +2518,6 @@ func TestExtractor_Cache_LegitimateEmptyValues(t *testing.T) {
 	}
 }
 
-func TestExtractor_Cache_ConcurrentSingleFlight(t *testing.T) {
-	setupTestRedis(t)
-	// Stub LLM with 50ms simulated latency
-	stub := withStubChatInvoker(t,
-		stubResponse{Content: "SingleFlight Summary Result", Delay: 50 * time.Millisecond},
-	)
-
-	params := map[string]any{
-		"llm_id": "llm-sf-test",
-		"summary": map[string]any{
-			"enabled": true,
-		},
-	}
-	comp, err := NewExtractorComponent(params)
-	if err != nil {
-		t.Fatalf("NewExtractorComponent: %v", err)
-	}
-
-	const concurrency = 10
-	var wg sync.WaitGroup
-	wg.Add(concurrency)
-	errCh := make(chan error, concurrency)
-	results := make([]string, concurrency)
-
-	for i := 0; i < concurrency; i++ {
-		go func(idx int) {
-			defer wg.Done()
-			in := map[string]any{
-				"tenant_id": "tenant-sf-1",
-				"chunks":    []map[string]any{{"text": "Concurrent SingleFlight test chunk."}},
-			}
-			out, err := comp.Invoke(t.Context(), nil, in)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			ck := out["chunks"].([]map[string]any)[0]
-			if sum, ok := ck["summary"].(string); ok {
-				results[idx] = sum
-			}
-		}(i)
-	}
-
-	wg.Wait()
-	close(errCh)
-	for err := range errCh {
-		t.Fatalf("concurrent invoke failed: %v", err)
-	}
-
-	// Verify LLM was called exactly ONCE due to SingleFlight collapsing
-	if calls := stub.Calls(); calls != 1 {
-		t.Fatalf("SingleFlight expected 1 LLM call across %d concurrent requests, got %d", concurrency, calls)
-	}
-
-	for i, res := range results {
-		if res != "SingleFlight Summary Result" {
-			t.Errorf("goroutine %d got summary %q, want 'SingleFlight Summary Result'", i, res)
-		}
-	}
-}
-
 func TestSetExtractorCachesForTest_Restore(t *testing.T) {
 	origText := getTextExtractCache()
 	origMeta := getMetadataCache()

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -37,6 +37,7 @@ import (
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
 	"ragflow/internal/entity"
+	"ragflow/internal/entity/models"
 	"ragflow/internal/ingestion/component/schema"
 	"ragflow/internal/tokenizer"
 	"ragflow/internal/utility"
@@ -2612,13 +2613,17 @@ func TestExtractor_Cache_EffectiveLLMIDResolution(t *testing.T) {
 	})
 	t.Cleanup(func() { SetExtractorChatTargetResolverOverride(nil) })
 
-	ctx := extractorStateCtx(t, "tenant-1")
-
 	stub := withStubChatInvoker(t,
+		// Phase 1 (CanvasState):
 		// Call 1 for default composite model summary
 		stubResponse{Content: "Summary from composite model"},
 		// Call 2 for pinned UUID model summary (after tenant default model change)
 		stubResponse{Content: "Summary from pinned model"},
+		// Phase 2 (inputs["tenant_id"] without CanvasState):
+		// Call 3 for plain tenant composite model summary
+		stubResponse{Content: "Summary from plain tenant composite model"},
+		// Call 4 for plain tenant pinned model summary (after tenant default model change)
+		stubResponse{Content: "Summary from plain tenant pinned model"},
 	)
 
 	comp, err := NewExtractorComponent(map[string]any{
@@ -2631,6 +2636,8 @@ func TestExtractor_Cache_EffectiveLLMIDResolution(t *testing.T) {
 		t.Fatalf("NewExtractorComponent: %v", err)
 	}
 
+	// ── Phase 1: Resolution via CanvasState Context ──
+	ctx := extractorStateCtx(t, "tenant-1")
 	in := map[string]any{
 		"chunks": []map[string]any{
 			{"text": "Text content for effective LLM ID test."},
@@ -2708,6 +2715,162 @@ func TestExtractor_Cache_EffectiveLLMIDResolution(t *testing.T) {
 	ck4 := out4["chunks"].([]map[string]any)[0]
 	if ck4["summary"] != "Summary from pinned model" {
 		t.Fatalf("expected cached summary 'Summary from pinned model', got %v", ck4["summary"])
+	}
+
+	// ── Phase 2: Resolution via inputs["tenant_id"] without CanvasState Context ──
+	status := "1"
+	tenantPlain := entity.Tenant{
+		ID:     "tenant-plain",
+		LLMID:  "qwen-plus@dashscope",
+		Status: &status,
+	}
+	if err := db.Create(&tenantPlain).Error; err != nil {
+		t.Fatalf("create tenant-plain: %v", err)
+	}
+
+	plainCtx := t.Context() // Pure context without CanvasState
+	inPlain1 := map[string]any{
+		"tenant_id": "tenant-plain",
+		"chunks": []map[string]any{
+			{"text": "Text for plain input tenant ID test."},
+		},
+	}
+
+	// 6. First plain run: resolves composite model "qwen-plus@dashscope" from inputs["tenant_id"], cache miss -> triggers LLM (call count = 3)
+	outPlain1, err := comp.Invoke(plainCtx, db, inPlain1)
+	if err != nil {
+		t.Fatalf("First Plain Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("expected 3 calls (first plain run), got %d", calls)
+	}
+	ckPlain1 := outPlain1["chunks"].([]map[string]any)[0]
+	if ckPlain1["summary"] != "Summary from plain tenant composite model" {
+		t.Fatalf("expected summary 'Summary from plain tenant composite model', got %v", ckPlain1["summary"])
+	}
+
+	// 7. Second plain run: cache hit -> 0 new LLM calls (call count = 3)
+	inPlain2 := map[string]any{
+		"tenant_id": "tenant-plain",
+		"chunks": []map[string]any{
+			{"text": "Text for plain input tenant ID test."},
+		},
+	}
+	outPlain2, err := comp.Invoke(plainCtx, db, inPlain2)
+	if err != nil {
+		t.Fatalf("Second Plain Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("expected 3 calls (cache hit for plain tenant), got %d", calls)
+	}
+	ckPlain2 := outPlain2["chunks"].([]map[string]any)[0]
+	if ckPlain2["summary"] != "Summary from plain tenant composite model" {
+		t.Fatalf("expected cached summary 'Summary from plain tenant composite model', got %v", ckPlain2["summary"])
+	}
+
+	// 8. Update tenant-plain default model in DB to pinned UUID model
+	plainPinnedUUID := "fedcba0123456789fedcba0123456789"
+	if err := db.Model(&entity.Tenant{}).Where("id = ?", "tenant-plain").Update("tenant_llm_id", plainPinnedUUID).Error; err != nil {
+		t.Fatalf("update tenant-plain default model: %v", err)
+	}
+
+	// 9. Third plain run: resolves pinned UUID model via inputs["tenant_id"] -> cache key differs -> cache miss -> triggers LLM (call count = 4)
+	inPlain3 := map[string]any{
+		"tenant_id": "tenant-plain",
+		"chunks": []map[string]any{
+			{"text": "Text for plain input tenant ID test."},
+		},
+	}
+	outPlain3, err := comp.Invoke(plainCtx, db, inPlain3)
+	if err != nil {
+		t.Fatalf("Third Plain Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 4 {
+		t.Fatalf("expected 4 calls (model changed for plain tenant, cache miss), got %d", calls)
+	}
+	ckPlain3 := outPlain3["chunks"].([]map[string]any)[0]
+	if ckPlain3["summary"] != "Summary from plain tenant pinned model" {
+		t.Fatalf("expected summary 'Summary from plain tenant pinned model', got %v", ckPlain3["summary"])
+	}
+
+	// 10. Fourth plain run: cache hit for new model (call count = 4)
+	inPlain4 := map[string]any{
+		"tenant_id": "tenant-plain",
+		"chunks": []map[string]any{
+			{"text": "Text for plain input tenant ID test."},
+		},
+	}
+	outPlain4, err := comp.Invoke(plainCtx, db, inPlain4)
+	if err != nil {
+		t.Fatalf("Fourth Plain Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 4 {
+		t.Fatalf("expected 4 calls (cache hit for pinned plain tenant), got %d", calls)
+	}
+	ckPlain4 := outPlain4["chunks"].([]map[string]any)[0]
+	if ckPlain4["summary"] != "Summary from plain tenant pinned model" {
+		t.Fatalf("expected cached summary 'Summary from plain tenant pinned model', got %v", ckPlain4["summary"])
+	}
+}
+
+func TestExtractor_ResolveEffectiveLLMID(t *testing.T) {
+	db := openExtractorContextTestDB(t)
+	seedExtractorContextModel(t, db, "")
+
+	// 1. Explicit llmID returns itself immediately
+	if got := resolveEffectiveLLMID(t.Context(), db, "tenant-1", "custom-model"); got != "custom-model" {
+		t.Errorf("resolveEffectiveLLMID with explicit llmID = %q, want %q", got, "custom-model")
+	}
+
+	// 2. Empty llmID with tenantID passed directly (no canvas state)
+	if got := resolveEffectiveLLMID(t.Context(), db, "tenant-1", ""); got != "gpt-4o@openai" {
+		t.Errorf("resolveEffectiveLLMID with tenantID = %q, want %q", got, "gpt-4o@openai")
+	}
+
+	// 3. Empty llmID with tenantID in CanvasState
+	ctx := extractorStateCtx(t, "tenant-1")
+	if got := resolveEffectiveLLMID(ctx, db, "", ""); got != "gpt-4o@openai" {
+		t.Errorf("resolveEffectiveLLMID with CanvasState = %q, want %q", got, "gpt-4o@openai")
+	}
+
+	// 4. Empty llmID with no tenantID and no CanvasState -> returns ""
+	if got := resolveEffectiveLLMID(t.Context(), db, "", ""); got != "" {
+		t.Errorf("resolveEffectiveLLMID with empty tenantID = %q, want empty string", got)
+	}
+
+	// 5. Pinned tenant_llm_id returns the pinned UUID reference
+	pinnedUUID := "0123456789abcdef0123456789abcdef"
+	if err := db.Model(&entity.Tenant{}).Where("id = ?", "tenant-1").Update("tenant_llm_id", pinnedUUID).Error; err != nil {
+		t.Fatalf("update tenant: %v", err)
+	}
+	if got := resolveEffectiveLLMID(t.Context(), db, "tenant-1", ""); got != pinnedUUID {
+		t.Errorf("resolveEffectiveLLMID with pinned model = %q, want %q", got, pinnedUUID)
+	}
+
+	// 6. When resolveTenantModelByType succeeds with driver and modelName, returns modelName@driver
+	origResolver := resolveTenantModelByType
+	defer func() { resolveTenantModelByType = origResolver }()
+	resolveTenantModelByType = func(ctx context.Context, db *gorm.DB, tenantID string, modelType entity.ModelType) (models.ModelDriver, string, *models.APIConfig, int, error) {
+		return models.NewDummyModel(nil, models.URLSuffix{}), "deepseek-chat", nil, 0, nil
+	}
+	if got := resolveEffectiveLLMID(t.Context(), db, "tenant-1", ""); got != "deepseek-chat@dummy" {
+		t.Errorf("resolveEffectiveLLMID with resolved driver = %q, want %q", got, "deepseek-chat@dummy")
+	}
+
+	// 7. When resolveTenantModelByType returns a composite modelName that already contains @, returns modelName directly
+	resolveTenantModelByType = func(ctx context.Context, db *gorm.DB, tenantID string, modelType entity.ModelType) (models.ModelDriver, string, *models.APIConfig, int, error) {
+		return models.NewDummyModel(nil, models.URLSuffix{}), "deepseek-chat@deepseek", nil, 0, nil
+	}
+	if got := resolveEffectiveLLMID(t.Context(), db, "tenant-1", ""); got != "deepseek-chat@deepseek" {
+		t.Errorf("resolveEffectiveLLMID with composite modelName = %q, want %q", got, "deepseek-chat@deepseek")
+	}
+
+	// 8. When resolveTenantModelByType returns error, falls back to defaultChatModelRef
+	resolveTenantModelByType = func(ctx context.Context, db *gorm.DB, tenantID string, modelType entity.ModelType) (models.ModelDriver, string, *models.APIConfig, int, error) {
+		return nil, "", nil, 0, errors.New("model not configured")
+	}
+	if got := resolveEffectiveLLMID(t.Context(), db, "tenant-1", ""); got != pinnedUUID {
+		t.Errorf("resolveEffectiveLLMID fallback on error = %q, want %q", got, pinnedUUID)
 	}
 }
 

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -26,18 +26,35 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	eschema "github.com/cloudwego/eino/schema"
 	"github.com/glebarez/sqlite"
+	goredis "github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 
 	"ragflow/internal/agent/runtime"
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
+	"ragflow/internal/engine/redis"
 	"ragflow/internal/entity"
 	"ragflow/internal/ingestion/component/schema"
 	"ragflow/internal/tokenizer"
 	"ragflow/internal/utility"
 )
+
+func setupTestRedis(t *testing.T) (*miniredis.Miniredis, *goredis.Client) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	restore := redis.SetGlobalClient(redis.NewTestClient(rdb))
+	t.Cleanup(restore)
+	return mr, rdb
+}
 
 // stubExtractorChatInvoker is the test seam for the package-level
 // extractorChatInvoker. It records every call (for assertions) and
@@ -55,11 +72,11 @@ type stubExtractorChatInvoker struct {
 	calls    atomic.Int32
 }
 
-// stubResponse couples a Content value and an Err. tests populate
-// either field — Err takes precedence over Content when non-nil.
+// stubResponse couples a Content value, an Err, and an optional Delay.
 type stubResponse struct {
 	Content string
 	Err     error
+	Delay   time.Duration
 }
 
 func (s *stubExtractorChatInvoker) Chat(_ context.Context, req extractorChatRequest) (*extractorChatResponse, error) {
@@ -72,6 +89,9 @@ func (s *stubExtractorChatInvoker) Chat(_ context.Context, req extractorChatRequ
 		s.responses = s.responses[1:]
 	}
 	s.mu.Unlock()
+	if resp.Delay > 0 {
+		time.Sleep(resp.Delay)
+	}
 	if resp.Err != nil {
 		return nil, resp.Err
 	}
@@ -2076,3 +2096,471 @@ func TestExtractor_KeywordsThenTagsSynergy(t *testing.T) {
 		t.Fatalf("expected chunk text to NOT contain title when content is present, got %q", chunkText)
 	}
 }
+
+func TestExtractor_IsValidLLMCachePayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"empty", "", false},
+		{"whitespace", "   \n\t  ", false},
+		{"error marker", "**ERROR**: something failed", false},
+		{"error marker mid text", "result **ERROR** output", false},
+		{"truncated marker upper", "summary content [TRUNCATED]", false},
+		{"truncated marker lower", "summary content [truncated]", false},
+		{"unclosed think tag", "<think> unfinished thinking...", false},
+		{"valid keywords", "apple, banana, orange", true},
+		{"valid questions", "What is ragflow?\nHow does it work?", true},
+		{"valid summary", "This document describes the caching mechanism.", true},
+		{"valid closed think tag", "<think>thoughts</think>final answer", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidLLMCachePayload(tt.input); got != tt.expected {
+				t.Errorf("isValidLLMCachePayload(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractor_ResolveInputs_TenantID(t *testing.T) {
+	comp := &ExtractorComponent{}
+
+	// 1. From inputs map directly
+	in1 := comp.resolveInputs(context.Background(), map[string]any{
+		"tenant_id": "tenant-direct-123",
+	})
+	if in1.tenantID != "tenant-direct-123" {
+		t.Errorf("tenantID = %q, want 'tenant-direct-123'", in1.tenantID)
+	}
+
+	// 2. From CanvasState in context
+	state := runtime.NewCanvasState("run-1", "session-1")
+	state.SetGlobal("tenant_id", "tenant-from-state-456")
+	ctx := runtime.WithState(context.Background(), state)
+	in2 := comp.resolveInputs(ctx, map[string]any{})
+	if in2.tenantID != "tenant-from-state-456" {
+		t.Errorf("tenantID = %q, want 'tenant-from-state-456'", in2.tenantID)
+	}
+
+	// 3. Inputs map overrides CanvasState if provided
+	in3 := comp.resolveInputs(ctx, map[string]any{
+		"tenant_id": "tenant-override-789",
+	})
+	if in3.tenantID != "tenant-override-789" {
+		t.Errorf("tenantID = %q, want 'tenant-override-789'", in3.tenantID)
+	}
+}
+
+func TestExtractor_AllExtractions_GetOrCompute(t *testing.T) {
+	// Provide mock responses for Keywords, Questions, Summary, Metadata
+	stub := withStubChatInvoker(t,
+		stubResponse{Content: "Go, Cache, Extraction"},
+		stubResponse{Content: "What is caching?\nHow does extractor work?"},
+		stubResponse{Content: "A summary of the chunk content."},
+		stubResponse{Content: `{"author": "DeepMind", "category": "AI"}`},
+	)
+
+	params := map[string]any{
+		"llm_id": "llm-test",
+		"keywords": map[string]any{
+			"top_n": 3,
+		},
+		"questions": map[string]any{
+			"top_n": 2,
+		},
+		"summary": map[string]any{
+			"enabled": true,
+		},
+		"metadata": map[string]any{
+			"enabled": true,
+			"metadata": []any{
+				map[string]any{"key": "author", "type": "string"},
+				map[string]any{"key": "category", "type": "string"},
+			},
+		},
+	}
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	in := map[string]any{
+		"tenant_id": "tenant-100",
+		"chunks": []map[string]any{
+			{"text": "Go is a statically typed, compiled high-level programming language."},
+		},
+	}
+
+	out, err := comp.Invoke(t.Context(), nil, in)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	chunks, ok := out["chunks"].([]map[string]any)
+	if !ok || len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %v", out)
+	}
+
+	ck := chunks[0]
+	// Verify keywords
+	kwds, ok := ck["important_kwd"].([]string)
+	if !ok || len(kwds) != 3 {
+		t.Errorf("important_kwd = %v, want 3 items", ck["important_kwd"])
+	}
+
+	// Verify questions
+	qs, ok := ck["question_kwd"].([]string)
+	if !ok || len(qs) != 2 {
+		t.Errorf("question_kwd = %v, want 2 items", ck["question_kwd"])
+	}
+
+	// Verify summary
+	sum, ok := ck["summary"].(string)
+	if !ok || sum != "A summary of the chunk content." {
+		t.Errorf("summary = %v", ck["summary"])
+	}
+
+	// Verify metadata
+	meta, ok := ck["metadata"].(map[string]any)
+	if !ok || meta["author"] != "DeepMind" || meta["category"] != "AI" {
+		t.Errorf("metadata = %v", ck["metadata"])
+	}
+
+	if calls := stub.Calls(); calls != 4 {
+		t.Errorf("calls = %d, want 4", calls)
+	}
+}
+
+func TestExtractor_Cache_KeywordsQuestionsSummary_FirstTriggersLLM_SecondHitsRedis(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		stubResponse{Content: "Go, Cache, Extraction"},
+		stubResponse{Content: "What is caching?\nHow does it work?"},
+		stubResponse{Content: "A concise summary of chunk text."},
+	)
+
+	params := map[string]any{
+		"llm_id": "llm-test",
+		"keywords": map[string]any{
+			"top_n": 3,
+		},
+		"questions": map[string]any{
+			"top_n": 2,
+		},
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	}
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	in := map[string]any{
+		"tenant_id": "tenant-cache-test",
+		"chunks": []map[string]any{
+			{"text": "Go is a statically typed, compiled high-level programming language."},
+		},
+	}
+
+	// 1. First invocation: Cache miss -> triggers LLM (3 calls: keywords, questions, summary)
+	out1, err := comp.Invoke(t.Context(), nil, in)
+	if err != nil {
+		t.Fatalf("First Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("first invoke expected 3 LLM calls, got %d", calls)
+	}
+	chunks1 := out1["chunks"].([]map[string]any)
+	if len(chunks1) != 1 {
+		t.Fatalf("expected 1 chunk, got %v", out1)
+	}
+	if kwds, ok := chunks1[0]["important_kwd"].([]string); !ok || len(kwds) != 3 {
+		t.Fatalf("expected 3 keywords, got %v", chunks1[0]["important_kwd"])
+	}
+	if qs, ok := chunks1[0]["question_kwd"].([]string); !ok || len(qs) != 2 {
+		t.Fatalf("expected 2 questions, got %v", chunks1[0]["question_kwd"])
+	}
+	if sum, ok := chunks1[0]["summary"].(string); !ok || sum != "A concise summary of chunk text." {
+		t.Fatalf("expected summary, got %v", chunks1[0]["summary"])
+	}
+
+	// 2. Second invocation: Cache hit -> directly served from Redis (0 new LLM calls)
+	in2 := map[string]any{
+		"tenant_id": "tenant-cache-test",
+		"chunks": []map[string]any{
+			{"text": "Go is a statically typed, compiled high-level programming language."},
+		},
+	}
+	out2, err := comp.Invoke(t.Context(), nil, in2)
+	if err != nil {
+		t.Fatalf("Second Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("second invoke expected 3 LLM calls (0 additional), got %d", calls)
+	}
+	chunks2 := out2["chunks"].([]map[string]any)
+	if len(chunks2) != 1 {
+		t.Fatalf("expected 1 chunk, got %v", out2)
+	}
+	if kwds, ok := chunks2[0]["important_kwd"].([]string); !ok || len(kwds) != 3 {
+		t.Fatalf("expected cached 3 keywords, got %v", chunks2[0]["important_kwd"])
+	}
+	if qs, ok := chunks2[0]["question_kwd"].([]string); !ok || len(qs) != 2 {
+		t.Fatalf("expected cached 2 questions, got %v", chunks2[0]["question_kwd"])
+	}
+	if sum, ok := chunks2[0]["summary"].(string); !ok || sum != "A concise summary of chunk text." {
+		t.Fatalf("expected cached summary, got %v", chunks2[0]["summary"])
+	}
+}
+
+func TestExtractor_Cache_MultiTenantIsolation(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		// TenantA first run
+		stubResponse{Content: "TenantA_Kw1, TenantA_Kw2"},
+		stubResponse{Content: "TenantA_Q1?\nTenantA_Q2?"},
+		stubResponse{Content: "TenantA summary."},
+		// TenantB first run (same text, different tenant)
+		stubResponse{Content: "TenantB_Kw1, TenantB_Kw2"},
+		stubResponse{Content: "TenantB_Q1?\nTenantB_Q2?"},
+		stubResponse{Content: "TenantB summary."},
+	)
+
+	params := map[string]any{
+		"llm_id": "llm-test",
+		"keywords": map[string]any{
+			"top_n": 2,
+		},
+		"questions": map[string]any{
+			"top_n": 2,
+		},
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	}
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	sameText := "Identical text content across tenants."
+
+	// 1. Run TenantA -> triggers LLM (3 calls)
+	inA := map[string]any{
+		"tenant_id": "TenantA",
+		"chunks":    []map[string]any{{"text": sameText}},
+	}
+	outA, err := comp.Invoke(t.Context(), nil, inA)
+	if err != nil {
+		t.Fatalf("TenantA Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("TenantA expected 3 calls, got %d", calls)
+	}
+	ckA := outA["chunks"].([]map[string]any)[0]
+	if sumA := ckA["summary"].(string); sumA != "TenantA summary." {
+		t.Fatalf("got TenantA summary %q", sumA)
+	}
+
+	// 2. Run TenantB with same text -> cache miss -> triggers LLM independently (3 calls -> 6 total)
+	inB := map[string]any{
+		"tenant_id": "TenantB",
+		"chunks":    []map[string]any{{"text": sameText}},
+	}
+	outB, err := comp.Invoke(t.Context(), nil, inB)
+	if err != nil {
+		t.Fatalf("TenantB Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 6 {
+		t.Fatalf("TenantB expected 6 total calls (no cross-tenant hit), got %d", calls)
+	}
+	ckB := outB["chunks"].([]map[string]any)[0]
+	if sumB := ckB["summary"].(string); sumB != "TenantB summary." {
+		t.Fatalf("got TenantB summary %q", sumB)
+	}
+
+	// 3. Re-run TenantA -> hits TenantA Redis cache (0 additional calls)
+	outA2, err := comp.Invoke(t.Context(), nil, inA)
+	if err != nil {
+		t.Fatalf("TenantA repeat Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 6 {
+		t.Fatalf("TenantA repeat expected 6 total calls (cache hit), got %d", calls)
+	}
+	ckA2 := outA2["chunks"].([]map[string]any)[0]
+	if sumA2 := ckA2["summary"].(string); sumA2 != "TenantA summary." {
+		t.Fatalf("got TenantA summary %q", sumA2)
+	}
+
+	// 4. Re-run TenantB -> hits TenantB Redis cache (0 additional calls)
+	outB2, err := comp.Invoke(t.Context(), nil, inB)
+	if err != nil {
+		t.Fatalf("TenantB repeat Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 6 {
+		t.Fatalf("TenantB repeat expected 6 total calls (cache hit), got %d", calls)
+	}
+	ckB2 := outB2["chunks"].([]map[string]any)[0]
+	if sumB2 := ckB2["summary"].(string); sumB2 != "TenantB summary." {
+		t.Fatalf("got TenantB summary %q", sumB2)
+	}
+}
+
+func TestExtractor_Cache_ErrorResponseNeverCached(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		// First run: LLM returns error marker
+		stubResponse{Content: "**ERROR**: LLM inference crashed"},
+		// Second run: LLM succeeds with valid result
+		stubResponse{Content: "Valid summary after recovery."},
+	)
+
+	params := map[string]any{
+		"llm_id": "llm-test",
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	}
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	in := map[string]any{
+		"tenant_id": "tenant-err-test",
+		"chunks":    []map[string]any{{"text": "Sample text for error test."}},
+	}
+
+	// 1. First run: LLM returns **ERROR**, validator rejects and does NOT cache
+	out1, err := comp.Invoke(t.Context(), nil, in)
+	if err != nil {
+		t.Fatalf("first invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+	ck1 := out1["chunks"].([]map[string]any)[0]
+	if _, hasSummary := ck1["summary"]; hasSummary {
+		t.Fatalf("error response should not be set on chunk, got %v", ck1["summary"])
+	}
+
+	// 2. Second run: LLM must be called again because error was NOT cached
+	in2 := map[string]any{
+		"tenant_id": "tenant-err-test",
+		"chunks":    []map[string]any{{"text": "Sample text for error test."}},
+	}
+	out2, err := comp.Invoke(t.Context(), nil, in2)
+	if err != nil {
+		t.Fatalf("second invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("second invoke expected 2 calls (error was not cached), got %d", calls)
+	}
+	ck2 := out2["chunks"].([]map[string]any)[0]
+	if sum, ok := ck2["summary"].(string); !ok || sum != "Valid summary after recovery." {
+		t.Fatalf("expected recovered summary, got %v", ck2["summary"])
+	}
+}
+
+func TestExtractor_Cache_LegitimateEmptyValues(t *testing.T) {
+	setupTestRedis(t)
+	stub := withStubChatInvoker(t,
+		// First run: LLM returns empty/whitespace
+		stubResponse{Content: "   \n\t   "},
+	)
+
+	params := map[string]any{
+		"llm_id": "llm-test",
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	}
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	in := map[string]any{
+		"tenant_id": "tenant-empty-test",
+		"chunks":    []map[string]any{{"text": "Empty output test."}},
+	}
+
+	out, err := comp.Invoke(t.Context(), nil, in)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+	ck := out["chunks"].([]map[string]any)[0]
+	if _, hasSum := ck["summary"]; hasSum {
+		t.Fatalf("empty summary should not be set, got %v", ck["summary"])
+	}
+}
+
+func TestExtractor_Cache_ConcurrentSingleFlight(t *testing.T) {
+	setupTestRedis(t)
+	// Stub LLM with 50ms simulated latency
+	stub := withStubChatInvoker(t,
+		stubResponse{Content: "SingleFlight Summary Result", Delay: 50 * time.Millisecond},
+	)
+
+	params := map[string]any{
+		"llm_id": "llm-sf-test",
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	}
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	const concurrency = 10
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	errCh := make(chan error, concurrency)
+	results := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			in := map[string]any{
+				"tenant_id": "tenant-sf-1",
+				"chunks":    []map[string]any{{"text": "Concurrent SingleFlight test chunk."}},
+			}
+			out, err := comp.Invoke(t.Context(), nil, in)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			ck := out["chunks"].([]map[string]any)[0]
+			if sum, ok := ck["summary"].(string); ok {
+				results[idx] = sum
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent invoke failed: %v", err)
+	}
+
+	// Verify LLM was called exactly ONCE due to SingleFlight collapsing
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("SingleFlight expected 1 LLM call across %d concurrent requests, got %d", concurrency, calls)
+	}
+
+	for i, res := range results {
+		if res != "SingleFlight Summary Result" {
+			t.Errorf("goroutine %d got summary %q, want 'SingleFlight Summary Result'", i, res)
+		}
+	}
+}
+
+

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -33,9 +33,9 @@ import (
 	"gorm.io/gorm"
 
 	"ragflow/internal/agent/runtime"
+	"ragflow/internal/cache/llmcache"
 	"ragflow/internal/common"
 	"ragflow/internal/dao"
-	"ragflow/internal/engine/redis"
 	"ragflow/internal/entity"
 	"ragflow/internal/ingestion/component/schema"
 	"ragflow/internal/tokenizer"
@@ -51,8 +51,23 @@ func setupTestRedis(t *testing.T) (*miniredis.Miniredis, *goredis.Client) {
 	t.Cleanup(mr.Close)
 	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = rdb.Close() })
-	restore := redis.SetGlobalClient(redis.NewTestClient(rdb))
-	t.Cleanup(restore)
+
+	testTextCache := llmcache.New[string](
+		llmcache.WithValidator(isValidLLMCachePayload),
+		llmcache.WithUniversalClient[string](rdb),
+	)
+	testMetaCache := llmcache.New[map[string]any](
+		llmcache.WithValidator(func(m map[string]any) bool { return m != nil }),
+		llmcache.WithUniversalClient[map[string]any](rdb),
+	)
+	testTagCache := llmcache.New[map[string]int](
+		llmcache.WithValidator(func(m map[string]int) bool { return m != nil }),
+		llmcache.WithUniversalClient[map[string]int](rdb),
+	)
+	restoreExtractor := SetExtractorCachesForTest(testTextCache, testMetaCache)
+	t.Cleanup(restoreExtractor)
+	restoreTag := SetTaggerCacheForTest(testTagCache)
+	t.Cleanup(restoreTag)
 	return mr, rdb
 }
 
@@ -2562,5 +2577,200 @@ func TestExtractor_Cache_ConcurrentSingleFlight(t *testing.T) {
 		}
 	}
 }
+
+func TestSetExtractorCachesForTest_Restore(t *testing.T) {
+	origText := getTextExtractCache()
+	origMeta := getMetadataCache()
+
+	customText := llmcache.New[string]()
+	customMeta := llmcache.New[map[string]any]()
+
+	restore := SetExtractorCachesForTest(customText, customMeta)
+	if getTextExtractCache() != customText {
+		t.Errorf("getTextExtractCache() did not return customText")
+	}
+	if getMetadataCache() != customMeta {
+		t.Errorf("getMetadataCache() did not return customMeta")
+	}
+
+	restore()
+	if getTextExtractCache() != origText {
+		t.Errorf("getTextExtractCache() did not restore origText")
+	}
+	if getMetadataCache() != origMeta {
+		t.Errorf("getMetadataCache() did not restore origMeta")
+	}
+}
+
+func TestExtractor_Cache_EffectiveLLMIDResolution(t *testing.T) {
+	setupTestRedis(t)
+	db := openExtractorContextTestDB(t)
+	seedExtractorContextModel(t, db, "")
+
+	SetExtractorChatTargetResolverOverride(func(llmID string) (string, string, string, string, bool) {
+		return "mock_driver", llmID, "", "", true
+	})
+	t.Cleanup(func() { SetExtractorChatTargetResolverOverride(nil) })
+
+	ctx := extractorStateCtx(t, "tenant-1")
+
+	stub := withStubChatInvoker(t,
+		// Call 1 for default composite model summary
+		stubResponse{Content: "Summary from composite model"},
+		// Call 2 for pinned UUID model summary (after tenant default model change)
+		stubResponse{Content: "Summary from pinned model"},
+	)
+
+	comp, err := NewExtractorComponent(map[string]any{
+		// llm_id omitted to test default model resolution
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	in := map[string]any{
+		"chunks": []map[string]any{
+			{"text": "Text content for effective LLM ID test."},
+		},
+	}
+
+	// 1. First run: resolves composite model "gpt-4o@openai", cache miss -> triggers LLM (call count = 1)
+	out1, err := comp.Invoke(ctx, db, in)
+	if err != nil {
+		t.Fatalf("First Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("expected 1 call on first run, got %d", calls)
+	}
+	ck1 := out1["chunks"].([]map[string]any)[0]
+	if ck1["summary"] != "Summary from composite model" {
+		t.Fatalf("expected summary 'Summary from composite model', got %v", ck1["summary"])
+	}
+
+	// 2. Second run: resolves composite model, cache hit -> 0 new LLM calls (call count = 1)
+	in2 := map[string]any{
+		"chunks": []map[string]any{
+			{"text": "Text content for effective LLM ID test."},
+		},
+	}
+	out2, err := comp.Invoke(ctx, db, in2)
+	if err != nil {
+		t.Fatalf("Second Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 1 {
+		t.Fatalf("expected 1 call (cache hit), got %d", calls)
+	}
+	ck2 := out2["chunks"].([]map[string]any)[0]
+	if ck2["summary"] != "Summary from composite model" {
+		t.Fatalf("expected cached summary 'Summary from composite model', got %v", ck2["summary"])
+	}
+
+	// 3. Update tenant default model in DB to pinned UUID model "0123456789abcdef0123456789abcdef"
+	pinnedUUID := "0123456789abcdef0123456789abcdef"
+	if err := db.Model(&entity.Tenant{}).Where("id = ?", "tenant-1").Update("tenant_llm_id", pinnedUUID).Error; err != nil {
+		t.Fatalf("update tenant default model: %v", err)
+	}
+
+	// 4. Third run: resolves pinned UUID model -> cache key differs -> cache miss -> triggers LLM (call count = 2)
+	in3 := map[string]any{
+		"chunks": []map[string]any{
+			{"text": "Text content for effective LLM ID test."},
+		},
+	}
+	out3, err := comp.Invoke(ctx, db, in3)
+	if err != nil {
+		t.Fatalf("Third Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("expected 2 calls (model changed, cache miss), got %d", calls)
+	}
+	ck3 := out3["chunks"].([]map[string]any)[0]
+	if ck3["summary"] != "Summary from pinned model" {
+		t.Fatalf("expected summary 'Summary from pinned model', got %v", ck3["summary"])
+	}
+
+	// 5. Fourth run with pinned UUID model: cache hit (call count = 2)
+	in4 := map[string]any{
+		"chunks": []map[string]any{
+			{"text": "Text content for effective LLM ID test."},
+		},
+	}
+	out4, err := comp.Invoke(ctx, db, in4)
+	if err != nil {
+		t.Fatalf("Fourth Invoke: %v", err)
+	}
+	if calls := stub.Calls(); calls != 2 {
+		t.Fatalf("expected 2 calls (cache hit for pinned model), got %d", calls)
+	}
+	ck4 := out4["chunks"].([]map[string]any)[0]
+	if ck4["summary"] != "Summary from pinned model" {
+		t.Fatalf("expected cached summary 'Summary from pinned model', got %v", ck4["summary"])
+	}
+}
+
+func TestExtractor_DoubleCleanElimination(t *testing.T) {
+	withStubChatInvoker(t,
+		// Keywords with think tag and surrounding whitespace
+		stubResponse{Content: "<think>deep reasoning</think>\n  golang, testing, cache  \n"},
+		// Questions with think tag
+		stubResponse{Content: "<think>thinking questions</think>\nWhat is Go?\nHow to test?"},
+		// Summary with think tag
+		stubResponse{Content: "<think>thinking summary</think>A concise summary."},
+	)
+
+	params := map[string]any{
+		"llm_id": "test-llm",
+		"keywords": map[string]any{
+			"top_n": 3,
+		},
+		"questions": map[string]any{
+			"top_n": 2,
+		},
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	}
+
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	in := map[string]any{
+		"chunks": []map[string]any{
+			{"text": "Sample text for extraction."},
+		},
+	}
+
+	out, err := comp.Invoke(t.Context(), nil, in)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	chunks := out["chunks"].([]map[string]any)
+	ck := chunks[0]
+
+	// Verify keywords cleaned
+	kwds, ok := ck["important_kwd"].([]string)
+	if !ok || len(kwds) != 3 || kwds[0] != "golang" || kwds[1] != "testing" || kwds[2] != "cache" {
+		t.Errorf("important_kwd = %v, want ['golang', 'testing', 'cache']", ck["important_kwd"])
+	}
+
+	// Verify questions cleaned
+	qs, ok := ck["question_kwd"].([]string)
+	if !ok || len(qs) != 2 || qs[0] != "What is Go?" || qs[1] != "How to test?" {
+		t.Errorf("question_kwd = %v, want ['What is Go?', 'How to test?']", ck["question_kwd"])
+	}
+
+	// Verify summary cleaned
+	sum, ok := ck["summary"].(string)
+	if !ok || sum != "A concise summary." {
+		t.Errorf("summary = %v, want 'A concise summary.'", ck["summary"])
+	}
+}
+
 
 

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -2934,6 +2934,3 @@ func TestExtractor_DoubleCleanElimination(t *testing.T) {
 		t.Errorf("summary = %v, want 'A concise summary.'", ck["summary"])
 	}
 }
-
-
-


### PR DESCRIPTION
### 📌 Summary

This PR introduces a generic, production-grade LLM result cache engine (`internal/cache/llmcache`) and unifies caching across all ingestion extractor operators (`keywords`, `questions`, `summary`, `metadata`, `tagger`). It provides multi-tenant physical isolation, zero-allocation key generation, 24h default TTL with anti-stampede lock-free jitter, dynamic default model resolution, and strict quality gates against corrupted/error payloads.

---

### 🚀 Key Capabilities & Architecture

#### 1. Generic Multi-Tenant Cache Engine (`internal/cache/llmcache`)
- **Type-Safe Generic API**: `Engine[T any]` supports arbitrary Go types (e.g. `string`, `map[string]any`, `map[string]int`) with JSON serialization and zero `reflect` overhead on cache reads.
- **Physical Tenant Isolation**: Hierarchical key structure `kc:llm:{tenant_id}:{task_type}:{xxhash64}` with NUL-byte field separators preventing cross-field hash collisions.
- **Direct Cache-Aside with Anti-Stampede TTL Jitter**:
  - Direct, non-blocking caching flow (`get -> compute -> validate -> set`).
  - **Default 24h TTL**: Standard 24h expiration window matching legacy Python cache behavior.
  - **Lock-Free TTL Jitter**: ±10% random TTL jitter (`21.6h ~ 26.4h`) powered by `math/rand/v2` to prevent synchronized cache expiration stampedes across batch-ingested chunks.
- **Zero-Alloc Key Generation**: Reuses `*xxhash.Digest` via `sync.Pool` (`xxhashPool`) to eliminate heap allocations in high-throughput chunk processing (`0 allocs/op`).
- **GDPR Tenant Purge**: `FlushTenant(ctx, tenantID)` performs streaming Redis `SCAN cursor COUNT 1000` with pipelined batch deletions and a reusable timer, avoiding unbounded set index growth.
- **Decoupled Observability**: Optional `WithMetrics` hook emits hit/miss/compute/skip/purge events for metric instrumentation.

#### 2. Extractor & Tagger Operators Integration
- **Unified Caching**: Integrated across all 5 extraction operators: `runAutoKeywords`, `runAutoQuestions`, `runAutoSummary`, `runEnableMetadata`, and `llmTagChunk`.
- **Dynamic Effective Model Resolution (`resolveEffectiveLLMID`)**:
  - Resolves tenant effective default chat model (`model@provider` / `tenant_model` UUID) before cache key construction.
  - When tenant admin updates the default model, cache keys automatically change to reflect the new model across both Canvas and pure input invocations.
- **Quality Gates & Clean Extractor Pipelines**:
  - Filters corrupted payloads (`**ERROR**`, `[TRUNCATED]`, unclosed `<think>` tags).
  - Consolidated single-pass text cleaning in `callTextCached`, eliminating redundant double-cleaning.
- **Optimized `awaitFutures`**: Simplified to sequential waiting, eliminating thousands of temporary goroutines and mutex locks during large-document ingestion.
- **Tagger Operator (`extractor_tag.go`)**: Migrated LLM tagger caching to `taggerCache` with effective model resolution, while strictly preserving local rule-based in-memory index `boundedTagCache`.

#### 3. Thread Safety & Test Seams
- **Atomic Global Redis Client**: Converted `redis.globalClient` to `sync/atomic.Pointer[Client]` for lock-free, race-free concurrency.
- **Clean Test Seams**: Exported `SetExtractorCachesForTest` and `SetTaggerCacheForTest` with restore closures to eliminate global Redis client swapping and prevent test race conditions.

---

### 🧪 Verification

- **Full Package Tests**:
  - `go test -race -v ./internal/cache/llmcache/...` -> **100% PASS**
  - `go test -race -v ./internal/engine/redis/...` -> **100% PASS**
  - `./build.sh --test ./internal/cache/llmcache ./internal/ingestion/component` -> **100% PASS**
- **Test Matrix Covered**:
  - Direct Cache-Aside read/write & validation.
  - TTL duration and ±10% random Jitter spread.
  - Multi-tenant physical data isolation.
  - Dynamic cache invalidation upon tenant default model switch.
  - Large-batch SCAN tenant purges and Redis outage handling.
  - Complex map/slice round-trips without reflection.
