### PR TITLE
fix(web): cap embed dialog User ID input length and add data-type hint

### DIFF
--- a/web/src/components/embed-dialog/index.tsx
+++ b/web/src/components/embed-dialog/index.tsx
@@ -59,6 +59,8 @@ import { SwitchFormField } from '../switch-fom-field';
 import { useIsDarkTheme } from '../theme-provider';
 import { Input } from '../ui/input';
 
+const MAX_EMBED_USER_ID_LENGTH = 255;
+
 const FormSchema = z.object({
   visibleAvatar: z.boolean(),
   published: z.boolean(),
@@ -67,7 +69,7 @@ const FormSchema = z.object({
   enableStreaming: z.boolean(),
   muteWidget: z.boolean(),
   theme: z.enum([ThemeEnum.Light, ThemeEnum.Dark]),
-  userId: z.string().optional(),
+  userId: z.string().max(MAX_EMBED_USER_ID_LENGTH).optional(),
   widgetTitle: z.string(),
   widgetSubtitle: z.string(),
   widgetFooterText: z.string(),
@@ -431,8 +433,15 @@ window.addEventListener('message',e=>{
                     ></SelectWithSearch>
                   </RAGFlowFormItem>
                   {isAgent && (
-                    <RAGFlowFormItem name="userId" label={t('flow.userId')}>
-                      <Input></Input>
+                    <RAGFlowFormItem
+                      name="userId"
+                      label={t('flow.userId')}
+                      tooltip={t('chat.embedUserIdTooltip')}
+                    >
+                      <Input
+                        maxLength={MAX_EMBED_USER_ID_LENGTH}
+                        placeholder={t('chat.embedUserIdPlaceholder')}
+                      ></Input>
                     </RAGFlowFormItem>
                   )}
                 </TabsContent>

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1150,6 +1150,9 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       created: 'Created',
       action: 'Action',
       embedModalTitle: 'Embed into webpage',
+      embedUserIdPlaceholder: 'e.g. user-001',
+      embedUserIdTooltip:
+        'A plain-text identifier (up to 255 characters) for the end user of the embedded page. It is appended to the embed URL as the userId parameter.',
       published: 'Published',
       publishedTooltip:
         'Use the published version for this embed. When enabled, the generated URL includes release=true.',

--- a/web/src/locales/fr.ts
+++ b/web/src/locales/fr.ts
@@ -1029,6 +1029,9 @@ Applicable lorsque vous avez besoin que le LLM résume le document entier.
       created: 'Créé',
       action: 'Action',
       embedModalTitle: 'Intégrer dans une page web',
+      embedUserIdPlaceholder: 'ex. user-001',
+      embedUserIdTooltip:
+        'Chaîne de texte (255 caractères maximum) identifiant l\'utilisateur final de la page intégrée. Elle est ajoutée à l\'URL d\'intégration comme paramètre userId.',
       comingSoon: 'Bientôt disponible',
       fullScreenTitle: 'Intégration complète',
       fullScreenDescription:

--- a/web/src/locales/it.ts
+++ b/web/src/locales/it.ts
@@ -1091,6 +1091,9 @@ Questa funzionalità di auto-tagging migliora il recupero aggiungendo un ulterio
       created: 'Creato',
       action: 'Azione',
       embedModalTitle: 'Incorpora nella pagina web',
+      embedUserIdPlaceholder: 'es. user-001',
+      embedUserIdTooltip:
+        'Stringa di testo (massimo 255 caratteri) che identifica l\'utente finale della pagina incorporata. Viene aggiunta all\'URL di incorporamento come parametro userId.',
       published: 'Pubblicato',
       publishedTooltip:
         "Usa la versione pubblicata per questo embed. Quando abilitato, l'URL generato include release=true.",

--- a/web/src/locales/ja.ts
+++ b/web/src/locales/ja.ts
@@ -894,6 +894,9 @@ export default {
       created: '作成日',
       action: 'アクション',
       embedModalTitle: 'ウェブサイトに埋め込む',
+      embedUserIdPlaceholder: '例: user-001',
+      embedUserIdTooltip:
+        '埋め込みページのエンドユーザーを識別する文字列（最大255文字）です。埋め込みURLに userId パラメータとして付加されます。',
       comingSoon: '近日公開',
       fullScreenTitle: '全画面埋め込み',
 

--- a/web/src/locales/ko.ts
+++ b/web/src/locales/ko.ts
@@ -1069,6 +1069,9 @@ export default {
       created: '생성됨',
       action: '작업',
       embedModalTitle: '웹페이지에 삽입',
+      embedUserIdPlaceholder: '예: user-001',
+      embedUserIdTooltip:
+        '임베드 페이지의 최종 사용자를 식별하는 문자열(최대 255자)입니다. 임베드 URL에 userId 매개변수로 추가됩니다.',
       published: '게시됨',
       publishedTooltip:
         '이 삽입에 게시된 버전을 사용합니다. 활성화하면 생성된 URL에 release=true가 포함됩니다.',

--- a/web/src/locales/ru.ts
+++ b/web/src/locales/ru.ts
@@ -892,6 +892,9 @@ export default {
       created: 'Создано',
       action: 'Действие',
       embedModalTitle: 'Встроить на веб-страницу',
+      embedUserIdPlaceholder: 'например: user-001',
+      embedUserIdTooltip:
+        'Строка (до 255 символов), идентифицирующая конечного пользователя встроенной страницы. Она добавляется в URL встраивания как параметр userId.',
       published: 'Опубликовано',
       publishedTooltip:
         'Использовать опубликованную версию для встраивания. В URL будет release=true.',

--- a/web/src/locales/tr.ts
+++ b/web/src/locales/tr.ts
@@ -1052,6 +1052,9 @@ Bu otomatik etiketleme özelliği, mevcut datasete alanına özgü bilgi katman�
       created: 'Oluşturuldu',
       action: 'İşlem',
       embedModalTitle: 'Web sayfasına göm',
+      embedUserIdPlaceholder: 'örn. user-001',
+      embedUserIdTooltip:
+        'Gömülü sayfanın son kullanıcısını tanımlayan bir metin (en fazla 255 karakter). Gömme URL\'sine userId parametresi olarak eklenir.',
       published: 'Yayınlandı',
       publishedTooltip: 'Bu göm için yayınlanan sürümü kullanın.',
       embedType: 'Embed türü',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1048,6 +1048,9 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
       created: '创建于',
       action: '操作',
       embedModalTitle: '嵌入网站',
+      embedUserIdPlaceholder: '例如：user-001',
+      embedUserIdTooltip:
+        '用于标识嵌入页面终端用户的字符串，最长 255 个字符，会作为 userId 参数附加到嵌入链接中。',
       published: '已发布',
       publishedTooltip:
         '在嵌入中使用已发布的版本。启用后，生成的 URL 将包含 release=true。',


### PR DESCRIPTION
### Summary

The "User ID" input in the agent embed-website dialog (Management → Embed into webpage → Embed Setup) had no input length limit and no data-type hint: users could paste an arbitrarily long string (a reporter pasted hundreds of `w` characters), which was appended verbatim as the `userId` query parameter of the generated iframe embed URL. The shared agent page forwards that value as `user_id`, and the backend stores it in a `CharField(max_length=255)` column (`api/db/db_models.py`), so over-long values overflow the column and bloat the embed code with no feedback to the user.

This PR constrains and documents the field:

- Add `maxLength={255}` to the User ID input, matching the backend `user_id` column size, so typing or pasting stops at 255 characters.
- Add the same `max(255)` constraint to the dialog's zod form schema (`FormSchema`) as a programmatic backstop.
- Add a placeholder (`e.g. user-001`) and a label tooltip stating the expected data type (a plain-text end-user identifier) and the 255-character limit, so the field now carries an explicit data-type hint.
- Add the two new i18n keys (`chat.embedUserIdPlaceholder`, `chat.embedUserIdTooltip`) to every locale that already carries the embed-dialog strings (en, zh, fr, it, ja, ko, ru, tr).

Verification: verified end-to-end in the browser (agent canvas → Management → Embed into webpage): typing 300 characters into the User ID input keeps exactly 255, the generated embed URL carries a 255-character `userId` param, the placeholder is visible, and the tooltip renders the type/length hint. `oxlint` passes on the changed files. `npm run type-check` already fails on the base branch with ~208 pre-existing errors; none of them are on the lines touched by this PR (the embed-dialog errors at lines 306-316 are a pre-existing `useWatch` partial-type issue unrelated to this change).
