### PR TITLE
fix(web): fall back a page when the dataset file list empties

### DIFF
--- a/web/src/pages/dataset/dataset/index.tsx
+++ b/web/src/pages/dataset/dataset/index.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useGoToPreviousPageOnEmpty } from '@/hooks/logic-hooks';
 import {
   useRowSelection,
   useSelectedIds,
@@ -54,6 +55,8 @@ export default function Dataset() {
     loading,
     checkValue,
   } = useFetchDocumentList();
+
+  useGoToPreviousPageOnEmpty(documents?.length, loading);
 
   const { filters, onOpenChange, filterGroup } = useSelectDatasetFilters();
 


### PR DESCRIPTION
### Summary

fix(web): fall back a page when the dataset file list empties

Deleting every document on the last page left the table stranded on an empty page. Reuse the existing useGoToPreviousPageOnEmpty hook, already applied on the agents/datasets/chats/searches list pages.
