### PR TITLE
fix(sandbox): sync the sandbox env with the Python version it requires

### DIFF
--- a/agent/sandbox/Makefile
+++ b/agent/sandbox/Makefile
@@ -32,7 +32,7 @@ all: setup start
 # 🌱 Initialize environment + install dependencies
 setup: ensure_env ensure_uv
 	@echo "📦 Installing dependencies with uv..."
-	@$(UV) sync --python 3.12
+	@$(UV) sync --python 3.13
 	source $(ACTIVATE_SCRIPT) && \
 	export PYTHONPATH=$(PYTHONPATH)
 	@$(UV) pip install -r executor_manager/requirements.txt


### PR DESCRIPTION
### Summary

`make setup` in `agent/sandbox` cannot complete. `agent/sandbox/Makefile:35` runs

```make
@$(UV) sync --python 3.12
```

but the project requires 3.13:

- `agent/sandbox/pyproject.toml:6` — `requires-python = ">=3.13,<3.14"`
- `agent/sandbox/uv.lock:3` — `requires-python = "==3.13.*"`

uv refuses the mismatch and exits before installing anything:

```
$ uv sync --python 3.12
Using CPython 3.12.13
error: The requested interpreter resolved to Python 3.12.13, which is incompatible
with the project's Python requirement: `==3.13.*` (from `project.requires-python`)
```

With 3.13 the same command resolves against the committed lockfile with no other
change:

```
$ uv sync --python 3.13
Using CPython 3.13.13
Resolved 29 packages in 4ms
Found up-to-date lockfile at: uv.lock
```

This is the documented entry point for the sandbox. `agent/sandbox/README.md`
lists `make setup` as "Initialize environment and install uv", and the default
target is `all: setup start`, so a plain `make` hits it too.

`--python 3.12` is the only 3.12 pin left under `agent/sandbox/`.
