### PR TITLE
fix(sdk): filter documents by multiple IDs

### DIFF
--- a/sdk/python/ragflow_sdk/modules/dataset.py
+++ b/sdk/python/ragflow_sdk/modules/dataset.py
@@ -92,10 +92,9 @@ class DataSet(Base):
             "create_time_from": create_time_from,
             "create_time_to": create_time_to,
         }
-        # Handle ids parameter - convert to multiple query params
+        # Handle ids parameter - requests expands list values into multiple query params
         if ids:
-            for doc_id in ids:
-                params.append(("ids", doc_id))
+            params["ids"] = ids
         res = self.get(f"/datasets/{self.id}/documents", params=params)
         res = res.json()
         documents = []

--- a/test/testcases/test_sdk_api/test_file_management_within_dataset/test_list_documents.py
+++ b/test/testcases/test_sdk_api/test_file_management_within_dataset/test_list_documents.py
@@ -200,6 +200,35 @@ class TestDocumentsList:
             if params["id"] not in [None, ""]:
                 assert documents[0].id == params["id"], str(documents)
 
+    @pytest.mark.p1
+    def test_ids(self, add_documents):
+        dataset, fixture_documents = add_documents
+        expected_ids = {document.id for document in fixture_documents[:2]}
+
+        documents = dataset.list_documents(ids=list(expected_ids))
+
+        assert len(documents) == 2, str(documents)
+        assert {document.id for document in documents} == expected_ids, str(documents)
+
+    @pytest.mark.p1
+    def test_empty_ids_is_unfiltered(self, add_documents):
+        dataset, fixture_documents = add_documents
+        expected_ids = {document.id for document in fixture_documents}
+
+        documents = dataset.list_documents(ids=[])
+
+        assert len(documents) == 5, str(documents)
+        assert {document.id for document in documents} == expected_ids, str(documents)
+
+    @pytest.mark.p1
+    def test_id_and_ids_raise_value_error(self, add_documents):
+        dataset, documents = add_documents
+
+        with pytest.raises(ValueError) as exception_info:
+            dataset.list_documents(id=documents[0].id, ids=[documents[1].id])
+
+        assert str(exception_info.value) == "Cannot use both 'id' and 'ids' parameters at the same time."
+
     @pytest.mark.p3
     @pytest.mark.parametrize(
         "document_id, name, expected_num, expected_message",


### PR DESCRIPTION
### Summary

Fix `DataSet.list_documents(ids=[...])` by passing the ID list through the request parameter mapping, which serializes it as repeated `ids` query parameters.

This preserves existing behavior for `ids=[]` as an unfiltered request and for combining `id` with non-empty `ids`, which raises `ValueError`. Add regression coverage for all three cases.

### Testing

- `git diff --check`
- Python syntax compilation for both changed files
- Hermetic request-preparation and fake-transport checks