### PR TITLE
fix go: migrate missing table chatchannel

### DIFF
--- a/internal/dao/database.go
+++ b/internal/dao/database.go
@@ -120,6 +120,7 @@ func InitDB(ctx context.Context, migrateDB bool) error {
 		&entity.File2Document{},
 		&entity.TenantLLM{},
 		&entity.Chat{},
+		&entity.ChatChannel{},
 		&entity.ChatSession{},
 		&entity.Task{},
 		&entity.APIToken{},


### PR DESCRIPTION
fix go: migrate missing table chatchannel