### PR TITLE
fix(build): keep the admin server in build.sh's cleanup trap

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -475,7 +475,13 @@ run() {
     print_section "Starting admin server (background)"
     "$RAGFLOW_SERVER_BINARY" --admin &
     ADMIN_PID=$!
-    trap 'kill "$ADMIN_PID" 2>/dev/null || true' EXIT INT TERM
+    # One trap for both background services: a second `trap ... EXIT INT TERM`
+    # would replace this one rather than add to it, leaving admin_server holding
+    # port 9383 after the foreground server exits. INGESTOR_PID is cleared first
+    # so a value inherited from the environment cannot be signalled during the
+    # window before the ingestor starts.
+    INGESTOR_PID=""
+    trap 'kill "$ADMIN_PID" ${INGESTOR_PID:+"$INGESTOR_PID"} 2>/dev/null || true' EXIT INT TERM
 
     # Give admin_server a moment to bind its listening port (9383) before
     # ragflow_server starts sending heartbeats to it.
@@ -484,7 +490,6 @@ run() {
     print_section "Starting ingestor (background)"
     "$RAGFLOW_SERVER_BINARY" --ingestor &
     INGESTOR_PID=$!
-    trap 'kill "$INGESTOR_PID" 2>/dev/null || true' EXIT INT TERM
     sleep 1
 
     print_section "Starting RAGFlow server (foreground)"


### PR DESCRIPTION
### Summary

`run()` registers two cleanup traps for the same signals:

```bash
build.sh:478    trap 'kill "$ADMIN_PID" 2>/dev/null || true' EXIT INT TERM
build.sh:487    trap 'kill "$INGESTOR_PID" 2>/dev/null || true' EXIT INT TERM
```

A second `trap` for a signal replaces the handler rather than adding to it, so the admin_server
cleanup registered first never runs. Reduced to the same shape, only the second one fires:

```
-- current shape (two traps, same signals) --
  [trap] ingestor cleanup ran
-- one trap --
  [trap] combined cleanup ran
```

`build.sh --run` therefore never signals the admin server it started. The comment directly above
notes why that matters:

> admin_server must be running before ragflow_server, otherwise ragflow_server's heartbeats to
> admin will error out

and that it binds port 9383, so a leftover holding that port affects the next run.

### Changes

One trap covering both PIDs, registered where the first one was.

`INGESTOR_PID` is expanded as `${INGESTOR_PID:-}` because the trap is installed before the
ingestor starts. If the trap fires in that window the empty argument makes `kill` return non-zero,
which the existing `2>/dev/null || true` already swallows, and I confirmed the admin PID is still
signalled in that case.
