### PR TITLE
Fix email and presentation parsers treating an empty upload as a missing binary

### DIFF
--- a/rag/app/email.py
+++ b/rag/app/email.py
@@ -51,7 +51,7 @@ def chunk(
     main_res = []
     attachment_res = []
 
-    if binary:
+    if binary is not None:
         with io.BytesIO(binary) as buffer:
             msg = BytesParser(policy=policy.default).parse(buffer)
     else:

--- a/rag/app/presentation.py
+++ b/rag/app/presentation.py
@@ -40,7 +40,7 @@ class Pdf(PdfParser):
     def __call__(self, filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, zoomin=3, callback=None, **kwargs):
         # 1. OCR
         callback(msg="OCR started")
-        self.__images__(filename if not binary else binary, zoomin, from_page, to_page, callback)
+        self.__images__(filename if binary is None else binary, zoomin, from_page, to_page, callback)
 
         # 2. Layout Analysis
         callback(msg="Layout Analysis")
@@ -118,7 +118,7 @@ class Pdf(PdfParser):
 
 class PlainPdf(PlainParser):
     def __call__(self, filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, callback=None, **kwargs):
-        self.pdf = pdf2_read(filename if not binary else BytesIO(binary))
+        self.pdf = pdf2_read(filename if binary is None else BytesIO(binary))
         page_txt = []
         for page in self.pdf.pages[from_page:to_page]:
             page_txt.append(page.extract_text())
@@ -141,7 +141,7 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
     if re.search(r"\.pptx?$", filename, re.IGNORECASE):
         try:
             ppt_parser = RAGFlowPptParser()
-            for pn, txt in enumerate(ppt_parser(filename if not binary else binary, from_page, MAXIMUM_PAGE_NUMBER, callback)):
+            for pn, txt in enumerate(ppt_parser(filename if binary is None else binary, from_page, MAXIMUM_PAGE_NUMBER, callback)):
                 d = copy.deepcopy(doc)
                 pn += from_page
                 d["doc_type_kwd"] = "image"
@@ -165,7 +165,7 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
                 logging.warning(f"{error_msg} for {filename}.")
                 raise NotImplementedError(error_msg)
 
-            if binary:
+            if binary is not None:
                 binary_data = binary
             else:
                 with open(filename, "rb") as f:

--- a/test/unit_test/rag/app/test_email_empty_binary.py
+++ b/test/unit_test/rag/app/test_email_empty_binary.py
@@ -1,0 +1,35 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from rag.app import email
+
+
+@pytest.fixture(autouse=True)
+def _stub_rag_tokenizer(monkeypatch):
+    def fake_tokenize(text):
+        return str(text)
+
+    monkeypatch.setattr("rag.nlp.rag_tokenizer.tokenize", fake_tokenize)
+    monkeypatch.setattr("rag.nlp.rag_tokenizer.fine_grained_tokenize", fake_tokenize)
+
+
+@pytest.mark.p2
+def test_empty_binary_does_not_open_display_name():
+    email.chunk("message.eml", binary=b"", callback=lambda *a, **k: None)


### PR DESCRIPTION
### What problem does this PR solve?

An upload of 0 bytes reaches the chunkers as `b""`, not as `None`.

`rag/svr/task_executor.py:312-313` reads the object and guards only against `None`:

```python
binary = await get_storage_binary(bucket, name)
if binary is None:
    raise FileNotFoundError(...)
```

`b""` is not `None`, so the guard passes. Line 361-363 then calls
`chunker.chunk(task["name"], binary=binary, ...)`. `task["name"]` is the document display
name, not a path on disk.

The email and presentation parsers chose between "use the bytes" and "open the path" with a
truthiness test. `b""` is falsy, so they took the path branch and opened the display name as
a file. The upload failed with `FileNotFoundError` on a name that never existed on disk.

PR #17904 fixed the same defect in `deepdoc/parser/html_parser.py` (commit `9ea83b7a`,
`if binary:` to `if binary is not None:`). This PR applies that fix to the remaining
reachable sites in two more files.

### Sites changed

| file | line | before | after |
|---|---|---|---|
| `rag/app/email.py` | 54 | `if binary:` | `if binary is not None:` |
| `rag/app/presentation.py` | 43 | `filename if not binary else binary` | `filename if binary is None else binary` |
| `rag/app/presentation.py` | 121 | `filename if not binary else BytesIO(binary)` | `filename if binary is None else BytesIO(binary)` |
| `rag/app/presentation.py` | 144 | `filename if not binary else binary` | `filename if binary is None else binary` |
| `rag/app/presentation.py` | 168 | `if binary:` | `if binary is not None:` |

All five are reachable from `chunk()`. A `.pptx` upload reaches line 144 and then the tika
fallback at 168. A `.pdf` upload reaches `Pdf.__call__` at 43 or `PlainPdf.__call__` at 121.

Behavior for a non-empty binary and for `binary=None` is unchanged. Only the `b""` case
moves, and it moves from a crash to normal parsing of an empty payload.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Test

New test `test/unit_test/rag/app/test_email_empty_binary.py`. It calls the real
`rag.app.email.chunk` with `binary=b""` and a display name that is not a file on disk.

With the fix:

```
$ .venv/bin/pytest test/unit_test/rag/app/test_email_empty_binary.py -q --noconftest
1 passed in 7.17s
```

With `rag/app/email.py` reverted and the test kept:

```
rag/app/email.py:58: in chunk
    with open(filename, "rb") as buffer:
E   FileNotFoundError: [Errno 2] No such file or directory: 'message.eml'
1 failed in 6.44s
```

The failure line is the path branch this PR removes, so the test is not vacuous.

Sibling test still passes:

```
$ .venv/bin/pytest test/unit_test/rag/app/test_qa_csv.py -q --noconftest
4 passed
```

`ruff check` on both changed files and the new test: All checks passed.

I did not add a test for `presentation.py`. That path needs python-pptx or tika, which is
larger than this fix.

Note on `--noconftest`: `test/unit_test/rag/conftest.py` stubs `deepdoc.parser.pdf_parser`
and breaks collection for several files in that directory with
`ImportError: cannot import name 'PlainParser'`. This is pre-existing and not changed here.

### Out of scope

The same truthiness pattern remains in `deepdoc/parser/mineru_parser.py`,
`somark_parser.py`, `tcadp_parser.py` and `rag/app/naive.py`. I did not trace whether an
empty upload reaches those, so I left them alone.
