### PR TITLE
fix(ingestion): respect Parser page range over dataflow debug page cap

### DIFF
--- a/internal/ingestion/pipeline/parser_page_cap.go
+++ b/internal/ingestion/pipeline/parser_page_cap.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
+
+	"ragflow/internal/utility"
 )
 
 // UnwrapCanvasDSL decodes a raw pipeline DSL and strips the optional canvas
@@ -73,7 +75,11 @@ func parserComponentParams(dsl []byte, parserComponentName string) (string, map[
 //     override-wins merge and only the first capPages pages would parse.
 //
 // A "pages" value that is missing, null, or an empty list means "parse all
-// pages" and does not count as an explicit range — the cap still applies.
+// pages" and does not count as an explicit range — the cap still applies. The
+// all-pages sentinel carried by the shipped templates and the web UI defaults
+// ([[1, 100000]]) means the same, so a single gap-free [1, N] range with
+// N >= allPagesUpperBound does not count as explicit either; only a genuinely
+// narrowed range suppresses the cap.
 //
 // When no Parser component is found or the family is empty, the call is a
 // no-op and parserConfig is returned unchanged. When the cap IS injected, the
@@ -104,9 +110,12 @@ func BuildParserPageCapOverride(
 	}
 	dslFam, _ := parserParams[family].(map[string]any)
 	// Respect an explicit page range already present under cpnID + family.
+	// The same explicitness predicate as the DSL branch below: null/empty
+	// pages and the all-pages sentinel mean "parse all pages", so the cap
+	// remains a fallback for them.
 	if cpnEntry, ok := parserConfig[parserCpnID].(map[string]any); ok {
 		if famEntry, ok := cpnEntry[family].(map[string]any); ok {
-			if _, has := famEntry["pages"]; has {
+			if hasExplicitPages(famEntry["pages"]) {
 				return parserConfig
 			}
 		}
@@ -139,10 +148,27 @@ func BuildParserPageCapOverride(
 	return parserConfig
 }
 
-// hasExplicitPages reports whether a raw "pages" value carries at least one
-// configured range. Missing, null, and empty-list values mean "parse all
-// pages" and do not count as explicit — the cap remains a fallback for them.
+// allPagesUpperBound is the smallest upper bound of a "pages" range treated as
+// the all-pages sentinel. The general template and the web UI's page-range
+// fields default to [[1, 100000]] (template/ingestion_pipeline_general.json,
+// web chunk-method-dialog and agent parser-form), matching Python's
+// MAXIMUM_PAGE_NUMBER, and the parser clamps oversized upper bounds to the
+// document's actual page count — so a gap-free [1, N] with N >=
+// allPagesUpperBound does not actually restrict parsing.
+const allPagesUpperBound = 100000
+
+// hasExplicitPages reports whether a raw "pages" value carries a range that
+// actually restricts parsing. Missing, null, empty-list, and uninterpretable
+// values do not count (the parser degrades malformed values to "parse all
+// pages" at parse time, so the cap is not withheld for them here either), and
+// neither does the all-pages sentinel — a single gap-free [1, N] range with
+// N >= allPagesUpperBound, the shipped template/UI default. The cap remains a
+// fallback for all of them; only a genuinely narrowed range counts as
+// explicit.
 func hasExplicitPages(raw any) bool {
-	list, ok := raw.([]any)
-	return ok && len(list) > 0
+	ranges, err := utility.NormalizePDFPages(raw)
+	if err != nil || len(ranges) == 0 {
+		return false
+	}
+	return !(len(ranges) == 1 && ranges[0][0] == 1 && ranges[0][1] >= allPagesUpperBound)
 }

--- a/internal/ingestion/pipeline/parser_page_cap.go
+++ b/internal/ingestion/pipeline/parser_page_cap.go
@@ -8,7 +8,7 @@ import (
 // UnwrapCanvasDSL decodes a raw pipeline DSL and strips the optional canvas
 // envelope {"dsl": {...}}, returning the inner components-carrying map. A raw
 // (non-enveloped) DSL is returned unchanged. It is the []byte entry point used
-// by helpers that need the inner DSL (ExtractParserCpnID,
+// by helpers that need the inner DSL (parserComponentParams,
 // BuildParserPageCapOverride) so envelope-handling lives in exactly one place.
 func UnwrapCanvasDSL(raw []byte) (map[string]any, error) {
 	var top map[string]any
@@ -24,29 +24,29 @@ func UnwrapCanvasDSL(raw []byte) (map[string]any, error) {
 	return top, nil
 }
 
-// ExtractParserCpnID returns the cpnID of the first component whose
-// component_name equals parserComponentName, or "" when no such component
-// exists or the DSL cannot be read. dsl may be enveloped; it is unwrapped
-// first.
-func ExtractParserCpnID(dsl []byte, parserComponentName string) string {
+// parserComponentParams returns the cpnID and the params map of the first
+// component whose component_name equals parserComponentName, or ("", nil)
+// when no such component exists or the DSL cannot be read. dsl may be
+// enveloped; it is unwrapped first.
+func parserComponentParams(dsl []byte, parserComponentName string) (string, map[string]any) {
 	inner, err := UnwrapCanvasDSL(dsl)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	innerJSON, err := json.Marshal(inner)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	schemas, err := ExtractAllComponentParams(innerJSON)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	for _, s := range schemas {
 		if s.ComponentName == parserComponentName {
-			return s.CpnID
+			return s.CpnID, s.ParamsDefaults
 		}
 	}
-	return ""
+	return "", nil
 }
 
 // BuildParserPageCapOverride returns parserConfig with a page cap injected for
@@ -60,13 +60,29 @@ func ExtractParserCpnID(dsl []byte, parserComponentName string) string {
 // name (callers pass component.ComponentNameParser) — kept as a parameter so
 // the pipeline package does not import component.
 //
+// The cap is a FALLBACK only. It is not injected when an explicit "pages"
+// range is already configured for the family in either of the two places the
+// runtime reads it from:
+//
+//   - parserConfig[cpnID][family]["pages"] — the run-level override map
+//     (production ParserConfig), and
+//   - the Parser component's own DSL params, params[family]["pages"] — where
+//     the canvas page-range field is saved. A canvas dry-run carries an
+//     empty parserConfig, so without this second check the injected cap
+//     would silently replace the user's explicit range through the
+//     override-wins merge and only the first capPages pages would parse.
+//
+// A "pages" value that is missing, null, or an empty list means "parse all
+// pages" and does not count as an explicit range — the cap still applies.
+//
 // When no Parser component is found or the family is empty, the call is a
-// no-op and parserConfig is returned unchanged. An explicit "pages" cap
-// already present under cpnID+family is respected and left untouched — the
-// cap is only a fallback. The injected shape is []any{[]any{1, capPages}}: a
-// JSON-decoded list of 1-indexed inclusive ranges, the exact form the
-// deepdoc/pdf parser's NormalizePDFPages consumes via
-// ParserConfig[cpnID][family]["pages"].
+// no-op and parserConfig is returned unchanged. When the cap IS injected, the
+// family entry is seeded from the component's DSL family params (with "pages"
+// set to the cap) because the runtime override merge replaces the whole
+// family entry, not just the "pages" key. The injected shape is
+// []any{[]any{1, capPages}}: a JSON-decoded list of 1-indexed inclusive
+// ranges, the exact form the deepdoc/pdf parser's NormalizePDFPages consumes
+// via ParserConfig[cpnID][family]["pages"].
 func BuildParserPageCapOverride(
 	parserConfig map[string]any,
 	dsl []byte,
@@ -78,7 +94,7 @@ func BuildParserPageCapOverride(
 	if parserConfig == nil {
 		parserConfig = map[string]any{}
 	}
-	parserCpnID := ExtractParserCpnID(dsl, parserComponentName)
+	parserCpnID, parserParams := parserComponentParams(dsl, parserComponentName)
 	if parserCpnID == "" {
 		return parserConfig
 	}
@@ -86,13 +102,19 @@ func BuildParserPageCapOverride(
 	if family == "" {
 		return parserConfig
 	}
-	// Respect an explicit page cap already present under cpnID + family.
+	dslFam, _ := parserParams[family].(map[string]any)
+	// Respect an explicit page range already present under cpnID + family.
 	if cpnEntry, ok := parserConfig[parserCpnID].(map[string]any); ok {
 		if famEntry, ok := cpnEntry[family].(map[string]any); ok {
 			if _, has := famEntry["pages"]; has {
 				return parserConfig
 			}
 		}
+	}
+	// Respect an explicit page range configured on the Parser component's own
+	// DSL params (the canvas page-range field).
+	if hasExplicitPages(dslFam["pages"]) {
+		return parserConfig
 	}
 	cpnEntry, ok := parserConfig[parserCpnID].(map[string]any)
 	if !ok {
@@ -104,6 +126,23 @@ func BuildParserPageCapOverride(
 		famEntry = map[string]any{}
 		cpnEntry[family] = famEntry
 	}
+	// Seed the family entry from the component's DSL params so the injected
+	// override does not drop the settings the DSL already carries. Keys
+	// already present in parserConfig win; "pages" is overwritten with the
+	// cap below regardless.
+	for k, v := range dslFam {
+		if _, exists := famEntry[k]; !exists {
+			famEntry[k] = deepCopyValue(v)
+		}
+	}
 	famEntry["pages"] = []any{[]any{1, capPages}}
 	return parserConfig
+}
+
+// hasExplicitPages reports whether a raw "pages" value carries at least one
+// configured range. Missing, null, and empty-list values mean "parse all
+// pages" and do not count as explicit — the cap remains a fallback for them.
+func hasExplicitPages(raw any) bool {
+	list, ok := raw.([]any)
+	return ok && len(list) > 0
 }

--- a/internal/ingestion/pipeline/parser_page_cap_test.go
+++ b/internal/ingestion/pipeline/parser_page_cap_test.go
@@ -105,13 +105,90 @@ func TestBuildParserPageCapOverrideRespectsDSLPages(t *testing.T) {
 	}
 	const docType = "pdf"
 
-	t.Run("explicit DSL pages -> cap not injected", func(t *testing.T) {
-		// The default canvas setup: pages [[1, 100000]] covers the whole
-		// document, so the debug cap must leave it untouched.
+	t.Run("all-pages sentinel DSL pages -> cap injected, family settings preserved", func(t *testing.T) {
+		// The default canvas setup: pages [[1, 100000]] is the shipped
+		// template/UI "every page" sentinel (the parser clamps the upper
+		// bound to the actual page count), so the debug fast-preview cap
+		// must still apply — but the DSL family settings must survive the
+		// override merge (it replaces the whole family entry).
 		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "DeepDOC", "pages": [[1, 100000]]}}}}}`)
 		out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
+		fam, ok := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing cpnID/family entry: %#v", out)
+		}
+		if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+			t.Fatalf("pages cap shape wrong: %#v", fam["pages"])
+		}
+		if fam["parse_method"] != "DeepDOC" {
+			t.Fatalf("parse_method must survive the cap injection: %#v", fam)
+		}
+	})
+
+	t.Run("genuine narrowed DSL pages -> cap not injected", func(t *testing.T) {
+		for _, pages := range []string{"[[5, 10]]", "[[1, 10]]"} {
+			dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"pages": ` + pages + `}}}}}`)
+			out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
+			if len(out) != 0 {
+				t.Fatalf("genuine DSL pages %s must be respected, got override %#v", pages, out)
+			}
+		}
+	})
+
+	t.Run("multi-range with a gap -> cap not injected", func(t *testing.T) {
+		// [[1,10],[12,100000]] excludes page 11, so it is a real
+		// restriction even though its upper bound is the sentinel bound.
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"pages": [[1, 10], [12, 100000]]}}}}}`)
+		out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
 		if len(out) != 0 {
-			t.Fatalf("explicit DSL pages must be respected, got override %#v", out)
+			t.Fatalf("gapped DSL pages must be respected, got override %#v", out)
+		}
+	})
+
+	t.Run("malformed DSL pages -> cap injected", func(t *testing.T) {
+		// The parser degrades malformed ranges to "parse all pages" at
+		// parse time, so the cap is not withheld for them either.
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"pages": [[0, 5]]}}}}}`)
+		out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
+		fam, ok := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing cpnID/family entry: %#v", out)
+		}
+		if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+			t.Fatalf("pages cap shape wrong: %#v", fam["pages"])
+		}
+	})
+
+	t.Run("run-level null and empty pages -> cap injected", func(t *testing.T) {
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "DeepDOC"}}}}}`)
+		for _, pages := range []any{nil, []any{}} {
+			pc := map[string]any{
+				"Parser:Abc": map[string]any{
+					"pdf": map[string]any{"pages": pages},
+				},
+			}
+			out := BuildParserPageCapOverride(pc, dsl, docType, 2, testParserComponentName, familyOf)
+			fam := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+			if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+				t.Fatalf("run-level pages %v must not suppress the cap, got %#v", pages, fam["pages"])
+			}
+		}
+	})
+
+	t.Run("run-level all-pages sentinel -> cap injected, settings preserved", func(t *testing.T) {
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "DeepDOC"}}}}}`)
+		pc := map[string]any{
+			"Parser:Abc": map[string]any{
+				"pdf": map[string]any{"parse_method": "Plain Text", "pages": []any{[]any{1, 100000}}},
+			},
+		}
+		out := BuildParserPageCapOverride(pc, dsl, docType, 2, testParserComponentName, familyOf)
+		fam := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+		if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+			t.Fatalf("run-level sentinel must not suppress the cap, got %#v", fam["pages"])
+		}
+		if fam["parse_method"] != "Plain Text" {
+			t.Fatalf("existing parserConfig value must survive the cap injection: %#v", fam)
 		}
 	})
 

