### PR TITLE
fix(web): add missing hover tooltips to dataset data source action buttons

### DIFF
--- a/web/src/pages/dataset/setting/go/components/link-data-source.tsx
+++ b/web/src/pages/dataset/setting/go/components/link-data-source.tsx
@@ -74,7 +74,7 @@ const DataSourceItem = (props: DataSourceItemProps) => {
           />
         </div>
         <Tooltip>
-          <TooltipTrigger>
+          <TooltipTrigger asChild>
             <Button
               variant={'transparent'}
               className="border-none hidden group-hover:block"
@@ -90,33 +90,45 @@ const DataSourceItem = (props: DataSourceItemProps) => {
             {t('knowledgeConfiguration.rebuildTip')}
           </TooltipContent>
         </Tooltip>
-        <Button
-          variant={'transparent'}
-          className="border-none hidden group-hover:block"
-          type="button"
-          onClick={() => {
-            toDetail(id);
-          }}
-        >
-          <Settings />
-        </Button>
-        <>
-          <Button
-            type="button"
-            variant={'transparent'}
-            className="border-none hidden group-hover:block"
-            onClick={() => {
-              delSourceModal({
-                data: props,
-                type: 'unlink',
-                dataSourceInfo: dataSourceInfo,
-                onOk: (data) => unbindFunc?.(data as DataSourceItemProps),
-              });
-            }}
-          >
-            <Unlink />
-          </Button>
-        </>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={'transparent'}
+              className="border-none hidden group-hover:block"
+              type="button"
+              onClick={() => {
+                toDetail(id);
+              }}
+            >
+              <Settings />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t('knowledgeConfiguration.settings')}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant={'transparent'}
+              className="border-none hidden group-hover:block"
+              onClick={() => {
+                delSourceModal({
+                  data: props,
+                  type: 'unlink',
+                  dataSourceInfo: dataSourceInfo,
+                  onOk: (data) => unbindFunc?.(data as DataSourceItemProps),
+                });
+              }}
+            >
+              <Unlink />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t('dataflowParser.unlinkSourceModalConfirmText')}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/web/src/pages/dataset/setting/python/components/link-data-source.tsx
+++ b/web/src/pages/dataset/setting/python/components/link-data-source.tsx
@@ -75,7 +75,7 @@ const DataSourceItem = (props: DataSourceItemProps) => {
           />
         </div>
         <Tooltip>
-          <TooltipTrigger>
+          <TooltipTrigger asChild>
             <Button
               variant={'transparent'}
               className="border-none hidden group-hover:block"
@@ -84,7 +84,6 @@ const DataSourceItem = (props: DataSourceItemProps) => {
                 handleRebuild({ source_id: id });
               }}
             >
-              {/* <Settings /> */}
               <IconFontFill name="reparse" className="text-text-primary" />
             </Button>
           </TooltipTrigger>
@@ -92,37 +91,45 @@ const DataSourceItem = (props: DataSourceItemProps) => {
             {t('knowledgeConfiguration.rebuildTip')}
           </TooltipContent>
         </Tooltip>
-        <Button
-          variant={'transparent'}
-          className="border-none hidden group-hover:block"
-          type="button"
-          onClick={() => {
-            toDetail(id);
-          }}
-          // onClick={() =>
-          //   openLinkModalFunc?.(true, { ...omit(props, ['openLinkModalFunc']) })
-          // }
-        >
-          <Settings />
-        </Button>
-        <>
-          <Button
-            type="button"
-            variant={'transparent'}
-            className="border-none hidden group-hover:block"
-            onClick={() => {
-              // openUnlinkModal();
-              delSourceModal({
-                data: props,
-                type: 'unlink',
-                dataSourceInfo: dataSourceInfo,
-                onOk: (data) => unbindFunc?.(data as DataSourceItemProps),
-              });
-            }}
-          >
-            <Unlink />
-          </Button>
-        </>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={'transparent'}
+              className="border-none hidden group-hover:block"
+              type="button"
+              onClick={() => {
+                toDetail(id);
+              }}
+            >
+              <Settings />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t('knowledgeConfiguration.settings')}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant={'transparent'}
+              className="border-none hidden group-hover:block"
+              onClick={() => {
+                delSourceModal({
+                  data: props,
+                  type: 'unlink',
+                  dataSourceInfo: dataSourceInfo,
+                  onOk: (data) => unbindFunc?.(data as DataSourceItemProps),
+                });
+              }}
+            >
+              <Unlink />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t('dataflowParser.unlinkSourceModalConfirmText')}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );


### PR DESCRIPTION
### Summary

On the dataset configuration page ("Data source" section), the icon-only action buttons that appear on hover next to a linked data source row gave no hint about what they do:

- The **reparse** button already had a tooltip, but its `TooltipTrigger` lacked `asChild`, so Radix rendered its own `<button>` around the shadcn `Button`, producing an invalid nested `<button>` in the DOM.
- The **settings (gear)** and **unlink** buttons had no `Tooltip` at all, so hovering them showed nothing.

Reported as: hovering the controls of an RSS data source in the dataset configuration shows no button tips.

## Fix

In `DataSourceItem` of both setting variants (`go` and `python`) of `web/src/pages/dataset/setting/*/components/link-data-source.tsx`:

- Wrap the settings button in `Tooltip` / `TooltipTrigger asChild` with the existing key `knowledgeConfiguration.settings` ("Settings" / "设置").
- Wrap the unlink button in `Tooltip` / `TooltipTrigger asChild` with the existing key `dataflowParser.unlinkSourceModalConfirmText` ("Unlink" / "取消链接") — the same label the unlink confirmation modal already uses.
- Add `asChild` to the existing reparse `TooltipTrigger` so the trigger is the button itself (no nested `<button>`), matching the pattern used by the other 70+ tooltip call sites in the codebase.
- Drop a useless `<>…</>` fragment and dead commented-out lines inside the rewritten region.

Both i18n keys already exist in all locales; no locale files were touched.

## Verification

- Reproduced locally on the dataset configuration page with a linked RSS data source: before the fix, hovering the settings/unlink buttons showed no tooltip; after the fix, all three buttons (reparse / settings / unlink) show their tooltips.
- Confirmed in the DOM that the invalid nested `<button>` around the reparse button is gone (5 → 4 buttons in the row).
- `npm run type-check`: no errors in the changed files (the repo has pre-existing unrelated errors).
- `npx oxlint` on both changed files: 0 errors (5 pre-existing `no-console` warnings in untouched code).
- The `go` variant was verified end-to-end in the browser; the `python` variant carries the identical symmetric change and is covered by the type-check (the variant is fixed per session by the backend language, so only one variant renders at a time).
