### PR TITLE
fix(web): make overflowing card description tooltips scrollable

### DIFF
--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -21,7 +21,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 overflow-auto scrollbar-auto rounded-md whitespace-pre-wrap border bg-bg-base px-3 py-1.5 text-sm text-text-primary shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-w-[30vw]',
+        'z-50 overflow-auto scrollbar-auto rounded-md whitespace-pre-wrap border bg-bg-base px-3 py-1.5 text-sm text-text-primary shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-[50vh] max-w-[30vw]',
         className,
       )}
       {...props}


### PR DESCRIPTION
### Summary

On the chat / search / agent list pages, each card's description is truncated to a single line and the full text is shown in a hover tooltip (introduced in #16787). When the description is very long, the tooltip grows taller than the viewport and there is no way to scroll it up/down, so the user cannot read the text beyond the screen edge.

Root cause: the shared `TooltipContent` (`web/src/components/ui/tooltip.tsx`) is styled with `overflow-auto scrollbar-auto` and `max-w-[30vw]` but has **no max-height**. Without a height cap the element always grows to fit its content, so `scrollHeight == clientHeight` and the `overflow-auto` rule never activates — the scrollbar logic is effectively dead code.

Fix: add `max-h-[50vh]` to the base `TooltipContent` classes. Tall tooltips are now capped at half the viewport height and scroll internally, which activates the existing `overflow-auto scrollbar-auto` styling. This is a single-point fix in the shared component, so all three list pages (chat, search, agent — they all render `HomeCard` → `TruncatedText` → `TooltipContent`) and any other tooltip with long content benefit at once; short tooltips are unaffected.

### Verification

- Reproduced in the browser on `/chats`: a card with a 3,621-char description produced a 3,194px-tall tooltip against a 616px viewport (overflowing 2,817px below the screen, `scrollHeight == clientHeight`, not scrollable).
- After the fix, the same tooltip is 308px (50vh), fully inside the viewport, `scrollHeight 3372 > clientHeight 306`, and scrolling to the bottom works (`scrollTop` reaches its max).
- `oxlint` clean on the changed file; `npm run type-check` clean.
- Verification boundary: checked end-to-end on the chat list; search and agent lists use the identical `HomeCard` → `TruncatedText` → `TooltipContent` chain, so the shared-component fix covers them (not separately re-walked in the browser).
