### PR TITLE
fix(build): pass GOPROXY to the ragflow-cli go build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -317,7 +317,7 @@ build_go() {
     [ -n "$STRIP_SYMBOLS" ] && strip_flags=(-ldflags="-s -w")
 
     echo "Building RAGFlow binary: $RAGFLOW_CLI_BINARY and $RAGFLOW_SERVER_BINARY"
-    GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct}
+    GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} \
         go build "${strip_flags[@]}" -o "$RAGFLOW_CLI_BINARY" cmd/ragflow-cli.go
 
     GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} CGO_ENABLED=1 \


### PR DESCRIPTION
### Summary

`build_go` sets `GOPROXY` on its own line, with no line continuation, so it is a plain shell assignment rather than a prefix to the `go build` on the next line. The CLI build runs without it.

https://github.com/infiniflow/ragflow/blob/b861b2553/build.sh#L320-L321

```sh
    GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct}
        go build "${strip_flags[@]}" -o "$RAGFLOW_CLI_BINARY" cmd/ragflow-cli.go
```

The `ragflow_server` build three lines below writes the same assignment as a prefix, with the continuation, and does get it:

```sh
    GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} CGO_ENABLED=1 \
        CGO_CFLAGS="$CGO_CFLAGS" CGO_LDFLAGS="$CGO_LDFLAGS" \
        go build "${strip_flags[@]}" -o "$RAGFLOW_SERVER_BINARY" cmd/ragflow_server.go
```

So with `GOPROXY` unset in the environment, `./build.sh --go` builds the CLI against Go's default proxy and the server against the `goproxy.cn` mirror — the split the default value exists to prevent.

The indentation on the `go build` line suggests the continuation was intended and lost.

### How to test

```sh
unset PROBE
PROBE=${PROBE:-mirror}
    env | grep -c "^PROBE="     # 0 — the next command does not inherit it

PROBE=${PROBE:-mirror} \
    env | grep -c "^PROBE="     # 1
```

The fix adds the trailing `\`. `bash -n build.sh` passes.