### PR TITLE
fix(go): drop the removed internal/cache package from run_go_tests.sh

### DIFF
--- a/run_go_tests.sh
+++ b/run_go_tests.sh
@@ -4,7 +4,6 @@ set -e
 PACKAGES=(
     "./internal/admin/..."
 #    "./internal/binding/..."
-    "./internal/cache/..."
     "./internal/cli/..."
     "./internal/common/..."
     "./internal/dao/..."


### PR DESCRIPTION
### Summary

`run_go_tests.sh:7` lists a package that no longer exists:

```bash
PACKAGES=(
    "./internal/admin/..."
#    "./internal/binding/..."
    "./internal/cache/..."      # <- internal/cache is not in the tree
    ...
)
```

It is the only missing entry of the fifteen the array names. A leftover reference in
`internal/agent/canvas/checkpoint_store.go:47` ("from internal/cache") suggests it was removed.

`go` resolves the pattern against the filesystem before building anything, so this fails
regardless of platform or of whether any package compiles:

```
$ go list ./internal/cache/...
pattern ./internal/cache/...: lstat ./internal/cache/: no such file or directory
exit 1
```

The script has `set -e` on line 2, so a non-zero `go test` ends the run and the entries after it
never execute.

### Verification

I could not run the script end to end to demonstrate the abort directly.
`internal/agent/sandbox/local.go:307` uses `syscall.SysProcAttr.Pdeathsig`, which is Linux-only,
and a cgo dependency wants a header that is not present on macOS, so several packages fail to
build on this machine for reasons unrelated to this change.

The two facts the change rests on are each verified on their own: the pattern-resolution failure
above, and `set -e` aborting a loop on the first non-zero command.

Removed rather than commented out, following AGENTS.md on deleting rather than retaining dead
references.
