### PR TITLE
fix(retrieval): keep file-filter chunk counts consistent in retrieval testing

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -1058,6 +1058,7 @@ async def search(dataset_id: str, tenant_id: str, req: dict):
     rerank_candidates_count = int(req.get("rerank_candidates_count", 64))
     question = req.get("question", "")
     doc_ids = req.get("doc_ids", [])
+    doc_ids_as_filter = bool(req.get("doc_ids_as_filter", False))
     use_kg = req.get("use_kg", False)
     similarity_threshold = float(req.get("similarity_threshold", 0.0))
     vector_similarity_weight = float(req.get("vector_similarity_weight", 0.3))
@@ -1168,6 +1169,7 @@ async def search(dataset_id: str, tenant_id: str, req: dict):
         similarity_threshold,
         vector_similarity_weight,
         doc_ids=local_doc_ids,
+        doc_ids_as_filter=doc_ids_as_filter,
         knn_top_k=knn_top_k,
         knn_num_candidates=knn_num_candidates,
         rerank_mdl=rerank_mdl,
@@ -1444,6 +1446,7 @@ async def search_datasets(tenant_id: str, req: dict):
     question = req.get("question", "")
     doc_ids = req.get("doc_ids", [])
     use_kg = req.get("use_kg", False)
+    doc_ids_as_filter = bool(req.get("doc_ids_as_filter", False))
     similarity_threshold = float(req.get("similarity_threshold", 0.0))
     vector_similarity_weight = float(req.get("vector_similarity_weight", 0.3))
     knn_top_k = max(1, min(int(req.get("knn_top_k", 1024)), 2048))
@@ -1569,6 +1572,7 @@ async def search_datasets(tenant_id: str, req: dict):
         similarity_threshold,
         vector_similarity_weight,
         doc_ids=local_doc_ids,
+        doc_ids_as_filter=doc_ids_as_filter,
         knn_top_k=knn_top_k,
         knn_num_candidates=knn_num_candidates,
         rerank_mdl=rerank_mdl,

