### PR TITLE
fix: align cross-language prompt separator with parser

### DIFF
--- a/rag/prompts/cross_languages_sys_prompt.md
+++ b/rag/prompts/cross_languages_sys_prompt.md
@@ -14,7 +14,7 @@ A streamlined multilingual translator.
 3. Output translations in the following format:
 
 [Translation in language1]
-###
+===
 [Translation in language2]
 
 ---
@@ -28,8 +28,7 @@ Chinese, French, Japanese
 
 **Output:**
 你好世界！让我们讨论人工智能安全问题。
-###
+===
 Bonjour le monde ! Parlons de la sécurité de l'IA.
-###
+===
 こんにちは世界！AIの安全性について話し合いましょう。
-


### PR DESCRIPTION
### Summary

The cross-language system prompt instructs the LLM to separate translations with `###`, while both the Python and Go implementations parse the response using `===`.

Because `###` is not recognized by the parser, it remains in the retrieval query and causes multiple translations to be incorrectly grouped as a single search term.

This change updates the prompt output format and example to use `===`, aligning the LLM output with the existing parsers.

### Example

With Chinese, English, and German enabled, the original cross-language output for `纳米复合材料` is:

```text
纳米复合材料 ###nanocomposite ###nanocomposit
```

Since the implementation splits translations using `===`, the `###` separators are preserved. The generated full-text query becomes:

```text
((纳米复合材料)^1.0)
OR
(("###nanocomposite ###nanocomposit")^1.0)
```

As a result, the English and German translations are grouped into one literal search expression containing `###`, instead of being processed as separate translated terms.

After this change, the prompt generates translations separated by `===`. The existing parser can then split them correctly and join them with newlines before retrieval, allowing each translated term to be tokenized independently.

### Testing

- Verified that the prompt contains no standalone `###` output separators.
- Verified that the prompt output separator matches both the Python and Go parsers.
- `git diff --check` passes.