### PR TITLE
fix(web): reactively render children delimiter field

### DIFF
--- a/web/src/components/children-delimiter-form.test.tsx
+++ b/web/src/components/children-delimiter-form.test.tsx
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Form } from '@/components/ui/form';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { ChildrenDelimiterForm } from './children-delimiter-form';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+type FormValues = {
+  parser_config: {
+    enable_children: boolean;
+    children_delimiter: string;
+  };
+};
+
+function Harness() {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      parser_config: {
+        enable_children: false,
+        children_delimiter: '',
+      },
+    },
+  });
+
+  return (
+    <TooltipProvider>
+      <Form {...form}>
+        <ChildrenDelimiterForm />
+      </Form>
+    </TooltipProvider>
+  );
+}
+
+describe('ChildrenDelimiterForm', () => {
+  it('updates delimiter input visibility when the children switch changes', () => {
+    render(<Harness />);
+
+    expect(
+      screen.queryByTestId('ds-settings-parser-child-chunk-delimiter-input'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch'));
+    expect(
+      screen.getByTestId('ds-settings-parser-child-chunk-delimiter-input'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch'));
+    expect(
+      screen.queryByTestId('ds-settings-parser-child-chunk-delimiter-input'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/children-delimiter-form.tsx
+++ b/web/src/components/children-delimiter-form.tsx
@@ -70,6 +70,7 @@ export function ChildrenDelimiterForm() {
   const form = useFormContext();
 
   const delimiterValue = form.watch('parser_config.children_delimiter');
+  const enableChildren = form.watch('parser_config.enable_children');
 
   return (
     <fieldset className="space-y-2">
@@ -104,7 +105,7 @@ export function ChildrenDelimiterForm() {
         )}
       />
 
-      {form.getValues('parser_config.enable_children') && (
+      {enableChildren && (
         <FormField
           control={form.control}
           name="parser_config.children_delimiter"


### PR DESCRIPTION
## Summary

- Watch `parser_config.enable_children` reactively in `ChildrenDelimiterForm`.
- Keep the children delimiter input synchronized with the switch state.
- Add a regression test covering toggle-on and toggle-off rendering.

## Validation

- `npx jest src/components/children-delimiter-form.test.tsx --runInBand --no-cache`
- `npx oxfmt --check src/components/children-delimiter-form.tsx src/components/children-delimiter-form.test.tsx`
- `npx oxlint src/components/children-delimiter-form.tsx src/components/children-delimiter-form.test.tsx`
- `git diff --check`

The full web TypeScript check was also run; it reports pre-existing errors in unrelated files, with no error in the changed files.