### PR TITLE
fix(metadata-filter): propagate resolved document IDs to retrieval

### DIFF
--- a/internal/service/chat_pipeline.go
+++ b/internal/service/chat_pipeline.go
@@ -567,7 +567,7 @@ func (s *ChatPipelineService) AsyncChat(
 					flattedMeta, mErr = s.MetadataSvc.GetFlattedMetaByKBs(ctx, kbIDs)
 				}
 				if mErr == nil {
-					if filtered, ok := ApplyMetaDataFilter(
+					if filtered, _ := ApplyMetaDataFilter(
 						ctx,
 						*chat.MetaDataFilter,
 						flattedMeta,
@@ -575,7 +575,7 @@ func (s *ChatPipelineService) AsyncChat(
 						chatModel,
 						docIDs,
 						kbIDs,
-					); ok {
+					); filtered != nil {
 						common.Debug("meta_data_filter applied",
 							zap.Int("filtered_count", len(filtered)),
 							zap.Int("pre_filter_count", len(docIDs)))


### PR DESCRIPTION
The chat pipeline was ignoring successful metadata-filter results because it checked the wrong boolean. It now applies any non-nil resolved document ID list.