### PR TITLE
fix: accept empty ASR verification results

### DIFF
--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -1332,7 +1332,7 @@ func verifyASRModel(ctx context.Context, driver modelModule.ModelDriver, modelNa
 	if err != nil {
 		return err
 	}
-	if resp == nil || resp.Text == "" {
+	if resp == nil {
 		return fmt.Errorf("ASR model %s returned no transcription", modelName)
 	}
 	return nil


### PR DESCRIPTION
### What problem does this PR solve?

ASR model verification incorrectly failed when a valid ASR response contained empty text, which is expected for silent audio.

The verification now only checks whether the ASR request returns an error, allowing valid empty transcriptions to pass.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)