### PR TITLE
Fix Go Agents tab ordering to match Python

### DIFF
--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -732,9 +732,9 @@ func (s *AgentService) listAgentsGroupsOnly(ctx context.Context, userID, keyword
 }
 
 // mergeAgentsAndGroups combines agents and the caller's compilation template
-// groups into a single list ordered by (canvas_category, name) ascending, then
-// pages in Go. desc is accepted for API signature parity but the ordering is
-// intentionally category/name based, not chronological.
+// groups into a single list ordered by update_time, then pages in Go. This
+// mirrors Python's merged /agents response. A stable sort retains the original
+// agent-before-group order when timestamps are equal.
 func (s *AgentService) mergeAgentsAndGroups(ctx context.Context, userID string, agentItems []*AgentItem, keywords, orderBy string, desc bool, page, pageSize int) (*ListAgentsResponse, common.ErrorCode, error) {
 	groups, err := s.compilationTemplateGroupDAO.ListOwnedSaved(ctx, dao.DB, userID, keywords, "", orderBy, desc)
 	if err != nil {
@@ -744,9 +744,8 @@ func (s *AgentService) mergeAgentsAndGroups(ctx context.Context, userID string, 
 	for _, item := range agentItems {
 		item.Type = AgentItemTypeAgent
 		merged = append(merged, mergeCanvasItem{
-			item:     item,
-			category: item.CanvasCategory,
-			name:     derefString(item.Title),
+			item: item,
+			time: intValuePtr(item.UpdateTime),
 		})
 	}
 	for _, g := range groups {
@@ -755,21 +754,15 @@ func (s *AgentService) mergeAgentsAndGroups(ctx context.Context, userID string, 
 			return nil, common.CodeServerError, fmt.Errorf("failed to build group item: %w", err)
 		}
 		merged = append(merged, mergeCanvasItem{
-			raw:      raw,
-			category: CompilationTemplateGroupCategory,
-			name:     g.Name,
+			raw:  raw,
+			time: intValuePtr(g.UpdateTime),
 		})
 	}
-	// Order the merged list by (category, name) ascending (A-Z): agents and
-	// compilation template groups are grouped by flow category, then sorted by
-	// display name within each category. The category sort key uses the raw
-	// canvas_category string so the natural order is agent_canvas <
-	// compilation_template_group < dataflow_canvas.
 	sort.SliceStable(merged, func(i, j int) bool {
-		if merged[i].category != merged[j].category {
-			return merged[i].category < merged[j].category
+		if desc {
+			return merged[i].time > merged[j].time
 		}
-		return strings.ToLower(merged[i].name) < strings.ToLower(merged[j].name)
+		return merged[i].time < merged[j].time
 	})
 	total := int64(len(merged))
 	merged = slicePage(merged, page, pageSize)
@@ -814,15 +807,12 @@ func (s *AgentService) marshalMergeGroupItem(ctx context.Context, userID string,
 	return b, nil
 }
 
-// mergeCanvasItem is a decoded entry in the merged /agents list: exactly one of
-// item (an agent) or raw (a marshalled group) is set. category is the flow
-// classification (canvas_category, or "compilation_template_group" for groups)
-// and name is the display title; the merged list is ordered by (category, name).
+// mergeCanvasItem is an entry in the merged /agents list. Exactly one of item
+// (an agent) or raw (a marshalled group) is set.
 type mergeCanvasItem struct {
-	item     *AgentItem
-	raw      json.RawMessage
-	category string
-	name     string
+	item *AgentItem
+	raw  json.RawMessage
+	time int64
 }
 
 // attachReleaseTimes populates ReleaseTime for each agent item from the latest


### PR DESCRIPTION
The Go Agents tab now sorts merged agents and template groups by update time.