### PR TITLE
fix(tests): let run_tests.py --help exit 0

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -329,8 +329,10 @@ Examples:
             return True
 
         except SystemExit:
-            # argparse already printed help, just exit
-            return False
+            # argparse already printed help or the error and chose a status:
+            # 0 for --help, 2 for a bad argument. Let it through instead of
+            # collapsing both into a failure.
+            raise
         except Exception as e:
             self.print_error(f"Error parsing arguments: {e}")
             return False


### PR DESCRIPTION
### Summary

`run_tests.py --help` prints the help text and then exits 1:

```
$ python3 run_tests.py --help
usage: run_tests.py [-h] [-c] [-p] [-i] [-v] [-t TEST] [-k KEYWORD] [-m MARKERS]
...
$ echo $?
1
```

`parse_arguments()` caught every `SystemExit` from argparse and returned `False`, which `run()`
turned into status 1. That collapses two different outcomes into a failure: `--help`, which
argparse exits 0 for, and a bad argument, which it exits 2 for.

The practical cost is that `run_tests.py --help` cannot be used in a `set -e` script or as a
smoke check, and CI reads a successful informational request as a failed command.

### Changes

Re-raise, so argparse's own status reaches `sys.exit(main())`:

| invocation | exit before | exit after |
|---|---|---|
| `--help` | 1 | 0 |
| `--nonsense` | 1 | 2 |

The successful parse path is untouched. `parse_arguments()` still returns `True` and populates the
options, confirmed with `-v -k foo --markers unit`.
