### PR TITLE
fix(web): stop saving fractional values for agent integer parameters

### DIFF
--- a/web/src/components/message-history-window-size-item.tsx
+++ b/web/src/components/message-history-window-size-item.tsx
@@ -44,7 +44,12 @@ export function MessageHistoryWindowSizeFormField({
             {t('flow.messageHistoryWindowSize')}
           </FormLabel>
           <FormControl>
-            <NumberInput {...field} min={min} className="w-full"></NumberInput>
+            <NumberInput
+              {...field}
+              min={min}
+              integer
+              className="w-full"
+            ></NumberInput>
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/web/src/components/originui/__tests__/number-input.test.tsx
+++ b/web/src/components/originui/__tests__/number-input.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render } from '@testing-library/react';
+import NumberInput from '../number-input';
+
+function getNumberInput(container: HTMLElement) {
+  return container.querySelector('input[type="number"]') as HTMLInputElement;
+}
+
+function getStepButtons(container: HTMLElement) {
+  const buttons = Array.from(
+    container.querySelectorAll('button'),
+  ) as HTMLButtonElement[];
+  return { decrement: buttons[0], increment: buttons[1] };
+}
+
+describe('NumberInput', () => {
+  describe('integer mode', () => {
+    it('propagates the rounded integer while a fractional value is typed', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <NumberInput value={12} integer onChange={onChange} />,
+      );
+      const input = getNumberInput(container);
+
+      fireEvent.change(input, { target: { value: '122.1' } });
+
+      expect(input.value).toBe('122.1');
+      expect(onChange).toHaveBeenCalledWith(122);
+    });
+
+    it('finalizes a fractional value to an integer on blur', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <NumberInput value={12} integer onChange={onChange} />,
+      );
+      const input = getNumberInput(container);
+
+      fireEvent.change(input, { target: { value: '122.1' } });
+      fireEvent.blur(input);
+
+      expect(input.value).toBe('122');
+      expect(onChange).toHaveBeenLastCalledWith(122);
+    });
+
+    it('clamps out-of-range values to max after rounding on blur', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <NumberInput value={3} min={0} max={8} integer onChange={onChange} />,
+      );
+      const input = getNumberInput(container);
+
+      fireEvent.change(input, { target: { value: '31.1' } });
+      fireEvent.blur(input);
+
+      expect(input.value).toBe('8');
+      expect(onChange).toHaveBeenLastCalledWith(8);
+    });
+
+    it('heals a fractional initial value by propagating the rounded integer', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <NumberInput value={12.5} integer onChange={onChange} />,
+      );
+      const input = getNumberInput(container);
+
+      expect(input.value).toBe('13');
+      expect(onChange).toHaveBeenCalledWith(13);
+    });
+
+    it('heals an out-of-range fractional initial value by clamping', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <NumberInput value={31.1} min={0} max={8} integer onChange={onChange} />,
+      );
+      const input = getNumberInput(container);
+
+      expect(input.value).toBe('8');
+      expect(onChange).toHaveBeenCalledWith(8);
+    });
+
+    it('steps from a rounded base value', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <NumberInput value={2} min={0} integer onChange={onChange} />,
+      );
+      const input = getNumberInput(container);
+      const { increment, decrement } = getStepButtons(container);
+
+      fireEvent.change(input, { target: { value: '2.6' } });
+      fireEvent.click(increment);
+
+      expect(input.value).toBe('4');
+      expect(onChange).toHaveBeenLastCalledWith(4);
+
+      fireEvent.click(decrement);
+
+      expect(input.value).toBe('3');
+      expect(onChange).toHaveBeenLastCalledWith(3);
+    });
+  });
+
+  it('keeps propagating fractional values when integer mode is off', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <NumberInput value={1} max={5} onChange={onChange} />,
+    );
+    const input = getNumberInput(container);
+
+    fireEvent.change(input, { target: { value: '4.8' } });
+    fireEvent.blur(input);
+
+    expect(input.value).toBe('4.8');
+    expect(onChange).toHaveBeenLastCalledWith(4.8);
+  });
+});

--- a/web/src/components/originui/number-input.tsx
+++ b/web/src/components/originui/number-input.tsx
@@ -21,6 +21,8 @@ interface NumberInputProps {
   min?: number;
   max?: number;
   hideIcons?: boolean;
+  // When true, only integers are propagated to the form: fractional values are
+  // rounded while typing/pasting and on blur, so decimals can never be saved.
   integer?: boolean;
   inputClassName?: string;
   precision?: number;
@@ -70,16 +72,32 @@ const NumberInput = forwardRef<
 
   const valueRef = useRef<number>();
 
+  const normalize = useCallback(
+    (v: number) => (integer ? Math.round(v) : v),
+    [integer],
+  );
+
   useEffect(() => {
     if (initialValue !== undefined) {
-      setValue(initialValue);
+      if (integer && isNumber(initialValue)) {
+        // Heal fractional or out-of-range values saved by older builds so
+        // they are never re-persisted as decimals.
+        const clamped = Math.min(Math.max(Math.round(initialValue), min), max);
+        setValue(clamped);
+        if (clamped !== initialValue) {
+          onChange?.(clamped);
+        }
+      } else {
+        setValue(initialValue);
+      }
     }
-  }, [initialValue]);
+  }, [initialValue, integer, min, max, onChange]);
 
   const handleDecrement = () => {
     if (isNumber(value) && value > min) {
-      setValue(value - 1);
-      onChange?.(value - 1);
+      const nextValue = Math.max(normalize(value) - 1, min);
+      setValue(nextValue);
+      onChange?.(nextValue);
     }
   };
 
