### PR TITLE
Fix: add Separator component and restore GlobalIndexModelItem in NaiveConfiguration

### DIFF
--- a/web/src/pages/dataset/setting/python/configuration/naive.tsx
+++ b/web/src/pages/dataset/setting/python/configuration/naive.tsx
@@ -19,6 +19,7 @@ import {
   OverlappedPercent,
 } from './common-item';
 import { FormLayout } from '@/constants/form';
+import { Separator } from '@/components/ui/separator';
 
 export function NaiveConfiguration() {
   const ownerTenantId = useOwnerTenantId();
@@ -29,7 +30,6 @@ export function NaiveConfiguration() {
           testId="ds-settings-parser-pdf-parser-select"
           ownerTenantId={ownerTenantId}
         ></LayoutRecognizeFormField>
-        <GlobalIndexModelItem />
         <MaxTokenNumberFormField
           initialValue={512}
           sliderTestId="ds-settings-parser-recommended-chunk-size-slider"
@@ -42,6 +42,8 @@ export function NaiveConfiguration() {
         <AutoMetadata />
       </ConfigurationFormContainer>
       <ConfigurationFormContainer>
+        <Separator />
+        <GlobalIndexModelItem />
         <AutoKeywordsFormField
           layout={FormLayout.Horizontal}
         ></AutoKeywordsFormField>


### PR DESCRIPTION

### Summary

Fix: add Separator component and restore GlobalIndexModelItem in NaiveConfiguration
