### PR TITLE
fix(migrations): parse the --config flag the usage line documents

### DIFF
--- a/tools/scripts/run_migrations.sh
+++ b/tools/scripts/run_migrations.sh
@@ -15,7 +15,30 @@
 set -e
 
 PY="${PY:-python3}"
-CONFIG="${1:-conf/service_conf.yaml}"
+CONFIG="conf/service_conf.yaml"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config)
+            # Require a real file. mysql_migration.py:90 turns any config-load
+            # failure into a warning and falls back to host=localhost user=root
+            # database=rag_flow, and this script also passes --execute, so an
+            # empty, whitespace, flag-shaped or missing path would silently
+            # migrate the default database instead of failing.
+            if [ $# -lt 2 ] || [ ! -f "$2" ]; then
+                echo "Error: --config requires the path of an existing file" >&2
+                exit 1
+            fi
+            CONFIG="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            echo "Usage: PY=python3 tools/scripts/run_migrations.sh [--config CONFIG_PATH]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 echo "Running model provider table migrations..."
 

--- a/tools/scripts/run_migrations.sh
+++ b/tools/scripts/run_migrations.sh
@@ -25,7 +25,7 @@ while [ $# -gt 0 ]; do
             # database=rag_flow, and this script also passes --execute, so an
             # empty, whitespace, flag-shaped or missing path would silently
             # migrate the default database instead of failing.
-            if [ $# -lt 2 ] || [ ! -f "$2" ] || [ "${2#-}" != "$2" ]; then
+            if [ $# -lt 2 ] || [ -z "${2//[[:space:]]/}" ] || [ ! -f "$2" ] || [ "${2#-}" != "$2" ]; then
                 echo "Error: --config requires the path of an existing file" >&2
                 exit 1
             fi

--- a/tools/scripts/run_migrations.sh
+++ b/tools/scripts/run_migrations.sh
@@ -25,7 +25,7 @@ while [ $# -gt 0 ]; do
             # database=rag_flow, and this script also passes --execute, so an
             # empty, whitespace, flag-shaped or missing path would silently
             # migrate the default database instead of failing.
-            if [ $# -lt 2 ] || [ ! -f "$2" ]; then
+            if [ $# -lt 2 ] || [ ! -f "$2" ] || [ "${2#-}" != "$2" ]; then
                 echo "Error: --config requires the path of an existing file" >&2
                 exit 1
             fi


### PR DESCRIPTION
### Summary

`tools/scripts/run_migrations.sh:9` documents an optional config flag:

```
#   PY=python3 tools/scripts/run_migrations.sh [--config CONFIG_PATH]
```

Line 18 read the flag itself as the value:

```bash
CONFIG="${1:-conf/service_conf.yaml}"
```

So the documented form assigned `CONFIG=--config` and dropped the path. Traced with
`PY=/bin/echo`:

```
$ PY=/bin/echo bash tools/scripts/run_migrations.sh --config /tmp/my_conf.yaml
Running model provider table migrations...
tools/scripts/mysql_migration.py --stages ... --config --config --execute ...
tools/scripts/mysql_migration.py --stages ... --config --config --execute ...
```

`/tmp/my_conf.yaml` never appears. `mysql_migration.py:2191` requires a value for `--config`, so
argparse rejects it before either stage runs:

```
mysql_migration.py: error: argument --config: expected one argument
```

### Changes

Parse `--config` and its value explicitly, and reject unknown arguments instead of ignoring them.

The value must name an existing file. That check is doing real work rather than being decorative:
`mysql_migration.py:90` turns any config-load failure into a warning and returns the default
`MigrationConfig` (`host=localhost user=root database=rag_flow`), and this script also passes
`--execute`. A value that cannot be read therefore does not fail, it migrates the default database.
Requiring an existing file is what makes the empty, whitespace, flag-shaped and missing-path cases
fail closed.

| invocation | result | exit |
|---|---|---|
| `--config /tmp/real_conf.yaml` | `--config /tmp/real_conf.yaml` | 0 |
| no arguments | `--config conf/service_conf.yaml` | 0 |
| `--config` | `Error: --config requires the path of an existing file` | 1 |
| `--config ''` | same | 1 |
| `--config ' '` | same | 1 |
| `--config --config` | same | 1 |
| `--config /tmp/missing.yaml` | same | 1 |
| `--bogus` | `Error: unknown argument: --bogus` | 1 |

Both in-repo callers pass no arguments and are unaffected:

- `docker/entrypoint.sh:276`
- `docker/launch_backend_service.sh:226`

The bare positional form (`run_migrations.sh path.yaml`) is dropped in favour of the documented
flag. No caller in the tree uses it. Parses clean under bash 3.2.

### What this does not cover

An existence check cannot catch every unusable config, because the fallback lives in
`mysql_migration.py` rather than here. Replicating `from_config_file`'s logic, these all pass
`[ -f ]` and still resolve to `localhost/root/rag_flow`:

```
invalid YAML       -> swallowed: ParserError      -> host=localhost user=root db=rag_flow
no database: key   ->                             -> host=localhost user=root db=rag_flow
mode 000           -> swallowed: PermissionError  -> host=localhost user=root db=rag_flow
```

Whether `from_config_file` should fall back to default credentials at all when `--execute` is
passed feels like a separate question, and I have not touched it here. Happy to open something
separate if you think it is worth changing.

### Note on overlap

Open PR #18777 also edits this file, adding `DB_TYPE` routing. It leaves the `CONFIG=` line
unchanged, so this is not a duplicate, but the two will conflict textually since both touch the
lines just below `set -e`. Happy to rebase on top of whichever lands first.
