### PR TITLE
fix(db): convert integer tenant_*_id columns to varchar(32) on upgrade

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -1984,6 +1984,108 @@ def alter_db_column_type(migrator, table_name, column_name, new_column_type):
         pass
 
 
+_INTEGER_COLUMN_TYPES = frozenset({"int", "integer", "bigint", "smallint", "mediumint", "tinyint"})
+_STRING_COLUMN_TYPES = frozenset({"varchar", "character varying", "char", "character", "text", "nvarchar"})
+
+# Matches tools/scripts/mysql_migration.py ModelTypeMergeStage.MODEL_TYPE_STR_TO_INT
+TENANT_MODEL_TYPE_NAME_TO_INT = {
+    "chat": 1,
+    "embedding": 2,
+    "asr": 4,
+    "speech2text": 4,
+    "vision": 8,
+    "image2text": 8,
+    "rerank": 16,
+    "tts": 32,
+    "ocr": 64,
+}
+
+
+def _get_column_data_type(table_name: str, column_name: str) -> str | None:
+    try:
+        if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+            cursor = DB.execute_sql(
+                """
+                SELECT data_type
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = %s
+                  AND column_name = %s
+                """,
+                (table_name, column_name),
+            )
+        else:
+            cursor = DB.execute_sql(
+                """
+                SELECT DATA_TYPE
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = %s
+                  AND column_name = %s
+                """,
+                (table_name, column_name),
+            )
+        row = cursor.fetchone()
+        return row[0].lower() if row else None
+    except Exception as ex:
+        logging.warning("Failed to inspect %s.%s column type: %s", table_name, column_name, ex)
+        return None
+
+
+def _tenant_model_type_postgres_using_sql() -> str:
+    name_cases = " ".join(f"WHEN lower(\"model_type\") = '{name}' THEN {value}" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
+    return (
+        'CASE WHEN "model_type" IS NULL OR btrim("model_type") = \'\' THEN 1 '
+        'WHEN "model_type" ~ \'^[0-9]+$\' THEN "model_type"::integer '
+        f"{name_cases} ELSE 1 END"
+    )
+
+
+def migrate_tenant_model_type_column(migrator):
+    """Convert tenant_model.model_type from varchar names to an integer bitmask.
+
+    The v0.27.0 provider-table migration creates model_type as VARCHAR(32) and
+    only the MySQL-only model_type_merge stage turns it into INT. Upgraded
+    PostgreSQL databases keep the string column, so bitmask predicates
+    (`model_type & N`) fail with `operator does not exist: character varying & integer`
+    (#18755).
+    """
+    table_name = "tenant_model"
+    column_name = "model_type"
+    target_field = IntegerField(null=False, default=1, index=True, help_text="Bit flags (LSB->MSB): 1=chat, 2=embedding, 4=asr, 8=vision, 16=rerank, 32=tts, 64=ocr")
+
+    try:
+        table_present = DB.table_exists(table_name)
+    except Exception as ex:
+        logging.warning("Failed to inspect table %s while migrating model_type: %s", table_name, ex)
+        return
+    if not table_present:
+        return
+
+    col_type = _get_column_data_type(table_name, column_name)
+    if col_type is None:
+        alter_db_add_column(migrator, table_name, column_name, target_field)
+        return
+
+    if col_type in _INTEGER_COLUMN_TYPES:
+        return
+
+    if col_type not in _STRING_COLUMN_TYPES:
+        logging.warning("Skipping tenant_model.model_type conversion from unexpected type %s", col_type)
+        return
+
+    try:
+        if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+            DB.execute_sql(f'ALTER TABLE "{table_name}" ALTER COLUMN "{column_name}" TYPE integer USING {_tenant_model_type_postgres_using_sql()}')
+        else:
+            name_cases = " ".join(f"WHEN '{name}' THEN '{value}'" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
+            DB.execute_sql(f"UPDATE `{table_name}` SET `{column_name}` = CASE LOWER(`{column_name}`) {name_cases} ELSE `{column_name}` END")
+            migrate(migrator.alter_column_type(table_name, column_name, target_field))
+        logging.info("Converted tenant_model.model_type from %s to integer bitmask", col_type)
+    except Exception as ex:
+        logging.critical("Failed to convert tenant_model.model_type from %s to integer: %s", col_type, ex)
+
+
 def alter_db_rename_column(migrator, table_name, old_column_name, new_column_name):
     try:
         migrate(migrator.rename_column(table_name, old_column_name, new_column_name))
@@ -2467,6 +2569,7 @@ def migrate_db():
     alter_db_column_type(migrator, "file", "size", BigIntegerField(default=0, index=True))
     alter_db_add_column(migrator, "tenant", "ocr_id", CharField(max_length=128, null=True, help_text="default ocr model ID", index=True))
     alter_db_add_column(migrator, "tenant", "tenant_ocr_id", CharField(max_length=32, null=True, help_text="id in tenant_model", index=True))
+    migrate_tenant_model_type_column(migrator)
     alter_db_column_type(migrator, "chat_channel", "status", IntegerField(default=1, index=True))
     alter_db_rename_column(migrator, "chat_channel", "dialog_id", "chat_id")
     # ---- FileCommit / FileCommitItem: artifact-page commit extension ----

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -2003,34 +2003,30 @@ _INTEGER_COLUMN_TYPES = frozenset({"int", "integer", "bigint", "smallint", "medi
 
 
 def _get_column_data_type(table_name: str, column_name: str) -> str | None:
-    try:
-        if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
-            cursor = DB.execute_sql(
-                """
-                SELECT data_type
-                FROM information_schema.columns
-                WHERE table_schema = current_schema()
-                  AND table_name = %s
-                  AND column_name = %s
-                """,
-                (table_name, column_name),
-            )
-        else:
-            cursor = DB.execute_sql(
-                """
-                SELECT DATA_TYPE
-                FROM information_schema.columns
-                WHERE table_schema = DATABASE()
-                  AND table_name = %s
-                  AND column_name = %s
-                """,
-                (table_name, column_name),
-            )
-        row = cursor.fetchone()
-        return row[0].lower() if row else None
-    except Exception:
-        logging.exception("Failed to inspect %s.%s column type", table_name, column_name)
-        raise
+    if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+        cursor = DB.execute_sql(
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = %s
+              AND column_name = %s
+            """,
+            (table_name, column_name),
+        )
+    else:
+        cursor = DB.execute_sql(
+            """
+            SELECT DATA_TYPE
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = %s
+              AND column_name = %s
+            """,
+            (table_name, column_name),
+        )
+    row = cursor.fetchone()
+    return row[0].lower() if row else None
 
 
 def migrate_tenant_model_id_column_types(migrator):
@@ -2054,8 +2050,13 @@ def migrate_tenant_model_id_column_types(migrator):
 
         try:
             col_type = _get_column_data_type(table_name, column_name)
-        except Exception as ex:
-            logging.warning("Skipping %s.%s tenant_*_id migration; column inspection failed: %s", table_name, column_name, ex)
+        except Exception:
+            logging.critical(
+                "Skipping %s.%s tenant_*_id migration; column inspection failed",
+                table_name,
+                column_name,
+                exc_info=True,
+            )
             continue
 
         if col_type is None:

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -2032,12 +2032,29 @@ def _get_column_data_type(table_name: str, column_name: str) -> str | None:
         return None
 
 
+def _tenant_model_type_normalized_tokens_sql(column_sql: str) -> str:
+    """Lowercase, trim, drop spaces, and split pipe-delimited model_type names."""
+    return f"REPLACE(REPLACE(LOWER(TRIM({column_sql})), ' ', ''), '|', ',')"
+
+
 def _tenant_model_type_postgres_using_sql() -> str:
-    name_cases = " ".join(f"WHEN lower(\"model_type\") = '{name}' THEN {value}" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
+    token_list = "string_to_array(replace(replace(lower(btrim(\"model_type\")), ' ', ''), '|', ','), ',')"
+    bits = " | ".join(f"CASE WHEN '{name}' = ANY({token_list}) THEN {value} ELSE 0 END" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
     return (
         'CASE WHEN "model_type" IS NULL OR btrim("model_type") = \'\' THEN 1 '
         'WHEN "model_type" ~ \'^[0-9]+$\' THEN "model_type"::integer '
-        f"{name_cases} ELSE 1 END"
+        f"ELSE COALESCE(NULLIF(({bits}), 0), 1) END"
+    )
+
+
+def _tenant_model_type_mysql_update_sql() -> str:
+    tokens = _tenant_model_type_normalized_tokens_sql("`model_type`")
+    bits = " | ".join(f"IF(FIND_IN_SET('{name}', {tokens}), {value}, 0)" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
+    return (
+        "UPDATE `tenant_model` SET `model_type` = CASE "
+        "WHEN `model_type` REGEXP '^[0-9]+$' THEN `model_type` "
+        "WHEN `model_type` IS NULL OR TRIM(`model_type`) = '' THEN '1' "
+        f"ELSE CAST(IFNULL(NULLIF(({bits}), 0), 1) AS CHAR) END"
     )
 
 
@@ -2078,8 +2095,7 @@ def migrate_tenant_model_type_column(migrator):
         if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
             DB.execute_sql(f'ALTER TABLE "{table_name}" ALTER COLUMN "{column_name}" TYPE integer USING {_tenant_model_type_postgres_using_sql()}')
         else:
-            name_cases = " ".join(f"WHEN '{name}' THEN '{value}'" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
-            DB.execute_sql(f"UPDATE `{table_name}` SET `{column_name}` = CASE LOWER(`{column_name}`) {name_cases} ELSE `{column_name}` END")
+            DB.execute_sql(_tenant_model_type_mysql_update_sql())
             migrate(migrator.alter_column_type(table_name, column_name, target_field))
         logging.info("Converted tenant_model.model_type from %s to integer bitmask", col_type)
     except Exception as ex:

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -1984,6 +1984,106 @@ def alter_db_column_type(migrator, table_name, column_name, new_column_type):
         pass
 
 
+TENANT_MODEL_ID_COLUMNS = (
+    ("tenant", "tenant_llm_id"),
+    ("tenant", "tenant_embd_id"),
+    ("tenant", "tenant_asr_id"),
+    ("tenant", "tenant_img2txt_id"),
+    ("tenant", "tenant_rerank_id"),
+    ("tenant", "tenant_tts_id"),
+    ("tenant", "tenant_ocr_id"),
+    ("knowledgebase", "tenant_embd_id"),
+    ("dialog", "tenant_llm_id"),
+    ("dialog", "tenant_rerank_id"),
+    ("memory", "tenant_llm_id"),
+    ("memory", "tenant_embd_id"),
+)
+
+_INTEGER_COLUMN_TYPES = frozenset({"int", "integer", "bigint", "smallint", "mediumint", "tinyint"})
+
+
+def _get_column_data_type(table_name: str, column_name: str) -> str | None:
+    try:
+        if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+            cursor = DB.execute_sql(
+                """
+                SELECT data_type
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = %s
+                  AND column_name = %s
+                """,
+                (table_name, column_name),
+            )
+        else:
+            cursor = DB.execute_sql(
+                """
+                SELECT DATA_TYPE
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = %s
+                  AND column_name = %s
+                """,
+                (table_name, column_name),
+            )
+        row = cursor.fetchone()
+        return row[0].lower() if row else None
+    except Exception as ex:
+        logging.warning("Failed to inspect %s.%s column type: %s", table_name, column_name, ex)
+        return None
+
+
+def migrate_tenant_model_id_column_types(migrator):
+    """Convert legacy IntegerField tenant_*_id columns to VARCHAR(32).
+
+    v0.26.x stored tenant_llm row ids (integers) in these columns. v0.27.0
+    stores tenant_model.id hex strings instead. Upgraded databases that never
+    ran the MySQL-only tenant_model_id_migration stage can still have integer
+    columns, which breaks default-model and dataset embedding updates (#18756).
+    """
+    target_field = CharField(max_length=32, null=True, help_text="id in tenant_model", index=True)
+
+    for table_name, column_name in TENANT_MODEL_ID_COLUMNS:
+        try:
+            table_present = DB.table_exists(table_name)
+        except Exception as ex:
+            logging.warning("Failed to inspect table %s while migrating tenant_*_id types: %s", table_name, ex)
+            continue
+        if not table_present:
+            continue
+
+        col_type = _get_column_data_type(table_name, column_name)
+        if col_type is None:
+            alter_db_add_column(migrator, table_name, column_name, target_field)
+            continue
+
+        if col_type not in _INTEGER_COLUMN_TYPES:
+            continue
+
+        try:
+            if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+                DB.execute_sql(
+                    f'ALTER TABLE "{table_name}" ALTER COLUMN "{column_name}" '
+                    f'TYPE varchar(32) USING CASE WHEN "{column_name}" IS NULL THEN NULL ELSE "{column_name}"::text END'
+                )
+            else:
+                migrate(migrator.alter_column_type(table_name, column_name, target_field))
+            logging.info(
+                "Converted %s.%s from %s to varchar(32) for tenant_model.id references",
+                table_name,
+                column_name,
+                col_type,
+            )
+        except Exception as ex:
+            logging.critical(
+                "Failed to convert %s.%s from %s to varchar(32): %s",
+                table_name,
+                column_name,
+                col_type,
+                ex,
+            )
+
+
 def alter_db_rename_column(migrator, table_name, old_column_name, new_column_name):
     try:
         migrate(migrator.rename_column(table_name, old_column_name, new_column_name))
@@ -2467,6 +2567,7 @@ def migrate_db():
     alter_db_column_type(migrator, "file", "size", BigIntegerField(default=0, index=True))
     alter_db_add_column(migrator, "tenant", "ocr_id", CharField(max_length=128, null=True, help_text="default ocr model ID", index=True))
     alter_db_add_column(migrator, "tenant", "tenant_ocr_id", CharField(max_length=32, null=True, help_text="id in tenant_model", index=True))
+    migrate_tenant_model_id_column_types(migrator)
     alter_db_column_type(migrator, "chat_channel", "status", IntegerField(default=1, index=True))
     alter_db_rename_column(migrator, "chat_channel", "dialog_id", "chat_id")
     # ---- FileCommit / FileCommitItem: artifact-page commit extension ----

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -2042,7 +2042,7 @@ def _tenant_model_type_postgres_using_sql() -> str:
     bits = " | ".join(f"CASE WHEN '{name}' = ANY({token_list}) THEN {value} ELSE 0 END" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
     return (
         'CASE WHEN "model_type" IS NULL OR btrim("model_type") = \'\' THEN 1 '
-        'WHEN "model_type" ~ \'^[0-9]+$\' THEN "model_type"::integer '
+        'WHEN btrim("model_type") ~ \'^[0-9]+$\' THEN btrim("model_type")::integer '
         f"ELSE COALESCE(NULLIF(({bits}), 0), 1) END"
     )
 
@@ -2052,7 +2052,7 @@ def _tenant_model_type_mysql_update_sql() -> str:
     bits = " | ".join(f"IF(FIND_IN_SET('{name}', {tokens}), {value}, 0)" for name, value in TENANT_MODEL_TYPE_NAME_TO_INT.items())
     return (
         "UPDATE `tenant_model` SET `model_type` = CASE "
-        "WHEN `model_type` REGEXP '^[0-9]+$' THEN `model_type` "
+        "WHEN TRIM(`model_type`) REGEXP '^[0-9]+$' THEN TRIM(`model_type`) "
         "WHEN `model_type` IS NULL OR TRIM(`model_type`) = '' THEN '1' "
         f"ELSE CAST(IFNULL(NULLIF(({bits}), 0), 1) AS CHAR) END"
     )

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -2030,12 +2030,22 @@ def _get_column_data_type(table_name: str, column_name: str) -> str | None:
 
 
 def migrate_tenant_model_id_column_types(migrator):
-    """Convert legacy IntegerField tenant_*_id columns to VARCHAR(32).
+    """Fallback: convert leftover IntegerField tenant_*_id columns to VARCHAR(32).
 
-    v0.26.x stored tenant_llm row ids (integers) in these columns. v0.27.0
-    stores tenant_model.id hex strings instead. Upgraded databases that never
-    ran the MySQL-only tenant_model_id_migration stage can still have integer
-    columns, which breaks default-model and dataset embedding updates (#18756).
+    Primary conversion and backfill belong in the pre-startup script
+    (``mysql_migration.py`` / ``postgres_migration.py`` stage
+    ``tenant_model_id_migration``). ``migrate_db()`` runs after that script, so
+    this helper is a no-op when columns are already ``varchar`` — it only
+    converts if the script did not run or did not finish.
+
+    It does not backfill ``tenant_model.id`` values. Postgres/GaussDB still run
+    ``migrate_postgres_family_model_provider_tables()`` later for seeding,
+    ``model_type`` merge, and id backfill.
+
+    There is no matching in-place ALTER for ``tenant_model.model_type``:
+    converting that column before ``tenant_model_seeding`` / ``model_type_merge``
+    would skip those stages. Both column types rely on the script (or that
+    startup fallback) for the real work.
     """
     target_field = CharField(max_length=32, null=True, help_text="id in tenant_model", index=True)
 
@@ -2123,13 +2133,15 @@ def _load_model_provider_migration_module():
 
 
 def migrate_postgres_family_model_provider_tables():
-    """Run table-init and data-backfill stages on postgres/gaussdb upgrades.
+    """Startup fallback: run provider stages if the pre-startup script did not.
 
-    Mirrors tools/scripts/mysql_migration.py, including TenantModelIdMigrationStage
-    (populate tenant_*_id from llm_id/embd_id) and ModelTypeMergeStage. MySQL
-    still uses the docker entrypoint script; postgres/gaussdb never ran that
-    path, so in-place upgrades left integer tenant_*_id values that match no
-    tenant_model.id.
+    Mirrors ``tools/scripts/postgres_migration.py`` / ``mysql_migration.py``
+    (``tenant_model_seeding`` → ``model_type_merge`` → ``tenant_model_id_migration``).
+    Docker ``run_migrations.sh`` is the primary path; this runs after schema
+    alters so in-place postgres/gaussdb upgrades still merge ``model_type`` and
+    backfill ``tenant_*_id`` when the script was skipped. Stages are idempotent.
+
+    Do not ALTER ``tenant_model.model_type`` to integer before these stages.
     """
     if settings.DATABASE_TYPE.upper() not in {"POSTGRES", "GAUSSDB"}:
         return
@@ -2628,6 +2640,9 @@ def migrate_db():
     alter_db_column_type(migrator, "file", "size", BigIntegerField(default=0, index=True))
     alter_db_add_column(migrator, "tenant", "ocr_id", CharField(max_length=128, null=True, help_text="default ocr model ID", index=True))
     alter_db_add_column(migrator, "tenant", "tenant_ocr_id", CharField(max_length=32, null=True, help_text="id in tenant_model", index=True))
+    # Fallback only: pre-startup mysql_migration.py / postgres_migration.py already
+    # convert tenant_*_id. This no-ops when columns are varchar. model_type is
+    # intentionally not converted here — merge stages must see varchar first.
     migrate_tenant_model_id_column_types(migrator)
     alter_db_column_type(migrator, "chat_channel", "status", IntegerField(default=1, index=True))
     alter_db_rename_column(migrator, "chat_channel", "dialog_id", "chat_id")

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -2054,6 +2054,7 @@ def migrate_tenant_model_id_column_types(migrator):
 
         col_type = _get_column_data_type(table_name, column_name)
         if col_type is None:
+            logging.info("Adding missing %s.%s tenant_model.id reference column", table_name, column_name)
             alter_db_add_column(migrator, table_name, column_name, target_field)
             continue
 
@@ -2062,12 +2063,18 @@ def migrate_tenant_model_id_column_types(migrator):
 
         try:
             if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+                # Legacy integers were tenant_llm row ids, never 32-char tenant_model.id
+                # values. Cast them away rather than leaving strings such as "42".
                 DB.execute_sql(
                     f'ALTER TABLE "{table_name}" ALTER COLUMN "{column_name}" '
-                    f'TYPE varchar(32) USING CASE WHEN "{column_name}" IS NULL THEN NULL ELSE "{column_name}"::text END'
+                    f"TYPE varchar(32) USING CAST(NULL AS varchar(32))"
                 )
             else:
                 migrate(migrator.alter_column_type(table_name, column_name, target_field))
+                DB.execute_sql(
+                    f"UPDATE `{table_name}` SET `{column_name}` = NULL "
+                    f"WHERE `{column_name}` IS NOT NULL AND CHAR_LENGTH(`{column_name}`) <> 32"
+                )
             logging.info(
                 "Converted %s.%s from %s to varchar(32) for tenant_model.id references",
                 table_name,

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -2028,9 +2028,9 @@ def _get_column_data_type(table_name: str, column_name: str) -> str | None:
             )
         row = cursor.fetchone()
         return row[0].lower() if row else None
-    except Exception as ex:
-        logging.warning("Failed to inspect %s.%s column type: %s", table_name, column_name, ex)
-        return None
+    except Exception:
+        logging.exception("Failed to inspect %s.%s column type", table_name, column_name)
+        raise
 
 
 def migrate_tenant_model_id_column_types(migrator):
@@ -2052,13 +2052,36 @@ def migrate_tenant_model_id_column_types(migrator):
         if not table_present:
             continue
 
-        col_type = _get_column_data_type(table_name, column_name)
+        try:
+            col_type = _get_column_data_type(table_name, column_name)
+        except Exception as ex:
+            logging.warning("Skipping %s.%s tenant_*_id migration; column inspection failed: %s", table_name, column_name, ex)
+            continue
+
         if col_type is None:
             logging.info("Adding missing %s.%s tenant_model.id reference column", table_name, column_name)
             alter_db_add_column(migrator, table_name, column_name, target_field)
             continue
 
+        mysql_family = settings.DATABASE_TYPE.upper() not in {"POSTGRES"} and not is_gaussdb_compatible_database()
+        leftover_sql = (
+            f"UPDATE `{table_name}` SET `{column_name}` = NULL "
+            f"WHERE `{column_name}` IS NOT NULL AND CHAR_LENGTH(`{column_name}`) <> 32"
+        )
+
         if col_type not in _INTEGER_COLUMN_TYPES:
+            # MySQL commits ALTER TABLE independently of the leftover UPDATE.
+            # A retry after a failed cleanup must still NULL non-32-char values.
+            if mysql_family:
+                try:
+                    DB.execute_sql(leftover_sql)
+                except Exception as ex:
+                    logging.critical(
+                        "Failed to clear leftover integer ids in converted %s.%s: %s",
+                        table_name,
+                        column_name,
+                        ex,
+                    )
             continue
 
         try:
@@ -2071,10 +2094,7 @@ def migrate_tenant_model_id_column_types(migrator):
                 )
             else:
                 migrate(migrator.alter_column_type(table_name, column_name, target_field))
-                DB.execute_sql(
-                    f"UPDATE `{table_name}` SET `{column_name}` = NULL "
-                    f"WHERE `{column_name}` IS NOT NULL AND CHAR_LENGTH(`{column_name}`) <> 32"
-                )
+                DB.execute_sql(leftover_sql)
             logging.info(
                 "Converted %s.%s from %s to varchar(32) for tenant_model.id references",
                 table_name,

--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -2112,6 +2112,39 @@ def migrate_tenant_model_id_column_types(migrator):
             )
 
 
+def _load_model_provider_migration_module():
+    import importlib.util
+
+    script_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tools", "scripts", "mysql_migration.py")
+    spec = importlib.util.spec_from_file_location("ragflow_mysql_migration", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def migrate_postgres_family_model_provider_tables():
+    """Run table-init and data-backfill stages on postgres/gaussdb upgrades.
+
+    Mirrors tools/scripts/mysql_migration.py, including TenantModelIdMigrationStage
+    (populate tenant_*_id from llm_id/embd_id) and ModelTypeMergeStage. MySQL
+    still uses the docker entrypoint script; postgres/gaussdb never ran that
+    path, so in-place upgrades left integer tenant_*_id values that match no
+    tenant_model.id.
+    """
+    if settings.DATABASE_TYPE.upper() not in {"POSTGRES", "GAUSSDB"}:
+        return
+
+    database_cfg = settings.DATABASE or {}
+    database_name = database_cfg.get("name") or database_cfg.get("database") or "rag_flow"
+    module = _load_model_provider_migration_module()
+    module.run_using_existing_connection(
+        peewee_db=DB,
+        dialect="postgres",
+        database_name=database_name,
+        options=database_cfg.get("options"),
+    )
+
+
 def alter_db_rename_column(migrator, table_name, old_column_name, new_column_name):
     try:
         migrate(migrator.rename_column(table_name, old_column_name, new_column_name))
@@ -2652,6 +2685,7 @@ def migrate_db():
     migrate_add_unique_email(migrator)
     migrate_model_type_names()
     ensure_model_indexes(migrator)
+    migrate_postgres_family_model_provider_tables()
 
 
 def migrate_model_type_names():

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -266,15 +266,10 @@ ensure_docling
 ensure_db_init
 
 if [[ "${INIT_MODEL_PROVIDER_TABLES}" -eq 1 ]]; then
-    DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"
-    DB_TYPE_NORMALIZED="${DB_TYPE_NORMALIZED,,}"
-    if [[ "${DB_TYPE_NORMALIZED}" == "gaussdb" || "${DB_TYPE_NORMALIZED}" == "gauss" ]]; then
-        # This migration script contains MySQL-only SQL and cannot run against
-        # a GaussDB metadata database.
-        echo "Skipping MySQL-specific model provider table migrations for DB_TYPE=${DB_TYPE:-mysql}."
-    else
-        tools/scripts/run_migrations.sh
-    fi
+    # run_migrations.sh selects mysql_migration.py or postgres_migration.py
+    # from DB_TYPE so postgres/gaussdb upgrades get the same table-init and
+    # tenant_*_id backfill as MySQL.
+    tools/scripts/run_migrations.sh
 fi
 
 if [[ "${ENABLE_ADMIN_SERVER}" -eq 1 ]]; then

--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -214,15 +214,9 @@ ensure_db_init() {
 }
 
 run_mysql_migrations() {
-    local db_type="${DB_TYPE:-mysql}"
-    db_type="${db_type,,}"
-    if [ "$db_type" = "gaussdb" ] || [ "$db_type" = "gauss" ]; then
-        # This migration script contains MySQL-only SQL and cannot run against
-        # a GaussDB metadata database.
-        echo "Skipping MySQL-specific model provider table migrations for DB_TYPE=${DB_TYPE:-mysql}."
-        return 0
-    fi
-
+    # run_migrations.sh selects mysql_migration.py or postgres_migration.py
+    # from DB_TYPE so postgres/gaussdb upgrades get TenantModelIdMigrationStage
+    # (and model_type_merge) rather than skipping or running MySQL SQL.
     tools/scripts/run_migrations.sh
 }
 

--- a/docs/administrator/migration/database_schema_and_migration.md
+++ b/docs/administrator/migration/database_schema_and_migration.md
@@ -47,9 +47,9 @@ The [postgres_migration.py](https://github.com/infiniflow/ragflow/blob/main/tool
 - Merging `tenant_model.model_type` into an integer bitmask (`model_type_merge`)
 - Converting integer `tenant_*_id` columns to `varchar(32)` **and** backfilling them from `llm_id` / `embd_id` by resolving `tenant_model.id` (`tenant_model_id_migration`)
 
-`tools/scripts/run_migrations.sh` selects this script automatically when `DB_TYPE` is `postgres` or `gaussdb`. `migrate_db()` also runs the same stages on those databases at startup so in-place upgrades do not depend on a manual extra command.
+`tools/scripts/run_migrations.sh` selects this script automatically when `DB_TYPE` is `postgres` or `gaussdb`. That pre-startup path is where column-type conversion and data stages run (`model_type_merge` and `tenant_model_id_migration`).
 
-Do not convert `tenant_model.model_type` to integer with a one-shot `ALTER` before these stages run. `tenant_model_seeding` and `model_type_merge` skip when that column is already an integer, which would leave unmerged duplicate rows.
+`migrate_db()` is only a fallback if the script did not run: it may retype leftover integer `tenant_*_id` columns, then invokes the same stages. It does **not** ALTER `tenant_model.model_type` to integer first — `tenant_model_seeding` and `model_type_merge` skip when that column is already an integer, which would leave unmerged duplicate rows.
 
 For GaussDB, connection parameters come from `GAUSSDB_METADATA_*` environment variables.
 

--- a/docs/administrator/migration/database_schema_and_migration.md
+++ b/docs/administrator/migration/database_schema_and_migration.md
@@ -17,6 +17,7 @@ Sync schemas and migrate data using official RAGFlow scripts.
 RAGFlow handles schema updates and migrations automatically at startup. However, for high-volume environments like Kubernetes, massive datasets can cause initialization to exceed 10 minutes, potentially triggering container timeouts or health check failures. To avoid this, you can disable the built-in auto-initialization and manually run these provided scripts to complete database upgrades before launching the service:
 
 - [mysql_migration.py](#mysql_migrationpy): Migrates data between MySQL tables.
+- [postgres_migration.py](#postgres_migrationpy): Same model-provider stages for PostgreSQL and GaussDB.
 - [db_schema_sync.py](#db_schema_syncpy): Syncs database schemas and manages changes using peewee-migrate.
 
 ## Mysql_migration.py
@@ -37,6 +38,18 @@ The [mysql_migration.py](https://github.com/infiniflow/ragflow/blob/main/tools/s
 - **Data normalization**: Necessary when consolidating multiple API keys or LLM providers into the updated system format.
 - **Kubernetes deployments**: Useful for setting up the database structure independently using the `--create-table-only` flag before main services start.
 - **Migration verification**: Used in dry-run mode to identify any legacy records that still need to be moved to the new tables.
+
+## Postgres_migration.py
+
+The [postgres_migration.py](https://github.com/infiniflow/ragflow/blob/main/tools/scripts/postgres_migration.py) script is the PostgreSQL / GaussDB equivalent of `mysql_migration.py`. It shares the same stages, including:
+
+- Creating `tenant_model_provider`, `tenant_model_instance`, and `tenant_model` when they are missing
+- Merging `tenant_model.model_type` into an integer bitmask (`model_type_merge`)
+- Converting integer `tenant_*_id` columns to `varchar(32)` **and** backfilling them from `llm_id` / `embd_id` by resolving `tenant_model.id` (`tenant_model_id_migration`)
+
+`tools/scripts/run_migrations.sh` selects this script automatically when `DB_TYPE` is `postgres` or `gaussdb`. `migrate_db()` also runs the same stages on those databases at startup so in-place upgrades do not depend on a manual extra command.
+
+For GaussDB, connection parameters come from `GAUSSDB_METADATA_*` environment variables.
 
 ## Db_schema_sync.py
 

--- a/test/unit_test/api/db/test_gaussdb_adaptation_points.py
+++ b/test/unit_test/api/db/test_gaussdb_adaptation_points.py
@@ -109,6 +109,7 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
     monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
     monkeypatch.setattr(db_models, "migrate_model_type_names", lambda: None)
     monkeypatch.setattr(db_models, "ensure_model_indexes", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_postgres_family_model_provider_tables", lambda: events.append(("pg_model_provider",)))
 
     db_models.migrate_db()
 
@@ -117,7 +118,9 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
         assert field.null is True
     assert set(migrated_fields) == {("document", "suffix"), ("user_canvas", "tags")}
     assert ("tenant_model_id_types",) in events
-    assert events[-1] == ("relax",)
+    assert ("pg_model_provider",) in events
+    assert events.index(("tenant_model_id_types",)) < events.index(("relax",))
+    assert events.index(("relax",)) < events.index(("pg_model_provider",))
 
 
 def test_empty_string_char_field_keeps_non_gaussdb_constraints(monkeypatch):
@@ -386,14 +389,16 @@ def test_docker_compose_metadata_profile_does_not_force_mysql_for_gaussdb():
         assert cn_compose["services"][service_name]["depends_on"]["mysql"]["required"] is False
 
 
-def test_docker_launch_scripts_skip_mysql_migration_for_gaussdb():
+def test_docker_launch_scripts_run_postgres_migration_for_gaussdb():
     entrypoint = read_repo_file("docker/entrypoint.sh")
     launcher = read_repo_file("docker/launch_backend_service.sh")
+    run_migrations = read_repo_file("tools/scripts/run_migrations.sh")
 
-    assert 'DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"' in entrypoint
-    assert 'if [[ "${DB_TYPE_NORMALIZED}" == "gaussdb" || "${DB_TYPE_NORMALIZED}" == "gauss" ]]; then' in entrypoint
-    assert "Skipping MySQL-specific model provider table migrations" in entrypoint
-
-    assert 'local db_type="${DB_TYPE:-mysql}"' in launcher
-    assert 'if [ "$db_type" = "gaussdb" ] || [ "$db_type" = "gauss" ]; then' in launcher
-    assert "Skipping MySQL-specific model provider table migrations" in launcher
+    assert "Skipping MySQL-specific model provider table migrations" not in entrypoint
+    assert "Skipping MySQL-specific model provider table migrations" not in launcher
+    assert "tools/scripts/run_migrations.sh" in entrypoint
+    assert "tools/scripts/run_migrations.sh" in launcher
+    assert "tools/scripts/postgres_migration.py" in run_migrations
+    assert 'DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"' in run_migrations
+    assert '"$DB_TYPE_NORMALIZED" == "gaussdb"' in run_migrations
+    assert '"$DB_TYPE_NORMALIZED" == "postgres"' in run_migrations

--- a/test/unit_test/api/db/test_gaussdb_adaptation_points.py
+++ b/test/unit_test/api/db/test_gaussdb_adaptation_points.py
@@ -103,6 +103,7 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
     monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append(("alter_type",)))
     monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append(("rename",)))
     monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append(("drop_index",)))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_id_column_types", lambda _migrator: events.append(("tenant_model_id_types",)))
     monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append(("relax",)))
     monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
     monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
@@ -115,6 +116,7 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
         assert isinstance(field, db_models.EmptyStringCharField)
         assert field.null is True
     assert set(migrated_fields) == {("document", "suffix"), ("user_canvas", "tags")}
+    assert ("tenant_model_id_types",) in events
     assert events[-1] == ("relax",)
 
 

--- a/test/unit_test/api/db/test_gaussdb_adaptation_points.py
+++ b/test/unit_test/api/db/test_gaussdb_adaptation_points.py
@@ -103,6 +103,7 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
     monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append(("alter_type",)))
     monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append(("rename",)))
     monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append(("drop_index",)))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_type_column", lambda _migrator: events.append(("tenant_model_type",)))
     monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append(("relax",)))
     monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
     monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
@@ -115,6 +116,7 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
         assert isinstance(field, db_models.EmptyStringCharField)
         assert field.null is True
     assert set(migrated_fields) == {("document", "suffix"), ("user_canvas", "tags")}
+    assert ("tenant_model_type",) in events
     assert events[-1] == ("relax",)
 
 

--- a/test/unit_test/api/db/test_postgres_model_provider_migration.py
+++ b/test/unit_test/api/db/test_postgres_model_provider_migration.py
@@ -1,0 +1,239 @@
+"""
+Tests for PostgreSQL/GaussDB model-provider migration (#18756 / #18777).
+
+Lynn-Inf review: type conversion alone leaves tenant_*_id holding old integer
+values. The postgres dialect must also backfill from llm_id/embd_id like
+MySQL TenantModelIdMigrationStage.
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MIGRATION_SCRIPT = REPO_ROOT / "tools" / "scripts" / "mysql_migration.py"
+
+
+def load_migration_module():
+    spec = importlib.util.spec_from_file_location("ragflow_mysql_migration_test", MIGRATION_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RecordingCursor:
+    def __init__(self, rows=None):
+        self._rows = list(rows or [])
+        self._offset = 0
+
+    def fetchone(self):
+        if not self._rows:
+            return (0,)
+        return self._rows[0]
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def fetchmany(self, size):
+        chunk = self._rows[self._offset : self._offset + size]
+        self._offset += size
+        return chunk
+
+
+class RecordingDB:
+    def __init__(self, column_types=None, columns=None, tables=None, select_rows=None):
+        self.queries = []
+        self.column_types = column_types or {}
+        self.columns = columns or set()
+        self.tables = tables or set()
+        self.select_rows = select_rows or {}
+
+    def execute_sql(self, sql, params=None):
+        self.queries.append((sql, params))
+        key = sql.strip().split()[0].upper()
+        if key == "SELECT":
+            for matcher, rows in self.select_rows.items():
+                if matcher in sql:
+                    return RecordingCursor(rows)
+            if "COUNT(*)" in sql:
+                return RecordingCursor([(0,)])
+            return RecordingCursor([])
+        return RecordingCursor([])
+
+
+def test_postgres_dialect_quotes_and_casts():
+    mod = load_migration_module()
+    config = mod.MigrationConfig(database="rag_flow")
+    db = mod.PostgresMigrationDatabase(config, peewee_db=RecordingDB())
+
+    assert db.quote_ident("tenant_llm_id") == '"tenant_llm_id"'
+    assert db.datetime_from_unix("1700000000") == "TO_TIMESTAMP(1700000000)"
+    assert db.column_as_text('"llm_id"') == '"llm_id"::text'
+    assert db.is_integer_type("integer")
+    assert db.is_integer_type("bigint")
+    assert not db.is_integer_type("character varying")
+
+
+def test_postgres_convert_column_uses_text_cast():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+
+    db.convert_column_to_varchar32("tenant", "tenant_llm_id")
+
+    sql, _params = recorder.queries[0]
+    assert 'ALTER TABLE "tenant" ALTER COLUMN "tenant_llm_id" TYPE varchar(32)' in sql
+    assert 'USING "tenant_llm_id"::text' in sql
+
+
+def test_mysql_convert_column_still_uses_modify():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.MigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+
+    db.convert_column_to_varchar32("tenant", "tenant_llm_id")
+
+    sql, _params = recorder.queries[0]
+    assert "MODIFY COLUMN `tenant_llm_id` VARCHAR(32) NULL" in sql
+
+
+def test_tenant_model_id_stage_backfills_from_legacy_model_name():
+    mod = load_migration_module()
+    recorder = RecordingDB(
+        tables={"tenant_model", "tenant_model_provider", "tenant_model_instance", "tenant"},
+        columns={
+            ("tenant", "tenant_llm_id"),
+            ("tenant", "llm_id"),
+            ("tenant", "tenant_embd_id"),
+            ("tenant", "embd_id"),
+        },
+        column_types={("tenant", "tenant_llm_id"): "integer"},
+        select_rows={
+            "FROM tenant_model tm": [
+                ("2fe23460a07a11f18c93a9473e17d659", "gpt-4o", 1, "tenant-1", "OpenAI"),
+            ],
+            "SELECT id,": [("tenant-1", "gpt-4o@default@OpenAI")],
+        },
+    )
+    recorder.column_exists = lambda table, column: (table, column) in recorder.columns
+    recorder.table_exists = lambda table: table in recorder.tables
+    recorder.get_column_type = lambda table, column: recorder.column_types.get((table, column))
+
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    # Peewee wrapper methods used by the stage go through MigrationDatabase.
+    db.table_exists = recorder.table_exists
+    db.column_exists = recorder.column_exists
+    db.get_column_type = recorder.get_column_type
+
+    stage = mod.TenantModelIdMigrationStage(db, dry_run=False)
+    # Only migrate tenant.tenant_llm_id in this case.
+    stage.TENANT_ID_FIELDS = {"tenant": [("tenant_llm_id", "llm_id", "chat")]}
+
+    rows, tables = stage.execute()
+
+    convert_sql = [sql for sql, _ in recorder.queries if "ALTER TABLE" in sql and "TYPE varchar(32)" in sql]
+    assert convert_sql
+    assert 'USING "tenant_llm_id"::text' in convert_sql[0]
+
+    updates = [(sql, params) for sql, params in recorder.queries if sql.strip().upper().startswith("UPDATE")]
+    assert any(params == ("2fe23460a07a11f18c93a9473e17d659", "tenant-1") for _sql, params in updates)
+    assert rows == 1
+    assert tables == ["tenant"]
+
+
+def test_tenant_model_id_stage_clears_unresolved_legacy_ids():
+    mod = load_migration_module()
+    recorder = RecordingDB(
+        tables={"tenant_model", "tenant_model_provider", "tenant_model_instance", "knowledgebase"},
+        columns={
+            ("knowledgebase", "tenant_embd_id"),
+            ("knowledgebase", "embd_id"),
+        },
+        column_types={("knowledgebase", "tenant_embd_id"): "character varying"},
+        select_rows={
+            "FROM tenant_model tm": [],
+            "SELECT id, tenant_id": [("kb-1", "tenant-1", "unknown-model@default@OpenAI")],
+        },
+    )
+    recorder.column_exists = lambda table, column: (table, column) in recorder.columns
+    recorder.table_exists = lambda table: table in recorder.tables
+    recorder.get_column_type = lambda table, column: recorder.column_types.get((table, column), "character varying")
+
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    db.table_exists = recorder.table_exists
+    db.column_exists = recorder.column_exists
+    db.get_column_type = recorder.get_column_type
+
+    stage = mod.TenantModelIdMigrationStage(db, dry_run=False)
+    stage.TENANT_ID_FIELDS = {"knowledgebase": [("tenant_embd_id", "embd_id", "embedding")]}
+
+    stage.execute()
+
+    updates = [(sql, params) for sql, params in recorder.queries if sql.strip().upper().startswith("UPDATE")]
+    assert any(params == ("kb-1",) and "= ''" in sql for sql, params in updates)
+
+
+def test_migrate_postgres_family_skips_mysql(monkeypatch):
+    from types import SimpleNamespace
+
+    from api.db import db_models
+    from common import settings
+
+    called = []
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
+    monkeypatch.setattr(db_models, "_load_model_provider_migration_module", lambda: called.append("load") or SimpleNamespace())
+
+    db_models.migrate_postgres_family_model_provider_tables()
+
+    assert not called
+
+
+def test_migrate_postgres_family_runs_existing_connection(monkeypatch):
+    from api.db import db_models
+    from common import settings
+
+    calls = []
+
+    class FakeModule:
+        @staticmethod
+        def run_using_existing_connection(**kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(settings, "DATABASE", {"name": "rag_flow", "options": None})
+    monkeypatch.setattr(db_models, "_load_model_provider_migration_module", lambda: FakeModule)
+    monkeypatch.setattr(db_models, "DB", object())
+
+    db_models.migrate_postgres_family_model_provider_tables()
+
+    assert len(calls) == 1
+    assert calls[0]["dialect"] == "postgres"
+    assert calls[0]["database_name"] == "rag_flow"
+
+
+def test_run_using_existing_connection_runs_both_version_groups(monkeypatch):
+    mod = load_migration_module()
+    seen = []
+
+    def fake_run_migration(**kwargs):
+        seen.append((kwargs["stages"], kwargs["database_version"], kwargs["dialect"], kwargs.get("peewee_db")))
+
+    monkeypatch.setattr(mod, "run_migration", fake_run_migration)
+
+    peewee_db = object()
+    mod.run_using_existing_connection(peewee_db, dialect="postgres", database_name="rag_flow")
+
+    assert [item[1] for item in seen] == ["v0.26.0", "v0.27.0"]
+    assert seen[0][0] == mod.PROVIDER_TABLE_STAGES
+    assert seen[1][0] == mod.PROVIDER_DATA_STAGES
+    assert "tenant_model_id_migration" in seen[1][0]
+    assert "model_type_merge" in seen[1][0]
+    assert all(item[2] == "postgres" for item in seen)
+    assert all(item[3] is peewee_db for item in seen)
+
+
+def test_normalize_migration_dialect_maps_gaussdb(monkeypatch):
+    mod = load_migration_module()
+    assert mod.normalize_migration_dialect("gaussdb") == "postgres"
+    assert mod.normalize_migration_dialect("postgres") == "postgres"
+    assert mod.normalize_migration_dialect("mysql") == "mysql"

--- a/test/unit_test/api/db/test_postgres_model_provider_migration.py
+++ b/test/unit_test/api/db/test_postgres_model_provider_migration.py
@@ -172,43 +172,16 @@ def test_tenant_model_id_stage_clears_unresolved_legacy_ids():
     assert any(params == ("kb-1",) and "= ''" in sql for sql, params in updates)
 
 
-def test_migrate_postgres_family_skips_mysql(monkeypatch):
-    from types import SimpleNamespace
+def test_migrate_postgres_family_is_gated_to_postgres_and_gaussdb():
+    source = (REPO_ROOT / "api" / "db" / "db_models.py").read_text()
+    func = source.split("def migrate_postgres_family_model_provider_tables():", 1)[1].split("\ndef ", 1)[0]
 
-    from api.db import db_models
-    from common import settings
-
-    called = []
-
-    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
-    monkeypatch.setattr(db_models, "_load_model_provider_migration_module", lambda: called.append("load") or SimpleNamespace())
-
-    db_models.migrate_postgres_family_model_provider_tables()
-
-    assert not called
-
-
-def test_migrate_postgres_family_runs_existing_connection(monkeypatch):
-    from api.db import db_models
-    from common import settings
-
-    calls = []
-
-    class FakeModule:
-        @staticmethod
-        def run_using_existing_connection(**kwargs):
-            calls.append(kwargs)
-
-    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
-    monkeypatch.setattr(settings, "DATABASE", {"name": "rag_flow", "options": None})
-    monkeypatch.setattr(db_models, "_load_model_provider_migration_module", lambda: FakeModule)
-    monkeypatch.setattr(db_models, "DB", object())
-
-    db_models.migrate_postgres_family_model_provider_tables()
-
-    assert len(calls) == 1
-    assert calls[0]["dialect"] == "postgres"
-    assert calls[0]["database_name"] == "rag_flow"
+    assert 'if settings.DATABASE_TYPE.upper() not in {"POSTGRES", "GAUSSDB"}:' in func
+    _gate, rest = func.split('{"POSTGRES", "GAUSSDB"}:', 1)
+    assert "return" in rest.split("database_cfg", 1)[0]
+    assert "run_using_existing_connection(" in rest
+    assert 'dialect="postgres"' in rest
+    assert "peewee_db=DB" in rest
 
 
 def test_run_using_existing_connection_runs_both_version_groups(monkeypatch):

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -97,7 +97,7 @@ def test_migrate_tenant_model_id_column_types_converts_mysql_integer(monkeypatch
 
     db_models.migrate_tenant_model_id_column_types(Migrator())
 
-    converted = [(table, column) for table, column, _field in altered if table != "migrate"]
+    converted = [(table, column) for table, column, *_rest in altered if table != "migrate"]
     assert converted == [("knowledgebase", "tenant_embd_id")]
     assert ("migrate", "alter knowledgebase.tenant_embd_id") in altered
 

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -2,6 +2,8 @@
 Tests for tenant_*_id column type migration on upgrade (#18756).
 """
 
+import logging
+
 import pytest
 
 from api.db import db_models
@@ -32,7 +34,7 @@ def test_migrate_tenant_model_id_column_types_skips_non_integer_columns(monkeypa
     assert not executed
 
 
-def test_migrate_tenant_model_id_column_types_skips_add_when_inspection_fails(monkeypatch):
+def test_migrate_tenant_model_id_column_types_skips_add_when_inspection_fails(monkeypatch, caplog):
     added = []
 
     def boom(*_args):
@@ -42,9 +44,15 @@ def test_migrate_tenant_model_id_column_types_skips_add_when_inspection_fails(mo
     monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
     monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: added.append("add"))
 
-    db_models.migrate_tenant_model_id_column_types(object())
+    logging.disable(logging.ERROR)
+    try:
+        with caplog.at_level(logging.CRITICAL):
+            db_models.migrate_tenant_model_id_column_types(object())
+    finally:
+        logging.disable(logging.NOTSET)
 
     assert not added
+    assert any("column inspection failed" in r.message for r in caplog.records if r.levelno >= logging.CRITICAL)
 
 
 def test_migrate_tenant_model_id_column_types_adds_missing_columns(monkeypatch):

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -2,6 +2,8 @@
 Tests for tenant_*_id column type migration on upgrade (#18756).
 """
 
+import pytest
+
 from api.db import db_models
 from common import settings
 
@@ -15,6 +17,7 @@ def test_migrate_tenant_model_id_column_types_skips_non_integer_columns(monkeypa
 
     monkeypatch.setattr(db_models, "_get_column_data_type", fake_get_column_data_type)
     monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
     monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: (_ for _ in ()).throw(AssertionError("should not add column")))
 
     executed = []
@@ -27,6 +30,21 @@ def test_migrate_tenant_model_id_column_types_skips_non_integer_columns(monkeypa
 
     assert len(inspected) == len(db_models.TENANT_MODEL_ID_COLUMNS)
     assert not executed
+
+
+def test_migrate_tenant_model_id_column_types_skips_add_when_inspection_fails(monkeypatch):
+    added = []
+
+    def boom(*_args):
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", boom)
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: added.append("add"))
+
+    db_models.migrate_tenant_model_id_column_types(object())
+
+    assert not added
 
 
 def test_migrate_tenant_model_id_column_types_adds_missing_columns(monkeypatch):
@@ -112,6 +130,37 @@ def test_migrate_tenant_model_id_column_types_converts_mysql_integer(monkeypatch
     assert converted == [("knowledgebase", "tenant_embd_id")]
     assert ("migrate", "alter knowledgebase.tenant_embd_id") in altered
     assert any("CHAR_LENGTH(`tenant_embd_id`) <> 32" in sql for sql in queries)
+
+
+@pytest.mark.parametrize("db_type", ["mysql", "oceanbase"])
+def test_migrate_tenant_model_id_column_types_retries_mysql_leftover_cleanup(monkeypatch, db_type):
+    queries = []
+    altered = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append(sql)
+
+    class Migrator:
+        def alter_column_type(self, *_args):
+            altered.append("alter")
+            raise AssertionError("already-converted varchar must not be altered again")
+
+    monkeypatch.setattr(db_models, "DB", FakeDB)
+    monkeypatch.setattr(settings, "DATABASE_TYPE", db_type)
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: "varchar")
+    monkeypatch.setattr(db_models, "migrate", lambda *_args: (_ for _ in ()).throw(AssertionError("should not migrate")))
+
+    db_models.migrate_tenant_model_id_column_types(Migrator())
+
+    assert not altered
+    assert len(queries) == len(db_models.TENANT_MODEL_ID_COLUMNS)
+    assert all("CHAR_LENGTH(" in sql and "<> 32" in sql for sql in queries)
 
 
 def test_migrate_db_invokes_tenant_model_id_column_migration(monkeypatch):

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -72,11 +72,22 @@ def test_migrate_tenant_model_id_column_types_converts_postgres_integer(monkeypa
     sql, _params = queries[0]
     assert 'ALTER TABLE "tenant" ALTER COLUMN "tenant_llm_id"' in sql
     assert "TYPE varchar(32)" in sql
-    assert 'USING CASE WHEN "tenant_llm_id" IS NULL THEN NULL ELSE "tenant_llm_id"::text END' in sql
+    assert "USING CAST(NULL AS varchar(32))" in sql
+    assert "::text" not in sql
 
 
 def test_migrate_tenant_model_id_column_types_converts_mysql_integer(monkeypatch):
     altered = []
+    queries = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append(sql)
 
     class Migrator:
         def alter_column_type(self, table_name, column_name, field):
@@ -86,7 +97,7 @@ def test_migrate_tenant_model_id_column_types_converts_mysql_integer(monkeypatch
     def fake_migrate(operation):
         altered.append(("migrate", operation))
 
-    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "DB", FakeDB)
     monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
     monkeypatch.setattr(
         db_models,
@@ -100,6 +111,7 @@ def test_migrate_tenant_model_id_column_types_converts_mysql_integer(monkeypatch
     converted = [(table, column) for table, column, *_rest in altered if table != "migrate"]
     assert converted == [("knowledgebase", "tenant_embd_id")]
     assert ("migrate", "alter knowledgebase.tenant_embd_id") in altered
+    assert any("CHAR_LENGTH(`tenant_embd_id`) <> 32" in sql for sql in queries)
 
 
 def test_migrate_db_invokes_tenant_model_id_column_migration(monkeypatch):

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -1,0 +1,123 @@
+"""
+Tests for tenant_*_id column type migration on upgrade (#18756).
+"""
+
+from api.db import db_models
+from common import settings
+
+
+def test_migrate_tenant_model_id_column_types_skips_non_integer_columns(monkeypatch):
+    inspected = {}
+
+    def fake_get_column_data_type(table_name, column_name):
+        inspected[(table_name, column_name)] = True
+        return "character varying"
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", fake_get_column_data_type)
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: (_ for _ in ()).throw(AssertionError("should not add column")))
+
+    executed = []
+
+    class Migrator:
+        def alter_column_type(self, *_args):
+            executed.append("alter")
+
+    db_models.migrate_tenant_model_id_column_types(Migrator())
+
+    assert len(inspected) == len(db_models.TENANT_MODEL_ID_COLUMNS)
+    assert not executed
+
+
+def test_migrate_tenant_model_id_column_types_adds_missing_columns(monkeypatch):
+    added = []
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: None)
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda _migrator, table, column, field: added.append((table, column, field)))
+
+    db_models.migrate_tenant_model_id_column_types(object())
+
+    assert len(added) == len(db_models.TENANT_MODEL_ID_COLUMNS)
+    for table_name, column_name, field in added:
+        assert (table_name, column_name) in db_models.TENANT_MODEL_ID_COLUMNS
+        assert isinstance(field, db_models.CharField)
+        assert field.max_length == 32
+
+
+def test_migrate_tenant_model_id_column_types_converts_postgres_integer(monkeypatch):
+    queries = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append((sql, params))
+
+    monkeypatch.setattr(db_models, "DB", FakeDB)
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(
+        db_models,
+        "_get_column_data_type",
+        lambda table_name, column_name: "integer" if (table_name, column_name) == ("tenant", "tenant_llm_id") else "character varying",
+    )
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: (_ for _ in ()).throw(AssertionError("should not add column")))
+
+    db_models.migrate_tenant_model_id_column_types(object())
+
+    assert len(queries) == 1
+    sql, _params = queries[0]
+    assert 'ALTER TABLE "tenant" ALTER COLUMN "tenant_llm_id"' in sql
+    assert "TYPE varchar(32)" in sql
+    assert 'USING CASE WHEN "tenant_llm_id" IS NULL THEN NULL ELSE "tenant_llm_id"::text END' in sql
+
+
+def test_migrate_tenant_model_id_column_types_converts_mysql_integer(monkeypatch):
+    altered = []
+
+    class Migrator:
+        def alter_column_type(self, table_name, column_name, field):
+            altered.append((table_name, column_name, field))
+            return f"alter {table_name}.{column_name}"
+
+    def fake_migrate(operation):
+        altered.append(("migrate", operation))
+
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
+    monkeypatch.setattr(
+        db_models,
+        "_get_column_data_type",
+        lambda table_name, column_name: "int" if (table_name, column_name) == ("knowledgebase", "tenant_embd_id") else "varchar",
+    )
+    monkeypatch.setattr(db_models, "migrate", fake_migrate)
+
+    db_models.migrate_tenant_model_id_column_types(Migrator())
+
+    converted = [(table, column) for table, column, _field in altered if table != "migrate"]
+    assert converted == [("knowledgebase", "tenant_embd_id")]
+    assert ("migrate", "alter knowledgebase.tenant_embd_id") in altered
+
+
+def test_migrate_db_invokes_tenant_model_id_column_migration(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: events.append("add"))
+    monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append("alter_type"))
+    monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append("rename"))
+    monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append("drop_index"))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_id_column_types", lambda _migrator: events.append("tenant_model_id_types"))
+    monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append("relax"))
+    monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
+    monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_model_type_names", lambda: None)
+    monkeypatch.setattr(db_models, "ensure_model_indexes", lambda _migrator: None)
+
+    db_models.migrate_db()
+
+    assert "tenant_model_id_types" in events
+    assert events.index("tenant_model_id_types") > events.index("add")

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -1,5 +1,9 @@
 """
-Tests for tenant_*_id column type migration on upgrade (#18756).
+Tests for tenant_*_id column type migration on upgrade (#18756 / #18777).
+
+migrate_tenant_model_id_column_types is a fallback for when the pre-startup
+script (tenant_model_id_migration) did not run. It only converts leftover
+integer columns; backfill still belongs in the script / postgres family stages.
 """
 
 import logging

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -190,3 +190,26 @@ def test_migrate_db_invokes_tenant_model_id_column_migration(monkeypatch):
 
     assert "tenant_model_id_types" in events
     assert events.index("tenant_model_id_types") > events.index("add")
+
+
+def test_migrate_db_invokes_postgres_model_provider_data_migration(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: events.append("add"))
+    monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append("alter_type"))
+    monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append("rename"))
+    monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append("drop_index"))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_id_column_types", lambda _migrator: events.append("tenant_model_id_types"))
+    monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append("relax"))
+    monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
+    monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_model_type_names", lambda: None)
+    monkeypatch.setattr(db_models, "ensure_model_indexes", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_postgres_family_model_provider_tables", lambda: events.append("pg_model_provider"))
+
+    db_models.migrate_db()
+
+    assert "pg_model_provider" in events
+    assert events.index("pg_model_provider") > events.index("tenant_model_id_types")
+    assert events.index("pg_model_provider") > events.index("relax")

--- a/test/unit_test/api/db/test_tenant_model_type_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_type_column_migration.py
@@ -9,10 +9,18 @@ from common import settings
 def test_migrate_tenant_model_type_column_skips_integer(monkeypatch):
     executed = []
 
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            executed.append("sql")
+
     monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: "integer")
-    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "DB", FakeDB)
     monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: executed.append("add"))
