### PR TITLE
fix(web): derive provider base_url visibility from the provider catalog

### DIFF
--- a/web/src/pages/user-setting/setting-model/provider-schema/field-config/generic-api-key-config.ts
+++ b/web/src/pages/user-setting/setting-model/provider-schema/field-config/generic-api-key-config.ts
@@ -92,15 +92,3 @@ export const GenericApiKeyConfig: ProviderConfig = {
     };
   },
 };
-
-/**
- * List of factories supporting base_url (used for the generic ApiKey modal)
- */
-export const FACTORIES_WITH_BASE_URL = [
-  LLMFactory.OpenAI,
-  LLMFactory.AzureOpenAI,
-  LLMFactory.TongYiQianWen,
-  LLMFactory.MiniMax,
-  LLMFactory.SILICONFLOW,
-  LLMFactory.TencentHunYuan,
-];

--- a/web/src/pages/user-setting/setting-model/provider-schema/field-config/index.ts
+++ b/web/src/pages/user-setting/setting-model/provider-schema/field-config/index.ts
@@ -17,5 +17,4 @@
 // Public entry point for the field-config folder.
 // Preserves the previous `./field-config` import path used by provider-modal/index.tsx.
 
-export { FACTORIES_WITH_BASE_URL } from './generic-api-key-config';
 export { getProviderConfig } from './get-provider-config';

--- a/web/src/pages/user-setting/setting-model/provider-schema/hooks/use-provider-fields.tsx
+++ b/web/src/pages/user-setting/setting-model/provider-schema/hooks/use-provider-fields.tsx
@@ -21,7 +21,7 @@ import { useTranslate } from '@/hooks/common-hooks';
 import { useMemo } from 'react';
 import { ControllerRenderProps, FieldValues } from 'react-hook-form';
 import { LIST_MODEL_FIELD_NAMES, LIST_MODEL_PROVIDERS } from '../constants';
-import { FACTORIES_WITH_BASE_URL, getProviderConfig } from '../field-config';
+import { getProviderConfig } from '../field-config';
 import type { FieldConfig, SelectOption } from '../types';
 
 interface UseProviderFieldsParams {
@@ -142,17 +142,17 @@ export const useProviderFields = ({
             if (Array.isArray(mt)) return mt.includes('tts');
             return mt === 'tts';
           };
+        // Driven by the provider catalog (`GET /providers`): a provider needs a
+        // base_url iff it advertises one or more URLs in its `url` map.
         case 'showBaseUrl':
-          return () =>
-            FACTORIES_WITH_BASE_URL.some((x) => x === llmFactory) ||
-            llmFactory?.toLowerCase() === 'Anthropic'.toLowerCase();
+          return () => (baseUrlOptions?.length ?? 0) > 0;
         case 'showGroupId':
           return () => llmFactory?.toLowerCase() === 'Minimax'.toLowerCase();
         default:
           return undefined;
       }
     };
-  }, [hideWhenInstanceExists, llmFactory]);
+  }, [hideWhenInstanceExists, llmFactory, baseUrlOptions]);
 
   // For each inputSelect field, build a URL → regionKey map from its
   // options (either inline `field.options` or the shared `baseUrlOptions`).


### PR DESCRIPTION
### Summary

fix(web): derive provider base_url visibility from the provider catalog

The generic API-key form gated its `base_url` field on a hardcoded `FACTORIES_WITH_BASE_URL` list, so providers such as Jina could not be given a base URL even though `GET /providers` advertises one for them. Gate the field on the URL options already derived from that response instead, and drop the list.