### PR TITLE
feat: extract images from xlsx parser

### DIFF
--- a/internal/ingestion/component/parser.go
+++ b/internal/ingestion/component/parser.go
@@ -506,6 +506,9 @@ func (c *ParserComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[st
 	if dispatched.Err != nil && fileTypeExt != utility.FileTypeOTHER {
 		return nil, dispatched.Err
 	}
+	for _, warning := range dispatched.Warnings {
+		runtime.ReportProgressMessage(ctx, "Parser", "WARNING: "+warning)
+	}
 
 	// 3. Build the legacy `pages` slice. When the dispatch path
 	//    produced a JSON payload, we re-shape it into the page

--- a/internal/ingestion/component/parser.go
+++ b/internal/ingestion/component/parser.go
@@ -506,9 +506,7 @@ func (c *ParserComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[st
 	if dispatched.Err != nil && fileTypeExt != utility.FileTypeOTHER {
 		return nil, dispatched.Err
 	}
-	for _, warning := range dispatched.Warnings {
-		runtime.ReportProgressMessage(ctx, "Parser", "WARNING: "+warning)
-	}
+	reportParserWarnings(ctx, dispatched.Warnings)
 
 	// 3. Build the legacy `pages` slice. When the dispatch path
 	//    produced a JSON payload, we re-shape it into the page
@@ -595,6 +593,12 @@ func (c *ParserComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[st
 	// callbacks) is owned by the canvas framework (realComponentBody),
 	// not by this component, so we return the work result directly.
 	return out, nil
+}
+
+func reportParserWarnings(ctx context.Context, warnings []string) {
+	for _, warning := range warnings {
+		runtime.ReportProgressMessage(ctx, "Parser", "WARNING: "+warning)
+	}
 }
 
 // buildPagesFromBytes reshapes already-prepared page bytes into the

--- a/internal/ingestion/component/parser_dispatch.go
+++ b/internal/ingestion/component/parser_dispatch.go
@@ -54,6 +54,7 @@ type parserDispatchResult struct {
 	Markdown     string
 	Text         string
 	HTML         string
+	Warnings     []string
 	Err          error
 }
 
@@ -179,6 +180,7 @@ func dispatchParse(ctx context.Context, fileType utility.FileType, filename stri
 		Markdown:     res.Markdown,
 		Text:         res.Text,
 		HTML:         res.HTML,
+		Warnings:     res.Warnings,
 	}
 }
 

--- a/internal/ingestion/component/parser_test.go
+++ b/internal/ingestion/component/parser_test.go
@@ -28,6 +28,19 @@ import (
 	"ragflow/internal/ingestion/component/schema"
 )
 
+func TestReportParserWarningsAsProgressMessages(t *testing.T) {
+	var got []string
+	ctx := runtime.WithProgressMessageCallback(t.Context(), func(component, message string) {
+		got = append(got, component+": "+message)
+	})
+
+	reportParserWarnings(ctx, []string{"sheet \"Summary\": unsupported image extension \"emf\""})
+
+	if len(got) != 1 || got[0] != "Parser: WARNING: sheet \"Summary\": unsupported image extension \"emf\"" {
+		t.Fatalf("progress warnings = %v", got)
+	}
+}
+
 // TestParserComponent_Registered asserts the factory lookup
 // succeeds for the canonical "Parser" name. This is the contract
 // the pipeline runner relies on (see plan §4 Phase 0, "category-

--- a/internal/parser/parser/office_table_render.go
+++ b/internal/parser/parser/office_table_render.go
@@ -44,26 +44,32 @@ const defaultTableChunkRows = 256
 // worksheet as structured parser items. Excelize exposes both kinds through
 // GetPictureCells/GetPictures; walking the reported anchor cells avoids
 // scanning the worksheet's entire coordinate space.
-func extractXLSXImages(f *excelize.File, sheet string) ([]map[string]any, error) {
+func extractXLSXImages(f *excelize.File, sheet string) ([]map[string]any, []string) {
 	cells, err := f.GetPictureCells(sheet)
 	if err != nil {
-		return nil, err
+		return nil, []string{fmt.Sprintf("XLSX image discovery failed for sheet %q: %v", sheet, err)}
 	}
 	if len(cells) == 0 {
 		return nil, nil
 	}
 
 	items := make([]map[string]any, 0, len(cells))
+	warnings := make([]string, 0)
 	for _, cell := range cells {
 		pictures, err := f.GetPictures(sheet, cell)
 		if err != nil {
-			return nil, fmt.Errorf("pictures at %s: %w", cell, err)
+			warnings = append(warnings, fmt.Sprintf("XLSX image extraction failed for sheet %q cell %s: %v", sheet, cell, err))
+			continue
 		}
 		for _, picture := range pictures {
 			if len(picture.File) == 0 {
 				continue
 			}
-			mimeType := xlsxImageMIMEType(picture.Extension)
+			mimeType, ok := xlsxImageMIMEType(picture.Extension)
+			if !ok {
+				warnings = append(warnings, fmt.Sprintf("XLSX image skipped for sheet %q cell %s: unsupported extension %q", sheet, cell, picture.Extension))
+				continue
+			}
 			encoded := base64.StdEncoding.EncodeToString(picture.File)
 			alt := cell
 			if picture.Format != nil && picture.Format.AltText != "" {
@@ -79,23 +85,35 @@ func extractXLSXImages(f *excelize.File, sheet string) ([]map[string]any, error)
 			})
 		}
 	}
-	return items, nil
+	return items, warnings
 }
 
-func xlsxImageMIMEType(extension string) string {
+func xlsxImageMIMEType(extension string) (string, bool) {
 	switch strings.TrimPrefix(strings.ToLower(extension), ".") {
 	case "jpg", "jpeg":
-		return "image/jpeg"
+		return "image/jpeg", true
 	case "gif":
-		return "image/gif"
+		return "image/gif", true
 	case "bmp":
-		return "image/bmp"
+		return "image/bmp", true
 	case "tif", "tiff":
-		return "image/tiff"
+		return "image/tiff", true
 	case "svg":
-		return "image/svg+xml"
+		return "image/svg+xml", true
+	case "png":
+		return "image/png", true
+	case "emf":
+		return "image/emf", true
+	case "emz":
+		return "image/emz", true
+	case "ico":
+		return "image/x-icon", true
+	case "wmf":
+		return "image/wmf", true
+	case "wmz":
+		return "image/wmz", true
 	default:
-		return "image/png"
+		return "", false
 	}
 }
 

--- a/internal/parser/parser/office_table_render.go
+++ b/internal/parser/parser/office_table_render.go
@@ -103,15 +103,15 @@ func xlsxImageMIMEType(extension string) (string, bool) {
 	case "png":
 		return "image/png", true
 	case "emf":
-		return "image/emf", true
+		return "image/x-emf", true
 	case "emz":
-		return "image/emz", true
+		return "image/x-emz", true
 	case "ico":
 		return "image/x-icon", true
 	case "wmf":
-		return "image/wmf", true
+		return "image/x-wmf", true
 	case "wmz":
-		return "image/wmz", true
+		return "image/x-wmz", true
 	default:
 		return "", false
 	}

--- a/internal/parser/parser/office_table_render.go
+++ b/internal/parser/parser/office_table_render.go
@@ -17,6 +17,8 @@
 package parser
 
 import (
+	"encoding/base64"
+	"fmt"
 	"html"
 	"regexp"
 	"strconv"
@@ -37,6 +39,65 @@ var tableIllegalCharsRe = regexp.MustCompile(`[\x00-\x08]|\x0B|\x0C|[\x0E-\x1F]`
 var numericCellRe = regexp.MustCompile(`^[\$\+\-]?[\d,]+(\.\d+)?%?$`)
 
 const defaultTableChunkRows = 256
+
+// extractXLSXImages returns the floating and in-cell images anchored to a
+// worksheet as structured parser items. Excelize exposes both kinds through
+// GetPictureCells/GetPictures; walking the reported anchor cells avoids
+// scanning the worksheet's entire coordinate space.
+func extractXLSXImages(f *excelize.File, sheet string) ([]map[string]any, error) {
+	cells, err := f.GetPictureCells(sheet)
+	if err != nil {
+		return nil, err
+	}
+	if len(cells) == 0 {
+		return nil, nil
+	}
+
+	items := make([]map[string]any, 0, len(cells))
+	for _, cell := range cells {
+		pictures, err := f.GetPictures(sheet, cell)
+		if err != nil {
+			return nil, fmt.Errorf("pictures at %s: %w", cell, err)
+		}
+		for _, picture := range pictures {
+			if len(picture.File) == 0 {
+				continue
+			}
+			mimeType := xlsxImageMIMEType(picture.Extension)
+			encoded := base64.StdEncoding.EncodeToString(picture.File)
+			alt := cell
+			if picture.Format != nil && picture.Format.AltText != "" {
+				alt = picture.Format.AltText
+			}
+			items = append(items, map[string]any{
+				"text":         alt,
+				"doc_type_kwd": "image",
+				"ck_type":      "image",
+				"image":        "data:" + mimeType + ";base64," + encoded,
+				"sheet":        sheet,
+				"cell":         cell,
+			})
+		}
+	}
+	return items, nil
+}
+
+func xlsxImageMIMEType(extension string) string {
+	switch strings.TrimPrefix(strings.ToLower(extension), ".") {
+	case "jpg", "jpeg":
+		return "image/jpeg"
+	case "gif":
+		return "image/gif"
+	case "bmp":
+		return "image/bmp"
+	case "tif", "tiff":
+		return "image/tiff"
+	case "svg":
+		return "image/svg+xml"
+	default:
+		return "image/png"
+	}
+}
 
 // maxMergeExtentCols caps how far a merged range may widen the header row.
 // excelize's GetRows truncates each row at its last valued cell, so a merged
@@ -82,8 +143,12 @@ func buildHeaderRow(row []string) string {
 // <thead>/<tbody>, so every <table> is one atomic chunk that downstream
 // chunkers can consume independently.
 func recordsToHTMLTableChunks(records [][]string, chunkRows int, caption string) string {
+	return strings.Join(recordsToHTMLTableChunkList(records, chunkRows, caption), "")
+}
+
+func recordsToHTMLTableChunkList(records [][]string, chunkRows int, caption string) []string {
 	if len(records) == 0 {
-		return "<table><caption>" + html.EscapeString(caption) + "</caption></table>"
+		return []string{"<table><caption>" + html.EscapeString(caption) + "</caption></table>"}
 	}
 
 	// Build the header row once — repeated in every chunk.
@@ -93,7 +158,7 @@ func recordsToHTMLTableChunks(records [][]string, chunkRows int, caption string)
 
 	if nData == 0 {
 		// Only a header row exists.
-		return "<table><caption>" + html.EscapeString(caption) + "</caption>\n" + headerHTML + "</table>"
+		return []string{"<table><caption>" + html.EscapeString(caption) + "</caption>\n" + headerHTML + "</table>"}
 	}
 
 	if chunkRows <= 0 {
@@ -101,7 +166,7 @@ func recordsToHTMLTableChunks(records [][]string, chunkRows int, caption string)
 	}
 
 	nChunks := (nData + chunkRows - 1) / chunkRows
-	var b strings.Builder
+	chunks := make([]string, 0, nChunks)
 	for ci := 0; ci < nChunks; ci++ {
 		start := ci * chunkRows
 		end := start + chunkRows
@@ -109,6 +174,7 @@ func recordsToHTMLTableChunks(records [][]string, chunkRows int, caption string)
 			end = nData
 		}
 
+		var b strings.Builder
 		b.WriteString("<table><caption>")
 		b.WriteString(html.EscapeString(caption))
 		b.WriteString("</caption>\n")
@@ -124,8 +190,9 @@ func recordsToHTMLTableChunks(records [][]string, chunkRows int, caption string)
 			b.WriteString("</tr>\n")
 		}
 		b.WriteString("</table>\n")
+		chunks = append(chunks, b.String())
 	}
-	return b.String()
+	return chunks
 }
 
 // ──────────────────────────────────────────────────────────── axis helpers
@@ -512,9 +579,13 @@ func decodeChunkRows(setup map[string]any) int {
 // data into chunkRows-sized atomic tables each repeating the header. An empty
 // or unreadable sheet yields an empty string.
 func renderSheetTables(f *excelize.File, sheet string, chunkRows int) string {
+	return strings.Join(renderSheetTableChunks(f, sheet, chunkRows), "")
+}
+
+func renderSheetTableChunks(f *excelize.File, sheet string, chunkRows int) []string {
 	rows, err := f.GetRows(sheet)
 	if err != nil || len(rows) == 0 {
-		return ""
+		return nil
 	}
 	rows = cleanIllegalControlChars(rows)
 
@@ -544,5 +615,5 @@ func renderSheetTables(f *excelize.File, sheet string, chunkRows int) string {
 		}
 		records = append(records, r)
 	}
-	return recordsToHTMLTableChunks(records, chunkRows, sheet)
+	return recordsToHTMLTableChunkList(records, chunkRows, sheet)
 }

--- a/internal/parser/parser/office_table_render_test.go
+++ b/internal/parser/parser/office_table_render_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/xuri/excelize/v2"
 )
 
+func xlsxTableHTML(res ParseResult) string {
+	var out strings.Builder
+	for _, item := range res.JSON {
+		if item["doc_type_kwd"] != "table" {
+			continue
+		}
+		text, _ := item["text"].(string)
+		out.WriteString(text)
+	}
+	return out.String()
+}
+
 // newTestXLSX builds an in-memory .xlsx from a cell writer.
 func newTestXLSX(t *testing.T, fill func(f *excelize.File)) []byte {
 	t.Helper()
@@ -119,7 +131,7 @@ func TestXLSXParser_HeaderAndCaption(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	html := res.HTML
+	html := xlsxTableHTML(res)
 	if !strings.Contains(html, `<caption>Sheet1</caption>`) {
 		t.Fatalf("want <caption>Sheet1</caption>, got:\n%s", html)
 	}
@@ -155,7 +167,7 @@ func TestXLSXParser_MergedHeaderInheritance(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	html := res.HTML
+	html := xlsxTableHTML(res)
 	// The merged master text must have propagated into all three <th> slots.
 	if !strings.Contains(html, "<tr><th>Sales Report</th><th>Sales Report</th><th>Sales Report</th></tr>") {
 		t.Fatalf("merged master text not inherited into header <th>, got:\n%s", html)
@@ -179,11 +191,11 @@ func TestDetectHeaderRow_ListObject(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	if !strings.Contains(res.HTML, "<tr><th>Name</th><th>Age</th></tr>") {
-		t.Fatalf("want ListObject header row detected, got:\n%s", res.HTML)
+	if !strings.Contains(xlsxTableHTML(res), "<tr><th>Name</th><th>Age</th></tr>") {
+		t.Fatalf("want ListObject header row detected, got:\n%s", xlsxTableHTML(res))
 	}
-	if strings.Contains(res.HTML, "<th>Title</th>") {
-		t.Fatalf("title row must not be the header:\n%s", res.HTML)
+	if strings.Contains(xlsxTableHTML(res), "<th>Title</th>") {
+		t.Fatalf("title row must not be the header:\n%s", xlsxTableHTML(res))
 	}
 }
 
@@ -206,11 +218,11 @@ func TestDetectHeaderRow_Lightweight(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	if !strings.Contains(res.HTML, "<tr><th>Item</th><th>Count</th></tr>") {
-		t.Fatalf("want row-2 header detected, got:\n%s", res.HTML)
+	if !strings.Contains(xlsxTableHTML(res), "<tr><th>Item</th><th>Count</th></tr>") {
+		t.Fatalf("want row-2 header detected, got:\n%s", xlsxTableHTML(res))
 	}
-	if strings.Contains(res.HTML, "<th>100</th>") {
-		t.Fatalf("numeric row 1 must not be the header:\n%s", res.HTML)
+	if strings.Contains(xlsxTableHTML(res), "<th>100</th>") {
+		t.Fatalf("numeric row 1 must not be the header:\n%s", xlsxTableHTML(res))
 	}
 }
 
@@ -228,8 +240,8 @@ func TestXLSXParser_CommonCaseNoRegression(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	if !strings.Contains(res.HTML, "<tr><th>col_a</th><th>col_b</th></tr>") {
-		t.Fatalf("common-case header must render as <th>:\n%s", res.HTML)
+	if !strings.Contains(xlsxTableHTML(res), "<tr><th>col_a</th><th>col_b</th></tr>") {
+		t.Fatalf("common-case header must render as <th>:\n%s", xlsxTableHTML(res))
 	}
 }
 
@@ -256,11 +268,11 @@ func TestDetectHeaderRow_BoldSubtotalNotHeader(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	if !strings.Contains(res.HTML, "<tr><th>2023</th><th>2024</th></tr>") {
-		t.Fatalf("numeric row 1 must remain the header:\n%s", res.HTML)
+	if !strings.Contains(xlsxTableHTML(res), "<tr><th>2023</th><th>2024</th></tr>") {
+		t.Fatalf("numeric row 1 must remain the header:\n%s", xlsxTableHTML(res))
 	}
-	if strings.Contains(res.HTML, "<th>Total</th>") {
-		t.Fatalf("bold subtotal row must not be promoted to header:\n%s", res.HTML)
+	if strings.Contains(xlsxTableHTML(res), "<th>Total</th>") {
+		t.Fatalf("bold subtotal row must not be promoted to header:\n%s", xlsxTableHTML(res))
 	}
 }
 
@@ -289,11 +301,11 @@ func TestDetectHeaderRow_StyledHeaderPastFarMerge(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	if !strings.Contains(res.HTML, "<th>Name</th><th>Desc</th>") {
-		t.Fatalf("narrow bold header past far merge must be detected:\n%s", res.HTML)
+	if !strings.Contains(xlsxTableHTML(res), "<th>Name</th><th>Desc</th>") {
+		t.Fatalf("narrow bold header past far merge must be detected:\n%s", xlsxTableHTML(res))
 	}
-	if strings.Contains(res.HTML, "<th>Sales Report</th>") {
-		t.Fatalf("wide merged title must not be the header:\n%s", res.HTML)
+	if strings.Contains(xlsxTableHTML(res), "<th>Sales Report</th>") {
+		t.Fatalf("wide merged title must not be the header:\n%s", xlsxTableHTML(res))
 	}
 }
 
@@ -319,11 +331,11 @@ func TestDetectHeaderRow_StyledTextHeaderOverNumeric(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	if !strings.Contains(res.HTML, "<tr><th>Product</th><th>Units</th></tr>") {
-		t.Fatalf("styled text header over numeric data must be detected:\n%s", res.HTML)
+	if !strings.Contains(xlsxTableHTML(res), "<tr><th>Product</th><th>Units</th></tr>") {
+		t.Fatalf("styled text header over numeric data must be detected:\n%s", xlsxTableHTML(res))
 	}
-	if strings.Contains(res.HTML, "<th>Report Title</th>") {
-		t.Fatalf("title stub must not be the header:\n%s", res.HTML)
+	if strings.Contains(xlsxTableHTML(res), "<th>Report Title</th>") {
+		t.Fatalf("title stub must not be the header:\n%s", xlsxTableHTML(res))
 	}
 }
 
@@ -438,7 +450,7 @@ func TestRenderSheetTables_FarMergeDoesNotBloatDataRows(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	html := res.HTML
+	html := xlsxTableHTML(res)
 	if !strings.Contains(html, "<tr><th>Name</th><th>Price</th></tr>") {
 		t.Fatalf("want row-2 header detected, got:\n%s", html)
 	}
@@ -477,7 +489,7 @@ func TestRenderSheetTables_MultiSheet(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	html := res.HTML
+	html := xlsxTableHTML(res)
 	if !strings.Contains(html, "<caption>Sheet1</caption>") {
 		t.Fatalf("want Sheet1 caption, got:\n%s", html)
 	}
@@ -500,7 +512,7 @@ func TestRenderSheetTables_EmptySheet(t *testing.T) {
 	if res.Err != nil {
 		t.Fatalf("ParseWithResult: %v", res.Err)
 	}
-	if res.HTML != "" {
-		t.Fatalf("empty sheet must yield empty HTML, got:\n%s", res.HTML)
+	if len(res.JSON) != 0 {
+		t.Fatalf("empty sheet must yield empty JSON, got:\n%v", res.JSON)
 	}
 }

--- a/internal/parser/parser/office_table_render_test.go
+++ b/internal/parser/parser/office_table_render_test.go
@@ -19,6 +19,38 @@ func xlsxTableHTML(res ParseResult) string {
 	return out.String()
 }
 
+func TestXLSXImageMIMEType(t *testing.T) {
+	tests := []struct {
+		extension string
+		mime      string
+		ok        bool
+	}{
+		{extension: ".png", mime: "image/png", ok: true},
+		{extension: ".JPG", mime: "image/jpeg", ok: true},
+		{extension: ".emf", mime: "image/x-emf", ok: true},
+		{extension: ".emz", mime: "image/x-emz", ok: true},
+		{extension: ".ico", mime: "image/x-icon", ok: true},
+		{extension: ".wmf", mime: "image/x-wmf", ok: true},
+		{extension: ".wmz", mime: "image/x-wmz", ok: true},
+		{extension: ".unknown", ok: false},
+	}
+	for _, tc := range tests {
+		mime, ok := xlsxImageMIMEType(tc.extension)
+		if mime != tc.mime || ok != tc.ok {
+			t.Errorf("xlsxImageMIMEType(%q) = (%q, %v), want (%q, %v)", tc.extension, mime, ok, tc.mime, tc.ok)
+		}
+	}
+}
+
+func TestExtractXLSXImagesWarningForInvalidSheet(t *testing.T) {
+	f := excelize.NewFile()
+	defer f.Close()
+	_, warnings := extractXLSXImages(f, "MissingSheet")
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "image discovery failed") {
+		t.Fatalf("warnings = %v, want image discovery warning", warnings)
+	}
+}
+
 // newTestXLSX builds an in-memory .xlsx from a cell writer.
 func newTestXLSX(t *testing.T, fill func(f *excelize.File)) []byte {
 	t.Helper()

--- a/internal/parser/parser/parse_result.go
+++ b/internal/parser/parser/parse_result.go
@@ -81,6 +81,9 @@ type ParseResult struct {
 	// Err is the failure reason. On non-nil Err, all payload
 	// fields are zero values.
 	Err error
+
+	// Warnings contains non-fatal issues encountered while parsing.
+	Warnings []string
 }
 
 // ParseResultProducer is the parser package's single structured-output

--- a/internal/parser/parser/xlsx_parse_method_test.go
+++ b/internal/parser/parser/xlsx_parse_method_test.go
@@ -122,6 +122,31 @@ func TestXLSXParser_ExtractsFloatingImages(t *testing.T) {
 	}
 }
 
+func TestXLSXParser_ImageWithoutAltTextUsesAnchorCell(t *testing.T) {
+	const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+	data := newTestXLSX(t, func(f *excelize.File) {
+		if err := f.AddPictureFromBytes("Sheet1", "C3", &excelize.Picture{
+			Extension: ".png",
+			File:      mustDecodeBase64(t, pngBase64),
+		}); err != nil {
+			t.Fatalf("AddPictureFromBytes: %v", err)
+		}
+	})
+
+	p, err := NewXLSXParser("")
+	if err != nil {
+		t.Fatalf("NewXLSXParser: %v", err)
+	}
+	res := p.ParseWithResult(t.Context(), "without-alt.xlsx", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if len(res.JSON) != 1 || res.JSON[0]["text"] != "C3" {
+		t.Fatalf("image item = %#v, want anchor-cell text C3", res.JSON)
+	}
+}
+
 func mustDecodeBase64(t *testing.T, encoded string) []byte {
 	t.Helper()
 	data, err := base64.StdEncoding.DecodeString(encoded)

--- a/internal/parser/parser/xlsx_parse_method_test.go
+++ b/internal/parser/parser/xlsx_parse_method_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -39,8 +40,7 @@ func TestNormalizeXLSXParseMethod(t *testing.T) {
 }
 
 // TestXLSXParser_DeepDocParseMethod verifies that both the lowercase "deepdoc"
-// and the uppercase "DeepDOC" (as shipped by the ingestion pipeline DSL templates)
-// parse_method values produce the default HTML table output.
+// and the uppercase "DeepDOC" produce structured spreadsheet output.
 func TestXLSXParser_DeepDocParseMethod(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -74,14 +74,61 @@ func TestXLSXParser_DeepDocParseMethod(t *testing.T) {
 			if res.Err != nil {
 				t.Fatalf("ParseWithResult(%s): %v", tc.method, res.Err)
 			}
-			if got, want := res.OutputFormat, "html"; got != want {
+			if got, want := res.OutputFormat, "json"; got != want {
 				t.Fatalf("OutputFormat = %q, want %q", got, want)
 			}
-			if !strings.Contains(res.HTML, tc.cellValue) {
-				t.Fatalf("HTML = %q, want it to contain cell content %q", res.HTML, tc.cellValue)
+			if len(res.JSON) != 1 {
+				t.Fatalf("JSON item count = %d, want 1", len(res.JSON))
+			}
+			text, _ := res.JSON[0]["text"].(string)
+			if !strings.Contains(text, tc.cellValue) {
+				t.Fatalf("JSON = %#v, want it to contain cell content %q", res.JSON, tc.cellValue)
 			}
 		})
 	}
+}
+
+func TestXLSXParser_ExtractsFloatingImages(t *testing.T) {
+	const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+	data := newTestXLSX(t, func(f *excelize.File) {
+		mustSetCell(t, f, "Sheet1", "A1", "table content")
+		if err := f.AddPictureFromBytes("Sheet1", "C3", &excelize.Picture{
+			Extension: ".png",
+			File:      mustDecodeBase64(t, pngBase64),
+			Format:    &excelize.GraphicOptions{AltText: "sheet image"},
+		}); err != nil {
+			t.Fatalf("AddPictureFromBytes: %v", err)
+		}
+	})
+
+	p, err := NewXLSXParser("")
+	if err != nil {
+		t.Fatalf("NewXLSXParser: %v", err)
+	}
+	res := p.ParseWithResult(t.Context(), "with-image.xlsx", data)
+	if res.Err != nil {
+		t.Fatalf("ParseWithResult: %v", res.Err)
+	}
+	if len(res.JSON) != 2 {
+		t.Fatalf("JSON item count = %d, want table and image", len(res.JSON))
+	}
+	image := res.JSON[1]
+	if image["text"] != "sheet image" || image["doc_type_kwd"] != "image" {
+		t.Fatalf("unexpected image item: %#v", image)
+	}
+	if image["image"] != "data:image/png;base64,"+pngBase64 {
+		t.Fatalf("image data = %v, want data URL", image["image"])
+	}
+}
+
+func mustDecodeBase64(t *testing.T, encoded string) []byte {
+	t.Helper()
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	return data
 }
 
 // TestCSVParser_DeepDocParseMethod asserts the CSV parser accepts the

--- a/internal/parser/parser/xlsx_parser.go
+++ b/internal/parser/parser/xlsx_parser.go
@@ -126,6 +126,7 @@ func (p *XLSXParser) ParseWithResult(ctx context.Context, filename string, data 
 	}
 
 	items := make([]map[string]any, 0)
+	warnings := make([]string, 0)
 	for _, sheet := range sheets {
 		for _, table := range renderSheetTableChunks(f, sheet, chunkRows) {
 			items = append(items, map[string]any{
@@ -135,16 +136,15 @@ func (p *XLSXParser) ParseWithResult(ctx context.Context, filename string, data 
 				"sheet":        sheet,
 			})
 		}
-		images, err := extractXLSXImages(f, sheet)
-		if err != nil {
-			return ParseResult{Err: fmt.Errorf("xlsx images in sheet %q: %w", sheet, err)}
-		}
+		images, imageWarnings := extractXLSXImages(f, sheet)
 		items = append(items, images...)
+		warnings = append(warnings, imageWarnings...)
 	}
 
 	return ParseResult{
 		OutputFormat: "json",
 		File:         map[string]any{"name": filename, "format": "xlsx", "sheets": len(sheets)},
 		JSON:         items,
+		Warnings:     warnings,
 	}
 }

--- a/internal/parser/parser/xlsx_parser.go
+++ b/internal/parser/parser/xlsx_parser.go
@@ -125,14 +125,26 @@ func (p *XLSXParser) ParseWithResult(ctx context.Context, filename string, data 
 		chunkRows = defaultTableChunkRows
 	}
 
-	var html strings.Builder
+	items := make([]map[string]any, 0)
 	for _, sheet := range sheets {
-		html.WriteString(renderSheetTables(f, sheet, chunkRows))
+		for _, table := range renderSheetTableChunks(f, sheet, chunkRows) {
+			items = append(items, map[string]any{
+				"text":         table,
+				"doc_type_kwd": "table",
+				"ck_type":      "table",
+				"sheet":        sheet,
+			})
+		}
+		images, err := extractXLSXImages(f, sheet)
+		if err != nil {
+			return ParseResult{Err: fmt.Errorf("xlsx images in sheet %q: %w", sheet, err)}
+		}
+		items = append(items, images...)
 	}
 
 	return ParseResult{
-		OutputFormat: "html",
+		OutputFormat: "json",
 		File:         map[string]any{"name": filename, "format": "xlsx", "sheets": len(sheets)},
-		HTML:         html.String(),
+		JSON:         items,
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

The Go XLSX parser previously returned the entire workbook as a single HTML payload and could not preserve embedded or floating images.

This PR changes XLSX parsing to structured JSON output:

- Splits tables according to `chunkRows`.
- Emits images as independent items with `doc_type_kwd: "image"`.
- Preserves image data as `data:image/...;base64,...`.
- Includes worksheet and cell metadata.
- Prevents image binary data from being treated as embedding text.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)