-    monkeypatch.setattr(db_models.DB, "execute_sql", lambda *_args, **_kwargs: executed.append("sql"))
 
     db_models.migrate_tenant_model_type_column(object())
 

--- a/test/unit_test/api/db/test_tenant_model_type_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_type_column_migration.py
@@ -63,11 +63,11 @@ def test_migrate_tenant_model_type_column_converts_postgres_varchar(monkeypatch)
     assert len(queries) == 1
     sql = queries[0]
     assert 'ALTER TABLE "tenant_model" ALTER COLUMN "model_type" TYPE integer USING' in sql
-    assert "WHEN lower(\"model_type\") = 'chat' THEN 1" in sql
-    assert "WHEN lower(\"model_type\") = 'embedding' THEN 2" in sql
-    assert "WHEN lower(\"model_type\") = 'speech2text' THEN 4" in sql
-    assert "WHEN lower(\"model_type\") = 'image2text' THEN 8" in sql
     assert "WHEN \"model_type\" ~ '^[0-9]+$' THEN \"model_type\"::integer" in sql
+    assert "string_to_array" in sql
+    assert "WHEN 'chat' = ANY(" in sql
+    assert "WHEN 'vision' = ANY(" in sql
+    assert "COALESCE(NULLIF((" in sql
 
 
 def test_migrate_tenant_model_type_column_converts_mysql_varchar(monkeypatch):
