### PR TITLE
fix(db): postgres in-place upgrade for model_type and tenant_*_id

### DIFF
--- a/api/db/db_models.py
+++ b/api/db/db_models.py
@@ -1985,6 +1985,255 @@ def alter_db_column_type(migrator, table_name, column_name, new_column_type):
         pass
 
 
+TENANT_MODEL_ID_COLUMNS = (
+    ("tenant", "tenant_llm_id"),
+    ("tenant", "tenant_embd_id"),
+    ("tenant", "tenant_asr_id"),
+    ("tenant", "tenant_img2txt_id"),
+    ("tenant", "tenant_rerank_id"),
+    ("tenant", "tenant_tts_id"),
+    ("tenant", "tenant_ocr_id"),
+    ("knowledgebase", "tenant_embd_id"),
+    ("dialog", "tenant_llm_id"),
+    ("dialog", "tenant_rerank_id"),
+    ("memory", "tenant_llm_id"),
+    ("memory", "tenant_embd_id"),
+)
+
+_INTEGER_COLUMN_TYPES = frozenset({"int", "integer", "bigint", "smallint", "mediumint", "tinyint"})
+
+
+def _get_column_data_type(table_name: str, column_name: str) -> str | None:
+    if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+        cursor = DB.execute_sql(
+            """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = %s
+              AND column_name = %s
+            """,
+            (table_name, column_name),
+        )
+    else:
+        cursor = DB.execute_sql(
+            """
+            SELECT DATA_TYPE
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = %s
+              AND column_name = %s
+            """,
+            (table_name, column_name),
+        )
+    row = cursor.fetchone()
+    return row[0].lower() if row else None
+
+
+def migrate_tenant_model_id_column_types(migrator):
+    """Fallback: convert leftover IntegerField tenant_*_id columns to VARCHAR(32).
+
+    Primary conversion and backfill belong in the pre-startup script
+    (``mysql_migration.py`` / ``postgres_migration.py`` stage
+    ``tenant_model_id_migration``). ``migrate_db()`` runs after that script, so
+    this helper is a no-op when columns are already ``varchar`` — it only
+    converts if the script did not run or did not finish.
+
+    It does not backfill ``tenant_model.id`` values. Postgres/GaussDB still run
+    ``migrate_postgres_family_model_provider_tables()`` later for seeding,
+    ``model_type`` merge, and id backfill.
+
+    There is no matching in-place ALTER for ``tenant_model.model_type`` on any
+    dialect: converting that column before ``tenant_model_seeding`` /
+    ``model_type_merge`` would skip those stages. Postgres/GaussDB also run
+    ``migrate_postgres_family_model_provider_tables()`` for seeding, merge, and
+    backfill. MySQL/OceanBase non-Docker deployments that skip
+    ``run_migrations.sh`` get only this ``tenant_*_id`` fallback — they must run
+    ``mysql_migration.py`` manually or #18755 (``model_type`` bitmask merge) can
+    persist.
+    """
+    target_field = CharField(max_length=32, null=True, help_text="id in tenant_model", index=True)
+
+    for table_name, column_name in TENANT_MODEL_ID_COLUMNS:
+        try:
+            table_present = DB.table_exists(table_name)
+        except Exception as ex:
+            logging.warning("Failed to inspect table %s while migrating tenant_*_id types: %s", table_name, ex)
+            continue
+        if not table_present:
+            continue
+
+        try:
+            col_type = _get_column_data_type(table_name, column_name)
+        except Exception:
+            logging.critical(
+                "Skipping %s.%s tenant_*_id migration; column inspection failed",
+                table_name,
+                column_name,
+                exc_info=True,
+            )
+            continue
+
+        if col_type is None:
+            logging.info("Adding missing %s.%s tenant_model.id reference column", table_name, column_name)
+            alter_db_add_column(migrator, table_name, column_name, target_field)
+            continue
+
+        mysql_family = settings.DATABASE_TYPE.upper() not in {"POSTGRES"} and not is_gaussdb_compatible_database()
+        leftover_sql = f"UPDATE `{table_name}` SET `{column_name}` = NULL WHERE `{column_name}` IS NOT NULL AND CHAR_LENGTH(`{column_name}`) <> 32"
+
+        if col_type not in _INTEGER_COLUMN_TYPES:
+            # MySQL commits ALTER TABLE independently of the leftover UPDATE.
+            # A retry after a failed cleanup must still NULL non-32-char values.
+            if mysql_family:
+                try:
+                    DB.execute_sql(leftover_sql)
+                except Exception as ex:
+                    logging.critical(
+                        "Failed to clear leftover integer ids in converted %s.%s: %s",
+                        table_name,
+                        column_name,
+                        ex,
+                    )
+            continue
+
+        try:
+            if settings.DATABASE_TYPE.upper() == "POSTGRES" or is_gaussdb_compatible_database():
+                # Legacy integers were tenant_llm row ids, never 32-char tenant_model.id
+                # values. Cast them away rather than leaving strings such as "42".
+                DB.execute_sql(f'ALTER TABLE "{table_name}" ALTER COLUMN "{column_name}" TYPE varchar(32) USING CAST(NULL AS varchar(32))')
+            else:
+                migrate(migrator.alter_column_type(table_name, column_name, target_field))
+                DB.execute_sql(leftover_sql)
+            logging.info(
+                "Converted %s.%s from %s to varchar(32) for tenant_model.id references",
+                table_name,
+                column_name,
+                col_type,
+            )
+        except Exception as ex:
+            logging.critical(
+                "Failed to convert %s.%s from %s to varchar(32): %s",
+                table_name,
+                column_name,
+                col_type,
+                ex,
+            )
+
+
+MODEL_PROVIDER_MIGRATION_VERSION_MARKER = "mysql_migration.database.version"
+MODEL_PROVIDER_MIGRATION_FINAL_VERSION = "v0.27.0"
+
+
+def _parse_model_provider_migration_version(version: str | None) -> tuple[int, ...] | None:
+    if not version:
+        return None
+    normalized = version.strip()
+    if normalized.startswith(("v", "V")):
+        normalized = normalized[1:]
+    parts = []
+    for token in normalized.split("."):
+        if not token.isdigit():
+            return None
+        parts.append(int(token))
+    return tuple(parts) or None
+
+
+def _model_provider_migration_complete(
+    current_version: str | None,
+    target_version: str = MODEL_PROVIDER_MIGRATION_FINAL_VERSION,
+) -> bool:
+    current = _parse_model_provider_migration_version(current_version)
+    target = _parse_model_provider_migration_version(target_version)
+    if current is None or target is None:
+        return False
+    max_len = max(len(current), len(target))
+    current_padded = current + (0,) * (max_len - len(current))
+    target_padded = target + (0,) * (max_len - len(target))
+    return current_padded >= target_padded
+
+
+def _get_model_provider_migration_version() -> str | None:
+    try:
+        if not DB.table_exists("system_settings"):
+            return None
+        cursor = DB.execute_sql(
+            "SELECT value FROM system_settings WHERE name = %s",
+            (MODEL_PROVIDER_MIGRATION_VERSION_MARKER,),
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except Exception:
+        return None
+
+
+def _load_model_provider_migration_module():
+    import importlib.util
+
+    script_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tools", "scripts", "mysql_migration.py")
+    if not os.path.isfile(script_path):
+        raise FileNotFoundError(f"Model provider migration script not found: {script_path}")
+    spec = importlib.util.spec_from_file_location("ragflow_mysql_migration", script_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load model provider migration module from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def migrate_postgres_family_model_provider_tables():
+    """Run model-provider data stages on PostgreSQL/GaussDB when the marker is behind v0.27.0.
+
+    Mirrors ``tools/scripts/postgres_migration.py`` / ``mysql_migration.py``
+    (``tenant_model_seeding`` → ``model_type_merge`` → ``tenant_model_id_migration``).
+    Docker ``run_migrations.sh`` is the primary path. This startup fallback runs
+    only when ``system_settings`` records a migration version below v0.27.0 so
+    steady-state boots avoid loading the migration script. The marker is written
+    only after ``run_migration(..., mark_database_version_on_success=True)``
+    finishes every stage without raising, so a crashed run is retried. Stages
+    are idempotent (merge no-ops once ``model_type`` is INT). Import or execution
+    failures are logged and do not abort service startup.
+
+    MySQL/OceanBase have no matching ``model_type`` fallback in ``migrate_db()``;
+    non-Docker deployments must run ``mysql_migration.py`` / ``run_migrations.sh``.
+
+    Do not ALTER ``tenant_model.model_type`` to integer before these stages.
+    """
+    if settings.DATABASE_TYPE.upper() not in {"POSTGRES", "GAUSSDB"}:
+        return
+
+    try:
+        current_version = _get_model_provider_migration_version()
+        if _model_provider_migration_complete(current_version):
+            logging.info(
+                "Skipping postgres-family model-provider migration; version marker is %s",
+                current_version,
+            )
+            return
+    except Exception as ex:
+        logging.warning(
+            "Failed to read model-provider migration version marker; will attempt fallback: %s",
+            ex,
+        )
+
+    database_cfg = settings.DATABASE or {}
+    database_name = database_cfg.get("name") or database_cfg.get("database") or "rag_flow"
+    try:
+        module = _load_model_provider_migration_module()
+        module.run_using_existing_connection(
+            peewee_db=DB,
+            dialect="postgres",
+            database_name=database_name,
+            options=database_cfg.get("options"),
+        )
+    except Exception as ex:
+        logging.critical(
+            "Failed postgres-family model-provider migration fallback; service will continue: %s",
+            ex,
+            exc_info=True,
+        )
+
+
 def alter_db_rename_column(migrator, table_name, old_column_name, new_column_name):
     try:
         migrate(migrator.rename_column(table_name, old_column_name, new_column_name))
@@ -2468,6 +2717,10 @@ def migrate_db():
     alter_db_column_type(migrator, "file", "size", BigIntegerField(default=0, index=True))
     alter_db_add_column(migrator, "tenant", "ocr_id", CharField(max_length=128, null=True, help_text="default ocr model ID", index=True))
     alter_db_add_column(migrator, "tenant", "tenant_ocr_id", CharField(max_length=32, null=True, help_text="id in tenant_model", index=True))
+    # Fallback only: pre-startup mysql_migration.py / postgres_migration.py already
+    # convert tenant_*_id. This no-ops when columns are varchar. model_type is
+    # intentionally not converted here — merge stages must see varchar first.
+    migrate_tenant_model_id_column_types(migrator)
     alter_db_column_type(migrator, "chat_channel", "status", IntegerField(default=1, index=True))
     alter_db_rename_column(migrator, "chat_channel", "dialog_id", "chat_id")
     alter_db_add_column(migrator, "chat_channel", "agent_id", CharField(max_length=32, null=True, help_text="connected agent id", index=True))
@@ -2524,6 +2777,9 @@ def migrate_db():
     # this is after re-enabling logging to allow logging changed user emails
     migrate_add_unique_email(migrator)
     migrate_model_type_names()
+    # Run data stages before ensure_model_indexes: ModelTypeMergeStage swaps
+    # tenant_model and would discard indexes created on the pre-merge table.
+    migrate_postgres_family_model_provider_tables()
     ensure_model_indexes(migrator)
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -279,15 +279,10 @@ run_with_restart() {
 }
 
 if [[ "${INIT_MODEL_PROVIDER_TABLES}" -eq 1 ]]; then
-    DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"
-    DB_TYPE_NORMALIZED="${DB_TYPE_NORMALIZED,,}"
-    if [[ "${DB_TYPE_NORMALIZED}" == "gaussdb" || "${DB_TYPE_NORMALIZED}" == "gauss" ]]; then
-        # This migration script contains MySQL-only SQL and cannot run against
-        # a GaussDB metadata database.
-        echo "Skipping MySQL-specific model provider table migrations for DB_TYPE=${DB_TYPE:-mysql}."
-    else
-        tools/scripts/run_migrations.sh
-    fi
+    # run_migrations.sh selects mysql_migration.py or postgres_migration.py
+    # from DB_TYPE so postgres/gaussdb upgrades get the same table-init and
+    # tenant_*_id backfill as MySQL.
+    tools/scripts/run_migrations.sh
 fi
 
 if [[ "${ENABLE_ADMIN_SERVER}" -eq 1 ]]; then

--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -227,15 +227,9 @@ ensure_db_init() {
 }
 
 run_mysql_migrations() {
-    local db_type="${DB_TYPE:-mysql}"
-    db_type="${db_type,,}"
-    if [ "$db_type" = "gaussdb" ] || [ "$db_type" = "gauss" ]; then
-        # This migration script contains MySQL-only SQL and cannot run against
-        # a GaussDB metadata database.
-        echo "Skipping MySQL-specific model provider table migrations for DB_TYPE=${DB_TYPE:-mysql}."
-        return 0
-    fi
-
+    # run_migrations.sh selects mysql_migration.py or postgres_migration.py
+    # from DB_TYPE so postgres/gaussdb upgrades get TenantModelIdMigrationStage
+    # (and model_type_merge) rather than skipping or running MySQL SQL.
     tools/scripts/run_migrations.sh
 }
 

--- a/docs/administrator/migration/database_schema_and_migration.md
+++ b/docs/administrator/migration/database_schema_and_migration.md
@@ -17,6 +17,7 @@ Sync schemas and migrate data using official RAGFlow scripts.
 RAGFlow handles schema updates and migrations automatically at startup. However, for high-volume environments like Kubernetes, massive datasets can cause initialization to exceed 10 minutes, potentially triggering container timeouts or health check failures. To avoid this, you can disable the built-in auto-initialization and manually run these provided scripts to complete database upgrades before launching the service:
 
 - [mysql_migration.py](#mysql_migrationpy): Migrates data between MySQL tables.
+- [postgres_migration.py](#postgres_migrationpy): Same model-provider stages for PostgreSQL and GaussDB.
 - [db_schema_sync.py](#db_schema_syncpy): Syncs database schemas and manages changes using peewee-migrate.
 
 ## Mysql_migration.py
@@ -37,6 +38,31 @@ The [mysql_migration.py](https://github.com/infiniflow/ragflow/blob/main/tools/s
 - **Data normalization**: Necessary when consolidating multiple API keys or LLM providers into the updated system format.
 - **Kubernetes deployments**: Useful for setting up the database structure independently using the `--create-table-only` flag before main services start.
 - **Migration verification**: Used in dry-run mode to identify any legacy records that still need to be moved to the new tables.
+
+## Postgres_migration.py
+
+The [postgres_migration.py](https://github.com/infiniflow/ragflow/blob/main/tools/scripts/postgres_migration.py) script is the PostgreSQL / GaussDB equivalent of `mysql_migration.py`. It shares the same stages, including:
+
+- Creating `tenant_model_provider`, `tenant_model_instance`, and `tenant_model` when they are missing
+- Merging `tenant_model.model_type` into an integer bitmask (`model_type_merge`)
+- Converting integer `tenant_*_id` columns to `varchar(32)` **and** backfilling them from `llm_id` / `embd_id` by resolving `tenant_model.id` (`tenant_model_id_migration`)
+
+`tools/scripts/run_migrations.sh` selects this script automatically when `DB_TYPE` is `postgres` or `gaussdb`. That pre-startup path is where column-type conversion and data stages run (`model_type_merge` and `tenant_model_id_migration`).
+
+`migrate_db()` is a fallback when the pre-startup script did not run or did not finish:
+
+| Database | `tenant_*_id` fallback in `migrate_db()` | `model_type` merge fallback in `migrate_db()` |
+|----------|------------------------------------------|-----------------------------------------------|
+| PostgreSQL / GaussDB | Yes (column retype) | Yes (`migrate_postgres_family_model_provider_tables()`, skipped when the version marker is already `v0.27.0`) |
+| MySQL / OceanBase | Yes (column retype) | **No** — run `mysql_migration.py` / `run_migrations.sh` manually |
+
+**Version marker:** `mysql_migration.database.version` is written only after every requested stage returns without raising (`mark_database_version_on_success`). A failed or interrupted run does not record `v0.27.0`, so the next script run or `migrate_db()` fallback retries. After a successful mark, later boots skip the fallback. Stages are idempotent (for example `model_type_merge` no-ops when `model_type` is already INT). Do not set this marker by hand after a partial upgrade.
+
+Neither path ALTERs `tenant_model.model_type` to integer first — `tenant_model_seeding` and `model_type_merge` skip when that column is already an integer, which would leave unmerged duplicate rows.
+
+**GaussDB rollout:** Existing GaussDB installations that previously skipped these stages will run `model_type_merge` and `tenant_model_id_migration` the first time `run_migrations.sh` or the `migrate_db()` fallback executes. That is data-affecting (row merge, table swap, `tenant_*_id` backfill); take a backup before upgrading production GaussDB metadata databases.
+
+For GaussDB, connection parameters come from `GAUSSDB_METADATA_*` environment variables.
 
 ## Db_schema_sync.py
 

--- a/test/unit_test/api/db/test_gaussdb_adaptation_points.py
+++ b/test/unit_test/api/db/test_gaussdb_adaptation_points.py
@@ -103,11 +103,13 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
     monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append(("alter_type",)))
     monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append(("rename",)))
     monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append(("drop_index",)))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_id_column_types", lambda _migrator: events.append(("tenant_model_id_types",)))
     monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append(("relax",)))
     monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
     monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
     monkeypatch.setattr(db_models, "migrate_model_type_names", lambda: None)
     monkeypatch.setattr(db_models, "ensure_model_indexes", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_postgres_family_model_provider_tables", lambda: events.append(("pg_model_provider",)))
 
     db_models.migrate_db()
 
@@ -115,7 +117,10 @@ def test_gaussdb_migration_adds_compatible_fields_before_relaxing_columns(monkey
         assert isinstance(field, db_models.EmptyStringCharField)
         assert field.null is True
     assert set(migrated_fields) == {("document", "suffix"), ("user_canvas", "tags")}
-    assert events[-1] == ("relax",)
+    assert ("tenant_model_id_types",) in events
+    assert ("pg_model_provider",) in events
+    assert events.index(("tenant_model_id_types",)) < events.index(("relax",))
+    assert events.index(("relax",)) < events.index(("pg_model_provider",))
 
 
 def test_empty_string_char_field_keeps_non_gaussdb_constraints(monkeypatch):
@@ -384,14 +389,16 @@ def test_docker_compose_metadata_profile_does_not_force_mysql_for_gaussdb():
         assert cn_compose["services"][service_name]["depends_on"]["mysql"]["required"] is False
 
 
-def test_docker_launch_scripts_skip_mysql_migration_for_gaussdb():
+def test_docker_launch_scripts_run_postgres_migration_for_gaussdb():
     entrypoint = read_repo_file("docker/entrypoint.sh")
     launcher = read_repo_file("docker/launch_backend_service.sh")
+    run_migrations = read_repo_file("tools/scripts/run_migrations.sh")
 
-    assert 'DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"' in entrypoint
-    assert 'if [[ "${DB_TYPE_NORMALIZED}" == "gaussdb" || "${DB_TYPE_NORMALIZED}" == "gauss" ]]; then' in entrypoint
-    assert "Skipping MySQL-specific model provider table migrations" in entrypoint
-
-    assert 'local db_type="${DB_TYPE:-mysql}"' in launcher
-    assert 'if [ "$db_type" = "gaussdb" ] || [ "$db_type" = "gauss" ]; then' in launcher
-    assert "Skipping MySQL-specific model provider table migrations" in launcher
+    assert "Skipping MySQL-specific model provider table migrations" not in entrypoint
+    assert "Skipping MySQL-specific model provider table migrations" not in launcher
+    assert "tools/scripts/run_migrations.sh" in entrypoint
+    assert "tools/scripts/run_migrations.sh" in launcher
+    assert "tools/scripts/postgres_migration.py" in run_migrations
+    assert 'DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"' in run_migrations
+    assert '"$DB_TYPE_NORMALIZED" == "gaussdb"' in run_migrations
+    assert '"$DB_TYPE_NORMALIZED" == "postgres"' in run_migrations

--- a/test/unit_test/api/db/test_model_provider_live_migration.py
+++ b/test/unit_test/api/db/test_model_provider_live_migration.py
@@ -1,0 +1,350 @@
+"""Live PostgreSQL / MySQL checks for model_type merge and tenant_*_id backfill.
+
+Lynn-Inf: unit stubs do not exercise the tenant_model table swap or INTEGER →
+varchar(32) backfill. These tests start ephemeral Docker databases when Docker
+is available, otherwise they skip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import socket
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MIGRATION_SCRIPT = REPO_ROOT / "tools" / "scripts" / "mysql_migration.py"
+
+TENANT_ID = "tenant00000000000000000000000001"
+PROVIDER_ID = "provider000000000000000000000001"
+INSTANCE_ID = "instance00000000000000000000001"
+CHAT_ROW_ID = "modelchat00000000000000000000001"
+VISION_ROW_ID = "modelvisn00000000000000000000001"
+
+
+def load_migration_module():
+    spec = importlib.util.spec_from_file_location("ragflow_mysql_migration_live_test", MIGRATION_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _docker_available() -> bool:
+    try:
+        subprocess.run(["docker", "info"], check=True, capture_output=True, timeout=15)
+        return True
+    except Exception:
+        return False
+
+
+def _wait_port(host: str, port: int, timeout: float = 90.0):
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except OSError as exc:
+            last_err = exc
+            time.sleep(0.5)
+    raise TimeoutError(f"{host}:{port} did not accept connections: {last_err}")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _docker_run(args: list[str]) -> str:
+    name = f"ragflow-mig-{uuid.uuid4().hex[:10]}"
+    subprocess.run(["docker", "run", "-d", "--rm", "--name", name, *args], check=True, capture_output=True, text=True)
+    return name
+
+
+def _docker_rm(name: str | None):
+    if not name:
+        return
+    subprocess.run(["docker", "rm", "-f", name], check=False, capture_output=True)
+
+
+def _legacy_schema_sql(dialect: str) -> list[str]:
+    ts = "TIMESTAMP" if dialect == "postgres" else "DATETIME"
+    int_type = "INTEGER" if dialect == "postgres" else "INT"
+    return [
+        f"""
+        CREATE TABLE system_settings (
+            name VARCHAR(255) PRIMARY KEY,
+            source VARCHAR(255),
+            data_type VARCHAR(32),
+            value TEXT,
+            create_time BIGINT,
+            create_date {ts},
+            update_time BIGINT,
+            update_date {ts}
+        )
+        """,
+        """
+        CREATE TABLE tenant_model_provider (
+            id VARCHAR(32) PRIMARY KEY,
+            provider_name VARCHAR(128) NOT NULL,
+            tenant_id VARCHAR(32) NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE tenant_model_instance (
+            id VARCHAR(32) PRIMARY KEY,
+            instance_name VARCHAR(128),
+            provider_id VARCHAR(32) NOT NULL,
+            api_key TEXT,
+            status VARCHAR(32),
+            extra VARCHAR(1024) DEFAULT '{}'
+        )
+        """,
+        f"""
+        CREATE TABLE tenant_model (
+            id VARCHAR(32) PRIMARY KEY,
+            model_name VARCHAR(128),
+            provider_id VARCHAR(32) NOT NULL,
+            instance_id VARCHAR(32) NOT NULL,
+            model_type VARCHAR(128) NOT NULL,
+            status VARCHAR(32) DEFAULT 'active',
+            extra VARCHAR(1024) DEFAULT '{{}}',
+            create_time BIGINT,
+            create_date {ts},
+            update_time BIGINT,
+            update_date {ts}
+        )
+        """,
+        f"""
+        CREATE TABLE tenant (
+            id VARCHAR(32) PRIMARY KEY,
+            llm_id VARCHAR(128),
+            tenant_llm_id {int_type}
+        )
+        """,
+    ]
+
+
+def _seed_legacy_rows(db):
+    db.execute_sql(
+        "INSERT INTO tenant_model_provider (id, provider_name, tenant_id) VALUES (%s, %s, %s)",
+        (PROVIDER_ID, "OpenAI", TENANT_ID),
+    )
+    db.execute_sql(
+        "INSERT INTO tenant_model_instance (id, instance_name, provider_id, api_key, status, extra) VALUES (%s, %s, %s, %s, %s, %s)",
+        (INSTANCE_ID, "default", PROVIDER_ID, "sk-test", "1", "{}"),
+    )
+    ts = 1700000000000
+    for row_id, model_type in ((CHAT_ROW_ID, "chat"), (VISION_ROW_ID, "vision")):
+        db.execute_sql(
+            """
+            INSERT INTO tenant_model
+            (id, model_name, provider_id, instance_id, model_type, status, extra, create_time, update_time)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (row_id, "gpt-4o", PROVIDER_ID, INSTANCE_ID, model_type, "active", "{}", ts, ts),
+        )
+    db.execute_sql(
+        "INSERT INTO tenant (id, llm_id, tenant_llm_id) VALUES (%s, %s, %s)",
+        (TENANT_ID, "gpt-4o@default@OpenAI", 42),
+    )
+
+
+def _run_data_stages(mod, dialect: str, database: str, host: str, port: int, user: str, password: str):
+    config = mod.MigrationConfig(host=host, port=port, user=user, password=password, database=database)
+    mod.run_migration(
+        config=config,
+        stages=["model_type_merge", "tenant_model_id_migration"],
+        dry_run=False,
+        database_version="v0.27.0",
+        mark_database_version_on_success=True,
+        dialect=dialect,
+    )
+
+
+def _assert_upgraded(db, dialect: str):
+    model_type = db.get_column_type("tenant_model", "model_type")
+    assert db.is_integer_type(model_type), model_type
+    assert db.table_exists("tenant_model_backup")
+
+    rows = db.execute_sql("SELECT model_name, model_type, status FROM tenant_model").fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "gpt-4o"
+    assert int(rows[0][1]) == 9  # chat | vision
+    assert rows[0][2] == "active"
+
+    llm_type = db.get_column_type("tenant", "tenant_llm_id")
+    assert llm_type and "char" in llm_type.lower()
+    tenant_row = db.execute_sql("SELECT tenant_llm_id FROM tenant WHERE id = %s", (TENANT_ID,)).fetchone()
+    hex_id = tenant_row[0]
+    assert hex_id and len(hex_id) == 32
+    assert hex_id != "42"
+    model_ids = {row[0] for row in db.execute_sql("SELECT id FROM tenant_model").fetchall()}
+    assert hex_id in model_ids
+
+    version = db.get_database_version()
+    assert version == "v0.27.0"
+
+
+def test_run_migration_does_not_mark_version_when_a_stage_raises(monkeypatch):
+    mod = load_migration_module()
+    versions = []
+
+    class FakeDB:
+        def connect(self):
+            return None
+
+        def close(self):
+            return None
+
+        def get_database_version(self):
+            return None
+
+        def set_database_version(self, version):
+            versions.append(version)
+
+    class BoomStage:
+        description = "boom"
+        source_tables = []
+        target_tables = []
+
+        def __init__(self, db, dry_run=False, create_table_only=False):
+            pass
+
+        def check(self):
+            return True
+
+        def execute(self):
+            raise RuntimeError("merge exploded")
+
+    monkeypatch.setattr(mod, "create_migration_database", lambda *args, **kwargs: FakeDB())
+    monkeypatch.setattr(mod, "MIGRATION_STAGES", {"model_type_merge": BoomStage})
+
+    with pytest.raises(RuntimeError, match="merge exploded"):
+        mod.run_migration(
+            config=mod.MigrationConfig(database="rag_flow"),
+            stages=["model_type_merge"],
+            dry_run=False,
+            database_version="v0.27.0",
+            mark_database_version_on_success=True,
+            dialect="postgres",
+        )
+
+    assert versions == []
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker is required for live migration tests")
+def test_postgres_merge_swaps_table_and_backfills_tenant_llm_id():
+    from peewee import PostgresqlDatabase
+
+    port = _free_port()
+    name = None
+    db = None
+    try:
+        name = _docker_run(
+            [
+                "-e",
+                "POSTGRES_PASSWORD=test",
+                "-e",
+                "POSTGRES_DB=rag_flow_mig",
+                "-p",
+                f"{port}:5432",
+                "postgres:16",
+            ]
+        )
+        _wait_port("127.0.0.1", port)
+        deadline = time.time() + 90
+        last_err = None
+        while time.time() < deadline:
+            try:
+                db = PostgresqlDatabase("rag_flow_mig", host="127.0.0.1", port=port, user="postgres", password="test")
+                db.connect()
+                break
+            except Exception as exc:
+                last_err = exc
+                time.sleep(0.5)
+        else:
+            raise TimeoutError(f"postgres not ready: {last_err}")
+
+        for stmt in _legacy_schema_sql("postgres"):
+            db.execute_sql(stmt)
+        _seed_legacy_rows(db)
+        db.close()
+
+        mod = load_migration_module()
+        _run_data_stages(mod, "postgres", "rag_flow_mig", "127.0.0.1", port, "postgres", "test")
+
+        db = PostgresqlDatabase("rag_flow_mig", host="127.0.0.1", port=port, user="postgres", password="test")
+        db.connect()
+        wrapper = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow_mig"), peewee_db=db)
+        _assert_upgraded(wrapper, "postgres")
+
+        before = db.execute_sql("SELECT id, model_type FROM tenant_model").fetchall()
+        _run_data_stages(mod, "postgres", "rag_flow_mig", "127.0.0.1", port, "postgres", "test")
+        after = db.execute_sql("SELECT id, model_type FROM tenant_model").fetchall()
+        assert after == before
+    finally:
+        if db is not None and not db.is_closed():
+            db.close()
+        _docker_rm(name)
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker is required for live migration tests")
+def test_mysql_merge_swaps_table_and_backfills_tenant_llm_id():
+    from peewee import MySQLDatabase
+
+    port = _free_port()
+    name = None
+    db = None
+    try:
+        name = _docker_run(
+            [
+                "-e",
+                "MYSQL_ROOT_PASSWORD=test",
+                "-e",
+                "MYSQL_DATABASE=rag_flow_mig",
+                "-p",
+                f"{port}:3306",
+                "mysql:8.0.40",
+            ]
+        )
+        _wait_port("127.0.0.1", port)
+        deadline = time.time() + 120
+        last_err = None
+        while time.time() < deadline:
+            try:
+                db = MySQLDatabase("rag_flow_mig", host="127.0.0.1", port=port, user="root", password="test")
+                db.connect()
+                break
+            except Exception as exc:
+                last_err = exc
+                time.sleep(1)
+        else:
+            raise TimeoutError(f"mysql not ready: {last_err}")
+
+        for stmt in _legacy_schema_sql("mysql"):
+            db.execute_sql(stmt)
+        _seed_legacy_rows(db)
+        db.close()
+
+        mod = load_migration_module()
+        _run_data_stages(mod, "mysql", "rag_flow_mig", "127.0.0.1", port, "root", "test")
+
+        db = MySQLDatabase("rag_flow_mig", host="127.0.0.1", port=port, user="root", password="test")
+        db.connect()
+        wrapper = mod.MigrationDatabase(mod.MigrationConfig(database="rag_flow_mig"), peewee_db=db)
+        _assert_upgraded(wrapper, "mysql")
+
+        before = db.execute_sql("SELECT id, model_type FROM tenant_model").fetchall()
+        _run_data_stages(mod, "mysql", "rag_flow_mig", "127.0.0.1", port, "root", "test")
+        after = db.execute_sql("SELECT id, model_type FROM tenant_model").fetchall()
+        assert after == before
+    finally:
+        if db is not None and not db.is_closed():
+            db.close()
+        _docker_rm(name)

--- a/test/unit_test/api/db/test_postgres_model_provider_migration.py
+++ b/test/unit_test/api/db/test_postgres_model_provider_migration.py
@@ -1,0 +1,280 @@
+"""
+Tests for PostgreSQL/GaussDB model-provider migration (#18755 / #18756 / #18777 / #18781).
+
+Lynn-Inf review: type conversion alone leaves tenant_*_id holding old integer
+values and skips ModelTypeMergeStage / TenantModelSeedingStage. The postgres
+dialect must run the same stages as mysql_migration.py.
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MIGRATION_SCRIPT = REPO_ROOT / "tools" / "scripts" / "mysql_migration.py"
+
+
+def load_migration_module():
+    spec = importlib.util.spec_from_file_location("ragflow_mysql_migration_test", MIGRATION_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RecordingCursor:
+    def __init__(self, rows=None):
+        self._rows = list(rows or [])
+        self._offset = 0
+
+    def fetchone(self):
+        if not self._rows:
+            return (0,)
+        return self._rows[0]
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def fetchmany(self, size):
+        chunk = self._rows[self._offset : self._offset + size]
+        self._offset += size
+        return chunk
+
+
+class RecordingDB:
+    def __init__(self, column_types=None, columns=None, tables=None, select_rows=None):
+        self.queries = []
+        self.column_types = column_types or {}
+        self.columns = columns or set()
+        self.tables = tables or set()
+        self.select_rows = select_rows or {}
+
+    def execute_sql(self, sql, params=None):
+        self.queries.append((sql, params))
+        key = sql.strip().split()[0].upper()
+        if key == "SELECT":
+            for matcher, rows in self.select_rows.items():
+                if matcher in sql:
+                    return RecordingCursor(rows)
+            if "COUNT(*)" in sql:
+                return RecordingCursor([(0,)])
+            return RecordingCursor([])
+        return RecordingCursor([])
+
+
+def test_postgres_dialect_quotes_and_casts():
+    mod = load_migration_module()
+    config = mod.MigrationConfig(database="rag_flow")
+    db = mod.PostgresMigrationDatabase(config, peewee_db=RecordingDB())
+
+    assert db.quote_ident("tenant_llm_id") == '"tenant_llm_id"'
+    assert db.datetime_from_unix("1700000000") == "TO_TIMESTAMP(1700000000)"
+    assert db.column_as_text('"llm_id"') == '"llm_id"::text'
+    assert db.is_integer_type("integer")
+    assert db.is_integer_type("bigint")
+    assert not db.is_integer_type("character varying")
+
+
+def test_postgres_convert_column_uses_text_cast():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+
+    db.convert_column_to_varchar32("tenant", "tenant_llm_id")
+
+    sql, _params = recorder.queries[0]
+    assert 'ALTER TABLE "tenant" ALTER COLUMN "tenant_llm_id" TYPE varchar(32)' in sql
+    assert 'USING "tenant_llm_id"::text' in sql
+
+
+def test_mysql_convert_column_still_uses_modify():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.MigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+
+    db.convert_column_to_varchar32("tenant", "tenant_llm_id")
+
+    sql, _params = recorder.queries[0]
+    assert "MODIFY COLUMN `tenant_llm_id` VARCHAR(32) NULL" in sql
+
+
+def test_tenant_model_id_stage_backfills_from_legacy_model_name():
+    mod = load_migration_module()
+    recorder = RecordingDB(
+        tables={"tenant_model", "tenant_model_provider", "tenant_model_instance", "tenant"},
+        columns={
+            ("tenant", "tenant_llm_id"),
+            ("tenant", "llm_id"),
+            ("tenant", "tenant_embd_id"),
+            ("tenant", "embd_id"),
+        },
+        column_types={("tenant", "tenant_llm_id"): "integer"},
+        select_rows={
+            "FROM tenant_model tm": [
+                ("2fe23460a07a11f18c93a9473e17d659", "gpt-4o", 1, "tenant-1", "OpenAI"),
+            ],
+            "SELECT id,": [("tenant-1", "gpt-4o@default@OpenAI")],
+        },
+    )
+    recorder.column_exists = lambda table, column: (table, column) in recorder.columns
+    recorder.table_exists = lambda table: table in recorder.tables
+    recorder.get_column_type = lambda table, column: recorder.column_types.get((table, column))
+
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    # Peewee wrapper methods used by the stage go through MigrationDatabase.
+    db.table_exists = recorder.table_exists
+    db.column_exists = recorder.column_exists
+    db.get_column_type = recorder.get_column_type
+
+    stage = mod.TenantModelIdMigrationStage(db, dry_run=False)
+    # Only migrate tenant.tenant_llm_id in this case.
+    stage.TENANT_ID_FIELDS = {"tenant": [("tenant_llm_id", "llm_id", "chat")]}
+
+    rows, tables = stage.execute()
+
+    convert_sql = [sql for sql, _ in recorder.queries if "ALTER TABLE" in sql and "TYPE varchar(32)" in sql]
+    assert convert_sql
+    assert 'USING "tenant_llm_id"::text' in convert_sql[0]
+
+    updates = [(sql, params) for sql, params in recorder.queries if sql.strip().upper().startswith("UPDATE")]
+    assert any(params == ("2fe23460a07a11f18c93a9473e17d659", "tenant-1") for _sql, params in updates)
+    assert rows == 1
+    assert tables == ["tenant"]
+
+
+def test_tenant_model_id_stage_clears_unresolved_legacy_ids():
+    mod = load_migration_module()
+    recorder = RecordingDB(
+        tables={"tenant_model", "tenant_model_provider", "tenant_model_instance", "knowledgebase"},
+        columns={
+            ("knowledgebase", "tenant_embd_id"),
+            ("knowledgebase", "embd_id"),
+        },
+        column_types={("knowledgebase", "tenant_embd_id"): "character varying"},
+        select_rows={
+            "FROM tenant_model tm": [],
+            "SELECT id, tenant_id": [("kb-1", "tenant-1", "unknown-model@default@OpenAI")],
+        },
+    )
+    recorder.column_exists = lambda table, column: (table, column) in recorder.columns
+    recorder.table_exists = lambda table: table in recorder.tables
+    recorder.get_column_type = lambda table, column: recorder.column_types.get((table, column), "character varying")
+
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    db.table_exists = recorder.table_exists
+    db.column_exists = recorder.column_exists
+    db.get_column_type = recorder.get_column_type
+
+    stage = mod.TenantModelIdMigrationStage(db, dry_run=False)
+    stage.TENANT_ID_FIELDS = {"knowledgebase": [("tenant_embd_id", "embd_id", "embedding")]}
+
+    stage.execute()
+
+    updates = [(sql, params) for sql, params in recorder.queries if sql.strip().upper().startswith("UPDATE")]
+    assert any(params == ("kb-1",) and "= ''" in sql for sql, params in updates)
+
+
+def test_postgres_add_auto_increment_quotes_sequence_and_id():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+
+    db.add_auto_increment_unique_id_column("tenant_llm")
+
+    assert recorder.queries == [
+        ('CREATE SEQUENCE IF NOT EXISTS "tenant_llm_id_seq"', None),
+        (
+            'ALTER TABLE "tenant_llm" ADD COLUMN "id" BIGINT UNIQUE DEFAULT nextval(\'tenant_llm_id_seq\')',
+            None,
+        ),
+        ('ALTER SEQUENCE "tenant_llm_id_seq" OWNED BY "tenant_llm"."id"', None),
+    ]
+
+
+def test_migrate_postgres_family_is_gated_to_postgres_and_gaussdb():
+    source = (REPO_ROOT / "api" / "db" / "db_models.py").read_text()
+    func = source.split("def migrate_postgres_family_model_provider_tables():", 1)[1].split("\ndef ", 1)[0]
+
+    assert 'if settings.DATABASE_TYPE.upper() not in {"POSTGRES", "GAUSSDB"}:' in func
+    _gate, rest = func.split('{"POSTGRES", "GAUSSDB"}:', 1)
+    assert "return" in rest.split("current_version", 1)[0]
+    assert "_model_provider_migration_complete(current_version)" in rest
+    assert "_load_model_provider_migration_module()" in rest
+    assert "run_using_existing_connection(" in rest
+    assert 'dialect="postgres"' in rest
+    assert "peewee_db=DB" in rest
+    assert "except Exception as ex:" in rest
+    assert "service will continue" in rest
+
+
+def test_run_using_existing_connection_runs_both_version_groups(monkeypatch):
+    mod = load_migration_module()
+    seen = []
+
+    def fake_run_migration(**kwargs):
+        seen.append((kwargs["stages"], kwargs["database_version"], kwargs["dialect"], kwargs.get("peewee_db")))
+
+    monkeypatch.setattr(mod, "run_migration", fake_run_migration)
+
+    peewee_db = object()
+    mod.run_using_existing_connection(peewee_db, dialect="postgres", database_name="rag_flow")
+
+    assert [item[1] for item in seen] == ["v0.26.0", "v0.27.0"]
+    assert seen[0][0] == mod.PROVIDER_TABLE_STAGES
+    assert seen[1][0] == mod.PROVIDER_DATA_STAGES
+    assert "tenant_model_id_migration" in seen[1][0]
+    assert "model_type_merge" in seen[1][0]
+    assert all(item[2] == "postgres" for item in seen)
+    assert all(item[3] is peewee_db for item in seen)
+
+
+def test_normalize_migration_dialect_maps_gaussdb(monkeypatch):
+    mod = load_migration_module()
+    assert mod.normalize_migration_dialect("gaussdb") == "postgres"
+    assert mod.normalize_migration_dialect("postgres") == "postgres"
+    assert mod.normalize_migration_dialect("mysql") == "mysql"
+
+
+def test_model_provider_migration_version_helpers():
+    from api.db import db_models
+
+    assert db_models._model_provider_migration_complete("v0.27.0")
+    assert db_models._model_provider_migration_complete("v0.28.0")
+    assert not db_models._model_provider_migration_complete("v0.26.0")
+    assert not db_models._model_provider_migration_complete(None)
+
+
+def test_migrate_postgres_family_skips_when_marker_is_current(monkeypatch):
+    from api.db import db_models
+    from common import settings
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(db_models, "_get_model_provider_migration_version", lambda: "v0.27.0")
+    calls = []
+    monkeypatch.setattr(
+        db_models,
+        "_load_model_provider_migration_module",
+        lambda: calls.append("load") or None,
+    )
+
+    db_models.migrate_postgres_family_model_provider_tables()
+
+    assert calls == []
+
+
+def test_migrate_postgres_family_swallows_import_errors(monkeypatch, caplog):
+    import logging
+
+    from api.db import db_models
+    from common import settings
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(db_models, "_get_model_provider_migration_version", lambda: None)
+
+    def boom():
+        raise RuntimeError("missing script")
+
+    monkeypatch.setattr(db_models, "_load_model_provider_migration_module", boom)
+
+    with caplog.at_level(logging.CRITICAL):
+        db_models.migrate_postgres_family_model_provider_tables()
+
+    assert any("service will continue" in rec.message for rec in caplog.records)

--- a/test/unit_test/api/db/test_tenant_model_id_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_id_column_migration.py
@@ -1,0 +1,221 @@
+"""
+Tests for tenant_*_id column type migration on upgrade (#18756 / #18777).
+
+migrate_tenant_model_id_column_types is a fallback for when the pre-startup
+script (tenant_model_id_migration) did not run. It only converts leftover
+integer columns; backfill still belongs in the script / postgres family stages.
+"""
+
+import logging
+
+import pytest
+
+from api.db import db_models
+from common import settings
+
+
+def test_migrate_tenant_model_id_column_types_skips_non_integer_columns(monkeypatch):
+    inspected = {}
+
+    def fake_get_column_data_type(table_name, column_name):
+        inspected[(table_name, column_name)] = True
+        return "character varying"
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", fake_get_column_data_type)
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: (_ for _ in ()).throw(AssertionError("should not add column")))
+
+    executed = []
+
+    class Migrator:
+        def alter_column_type(self, *_args):
+            executed.append("alter")
+
+    db_models.migrate_tenant_model_id_column_types(Migrator())
+
+    assert len(inspected) == len(db_models.TENANT_MODEL_ID_COLUMNS)
+    assert not executed
+
+
+def test_migrate_tenant_model_id_column_types_skips_add_when_inspection_fails(monkeypatch, caplog):
+    added = []
+
+    def boom(*_args):
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", boom)
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: added.append("add"))
+
+    logging.disable(logging.ERROR)
+    try:
+        with caplog.at_level(logging.CRITICAL):
+            db_models.migrate_tenant_model_id_column_types(object())
+    finally:
+        logging.disable(logging.NOTSET)
+
+    assert not added
+    assert any("column inspection failed" in r.message for r in caplog.records if r.levelno >= logging.CRITICAL)
+
+
+def test_migrate_tenant_model_id_column_types_adds_missing_columns(monkeypatch):
+    added = []
+
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: None)
+    monkeypatch.setattr(db_models, "DB", type("DB", (), {"table_exists": staticmethod(lambda _name: True)})())
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda _migrator, table, column, field: added.append((table, column, field)))
+
+    db_models.migrate_tenant_model_id_column_types(object())
+
+    assert len(added) == len(db_models.TENANT_MODEL_ID_COLUMNS)
+    for table_name, column_name, field in added:
+        assert (table_name, column_name) in db_models.TENANT_MODEL_ID_COLUMNS
+        assert isinstance(field, db_models.CharField)
+        assert field.max_length == 32
+
+
+def test_migrate_tenant_model_id_column_types_converts_postgres_integer(monkeypatch):
+    queries = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append((sql, params))
+
+    monkeypatch.setattr(db_models, "DB", FakeDB)
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(
+        db_models,
+        "_get_column_data_type",
+        lambda table_name, column_name: "integer" if (table_name, column_name) == ("tenant", "tenant_llm_id") else "character varying",
+    )
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: (_ for _ in ()).throw(AssertionError("should not add column")))
+
+    db_models.migrate_tenant_model_id_column_types(object())
+
+    assert len(queries) == 1
+    sql, _params = queries[0]
+    assert 'ALTER TABLE "tenant" ALTER COLUMN "tenant_llm_id"' in sql
+    assert "TYPE varchar(32)" in sql
+    assert "USING CAST(NULL AS varchar(32))" in sql
+    assert "::text" not in sql
+
+
+def test_migrate_tenant_model_id_column_types_converts_mysql_integer(monkeypatch):
+    altered = []
+    queries = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append(sql)
+
+    class Migrator:
+        def alter_column_type(self, table_name, column_name, field):
+            altered.append((table_name, column_name, field))
+            return f"alter {table_name}.{column_name}"
+
+    def fake_migrate(operation):
+        altered.append(("migrate", operation))
+
+    monkeypatch.setattr(db_models, "DB", FakeDB)
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
+    monkeypatch.setattr(
+        db_models,
+        "_get_column_data_type",
+        lambda table_name, column_name: "int" if (table_name, column_name) == ("knowledgebase", "tenant_embd_id") else "varchar",
+    )
+    monkeypatch.setattr(db_models, "migrate", fake_migrate)
+
+    db_models.migrate_tenant_model_id_column_types(Migrator())
+
+    converted = [(table, column) for table, column, *_rest in altered if table != "migrate"]
+    assert converted == [("knowledgebase", "tenant_embd_id")]
+    assert ("migrate", "alter knowledgebase.tenant_embd_id") in altered
+    assert any("CHAR_LENGTH(`tenant_embd_id`) <> 32" in sql for sql in queries)
+
+
+@pytest.mark.parametrize("db_type", ["mysql", "oceanbase"])
+def test_migrate_tenant_model_id_column_types_retries_mysql_leftover_cleanup(monkeypatch, db_type):
+    queries = []
+    altered = []
+
+    class FakeDB:
+        @staticmethod
+        def table_exists(_name):
+            return True
+
+        @staticmethod
+        def execute_sql(sql, params=None):
+            queries.append(sql)
+
+    class Migrator:
+        def alter_column_type(self, *_args):
+            altered.append("alter")
+            raise AssertionError("already-converted varchar must not be altered again")
+
+    monkeypatch.setattr(db_models, "DB", FakeDB)
+    monkeypatch.setattr(settings, "DATABASE_TYPE", db_type)
+    monkeypatch.setattr(db_models, "_get_column_data_type", lambda *_args: "varchar")
+    monkeypatch.setattr(db_models, "migrate", lambda *_args: (_ for _ in ()).throw(AssertionError("should not migrate")))
+
+    db_models.migrate_tenant_model_id_column_types(Migrator())
+
+    assert not altered
+    assert len(queries) == len(db_models.TENANT_MODEL_ID_COLUMNS)
+    assert all("CHAR_LENGTH(" in sql and "<> 32" in sql for sql in queries)
+
+
+def test_migrate_db_invokes_tenant_model_id_column_migration(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "mysql")
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: events.append("add"))
+    monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append("alter_type"))
+    monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append("rename"))
+    monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append("drop_index"))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_id_column_types", lambda _migrator: events.append("tenant_model_id_types"))
+    monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append("relax"))
+    monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
+    monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_model_type_names", lambda: None)
+    monkeypatch.setattr(db_models, "ensure_model_indexes", lambda _migrator: None)
+
+    db_models.migrate_db()
+
+    assert "tenant_model_id_types" in events
+    assert events.index("tenant_model_id_types") > events.index("add")
+
+
+def test_migrate_db_invokes_postgres_model_provider_data_migration(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(settings, "DATABASE_TYPE", "postgres")
+    monkeypatch.setattr(db_models, "alter_db_add_column", lambda *_args: events.append("add"))
+    monkeypatch.setattr(db_models, "alter_db_column_type", lambda *_args: events.append("alter_type"))
+    monkeypatch.setattr(db_models, "alter_db_rename_column", lambda *_args: events.append("rename"))
+    monkeypatch.setattr(db_models, "alter_db_drop_index", lambda *_args: events.append("drop_index"))
+    monkeypatch.setattr(db_models, "migrate_tenant_model_id_column_types", lambda _migrator: events.append("tenant_model_id_types"))
+    monkeypatch.setattr(db_models, "relax_gaussdb_empty_string_compatible_columns", lambda: events.append("relax"))
+    monkeypatch.setattr(db_models, "migrate", lambda *_operations: None)
+    monkeypatch.setattr(db_models, "migrate_add_unique_email", lambda _migrator: None)
+    monkeypatch.setattr(db_models, "migrate_model_type_names", lambda: None)
+    ensure_events = []
+    monkeypatch.setattr(db_models, "ensure_model_indexes", lambda _migrator: ensure_events.append("ensure_indexes"))
+    monkeypatch.setattr(db_models, "migrate_postgres_family_model_provider_tables", lambda: events.append("pg_model_provider"))
+
+    db_models.migrate_db()
+
+    assert "pg_model_provider" in events
+    assert events.index("pg_model_provider") > events.index("tenant_model_id_types")
+    assert events.index("pg_model_provider") > events.index("relax")
+    assert ensure_events == ["ensure_indexes"]

--- a/test/unit_test/api/db/test_tenant_model_type_column_migration.py
+++ b/test/unit_test/api/db/test_tenant_model_type_column_migration.py
@@ -1,0 +1,210 @@
+"""
+Tests for tenant_model.model_type integer conversion on upgrade (#18755 / #18781).
+
+Lynn-Inf review: an in-place ALTER in migrate_db() only does type/value
+conversion. ModelTypeMergeStage also merges duplicate rows, and
+TenantModelSeedingStage seeds missing models — both skip when model_type is
+already INT. Postgres upgrades must run those stages, not a shallow ALTER.
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MIGRATION_SCRIPT = REPO_ROOT / "tools" / "scripts" / "mysql_migration.py"
+DB_MODELS_PATH = REPO_ROOT / "api" / "db" / "db_models.py"
+
+
+def load_migration_module():
+    spec = importlib.util.spec_from_file_location("ragflow_mysql_migration_model_type_test", MIGRATION_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RecordingCursor:
+    def __init__(self, rows=None):
+        self._rows = list(rows or [])
+        self._offset = 0
+
+    def fetchone(self):
+        if not self._rows:
+            return (0,)
+        return self._rows[0]
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def fetchmany(self, size):
+        chunk = self._rows[self._offset : self._offset + size]
+        self._offset += size
+        return chunk
+
+
+class RecordingDB:
+    def __init__(self, select_rows=None):
+        self.queries = []
+        self.select_rows = select_rows or {}
+
+    def execute_sql(self, sql, params=None):
+        self.queries.append((sql, params))
+        key = sql.strip().split()[0].upper()
+        if key == "SELECT":
+            for matcher, rows in self.select_rows.items():
+                if matcher in sql:
+                    return RecordingCursor(rows)
+            if "COUNT(*)" in sql:
+                return RecordingCursor([(0,)])
+            return RecordingCursor([])
+        return RecordingCursor([])
+
+
+def _tenant_row(row_id, model_name, provider_id, instance_id, model_type, status="active", extra="{}"):
+    ts = 1700000000000
+    return (row_id, model_name, provider_id, instance_id, model_type, status, extra, ts, None, ts, None)
+
+
+def test_model_type_to_bits_maps_names_aliases_numbers_and_combined_tokens():
+    merge = load_migration_module().ModelTypeMergeStage
+
+    assert merge.model_type_to_bits(None) == 0
+    assert merge.model_type_to_bits("") == 0
+    assert merge.model_type_to_bits("   ") == 0
+    assert merge.model_type_to_bits("chat") == 1
+    assert merge.model_type_to_bits("embedding") == 2
+    assert merge.model_type_to_bits("speech2text") == 4
+    assert merge.model_type_to_bits("asr") == 4
+    assert merge.model_type_to_bits("image2text") == 8
+    assert merge.model_type_to_bits("vision") == 8
+    assert merge.model_type_to_bits("rerank") == 16
+    assert merge.model_type_to_bits("tts") == 32
+    assert merge.model_type_to_bits("ocr") == 64
+    assert merge.model_type_to_bits("9") == 9
+    assert merge.model_type_to_bits(" 9 ") == 9
+    assert merge.model_type_to_bits(9) == 9
+    assert merge.model_type_to_bits("chat|vision") == 9
+    assert merge.model_type_to_bits(" chat | vision ") == 9
+    assert merge.model_type_to_bits("unknown") == 0
+
+
+def test_model_type_merge_skips_when_column_is_already_integer():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    db.table_exists = lambda table: table == "tenant_model"
+    db.get_column_type = lambda table, column: "integer"
+
+    stage = mod.ModelTypeMergeStage(db, dry_run=False)
+
+    assert stage.check() is False
+    assert stage.noop_completes_migration() is True
+
+
+def test_model_type_merge_runs_while_column_is_varchar():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    db.table_exists = lambda table: table == "tenant_model"
+    db.get_column_type = lambda table, column: "character varying"
+
+    stage = mod.ModelTypeMergeStage(db, dry_run=False)
+
+    assert stage.check() is True
+    assert stage.noop_completes_migration() is False
+
+
+def test_tenant_model_seeding_skips_when_model_type_is_already_integer():
+    mod = load_migration_module()
+    recorder = RecordingDB()
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    db.table_exists = lambda table: table in {"tenant_model", "tenant_model_provider", "tenant_model_instance"}
+    db.get_column_type = lambda table, column: "integer"
+
+    stage = mod.TenantModelSeedingStage(db, dry_run=False)
+
+    assert stage.check() is False
+    assert stage.noop_completes_migration() is True
+
+
+def test_provider_data_stages_seed_then_merge_then_id_backfill():
+    mod = load_migration_module()
+
+    assert mod.PROVIDER_DATA_STAGES == [
+        "tenant_model_seeding",
+        "model_type_merge",
+        "tenant_model_id_migration",
+    ]
+
+
+def test_model_type_merge_dedupes_chat_and_embedding_rows_to_bitmask():
+    mod = load_migration_module()
+    rows = [
+        _tenant_row("id-chat", "gpt-4o", "p1", "i1", "chat"),
+        _tenant_row("id-embd", "gpt-4o", "p1", "i1", "embedding"),
+        _tenant_row("id-other", "text-embedding-3", "p1", "i1", "embedding"),
+    ]
+    recorder = RecordingDB(select_rows={"FROM tenant_model ORDER BY id": rows})
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    db.table_exists = lambda table: table == "tenant_model"
+
+    stage = mod.ModelTypeMergeStage(db, dry_run=False)
+    uuids = iter(["merged00000000000000000000000001", "merged00000000000000000000000002"])
+    stage.generate_uuid = lambda: next(uuids)
+
+    inserted, tables = stage.execute()
+
+    assert inserted == 2
+    assert "tenant_model" in tables
+    insert_sql = [sql for sql, _ in recorder.queries if sql.strip().upper().startswith("INSERT")]
+    assert len(insert_sql) == 1
+    assert ", 3, 'active'" in insert_sql[0]
+    assert ", 2, 'active'" in insert_sql[0]
+    assert "CREATE TABLE IF NOT EXISTS tenant_model_merge_tmp" in "".join(sql for sql, _ in recorder.queries)
+    assert "model_type INT NOT NULL" in "".join(sql for sql, _ in recorder.queries)
+    assert "CREATE INDEX IF NOT EXISTS idx_instance_id_merge_tmp ON tenant_model_merge_tmp" in "".join(sql for sql, _ in recorder.queries)
+    assert any("RENAME TO tenant_model_backup" in sql for sql, _ in recorder.queries)
+    assert any("RENAME TO tenant_model" in sql and "tenant_model_merge_tmp" in sql for sql, _ in recorder.queries)
+
+
+def test_model_type_merge_ors_combined_tokens_and_defaults_empty_to_chat():
+    mod = load_migration_module()
+    rows = [
+        _tenant_row("id-combo", "gpt-4o", "p1", "i1", "chat|vision"),
+        _tenant_row("id-empty", "legacy-model", "p1", "i1", ""),
+        _tenant_row("id-unsupported", "gpt-4o", "p1", "i1", "embedding", status="unsupported"),
+    ]
+    recorder = RecordingDB(select_rows={"FROM tenant_model ORDER BY id": rows})
+    db = mod.PostgresMigrationDatabase(mod.MigrationConfig(database="rag_flow"), peewee_db=recorder)
+    db.table_exists = lambda table: table == "tenant_model"
+
+    stage = mod.ModelTypeMergeStage(db, dry_run=False)
+    uuids = iter(["idcombo000000000000000000000001", "idempty000000000000000000000001"])
+    stage.generate_uuid = lambda: next(uuids)
+
+    inserted, _tables = stage.execute()
+
+    assert inserted == 2
+    insert_sql = [sql for sql, _ in recorder.queries if sql.strip().upper().startswith("INSERT")][0]
+    # chat|vision (9) with unsupported embedding (2) keeps chat|vision bits.
+    assert ", 9, 'active'" in insert_sql
+    # empty/unknown bits default to chat (1) so lookups still match.
+    assert ", 1, 'active'" in insert_sql
+
+
+def test_migrate_db_does_not_alter_model_type_in_place_before_merge():
+    source = DB_MODELS_PATH.read_text()
+
+    assert "def migrate_tenant_model_type_column" not in source
+    assert 'ALTER COLUMN "model_type" TYPE integer' not in source
+    assert "migrate_postgres_family_model_provider_tables()" in source
+
+    helper = source.split("def migrate_tenant_model_id_column_types(", 1)[1].split("\ndef ", 1)[0]
+    helper_flat = " ".join(helper.split())
+    assert "Fallback:" in helper
+    assert "converts if the script did not run" in helper_flat
+
+    migrate_db = source.split("def migrate_db(", 1)[1].split("\ndef ", 1)[0]
+    assert "migrate_postgres_family_model_provider_tables()" in migrate_db
+    assert "migrate_tenant_model_id_column_types(migrator)" in migrate_db
+    assert "Fallback only:" in migrate_db
+    assert migrate_db.index("migrate_postgres_family_model_provider_tables()") < migrate_db.index("ensure_model_indexes(migrator)")

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -2,7 +2,8 @@
 
 This directory contains database-related utility scripts for RAGFlow.
 
-- **mysql_migration.py**: Data migration between tables with stage-based execution
+- **mysql_migration.py**: Data migration between tables with stage-based execution (MySQL / OceanBase)
+- **postgres_migration.py**: Same stages as mysql_migration.py for PostgreSQL and GaussDB
 - **db_schema_sync.py**: Database schema synchronization using peewee-migrate
 
 ---
@@ -163,6 +164,39 @@ python mysql_migration.py --stages tenant_model_provider,tenant_model_instance,t
 
 # Use config file with command line password override
 python mysql_migration.py --stages tenant_model_provider --config /path/to/config.yaml --password mypassword --execute
+```
+
+## postgres_migration.py
+
+PostgreSQL / GaussDB counterpart to `mysql_migration.py`. It runs the same stages
+(`tenant_model_provider` through `tenant_model_id_migration`) with Postgres SQL
+(`TO_TIMESTAMP`, `USING …::text`, `ON CONFLICT`). `run_migrations.sh` selects
+this script when `DB_TYPE` is `postgres`, `postgresql`, `gaussdb`, or `gauss`.
+
+For GaussDB metadata, connection settings come from `GAUSSDB_METADATA_*`
+environment variables (not the `gaussdb:` DOC_ENGINE section in
+`service_conf.yaml`).
+
+Pre-startup `run_migrations.sh` is the primary path for both `model_type`
+merge and `tenant_*_id` conversion/backfill. `migrate_db()` only reruns the
+same stages (and a skip-if-already-varchar `tenant_*_id` type fallback) if
+that script did not run.
+
+`--mark-database-version-on-success` writes `mysql_migration.database.version`
+only after every requested stage returns without raising. A crash therefore
+leaves the marker unset (or below `v0.27.0`), and the next boot retries.
+`migrate_db()` skips the postgres-family fallback once the marker is already
+`>= v0.27.0`. Stages are idempotent; do not set the marker by hand after a
+partial run.
+
+Do not convert `tenant_model.model_type` to integer in `migrate_db()` first:
+`tenant_model_seeding` and `model_type_merge` skip when the column is already
+INT, which would leave unmerged duplicate rows.
+
+```bash
+python postgres_migration.py --list-stages
+python postgres_migration.py --stages tenant_model_seeding,model_type_merge,tenant_model_id_migration \
+    --config /path/to/config.yaml --execute --database-version v0.27.0 --mark-database-version-on-success
 ```
 
 ## Output Interpretation

--- a/tools/scripts/mysql_migration.py
+++ b/tools/scripts/mysql_migration.py
@@ -39,6 +39,7 @@ from peewee import (
     IntegerField,
     Model,
     MySQLDatabase,
+    PostgresqlDatabase,
     PrimaryKeyField,
     TextField,
 )
@@ -48,47 +49,99 @@ from playhouse.migrate import MySQLMigrator
 PROJECT_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_BASE)
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 MIGRATION_DB_VERSION_MARKER = "mysql_migration.database.version"
 
 
-class MigrationConfig:
-    """Configuration for MySQL connection"""
+INTEGER_COLUMN_TYPES = frozenset({"int", "integer", "bigint", "smallint", "mediumint", "tinyint", "int2", "int4", "int8"})
+POSTGRES_FAMILY_DIALECTS = frozenset({"postgres", "postgresql", "gaussdb", "gauss"})
 
-    def __init__(self, host: str = "localhost", port: int = 3306, user: str = "root", password: str = "", database: str = "rag_flow"):
+
+def normalize_migration_dialect(dialect: str | None = None) -> str:
+    raw = (dialect or os.getenv("DB_TYPE", "mysql")).strip().lower()
+    if raw in POSTGRES_FAMILY_DIALECTS:
+        return "postgres"
+    return "mysql"
+
+
+class MigrationConfig:
+    """Configuration for the metadata database connection."""
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 3306,
+        user: str = "root",
+        password: str = "",
+        database: str = "rag_flow",
+        options: str | None = None,
+    ):
         self.host = host
         self.port = port
         self.user = user
         self.password = password
         self.database = database
+        self.options = options
 
     @classmethod
-    def from_config_file(cls, config_path: str) -> "MigrationConfig":
-        """Load configuration from YAML config file"""
+    def from_gaussdb_env(cls) -> "MigrationConfig":
+        """Load GaussDB metadata settings from GAUSSDB_METADATA_* (not DOC_ENGINE)."""
+        schema = os.environ.get("GAUSSDB_METADATA_SCHEMA", "public").strip() or "public"
+        options = os.environ.get("GAUSSDB_METADATA_OPTIONS")
+        if options is None:
+            options = f"-c search_path={schema} -c client_encoding=UTF8 -c default_transaction_read_only=off"
+        try:
+            port = int(os.environ.get("GAUSSDB_METADATA_PORT", "8000"))
+        except (TypeError, ValueError):
+            port = 8000
+        return cls(
+            host=os.environ.get("GAUSSDB_METADATA_HOST", "gaussdb"),
+            port=port,
+            user=os.environ.get("GAUSSDB_METADATA_USER", "rag_flow"),
+            password=os.environ.get("GAUSSDB_METADATA_PASSWORD", "infini_rag_flow"),
+            database=os.environ.get("GAUSSDB_METADATA_DBNAME", "rag_flow"),
+            options=options,
+        )
+
+    @classmethod
+    def from_config_file(cls, config_path: str, dialect: str = "mysql") -> "MigrationConfig":
+        """Load configuration from YAML config file."""
+        dialect = normalize_migration_dialect(dialect)
+        if dialect == "postgres" and os.getenv("DB_TYPE", "").strip().lower() in {"gaussdb", "gauss"}:
+            return cls.from_gaussdb_env()
+
         try:
             from ruamel.yaml import YAML
 
             yaml = YAML(typ="safe", pure=True)
 
             with open(config_path, "r") as f:
-                config = yaml.load(f)
+                config = yaml.load(f) or {}
 
-            # Try to get database config
-            db_config = config.get("database", config.get("mysql", {}))
+            if dialect == "postgres":
+                db_config = config.get("postgres") or config.get("database") or config.get("mysql") or {}
+                default_port = 5432
+                default_user = "rag_flow"
+            else:
+                db_config = config.get("database", config.get("mysql", {}))
+                default_port = 3306
+                default_user = "root"
 
             return cls(
                 host=db_config.get("host", "localhost"),
-                port=db_config.get("port", 3306),
-                user=db_config.get("user", "root"),
+                port=db_config.get("port", default_port),
+                user=db_config.get("user", default_user),
                 password=db_config.get("password", ""),
                 database=db_config.get("name", db_config.get("database", "rag_flow")),
             )
         except Exception as e:
             logger.warning(f"Failed to load config file: {e}, using defaults")
+            if dialect == "postgres":
+                return cls(port=5432, user="rag_flow")
             return cls()
 
 
@@ -129,18 +182,31 @@ class MigrationStats:
 
 
 class MigrationDatabase:
-    """Database wrapper for migrations"""
+    """Database wrapper for migrations. MySQL dialect by default."""
 
-    def __init__(self, config: MigrationConfig):
+    dialect = "mysql"
+    datetime_type = "DATETIME"
+
+    def __init__(self, config: MigrationConfig, peewee_db=None):
         self.config = config
-        self.db = MySQLDatabase(config.database, host=config.host, port=config.port, user=config.user, password=config.password, charset="utf8mb4")
-        self.migrator = MySQLMigrator(self.db)
+        self._owns_connection = peewee_db is None
+        if peewee_db is not None:
+            self.db = peewee_db
+            self.migrator = None
+        else:
+            self.db = MySQLDatabase(config.database, host=config.host, port=config.port, user=config.user, password=config.password, charset="utf8mb4")
+            self.migrator = MySQLMigrator(self.db)
 
     def connect(self):
-        self.db.connect()
-        logger.info(f"Connected to MySQL database: {self.config.database}")
+        if not self._owns_connection:
+            return
+        if self.db.is_closed():
+            self.db.connect()
+        logger.info(f"Connected to {self.dialect} database: {self.config.database}")
 
     def close(self):
+        if not self._owns_connection:
+            return
         if not self.db.is_closed():
             self.db.close()
             logger.info("Database connection closed")
@@ -148,26 +214,75 @@ class MigrationDatabase:
     def execute_sql(self, sql: str, params=None):
         return self.db.execute_sql(sql, params)
 
+    def quote_ident(self, name: str) -> str:
+        return f"`{name}`"
+
+    def datetime_from_unix(self, seconds_sql: str) -> str:
+        return f"FROM_UNIXTIME({seconds_sql})"
+
+    def column_as_text(self, quoted_column: str) -> str:
+        return quoted_column
+
+    def is_integer_type(self, col_type: str | None) -> bool:
+        return bool(col_type) and col_type.lower() in INTEGER_COLUMN_TYPES
+
+    def _schema_predicate(self) -> tuple[str, tuple]:
+        return "table_schema = %s", (self.config.database,)
+
     def table_exists(self, table_name: str) -> bool:
-        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s", (self.config.database, table_name))
+        schema_sql, schema_params = self._schema_predicate()
+        cursor = self.execute_sql(f"SELECT COUNT(*) FROM information_schema.tables WHERE {schema_sql} AND table_name = %s", (*schema_params, table_name))
         return cursor.fetchone()[0] > 0
 
     def column_exists(self, table_name: str, column_name: str) -> bool:
-        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self.config.database, table_name, column_name))
+        schema_sql, schema_params = self._schema_predicate()
+        cursor = self.execute_sql(
+            f"SELECT COUNT(*) FROM information_schema.columns WHERE {schema_sql} AND table_name = %s AND column_name = %s",
+            (*schema_params, table_name, column_name),
+        )
         return cursor.fetchone()[0] > 0
 
     def get_column_type(self, table_name: str, column_name: str) -> str | None:
         """Get the DATA_TYPE of a column from information_schema, returns None if column does not exist"""
-        cursor = self.execute_sql("SELECT DATA_TYPE FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self.config.database, table_name, column_name))
+        schema_sql, schema_params = self._schema_predicate()
+        cursor = self.execute_sql(
+            f"SELECT DATA_TYPE FROM information_schema.columns WHERE {schema_sql} AND table_name = %s AND column_name = %s",
+            (*schema_params, table_name, column_name),
+        )
         row = cursor.fetchone()
         return row[0] if row else None
+
+    def add_varchar32_column(self, table_name: str, column_name: str):
+        self.execute_sql(f"ALTER TABLE {self.quote_ident(table_name)} ADD COLUMN {self.quote_ident(column_name)} VARCHAR(32) NULL")
+
+    def convert_column_to_varchar32(self, table_name: str, column_name: str):
+        q_table = self.quote_ident(table_name)
+        q_col = self.quote_ident(column_name)
+        self.execute_sql(f"ALTER TABLE {q_table} MODIFY COLUMN {q_col} VARCHAR(32) NULL")
+
+    def add_auto_increment_unique_id_column(self, table_name: str):
+        self.execute_sql(f"ALTER TABLE {self.quote_ident(table_name)} ADD COLUMN id BIGINT AUTO_INCREMENT UNIQUE")
+
+    def create_table(self, table_name: str, columns: list[str], indexes: list[tuple[str, list[str], bool]] | None = None):
+        """Create a table. Column defs may use DATETIME as a dialect-neutral timestamp token."""
+        indexes = indexes or []
+        col_sql = [col.replace("DATETIME", self.datetime_type) for col in columns]
+        extra = []
+        for name, cols, unique in indexes:
+            prefix = "UNIQUE INDEX" if unique else "INDEX"
+            extra.append(f"{prefix} {name} ({', '.join(cols)})")
+        body = ",\n            ".join(col_sql + extra)
+        self.execute_sql(f"CREATE TABLE IF NOT EXISTS {table_name} (\n            {body}\n        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")
 
     def get_system_setting_value(self, name: str) -> str | None:
         if not self.table_exists("system_settings"):
             logger.info("Table 'system_settings' does not exist, migration marker is unavailable")
             return None
+        q_table = self.quote_ident("system_settings")
+        q_value = self.quote_ident("value")
+        q_name = self.quote_ident("name")
         cursor = self.execute_sql(
-            "SELECT `value` FROM `system_settings` WHERE `name` = %s",
+            f"SELECT {q_value} FROM {q_table} WHERE {q_name} = %s",
             (name,),
         )
         row = cursor.fetchone()
@@ -179,17 +294,20 @@ class MigrationDatabase:
             return
 
         current_ts = int(time.time())
+        ts_sql = self.datetime_from_unix("%s")
         self.execute_sql(
-            """
-            INSERT INTO `system_settings`
-            (`name`, `source`, `data_type`, `value`, `create_time`, `create_date`, `update_time`, `update_date`)
-            VALUES (%s, %s, %s, %s, %s, FROM_UNIXTIME(%s), %s, FROM_UNIXTIME(%s))
+            f"""
+            INSERT INTO {self.quote_ident("system_settings")}
+            ({self.quote_ident("name")}, {self.quote_ident("source")}, {self.quote_ident("data_type")},
+             {self.quote_ident("value")}, {self.quote_ident("create_time")}, {self.quote_ident("create_date")},
+             {self.quote_ident("update_time")}, {self.quote_ident("update_date")})
+            VALUES (%s, %s, %s, %s, %s, {ts_sql}, %s, {ts_sql})
             ON DUPLICATE KEY UPDATE
-              `source` = VALUES(`source`),
-              `data_type` = VALUES(`data_type`),
-              `value` = VALUES(`value`),
-              `update_time` = VALUES(`update_time`),
-              `update_date` = VALUES(`update_date`)
+              {self.quote_ident("source")} = VALUES({self.quote_ident("source")}),
+              {self.quote_ident("data_type")} = VALUES({self.quote_ident("data_type")}),
+              {self.quote_ident("value")} = VALUES({self.quote_ident("value")}),
+              {self.quote_ident("update_time")} = VALUES({self.quote_ident("update_time")}),
+              {self.quote_ident("update_date")} = VALUES({self.quote_ident("update_date")})
             """,
             (
                 name,
@@ -208,6 +326,108 @@ class MigrationDatabase:
 
     def set_database_version(self, version: str):
         self.upsert_system_setting(MIGRATION_DB_VERSION_MARKER, version)
+
+
+class PostgresMigrationDatabase(MigrationDatabase):
+    """PostgreSQL / GaussDB dialect wrapper for the same migration stages."""
+
+    dialect = "postgres"
+    datetime_type = "TIMESTAMP"
+
+    def __init__(self, config: MigrationConfig, peewee_db=None):
+        self.config = config
+        self._owns_connection = peewee_db is None
+        if peewee_db is not None:
+            self.db = peewee_db
+            self.migrator = None
+            return
+        kwargs = {
+            "host": config.host,
+            "port": config.port,
+            "user": config.user,
+            "password": config.password,
+        }
+        if config.options:
+            kwargs["options"] = config.options
+        self.db = PostgresqlDatabase(config.database, **kwargs)
+        self.migrator = None
+
+    def quote_ident(self, name: str) -> str:
+        return '"' + name.replace('"', '""') + '"'
+
+    def datetime_from_unix(self, seconds_sql: str) -> str:
+        return f"TO_TIMESTAMP({seconds_sql})"
+
+    def column_as_text(self, quoted_column: str) -> str:
+        return f"{quoted_column}::text"
+
+    def _schema_predicate(self) -> tuple[str, tuple]:
+        return "table_schema = current_schema()", ()
+
+    def convert_column_to_varchar32(self, table_name: str, column_name: str):
+        q_table = self.quote_ident(table_name)
+        q_col = self.quote_ident(column_name)
+        self.execute_sql(f"ALTER TABLE {q_table} ALTER COLUMN {q_col} TYPE varchar(32) USING {q_col}::text")
+
+    def add_auto_increment_unique_id_column(self, table_name: str):
+        seq_name = f"{table_name}_id_seq"
+        q_seq = self.quote_ident(seq_name)
+        q_table = self.quote_ident(table_name)
+        q_id = self.quote_ident("id")
+        self.execute_sql(f"CREATE SEQUENCE IF NOT EXISTS {q_seq}")
+        self.execute_sql(f"ALTER TABLE {q_table} ADD COLUMN {q_id} BIGINT UNIQUE DEFAULT nextval('{seq_name}')")
+        self.execute_sql(f"ALTER SEQUENCE {q_seq} OWNED BY {q_table}.{q_id}")
+
+    def create_table(self, table_name: str, columns: list[str], indexes: list[tuple[str, list[str], bool]] | None = None):
+        indexes = indexes or []
+        col_sql = [col.replace("DATETIME", self.datetime_type) for col in columns]
+        body = ",\n            ".join(col_sql)
+        self.execute_sql(f"CREATE TABLE IF NOT EXISTS {table_name} (\n            {body}\n        )")
+        for name, cols, unique in indexes:
+            unique_sql = "UNIQUE " if unique else ""
+            self.execute_sql(f"CREATE {unique_sql}INDEX IF NOT EXISTS {name} ON {table_name} ({', '.join(cols)})")
+
+    def upsert_system_setting(self, name: str, value: str, source: str = "migration", data_type: str = "string"):
+        if not self.table_exists("system_settings"):
+            logger.warning("Table 'system_settings' does not exist, migration marker was not saved")
+            return
+
+        current_ts = int(time.time())
+        ts_sql = self.datetime_from_unix("%s")
+        self.execute_sql(
+            """
+            INSERT INTO system_settings
+            (name, source, data_type, value, create_time, create_date, update_time, update_date)
+            VALUES (%s, %s, %s, %s, %s, """
+            + ts_sql
+            + """, %s, """
+            + ts_sql
+            + """)
+            ON CONFLICT (name) DO UPDATE SET
+              source = EXCLUDED.source,
+              data_type = EXCLUDED.data_type,
+              value = EXCLUDED.value,
+              update_time = EXCLUDED.update_time,
+              update_date = EXCLUDED.update_date
+            """,
+            (
+                name,
+                source,
+                data_type,
+                value,
+                current_ts * 1000,
+                current_ts,
+                current_ts * 1000,
+                current_ts,
+            ),
+        )
+
+
+def create_migration_database(config: MigrationConfig, dialect: str = "mysql", peewee_db=None) -> MigrationDatabase:
+    dialect = normalize_migration_dialect(dialect)
+    if dialect == "postgres":
+        return PostgresMigrationDatabase(config, peewee_db=peewee_db)
+    return MigrationDatabase(config, peewee_db=peewee_db)
 
 
 def parse_migration_version(version: str | None) -> Version | None:
@@ -307,6 +527,9 @@ class MigrationStage:
     def noop_completes_migration(self) -> bool:
         return self._noop_completes_migration
 
+    def q(self, name: str) -> str:
+        return self.db.quote_ident(name)
+
 
 class TenantModelProviderStage(MigrationStage):
     """Migrate tenant_llm to tenant_model_provider"""
@@ -399,7 +622,7 @@ class TenantModelProviderStage(MigrationStage):
             params = []
             for tenant_id, llm_factory in batch:
                 record_id = self.generate_uuid()
-                placeholders.append("(%s, %s, %s, %s, FROM_UNIXTIME(%s), %s, FROM_UNIXTIME(%s))")
+                placeholders.append(f"(%s, %s, %s, %s, {self.db.datetime_from_unix('%s')}, %s, {self.db.datetime_from_unix('%s')})")
                 params.extend(
                     [
                         record_id,
@@ -424,21 +647,23 @@ class TenantModelProviderStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model_provider table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_provider (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            provider_name VARCHAR(128) NOT NULL,
-            tenant_id VARCHAR(32) NOT NULL,
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_provider_name (provider_name),
-            INDEX idx_tenant_id (tenant_id),
-            UNIQUE INDEX idx_tenant_provider_unique (tenant_id, provider_name)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model_provider",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "provider_name VARCHAR(128) NOT NULL",
+                "tenant_id VARCHAR(32) NOT NULL",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [
+                ("idx_provider_name", ["provider_name"], False),
+                ("idx_tenant_id", ["tenant_id"], False),
+                ("idx_tenant_provider_unique", ["tenant_id", "provider_name"], True),
+            ],
+        )
         logger.info("Created tenant_model_provider table")
 
 
@@ -575,8 +800,8 @@ class TenantModelInstanceStage(MigrationStage):
                 values.append(
                     f"('{record_id}', '{instance_name}', '{provider_id}', "
                     f"'{api_key_escaped}', '{status_val}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))}, "
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))})"
                 )
 
             insert_sql = f"""
@@ -677,22 +902,22 @@ class TenantModelInstanceStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model_instance table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_instance (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            instance_name VARCHAR(128) NOT NULL,
-            provider_id VARCHAR(32) NOT NULL,
-            api_key VARCHAR(512) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(512) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_provider_id (provider_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model_instance",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "instance_name VARCHAR(128) NOT NULL",
+                "provider_id VARCHAR(32) NOT NULL",
+                "api_key VARCHAR(512) NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(512) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_provider_id", ["provider_id"], False)],
+        )
         logger.info("Created tenant_model_instance table")
 
 
@@ -890,8 +1115,8 @@ class TenantModelStage(MigrationStage):
                     f"('{record_id}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', '{model_type_escaped}', '{status_val}', "
                     f"'{extra_escaped}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))}, "
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))})"
                 )
 
             insert_sql = f"""
@@ -912,9 +1137,9 @@ class TenantModelStage(MigrationStage):
         Very old tenant_llm tables may predate the id column, while the migration
         SELECT relies on it (tl.id is carried as source_id for audit logging).
         The id is only used as a unique audit key, so it is added as an
-        AUTO_INCREMENT UNIQUE column rather than PRIMARY KEY: old tables may
-        already have another primary key. MySQL back-fills existing rows with
-        sequential values when adding an AUTO_INCREMENT column.
+        auto-increment UNIQUE column rather than PRIMARY KEY: old tables may
+        already have another primary key. Existing rows are back-filled with
+        sequential values when the column is added.
 
         Returns:
             True if the column exists (or was added successfully), False otherwise.
@@ -928,7 +1153,7 @@ class TenantModelStage(MigrationStage):
             return False
 
         try:
-            self.db.execute_sql("ALTER TABLE tenant_llm ADD COLUMN id BIGINT AUTO_INCREMENT UNIQUE")
+            self.db.add_auto_increment_unique_id_column("tenant_llm")
         except Exception as e:
             logger.error(f"Failed to add auto-increment id column to tenant_llm: {e}")
             return False
@@ -1014,23 +1239,23 @@ class TenantModelStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type VARCHAR(32) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "model_name VARCHAR(128)",
+                "provider_id VARCHAR(32) NOT NULL",
+                "instance_id VARCHAR(32) NOT NULL",
+                "model_type VARCHAR(32) NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(1024) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_instance_id", ["instance_id"], False)],
+        )
         logger.info("Created tenant_model table")
 
 
@@ -1158,8 +1383,11 @@ class ModelIdConfigStage(MigrationStage):
 
     def iter_string_changes(self):
         for table_name, column_name in self.existing_columns(self.string_columns):
+            q_table = self.q(table_name)
+            q_col = self.q(column_name)
+            col_text = self.db.column_as_text(q_col)
             cursor = self.db.execute_sql(
-                f"SELECT id, `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL AND `{column_name}` != '' AND `{column_name}` LIKE %s",
+                f"SELECT id, {q_col} FROM {q_table} WHERE {q_col} IS NOT NULL AND {col_text} != '' AND {col_text} LIKE %s",
                 ("%@%",),
             )
             while True:
@@ -1173,8 +1401,11 @@ class ModelIdConfigStage(MigrationStage):
 
     def iter_json_changes(self):
         for table_name, column_name in self.existing_columns(self.json_columns):
+            q_table = self.q(table_name)
+            q_col = self.q(column_name)
+            col_text = self.db.column_as_text(q_col)
             cursor = self.db.execute_sql(
-                f"SELECT id, `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL AND `{column_name}` != '' AND `{column_name}` LIKE %s",
+                f"SELECT id, {q_col} FROM {q_table} WHERE {q_col} IS NOT NULL AND {col_text} != '' AND {col_text} LIKE %s",
                 ("%@%",),
             )
             while True:
@@ -1240,7 +1471,7 @@ class ModelIdConfigStage(MigrationStage):
                 )
             if not self.dry_run:
                 self.db.execute_sql(
-                    f"UPDATE `{table_name}` SET `{column_name}` = %s WHERE id = %s",
+                    f"UPDATE {self.q(table_name)} SET {self.q(column_name)} = %s WHERE id = %s",
                     (normalized, row_id),
                 )
 
@@ -1257,7 +1488,7 @@ class ModelIdConfigStage(MigrationStage):
                 )
             if not self.dry_run:
                 self.db.execute_sql(
-                    f"UPDATE `{table_name}` SET `{column_name}` = %s WHERE id = %s",
+                    f"UPDATE {self.q(table_name)} SET {self.q(column_name)} = %s WHERE id = %s",
                     (normalized_json, row_id),
                 )
 
@@ -1312,7 +1543,7 @@ class TenantModelSeedingStage(MigrationStage):
 
         # If model_type is already INT, the merge stage has been executed — seeding is not applicable
         model_type_dtype = self.db.get_column_type("tenant_model", "model_type")
-        if model_type_dtype and model_type_dtype.lower() == "int":
+        if self.db.is_integer_type(model_type_dtype):
             self.mark_noop_completes_migration()
             logger.info("tenant_model.model_type is already INT, seeding stage is not applicable (merge already done)")
             return False
@@ -1522,8 +1753,8 @@ class TenantModelSeedingStage(MigrationStage):
                     f"('{record_id}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', '{mt_escaped}', '{status_escaped}', "
                     f"'{extra_escaped}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))}, "
+                    f"{current_ts * 1000}, {self.db.datetime_from_unix(str(current_ts))})"
                 )
 
             insert_sql = f"""
@@ -1540,23 +1771,23 @@ class TenantModelSeedingStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type VARCHAR(32) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "model_name VARCHAR(128)",
+                "provider_id VARCHAR(32) NOT NULL",
+                "instance_id VARCHAR(32) NOT NULL",
+                "model_type VARCHAR(32) NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(1024) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_instance_id", ["instance_id"], False)],
+        )
         logger.info("Created tenant_model table")
 
 
@@ -1581,6 +1812,35 @@ class ModelTypeMergeStage(MigrationStage):
         "ocr": 64,  # 0b1000000
     }
 
+    @classmethod
+    def model_type_to_bits(cls, model_type) -> int:
+        """Map a stored model_type value to bitmask bits.
+
+        Accepts integer bits, numeric strings (\"9\"), named values (\"chat\"),
+        aliases (speech2text/image2text), and combined tokens (\"chat|vision\").
+        Empty/unknown values return 0; callers may default that to chat (1).
+        """
+        if model_type is None:
+            return 0
+        if isinstance(model_type, bool):
+            return 0
+        if isinstance(model_type, int):
+            return model_type
+        text = str(model_type).strip()
+        if not text:
+            return 0
+        if text.lstrip("+-").isdigit():
+            return int(text)
+        bits = 0
+        for token in text.replace("|", ",").replace(" ", "").split(","):
+            if not token:
+                continue
+            if token.lstrip("+-").isdigit():
+                bits |= int(token)
+                continue
+            bits |= cls.MODEL_TYPE_STR_TO_INT.get(token.lower(), 0)
+        return bits
+
     def current_timestamp(self) -> int:
         return int(time.time())
 
@@ -1596,7 +1856,7 @@ class ModelTypeMergeStage(MigrationStage):
 
         # If model_type is already INT, the merge has already been executed — no work needed
         model_type_dtype = self.db.get_column_type("tenant_model", "model_type")
-        if model_type_dtype and model_type_dtype.lower() == "int":
+        if self.db.is_integer_type(model_type_dtype):
             self.mark_noop_completes_migration()
             logger.info("tenant_model.model_type is already INT, merge stage is not applicable (already done)")
             return False
@@ -1644,7 +1904,7 @@ class ModelTypeMergeStage(MigrationStage):
 
             for row in rows:
                 _, _, _, _, model_type_str, status, _, _, _, _, _ = row
-                type_bit = self.MODEL_TYPE_STR_TO_INT.get(model_type_str, 0)
+                type_bit = self.model_type_to_bits(model_type_str)
                 if status == "unsupported":
                     unsupported_bits |= type_bit
                 else:
@@ -1654,6 +1914,8 @@ class ModelTypeMergeStage(MigrationStage):
 
             merged_type = supported_bits & ~unsupported_bits
             merged_status = first_non_unsupported_status or "active"
+            if merged_type == 0:
+                merged_type = 1
 
             # Use first row's values for all other fields, but replace id, model_type, status
             id_, model_name, provider_id, instance_id, _, _, extra, create_time, create_date, update_time, update_date = first_row
@@ -1692,8 +1954,8 @@ class ModelTypeMergeStage(MigrationStage):
                 # Handle NULL date fields
                 create_time_val = create_time if create_time is not None else current_ts * 1000
                 update_time_val = update_time if update_time is not None else current_ts * 1000
-                create_date_sql = f"FROM_UNIXTIME({int(create_time_val / 1000)})" if create_time_val else "NULL"
-                update_date_sql = f"FROM_UNIXTIME({int(update_time_val / 1000)})" if update_time_val else "NULL"
+                create_date_sql = self.db.datetime_from_unix(str(int(create_time_val / 1000))) if create_time_val else "NULL"
+                update_date_sql = self.db.datetime_from_unix(str(int(update_time_val / 1000))) if update_time_val else "NULL"
                 values.append(
                     f"('{id_}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', {merged_type}, '{status_escaped}', "
@@ -1723,23 +1985,23 @@ class ModelTypeMergeStage(MigrationStage):
 
     def create_target_table(self):
         """Create temporary table tenant_model_merge_tmp with model_type as INTEGER"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_merge_tmp (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type INT NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
+        self.db.create_table(
+            "tenant_model_merge_tmp",
+            [
+                "id VARCHAR(32) NOT NULL PRIMARY KEY",
+                "model_name VARCHAR(128)",
+                "provider_id VARCHAR(32) NOT NULL",
+                "instance_id VARCHAR(32) NOT NULL",
+                "model_type INT NOT NULL",
+                "status VARCHAR(32) DEFAULT 'active'",
+                "extra VARCHAR(1024) DEFAULT '{}'",
+                "create_time BIGINT",
+                "create_date DATETIME",
+                "update_time BIGINT",
+                "update_date DATETIME",
+            ],
+            [("idx_instance_id_merge_tmp", ["instance_id"], False)],
+        )
         logger.info("Created tenant_model_merge_tmp table")
 
 
@@ -1791,6 +2053,16 @@ class TenantModelIdMigrationStage(MigrationStage):
 
     scan_batch_size = 500
 
+    def _unpopulated_predicate(self, tenant_id_col: str) -> str:
+        q_col = self.q(tenant_id_col)
+        col_text = self.db.column_as_text(q_col)
+        return f"({q_col} IS NULL OR {col_text} = '' OR LENGTH({col_text}) <> 32)"
+
+    def _legacy_present_predicate(self, legacy_col: str) -> str:
+        q_legacy = self.q(legacy_col)
+        legacy_text = self.db.column_as_text(q_legacy)
+        return f"{q_legacy} IS NOT NULL AND {legacy_text} != ''"
+
     def check(self) -> bool:
         """Check if migration is needed - any tenant_*_id column is still INT or empty."""
         if not self.db.table_exists("tenant_model"):
@@ -1816,11 +2088,11 @@ class TenantModelIdMigrationStage(MigrationStage):
                     break
                 # Check if column is still INT type -> needs conversion
                 col_type = self.db.get_column_type(table_name, tenant_id_col)
-                if col_type and col_type.lower() in ("int", "bigint", "integer"):
+                if self.db.is_integer_type(col_type):
                     has_work = True
                     break
                 # Check if there are NULL values that should be populated
-                cursor = self.db.execute_sql(f"SELECT COUNT(*) FROM `{table_name}` WHERE `{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32")
+                cursor = self.db.execute_sql(f"SELECT COUNT(*) FROM {self.q(table_name)} WHERE {self._unpopulated_predicate(tenant_id_col)}")
                 null_count = cursor.fetchone()[0]
                 if null_count > 0:
                     has_work = True
@@ -1853,14 +2125,14 @@ class TenantModelIdMigrationStage(MigrationStage):
                     # Column does not exist yet — add it as VARCHAR(32)
                     logger.info(f"Adding column {table_name}.{tenant_id_col} as VARCHAR(32) NULL")
                     if not self.dry_run:
-                        self.db.execute_sql(f"ALTER TABLE `{table_name}` ADD COLUMN `{tenant_id_col}` VARCHAR(32) NULL")
+                        self.db.add_varchar32_column(table_name, tenant_id_col)
                     tables_operated.add(table_name)
                     continue
                 col_type = self.db.get_column_type(table_name, tenant_id_col)
-                if col_type and col_type.lower() in ("int", "bigint", "integer"):
+                if self.db.is_integer_type(col_type):
                     logger.info(f"Converting {table_name}.{tenant_id_col} from {col_type} to VARCHAR(32)")
                     if not self.dry_run:
-                        self.db.execute_sql(f"ALTER TABLE `{table_name}` MODIFY COLUMN `{tenant_id_col}` VARCHAR(32) NULL")
+                        self.db.convert_column_to_varchar32(table_name, tenant_id_col)
                     tables_operated.add(table_name)
 
         # Step 2: Build lookup cache from tenant_model joined with provider + instance
@@ -1880,13 +2152,17 @@ class TenantModelIdMigrationStage(MigrationStage):
                     logger.info(f"Column {table_name}.{legacy_col} does not exist, skipping")
                     continue
 
+                q_table = self.q(table_name)
+                q_tenant_id_col = self.q(tenant_id_col)
+                q_legacy = self.q(legacy_col)
+                unpopulated = self._unpopulated_predicate(tenant_id_col)
+                legacy_present = self._legacy_present_predicate(legacy_col)
+
                 # Also need tenant_id for model lookup
                 # For tenant table, the PK is the tenant_id
                 # For knowledgebase, dialog, memory we also need tenant_id
                 if table_name == "tenant":
-                    cursor = self.db.execute_sql(
-                        f"SELECT id, `{legacy_col}` FROM `{table_name}` WHERE (`{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32) AND `{legacy_col}` IS NOT NULL AND `{legacy_col}` != ''"
-                    )
+                    cursor = self.db.execute_sql(f"SELECT id, {q_legacy} FROM {q_table} WHERE {unpopulated} AND {legacy_present}")
                     while True:
                         rows = cursor.fetchmany(self.scan_batch_size)
                         if not rows:
@@ -1897,21 +2173,19 @@ class TenantModelIdMigrationStage(MigrationStage):
                             if resolved_id:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = %s WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = %s WHERE id = %s",
                                         (resolved_id, row_id),
                                     )
                             else:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = '' WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = '' WHERE id = %s",
                                         (row_id,),
                                     )
                             rows_updated += 1
                             tables_operated.add(table_name)
                 else:
-                    cursor = self.db.execute_sql(
-                        f"SELECT id, tenant_id, `{legacy_col}` FROM `{table_name}` WHERE (`{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32) AND `{legacy_col}` IS NOT NULL AND `{legacy_col}` != ''"
-                    )
+                    cursor = self.db.execute_sql(f"SELECT id, tenant_id, {q_legacy} FROM {q_table} WHERE {unpopulated} AND {legacy_present}")
                     while True:
                         rows = cursor.fetchmany(self.scan_batch_size)
                         if not rows:
@@ -1921,13 +2195,13 @@ class TenantModelIdMigrationStage(MigrationStage):
                             if resolved_id:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = %s WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = %s WHERE id = %s",
                                         (resolved_id, row_id),
                                     )
                             else:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = '' WHERE id = %s",
+                                        f"UPDATE {q_table} SET {q_tenant_id_col} = '' WHERE id = %s",
                                         (row_id,),
                                     )
                             rows_updated += 1
@@ -1962,9 +2236,16 @@ class TenantModelIdMigrationStage(MigrationStage):
         )
         lookup = {}
         for model_id, model_name, model_type, tenant_id, provider_name in cursor.fetchall():
-            # model_type is a binary integer; we check each bit
+            # model_type is a binary integer after model_type_merge; tolerate leftover
+            # varchar names/numeric strings on postgres upgrades that skipped merge.
+            try:
+                model_type_int = int(model_type)
+            except (TypeError, ValueError):
+                model_type_int = self.MODEL_TYPE_TO_INT.get(str(model_type).lower() if model_type is not None else "", 0)
+                if not model_type_int:
+                    continue
             for type_str, type_bit in self.MODEL_TYPE_TO_INT.items():
-                if model_type & type_bit:
+                if model_type_int & type_bit:
                     key = (tenant_id, model_name, provider_name, type_str)
                     lookup[key] = model_id
         return lookup
@@ -2013,6 +2294,10 @@ def list_available_stages():
         logger.info(f"    Target tables: {stage_cls.target_tables}")
 
 
+PROVIDER_TABLE_STAGES = ["tenant_model_provider", "tenant_model_instance", "tenant_model", "model_id_config"]
+PROVIDER_DATA_STAGES = ["tenant_model_seeding", "model_type_merge", "tenant_model_id_migration"]
+
+
 def run_migration(
     config: MigrationConfig,
     stages: list,
@@ -2020,12 +2305,21 @@ def run_migration(
     create_table_only: bool = False,
     database_version: str | None = None,
     mark_database_version_on_success: bool = False,
+    dialect: str = "mysql",
+    peewee_db=None,
 ):
-    """Run migration with specified stages"""
+    """Run migration with specified stages.
+
+    When ``mark_database_version_on_success`` is set, the
+    ``mysql_migration.database.version`` marker is written only after every
+    stage returns without raising (and not in dry-run / create-table-only).
+    A raised stage therefore leaves the marker unset so the next boot retries.
+    Stages that ``check()`` as already done still count as complete.
+    """
     stats = MigrationStats()
     stats.start()
 
-    db = MigrationDatabase(config)
+    db = create_migration_database(config, dialect=dialect, peewee_db=peewee_db)
 
     try:
         db.connect()
@@ -2090,6 +2384,8 @@ def run_migration(
             stats.add_stage_stats(stage_name, tables, rows, stage_duration)
             logger.info(f"Stage '{stage_name}' completed: {rows} rows in {stage_duration:.2f}s")
 
+        # Do not write the marker from `finally`: a raised stage must leave the
+        # version unset so migrate_db() / the next script run can retry.
         if mark_database_version_on_success and not dry_run and not create_table_only and database_version and all_stages_completed:
             db.set_database_version(database_version)
             logger.info("Marked database migration version as %s", database_version)
@@ -2100,8 +2396,31 @@ def run_migration(
         stats.print_summary()
 
 
-def check_database_version(config: MigrationConfig, target_version: str) -> int:
-    db = MigrationDatabase(config)
+def run_using_existing_connection(peewee_db, dialect: str = "postgres", database_name: str = "rag_flow", options: str | None = None):
+    """Run the docker-equivalent stage groups against an already-open connection.
+
+    Used by migrate_db() for in-place PostgreSQL / GaussDB upgrades so
+    TenantModelIdMigrationStage and ModelTypeMergeStage run automatically.
+    """
+    config = MigrationConfig(database=database_name, options=options)
+    dialect = normalize_migration_dialect(dialect)
+    for stages, version in (
+        (PROVIDER_TABLE_STAGES, "v0.26.0"),
+        (PROVIDER_DATA_STAGES, "v0.27.0"),
+    ):
+        run_migration(
+            config=config,
+            stages=stages,
+            dry_run=False,
+            database_version=version,
+            mark_database_version_on_success=True,
+            dialect=dialect,
+            peewee_db=peewee_db,
+        )
+
+
+def check_database_version(config: MigrationConfig, target_version: str, dialect: str = "mysql") -> int:
+    db = create_migration_database(config, dialect=dialect)
     try:
         db.connect()
         current_db_version = db.get_database_version()
@@ -2129,8 +2448,8 @@ def check_database_version(config: MigrationConfig, target_version: str) -> int:
         db.close()
 
 
-def mark_database_version(config: MigrationConfig, version: str) -> None:
-    db = MigrationDatabase(config)
+def mark_database_version(config: MigrationConfig, version: str, dialect: str = "mysql") -> None:
+    db = create_migration_database(config, dialect=dialect)
     try:
         db.connect()
         db.set_database_version(version)
@@ -2139,9 +2458,14 @@ def mark_database_version(config: MigrationConfig, version: str) -> None:
         db.close()
 
 
-def main():
+def main(default_dialect: str = "mysql"):
+    dialect = normalize_migration_dialect(default_dialect)
+    default_port = 5432 if dialect == "postgres" else 3306
+    default_user = "rag_flow" if dialect == "postgres" else "root"
+    engine_label = "PostgreSQL/GaussDB" if dialect == "postgres" else "MySQL"
+
     parser = argparse.ArgumentParser(
-        description="MySQL Data Migration Tool",
+        description=f"{engine_label} Data Migration Tool",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -2180,12 +2504,11 @@ Examples:
 """,
     )
 
-    # MySQL connection options
-    parser.add_argument("--host", type=str, default="localhost", help="MySQL host (default: localhost)")
-    parser.add_argument("--port", type=int, default=3306, help="MySQL port (default: 3306)")
-    parser.add_argument("--user", type=str, default="root", help="MySQL user (default: root)")
-    parser.add_argument("--password", type=str, default="", help="MySQL password (default: empty)")
-    parser.add_argument("--database", type=str, default="rag_flow", help="MySQL database name (default: rag_flow)")
+    parser.add_argument("--host", type=str, default="localhost", help=f"{engine_label} host (default: localhost)")
+    parser.add_argument("--port", type=int, default=default_port, help=f"{engine_label} port (default: {default_port})")
+    parser.add_argument("--user", type=str, default=default_user, help=f"{engine_label} user (default: {default_user})")
+    parser.add_argument("--password", type=str, default="", help=f"{engine_label} password (default: empty)")
+    parser.add_argument("--database", type=str, default="rag_flow", help=f"{engine_label} database name (default: rag_flow)")
 
     # Configuration options
     parser.add_argument("--config", "-c", type=str, help="Path to YAML config file")
@@ -2209,13 +2532,13 @@ Examples:
 
     # Load configuration: command line args take precedence over config file
     if args.config:
-        config = MigrationConfig.from_config_file(args.config)
+        config = MigrationConfig.from_config_file(args.config, dialect=dialect)
         # Override with command line args if provided
         if args.host != "localhost":
             config.host = args.host
-        if args.port != 3306:
+        if args.port != default_port:
             config.port = args.port
-        if args.user != "root":
+        if args.user != default_user:
             config.user = args.user
         if args.password != "":
             config.password = args.password
@@ -2225,7 +2548,7 @@ Examples:
         # Use command line args directly
         config = MigrationConfig(host=args.host, port=args.port, user=args.user, password=args.password, database=args.database)
 
-    logger.info(f"MySQL Configuration: host={config.host}, port={config.port}, user={config.user}, database={config.database}")
+    logger.info(f"{engine_label} Configuration: host={config.host}, port={config.port}, user={config.user}, database={config.database}")
 
     if args.check_database_version and args.mark_database_version:
         logger.error("--check-database-version and --mark-database-version are mutually exclusive")
@@ -2235,13 +2558,13 @@ Examples:
         if not args.database_version:
             logger.error("--check-database-version requires --database-version")
             sys.exit(1)
-        sys.exit(check_database_version(config, args.database_version))
+        sys.exit(check_database_version(config, args.database_version, dialect=dialect))
 
     if args.mark_database_version:
         if not args.database_version:
             logger.error("--mark-database-version requires --database-version")
             sys.exit(1)
-        mark_database_version(config, args.database_version)
+        mark_database_version(config, args.database_version, dialect=dialect)
         return
 
     if args.mark_database_version_on_success and not args.database_version:
@@ -2278,6 +2601,7 @@ Examples:
         create_table_only=create_table_only,
         database_version=args.database_version,
         mark_database_version_on_success=args.mark_database_version_on_success,
+        dialect=dialect,
     )
 
 

--- a/tools/scripts/postgres_migration.py
+++ b/tools/scripts/postgres_migration.py
@@ -1,0 +1,31 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+PostgreSQL / GaussDB data migration script.
+
+Same stages as mysql_migration.py (provider tables, model_type_merge,
+tenant_model_id_migration). Used for in-place upgrades when DB_TYPE is
+postgres or gaussdb, where the MySQL-only docker path never ran.
+"""
+
+import logging
+
+from mysql_migration import main
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    main(default_dialect="postgres")

--- a/tools/scripts/run_migrations.sh
+++ b/tools/scripts/run_migrations.sh
@@ -9,7 +9,8 @@
 #   PY=python3 tools/scripts/run_migrations.sh [--config CONFIG_PATH]
 #
 # Environment variables:
-#   PY  - Python interpreter path (default: python3)
+#   PY       - Python interpreter path (default: python3)
+#   DB_TYPE  - metadata database type (mysql, postgres, gaussdb, oceanbase)
 # -----------------------------------------------------------------------------
 
 set -e
@@ -40,10 +41,21 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-echo "Running model provider table migrations..."
+DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"
+DB_TYPE_NORMALIZED="${DB_TYPE_NORMALIZED,,}"
+
+if [[ "$DB_TYPE_NORMALIZED" == "postgres" || "$DB_TYPE_NORMALIZED" == "postgresql" || "$DB_TYPE_NORMALIZED" == "gaussdb" || "$DB_TYPE_NORMALIZED" == "gauss" ]]; then
+    MIGRATION_SCRIPT="tools/scripts/postgres_migration.py"
+    ENGINE_LABEL="PostgreSQL/GaussDB"
+else
+    MIGRATION_SCRIPT="tools/scripts/mysql_migration.py"
+    ENGINE_LABEL="MySQL"
+fi
+
+echo "Running model provider table migrations (${ENGINE_LABEL}, DB_TYPE=${DB_TYPE:-mysql})..."
 
 # Step 1: Create base model provider tables
-"$PY" tools/scripts/mysql_migration.py \
+"$PY" "$MIGRATION_SCRIPT" \
     --stages tenant_model_provider,tenant_model_instance,tenant_model,model_id_config \
     --config "$CONFIG" \
     --execute \
@@ -51,7 +63,7 @@ echo "Running model provider table migrations..."
     --mark-database-version-on-success
 
 # Step 2: Seed, merge model types, and migrate model IDs
-"$PY" tools/scripts/mysql_migration.py \
+"$PY" "$MIGRATION_SCRIPT" \
     --stages tenant_model_seeding,model_type_merge,tenant_model_id_migration \
     --config "$CONFIG" \
     --execute \


### PR DESCRIPTION
Combines #18777 and #18781 into one postgres/gaussdb in-place upgrade path (per review).

## Problems

v0.27.0 stores `tenant_model.id` hex strings and an integer `model_type` bitmask. MySQL runs `mysql_migration.py` at docker start; postgres/gaussdb never did, so upgrades fail with:

- `operator does not exist: character varying & integer` on `tenant_model.model_type` (#18755)
- `invalid input syntax for type integer` when writing hex ids into leftover integer `tenant_*_id` columns (#18756)

## Fix

One framework, both data fixes:

- `tools/scripts/postgres_migration.py` + `run_migrations.sh` when `DB_TYPE` is postgres/gaussdb (same stages as `mysql_migration.py`)
- Ordered data stages: `tenant_model_seeding` → `model_type_merge` → `tenant_model_id_migration`
- `model_type_merge` maps names/aliases/numeric strings/combined tokens, ORs bits, defaults empty/unknown to chat (`1`), rebuilds the column as `INT`
- `tenant_model_id_migration` converts integer `tenant_*_id` columns to `varchar(32)` and backfills from `llm_id` / `embd_id`

Pre-startup scripts are the primary path. `migrate_db()` is only a fallback if those scripts did not run:

- leftover integer `tenant_*_id` columns may be retyped (no-op when already varchar)
- then `migrate_postgres_family_model_provider_tables()` runs the same stages
- **no** in-place `ALTER` of `model_type` before merge (those stages skip when the column is already INT)

## Verification

- Unit tests: `test_tenant_model_type_column_migration.py`, `test_postgres_model_provider_migration.py`, `test_tenant_model_id_column_migration.py`

Fixes #18755
Fixes #18756

Supersedes #18777 (same branch tip; close that PR to avoid conflicting merges).