### PR TITLE
fix(web): use a dedicated label for the thinking mode field

### DIFF
--- a/web/src/components/llm-setting-items/next.tsx
+++ b/web/src/components/llm-setting-items/next.tsx
@@ -262,7 +262,7 @@ export function LlmSettingFieldItems({
           render={({ field }) => (
             <FormItem className="flex justify-between items-center">
               <FormLabel className="flex-1" tooltip={t('thinkingTip')}>
-                {t('thinking')}
+                {t('thinkingMode')}
               </FormLabel>
               <FormControl>
                 <Select

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1113,6 +1113,7 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       maxTokensInvalidMessage: 'Please enter a valid number for Max tokens.',
       maxTokensMinMessage: 'Max tokens cannot be less than 0.',
       thinking: 'Thinking',
+      thinkingMode: 'Thinking',
       thought: 'Thought',
       thinkingDefault: 'System default',
       thinkingEnabled: 'Enabled',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1011,6 +1011,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
       maxTokensInvalidMessage: '请输入有效的最大令牌数。',
       maxTokensMinMessage: '最大令牌数不能小于 0。',
       thinking: '思考中...',
+      thinkingMode: '思考',
       thought: '思考完成',
       thinkingDefault: '系统默认',
       thinkingEnabled: '开启',


### PR DESCRIPTION
### Summary

fix(web): use a dedicated label for the thinking mode field

The thinking mode selector reused the `thinking` key, which is the streaming status text ("思考中..." in Chinese), so the field label read as an in-progress status. Add a `thinkingMode` key for the label instead.
