### PR TITLE
fix(parser): keep audio/video pipeline model config backward compatible

### DIFF
--- a/rag/flow/parser/parser.py
+++ b/rag/flow/parser/parser.py
@@ -64,6 +64,7 @@ from rag.flow.parser.utils import (
     remove_toc_pdf,
     remove_toc_word,
 )
+from rag.flow.parser.vlm_config import get_vlm_config
 from rag.llm.cv_model import Base as VLM
 from rag.utils.base64_image import image2id
 
@@ -307,12 +308,12 @@ class ParserParam(ProcessParamBase):
 
         audio_config = self.setups.get("audio", "")
         if audio_config:
-            audio_vlm = audio_config.get("vlm") or {}
+            audio_vlm = get_vlm_config(audio_config)
             self.check_empty(audio_vlm.get("llm_id"), "Audio VLM")
 
         video_config = self.setups.get("video", "")
         if video_config:
-            video_vlm = video_config.get("vlm") or {}
+            video_vlm = get_vlm_config(video_config)
             self.check_empty(video_vlm.get("llm_id"), "Video VLM")
         email_config = self.setups.get("email", "")
         if email_config:
@@ -1209,7 +1210,7 @@ class Parser(ProcessBase):
         self.callback(random.randint(1, 5) / 100.0, "Start to work on an audio.")
 
         conf = self._param.setups["audio"]
-        vlm = conf.get("vlm")
+        vlm = get_vlm_config(conf)
         self.set_output("output_format", conf["output_format"])
         _, ext = os.path.splitext(name)
         with tempfile.NamedTemporaryFile(suffix=ext) as tmpf:
@@ -1227,7 +1228,7 @@ class Parser(ProcessBase):
         self.callback(random.randint(1, 5) / 100.0, "Start to work on an video.")
 
         conf = self._param.setups["video"]
-        vlm = conf.get("vlm")
+        vlm = get_vlm_config(conf)
         self.set_output("output_format", conf["output_format"])
         cv_model_config = resolve_model_config(self._canvas.get_tenant_id(), LLMType.VISION, vlm["llm_id"])
         cv_mdl = LLMBundle(self._canvas.get_tenant_id(), cv_model_config)

--- a/rag/flow/parser/vlm_config.py
+++ b/rag/flow/parser/vlm_config.py
@@ -1,0 +1,18 @@
+from collections.abc import Mapping
+from typing import Any
+
+
+def get_vlm_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    nested = config.get("vlm")
+    legacy_llm_id = config.get("llm_id")
+
+    if isinstance(nested, Mapping):
+        resolved = dict(nested)
+        if resolved.get("llm_id") or not legacy_llm_id:
+            return resolved
+        resolved["llm_id"] = legacy_llm_id
+        return resolved
+
+    if legacy_llm_id:
+        return {"llm_id": legacy_llm_id}
+    return {}

--- a/rag/flow/tests/dsl_examples/general_pdf_all.json
+++ b/rag/flow/tests/dsl_examples/general_pdf_all.json
@@ -87,7 +87,9 @@
                     "ape"
                   ],
                   "lang": "Chinese",
-                  "llm_id": "SenseVoiceSmall",
+                  "vlm": {
+                    "llm_id": "SenseVoiceSmall"
+                  },
                   "output_format": "json"
                 },
                 "email": {

--- a/rag/flow/tests/test_vlm_config.py
+++ b/rag/flow/tests/test_vlm_config.py
@@ -1,0 +1,22 @@
+from rag.flow.parser.vlm_config import get_vlm_config
+
+
+def test_nested_vlm_config_is_preferred():
+    assert get_vlm_config({"vlm": {"llm_id": "new-model"}, "llm_id": "legacy-model"}) == {
+        "llm_id": "new-model"
+    }
+
+
+def test_legacy_llm_id_fills_missing_nested_config():
+    assert get_vlm_config({"vlm": {"temperature": 0.2}, "llm_id": "legacy-model"}) == {
+        "temperature": 0.2,
+        "llm_id": "legacy-model",
+    }
+
+
+def test_legacy_llm_id_is_supported_without_nested_config():
+    assert get_vlm_config({"llm_id": "legacy-model"}) == {"llm_id": "legacy-model"}
+
+
+def test_missing_vlm_config_stays_empty():
+    assert get_vlm_config({}) == {}


### PR DESCRIPTION
## Summary
- resolve audio/video parser model ids from nested `vlm.llm_id` while preserving legacy top-level `llm_id` DSLs
- migrate the default audio fixture to the nested shape
- add focused regression coverage for nested, legacy, and missing configs

## Validation
- `pytest -q rag/flow/tests/test_vlm_config.py`
- `ruff check rag/flow/parser/vlm_config.py rag/flow/tests/test_vlm_config.py rag/flow/parser/parser.py`
- Python compile, JSON parse, and diff checks