### PR TITLE
fix(web): expose use_kg toggle in Retrieval canvas settings

### DIFF
--- a/web/src/pages/agent/constant/index.tsx
+++ b/web/src/pages/agent/constant/index.tsx
@@ -94,6 +94,7 @@ export const initialRetrievalValues = {
   ...initialSimilarityThresholdValue,
   ...initialKeywordsSimilarityWeightValue,
   cross_languages: [],
+  use_kg: false,
   retrieval_from: RetrievalFrom.Dataset,
   outputs: {
     formalized_content: {

--- a/web/src/pages/agent/form/retrieval-form/next.tsx
+++ b/web/src/pages/agent/form/retrieval-form/next.tsx
@@ -24,6 +24,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Radio } from '@/components/ui/radio';
+import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import {
   useRevalidateStaleDatasetIds,
@@ -58,6 +59,7 @@ export const RetrievalPartialSchema = {
   dataset_ids: z.array(z.string()),
   rerank_id: z.string(),
   empty_response: z.string(),
+  use_kg: z.boolean().default(false),
   cross_languages: z.array(z.string()),
   ...MetadataFilterSchema,
   memory_ids: z.array(z.string()).optional(),
@@ -139,6 +141,30 @@ export function EmptyResponseField() {
   );
 }
 
+export function UseKnowledgeGraphFormField() {
+  const { t } = useTranslation();
+
+  return (
+    <RAGFlowFormItem
+      name="use_kg"
+      label={t('chat.useKnowledgeGraph')}
+      tooltip={t('chat.useKnowledgeGraphTip')}
+      horizontal={true}
+      labelClassName="w-full"
+      valueClassName="w-8"
+    >
+      {(field) => (
+        <Switch
+          checked={field.value}
+          onCheckedChange={(checked) => {
+            field.onChange?.(checked);
+          }}
+        />
+      )}
+    </RAGFlowFormItem>
+  );
+}
+
 function RetrievalForm({ node }: INextOperatorForm) {
   const { t } = useTranslation();
   const ownerTenantId = useOwnerTenantId();
@@ -203,6 +229,7 @@ function RetrievalForm({ node }: INextOperatorForm) {
             {hideKnowledgeGraphField || (
               <>
                 <CrossLanguageFormField name="cross_languages"></CrossLanguageFormField>
+                <UseKnowledgeGraphFormField></UseKnowledgeGraphFormField>
               </>
             )}
           </section>

--- a/web/src/pages/agent/form/tool-form/retrieval-form/index.tsx
+++ b/web/src/pages/agent/form/tool-form/retrieval-form/index.tsx
@@ -25,6 +25,7 @@ import {
   EmptyResponseField,
   MemoryDatasetForm,
   RetrievalPartialSchema,
+  UseKnowledgeGraphFormField,
   useHideKnowledgeGraphField,
 } from '../../retrieval-form/next';
 import { useValues } from '../use-values';
@@ -84,6 +85,7 @@ const RetrievalForm = () => {
             {hideKnowledgeGraphField || (
               <>
                 <CrossLanguageFormField name="cross_languages"></CrossLanguageFormField>
+                <UseKnowledgeGraphFormField></UseKnowledgeGraphFormField>
               </>
             )}
           </FormContainer>


### PR DESCRIPTION
### Problem
The Retrieval component already supports `use_kg` in `agent/tools/retrieval.py`, but the agent canvas settings form did not expose the switch, so knowledge-graph retrieval could not be enabled for a canvas Retrieval node (reported in #18778).

### Changes
- Add `use_kg` to the Retrieval form schema and default values.
- Add a shared `UseKnowledgeGraphFormField` switch under Advanced Settings.
- Render it for both the agent Retrieval node form and the tool Retrieval form.
- Hide the field when the retrieval source is Memory, since KG retrieval applies only to datasets.

### Verification
- `pnpm run type-check` reports no new errors in the touched files (the repository has pre-existing type errors in unrelated files).
- The existing backend `RetrievalParam.use_kg` path consumes the value once it is persisted in the DSL.

Closes #18778