### PR TITLE
fix(wiki): stamp retrieval fields so compiled pages are searchable

### DIFF
--- a/rag/advanced_rag/knowlege_compile/wiki_incremental.py
+++ b/rag/advanced_rag/knowlege_compile/wiki_incremental.py
@@ -503,7 +503,10 @@ def _build_canonical_entity_doc(
     source_chunk_ids: list[str] | None = None,
 ) -> dict:
     """Build a canonical entity row for insert or update."""
+    from rag.nlp import rag_tokenizer
+
     dim = len(embedding) if embedding else 768
+    content_ltks = rag_tokenizer.tokenize(entity_name) if entity_name else ""
     doc = {
         "id": _stable_row_id(WIKI_CANONICAL_ENTITY_COMPILE_KWD, kb_id, entity_name),
         "entity_kwd": entity_name,
@@ -517,6 +520,8 @@ def _build_canonical_entity_doc(
         "doc_id": kb_id,  # KB-scoped sentinel; real provenance is source_doc_ids
         "available_int": 1,
         "content_with_weight": entity_name,
+        "content_ltks": content_ltks,
+        "content_sm_ltks": rag_tokenizer.fine_grained_tokenize(content_ltks) if content_ltks else "",
     }
     if embedding is not None:
         vec_col = f"q_{dim}_vec"

--- a/rag/advanced_rag/knowlege_compile/wiki_incremental.py
+++ b/rag/advanced_rag/knowlege_compile/wiki_incremental.py
@@ -514,6 +514,9 @@ def _build_canonical_entity_doc(
         "mention_count_int": claim_count,
         "compile_kwd": WIKI_CANONICAL_ENTITY_COMPILE_KWD,
         "kb_id": kb_id,
+        "doc_id": kb_id,  # KB-scoped sentinel; real provenance is source_doc_ids
+        "available_int": 1,
+        "content_with_weight": entity_name,
     }
     if embedding is not None:
         vec_col = f"q_{dim}_vec"
@@ -2243,9 +2246,12 @@ async def _wiki_refine_page(
 
     page = {
         "id": _stable_row_id(WIKI_PAGE_COMPILE_KWD, kb_id, page_id),
+        "kb_id": kb_id,
+        "doc_id": kb_id,  # KB-scoped sentinel; real provenance is source_doc_ids
         "slug_kwd": page_id,
         "title_kwd": title,
         "md_with_weight": content,
+        "content_with_weight": content,
         "summary_with_weight": summary or title,
         "entity_names_kwd": sorted(set(entity_names or [page_title])),
         "source_chunk_ids": sorted(source_chunk_ids),
@@ -2260,6 +2266,7 @@ async def _wiki_refine_page(
         "title_tks": rag_tokenizer.tokenize(title),
         "content_ltks": content_ltks,
         "content_sm_ltks": rag_tokenizer.fine_grained_tokenize(content_ltks),
+        "available_int": 1,
     }
     # Insert vector (adds q_{dim}_vec field)
     vec_col = f"q_{vec_dim}_vec"
@@ -3429,6 +3436,13 @@ async def _wiki_finalize(
         outlinks = outlink_map.get(pid) or []
         update["outlinks_kwd"] = list(outlinks)
         update["outlinks_int"] = len(outlinks)
+        # Backfill retrieval fields on every FINALIZE so pages written before
+        # available_int/doc_id were stamped become visible to RAG on re-run.
+        update["available_int"] = 1
+        update["doc_id"] = kb_id
+        body = rendered_content or original or page.get("md_with_weight") or ""
+        if body:
+            update["content_with_weight"] = body
 
         await thread_pool_exec(
             settings.docStoreConn.update,

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -57,16 +57,22 @@ def _chunk_scalar(value) -> str:
 def is_kb_scoped_chunk(chunk: dict | None) -> bool:
     """True for compilation/graph rows keyed to the KB, not a source document.
 
-    Wiki persist stamps ``doc_id = kb_id`` (or omits ``doc_id``). Those rows
-    must not be treated as leftover chunks from a deleted ``document`` row.
+    Wiki persist stamps ``doc_id = kb_id``. Those rows must not be treated as
+    leftover chunks from a deleted ``document`` row. A missing ``doc_id`` is
+    not enough on its own: only an explicit compilation marker (``compile_kwd``)
+    or the KB-id sentinel bypasses deleted-document pruning. Otherwise stale
+    ordinary chunks without ``doc_id`` would stay retrievable after their
+    source document is deleted.
     """
     if not isinstance(chunk, dict):
         return False
     doc_id = _chunk_scalar(chunk.get("doc_id"))
-    if not doc_id:
-        return True
     kb_id = _chunk_scalar(chunk.get("kb_id"))
-    return bool(kb_id) and doc_id == kb_id
+    if kb_id and doc_id == kb_id:
+        return True
+    if doc_id:
+        return False
+    return bool(_chunk_scalar(chunk.get("compile_kwd")))
 
 
 class Dealer:
@@ -165,17 +171,20 @@ class Dealer:
             )
 
         chunk_doc_ids = []
+        unscoped_missing_doc_id = False
         for chunk in fields.values():
             if not chunk or is_kb_scoped_chunk(chunk):
                 continue
             doc_id = _chunk_scalar(chunk.get("doc_id"))
             if doc_id:
                 chunk_doc_ids.append(doc_id)
-        if not chunk_doc_ids:
+            else:
+                unscoped_missing_doc_id = True
+        if not chunk_doc_ids and not unscoped_missing_doc_id:
             return sres
 
-        existing_doc_ids = await self._existing_doc_ids(chunk_doc_ids)
-        if len(existing_doc_ids) == len(set(chunk_doc_ids)):
+        existing_doc_ids = await self._existing_doc_ids(chunk_doc_ids) if chunk_doc_ids else set()
+        if chunk_doc_ids and not unscoped_missing_doc_id and len(existing_doc_ids) == len(set(chunk_doc_ids)):
             return sres
 
         filtered_ids = []

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -47,6 +47,28 @@ def index_name(uid):
     return f"ragflow_{uid}"
 
 
+def _chunk_scalar(value) -> str:
+    """Normalize a doc-store scalar that Infinity may return as a one-item list."""
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else ""
+    return str(value or "").strip()
+
+
+def is_kb_scoped_chunk(chunk: dict | None) -> bool:
+    """True for compilation/graph rows keyed to the KB, not a source document.
+
+    Wiki persist stamps ``doc_id = kb_id`` (or omits ``doc_id``). Those rows
+    must not be treated as leftover chunks from a deleted ``document`` row.
+    """
+    if not isinstance(chunk, dict):
+        return False
+    doc_id = _chunk_scalar(chunk.get("doc_id"))
+    if not doc_id:
+        return True
+    kb_id = _chunk_scalar(chunk.get("kb_id"))
+    return bool(kb_id) and doc_id == kb_id
+
+
 class Dealer:
     # Short-lived cache of "doc_id exists in MySQL" used by _prune_deleted_chunks.
     # Every retrieval would otherwise hit MySQL per query (fan-out searches and the
@@ -124,7 +146,14 @@ class Dealer:
         # is removed but the vector record is not fully cleaned up. We filter those
         # chunks here so chat/retrieval does not surface content from deleted docs.
         # Keep this as a fallback, not as the primary delete mechanism.
-        chunk_doc_ids = [chunk.get("doc_id") for chunk in sres.field.values() if chunk and chunk.get("doc_id")]
+        fields = sres.field or {}
+        chunk_doc_ids = []
+        for chunk in fields.values():
+            if not chunk or is_kb_scoped_chunk(chunk):
+                continue
+            doc_id = _chunk_scalar(chunk.get("doc_id"))
+            if doc_id:
+                chunk_doc_ids.append(doc_id)
         if not chunk_doc_ids:
             return sres
 
@@ -138,8 +167,17 @@ class Dealer:
         removed = 0
 
         for chunk_id in sres.ids:
-            chunk = sres.field.get(chunk_id)
-            if not chunk or chunk.get("doc_id") not in existing_doc_ids:
+            chunk = fields.get(chunk_id)
+            if not chunk:
+                removed += 1
+                continue
+            if is_kb_scoped_chunk(chunk):
+                filtered_ids.append(chunk_id)
+                filtered_field[chunk_id] = chunk
+                if sres.highlight and chunk_id in sres.highlight:
+                    filtered_highlight[chunk_id] = sres.highlight[chunk_id]
+                continue
+            if _chunk_scalar(chunk.get("doc_id")) not in existing_doc_ids:
                 removed += 1
                 continue
 

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -147,6 +147,23 @@ class Dealer:
         # chunks here so chat/retrieval does not surface content from deleted docs.
         # Keep this as a fallback, not as the primary delete mechanism.
         fields = sres.field or {}
+        aligned_ids = [chunk_id for chunk_id in sres.ids if fields.get(chunk_id)]
+        if len(aligned_ids) != len(sres.ids):
+            fields = {chunk_id: fields[chunk_id] for chunk_id in aligned_ids}
+            highlight = sres.highlight
+            if highlight:
+                highlight = {chunk_id: highlight[chunk_id] for chunk_id in aligned_ids if chunk_id in highlight}
+            sres = self.SearchResult(
+                total=len(aligned_ids),
+                ids=aligned_ids,
+                query_vector=sres.query_vector,
+                field=fields,
+                highlight=highlight,
+                aggregation=sres.aggregation,
+                keywords=sres.keywords,
+                group_docs=sres.group_docs,
+            )
+
         chunk_doc_ids = []
         for chunk in fields.values():
             if not chunk or is_kb_scoped_chunk(chunk):

--- a/test/unit_test/rag/advanced_rag/knowlege_compile/test_wiki_incremental.py
+++ b/test/unit_test/rag/advanced_rag/knowlege_compile/test_wiki_incremental.py
@@ -2084,21 +2084,27 @@ async def test_reduce_entity_deletes_page_when_last_chunk_is_removed():
 
 
 def test_canonical_entity_doc_stamps_retrieval_fields():
-    doc = _wiki._build_canonical_entity_doc(
-        tenant_id="t1",
-        kb_id="kb1",
-        entity_name="Apple",
-        entity_type="org",
-        aliases=["Apple Inc."],
-        source_doc_ids=["doc_1"],
-        claim_count=2,
-        embedding=[0.1, 0.2],
-    )
+    tokenizer = MagicMock()
+    tokenizer.tokenize.side_effect = lambda text: text
+    tokenizer.fine_grained_tokenize.side_effect = lambda text: text
+    with patch("rag.nlp.rag_tokenizer", tokenizer, create=True):
+        doc = _wiki._build_canonical_entity_doc(
+            tenant_id="t1",
+            kb_id="kb1",
+            entity_name="Apple",
+            entity_type="org",
+            aliases=["Apple Inc."],
+            source_doc_ids=["doc_1"],
+            claim_count=2,
+            embedding=[0.1, 0.2],
+        )
 
     assert doc["available_int"] == 1
     assert doc["doc_id"] == "kb1"
     assert doc["kb_id"] == "kb1"
     assert doc["content_with_weight"] == "Apple"
+    assert doc["content_ltks"] == "Apple"
+    assert doc["content_sm_ltks"] == "Apple"
     assert doc["q_2_vec"] == [0.1, 0.2]
 
 

--- a/test/unit_test/rag/advanced_rag/knowlege_compile/test_wiki_incremental.py
+++ b/test/unit_test/rag/advanced_rag/knowlege_compile/test_wiki_incremental.py
@@ -1117,6 +1117,9 @@ async def test_finalize_writes_outlinks():
             # the old-mode writer) which Infinity stores/reads back correctly.
             assert upd["outlinks_kwd"] == ["concept/B"], f"Got {upd['outlinks_kwd']}"
             assert upd["outlinks_int"] == 1
+            assert upd["available_int"] == 1
+            assert upd["doc_id"] == "kb1"
+            assert upd["content_with_weight"]
             break
     else:
         pytest.fail("No update for concept/A found")
@@ -1545,6 +1548,11 @@ def test_refine_page_persists_source_doc_ids_as_array():
     inserted_page = doc_store.insert.call_args.args[0][0]
     assert inserted_page["source_doc_ids"] == ["doc_1", "doc_2"]
     assert inserted_page["topic_kwd"] == "Technology companies"
+    assert inserted_page["available_int"] == 1
+    assert inserted_page["doc_id"] == "kb1"
+    assert inserted_page["kb_id"] == "kb1"
+    assert inserted_page["content_with_weight"] == inserted_page["md_with_weight"]
+    assert inserted_page["content_with_weight"]
 
 
 def test_topics_for_docs_only_returns_source_scoped_candidates():
@@ -2073,6 +2081,25 @@ async def test_reduce_entity_deletes_page_when_last_chunk_is_removed():
     assert delta["action"] == "delete"
     assert delta["source_chunk_ids"] == []
     assert [claim["statement"] for claim in delta["retractions"]] == ["only claim"]
+
+
+def test_canonical_entity_doc_stamps_retrieval_fields():
+    doc = _wiki._build_canonical_entity_doc(
+        tenant_id="t1",
+        kb_id="kb1",
+        entity_name="Apple",
+        entity_type="org",
+        aliases=["Apple Inc."],
+        source_doc_ids=["doc_1"],
+        claim_count=2,
+        embedding=[0.1, 0.2],
+    )
+
+    assert doc["available_int"] == 1
+    assert doc["doc_id"] == "kb1"
+    assert doc["kb_id"] == "kb1"
+    assert doc["content_with_weight"] == "Apple"
+    assert doc["q_2_vec"] == [0.1, 0.2]
 
 
 def test_as_int_accepts_string_doc_store_values():

--- a/test/unit_test/rag/nlp/test_prune_deleted_chunks.py
+++ b/test/unit_test/rag/nlp/test_prune_deleted_chunks.py
@@ -1,0 +1,110 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""KB-scoped wiki/compilation rows must survive deleted-document pruning."""
+
+import asyncio
+import sys
+import types
+
+# Stub the heavy / circular-importing dependencies before importing search,
+# mirroring test_search_pagination.py so the module imports in isolation.
+_fake_query = types.ModuleType("rag.nlp.query")
+
+
+class _DummyFulltextQueryer:
+    pass
+
+
+_fake_query.FulltextQueryer = _DummyFulltextQueryer
+_fake_tokenizer = types.ModuleType("rag.nlp.rag_tokenizer")
+sys.modules.setdefault("rag.nlp.query", _fake_query)
+sys.modules.setdefault("rag.nlp.rag_tokenizer", _fake_tokenizer)
+sys.modules.setdefault("common.settings", types.ModuleType("common.settings"))
+
+from rag.nlp.search import Dealer, is_kb_scoped_chunk  # noqa: E402
+
+
+def test_is_kb_scoped_chunk_missing_or_empty_doc_id():
+    assert is_kb_scoped_chunk({"kb_id": "kb1"}) is True
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": ""}) is True
+
+
+def test_is_kb_scoped_chunk_sentinel_matches_kb():
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": "kb1"}) is True
+    assert is_kb_scoped_chunk({"kb_id": ["kb1"], "doc_id": ["kb1"]}) is True
+
+
+def test_is_kb_scoped_chunk_real_document():
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": "doc1"}) is False
+    assert is_kb_scoped_chunk(None) is False
+
+
+def _result(ids, field):
+    return Dealer.SearchResult(total=len(ids), ids=list(ids), field=field)
+
+
+def test_prune_keeps_wiki_pages_when_mixed_with_source_chunks():
+    dealer = Dealer(dataStore=None)
+
+    async def existing(doc_ids):
+        return {d for d in doc_ids if d == "doc-live"}
+
+    dealer._existing_doc_ids = existing
+    sres = _result(
+        ["src-live", "src-dead", "wiki-page"],
+        {
+            "src-live": {"doc_id": "doc-live", "kb_id": "kb1"},
+            "src-dead": {"doc_id": "doc-gone", "kb_id": "kb1"},
+            "wiki-page": {"doc_id": "kb1", "kb_id": "kb1", "compile_kwd": "wiki_page"},
+        },
+    )
+    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    assert out.ids == ["src-live", "wiki-page"]
+    assert "src-dead" not in out.field
+    assert "wiki-page" in out.field
+
+
+def test_prune_keeps_wiki_pages_that_omit_doc_id():
+    dealer = Dealer(dataStore=None)
+
+    async def existing(doc_ids):
+        return {d for d in doc_ids if d == "doc-live"}
+
+    dealer._existing_doc_ids = existing
+    sres = _result(
+        ["src-live", "wiki-page"],
+        {
+            "src-live": {"doc_id": "doc-live", "kb_id": "kb1"},
+            "wiki-page": {"kb_id": "kb1", "compile_kwd": "wiki_page"},
+        },
+    )
+    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    assert out.ids == ["src-live", "wiki-page"]
+
+
+def test_prune_skips_lookup_when_all_hits_are_kb_scoped():
+    dealer = Dealer(dataStore=None)
+    called = []
+
+    async def existing(doc_ids):
+        called.append(list(doc_ids))
+        return set()
+
+    dealer._existing_doc_ids = existing
+    sres = _result(["wiki"], {"wiki": {"doc_id": "kb1", "kb_id": "kb1"}})
+    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    assert out.ids == ["wiki"]
+    assert called == []

--- a/test/unit_test/rag/test_prune_deleted_chunks.py
+++ b/test/unit_test/rag/test_prune_deleted_chunks.py
@@ -16,25 +16,65 @@
 """KB-scoped wiki/compilation rows must survive deleted-document pruning."""
 
 import asyncio
+import importlib.util
 import sys
 import types
+from pathlib import Path
 
-# Stub the heavy / circular-importing dependencies before importing search,
-# mirroring test_search_pagination.py so the module imports in isolation.
-_fake_query = types.ModuleType("rag.nlp.query")
-
-
-class _DummyFulltextQueryer:
-    pass
+_ROOT = Path(__file__).parents[3]
 
 
-_fake_query.FulltextQueryer = _DummyFulltextQueryer
-_fake_tokenizer = types.ModuleType("rag.nlp.rag_tokenizer")
-sys.modules.setdefault("rag.nlp.query", _fake_query)
-sys.modules.setdefault("rag.nlp.rag_tokenizer", _fake_tokenizer)
-sys.modules.setdefault("common.settings", types.ModuleType("common.settings"))
+def _load_search():
+    fake_rag_nlp = types.ModuleType("rag.nlp")
+    fake_rag_nlp.__path__ = []
 
-from rag.nlp.search import Dealer, is_kb_scoped_chunk  # noqa: E402
+    fake_tokenizer = types.ModuleType("rag.nlp.rag_tokenizer")
+    fake_rag_nlp.rag_tokenizer = fake_tokenizer
+
+    fake_query = types.ModuleType("rag.nlp.query")
+
+    class _DummyFulltextQueryer:
+        pass
+
+    fake_query.FulltextQueryer = _DummyFulltextQueryer
+    fake_rag_nlp.query = fake_query
+    fake_settings = types.ModuleType("common.settings")
+
+    stub_names = ("rag.nlp", "rag.nlp.rag_tokenizer", "rag.nlp.query", "common.settings")
+    saved = {name: sys.modules.get(name) for name in stub_names}
+    sys.modules["rag.nlp"] = fake_rag_nlp
+    sys.modules["rag.nlp.rag_tokenizer"] = fake_tokenizer
+    sys.modules["rag.nlp.query"] = fake_query
+    sys.modules["common.settings"] = fake_settings
+
+    import common
+
+    saved_common_settings = getattr(common, "settings", None)
+    common.settings = fake_settings
+
+    spec = importlib.util.spec_from_file_location("rag.nlp.search_prune_test", _ROOT / "rag" / "nlp" / "search.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["rag.nlp.search_prune_test"] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if saved_common_settings is None:
+            if getattr(common, "settings", None) is fake_settings:
+                delattr(common, "settings")
+        else:
+            common.settings = saved_common_settings
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module
+
+
+_search = _load_search()
+Dealer = _search.Dealer
+is_kb_scoped_chunk = _search.is_kb_scoped_chunk
 
 
 def test_is_kb_scoped_chunk_missing_or_empty_doc_id():

--- a/test/unit_test/rag/test_prune_deleted_chunks.py
+++ b/test/unit_test/rag/test_prune_deleted_chunks.py
@@ -148,3 +148,19 @@ def test_prune_skips_lookup_when_all_hits_are_kb_scoped():
     out = asyncio.run(dealer._prune_deleted_chunks(sres))
     assert out.ids == ["wiki"]
     assert called == []
+
+
+def test_prune_drops_ids_missing_from_fields_when_all_hits_are_kb_scoped():
+    dealer = Dealer(dataStore=None)
+    called = []
+
+    async def existing(doc_ids):
+        called.append(list(doc_ids))
+        return set()
+
+    dealer._existing_doc_ids = existing
+    sres = _result(["wiki", "ghost"], {"wiki": {"doc_id": "kb1", "kb_id": "kb1"}})
+    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    assert out.ids == ["wiki"]
+    assert "ghost" not in out.field
+    assert called == []

--- a/test/unit_test/rag/test_prune_deleted_chunks.py
+++ b/test/unit_test/rag/test_prune_deleted_chunks.py
@@ -78,17 +78,24 @@ is_kb_scoped_chunk = _search.is_kb_scoped_chunk
 
 
 def test_is_kb_scoped_chunk_missing_or_empty_doc_id():
-    assert is_kb_scoped_chunk({"kb_id": "kb1"}) is True
-    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": ""}) is True
+    assert is_kb_scoped_chunk({"kb_id": "kb1"}) is False
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": ""}) is False
+
+
+def test_is_kb_scoped_chunk_compilation_row_without_doc_id():
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "compile_kwd": "wiki_page"}) is True
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": "", "compile_kwd": ["wiki_canonical_entity"]}) is True
 
 
 def test_is_kb_scoped_chunk_sentinel_matches_kb():
     assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": "kb1"}) is True
     assert is_kb_scoped_chunk({"kb_id": ["kb1"], "doc_id": ["kb1"]}) is True
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": "kb1", "compile_kwd": "wiki_page"}) is True
 
 
 def test_is_kb_scoped_chunk_real_document():
     assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": "doc1"}) is False
+    assert is_kb_scoped_chunk({"kb_id": "kb1", "doc_id": "doc1", "compile_kwd": "wiki_doc_page_source"}) is False
     assert is_kb_scoped_chunk(None) is False
 
 
@@ -133,6 +140,67 @@ def test_prune_keeps_wiki_pages_that_omit_doc_id():
     )
     out = asyncio.run(dealer._prune_deleted_chunks(sres))
     assert out.ids == ["src-live", "wiki-page"]
+
+
+def test_prune_drops_ordinary_chunks_that_omit_doc_id():
+    dealer = Dealer(dataStore=None)
+    called = []
+
+    async def existing(doc_ids):
+        called.append(list(doc_ids))
+        return {d for d in doc_ids if d == "doc-live"}
+
+    dealer._existing_doc_ids = existing
+    sres = _result(
+        ["src-live", "src-orphan", "wiki-page"],
+        {
+            "src-live": {"doc_id": "doc-live", "kb_id": "kb1"},
+            "src-orphan": {"kb_id": "kb1"},
+            "wiki-page": {"kb_id": "kb1", "compile_kwd": "wiki_page"},
+        },
+    )
+    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    assert out.ids == ["src-live", "wiki-page"]
+    assert "src-orphan" not in out.field
+    assert called == [["doc-live"]]
+
+
+def test_prune_drops_orphan_chunks_when_every_hit_omits_doc_id():
+    dealer = Dealer(dataStore=None)
+    called = []
+
+    async def existing(doc_ids):
+        called.append(list(doc_ids))
+        return set()
+
+    dealer._existing_doc_ids = existing
+    sres = _result(
+        ["src-orphan", "wiki-page"],
+        {
+            "src-orphan": {"kb_id": "kb1", "doc_id": ""},
+            "wiki-page": {"kb_id": "kb1", "compile_kwd": "wiki_page"},
+        },
+    )
+    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    assert out.ids == ["wiki-page"]
+    assert "src-orphan" not in out.field
+    assert called == []
+
+
+def test_prune_drops_all_ordinary_chunks_without_doc_id():
+    dealer = Dealer(dataStore=None)
+    called = []
+
+    async def existing(doc_ids):
+        called.append(list(doc_ids))
+        return set()
+
+    dealer._existing_doc_ids = existing
+    sres = _result(["src-orphan"], {"src-orphan": {"kb_id": "kb1"}})
+    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    assert out.ids == []
+    assert out.field == {}
+    assert called == []
 
 
 def test_prune_skips_lookup_when_all_hits_are_kb_scoped():

--- a/test/unit_test/rag/test_prune_deleted_chunks.py
+++ b/test/unit_test/rag/test_prune_deleted_chunks.py
@@ -15,11 +15,12 @@
 #
 """KB-scoped wiki/compilation rows must survive deleted-document pruning."""
 
-import asyncio
 import importlib.util
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 _ROOT = Path(__file__).parents[3]
 
@@ -103,7 +104,8 @@ def _result(ids, field):
     return Dealer.SearchResult(total=len(ids), ids=list(ids), field=field)
 
 
-def test_prune_keeps_wiki_pages_when_mixed_with_source_chunks():
+@pytest.mark.asyncio
+async def test_prune_keeps_wiki_pages_when_mixed_with_source_chunks():
     dealer = Dealer(dataStore=None)
 
     async def existing(doc_ids):
@@ -118,13 +120,14 @@ def test_prune_keeps_wiki_pages_when_mixed_with_source_chunks():
             "wiki-page": {"doc_id": "kb1", "kb_id": "kb1", "compile_kwd": "wiki_page"},
         },
     )
-    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    out = await dealer._prune_deleted_chunks(sres)
     assert out.ids == ["src-live", "wiki-page"]
     assert "src-dead" not in out.field
     assert "wiki-page" in out.field
 
 
-def test_prune_keeps_wiki_pages_that_omit_doc_id():
+@pytest.mark.asyncio
+async def test_prune_keeps_wiki_pages_that_omit_doc_id():
     dealer = Dealer(dataStore=None)
 
     async def existing(doc_ids):
@@ -138,11 +141,12 @@ def test_prune_keeps_wiki_pages_that_omit_doc_id():
             "wiki-page": {"kb_id": "kb1", "compile_kwd": "wiki_page"},
         },
     )
-    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    out = await dealer._prune_deleted_chunks(sres)
     assert out.ids == ["src-live", "wiki-page"]
 
 
-def test_prune_drops_ordinary_chunks_that_omit_doc_id():
+@pytest.mark.asyncio
+async def test_prune_drops_ordinary_chunks_that_omit_doc_id():
     dealer = Dealer(dataStore=None)
     called = []
 
@@ -159,13 +163,14 @@ def test_prune_drops_ordinary_chunks_that_omit_doc_id():
             "wiki-page": {"kb_id": "kb1", "compile_kwd": "wiki_page"},
         },
     )
-    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    out = await dealer._prune_deleted_chunks(sres)
     assert out.ids == ["src-live", "wiki-page"]
     assert "src-orphan" not in out.field
     assert called == [["doc-live"]]
 
 
-def test_prune_drops_orphan_chunks_when_every_hit_omits_doc_id():
+@pytest.mark.asyncio
+async def test_prune_drops_orphan_chunks_when_every_hit_omits_doc_id():
     dealer = Dealer(dataStore=None)
     called = []
 
@@ -181,13 +186,14 @@ def test_prune_drops_orphan_chunks_when_every_hit_omits_doc_id():
             "wiki-page": {"kb_id": "kb1", "compile_kwd": "wiki_page"},
         },
     )
-    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    out = await dealer._prune_deleted_chunks(sres)
     assert out.ids == ["wiki-page"]
     assert "src-orphan" not in out.field
     assert called == []
 
 
-def test_prune_drops_all_ordinary_chunks_without_doc_id():
+@pytest.mark.asyncio
+async def test_prune_drops_all_ordinary_chunks_without_doc_id():
     dealer = Dealer(dataStore=None)
     called = []
 
@@ -197,13 +203,14 @@ def test_prune_drops_all_ordinary_chunks_without_doc_id():
 
     dealer._existing_doc_ids = existing
     sres = _result(["src-orphan"], {"src-orphan": {"kb_id": "kb1"}})
-    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    out = await dealer._prune_deleted_chunks(sres)
     assert out.ids == []
     assert out.field == {}
     assert called == []
 
 
-def test_prune_skips_lookup_when_all_hits_are_kb_scoped():
+@pytest.mark.asyncio
+async def test_prune_skips_lookup_when_all_hits_are_kb_scoped():
     dealer = Dealer(dataStore=None)
     called = []
 
@@ -213,12 +220,13 @@ def test_prune_skips_lookup_when_all_hits_are_kb_scoped():
 
     dealer._existing_doc_ids = existing
     sres = _result(["wiki"], {"wiki": {"doc_id": "kb1", "kb_id": "kb1"}})
-    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    out = await dealer._prune_deleted_chunks(sres)
     assert out.ids == ["wiki"]
     assert called == []
 
 
-def test_prune_drops_ids_missing_from_fields_when_all_hits_are_kb_scoped():
+@pytest.mark.asyncio
+async def test_prune_drops_ids_missing_from_fields_when_all_hits_are_kb_scoped():
     dealer = Dealer(dataStore=None)
     called = []
 
@@ -228,7 +236,7 @@ def test_prune_drops_ids_missing_from_fields_when_all_hits_are_kb_scoped():
 
     dealer._existing_doc_ids = existing
     sres = _result(["wiki", "ghost"], {"wiki": {"doc_id": "kb1", "kb_id": "kb1"}})
-    out = asyncio.run(dealer._prune_deleted_chunks(sres))
+    out = await dealer._prune_deleted_chunks(sres)
     assert out.ids == ["wiki"]
     assert "ghost" not in out.field
     assert called == []


### PR DESCRIPTION
Knowledge Compilation wiki pages are browsable in Artifacts but never come back as RAG context. Production persist (`wiki_incremental`) wrote `wiki_page` / `wiki_canonical_entity` without `available_int`, `doc_id`, or `content_with_weight`. `retriever.retrieval()` always filters `available_int=1`, and `_prune_deleted_chunks` dropped any hit whose `doc_id` was missing or was the KB-id sentinel as soon as source-document chunks were also in the result set.

`include_knowledge_compilation` only toggles `must_not: {exists: compile_kwd}`; it cannot bypass those gates. Graph rows (`wiki_entity` / `wiki_relation`) already stamped the fields, which is why they appeared in the index while pages did not.

**Fix**

- Incremental wiki page persist and canonical-entity persist stamp `available_int=1`, `doc_id=<kb_id>`, and `content_with_weight` (same sentinel as `persist_wiki_pages`).
- FINALIZE backfills those fields on re-run so existing pages become retrievable without a full rewrite.
- `_prune_deleted_chunks` keeps KB-scoped rows (`doc_id` missing or `doc_id == kb_id`) and still drops stale source chunks whose parent document is gone.

**Verification**

- `test_prune_deleted_chunks.py`: keep wiki pages mixed with live/deleted source chunks; keep pages that omit `doc_id`; skip DocumentService lookup when every hit is KB-scoped.
- `test_wiki_incremental.py`: refine persist and canonical-entity builder stamp retrieval fields; FINALIZE writes `available_int` / `doc_id` / `content_with_weight`.
- 75 passed in `infiniflow/ragflow:v0.27.0` (`test_wiki_incremental.py` + `test_prune_deleted_chunks.py`).

Fixes #18779