### PR TITLE
fix(web): require chunk content when creating or editing a chunk

### DIFF
--- a/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-creating-modal/index.tsx
+++ b/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-creating-modal/index.tsx
@@ -128,9 +128,13 @@ const ChunkCreatingModal: React.FC<IModalProps<any> & kFProps> = ({
           <FormField
             control={form.control}
             name="content_with_weight"
+            rules={{
+              validate: (value: string) =>
+                value?.trim() ? true : t('chunk.chunkMessage'),
+            }}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>{t('chunk.chunk')}</FormLabel>
+                <FormLabel required>{t('chunk.chunk')}</FormLabel>
                 <FormControl>
                   <Textarea
                     {...field}


### PR DESCRIPTION
### Summary

fix(web): require chunk content when creating or editing a chunk

Chunk content could be submitted empty or whitespace-only, producing useless chunks. Validate it in the form instead of relying on the backend.