--- a/internal/service/dataset/search.go
+++ b/internal/service/dataset/search.go
@@ -276,6 +276,7 @@ func (d *DatasetService) SearchDatasets(ctx context.Context, req *service.Search
 		Question:               modifiedQuestion,
 		KbIDs:                  datasetIDs,
 		DocIDs:                 docIDs,
+		DocIDsAsFilter:         req.DocIDsAsFilter != nil && *req.DocIDsAsFilter,
 		Page:                   page,
 		PageSize:               pageSize,
 		RerankCandidatesCount:  &rerankCandidatesCount,

--- a/internal/service/dataset_types.go
+++ b/internal/service/dataset_types.go
@@ -43,6 +43,7 @@ type SearchDatasetsRequest struct {
 	Size                   *int                   `json:"size,omitempty"`
 	RerankCandidatesCount  *int                   `json:"rerank_candidates_count,omitempty"`
 	DocIDs                 []string               `json:"doc_ids,omitempty"`
+	DocIDsAsFilter         *bool                  `json:"doc_ids_as_filter,omitempty"`
 	UseKG                  *bool                  `json:"use_kg,omitempty"`
 	KNNTopK                *int                   `json:"knn_top_k,omitempty"`
 	TopK                   *int                   `json:"top_k,omitempty"` // Legacy alias for knn_top_k.
@@ -73,6 +74,7 @@ type SearchDatasetRequest struct {
 	Size                   *int                   `json:"size,omitempty"`
 	RerankCandidatesCount  *int                   `json:"rerank_candidates_count,omitempty"`
 	DocIDs                 []string               `json:"doc_ids,omitempty"`
+	DocIDsAsFilter         *bool                  `json:"doc_ids_as_filter,omitempty"`
 	UseKG                  *bool                  `json:"use_kg,omitempty"`
 	KNNTopK                *int                   `json:"knn_top_k,omitempty"`
 	TopK                   *int                   `json:"top_k,omitempty"` // Legacy alias for knn_top_k.
@@ -99,6 +101,7 @@ func (req *SearchDatasetRequest) ToSearchDatasetsRequest(datasetID string) *Sear
 		Size:                   req.Size,
 		RerankCandidatesCount:  req.RerankCandidatesCount,
 		DocIDs:                 req.DocIDs,
+		DocIDsAsFilter:         req.DocIDsAsFilter,
 		UseKG:                  req.UseKG,
 		KNNTopK:                req.KNNTopK,
 		TopK:                   req.TopK,

--- a/internal/service/nlp/retrieval.go
+++ b/internal/service/nlp/retrieval.go
@@ -47,10 +47,15 @@ func NewRetrievalService(docEngine engine.DocEngine, documentDAO *dao.DocumentDA
 
 // RetrievalRequest request for retrieval search
 type RetrievalRequest struct {
-	Question               string
-	TenantIDs              []string
-	KbIDs                  []string
-	DocIDs                 []string
+	Question  string
+	TenantIDs []string
+	KbIDs     []string
+	DocIDs    []string
+	// DocIDsAsFilter narrows the threshold-valid candidate set by DocIDs
+	// after retrieval instead of pushing DocIDs into the engine query. UI
+	// file filters set it so the per-file doc_aggs counts shown before
+	// filtering match the totals returned after filtering.
+	DocIDsAsFilter         bool
 	Page                   int
 	PageSize               int
 	RerankCandidatesCount  *int
@@ -128,12 +133,19 @@ func (s *RetrievalService) Retrieval(ctx context.Context, req *RetrievalRequest)
 	}
 	common.Debug("Retrieval rerank candidate params", zap.Int("page", req.Page), zap.Int("pageSize", pageSize), zap.Int("rerankCandidatesCount", rerankCandidatesCount))
 
+	// With DocIDsAsFilter the engine query stays unscoped so the candidate
+	// window matches the unfiltered run; DocIDs narrow the valid set later.
+	searchDocIDs := req.DocIDs
+	if req.DocIDsAsFilter && len(req.DocIDs) > 0 {
+		searchDocIDs = nil
+	}
+
 	// Execute search via Search()
 	searchReq := &RetrievalSearchRequest{
 		TenantIDs:              req.TenantIDs,
 		Question:               req.Question,
 		KbIDs:                  req.KbIDs,
-		DocIDs:                 req.DocIDs,
+		DocIDs:                 searchDocIDs,
 		Page:                   1,
 		PageSize:               rerankCandidatesCount,
 		KNNTopK:                *req.KNNTopK,
@@ -191,6 +203,33 @@ func (s *RetrievalService) Retrieval(ctx context.Context, req *RetrievalRequest)
 	}
 	if len(validIdx) == 0 {
 		return &RetrievalResult{Chunks: []map[string]interface{}{}, DocAggs: []map[string]interface{}{}, Total: 0}, nil
+	}
+
+	// doc_aggs describe the unfiltered candidate window; a doc_ids filter
+	// only narrows the returned page and total so the per-file counts the
+	// file filter showed before submitting stay correct afterwards.
+	aggsIdx := validIdx
+	if req.DocIDsAsFilter && len(req.DocIDs) > 0 {
+		docIDSet := make(map[string]struct{}, len(req.DocIDs))
+		for _, id := range req.DocIDs {
+			docIDSet[id] = struct{}{}
+		}
+		filteredIdx := make([]int, 0, len(validIdx))
+		for _, i := range validIdx {
+			if i < 0 || i >= len(searchResult.IDs) {
+				continue
+			}
+			chunk, ok := searchResult.Field[searchResult.IDs[i]]
+			if !ok {
+				continue
+			}
+			if docID, _ := chunk["doc_id"].(string); docID != "" {
+				if _, wanted := docIDSet[docID]; wanted {
+					filteredIdx = append(filteredIdx, i)
+				}
+			}
+		}
+		validIdx = filteredIdx
 	}
 
 	// Calculate pagination
@@ -347,7 +386,7 @@ func (s *RetrievalService) Retrieval(ctx context.Context, req *RetrievalRequest)
 			docID string
 			count int
 		})
-		for _, i := range validIdx {
+		for _, i := range aggsIdx {
 			if i < 0 || i >= len(searchResult.IDs) {
 				continue
 			}

--- a/internal/service/nlp/retrieval_test.go
+++ b/internal/service/nlp/retrieval_test.go
@@ -9,9 +9,12 @@ import (
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
 	"ragflow/internal/engine/types"
+	"ragflow/internal/entity"
 	modelModule "ragflow/internal/entity/models"
 
+	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestRetrievalUsesRerankCandidatesCountAsCandidateSet(t *testing.T) {
@@ -65,6 +68,130 @@ func TestRetrievalUsesRerankCandidatesCountAsCandidateSet(t *testing.T) {
 		if !ok || mustNot["exists"] != "compile_kwd" {
 			t.Fatalf("must_not filter = %#v", filters["must_not"])
 		}
+	}
+}
+
+func TestRetrievalDocIDsAsFilterKeepsCountsConsistent(t *testing.T) {
+	oldQueryBuilder := globalQueryBuilder
+	globalQueryBuilder = NewQueryBuilder()
+	defer func() { globalQueryBuilder = oldQueryBuilder }()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&entity.Document{}); err != nil {
+		t.Fatalf("migrate sqlite: %v", err)
+	}
+	for _, docID := range []string{"doc-a", "doc-b"} {
+		if err := db.Create(&entity.Document{ID: docID, ParserConfig: entity.JSONMap{}}).Error; err != nil {
+			t.Fatalf("seed %s: %v", docID, err)
+		}
+	}
+	oldDB := dao.DB
+	dao.DB = db
+	t.Cleanup(func() { dao.DB = oldDB })
+
+	rows := make([]map[string]interface{}, 0, 60)
+	for i := 0; i < 60; i++ {
+		docID, docName := "doc-a", "a.pdf"
+		if i >= 30 {
+			docID, docName = "doc-b", "b.pdf"
+		}
+		rows = append(rows, map[string]interface{}{
+			"id":                  fmt.Sprintf("chunk-%02d", i),
+			"content_ltks":        "alpha",
+			"content_with_weight": "alpha",
+			"doc_id":              docID,
+			"docnm_kwd":           docName,
+			"_score":              0.9,
+		})
+	}
+
+	top := 100
+	threshold := 0.5
+	vectorWeight := 1.0
+	rerankCandidatesCount := 70
+	newReq := func() *RetrievalRequest {
+		return &RetrievalRequest{
+			Question:               "alpha",
+			TenantIDs:              []string{"tenant-1"},
+			Page:                   1,
+			PageSize:               10,
+			KNNTopK:                &top,
+			SimilarityThreshold:    &threshold,
+			VectorSimilarityWeight: &vectorWeight,
+			RerankCandidatesCount:  &rerankCandidatesCount,
+		}
+	}
+	aggCount := func(aggs []map[string]interface{}, docID string) int {
+		for _, agg := range aggs {
+			if agg["doc_id"] == docID {
+				count, _ := agg["count"].(int)
+				return count
+			}
+		}
+		return 0
+	}
+
+	unfilteredEngine := &retrievalCountEngine{rows: rows}
+	unfiltered, err := NewRetrievalService(unfilteredEngine, &dao.DocumentDAO{}).Retrieval(context.Background(), newReq())
+	if err != nil {
+		t.Fatalf("unfiltered Retrieval failed: %v", err)
+	}
+	if unfiltered.Total != 60 {
+		t.Fatalf("unfiltered total = %d, want 60", unfiltered.Total)
+	}
+	if got := aggCount(unfiltered.DocAggs, "doc-a"); got != 30 {
+		t.Fatalf("unfiltered doc-a count = %d, want 30", got)
+	}
+	if got := aggCount(unfiltered.DocAggs, "doc-b"); got != 30 {
+		t.Fatalf("unfiltered doc-b count = %d, want 30", got)
+	}
+
+	filteredReq := newReq()
+	filteredReq.DocIDs = []string{"doc-a"}
+	filteredReq.DocIDsAsFilter = true
+	filteredEngine := &retrievalCountEngine{rows: rows}
+	filtered, err := NewRetrievalService(filteredEngine, &dao.DocumentDAO{}).Retrieval(context.Background(), filteredReq)
+	if err != nil {
+		t.Fatalf("filtered Retrieval failed: %v", err)
+	}
+	if len(filteredEngine.searchFilters) == 0 {
+		t.Fatal("expected an engine search call")
+	}
+	for _, filters := range filteredEngine.searchFilters {
+		if _, scoped := filters["doc_id"]; scoped {
+			t.Fatalf("engine query was scoped by doc_id despite doc_ids_as_filter: %#v", filters["doc_id"])
+		}
+	}
+	if filtered.Total != 30 {
+		t.Fatalf("filtered total = %d, want 30 (the count doc_aggs showed for doc-a)", filtered.Total)
+	}
+	for _, chunk := range filtered.Chunks {
+		if chunk["doc_id"] != "doc-a" {
+			t.Fatalf("filtered chunk from %v, want doc-a", chunk["doc_id"])
+		}
+	}
+	if got := aggCount(filtered.DocAggs, "doc-a"); got != 30 {
+		t.Fatalf("filtered doc-a agg count = %d, want 30", got)
+	}
+	if got := aggCount(filtered.DocAggs, "doc-b"); got != 30 {
+		t.Fatalf("filtered doc-b agg count = %d, want 30 (doc_aggs must describe the unfiltered window)", got)
+	}
+
+	scopedReq := newReq()
+	scopedReq.DocIDs = []string{"doc-a"}
+	scopedEngine := &retrievalCountEngine{rows: rows}
+	if _, err := NewRetrievalService(scopedEngine, &dao.DocumentDAO{}).Retrieval(context.Background(), scopedReq); err != nil {
+		t.Fatalf("scoped Retrieval failed: %v", err)
+	}
+	if len(scopedEngine.searchFilters) == 0 {
+		t.Fatal("expected an engine search call")
+	}
+	scopedDocIDs, _ := scopedEngine.searchFilters[0]["doc_id"].([]string)
+	if len(scopedDocIDs) != 1 || scopedDocIDs[0] != "doc-a" {
+		t.Fatalf("scoped engine query missing doc_id filter: %#v", scopedEngine.searchFilters[0]["doc_id"])
 	}
 }
 

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -565,6 +565,7 @@ class Dealer:
         similarity_threshold=0.2,
         vector_similarity_weight=0.3,
         doc_ids=None,
+        doc_ids_as_filter=False,
         aggs=True,
         rerank_mdl=None,
         highlight=False,
@@ -596,9 +597,12 @@ class Dealer:
             raise Exception(f"Pagination is not supported when rerank_mdl is specified. Please set page=1 to retrieve the top {page_size} results.")
 
         rerank_candidates_page = 1
+        # doc_ids_as_filter keeps the engine query unscoped so the candidate
+        # window matches the unfiltered run; doc_ids narrow valid_idx later.
+        engine_doc_ids = None if (doc_ids_as_filter and doc_ids) else doc_ids
         req = {
             "kb_ids": kb_ids,
-            "doc_ids": doc_ids,
+            "doc_ids": engine_doc_ids,
             "page": rerank_candidates_page,
             "size": rerank_candidates_count,
             "question": question,
@@ -698,10 +702,17 @@ class Dealer:
         post_threshold = 0.0 if vector_similarity_weight <= 0 else similarity_threshold
 
         valid_idx = [int(i) for i in sorted_idx if sim_np[i] >= post_threshold]
+        # doc_aggs describe the unfiltered candidate window; a doc_ids filter
+        # only narrows the returned page and total so the per-file counts the
+        # file filter showed before submitting stay correct afterwards.
+        aggs_idx = valid_idx
+        if doc_ids_as_filter and doc_ids:
+            wanted_doc_ids = set(doc_ids)
+            valid_idx = [i for i in valid_idx if sres.field.get(sres.ids[i], {}).get("doc_id") in wanted_doc_ids]
         filtered_count = len(valid_idx)
         ranks["total"] = int(filtered_count)
 
-        if filtered_count == 0:
+        if filtered_count == 0 and not aggs_idx:
             ranks["doc_aggs"] = []
             return ranks
 
@@ -752,7 +763,7 @@ class Dealer:
             ranks["chunks"].append(d)
 
         if aggs:
-            for i in valid_idx:
+            for i in aggs_idx:
                 id = sres.ids[i]
                 chunk = sres.field[id]
                 dnm = chunk.get("docnm_kwd", "")

--- a/web/src/services/knowledge-service.ts
+++ b/web/src/services/knowledge-service.ts
@@ -158,7 +158,14 @@ const chunkService = {
     delete rest.kb_id;
     delete rest.knowledge_id;
     return request.post(api.retrievalTest, {
-      data: { ...rest, dataset_ids: datasetIds },
+      data: {
+        ...rest,
+        dataset_ids: datasetIds,
+        // Treat doc_ids as a filter over the current retrieval results (not a
+        // re-scoped search) so the per-file counts shown in the File filter
+        // match the totals returned after applying it.
+        doc_ids_as_filter: true,
+      },
     });
   },
   chunkList: async (params: Record<string, any>) => {


### PR DESCRIPTION
### Summary

In knowledge-base retrieval testing, the per-file chunk counts shown in the "File" filter popup did not match the results returned after applying the filter (reported: a file listed with 23 chunks returned 90 once it was the only one selected; the popup also collapsed to the single selected file).

Root cause: `doc_aggs` and `total` are derived from the threshold-valid subset of the rerank candidate window. When `doc_ids` was passed, the engine query itself was re-scoped to those documents, so the candidate window was refilled by the selected documents alone. The numbers shown before filtering (a document's share of the unfiltered window) and after filtering (the document's own window-filling count) therefore described two different result universes and could not match.

This PR adds an opt-in `doc_ids_as_filter` request flag for UI file filters on `POST /api/v1/datasets/search`:

- When the flag is set (web retrieval-testing and search file filters now always set it), the engine query stays unscoped, so the candidate window is identical to the unfiltered run. `doc_ids` then narrow the threshold-valid set that backs the returned page and `total`, while `doc_aggs` are always computed over the unfiltered window.
- Result: selecting files returns exactly the counts the popup showed, `total` equals the sum over the selected files, and the popup keeps listing all files with stable counts so filters can be switched without clearing.
- When the flag is absent, behavior is unchanged: `doc_ids` still scopes the engine query (SDK `document_ids`/`doc_ids` scoping semantics are preserved).

Implemented symmetrically in the Go backend (`internal/service/nlp/retrieval.go`, request plumbing in `internal/service/dataset/*`) and the Python backend (`rag/nlp/search.py`, `api/apps/services/dataset_api_service.py`); the web client sends the flag from `kbService.retrievalTest`.

### Verification

- Go unit test `TestRetrievalDocIDsAsFilterKeepsCountsConsistent` (in-memory sqlite + fake engine) pins: unfiltered totals/counts, that the flagged run does not push `doc_id` into the engine query, that its `total` equals the count `doc_aggs` showed for the selected document, that `doc_aggs` still describe the unfiltered window, and that a non-flagged run still scopes the engine query. `bash build.sh --test ./internal/service/nlp/... ./internal/service/dataset/...` passes.
- Live check against the local Go API: with `doc_ids_as_filter: true`, the filtered run returns `total` equal to the file's unfiltered `doc_aggs` count and a stable full `doc_aggs` list; without the flag the response is unchanged from before.
- Note on scope: counts remain bounded by the rerank candidate window (`rerank_candidates_count`, 64-256) by design — `total` semantics ("threshold-valid matches across the candidate set", settled in #18071/#18750) are intentionally preserved; this PR only makes the file filter consistent with that universe.
