### PR TITLE
docs(deepdoc): point the build examples at the Dockerfile's real path

### DIFF
--- a/Dockerfile_deepdoc_oss
+++ b/Dockerfile_deepdoc_oss
@@ -1,6 +1,6 @@
 # OSS DeepDoc server — minimal image with ONNX-only inference.
-# Build: docker build -f docker/Dockerfile_deepdoc_oss -t deepdoc_oss:latest .
-# With mirror (China): docker build --build-arg NEED_MIRROR=1 -f docker/Dockerfile_deepdoc_oss -t deepdoc_oss:latest .
+# Build: docker build -f Dockerfile_deepdoc_oss -t deepdoc_oss:latest .
+# With mirror (China): docker build --build-arg NEED_MIRROR=1 -f Dockerfile_deepdoc_oss -t deepdoc_oss:latest .
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
### Summary

`Dockerfile_deepdoc_oss` documents its own build command with a `docker/` prefix:

```dockerfile
# Build: docker build -f docker/Dockerfile_deepdoc_oss -t deepdoc_oss:latest .
# With mirror (China): docker build --build-arg NEED_MIRROR=1 -f docker/Dockerfile_deepdoc_oss ...
```

The file is at the repository root. There is no `docker/Dockerfile_deepdoc_oss`, so both commands
fail on the `-f` path before any build starts.

The two other references in the tree already use the root path, which is what makes this the odd
one out rather than a naming question:

```
deepdoc/server/README.md:11    docker build -f Dockerfile_deepdoc_oss -t deepdoc_oss:latest .
docker/docker-compose.yml:10   context: ..
                               dockerfile: Dockerfile_deepdoc_oss
```

### Verification

By path rather than by running docker; no daemon was available here.
`docker/Dockerfile_deepdoc_oss` does not exist in the tree, and `Dockerfile_deepdoc_oss` does.
