### PR TITLE
fix(agent): reject fractional integer DSL parameters

### DIFF
--- a/internal/agent/component/integer_params.go
+++ b/internal/agent/component/integer_params.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// integerParams lists persisted Agent DSL fields consumed as integer counts by
+// their component implementations. Decimal-valued component parameters are
+// deliberately absent.
+var integerParams = map[string]map[string]struct{}{
+	"agent": {
+		"max_retries":                 {},
+		"max_rounds":                  {},
+		"max_tokens":                  {},
+		"message_history_window_size": {},
+		"optimize_history_window":     {},
+	},
+	"browser": {
+		"max_retries":                 {},
+		"max_steps":                   {},
+		"max_tokens":                  {},
+		"message_history_window_size": {},
+		"timeout":                     {},
+	},
+	"categorize": {
+		"max_retries":                 {},
+		"max_tokens":                  {},
+		"message_history_window_size": {},
+	},
+	"docgenerator":   {"font_size": {}},
+	"docsgenerator":  {"font_size": {}},
+	"invoke":         {"max_retries": {}, "timeout": {}},
+	"iteration":      {"max_concurrency": {}},
+	"listoperations": {"n": {}},
+	"llm": {
+		"max_retries":                 {},
+		"max_tokens":                  {},
+		"message_history_window_size": {},
+	},
+	"loop":              {"maximum_loop_count": {}},
+	"parallel":          {"max_concurrency": {}},
+	"retrieval":         {"top_k": {}, "top_n": {}},
+	"search_my_dataset": {"top_k": {}, "top_n": {}},
+	"search_my_dateset": {"top_k": {}, "top_n": {}},
+	"searchmydateset":   {"top_k": {}, "top_n": {}},
+	"searchmydataset":   {"top_k": {}, "top_n": {}},
+}
+
+// ValidateIntegerParameters rejects fractional numeric values in the Agent
+// configuration fields whose component contract requires an integer. Agent
+// update requests preserve numeric JSON lexemes as json.Number, so 1.0 and
+// fractional values are rejected instead of being coerced.
+func ValidateIntegerParameters(dsl map[string]any) error {
+	return validateIntegerParameters(dsl, "")
+}
+
+func validateIntegerParameters(value any, path string) error {
+	switch node := value.(type) {
+	case map[string]any:
+		if err := validateComponentIntegerParameters(node, path); err != nil {
+			return err
+		}
+		for key, child := range node {
+			childPath := key
+			if path != "" {
+				childPath = path + "." + key
+			}
+			if err := validateIntegerParameters(child, childPath); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for i, child := range node {
+			if err := validateIntegerParameters(child, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateComponentIntegerParameters(node map[string]any, path string) error {
+	name, _ := node["component_name"].(string)
+	params, _ := node["params"].(map[string]any)
+	if name == "" || params == nil {
+		return nil
+	}
+	fields := integerParams[strings.ToLower(name)]
+	for field := range fields {
+		value, ok := params[field]
+		if !ok || value == nil || isIntegerNumber(value) {
+			continue
+		}
+		if isNonIntegerNumber(value) {
+			return fmt.Errorf("component %q parameter %q must be an integer", componentPath(path, name), field)
+		}
+	}
+	return nil
+}
+
+func componentPath(path, name string) string {
+	path = strings.TrimSuffix(path, ".obj")
+	if path == "" {
+		return name
+	}
+	return path
+}
+
+func isIntegerNumber(value any) bool {
+	switch n := value.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return true
+	case json.Number:
+		_, err := n.Int64()
+		return err == nil
+	case float32:
+		return !math.IsNaN(float64(n)) && !math.IsInf(float64(n), 0) && math.Trunc(float64(n)) == float64(n)
+	case float64:
+		return !math.IsNaN(n) && !math.IsInf(n, 0) && math.Trunc(n) == n
+	default:
+		return false
+	}
+}
+
+func isNonIntegerNumber(value any) bool {
+	switch n := value.(type) {
+	case json.Number:
+		_, err := n.Int64()
+		return err != nil
+	case float32:
+		return !math.IsNaN(float64(n)) && !math.IsInf(float64(n), 0) && math.Trunc(float64(n)) != float64(n)
+	case float64:
+		return !math.IsNaN(n) && !math.IsInf(n, 0) && math.Trunc(n) != n
+	default:
+		return false
+	}
+}

--- a/internal/agent/component/integer_params.go
+++ b/internal/agent/component/integer_params.go
@@ -46,7 +46,7 @@ var integerParams = map[string]map[string]struct{}{
 	},
 	"docgenerator":   {"font_size": {}},
 	"docsgenerator":  {"font_size": {}},
-	"invoke":         {"max_retries": {}, "timeout": {}},
+	"invoke":         {"max_retries": {}},
 	"iteration":      {"max_concurrency": {}},
 	"listoperations": {"n": {}},
 	"llm": {
@@ -98,6 +98,9 @@ func validateIntegerParameters(value any, path string) error {
 
 func validateComponentIntegerParameters(node map[string]any, path string) error {
 	name, _ := node["component_name"].(string)
+	if name == "" {
+		name, _ = node["name"].(string)
+	}
 	params, _ := node["params"].(map[string]any)
 	if name == "" || params == nil {
 		return nil

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -320,7 +320,7 @@ func (h *AgentHandler) CreateAgent(c *gin.Context) {
 		return
 	}
 	var req service.CreateAgentRequest
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+	if err := decodeJSONWithNumber(c.Request.Body, &req); err != nil && !errors.Is(err, io.EOF) {
 		common.ResponseWithCodeData(c, common.CodeArgumentError, nil, "Invalid request: "+err.Error())
 		return
 	}
@@ -381,6 +381,12 @@ type agentDetailResponse struct {
 // updateAgentRequest is the wire shape for PUT /api/v1/agents/:canvas_id.
 type updateAgentRequest map[string]interface{}
 
+func decodeJSONWithNumber(body io.Reader, target any) error {
+	decoder := json.NewDecoder(body)
+	decoder.UseNumber()
+	return decoder.Decode(target)
+}
+
 // UpdateAgent applies a partial update to the canvas draft.
 // @Summary Update Agent
 // @Tags agents
@@ -398,9 +404,7 @@ func (h *AgentHandler) UpdateAgent(c *gin.Context) {
 	}
 	canvasID := c.Param("canvas_id")
 	var req updateAgentRequest
-	decoder := json.NewDecoder(c.Request.Body)
-	decoder.UseNumber()
-	if err := decoder.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+	if err := decodeJSONWithNumber(c.Request.Body, &req); err != nil && !errors.Is(err, io.EOF) {
 		common.ResponseWithCodeData(c, common.CodeArgumentError, nil, "Invalid request: "+err.Error())
 		return
 	}
@@ -723,7 +727,7 @@ func (h *AgentHandler) PublishAgent(c *gin.Context) {
 	}
 	canvasID := c.Param("canvas_id")
 	var req publishAgentRequest
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+	if err := decodeJSONWithNumber(c.Request.Body, &req); err != nil && !errors.Is(err, io.EOF) {
 		common.ResponseWithCodeData(c, common.CodeArgumentError, nil, "Invalid request: "+err.Error())
 		return
 	}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -398,7 +398,9 @@ func (h *AgentHandler) UpdateAgent(c *gin.Context) {
 	}
 	canvasID := c.Param("canvas_id")
 	var req updateAgentRequest
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.UseNumber()
+	if err := decoder.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		common.ResponseWithCodeData(c, common.CodeArgumentError, nil, "Invalid request: "+err.Error())
 		return
 	}

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -35,6 +35,7 @@ import (
 	"gorm.io/gorm"
 
 	"ragflow/internal/agent/canvas"
+	"ragflow/internal/agent/component"
 	"ragflow/internal/agent/runtime"
 	agentsandbox "ragflow/internal/agent/sandbox"
 	agenttool "ragflow/internal/agent/tool"
@@ -970,6 +971,9 @@ func (s *AgentService) CreateAgent(ctx context.Context, req *CreateAgentRequest)
 	} else if existing != nil {
 		return nil, common.CodeDataError, agentTitleAlreadyExistsError(title)
 	}
+	if err := component.ValidateIntegerParameters(req.DSL); err != nil {
+		return nil, common.CodeArgumentError, fmt.Errorf("create agent: %w", err)
+	}
 	// Normalize legacy v1 / Go-v2 payloads to a React-Flow-shaped graph so
 	// the front-end can render the canvas without a migration. Idempotent;
 	// no-op when graph.nodes is already non-empty.
@@ -1155,6 +1159,9 @@ func (s *AgentService) UpdateAgent(ctx context.Context, userID, canvasID string,
 				return fmt.Errorf("update agent %s: dsl must be an object", canvasID)
 			}
 		}
+		if err := component.ValidateIntegerParameters(dslMap); err != nil {
+			return fmt.Errorf("update agent %s: %w", canvasID, err)
+		}
 		updates["dsl"] = entity.JSONMap(dslpkg.NormalizeForCanvas(dslMap))
 	}
 
@@ -1289,6 +1296,9 @@ func (s *AgentService) PublishAgent(ctx context.Context, userID, canvasID string
 	description := canvasInstance.Description
 	if req != nil {
 		if req.DSL != nil {
+			if err := component.ValidateIntegerParameters(req.DSL); err != nil {
+				return nil, fmt.Errorf("publish agent %s: %w", canvasID, err)
+			}
 			dsl = dslpkg.NormalizeForCanvas(req.DSL)
 		}
 		if req.Title != nil {


### PR DESCRIPTION
Agent DSL fields that require whole numbers now reject fractional values. Decimal fields such as retry delay remain supported.