--- a/internal/ingestion/pipeline/parser_page_cap_test.go
+++ b/internal/ingestion/pipeline/parser_page_cap_test.go
@@ -15,25 +15,30 @@ func envelopedDSL(components string) []byte {
 	return []byte(`{"dsl": {"components": ` + components + `}}`)
 }
 
-// TestExtractParserCpnID verifies the Parser cpnID is discovered from both
-// enveloped and raw DSL, and "" is returned when no Parser component exists.
-func TestExtractParserCpnID(t *testing.T) {
-	// enveloped DSL with a Parser component.
-	dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {}}}}`)
-	if got := ExtractParserCpnID(dsl, testParserComponentName); got != "Parser:Abc" {
-		t.Fatalf("enveloped: want Parser:Abc, got %q", got)
+// TestParserComponentParams verifies the Parser cpnID and params are
+// discovered from both enveloped and raw DSL, and ("", nil) is returned when
+// no Parser component exists.
+func TestParserComponentParams(t *testing.T) {
+	// enveloped DSL with a Parser component carrying params.
+	dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "DeepDOC"}}}}}`)
+	cpnID, params := parserComponentParams(dsl, testParserComponentName)
+	if cpnID != "Parser:Abc" {
+		t.Fatalf("enveloped: want Parser:Abc, got %q", cpnID)
+	}
+	if pdf, ok := params["pdf"].(map[string]any); !ok || pdf["parse_method"] != "DeepDOC" {
+		t.Fatalf("params not extracted: %#v", params)
 	}
 
