### PR TITLE
fix(web): stop RAGFlow brand block from overlapping embedded share header

### DIFF
--- a/web/src/components/embed-container.tsx
+++ b/web/src/components/embed-container.tsx
@@ -38,10 +38,6 @@ export function EmbedContainer({
 
   return (
     <section className="h-[100vh] flex justify-center items-center">
-      <div className="hidden xl:flex w-40 gap-2 absolute left-3 top-12 items-center">
-        <img src="/logo.svg" alt="" />
-        <span className="text-2xl font-bold">{appConf.appName}</span>
-      </div>
       <div className="w-full h-full md:w-[80vw] md:h-auto border-0 md:border rounded-none md:rounded-lg">
         <div className="flex justify-between items-center border-b p-3 relative">
           <div className="flex gap-2 items-center absolute left-1/2 -translate-x-1/2 md:static md:left-auto md:translate-x-0">
@@ -53,8 +49,11 @@ export function EmbedContainer({
             />
             <div className="md:text-xl text-foreground">{title}</div>
           </div>
-          <div className="flex md:hidden items-center">
-            <img src="/logo.svg" alt="" className="h-6" />
+          <div className="flex items-center gap-2 md:ml-auto md:mr-3">
+            <img src="/logo.svg" alt="" className="h-6 md:h-8" />
+            <span className="hidden md:inline-block text-lg font-bold text-foreground">
+              {appConf.appName}
+            </span>
           </div>
           {hideReset || (
             <Button


### PR DESCRIPTION
### Summary

Fixes the "RAGFlow" text clipping/overlapping reported on the agent embedded/share page (`/agent/share?shared_id=...`).

**Background**

`EmbedContainer` (shared by the agent share page and the chat share page) rendered the RAGFlow brand — logo + app name — as an absolutely-positioned block:

```tsx
<div className="hidden xl:flex w-40 gap-2 absolute left-3 top-12 items-center">
  <img src="/logo.svg" alt="" />
  <span className="text-2xl font-bold">{appConf.appName}</span>
</div>
```

The chat card it decorates is centered at `md:w-[80vw]`, so its left margin is only `10vw` (128px at a 1280px viewport). The floating brand block is 160px wide (`w-40`) starting at `left-3` (12px) and therefore ends at 172px — 44px past the card's left edge. At xl viewports (including effective widths after browser zoom, as in the report) the logo and "RAGFlow" text sit on top of the card header (border + avatar/title row) instead of beside it.

Reproduced at 1280×800 via `getBoundingClientRect()`: brand block `x=12..172, y=48..82` vs. card header `x=129..1151, y=-4.5..60.5` → a 43×12.5px overlap.

**Fix**

- Remove the absolutely-positioned brand block.
- Render the brand inside the header row, right-aligned before the Reset button: logo icon at all sizes (`h-6 md:h-8`), app-name text `hidden md:inline-block` so mobile keeps the icon-only look.
- Mobile layout is unchanged: icon-only logo on the left, centered avatar/title, Reset on the right.

**Verification**

- Browser check on `/agent/share` (published agent) at 1600px, 1280px and 500px viewports: no absolutely-positioned brand block remains; header children (avatar/title, brand, Reset) have zero bounding-box overlaps and nothing overflows the header row; on mobile the app-name span is `display:none` as intended.
- `oxlint src/components/embed-container.tsx`: 0 warnings / 0 errors.
- `tsc --noEmit`: no errors in the changed file (the remaining repo-wide errors are pre-existing on main and unrelated to this change).
