### PR TITLE
feat(extractor): add inline 24h Redis LLM cache for keywords, questions, and summary

### DIFF
--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -638,6 +638,40 @@ func (c *ExtractorComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map
 	}, nil
 }
 
+// extractorLLMCacheKey builds a Redis key for textual extractions.
+func extractorLLMCacheKey(taskType, modelID, systemPrompt, text string) string {
+	h := xxhash.New()
+	h.WriteString(taskType)
+	h.WriteString("\x00")
+	h.WriteString(modelID)
+	h.WriteString("\x00")
+	h.WriteString(systemPrompt)
+	h.WriteString("\x00")
+	h.WriteString(text)
+	return fmt.Sprintf("kc:extractor:%s:%x", taskType, h.Sum64())
+}
+
+// callTextCached wraps callText with a 24-hour Redis cache.
+func (c *ExtractorComponent) callTextCached(ctx context.Context, db *gorm.DB, in extractorInputs, taskType, systemPrompt, chunkText string) (string, error) {
+	key := extractorLLMCacheKey(taskType, in.llmID, systemPrompt, chunkText)
+	if client := redis.Get(); client != nil {
+		if data, err := client.Get(ctx, key); err == nil && data != "" {
+			return data, nil
+		}
+	}
+	res, err := c.callText(ctx, db, in, systemPrompt, chunkText)
+	if err != nil {
+		return "", err
+	}
+	res = cleanExtractionResult(res)
+	if res != "" && !strings.Contains(res, "**ERROR**") {
+		if client := redis.Get(); client != nil {
+			client.Set(ctx, key, res, 24*time.Hour)
+		}
+	}
+	return res, nil
+}
+
 // runAutoKeywords extracts keywords for the current chunk and stores
 // them on ck["important_kwd"]. Keyword extraction pins
 // temperature to extractorTemperature (0.2) to mirror generator.py.
@@ -659,11 +693,10 @@ func (c *ExtractorComponent) runAutoKeywords(ctx context.Context, db *gorm.DB, i
 		llmID:       in.llmID,
 		temperature: &kwTemp,
 	}
-	resultStr, err := c.callText(ctx, db, kwIn, systemPrompt, chunkText)
+	resultStr, err := c.callTextCached(ctx, db, kwIn, "keywords", systemPrompt, chunkText)
 	if err != nil {
 		return err
 	}
-	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil
 	}
@@ -700,11 +733,10 @@ func (c *ExtractorComponent) runAutoQuestions(ctx context.Context, db *gorm.DB, 
 		llmID:       in.llmID,
 		temperature: &qTemp,
 	}
-	resultStr, err := c.callText(ctx, db, qIn, systemPrompt, chunkText)
+	resultStr, err := c.callTextCached(ctx, db, qIn, "questions", systemPrompt, chunkText)
 	if err != nil {
 		return err
 	}
-	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil
 	}
@@ -747,11 +779,10 @@ func (c *ExtractorComponent) runAutoSummary(ctx context.Context, db *gorm.DB, in
 		llmID:       in.llmID,
 		temperature: &sumTemp,
 	}
-	resultStr, err := c.callText(ctx, db, sumIn, systemPrompt, chunkText)
+	resultStr, err := c.callTextCached(ctx, db, sumIn, "summary", systemPrompt, chunkText)
 	if err != nil {
 		return err
 	}
-	resultStr = cleanExtractionResult(resultStr)
 	if resultStr == "" {
 		return nil
 	}

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -2076,3 +2076,73 @@ func TestExtractor_KeywordsThenTagsSynergy(t *testing.T) {
 		t.Fatalf("expected chunk text to NOT contain title when content is present, got %q", chunkText)
 	}
 }
