### PR TITLE
fix(web): stop the field label from toggling the Switch

### DIFF
--- a/web/src/components/excel-to-html-form-field.tsx
+++ b/web/src/components/excel-to-html-form-field.tsx
@@ -41,14 +41,14 @@ export function ExcelToHtmlFormField() {
 
         return (
           <FormItem defaultChecked={false} className=" items-center space-y-0 ">
-            <div className="flex items-center gap-1">
+            <div className="flex items-center justify-between  gap-1">
               <FormLabel
                 tooltip={t('html4excelTip')}
                 className="text-sm text-text-secondary whitespace-break-spaces w-1/4"
               >
                 {t('html4excel')}
               </FormLabel>
-              <div className="w-3/4">
+              <div className="flex-none">
                 <FormControl>
                   <Switch
                     checked={field.value}

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -8,29 +8,38 @@ import { cn } from '@/lib/utils';
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'group/switch inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full',
-      'border-2 border-transparent overflow-hidden transition-colors',
-      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary',
-      'disabled:cursor-not-allowed disabled:opacity-50',
-      'data-[state=checked]:bg-accent-primary data-[state=unchecked]:bg-text-sub-title',
-      className,
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
-      className="
+>(({ className, ...props }, ref) => {
+  const switchId = React.useId();
+
+  return (
+    <SwitchPrimitives.Root
+      className={cn(
+        'group/switch inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full',
+        'border-2 border-transparent overflow-hidden transition-colors',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        'data-[state=checked]:bg-accent-primary data-[state=unchecked]:bg-text-sub-title',
+        className,
+      )}
+      {...props}
+      // Own the switch id, like `SelectWithSearch` does. Radix's Slot lets
+      // child props win, so this keeps shadcn's `FormControl` from putting the
+      // form item id here — otherwise a `FormLabel` (`<label htmlFor>`) would
+      // forward its clicks to this switch, making the whole label row toggle it.
+      id={switchId}
+      ref={ref}
+    >
+      <SwitchPrimitives.Thumb
+        className="
         pointer-events-none block w-3 h-3 rounded-full bg-white shadow-lg ring-0 transition-all ease-out
         group-hover/switch:w-4 group-focus-visible/switch:w-4
         data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0
         group-hover/switch:data-[state=checked]:translate-x-2 group-focus-visible/switch:data-[state=checked]:translate-x-2
       "
-    />
-  </SwitchPrimitives.Root>
-));
+      />
+    </SwitchPrimitives.Root>
+  );
+});
 Switch.displayName = SwitchPrimitives.Root.displayName;
 
 export { Switch };


### PR DESCRIPTION
### Summary

`FormControl` slots the form item id onto its child, so a sibling `FormLabel` (`<label htmlFor>`) forwarded its clicks to the Switch and clicking anywhere on the label row flipped the toggle. Let `Switch` own its id, mirroring `SelectWithSearch` and the earlier MultiSelect fix.

Also right-align the html4excel toggle so the Switch no longer stretches across three quarters of the row.
