### PR TITLE
Fix the naive parser treating an empty upload as a missing binary

### DIFF
--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -116,7 +116,7 @@ def _normalize_section_text_for_rtl_presentation_forms(sections):
 
 def by_deepdoc(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang="Chinese", callback=None, pdf_cls=None, **kwargs):
     pdf_parser = pdf_cls() if pdf_cls else Pdf()
-    sections, tables = pdf_parser(filename if not binary else binary, from_page=from_page, to_page=to_page, callback=callback)
+    sections, tables = pdf_parser(filename if binary is None else binary, from_page=from_page, to_page=to_page, callback=callback)
 
     tables = vision_figure_parser_pdf_wrapper(
         tbls=tables,
@@ -490,7 +490,7 @@ def by_plaintext(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER
         )
         pdf_parser = VisionParser(vision_model=vision_model, **kwargs)
 
-    sections, tables = pdf_parser(filename if not binary else binary, from_page=from_page, to_page=to_page, callback=callback)
+    sections, tables = pdf_parser(filename if binary is None else binary, from_page=from_page, to_page=to_page, callback=callback)
     return sections, tables, pdf_parser
 
 
@@ -621,7 +621,7 @@ class Docx(DocxParser):
         return ""
 
     def __call__(self, filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER):
-        self.doc = Document(filename) if not binary else Document(BytesIO(binary))
+        self.doc = Document(filename) if binary is None else Document(BytesIO(binary))
         pn = 0
         lines = []
         last_image = None
@@ -746,7 +746,7 @@ class Docx(DocxParser):
         import mammoth
         from markdownify import markdownify
 
-        docx_file = BytesIO(binary) if binary else open(filename, "rb")
+        docx_file = BytesIO(binary) if binary is not None else open(filename, "rb")
 
         def _convert_image_to_base64(image):
             try:
@@ -775,7 +775,7 @@ class Docx(DocxParser):
             return markdown_text
 
         finally:
-            if not binary:
+            if binary is None:
                 docx_file.close()
 
 
@@ -787,7 +787,7 @@ class Pdf(PdfParser):
         start = timer()
         first_start = start
         callback(msg="OCR started")
-        self.__images__(filename if not binary else binary, zoomin, from_page, to_page, callback)
+        self.__images__(filename if binary is None else binary, zoomin, from_page, to_page, callback)
         callback(msg="OCR finished ({:.2f}s)".format(timer() - start))
         logging.info("OCR({}~{}): {:.2f}s".format(from_page, to_page, timer() - start))
 

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -147,11 +147,7 @@ def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None, layo
     to :func:`by_plaintext`, which would otherwise try to resolve the UUID
     as an IMAGE2TEXT vision model and crash.
     """
-    raw_layout_recognize = (
-        layout_recognize_override
-        if layout_recognize_override is not None
-        else parser_config.get("layout_recognize", "DeepDOC")
-    )
+    raw_layout_recognize = layout_recognize_override if layout_recognize_override is not None else parser_config.get("layout_recognize", "DeepDOC")
     layout_recognizer, parser_model_name = normalize_layout_recognizer(raw_layout_recognize)
     if layout_recognizer == "OpenDataLoader" and parser_model_name:
         opendataloader_llm_name = parser_model_name
@@ -182,9 +178,7 @@ def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None, layo
     # must keep honoring PlainText, not be silently rerouted to MinerU.
     if name not in PARSERS and parser is by_plaintext and has_mineru_options(parser_config):
         logging.warning(
-            "[naive] layout_recognize=%r does not match a known parser; "
-            "falling back to MinerU because mineru_* options are set "
-            "(see issue #17114).",
+            "[naive] layout_recognize=%r does not match a known parser; falling back to MinerU because mineru_* options are set (see issue #17114).",
             layout_recognizer,
         )
         parser = by_mineru
@@ -1127,7 +1121,9 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
         # turned a TenantModel UUID into a "<model>@<instance>@<provider>" form)
         # so the dispatch can extract the right parser_model_name.
         parser, name, layout_recognizer, opendataloader_llm_name, parser_model_name = _dispatch_pdf_parser(
-            parser_config, opendataloader_llm_name, layout_recognize_override=layout_recognize_raw,
+            parser_config,
+            opendataloader_llm_name,
+            layout_recognize_override=layout_recognize_raw,
         )
 
         if parser_config.get("analyze_hyperlink", False) and is_root:

--- a/test/unit_test/rag/app/test_naive_empty_binary.py
+++ b/test/unit_test/rag/app/test_naive_empty_binary.py
@@ -1,0 +1,80 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from __future__ import annotations
+
+from io import BytesIO
+from types import SimpleNamespace
+from zipfile import BadZipFile
+
+import mammoth
+import pytest
+
+from rag.app import naive
+
+
+@pytest.fixture(autouse=True)
+def _stub_rag_tokenizer(monkeypatch):
+    def fake_tokenize(text):
+        return str(text)
+
+    monkeypatch.setattr("rag.nlp.rag_tokenizer.tokenize", fake_tokenize)
+    monkeypatch.setattr("rag.nlp.rag_tokenizer.fine_grained_tokenize", fake_tokenize)
+
+
+@pytest.mark.p2
+def test_docx_empty_binary_does_not_open_display_name():
+    with pytest.raises(BadZipFile, match="File is not a zip file"):
+        naive.Docx()("report.docx", b"")
+
+
+@pytest.mark.p2
+def test_docx_to_markdown_empty_binary_does_not_open_display_name(monkeypatch):
+    opened = []
+    converted = []
+
+    def fail_open(filename, *args, **kwargs):
+        opened.append(filename)
+        raise AssertionError(f"unexpected open: {filename}")
+
+    def fake_convert_to_html(docx_file):
+        converted.append(docx_file)
+        assert isinstance(docx_file, BytesIO)
+        assert docx_file.getvalue() == b""
+        return SimpleNamespace(value="")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    monkeypatch.setattr(mammoth, "convert_to_html", fake_convert_to_html)
+
+    assert naive.Docx().to_markdown("report.docx", binary=b"", inline_images=False) == ""
+    assert opened == []
+    assert not converted[0].closed
+
+
+@pytest.mark.p2
+def test_deepdoc_empty_binary_passes_bytes_to_pdf_parser(monkeypatch):
+    captured = []
+
+    class CapturingPdf:
+        def __call__(self, source, **kwargs):
+            captured.append(source)
+            return [], []
+
+    monkeypatch.setattr(naive, "vision_figure_parser_pdf_wrapper", lambda **kwargs: kwargs["tbls"])
+
+    naive.by_deepdoc("report.pdf", binary=b"", pdf_cls=CapturingPdf)
+
+    assert captured == [b""]


### PR DESCRIPTION
Follow-up to #18712, which fixed this in `rag/app/email.py` and `rag/app/presentation.py`. `rag/app/naive.py` is the default chunker and was not covered.

## Problem

A 0-byte upload arrives at the parsers as `b""`, not `None`.

`rag/svr/task_executor.py:312` reads the object, and `:313` guards only `if binary is None:`, so `b""` passes through. `:361` then calls `chunker.chunk(task["name"], binary=binary, ...)`.

`task["name"]` is a display name, not a local path. So any branch that falls back to opening `filename` tries to open a file that is not there.

Six sites in `naive.py` still chose that branch on a falsy test:

| line | code |
|---|---|
| 119 | `pdf_parser(filename if not binary else binary, ...)` in `by_deepdoc` |
| 493 | the same expression in `by_plaintext` |
| 624 | `Document(filename) if not binary else Document(BytesIO(binary))` |
| 749 | `BytesIO(binary) if binary else open(filename, "rb")` |
| 778 | `if not binary: docx_file.close()`, the cleanup paired with 749 |
| 790 | `self.__images__(filename if not binary else binary, ...)` in `Pdf.__call__` |

`by_deepdoc` is the default PDF path, so a 0-byte PDF upload reaches line 119 with stock settings.

## Change

Each site now tests `binary is None` instead. Lines 749 and 778 flip together, so the handle is still closed only when it was opened from a path.

The file already used this form at `:960` and `:1052`. Those two are unchanged; the other six now match them.

## Proof

```
pytest test/unit_test/rag/app/test_naive_empty_binary.py --noconftest
3 passed
```

With the six lines reverted to the falsy form, all three fail:

```
naive.py:624   PackageNotFoundError: Package not found at 'report.docx'
naive.py:749   AssertionError: unexpected open: report.docx
deepdoc path   assert ['report.pdf'] == [b'']
```

The three tests assert that empty docx bytes produce the expected `BadZipFile` rather than a display-name lookup, that the markdown path receives an empty `BytesIO` and never opens `report.docx`, and that the deepdoc path receives `b""` rather than `report.pdf`.

`test/unit_test/rag/app/test_email_empty_binary.py`, added by #18712, still passes.

`ruff check`: All checks passed.

## The second commit

`rag/app/naive.py` is the only file of 57 under `rag/app`, `rag/nlp` and `api/db/services` that fails `ruff format --check` on current main. The `ruff-format` preflight hook runs on staged files, so any PR that stages this file fails it.

The formatting is a separate commit for that reason. It touches three pre-existing blocks that this fix does not otherwise change, and none of the six changed lines appear in it. Happy to drop that commit if you would rather handle the formatting separately.