@@ -96,8 +96,13 @@ def test_migrate_tenant_model_type_column_converts_mysql_varchar(monkeypatch):
     db_models.migrate_tenant_model_type_column(Migrator())
 
     assert len(queries) == 1
-    assert "UPDATE `tenant_model` SET `model_type` = CASE LOWER(`model_type`)" in queries[0]
-    assert "WHEN 'chat' THEN '1'" in queries[0]
+    sql = queries[0]
+    assert "UPDATE `tenant_model` SET `model_type` = CASE" in sql
+    assert "WHEN `model_type` REGEXP '^[0-9]+$' THEN `model_type`" in sql
+    assert "WHEN `model_type` IS NULL OR TRIM(`model_type`) = '' THEN '1'" in sql
+    assert "FIND_IN_SET('chat'" in sql
+    assert "FIND_IN_SET('vision'" in sql
+    assert "IFNULL(NULLIF((" in sql
     assert ("tenant_model", "model_type") in [(table, column) for table, column, *_rest in altered if table != "migrate"]
     assert ("migrate", "alter tenant_model.model_type") in altered
 

--- a/test/unit_test/api/db/test_tenant_model_type_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_type_column_migration.py
@@ -198,7 +198,13 @@ def test_migrate_db_does_not_alter_model_type_in_place_before_merge():
     assert 'ALTER COLUMN "model_type" TYPE integer' not in source
     assert "migrate_postgres_family_model_provider_tables()" in source
 