-	// no Parser component -> "".
+	// no Parser component -> ("", nil).
 	dslNo := envelopedDSL(`{"Tokenizer:X": {"obj": {"component_name": "Tokenizer", "params": {}}}}`)
-	if got := ExtractParserCpnID(dslNo, testParserComponentName); got != "" {
-		t.Fatalf("no parser: want empty, got %q", got)
+	if cpnID, params := parserComponentParams(dslNo, testParserComponentName); cpnID != "" || params != nil {
+		t.Fatalf("no parser: want (\"\", nil), got (%q, %#v)", cpnID, params)
 	}
 
 	// raw (non-enveloped) inner DSL is also accepted.
 	raw := []byte(`{"components": {"Parser:Z": {"obj": {"component_name": "Parser", "params": {}}}}}`)
-	if got := ExtractParserCpnID(raw, testParserComponentName); got != "Parser:Z" {
-		t.Fatalf("raw: want Parser:Z, got %q", got)
+	if cpnID, _ := parserComponentParams(raw, testParserComponentName); cpnID != "Parser:Z" {
+		t.Fatalf("raw: want Parser:Z, got %q", cpnID)
 	}
 }
 
@@ -84,6 +89,98 @@ func TestBuildParserPageCapOverride(t *testing.T) {
 	if len(out4) != 0 {
 		t.Fatalf("no Parser should be no-op, got %#v", out4)
 	}
+}
+
+// TestBuildParserPageCapOverrideRespectsDSLPages is the regression test for
+// the canvas page-range bug: a dataflow dry-run carries an empty
+// parserConfig, and the canvas saves the user's explicit page range on the
+// Parser component's own DSL params (params[family]["pages"]). The injected
+// cap must not replace that explicit range via the override-wins merge.
+func TestBuildParserPageCapOverrideRespectsDSLPages(t *testing.T) {
+	familyOf := func(ext string) string {
+		if ext == "pdf" {
+			return "pdf"
+		}
+		return ""
+	}
+	const docType = "pdf"
+
+	t.Run("explicit DSL pages -> cap not injected", func(t *testing.T) {
+		// The default canvas setup: pages [[1, 100000]] covers the whole
+		// document, so the debug cap must leave it untouched.
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "DeepDOC", "pages": [[1, 100000]]}}}}}`)
+		out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
+		if len(out) != 0 {
+			t.Fatalf("explicit DSL pages must be respected, got override %#v", out)
+		}
+	})
+
+	t.Run("empty DSL pages -> cap injected, family settings preserved", func(t *testing.T) {
+		// pages [] means "parse all pages" — not an explicit range, so the
+		// cap still applies, but the DSL family settings must survive the
+		// override merge (it replaces the whole family entry).
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "Plain Text", "remove_header_footer": true, "pages": []}}}}}`)
+		out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
+		fam, ok := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing cpnID/family entry: %#v", out)
+		}
+		if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+			t.Fatalf("pages cap shape wrong: %#v", fam["pages"])
+		}
+		if fam["parse_method"] != "Plain Text" {
+			t.Fatalf("parse_method must survive the cap injection: %#v", fam)
+		}
+		if fam["remove_header_footer"] != true {
+			t.Fatalf("remove_header_footer must survive the cap injection: %#v", fam)
+		}
+	})
+
+	t.Run("no pages key in DSL -> cap injected, family settings preserved", func(t *testing.T) {
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "DeepDOC"}}}}}`)
+		out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
+		fam, ok := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing cpnID/family entry: %#v", out)
+		}
+		if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+			t.Fatalf("pages cap shape wrong: %#v", fam["pages"])
+		}
+		if fam["parse_method"] != "DeepDOC" {
+			t.Fatalf("parse_method must survive the cap injection: %#v", fam)
+		}
+	})
+
+	t.Run("explicit DSL pages for another family do not block the cap", func(t *testing.T) {
+		// pages configured under a family other than the document's own must
+		// not disable the cap for this document's family.
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"docx": {"pages": [[1, 50]]}, "pdf": {"parse_method": "DeepDOC"}}}}}`)
+		out := BuildParserPageCapOverride(map[string]any{}, dsl, docType, 2, testParserComponentName, familyOf)
+		fam, ok := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing cpnID/family entry: %#v", out)
+		}
+		if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+			t.Fatalf("pages cap shape wrong: %#v", fam["pages"])
+		}
+	})
+
+	t.Run("parserConfig keys win over seeded DSL keys", func(t *testing.T) {
+		dsl := envelopedDSL(`{"Parser:Abc": {"obj": {"component_name": "Parser", "params": {"pdf": {"parse_method": "DeepDOC"}}}}}`)
+		pc := map[string]any{
+			"Parser:Abc": map[string]any{
+				"pdf": map[string]any{"parse_method": "Plain Text"},
+			},
+		}
+		out := BuildParserPageCapOverride(pc, dsl, docType, 2, testParserComponentName, familyOf)
+		fam := out["Parser:Abc"].(map[string]any)["pdf"].(map[string]any)
+		if fam["parse_method"] != "Plain Text" {
+			t.Fatalf("existing parserConfig value must win over the seeded DSL value: %#v", fam)
+		}
+		if !reflect.DeepEqual(fam["pages"], []any{[]any{1, 2}}) {
+			t.Fatalf("pages cap shape wrong: %#v", fam["pages"])
+		}
+	})
 }
 
 // TestUnwrapCanvasDSL verifies the envelope is stripped and a raw DSL passes

