### PR TITLE
fix(web): keep Firefox chat auto-scroll pinned to the bottom

### DIFF
--- a/web/src/hooks/logic-hooks.ts
+++ b/web/src/hooks/logic-hooks.ts
@@ -414,6 +414,12 @@ export const useSpeechWithSse = (url: string = api.chatsTts) => {
 
 //#region chat hooks
 
+// Firefox reports a fractional `scrollTop`, while `scrollHeight` / `clientHeight`
+// are rounded. `scrollToBottom` therefore lands a sub-pixel *below* the position
+// a native clamp had produced, which reads as a decreasing `scrollTop`. Require a
+// real gesture's worth of movement so that jitter is not mistaken for one.
+const UserScrollUpThreshold = 2;
+
 export const useScrollToBottom = (
   messages?: unknown,
   containerRef?: React.RefObject<HTMLDivElement>,
@@ -429,6 +435,18 @@ export const useScrollToBottom = (
     isAtBottomRef.current = isAtBottom;
   }, [isAtBottom]);
 
+  // We pin the transcript to the bottom ourselves, so browser scroll anchoring is
+  // pure interference: when a streamed answer re-lays out (markdown turning a
+  // paragraph into a code block, a line re-wrapping), Firefox shifts `scrollTop`
+  // to hold its anchor node still. That shift is indistinguishable from a user
+  // scrolling up in the handler below, so it latched auto-follow off mid-answer.
+  // Chrome suppresses the adjustment while pinned to the bottom, which is why
+  // only Firefox drifted away from the bottom.
+  useEffect(() => {
+    if (!containerRef?.current) return;
+    containerRef.current.style.overflowAnchor = 'none';
+  }, [containerRef]);
+
   const checkIfNearBottom = useCallback(() => {
     if (!containerRef?.current) return true;
     const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
@@ -438,7 +456,7 @@ export const useScrollToBottom = (
     // not fire a `scroll` event, so no later check would ever re-arm the flag
     // and the view would never track the incoming message.
     if (scrollHeight <= clientHeight) return true;
-    return Math.abs(scrollTop + clientHeight - scrollHeight) < 25;
+    return Math.abs(scrollTop + clientHeight - scrollHeight) < 60;
   }, [containerRef]);
 
   useEffect(() => {
@@ -454,9 +472,13 @@ export const useScrollToBottom = (
       let atBottom: boolean;
       if (nearBottom) {
         atBottom = true;
-      } else if (previousScrollTop === null || scrollTop < previousScrollTop) {
-        // Only a user gesture (wheel, drag, keys, touch) can shrink `scrollTop`,
-        // so this is the one reliable signal that they want to leave the bottom.
+      } else if (
+        previousScrollTop === null ||
+        scrollTop < previousScrollTop - UserScrollUpThreshold
+      ) {
+        // With scroll anchoring off, only a user gesture (wheel, drag, keys,
+        // touch) can shrink `scrollTop` by a meaningful amount, so this is the
+        // one reliable signal that they want to leave the bottom.
         atBottom = false;
       } else {
         // We are far from the bottom yet `scrollTop` did not move: the gap comes
@@ -484,8 +506,11 @@ export const useScrollToBottom = (
   const scrollToBottom = useCallback(() => {
     if (containerRef?.current) {
       const container = containerRef.current;
+      // Overshoot and let the browser clamp. `scrollHeight - clientHeight` is a
+      // difference of two rounded values, so in Firefox — where the real maximum
+      // is fractional — it can land just short of the bottom.
       container.scrollTo({
-        top: container.scrollHeight - container.clientHeight,
+        top: container.scrollHeight,
         behavior: 'auto',
       });
     }


### PR DESCRIPTION
### Summary

fix(web): keep Firefox chat auto-scroll pinned to the bottom

Firefox drifted off the bottom partway through a streamed answer for three reasons Chrome does not hit. Scroll anchoring shifted `scrollTop` to hold its anchor node still whenever the answer re-laid out, and the scroll handler cannot tell that apart from a user scrolling up, so auto-follow latched off for the rest of the answer. Firefox's fractional `scrollTop` also made sub-pixel jitter read as an upward gesture. And `scrollHeight - clientHeight` is a difference of two rounded values, so it lands just short of a fractional maximum.

Disable anchoring on the transcript, require a gesture's worth of movement before disarming auto-follow, overshoot so the browser clamps to the real bottom, and widen the near-bottom tolerance.