+    helper = source.split("def migrate_tenant_model_id_column_types(", 1)[1].split("\ndef ", 1)[0]
+    helper_flat = " ".join(helper.split())
+    assert "Fallback:" in helper
+    assert "converts if the script did not run" in helper_flat
+
     migrate_db = source.split("def migrate_db(", 1)[1].split("\ndef ", 1)[0]
     assert "migrate_postgres_family_model_provider_tables()" in migrate_db
     assert "migrate_tenant_model_id_column_types(migrator)" in migrate_db
+    assert "Fallback only:" in migrate_db
     assert migrate_db.index("ensure_model_indexes(migrator)") < migrate_db.index("migrate_postgres_family_model_provider_tables()")

--- a/test/unit_test/api/db/test_tenant_model_type_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_type_column_migration.py
@@ -1,0 +1,115 @@
+"""
+Tests for tenant_model.model_type varchar-to-integer migration on upgrade (#18755).
+"""
+
+from api.db import db_models
+from common import settings
+
+
+def test_migrate_tenant_model_type_column_skips_integer(monkeypatch):
+    executed = []
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: "integer")
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: executed.append("add"))
+    monkeypatch.setattr(db_models.DB, "execute_sql", lambda *_args, **_kwargs: executed.append("sql"))
+
+    db_models.migrate_tenant_model_type_column(object())
+
+    assert not executed
+
+
+def test_migrate_tenant_model_type_column_adds_missing_column(monkeypatch):
+    added = []
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: None)
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda _migrator, table, column, field: added.append((table, column, field)))
+
+    db_models.migrate_tenant_model_type_column(object())
+
+    assert len(added) == 1
+    table, column, field = added[0]
+    assert (table, column) == ("tenant_model", "model_type")
+    assert isinstance(field, db_models.IntegerField)
+
+
+def test_migrate_tenant_model_type_column_converts_postgres_varchar(monkeypatch):
+    queries = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append(sql)
+
+    monkeypatch.setattr(db_models, "DB", FakeDB)
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: "character varying")
+
+    db_models.migrate_tenant_model_type_column(object())
+
+    assert len(queries) == 1
+    sql = queries[0]
+    assert 'ALTER TABLE "tenant_model" ALTER COLUMN "model_type" TYPE integer USING' in sql
+    assert "WHEN lower(\"model_type\") = 'chat' THEN 1" in sql
+    assert "WHEN lower(\"model_type\") = 'embedding' THEN 2" in sql
+    assert "WHEN lower(\"model_type\") = 'speech2text' THEN 4" in sql
+    assert "WHEN lower(\"model_type\") = 'image2text' THEN 8" in sql
+    assert "WHEN \"model_type\" ~ '^[0-9]+$' THEN \"model_type\"::integer" in sql
+
+
+def test_migrate_tenant_model_type_column_converts_mysql_varchar(monkeypatch):
+    queries = []
+    altered = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append(sql)
+
+    class Migrator:
+        def alter_column_type(self, table_name, column_name, field):
+            altered.append((table_name, column_name, field))
+            return "alter tenant_model.model_type"
+
+    monkeypatch.setattr(db_models, "DB", FakeDB)
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: "varchar")
+    monkeypatch.setattr(db_models, "migrate", lambda operation: altered.append(("migrate", operation)))
+
+    db_models.migrate_tenant_model_type_column(Migrator())
+
+    assert len(queries) == 1
+    assert "UPDATE `tenant_model` SET `model_type` = CASE LOWER(`model_type`)" in queries[0]
+    assert "WHEN 'chat' THEN '1'" in queries[0]
+    assert ("tenant_model", "model_type") in [(table, column) for table, column, *_rest in altered if table != "migrate"]
+    assert ("migrate", "alter tenant_model.model_type") in altered
+
+
+def test_migrate_db_invokes_tenant_model_type_column_migration(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: events.append("add"))
+    monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append("alter_type"))
+    monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append("rename"))
+    monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append("drop_index"))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_type_column", lambda _migrator: events.append("tenant_model_type"))
+    monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append("relax"))
+    monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
+    monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_model_type_names", lambda: None)
+    monkeypatch.setattr(db_models, "ensure_model_indexes", lambda _migrator: None)
+
+    db_models.migrate_db()
+
+    assert "tenant_model_type" in events
+    assert events.index("tenant_model_type") > events.index("add")

