### PR TITLE
fix(api): reject empty provider instance deletes

### DIFF
--- a/internal/handler/providers.go
+++ b/internal/handler/providers.go
@@ -641,7 +641,7 @@ func (h *ProviderHandler) AlterProviderInstance(c *gin.Context) {
 }
 
 type DropProviderInstanceRequest struct {
-	Instances []string `json:"instances" binding:"required"`
+	Instances []string `json:"instances" binding:"required,min=1,dive,required"`
 }
 
 func (h *ProviderHandler) DropProviderInstance(c *gin.Context) {

--- a/internal/handler/providers_test.go
+++ b/internal/handler/providers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
@@ -16,6 +17,32 @@ import (
 	"ragflow/internal/entity"
 	"ragflow/internal/service"
 )
+
+func TestDropProviderInstanceRequestRequiresNonEmptyInstances(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		valid   bool
+	}{
+		{name: "missing", payload: `{}`, valid: false},
+		{name: "empty", payload: `{"instances":[]}`, valid: false},
+		{name: "empty element", payload: `{"instances":[""]}`, valid: false},
+		{name: "instance", payload: `{"instances":["instance-a"]}`, valid: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req DropProviderInstanceRequest
+			if err := json.Unmarshal([]byte(tt.payload), &req); err != nil {
+				t.Fatal(err)
+			}
+			err := binding.Validator.ValidateStruct(&req)
+			if (err == nil) != tt.valid {
+				t.Fatalf("validation error = %v, valid = %v", err, tt.valid)
+			}
+		})
+	}
+}
 
 func setupProviderHandlerTestDB(t *testing.T) *gorm.DB {
 	t.Helper()


### PR DESCRIPTION
## What does this PR do?

- require at least one provider instance in batch-delete requests
- reject empty instance names during request binding
- add focused validation coverage while preserving existing provider handler tests

## Why is this change needed?

The request only required the `instances` field, so an empty list could reach the service and return success without deleting anything.

## Validation

- `gofmt`
- `git diff --check`
- focused request validation test added

The package test command is blocked in this checkout by the missing cgo header `office_oxide.h`.