### PR TITLE
Fix: The models for audio and video parsers are required fields.

### DIFF
--- a/web/src/pages/agent/form/parser-form/video-form-fields.tsx
+++ b/web/src/pages/agent/form/parser-form/video-form-fields.tsx
@@ -20,6 +20,7 @@ export function AudioFormFields({ prefix }: OutputFormatFormFieldProps) {
         modelTypes={ModelTypeMap.asr_id}
         allowClear
         ownerTenantId={ownerTenantId}
+        required
       />
     </>
   );
@@ -38,6 +39,7 @@ export function VideoFormFields({ prefix }: OutputFormatFormFieldProps) {
         modelTypes={ModelTypeMap.img2txt_id}
         allowClear
         ownerTenantId={ownerTenantId}
+        required
       />
     </>
   );


### PR DESCRIPTION
### Summary
Fix: The models for audio and video parsers are required fields.