### PR TITLE
Fix: Switching the file type of the parser operator caused the corresponding parse method to fail to switch.

### DIFF
--- a/web/src/pages/agent/form/parser-form/image-form-fields.tsx
+++ b/web/src/pages/agent/form/parser-form/image-form-fields.tsx
@@ -5,11 +5,11 @@ import { isEmpty } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ImageParseMethod } from '../../constant/pipeline';
+import { FileType, ImageParseMethod } from '../../constant/pipeline';
 import { LanguageFormField, ParserMethodFormField } from './common-form-fields';
 import { CommonProps } from './interface';
 import { useSetInitialLanguage } from './use-set-initial-language';
-import { buildFieldNameWithPrefix } from './utils';
+import { buildFieldNameWithPrefix, isForeignParseMethod } from './utils';
 
 export function ImageFormFields({ prefix }: CommonProps) {
   const { t } = useTranslation();
@@ -30,7 +30,11 @@ export function ImageFormFields({ prefix }: CommonProps) {
   }, [parseMethod]);
 
   useEffect(() => {
-    if (isEmpty(form.getValues(parseMethodName))) {
+    const current = form.getValues(parseMethodName);
+    // On a file-type switch the field remounts and react-hook-form re-seeds it
+    // from the node's saved form data, so it can hold another file type's
+    // static parse method (e.g. DeepDOC) — reset it to OCR in that case too.
+    if (isEmpty(current) || isForeignParseMethod(FileType.Image, current)) {
       form.setValue(parseMethodName, ImageParseMethod.OCR, {
         shouldValidate: true,
         shouldDirty: true,

--- a/web/src/pages/agent/form/parser-form/index.tsx
+++ b/web/src/pages/agent/form/parser-form/index.tsx
@@ -11,7 +11,7 @@ import { buildOptions } from '@/utils/form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useHover } from 'ahooks';
 import { Trash2 } from 'lucide-react';
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   useFieldArray,
   UseFieldArrayRemove,
@@ -108,7 +108,26 @@ function ParserItem({
   const isHovering = useHover(ref);
 
   const prefix = `${name}.${index}`;
-  const fileFormat = form.getValues(`setups.${index}.fileFormat`);
+  const fileFormat = form.watch(`setups.${index}.fileFormat`);
+  const prevFileFormatRef = useRef(fileFormat);
+
+  useEffect(() => {
+    if (!fileFormat || prevFileFormatRef.current === fileFormat) {
+      return;
+    }
+    prevFileFormatRef.current = fileFormat;
+
+    form.setValue(
+      `setups.${index}.output_format`,
+      InitialOutputFormatMap[fileFormat as FileType],
+      { shouldDirty: true, shouldValidate: true, shouldTouch: true },
+    );
+    form.setValue(
+      `setups.${index}.parse_method`,
+      getInitialParseMethod(fileFormat as FileType),
+      { shouldDirty: true, shouldValidate: true, shouldTouch: true },
+    );
+  }, [fileFormat, form, index]);
 
   const values = form.getValues();
   const parserList = values.setups.slice(); // Adding, deleting, or modifying the parser array will not change the reference.
@@ -127,22 +146,6 @@ function ParserItem({
     typeof fileFormat === 'string' && fileFormat in FileFormatWidgetMap
       ? FileFormatWidgetMap[fileFormat as keyof typeof FileFormatWidgetMap]
       : () => <></>;
-
-  const handleFileTypeChange = useCallback(
-    (value: FileType) => {
-      form.setValue(
-        `setups.${index}.output_format`,
-        InitialOutputFormatMap[value],
-        { shouldDirty: true, shouldValidate: true, shouldTouch: true },
-      );
-      form.setValue(
-        `setups.${index}.parse_method`,
-        getInitialParseMethod(value),
-        { shouldDirty: true, shouldValidate: true, shouldTouch: true },
-      );
-    },
-    [form, index],
-  );
 
   return (
     <section
@@ -167,10 +170,7 @@ function ParserItem({
         {(field) => (
           <SelectWithSearch
             value={field.value}
-            onChange={(val) => {
-              field.onChange(val);
-              handleFileTypeChange(val as FileType);
-            }}
+            onChange={field.onChange}
             options={filteredFileFormatOptions}
           ></SelectWithSearch>
         )}

--- a/web/src/pages/agent/form/parser-form/pdf-form-fields.tsx
+++ b/web/src/pages/agent/form/parser-form/pdf-form-fields.tsx
@@ -14,6 +14,7 @@ import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useOwnerTenantId } from '../../context';
+import { FileType } from '../../constant/pipeline';
 import {
   FlattenMediaToTextFormField,
   LanguageFormField,
@@ -25,7 +26,7 @@ import {
 import { CommonProps } from './interface';
 import { DynamicPageRange } from './dynamic-page-range';
 import { useSetInitialLanguage } from './use-set-initial-language';
-import { buildFieldNameWithPrefix } from './utils';
+import { buildFieldNameWithPrefix, isForeignParseMethod } from './utils';
 
 const tableResultTypeOptions: SelectWithSearchFlagOptionType[] = [
   { label: 'Markdown', value: '0' },
@@ -69,7 +70,11 @@ export function PdfFormFields({ prefix }: CommonProps) {
   useSetInitialLanguage({ prefix, languageShown });
 
   useEffect(() => {
-    if (isEmpty(form.getValues(parseMethodName))) {
+    const current = form.getValues(parseMethodName);
+    // On a file-type switch the field remounts and react-hook-form re-seeds it
+    // from the node's saved form data, so it can hold another file type's
+    // static parse method (e.g. ocr) — reset it to DeepDOC in that case too.
+    if (isEmpty(current) || isForeignParseMethod(FileType.PDF, current)) {
       form.setValue(parseMethodName, ParseDocumentType.DeepDOC, {
         shouldValidate: true,
         shouldDirty: true,

--- a/web/src/pages/agent/form/parser-form/ppt-form-fields.tsx
+++ b/web/src/pages/agent/form/parser-form/ppt-form-fields.tsx
@@ -8,9 +8,10 @@ import { isEmpty } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { FileType } from '../../constant/pipeline';
 import { ParserMethodFormField } from './common-form-fields';
 import { CommonProps } from './interface';
-import { buildFieldNameWithPrefix } from './utils';
+import { buildFieldNameWithPrefix, isForeignParseMethod } from './utils';
 
 const tableResultTypeOptions: SelectWithSearchFlagOptionType[] = [
   { label: 'Markdown', value: '0' },
@@ -48,7 +49,11 @@ export function PptFormFields({ prefix }: CommonProps) {
   }, [parseMethod]);
 
   useEffect(() => {
-    if (isEmpty(form.getValues(parseMethodName))) {
+    const current = form.getValues(parseMethodName);
+    // On a file-type switch the field remounts and react-hook-form re-seeds it
+    // from the node's saved form data, so it can hold another file type's
+    // static parse method (e.g. ocr) — reset it to DeepDOC in that case too.
+    if (isEmpty(current) || isForeignParseMethod(FileType.PowerPoint, current)) {
       form.setValue(parseMethodName, ParseDocumentType.DeepDOC, {
         shouldValidate: true,
         shouldDirty: true,

--- a/web/src/pages/agent/form/parser-form/spreadsheet-form-fields.tsx
+++ b/web/src/pages/agent/form/parser-form/spreadsheet-form-fields.tsx
@@ -13,12 +13,13 @@ import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useOwnerTenantId } from '../../context';
+import { FileType } from '../../constant/pipeline';
 import {
   FlattenMediaToTextFormField,
   ParserMethodFormField,
 } from './common-form-fields';
 import { CommonProps } from './interface';
-import { buildFieldNameWithPrefix } from './utils';
+import { buildFieldNameWithPrefix, isForeignParseMethod } from './utils';
 
 const tableResultTypeOptions: SelectWithSearchFlagOptionType[] = [
   { label: 'Markdown', value: '0' },
@@ -60,7 +61,11 @@ export function SpreadsheetFormFields({ prefix }: CommonProps) {
   }, [parseMethod]);
 
   useEffect(() => {
-    if (isEmpty(form.getValues(parseMethodName))) {
+    const current = form.getValues(parseMethodName);
+    // On a file-type switch the field remounts and react-hook-form re-seeds it
+    // from the node's saved form data, so it can hold another file type's
+    // static parse method (e.g. ocr) — reset it to DeepDOC in that case too.
+    if (isEmpty(current) || isForeignParseMethod(FileType.Spreadsheet, current)) {
       form.setValue(parseMethodName, ParseDocumentType.DeepDOC, {
         shouldValidate: true,
         shouldDirty: true,

--- a/web/src/pages/agent/form/parser-form/utils.test.ts
+++ b/web/src/pages/agent/form/parser-form/utils.test.ts
@@ -1,0 +1,57 @@
+import { ParseDocumentType } from '@/components/layout-recognize-form-field';
+import { FileType, ImageParseMethod } from '../../constant/pipeline';
+import { getInitialParseMethod, isForeignParseMethod } from './utils';
+
+describe('parser-form utils', () => {
+  describe('getInitialParseMethod', () => {
+    it('returns ocr for image', () => {
+      expect(getInitialParseMethod(FileType.Image)).toBe(ImageParseMethod.OCR);
+    });
+
+    it('returns DeepDOC for pdf/spreadsheet/powerpoint', () => {
+      expect(getInitialParseMethod(FileType.PDF)).toBe(ParseDocumentType.DeepDOC);
+      expect(getInitialParseMethod(FileType.Spreadsheet)).toBe(
+        ParseDocumentType.DeepDOC,
+      );
+      expect(getInitialParseMethod(FileType.PowerPoint)).toBe(
+        ParseDocumentType.DeepDOC,
+      );
+    });
+
+    it('returns empty string for file types without a parse method', () => {
+      expect(getInitialParseMethod(FileType.Email)).toBe('');
+    });
+  });
+
+  describe('isForeignParseMethod', () => {
+    it('treats a static method from another file type as foreign', () => {
+      // The bug: switching pdf -> image left DeepDOC in parse_method
+      expect(isForeignParseMethod(FileType.Image, ParseDocumentType.DeepDOC)).toBe(
+        true,
+      );
+      expect(isForeignParseMethod(FileType.PDF, ImageParseMethod.OCR)).toBe(true);
+    });
+
+    it('accepts the file type’s own initial method', () => {
+      expect(isForeignParseMethod(FileType.Image, ImageParseMethod.OCR)).toBe(
+        false,
+      );
+      expect(isForeignParseMethod(FileType.PDF, ParseDocumentType.DeepDOC)).toBe(
+        false,
+      );
+    });
+
+    it('never treats an LLM model id as foreign', () => {
+      expect(isForeignParseMethod(FileType.PDF, 'gpt-4o@OpenAI')).toBe(false);
+      expect(isForeignParseMethod(FileType.Image, 'deepseek-v3@Moonshot')).toBe(
+        false,
+      );
+    });
+
+    it('ignores empty and non-string values', () => {
+      expect(isForeignParseMethod(FileType.Image, '')).toBe(false);
+      expect(isForeignParseMethod(FileType.Image, undefined)).toBe(false);
+      expect(isForeignParseMethod(FileType.Image, null)).toBe(false);
+    });
+  });
+});

--- a/web/src/pages/agent/form/parser-form/utils.ts
+++ b/web/src/pages/agent/form/parser-form/utils.ts
@@ -1,4 +1,9 @@
-import { FileType, initialParserValues } from '../../constant/pipeline';
+import { ParseDocumentType } from '@/components/layout-recognize-form-field';
+import {
+  FileType,
+  ImageParseMethod,
+  initialParserValues,
+} from '../../constant/pipeline';
 
 export function buildFieldNameWithPrefix(name: string, prefix: string) {
   return `${prefix}.${name}`;
@@ -9,4 +14,31 @@ export function getInitialParseMethod(fileType: FileType): string {
     (x) => x.fileFormat === fileType,
   );
   return setup?.parse_method ?? '';
+}
+
+// Static parse-method values across all file types. With shouldUnregister the
+// parse_method field is re-seeded from the node's saved form data when its
+// widget remounts on a file-type switch, so it can hold a previous file type's
+// static value. LLM model ids from the model tree are never in this set, so a
+// user-picked model is never treated as foreign.
+// Note: ParseDocumentType is a const enum — list members explicitly instead of
+// Object.values, which is not allowed on const enums (TS2475).
+const KnownStaticParseMethods = new Set<string>([
+  ParseDocumentType.DeepDOC,
+  ParseDocumentType.PlainText,
+  ParseDocumentType.Docling,
+  ParseDocumentType.OpenDataLoader,
+  ParseDocumentType.TCADPParser,
+  ImageParseMethod.OCR,
+]);
+
+export function isForeignParseMethod(
+  fileType: FileType,
+  value: unknown,
+): value is string {
+  return (
+    typeof value === 'string' &&
+    KnownStaticParseMethods.has(value) &&
+    value !== getInitialParseMethod(fileType)
+  );
 }


### PR DESCRIPTION


### Summary

Fix: Switching the file type of the parser operator caused the corresponding parse method to fail to switch.