### PR TITLE
fix(web): list the agent flow type card first

### DIFF
--- a/web/src/pages/agents/create-agent-form.tsx
+++ b/web/src/pages/agents/create-agent-form.tsx
@@ -41,7 +41,7 @@ function FlowTypeCards({ value, onChange }: FlowTypeCardProps) {
 
   return (
     <section className="flex gap-10">
-      {[FlowType.Flow, FlowType.Compiler, FlowType.Agent].map((val) => {
+      {[FlowType.Agent, FlowType.Flow, FlowType.Compiler].map((val) => {
         const isActive = value === val;
         const config = FlowTypeConfig[val];
         const Icon = config.icon;


### PR DESCRIPTION
### Summary

fix(web): list the agent flow type card first

Agent is the primary choice when creating a flow, so surface it ahead of Flow and Compiler instead of burying it at the end of the card row.
