### PR TITLE
fix(agent): stop persisting empty Message entries from the agent form

### DIFF
--- a/web/src/pages/agent/form/message-form/index.tsx
+++ b/web/src/pages/agent/form/message-form/index.tsx
@@ -35,7 +35,7 @@ function MessageForm({ node }: INextOperatorForm) {
     content: z
       .array(
         z.object({
-          value: z.string(),
+          value: z.string().min(1, t('flow.messageMsg')),
         }),
       )
       .optional(),
@@ -47,6 +47,7 @@ function MessageForm({ node }: INextOperatorForm) {
   });
 
   const form = useForm({
+    mode: 'onChange',
     defaultValues: {
       ...values,
       output_format: values.output_format,
@@ -87,6 +88,7 @@ function MessageForm({ node }: INextOperatorForm) {
                           placeholder={t('flow.messagePlaceholder')}
                         ></PromptEditor>
                       </FormControl>
+                      <FormMessage />
                     </FormItem>
                   )}
                 />

--- a/web/src/pages/agent/form/message-form/use-watch-change.ts
+++ b/web/src/pages/agent/form/message-form/use-watch-change.ts
@@ -15,7 +15,11 @@ export function useWatchFormChange(id?: string, form?: UseFormReturn) {
 
       nextValues = {
         ...values,
-        content: convertToStringArray(values.content),
+        // Empty message entries must never reach the canvas DSL: the
+        // backend rejects all-empty content and blank entries are junk.
+        content: convertToStringArray(values.content).filter(
+          (x) => typeof x === 'string' && x.trim().length > 0,
+        ),
       };
 
       updateNodeForm(id, nextValues);


### PR DESCRIPTION
# Summary

## Background

In the Agent canvas (e.g. the "Beginner chat assistant" template), the Message component lets users append extra message cards via "Add message". Each card that was left empty was nevertheless synced into the canvas DSL and persisted, so junk empty entries accumulated in `params.content` and reappeared on every reload (see the reported screenshot: one real message plus several empty cards saved on `Message_0`).

The backend already guards the runtime side — `agent/component/message.py` (`_valid_message_content`, added in #18676) ignores blank entries and `MessageParam.check()` rejects content that is empty after filtering — but nothing prevented blank entries from being written into the saved DSL in the first place.

## What this PR does

Frontend-only fix in the Message form (`web/src/pages/agent/form/message-form/`):

- `use-watch-change.ts`: drop empty / whitespace-only strings from `content` before syncing form values into the canvas store, so blank cards never reach the persisted DSL (manual Save and autosave both go through this path).
- `index.tsx`: tighten the zod schema to `z.string().min(1)` with the existing `flow.messageMsg` message, switch the form to `mode: 'onChange'`, and render `<FormMessage />` under each message editor so an emptied card visibly flags "Please input message or delete this field." instead of failing silently.

Empty cards remain visible (and editable) in the open form — the user can still fill or delete them — but they are no longer persisted.

## How it was verified

- Reproduced on the running stack: a Message node saved under the old code held `content: ["hello world", ""]`; the junk empty card reappeared on reload.
- With the fix: clicked "Add message" (2 empty cards in the form) → Save → captured the outgoing `PUT /api/v1/agents/:id` payload: `content: ["hello world"]` — the empty entries were dropped before persistence.
- Reloaded the agent: the Message panel shows exactly one card; a backend GET of the canvas confirms `content: ["hello world"]`.
- `oxlint` on the changed files passes (one pre-existing useEffect dependency warning that also exists on main); `npm run type-check` passes.

No backend behavior is changed; this complements (does not overlap) the runtime-side validation from #18676.
