### PR TITLE
fix(pdf): do not cross-page merge tables whose anchor is not at page bottom

### DIFF
--- a/internal/deepdoc/parser/pdf/table/table_merge.go
+++ b/internal/deepdoc/parser/pdf/table/table_merge.go
@@ -117,9 +117,26 @@ func MergeTablesAcrossPages(tables []pdf.TableItem, medianHeights, pageHeights m
 				if anchorPageH, ok := pageHeights[anchorPg]; ok && anchorPageH > 0 {
 					yDis += anchorPageH
 				}
-			}
-			if yDis > mh*23 {
-				continue
+				if yDis > mh*23 {
+					continue
+				}
+			} else {
+				// A NEGATIVE page-local yDis means the continuation sits at the
+				// TOP of the next page (in page-local coordinates it is "above"
+				// the anchor). A genuine cross-page split is cut off at the page
+				// boundary, so its anchor must END NEAR THE BOTTOM of its page.
+				// Two independent tables that merely both start near the top of
+				// consecutive pages (e.g. ZoomNeXt's R3→R5) also produce a
+				// negative yDis but their anchor ends high on its page — merging
+				// them wrongly collapses the second table into the first and
+				// silently drops it. Reject the merge unless the anchor bottom is
+				// within mh*23 of the page bottom (the same proximity used for
+				// the Y gate), so only real page-boundary continuations merge.
+				if anchorPageH, ok := pageHeights[anchorPg]; ok && anchorPageH > 0 {
+					if maxBottomOnPage(anchor.Positions, anchorPg) < anchorPageH-mh*23 {
+						continue
+					}
+				}
 			}
 			// Merge: combine cells and positions.
 			anchor.Cells = append(anchor.Cells, tables[jt.idx].Cells...)
@@ -213,6 +230,31 @@ func MergeTablesAcrossPages(tables []pdf.TableItem, medianHeights, pageHeights m
 		}
 	}
 	return result
+}
+
+// maxBottomOnPage returns the largest Bottom among the table's positions that
+// carry page number pg. Page-local Y resets to 0 at each page top, so a
+// multi-page anchor's positions across different pages are not directly
+// comparable; this isolates the anchor's extent on the specific page it is
+// being tested against for a cross-page continuation.
+func maxBottomOnPage(positions []pdf.Position, pg int) float64 {
+	var mb float64
+	for _, p := range positions {
+		onPage := false
+		for _, pn := range p.PageNumbers {
+			if pn == pg {
+				onPage = true
+				break
+			}
+		}
+		if !onPage {
+			continue
+		}
+		if p.Bottom > mb {
+			mb = p.Bottom
+		}
+	}
+	return mb
 }
 
 // stackGrids concatenates per-page grids (each already built correctly by

--- a/internal/deepdoc/parser/pdf/table/table_merge_top_table_test.go
+++ b/internal/deepdoc/parser/pdf/table/table_merge_top_table_test.go
@@ -1,0 +1,55 @@
+package table
+
+import (
+	"testing"
+
+	pdf "ragflow/internal/deepdoc/parser/pdf/type"
+)
+
+// TestMergeTablesAcrossPages_TopTablesOnConsecutivePagesNotMerged locks the
+// ZoomNeXt regression: Table 3 sits at the TOP of page 11 and Table 5 sits at
+// the TOP of page 12. Both are complete, top-of-page tables whose page-local Y
+// repeats near 0, so the continuation's page-local yDis is NEGATIVE. #18740's
+// "negative yDis ⇒ merge" rule wrongly merges them, which (a) gives Table 3 a
+// false cross-page span (pages 11-12) and (b) drops Table 5 entirely from the
+// output. A genuine cross-page continuation only exists when the ANCHOR table
+// reaches near the BOTTOM of its page; a top-of-page anchor is a complete
+// table, and the next page's top table is a NEW table.
+//
+// Geometry mirrors ZoomNeXt: anchor first box bottom ~81 (near the table top),
+// but the table's true bottom extent ~198; continuation is at the very top of
+// the next page (top 52). Page height 842, median char height 10.
+func TestMergeTablesAcrossPages_TopTablesOnConsecutivePagesNotMerged(t *testing.T) {
+	anchor := pdf.TableItem{
+		Page: 10,
+		Positions: []pdf.Position{
+			{PageNumbers: []int{10}, Left: 226, Right: 457, Top: 61, Bottom: 81},   // first OCR box, near table top
+			{PageNumbers: []int{10}, Left: 117, Right: 473, Top: 189, Bottom: 198}, // true bottom extent of the table
+		},
+		Cells: []pdf.TSRCell{{Text: "No. Model"}},
+	}
+	cont := pdf.TableItem{
+		Page: 11,
+		Positions: []pdf.Position{
+			{PageNumbers: []int{11}, Left: 143, Right: 444, Top: 52, Bottom: 61},
+		},
+		Cells: []pdf.TSRCell{{Text: "Input Scale"}},
+	}
+	pageH := map[int]float64{10: 842, 11: 842}
+	medianH := map[int]float64{10: 10, 11: 10}
+
+	merged := MergeTablesAcrossPages([]pdf.TableItem{anchor, cont}, medianH, pageH)
+	if len(merged) != 2 {
+		t.Fatalf("top-of-page tables on consecutive pages: expected 2 SEPARATE tables (no over-merge), got %d (Table 5 dropped)", len(merged))
+	}
+	// The anchor must NOT have gained page 11.
+	pages := map[int]bool{}
+	for _, p := range merged[0].Positions {
+		for _, pn := range p.PageNumbers {
+			pages[pn] = true
+		}
+	}
+	if pages[11] {
+		t.Errorf("anchor wrongly merged across pages; pages=%v (want only page 10)", pages)
+	}
+}


### PR DESCRIPTION
## Problem

`MergeTablesAcrossPages` (changed by #18740) merges any cross-page continuation whose page-local yDis is negative — i.e. a table starting near the top of the next page. Two *independent* tables that merely both start near the top of consecutive pages also satisfy this. On ZoomNeXt this wrongly merged R3 (page 11, top-of-page) with R5 (page 12, top-of-page): R5's grid was discarded in the degenerate-grid branch, so Go emitted **8 tables instead of 9**, and R3 incorrectly spanned pages 11–12.

## Root cause

A negative page-local yDis is necessary but not sufficient for a genuine cross-page split. A genuine split is cut off at the page boundary, so its anchor must **end near the bottom** of its page. The #18740 change dropped that anchor-position check.

## Fix

Gate the negative-yDis merge on the anchor ending within `mh*23` of the page bottom (the same proximity already used for the Y gate). Genuine continuations (anchor near page bottom) still merge; top-of-page anchors stay separate — which never loses data.

## Verification

- Unit test `TestMergeTablesAcrossPages_TopTablesOnConsecutivePagesNotMerged` reproduces the R3→R5 geometry (anchor top-of-page on page N, continuation top-of-page on page N+1) and asserts two separate tables.
- Live ZoomNeXt dump: **9 tables** (was 8); R3 stays on page 11 only; R5 recovered as an independent table on page 12.
- Pipeline-parity regression (assembly logic on replayed Python intermediates):
  - 35 simple PDFs: aligned=32, failed=0 — **unchanged** vs baseline.
  - real_pdfs (56 PDFs): aligned=9, failed=33 (all 33 are pre-existing dense row/col segmentation gaps) — **unchanged** vs baseline (identical FAIL set).
- Full `pdf` package unit tests pass.

No regression introduced.