### PR TITLE
fix(pdf): remove unused context import breaking manual test build

### DIFF
--- a/internal/deepdoc/parser/pdf/parser_pipeline_integration_test.go
+++ b/internal/deepdoc/parser/pdf/parser_pipeline_integration_test.go
@@ -4,7 +4,6 @@ package pdf
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"image"

--- a/internal/deepdoc/parser/pdf/parser_pipeline_manual_test.go
+++ b/internal/deepdoc/parser/pdf/parser_pipeline_manual_test.go
@@ -3,7 +3,6 @@
 package pdf
 
 import (
-	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
## Problem

The `pdf` package's `cgo && manual` test build is currently broken on `main`. Two test files import `context` but never use it, so the package fails to compile:

```
internal/deepdoc/parser/pdf/parser_pipeline_integration_test.go:7:2: "context" imported and not used
internal/deepdoc/parser/pdf/parser_pipeline_manual_test.go:6:2: "context" imported and not used
```

Because the whole package fails to compile, `TestPipelineParity` and every other manual/integration test in `package pdf` cannot run.

## Root cause

Commit #18821 ("Go: fix context, part3") replaced `context.Background()` with `t.Context()` in both files but left the `"context"` import behind. `t.Context()` needs no explicit `context` import, so the import became dead.

## Fix

Remove the now-unused `"context"` import from both files.

## Verification

- `bash build.sh --test-manual ./internal/deepdoc/parser/pdf/ -run NONE` now compiles the package cleanly (`ok ... [no tests to run]`).
- This restores the ability to run the `pdf` manual/integration suite (e.g. `TestPipelineParity`) on `main`.

Refs #18821.