### PR TITLE
fix(file): stop is_parent_folder_exist raising on a missing parent

### DIFF
--- a/api/db/services/file_service.py
+++ b/api/db/services/file_service.py
@@ -260,10 +260,7 @@ class FileService(CommonService):
         # Returns:
         #     Boolean indicating if folder exists
         parent_files = cls.model.select().where(cls.model.id == parent_id)
-        if parent_files.count():
-            return True
-        cls.delete_folder_by_pf_id(parent_id)
-        return False
+        return bool(parent_files.count())
 
     @classmethod
     @DB.connection_context()


### PR DESCRIPTION
### Summary

`FileService.is_parent_folder_exist` calls the cleanup helper with one argument:

```python
parent_files = cls.model.select().where(cls.model.id == parent_id)
if parent_files.count():
    return True
cls.delete_folder_by_pf_id(parent_id)
return False
```

but that method takes two:

```python
def delete_folder_by_pf_id(cls, user_id, folder_id):
```

So on the one path this function exists to handle — a parent folder that was deleted or never existed — it raises `TypeError: delete_folder_by_pf_id() missing 1 required positional argument: 'folder_id'` and never returns `False`. `POST /api/v1/files` with such a `parent_id` reports `"Internal server error"` instead of the intended `"Parent Folder Doesn't Exist!"`.

The call has never worked: the callee already took two arguments in the same commit that introduced this call site.

### Why drop the cleanup rather than pass an argument

That recursive delete has not executed in any release, so wiring it up now would newly destroy rows as a side effect of an existence check. `is_parent_folder_exist` also has no tenant in scope, while `delete_folder_by_pf_id` filters by `tenant_id` and would need one to be safe. Removing the dead call keeps the function doing exactly what its name and docstring say.

The two tests that touch this monkeypatch it as a one-argument lambda, so the signature is unchanged.

### How to test

```
POST /api/v1/files
{"name": "docs", "parent_id": "<id of a folder that does not exist>"}
```

Before: HTTP 500, `"Internal server error"`.
After: the documented `"Parent Folder Doesn't Exist!"` response.