### PR TITLE
fix(memory): align Go semantic valid_at prompt with the Python wording

### DIFF
--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -154,7 +154,7 @@ var TYPE_INSTRUCTIONS = map[string]string{
 
 // OUTPUT_TEMPLATES defines the output format for each memory type
 var OUTPUT_TEMPLATES = map[string]string{
-	"semantic":   `"semantic": [{"content": "Clear factual statement", "valid_at": "timestamp or empty", "invalid_at": "timestamp or empty"}]`,
+	"semantic":   `"semantic": [{"content": "Clear factual statement", "valid_at": "timestamp — use the conversation time when the fact has no date of its own", "invalid_at": "timestamp or empty"}]`,
 	"episodic":   `"episodic": [{"content": "Narrative event description", "valid_at": "event start timestamp", "invalid_at": "event end timestamp or empty"}]`,
 	"procedural": `"procedural": [{"content": "Actionable instructions", "valid_at": "procedure effective timestamp", "invalid_at": "procedure expiration timestamp or empty"}]`,
 }


### PR DESCRIPTION
### What

`OUTPUT_TEMPLATES["semantic"]` in `internal/service/memory.go` still instructs the model with `"valid_at": "timestamp or empty"`, while the Python extractor prompt at `memory/utils/prompt_util.py` now says:

```
"valid_at": "timestamp — use the conversation time when the fact has no date of its own"
```

This PR aligns the Go wording with the Python wording verbatim. One line, no behaviour change on the Go side beyond the prompt text itself.

### Why

The Python wording was tightened because `"timestamp or empty"` contradicts the other two places the same prompt states the rule — `SYSTEM_BASE_TEMPLATE` says every item must have a `valid_at`, and the semantic `TYPE_INSTRUCTIONS` says `Default: valid_at = conversation time`. The model follows the output-format block, so the `or empty` phrasing is what produced empty `valid_at` values for semantic items specifically.

That asymmetry was reported in #18415, where the reporter's 4132 records had 144 empty `valid_at` — **6.5% of semantic items, and 0% of episodic and raw**, matching the shape of the prompt asymmetry exactly.

The Python side of that report was fixed. The Go implementation carries the same output-format block and was not updated, so memories extracted through the Go path can still come back with an empty `valid_at`, and the two implementations now instruct the model differently for the same memory type.

Worth noting the drift runs both ways here: `formatMemoryTime` in `internal/service/memory_extractor.go` has had the "unparseable or empty input falls back to the supplied time" behaviour for a while, which the Python side only picked up more recently. This PR is just the other half.

### A question rather than a change

Go's `TYPE_INSTRUCTIONS["semantic"]` also omits the line Python has:

```
- Default: valid_at = conversation time, invalid_at = "" for timeless facts
```

I deliberately left that alone. The Go instruction blocks look intentionally condensed relative to Python's (the `Examples:` lines are dropped throughout too), so adding it back felt like it could be cutting against a deliberate style choice rather than fixing a drift. Happy to add it in this PR if you'd prefer full parity on the rule text — just say the word.

More generally: is keeping the Go and Python extractor prompts in sync something you want tracked, or is the Go path expected to diverge as it takes over? Answering that would tell me whether drift like this is worth reporting when I come across it.

### Verification

- `gofmt` clean on the changed file.
- Parsed the file with `go/parser` and unquoted all three `OUTPUT_TEMPLATES` literals to confirm the raw string is still well-formed with the non-ASCII em-dash in it.
- `generateOutputFormat` only appends the template and `strings.Join`s it, so the value is embedded into the prompt and never parsed by Go — nothing in the package inspects its contents.
- No test in `internal/service/` references `OUTPUT_TEMPLATES` or `AssembleSystemPrompt`.
- `go vet ./internal/service/` does not complete on macOS for reasons unrelated to this change (a cgo dependency needs `office_oxide.h`, and `internal/agent/sandbox` uses the Linux-only `syscall.Pdeathsig`). Leaving the full build to CI.