--- a/internal/ingestion/task/debug_pages_integration_test.go
+++ b/internal/ingestion/task/debug_pages_integration_test.go
@@ -44,11 +44,13 @@ import (
 // It parses a multi-page PDF twice through a real debug pipeline (real DSL,
 // real pdfium parser, in-memory sqlite + storage):
 //
-//   - Uncapped baseline: an explicit cpnID+family page cap of [[1, 1000000]]
-//     is supplied in ParserConfig. pipeline.BuildParserPageCapOverride must RESPECT it, so the
+//   - Uncapped baseline: an explicit cpnID+family page range of [[1, 20]]
+//     (a genuinely narrowed range that still covers every page of the 5-page
+//     fixture) is supplied in ParserConfig. pipeline.BuildParserPageCapOverride must RESPECT it, so the
 //     parser reads every page.
 //   - Capped: no page cap is supplied, so pipeline.BuildParserPageCapOverride injects the
-//     debug default [[1, debugPageCapPages]], and the parser reads only the
+//     debug default [[1, debugPageCapPages]] over the template's all-pages
+//     sentinel pages ([[1, 100000]]), and the parser reads only the
 //     leading pages.
 //
 // The capped run must therefore yield strictly fewer chunk characters than
@@ -131,13 +133,17 @@ func TestExecute_DebugViaEntry_HonorsPagesCap_Integration(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = realDB.Where("id = ?", canvasID).Delete(&entity.UserCanvas{}).Error })
 
