### PR TITLE
fix(web): chat settings panel overlapped by chat input on narrow viewports

### DIFF
--- a/web/src/pages/next-chats/chat/index.tsx
+++ b/web/src/pages/next-chats/chat/index.tsx
@@ -111,7 +111,7 @@ export default function Chat() {
 
           <Card className="flex-1 min-w-0 bg-transparent border-none shadow-none h-full">
             <CardContent className="flex p-0 h-full">
-              <Card className="flex flex-col flex-1 bg-transparent min-w-0">
+              <Card className="flex flex-col flex-1 bg-transparent min-w-0 overflow-hidden">
                 <CardHeader
                   className={cn('p-5', {
                     'border-b-0.5 border-border-button': hasSingleChatBox,


### PR DESCRIPTION
### Summary

On the chat detail page (`/chat/:id`), when the **聊天设置 (chat settings)** panel is open on a narrow viewport (small browser window, high zoom level — e.g. 110%), the underlying chat page bleeds through into the settings panel: the chat input toolbar (paperclip / thinking-level "Low" select / mic / send), the input's drag-resize handle and the message list scrollbar are painted on top of the settings panel's lower-left area.

Root cause: the layout row is `sessions sidebar (296px) | chat column (flex-1 min-w-0) | ChatSettings panel (440px, flex-shrink-0)`. On a narrow viewport the chat column is squeezed to less than the message input toolbar's min-content width (~220px). The toolbar then overflows the chat column Card horizontally, and because the message input `<form>` is `position: relative` (with a `z-10` resize handle) while the settings `<section>` is statically positioned, the overflowing content paints **above** the settings panel.

Fix: add `overflow-hidden` to the chat column Card in `web/src/pages/next-chats/chat/index.tsx` so its content is clipped at the column boundary. This mirrors the `overflow-hidden` the ChatSettings panel section already applies to itself for the same class of problem, and is a one-class, layout-preserving change.

Verification:
- Reproduced the original bleed at 880×700 (send button hit-tested inside the panel region, 46px past the panel's left edge).
- After the fix, hit-testing (`document.elementFromPoint`) across the settings panel at 800/880/1440 px widths returns only panel elements; the wide (1440px) layout is unchanged (send button fully left of the panel, textarea unclipped).
- `npx oxlint src/pages/next-chats/chat/index.tsx` clean; `npm run type-check` clean.