--- a/test/unit_test/api/db/test_tenant_model_type_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_type_column_migration.py
@@ -63,7 +63,7 @@ def test_migrate_tenant_model_type_column_converts_postgres_varchar(monkeypatch)
     assert len(queries) == 1
     sql = queries[0]
     assert 'ALTER TABLE "tenant_model" ALTER COLUMN "model_type" TYPE integer USING' in sql
-    assert "WHEN \"model_type\" ~ '^[0-9]+$' THEN \"model_type\"::integer" in sql
+    assert "WHEN btrim(\"model_type\") ~ '^[0-9]+$' THEN btrim(\"model_type\")::integer" in sql
     assert "string_to_array" in sql
     assert "WHEN 'chat' = ANY(" in sql
     assert "WHEN 'vision' = ANY(" in sql
@@ -98,7 +98,7 @@ def test_migrate_tenant_model_type_column_converts_mysql_varchar(monkeypatch):
     assert len(queries) == 1
     sql = queries[0]
     assert "UPDATE `tenant_model` SET `model_type` = CASE" in sql
-    assert "WHEN `model_type` REGEXP '^[0-9]+$' THEN `model_type`" in sql
+    assert "WHEN TRIM(`model_type`) REGEXP '^[0-9]+$' THEN TRIM(`model_type`)" in sql
     assert "WHEN `model_type` IS NULL OR TRIM(`model_type`) = '' THEN '1'" in sql
     assert "FIND_IN_SET('chat'" in sql
     assert "FIND_IN_SET('vision'" in sql

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -177,9 +177,10 @@ For GaussDB metadata, connection settings come from `GAUSSDB_METADATA_*`
 environment variables (not the `gaussdb:` DOC_ENGINE section in
 `service_conf.yaml`).
 
-In-place upgrades also invoke these stages from `migrate_db()` so postgres
-installs merge `tenant_model.model_type` into an integer bitmask and backfill
-`tenant_*_id` from `llm_id` / `embd_id`, instead of only retyping columns.
+Pre-startup `run_migrations.sh` is the primary path for both `model_type`
+merge and `tenant_*_id` conversion/backfill. `migrate_db()` only reruns the
+same stages (and a skip-if-already-varchar `tenant_*_id` type fallback) if
+that script did not run.
 
 Do not convert `tenant_model.model_type` to integer in `migrate_db()` first:
 `tenant_model_seeding` and `model_type_merge` skip when the column is already

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -2,7 +2,8 @@
 
 This directory contains database-related utility scripts for RAGFlow.
 
-- **mysql_migration.py**: Data migration between tables with stage-based execution
+- **mysql_migration.py**: Data migration between tables with stage-based execution (MySQL / OceanBase)
+- **postgres_migration.py**: Same stages as mysql_migration.py for PostgreSQL and GaussDB
 - **db_schema_sync.py**: Database schema synchronization using peewee-migrate
 
 ---
@@ -163,6 +164,27 @@ python mysql_migration.py --stages tenant_model_provider,tenant_model_instance,t
 
 # Use config file with command line password override
 python mysql_migration.py --stages tenant_model_provider --config /path/to/config.yaml --password mypassword --execute
