### PR TITLE
docs(configuration): name the ragflow serving-port key http_port

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -187,7 +187,7 @@ Before setting `DOC_ENGINE=oceanbase`, make sure the host OS allows the file des
 
 - `ragflow`
   - `host`: The API server's IP address inside the Docker container. Defaults to `0.0.0.0`.
-  - `port`: The API server's serving port inside the Docker container. Defaults to `9380`.
+  - `http_port`: The API server's serving port inside the Docker container. Defaults to `9380`.
 
 - `deepdoc`
   The OSS DeepDoc vision service provides DLA, OCR, and TSR inference via ONNX Runtime.

--- a/docs/administrator/configurations/configurations.md
+++ b/docs/administrator/configurations/configurations.md
@@ -149,7 +149,7 @@ If you cannot download the RAGFlow Docker image, try the following mirrors.
 ### `ragflow`
 
 - `host`: The API server's IP address inside the Docker container. Defaults to `0.0.0.0`.
-- `port`: The API server's serving port inside the Docker container. Defaults to `9380`.
+- `http_port`: The API server's serving port inside the Docker container. Defaults to `9380`.
 
 ### `mysql`
 


### PR DESCRIPTION
### Summary

Both configuration guides document the API server's port as `port`:

- `docs/administrator/configurations/configurations.md:152`
- `docker/README.md:190`

The key in `docker/service_conf.yaml.template:5` is `http_port`, and that is the only spelling
either runtime accepts:

```
common/settings.py:376                        get_base_config(...).get("http_port")
internal/server/config/api_server_config.go:28,50-51
                                              mapstructure:"http_port"
                                              sub.GetInt("http_port")
```

Neither loader falls back to a bare `port` for this section, so following either guide does not set
the port.

What happens instead depends on how the operator applies it. An edit that leaves `http_port` in
place is simply ignored. A `local.service_conf.yaml` override is merged with a shallow
`global_config.update(local_config)` (`common/config_utils.py:71`), which replaces the whole
`ragflow` section and drops `http_port`, leaving `HOST_PORT` unset.

### Scope

Only the `ragflow` section is affected. `ragflow` and `admin` use `http_port`; `mysql`, `serenedb`,
`oceanbase`, `gaussdb`, `seekdb`, `nats` and `clickhouse` all really do use `port`, so the MySQL
entry a few lines below is correct and is left alone. The `admin` section is not documented in
either guide.
