### PR TITLE
fix: correct hyphens utility on agent template descriptions

### DIFF
--- a/web/src/pages/agents/template-card.tsx
+++ b/web/src/pages/agents/template-card.tsx
@@ -42,7 +42,7 @@ export function TemplateCard({ data, showModal }: IProps) {
             {data?.title[language]}
           </div>
         </div>
-        <p className="break-words hypens-auto" lang={language}>
+        <p className="break-words hyphens-auto" lang={language}>
           {data?.description[language]}
         </p>
         <div className="group-hover:bg-gradient-to-t from-black/70 from-10% via-black/0 via-50% to-black/0 w-full h-full group-hover:block absolute top-0 left-0 hidden rounded-xl">


### PR DESCRIPTION
## What problem does this PR solve?

The agent template card description uses the misspelled `hypens-auto` utility. Tailwind does not generate that class, so automatic hyphenation is not applied to long localized descriptions.

## What does this PR do?

Replace `hypens-auto` with the valid `hyphens-auto` utility. The sibling title element already uses the intended spelling. This is a one-line fix with no copy, layout, or locale changes.

## Verification

- Confirmed the typo on current `main`.
- Confirmed the corrected class with a source regression assertion.
- `oxfmt --check` passed.
- `git diff --check` passed.
