### PR TITLE
fix(web): cap description length at 512 characters

### DIFF
--- a/web/src/constants/common.ts
+++ b/web/src/constants/common.ts
@@ -236,3 +236,5 @@ export enum ThemeEnum {
   Light = 'light',
   System = 'system',
 }
+
+export const DESCRIPTION_MAX_LENGTH = 512;

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -24,6 +24,7 @@ export default {
       namePlaceholder: 'Please input name',
       nameSlashError: 'Name cannot contain "/"',
       descriptionPlaceholder: 'Enter description',
+      descriptionMaxLength: 'Description must be at most {{max}} characters.',
       next: 'Next',
       create: 'Create',
       edit: 'Edit',
@@ -1593,12 +1594,18 @@ Example: Virtual Hosted Style`,
       sharepointSiteUrlTip:
         'Full URL of the SharePoint site to index, e.g. https://contoso.sharepoint.com/sites/MySite. Requires an Azure AD app with Sites.Read.All and Files.Read.All application permissions (admin consent).',
       azureDevOpsPatTip: 'A personal access token with the Code (Read) scope.',
-      azureDevOpsOrganizationTip: 'Organization name (e.g. "contoso"), or the full collection URL of a self-hosted Azure DevOps Server (e.g. https://tfs.contoso.com/DefaultCollection).',
-      azureDevOpsProjectsTip: 'Comma separated team project names. E.g., Project1,Project2',
-      azureDevOpsRepositoriesTip: 'Comma separated repositories. Use project/repo to disambiguate repositories that share a name.',
-      azureDevOpsOrganizationScopeTip: 'Every repository visible to the token in this organization will be indexed.',
-      azureDevOpsContentTypesTip: 'Choose what to index: source files, pull requests, or both.',
-      azure_devopsDescription: 'Connect Azure DevOps to sync repository files and pull requests.',
+      azureDevOpsOrganizationTip:
+        'Organization name (e.g. "contoso"), or the full collection URL of a self-hosted Azure DevOps Server (e.g. https://tfs.contoso.com/DefaultCollection).',
+      azureDevOpsProjectsTip:
+        'Comma separated team project names. E.g., Project1,Project2',
+      azureDevOpsRepositoriesTip:
+        'Comma separated repositories. Use project/repo to disambiguate repositories that share a name.',
+      azureDevOpsOrganizationScopeTip:
+        'Every repository visible to the token in this organization will be indexed.',
+      azureDevOpsContentTypesTip:
+        'Choose what to index: source files, pull requests, or both.',
+      azure_devopsDescription:
+        'Connect Azure DevOps to sync repository files and pull requests.',
       bitbucketDescription: 'Connect Bitbucket to sync PR content.',
       bitbucketTopWorkspaceTip:
         'The Bitbucket workspace to index (e.g., "atlassian" from https://bitbucket.org/atlassian/workspace ).',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -24,6 +24,7 @@ export default {
       namePlaceholder: '请输入名称',
       nameSlashError: '名称不能包含 "/"',
       descriptionPlaceholder: '请输入描述',
+      descriptionMaxLength: '描述最多 {{max}} 个字符。',
       next: '下一步',
       create: '创建',
       edit: '编辑',
@@ -1263,11 +1264,15 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
         '要索引的 SharePoint 站点完整 URL，例如 https://contoso.sharepoint.com/sites/MySite。需要具备 Sites.Read.All 与 Files.Read.All 应用权限（管理员同意）的 Azure AD 应用。',
       boxDescription: '连接你的 Box 云盘以同步文件和文件夹。',
       azureDevOpsPatTip: '需要具有 Code (Read) 权限的个人访问令牌。',
-      azureDevOpsOrganizationTip: '组织名称（例如 contoso），或自托管 Azure DevOps Server 的集合地址（例如 https://tfs.contoso.com/DefaultCollection）。',
-      azureDevOpsProjectsTip: '以逗号分隔的团队项目名称。例如：Project1,Project2',
-      azureDevOpsRepositoriesTip: '以逗号分隔的仓库。可使用 project/repo 形式以区分同名仓库。',
+      azureDevOpsOrganizationTip:
+        '组织名称（例如 contoso），或自托管 Azure DevOps Server 的集合地址（例如 https://tfs.contoso.com/DefaultCollection）。',
+      azureDevOpsProjectsTip:
+        '以逗号分隔的团队项目名称。例如：Project1,Project2',
+      azureDevOpsRepositoriesTip:
+        '以逗号分隔的仓库。可使用 project/repo 形式以区分同名仓库。',
       azureDevOpsOrganizationScopeTip: '将索引该组织中令牌可见的所有仓库。',
-      azureDevOpsContentTypesTip: '选择要索引的内容：源文件、拉取请求，或两者。',
+      azureDevOpsContentTypesTip:
+        '选择要索引的内容：源文件、拉取请求，或两者。',
       azure_devopsDescription: '连接 Azure DevOps 以同步仓库文件和拉取请求。',
       bitbucketDescription: '连接 Bitbucket，同步 PR 内容。',
       bitbucketTopWorkspaceTip:

--- a/web/src/pages/dataset/setting/go/form-schema.ts
+++ b/web/src/pages/dataset/setting/go/form-schema.ts
@@ -1,3 +1,4 @@
+import { DESCRIPTION_MAX_LENGTH } from '@/constants/common';
 import { ParseType } from '@/constants/knowledge';
 import { t } from 'i18next';
 import { z } from 'zod';
@@ -11,7 +12,14 @@ export const formSchema = z
     name: z.string().min(1, {
       message: 'Username must be at least 2 characters.',
     }),
-    description: z.string().optional(),
+    description: z
+      .string()
+      .max(DESCRIPTION_MAX_LENGTH, {
+        message: t('common.descriptionMaxLength', {
+          max: DESCRIPTION_MAX_LENGTH,
+        }),
+      })
+      .optional(),
     parser_id: z.string().optional(),
     avatar: z.any().nullish(),
     permission: z.string().optional(),

--- a/web/src/pages/dataset/setting/go/general-form.tsx
+++ b/web/src/pages/dataset/setting/go/general-form.tsx
@@ -10,7 +10,10 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { LanguageTranslationMap } from '@/constants/common';
+import {
+  DESCRIPTION_MAX_LENGTH,
+  LanguageTranslationMap,
+} from '@/constants/common';
 import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -111,6 +114,7 @@ export function GeneralForm() {
                 <FormControl className="w-3/4">
                   <Input
                     {...field}
+                    maxLength={DESCRIPTION_MAX_LENGTH}
                     placeholder={t('knowledgeConfiguration.datasetDescription')}
                     data-testid="ds-settings-basic-description-input"
                   ></Input>

--- a/web/src/pages/dataset/setting/python/form-schema.ts
+++ b/web/src/pages/dataset/setting/python/form-schema.ts
@@ -1,3 +1,4 @@
+import { DESCRIPTION_MAX_LENGTH } from '@/constants/common';
 import { ParseType } from '@/constants/knowledge';
 import { t } from 'i18next';
 import { z } from 'zod';
@@ -8,7 +9,14 @@ export const formSchema = z
     name: z.string().min(1, {
       message: 'Username must be at least 2 characters.',
     }),
-    description: z.string().optional(),
+    description: z
+      .string()
+      .max(DESCRIPTION_MAX_LENGTH, {
+        message: t('common.descriptionMaxLength', {
+          max: DESCRIPTION_MAX_LENGTH,
+        }),
+      })
+      .optional(),
     // avatar: z.instanceof(File),
     avatar: z.any().nullish(),
     permission: z.string().optional(),

--- a/web/src/pages/dataset/setting/python/general-form.tsx
+++ b/web/src/pages/dataset/setting/python/general-form.tsx
@@ -10,7 +10,10 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { LanguageTranslationMap } from '@/constants/common';
+import {
+  DESCRIPTION_MAX_LENGTH,
+  LanguageTranslationMap,
+} from '@/constants/common';
 import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -111,6 +114,7 @@ export function GeneralForm() {
                 <FormControl className="w-3/4">
                   <Input
                     {...field}
+                    maxLength={DESCRIPTION_MAX_LENGTH}
                     placeholder={t('knowledgeConfiguration.datasetDescription')}
                     data-testid="ds-settings-basic-description-input"
                   ></Input>

--- a/web/src/pages/memory/memory-setting/basic-form.tsx
+++ b/web/src/pages/memory/memory-setting/basic-form.tsx
@@ -1,12 +1,20 @@
 import { AvatarUpload } from '@/components/avatar-upload';
 import { RAGFlowFormItem } from '@/components/ragflow-form';
 import { Input } from '@/components/ui/input';
+import { DESCRIPTION_MAX_LENGTH } from '@/constants/common';
 import { t } from 'i18next';
 import { z } from 'zod';
 export const basicInfoSchema = {
   name: z.string().min(1, { message: t('setting.nameRequired') }),
   avatar: z.string().optional(),
-  description: z.string().optional(),
+  description: z
+    .string()
+    .max(DESCRIPTION_MAX_LENGTH, {
+      message: t('common.descriptionMaxLength', {
+        max: DESCRIPTION_MAX_LENGTH,
+      }),
+    })
+    .optional(),
 };
 export const defaultBasicInfo = { name: '', avatar: '', description: '' };
 export const BasicInfo = () => {
@@ -49,6 +57,7 @@ export const BasicInfo = () => {
           return (
             <Input
               {...field}
+              maxLength={DESCRIPTION_MAX_LENGTH}
               placeholder={t('memory.config.descriptionPlaceholder')}
             ></Input>
           );


### PR DESCRIPTION
### Summary

fix(web): cap description length at 512 characters

Dataset settings and memory settings accepted arbitrarily long descriptions, which the backend rejects. Add a shared DESCRIPTION_MAX_LENGTH constant, enforce it in the zod schemas with a localized message, and set maxLength on the inputs so typing stops at the limit instead of failing on submit.
