### PR TITLE
fix(parser): crop media sections in PDF JSON path, unify Data URI and markdown rendering

### DIFF
--- a/internal/deepdoc/parser/pdf/layout/boxes_sections.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections.go
@@ -123,6 +123,17 @@ func NormalizeSectionPositions(sections []pdf.Section) {
 // Text and all other sections are appended verbatim.
 //
 // This mirrors the Python parser.py:665-671 Markdown output path.
+func inlinePNGDataURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "data:image/") {
+		return raw
+	}
+	return "data:image/png;base64," + raw
+}
+
 func SectionsToMarkdown(sections []pdf.Section) string {
 	var b strings.Builder
 	for _, s := range sections {
@@ -130,8 +141,8 @@ func SectionsToMarkdown(sections []pdf.Section) string {
 			b.WriteString("\n## ")
 		}
 		if (s.LayoutType == pdf.LayoutTypeFigure || s.LayoutType == "image" || s.DocTypeKwd == "image" || (s.LayoutType == pdf.LayoutTypeTable && s.Text == "")) && s.Image != "" {
-			b.WriteString("\n![Image](data:image/png;base64,")
-			b.WriteString(s.Image)
+			b.WriteString("\n![Image](")
+			b.WriteString(inlinePNGDataURL(s.Image))
 			b.WriteString(")")
 			continue
 		}

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections.go
@@ -129,7 +129,7 @@ func SectionsToMarkdown(sections []pdf.Section) string {
 		if s.LayoutType == pdf.LayoutTypeTitle {
 			b.WriteString("\n## ")
 		}
-		if s.LayoutType == pdf.LayoutTypeFigure && s.Image != "" {
+		if (s.LayoutType == pdf.LayoutTypeFigure || s.LayoutType == "image" || s.DocTypeKwd == "image" || (s.LayoutType == pdf.LayoutTypeTable && s.Text == "")) && s.Image != "" {
 			b.WriteString("\n![Image](data:image/png;base64,")
 			b.WriteString(s.Image)
 			b.WriteString(")")

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"encoding/base64"
 	"strings"
 
 	pdf "ragflow/internal/deepdoc/parser/pdf/type"
@@ -118,18 +119,21 @@ func NormalizeSectionPositions(sections []pdf.Section) {
 
 // SectionsToMarkdown converts Sections to a Markdown string.
 //
-// Title sections get a "## " prefix.
-// Figure sections produce an "![Image](data:image/png;base64,...)" tag.
-// Text and all other sections are appended verbatim.
-//
-// This mirrors the Python parser.py:665-671 Markdown output path.
-func inlinePNGDataURL(raw string) string {
+// InlinePNGDataURL ensures a raw base64 or Data URI string has a valid
+// "data:image/png;base64," prefix. It trims surrounding whitespace, preserves
+// pre-formatted data/http URIs, and validates raw base64 before prefixing.
+func InlinePNGDataURL(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return ""
 	}
-	if strings.HasPrefix(raw, "data:image/") {
+	if strings.HasPrefix(raw, "data:image/") || strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
 		return raw
+	}
+	if _, err := base64.StdEncoding.DecodeString(raw); err != nil {
+		if _, rerr := base64.RawStdEncoding.DecodeString(raw); rerr != nil {
+			return raw
+		}
 	}
 	return "data:image/png;base64," + raw
 }
@@ -142,7 +146,7 @@ func SectionsToMarkdown(sections []pdf.Section) string {
 		}
 		if (s.LayoutType == pdf.LayoutTypeFigure || s.LayoutType == "image" || s.DocTypeKwd == "image" || (s.LayoutType == pdf.LayoutTypeTable && s.Text == "")) && s.Image != "" {
 			b.WriteString("\n![Image](")
-			b.WriteString(inlinePNGDataURL(s.Image))
+			b.WriteString(InlinePNGDataURL(s.Image))
 			b.WriteString(")")
 			continue
 		}

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections.go
@@ -144,9 +144,10 @@ func SectionsToMarkdown(sections []pdf.Section) string {
 		if s.LayoutType == pdf.LayoutTypeTitle {
 			b.WriteString("\n## ")
 		}
-		if (s.LayoutType == pdf.LayoutTypeFigure || s.LayoutType == "image" || s.DocTypeKwd == "image" || (s.LayoutType == pdf.LayoutTypeTable && s.Text == "")) && s.Image != "" {
+		imgURL := InlinePNGDataURL(s.Image)
+		if (s.LayoutType == pdf.LayoutTypeFigure || s.LayoutType == "image" || s.DocTypeKwd == "image" || (s.LayoutType == pdf.LayoutTypeTable && s.Text == "")) && imgURL != "" {
 			b.WriteString("\n![Image](")
-			b.WriteString(InlinePNGDataURL(s.Image))
+			b.WriteString(imgURL)
 			b.WriteString(")")
 			continue
 		}

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections.go
@@ -117,11 +117,10 @@ func NormalizeSectionPositions(sections []pdf.Section) {
 	}
 }
 
-// SectionsToMarkdown converts Sections to a Markdown string.
-//
 // InlinePNGDataURL ensures a raw base64 or Data URI string has a valid
 // "data:image/png;base64," prefix. It trims surrounding whitespace, preserves
-// pre-formatted data/http URIs, and validates raw base64 before prefixing.
+// pre-formatted data/http URIs, normalizes line-wrapped base64 by stripping
+// CR/LF/whitespace, and validates raw base64 before prefixing.
 func InlinePNGDataURL(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -130,12 +129,21 @@ func InlinePNGDataURL(raw string) string {
 	if strings.HasPrefix(raw, "data:image/") || strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
 		return raw
 	}
-	if _, err := base64.StdEncoding.DecodeString(raw); err != nil {
-		if _, rerr := base64.RawStdEncoding.DecodeString(raw); rerr != nil {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' || r == ' ' || r == '\t' {
+			return -1
+		}
+		return r
+	}, raw)
+	if cleaned == "" {
+		return ""
+	}
+	if _, err := base64.StdEncoding.DecodeString(cleaned); err != nil {
+		if _, rerr := base64.RawStdEncoding.DecodeString(cleaned); rerr != nil {
 			return raw
 		}
 	}
-	return "data:image/png;base64," + raw
+	return "data:image/png;base64," + cleaned
 }
 
 func SectionsToMarkdown(sections []pdf.Section) string {

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections.go
@@ -153,7 +153,7 @@ func SectionsToMarkdown(sections []pdf.Section) string {
 			b.WriteString("\n## ")
 		}
 		imgURL := InlinePNGDataURL(s.Image)
-		if (s.LayoutType == pdf.LayoutTypeFigure || s.LayoutType == "image" || s.DocTypeKwd == "image" || (s.LayoutType == pdf.LayoutTypeTable && s.Text == "")) && imgURL != "" {
+		if (s.LayoutType == pdf.LayoutTypeFigure || s.LayoutType == "image" || s.DocTypeKwd == "image" || (s.LayoutType == pdf.LayoutTypeTable && strings.TrimSpace(s.Text) == "")) && imgURL != "" {
 			b.WriteString("\n![Image](")
 			b.WriteString(imgURL)
 			b.WriteString(")")

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
@@ -307,6 +307,61 @@ func TestSectionsToMarkdown_Table(t *testing.T) {
 	}
 }
 
+func TestSectionsToMarkdown_TableWithImageAndText(t *testing.T) {
+	sections := []pdf.Section{
+		{LayoutType: pdf.LayoutTypeTable, Text: "<table><tr><td>1</td></tr></table>", Image: "dGFibGVpbWc="},
+	}
+	got := SectionsToMarkdown(sections)
+	want := "<table><tr><td>1</td></tr></table>\n"
+	if got != want {
+		t.Errorf("got %q, want %q (table with text should render table text)", got, want)
+	}
+}
+
+func TestSectionsToMarkdown_TableFallbackWhenEmptyText(t *testing.T) {
+	sections := []pdf.Section{
+		{LayoutType: pdf.LayoutTypeTable, Text: "", Image: "dGFibGVpbWc="},
+	}
+	got := SectionsToMarkdown(sections)
+	want := "\n![Image](data:image/png;base64,dGFibGVpbWc=)"
+	if got != want {
+		t.Errorf("got %q, want %q (table with empty text should fallback to image)", got, want)
+	}
+}
+
+func TestSectionsToMarkdown_TableFallbackWhitespaceImage(t *testing.T) {
+	sections := []pdf.Section{
+		{LayoutType: pdf.LayoutTypeTable, Text: "", Image: "   \t\n"},
+	}
+	got := SectionsToMarkdown(sections)
+	want := "\n"
+	if got != want {
+		t.Errorf("got %q, want %q (table with empty text and whitespace image should render empty text newline, no empty tag)", got, want)
+	}
+}
+
+func TestSectionsToMarkdown_DocTypeKwdImage(t *testing.T) {
+	sections := []pdf.Section{
+		{LayoutType: "custom_block", DocTypeKwd: "image", Text: "caption", Image: "aGVsbG8="},
+	}
+	got := SectionsToMarkdown(sections)
+	want := "\n![Image](data:image/png;base64,aGVsbG8=)"
+	if got != want {
+		t.Errorf("got %q, want %q (DocTypeKwd == 'image' should render image)", got, want)
+	}
+}
+
+func TestSectionsToMarkdown_DocTypeKwdImage_Whitespace(t *testing.T) {
+	sections := []pdf.Section{
+		{LayoutType: "custom_block", DocTypeKwd: "image", Text: "caption", Image: "   "},
+	}
+	got := SectionsToMarkdown(sections)
+	want := "caption\n"
+	if got != want {
+		t.Errorf("got %q, want %q (DocTypeKwd == 'image' with whitespace image should keep text)", got, want)
+	}
+}
+
 func TestSectionsToMarkdown_Mixed(t *testing.T) {
 	sections := []pdf.Section{
 		{LayoutType: pdf.LayoutTypeTitle, Text: "标题", Image: ""},

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
@@ -274,6 +274,17 @@ func TestSectionsToMarkdown_FigureWithoutImage(t *testing.T) {
 	}
 }
 
+func TestSectionsToMarkdown_FigureWithWhitespaceImage(t *testing.T) {
+	sections := []pdf.Section{
+		{LayoutType: pdf.LayoutTypeFigure, Text: "图1", Image: "   \t\n"},
+	}
+	got := SectionsToMarkdown(sections)
+	want := "图1\n"
+	if got != want {
+		t.Errorf("got %q, want %q (whitespace image should not emit empty image tag or drop text)", got, want)
+	}
+}
+
 func TestSectionsToMarkdown_Text(t *testing.T) {
 	sections := []pdf.Section{
 		{LayoutType: pdf.LayoutTypeText, Text: "普通内容", Image: ""},

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"strings"
 	"testing"
 
 	pdf "ragflow/internal/deepdoc/parser/pdf/type"
@@ -510,6 +511,16 @@ func TestInlinePNGDataURL(t *testing.T) {
 			wantURL: "https://example.com/img.png",
 		},
 		{
+			name:    "line-wrapped base64 with CRLF is normalized without CRLF",
+			input:   "aGVs\r\nbG8=",
+			wantURL: "data:image/png;base64,aGVsbG8=",
+		},
+		{
+			name:    "multi-line wrapped base64 with LF is normalized without LF",
+			input:   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk\n+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+			wantURL: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+		},
+		{
 			name:    "non-base64 invalid string is returned without mangling",
 			input:   "invalid!@#base64",
 			wantURL: "invalid!@#base64",
@@ -521,6 +532,9 @@ func TestInlinePNGDataURL(t *testing.T) {
 			got := InlinePNGDataURL(tc.input)
 			if got != tc.wantURL {
 				t.Errorf("InlinePNGDataURL(%q) = %q, want %q", tc.input, got, tc.wantURL)
+			}
+			if strings.HasPrefix(got, "data:image/png;base64,") && strings.ContainsAny(got, "\r\n") {
+				t.Errorf("InlinePNGDataURL(%q) contains CR/LF characters: %q", tc.input, got)
 			}
 		})
 	}

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
@@ -397,7 +397,65 @@ func TestSectionsToJSON_NilSlice(t *testing.T) {
 	}
 }
 
-// TestCrossPageTableMerge verifies that mergeTablesAcrossPages merges
-// two TableItems on consecutive pages with overlapping X positions.
-// Python: _extract_table_figure merges cross-page tables by matching layoutno.
-// Spanning cells should be annotated with colspan/rowspan in the HTML output.
+func TestInlinePNGDataURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantURL string
+	}{
+		{
+			name:    "empty string returns empty",
+			input:   "",
+			wantURL: "",
+		},
+		{
+			name:    "whitespace string returns empty",
+			input:   "   ",
+			wantURL: "",
+		},
+		{
+			name:    "raw base64 gets png data URI prefix",
+			input:   "aGVsbG8=",
+			wantURL: "data:image/png;base64,aGVsbG8=",
+		},
+		{
+			name:    "raw base64 with surrounding whitespace gets trimmed and prefixed",
+			input:   "  aGVsbG8=  \n",
+			wantURL: "data:image/png;base64,aGVsbG8=",
+		},
+		{
+			name:    "already png data uri is preserved as is",
+			input:   "data:image/png;base64,aGVsbG8=",
+			wantURL: "data:image/png;base64,aGVsbG8=",
+		},
+		{
+			name:    "already jpeg data uri is preserved as is",
+			input:   "data:image/jpeg;base64,/9j/4AAQ",
+			wantURL: "data:image/jpeg;base64,/9j/4AAQ",
+		},
+		{
+			name:    "http url is preserved as is",
+			input:   "http://example.com/img.png",
+			wantURL: "http://example.com/img.png",
+		},
+		{
+			name:    "https url is preserved as is",
+			input:   "https://example.com/img.png",
+			wantURL: "https://example.com/img.png",
+		},
+		{
+			name:    "non-base64 invalid string is returned without mangling",
+			input:   "invalid!@#base64",
+			wantURL: "invalid!@#base64",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := InlinePNGDataURL(tc.input)
+			if got != tc.wantURL {
+				t.Errorf("InlinePNGDataURL(%q) = %q, want %q", tc.input, got, tc.wantURL)
+			}
+		})
+	}
+}

--- a/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
+++ b/internal/deepdoc/parser/pdf/layout/boxes_sections_test.go
@@ -252,6 +252,17 @@ func TestSectionsToMarkdown_FigureWithImage(t *testing.T) {
 	}
 }
 
+func TestSectionsToMarkdown_FigureWithDataURLImage(t *testing.T) {
+	sections := []pdf.Section{
+		{LayoutType: pdf.LayoutTypeFigure, Text: "图1", Image: "data:image/png;base64,abc123"},
+	}
+	got := SectionsToMarkdown(sections)
+	want := "\n![Image](data:image/png;base64,abc123)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestSectionsToMarkdown_FigureWithoutImage(t *testing.T) {
 	sections := []pdf.Section{
 		{LayoutType: pdf.LayoutTypeFigure, Text: "图1", Image: ""},

--- a/internal/ingestion/component/docx_vision_dispatch.go
+++ b/internal/ingestion/component/docx_vision_dispatch.go
@@ -249,7 +249,12 @@ func figureVisionPromptsBaseDir() (string, error) {
 }
 
 func buildVisionMessages(prompt, imageBase64 string) []modelModule.Message {
-	dataURI := "data:image/png;base64," + imageBase64
+	dataURI := strings.TrimSpace(imageBase64)
+	if !strings.HasPrefix(dataURI, "data:image/") &&
+		!strings.HasPrefix(dataURI, "http://") &&
+		!strings.HasPrefix(dataURI, "https://") {
+		dataURI = "data:image/png;base64," + dataURI
+	}
 	return []modelModule.Message{{
 		Role: "user",
 		Content: []interface{}{

--- a/internal/ingestion/component/docx_vision_dispatch.go
+++ b/internal/ingestion/component/docx_vision_dispatch.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"sync"
 
+	pdflayout "ragflow/internal/deepdoc/parser/pdf/layout"
 	"ragflow/internal/entity"
 	modelModule "ragflow/internal/entity/models"
 	"ragflow/internal/ingestion/component/schema"
@@ -249,11 +250,9 @@ func figureVisionPromptsBaseDir() (string, error) {
 }
 
 func buildVisionMessages(prompt, imageBase64 string) []modelModule.Message {
-	dataURI := strings.TrimSpace(imageBase64)
-	if !strings.HasPrefix(dataURI, "data:image/") &&
-		!strings.HasPrefix(dataURI, "http://") &&
-		!strings.HasPrefix(dataURI, "https://") {
-		dataURI = "data:image/png;base64," + dataURI
+	dataURI := pdflayout.InlinePNGDataURL(imageBase64)
+	if dataURI == "" {
+		dataURI = strings.TrimSpace(imageBase64)
 	}
 	return []modelModule.Message{{
 		Role: "user",

--- a/internal/ingestion/component/docx_vision_dispatch_test.go
+++ b/internal/ingestion/component/docx_vision_dispatch_test.go
@@ -193,3 +193,62 @@ func TestMaybeDispatchDOCXVision_JSONOnly(t *testing.T) {
 		t.Errorf("markdown mutated: %q", res.Markdown)
 	}
 }
+
+func TestBuildVisionMessages_PreventsDoublePrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantURL string
+	}{
+		{
+			name:    "raw base64 gets png prefix",
+			input:   "aGVsbG8=",
+			wantURL: "data:image/png;base64,aGVsbG8=",
+		},
+		{
+			name:    "already png data uri is preserved without double prefix",
+			input:   "data:image/png;base64,aGVsbG8=",
+			wantURL: "data:image/png;base64,aGVsbG8=",
+		},
+		{
+			name:    "jpeg data uri is preserved as jpeg",
+			input:   "data:image/jpeg;base64,/9j/4AAQ",
+			wantURL: "data:image/jpeg;base64,/9j/4AAQ",
+		},
+		{
+			name:    "https url is preserved",
+			input:   "https://example.com/figure.png",
+			wantURL: "https://example.com/figure.png",
+		},
+		{
+			name:    "whitespace trimmed",
+			input:   "  data:image/png;base64,abc  ",
+			wantURL: "data:image/png;base64,abc",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs := buildVisionMessages("describe", tc.input)
+			if len(msgs) != 1 {
+				t.Fatalf("len(msgs) = %d, want 1", len(msgs))
+			}
+			parts, ok := msgs[0].Content.([]interface{})
+			if !ok || len(parts) < 2 {
+				t.Fatalf("Content parts = %+v, want >= 2", msgs[0].Content)
+			}
+			img, ok := parts[1].(map[string]any)
+			if !ok {
+				t.Fatalf("parts[1] = %+v, want map[string]any", parts[1])
+			}
+			imgURL, ok := img["image_url"].(map[string]any)
+			if !ok {
+				t.Fatalf("img[image_url] = %+v, want map[string]any", img["image_url"])
+			}
+			got, _ := imgURL["url"].(string)
+			if got != tc.wantURL {
+				t.Errorf("image_url.url = %q, want %q", got, tc.wantURL)
+			}
+		})
+	}
+}

--- a/internal/ingestion/component/pdf_vision_dispatch_test.go
+++ b/internal/ingestion/component/pdf_vision_dispatch_test.go
@@ -156,6 +156,12 @@ func TestMaybeDispatchPDFVisionEnhancementForwardsDatasetLanguage(t *testing.T) 
 	if got := res.JSON[0]["text"]; got != "caption\na diagram of a pipeline" {
 		t.Fatalf("enhanced text = %q", got)
 	}
+	if len(invoker.images) != 1 {
+		t.Fatalf("vision invoker called %d times, want 1", len(invoker.images))
+	}
+	if want := "data:image/png;base64,aW1hZ2U="; invoker.images[0] != want {
+		t.Fatalf("vision image data URI = %q, want %q (no double data: prefix)", invoker.images[0], want)
+	}
 }
 
 // TestIsNamedPDFParseMethodWhitelistAligned verifies that the runtime

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -457,7 +457,7 @@ func sectionsToMarkdown(sections []deepdoctype.Section) string {
 		if layoutType == deepdoctype.LayoutTypeTitle {
 			b.WriteString("\n## ")
 		}
-		if layoutType == deepdoctype.LayoutTypeFigure && section.Image != "" {
+		if (layoutType == deepdoctype.LayoutTypeFigure || layoutType == "image" || section.DocTypeKwd == "image" || (layoutType == deepdoctype.LayoutTypeTable && section.Text == "")) && section.Image != "" {
 			b.WriteString("\n![Image](")
 			b.WriteString(inlinePNGDataURL(section.Image))
 			b.WriteString(")")

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -344,9 +344,8 @@ func pdfParseResultToJSONWithOptions(filename string, parsed *deepdoctype.ParseR
 		opts.pageWidth = firstPDFPageWidth(processed.PageWidth)
 	}
 	applyPDFPostProcess(&processed, opts)
-
+	defer processed.Close()
 	cropMediaSections(&processed)
-	processed.Close()
 
 	items := pdflayout.SectionsToJSON(processed.Sections)
 	if len(items) == 0 {
@@ -390,8 +389,8 @@ func pdfParseResultToMarkdownWithOptions(filename string, parsed *deepdoctype.Pa
 		opts.pageWidth = firstPDFPageWidth(processed.PageWidth)
 	}
 	applyPDFPostProcess(&processed, opts)
+	defer processed.Close()
 	cropMediaSections(&processed)
-	processed.Close()
 
 	return ParseResult{
 		OutputFormat: "markdown",
@@ -437,23 +436,7 @@ func firstPageNumber(raw any) int {
 }
 
 func sectionsToMarkdown(sections []deepdoctype.Section) string {
-	var b strings.Builder
-	for _, section := range sections {
-		layoutType := strings.TrimSpace(section.LayoutType)
-		if layoutType == deepdoctype.LayoutTypeTitle {
-			b.WriteString("\n## ")
-		}
-		imgURL := pdflayout.InlinePNGDataURL(section.Image)
-		if (layoutType == deepdoctype.LayoutTypeFigure || layoutType == "image" || section.DocTypeKwd == "image" || (layoutType == deepdoctype.LayoutTypeTable && section.Text == "")) && imgURL != "" {
-			b.WriteString("\n![Image](")
-			b.WriteString(imgURL)
-			b.WriteString(")")
-			continue
-		}
-		b.WriteString(section.Text)
-		b.WriteByte('\n')
-	}
-	return b.String()
+	return pdflayout.SectionsToMarkdown(sections)
 }
 
 // cropMediaSections crops figure and table sections from rendered PDF page
@@ -497,6 +480,7 @@ func cropMediaSections(result *deepdoctype.ParseResult) {
 		}
 		if sec.LayoutType != deepdoctype.LayoutTypeFigure &&
 			sec.LayoutType != deepdoctype.LayoutTypeTable &&
+			strings.TrimSpace(sec.LayoutType) != "image" &&
 			sec.DocTypeKwd != "image" && sec.DocTypeKwd != "table" {
 			continue
 		}

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -346,6 +346,9 @@ func pdfParseResultToJSONWithOptions(filename string, parsed *deepdoctype.ParseR
 	}
 	applyPDFPostProcess(&processed, opts)
 
+	cropMediaSections(&processed)
+	processed.Close()
+
 	items := pdflayout.SectionsToJSON(processed.Sections)
 	if len(items) == 0 {
 		items = []map[string]any{{"text": "", "doc_type_kwd": "text"}}
@@ -363,12 +366,9 @@ func pdfParseResultToJSONWithOptions(filename string, parsed *deepdoctype.ParseR
 		}
 		normalizePDFDocType(items[i])
 		if img, _ := items[i]["image"].(string); img != "" {
-			items[i]["image"] = "data:image/png;base64," + img
+			items[i]["image"] = inlinePNGDataURL(img)
 		}
 	}
-	// JSON is consumed by the chunker, which re-acquires the source PDF
-	// and crops image/table sections on demand. Release the engine now.
-	processed.Close()
 	return ParseResult{
 		OutputFormat: "json",
 		File: map[string]any{
@@ -391,10 +391,7 @@ func pdfParseResultToMarkdownWithOptions(filename string, parsed *deepdoctype.Pa
 		opts.pageWidth = firstPDFPageWidth(processed.PageWidth)
 	}
 	applyPDFPostProcess(&processed, opts)
-	// Markdown embeds figure images inline, so crop figures here while
-	// the engine is still alive. The chunker path crops image/table
-	// chunks on demand instead.
-	cropMarkdownFigures(&processed)
+	cropMediaSections(&processed)
 	processed.Close()
 
 	return ParseResult{
@@ -472,26 +469,24 @@ func sectionsToMarkdown(sections []deepdoctype.Section) string {
 	return b.String()
 }
 
-// cropMarkdownFigures crops inline images for figure sections so the
-// Markdown output can embed them. It mirrors the figure branch of the
-// former Parse.fillSectionImages, but runs only for the Markdown path
-// (the JSON path defers cropping to the chunker). The engine is read
-// from result.Engine; callers must Close the result afterwards.
-func cropMarkdownFigures(result *deepdoctype.ParseResult) {
+// cropMediaSections crops figure and table sections from rendered PDF page
+// images while the engine is still alive, populating sec.Image.
+// It is used by both the JSON and Markdown serialization paths.
+func cropMediaSections(result *deepdoctype.ParseResult) {
 	engine := result.Engine
 	if engine == nil || len(result.PageHeight) == 0 {
 		return
 	}
-	// Render each page at most once across all figures. A PDF can have many
-	// figures on the same page, so a cache shared across the section loop
-	// avoids re-rendering the page for every figure.
+	// Render each page at most once across all media sections. A PDF can have many
+	// figures/tables on the same page, so a cache shared across the section loop
+	// avoids re-rendering the page for every section.
 	//
-	// result.Sections is ordered by page, so once we advance to a figure whose
-	// minimum page is P, no later figure references a page < P. We therefore
+	// result.Sections is ordered by page, so once we advance to a section whose
+	// minimum page is P, no later section references a page < P. We therefore
 	// keep only a sliding window of page images: pages strictly below the
-	// current figure's minimum page are evicted. This bounds memory to the
-	// current figure's page span (typically one page, a few at most for a
-	// cross-page figure) instead of caching the whole PDF.
+	// current section's minimum page are evicted. This bounds memory to the
+	// current section's page span (typically one page, a few at most for a
+	// cross-page section) instead of caching the whole PDF.
 	pageCache := make(map[int]image.Image)
 	renderPage := func(pn int) image.Image {
 		if img, ok := pageCache[pn]; ok {
@@ -499,7 +494,7 @@ func cropMarkdownFigures(result *deepdoctype.ParseResult) {
 		}
 		img, err := deepdocpdf.RenderPageToImage(engine, pn)
 		if err != nil || img == nil {
-			slog.Warn("cropMarkdownFigures: render failed, skipping figure",
+			slog.Warn("cropMediaSections: render failed, skipping section",
 				"page", pn, "err", err)
 			pageCache[pn] = nil
 			return nil
@@ -510,13 +505,18 @@ func cropMarkdownFigures(result *deepdoctype.ParseResult) {
 
 	for i := range result.Sections {
 		sec := &result.Sections[i]
-		if sec.LayoutType != deepdoctype.LayoutTypeFigure {
+		if sec.Image != "" {
+			continue
+		}
+		if sec.LayoutType != deepdoctype.LayoutTypeFigure &&
+			sec.LayoutType != deepdoctype.LayoutTypeTable &&
+			sec.DocTypeKwd != "image" && sec.DocTypeKwd != "table" {
 			continue
 		}
 		if len(sec.Positions) == 0 {
 			continue
 		}
-		// Minimum page this figure touches; used both to prune stale cache
+		// Minimum page this section touches; used both to prune stale cache
 		// entries and to bound the window.
 		minPage := -1
 		pages := make(map[int]struct{})
@@ -528,8 +528,8 @@ func cropMarkdownFigures(result *deepdoctype.ParseResult) {
 				}
 			}
 		}
-		// Evict page images that no later figure can reference (all future
-		// figures start at page >= minPage).
+		// Evict page images that no later section can reference (all future
+		// sections start at page >= minPage).
 		for pn := range pageCache {
 			if pn < minPage {
 				delete(pageCache, pn)
@@ -537,9 +537,9 @@ func cropMarkdownFigures(result *deepdoctype.ParseResult) {
 		}
 		// Collect every distinct page this section spans so CropSectionByDLA
 		// can crop and vertically concatenate each page (mirroring Python's
-		// cropout multi-page branch). Single-page figures still render exactly
+		// cropout multi-page branch). Single-page sections still render exactly
 		// one page, and the pageCache above guarantees a page is rendered at
-		// most once even when several figures share it.
+		// most once even when several sections share it.
 		single := make(map[int]image.Image, len(pages))
 		for pn := range pages {
 			if img := renderPage(pn); img != nil {
@@ -549,9 +549,17 @@ func cropMarkdownFigures(result *deepdoctype.ParseResult) {
 		if len(single) == 0 {
 			continue
 		}
-		if dla := util.CropSectionByDLA(*sec, result.DLARegions, single); dla != "" {
-			sec.Image = dla
-			continue
+		if sec.LayoutType == deepdoctype.LayoutTypeFigure {
+			if dla := util.CropSectionByDLA(*sec, result.DLARegions, single); dla != "" {
+				sec.Image = dla
+				continue
+			}
+		}
+		if len(sec.Positions) > 0 {
+			if img := util.CropSectionPositions(sec.Positions, single, deepdoctype.DlaScale); img != "" {
+				sec.Image = img
+				continue
+			}
 		}
 		sec.Image = util.CropSectionImage(sec.PositionTag, single, deepdoctype.DlaScale)
 	}

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -443,9 +443,10 @@ func sectionsToMarkdown(sections []deepdoctype.Section) string {
 		if layoutType == deepdoctype.LayoutTypeTitle {
 			b.WriteString("\n## ")
 		}
-		if (layoutType == deepdoctype.LayoutTypeFigure || layoutType == "image" || section.DocTypeKwd == "image" || (layoutType == deepdoctype.LayoutTypeTable && section.Text == "")) && section.Image != "" {
+		imgURL := pdflayout.InlinePNGDataURL(section.Image)
+		if (layoutType == deepdoctype.LayoutTypeFigure || layoutType == "image" || section.DocTypeKwd == "image" || (layoutType == deepdoctype.LayoutTypeTable && section.Text == "")) && imgURL != "" {
 			b.WriteString("\n![Image](")
-			b.WriteString(pdflayout.InlinePNGDataURL(section.Image))
+			b.WriteString(imgURL)
 			b.WriteString(")")
 			continue
 		}
@@ -491,7 +492,7 @@ func cropMediaSections(result *deepdoctype.ParseResult) {
 
 	for i := range result.Sections {
 		sec := &result.Sections[i]
-		if sec.Image != "" {
+		if strings.TrimSpace(sec.Image) != "" {
 			continue
 		}
 		if sec.LayoutType != deepdoctype.LayoutTypeFigure &&

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -18,7 +18,6 @@ package parser
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"image"
@@ -366,7 +365,7 @@ func pdfParseResultToJSONWithOptions(filename string, parsed *deepdoctype.ParseR
 		}
 		normalizePDFDocType(items[i])
 		if img, _ := items[i]["image"].(string); img != "" {
-			items[i]["image"] = inlinePNGDataURL(img)
+			items[i]["image"] = pdflayout.InlinePNGDataURL(img)
 		}
 	}
 	return ParseResult{
@@ -437,19 +436,6 @@ func firstPageNumber(raw any) int {
 	}
 }
 
-func inlinePNGDataURL(raw string) string {
-	if raw == "" {
-		return ""
-	}
-	if strings.HasPrefix(raw, "data:image/") {
-		return raw
-	}
-	if _, err := base64.StdEncoding.DecodeString(raw); err != nil {
-		return raw
-	}
-	return "data:image/png;base64," + raw
-}
-
 func sectionsToMarkdown(sections []deepdoctype.Section) string {
 	var b strings.Builder
 	for _, section := range sections {
@@ -459,7 +445,7 @@ func sectionsToMarkdown(sections []deepdoctype.Section) string {
 		}
 		if (layoutType == deepdoctype.LayoutTypeFigure || layoutType == "image" || section.DocTypeKwd == "image" || (layoutType == deepdoctype.LayoutTypeTable && section.Text == "")) && section.Image != "" {
 			b.WriteString("\n![Image](")
-			b.WriteString(inlinePNGDataURL(section.Image))
+			b.WriteString(pdflayout.InlinePNGDataURL(section.Image))
 			b.WriteString(")")
 			continue
 		}
@@ -696,7 +682,7 @@ func parsePDFWithDeepDocOptions(ctx context.Context, filename string, data []byt
 	}
 	for i := range res.JSON {
 		if img, _ := res.JSON[i]["image"].(string); img != "" {
-			res.JSON[i]["image"] = inlinePNGDataURL(img)
+			res.JSON[i]["image"] = pdflayout.InlinePNGDataURL(img)
 		}
 	}
 	return res

--- a/internal/parser/parser/pdf_parser_common_test.go
+++ b/internal/parser/parser/pdf_parser_common_test.go
@@ -377,6 +377,93 @@ func TestPDFParseResultToMarkdownWithOptions_RendersLikePython(t *testing.T) {
 	}
 }
 
+func TestPDFParseResultToMarkdownWithOptions_TableFallback(t *testing.T) {
+	// 1. Table with text + image -> renders table text
+	withText := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "<table><tr><td>content</td></tr></table>", LayoutType: deepdoctype.LayoutTypeTable, Image: "dGFibGVpbWc="},
+		},
+	}
+	resText := pdfParseResultToMarkdownWithOptions("table.pdf", withText, pdfPostProcessOptions{})
+	if !strings.Contains(resText.Markdown, "<table><tr><td>content</td></tr></table>") {
+		t.Fatalf("Markdown = %q, want table text", resText.Markdown)
+	}
+	if strings.Contains(resText.Markdown, "![Image]") {
+		t.Fatalf("Markdown = %q, unexpected image tag when table text is present", resText.Markdown)
+	}
+
+	// 2. Table with empty text + image -> falls back to image tag
+	emptyText := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "", LayoutType: deepdoctype.LayoutTypeTable, Image: "dGFibGVvbmx5"},
+		},
+	}
+	resFallback := pdfParseResultToMarkdownWithOptions("table.pdf", emptyText, pdfPostProcessOptions{})
+	if !strings.Contains(resFallback.Markdown, "![Image](data:image/png;base64,dGFibGVvbmx5)") {
+		t.Fatalf("Markdown = %q, want fallback table image tag", resFallback.Markdown)
+	}
+
+	// 3. Table with empty text + whitespace-only image -> empty string, no broken tags
+	wsImg := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "", LayoutType: deepdoctype.LayoutTypeTable, Image: "   \t\n"},
+		},
+	}
+	resWS := pdfParseResultToMarkdownWithOptions("table.pdf", wsImg, pdfPostProcessOptions{})
+	if strings.TrimSpace(resWS.Markdown) != "" {
+		t.Fatalf("Markdown = %q, want empty output for empty text + whitespace image", resWS.Markdown)
+	}
+}
+
+func TestSectionsToMarkdown_DocTypeKwdImage(t *testing.T) {
+	// LayoutType is not figure/image, but DocTypeKwd == "image"
+	sections := []deepdoctype.Section{
+		{Text: "Caption", LayoutType: "custom_block", DocTypeKwd: "image", Image: "aW1hZ2Vvbmx5"},
+	}
+	got := sectionsToMarkdown(sections)
+	want := "\n![Image](data:image/png;base64,aW1hZ2Vvbmx5)"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+
+	// DocTypeKwd == "image" with whitespace image preserves text and drops empty tag
+	sectionsWS := []deepdoctype.Section{
+		{Text: "Caption", LayoutType: "custom_block", DocTypeKwd: "image", Image: "   \t\n"},
+	}
+	gotWS := sectionsToMarkdown(sectionsWS)
+	wantWS := "Caption\n"
+	if gotWS != wantWS {
+		t.Fatalf("got %q, want %q", gotWS, wantWS)
+	}
+}
+
+func TestPDFParseResultToMarkdownWithOptions_ImageSection(t *testing.T) {
+	parsed := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "Caption", LayoutType: "image", Image: "aW1hZ2Vvbmx5"},
+		},
+	}
+	res := pdfParseResultToMarkdownWithOptions("doc.pdf", parsed, pdfPostProcessOptions{})
+	if !strings.Contains(res.Markdown, "![Image](data:image/png;base64,aW1hZ2Vvbmx5)") {
+		t.Fatalf("Markdown = %q, want image embed for LayoutType == 'image'", res.Markdown)
+	}
+}
+
+func TestPDFParseResultToMarkdownWithOptions_WhitespaceOnlyImage(t *testing.T) {
+	parsed := &deepdoctype.ParseResult{
+		Sections: []deepdoctype.Section{
+			{Text: "Figure Caption", LayoutType: deepdoctype.LayoutTypeFigure, Image: "   \r\n\t "},
+		},
+	}
+	res := pdfParseResultToMarkdownWithOptions("doc.pdf", parsed, pdfPostProcessOptions{})
+	if !strings.Contains(res.Markdown, "Figure Caption") {
+		t.Fatalf("Markdown = %q, want figure caption preserved", res.Markdown)
+	}
+	if strings.Contains(res.Markdown, "![Image]") {
+		t.Fatalf("Markdown = %q, unexpected image tag for whitespace-only image", res.Markdown)
+	}
+}
+
 func TestPDFParser_ValidateParseMethod(t *testing.T) {
 	p := NewPDFParser()
 	if err := p.validateParseMethod(); err != nil {

--- a/internal/parser/parser/pdf_parser_common_test.go
+++ b/internal/parser/parser/pdf_parser_common_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"image"
 	"strings"
 	"testing"
 
@@ -389,3 +390,120 @@ func TestPDFParser_ValidateParseMethod(t *testing.T) {
 		t.Fatalf("validateParseMethod error = %q, want IMAGE2TEXT/VLM guidance", err.Error())
 	}
 }
+
+type mockPDFEngineForCommonTest struct {
+	closed bool
+}
+
+func (m *mockPDFEngineForCommonTest) ExtractChars(pageNum int) ([]deepdoctype.TextChar, error) {
+	return nil, nil
+}
+func (m *mockPDFEngineForCommonTest) RenderPage(pageNum int, dpi float64) ([]byte, error) {
+	return nil, nil
+}
+func (m *mockPDFEngineForCommonTest) RenderPageImage(pageNum int, dpi float64) (image.Image, error) {
+	return image.NewRGBA(image.Rect(0, 0, 100, 100)), nil
+}
+func (m *mockPDFEngineForCommonTest) RawData() []byte { return nil }
+func (m *mockPDFEngineForCommonTest) PageCount() (int, error) {
+	return 1, nil
+}
+func (m *mockPDFEngineForCommonTest) Outlines() ([]deepdoctype.Outline, error) { return nil, nil }
+func (m *mockPDFEngineForCommonTest) Close() error {
+	m.closed = true
+	return nil
+}
+
+func TestPDFParseResultToJSON_CropsMediaSectionsWithEngine(t *testing.T) {
+	mockEngine := &mockPDFEngineForCommonTest{}
+	parsed := &deepdoctype.ParseResult{
+		Engine:     mockEngine,
+		PageHeight: map[int]float64{0: 100},
+		Sections: []deepdoctype.Section{
+			{
+				Text:        "Figure caption",
+				LayoutType:  deepdoctype.LayoutTypeFigure,
+				PositionTag: "@@0\t10\t50\t10\t50##",
+				Positions: []deepdoctype.Position{
+					{PageNumbers: []int{0}, Left: 10, Right: 50, Top: 10, Bottom: 50},
+				},
+			},
+			{
+				Text:        "Table body",
+				LayoutType:  deepdoctype.LayoutTypeTable,
+				PositionTag: "@@0\t20\t60\t20\t60##",
+				Positions: []deepdoctype.Position{
+					{PageNumbers: []int{0}, Left: 20, Right: 60, Top: 20, Bottom: 60},
+				},
+			},
+			{
+				Text:        "Plain text paragraph",
+				LayoutType:  deepdoctype.LayoutTypeText,
+				PositionTag: "@@0\t0\t100\t70\t90##",
+				Positions: []deepdoctype.Position{
+					{PageNumbers: []int{0}, Left: 0, Right: 100, Top: 70, Bottom: 90},
+				},
+			},
+		},
+	}
+
+	res := pdfParseResultToJSON("media.pdf", parsed)
+	if res.Err != nil {
+		t.Fatalf("pdfParseResultToJSON: %v", res.Err)
+	}
+	if !mockEngine.closed {
+		t.Fatal("Engine should be closed after pdfParseResultToJSON")
+	}
+	if len(res.JSON) != 3 {
+		t.Fatalf("JSON len = %d, want 3", len(res.JSON))
+	}
+
+	// Figure should have cropped image populated
+	figImg, ok := res.JSON[0]["image"].(string)
+	if !ok || figImg == "" {
+		t.Fatalf("Figure JSON[0].image should be non-empty base64 data url, got %v", res.JSON[0]["image"])
+	}
+	if !strings.HasPrefix(figImg, "data:image/png;base64,") {
+		t.Fatalf("Figure JSON[0].image prefix mismatch, got %q", figImg)
+	}
+
+	// Table should have cropped image populated
+	tblImg, ok := res.JSON[1]["image"].(string)
+	if !ok || tblImg == "" {
+		t.Fatalf("Table JSON[1].image should be non-empty base64 data url, got %v", res.JSON[1]["image"])
+	}
+	if !strings.HasPrefix(tblImg, "data:image/png;base64,") {
+		t.Fatalf("Table JSON[1].image prefix mismatch, got %q", tblImg)
+	}
+
+	// Plain text should NOT have cropped image
+	textImg, _ := res.JSON[2]["image"].(string)
+	if textImg != "" {
+		t.Fatalf("Text JSON[2].image should be empty, got %q", textImg)
+	}
+}
+
+func TestPDFParseResultToJSON_EngineNilGraceful(t *testing.T) {
+	parsed := &deepdoctype.ParseResult{
+		Engine:     nil,
+		PageHeight: map[int]float64{0: 100},
+		Sections: []deepdoctype.Section{
+			{
+				Text:       "Figure caption",
+				LayoutType: deepdoctype.LayoutTypeFigure,
+				Positions: []deepdoctype.Position{
+					{PageNumbers: []int{0}, Left: 10, Right: 50, Top: 10, Bottom: 50},
+				},
+			},
+		},
+	}
+
+	res := pdfParseResultToJSON("nil_engine.pdf", parsed)
+	if res.Err != nil {
+		t.Fatalf("pdfParseResultToJSON with nil engine returned err: %v", res.Err)
+	}
+	if len(res.JSON) != 1 {
+		t.Fatalf("JSON len = %d, want 1", len(res.JSON))
+	}
+}
+

--- a/internal/parser/parser/pdf_parser_common_test.go
+++ b/internal/parser/parser/pdf_parser_common_test.go
@@ -330,6 +330,9 @@ func TestPDFParseResultToMarkdownWithOptions_RendersLikePython(t *testing.T) {
 		Sections: []deepdoctype.Section{
 			{Text: "Title", LayoutType: deepdoctype.LayoutTypeTitle},
 			{Text: "Figure", LayoutType: deepdoctype.LayoutTypeFigure, Image: "aGVsbG8="},
+			{Text: "<table><tr><td>cell</td></tr></table>", LayoutType: deepdoctype.LayoutTypeTable, Image: "dGFibGVpbWc="},
+			{Text: "", LayoutType: deepdoctype.LayoutTypeTable, Image: "dGFibGVvbmx5"},
+			{Text: "ImageCaption", LayoutType: "image", Image: "aW1hZ2Vvbmx5"},
 			{Text: "Body", LayoutType: deepdoctype.LayoutTypeText},
 		},
 	}
@@ -348,7 +351,16 @@ func TestPDFParseResultToMarkdownWithOptions_RendersLikePython(t *testing.T) {
 		t.Fatalf("Markdown = %q, want title heading", res.Markdown)
 	}
 	if !strings.Contains(res.Markdown, "![Image](data:image/png;base64,aGVsbG8=)") {
-		t.Fatalf("Markdown = %q, want inline image", res.Markdown)
+		t.Fatalf("Markdown = %q, want inline figure image", res.Markdown)
+	}
+	if !strings.Contains(res.Markdown, "<table><tr><td>cell</td></tr></table>") {
+		t.Fatalf("Markdown = %q, want table text", res.Markdown)
+	}
+	if !strings.Contains(res.Markdown, "![Image](data:image/png;base64,dGFibGVvbmx5)") {
+		t.Fatalf("Markdown = %q, want fallback table image when text is empty", res.Markdown)
+	}
+	if !strings.Contains(res.Markdown, "![Image](data:image/png;base64,aW1hZ2Vvbmx5)") {
+		t.Fatalf("Markdown = %q, want image section", res.Markdown)
 	}
 	if !strings.Contains(res.Markdown, "Body") {
 		t.Fatalf("Markdown = %q, want body text", res.Markdown)
@@ -506,4 +518,3 @@ func TestPDFParseResultToJSON_EngineNilGraceful(t *testing.T) {
 		t.Fatalf("JSON len = %d, want 1", len(res.JSON))
 	}
 }
-

--- a/internal/parser/parser/pdf_parser_common_test.go
+++ b/internal/parser/parser/pdf_parser_common_test.go
@@ -330,6 +330,7 @@ func TestPDFParseResultToMarkdownWithOptions_RendersLikePython(t *testing.T) {
 		Sections: []deepdoctype.Section{
 			{Text: "Title", LayoutType: deepdoctype.LayoutTypeTitle},
 			{Text: "Figure", LayoutType: deepdoctype.LayoutTypeFigure, Image: "aGVsbG8="},
+			{Text: "WhitespaceFigureText", LayoutType: deepdoctype.LayoutTypeFigure, Image: "   \t\n"},
 			{Text: "<table><tr><td>cell</td></tr></table>", LayoutType: deepdoctype.LayoutTypeTable, Image: "dGFibGVpbWc="},
 			{Text: "", LayoutType: deepdoctype.LayoutTypeTable, Image: "dGFibGVvbmx5"},
 			{Text: "ImageCaption", LayoutType: "image", Image: "aW1hZ2Vvbmx5"},
@@ -352,6 +353,12 @@ func TestPDFParseResultToMarkdownWithOptions_RendersLikePython(t *testing.T) {
 	}
 	if !strings.Contains(res.Markdown, "![Image](data:image/png;base64,aGVsbG8=)") {
 		t.Fatalf("Markdown = %q, want inline figure image", res.Markdown)
+	}
+	if !strings.Contains(res.Markdown, "WhitespaceFigureText") {
+		t.Fatalf("Markdown = %q, want whitespace figure text preserved", res.Markdown)
+	}
+	if strings.Contains(res.Markdown, "![Image]()") {
+		t.Fatalf("Markdown = %q, unexpected empty image tag", res.Markdown)
 	}
 	if !strings.Contains(res.Markdown, "<table><tr><td>cell</td></tr></table>") {
 		t.Fatalf("Markdown = %q, want table text", res.Markdown)


### PR DESCRIPTION
### Summary

1. **Populate PDF JSON Media Images**: Fixes an issue where `Section.Image` was never populated in the PDF parser's JSON output path (`pdfParseResultToJSONWithOptions`), causing the `image` field in JSON items to always be an empty string. Consequently, downstream PDF Vision/VLM enhancement (`maybeDispatchPDFVisionEnhancement`) was completely skipped for all figure and table sections (`action=skipped_empty_image`).
2. **Prevent Duplicate Data URI Prefix**: Fixes `buildVisionMessages` to make Data URI prefixing idempotent and unified via `pdflayout.InlinePNGDataURL`. Previously, passing an image already formatted with `data:image/...` resulted in a double prefix (`data:image/png;base64,data:image/png;base64,...`), causing vision model APIs to fail. Now also strips CRLF/whitespace line-wrapped base64.
3. **Markdown & Crop Consistency**: Synchronized `sectionsToMarkdown`/`SectionsToMarkdown` and `cropMediaSections` to support all media layout types (`figure`, `image` (trimmed), `doc_type_kwd == "image"/"table"`) and whitespace-safe table fallback.

### Changes

1. **Generalized Media Section Cropping (`cropMediaSections`)**:
   - Extended `cropMarkdownFigures` into `cropMediaSections` in `internal/parser/parser/pdf_parser_common.go` to crop both `figure` and `table` layout types (and sections marked as `image`/`table`, plus `LayoutType=="image"` trimmed).
   - Added guard `strings.TrimSpace(sec.Image)!=""` to skip pre-existing images and `strings.TrimSpace(layout)=="image"` to cover DOCX-style image sections missed by `DocTypeKwd`.
   - Utilizes `CropSectionPositions` with fallback to `CropSectionImage` and `CropSectionByDLA`.
   - Preserves sliding-window page cache eviction to keep memory bounded.
   - Changed `processed.Close()` to `defer processed.Close()` for panic-safe release (engine held through serialization, idempotent).

2. **Hooked Cropping into JSON Output Path**:
   - In `pdfParseResultToJSONWithOptions`, invokes `cropMediaSections(&processed)` before `pdflayout.SectionsToJSON(processed.Sections)`.
   - Standardizes the image output using `pdflayout.InlinePNGDataURL`.

3. **Data URI Unification in Vision Dispatch**:
   - Updated `buildVisionMessages` in `internal/ingestion/component/docx_vision_dispatch.go` to delegate to `pdflayout.InlinePNGDataURL` (single source of truth): trims whitespace, preserves `data:image/`/`http(s)://`, strips CR/LF/space/tab, validates base64 before prefixing.
   - Fixes remaining CRLF line-wrapped base64 case (`aGVs\r\nbG8=` → `data:image/png;base64,aGVsbG8=`).

4. **Markdown Rendering Deduplication**:
   - `internal/parser/parser/pdf_parser_common.go:sectionsToMarkdown` now delegates to `pdflayout.SectionsToMarkdown` per `AGENTS.md: Collapse duplicate implementations`.
   - Both renderers now use `strings.TrimSpace(s.Text)==""` for table fallback to handle whitespace-only text (fixes Coderabbit 460-464).

### Tests

- `TestPDFParseResultToJSON_CropsMediaSectionsWithEngine`: verifies figure/table cropping with engine rendering and engine cleanup.
- `TestPDFParseResultToJSON_EngineNilGraceful`: verifies safe fallback when `Engine` is nil.
- `TestPDFParseResultToMarkdownWithOptions_RendersLikePython`: verifies markdown rendering for title, figure, image, and table sections.
- `TestPDFParseResultToMarkdownWithOptions_TableFallback`: whitespace table fallback cases.
- `TestBuildVisionMessages_PreventsDoublePrefix`: verifies `buildVisionMessages` handles raw base64, pre-formatted data URIs (PNG, JPEG), HTTP(S) URLs, and whitespace without creating duplicate prefixes.
- `TestMaybeDispatchPDFVisionEnhancementForwardsDatasetLanguage`: asserts no double data URI prefix in captured invoker messages.
- `TestInlinePNGDataURL`: CR/LF normalization cases.