### PR TITLE
fix(graph): ignore malformed n-hop metadata

### DIFF
--- a/rag/graphrag/search.py
+++ b/rag/graphrag/search.py
@@ -23,7 +23,7 @@ import pandas as pd
 
 from common.misc_utils import get_uuid
 from rag.graphrag.query_analyze_prompt import PROMPTS
-from rag.graphrag.utils import get_entity_type2samples, get_llm_cache, set_llm_cache, get_relation
+from rag.graphrag.utils import _iter_valid_n_hop_edges, get_entity_type2samples, get_llm_cache, set_llm_cache, get_relation
 from common.token_utils import num_tokens_from_string
 
 from rag.nlp.search import Dealer, index_name
@@ -170,20 +170,12 @@ class KGSearch(Dealer):
         rels_from_txt = await self.get_relevant_relations_by_txt(qst, filters, idxnms, kb_ids, emb_mdl, rel_sim_threshold)
         nhop_pathes = defaultdict(dict)
         for _, ent in ents_from_query.items():
-            nhops = ent.get("n_hop_ents", [])
-            if not isinstance(nhops, list):
-                logging.warning(f"Abnormal n_hop_ents: {nhops}")
-                continue
-            for nbr in nhops:
-                path = nbr["path"]
-                wts = nbr["weights"]
-                for i in range(len(path) - 1):
-                    f, t = path[i], path[i + 1]
-                    if (f, t) in nhop_pathes:
-                        nhop_pathes[(f, t)]["sim"] += ent["sim"] / (2 + i)
-                    else:
-                        nhop_pathes[(f, t)]["sim"] = ent["sim"] / (2 + i)
-                    nhop_pathes[(f, t)]["pagerank"] = max(nhop_pathes[(f, t)].get("pagerank", 0), wts[i])
+            for i, f, t, weight in _iter_valid_n_hop_edges(ent.get("n_hop_ents", []), ent.get("entity_kwd")):
+                if (f, t) in nhop_pathes:
+                    nhop_pathes[(f, t)]["sim"] += ent["sim"] / (2 + i)
+                else:
+                    nhop_pathes[(f, t)]["sim"] = ent["sim"] / (2 + i)
+                nhop_pathes[(f, t)]["pagerank"] = max(nhop_pathes[(f, t)].get("pagerank", 0), weight)
 
         logging.info("Retrieved entities: {}".format(list(ents_from_query.keys())))
         logging.info("Retrieved relations: {}".format(list(rels_from_txt.keys())))

--- a/rag/graphrag/search.py
+++ b/rag/graphrag/search.py
@@ -169,8 +169,8 @@ class KGSearch(Dealer):
         ents_from_types = self.get_relevant_ents_by_types(ty_kwds, filters, idxnms, kb_ids, 10000)
         rels_from_txt = await self.get_relevant_relations_by_txt(qst, filters, idxnms, kb_ids, emb_mdl, rel_sim_threshold)
         nhop_pathes = defaultdict(dict)
