### PR TITLE
fix(model-provider): resolve instances by persisted ID

### DIFF
--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -857,7 +857,6 @@ func (m *ModelProviderService) ListProviderInstances(ctx context.Context, provid
 
 func (m *ModelProviderService) ShowProviderInstance(ctx context.Context, providerName, instanceIDOrName, userID string) (map[string]interface{}, common.ErrorCode, error) {
 	providerName = strings.TrimSpace(providerName)
-	providerName = strings.ToLower(providerName)
 
 	// Get tenant ID from user
 	tenants, err := m.userTenantDAO.GetByUserIDAndRole(ctx, dao.DB, userID, "owner")


### PR DESCRIPTION
### Summary

Provider settings were saved correctly, but reopening them requested the instance by ID while the running backend could only find it by name. 
The fix makes provider instance reads honor the saved ID, so configurations load correctly after reopening.