### PR TITLE
fix(agent): let global variable textareas resize vertically

### DIFF
--- a/web/src/pages/agent/gobal-variable-sheet/constant.ts
+++ b/web/src/pages/agent/gobal-variable-sheet/constant.ts
@@ -37,12 +37,14 @@ export const GlobalFormFields = (t: TFunction<'translation', undefined>) =>
       name: 'value',
       placeholder: '',
       type: FormFieldType.Textarea,
+      fieldConfig: { className: 'overflow-auto', resize: 'vertical' },
     },
     {
       label: t('flow.description'),
       name: 'description',
       placeholder: t('flow.variableDescription'),
       type: FormFieldType.Textarea,
+      fieldConfig: { className: 'overflow-auto', resize: 'vertical' },
     },
   ] as FormFieldConfig[];
 


### PR DESCRIPTION
### Summary

The value and description textareas in the global variable sheet were fixed-height, making long values hard to read or edit. Enable vertical resizing with scrolling overflow so users can expand them as needed.
