### PR TITLE
fix(web): guard tenant info in embed app modal

### DIFF
--- a/web/src/pages/next-search/embed-app-modal.tsx
+++ b/web/src/pages/next-search/embed-app-modal.tsx
@@ -41,7 +41,7 @@ type IEmbedAppModalProps = {
 const EmbedAppModal = (props: IEmbedAppModalProps) => {
   const { t } = useTranslate('search');
   const { data: tenantInfo } = useFetchTenantInfo();
-  const tenantId = tenantInfo.tenant_id;
+  const tenantId = tenantInfo?.tenant_id ?? '';
   const { open, setOpen, token = '', from, url, beta = '' } = props;
 
   const [hideAvatar, setHideAvatar] = useState(false);


### PR DESCRIPTION
## Summary
- avoid dereferencing tenant info before the tenant-info hook has returned
- keep generated embed URLs free of an `undefined` tenantId

## Validation
- source wiring assertion for optional tenantId fallback
- git diff check