### PR TITLE
fix(chat): keep reasoning chats grounded when LLM lacks tool calling

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -2001,6 +2001,21 @@ async def rag_agent(dialog, messages, stream=True, **kwargs):
             yield ans
         return
     kbs, embd_mdl, rerank_mdl, chat_mdl, tts_mdl = get_models(dialog)
+
+    # Agentic RAG depends on the outer model being able to call the bound
+    # ``rag`` tool. Models without tool-calling support would otherwise receive
+    # only the router prompt and could answer from their own knowledge without
+    # ever running retrieval. Reuse the regular RAG path for those models so
+    # the configured knowledge base and citation flow remain authoritative.
+    if not getattr(chat_mdl, "is_tools", False):
+        logging.info("LLM does not support tool calls; falling back to regular RAG chat")
+        fallback_kwargs = dict(kwargs)
+        if isinstance(fallback_kwargs.get("doc_ids"), list):
+            fallback_kwargs["doc_ids"] = ",".join(str(doc_id) for doc_id in fallback_kwargs["doc_ids"] if doc_id)
+        async for ans in async_chat(dialog, messages, stream, **fallback_kwargs):
+            yield ans
+        return
+
     model_type = chat_mdl.model_config["model_type"]
     factory = chat_mdl.model_config.get("llm_factory", "") if chat_mdl.model_config else ""
     text_attachments_content, image_attachments, image_files = get_files_content(messages[-1], model_type)

--- a/test/unit_test/api/db/services/test_dialog_service_rag_agent_messages.py
+++ b/test/unit_test/api/db/services/test_dialog_service_rag_agent_messages.py
@@ -88,6 +88,7 @@ class _RecordingChatModel:
     """Records the message list rag_agent() hands to the provider."""
 
     def __init__(self):
+        self.is_tools = True
         self.model_config = {"model_type": "chat", "llm_factory": "OpenAI"}
         self.mdl = None
         self.sent_messages = None
@@ -121,6 +122,43 @@ def _drive_rag_agent(monkeypatch, messages):
     events = asyncio.run(_run())
     assert events, "rag_agent must yield an answer event"
     return chat_mdl
+
+
+@pytest.mark.p2
+def test_rag_agent_falls_back_to_retrieval_when_model_has_no_tools(monkeypatch):
+    """Reasoning must not bypass KB retrieval for models without tool support."""
+
+    class _NoToolsChatModel(_RecordingChatModel):
+        def __init__(self):
+            super().__init__()
+            self.is_tools = False
+
+    chat_mdl = _NoToolsChatModel()
+    fallback_calls = []
+
+    async def _fallback(_dialog, _messages, stream=True, **_kwargs):
+        fallback_calls.append((stream, _kwargs))
+        yield {"answer": "retrieved answer", "reference": {"chunks": [{"doc_id": "doc-1"}]}}
+
+    monkeypatch.setattr(dialog_service, "get_models", lambda _dialog, **_kw: ([_KB], None, None, chat_mdl, None))
+    monkeypatch.setattr(dialog_service, "async_chat", _fallback)
+
+    async def _run():
+        return [
+            event
+            async for event in dialog_service.rag_agent(
+                _DIALOG,
+                [{"role": "user", "content": "What is RAGFlow?"}],
+                False,
+                reasoning="2",
+                doc_ids=["doc-1"],
+            )
+        ]
+
+    events = asyncio.run(_run())
+
+    assert fallback_calls == [(False, {"reasoning": "2", "doc_ids": "doc-1"})]
+    assert events[0]["answer"] == "retrieved answer"
 
 
 @pytest.mark.p2


### PR DESCRIPTION
## Problem

When a chat assistant has a knowledge base and the message-box reasoning level is enabled, the request enters `rag_agent`. If the selected LLM does not support tool calling, `bind_tools` is skipped, but the agentic path still sends the router prompt to the model. The model can then answer from general knowledge without running knowledge-base retrieval or producing citations. The dataset retrieval-test page does not have this problem because it uses the retrieval path directly.

## Solution

- Detect the LLM tool-calling capability immediately after loading the chat models.
- Fall back to the existing `async_chat` RAG path when tool calling is unavailable, preserving knowledge injection, empty responses, and citation generation.
- Normalize list-shaped `doc_ids` only at this fallback boundary so the existing shared `async_chat` parser and its broader callers remain unchanged.
- Add a regression test covering reasoning-enabled fallback and list-shaped document scope forwarding.

Tool-capable models keep the existing agentic RAG flow unchanged.

## Verification

- `ruff check api/db/services/dialog_service.py test/unit_test/api/db/services/test_dialog_service_rag_agent_messages.py`
- `python -m py_compile api/db/services/dialog_service.py test/unit_test/api/db/services/test_dialog_service_rag_agent_messages.py`
- `git diff --check`
- GitNexus staged/compare impact detection: low risk for the two-file change

The focused pytest could not be collected in the local Windows environment because the temporary dependency environment was missing `azure.storage.filedatalake`; live provider and browser verification were not available.