### PR TITLE
fix(serenedb): keep the available_int=0 chunk filter

### DIFF
--- a/rag/utils/serenedb_conn.py
+++ b/rag/utils/serenedb_conn.py
@@ -309,6 +309,12 @@ class SereneDBConnection(DocStoreConnection):
     def _get_filters(self, condition: dict) -> list[str]:
         filters = []
         for k, v in condition.items():
+            if k == "available_int":
+                # Handled before the falsy skip below: 0 is the "disabled only" filter, and
+                # skipping it drops the predicate entirely rather than narrowing the result.
+                # NULL counts as available, matching DEFAULTS and the other backends.
+                filters.append(f"COALESCE(available_int, 1) {'< 1' if v == 0 else '>= 1'}")
+                continue
             if not v:
                 continue
             if k == "exists":

--- a/test/unit_test/rag/utils/test_serenedb_conn.py
+++ b/test/unit_test/rag/utils/test_serenedb_conn.py
@@ -94,3 +94,9 @@ class TestGetFilters:
 
     def test_unknown_and_empty_are_skipped(self):
         assert self.filters({"not_a_column": "x", "doc_id": ""}) == []
+
+    def test_available_int_keeps_the_zero_predicate(self):
+        # 0 is the "disabled only" filter and is falsy, so the generic empty-value skip in
+        # _get_filters would drop the predicate and widen the result instead of narrowing it.
+        assert self.filters({"available_int": 0}) == ["COALESCE(available_int, 1) < 1"]
+        assert self.filters({"available_int": 1}) == ["COALESCE(available_int, 1) >= 1"]


### PR DESCRIPTION
### Summary

`SereneDBConnection._get_filters` skips every falsy value before it reaches the column handling:

```python
for k, v in condition.items():
    if not v:
        continue
```

`available_int` is a real `INTEGER` column, and `0` is the "disabled only" filter rather than an absent value, so that branch drops the predicate entirely instead of narrowing the result.

`chunk_api.py:524` sets it directly from the request:

```python
query["available_int"] = 1 if req["available"] == "true" else 0
```

so `GET /api/v1/datasets/{ds}/documents/{doc}/chunks?available=false` returns **every** chunk of the document, enabled ones included, with a `total` to match.

Every other backend handles this key ahead of its own falsy check, because `0` is meaningful here: `es_conn.py:204`, `opensearch_conn.py:341`, `ob_conn.py:606`, `common/doc_store/infinity_conn_base.py:330`. SereneDB is the only one that does not. `NULL` is read as available, matching `DEFAULTS = {"available_int": 1, ...}` and those backends.

### How to test

Running the helper directly, before:

```
condition {"doc_id": ["d1"], "available_int": 0, "kb_id": ["kb1"]}
  -> ["doc_id IN (%s)", "kb_id IN (%s)"]                     # no available_int predicate
condition {"doc_id": ["d1"], "available_int": 1, "kb_id": ["kb1"]}
  -> ["doc_id IN (%s)", "available_int = 1", "kb_id IN (%s)"]
```

After:

```
available_int=0 -> ["doc_id IN (%s)", "COALESCE(available_int, 1) < 1",  "kb_id IN (%s)"]
available_int=1 -> ["doc_id IN (%s)", "COALESCE(available_int, 1) >= 1", "kb_id IN (%s)"]
```

The same helper builds `update()` and `delete()` conditions, so those lose the predicate today too.