### PR TITLE
fix: allow empty GitHub repositories

### DIFF
--- a/common/data_source/github/connector.py
+++ b/common/data_source/github/connector.py
@@ -702,9 +702,8 @@ class GithubConnector(CheckpointedConnectorWithPermSyncGH[GithubConnectorCheckpo
                             continue
 
                         try:
-                            test_repo = self.github_client.get_repo(f"{self.repo_owner}/{repo_name}")
+                            self.github_client.get_repo(f"{self.repo_owner}/{repo_name}")
                             logging.info(f"Successfully accessed repository: {self.repo_owner}/{repo_name}")
-                            test_repo.get_contents("")
                             valid_repos = True
                             # If at least one repo is valid, we can proceed
                             break
@@ -717,8 +716,7 @@ class GithubConnector(CheckpointedConnectorWithPermSyncGH[GithubConnectorCheckpo
                         raise ConnectorValidationError(error_msg)
                 else:
                     # Single repository (backward compatibility)
-                    test_repo = self.github_client.get_repo(f"{self.repo_owner}/{self.repositories}")
-                    test_repo.get_contents("")
+                    self.github_client.get_repo(f"{self.repo_owner}/{self.repositories}")
             else:
                 # Try to get organization first
                 try:


### PR DESCRIPTION
### What problem does this PR solve?

GitHub connector validation failed for empty repositories because it called `get_contents("")` and treated the resulting 404 as a missing repository.

The validation now only checks repository accessibility with `get_repo()`, allowing valid empty repositories to pass configuration validation.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)