### PR TITLE
fix(examples): wait for the DONE status the API actually returns

### DIFF
--- a/example/sdk/chunk_example.py
+++ b/example/sdk/chunk_example.py
@@ -50,7 +50,7 @@ try:
     elapsed = 0
     while elapsed < MAX_WAIT:
         doc_status = dataset.list_documents(id=doc.id)[0]
-        if doc_status.run == "1" and doc_status.progress >= 1.0:
+        if doc_status.run == "DONE" and doc_status.progress >= 1.0:
             print("Parsing completed.")
             break
         print(f"Parsing progress: {doc_status.progress:.2f}")

--- a/example/sdk/chunk_example.py
+++ b/example/sdk/chunk_example.py
@@ -51,7 +51,7 @@ try:
     while elapsed < MAX_WAIT:
         doc_status = dataset.list_documents(id=doc.id)[0]
         if doc_status.run == "DONE" and doc_status.progress >= 1.0:
-            print("Parsing completed.")
+            print(f"Parsing completed for {doc.id} after {elapsed}s.")
             break
         print(f"Parsing progress: {doc_status.progress:.2f}")
         time.sleep(2)

--- a/example/sdk/retrieval_example.py
+++ b/example/sdk/retrieval_example.py
@@ -47,7 +47,7 @@ try:
     elapsed = 0
     while elapsed < MAX_WAIT:
         doc_status = dataset.list_documents(id=doc.id)[0]
-        if doc_status.run == "1" and doc_status.progress >= 1.0:
+        if doc_status.run == "DONE" and doc_status.progress >= 1.0:
             break
         print(f"Parsing progress: {doc_status.progress:.2f}")
         time.sleep(2)

--- a/example/sdk/retrieval_example.py
+++ b/example/sdk/retrieval_example.py
@@ -55,7 +55,7 @@ try:
     else:
         print("Parsing timed out.")
         sys.exit(-1)
-    print("Document parsed and ready for retrieval.")
+    print(f"Document {doc.id} parsed after {elapsed}s and ready for retrieval.")
 
     # 3. Perform retrieval (Semantic Search)
     print("\n--- Performing Retrieval ---")


### PR DESCRIPTION
### Summary

`example/sdk/chunk_example.py:53` and `example/sdk/retrieval_example.py:50` poll for a status the
API never returns:

```python
if doc_status.run == "1" and doc_status.progress >= 1.0:
```

`DataSet.list_documents()` calls `GET /datasets/{id}/documents`
(`sdk/python/ragflow_sdk/modules/dataset.py:98`), and that handler maps every document through
`map_doc_keys` (`api/apps/restful_apis/document_api.py:851`), which converts the numeric code to a
word (`api/apps/services/document_api_service.py:301-306`):

```
"0" -> UNSTART   "1" -> RUNNING   "2" -> CANCEL   "3" -> DONE   "4" -> FAIL
```

So `run` is never the string `"1"`, the condition cannot become true, and both loops run the full
120 seconds and fall through to the `else`:

```python
print("Parsing timed out.")
sys.exit(-1)
```

even when parsing succeeded. Waiting on `"1"` would also have meant waiting for `RUNNING` rather
than for completion.

The rest of the repository already compares against the mapped value, for example
`test/testcases/test_sdk_api/conftest.py:97` and `test/benchmark/dataset.py:127`.

### On the `progress >= 1.0` half of the condition

Left as is, and it does not reintroduce a hang: `progress` and the status are written in the same
branch (`api/db/services/document_service.py:1131-1133`), so `prg = 1` lands together with
`TaskStatus.DONE`.

### The SDK already does this correctly

`DataSet._get_documents_status()` a few lines away polls the same field against the same mapped
words (`sdk/python/ragflow_sdk/modules/dataset.py:116,133`):

```python
terminal_states = {"DONE", "FAIL", "CANCEL"}
...
if isinstance(doc.run, str) and doc.run.upper() in terminal_states:
```

so the examples were the outlier rather than the mapping being ambiguous.

### What this does not fix

A failed parse still waits out the full timeout. `document_service.py:1128-1130` sets
`TaskStatus.FAIL` with `prg = -1`, and neither example treats `FAIL` as terminal, so a failure is
reported as `Parsing timed out.` after 120 seconds rather than as a failure. That is pre-existing
and separate from the status-name bug, so I left it alone. Happy to add a `FAIL` branch here or in
a follow-up if you would like it.
