### PR TITLE
fix(chat): restore required prefetch persistence

### DIFF
--- a/internal/entity/chat.go
+++ b/internal/entity/chat.go
@@ -41,6 +41,7 @@ type Chat struct {
 	SimilarityThreshold    float64   `gorm:"column:similarity_threshold" json:"similarity_threshold"`
 	VectorSimilarityWeight float64   `gorm:"column:vector_similarity_weight" json:"vector_similarity_weight"`
 	TopN                   int64     `gorm:"column:top_n" json:"top_n"`
+	PrefetchSize           int64     `gorm:"column:prefetch_size" json:"-"`
 	RerankCandidatesCount  int64     `gorm:"column:rerank_candidates_count" json:"rerank_candidates_count"`
 	TopK                   int64     `gorm:"column:top_k" json:"top_k"`
 	DoRefer                string    `gorm:"column:do_refer;size:1;not null" json:"do_refer"`

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -553,6 +553,7 @@ func buildCreateChatEntity(req map[string]interface{}, tenantID string) *entity.
 		SimilarityThreshold:    floatFromValue(req["similarity_threshold"]),
 		VectorSimilarityWeight: floatFromValue(req["vector_similarity_weight"]),
 		TopN:                   int64FromValue(req["top_n"]),
+		PrefetchSize:           int64FromValue(req["rerank_candidates_count"]),
 		RerankCandidatesCount:  int64FromValue(req["rerank_candidates_count"]),
 		TopK:                   int64FromValue(req["top_k"]),
 		DoRefer:                stringFromValue(req["do_refer"]),


### PR DESCRIPTION
### Summary

Go chat creation failed because MySQL required the missing prefetch_size column. The fix persists that column alongside rerank_candidates_count