### PR TITLE
fix(docker): let the backend launcher retry loops actually run

### DIFF
--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -103,12 +103,12 @@ task_exe(){
     local retry_count=0
     while ! $STOP && [ $retry_count -lt $MAX_RETRIES ]; do
         echo "Starting $task_name (Attempt $((retry_count+1)))"
+        EXIT_CODE=0
         if [[ "${API_PROXY_SCHEME}" == "go" ]]; then
-            "${task_cmd[@]}"
+            "${task_cmd[@]}" || EXIT_CODE=$?
         else
-            LD_PRELOAD=$JEMALLOC_PATH "${task_cmd[@]}"
+            LD_PRELOAD=$JEMALLOC_PATH "${task_cmd[@]}" || EXIT_CODE=$?
         fi
-        EXIT_CODE=$?
         if [ $EXIT_CODE -eq 0 ]; then
             echo "$task_name exited successfully."
             break
@@ -137,8 +137,8 @@ run_server(){
     local retry_count=0
     while ! $STOP && [ $retry_count -lt $MAX_RETRIES ]; do
         echo "Starting $server_name (Attempt $((retry_count+1)))"
-        "${server_cmd[@]}"
-        EXIT_CODE=$?
+        EXIT_CODE=0
+        "${server_cmd[@]}" || EXIT_CODE=$?
         if [ $EXIT_CODE -eq 0 ]; then
             echo "$server_name exited successfully."
             break
@@ -167,8 +167,8 @@ run_admin_server(){
     local retry_count=0
     while ! $STOP && [ $retry_count -lt $MAX_RETRIES ]; do
         echo "Starting $server_name (Attempt $((retry_count+1)))"
-        "${server_cmd[@]}"
-        EXIT_CODE=$?
+        EXIT_CODE=0
+        "${server_cmd[@]}" || EXIT_CODE=$?
         if [ $EXIT_CODE -eq 0 ]; then
             echo "$server_name exited successfully."
             break
@@ -189,8 +189,8 @@ run_data_sync(){
     local retry_count=0
     while ! $STOP && [ $retry_count -lt $MAX_RETRIES ]; do
         echo "Starting sync_data_source.py (Attempt $((retry_count+1)))"
-        $PY rag/svr/sync_data_source.py
-        EXIT_CODE=$?
+        EXIT_CODE=0
+        $PY rag/svr/sync_data_source.py || EXIT_CODE=$?
         if [ $EXIT_CODE -eq 0 ]; then
             echo "sync_data_source.py exited successfully."
             break


### PR DESCRIPTION
### Summary

`docker/launch_backend_service.sh` sets `set -e` at the top, and each of the four service runners executes its command bare inside a `while` body before reading `EXIT_CODE=$?`:

```sh
while ! $STOP && [ $retry_count -lt $MAX_RETRIES ]; do
    echo "Starting $server_name (Attempt $((retry_count+1)))"
    "${server_cmd[@]}"
    EXIT_CODE=$?
```

errexit is suppressed for a command in a condition context, but not in a loop body. A non-zero exit therefore terminates the subshell at the command itself, and `EXIT_CODE=$?` never runs — so `MAX_RETRIES`, the `"Retrying..."` message and the `"failed after N attempts"` branch are all unreachable.

Each service is launched in the background (`run_server &`, `run_admin_server &`, `run_data_sync &`, `task_exe "$i" &`), so the parent's `wait` returns 0 and the launcher reports success with nothing running, instead of restarting or exiting.

`run_with_restart` in `docker/entrypoint.sh` already handles the identical pattern correctly, bracketing the call with `set +e` / `set -e`. This change uses `|| EXIT_CODE=$?`, which keeps errexit in force for the rest of the script.

### How to test

Same shape as the script, with a command that fails:

```sh
#!/bin/bash
set -e
MAX_RETRIES=3; STOP=false
run_server(){
    local retry_count=0
    while ! $STOP && [ $retry_count -lt $MAX_RETRIES ]; do
        echo "Starting (Attempt $((retry_count+1)))"
        false
        EXIT_CODE=$?
        if [ $EXIT_CODE -eq 0 ]; then break; else
            echo "failed with $EXIT_CODE. Retrying..." >&2
            retry_count=$((retry_count + 1)); sleep 0.1
        fi
    done
    if [ $retry_count -ge $MAX_RETRIES ]; then echo "failed after $MAX_RETRIES attempts" >&2; fi
}
run_server &
wait
```

Before — one attempt, no retry, exit 0:

```
Starting (Attempt 1)
```

Replacing `false` / `EXIT_CODE=$?` with `EXIT_CODE=0` / `false || EXIT_CODE=$?` gives the intended behaviour:

```
Starting (Attempt 1)
failed with 1. Retrying...
Starting (Attempt 2)
failed with 1. Retrying...
Starting (Attempt 3)
failed with 1. Retrying...
failed after 3 attempts
```

`bash -n docker/launch_backend_service.sh` passes.