### PR TITLE
fix: reject wiki LLM error responses

### DIFF
--- a/rag/advanced_rag/knowlege_compile/wiki_incremental.py
+++ b/rag/advanced_rag/knowlege_compile/wiki_incremental.py
@@ -161,7 +161,10 @@ async def _chat_mdl_ask(chat_mdl, system_prompt: str, user_prompt: str, temperat
         raise
     if isinstance(raw, tuple):
         raw = raw[0]
-    return _strip_think(raw or "")
+    response = _strip_think(raw or "")
+    if any(line.lstrip().startswith("**ERROR**") for line in response.splitlines()):
+        raise RuntimeError(f"Wiki LLM call failed: {response}")
+    return response
 
 
 def _wiki_should_re_synthesize(

--- a/test/unit_test/rag/advanced_rag/knowlege_compile/test_wiki_incremental.py
+++ b/test/unit_test/rag/advanced_rag/knowlege_compile/test_wiki_incremental.py
@@ -79,6 +79,51 @@ class MockChatModel:
         pass
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        "**ERROR**: ERROR_MAX_RETRIES - upstream unavailable",
+        "partial response\n**ERROR**: ERROR_SERVER - connection lost",
+        ("**ERROR**: ERROR_GENERIC - invalid request", 0),
+    ],
+)
+async def test_chat_mdl_ask_raises_for_model_error_response(response):
+    chat_mdl = MockChatModel(response)
+
+    with pytest.raises(RuntimeError, match="Wiki LLM call failed"):
+        await _wiki._chat_mdl_ask(chat_mdl, "system", "user")
+
+
+@pytest.mark.asyncio
+async def test_chat_mdl_ask_returns_normal_response():
+    response = "SUMMARY: Apple\n\nApple is a company."
+
+    assert await _wiki._chat_mdl_ask(MockChatModel(response), "system", "user") == response
+
+
+@pytest.mark.asyncio
+async def test_refine_page_does_not_persist_model_error_response():
+    doc_store = make_doc_store()
+
+    with patch("common.settings.docStoreConn", doc_store):
+        with pytest.raises(RuntimeError, match="Wiki LLM call failed"):
+            await _wiki._wiki_refine_page(
+                mode="generate",
+                page_id="entity/Apple",
+                page_title="Apple",
+                existing_page=None,
+                chat_mdl=MockChatModel("**ERROR**: ERROR_MAX_RETRIES - upstream unavailable"),
+                embd_mdl=MockEmbeddingModel(),
+                tenant_id="t1",
+                kb_id="kb1",
+                page_version=0,
+            )
+
+    doc_store.insert.assert_not_called()
+    doc_store.update.assert_not_called()
+
+
 def make_doc_store(search_results: list[dict] | None = None):
     """Create a mock settings.docStoreConn."""
     conn = MagicMock()


### PR DESCRIPTION
### What problem does this PR solve?

Wiki page generation treated LLM error responses such as `**ERROR**: ERROR_MAX_RETRIES` as valid content and persisted them as page bodies.

This change detects standard LLM error responses and raises an exception instead, allowing the page to be marked as failed and retried without polluting Wiki content.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)