### PR TITLE
fix(search): safely append extracted keywords

### DIFF
--- a/api/apps/restful_apis/bot_api.py
+++ b/api/apps/restful_apis/bot_api.py
@@ -41,7 +41,7 @@ from common.misc_utils import thread_pool_exec
 from api.utils.api_utils import get_error_data_result, get_json_result, add_tenant_id_to_kwargs, get_result, get_request_json, server_error_response, validate_request
 from rag.app.tag import label_question
 from rag.prompts.template import load_prompt
-from rag.prompts.generator import cross_languages, keyword_extraction
+from rag.prompts.generator import append_keywords, cross_languages, keyword_extraction
 from common.constants import RetCode, LLMType, StatusEnum
 from common import settings
 from rag.utils.web_search_conn import has_web_search_provider
@@ -433,7 +433,7 @@ async def retrieval_test_embedded(tenant_id=None):
         if req.get("keyword", False):
             default_chat_model = await thread_pool_exec(get_tenant_default_model_by_type, kb.tenant_id, LLMType.CHAT)
             chat_mdl = LLMBundle(kb.tenant_id, default_chat_model)
-            _question += await keyword_extraction(chat_mdl, _question)
+            _question = append_keywords(_question, await keyword_extraction(chat_mdl, _question))
 
         labels = label_question(_question, [kb])
         ranks = await settings.retriever.retrieval(

--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -63,7 +63,7 @@ from common.string_utils import is_content_empty, remove_redundant_spaces
 from common.tag_feature_utils import validate_tag_features
 from rag.app.tag import label_question
 from rag.nlp import search
-from rag.prompts.generator import cross_languages, keyword_extraction
+from rag.prompts.generator import append_keywords, cross_languages, keyword_extraction
 
 DOC_STOP_PARSING_INVALID_STATE_MESSAGE = "Can't stop parsing document that has not started or already completed"
 DOC_STOP_PARSING_INVALID_STATE_ERROR_CODE = "DOC_STOP_PARSING_INVALID_STATE"
@@ -431,7 +431,7 @@ async def retrieval_test(tenant_id):
             question = await cross_languages(kb.tenant_id, None, question, langs)
         if req.get("keyword", False):
             chat_model_config = get_tenant_default_model_by_type(kb.tenant_id, LLMType.CHAT)
-            question += await keyword_extraction(LLMBundle(kb.tenant_id, chat_model_config), question)
+            question = append_keywords(question, await keyword_extraction(LLMBundle(kb.tenant_id, chat_model_config), question))
 
         ranks = await settings.retriever.retrieval(
             question,

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -1044,7 +1044,7 @@ async def search(dataset_id: str, tenant_id: str, req: dict):
     from common.constants import LLMType
     from common.metadata_utils import apply_meta_data_filter
     from rag.app.tag import label_question
-    from rag.prompts.generator import cross_languages, keyword_extraction
+    from rag.prompts.generator import append_keywords, cross_languages, keyword_extraction
 
     logging.debug(
         "search(dataset=%s, tenant=%s, question_len=%s)",
@@ -1155,7 +1155,7 @@ async def search(dataset_id: str, tenant_id: str, req: dict):
     if search_config.get("keyword", req.get("keyword", False)):
         default_chat_model_config = get_tenant_default_model_by_type(kb.tenant_id, LLMType.CHAT)
         chat_mdl = LLMBundle(kb.tenant_id, default_chat_model_config)
-        _question += await keyword_extraction(chat_mdl, _question)
+        _question = append_keywords(_question, await keyword_extraction(chat_mdl, _question))
 
     labels = label_question(_question, [kb])
     ranks = await settings.retriever.retrieval(
@@ -1435,7 +1435,7 @@ async def search_datasets(tenant_id: str, req: dict):
     from common.constants import LLMType
     from common.metadata_utils import apply_meta_data_filter
     from rag.app.tag import label_question
-    from rag.prompts.generator import cross_languages, keyword_extraction
+    from rag.prompts.generator import append_keywords, cross_languages, keyword_extraction
 
     kb_ids = req.get("dataset_ids", [])
     page = int(req.get("page", 1))
@@ -1556,7 +1556,7 @@ async def search_datasets(tenant_id: str, req: dict):
     if search_config.get("keyword", req.get("keyword", False)):
         default_chat_model_config = get_tenant_default_model_by_type(kb.tenant_id, LLMType.CHAT)
         chat_mdl = LLMBundle(kb.tenant_id, default_chat_model_config)
-        _question += await keyword_extraction(chat_mdl, _question)
+        _question = append_keywords(_question, await keyword_extraction(chat_mdl, _question))
 
     labels = label_question(_question, kbs)
     ranks = await settings.retriever.retrieval(

--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -48,7 +48,7 @@ from rag.advanced_rag.knowlege_compile.mind_map_extractor import MindMapExtracto
 from rag.advanced_rag import DeepResearcher
 from rag.app.tag import label_question
 from rag.nlp.search import index_name
-from rag.prompts.generator import chunks_format, citation_prompt, cross_languages, full_question, kb_prompt, keyword_extraction, message_fit_in, PROMPT_JINJA_ENV, ASK_SUMMARY
+from rag.prompts.generator import ASK_SUMMARY, PROMPT_JINJA_ENV, append_keywords, chunks_format, citation_prompt, cross_languages, full_question, kb_prompt, keyword_extraction, message_fit_in
 from common.token_utils import num_tokens_from_string
 from rag.utils.web_search_conn import create_web_search_provider, has_web_search_provider
 from rag.utils.tts_cache import synthesize_with_cache
@@ -718,7 +718,7 @@ async def async_chat(dialog, messages, stream=True, **kwargs):
         questions = [await cross_languages(dialog.tenant_id, dialog.llm_id, questions[0], prompt_config["cross_languages"])]
 
     if prompt_config.get("keyword", False):
-        questions[-1] = questions[-1] + "," + await keyword_extraction(chat_mdl, questions[-1])
+        questions[-1] = append_keywords(questions[-1], await keyword_extraction(chat_mdl, questions[-1]))
     refine_question_ts = timer()
 
     thought = ""

--- a/rag/prompts/generator.py
+++ b/rag/prompts/generator.py
@@ -38,6 +38,13 @@ def get_value(d, k1, k2):
     return d.get(k1, d.get(k2))
 
 
+def append_keywords(question, keywords):
+    """Append extracted keywords without changing the question when none exist."""
+    if not keywords:
+        return question
+    return question + "," + keywords
+
+
 def chunks_format(reference):
     if not reference or not isinstance(reference, dict):
         return []

--- a/test/unit_test/rag/prompts/test_generator_message_fit_in.py
+++ b/test/unit_test/rag/prompts/test_generator_message_fit_in.py
@@ -170,3 +170,12 @@ def test_message_fit_in_zero_budget_preserves_non_empty_messages(monkeypatch):
     assert used_tokens == expected_total
     assert trimmed[0]["content"] == "s" * system_len
     assert trimmed[-1]["content"] == user_content
+
+
+@pytest.mark.p1
+def test_append_keywords_uses_comma_only_for_non_empty_keywords(monkeypatch):
+    generator = _load_generator_module(monkeypatch)
+
+    assert generator.append_keywords("question", "keyword one") == "question,keyword one"
+    assert generator.append_keywords("question", "") == "question"
+    assert generator.append_keywords("question", None) == "question"


### PR DESCRIPTION
## Summary

- add a shared helper that appends extracted keywords with one English comma only when the result is non-empty
- apply it to the active dialog, bot, chunk, and dataset retrieval paths
- add focused regression coverage for populated, empty, and null extraction results

## Validation

- focused append_keywords test: passed (1/1)
- ruff, compileall, git diff --check: passed

The candidate referenced SDK paths that are absent from current main; this PR is limited to the four active retrieval call sites found during current-main verification.
