### PR TITLE
fix(schema-sync): stop reporting BaseModel timestamps as dropped columns

### DIFF
--- a/tools/scripts/db_schema_sync.py
+++ b/tools/scripts/db_schema_sync.py
@@ -233,8 +233,10 @@ def compare_fields(model_fields: dict, db_columns: dict) -> dict:
         "removed": {},
     }
 
-    # Skip auto-generated fields like id, create_time, etc.
-    skip_fields = {"id"}
+    # Skip auto-generated fields like id, create_time, etc. These must match the
+    # set the callers strip from model_fields, or the removed-field detection
+    # below reports them as columns to drop.
+    skip_fields = {"id", "create_time", "create_date", "update_time", "update_date"}
 
     for field_name, field in model_fields.items():
         if field_name in skip_fields:

--- a/tools/scripts/db_schema_sync.py
+++ b/tools/scripts/db_schema_sync.py
@@ -89,6 +89,11 @@ def create_database_connection(host: str, port: int, user: str, password: str, d
 
 
 # MySQL type to Peewee field type mapping
+# Fields peewee/BaseModel manage on their own. compare_fields() and both of its
+# callers must exclude the same set, or columns filtered out on one side get
+# reported as removed on the other.
+AUTO_GENERATED_FIELDS = {"id", "create_time", "create_date", "update_time", "update_date"}
+
 MYSQL_TO_PEEWEE_TYPE = {
     "varchar": "CharField",
     "char": "CharField",
@@ -233,10 +238,8 @@ def compare_fields(model_fields: dict, db_columns: dict) -> dict:
         "removed": {},
     }
 
-    # Skip auto-generated fields like id, create_time, etc. These must match the
-    # set the callers strip from model_fields, or the removed-field detection
-    # below reports them as columns to drop.
-    skip_fields = {"id", "create_time", "create_date", "update_time", "update_date"}
+    skip_fields = AUTO_GENERATED_FIELDS
+    logger.debug("Excluding auto-generated fields from schema comparison: %s", sorted(skip_fields))
 
     for field_name, field in model_fields.items():
         if field_name in skip_fields:
@@ -678,7 +681,7 @@ def create_migration(router: Router, models: list, db, name: str = "auto", drop_
                 model_fields = {}
                 for field_name, field in model._meta.fields.items():
                     # Skip id and base model fields
-                    if field_name in ("id", "create_time", "create_date", "update_time", "update_date"):
+                    if field_name in AUTO_GENERATED_FIELDS:
                         continue
                     if hasattr(field, "_auto_created") and field._auto_created:
                         continue
@@ -805,7 +808,7 @@ def diff_schema(models: list, db):
             # Get model fields
             model_fields = {}
             for field_name, field in model._meta.fields.items():
-                if field_name in ("id", "create_time", "create_date", "update_time", "update_date"):
+                if field_name in AUTO_GENERATED_FIELDS:
                     continue
                 model_fields[field_name] = field
 


### PR DESCRIPTION
### Summary

`compare_fields()` skips only `"id"`:

```python
# Skip auto-generated fields like id, create_time, etc.
skip_fields = {"id"}
```

but both of its callers strip five names from `model_fields` before calling it
(`db_schema_sync.py:679` and `:806`):

```python
if field_name in ("id", "create_time", "create_date", "update_time", "update_date"):
    continue
```

The removed-field detection then walks the database columns and reports anything absent from
`model_fields`, so the four `BaseModel` timestamps (`api/db/db_models.py:239-242`) come back as
*removed* for every table that inherits `BaseModel`.

Exercising `compare_fields()` directly, with the timestamps stripped from `model_fields` exactly
as the callers strip them:

```
before: removed -> ['create_date', 'create_time', 'update_date', 'update_time']
after:  removed -> []
```

### Why it matters

`--drop` is reachable: a CLI flag at `db_schema_sync.py:875`, passed to `create_migration()` at
`:920` under `--create`. With it, those false removals become statements the script itself labels
destructive (`:588-595`):

```
# WARNING: Dropping column `create_time` from `<table>` - this will permanently delete data!
migrator.sql("ALTER TABLE <table> DROP COLUMN create_time")
```

And because `has_removed` is true, the "No schema changes detected, migration not created" early
return at `:708` is skipped. So an already-in-sync database still produces a migration whose only
content is dropping those columns.

Without `--drop` they surface instead as a warning naming every table's timestamp columns (`:702`).

### Scope

The comment above `skip_fields` already said "id, create_time, etc.", so the set had drifted from
its own description.

Both current callers already exclude these five names, so no reachable comparison changes. To be
precise about what the shared skip set does: if `compare_fields()` were called directly with a
timestamp field present in `model_fields`, it would now skip that field rather than report it. No
caller does that today, but it is a property of the change rather than something the diff hides.

A column that is genuinely in the database and genuinely absent from the model is still reported.
