### PR TITLE
fix(setting-model): stop silently dropping a duplicate-named provider  instance

### DIFF
--- a/web/src/hooks/use-llm-request.tsx
+++ b/web/src/hooks/use-llm-request.tsx
@@ -299,19 +299,8 @@ export const useAddProviderInstance = () => {
     ) => {
       try {
         await addProvider({ provider_name: params.llm_factory });
-
-        const { data: instancesRes } = await llmService.listProviderInstances(
-          { provider_name: params.llm_factory },
-          true,
-        );
-        const instanceExists = instancesRes?.data?.some(
-          (i: IProviderInstance) => i.instance_name === params.instance_name,
-        );
-        if (instanceExists && !params.verify) {
-          return { code: 0, data: null };
-        }
       } catch {
-        // ignore list failure and proceed to add
+        // ignore and proceed to add
       }
 
       // The provider is carried in the URL path

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -2020,6 +2020,7 @@ Example: Virtual Hosted Style`,
       instanceNameTip:
         'A unique name to identify this provider instance under the same factory.',
       instanceNamePlaceholder: 'Please input instance name',
+      instanceNameExists: 'Instance name already exists',
       deleteInstance: 'Delete instance',
       modelName: 'Model name',
       modelID: 'Model ID',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1700,6 +1700,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
       instanceNameMessage: '请输入实例名称！',
       instanceNameTip: '用于在同一厂商下唯一标识该实例的名称。',
       instanceNamePlaceholder: '请输入实例名称',
+      instanceNameExists: '实例名称已存在',
       deleteInstance: '删除实例',
       modelName: '模型名称',
       modelID: '模型ID',

--- a/web/src/pages/user-setting/setting-model/index.tsx
+++ b/web/src/pages/user-setting/setting-model/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import Spotlight from '@/components/spotlight';
+import message from '@/components/ui/message';
 import { useTranslate } from '@/hooks/common-hooks';
 import {
   LlmKeys,
@@ -180,6 +181,21 @@ const SettingModelV2: FC = () => {
       .filter((e) => e.payload !== null);
     if (dirty.length === 0) return;
 
+    // Reject duplicate instance names before any API call: a draft may
+    // not reuse the name of a persisted instance, nor of another draft
+    // in the same batch. Without this the backend would either error or
+    // silently create a second instance sharing the name.
+    const takenNames = new Set(instances.map((i) => i.instance_name));
+    for (const { payload } of dirty) {
+      if (!payload) continue;
+      const name = payload.instanceName.trim();
+      if (payload.isDraft && takenNames.has(name)) {
+        message.error(tSetting('instanceNameExists'));
+        return;
+      }
+      takenNames.add(name);
+    }
+
     const validations = await Promise.all(
       dirty.map(async (e) => ({ ...e, valid: await e.ref.validate() })),
     );
@@ -237,6 +253,8 @@ const SettingModelV2: FC = () => {
     updateProviderInstance,
     queryClient,
     providerQueryName,
+    instances,
+    tSetting,
   ]);
 
   // Whether the Save button should be enabled. We avoid an O(n) ref


### PR DESCRIPTION
### Summary


fix(setting-model): stop silently dropping a duplicate-named provider  instance

Adding an instance whose name matched an already-saved one never reached the server: useAddProviderInstance pre-listed the instances and returned a fake `{ code: 0 }` on a name collision, so the POST was skipped while the page treated the save as successful and cleared the draft card. The new instance vanished with no feedback.

Drop the pre-flight check and reject the collision up front in the batch save handler instead, so the user sees "instance name already exists" and no request is issued. Living in the parent it also covers Bedrock cards and two drafts sharing a name within one batch.


