### PR TITLE
docs(api): document the document-update endpoint as PATCH

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -1522,10 +1522,6 @@ Failure:
 
 Updates configurations for a specified document.
 
-:::caution DEPRECATED
-`PUT /api/v1/datasets/{dataset_id}/documents/{document_id}` is deprecated. Use this endpoint instead.
-:::
-
 #### Request
 
 - Method: PATCH

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -1518,13 +1518,17 @@ Failure:
 
 ### Update document
 
-**PUT** `/api/v1/datasets/{dataset_id}/documents/{document_id}`
+**PATCH** `/api/v1/datasets/{dataset_id}/documents/{document_id}`
 
 Updates configurations for a specified document.
 
+:::caution DEPRECATED
+`PUT /api/v1/datasets/{dataset_id}/documents/{document_id}` is deprecated. Use this endpoint instead.
+:::
+
 #### Request
 
-- Method: PUT
+- Method: PATCH
 - URL: `/api/v1/datasets/{dataset_id}/documents/{document_id}`
 - Headers:
   - `'content-Type: application/json'`
@@ -1538,7 +1542,7 @@ Updates configurations for a specified document.
 ##### Request example
 
 ```bash
-curl --request PUT \
+curl --request PATCH \
      --url http://{address}/api/v1/datasets/{dataset_id}/documents/{document_id} \
      --header 'Authorization: Bearer <YOUR_API_KEY>' \
      --header 'Content-Type: application/json' \


### PR DESCRIPTION
### Summary

`PUT /api/v1/datasets/{dataset_id}/documents/{document_id}` is a deprecated alias.
`api/apps/backward_compat.py:562` registers it, logs a deprecation warning, and
forwards to the real handler:

```python
@manager.route("/datasets/<dataset_id>/documents/<document_id>", methods=["PUT"])
async def deprecated_update_document(dataset_id, document_id):
    """
    Deprecated: Use PATCH /api/v1/datasets/{dataset_id}/documents/{document_id} instead.
    """
```

The live route is PATCH, at `api/apps/restful_apis/document_api.py:191`.

The HTTP reference still presents PUT as the endpoint, and there is no PATCH
section anywhere in the file, so the only documented way to update a document is
the deprecated one and every request built from the reference logs a deprecation
warning server-side.

The chunk-update endpoint went through the same PUT to PATCH migration and its
section *was* updated. This change gives the document section the same shape,
including the caution block, so the two read consistently:

- "Update chunk" (`http_api_reference.md:2467`) — **PATCH**, with a caution block naming the old PUT
- "Update document" (`http_api_reference.md:1521`) — **PUT**, with no caution block

The official Python SDK already calls PATCH:

- `sdk/python/ragflow_sdk/modules/document.py:57` — `self.patch(f"/datasets/{self.dataset_id}/documents/{self.id}", update_message)`

### Note

I left the "Deprecated API Aliases" table alone. It lists the chunk
`PUT` to `PATCH` migration but not this one, so a row is arguably missing there
too. I kept it out to hold this diff to the section in question. Happy to add it
if you'd prefer it in the same PR.
