### PR TITLE
fix(agent): panic and raw error when auto play runs without a default TTS model

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -656,8 +656,15 @@ class Canvas(Graph):
                 cpn_obj = self.get_component_obj(self.path[i])
                 if cpn_obj.component_name.lower() == "message":
                     if cpn_obj.get_param("auto_play"):
-                        tts_model_config = get_tenant_default_model_by_type(self._tenant_id, LLMType.TTS)
-                        tts_mdl = LLMBundle(self._tenant_id, tts_model_config)
+                        try:
+                            tts_model_config = get_tenant_default_model_by_type(self._tenant_id, LLMType.TTS)
+                            tts_mdl = LLMBundle(self._tenant_id, tts_model_config)
+                        except Exception as e:
+                            # A missing/unresolvable default TTS model must not
+                            # fail the whole run: skip auto play and keep the
+                            # textual answer flowing.
+                            _logger.warning("Auto play skipped: default TTS model is not available: %s", e)
+                            tts_mdl = None
                     if isinstance(cpn_obj.output("content"), partial):
                         _m = ""
                         buff_m = ""

--- a/internal/agent/audio/tts_dispatch.go
+++ b/internal/agent/audio/tts_dispatch.go
@@ -77,8 +77,10 @@ type TTSDispatcher interface {
 //
 //   - ModelProviderRequest.ModelName (from req.Engine)  → modelName
 //     The Engine field is repurposed as a model identifier hint
-//     in the audio package's contract. Empty falls through to the
-//     model's default TTS model.
+//     in the audio package's contract. Built-in engine selectors
+//     ("gtts" / "edge-tts" / "custom") and an empty hint fall
+//     through to the tenant's default TTS model; any other value
+//     is passed as an explicit model name to the by-name lookup.
 //   - Text  → audioContent
 //   - Voice → TTSConfig.Params["voice"]
 //   - Lang  → TTSConfig.Params["lang"]
@@ -94,11 +96,17 @@ func NewTTSDispatchFunc(d TTSDispatcher) ModelProviderFunc {
 		return nil
 	}
 	return func(ctx context.Context, req ModelProviderRequest) (*SynthesizeResponse, error) {
-		// ModelName / Engine may both be empty; both are legal —
-		// the model dispatcher will fall back to the tenant's
-		// default TTS model in that case.
+		// ModelName carries the audio engine id ("gtts" / "edge-tts")
+		// when auto_play is the boolean UI toggle — those are built-in
+		// engine selectors, not tenant model names. Leave modelName nil
+		// for them (and for an empty hint) so the dispatcher falls back
+		// to the tenant's default TTS model, mirroring Python's canvas
+		// auto_play. Only an explicit model name is passed through to
+		// the by-name lookup.
 		var modelName *string
-		if req.ModelName != "" {
+		switch Engine(req.ModelName) {
+		case EngineEmpty, EngineGTTS, EngineEdge, EngineCustom:
+		default:
 			mn := req.ModelName
 			modelName = &mn
 		}
@@ -110,8 +118,9 @@ func NewTTSDispatchFunc(d TTSDispatcher) ModelProviderFunc {
 		// Build a TTSConfig from the request's voice + lang so
 		// the model driver can select a voice variant when the
 		// provider supports it (e.g. OpenAI's alloy/echo fable,
-		// edge-tts' voice short-name).
-		ttsConfig := &modelModule.TTSConfig{Params: map[string]any{}}
+		// edge-tts' voice short-name). MP3 matches the chat TTS
+		// endpoint's default response format.
+		ttsConfig := &modelModule.TTSConfig{Format: "mp3", Params: map[string]any{}}
 		if req.Voice != "" {
 			ttsConfig.Params["voice"] = req.Voice
 		}

--- a/internal/agent/audio/tts_dispatch_test.go
+++ b/internal/agent/audio/tts_dispatch_test.go
@@ -145,6 +145,37 @@ func TestNewTTSDispatchFunc_EmptyModelName(t *testing.T) {
 	}
 }
 
+func TestNewTTSDispatchFunc_PseudoEngineFallsBackToDefault(t *testing.T) {
+	// "gtts" / "edge-tts" are the boolean auto_play UI toggle's engine
+	// selectors, not tenant model names. Passing them as modelName made
+	// the real ModelProviderService dereference nil provider/instance
+	// pointers and panic. The dispatch must leave modelName nil for them
+	// so the dispatcher resolves the tenant's default TTS model.
+	for _, engine := range []string{"gtts", "edge-tts", "custom"} {
+		t.Run(engine, func(t *testing.T) {
+			fake := &fakeTTSDispatcher{
+				resp: &modelModule.TTSResponse{Audio: []byte("x")},
+				code: common.CodeSuccess,
+			}
+			fn := NewTTSDispatchFunc(fake)
+			_, err := fn(t.Context(), ModelProviderRequest{
+				TenantID:  "t1",
+				ModelName: engine,
+				Text:      "hi",
+			})
+			if err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			if fake.gotModelName != nil {
+				t.Errorf("modelName = %q, want nil for built-in engine %q", *fake.gotModelName, engine)
+			}
+			if fake.gotTTSConfig == nil || fake.gotTTSConfig.Format != "mp3" {
+				t.Errorf("ttsConfig = %+v, want Format mp3", fake.gotTTSConfig)
+			}
+		})
+	}
+}
+
 func TestNewTTSDispatchFunc_EmptyVoiceAndLang(t *testing.T) {
 	ctx := t.Context()
 	// Voice and Lang empty → TTSConfig.Params should be nil (not

--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -2582,6 +2582,9 @@ func maxTokensFromTenantModelExtra(modelEntity *entity.TenantModel, fallback int
 }
 
 func (m *ModelProviderService) getModelInstanceAndProviderByName(ctx context.Context, providerName, instanceName, modelName *string, userID string, apiConfig *modelModule.APIConfig) (*ModelInstanceAndProviderInfo, error) {
+	if providerName == nil || instanceName == nil || modelName == nil {
+		return nil, errors.New("provider name, instance name and model name are required when model id is absent")
+	}
 	// Get tenant ID from user
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(ctx, dao.DB, userID, "owner")
 	if err != nil {
@@ -2589,7 +2592,7 @@ func (m *ModelProviderService) getModelInstanceAndProviderByName(ctx context.Con
 	}
 
 	if len(tenants) == 0 {
-		return nil, err
+		return nil, fmt.Errorf("no tenant found for user %s", userID)
 	}
 
 	tenantID := tenants[0].TenantID
@@ -3164,6 +3167,28 @@ func (m *ModelProviderService) AudioSpeech(ctx context.Context, providerName, in
 		if err != nil || info == nil {
 			return nil, common.CodeNotFound, err
 		}
+	} else if providerName == nil && instanceName == nil && modelName == nil {
+		// No explicit model selection: synthesize through the tenant's
+		// default TTS model, mirroring Python's canvas auto_play which
+		// always resolves get_tenant_default_model_by_type(LLMType.TTS).
+		// A missing default surfaces as a typed error ("no default tts
+		// model is set") instead of a nil-pointer panic.
+		driver, name, defaultConfig, _, derr := m.GetTenantDefaultModelByType(ctx, userID, entity.ModelTypeTTS)
+		if derr != nil {
+			return nil, common.CodeNotFound, derr
+		}
+		if modelConfig == nil {
+			modelConfig = &modelModule.TTSConfig{}
+		}
+		var response *modelModule.TTSResponse
+		response, derr = driver.AudioSpeech(ctx, &name, audioContent, defaultConfig, modelConfig, nil)
+		if derr != nil {
+			return nil, common.CodeServerError, derr
+		}
+		if response == nil {
+			return nil, common.CodeServerError, errors.New("empty chat response")
+		}
+		return response, common.CodeSuccess, nil
 	} else {
 		info, err = m.getModelInstanceAndProviderByName(ctx, providerName, instanceName, modelName, userID, apiConfig)
 		if err != nil || info == nil {
@@ -3559,9 +3584,9 @@ func defaultModelRefs(tenant *entity.Tenant, modelType entity.ModelType) (string
 	case entity.ModelTypeImage2Text:
 		return tenant.Img2TxtID, ptrStringValue(tenant.TenantImg2TxtID)
 	case entity.ModelTypeTTS:
-		return *tenant.TTSID, ptrStringValue(tenant.TenantTTSID)
+		return ptrStringValue(tenant.TTSID), ptrStringValue(tenant.TenantTTSID)
 	case entity.ModelTypeOCR:
-		return *tenant.OCRID, ptrStringValue(tenant.TenantOCRID)
+		return ptrStringValue(tenant.OCRID), ptrStringValue(tenant.TenantOCRID)
 	default:
 		return "", ""
 	}

--- a/internal/service/model_service_tts_test.go
+++ b/internal/service/model_service_tts_test.go
@@ -1,0 +1,112 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"ragflow/internal/common"
+	"ragflow/internal/dao"
+	"ragflow/internal/entity"
+)
+
+// insertTTSTestTenant inserts a tenant row; ttsID may be nil (no default
+// TTS model configured).
+func insertTTSTestTenant(t *testing.T, id string, ttsID *string) {
+	t.Helper()
+	name := "tts-test-tenant"
+	row := &entity.Tenant{
+		ID:        id,
+		Name:      &name,
+		LLMID:     "glm-4-flash@ZHIPU-AI",
+		EmbdID:    "BAAI/bge-m3@ZHIPU-AI",
+		TTSID:     ttsID,
+		ParserIDs: "naive",
+	}
+	if err := dao.DB.Create(row).Error; err != nil {
+		t.Fatalf("insert test tenant: %v", err)
+	}
+}
+
+// TestAudioSpeech_NoSelectionNoDefaultTTS covers the agent Message
+// auto_play path: no model id and no provider/instance/model names. When
+// the tenant has no default TTS model the call must return the typed
+// "no default tts model is set" error instead of panicking on a nil
+// provider-name dereference.
+func TestAudioSpeech_NoSelectionNoDefaultTTS(t *testing.T) {
+	testDB := setupServiceTestDB(t)
+	pushServiceDB(t, testDB)
+	insertTTSTestTenant(t, "tenant-1", nil)
+
+	svc := NewModelProviderService()
+	text := "hello"
+	resp, code, err := svc.AudioSpeech(t.Context(), nil, nil, nil, nil, "tenant-1", &text, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error for missing default TTS model, got resp=%v", resp)
+	}
+	if !strings.Contains(err.Error(), "no default tts model is set") {
+		t.Fatalf("err = %v, want it to mention 'no default tts model is set'", err)
+	}
+	if code != common.CodeNotFound {
+		t.Errorf("code = %d, want %d", code, common.CodeNotFound)
+	}
+	if resp != nil {
+		t.Errorf("resp = %v, want nil", resp)
+	}
+}
+
+// TestAudioSpeech_PartialNamesRejected verifies the by-name lookup guard:
+// a modelName without provider/instance names (the shape the auto_play
+// dispatch used to send, e.g. "gtts") returns a clear error instead of
+// panicking.
+func TestAudioSpeech_PartialNamesRejected(t *testing.T) {
+	testDB := setupServiceTestDB(t)
+	pushServiceDB(t, testDB)
+
+	svc := NewModelProviderService()
+	text := "hello"
+	badModel := "gtts"
+	resp, code, err := svc.AudioSpeech(t.Context(), nil, nil, &badModel, nil, "tenant-1", &text, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error for partial model names, got resp=%v", resp)
+	}
+	if !strings.Contains(err.Error(), "provider name, instance name and model name are required") {
+		t.Fatalf("err = %v, want it to mention the required-name guard", err)
+	}
+	if code != common.CodeNotFound {
+		t.Errorf("code = %d, want %d", code, common.CodeNotFound)
+	}
+}
+
+// TestGetTenantDefaultModelByType_NilTTSPointer verifies the tenant
+// default-model resolution is nil-safe when the tts_id column is NULL
+// (the reporter's configuration: every default set except TTS).
+func TestGetTenantDefaultModelByType_NilTTSPointer(t *testing.T) {
+	testDB := setupServiceTestDB(t)
+	pushServiceDB(t, testDB)
+	insertTTSTestTenant(t, "tenant-2", nil)
+
+	svc := NewModelProviderService()
+	_, _, _, _, err := svc.GetTenantDefaultModelByType(t.Context(), "tenant-2", entity.ModelTypeTTS)
+	if err == nil {
+		t.Fatal("expected error for nil tts_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "no default tts model is set") {
+		t.Fatalf("err = %v, want 'no default tts model is set'", err)
+	}
+}


### PR DESCRIPTION
### Summary

When a tenant has no default TTS model configured (System Model Settings → TTS empty) and an agent Message node enables auto play (自动播放), running the agent failed in an unfriendly way:

- **Go backend**: the run crashed with `runtime error: invalid memory address or nil pointer dereference` and the UI surfaced the raw Go panic stack. The Message component maps the `auto_play` boolean to the built-in engine selector `"gtts"`; the audio dispatch passed it as a model name together with nil provider/instance pointers, and `ModelProviderService.getModelInstanceAndProviderByName` dereferenced the nil `providerName`.
- **Python backend**: `agent/canvas.py` resolved the tenant default TTS model outside any error handling, so `Exception("No default tts model is set.")` aborted the whole run and the raw error text replaced the agent reply.

**Fix**

- `ModelProviderService.AudioSpeech`: when no model id and no provider/instance/model names are given (the auto_play path), resolve the tenant's default TTS model via `GetTenantDefaultModelByType` and synthesize through it — the same call shape the `/api/v1/chat/audio/speech` endpoint uses. A missing default now yields the typed error `no default tts model is set`.
- `internal/agent/audio/tts_dispatch.go`: built-in engine selectors (`gtts`/`edge-tts`/`custom`) and an empty hint no longer masquerade as model names; they fall through to the tenant-default path (mirrors Python `canvas.run` auto_play semantics). The requested format defaults to `mp3`, matching the chat TTS endpoint.
- `getModelInstanceAndProviderByName`: nil name pointers return a clear error instead of panicking; a user without a tenant no longer returns `(nil, nil)`.
- `defaultModelRefs`: read `tenant.tts_id`/`ocr_id` through `ptrStringValue` — both columns are nullable and the previous unconditional dereference panicked exactly in the reported configuration (every default set except TTS).
- `agent/canvas.py` (Python): the default TTS resolution for auto_play is wrapped in try/except; on failure the run logs a warning and continues without audio instead of replacing the answer with the error text.

TTS failures in the Go Message component were already non-fatal (the textual answer is preserved and the failure is recorded under `outputs["audio_error"]`), so after this change an agent without a default TTS model answers normally and simply skips the audio.

**Verification**

- Reproduced the Go panic end-to-end in the browser UI (agent `Begin → Message(auto_play=true)`, tenant without a default TTS model): the run failed with a toast containing the full panic stack at `getModelInstanceAndProviderByName`. After the fix the same agent run returns the text answer with no error.
- Unit tests: `bash build.sh --test ./internal/agent/audio/... ./internal/service/...` passes, including new cases for the pseudo-engine fallback, the no-default-TTS error path, the partial-name guard, and the NULL `tts_id` column.
- Boundary: actual audio synthesis with a configured default TTS model was not exercised end-to-end (no TTS provider available in this environment); that path reuses the same `GetTenantDefaultModelByType` → `driver.AudioSpeech` call shape as the working chat TTS endpoint.
