### PR TITLE
fix(api): preserve parent-child config on partial updates

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -351,15 +351,18 @@ async def update_dataset(tenant_id: str, dataset_id: str, req: dict):
         del req["connectors"]
 
     if req.get("parser_config"):
-        # Flatten parent_child config into children_delimiter for the execution layer
-        pc = req["parser_config"].get("parent_child", {})
-        if pc.get("use_parent_child"):
-            req["parser_config"]["children_delimiter"] = pc.get("children_delimiter", "\n")
-            req["parser_config"]["enable_children"] = pc.get("use_parent_child", True)
-        else:
-            req["parser_config"]["children_delimiter"] = ""
-            req["parser_config"]["enable_children"] = False
-            req["parser_config"]["parent_child"] = {}
+        # Flatten parent_child config only when the caller explicitly updates it.
+        # A partial parser_config update must preserve the existing parent-child
+        # execution settings instead of treating an omitted field as disabled.
+        if "parent_child" in req["parser_config"]:
+            pc = req["parser_config"]["parent_child"]
+            if pc.get("use_parent_child"):
+                req["parser_config"]["children_delimiter"] = pc.get("children_delimiter", "\n")
+                req["parser_config"]["enable_children"] = pc.get("use_parent_child", True)
+            else:
+                req["parser_config"]["children_delimiter"] = ""
+                req["parser_config"]["enable_children"] = False
+                req["parser_config"]["parent_child"] = {}
 
         parser_config = req["parser_config"]
         req_ext_fields = parser_config.pop("ext", {})

--- a/test/testcases/test_http_api/test_dataset_management/test_update_dataset.py
+++ b/test/testcases/test_http_api/test_dataset_management/test_update_dataset.py
@@ -650,6 +650,25 @@ class TestDatasetUpdate:
             else:
                 assert res["data"][0]["parser_config"][k] == v, res
 
+    @pytest.mark.p1
+    def test_parser_config_partial_update_preserves_parent_child(self, HttpApiAuth, add_dataset_func):
+        dataset_id = add_dataset_func
+        parent_child = {"use_parent_child": True, "children_delimiter": "\n\n"}
+
+        res = update_dataset(HttpApiAuth, dataset_id, {"parser_config": {"parent_child": parent_child}})
+        assert res["code"] == 0, res
+
+        res = update_dataset(HttpApiAuth, dataset_id, {"parser_config": {"auto_keywords": 5}})
+        assert res["code"] == 0, res
+
+        res = list_datasets(HttpApiAuth, {"id": dataset_id})
+        assert res["code"] == 0, res
+        parser_config = res["data"][0]["parser_config"]
+        assert parser_config["parent_child"] == parent_child, res
+        assert parser_config["children_delimiter"] == parent_child["children_delimiter"], res
+        assert parser_config["enable_children"] is True, res
+        assert parser_config["auto_keywords"] == 5, res
+
     @pytest.mark.p2
     @pytest.mark.parametrize(
         "parser_config, expected_message",


### PR DESCRIPTION
## What does this PR do?\n\nPreserves the existing parent-child parser configuration when a dataset PATCH updates an unrelated parser_config field. The flattening logic now runs only when parser_config.parent_child is explicitly present, so explicit enable/disable requests retain their existing behavior.\n\n## Why is this needed?\n\nA partial REST/SDK parser_config update such as auto_keywords could previously be interpreted as parent-child disabled, leaving execution-layer fields inconsistent with the nested configuration.\n\n## Validation\n\n- Production update_dataset behavior check: passed (enable parent-child, then partial update, state preserved).\n- git diff --check: passed.\n- Python compileall: passed.\n- ruff check and ruff format --check: passed.\n- HTTP integration collection could not start in this environment because ZHIPU_AI_API_KEY is unset.\n\nRelated to #14167.