### PR TITLE
Fix: When the pipeline-paeser component switches the file type from PDF to image, the default parsing method should be OCR.

### DIFF
--- a/web/src/pages/agent/form/parser-form/email-form-fields.tsx
+++ b/web/src/pages/agent/form/parser-form/email-form-fields.tsx
@@ -15,6 +15,7 @@ export function EmailFormFields({ prefix }: CommonProps) {
       <RAGFlowFormItem
         name={buildFieldNameWithPrefix(`fields`, prefix)}
         label={t('flow.fields')}
+        required
       >
         {(field) => (
           <MultiSelect

--- a/web/src/pages/agent/form/parser-form/index.tsx
+++ b/web/src/pages/agent/form/parser-form/index.tsx
@@ -41,7 +41,7 @@ import {
   HtmlFormFields,
   TextMarkdownFormFields,
 } from './text-html-form-fields';
-import { buildFieldNameWithPrefix } from './utils';
+import { buildFieldNameWithPrefix, getInitialParseMethod } from './utils';
 import { AudioFormFields, VideoFormFields } from './video-form-fields';
 import { WordFormFields } from './word-form-fields';
 
@@ -133,6 +133,11 @@ function ParserItem({
       form.setValue(
         `setups.${index}.output_format`,
         InitialOutputFormatMap[value],
+        { shouldDirty: true, shouldValidate: true, shouldTouch: true },
+      );
+      form.setValue(
+        `setups.${index}.parse_method`,
+        getInitialParseMethod(value),
         { shouldDirty: true, shouldValidate: true, shouldTouch: true },
       );
     },

--- a/web/src/pages/agent/form/parser-form/utils.ts
+++ b/web/src/pages/agent/form/parser-form/utils.ts
@@ -1,3 +1,12 @@
+import { FileType, initialParserValues } from '../../constant/pipeline';
+
 export function buildFieldNameWithPrefix(name: string, prefix: string) {
   return `${prefix}.${name}`;
+}
+
+export function getInitialParseMethod(fileType: FileType): string {
+  const setup = initialParserValues.setups.find(
+    (x) => x.fileFormat === fileType,
+  );
+  return setup?.parse_method ?? '';
 }


### PR DESCRIPTION


### Summary

Fix: When the pipeline-paeser component switches the file type from PDF to image, the default parsing method should be OCR.
