### PR TITLE
fix(web): dataset auto-metadata toggle reverts to off after save

### DIFF
--- a/web/src/pages/dataset/setting/go/hooks.test.tsx
+++ b/web/src/pages/dataset/setting/go/hooks.test.tsx
@@ -1,0 +1,96 @@
+import { useUpdateKnowledge } from '@/hooks/use-knowledge-request';
+import { renderHook } from '@testing-library/react';
+import { useSaveDatasetSetting } from './hooks';
+
+let mockIsGoBackend = true;
+jest.mock('@/utils/backend-runtime', () => ({
+  isGoBackend: () => mockIsGoBackend,
+  getBackendLanguage: () => (mockIsGoBackend ? 'go' : 'python'),
+}));
+jest.mock('@/hooks/use-knowledge-request', () => ({
+  useFetchDatasetPipelineConfiguration: jest.fn(),
+  useUpdateKnowledge: jest.fn(),
+}));
+jest.mock('@/pages/user-setting/data-source/constant', () => ({
+  useDataSourceInfo: jest.fn(() => ({ dataSourceInfo: {} })),
+}));
+jest.mock('@/services/knowledge-service', () => ({
+  checkEmbedding: jest.fn(),
+}));
+
+const mockUseUpdateKnowledge = jest.mocked(useUpdateKnowledge);
+
+describe('useSaveDatasetSetting parser_config metadata lift', () => {
+  beforeEach(() => {
+    mockIsGoBackend = true;
+    mockUseUpdateKnowledge.mockReset();
+  });
+
+  function setup() {
+    const saveKnowledgeConfiguration = jest.fn();
+    mockUseUpdateKnowledge.mockReturnValue({
+      saveKnowledgeConfiguration,
+      loading: false,
+    } as never);
+    const {
+      result: { current },
+    } = renderHook(() => useSaveDatasetSetting());
+    return { handleSave: current.handleSave, saveKnowledgeConfiguration };
+  }
+
+  it('makes the extractor metadata group authoritative over the stale top-level copy', async () => {
+    const { handleSave, saveKnowledgeConfiguration } = setup();
+
+    await handleSave({
+      parse_type: 'built-in',
+      parser_config: {
+        'Extractor:AutoExtractDefault': {
+          llm_id: 'llm-a',
+          metadata: {
+            enabled: true,
+            metadata: [],
+            built_in_metadata: [{ key: 'update_time', type: 'time' }],
+          },
+        },
+        metadata: {
+          enabled: false,
+          metadata: [],
+          built_in_metadata: [],
+        },
+      },
+    } as never);
+
+    const payload = saveKnowledgeConfiguration.mock.calls[0][0];
+    expect(payload.parser_config.metadata).toEqual({
+      enabled: true,
+      metadata: [],
+      built_in_metadata: [{ key: 'update_time', type: 'time' }],
+    });
+    expect(
+      payload.parser_config['Extractor:AutoExtractDefault'].metadata.enabled,
+    ).toBe(true);
+  });
+
+  it('leaves the top-level object untouched when the pipeline has no extractor', async () => {
+    const { handleSave, saveKnowledgeConfiguration } = setup();
+
+    await handleSave({
+      parse_type: 'built-in',
+      parser_config: {
+        'Tokenizer:SomeNode': { fields: 'text' },
+        metadata: {
+          enabled: true,
+          metadata: [],
+          built_in_metadata: [],
+        },
+      },
+    } as never);
+
+    const payload = saveKnowledgeConfiguration.mock.calls[0][0];
+    expect(payload.parser_config.metadata).toEqual({
+      enabled: true,
+      metadata: [],
+      built_in_metadata: [],
+    });
+  });
+});

