### PR TITLE
fix(chat): propagate mind map stream failures

### DIFF
--- a/internal/handler/mindmap.go
+++ b/internal/handler/mindmap.go
@@ -72,24 +72,37 @@ func runMindMap(ctx context.Context, config mindMapRunConfig) (mindMapNode, erro
 	// composite-name parsing which fails for bare IDs. If the configured
 	// model can't be resolved, fall back to the tenant's default chat model
 	// (mirrors Python's gen_mindmap get_tenant_default_model_by_type).
-	ch, _, streamErr := config.LLM.ChatStream(streamCtx, modelTenantID, modelID, messages, &modelModule.ChatConfig{})
+	ch, streamErrs, streamErr := config.LLM.ChatStream(streamCtx, modelTenantID, modelID, messages, &modelModule.ChatConfig{})
 	if streamErr != nil && config.TenantSvc != nil {
 		if defaultModel, err := config.TenantSvc.GetDefaultModelName(streamCtx, modelTenantID, entity.ModelTypeChat); err == nil && defaultModel != "" && defaultModel != modelID {
-			ch, _, streamErr = config.LLM.ChatStream(streamCtx, modelTenantID, defaultModel, messages, &modelModule.ChatConfig{})
+			ch, streamErrs, streamErr = config.LLM.ChatStream(streamCtx, modelTenantID, defaultModel, messages, &modelModule.ChatConfig{})
 		}
 	}
 	if streamErr != nil {
 		return mindMapNode{}, streamErr
 	}
-	var sb strings.Builder
-	for delta := range ch {
-		sb.WriteString(delta)
+	fullText, err := collectMindMapStream(streamCtx, ch, streamErrs)
+	if err != nil {
+		return mindMapNode{}, err
 	}
-	fullText := sb.String()
 	if strings.TrimSpace(fullText) == "" {
 		return mindMapNode{ID: "root", Children: []mindMapNode{}}, nil
 	}
 	return parseMindMapMarkdown(fullText), nil
+}
+
+func collectMindMapStream(ctx context.Context, chunks <-chan string, streamErrs <-chan error) (string, error) {
+	var sb strings.Builder
+	for chunk := range chunks {
+		sb.WriteString(chunk)
+	}
+	if err := <-streamErrs; err != nil {
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
 }
 
 func searchConfigFromDetail(detail map[string]interface{}) map[string]interface{} {

--- a/internal/handler/mindmap.go
+++ b/internal/handler/mindmap.go
@@ -72,14 +72,14 @@ func runMindMap(ctx context.Context, config mindMapRunConfig) (mindMapNode, erro
 	// composite-name parsing which fails for bare IDs. If the configured
 	// model can't be resolved, fall back to the tenant's default chat model
 	// (mirrors Python's gen_mindmap get_tenant_default_model_by_type).
-	ch, streamErrs, streamErr := config.LLM.ChatStream(streamCtx, modelTenantID, modelID, messages, &modelModule.ChatConfig{})
-	if streamErr != nil && config.TenantSvc != nil {
+	ch, streamErrs, findChatModelErr := config.LLM.ChatStream(streamCtx, modelTenantID, modelID, messages, &modelModule.ChatConfig{})
+	if findChatModelErr != nil && config.TenantSvc != nil {
 		if defaultModel, err := config.TenantSvc.GetDefaultModelName(streamCtx, modelTenantID, entity.ModelTypeChat); err == nil && defaultModel != "" && defaultModel != modelID {
-			ch, streamErrs, streamErr = config.LLM.ChatStream(streamCtx, modelTenantID, defaultModel, messages, &modelModule.ChatConfig{})
+			ch, streamErrs, findChatModelErr = config.LLM.ChatStream(streamCtx, modelTenantID, defaultModel, messages, &modelModule.ChatConfig{})
 		}
 	}
-	if streamErr != nil {
-		return mindMapNode{}, streamErr
+	if findChatModelErr != nil {
+		return mindMapNode{}, findChatModelErr
 	}
 	fullText, err := collectMindMapStream(streamCtx, ch, streamErrs)
 	if err != nil {

--- a/internal/handler/mindmap_test.go
+++ b/internal/handler/mindmap_test.go
@@ -16,7 +16,59 @@
 
 package handler
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCollectMindMapStream(t *testing.T) {
+	t.Run("joins successful chunks", func(t *testing.T) {
+		chunks := make(chan string, 2)
+		chunks <- "# Title"
+		chunks <- "\n## Section"
+		close(chunks)
+		streamErrs := make(chan error)
+		close(streamErrs)
+
+		got, err := collectMindMapStream(context.Background(), chunks, streamErrs)
+		if err != nil {
+			t.Fatalf("collect stream: %v", err)
+		}
+		if got != "# Title\n## Section" {
+			t.Fatalf("unexpected stream content: %q", got)
+		}
+	})
+
+	t.Run("returns asynchronous provider error after partial output", func(t *testing.T) {
+		providerErr := errors.New("provider stream failed")
+		chunks := make(chan string, 1)
+		chunks <- "# Partial"
+		close(chunks)
+		streamErrs := make(chan error, 1)
+		streamErrs <- providerErr
+		close(streamErrs)
+
+		_, err := collectMindMapStream(context.Background(), chunks, streamErrs)
+		if !errors.Is(err, providerErr) {
+			t.Fatalf("expected provider error, got %v", err)
+		}
+	})
+
+	t.Run("returns canceled context after channels close", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		chunks := make(chan string)
+		close(chunks)
+		streamErrs := make(chan error)
+		close(streamErrs)
+
+		_, err := collectMindMapStream(ctx, chunks, streamErrs)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	})
+}
 
 // The mind map contract: when there is nothing to map, the backend returns an
 // honest empty tree (root with no children) and the frontend renders an empty


### PR DESCRIPTION
### Summary

Mind map generation currently discards the asynchronous error channel returned by `ChatStream`. When a provider fails after emitting partial Markdown, the handler parses and returns an incomplete tree as a successful response.

This change consumes the active error channel for both the configured and fallback models, propagates provider failures, and surfaces cancellation or deadline errors after the stream closes. Successful stream behavior remains unchanged.

Follow-up to https://github.com/infiniflow/ragflow/pull/18615#discussion_r3828866157

### Testing

- Added deterministic tests for successful chunk collection.
- Added coverage for partial output followed by an asynchronous provider error.
- Added coverage for cancellation after stream channels close.
- `gofmt` and `git diff --check` passed.
- Local package execution is blocked before test startup by existing Windows native dependencies; Linux CI will provide package-level confirmation.