### PR TITLE
fix(nats): increase RAGFLOW_TASKS MaxBytes from 1M to 64M and auto-migrate existing stream

### DIFF
--- a/internal/engine/nats/nats.go
+++ b/internal/engine/nats/nats.go
@@ -80,7 +80,7 @@ func (n *NatsEngine) Init() error {
 		Retention: jetstream.WorkQueuePolicy,
 		Storage:   jetstream.FileStorage,
 		MaxMsgs:   1024 * 128,
-		MaxBytes:  1024 * 1024,
+		MaxBytes:  1024 * 1024 * 64,
 	}
 
 	n.stream, err = n.jetStream.CreateStream(ctx, streamCfg)
@@ -95,6 +95,16 @@ func (n *NatsEngine) Init() error {
 		if err != nil {
 			n.nc.Close()
 			return fmt.Errorf("fail to get existing stream at %s: %w", natsURL, err)
+		}
+		if info, infoErr := n.stream.Info(ctx); infoErr == nil && info.Config.MaxBytes != streamCfg.MaxBytes {
+			info.Config.MaxBytes = streamCfg.MaxBytes
+			info.Config.MaxMsgs = streamCfg.MaxMsgs
+			if updated, updErr := n.jetStream.UpdateStream(ctx, info.Config); updErr == nil {
+				n.stream = updated
+				common.Info(fmt.Sprintf("NATS stream MaxBytes updated to %d", streamCfg.MaxBytes))
+			} else {
+				common.Warn(fmt.Sprintf("failed to update NATS stream MaxBytes: %v", updErr))
+			}
 		}
 	} else {
 		common.Info(fmt.Sprintf("NATS stream create successfully at %s", natsURL))


### PR DESCRIPTION
### Bug

`internal/engine/nats/nats.go:83` caps `RAGFLOW_TASKS` at `1M` (`1024*1024`).

* Ingestion `TaskMessage` JSON is 75B → 118B on disk (`30+slen+payload`), so 1M holds only ~8886 tasks (memory tasks 594B → 1765). `MaxMsgs=131k` never hits first.
* `WorkQueue/FileStorage` keeps un-acked messages; a few batch parses or a stalled `Ingestor` fills the stream. Default `DiscardOld` then silently evicts the oldest tasks before `consumeLoop@ingestion_service.go:209` → `StartRunning CREATED→RUNNING@ingestion_task_service.go:209`, leaving `DB ingestion_task` rows stuck at `CREATED`.
* Subsequent `CreateAndEnqueue@ingestion_task_service.go:387` only allows `FAILED/STOPPED → CREATED`, so any retry hits `already exists, status: CREATED, task id: ...@ingestion_task_service.go:412` → `failed to enqueue document ...` for all files (global block). Single-doc double-click also hits the same `CREATED` window.

Other streams (`RAGFLOW_SYNC_TASKS`, `RAGFLOW_KNOWLEDGE_COMPILE_EVENTS`) already use 64M.

### Fix

* `nats.go:83` `MaxBytes: 1M → 64M` (consistent with syncer, ~540k ingestion tasks).
* On `Init()` if stream already exists, compare `Info.Config.MaxBytes` and `UpdateStream` so deployed clusters self-heal without manual `rm -rf /data/jetstream` + `DELETE FROM rag_flow.ingestion_task WHERE status='CREATED'`.

### Verification

* `gofmt`/`go vet` pass.
* Sub-agent measured: 75B JSON → 118B stored, 1M/118=8886 (verified 20k publishes → retain 8886), memory 551B → 594B → 1765.
* Worktree: `/tmp/wt-nats-maxbytes` branch `fix/nats-maxbytes`.

Fixes: `failed to enqueue document ... already exists, status: CREATED`
