### PR TITLE
fix(web): stop the note node resize handle from covering its textarea

### DIFF
--- a/web/src/pages/agent/canvas/node/note-node/index.tsx
+++ b/web/src/pages/agent/canvas/node/note-node/index.tsx
@@ -102,7 +102,7 @@ function NoteNode({
               control={form.control}
               name="text"
               render={({ field }) => (
-                <FormItem className="h-full">
+                <FormItem className="h-full pb-2">
                   <FormControl>
                     <Textarea
                       placeholder={t('flow.notePlaceholder')}

--- a/web/src/pages/agent/canvas/node/resize-icon.tsx
+++ b/web/src/pages/agent/canvas/node/resize-icon.tsx
@@ -2,8 +2,8 @@ export function ResizeIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="14"
-      height="14"
+      width="10"
+      height="10"
       viewBox="0 0 24 24"
       strokeWidth="2"
       stroke="var(--text-disabled)"


### PR DESCRIPTION
### Summary

The 14px resize icon sat on top of the textarea's bottom-right corner, hiding text and making the last line hard to click. Shrink the icon to 10px and give the text field bottom padding so the handle has room of its own.