+```
+
+## postgres_migration.py
+
+PostgreSQL / GaussDB counterpart to `mysql_migration.py`. It runs the same stages
+(`tenant_model_provider` through `tenant_model_id_migration`) with Postgres SQL
+(`TO_TIMESTAMP`, `USING …::text`, `ON CONFLICT`). `run_migrations.sh` selects
+this script when `DB_TYPE` is `postgres`, `postgresql`, `gaussdb`, or `gauss`.
+
+For GaussDB metadata, connection settings come from `GAUSSDB_METADATA_*`
+environment variables (not the `gaussdb:` DOC_ENGINE section in
+`service_conf.yaml`).
+
+In-place upgrades also invoke these stages from `migrate_db()` so postgres
+installs backfill `tenant_*_id` from `llm_id` / `embd_id` instead of only
+retyping integer columns.
+
+```bash
+python postgres_migration.py --list-stages
+python postgres_migration.py --stages tenant_model_seeding,model_type_merge,tenant_model_id_migration \
+    --config /path/to/config.yaml --execute --database-version v0.27.0 --mark-database-version-on-success
 ```
 
 ## Output Interpretation

--- a/tools/scripts/mysql_migration.py
+++ b/tools/scripts/mysql_migration.py
@@ -39,6 +39,7 @@ from peewee import (
     IntegerField,
     Model,
     MySQLDatabase,
+    PostgresqlDatabase,
     PrimaryKeyField,
     TextField,
 )
@@ -48,47 +49,99 @@ from playhouse.migrate import MySQLMigrator
 PROJECT_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_BASE)
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 MIGRATION_DB_VERSION_MARKER = "mysql_migration.database.version"
 
 
-class MigrationConfig:
-    """Configuration for MySQL connection"""
+INTEGER_COLUMN_TYPES = frozenset({"int", "integer", "bigint", "smallint", "mediumint", "tinyint", "int2", "int4", "int8"})
+POSTGRES_FAMILY_DIALECTS = frozenset({"postgres", "postgresql", "gaussdb", "gauss"})
 
-    def __init__(self, host: str = "localhost", port: int = 3306, user: str = "root", password: str = "", database: str = "rag_flow"):
+
+def normalize_migration_dialect(dialect: str | None = None) -> str:
+    raw = (dialect or os.getenv("DB_TYPE", "mysql")).strip().lower()
+    if raw in POSTGRES_FAMILY_DIALECTS:
+        return "postgres"
+    return "mysql"
+
+
+class MigrationConfig:
+    """Configuration for the metadata database connection."""
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 3306,
+        user: str = "root",
+        password: str = "",
+        database: str = "rag_flow",
+        options: str | None = None,
+    ):
         self.host = host
         self.port = port
         self.user = user
         self.password = password
         self.database = database
+        self.options = options
 
     @classmethod
-    def from_config_file(cls, config_path: str) -> "MigrationConfig":
-        """Load configuration from YAML config file"""
+    def from_gaussdb_env(cls) -> "MigrationConfig":
+        """Load GaussDB metadata settings from GAUSSDB_METADATA_* (not DOC_ENGINE)."""
+        schema = os.environ.get("GAUSSDB_METADATA_SCHEMA", "public").strip() or "public"
+        options = os.environ.get("GAUSSDB_METADATA_OPTIONS")
+        if options is None:
+            options = f"-c search_path={schema} -c client_encoding=UTF8 -c default_transaction_read_only=off"
+        try:
+            port = int(os.environ.get("GAUSSDB_METADATA_PORT", "8000"))
+        except (TypeError, ValueError):
+            port = 8000
+        return cls(
+            host=os.environ.get("GAUSSDB_METADATA_HOST", "gaussdb"),
+            port=port,
+            user=os.environ.get("GAUSSDB_METADATA_USER", "rag_flow"),
+            password=os.environ.get("GAUSSDB_METADATA_PASSWORD", "infini_rag_flow"),
+            database=os.environ.get("GAUSSDB_METADATA_DBNAME", "rag_flow"),
+            options=options,
+        )
+
+    @classmethod
+    def from_config_file(cls, config_path: str, dialect: str = "mysql") -> "MigrationConfig":
+        """Load configuration from YAML config file."""
+        dialect = normalize_migration_dialect(dialect)
+        if dialect == "postgres" and os.getenv("DB_TYPE", "").strip().lower() in {"gaussdb", "gauss"}:
+            return cls.from_gaussdb_env()
+
         try:
             from ruamel.yaml import YAML
 
             yaml = YAML(typ="safe", pure=True)
 
             with open(config_path, "r") as f:
-                config = yaml.load(f)
+                config = yaml.load(f) or {}
 
-            # Try to get database config
-            db_config = config.get("database", config.get("mysql", {}))
+            if dialect == "postgres":
+                db_config = config.get("postgres") or config.get("database") or config.get("mysql") or {}
+                default_port = 5432
+                default_user = "rag_flow"
+            else:
+                db_config = config.get("database", config.get("mysql", {}))
+                default_port = 3306
+                default_user = "root"
 
             return cls(
                 host=db_config.get("host", "localhost"),
-                port=db_config.get("port", 3306),
-                user=db_config.get("user", "root"),
+                port=db_config.get("port", default_port),
+                user=db_config.get("user", default_user),
                 password=db_config.get("password", ""),
                 database=db_config.get("name", db_config.get("database", "rag_flow")),
             )
         except Exception as e:
             logger.warning(f"Failed to load config file: {e}, using defaults")
+            if dialect == "postgres":
+                return cls(port=5432, user="rag_flow")
             return cls()
 
 
@@ -129,18 +182,31 @@ class MigrationStats:
 
 
 class MigrationDatabase:
-    """Database wrapper for migrations"""
+    """Database wrapper for migrations. MySQL dialect by default."""
 
-    def __init__(self, config: MigrationConfig):
+    dialect = "mysql"
+    datetime_type = "DATETIME"
+
+    def __init__(self, config: MigrationConfig, peewee_db=None):
         self.config = config
-        self.db = MySQLDatabase(config.database, host=config.host, port=config.port, user=config.user, password=config.password, charset="utf8mb4")
-        self.migrator = MySQLMigrator(self.db)
+        self._owns_connection = peewee_db is None
+        if peewee_db is not None:
+            self.db = peewee_db
+            self.migrator = None
+        else:
+            self.db = MySQLDatabase(config.database, host=config.host, port=config.port, user=config.user, password=config.password, charset="utf8mb4")
+            self.migrator = MySQLMigrator(self.db)
 
     def connect(self):
-        self.db.connect()
-        logger.info(f"Connected to MySQL database: {self.config.database}")
+        if not self._owns_connection:
+            return
+        if self.db.is_closed():
+            self.db.connect()
+        logger.info(f"Connected to {self.dialect} database: {self.config.database}")
 
     def close(self):
+        if not self._owns_connection:
+            return
         if not self.db.is_closed():
             self.db.close()
             logger.info("Database connection closed")
@@ -148,26 +214,75 @@ class MigrationDatabase:
     def execute_sql(self, sql: str, params=None):
         return self.db.execute_sql(sql, params)
 
+    def quote_ident(self, name: str) -> str:
+        return f"`{name}`"
+
+    def datetime_from_unix(self, seconds_sql: str) -> str:
+        return f"FROM_UNIXTIME({seconds_sql})"
+
+    def column_as_text(self, quoted_column: str) -> str:
+        return quoted_column
+
+    def is_integer_type(self, col_type: str | None) -> bool:
+        return bool(col_type) and col_type.lower() in INTEGER_COLUMN_TYPES
+
+    def _schema_predicate(self) -> tuple[str, tuple]:
+        return "table_schema = %s", (self.config.database,)
+
     def table_exists(self, table_name: str) -> bool:
-        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s", (self.config.database, table_name))
+        schema_sql, schema_params = self._schema_predicate()
+        cursor = self.execute_sql(f"SELECT COUNT(*) FROM information_schema.tables WHERE {schema_sql} AND table_name = %s", (*schema_params, table_name))
         return cursor.fetchone()[0] > 0
 
     def column_exists(self, table_name: str, column_name: str) -> bool:
-        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self.config.database, table_name, column_name))
+        schema_sql, schema_params = self._schema_predicate()
+        cursor = self.execute_sql(
+            f"SELECT COUNT(*) FROM information_schema.columns WHERE {schema_sql} AND table_name = %s AND column_name = %s",
+            (*schema_params, table_name, column_name),
+        )
         return cursor.fetchone()[0] > 0
 
     def get_column_type(self, table_name: str, column_name: str) -> str | None:
         """Get the DATA_TYPE of a column from information_schema, returns None if column does not exist"""
-        cursor = self.execute_sql("SELECT DATA_TYPE FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self.config.database, table_name, column_name))
+        schema_sql, schema_params = self._schema_predicate()
+        cursor = self.execute_sql(
+            f"SELECT DATA_TYPE FROM information_schema.columns WHERE {schema_sql} AND table_name = %s AND column_name = %s",
+            (*schema_params, table_name, column_name),
+        )
         row = cursor.fetchone()
         return row[0] if row else None
+
+    def add_varchar32_column(self, table_name: str, column_name: str):
+        self.execute_sql(f"ALTER TABLE {self.quote_ident(table_name)} ADD COLUMN {self.quote_ident(column_name)} VARCHAR(32) NULL")
+
+    def convert_column_to_varchar32(self, table_name: str, column_name: str):
+        q_table = self.quote_ident(table_name)
+        q_col = self.quote_ident(column_name)
+        self.execute_sql(f"ALTER TABLE {q_table} MODIFY COLUMN {q_col} VARCHAR(32) NULL")
+
+    def add_auto_increment_unique_id_column(self, table_name: str):
+        self.execute_sql(f"ALTER TABLE {self.quote_ident(table_name)} ADD COLUMN id BIGINT AUTO_INCREMENT UNIQUE")
+
+    def create_table(self, table_name: str, columns: list[str], indexes: list[tuple[str, list[str], bool]] | None = None):
+        """Create a table. Column defs may use DATETIME as a dialect-neutral timestamp token."""
+        indexes = indexes or []
+        col_sql = [col.replace("DATETIME", self.datetime_type) for col in columns]
+        extra = []
+        for name, cols, unique in indexes:
+            prefix = "UNIQUE INDEX" if unique else "INDEX"
+            extra.append(f"{prefix} {name} ({', '.join(cols)})")
+        body = ",\n            ".join(col_sql + extra)
+        self.execute_sql(f"CREATE TABLE IF NOT EXISTS {table_name} (\n            {body}\n        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")
 
     def get_system_setting_value(self, name: str) -> str | None:
         if not self.table_exists("system_settings"):
             logger.info("Table 'system_settings' does not exist, migration marker is unavailable")
             return None
+        q_table = self.quote_ident("system_settings")
+        q_value = self.quote_ident("value")
+        q_name = self.quote_ident("name")
         cursor = self.execute_sql(
-            "SELECT `value` FROM `system_settings` WHERE `name` = %s",
+            f"SELECT {q_value} FROM {q_table} WHERE {q_name} = %s",
             (name,),
         )
         row = cursor.fetchone()
@@ -179,17 +294,20 @@ class MigrationDatabase:
             return
 
         current_ts = int(time.time())
+        ts_sql = self.datetime_from_unix("%s")
         self.execute_sql(
-            """
-            INSERT INTO `system_settings`
-            (`name`, `source`, `data_type`, `value`, `create_time`, `create_date`, `update_time`, `update_date`)
-            VALUES (%s, %s, %s, %s, %s, FROM_UNIXTIME(%s), %s, FROM_UNIXTIME(%s))
+            f"""
+            INSERT INTO {self.quote_ident("system_settings")}
+            ({self.quote_ident("name")}, {self.quote_ident("source")}, {self.quote_ident("data_type")},
+             {self.quote_ident("value")}, {self.quote_ident("create_time")}, {self.quote_ident("create_date")},
+             {self.quote_ident("update_time")}, {self.quote_ident("update_date")})
+            VALUES (%s, %s, %s, %s, %s, {ts_sql}, %s, {ts_sql})
             ON DUPLICATE KEY UPDATE
-              `source` = VALUES(`source`),
-              `data_type` = VALUES(`data_type`),
-              `value` = VALUES(`value`),
-              `update_time` = VALUES(`update_time`),
-              `update_date` = VALUES(`update_date`)
+              {self.quote_ident("source")} = VALUES({self.quote_ident("source")}),
+              {self.quote_ident("data_type")} = VALUES({self.quote_ident("data_type")}),
+              {self.quote_ident("value")} = VALUES({self.quote_ident("value")}),
+              {self.quote_ident("update_time")} = VALUES({self.quote_ident("update_time")}),
+              {self.quote_ident("update_date")} = VALUES({self.quote_ident("update_date")})
             """,
             (
                 name,
@@ -208,6 +326,106 @@ class MigrationDatabase:
 
     def set_database_version(self, version: str):
         self.upsert_system_setting(MIGRATION_DB_VERSION_MARKER, version)
+
+
+class PostgresMigrationDatabase(MigrationDatabase):
+    """PostgreSQL / GaussDB dialect wrapper for the same migration stages."""
+
+    dialect = "postgres"
+    datetime_type = "TIMESTAMP"
+
+    def __init__(self, config: MigrationConfig, peewee_db=None):
+        self.config = config
+        self._owns_connection = peewee_db is None
+        if peewee_db is not None:
+            self.db = peewee_db
+            self.migrator = None
+            return
+        kwargs = {
+            "host": config.host,
+            "port": config.port,
+            "user": config.user,
+            "password": config.password,
+        }
+        if config.options:
+            kwargs["options"] = config.options
+        self.db = PostgresqlDatabase(config.database, **kwargs)
+        self.migrator = None
+
+    def quote_ident(self, name: str) -> str:
+        return '"' + name.replace('"', '""') + '"'
+
+    def datetime_from_unix(self, seconds_sql: str) -> str:
+        return f"TO_TIMESTAMP({seconds_sql})"
+
+    def column_as_text(self, quoted_column: str) -> str:
+        return f"{quoted_column}::text"
+
+    def _schema_predicate(self) -> tuple[str, tuple]:
+        return "table_schema = current_schema()", ()
+
+    def convert_column_to_varchar32(self, table_name: str, column_name: str):
+        q_table = self.quote_ident(table_name)
+        q_col = self.quote_ident(column_name)
+        self.execute_sql(f"ALTER TABLE {q_table} ALTER COLUMN {q_col} TYPE varchar(32) USING {q_col}::text")
+
+    def add_auto_increment_unique_id_column(self, table_name: str):
+        seq = f"{table_name}_id_seq"
+        q_table = self.quote_ident(table_name)
+        self.execute_sql(f"CREATE SEQUENCE IF NOT EXISTS {seq}")
+        self.execute_sql(f"ALTER TABLE {q_table} ADD COLUMN id BIGINT UNIQUE DEFAULT nextval('{seq}')")
+        self.execute_sql(f"ALTER SEQUENCE {seq} OWNED BY {table_name}.id")
+
+    def create_table(self, table_name: str, columns: list[str], indexes: list[tuple[str, list[str], bool]] | None = None):
+        indexes = indexes or []
+        col_sql = [col.replace("DATETIME", self.datetime_type) for col in columns]
+        body = ",\n            ".join(col_sql)
+        self.execute_sql(f"CREATE TABLE IF NOT EXISTS {table_name} (\n            {body}\n        )")
+        for name, cols, unique in indexes:
+            unique_sql = "UNIQUE " if unique else ""
+            self.execute_sql(f"CREATE {unique_sql}INDEX IF NOT EXISTS {name} ON {table_name} ({', '.join(cols)})")
+
+    def upsert_system_setting(self, name: str, value: str, source: str = "migration", data_type: str = "string"):
+        if not self.table_exists("system_settings"):
+            logger.warning("Table 'system_settings' does not exist, migration marker was not saved")
+            return
+
+        current_ts = int(time.time())
+        ts_sql = self.datetime_from_unix("%s")
+        self.execute_sql(
+            """
+            INSERT INTO system_settings
+            (name, source, data_type, value, create_time, create_date, update_time, update_date)
+            VALUES (%s, %s, %s, %s, %s, """
+            + ts_sql
+            + """, %s, """
+            + ts_sql
+            + """)
+            ON CONFLICT (name) DO UPDATE SET
+              source = EXCLUDED.source,
+              data_type = EXCLUDED.data_type,
+              value = EXCLUDED.value,
+              update_time = EXCLUDED.update_time,
+              update_date = EXCLUDED.update_date
+            """,
+            (
+                name,
+                source,
+                data_type,
+                value,
+                current_ts * 1000,
+                current_ts,
+                current_ts * 1000,
+                current_ts,
+            ),
+        )
+
+
+def create_migration_database(config: MigrationConfig, dialect: str = "mysql", peewee_db=None) -> MigrationDatabase:
+    dialect = normalize_migration_dialect(dialect)
+    if dialect == "postgres":
+        return PostgresMigrationDatabase(config, peewee_db=peewee_db)
+    return MigrationDatabase(config, peewee_db=peewee_db)
 
 
 def parse_migration_version(version: str | None) -> Version | None:
@@ -307,6 +525,9 @@ class MigrationStage:
     def noop_completes_migration(self) -> bool:
         return self._noop_completes_migration
 
+    def q(self, name: str) -> str:
+        return self.db.quote_ident(name)
+
 
 class TenantModelProviderStage(MigrationStage):
     """Migrate tenant_llm to tenant_model_provider"""
@@ -399,7 +620,7 @@ class TenantModelProviderStage(MigrationStage):
             params = []
             for tenant_id, llm_factory in batch:
                 record_id = self.generate_uuid()
-                placeholders.append("(%s, %s, %s, %s, FROM_UNIXTIME(%s), %s, FROM_UNIXTIME(%s))")
+                placeholders.append(f"(%s, %s, %s, %s, {self.db.datetime_from_unix('%s')}, %s, {self.db.datetime_from_unix('%s')})")
                 params.extend(
                     [
                         record_id,
@@ -424,21 +645,23 @@ class TenantModelProviderStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model_provider table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_provider (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            provider_name VARCHAR(128) NOT NULL,
-            tenant_id VARCHAR(32) NOT NULL,
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_provider_name (provider_name),
-            INDEX idx_tenant_id (tenant_id),
-            UNIQUE INDEX idx_tenant_provider_unique (tenant_id, provider_name)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model_provider",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "provider_name VARCHAR(128) NOT NULL",
+                "tenant_id VARCHAR(32) NOT NULL",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [
+                ("idx_provider_name", ["provider_name"], False),
+                ("idx_tenant_id", ["tenant_id"], False),
+                ("idx_tenant_provider_unique", ["tenant_id", "provider_name"], True),
+            ],
+        )
         logger.info("Created tenant_model_provider table")
 
 
@@ -575,8 +798,8 @@ class TenantModelInstanceStage(MigrationStage):
                 values.append(
                     f"('{record_id}', '{instance_name}', '{provider_id}', "
                     f"'{api_key_escaped}', '{status_val}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))}, "
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))})"
                 )
 
             insert_sql = f"""
@@ -677,22 +900,22 @@ class TenantModelInstanceStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model_instance table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_instance (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            instance_name VARCHAR(128) NOT NULL,
-            provider_id VARCHAR(32) NOT NULL,
-            api_key VARCHAR(512) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(512) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_provider_id (provider_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model_instance",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "instance_name VARCHAR(128) NOT NULL",
+                "provider_id VARCHAR(32) NOT NULL",
+                "api_key VARCHAR(512) NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(512) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_provider_id", ["provider_id"], False)],
+        )
         logger.info("Created tenant_model_instance table")
 
 
@@ -890,8 +1113,8 @@ class TenantModelStage(MigrationStage):
                     f"('{record_id}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', '{model_type_escaped}', '{status_val}', "
                     f"'{extra_escaped}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))}, "
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))})"
                 )
 
             insert_sql = f"""
@@ -912,9 +1135,9 @@ class TenantModelStage(MigrationStage):
         Very old tenant_llm tables may predate the id column, while the migration
         SELECT relies on it (tl.id is carried as source_id for audit logging).
         The id is only used as a unique audit key, so it is added as an
-        AUTO_INCREMENT UNIQUE column rather than PRIMARY KEY: old tables may
-        already have another primary key. MySQL back-fills existing rows with
-        sequential values when adding an AUTO_INCREMENT column.
+        auto-increment UNIQUE column rather than PRIMARY KEY: old tables may
+        already have another primary key. Existing rows are back-filled with
+        sequential values when the column is added.
 
         Returns:
             True if the column exists (or was added successfully), False otherwise.
@@ -928,7 +1151,7 @@ class TenantModelStage(MigrationStage):
             return False
 
         try:
-            self.db.execute_sql("ALTER TABLE tenant_llm ADD COLUMN id BIGINT AUTO_INCREMENT UNIQUE")
+            self.db.add_auto_increment_unique_id_column("tenant_llm")
         except Exception as e:
             logger.error(f"Failed to add auto-increment id column to tenant_llm: {e}")
             return False
@@ -1014,23 +1237,23 @@ class TenantModelStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type VARCHAR(32) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "model_name VARCHAR(128)",
+                "provider_id VARCHAR(32) NOT NULL",
+                "instance_id VARCHAR(32) NOT NULL",
+                "model_type VARCHAR(32) NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(1024) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_instance_id", ["instance_id"], False)],
+        )
         logger.info("Created tenant_model table")
 
 
@@ -1158,8 +1381,11 @@ class ModelIdConfigStage(MigrationStage):
 
     def iter_string_changes(self):
         for table_name, column_name in self.existing_columns(self.string_columns):
+            q_table = self.q(table_name)
+            q_col = self.q(column_name)
+            col_text = self.db.column_as_text(q_col)
             cursor = self.db.execute_sql(
-                f"SELECT id, `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL AND `{column_name}` != '' AND `{column_name}` LIKE %s",
+                f"SELECT id, {q_col} FROM {q_table} WHERE {q_col} IS NOT NULL AND {col_text} != '' AND {col_text} LIKE %s",
                 ("%@%",),
             )
             while True:
