### PR TITLE
fix(mcp): include dataset name in list_datasets output (#17133)

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -242,7 +242,7 @@ class RAGFlowConnector:
 
         result_list = []
         for data in datasets:
-            d = {"description": data["description"], "id": data["id"]}
+            d = {"id": data["id"], "name": data.get("name"), "description": data.get("description")}
             result_list.append(json.dumps(d, ensure_ascii=False))
         return "\n".join(result_list)
 

--- a/test/unit_test/mcp/test_server_datasets.py
+++ b/test/unit_test/mcp/test_server_datasets.py
@@ -39,8 +39,14 @@ class _FakeResponse:
         return self._payload
 
 
-def _datasets(count):
-    return [{"id": f"dataset-{idx}", "description": f"description-{idx}"} for idx in range(count)]
+def _datasets(count, *, with_name=True):
+    out = []
+    for idx in range(count):
+        row = {"id": f"dataset-{idx}", "description": f"description-{idx}"}
+        if with_name:
+            row["name"] = f"name-{idx}"
+        out.append(row)
+    return out
 
 
 @pytest.fixture()
@@ -115,3 +121,56 @@ async def test_list_datasets_clamps_explicit_page_size_to_rest_limit_and_preserv
         "id": "dataset-1",
         "name": "target",
     }
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_includes_name_field(monkeypatch, mcp_server):
+    """``list_datasets`` must surface each dataset's ``name`` so MCP clients
+    can show a human-readable label next to the opaque ``id``.
+
+    Regression for #17133: pre-fix the per-row dict was
+    ``{"description": ..., "id": ...}`` and dropped the ``name`` that
+    the REST API returns. The sibling ``list_chats`` already
+    includes ``id`` / ``name`` / ``description`` — the datasets
+    branch was the inconsistency.
+    """
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    _stub_dataset_pages(monkeypatch, connector, _datasets(3))
+
+    result = await connector.list_datasets(api_key="unit-key")
+
+    rows = [json.loads(line) for line in result.splitlines()]
+    assert len(rows) == 3
+    # Every row has the three fields the REST API returns.
+    for row in rows:
+        assert set(row.keys()) == {"id", "name", "description"}, f"row {row!r} is missing one of id/name/description"
+    # Names round-trip in document order.
+    assert [row["name"] for row in rows] == ["name-0", "name-1", "name-2"]
+    assert [row["id"] for row in rows] == ["dataset-0", "dataset-1", "dataset-2"]
+    assert [row["description"] for row in rows] == [
+        "description-0",
+        "description-1",
+        "description-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_name_omitted_when_missing(monkeypatch, mcp_server):
+    """If the REST API does not include ``name`` for some row (older
+    dataset rows, partial records, migration backlog), the per-row
+    dict must still serialise with ``name`` set to ``None`` so the
+    shape is stable. The client can then show a fallback label.
+    """
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    # No ``name`` field on any row — matches a real API response
+    # where the field is absent.
+    _stub_dataset_pages(monkeypatch, connector, _datasets(2, with_name=False))
+
+    result = await connector.list_datasets(api_key="unit-key")
+
+    rows = [json.loads(line) for line in result.splitlines()]
+    assert len(rows) == 2
+    for row in rows:
+        assert "name" in row
+        assert row["name"] is None
+        assert set(row.keys()) == {"id", "name", "description"}


### PR DESCRIPTION
Fixes #17133

## Problem

The MCP server's `ragflow_list_datasets` tool serialised each row as `{"description": "...", "id": "..."}` and dropped the `name` field that the REST API returns. The sibling `ragflow_list_chats` already includes `id` / `name` / `description` — the datasets branch was the inconsistency.

MCP clients can show a human-readable label next to the opaque dataset ID, but only if the label is in the response. Pre-fix the dataset name was lost in transit from the REST API to the MCP client, so users saw only "dataset-46ea1644..." with no way to distinguish multiple datasets by name. The dataset description text embedded in the sibling `ragflow_retrieval` / `ragflow_list_chats` tool descriptions (the `list_tools` output) was also affected — the bug is in the per-row dict shape, so the MCP tool description builder also dropped `name`.

Example from the issue:
```
$ MCP tool call: ragflow_list_datasets
{"description": null, "id": "46ea1644813211f1bc41abcb1d4727a4"}
# (no "name" field, even though the dataset genuinely has one)

$ REST API call: GET /api/v1/datasets
{"id": "46ea1644813211f1bc41abcb1d4727a4", "name": "B3 Documentation", ...}
```

## Fix

In `mcp/server/server.py::list_datasets`, reorder the per-row dict construction to `{"id": ..., "name": ..., "description": ...}` and use `data.get("name")` / `data.get("description")` so older API rows or partial records without a `name` still serialise with `name: null` (a stable shape, so the client can show a fallback label).

This matches the established pattern in `list_chats` (line 192), which builds `{"id": data.get("id"), "name": data.get("name"), "description": data.get("description", "")}`. Pre-fix the datasets branch had a different (broken) key set; post-fix the two paths agree.

## Tests

Two new regression tests in `test/unit_test/mcp/test_server_datasets.py` (extending the existing `_datasets` helper to accept a `with_name` flag):

- `test_list_datasets_includes_name_field` — three rows with `id` / `name` / `description` round-trip in document order; the per-row key set is exactly those three fields. **Pre-fix this fails with `row {'description': 'description-0', 'id': 'dataset-0'} is missing one of id/name/description`.**
- `test_list_datasets_name_omitted_when_missing` — when the REST API does not include `name` for a row (older dataset rows, partial records, migration backlog), the per-row dict still serialises with `name: null`. This pins the stable-shape contract so the client can show a fallback label and doesn't need to handle `KeyError`.

5/5 tests pass post-fix (the 3 pre-existing tests in the file still pass; the 2 new tests are the regression guards). `ruff check` + `ruff format --check` clean on both files.

## consult-kiro note

Per the standing rule (2026-08-24), the local OpenCode Tier A panel was attempted. All four models (`opencode/big-pickle`, `opencode/gemini-3.7-flash`, `opencode/gpt-5-nano`, `opencode/deepseek-v4-flash-free`) returned empty answers / `rc=124` within the 180s hard-timeout window — same pattern as the prior 6 cycles. The change is small (one line in `list_datasets` + the regression tests) and the diff is the primary review surface; the consult is recorded here for completeness.

## Risk

- Backward compatible for the only existing client path: the dict now has one more key (`name`) than before. Any client iterating over the dict's keys will see the new key, but no client was iterating over the keys (the dict was being serialised to a JSON string in `list_datasets` and consumed by an LLM that ignores unknown fields). The pre-fix `description: null` shape becomes `name: ..., description: null` — both null-shape keys are still there.
- Stable shape: `data.get("name")` returns `None` when the key is missing, so the per-row dict is `{"id": ..., "name": None, "description": ...}`. Old clients that didn't know about `name` continue to work; new clients that show the name get the new field. No client needs to change.
- No schema or response-format change for the underlying REST API. The MCP server is the only consumer of the fix; the REST API at `GET /api/v1/datasets` already returns `name`.
