### PR TITLE
test(sandbox): cover matplotlib CJK defaults

### DIFF
--- a/agent/sandbox/tests/sandbox_security_tests_full.py
+++ b/agent/sandbox/tests/sandbox_security_tests_full.py
@@ -364,6 +364,20 @@ def main():
             "arguments": {},
             "language": "python",
         },
+        "18 Normal test: matplotlib CJK font configuration should be loaded": {
+            "code": """
+import matplotlib
+
+def main():
+    assert matplotlib.get_backend().lower() == "agg"
+    assert matplotlib.matplotlib_fname() == "/usr/local/etc/matplotlibrc"
+    assert "Noto Sans CJK SC" in matplotlib.rcParams["font.sans-serif"]
+    assert matplotlib.rcParams["axes.unicode_minus"] is False
+            """,
+            "should_fail": False,
+            "arguments": {},
+            "language": "python",
+        },
     }
 
 


### PR DESCRIPTION
The sandbox image relies on a matplotlibrc configuration for headless rendering and Chinese text. Add one normal Python case to the existing security-test matrix that verifies the Agg backend, configured matplotlibrc path, Noto Sans CJK SC, and Unicode minus behavior.

Validation:
- python3 -m py_compile: passed
- git diff --check: passed
- Full sandbox runner: not run; it requires the configured sandbox API