@@ -1173,8 +1399,11 @@ class ModelIdConfigStage(MigrationStage):
 
     def iter_json_changes(self):
         for table_name, column_name in self.existing_columns(self.json_columns):
+            q_table = self.q(table_name)
+            q_col = self.q(column_name)
+            col_text = self.db.column_as_text(q_col)
             cursor = self.db.execute_sql(
-                f"SELECT id, `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL AND `{column_name}` != '' AND `{column_name}` LIKE %s",
+                f"SELECT id, {q_col} FROM {q_table} WHERE {q_col} IS NOT NULL AND {col_text} != '' AND {col_text} LIKE %s",
                 ("%@%",),
             )
             while True:
@@ -1240,7 +1469,7 @@ class ModelIdConfigStage(MigrationStage):
                 )
             if not self.dry_run:
                 self.db.execute_sql(
-                    f"UPDATE `{table_name}` SET `{column_name}` = %s WHERE id = %s",
+                    f"UPDATE {self.q(table_name)} SET {self.q(column_name)} = %s WHERE id = %s",
                     (normalized, row_id),
                 )
 
@@ -1257,7 +1486,7 @@ class ModelIdConfigStage(MigrationStage):
                 )
             if not self.dry_run:
                 self.db.execute_sql(
-                    f"UPDATE `{table_name}` SET `{column_name}` = %s WHERE id = %s",
+                    f"UPDATE {self.q(table_name)} SET {self.q(column_name)} = %s WHERE id = %s",
                     (normalized_json, row_id),
                 )
 
@@ -1312,7 +1541,7 @@ class TenantModelSeedingStage(MigrationStage):
 
         # If model_type is already INT, the merge stage has been executed — seeding is not applicable
         model_type_dtype = self.db.get_column_type("tenant_model", "model_type")
-        if model_type_dtype and model_type_dtype.lower() == "int":
+        if self.db.is_integer_type(model_type_dtype):
             self.mark_noop_completes_migration()
             logger.info("tenant_model.model_type is already INT, seeding stage is not applicable (merge already done)")
             return False
@@ -1522,8 +1751,8 @@ class TenantModelSeedingStage(MigrationStage):
                     f"('{record_id}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', '{mt_escaped}', '{status_escaped}', "
                     f"'{extra_escaped}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))}, "
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))})"
                 )
 
             insert_sql = f"""
@@ -1540,23 +1769,23 @@ class TenantModelSeedingStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type VARCHAR(32) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "model_name VARCHAR(128)",
+                "provider_id VARCHAR(32) NOT NULL",
+                "instance_id VARCHAR(32) NOT NULL",
+                "model_type VARCHAR(32) NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(1024) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_instance_id", ["instance_id"], False)],
+        )
         logger.info("Created tenant_model table")
 
 
@@ -1596,7 +1825,7 @@ class ModelTypeMergeStage(MigrationStage):
 
         # If model_type is already INT, the merge has already been executed — no work needed
         model_type_dtype = self.db.get_column_type("tenant_model", "model_type")
-        if model_type_dtype and model_type_dtype.lower() == "int":
+        if self.db.is_integer_type(model_type_dtype):
             self.mark_noop_completes_migration()
             logger.info("tenant_model.model_type is already INT, merge stage is not applicable (already done)")
             return False
@@ -1692,8 +1921,8 @@ class ModelTypeMergeStage(MigrationStage):
                 # Handle NULL date fields
                 create_time_val = create_time if create_time is not None else current_ts * 1000
                 update_time_val = update_time if update_time is not None else current_ts * 1000
-                create_date_sql = f"FROM_UNIXTIME({int(create_time_val / 1000)})" if create_time_val else "NULL"
-                update_date_sql = f"FROM_UNIXTIME({int(update_time_val / 1000)})" if update_time_val else "NULL"
+                create_date_sql = self.db.datetime_from_unix(str(int(create_time_val / 1000))) if create_time_val else "NULL"
+                update_date_sql = self.db.datetime_from_unix(str(int(update_time_val / 1000))) if update_time_val else "NULL"
                 values.append(
                     f"('{id_}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', {merged_type}, '{status_escaped}', "
@@ -1723,23 +1952,23 @@ class ModelTypeMergeStage(MigrationStage):
 
     def create_target_table(self):
         """Create temporary table tenant_model_merge_tmp with model_type as INTEGER"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_merge_tmp (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type INT NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model_merge_tmp",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "model_name VARCHAR(128)",
+                "provider_id VARCHAR(32) NOT NULL",
+                "instance_id VARCHAR(32) NOT NULL",
+                "model_type INT NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(1024) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_instance_id_merge_tmp", ["instance_id"], False)],
+        )
         logger.info("Created tenant_model_merge_tmp table")
 
 
@@ -1791,6 +2020,16 @@ class TenantModelIdMigrationStage(MigrationStage):
 
     scan_batch_size = 500
 
+    def _unpopulated_predicate(self, tenant_id_col: str) -> str:
+        q_col = self.q(tenant_id_col)
+        col_text = self.db.column_as_text(q_col)
+        return f"({q_col} IS NULL OR {col_text} = '' OR LENGTH({col_text}) <> 32)"
+
+    def _legacy_present_predicate(self, legacy_col: str) -> str:
+        q_legacy = self.q(legacy_col)
+        legacy_text = self.db.column_as_text(q_legacy)
+        return f"{q_legacy} IS NOT NULL AND {legacy_text} != ''"
+
     def check(self) -> bool:
         """Check if migration is needed - any tenant_*_id column is still INT or empty."""
         if not self.db.table_exists("tenant_model"):
@@ -1816,11 +2055,13 @@ class TenantModelIdMigrationStage(MigrationStage):
                     break
                 # Check if column is still INT type -> needs conversion
                 col_type = self.db.get_column_type(table_name, tenant_id_col)
-                if col_type and col_type.lower() in ("int", "bigint", "integer"):
+                if self.db.is_integer_type(col_type):
                     has_work = True
                     break
                 # Check if there are NULL values that should be populated
-                cursor = self.db.execute_sql(f"SELECT COUNT(*) FROM `{table_name}` WHERE `{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32")
+                cursor = self.db.execute_sql(
+                    f"SELECT COUNT(*) FROM {self.q(table_name)} WHERE {self._unpopulated_predicate(tenant_id_col)}"
+                )
                 null_count = cursor.fetchone()[0]
                 if null_count > 0:
                     has_work = True
@@ -1853,14 +2094,14 @@ class TenantModelIdMigrationStage(MigrationStage):
                     # Column does not exist yet — add it as VARCHAR(32)
                     logger.info(f"Adding column {table_name}.{tenant_id_col} as VARCHAR(32) NULL")
                     if not self.dry_run:
-                        self.db.execute_sql(f"ALTER TABLE `{table_name}` ADD COLUMN `{tenant_id_col}` VARCHAR(32) NULL")
+                        self.db.add_varchar32_column(table_name, tenant_id_col)
                     tables_operated.add(table_name)
                     continue
                 col_type = self.db.get_column_type(table_name, tenant_id_col)
-                if col_type and col_type.lower() in ("int", "bigint", "integer"):
+                if self.db.is_integer_type(col_type):
                     logger.info(f"Converting {table_name}.{tenant_id_col} from {col_type} to VARCHAR(32)")
                     if not self.dry_run:
-                        self.db.execute_sql(f"ALTER TABLE `{table_name}` MODIFY COLUMN `{tenant_id_col}` VARCHAR(32) NULL")
+                        self.db.convert_column_to_varchar32(table_name, tenant_id_col)
                     tables_operated.add(table_name)
 
         # Step 2: Build lookup cache from tenant_model joined with provider + instance