@@ -87,11 +105,12 @@ const NumberInput = forwardRef<
     if (!isNumber(value)) {
       return;
     }
-    if (value > max - 1) {
+    const base = normalize(value);
+    if (base > max - 1) {
       return;
     }
-    setValue(value + 1);
-    onChange?.(value + 1);
+    setValue(base + 1);
+    onChange?.(base + 1);
   };
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
@@ -126,18 +145,14 @@ const NumberInput = forwardRef<
         e.target.value = String(limitedValue);
       }
 
-      // Pasted decimals bypass the keydown guard; reject them in integer
-      // mode instead of rounding silently.
-      if (integer && !Number.isInteger(newValue)) {
-        return;
-      }
       // Show the raw typed value as-is, even when it falls outside [min, max]
       // (e.g. deleting "1024" → "102" when min=512), so the controlled input
       // never snaps back mid-edit. Out-of-range values are not propagated to
       // the form; handleBlur clamps them into range on focus loss.
       setValue(limitedValue);
-      if (limitedValue >= min && limitedValue <= max) {
-        onChange?.(limitedValue);
+      const propagated = normalize(limitedValue);
+      if (propagated >= min && propagated <= max) {
+        onChange?.(propagated);
       }
     }
   };
@@ -145,10 +160,10 @@ const NumberInput = forwardRef<
   const handleBlur: FocusEventHandler<HTMLInputElement> = useCallback(
     (e) => {
       if (isNumber(value)) {
-        let finalValue = value;
-        if (value < min) {
+        let finalValue = normalize(value);
+        if (finalValue < min) {
           finalValue = min;
-        } else if (value > max) {
+        } else if (finalValue > max) {
           finalValue = max;
         }
         if (finalValue !== value) {
@@ -156,11 +171,10 @@ const NumberInput = forwardRef<
         }
         onChange?.(finalValue);
       } else {
-        const previousValue = valueRef.current ?? min;
-        let finalValue = previousValue;
-        if (previousValue < min) {
+        let finalValue = normalize(valueRef.current ?? min);
+        if (finalValue < min) {
           finalValue = min;
-        } else if (previousValue > max) {
+        } else if (finalValue > max) {
           finalValue = max;
         }
         setValue(finalValue);
@@ -171,7 +185,7 @@ const NumberInput = forwardRef<
       // spread below cannot silently replace this handler.
       onBlurProp?.(e);
     },
-    [min, max, onChange, onBlurProp, value],
+    [min, max, onChange, onBlurProp, value, normalize],
   );
 
   const style = useMemo(

--- a/web/src/pages/agent/form/agent-form/index.tsx
+++ b/web/src/pages/agent/form/agent-form/index.tsx
@@ -15,7 +15,8 @@ import {
   FormItem,
   FormLabel,
 } from '@/components/ui/form';
-import { Input, NumberInput } from '@/components/ui/input';
+import NumberInput from '@/components/originui/number-input';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
@@ -236,7 +237,13 @@ function AgentForm({ node }: INextOperatorForm) {
                   <FormItem className="flex-1">
                     <FormLabel>{t('flow.maxRetries')}</FormLabel>
                     <FormControl>
-                      <NumberInput {...field} max={8} min={0}></NumberInput>
+                      <NumberInput
+                        {...field}
+                        max={8}
+                        min={0}
+                        integer
+                        className="w-full"
+                      ></NumberInput>
                     </FormControl>
                   </FormItem>
                 )}
@@ -248,7 +255,12 @@ function AgentForm({ node }: INextOperatorForm) {
                   <FormItem className="flex-1">
                     <FormLabel>{t('flow.delayAfterError')}</FormLabel>
                     <FormControl>
-                      <NumberInput {...field} max={5} step={0.1}></NumberInput>
+                      <NumberInput
+                        {...field}
+                        max={5}
+                        step={0.1}
+                        className="w-full"
+                      ></NumberInput>
                     </FormControl>
                   </FormItem>
                 )}
@@ -279,7 +291,12 @@ function AgentForm({ node }: INextOperatorForm) {
                     <FormItem className="flex-1">
                       <FormLabel>{t('flow.maxRounds')}</FormLabel>
                       <FormControl>
-                        <NumberInput {...field} min={0}></NumberInput>
+                        <NumberInput
+                          {...field}
+                          min={0}
+                          integer
+                          className="w-full"
+                        ></NumberInput>
                       </FormControl>
                     </FormItem>
                   )}

--- a/web/src/pages/agent/form/agent-form/use-values.ts
+++ b/web/src/pages/agent/form/agent-form/use-values.ts
@@ -12,6 +12,26 @@ function omitToolsAndMcp(values: Record<string, any>) {
   return omit(values, ['mcp', 'tools', 'outputs']);
 }
 
+// The backend expects non-negative integers for these fields. Canvases saved
+// by older builds may hold fractional values; round them on load so they are
+// displayed and re-saved as integers.
+const INTEGER_FIELDS = [
+  'message_history_window_size',
+  'max_retries',
+  'max_rounds',
+] as const;
+
+function toIntegerValues(values: Record<string, any>) {
+  const next = { ...values };
+  for (const key of INTEGER_FIELDS) {
+    const v = next[key];
+    if (typeof v === 'number' && !Number.isInteger(v)) {
+      next[key] = Math.round(v);
+    }
+  }
+  return next;
+}
+
 export function useValues(node?: RAGFlowNodeType) {
   const defaultModelDictionary = useFetchDefaultModelDictionary();
 
@@ -32,7 +52,7 @@ export function useValues(node?: RAGFlowNodeType) {
     }
 
     return {
-      ...omitToolsAndMcp(formData),
+      ...toIntegerValues(omitToolsAndMcp(formData)),
       tool_timeout: get(formData, 'tool_timeout', 10),
       prompts: get(formData, 'prompts.0.content', ''),
     };


### PR DESCRIPTION
### Summary

The Agent component's advanced settings let fractional values be saved for parameters the backend requires as integers. As reported in the Feishu group ("智能体 agent 高级设置 保存了小数参数"), a saved Agent node showed 历史消息窗口大小 (message window size) = 122.1, 最大重试轮数 (max retry rounds) = 31.1, 错误后延迟 (delay after error) = 14.8 and 最大反思轮数 (max reflect rounds) = 11.1.

**Root cause**

- `message_history_window_size` was rendered with the originui `NumberInput`, which propagates any value inside `[min, max]` — and this field has no `max`, so every decimal (e.g. `122.1`) was written to the canvas DSL and persisted on save.
- `max_retries` / `delay_after_error` / `max_rounds` were rendered with the `ui/input` `NumberInput`, a thin wrapper that propagates raw `Number(value)` with no clamping or integer enforcement at all (`min`/`max` only land as inert DOM attributes), which is how out-of-range values such as `31.1` and `14.8` got saved by builds before the bounds existed.
- Nothing downstream corrected this: the zod schema uses plain `z.coerce.number()` and `useWatchFormChange` persists whatever the form holds.
- The Python runtime already rejects these values at run time (`agent/component/llm.py` validates `max_retries` / `max_rounds` as non-negative integers, added in #18051), so a canvas saved with decimals fails when run. This PR prevents the invalid data from being saved in the first place, which is the complementary frontend half of #18051 rather than a resubmission of it.

**Fix**

- `web/src/components/originui/number-input.tsx`: new opt-in `integer` mode — fractional input is rounded before it is propagated to the form (typing `122.1` saves `122`), out-of-range values clamp on blur (`31.1` → `8` with `max=8`), steppers step from a rounded base, and a fractional/out-of-range legacy value is healed (rounded + clamped and propagated) on mount.
- `web/src/components/message-history-window-size-item.tsx`: the shared window-size field (used by the Agent, Categorize and Rewrite-question forms) is now `integer`.
- `web/src/pages/agent/form/agent-form/index.tsx`: the advanced-settings number fields now use the clamping originui `NumberInput`; `max_retries` and `max_rounds` are `integer`. `delay_after_error` intentionally keeps fractional support (delay in seconds, step 0.1, backend default 2.0) with its 0–5 range enforced.
- `web/src/pages/agent/form/agent-form/use-values.ts`: legacy fractional values of the integer fields are rounded when node data is loaded, so already-saved canvases display and re-save as integers.

**Verification**

- Reproduced before the fix in a local canvas: entering `122.1` in the agent's message window size and saving persisted `message_history_window_size: 122.1` (and a previous session had persisted `max_retries: 2.5`) in the saved DSL.
- After the fix (browser, same canvas): legacy `122.1` / `2.5` are displayed healed as `122` / `3`; entering `122.9` propagates `123`; entering `31.1` in max retry rounds clamps to `8` on blur; after saving, the server DSL contains only integers (`123 / 8 / 1 / 1`).
- New unit tests: `web/src/components/originui/__tests__/number-input.test.tsx` (7 cases: rounding on typing, blur finalization, clamping, legacy heal, stepper behavior, fractional passthrough when integer mode is off) — all pass. `npx oxlint` clean on all changed files; `tsc --noEmit` reports no new errors in changed files.
