### PR TITLE
fix(dataset): rebuild the navigation tree in the dataset owner index

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -3689,7 +3689,7 @@ async def generate_nav(
             continue
         try:
             await upsert_dataset_nav_doc(
-                tenant_id=tenant_id,
+                tenant_id=kb.tenant_id,
                 kb_id=dataset_id,
                 doc_id=doc_id,
                 summary_or_tree=summary,


### PR DESCRIPTION
### Summary

`generate_nav` deletes the navigation tree from one index and rebuilds it into another.

The wipe uses the dataset owner:

```python
pack = _compiled_index_or_none(kb.tenant_id, dataset_id)
```

the rebuild uses the caller:

```python
await upsert_dataset_nav_doc(
    tenant_id=tenant_id,
    kb_id=dataset_id,
```

`tenant_id` here is injected by `@add_tenant_id_to_kwargs`, which sets `kwargs["tenant_id"] = current_user.id`.

`KnowledgebaseService.accessible` admits team members, so for a dataset owned by tenant `A` with `permission="team"`, a member `B` calling `POST /api/v1/datasets/<id>/navigation` wipes every `dataset_nav` row from A's index and writes the rebuilt rows into B's. The response reports the deleted and upserted counts, so it looks like it worked; the follow-up `GET .../navigation` reads `kb.tenant_id` and returns an empty tree. A's tree is gone and B's index carries orphaned rows.

Every other `_compiled_index_or_none` call site in this file passes `kb.tenant_id` — lines 1914, 2471, 3277, 3363, 3397, 3577, 3974, and the wipe at 3649 inside this same function. The rebuild is the only one that does not.

This is the same class as `03d0ad2ac` ("derive SQL retrieval tenant from dataset owner, not chat tenant").

### How to test

1. Tenant A creates a dataset with `permission="team"` and generates its navigation tree.
2. `GET /api/v1/datasets/<id>/navigation` as A — tree present.
3. Team member B calls `POST /api/v1/datasets/<id>/navigation`; the response reports a non-zero `deleted` and `upserted`.
4. `GET /api/v1/datasets/<id>/navigation` as A — empty before this change, intact after.
