### PR TITLE
docs(api): spell the recommendation endpoint the way the server registers it

### DIFF
--- a/api/apps/backward_compat.py
+++ b/api/apps/backward_compat.py
@@ -41,7 +41,7 @@ Deprecated APIs and their replacements:
 - GET /api/v1/document/download/{doc_id} -> GET /api/v1/agents/attachments/{doc_id}/download
 - GET /v1/document/download/{attachment_id} -> GET /api/v1/agents/attachments/{attachment_id}/download
 - GET /v1/system/healthz -> GET /api/v1/system/healthz
-- POST /api/v1/sessions/related_questions -> POST /api/v1/chat/recommandation
+- POST /api/v1/sessions/related_questions -> POST /api/v1/chat/recommendation
 - PUT (chunk update) -> PATCH (chunk update)
 """
 

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -36,7 +36,7 @@ The following v0.24.0 REST API paths are deprecated. They remain available throu
 | **POST** `/api/v1/chats_openai/{chat_id}/chat/completions`                        | **POST** `/api/v1/openai/{chat_id}/chat/completions`                                |
 | **PUT** `/api/v1/chats/{chat_id}/sessions/{session_id}`                           | **PATCH** `/api/v1/chats/{chat_id}/sessions/{session_id}`                           |
 | **POST** `/api/v1/chats/{chat_id}/completions`                                    | **POST** `/api/v1/chat/completions`                                                 |
-| **POST** `/api/v1/sessions/related_questions`                                     | **POST** `/api/v1/chat/recommandation`                                              |
+| **POST** `/api/v1/sessions/related_questions`                                     | **POST** `/api/v1/chat/recommendation`                                              |
 | **PUT** `/api/v1/datasets/{dataset_id}/documents/{document_id}/chunks/{chunk_id}` | **PATCH** `/api/v1/datasets/{dataset_id}/documents/{document_id}/chunks/{chunk_id}` |
 | **GET** `/v1/system/healthz`                                                      | **GET** `/api/v1/system/healthz`                                                    |
 | **POST** `/v1/document/upload_info`                                               | **POST** `/api/v1/documents/upload`                                                 |
@@ -5425,7 +5425,7 @@ Failure:
 
 ### Generate related questions
 
-**POST** `/api/v1/chat/recommandation`
+**POST** `/api/v1/chat/recommendation`
 
 Generates five to ten alternative question strings from the user's original query to retrieve more relevant search results.
 
@@ -5444,7 +5444,7 @@ The chat model autonomously determines the number of questions to generate based
 #### Request
 
 - Method: POST
-- URL: `/api/v1/chat/recommandation`
+- URL: `/api/v1/chat/recommendation`
 - Headers:
   - `'content-Type: application/json'`
   - `'Authorization: Bearer <YOUR_LOGIN_TOKEN>'`
@@ -5456,7 +5456,7 @@ The chat model autonomously determines the number of questions to generate based
 
 ```bash
 curl --request POST \
-     --url http://{address}/api/v1/chat/recommandation \
+     --url http://{address}/api/v1/chat/recommendation \
      --header 'Content-Type: application/json' \
      --header 'Authorization: Bearer <YOUR_LOGIN_TOKEN>' \
      --data '{


### PR DESCRIPTION
### Summary

The HTTP API reference documents the "Generate related questions" endpoint as
`POST /api/v1/chat/recommandation`. That path is not served by anything in this
repository.

Both backends register the path with an `e`:

- `api/apps/restful_apis/chat_api.py:1195` — `@manager.route("/chat/recommendation", methods=["POST"])`
- `internal/router/router.go:338` — `chat.POST("/recommendation", r.chatHandler.Recommendation)`

Nothing registers the misspelled path, and neither the nginx configs under
`docker/` nor the Helm ingress rewrite it, so a request built from the reference
reaches an undefined route and returns 404.

The reason this one stings a little: that section is the *migration target* for a
deprecated endpoint. Its own caution block says

> `POST /api/v1/sessions/related_questions` is deprecated. Use this endpoint instead.

So a reader following the deprecation notice moves a working integration onto a
path that does not exist.

The correct spelling is already used everywhere else that matters:

- `web/src/utils/api.ts:317` — `chatsRelatedQuestions: \`${restAPIv1}/chat/recommendation\``
- `test/testcases/restful_api/test_sessions.py:586` — `rest_client.post("/chat/recommendation", json={})`

### Changes

Four occurrences in `docs/references/http_api_reference.md`: the deprecated-alias
table row, the endpoint heading, the `URL:` field, and the copy-pasteable `curl`
example.

One occurrence in the `api/apps/backward_compat.py` module docstring, which
listed the replacement as `/chat/recommandation` while the same file spells it
correctly in the handler docstring and log message a few hundred lines below
(`api/apps/backward_compat.py:484-491`).

After the change there are no remaining occurrences of the misspelling in the
repository.