@@ -1880,12 +2121,18 @@ class TenantModelIdMigrationStage(MigrationStage):
                     logger.info(f"Column {table_name}.{legacy_col} does not exist, skipping")
                     continue
 
+                q_table = self.q(table_name)
+                q_tenant_id_col = self.q(tenant_id_col)
+                q_legacy = self.q(legacy_col)
+                unpopulated = self._unpopulated_predicate(tenant_id_col)
+                legacy_present = self._legacy_present_predicate(legacy_col)
+
                 # Also need tenant_id for model lookup
                 # For tenant table, the PK is the tenant_id
                 # For knowledgebase, dialog, memory we also need tenant_id
                 if table_name == "tenant":
                     cursor = self.db.execute_sql(
-                        f"SELECT id, `{legacy_col}` FROM `{table_name}` WHERE (`{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32) AND `{legacy_col}` IS NOT NULL AND `{legacy_col}` != ''"
+                        f"SELECT id, {q_legacy} FROM {q_table} WHERE {unpopulated} AND {legacy_present}"
                     )
                     while True:
                         rows = cursor.fetchmany(self.scan_batch_size)
@@ -1897,20 +2144,20 @@ class TenantModelIdMigrationStage(MigrationStage):
                             if resolved_id:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = %s WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = %s WHERE id = %s",
                                         (resolved_id, row_id),
                                     )
                             else:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = '' WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = '' WHERE id = %s",
                                         (row_id,),
                                     )
                             rows_updated += 1
                             tables_operated.add(table_name)
                 else:
                     cursor = self.db.execute_sql(
-                        f"SELECT id, tenant_id, `{legacy_col}` FROM `{table_name}` WHERE (`{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32) AND `{legacy_col}` IS NOT NULL AND `{legacy_col}` != ''"
+                        f"SELECT id, tenant_id, {q_legacy} FROM {q_table} WHERE {unpopulated} AND {legacy_present}"
                     )
                     while True:
                         rows = cursor.fetchmany(self.scan_batch_size)
@@ -1921,13 +2168,13 @@ class TenantModelIdMigrationStage(MigrationStage):
                             if resolved_id:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = %s WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = %s WHERE id = %s",
                                         (resolved_id, row_id),
                                     )
                             else:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = '' WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = '' WHERE id = %s",
                                         (row_id,),
                                     )
                             rows_updated += 1
@@ -1962,9 +2209,16 @@ class TenantModelIdMigrationStage(MigrationStage):
         )
         lookup = {}
         for model_id, model_name, model_type, tenant_id, provider_name in cursor.fetchall():
-            # model_type is a binary integer; we check each bit
+            # model_type is a binary integer after model_type_merge; tolerate leftover
+            # varchar names/numeric strings on postgres upgrades that skipped merge.
+            try:
+                model_type_int = int(model_type)
+            except (TypeError, ValueError):
+                model_type_int = self.MODEL_TYPE_TO_INT.get(str(model_type).lower() if model_type is not None else "", 0)
+                if not model_type_int:
+                    continue
             for type_str, type_bit in self.MODEL_TYPE_TO_INT.items():
-                if model_type & type_bit:
+                if model_type_int & type_bit:
                     key = (tenant_id, model_name, provider_name, type_str)
                     lookup[key] = model_id
         return lookup
@@ -2013,6 +2267,10 @@ def list_available_stages():
         logger.info(f"    Target tables: {stage_cls.target_tables}")
 
 
+PROVIDER_TABLE_STAGES = ["tenant_model_provider", "tenant_model_instance", "tenant_model", "model_id_config"]
+PROVIDER_DATA_STAGES = ["tenant_model_seeding", "model_type_merge", "tenant_model_id_migration"]
+
+
 def run_migration(
     config: MigrationConfig,
     stages: list,
@@ -2020,12 +2278,14 @@ def run_migration(
     create_table_only: bool = False,
     database_version: str | None = None,
     mark_database_version_on_success: bool = False,
+    dialect: str = "mysql",
+    peewee_db=None,
 ):
     """Run migration with specified stages"""
     stats = MigrationStats()
     stats.start()
 
-    db = MigrationDatabase(config)
+    db = create_migration_database(config, dialect=dialect, peewee_db=peewee_db)
 
     try:
         db.connect()
@@ -2100,8 +2360,31 @@ def run_migration(
         stats.print_summary()
 
 
-def check_database_version(config: MigrationConfig, target_version: str) -> int:
-    db = MigrationDatabase(config)
+def run_using_existing_connection(peewee_db, dialect: str = "postgres", database_name: str = "rag_flow", options: str | None = None):
+    """Run the docker-equivalent stage groups against an already-open connection.
+
+    Used by migrate_db() for in-place PostgreSQL / GaussDB upgrades so
+    TenantModelIdMigrationStage and ModelTypeMergeStage run automatically.
+    """
+    config = MigrationConfig(database=database_name, options=options)
+    dialect = normalize_migration_dialect(dialect)
+    for stages, version in (
+        (PROVIDER_TABLE_STAGES, "v0.26.0"),
+        (PROVIDER_DATA_STAGES, "v0.27.0"),
+    ):
+        run_migration(
+            config=config,
+            stages=stages,
+            dry_run=False,
+            database_version=version,
+            mark_database_version_on_success=True,
+            dialect=dialect,
+            peewee_db=peewee_db,
+        )
+
+
+def check_database_version(config: MigrationConfig, target_version: str, dialect: str = "mysql") -> int:
+    db = create_migration_database(config, dialect=dialect)
     try:
         db.connect()
         current_db_version = db.get_database_version()
@@ -2129,8 +2412,8 @@ def check_database_version(config: MigrationConfig, target_version: str) -> int:
         db.close()
 
 
-def mark_database_version(config: MigrationConfig, version: str) -> None:
-    db = MigrationDatabase(config)
+def mark_database_version(config: MigrationConfig, version: str, dialect: str = "mysql") -> None:
+    db = create_migration_database(config, dialect=dialect)
     try:
         db.connect()
         db.set_database_version(version)
@@ -2139,9 +2422,14 @@ def mark_database_version(config: MigrationConfig, version: str) -> None:
         db.close()
 
 
-def main():
+def main(default_dialect: str = "mysql"):
+    dialect = normalize_migration_dialect(default_dialect)
+    default_port = 5432 if dialect == "postgres" else 3306
+    default_user = "rag_flow" if dialect == "postgres" else "root"
+    engine_label = "PostgreSQL/GaussDB" if dialect == "postgres" else "MySQL"
+
     parser = argparse.ArgumentParser(
-        description="MySQL Data Migration Tool",
+        description=f"{engine_label} Data Migration Tool",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -2180,12 +2468,11 @@ Examples:
 """,
     )
 
-    # MySQL connection options
-    parser.add_argument("--host", type=str, default="localhost", help="MySQL host (default: localhost)")
-    parser.add_argument("--port", type=int, default=3306, help="MySQL port (default: 3306)")
-    parser.add_argument("--user", type=str, default="root", help="MySQL user (default: root)")
-    parser.add_argument("--password", type=str, default="", help="MySQL password (default: empty)")
-    parser.add_argument("--database", type=str, default="rag_flow", help="MySQL database name (default: rag_flow)")
+    parser.add_argument("--host", type=str, default="localhost", help=f"{engine_label} host (default: localhost)")
+    parser.add_argument("--port", type=int, default=default_port, help=f"{engine_label} port (default: {default_port})")
+    parser.add_argument("--user", type=str, default=default_user, help=f"{engine_label} user (default: {default_user})")
+    parser.add_argument("--password", type=str, default="", help=f"{engine_label} password (default: empty)")
+    parser.add_argument("--database", type=str, default="rag_flow", help=f"{engine_label} database name (default: rag_flow)")
 
     # Configuration options
     parser.add_argument("--config", "-c", type=str, help="Path to YAML config file")
@@ -2209,13 +2496,13 @@ Examples:
 
     # Load configuration: command line args take precedence over config file
     if args.config:
-        config = MigrationConfig.from_config_file(args.config)
+        config = MigrationConfig.from_config_file(args.config, dialect=dialect)
         # Override with command line args if provided
         if args.host != "localhost":
             config.host = args.host
-        if args.port != 3306:
+        if args.port != default_port:
             config.port = args.port
-        if args.user != "root":
+        if args.user != default_user:
             config.user = args.user
         if args.password != "":
             config.password = args.password
@@ -2225,7 +2512,7 @@ Examples:
         # Use command line args directly
         config = MigrationConfig(host=args.host, port=args.port, user=args.user, password=args.password, database=args.database)
 
-    logger.info(f"MySQL Configuration: host={config.host}, port={config.port}, user={config.user}, database={config.database}")
+    logger.info(f"{engine_label} Configuration: host={config.host}, port={config.port}, user={config.user}, database={config.database}")
 
     if args.check_database_version and args.mark_database_version:
         logger.error("--check-database-version and --mark-database-version are mutually exclusive")
@@ -2235,13 +2522,13 @@ Examples:
         if not args.database_version:
             logger.error("--check-database-version requires --database-version")
             sys.exit(1)
-        sys.exit(check_database_version(config, args.database_version))
+        sys.exit(check_database_version(config, args.database_version, dialect=dialect))
 
     if args.mark_database_version:
         if not args.database_version:
             logger.error("--mark-database-version requires --database-version")
             sys.exit(1)
-        mark_database_version(config, args.database_version)
+        mark_database_version(config, args.database_version, dialect=dialect)
         return
 
     if args.mark_database_version_on_success and not args.database_version:
@@ -2278,6 +2565,7 @@ Examples:
         create_table_only=create_table_only,
         database_version=args.database_version,
         mark_database_version_on_success=args.mark_database_version_on_success,
+        dialect=dialect,
     )
 
 

--- a/tools/scripts/postgres_migration.py
+++ b/tools/scripts/postgres_migration.py
@@ -1,0 +1,31 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+PostgreSQL / GaussDB data migration script.
+
+Same stages as mysql_migration.py (provider tables, model_type_merge,
+tenant_model_id_migration). Used for in-place upgrades when DB_TYPE is
+postgres or gaussdb, where the MySQL-only docker path never ran.
+"""
+
+import logging
+
+from mysql_migration import main
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    main(default_dialect="postgres")

--- a/tools/scripts/run_migrations.sh
+++ b/tools/scripts/run_migrations.sh
@@ -9,18 +9,29 @@
 #   PY=python3 tools/scripts/run_migrations.sh [--config CONFIG_PATH]
 #
 # Environment variables:
-#   PY  - Python interpreter path (default: python3)
+#   PY       - Python interpreter path (default: python3)
+#   DB_TYPE  - metadata database type (mysql, postgres, gaussdb, oceanbase)
 # -----------------------------------------------------------------------------
 
 set -e
 
 PY="${PY:-python3}"
 CONFIG="${1:-conf/service_conf.yaml}"
+DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"
+DB_TYPE_NORMALIZED="${DB_TYPE_NORMALIZED,,}"
 
-echo "Running model provider table migrations..."
+if [[ "$DB_TYPE_NORMALIZED" == "postgres" || "$DB_TYPE_NORMALIZED" == "postgresql" || "$DB_TYPE_NORMALIZED" == "gaussdb" || "$DB_TYPE_NORMALIZED" == "gauss" ]]; then
+    MIGRATION_SCRIPT="tools/scripts/postgres_migration.py"
+    ENGINE_LABEL="PostgreSQL/GaussDB"
+else
+    MIGRATION_SCRIPT="tools/scripts/mysql_migration.py"
+    ENGINE_LABEL="MySQL"
+fi
+
+echo "Running model provider table migrations (${ENGINE_LABEL}, DB_TYPE=${DB_TYPE:-mysql})..."
 
 # Step 1: Create base model provider tables
-"$PY" tools/scripts/mysql_migration.py \
+"$PY" "$MIGRATION_SCRIPT" \
     --stages tenant_model_provider,tenant_model_instance,tenant_model,model_id_config \
     --config "$CONFIG" \
     --execute \
@@ -28,7 +39,7 @@ echo "Running model provider table migrations..."
     --mark-database-version-on-success
 
 # Step 2: Seed, merge model types, and migrate model IDs
-"$PY" tools/scripts/mysql_migration.py \
+"$PY" "$MIGRATION_SCRIPT" \
     --stages tenant_model_seeding,model_type_merge,tenant_model_id_migration \
     --config "$CONFIG" \
     --execute \


### PR DESCRIPTION
`tenant_*_id` columns (`tenant_llm_id`, `tenant_embd_id`, and the rest of the tenant-model references) were `IntegerField` in v0.26.x, pointing at `tenant_llm.id`. v0.27.0 stores `tenant_model.id` — 32-char hex strings — in those columns, but `migrate_db()` never altered the existing integer types.

On an in-place upgrade (especially `DB_TYPE=postgres`, where the MySQL-only `tenant_model_id_migration` stage never runs), `PATCH /api/v1/models/default` and `PUT /api/v1/datasets/{id}` with `embedding_model` fail with:

```
peewee.DataError: invalid input syntax for type integer: "2fe23460a07a11f18c93a9473e17d659"
```

`tenant_ocr_id` is already added as `varchar(32)` by `migrate_db()`; the older columns are left as integer.

**Fix**

During `migrate_db()`, inspect each `tenant_*_id` column:

- missing → add as `varchar(32)`
- integer / bigint → convert to `varchar(32)` (PostgreSQL/GaussDB use `USING …::text` so the cast is legal)
- already `varchar` → leave unchanged

Covered tables: `tenant`, `dialog`, `knowledgebase`, `memory`.

**Verification**

- Reproduced on PostgreSQL 17: `UPDATE tenant SET tenant_llm_id = '<32-char hex>'` failed with `invalid input syntax for type integer`. After the same `ALTER … TYPE varchar(32) USING …::text` the migration emits, the hex id stored and all listed columns reported `character varying`.
- Unit tests: `test_tenant_model_id_column_migration.py` plus `test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns` — 6 passed.

Fixes #18756