### PR TITLE
ci: check release version references

### DIFF
--- a/test/test_release_version_refs.py
+++ b/test/test_release_version_refs.py
@@ -1,0 +1,63 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import importlib.util
+from pathlib import Path
+
+
+def _load_checker():
+    repo_root = Path(__file__).resolve().parents[1]
+    checker_path = repo_root / "tools" / "scripts" / "check_release_version_refs.py"
+    spec = importlib.util.spec_from_file_location("check_release_version_refs", checker_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_fixture(root: Path, *, readme_version: str = "v1.2.3"):
+    version = "v1.2.3"
+    migration_dir = "v1_2_3"
+    (root / "docker").mkdir(parents=True)
+    (root / "tools" / "scripts").mkdir(parents=True)
+    (root / "docs" / "administrator" / "migration").mkdir(parents=True)
+    (root / "docker" / ".env").write_text(f"RAGFLOW_IMAGE=infiniflow/ragflow:{version}\n", encoding="utf-8")
+    (root / "README.md").write_text(
+        f"downloads the `{readme_version}` edition\n$ git checkout {version}\n", encoding="utf-8"
+    )
+    (root / "tools" / "scripts" / "README.md").write_text(
+        f"Example: Version `{version}` → Directory `tools/migrate/{migration_dir}/`\n", encoding="utf-8"
+    )
+    (root / "tools" / "scripts" / "db_schema_sync.py").write_text(
+        f"--version {version}\n'{version}' -> '{migration_dir}'\n", encoding="utf-8"
+    )
+    (root / "docs" / "administrator" / "migration" / "database_schema_and_migration.md").write_text(
+        f"tools/migrate/{migration_dir}/\n", encoding="utf-8"
+    )
+
+
+def test_current_release_references_are_consistent():
+    module = _load_checker()
+    repo_root = Path(__file__).resolve().parents[1]
+
+    assert module.check_release_version_refs(repo_root) == []
+
+
+def test_release_reference_checker_reports_stale_docker_edition(tmp_path):
+    module = _load_checker()
+    _write_fixture(tmp_path, readme_version="v0.27.0")
+
+    errors = module.check_release_version_refs(tmp_path)
+
+    assert any("README.md: Docker edition reference" in error for error in errors)

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -278,6 +278,14 @@ Version must be in format `vxx.xx.xx` where `xx` are digits:
 - Valid: `v0.27.0`, `v1.0.0`, `v10.20.30`
 - Invalid: `0.27.0`, `v0.25`, `v0.27.0.1`
 
+### Release Reference Check
+
+Run this lightweight check before publishing a release to catch drift between the pinned Docker image, README instructions, and migration-directory examples:
+
+```bash
+python tools/scripts/check_release_version_refs.py
+```
+
 ### Migration File Location
 
 Migration files are stored in:

--- a/tools/scripts/check_release_version_refs.py
+++ b/tools/scripts/check_release_version_refs.py
@@ -1,0 +1,87 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Check release-version references that must agree with docker/.env."""
+
+import argparse
+import re
+from pathlib import Path
+
+
+def _read(root: Path, relative_path: str, errors: list[str]) -> str:
+    try:
+        return (root / relative_path).read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"{relative_path}: cannot read file: {exc}")
+        return ""
+
+
+def _configured_version(root: Path, errors: list[str]) -> str:
+    env = _read(root, "docker/.env", errors)
+    versions = re.findall(r"^RAGFLOW_IMAGE=infiniflow/ragflow:(v\d+\.\d+\.\d+)\s*$", env, re.MULTILINE)
+    if len(versions) != 1:
+        errors.append(f"docker/.env: expected exactly one pinned RAGFLOW_IMAGE, found {len(versions)}")
+        return ""
+    return versions[0]
+
+
+def check_release_version_refs(root: Path) -> list[str]:
+    """Return release-reference mismatches for a repository root."""
+    errors: list[str] = []
+    version = _configured_version(root, errors)
+    if not version:
+        return errors
+    migration_dir = version.replace(".", "_")
+
+    readme = _read(root, "README.md", errors)
+    if f"downloads the `{version}` edition" not in readme:
+        errors.append(f"README.md: Docker edition reference is not {version}")
+    if f"git checkout {version}" not in readme:
+        errors.append(f"README.md: checkout reference is not {version}")
+
+    scripts_readme = _read(root, "tools/scripts/README.md", errors)
+    expected_location = f"Example: Version `{version}` → Directory `tools/migrate/{migration_dir}/`"
+    if expected_location not in scripts_readme:
+        errors.append("tools/scripts/README.md: migration directory example does not match the release")
+
+    schema_sync = _read(root, "tools/scripts/db_schema_sync.py", errors)
+    concrete_versions = set(re.findall(r"--version\s+(v\d+\.\d+\.\d+)", schema_sync))
+    if concrete_versions != {version}:
+        errors.append(f"tools/scripts/db_schema_sync.py: --version examples are {sorted(concrete_versions)}, expected {version}")
+    if f"'{version}' -> '{migration_dir}'" not in schema_sync:
+        errors.append("tools/scripts/db_schema_sync.py: version-to-directory example is stale")
+
+    migration_doc = _read(root, "docs/administrator/migration/database_schema_and_migration.md", errors)
+    if f"tools/migrate/{migration_dir}/" not in migration_doc:
+        errors.append("database migration documentation: version-specific directory example is stale")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2], help="repository root")
+    args = parser.parse_args()
+    errors = check_release_version_refs(args.root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("release-version-refs: passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dependency-free check that derives the pinned release from `docker/.env`
- validate stable README, migration-directory, and `db_schema_sync` examples against that release
- add current-tree and stale-fixture regression coverage and document the command

## Tests
- `python tools/scripts/check_release_version_refs.py`
- `pytest --noconftest test/test_release_version_refs.py -q`
- `ruff check tools/scripts/check_release_version_refs.py test/test_release_version_refs.py`
- `python3 -m compileall -q tools/scripts/check_release_version_refs.py test/test_release_version_refs.py`
- `git diff --check`