### PR TITLE
Stop splitting resume documents into per-page parsing tasks

### DIFF
--- a/api/db/services/task_service.py
+++ b/api/db/services/task_service.py
@@ -494,6 +494,10 @@ def queue_tasks(doc: dict, bucket: str, name: str, priority: int):
         if doc["parser_id"] in ["one", "knowledge_graph", "resume"] or doc["parser_config"].get("toc_extraction", False) or is_mineru:
             page_size = MAXIMUM_TASK_PAGE_NUMBER
         page_ranges = doc["parser_config"].get("pages") or [(1, MAXIMUM_PAGE_NUMBER)]
+        if doc["parser_id"] == "resume":
+            # The resume parser ignores from_page and to_page, so every task parses the whole
+            # file. Collapse the configured ranges into one range to keep a resume document at a single task.
+            page_ranges = [(1, MAXIMUM_PAGE_NUMBER)]
         for s, e in page_ranges:
             s -= 1
             s = max(0, s)

--- a/api/db/services/task_service.py
+++ b/api/db/services/task_service.py
@@ -491,7 +491,7 @@ def queue_tasks(doc: dict, bucket: str, name: str, priority: int):
                 pass
         if is_mineru:
             logging.info("Document %s selected MinerU unsplit-task mode with page size %s", doc["id"], MAXIMUM_TASK_PAGE_NUMBER)
-        if doc["parser_id"] in ["one", "knowledge_graph"] or doc["parser_config"].get("toc_extraction", False) or is_mineru:
+        if doc["parser_id"] in ["one", "knowledge_graph", "resume"] or doc["parser_config"].get("toc_extraction", False) or is_mineru:
             page_size = MAXIMUM_TASK_PAGE_NUMBER
         page_ranges = doc["parser_config"].get("pages") or [(1, MAXIMUM_PAGE_NUMBER)]
         for s, e in page_ranges:

--- a/test/unit_test/api/db/services/test_task_service_queue_tasks.py
+++ b/test/unit_test/api/db/services/test_task_service_queue_tasks.py
@@ -1,0 +1,64 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from types import SimpleNamespace
+
+import pytest
+
+from api.db import FileType
+from api.db.services import task_service
+
+
+def _queue_tasks(monkeypatch, parser_id, parser_config):
+    queued_tasks = []
+    monkeypatch.setattr(task_service.settings, "STORAGE_IMPL", SimpleNamespace(get=lambda *_args: b"pdf"))
+    monkeypatch.setattr(task_service.PdfParser, "total_page_number", lambda *_args: 20)
+    monkeypatch.setattr(task_service.DocumentService, "get_chunking_config", lambda *_args: {})
+    monkeypatch.setattr(task_service.TaskService, "get_tasks", lambda *_args: [])
+    monkeypatch.setattr(task_service.DocumentService, "update_by_id", lambda *_args: None)
+    monkeypatch.setattr(task_service, "bulk_insert_into_db", lambda _model, tasks, _replace: queued_tasks.extend(tasks))
+    monkeypatch.setattr(task_service.DocumentService, "begin2parse", lambda *_args: None)
+    monkeypatch.setattr(task_service, "seed_doc_chunking_counter", lambda *_args: True)
+    monkeypatch.setattr(task_service.REDIS_CONN, "queue_product", lambda *_args, **_kwargs: True)
+
+    task_service.queue_tasks(
+        {
+            "id": "doc-id",
+            "name": "resume.pdf",
+            "type": FileType.PDF.value,
+            "parser_id": parser_id,
+            "parser_config": parser_config,
+        },
+        "bucket",
+        "resume.pdf",
+        0,
+    )
+    return queued_tasks
+
+
+@pytest.mark.p2
+def test_queue_tasks_collapses_multiple_page_ranges_for_resume(monkeypatch):
+    queued_tasks = _queue_tasks(monkeypatch, "resume", {"pages": [[1, 5], [10, 15]]})
+
+    assert len(queued_tasks) == 1
+    assert queued_tasks[0]["from_page"] == 0
+    assert queued_tasks[0]["to_page"] == 20
+
+
+@pytest.mark.p2
+def test_queue_tasks_keeps_multiple_page_ranges_for_naive(monkeypatch):
+    queued_tasks = _queue_tasks(monkeypatch, "naive", {"pages": [[1, 5], [10, 15]], "task_page_size": 12})
+
+    assert len(queued_tasks) > 1


### PR DESCRIPTION
### Summary

### What problem does this PR solve?

A multi-page PDF parsed with the resume parser is parsed once per page range, not once. The document's reported `chunk_num` and `token_num` come out multiplied, and the embedding work is repeated on identical content.

The resume parser does not support page bounds. `rag/app/resume.py:2482` takes `from_page` and `to_page`, and its own docstring says:

```
from_page: Start page number (not used in resume parsing)
to_page: End page number (not used in resume parsing)
```

The body calls `parse_resume(filename, binary, tenant_id, lang)` at line 2513, which takes no page bounds at all. It always parses the whole file.

`queue_tasks` (`api/db/services/task_service.py:472`) splits work by file type, not by parser:

```python
if doc["type"] == FileType.PDF.value:
    ...
    page_size = doc["parser_config"].get("task_page_size") or 12
    if doc["parser_id"] in ["one", "knowledge_graph"] or doc["parser_config"].get("toc_extraction", False):
        page_size = MAXIMUM_TASK_PAGE_NUMBER
```

That list already exists to force a single task for parsers that cannot handle a page slice. `resume` belongs in it and is missing.

`task_page_size` is user-settable and validated at `api/utils/validation_utils.py:467` with `ge=1`, so a dataset can be configured with a page size below the resume's page count. `queue_tasks` then creates one task per slice, and `rag/svr/task_executor.py` dispatches each to `FACTORY[ParserType.RESUME.value]`, which reparses the entire document every time.

The counters accumulate per task. `DocumentService.increment_chunk_num` (`api/db/services/document_service.py:766-772`) does:

```python
token_num=cls.model.token_num + token_num,
chunk_num=cls.model.chunk_num + chunk_num,
```

so N redundant tasks leave the document reporting N times its true `chunk_num` and `token_num` in the UI and API, and N times the embedding cost is spent.

Indexed content itself converges correctly, because chunk IDs are content-hashed. The damage is to the reported counters and to the wasted work, not to search results.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Change

Add `"resume"` to the parser list that already forces `MAXIMUM_TASK_PAGE_NUMBER`. One line.

A resume PDF now queues a single task, which matches what the parser actually does.

### Test

I did not add a test. `queue_tasks` reads storage, calls `PdfParser.total_page_number`, and writes tasks through the DB layer, so a unit test needs substantial mocking for a one-line addition to an existing list. The existing references to `queue_tasks` under `test/` are HTTP route tests, not unit tests of the split logic.

The change can be checked by reading: the resume parser ignores the bounds this split creates, and the list it is being added to exists for exactly that case.

`ruff check api/db/services/task_service.py`: All checks passed.