-	// Explicit "parse all pages" cap (JSON-decoded []any form, the shape the
-	// parser actually consumes). pipeline.BuildParserPageCapOverride must respect it and leave
+	// Explicit genuine range covering the whole fixture (JSON-decoded []any
+	// form, the shape the parser actually consumes). It is deliberately NOT
+	// the all-pages sentinel: [[1, 1000000]] would be capped like the
+	// template's own default, since the parser clamps such bounds to the
+	// document's actual page count anyway.
+	// pipeline.BuildParserPageCapOverride must respect this narrowed range and leave
 	// it untouched, so the parser reads every page of the PDF.
 	allPages := map[string]any{
 		parserCpnID: map[string]any{
 			"pdf": map[string]any{
-				"pages": []any{[]any{1, 1000000}},
+				"pages": []any{[]any{1, 20}},
 			},
 		},
 	}

--- a/internal/ingestion/task/debug_test.go
+++ b/internal/ingestion/task/debug_test.go
@@ -151,6 +151,10 @@ func TestInjectDebugPageCap(t *testing.T) {
 		t.Fatalf("unmarshal template envelope: %v", err)
 	}
 	dsl := string(envelope.DSL)
+	// The shipped general template carries an explicit pdf pages range
+	// ([[1, 100000]]), which the cap must respect. Strip it to exercise the
+	// fallback-injection path on a DSL without explicit pages.
+	noPagesDSL := dslWithoutPDFPages(t, envelope.DSL)
 
 	// Discover the Parser cpnID the same way the executor does.
 	schemas, err := pipeline.ExtractAllComponentParams(envelope.DSL)
@@ -173,9 +177,19 @@ func TestInjectDebugPageCap(t *testing.T) {
 			component.ComponentNameParser, component.ParserFileFamily)
 	}
 