-        for _, ent in ents_from_query.items():
-            for i, f, t, weight in _iter_valid_n_hop_edges(ent.get("n_hop_ents", []), ent.get("entity_kwd")):
+        for entity_name, ent in ents_from_query.items():
+            for i, f, t, weight in _iter_valid_n_hop_edges(ent.get("n_hop_ents", []), entity_name):
                 if (f, t) in nhop_pathes:
                     nhop_pathes[(f, t)]["sim"] += ent["sim"] / (2 + i)
                 else:

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -846,32 +846,62 @@ def _iter_valid_n_hop_edges(n_hop_ents, entity_name):
     paths from the same result set.
     """
     if not isinstance(n_hop_ents, list):
-        logger.warning("Abnormal n_hop_ents for entity %s: %r", entity_name, n_hop_ents)
+        logger.warning(
+            "Abnormal n_hop_ents for entity %s: expected list, got %s",
+            entity_name,
+            type(n_hop_ents).__name__,
+        )
         return
 
     for neighbor in n_hop_ents:
         if not isinstance(neighbor, dict):
-            logger.warning("Skipping malformed n-hop entry for entity %s: %r", entity_name, neighbor)
+            logger.warning(
+                "Skipping malformed n-hop entry for entity %s: expected dict, got %s",
+                entity_name,
+                type(neighbor).__name__,
+            )
             continue
 
         path = neighbor.get("path")
         weights = neighbor.get("weights")
         if not isinstance(path, list) or not isinstance(weights, list) or len(path) < 2 or len(weights) != len(path) - 1:
-            logger.warning("Skipping malformed n-hop path for entity %s: %r", entity_name, neighbor)
+            logger.warning(
+                "Skipping malformed n-hop path for entity %s: path_type=%s, path_len=%s, weights_type=%s, weights_len=%s",
+                entity_name,
+                type(path).__name__,
+                len(path) if isinstance(path, list) else "n/a",
+                type(weights).__name__,
+                len(weights) if isinstance(weights, list) else "n/a",
+            )
             continue
 
         edges = []
         for edge_index, (source, target, weight) in enumerate(zip(path, path[1:], weights)):
             if not isinstance(source, str) or not isinstance(target, str) or not source or not target:
-                logger.warning("Skipping n-hop path with invalid entities for %s: %r", entity_name, neighbor)
+                logger.warning(
+                    "Skipping n-hop path with invalid entities for entity %s at edge %s: source_type=%s, target_type=%s",
+                    entity_name,
+                    edge_index,
+                    type(source).__name__,
+                    type(target).__name__,
+                )
                 break
             try:
                 normalized_weight = float(weight)
             except (TypeError, ValueError):
-                logger.warning("Skipping n-hop path with invalid weight for %s: %r", entity_name, neighbor)
+                logger.warning(
+                    "Skipping n-hop path with invalid weight for entity %s at edge %s: weight_type=%s",
+                    entity_name,
+                    edge_index,
+                    type(weight).__name__,
+                )
                 break
             if not math.isfinite(normalized_weight):
-                logger.warning("Skipping n-hop path with non-finite weight for %s: %r", entity_name, neighbor)
+                logger.warning(
+                    "Skipping n-hop path with non-finite weight for entity %s at edge %s",
+                    entity_name,
+                    edge_index,
+                )
                 break
             edges.append((edge_index, source, target, normalized_weight))
         else:

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -14,6 +14,7 @@ import dataclasses
 import html
 import json
 import logging
+import math
 import os
 import re
 import time
@@ -36,6 +37,7 @@ from common import settings
 from common.doc_store.doc_store_base import OrderByExpr
 
 GRAPH_FIELD_SEP = "<SEP>"
+logger = logging.getLogger(__name__)
 
 ErrorHandlerFn = Callable[[BaseException | None, str | None, dict | None], None]
 
@@ -833,6 +835,47 @@ def n_neighbor(graph: nx.Graph, node, n_hop: int = 2):
             nbr["weights"].append(w)
         nbrs.append(nbr)
     return nbrs
+
+
+def _iter_valid_n_hop_edges(n_hop_ents, entity_name):
+    """Yield well-formed weighted edges from serialized n-hop metadata.
+
+    N-hop metadata is persisted with entity chunks, so older or partially
+    written records can outlive the code that produced them.  Keep malformed
+    records from aborting the whole GraphRAG query while preserving valid
+    paths from the same result set.
+    """
+    if not isinstance(n_hop_ents, list):
+        logger.warning("Abnormal n_hop_ents for entity %s: %r", entity_name, n_hop_ents)
+        return
+
+    for neighbor in n_hop_ents:
+        if not isinstance(neighbor, dict):
+            logger.warning("Skipping malformed n-hop entry for entity %s: %r", entity_name, neighbor)
+            continue
+
+        path = neighbor.get("path")
+        weights = neighbor.get("weights")
+        if not isinstance(path, list) or not isinstance(weights, list) or len(path) < 2 or len(weights) != len(path) - 1:
+            logger.warning("Skipping malformed n-hop path for entity %s: %r", entity_name, neighbor)
+            continue
+
+        edges = []
+        for edge_index, (source, target, weight) in enumerate(zip(path, path[1:], weights)):
+            if not isinstance(source, str) or not isinstance(target, str) or not source or not target:
+                logger.warning("Skipping n-hop path with invalid entities for %s: %r", entity_name, neighbor)
+                break
+            try:
+                normalized_weight = float(weight)
+            except (TypeError, ValueError):
+                logger.warning("Skipping n-hop path with invalid weight for %s: %r", entity_name, neighbor)
+                break
+            if not math.isfinite(normalized_weight):
+                logger.warning("Skipping n-hop path with non-finite weight for %s: %r", entity_name, neighbor)
+                break
+            edges.append((edge_index, source, target, normalized_weight))
+        else:
+            yield from edges
 
 
 async def get_entity_type2samples(idxnms, kb_ids: list):

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -888,7 +888,7 @@ def _iter_valid_n_hop_edges(n_hop_ents, entity_name):
                 break
             try:
                 normalized_weight = float(weight)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
                 logger.warning(
                     "Skipping n-hop path with invalid weight for entity %s at edge %s: weight_type=%s",
                     entity_name,

--- a/test/unit_test/rag/graphrag/test_graphrag_utils.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_utils.py
@@ -25,6 +25,7 @@ import rag.graphrag.utils as graphrag_utils
 from rag.graphrag.utils import (
     GRAPH_FIELD_SEP,
     GraphChange,
+    _iter_valid_n_hop_edges,
     clean_str,
     compute_args_hash,
     dict_has_keys_with_types,
@@ -569,6 +570,28 @@ class TestNNeighbor:
         nbrs = n_neighbor(self._line_graph(), "D", n_hop=1)
         assert nbrs[0]["path"][0] == "D"
         assert nbrs[0]["weights"] == [3]
+
+
+@pytest.mark.p1
+class TestValidNHopEdges:
+    """Tests for defensive parsing of persisted n-hop relation metadata."""
+
+    def test_skips_malformed_entries_and_keeps_valid_edges(self, caplog):
+        n_hop_ents = [
+            {"path": ["A", "B"], "weights": []},
+            {"path": ["B", "C"], "weights": ["2"]},
+            {"path": ["C", "D"], "weights": ["not-a-number"]},
+            {"path": ["E", "F", "G"], "weights": [3, 4]},
+            "not an entry",
+        ]
+
+        edges = list(_iter_valid_n_hop_edges(n_hop_ents, "ROOT"))
+
+        assert edges == [(0, "B", "C", 2.0), (0, "E", "F", 3.0), (1, "F", "G", 4.0)]
+        assert "Skipping malformed n-hop" in caplog.text
+
+    def test_non_list_metadata_is_ignored(self):
+        assert list(_iter_valid_n_hop_edges({"path": ["A", "B"]}, "ROOT")) == []
 
 
 @pytest.mark.p1

--- a/test/unit_test/rag/graphrag/test_graphrag_utils.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_utils.py
@@ -593,6 +593,14 @@ class TestValidNHopEdges:
     def test_non_list_metadata_is_ignored(self):
         assert list(_iter_valid_n_hop_edges({"path": ["A", "B"]}, "ROOT")) == []
 
+    def test_warning_uses_entity_context_without_raw_payload(self, caplog):
+        invalid_weight = "do-not-log-this-persisted-value"
+
+        assert list(_iter_valid_n_hop_edges([{"path": ["A", "B"], "weights": [invalid_weight]}], "ROOT")) == []
+        assert "entity ROOT" in caplog.text
+        assert "weight_type=str" in caplog.text
+        assert invalid_weight not in caplog.text
+
 
 @pytest.mark.p1
 class TestGraphNodeToChunk:

--- a/test/unit_test/rag/graphrag/test_graphrag_utils.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_utils.py
@@ -601,6 +601,11 @@ class TestValidNHopEdges:
         assert "weight_type=str" in caplog.text
         assert invalid_weight not in caplog.text
 
+    def test_overflowing_weight_is_ignored(self):
+        n_hop_ents = [{"path": ["A", "B"], "weights": [10**400]}]
+
+        assert list(_iter_valid_n_hop_edges(n_hop_ents, "ROOT")) == []
+
 
 @pytest.mark.p1
 class TestGraphNodeToChunk:


### PR DESCRIPTION
### Summary

GraphRAG persists n-hop relation paths in entity chunks. When a legacy or partially written record is missing path/weights, has mismatched lengths, or contains non-numeric weights, the retrieval loop can raise and fail the whole query.

This change validates each persisted path, normalizes finite numeric weights, logs and skips malformed entries, and keeps valid paths available for retrieval.

### Tests

- Targeted GraphRAG unit test file: 99 passed
- Python syntax compilation for the modified files
- git diff --check