### PR TITLE
fix(naive): route misconfigured MinerU PDFs to by_mineru instead of by_plaintext (#17114)

### DIFF
--- a/common/parser_config_utils.py
+++ b/common/parser_config_utils.py
@@ -17,6 +17,28 @@
 from typing import Any
 
 
+# Parser-specific option keys. ``_has_mineru_options`` uses these to detect
+# whether the operator clearly intended the MinerU parser (issue #17114).
+MINERU_OPTION_KEYS: tuple[str, ...] = (
+    "mineru_parse_method",
+    "mineru_formula_enable",
+    "mineru_table_enable",
+    "mineru_lang",
+)
+
+
+def has_mineru_options(parser_config: Any) -> bool:
+    """Return True if parser_config carries any MinerU-specific option.
+
+    Used by the PDF dispatch in :mod:`rag.app.naive` to recover from a
+    misconfigured ``layout_recognize`` value (a stale TenantModel id rather
+    than the ``"MinerU"`` keyword) — see issue #17114.
+    """
+    if not isinstance(parser_config, dict):
+        return False
+    return any(k in parser_config for k in MINERU_OPTION_KEYS)
+
+
 def normalize_layout_recognizer(layout_recognizer_raw: Any) -> tuple[Any, str | None]:
     parser_model_name: str | None = None
     layout_recognizer = layout_recognizer_raw

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -127,22 +127,13 @@ def by_deepdoc(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, 
     return sections, tables, pdf_parser
 
 
-_MINERU_OPTION_KEYS = (
-    "mineru_parse_method",
-    "mineru_formula_enable",
-    "mineru_table_enable",
-    "mineru_lang",
-)
-
-
 def _has_mineru_options(parser_config: dict) -> bool:
     """Return True if parser_config carries any MinerU-specific option.
 
     Thin wrapper around :func:`common.parser_config_utils.has_mineru_options`
     kept here so callers in this module don't need to import the helper
-    separately. Used by :func:`_dispatch_pdf_parser` to recover from a
-    misconfigured ``layout_recognize`` value (a stale TenantModel id
-    rather than the ``"MinerU"`` keyword) — see issue #17114.
+    separately. The MinerU option-key contract lives in
+    :data:`common.parser_config_utils.MINERU_OPTION_KEYS` — see issue #17114.
     """
     from common.parser_config_utils import has_mineru_options
     return has_mineru_options(parser_config)

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -20,6 +20,7 @@ import os
 from functools import reduce
 from io import BytesIO
 from timeit import default_timer as timer
+from typing import Any, Callable
 from docx import Document
 from docx.opc.pkgreader import _SerializedRelationships, _SerializedRelationship
 from docx.table import Table as DocxTable
@@ -47,7 +48,7 @@ from deepdoc.parser.pdf_parser import PlainParser, VisionParser
 from deepdoc.parser.docling_parser import DoclingParser
 from deepdoc.parser.tcadp_parser import TCADPParser
 from common.float_utils import normalize_overlapped_percent
-from common.parser_config_utils import normalize_layout_recognizer
+from common.parser_config_utils import has_mineru_options, normalize_layout_recognizer
 from common.text_utils import normalize_arabic_presentation_forms
 from rag.nlp import (
     concat_img,
@@ -127,18 +128,6 @@ def by_deepdoc(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, 
     return sections, tables, pdf_parser
 
 
-def _has_mineru_options(parser_config: dict) -> bool:
-    """Return True if parser_config carries any MinerU-specific option.
-
-    Thin wrapper around :func:`common.parser_config_utils.has_mineru_options`
-    kept here so callers in this module don't need to import the helper
-    separately. The MinerU option-key contract lives in
-    :data:`common.parser_config_utils.MINERU_OPTION_KEYS` — see issue #17114.
-    """
-    from common.parser_config_utils import has_mineru_options
-    return has_mineru_options(parser_config)
-
-
 def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None) -> tuple[Callable, str, Any, str, Any]:
     """Resolve the PDF parser callable for the current ``parser_config``.
 
@@ -160,6 +149,12 @@ def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None) -> t
     if isinstance(layout_recognizer, bool):
         layout_recognizer = "DeepDOC" if layout_recognizer else "PlainText"
 
+    # Normalize "Plain Text" to "plaintext" so the PARSERS lookup below
+    # hits the explicit "plaintext" entry instead of falling through to
+    # the by_plaintext default — important because the MinerU fallback
+    # guard below keys off whether the parsed name is a known keyword.
+    if layout_recognizer == "Plain Text":
+        layout_recognizer = "plaintext"
     name = layout_recognizer.strip().lower()
     parser = PARSERS.get(name, by_plaintext)
 
@@ -171,7 +166,11 @@ def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None) -> t
     # options are set in parser_config, the operator clearly intended the
     # MinerU parser, so route there instead and surface a clear log line
     # rather than masking the misconfiguration silently.
-    if parser is by_plaintext and _has_mineru_options(parser_config):
+    # Guard: only fall back when the parser name is NOT a known keyword
+    # (e.g. "DeepDOC", "Plain Text"). A configuration like
+    # ``{"layout_recognize": "Plain Text", "mineru_lang": "English"}``
+    # must keep honoring PlainText, not be silently rerouted to MinerU.
+    if name not in PARSERS and parser is by_plaintext and has_mineru_options(parser_config):
         logging.warning(
             "[naive] layout_recognize=%r does not match a known parser; "
             "falling back to MinerU because mineru_* options are set "

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -1118,14 +1118,17 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
                 layout_recognize_raw = get_composite_model_name_by_id(layout_recognize_raw)
             except LookupError:
                 pass
-        layout_recognizer, parser_model_name = normalize_layout_recognizer(layout_recognize_raw)
+        # Skip the local normalize_layout_recognizer() call — the dispatcher
+        # does it internally on the layout_recognize_override argument, so a
+        # second call here just discards the parsed model_name and breaks the
+        # @mineru/@paddleocr/@opendataloader/@somark composite-name wiring
+        # (CodeRabbit review #5 on #17114).
         opendataloader_llm_name = kwargs.pop("opendataloader_llm_name", None)
         # Pass the resolved layout_recognize (after get_composite_model_name_by_id
-        # turned a TenantModel UUID into a "<model>@<instance>@<provider>" form) so
-        # the dispatch doesn't re-read the stale UUID from parser_config and
-        # fall back through to by_mineru / by_plaintext (issue #17114 review).
+        # turned a TenantModel UUID into a "<model>@<instance>@<provider>" form)
+        # so the dispatch can extract the right parser_model_name.
         parser, name, layout_recognizer, opendataloader_llm_name, parser_model_name = _dispatch_pdf_parser(
-            parser_config, opendataloader_llm_name, layout_recognize_override=layout_recognizer,
+            parser_config, opendataloader_llm_name, layout_recognize_override=layout_recognize_raw,
         )
 
         if parser_config.get("analyze_hyperlink", False) and is_root:

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -128,12 +128,17 @@ def by_deepdoc(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, 
     return sections, tables, pdf_parser
 
 
-def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None) -> tuple[Callable, str, Any, str, Any]:
+def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None, layout_recognize_override: str | None = None) -> tuple[Callable, str, Any, str, Any]:
     """Resolve the PDF parser callable for the current ``parser_config``.
 
     Returns a 5-tuple ``(parser_callable, parser_name, layout_recognizer,
     opendataloader_llm_name, parser_model_name)`` so the dispatch logic
     stays testable in isolation (issue #17114).
+
+    ``layout_recognize_override`` lets callers pass an already-resolved
+    layout_recognize value (e.g. a UUID resolved via
+    :func:`get_composite_model_name_by_id`) so the dispatch doesn't
+    re-read the stale UUID from ``parser_config`` and re-normalize it.
 
     When ``layout_recognize`` is a value that does not match any known parser
     name — typically a stale ``TenantModel`` UUID stored on the document —
@@ -142,7 +147,12 @@ def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None) -> t
     to :func:`by_plaintext`, which would otherwise try to resolve the UUID
     as an IMAGE2TEXT vision model and crash.
     """
-    layout_recognizer, parser_model_name = normalize_layout_recognizer(parser_config.get("layout_recognize", "DeepDOC"))
+    raw_layout_recognize = (
+        layout_recognize_override
+        if layout_recognize_override is not None
+        else parser_config.get("layout_recognize", "DeepDOC")
+    )
+    layout_recognizer, parser_model_name = normalize_layout_recognizer(raw_layout_recognize)
     if layout_recognizer == "OpenDataLoader" and parser_model_name:
         opendataloader_llm_name = parser_model_name
 
@@ -1110,7 +1120,13 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
                 pass
         layout_recognizer, parser_model_name = normalize_layout_recognizer(layout_recognize_raw)
         opendataloader_llm_name = kwargs.pop("opendataloader_llm_name", None)
-        parser, name, layout_recognizer, opendataloader_llm_name, parser_model_name = _dispatch_pdf_parser(parser_config, opendataloader_llm_name)
+        # Pass the resolved layout_recognize (after get_composite_model_name_by_id
+        # turned a TenantModel UUID into a "<model>@<instance>@<provider>" form) so
+        # the dispatch doesn't re-read the stale UUID from parser_config and
+        # fall back through to by_mineru / by_plaintext (issue #17114 review).
+        parser, name, layout_recognizer, opendataloader_llm_name, parser_model_name = _dispatch_pdf_parser(
+            parser_config, opendataloader_llm_name, layout_recognize_override=layout_recognizer,
+        )
 
         if parser_config.get("analyze_hyperlink", False) and is_root:
             urls = extract_links_from_pdf(binary)

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -127,6 +127,72 @@ def by_deepdoc(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, 
     return sections, tables, pdf_parser
 
 
+_MINERU_OPTION_KEYS = (
+    "mineru_parse_method",
+    "mineru_formula_enable",
+    "mineru_table_enable",
+    "mineru_lang",
+)
+
+
+def _has_mineru_options(parser_config: dict) -> bool:
+    """Return True if parser_config carries any MinerU-specific option.
+
+    Thin wrapper around :func:`common.parser_config_utils.has_mineru_options`
+    kept here so callers in this module don't need to import the helper
+    separately. Used by :func:`_dispatch_pdf_parser` to recover from a
+    misconfigured ``layout_recognize`` value (a stale TenantModel id
+    rather than the ``"MinerU"`` keyword) — see issue #17114.
+    """
+    from common.parser_config_utils import has_mineru_options
+    return has_mineru_options(parser_config)
+
+
+def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None) -> tuple[Callable, str, Any, str, Any]:
+    """Resolve the PDF parser callable for the current ``parser_config``.
+
+    Returns a 5-tuple ``(parser_callable, parser_name, layout_recognizer,
+    opendataloader_llm_name, parser_model_name)`` so the dispatch logic
+    stays testable in isolation (issue #17114).
+
+    When ``layout_recognize`` is a value that does not match any known parser
+    name — typically a stale ``TenantModel`` UUID stored on the document —
+    and the parser config carries MinerU-specific options (``mineru_*``
+    keys), the dispatch falls back to :func:`by_mineru` instead of routing
+    to :func:`by_plaintext`, which would otherwise try to resolve the UUID
+    as an IMAGE2TEXT vision model and crash.
+    """
+    layout_recognizer, parser_model_name = normalize_layout_recognizer(parser_config.get("layout_recognize", "DeepDOC"))
+    if layout_recognizer == "OpenDataLoader" and parser_model_name:
+        opendataloader_llm_name = parser_model_name
+
+    if isinstance(layout_recognizer, bool):
+        layout_recognizer = "DeepDOC" if layout_recognizer else "PlainText"
+
+    name = layout_recognizer.strip().lower()
+    parser = PARSERS.get(name, by_plaintext)
+
+    # Closes #17114: when the document's layout_recognize is a model id
+    # (e.g. a TenantModel UUID) that does not match any known parser name,
+    # the previous dispatch fell through to by_plaintext, which tried to
+    # resolve the id as an IMAGE2TEXT vision model and failed with
+    # ``Provider <empty> not found for model <id>``. If mineru-specific
+    # options are set in parser_config, the operator clearly intended the
+    # MinerU parser, so route there instead and surface a clear log line
+    # rather than masking the misconfiguration silently.
+    if parser is by_plaintext and _has_mineru_options(parser_config):
+        logging.warning(
+            "[naive] layout_recognize=%r does not match a known parser; "
+            "falling back to MinerU because mineru_* options are set "
+            "(see issue #17114).",
+            layout_recognizer,
+        )
+        parser = by_mineru
+        name = "mineru"
+
+    return parser, name, layout_recognizer, opendataloader_llm_name, parser_model_name
+
+
 def by_mineru(
     filename,
     binary=None,
@@ -1054,17 +1120,10 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
                 pass
         layout_recognizer, parser_model_name = normalize_layout_recognizer(layout_recognize_raw)
         opendataloader_llm_name = kwargs.pop("opendataloader_llm_name", None)
-        if layout_recognizer == "OpenDataLoader" and parser_model_name:
-            opendataloader_llm_name = parser_model_name
+        parser, name, layout_recognizer, opendataloader_llm_name, parser_model_name = _dispatch_pdf_parser(parser_config, opendataloader_llm_name)
 
         if parser_config.get("analyze_hyperlink", False) and is_root:
             urls = extract_links_from_pdf(binary)
-
-        if isinstance(layout_recognizer, bool):
-            layout_recognizer = "DeepDOC" if layout_recognizer else "PlainText"
-
-        name = layout_recognizer.strip().lower()
-        parser = PARSERS.get(name, by_plaintext)
         callback(0.1, "Start to parse.")
         if name == "mineru":
             kwargs["parse_method"] = "naive"

--- a/test/unit_test/rag/test_naive_dispatch.py
+++ b/test/unit_test/rag/test_naive_dispatch.py
@@ -26,19 +26,18 @@ The fix routes the dispatch to :func:`by_mineru` whenever
 ``layout_recognize`` does not match any known parser name AND the parser
 config carries MinerU-specific options (``mineru_*`` keys).
 
-These tests cover the two helper entry points:
-
-1. :func:`common.parser_config_utils.has_mineru_options` — the predicate
-   that detects MinerU intent (the easy bit, but easy to regress).
-2. :func:`common.parser_config_utils.normalize_layout_recognizer` — the
-   hook that strips the ``@mineru`` / ``@opendataloader`` / ``@paddleocr``
-   / ``@somark`` suffixes produced by the Tenant LLM Provider UI.
-
-The full dispatch in :func:`rag.app.naive._dispatch_pdf_parser` is wired
-up by the chunk() call site and is verified end-to-end via the
-``testcases`` integration suite; we keep the unit tests focused on the
-helper predicates that drive the recovery branch.
+The dispatch helper ``_dispatch_pdf_parser`` lives in
+:mod:`rag.app.naive`, which pulls in a heavy stack (Deepdoc, PaddleOCR,
+Docling, etc.). These tests stub the heavy modules so the helper can be
+loaded and exercised directly.
 """
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
 
 from common.parser_config_utils import (
     MINERU_OPTION_KEYS,
@@ -108,98 +107,271 @@ def test_normalize_layout_recognizer_passes_stale_uuid_through():
 
 
 # --------------------------------------------------------------------------- #
-# _dispatch_pdf_parser — guarded MinerU fallback (CodeRabbit review #3)
+# _dispatch_pdf_parser — actually exercised via stubbed load of rag.app.naive
 # --------------------------------------------------------------------------- #
 #
-# These tests cover the dispatch's MinerU fallback guard. They intentionally
-# focus on the predicate that matters (whether the dispatch routes a
-# known keyword to its expected parser) rather than exhaustively stubbing
-# the heavy naive.py module — the full dispatch integration is verified
-# via the testcases suite.
-#
-# CodeRabbit review pointed out that ``parser is by_plaintext`` is also true
-# for the explicit "Plain Text" selection, so guarding the fallback on
-# ``name not in PARSERS`` alone was insufficient. The fix normalizes
-# "Plain Text" -> "plaintext" before the lookup so the guard correctly
-# distinguishes explicit operator choices from stale UUIDs.
-KNOWN_PARSER_KEYWORDS = ("deepdoc", "mineru", "docling", "opendataloader", "tcadp parser",
-                         "paddleocr", "somark", "mistral ocr", "plaintext")
+# naive.py pulls in a heavy stack (Deepdoc, PaddleOCR, Docling, etc.). The
+# fixture below stubs just enough to load the module and exposes
+# ``naive_module`` so individual tests can call _dispatch_pdf_parser
+# directly and assert on the returned parser, normalized name, and
+# parser_model_name.
 
 
-def _expected_parser_name_for(layout_recognize: str) -> str:
-    """Return the normalized PARSERS key for the operator's choice."""
-    if layout_recognize == "Plain Text":
-        return "plaintext"
-    return layout_recognize.strip().lower()
+def _stub(name, **attrs):
+    """Stub a module that *replaces* whatever may already be registered
+    under the same name (e.g. by test_laws_docx_tables). naive.py's
+    fixture needs the same module slots, but with our marker classes —
+    a setdefault would leave stale attributes behind."""
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
 
 
-def test_dispatch_does_not_fall_back_to_mineru_for_plain_text_with_mineru_options():
-    """Regression for CodeRabbit review #3 on #17114: an operator who
-    explicitly chose ``layout_recognize='Plain Text'`` must not be
-    silently rerouted to MinerU just because they also set a
-    ``mineru_lang`` (or any other mineru_* key) on the parser config."""
-    parser_config = {
-        "layout_recognize": "Plain Text",
-        "mineru_lang": "English",
-    }
-    expected = _expected_parser_name_for("Plain Text")
-    assert expected == "plaintext"
-    # The exact dispatch invariant the fix preserves: every known keyword
-    # must still resolve to its own parser, regardless of mineru_* noise.
-    assert expected in KNOWN_PARSER_KEYWORDS
+class _Parser:
+    """Marker class so the dispatch can identify by_parser by instance."""
+
+    NAME = ""
+
+    def __init__(self):
+        type(self).NAME = self.__class__.__name__
 
 
-def test_dispatch_does_not_fall_back_to_mineru_for_plaintext_with_mineru_options():
-    parser_config = {
-        "layout_recognize": "plaintext",
-        "mineru_lang": "English",
-    }
-    assert _expected_parser_name_for("plaintext") in KNOWN_PARSER_KEYWORDS
+class _ByDeepdoc(_Parser):
+    pass
 
 
-def test_dispatch_does_not_fall_back_to_mineru_for_deepdoc_with_mineru_options():
-    parser_config = {
-        "layout_recognize": "DeepDOC",
-        "mineru_lang": "English",
-    }
-    assert _expected_parser_name_for("DeepDOC") in KNOWN_PARSER_KEYWORDS
+class _ByMineru(_Parser):
+    pass
 
 
-def test_dispatch_falls_back_to_mineru_only_for_unknown_layout_recognize():
-    """The MinerU fallback must only trigger when layout_recognize is not
-    a known keyword — e.g. a stale TenantModel UUID like the one the issue
-    reports."""
+class _ByDocling(_Parser):
+    pass
+
+
+class _ByOpenDataLoader(_Parser):
+    pass
+
+
+class _ByPlaintext(_Parser):
+    pass
+
+
+@pytest.fixture(scope="module")
+def naive_module():
+    """Load rag.app.naive with all heavy siblings stubbed.
+
+    Yields the loaded module so tests can call _dispatch_pdf_parser
+    directly. Stubs the dispatch's full dependency chain (Deepdoc, the
+    LLM stack, PaddleOCR, Docling, ...) so the module can be loaded
+    inside a minimal pytest env.
+    """
+    # Save sys.modules so the fixture restores it on teardown — naive.py's
+    # import-time side effects would otherwise leak into the rest of the
+    # test suite.
+    saved = {name: sys.modules.get(name) for name in list(sys.modules)}
+
+    try:
+        # Stub the parser stack used at naive.py import time.
+        _stub(
+            "deepdoc.parser",
+            PdfParser=_Parser,
+            DocxParser=_Parser,
+            EpubParser=_Parser,
+            HtmlParser=_Parser,
+            ExcelParser=_Parser,
+            JsonParser=_Parser,
+            MarkdownElementExtractor=_Parser,
+            MarkdownParser=_Parser,
+            PdfParser_module=_Parser,
+            TxtParser=_Parser,
+            RAGFlowPdfParser=_Parser,
+            PlainParser=_Parser,
+            VisionParser=_Parser,
+            DoclingParser=_ByDocling,
+            TCADPParser=_Parser,
+        )
+        _stub("deepdoc.parser.figure_parser",
+              VisionFigureParser=_Parser,
+              vision_figure_parser_docx_wrapper_naive=lambda *a, **k: None,
+              vision_figure_parser_pdf_wrapper=lambda *a, **k: None)
+        _stub("deepdoc.parser.pdf_parser",
+              PlainParser=_ByPlaintext,
+              VisionParser=_Parser,
+              RAGFlowPdfParser=_Parser)
+        _stub("deepdoc.parser.docling_parser", DoclingParser=_ByDocling)
+        _stub("deepdoc.parser.tcadp_parser", TCADPParser=_Parser)
+        _stub("deepdoc.parser.utils", extract_pdf_outlines=lambda *a, **k: [])
+
+        _stub("common.parser_config_utils",
+              normalize_layout_recognizer=normalize_layout_recognizer,
+              MINERU_OPTION_KEYS=MINERU_OPTION_KEYS,
+              has_mineru_options=has_mineru_options)
+        _stub("common.float_utils", normalize_overlapped_percent=lambda x: x)
+        _stub("common.text_utils", normalize_arabic_presentation_forms=lambda x: x)
+        _stub("common.token_utils", num_tokens_from_string=lambda s: len((s or "").split()))
+
+        _stub("rag.utils.file_utils",
+              extract_embed_file=lambda *a, **k: None,
+              extract_links_from_pdf=lambda *a, **k: [],
+              extract_links_from_docx=lambda *a, **k: [],
+              extract_html=lambda *a, **k: (None, None))
+
+        _stub("rag.nlp",
+              num_tokens_from_string=lambda s: len((s or "").split()),
+              find_codec=lambda b: "utf-8",
+              rag_tokenizer=types.SimpleNamespace(tokenize=lambda s: ((s or "").split(), [])),
+              concat_img=lambda *a, **k: None,
+              naive_merge=lambda *a, **k: [],
+              naive_merge_with_images=lambda *a, **k: [],
+              naive_merge_docx=lambda *a, **k: [],
+              tokenize_chunks=lambda *a, **k: [],
+              doc_tokenize_chunks_with_images=lambda *a, **k: [],
+              tokenize_chunks_with_images=lambda *a, **k: [],
+              tokenize_table=lambda *a, **k: [],
+              append_context2table_image4pdf=lambda *a, **k: [])
+
+        _stub("rag.llm.ocr_model",
+              ensure_mineru_from_env=lambda *a, **k: None,
+              get_first_provider_model_name=lambda *a, **k: None)
+
+        _stub("api.db.joint_services.tenant_model_service",
+              resolve_model_config=lambda *a, **k: None,
+              ensure_mineru_from_env=lambda *a, **k: None,
+              get_tenant_default_model_by_type=lambda *a, **k: None,
+              ensure_opendataloader_from_env=lambda *a, **k: None,
+              ensure_paddleocr_from_env=lambda *a, **k: None,
+              ensure_somark_from_env=lambda *a, **k: None,
+              get_first_provider_model_name=lambda *a, **k: None,
+              get_composite_model_name_by_id=lambda *a, **k: (_ for _ in ()).throw(LookupError()))
+
+        _stub("api.db.services.llm_service", LLMBundle=_Parser)
+
+        # Stub the docx stack so the file_format checks at import time succeed.
+        _stub("docx", Document=_Parser)
+        _stub("docx.opc.pkgreader",
+              _SerializedRelationships=_Parser,
+              _SerializedRelationship=_Parser)
+        _stub("docx.table", Table=_Parser)
+        _stub("docx.text.paragraph", Paragraph=_Parser)
+        _stub("docx.opc.oxml", parse_xml=lambda *a, **k: None)
+        _stub("markdown", markdown=lambda *a, **k: "")
+        _stub("PIL", Image=_Parser)
+
+        # Load naive.py from source — we can do this even with stubs in place
+        # because the module only imports the names listed above.
+        repo_root = Path(__file__).resolve().parents[3]
+        spec = importlib.util.spec_from_file_location(
+            "rag.app.naive_test_module", repo_root / "rag" / "app" / "naive.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["rag.app.naive_test_module"] = module
+        spec.loader.exec_module(module)
+
+        # Replace the dispatch's PARSERS entries with our marker classes
+        # so assertions can identify which parser the dispatch selected.
+        module.PARSERS["deepdoc"] = _ByDeepdoc
+        module.PARSERS["mineru"] = _ByMineru
+        module.PARSERS["docling"] = _ByDocling
+        module.PARSERS["opendataloader"] = _ByOpenDataLoader
+        module.PARSERS["plaintext"] = _ByPlaintext
+
+        yield module
+    finally:
+        # Restore sys.modules exactly — naive.py's import-time side
+        # effects would otherwise leak into the rest of the test suite.
+        for name in list(sys.modules):
+            if name not in saved:
+                del sys.modules[name]
+        sys.modules.update(saved)
+
+
+def _dispatch(naive_module, layout_recognize, parser_config=None):
+    """Invoke _dispatch_pdf_parser with the given layout_recognize and
+    parser_config extras. Returns the (parser, name, layout_recognizer,
+    opendataloader_llm_name, parser_model_name) tuple."""
+    cfg = dict(parser_config or {})
+    cfg["layout_recognize"] = layout_recognize
+    return naive_module._dispatch_pdf_parser(cfg)
+
+
+# CodeRabbit review #3: don't fall back to MinerU for known keywords.
+def test_dispatch_does_not_fall_back_to_mineru_for_plain_text_with_mineru_options(naive_module):
+    """layout_recognize='Plain Text' is a known keyword — the dispatcher
+    must keep routing to by_plaintext even if mineru_* options are set."""
+    parser, name, _lr, _op, _model = _dispatch(
+        naive_module, "Plain Text", {"mineru_lang": "English"},
+    )
+    assert name == "plaintext"
+    assert parser is _ByPlaintext
+
+
+def test_dispatch_does_not_fall_back_to_mineru_for_plaintext_with_mineru_options(naive_module):
+    parser, name, _lr, _op, _model = _dispatch(
+        naive_module, "plaintext", {"mineru_lang": "English"},
+    )
+    assert name == "plaintext"
+    assert parser is _ByPlaintext
+
+
+def test_dispatch_does_not_fall_back_to_mineru_for_deepdoc_with_mineru_options(naive_module):
+    parser, name, _lr, _op, _model = _dispatch(
+        naive_module, "DeepDOC", {"mineru_lang": "English"},
+    )
+    assert name == "deepdoc"
+    assert parser is _ByDeepdoc
+
+
+# Issue #17114: the actual dispatch recovery path.
+def test_dispatch_falls_back_to_mineru_only_for_unknown_layout_recognize(naive_module):
+    """A stale TenantModel UUID with mineru_* options must route to
+    by_mineru so the operator's MinerU intent is honored (issue #17114)."""
     stale_uuid = "06d85f8e819111f1995ef33d60f3a479"
-    # The UUID must NOT be a known keyword (that's the whole point).
-    assert stale_uuid.strip().lower() not in KNOWN_PARSER_KEYWORDS
+    parser, name, _lr, _op, _model = _dispatch(
+        naive_module, stale_uuid, {"mineru_lang": "English"},
+    )
+    assert name == "mineru"
+    # The fallback branch reassigns parser=by_mineru directly (not via
+    # PARSERS["mineru"]), so identify it by the function name.
+    assert parser.__name__ == "by_mineru"
 
 
-def test_dispatch_uses_resolved_layout_recognize_via_override():
-    """Regression for CodeRabbit review #4 on #17114: the chunk() call
-    site resolves a valid TenantModel UUID to its composite name via
-    get_composite_model_name_by_id() before reaching the dispatch. The
-    dispatch must honor that resolved value (e.g. "model@instance@provider")
-    via the layout_recognize_override argument — otherwise it would
-    re-normalize the original UUID and either fall through to by_mineru or
-    by_plaintext (issue #17114) and discard the configured model."""
-    # We assert the invariant at the helper level: when the dispatch is
-    # called with an override, it must NOT re-read parser_config's
-    # layout_recognize. Simulate that by giving parser_config a stale UUID
-    # but passing the resolved composite name as the override.
-    parser_config = {"layout_recognize": "06d85f8e819111f1995ef33d60f3a479"}
+# CodeRabbit review #4: layout_recognize_override preserves parser_model_name.
+def test_dispatch_uses_resolved_layout_recognize_via_override(naive_module):
+    """The chunk() call site resolves a valid TenantModel UUID via
+    get_composite_model_name_by_id() into "<model>@<instance>@<provider>"
+    before reaching the dispatch. The dispatch must honor that resolved
+    value via the layout_recognize_override argument so the configured
+    MinerU model name is preserved as parser_model_name (CodeRabbit
+    review #4)."""
+    stale_uuid = "06d85f8e819111f1995ef33d60f3a479"
     resolved = "my-llm@my-instance@my-provider@mineru"
-    # The override path is exercised in chunk() — we can't directly invoke
-    # _dispatch_pdf_parser here without standing up the heavy naive.py
-    # module, so we verify the contract instead:
-    # 1. parser_config["layout_recognize"] alone would route to by_mineru
-    #    fallback (UUID, no mineru_* options).
-    # 2. The resolved composite name, after normalize_layout_recognizer,
-    #    yields the keyword "MinerU" + the composite model name as
-    #    parser_model_name — which is the value the dispatch must see when
-    #    layout_recognize_override is set.
-    name, model = normalize_layout_recognizer(resolved)
-    assert name == "MinerU"
+
+    # If we passed layout_recognizer="MinerU" (the post-normalize form)
+    # instead of layout_recognize_raw, parser_model_name would be None.
+    # Passing the full composite name preserves the model so by_mineru can
+    # bind to the operator's configured OCR model.
+    parser, name, _lr, _op, model = naive_module._dispatch_pdf_parser(
+        {"layout_recognize": stale_uuid},
+        layout_recognize_override=resolved,
+    )
+    assert name == "mineru"
+    # PARSERS["mineru"] resolves to the by_mineru dispatch, which the
+    # fixture exposes as the _ByMineru marker class.
+    assert parser.__name__ == "_ByMineru"
     assert model == resolved
-    # The pre-override parser_config still has the stale UUID so we don't
-    # accidentally pass it via the override.
-    assert parser_config["layout_recognize"] != resolved
+
+
+# CodeRabbit review #4 follow-up: layout_recognize_override threads the
+# opendataloader_llm_name through too.
+def test_dispatch_uses_resolved_layout_recognize_via_override_for_opendataloader(naive_module):
+    resolved = "my-llm@my-instance@my-provider@opendataloader"
+
+    parser, name, _lr, op_name, _model = naive_module._dispatch_pdf_parser(
+        {"layout_recognize": "06d85f8e819111f1995ef33d60f3a479"},
+        layout_recognize_override=resolved,
+    )
+    assert name == "opendataloader"
+    assert parser is _ByOpenDataLoader
+    assert op_name == resolved

--- a/test/unit_test/rag/test_naive_dispatch.py
+++ b/test/unit_test/rag/test_naive_dispatch.py
@@ -172,3 +172,34 @@ def test_dispatch_falls_back_to_mineru_only_for_unknown_layout_recognize():
     stale_uuid = "06d85f8e819111f1995ef33d60f3a479"
     # The UUID must NOT be a known keyword (that's the whole point).
     assert stale_uuid.strip().lower() not in KNOWN_PARSER_KEYWORDS
+
+
+def test_dispatch_uses_resolved_layout_recognize_via_override():
+    """Regression for CodeRabbit review #4 on #17114: the chunk() call
+    site resolves a valid TenantModel UUID to its composite name via
+    get_composite_model_name_by_id() before reaching the dispatch. The
+    dispatch must honor that resolved value (e.g. "model@instance@provider")
+    via the layout_recognize_override argument — otherwise it would
+    re-normalize the original UUID and either fall through to by_mineru or
+    by_plaintext (issue #17114) and discard the configured model."""
+    # We assert the invariant at the helper level: when the dispatch is
+    # called with an override, it must NOT re-read parser_config's
+    # layout_recognize. Simulate that by giving parser_config a stale UUID
+    # but passing the resolved composite name as the override.
+    parser_config = {"layout_recognize": "06d85f8e819111f1995ef33d60f3a479"}
+    resolved = "my-llm@my-instance@my-provider@mineru"
+    # The override path is exercised in chunk() — we can't directly invoke
+    # _dispatch_pdf_parser here without standing up the heavy naive.py
+    # module, so we verify the contract instead:
+    # 1. parser_config["layout_recognize"] alone would route to by_mineru
+    #    fallback (UUID, no mineru_* options).
+    # 2. The resolved composite name, after normalize_layout_recognizer,
+    #    yields the keyword "MinerU" + the composite model name as
+    #    parser_model_name — which is the value the dispatch must see when
+    #    layout_recognize_override is set.
+    name, model = normalize_layout_recognizer(resolved)
+    assert name == "MinerU"
+    assert model == resolved
+    # The pre-override parser_config still has the stale UUID so we don't
+    # accidentally pass it via the override.
+    assert parser_config["layout_recognize"] != resolved

--- a/test/unit_test/rag/test_naive_dispatch.py
+++ b/test/unit_test/rag/test_naive_dispatch.py
@@ -105,3 +105,70 @@ def test_normalize_layout_recognizer_passes_stale_uuid_through():
     silently broken."""
     stale_uuid = "06d85f8e819111f1995ef33d60f3a479"
     assert normalize_layout_recognizer(stale_uuid) == (stale_uuid, None)
+
+
+# --------------------------------------------------------------------------- #
+# _dispatch_pdf_parser — guarded MinerU fallback (CodeRabbit review #3)
+# --------------------------------------------------------------------------- #
+#
+# These tests cover the dispatch's MinerU fallback guard. They intentionally
+# focus on the predicate that matters (whether the dispatch routes a
+# known keyword to its expected parser) rather than exhaustively stubbing
+# the heavy naive.py module — the full dispatch integration is verified
+# via the testcases suite.
+#
+# CodeRabbit review pointed out that ``parser is by_plaintext`` is also true
+# for the explicit "Plain Text" selection, so guarding the fallback on
+# ``name not in PARSERS`` alone was insufficient. The fix normalizes
+# "Plain Text" -> "plaintext" before the lookup so the guard correctly
+# distinguishes explicit operator choices from stale UUIDs.
+KNOWN_PARSER_KEYWORDS = ("deepdoc", "mineru", "docling", "opendataloader", "tcadp parser",
+                         "paddleocr", "somark", "mistral ocr", "plaintext")
+
+
+def _expected_parser_name_for(layout_recognize: str) -> str:
+    """Return the normalized PARSERS key for the operator's choice."""
+    if layout_recognize == "Plain Text":
+        return "plaintext"
+    return layout_recognize.strip().lower()
+
+
+def test_dispatch_does_not_fall_back_to_mineru_for_plain_text_with_mineru_options():
+    """Regression for CodeRabbit review #3 on #17114: an operator who
+    explicitly chose ``layout_recognize='Plain Text'`` must not be
+    silently rerouted to MinerU just because they also set a
+    ``mineru_lang`` (or any other mineru_* key) on the parser config."""
+    parser_config = {
+        "layout_recognize": "Plain Text",
+        "mineru_lang": "English",
+    }
+    expected = _expected_parser_name_for("Plain Text")
+    assert expected == "plaintext"
+    # The exact dispatch invariant the fix preserves: every known keyword
+    # must still resolve to its own parser, regardless of mineru_* noise.
+    assert expected in KNOWN_PARSER_KEYWORDS
+
+
+def test_dispatch_does_not_fall_back_to_mineru_for_plaintext_with_mineru_options():
+    parser_config = {
+        "layout_recognize": "plaintext",
+        "mineru_lang": "English",
+    }
+    assert _expected_parser_name_for("plaintext") in KNOWN_PARSER_KEYWORDS
+
+
+def test_dispatch_does_not_fall_back_to_mineru_for_deepdoc_with_mineru_options():
+    parser_config = {
+        "layout_recognize": "DeepDOC",
+        "mineru_lang": "English",
+    }
+    assert _expected_parser_name_for("DeepDOC") in KNOWN_PARSER_KEYWORDS
+
+
+def test_dispatch_falls_back_to_mineru_only_for_unknown_layout_recognize():
+    """The MinerU fallback must only trigger when layout_recognize is not
+    a known keyword — e.g. a stale TenantModel UUID like the one the issue
+    reports."""
+    stale_uuid = "06d85f8e819111f1995ef33d60f3a479"
+    # The UUID must NOT be a known keyword (that's the whole point).
+    assert stale_uuid.strip().lower() not in KNOWN_PARSER_KEYWORDS

--- a/test/unit_test/rag/test_naive_dispatch.py
+++ b/test/unit_test/rag/test_naive_dispatch.py
@@ -1,0 +1,107 @@
+#
+#  Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Regression tests for the PDF parser dispatch in :mod:`rag.app.naive`.
+
+Issue #17114: a document whose ``parser_config.layout_recognize`` was a stale
+``TenantModel`` UUID (rather than the literal ``"MinerU"`` keyword) was being
+dispatched to :func:`by_plaintext`, which tried to resolve the id as an
+IMAGE2TEXT vision model and failed with
+``Provider <empty> not found for model <id>``.
+
+The fix routes the dispatch to :func:`by_mineru` whenever
+``layout_recognize`` does not match any known parser name AND the parser
+config carries MinerU-specific options (``mineru_*`` keys).
+
+These tests cover the two helper entry points:
+
+1. :func:`common.parser_config_utils.has_mineru_options` — the predicate
+   that detects MinerU intent (the easy bit, but easy to regress).
+2. :func:`common.parser_config_utils.normalize_layout_recognizer` — the
+   hook that strips the ``@mineru`` / ``@opendataloader`` / ``@paddleocr``
+   / ``@somark`` suffixes produced by the Tenant LLM Provider UI.
+
+The full dispatch in :func:`rag.app.naive._dispatch_pdf_parser` is wired
+up by the chunk() call site and is verified end-to-end via the
+``testcases`` integration suite; we keep the unit tests focused on the
+helper predicates that drive the recovery branch.
+"""
+
+from common.parser_config_utils import (
+    MINERU_OPTION_KEYS,
+    has_mineru_options,
+    normalize_layout_recognizer,
+)
+
+
+# --------------------------------------------------------------------------- #
+# has_mineru_options
+# --------------------------------------------------------------------------- #
+
+
+def test_has_mineru_options_recognizes_mineru_keys():
+    assert has_mineru_options({"mineru_parse_method": "auto"})
+    assert has_mineru_options({"mineru_formula_enable": True})
+    assert has_mineru_options({"mineru_table_enable": True})
+    assert has_mineru_options({"mineru_lang": "English"})
+
+
+def test_has_mineru_options_returns_false_without_mineru_keys():
+    assert not has_mineru_options({"layout_recognize": "DeepDOC"})
+    assert not has_mineru_options({"layout_recognize": "Plain Text"})
+    assert not has_mineru_options({})
+
+
+def test_has_mineru_options_handles_non_dict():
+    # Defensive: the dispatch must not crash on unexpected shapes.
+    assert not has_mineru_options(None)
+    assert not has_mineru_options("mineru_parse_method")
+    assert not has_mineru_options(["mineru_parse_method"])
+
+
+def test_mineru_option_keys_are_exhaustive():
+    # Guards against a regression where a new mineru_* option is added in
+    # the API but forgotten in the dispatch predicate.
+    expected = {"mineru_parse_method", "mineru_formula_enable", "mineru_table_enable", "mineru_lang"}
+    assert set(MINERU_OPTION_KEYS) == expected
+
+
+# --------------------------------------------------------------------------- #
+# normalize_layout_recognizer (existing helper, regression pinning)
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_layout_recognizer_passes_through_known_keywords():
+    assert normalize_layout_recognizer("DeepDOC") == ("DeepDOC", None)
+    assert normalize_layout_recognizer("MinerU") == ("MinerU", None)
+    assert normalize_layout_recognizer("docling") == ("docling", None)
+
+
+def test_normalize_layout_recognizer_strips_known_provider_suffix():
+    assert normalize_layout_recognizer("my-llm@my-instance@my-provider@mineru") == ("MinerU", "my-llm@my-instance@my-provider@mineru")
+    assert normalize_layout_recognizer("my-llm@my-instance@my-provider@paddleocr") == ("PaddleOCR", "my-llm@my-instance@my-provider@paddleocr")
+    assert normalize_layout_recognizer("my-llm@my-instance@my-provider@opendataloader") == ("OpenDataLoader", "my-llm@my-instance@my-provider@opendataloader")
+    assert normalize_layout_recognizer("my-llm@my-instance@my-provider@somark") == ("SoMark", "my-llm@my-instance@my-provider@somark")
+
+
+def test_normalize_layout_recognizer_passes_stale_uuid_through():
+    """The dispatcher relies on normalize_layout_recognizer leaving a stale
+    TenantModel UUID unchanged so that the by_mineru fallback branch can
+    detect it (issue #17114). If this test ever fails because the UUID is
+    rewritten to something else, the dispatch recovery in naive.py is
+    silently broken."""
+    stale_uuid = "06d85f8e819111f1995ef33d60f3a479"
+    assert normalize_layout_recognizer(stale_uuid) == (stale_uuid, None)


### PR DESCRIPTION
Closes #17114

## Problem
When a document's `parser_config.layout_recognize` held a stale `TenantModel` UUID (rather than the literal `"MinerU"` keyword) **and** the same config carried mineru_* options, `naive.chunk()` dispatched the PDF to `by_plaintext`, which tried to resolve the UUID as an IMAGE2TEXT vision model and crashed with:

```
LookupError: Provider <empty> not found for model <uuid>
```

This is the silent failure mode that #17114 reports: the MinerU access detection in the KB config passes (because the operator selected MinerU), but actual document parsing fails because the per-document `layout_recognize` is a stale UUID that the dispatch doesn't recognize.

## Fix shape
Extracted the parser dispatch out of `naive.chunk()` into a small, isolated `_dispatch_pdf_parser` helper, and added a recovery branch:

- If `layout_recognize` does not match any known parser name **and** `parser_config` carries any `mineru_*` option (`mineru_parse_method`, `mineru_formula_enable`, `mineru_table_enable`, `mineru_lang`) → route to `by_mineru` and emit a clear `[naive]` warning so the operator sees the misconfiguration.
- Otherwise → preserve the previous dispatch (defaults to `by_plaintext`).

The mineru-intent predicate lives in `common/parser_config_utils.has_mineru_options` (with `MINERU_OPTION_KEYS` exposed) so the recovery branch is testable without standing up the full PDF chunking pipeline.

## Verification
```
$ pytest test/unit_test/rag/test_naive_dispatch.py
7 passed
```

New tests cover:
- `has_mineru_options` for the four mineru keys / unknown keys / non-dict inputs
- exhaustive `MINERU_OPTION_KEYS` guard (catches missing keys when a new option is added in the API)
- `normalize_layout_recognizer` on known keywords, the four `@provider` suffixes, and stale UUIDs (the regression invariant that makes the dispatch recovery work).