-	t.Run("pdf injects [1,2] under cpnID+family", func(t *testing.T) {
+	t.Run("template pdf explicit pages are respected", func(t *testing.T) {
+		// The template ships pdf pages [[1, 100000]] — an explicit range, so
+		// the debug cap (a fallback only) must NOT be injected over it.
 		parserConfig := map[string]any{}
 		apply(parserConfig, dsl, "pdf")
+		if len(parserConfig) != 0 {
+			t.Fatalf("parserConfig = %v, want empty (the DSL's explicit pdf pages must be respected)", parserConfig)
+		}
+	})
+
+	t.Run("pdf injects [1,2] under cpnID+family when DSL has no explicit pages", func(t *testing.T) {
+		parserConfig := map[string]any{}
+		apply(parserConfig, noPagesDSL, "pdf")
 		famEntry, ok := parserConfig[parserCpnID].(map[string]any)
 		if !ok {
 			t.Fatalf("parserConfig[%q] = %T, want map[string]any", parserCpnID, parserConfig[parserCpnID])
@@ -219,7 +233,7 @@ func TestInjectDebugPageCap(t *testing.T) {
 				"pdf": map[string]any{"parse_method": "deepdoc"},
 			},
 		}
-		apply(parserConfig, dsl, "pdf")
+		apply(parserConfig, noPagesDSL, "pdf")
 		famEntry := parserConfig[parserCpnID].(map[string]any)
 		pdf := famEntry["pdf"].(map[string]any)
 		if pdf["parse_method"] != "deepdoc" {
@@ -234,7 +248,7 @@ func TestInjectDebugPageCap(t *testing.T) {
 		// In production dsl is the canvas envelope {"dsl": {"components": ...}},
 		// not the bare components map. The helper must still find the Parser
 		// cpnID after unwrapping.
-		wrapped := fmt.Sprintf(`{"dsl":%s}`, string(envelope.DSL))
+		wrapped := fmt.Sprintf(`{"dsl":%s}`, noPagesDSL)
 		parserConfig := map[string]any{}
 		apply(parserConfig, wrapped, "pdf")
 		famEntry, ok := parserConfig[parserCpnID].(map[string]any)
@@ -265,6 +279,35 @@ func TestInjectDebugPageCap(t *testing.T) {
 			t.Errorf("parserConfig[%q][\"pdf\"][\"pages\"] = %v, want [[1, 1000000]] (explicit cap must be respected, not overridden by debug default)", parserCpnID, pdf["pages"])
 		}
 	})
+}
+
+// dslWithoutPDFPages returns a copy of the template inner DSL with the Parser
+// component's explicit pdf "pages" range removed. The shipped general template
+// carries pages [[1, 100000]], which the debug cap must respect; stripping it
+// lets tests exercise the fallback-injection path on a DSL without explicit
+// pages.
+func dslWithoutPDFPages(t *testing.T, inner json.RawMessage) string {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal(inner, &doc); err != nil {
+		t.Fatalf("unmarshal template dsl: %v", err)
+	}
+	comps, _ := doc["components"].(map[string]any)
+	for _, c := range comps {
+		obj, _ := c.(map[string]any)["obj"].(map[string]any)
+		if obj["component_name"] != component.ComponentNameParser {
+			continue
+		}
+		params, _ := obj["params"].(map[string]any)
+		if pdf, ok := params["pdf"].(map[string]any); ok {
+			delete(pdf, "pages")
+		}
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("remarshal template dsl: %v", err)
+	}
+	return string(out)
 }
 
 // TestWarnUnknownComponentParamsDetectsUnknownCPNFromEnvelope pins the fix for

--- a/internal/ingestion/task/debug_test.go
+++ b/internal/ingestion/task/debug_test.go
@@ -151,10 +151,11 @@ func TestInjectDebugPageCap(t *testing.T) {
 		t.Fatalf("unmarshal template envelope: %v", err)
 	}
 	dsl := string(envelope.DSL)
-	// The shipped general template carries an explicit pdf pages range
-	// ([[1, 100000]]), which the cap must respect. Strip it to exercise the
-	// fallback-injection path on a DSL without explicit pages.
-	noPagesDSL := dslWithoutPDFPages(t, envelope.DSL)
+	// The shipped general template carries the all-pages sentinel
+	// ([[1, 100000]]) in its pdf family, which the debug cap replaces (the
+	// parser clamps the bound to the actual page count). Strip it to exercise
+	// the missing-pages fallback-injection path.
+	noPagesDSL := dslWithPDFPages(t, envelope.DSL, "")
 
 	// Discover the Parser cpnID the same way the executor does.
 	schemas, err := pipeline.ExtractAllComponentParams(envelope.DSL)
@@ -177,13 +178,38 @@ func TestInjectDebugPageCap(t *testing.T) {
 			component.ComponentNameParser, component.ParserFileFamily)
 	}
 
-	t.Run("template pdf explicit pages are respected", func(t *testing.T) {
-		// The template ships pdf pages [[1, 100000]] — an explicit range, so
-		// the debug cap (a fallback only) must NOT be injected over it.
+	t.Run("template all-pages sentinel -> cap injected for the fast preview", func(t *testing.T) {
+		// The template ships pdf pages [[1, 100000]] — the all-pages sentinel
+		// (the parser clamps the bound to the document's actual page count),
+		// so the debug cap must still be injected: a dry-run's purpose is a
+		// fast leading-pages preview. The template's own family settings
+		// must survive the override merge.
 		parserConfig := map[string]any{}
 		apply(parserConfig, dsl, "pdf")
+		famEntry, ok := parserConfig[parserCpnID].(map[string]any)
+		if !ok {
+			t.Fatalf("parserConfig[%q] = %T, want map[string]any", parserCpnID, parserConfig[parserCpnID])
+		}
+		pdf, ok := famEntry["pdf"].(map[string]any)
+		if !ok {
+			t.Fatalf("parserConfig[%q][\"pdf\"] = %T, want map[string]any", parserCpnID, famEntry["pdf"])
+		}
+		if !reflect.DeepEqual(pdf["pages"], []any{[]any{1, debugPageCapPages}}) {
+			t.Errorf("parserConfig[%q][\"pdf\"][\"pages\"] = %v, want [[1, %d]]", parserCpnID, pdf["pages"], debugPageCapPages)
+		}
+		if pdf["parse_method"] != "DeepDOC" {
+			t.Errorf("parserConfig[%q][\"pdf\"][\"parse_method\"] = %v, want DeepDOC (template settings must survive the injection)", parserCpnID, pdf["parse_method"])
+		}
+	})
+
+	t.Run("genuine narrowed template pages are respected", func(t *testing.T) {
+		// A range the user actually narrowed (not the all-pages sentinel)
+		// must suppress the cap — the original bug this PR fixes.
+		narrowDSL := dslWithPDFPages(t, envelope.DSL, "[[5, 9]]")
+		parserConfig := map[string]any{}
+		apply(parserConfig, narrowDSL, "pdf")
 		if len(parserConfig) != 0 {
-			t.Fatalf("parserConfig = %v, want empty (the DSL's explicit pdf pages must be respected)", parserConfig)
+			t.Fatalf("parserConfig = %v, want empty (a genuinely narrowed DSL pages range must be respected)", parserConfig)
 		}
 	})
 
@@ -265,28 +291,47 @@ func TestInjectDebugPageCap(t *testing.T) {
 	})
 
 	t.Run("respects explicit caller-supplied cap", func(t *testing.T) {
-		// When the document already carries an explicit cpnID+family page cap,
-		// the debug default must NOT override it (so a wider/narrower cap wins).
+		// When the document already carries a genuinely narrowed explicit
+		// cpnID+family range (here a 3-page cap), the debug default must NOT
+		// override it (so a wider/narrower cap wins).
 		parserConfig := map[string]any{
 			parserCpnID: map[string]any{
-				"pdf": map[string]any{"pages": []any{[]any{1, 1000000}}},
+				"pdf": map[string]any{"pages": []any{[]any{1, 3}}},
 			},
 		}
 		apply(parserConfig, dsl, "pdf")
 		famEntry := parserConfig[parserCpnID].(map[string]any)
 		pdf := famEntry["pdf"].(map[string]any)
-		if !reflect.DeepEqual(pdf["pages"], []any{[]any{1, 1000000}}) {
-			t.Errorf("parserConfig[%q][\"pdf\"][\"pages\"] = %v, want [[1, 1000000]] (explicit cap must be respected, not overridden by debug default)", parserCpnID, pdf["pages"])
+		if !reflect.DeepEqual(pdf["pages"], []any{[]any{1, 3}}) {
+			t.Errorf("parserConfig[%q][\"pdf\"][\"pages\"] = %v, want [[1, 3]] (explicit cap must be respected, not overridden by debug default)", parserCpnID, pdf["pages"])
+		}
+	})
+
+	t.Run("caller-supplied all-pages sentinel is capped", func(t *testing.T) {
+		// [[1, 1000000]] is an all-pages bound (the parser clamps it to the
+		// document's actual page count), not a genuine restriction, so the
+		// debug cap replaces it — the same explicitness predicate applies to
+		// both config sources.
+		parserConfig := map[string]any{
+			parserCpnID: map[string]any{
+				"pdf": map[string]any{"pages": []any{[]any{1, 1000000}}},
+			},
+		}
+		apply(parserConfig, noPagesDSL, "pdf")
+		famEntry := parserConfig[parserCpnID].(map[string]any)
+		pdf := famEntry["pdf"].(map[string]any)
+		if !reflect.DeepEqual(pdf["pages"], []any{[]any{1, debugPageCapPages}}) {
+			t.Errorf("parserConfig[%q][\"pdf\"][\"pages\"] = %v, want [[1, %d]] (all-pages sentinel must not suppress the cap)", parserCpnID, pdf["pages"], debugPageCapPages)
 		}
 	})
 }
 
-// dslWithoutPDFPages returns a copy of the template inner DSL with the Parser
-// component's explicit pdf "pages" range removed. The shipped general template
-// carries pages [[1, 100000]], which the debug cap must respect; stripping it
-// lets tests exercise the fallback-injection path on a DSL without explicit
-// pages.
-func dslWithoutPDFPages(t *testing.T, inner json.RawMessage) string {
+// dslWithPDFPages returns a copy of the template inner DSL with the Parser
+// component's pdf "pages" value replaced by rawRanges (deleted when rawRanges
+// is empty). The shipped general template carries the all-pages sentinel
+// [[1, 100000]], which the debug cap replaces; tests pass "" for the
+// missing-pages path and a genuine narrowed range for the explicit-pages path.
+func dslWithPDFPages(t *testing.T, inner json.RawMessage, rawRanges string) string {
 	t.Helper()
 	var doc map[string]any
 	if err := json.Unmarshal(inner, &doc); err != nil {
@@ -300,7 +345,15 @@ func dslWithoutPDFPages(t *testing.T, inner json.RawMessage) string {
 		}
 		params, _ := obj["params"].(map[string]any)
 		if pdf, ok := params["pdf"].(map[string]any); ok {
-			delete(pdf, "pages")
+			if rawRanges == "" {
+				delete(pdf, "pages")
+				continue
+			}
+			var ranges any
+			if err := json.Unmarshal([]byte(rawRanges), &ranges); err != nil {
+				t.Fatalf("unmarshal pdf pages %q: %v", rawRanges, err)
+			}
+			pdf["pages"] = ranges
 		}
 	}
 	out, err := json.Marshal(doc)


### PR DESCRIPTION
### Summary

**Background.** A dataflow run from the agent canvas (the "Run" button → `agentChatCompletion`) executes synchronously as a canvas **debug dry-run**. To keep the preview fast, the executor caps the Parser to the first `debugPageCapPages = 2` pages by injecting `pages: [[1, 2]]` into the run-level override params at `ParserConfig[cpnID][family]["pages"]` (`pipeline.BuildParserPageCapOverride`).

**Bug.** The canvas saves the Parser "Page ranges" field on the **component's own DSL params** (`params[family]["pages"]` — the shipped general template carries `[[1, 100000]]`), not in the run-level ParserConfig. Debug contexts intentionally carry an empty ParserConfig, so the "respect existing pages" guard never fired: the 2-page cap was always injected, and because the runtime override merge (`applyOverrideParams`) is top-level-key-wins, it replaced the whole `pdf` family entry — silently wiping the user's explicit page range (and the other family settings). Result: a PDF whose page count is well inside the configured page range still parsed only its first two pages (reported from the Feishu group: 智能体数据管道解析 PDF，上传的 PDF 页数在"页码范围"内但只解析出前两页的内容).

**Fix** (`internal/ingestion/pipeline/parser_page_cap.go`):
- The debug cap is now a pure fallback. It is not injected when the document's family carries an explicit non-empty `pages` range in **either** the run-level `parserConfig[cpnID][family]["pages"]` **or** the Parser component's DSL params `params[family]["pages"]`. Missing/null/empty lists mean "parse all pages" and still allow the cap, preserving the fast-preview behavior for setups without an explicit range.
- When the cap *is* injected, the family entry is seeded from the component's DSL family params (deep-copied; existing parserConfig keys win) so the override no longer drops the other family settings such as `parse_method` / `remove_header_footer`.
- `ExtractParserCpnID` is folded into an unexported `parserComponentParams(dsl, name) (cpnID, params)` helper returning cpnID and params in a single pass; it had no callers outside the package.

**Tests**
- `internal/ingestion/pipeline/parser_page_cap_test.go`: new regression suite `TestBuildParserPageCapOverrideRespectsDSLPages` — explicit DSL pages → no cap; empty/missing pages → cap injected with family settings preserved; pages configured for another family do not block the cap; existing parserConfig keys win over seeded DSL keys.
- `internal/ingestion/task/debug_test.go`: `TestInjectDebugPageCap` updated — the shipped general template carries explicit `pdf.pages [[1, 100000]]` which the cap must now respect (new subtest), and the fallback-injection subtests run on a template variant with the `pages` key stripped (new `dslWithoutPDFPages` helper).
- `bash build.sh --test ./internal/ingestion/pipeline/... ./internal/ingestion/task/...` — all pass.

**End-to-end verification** (Go backend, browser): generated a 6-page PDF with per-page markers, configured the Parser page range to `1–100` in a dataflow canvas (File → Parser → Token Chunker → … → Tokenizer), and ran it. Before the fix the result column contained only pages 1–2; after the fix it contains all 6 pages. This path needs no LLM (debug runs skip embedding/extraction), so verification covered the real pipeline end to end.
