### PR TITLE
fix(web): prevent agent session menu clicks from selecting cards

### DIFF
--- a/web/src/pages/agent/explore/components/session-dropdown.test.tsx
+++ b/web/src/pages/agent/explore/components/session-dropdown.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('@/components/confirm-delete-dialog', () => ({
+  ConfirmDeleteDialog: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('@/components/ui/dropdown-menu', () => {
+  const DropdownMenu = ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  );
+  type TriggerProps = React.PropsWithChildren<
+    React.HTMLAttributes<HTMLElement> & { asChild?: boolean }
+  >;
+  const DropdownMenuTrigger = ({
+    children,
+    asChild,
+    ...props
+  }: TriggerProps) =>
+    asChild
+      ? React.cloneElement(
+          children as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
+          props,
+        )
+      : children;
+  const DropdownMenuContent = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  const DropdownMenuItem = ({
+    children,
+    ...props
+  }: React.PropsWithChildren<
+    React.ButtonHTMLAttributes<HTMLButtonElement>
+  >) => <button {...props}>{children}</button>;
+
+  return {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+  };
+});
+
+jest.mock('@/hooks/use-agent-request', () => ({
+  useDeleteAgentSession: () => ({
+    deleteAgentSession: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/use-explore-url-params', () => ({
+  useExploreUrlParams: () => ({
+    canvasId: 'canvas-1',
+    setSessionId: jest.fn(),
+    sessionId: 'session-1',
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('lucide-react', () => ({
+  Trash2: () => <span />,
+}));
+
+import { SessionDropdown } from './session-dropdown';
+
+describe('SessionDropdown', () => {
+  it('does not let the trigger click select the surrounding session card', () => {
+    const onCardClick = jest.fn();
+
+    render(
+      <div onClick={onCardClick}>
+        <SessionDropdown
+          session={{ id: 'session-1', name: 'Session 1' } as never}
+        >
+          <button data-testid="session-menu-trigger" type="button">
+            More
+          </button>
+        </SessionDropdown>
+      </div>,
+    );
+
+    fireEvent.click(screen.getByTestId('session-menu-trigger'));
+
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/agent/explore/components/session-dropdown.tsx
+++ b/web/src/pages/agent/explore/components/session-dropdown.tsx
@@ -51,7 +51,14 @@ export function SessionDropdown({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuTrigger
+        asChild
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        {children}
+      </DropdownMenuTrigger>
       <DropdownMenuContent>
         <ConfirmDeleteDialog onOk={handleDelete}>
           <DropdownMenuItem


### PR DESCRIPTION
## What does this PR do?\n\nStops clicks on the agent explore session dropdown trigger from bubbling into the surrounding SessionCard. Opening the more menu no longer selects or fetches that session.\n\n## Why is this needed?\n\nSessionCard owns the click handler for session selection, while SessionDropdown renders its trigger inside the card. The missing event boundary causes a menu click to run the card selection path as a side effect.\n\n## Validation\n\n- Added a focused SessionDropdown regression test for trigger-click propagation.\n- git diff --check: passed.\n- The checkout has no node_modules, so Jest, type-check, lint, and format checks could not run locally.\n\nThe change is limited to the dropdown trigger and its test.