### PR TITLE
fix(parser): align image output_format to json and use per-family defaults (strict)

### DIFF
--- a/agent/templates/advanced_ingestion_pipeline.json
+++ b/agent/templates/advanced_ingestion_pipeline.json
@@ -248,7 +248,7 @@
                             ]
                         },
                         "image": {
-                            "output_format": "text",
+                            "output_format": "json",
                             "parse_method": "ocr",
                             "preprocess": "main_content",
                             "suffix": [
@@ -498,7 +498,7 @@
                                 },
                                 {
                                     "fileFormat": "image",
-                                    "output_format": "text",
+                                    "output_format": "json",
                                     "parse_method": "ocr",
                                     "preprocess": "main_content",
                                     "system_prompt": ""

--- a/agent/templates/chunk_summary.json
+++ b/agent/templates/chunk_summary.json
@@ -131,7 +131,7 @@
                             ]
                         },
                         "image": {
-                            "output_format": "text",
+                            "output_format": "json",
                             "parse_method": "ocr",
                             "preprocess": "main_content",
                             "suffix": [
@@ -352,7 +352,7 @@
                                 },
                                 {
                                     "fileFormat": "image",
-                                    "output_format": "text",
+                                    "output_format": "json",
                                     "parse_method": "ocr",
                                     "preprocess": "main_content",
                                     "system_prompt": ""

--- a/agent/templates/compiler.json
+++ b/agent/templates/compiler.json
@@ -105,7 +105,7 @@
             },
             "image": {
               "order_index": 2,
-              "output_format": "text",
+              "output_format": "json",
               "parse_method": "ocr",
               "suffix": [
                 "jpg",
@@ -299,7 +299,7 @@
               },
               {
                 "fileFormat": "image",
-                "output_format": "text",
+                "output_format": "json",
                 "parse_method": "ocr"
               },
               {

--- a/agent/templates/title_chunker.json
+++ b/agent/templates/title_chunker.json
@@ -131,7 +131,7 @@
                                 ]
                             },
                             "image": {
-                                "output_format": "text",
+                                "output_format": "json",
                                 "parse_method": "ocr",
                                 "preprocess": "main_content",
                                 "suffix": [
@@ -371,7 +371,7 @@
                                     },
                                     {
                                         "fileFormat": "image",
-                                        "output_format": "text",
+                                        "output_format": "json",
                                         "parse_method": "ocr",
                                         "preprocess": "main_content",
                                         "system_prompt": ""

--- a/internal/ingestion/component/parser_dispatch.go
+++ b/internal/ingestion/component/parser_dispatch.go
@@ -101,9 +101,7 @@ func configureParserFromSetups(p any, fileType utility.FileType, setups map[stri
 // component short-circuits with _ERROR rather than emitting a
 // payload the downstream chunker cannot consume.
 //
-// Strict mode: explicit legacy image:text is NOT coerced. Old canvases
-// must be re-saved/migrated; this keeps the contract tight and makes
-// the breakage explicit rather than silently fixing.
+// Strict mode: explicit image:text is rejected by the whitelist.
 func resolveOutputFormat(family string, setups map[string]schema.ParserSetup, allowed map[string][]string) (string, error) {
 	setup, ok := setups[family]
 	if !ok {
@@ -114,7 +112,7 @@ func resolveOutputFormat(family string, setups map[string]schema.ParserSetup, al
 	allowedList, ok := allowed[family]
 	if !ok || len(allowedList) == 0 {
 		// No whitelist entry — accept what the setup asked for, or
-		// fall back to "text" for legacy families with no constraint.
+		// fall back to "text" for families without a whitelist.
 		if format == "" {
 			format = "text"
 		}
@@ -154,7 +152,7 @@ func defaultOutputFormatForFamily(family string) (string, bool) {
 	case "doc", "docx", "slides", "image", "markdown", "text&code", "html", "epub", "json":
 		return "json", true
 	case "email":
-		return "json", true
+		return "text", true
 	case "audio", "video":
 		return "text", true
 	default:

--- a/internal/ingestion/component/parser_dispatch.go
+++ b/internal/ingestion/component/parser_dispatch.go
@@ -139,27 +139,30 @@ func resolveOutputFormat(family string, setups map[string]schema.ParserSetup, al
 	)
 }
 
-// defaultOutputFormatForFamily returns the Python/Go canonical default
-// output_format for a family, as declared in rag/flow/parser/parser.py
-// ParserParam.setups and mirrored in parser.go:defaultSetups(). Used when
-// setups[family] exists but output_format is empty.
+// defaultOutputFormatForFamily returns the per-family default
+// output_format used when setups[family] exists but output_format is
+// empty. For most families it is the value in defaultSetups()
+// (which mirrors rag/flow/parser/parser.py ParserParam.setups).
+// Two families diverge intentionally and are overridden here:
+//   - email: defaultSetups is "json" (Python), but dispatch defaults
+//     to "text" to match frontend InitialOutputFormatMap, EmailParser
+//     text fallback, and ingestion_pipeline_email.json.
+//   - audio: defaultSetups is "text" (Python), but dispatch defaults
+//     to "json" to match media_dispatch json fallback and Python
+//     whitelist [json] (audio:text would be rejected if validated).
 func defaultOutputFormatForFamily(family string) (string, bool) {
-	switch family {
-	case "pdf":
-		return "json", true
-	case "spreadsheet":
-		return "html", true
-	case "doc", "docx", "slides", "image", "markdown", "text&code", "html", "epub", "json":
-		return "json", true
-	case "email":
+	if family == "email" {
 		return "text", true
-	case "audio":
-		return "json", true
-	case "video":
-		return "text", true
-	default:
-		return "", false
 	}
+	if family == "audio" {
+		return "json", true
+	}
+	if s, ok := defaultSetups()[family]; ok {
+		if v, ok := s["output_format"].(string); ok && v != "" {
+			return v, true
+		}
+	}
+	return "", false
 }
 
 // dispatchParse resolves the parser for the given fileType and invokes

--- a/internal/ingestion/component/parser_dispatch.go
+++ b/internal/ingestion/component/parser_dispatch.go
@@ -87,9 +87,10 @@ func configureParserFromSetups(p any, fileType utility.FileType, setups map[stri
 //
 //  1. setups[fileType].output_format (or "" when absent),
 //  2. if absent and the family has an allowed_output_format entry,
-//     use the first allowed value as the default (mirrors Python's
-//     per-family explicit default in ParserParam.__init__ setups,
-//     e.g. "image" → "json", "pdf" → "json"),
+//     use the Python per-family default (mirrors ParserParam.__init__
+//     setups, e.g. "image" → "json", "pdf" → "json", "spreadsheet" →
+//     "html"), falling back to allowed[0] only when no explicit default
+//     is known,
 //  3. if absent and the family has no allowed_output_format entry,
 //     return "" (the component falls back to text-page mode
 //     without validating).
@@ -99,6 +100,10 @@ func configureParserFromSetups(p any, fileType utility.FileType, setups map[stri
 // via check_empty / check_valid_value, surfaced as an error so the
 // component short-circuits with _ERROR rather than emitting a
 // payload the downstream chunker cannot consume.
+//
+// Strict mode: explicit legacy image:text is NOT coerced. Old canvases
+// must be re-saved/migrated; this keeps the contract tight and makes
+// the breakage explicit rather than silently fixing.
 func resolveOutputFormat(family string, setups map[string]schema.ParserSetup, allowed map[string][]string) (string, error) {
 	setup, ok := setups[family]
 	if !ok {
@@ -116,9 +121,13 @@ func resolveOutputFormat(family string, setups map[string]schema.ParserSetup, al
 		return format, nil
 	}
 	if format == "" {
-		// No explicit format: use the first entry from the whitelist,
-		// which matches the Python per-family default declared in
-		// ParserParam.__init__ (e.g. image → json, pdf → json).
+		// No explicit format: use the Python per-family default declared
+		// in ParserParam.__init__ / defaultSetups(). This is not always
+		// allowed[0] (e.g. spreadsheet default is "html" but allowed[0]
+		// is "json"; markdown default is "json" but allowed[0] is "text").
+		if def, ok := defaultOutputFormatForFamily(family); ok {
+			return def, nil
+		}
 		return allowedList[0], nil
 	}
 	for _, candidate := range allowedList {
@@ -130,6 +139,27 @@ func resolveOutputFormat(family string, setups map[string]schema.ParserSetup, al
 		"parser: output_format %q for %q is not in allowed_output_format %v",
 		format, family, allowedList,
 	)
+}
+
+// defaultOutputFormatForFamily returns the Python/Go canonical default
+// output_format for a family, as declared in rag/flow/parser/parser.py
+// ParserParam.setups and mirrored in parser.go:defaultSetups(). Used when
+// setups[family] exists but output_format is empty.
+func defaultOutputFormatForFamily(family string) (string, bool) {
+	switch family {
+	case "pdf":
+		return "json", true
+	case "spreadsheet":
+		return "html", true
+	case "doc", "docx", "slides", "image", "markdown", "text&code", "html", "epub", "json":
+		return "json", true
+	case "email":
+		return "json", true
+	case "audio", "video":
+		return "text", true
+	default:
+		return "", false
+	}
 }
 
 // dispatchParse resolves the parser for the given fileType and invokes

--- a/internal/ingestion/component/parser_dispatch.go
+++ b/internal/ingestion/component/parser_dispatch.go
@@ -153,7 +153,9 @@ func defaultOutputFormatForFamily(family string) (string, bool) {
 		return "json", true
 	case "email":
 		return "text", true
-	case "audio", "video":
+	case "audio":
+		return "json", true
+	case "video":
 		return "text", true
 	default:
 		return "", false

--- a/internal/ingestion/component/parser_dispatch.go
+++ b/internal/ingestion/component/parser_dispatch.go
@@ -86,8 +86,10 @@ func configureParserFromSetups(p any, fileType utility.FileType, setups map[stri
 // allowed_output_format[fileType]. We mirror that exact sequence:
 //
 //  1. setups[fileType].output_format (or "" when absent),
-//  2. if absent, default to "text" (the most permissive option
-//     that every family accepts),
+//  2. if absent and the family has an allowed_output_format entry,
+//     use the first allowed value as the default (mirrors Python's
+//     per-family explicit default in ParserParam.__init__ setups,
+//     e.g. "image" → "json", "pdf" → "json"),
 //  3. if absent and the family has no allowed_output_format entry,
 //     return "" (the component falls back to text-page mode
 //     without validating).
@@ -104,13 +106,20 @@ func resolveOutputFormat(family string, setups map[string]schema.ParserSetup, al
 		return "", nil
 	}
 	format, _ := setup["output_format"].(string)
-	if format == "" {
-		format = "text"
-	}
 	allowedList, ok := allowed[family]
 	if !ok || len(allowedList) == 0 {
-		// No whitelist entry — accept what the setup asked for.
+		// No whitelist entry — accept what the setup asked for, or
+		// fall back to "text" for legacy families with no constraint.
+		if format == "" {
+			format = "text"
+		}
 		return format, nil
+	}
+	if format == "" {
+		// No explicit format: use the first entry from the whitelist,
+		// which matches the Python per-family default declared in
+		// ParserParam.__init__ (e.g. image → json, pdf → json).
+		return allowedList[0], nil
 	}
 	for _, candidate := range allowedList {
 		if strings.EqualFold(candidate, format) {

--- a/internal/ingestion/component/parser_dispatch_test.go
+++ b/internal/ingestion/component/parser_dispatch_test.go
@@ -229,6 +229,7 @@ func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 	allowed := map[string][]string{
 		"pdf":      {"json", "markdown"},
 		"markdown": {"text", "json"},
+		"image":    {"json"},
 	}
 	cases := []struct {
 		name    string

--- a/internal/ingestion/component/parser_dispatch_test.go
+++ b/internal/ingestion/component/parser_dispatch_test.go
@@ -223,13 +223,16 @@ func TestFileTypeFromInputs_ResolutionOrder(t *testing.T) {
 
 // TestResolveOutputFormat_DefaultsAndWhitelist pins the two-layer
 // behavior of resolveOutputFormat: it returns the setup's
-// output_format when present (or "text" when absent), and
-// rejects values not in the allowed_output_format list.
+// output_format when present (or the per-family default when absent,
+// e.g. markdown→json, spreadsheet→html), and rejects values not in
+// the allowed_output_format list. Legacy image:text is coerced to json.
 func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 	allowed := map[string][]string{
-		"pdf":      {"json", "markdown"},
-		"markdown": {"text", "json"},
-		"image":    {"json"},
+		"pdf":         {"json", "markdown"},
+		"markdown":    {"text", "json"},
+		"image":       {"json"},
+		"spreadsheet": {"json", "markdown", "html"},
+		"email":       {"text", "json"},
 	}
 	cases := []struct {
 		name    string
@@ -257,10 +260,34 @@ func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 			want:   "markdown",
 		},
 		{
-			name:   "setup without output_format → default text",
+			name:   "setup without output_format → per-family default (markdown→json)",
 			setups: map[string]schema.ParserSetup{"markdown": {}},
 			family: "markdown",
-			want:   "text",
+			want:   "json",
+		},
+		{
+			name:   "setup without output_format → per-family default (spreadsheet→html)",
+			setups: map[string]schema.ParserSetup{"spreadsheet": {}},
+			family: "spreadsheet",
+			want:   "html",
+		},
+		{
+			name:   "setup without output_format → per-family default (image→json)",
+			setups: map[string]schema.ParserSetup{"image": {}},
+			family: "image",
+			want:   "json",
+		},
+		{
+			name:    "image explicit text (legacy) → strict reject",
+			setups:  map[string]schema.ParserSetup{"image": {"output_format": "text"}},
+			family:  "image",
+			wantErr: true,
+		},
+		{
+			name:    "image explicit TEXT uppercase → strict reject",
+			setups:  map[string]schema.ParserSetup{"image": {"output_format": "TEXT"}},
+			family:  "image",
+			wantErr: true,
 		},
 		{
 			name:    "pdf asking for html (not allowed) → reject",
@@ -273,6 +300,12 @@ func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 			setups: map[string]schema.ParserSetup{"video": {"output_format": "json"}},
 			family: "video",
 			want:   "json",
+		},
+		{
+			name:   "family with no whitelist empty → default text",
+			setups: map[string]schema.ParserSetup{"video": {}},
+			family: "video",
+			want:   "text",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/ingestion/component/parser_dispatch_test.go
+++ b/internal/ingestion/component/parser_dispatch_test.go
@@ -233,6 +233,7 @@ func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 		"image":       {"json"},
 		"spreadsheet": {"json", "markdown", "html"},
 		"email":       {"text", "json"},
+		"audio":       {"text", "json"},
 	}
 	cases := []struct {
 		name    string
@@ -302,6 +303,18 @@ func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:   "setup without output_format → per-family default (audio→json)",
+			setups: map[string]schema.ParserSetup{"audio": {}},
+			family: "audio",
+			want:   "json",
+		},
+		{
+			name:   "setup without output_format → per-family default (pdf→json)",
+			setups: map[string]schema.ParserSetup{"pdf": {}},
+			family: "pdf",
+			want:   "json",
+		},
+		{
 			name:   "family with no whitelist → accept setup value",
 			setups: map[string]schema.ParserSetup{"video": {"output_format": "json"}},
 			family: "video",
@@ -345,6 +358,65 @@ func TestDefaultSetups_DOCX_OutputFormatMarkdown(t *testing.T) {
 	}
 	if got != "json" {
 		t.Errorf("docx.output_format = %q, want %q", got, "json")
+	}
+}
+
+// TestDefaultOutputFormatForFamily_Sync verifies the dispatch default
+// stays in sync with the allowed whitelist and, except for the two
+// intentional overrides (email:text, audio:json), with defaultSetups.
+func TestDefaultOutputFormatForFamily_Sync(t *testing.T) {
+	allowed := schema.ParserParam{}.Defaults().AllowedOutputFormat
+	overrides := map[string]string{"email": "text", "audio": "json"}
+	for family, def := range map[string]string{
+		"pdf":         "json",
+		"spreadsheet": "html",
+		"doc":         "json",
+		"docx":        "json",
+		"slides":      "json",
+		"image":       "json",
+		"markdown":    "json",
+		"text&code":   "json",
+		"html":        "json",
+		"epub":        "json",
+		"json":        "json",
+		"email":       "text",
+		"audio":       "json",
+		"video":       "text",
+	} {
+		got, ok := defaultOutputFormatForFamily(family)
+		if !ok {
+			t.Errorf("defaultOutputFormatForFamily(%q) missing", family)
+			continue
+		}
+		if got != def {
+			t.Errorf("defaultOutputFormatForFamily(%q)=%q, want %q", family, got, def)
+		}
+		if list, hasWL := allowed[family]; hasWL && len(list) > 0 {
+			found := false
+			for _, c := range list {
+				if strings.EqualFold(c, got) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("default %q for %q not in allowed %v", got, family, list)
+			}
+		}
+		if ov, isOverride := overrides[family]; isOverride {
+			if got != ov {
+				t.Errorf("override %q got %q want %q", family, got, ov)
+			}
+			continue
+		}
+		if ds, ok := defaultSetups()[family]; ok {
+			if want, ok := ds["output_format"].(string); ok && want != got {
+				t.Errorf("family %q dispatch default %q != defaultSetups %q (should be synced or listed as override)", family, got, want)
+			}
+		}
+	}
+	if _, ok := defaultOutputFormatForFamily("unknown"); ok {
+		t.Errorf("unknown family should return !ok")
 	}
 }
 

--- a/internal/ingestion/component/parser_dispatch_test.go
+++ b/internal/ingestion/component/parser_dispatch_test.go
@@ -225,7 +225,7 @@ func TestFileTypeFromInputs_ResolutionOrder(t *testing.T) {
 // behavior of resolveOutputFormat: it returns the setup's
 // output_format when present (or the per-family default when absent,
 // e.g. markdown→json, spreadsheet→html), and rejects values not in
-// the allowed_output_format list. Legacy image:text is coerced to json.
+// the allowed_output_format list. Explicit image:text is rejected.
 func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 	allowed := map[string][]string{
 		"pdf":         {"json", "markdown"},
@@ -276,6 +276,12 @@ func TestResolveOutputFormat_DefaultsAndWhitelist(t *testing.T) {
 			setups: map[string]schema.ParserSetup{"image": {}},
 			family: "image",
 			want:   "json",
+		},
+		{
+			name:   "setup without output_format → per-family default (email→text)",
+			setups: map[string]schema.ParserSetup{"email": {}},
+			family: "email",
+			want:   "text",
 		},
 		{
 			name:    "image explicit text (legacy) → strict reject",

--- a/internal/parser/parser/picture_parser.go
+++ b/internal/parser/parser/picture_parser.go
@@ -121,9 +121,12 @@ func (p *PictureParser) ParseWithResult(ctx context.Context, filename string, da
 
 	// OutputFormat, VLMModelID, ImageContextSize, and LayoutRecognize
 	// are consumed by maybeDispatchImage at the component layer.
+	// Image family only allows json (schema/parser.go, Python parser.py),
+	// so default empty to json. Strict: explicit text is kept as-is
+	// and will be rejected by the dispatch whitelist.
 	outFmt := p.OutputFormat
 	if outFmt == "" {
-		outFmt = "text"
+		outFmt = "json"
 	}
 
 	return ParseResult{

--- a/internal/parser/parser/picture_parser_test.go
+++ b/internal/parser/parser/picture_parser_test.go
@@ -73,8 +73,8 @@ func TestPictureParser_ParseWithResult_NilSetup(t *testing.T) {
 	if res.Err != nil {
 		t.Errorf("unexpected error for nil setup: %v", res.Err)
 	}
-	if res.OutputFormat != "text" {
-		t.Errorf("OutputFormat = %q, want text", res.OutputFormat)
+	if res.OutputFormat != "json" {
+		t.Errorf("OutputFormat = %q, want json (image only allows json)", res.OutputFormat)
 	}
 	file, ok := res.File["doc_type_kwd"].(string)
 	if !ok || file != "image" {
@@ -92,8 +92,8 @@ func TestPictureParser_ParseWithResult_ValidExtensions(t *testing.T) {
 		if res.Err != nil {
 			t.Errorf("unexpected error for .%s: %v", ext, res.Err)
 		}
-		if res.OutputFormat != "text" {
-			t.Errorf("OutputFormat = %q for .%s, want text", res.OutputFormat, ext)
+		if res.OutputFormat != "json" {
+			t.Errorf("OutputFormat = %q for .%s, want json (image only allows json)", res.OutputFormat, ext)
 		}
 	}
 }

--- a/web/src/pages/agent/constant/pipeline.tsx
+++ b/web/src/pages/agent/constant/pipeline.tsx
@@ -29,7 +29,7 @@ export enum SpreadsheetOutputFormat {
 }
 
 export enum ImageOutputFormat {
-  Text = 'text',
+  Json = 'json',
 }
 
 export enum EmailOutputFormat {
@@ -81,7 +81,7 @@ export const OutputFormatMap = {
 export const InitialOutputFormatMap = {
   [FileType.PDF]: PdfOutputFormat.Json,
   [FileType.Spreadsheet]: SpreadsheetOutputFormat.Html,
-  [FileType.Image]: ImageOutputFormat.Text,
+  [FileType.Image]: ImageOutputFormat.Json,
   [FileType.Email]: EmailOutputFormat.Text,
   [FileType.TextMarkdown]: TextMarkdownOutputFormat.Text,
   [FileType.Code]: TextJsonOutputFormat.Json,
@@ -208,7 +208,7 @@ export const initialParserValues = {
     },
     {
       fileFormat: FileType.Image,
-      output_format: ImageOutputFormat.Text,
+      output_format: ImageOutputFormat.Json,
       parse_method: ImageParseMethod.OCR,
       preprocess: PreprocessValue.main_content,
       system_prompt: '',


### PR DESCRIPTION
Fixes ingestion failure when image document hits Parser:

`parser: output_format "text" for "image" is not in allowed_output_format [json]` (`task 94c74573647748feb9ab3513c39949b8, canvas 复杂/bb8f464d5b38495e9ae7f5dfd9ae3e75, document 2957e0fc`)

**Root cause**
- Frontend `web/src/pages/agent/constant/pipeline.tsx:31` `ImageOutputFormat={Text='text'}` + `84`/`211` defaulted image to `text`, but backend `internal/ingestion/component/schema/parser.go:83` allows only `[json]` (`rag/flow/parser/parser.py:95/208` same) and `internal/ingestion/component/parser.go:295` defaults to `json`. New canvases always persisted `image:{output_format:text}`, hitting `internal/ingestion/component/parser.go:443` -> `parser_dispatch.go:120` whitelist check.
- Go fallback `parser_dispatch.go:104` unconditionally defaulted empty `output_format` to `text`, so even `image:{}` became `text∉[json]`.
- `internal/parser/parser/picture_parser.go:129` also defaulted empty to `text`.

**Fix (strict, no compat for explicit legacy text)**
- Frontend: `ImageOutputFormat.Text->Json`, `InitialOutputFormatMap[Image]` and `initialParserValues` to `Json` (also fixes Python path which hardcodes json in `parser.py:1171`)
- Templates: `agent/templates/*.json` 4 files `image:text->json`
- Backend `parser_dispatch.go`: empty `output_format` now uses per-family canonical defaults via `defaultSetups()` (DRY, mirrors `ParserParam.setups` / `parser.go:defaultSetups()`), not `allowed[0]`. Keeps intentional overrides with rationale:
  - `email -> text` to match frontend `InitialOutputFormatMap`, `EmailParser` text fallback and `ingestion_pipeline_email.json`
  - `audio -> json` to match Python `allowed_output_format["audio"]=["json"]` and media_dispatch json path (otherwise `text` would be rejected)
  - e.g. `image->json`, `pdf->json`, `spreadsheet->html`, `markdown/text&code/html->json`, `video->text`
- `picture_parser.go`: empty -> `json`; explicit `text` kept for whitelist rejection
- Comments: remove compat/migration wording per AGENTS.md (`Strict mode: explicit image:text is rejected by the whitelist.` and `families without a whitelist`)
- Tests: `TestResolveOutputFormat_DefaultsAndWhitelist` updated (markdown->json, spreadsheet->html, image->json, email->text, audio->json, pdf->json), add `TestDefaultOutputFormatForFamily_Sync` to guard drift; `picture_parser_test.go` expectations `text->json` (image only allows json) – fixes CI `internal/parser/parser` failure

**Compatibility**
Existing canvases with explicit `image:text` are rejected (strict) and must be re-saved / migrated; no silent coercion. `image:{}` and new canvases now succeed.

**Verification**
`bash build.sh --test ./internal/ingestion/component` `ok` and `bash build.sh --test ./internal/parser/parser` `ok`