+
+func TestExtractor_LLMCacheKey(t *testing.T) {
+	k1 := extractorLLMCacheKey("keywords", "modelA", "prompt1", "text1")
+	k2 := extractorLLMCacheKey("keywords", "modelA", "prompt1", "text1")
+	if k1 != k2 {
+		t.Errorf("extractorLLMCacheKey should be deterministic: %s != %s", k1, k2)
+	}
+
+	// Task type isolation
+	kQuestions := extractorLLMCacheKey("questions", "modelA", "prompt1", "text1")
+	if k1 == kQuestions {
+		t.Errorf("Different task types must produce different keys: %s == %s", k1, kQuestions)
+	}
+
+	// Model isolation
+	kModelB := extractorLLMCacheKey("keywords", "modelB", "prompt1", "text1")
+	if k1 == kModelB {
+		t.Errorf("Different models must produce different keys: %s == %s", k1, kModelB)
+	}
+
+	// NUL separator collision test ("ab", "c") vs ("a", "bc")
+	kColl1 := extractorLLMCacheKey("k", "m", "ab", "c")
+	kColl2 := extractorLLMCacheKey("k", "m", "a", "bc")
+	if kColl1 == kColl2 {
+		t.Errorf("NUL separator should prevent collisions: %s == %s", kColl1, kColl2)
+	}
+}
+
+func TestExtractor_CallTextCached_NoRedis_FailOpen(t *testing.T) {
+	stub := withStubChatInvoker(t,
+		stubResponse{Content: "Alpha, Beta"},
+		stubResponse{Content: "What is Alpha?\nWhat is Beta?"},
+		stubResponse{Content: "This is a summary without Redis."},
+	)
+
+	params := map[string]any{
+		"llm_id": "llm-test-noredis",
+		"keywords": map[string]any{
+			"top_n": 2,
+		},
+		"questions": map[string]any{
+			"top_n": 2,
+		},
+		"summary": map[string]any{
+			"enabled": true,
+		},
+	}
+	comp, err := NewExtractorComponent(params)
+	if err != nil {
+		t.Fatalf("NewExtractorComponent: %v", err)
+	}
+
+	in := map[string]any{
+		"chunks": []map[string]any{
+			{"text": "Sample text for fail open test."},
+		},
+	}
+
+	out, err := comp.Invoke(t.Context(), nil, in)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	if calls := stub.Calls(); calls != 3 {
+		t.Fatalf("Expected 3 LLM calls, got %d", calls)
+	}
+	ck := out["chunks"].([]map[string]any)[0]
+	if sum, ok := ck["summary"].(string); !ok || sum != "This is a summary without Redis." {
+		t.Errorf("got summary %v, want 'This is a summary without Redis.'", ck["summary"])
+	}
+}


### PR DESCRIPTION
### 📌 Summary

This PR adds a minimal, direct 24-hour Redis LLM cache to the Extractor component for textual extractions (`keywords`, `questions`, `summary`). 

Identical chunk extractions under the same task type, model, and system prompt now hit Redis directly within a 24-hour window, matching the behavior already present in `metadata` and `tagger` extractions without adding heavy abstraction layers or touching other modules.

---

### 🚀 Changes

1. **Inline Cache Helper (`extractor.go`)**:
   - `extractorLLMCacheKey(taskType, modelID, systemPrompt, text)` creates Redis keys using xxhash: `kc:extractor:{taskType}:{hash}`.
   - `callTextCached`: checks Redis for cached results; on cache miss, invokes LLM via `callText(ctx, db, in, systemPrompt, chunkText)`, cleans the output, and writes back to Redis for 24 hours.
2. **Extractor Integration**:
   - `runAutoKeywords`, `runAutoQuestions`, `runAutoSummary` now use `callTextCached`.
3. **Unit Tests (`extractor_test.go`)**:
   - Added `TestExtractor_LLMCacheKey` (testing key determinism, task/model isolation, and NUL delimiter collision prevention).
   - Added `TestExtractor_CallTextCached_NoRedis_FailOpen` (testing graceful fallback when Redis is absent).

---

### 🧪 Verification

- `./build.sh --test ./internal/ingestion/component` -> **100% PASS**
