### PR TITLE
fix(wiki): guard generation without compilation config

### DIFF
--- a/web/src/pages/dataset/compilation/llm-wiki-view.tsx
+++ b/web/src/pages/dataset/compilation/llm-wiki-view.tsx
@@ -25,6 +25,7 @@ import CompilationEmptyState from './empty-state';
 import { useCompilationArtifact } from './hooks/use-compilation-artifact';
 import { useRunEndEffect } from './hooks/use-run-end-effect';
 import { CompilationLoadingCard } from './loading-card';
+import { canGenerateWiki } from './wiki-generation-eligibility';
 import { WikiDetailContent } from './wiki-detail-content';
 import { WikiLeftPanel } from './wiki-left-panel';
 
@@ -63,7 +64,7 @@ export function LlmWikiView() {
     setLeftTab(value as LeftPanelTab);
   }, []);
 
-  const canGenerate = (knowledgeBase?.chunk_count ?? 0) > 0;
+  const canGenerate = canGenerateWiki(knowledgeBase);
   const isLoading = topicListLoading && topics.length === 0;
   const isEmpty = topics.length === 0 && !topicListLoading;
 

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
@@ -56,6 +56,19 @@ describe('canGenerateWiki', () => {
     ).toBe(true);
   });
 
+  it('checks plural and singular template group fields independently', () => {
+    expect(
+      canGenerateWiki(
+        dataset({
+          parser_config: parserConfig({
+            compilation_template_group_ids: [],
+            compilation_template_group_id: ['group-id'],
+          }),
+        }),
+      ),
+    ).toBe(true);
+  });
+
   it('ignores blank pipeline and template group values', () => {
     expect(
       canGenerateWiki(

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
@@ -1,0 +1,71 @@
+import { IDataset } from '@/interfaces/database/dataset';
+
+import { canGenerateWiki } from './wiki-generation-eligibility';
+
+function dataset(overrides: Partial<IDataset> = {}): IDataset {
+  return {
+    chunk_count: 1,
+    pipeline_id: '',
+    parser_config: {},
+    ...overrides,
+  } as IDataset;
+}
+
+function parserConfig(
+  overrides: Record<string, unknown>,
+): IDataset['parser_config'] {
+  return overrides as unknown as IDataset['parser_config'];
+}
+
+describe('canGenerateWiki', () => {
+  it('requires parsed chunks', () => {
+    expect(canGenerateWiki(dataset({ chunk_count: 0, pipeline_id: 'pipeline' }))).toBe(
+      false,
+    );
+  });
+
+  it('blocks generation when no compilation configuration is present', () => {
+    expect(canGenerateWiki(dataset())).toBe(false);
+  });
+
+  it('allows pipeline-backed datasets', () => {
+    expect(canGenerateWiki(dataset({ pipeline_id: 'pipeline-id' }))).toBe(true);
+  });
+
+  it('allows the singular parser-config template group field', () => {
+    expect(
+      canGenerateWiki(
+        dataset({
+          parser_config: parserConfig({
+            compilation_template_group_id: ['group-id'],
+          }),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('allows the plural parser-config template group field', () => {
+    expect(
+      canGenerateWiki(
+        dataset({
+          parser_config: parserConfig({
+            compilation_template_group_ids: ['group-id'],
+          }),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores blank pipeline and template group values', () => {
+    expect(
+      canGenerateWiki(
+        dataset({
+          pipeline_id: '   ',
+          parser_config: parserConfig({
+            compilation_template_group_id: [' ', ''],
+          }),
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
@@ -11,20 +11,14 @@ function dataset(overrides: Partial<IDataset> = {}): IDataset {
   } as IDataset;
 }
 
-function parserConfig(
-  overrides: Record<string, unknown>,
-): IDataset['parser_config'] {
-  return overrides as unknown as IDataset['parser_config'];
-}
-
 describe('canGenerateWiki', () => {
   it('requires parsed chunks', () => {
-    expect(canGenerateWiki(dataset({ chunk_count: 0, pipeline_id: 'pipeline' }))).toBe(
-      false,
-    );
+    expect(
+      canGenerateWiki(dataset({ chunk_count: 0, pipeline_id: 'pipeline' })),
+    ).toBe(false);
   });
 
-  it('blocks generation when no compilation configuration is present', () => {
+  it('requires an ingestion pipeline', () => {
     expect(canGenerateWiki(dataset())).toBe(false);
   });
 
@@ -32,53 +26,7 @@ describe('canGenerateWiki', () => {
     expect(canGenerateWiki(dataset({ pipeline_id: 'pipeline-id' }))).toBe(true);
   });
 
-  it('allows the singular parser-config template group field', () => {
-    expect(
-      canGenerateWiki(
-        dataset({
-          parser_config: parserConfig({
-            compilation_template_group_id: ['group-id'],
-          }),
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it('allows the plural parser-config template group field', () => {
-    expect(
-      canGenerateWiki(
-        dataset({
-          parser_config: parserConfig({
-            compilation_template_group_ids: ['group-id'],
-          }),
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it('checks plural and singular template group fields independently', () => {
-    expect(
-      canGenerateWiki(
-        dataset({
-          parser_config: parserConfig({
-            compilation_template_group_ids: [],
-            compilation_template_group_id: ['group-id'],
-          }),
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it('ignores blank pipeline and template group values', () => {
-    expect(
-      canGenerateWiki(
-        dataset({
-          pipeline_id: '   ',
-          parser_config: parserConfig({
-            compilation_template_group_id: [' ', ''],
-          }),
-        }),
-      ),
-    ).toBe(false);
+  it('ignores a blank pipeline id', () => {
+    expect(canGenerateWiki(dataset({ pipeline_id: '   ' }))).toBe(false);
   });
 });

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
@@ -1,33 +1,8 @@
 import { IDataset } from '@/interfaces/database/dataset';
 
-type CompilationParserConfig = IDataset['parser_config'] & {
-  compilation_template_group_id?: string | string[];
-  compilation_template_group_ids?: string | string[];
-};
-
-function hasConfiguredGroup(value: unknown): boolean {
-  if (Array.isArray(value)) {
-    return value.some(
-      (groupId) => typeof groupId === 'string' && groupId.trim().length > 0,
-    );
-  }
-
-  return typeof value === 'string' && value.trim().length > 0;
-}
-
 export function canGenerateWiki(knowledgeBase?: IDataset): boolean {
-  if ((knowledgeBase?.chunk_count ?? 0) <= 0) {
-    return false;
-  }
-
-  const parserConfig = knowledgeBase?.parser_config as
-    | CompilationParserConfig
-    | undefined;
-  const hasDirectCompilationTemplate =
-    hasConfiguredGroup(parserConfig?.compilation_template_group_ids) ||
-    hasConfiguredGroup(parserConfig?.compilation_template_group_id);
-
   return (
-    Boolean(knowledgeBase?.pipeline_id?.trim()) || hasDirectCompilationTemplate
+    (knowledgeBase?.chunk_count ?? 0) > 0 &&
+    Boolean(knowledgeBase?.pipeline_id?.trim())
   );
 }

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
@@ -1,0 +1,34 @@
+import { IDataset } from '@/interfaces/database/dataset';
+
+type CompilationParserConfig = IDataset['parser_config'] & {
+  compilation_template_group_id?: string | string[];
+  compilation_template_group_ids?: string | string[];
+};
+
+function hasConfiguredGroup(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(
+      (groupId) => typeof groupId === 'string' && groupId.trim().length > 0,
+    );
+  }
+
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function canGenerateWiki(knowledgeBase?: IDataset): boolean {
+  if ((knowledgeBase?.chunk_count ?? 0) <= 0) {
+    return false;
+  }
+
+  const parserConfig = knowledgeBase?.parser_config as
+    | CompilationParserConfig
+    | undefined;
+  const compilationGroupIds =
+    parserConfig?.compilation_template_group_ids ??
+    parserConfig?.compilation_template_group_id;
+
+  return (
+    Boolean(knowledgeBase?.pipeline_id?.trim()) ||
+    hasConfiguredGroup(compilationGroupIds)
+  );
+}

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
@@ -23,12 +23,11 @@ export function canGenerateWiki(knowledgeBase?: IDataset): boolean {
   const parserConfig = knowledgeBase?.parser_config as
     | CompilationParserConfig
     | undefined;
-  const compilationGroupIds =
-    parserConfig?.compilation_template_group_ids ??
-    parserConfig?.compilation_template_group_id;
+  const hasDirectCompilationTemplate =
+    hasConfiguredGroup(parserConfig?.compilation_template_group_ids) ||
+    hasConfiguredGroup(parserConfig?.compilation_template_group_id);
 
   return (
-    Boolean(knowledgeBase?.pipeline_id?.trim()) ||
-    hasConfiguredGroup(compilationGroupIds)
+    Boolean(knowledgeBase?.pipeline_id?.trim()) || hasDirectCompilationTemplate
   );
 }


### PR DESCRIPTION
### Summary

Closes #18683.

The Wiki artifact view previously enabled **Generate** whenever a dataset had parsed chunks. Built-in datasets can have chunks without an ingestion pipeline, so the backend finds no wiki-eligible documents and exits without generating pages.

This PR adds a focused frontend eligibility check so Wiki generation is offered only when the dataset has parsed chunks and is associated with an ingestion pipeline.

### Changes

- replace the chunk-count-only guard in `LlmWikiView` with `canGenerateWiki`
- require a non-blank dataset `pipeline_id`; compilation templates are resolved through that pipeline
- add focused unit coverage for missing chunks, missing/blank pipeline IDs, and pipeline-backed datasets

### Validation

- `npx jest --runInBand --no-cache src/pages/dataset/compilation/wiki-generation-eligibility.test.ts`: 4 tests passed
- `npx oxfmt --check` passes for both changed eligibility files
- `npx oxlint` passes for both changed eligibility files
- repository test jobs for this external PR are currently skipped, so this PR does not claim a green end-to-end CI run

### Scope

The frontend checks only whether the dataset is pipeline-backed. The backend remains responsible for resolving and validating the pipeline's Compiler and Wiki template configuration.
