### PR TITLE
fix(web): skip canvas autosave of empty nodes/edges

### DIFF
--- a/web/src/pages/agent/hooks/use-fetch-data.test.ts
+++ b/web/src/pages/agent/hooks/use-fetch-data.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+import { useFetchDataOnMount } from './use-fetch-data';
+
+const mockSetGraphInfo = jest.fn();
+const mockRefetch = jest.fn();
+const mockUseFetchAgent = jest.fn();
+
+jest.mock('@/hooks/use-agent-request', () => ({
+  useFetchAgent: () => mockUseFetchAgent(),
+}));
+
+jest.mock('./use-set-graph', () => ({
+  useSetGraphInfo: () => mockSetGraphInfo,
+}));
+
+jest.mock('../utils/dsl-bridge', () => ({
+  dslToGraph: (dsl: { graph?: { nodes: unknown[]; edges: unknown[] } }) => ({
+    nodes: dsl.graph?.nodes ?? [],
+    edges: dsl.graph?.edges ?? [],
+  }),
+}));
+
+describe('useFetchDataOnMount', () => {
+  beforeEach(() => {
+    mockSetGraphInfo.mockClear();
+    mockRefetch.mockClear();
+  });
+
+  it('does not apply an empty graph while agent detail has no dsl', () => {
+    mockUseFetchAgent.mockReturnValue({
+      loading: true,
+      data: {},
+      refetch: mockRefetch,
+    });
+
+    renderHook(() => useFetchDataOnMount());
+
+    expect(mockSetGraphInfo).not.toHaveBeenCalled();
+  });
+
+  it('applies the fetched dsl once it is present', () => {
+    mockUseFetchAgent.mockReturnValue({
+      loading: false,
+      data: {
+        id: 'agent-1',
+        dsl: { graph: { nodes: [{ id: 'begin:0' }], edges: [] } },
+      },
+      refetch: mockRefetch,
+    });
+
+    renderHook(() => useFetchDataOnMount());
+
+    expect(mockSetGraphInfo).toHaveBeenCalledWith({
+      nodes: [{ id: 'begin:0' }],
+      edges: [],
+    });
+  });
+
+  it('does not clear a loaded canvas when later detail snapshots omit dsl', () => {
+    mockUseFetchAgent.mockReturnValue({
+      loading: false,
+      data: {
+        id: 'agent-1',
+        dsl: { graph: { nodes: [{ id: 'begin:0' }], edges: [] } },
+      },
+      refetch: mockRefetch,
+    });
+
+    const { rerender } = renderHook(() => useFetchDataOnMount());
+
+    mockUseFetchAgent.mockReturnValue({
+      loading: false,
+      data: {},
+      refetch: mockRefetch,
+    });
+
+    act(() => {
+      rerender();
+    });
+
+    expect(mockSetGraphInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/agent/hooks/use-fetch-data.ts
+++ b/web/src/pages/agent/hooks/use-fetch-data.ts
@@ -8,7 +8,10 @@ export const useFetchDataOnMount = () => {
   const setGraphInfo = useSetGraphInfo();
 
   useEffect(() => {
-    setGraphInfo(dslToGraph(data?.dsl));
+    if (!data?.dsl) {
+      return;
+    }
+    setGraphInfo(dslToGraph(data.dsl));
   }, [setGraphInfo, data]);
 
   useEffect(() => {

--- a/web/src/pages/agent/hooks/use-save-graph.test.ts
+++ b/web/src/pages/agent/hooks/use-save-graph.test.ts
@@ -1,0 +1,39 @@
+import { shouldAutosaveCanvas } from './use-save-graph';
+
+describe('shouldAutosaveCanvas', () => {
+  const ready = {
+    chatDrawerVisible: false,
+    agentId: 'agent-1',
+    agentLoaded: true,
+    nodeCount: 2,
+    edgeCount: 1,
+  };
+
+  it('autosaves a loaded canvas with nodes', () => {
+    expect(shouldAutosaveCanvas(ready)).toBe(true);
+  });
+
+  it('skips while the chat drawer is open', () => {
+    expect(shouldAutosaveCanvas({ ...ready, chatDrawerVisible: true })).toBe(
+      false,
+    );
+  });
+
+  it('skips before the agent id is on the route', () => {
+    expect(shouldAutosaveCanvas({ ...ready, agentId: undefined })).toBe(false);
+  });
+
+  it('skips before the agent detail has loaded', () => {
+    expect(shouldAutosaveCanvas({ ...ready, agentLoaded: false })).toBe(false);
+  });
+
+  it('skips an empty nodes/edges store so autosave cannot wipe a pipeline', () => {
+    expect(
+      shouldAutosaveCanvas({ ...ready, nodeCount: 0, edgeCount: 0 }),
+    ).toBe(false);
+  });
+
+  it('still autosaves when there are nodes but no edges', () => {
+    expect(shouldAutosaveCanvas({ ...ready, edgeCount: 0 })).toBe(true);
+  });
+});

--- a/web/src/pages/agent/hooks/use-save-graph.ts
+++ b/web/src/pages/agent/hooks/use-save-graph.ts
@@ -31,6 +31,10 @@ export const useSaveGraph = (
       },
       release?: boolean,
     ) => {
+      if (!id) {
+        return;
+      }
+
       const params: Record<string, any> = {
         id,
         title: data.title,
@@ -71,8 +75,37 @@ export const useSaveGraphBeforeOpeningDebugDrawer = (show: () => void) => {
   return { handleRun, loading };
 };
 
+export function shouldAutosaveCanvas({
+  chatDrawerVisible,
+  agentId,
+  agentLoaded,
+  nodeCount,
+  edgeCount,
+}: {
+  chatDrawerVisible: boolean;
+  agentId?: string;
+  agentLoaded: boolean;
+  nodeCount: number;
+  edgeCount: number;
+}): boolean {
+  if (chatDrawerVisible) {
+    return false;
+  }
+  if (!agentId || !agentLoaded) {
+    return false;
+  }
+  // An empty store is the Zustand default and also the fallback when DSL has
+  // not been applied yet. Autosaving it would PUT components:{} over a real
+  // pipeline (#18771). Explicit Save still persists an empty canvas.
+  if (nodeCount === 0 && edgeCount === 0) {
+    return false;
+  }
+  return true;
+}
+
 export const useWatchAgentChange = (chatDrawerVisible: boolean) => {
   const [time, setTime] = useState<string>();
+  const { id } = useParams();
   const nodes = useGraphStore((state) => state.nodes);
   const edges = useGraphStore((state) => state.edges);
   const { saveGraph } = useSaveGraph(false, true);
@@ -87,11 +120,30 @@ export const useWatchAgentChange = (chatDrawerVisible: boolean) => {
   }, [flowDetail, setSaveTime]);
 
   const saveAgent = useCallback(async () => {
-    if (!chatDrawerVisible) {
-      const ret = await saveGraph();
-      setSaveTime(ret.data.update_time ?? Date.now());
+    if (
+      !shouldAutosaveCanvas({
+        chatDrawerVisible,
+        agentId: id,
+        agentLoaded: Boolean(flowDetail?.id),
+        nodeCount: nodes.length,
+        edgeCount: edges.length,
+      })
+    ) {
+      return;
     }
-  }, [chatDrawerVisible, saveGraph, setSaveTime]);
+    const ret = await saveGraph();
+    if (ret?.data?.update_time) {
+      setSaveTime(ret.data.update_time);
+    }
+  }, [
+    chatDrawerVisible,
+    edges.length,
+    flowDetail?.id,
+    id,
+    nodes.length,
+    saveGraph,
+    setSaveTime,
+  ]);
 
   useDebounceEffect(
     () => {


### PR DESCRIPTION
Canvas autosave in `useWatchAgentChange` fired `saveGraph()` 20s after any `nodes`/`edges` change, including a transition to `[]`. The Zustand store starts empty and `setGraphInfo` defaults missing DSL to empty arrays, so a remount or backend restart with the editor tab left open could PUT `components: {}` / `graph: { nodes: [], edges: [] }` over a working pipeline.

That matches the wiped Data Pipeline in #18771.

**Fix**

- Autosave only when the agent id is present, agent detail has loaded, the chat drawer is closed, and the canvas has at least one node or edge.
- `useSaveGraph` no longer PUTs without an id.
- `useFetchDataOnMount` does not apply `dslToGraph` until `data.dsl` exists, so a `{}` fetch snapshot cannot clear a loaded canvas.
- Explicit Save still persists an empty canvas if the user actually cleared it.

**Verification**

- `shouldAutosaveCanvas` cases: skip empty store, skip unloaded agent, skip chat drawer, still save a graph with nodes and no edges.
- `useFetchDataOnMount`: no `setGraphInfo` without `dsl`; applies fetched graph; later `data: {}` does not clear the store.
- Full `web` Jest was not run in this environment (no frontend node_modules). The new tests are `web/src/pages/agent/hooks/use-save-graph.test.ts` and `use-fetch-data.test.ts`.

Fixes #18771