### PR TITLE
feat(web): display similarity threshold as a percentage

### DIFF
--- a/web/src/components/similarity-slider/index.tsx
+++ b/web/src/components/similarity-slider/index.tsx
@@ -88,6 +88,7 @@ export function SimilaritySliderFormField({
         layout={FormLayout.Vertical}
         tooltip={isTooltipShown && t('similarityThresholdTip')}
         numberInputClassName={numberInputClassName}
+        percentage
       ></SliderInputFormField>
       <FormField
         control={form.control}


### PR DESCRIPTION
### Summary

The similarity threshold is stored as a 0-1 float but was shown raw in the slider and number input. Enable the percentage mode of SliderInputFormField so the control reads 0-100 while the underlying form value stays unchanged.