--- a/web/src/pages/dataset/setting/go/hooks.ts
+++ b/web/src/pages/dataset/setting/go/hooks.ts
@@ -1,3 +1,4 @@
+import { Operator } from '@/constants/agent';
 import { ParseType } from '@/constants/knowledge';
 import {
   useFetchDatasetPipelineConfiguration,
@@ -130,14 +131,30 @@ export const useSaveDatasetSetting = () => {
       // Apply forward transforms to parser_config if in pipeline mode
       if (payload.parser_config) {
         const transformedConfig: Record<string, any> = {};
+        let extractorMetadataGroup: Record<string, any> | undefined;
         for (const [operatorId, config] of Object.entries(
           payload.parser_config,
         )) {
           const operatorType = getOperatorType(operatorId);
-          transformedConfig[operatorId] = transformFormConfigToApi(
+          const transformed = transformFormConfigToApi(
             operatorType,
             config as Record<string, any>,
           );
+          transformedConfig[operatorId] = transformed;
+          if (
+            operatorType === Operator.Extractor &&
+            extractorMetadataGroup === undefined
+          ) {
+            extractorMetadataGroup = transformed?.metadata;
+          }
+        }
+        // parser_config.metadata is the dataset-level object the backend
+        // preserves and re-scopes into every Extractor node. The extractor
+        // tab is the only place the user edits it, so lift its metadata
+        // group to the top level — otherwise the stale copy loaded with the
+        // form would silently revert the toggle the user just set.
+        if (extractorMetadataGroup) {
+          transformedConfig.metadata = extractorMetadataGroup;
         }
         payload.parser_config = transformedConfig;
       }

--- a/web/src/utils/__tests__/pipeline-operator.test.ts
+++ b/web/src/utils/__tests__/pipeline-operator.test.ts
@@ -55,13 +55,26 @@ describe('buildOperatorNode dataset-level metadata precedence', () => {
     ]);
   });
 
-  it('ignores a legacy flat metadata array at the top level', () => {
+  it('ignores a flat metadata array at the top level', () => {
     const node = buildOperatorNode(extractorNode, {
       'Extractor:AutoExtractDefault': {
         llm_id: 'llm-a',
         metadata: { enabled: false, metadata: [], built_in_metadata: [] },
       },
       metadata: [{ key: 'category', type: 'string' }],
+    });
+
+    const form = (node.data as Record<string, any>).form;
+    expect(form.metadata.enabled).toBe(false);
+  });
+
+  it('ignores an object without the metadata group shape', () => {
+    const node = buildOperatorNode(extractorNode, {
+      'Extractor:AutoExtractDefault': {
+        llm_id: 'llm-a',
+        metadata: { enabled: false, metadata: [], built_in_metadata: [] },
+      },
+      metadata: { enabled: 'yes', metadata: [], built_in_metadata: [] },
     });
 
     const form = (node.data as Record<string, any>).form;

--- a/web/src/utils/__tests__/pipeline-operator.test.ts
+++ b/web/src/utils/__tests__/pipeline-operator.test.ts
@@ -1,0 +1,91 @@
+import { buildOperatorNode } from '@/utils/pipeline-operator';
+
+let mockIsGoBackend = true;
+jest.mock('@/utils/backend-runtime', () => ({
+  isGoBackend: () => mockIsGoBackend,
+  getBackendLanguage: () => (mockIsGoBackend ? 'go' : 'python'),
+}));
+
+const extractorNode = {
+  id: 'Extractor:AutoExtractDefault',
+  data: { form: {} },
+} as any;
+
+describe('buildOperatorNode dataset-level metadata precedence', () => {
+  beforeEach(() => {
+    mockIsGoBackend = true;
+  });
+
+  it('seeds the extractor metadata toggle from the dataset-level object', () => {
+    const node = buildOperatorNode(extractorNode, {
+      'Extractor:AutoExtractDefault': {
+        llm_id: 'llm-a',
+        metadata: { enabled: false, metadata: [], built_in_metadata: [] },
+      },
+      metadata: {
+        enabled: true,
+        metadata: [],
+        built_in_metadata: [{ key: 'update_time', type: 'time' }],
+      },
+    });
+
+    const form = (node.data as Record<string, any>).form;
+    expect(form.metadata.enabled).toBe(true);
+    expect(form.metadata.built_in_metadata).toEqual([
+      { key: 'update_time', type: 'time' },
+    ]);
+  });
+
+  it('falls back to the per-node metadata group without a dataset-level object', () => {
+    const node = buildOperatorNode(extractorNode, {
+      'Extractor:AutoExtractDefault': {
+        llm_id: 'llm-a',
+        metadata: {
+          enabled: true,
+          metadata: [],
+          built_in_metadata: [{ key: 'file_name', type: 'string' }],
+        },
+      },
+    });
+
+    const form = (node.data as Record<string, any>).form;
+    expect(form.metadata.enabled).toBe(true);
+    expect(form.metadata.built_in_metadata).toEqual([
+      { key: 'file_name', type: 'string' },
+    ]);
+  });
+
+  it('ignores a legacy flat metadata array at the top level', () => {
+    const node = buildOperatorNode(extractorNode, {
+      'Extractor:AutoExtractDefault': {
+        llm_id: 'llm-a',
+        metadata: { enabled: false, metadata: [], built_in_metadata: [] },
+      },
+      metadata: [{ key: 'category', type: 'string' }],
+    });
+
+    const form = (node.data as Record<string, any>).form;
+    expect(form.metadata.enabled).toBe(false);
+  });
+
+  it('does not touch non-extractor operators', () => {
+    const node = buildOperatorNode(
+      {
+        id: 'Tokenizer:SomeNode',
+        data: { form: {} },
+      } as any,
+      {
+        'Tokenizer:SomeNode': { fields: 'text' },
+        metadata: {
+          enabled: true,
+          metadata: [],
+          built_in_metadata: [],
+        },
+      },
+    );
+
+    const form = (node.data as Record<string, any>).form;
+    expect(form.fields).toBe('text');
+    expect(form).not.toHaveProperty('metadata');
+  });
+});

--- a/web/src/utils/pipeline-operator.ts
+++ b/web/src/utils/pipeline-operator.ts
@@ -39,6 +39,17 @@ export function getOperatorType(operatorId: string): Operator {
   return (operatorId.split(':')[0] || operatorId) as Operator;
 }
 
+// The dataset-level modular metadata object stored at parser_config.metadata.
+// A flat legacy "metadata" field is an array of fields, which distinguishes
+// it from the group object {enabled, metadata, built_in_metadata}.
+function isDatasetMetadataGroup(value: any): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
 export function transformParserConfigSetups(
   setups: Record<string, any> | undefined,
 ): any[] {
@@ -397,10 +408,24 @@ export function buildOperatorNode(
   };
 
   if (!isEmpty(pipelineParserConfig)) {
+    let apiConfig = pipelineParserConfig[operatorId];
+    // Dataset-level auto-metadata lives at parser_config.metadata; the
+    // backend preserves that object and re-scopes it into every Extractor
+    // node on write, so it is the authoritative source for the metadata
+    // toggle's initial state — prefer it over a possibly stale per-node copy.
+    if (
+      operatorType === Operator.Extractor &&
+      isDatasetMetadataGroup(pipelineParserConfig.metadata)
+    ) {
+      apiConfig = {
+        ...apiConfig,
+        metadata: pipelineParserConfig.metadata,
+      };
+    }
     // user overrides from API (now also form format)
     Object.assign(
       rawForm,
-      transformApiConfigToForm(operatorType, pipelineParserConfig[operatorId]), // Convert API config to form format, then merge (DSL template is baseline, API overrides)
+      transformApiConfigToForm(operatorType, apiConfig), // Convert API config to form format, then merge (DSL template is baseline, API overrides)
     );
   }
 

--- a/web/src/utils/pipeline-operator.ts
+++ b/web/src/utils/pipeline-operator.ts
@@ -39,14 +39,16 @@ export function getOperatorType(operatorId: string): Operator {
   return (operatorId.split(':')[0] || operatorId) as Operator;
 }
 
-// The dataset-level modular metadata object stored at parser_config.metadata.
-// A flat legacy "metadata" field is an array of fields, which distinguishes
-// it from the group object {enabled, metadata, built_in_metadata}.
+// The dataset-level metadata group stored at parser_config.metadata. The group
+// is shaped {enabled, metadata, built_in_metadata}; the boolean enabled flag
+// and the built_in_metadata array identify it among other values.
 function isDatasetMetadataGroup(value: any): boolean {
   return (
     typeof value === 'object' &&
     value !== null &&
-    !Array.isArray(value)
+    !Array.isArray(value) &&
+    typeof value.enabled === 'boolean' &&
+    Array.isArray(value.built_in_metadata)
   );
 }
 


### PR DESCRIPTION
### Summary

On the Go-variant dataset configuration page, the Extractor tab's **auto metadata** switch silently reverted after saving: the user toggles it on, clicks Save, and the switch comes back off — while the dataset-level config (and thus the actual extraction behavior) keeps the old state, so the UI and the API disagree (reported as "toggle auto-turns off but the feature still works").

Root cause (frontend, two gaps around the dataset-level metadata object):

- Dataset-level auto-metadata is stored at `parser_config.metadata` (`{enabled, metadata, built_in_metadata}`). The Go backend preserves that object on every dataset update and re-scopes it into every `Extractor:*` node (`preserveDatasetParserConfigMetadata` + `ApplyComponentScopedParserConfig`), so it is the authoritative state.
- **Load gap**: `buildOperatorNode` seeded the Extractor form only from the per-node scoped copy, so a stale/divergent node copy showed the wrong toggle state even when the dataset-level object said enabled.
- **Save gap**: the form kept forwarding the dataset-level `metadata` object loaded at mount, untouched by the toggle (which only wrote `parser_config["Extractor:*"].metadata.enabled`). On save the backend preferred that stale incoming object and re-scoped it over the extractor group, reverting whatever the user had just toggled.

Fix:

- `web/src/utils/pipeline-operator.ts` — `buildOperatorNode` now seeds the Extractor node's metadata group from the dataset-level `parser_config.metadata` when that modular object exists (a legacy flat `metadata` array is ignored), so the toggle initializes from the authoritative state.
- `web/src/pages/dataset/setting/go/hooks.ts` — `useSaveDatasetSetting` lifts the (first) Extractor operator's transformed `metadata` group to the top-level `parser_config.metadata` on save, making the extractor tab the single source of truth; pipelines without an Extractor keep the previous preserve-from-existing behavior.

### Verification

- Reproduced live before the fix: with a dataset-level `metadata` object present (`enabled:false`), toggling auto-metadata on and saving reverted the backend to `enabled:false`; the toggle then showed off after reload. Also captured the PUT payload carrying both the extractor group (`enabled:true`) and the stale top-level copy (`enabled:false`) — the exact clobbering input.
- After the fix, re-walked the same path in the browser: toggle on → save → `parser_config.metadata.enabled=true` and the scoped Extractor copy `enabled=true`; after reload the switch stays on. Toggling off → save → both objects `false`. Built-in fields (`update_time`, `file_name`) round-trip correctly.
- Added unit tests: `web/src/utils/__tests__/pipeline-operator.test.ts` (dataset-level precedence, per-node fallback, legacy array ignored, non-extractor untouched) and `web/src/pages/dataset/setting/go/hooks.test.tsx` (save lifts the extractor group over the stale top-level copy; extractor-less pipelines untouched). All pass, along with the existing `extractor-transform` and python setting hooks suites. oxlint clean on changed files; `tsc` reports no errors in the changed files.
