### PR TITLE
Fix: pass the kb id to the wiki page insert-error warning

### DIFF
--- a/rag/svr/task_executor_refactor/dataset_wiki_generator.py
+++ b/rag/svr/task_executor_refactor/dataset_wiki_generator.py
@@ -984,6 +984,7 @@ async def persist_wiki_pages(
         logging.warning(
             "wiki_persist: page insert returned %d error(s) for kb=%s",
             len(insert_errors),
+            kb_id_str,
         )
 
     # Verify the rows that are actually visible after the bulk operation. Some


### PR DESCRIPTION
### Summary

`persist_wiki_pages` logs a warning when the bulk page insert reports errors without raising. Its format string has two placeholders, `%d` and `%s`, but only one argument is passed:

```python
if insert_errors:
    logging.warning(
        "wiki_persist: page insert returned %d error(s) for kb=%s",
        len(insert_errors),
    )
```

At runtime the logging module cannot format the record. It catches the `TypeError`, writes a `Logging error` traceback to stderr, and the warning line is never emitted. So the knowledge base whose rows were dropped is invisible in exactly the situation this line exists to report, and what an operator sees instead is a logging traceback with no kb id in it.

Reproduction, on stock Python:

```python
>>> import logging
>>> logging.warning("wiki_persist: page insert returned %d error(s) for kb=%s", 3)
--- Logging error ---
Traceback (most recent call last):
  ...
TypeError: not enough arguments for format string
Message: 'wiki_persist: page insert returned %d error(s) for kb=%s'
Arguments: (3,)
```

The intended argument is unambiguous: `kb_id_str` is in scope, and every other logging call in `persist_wiki_pages` that carries `kb=%s` passes it, seven of them. This adds it, and the diff is one line.

The line has been on `main` since 8379165 (#17931, 6 Aug). Found by running `ruff check --select PLE1205,PLE1206` over the tree; it is the only hit in 1236 Python files, so there is no wider cleanup hiding behind it. Re-running the check on the patched tree returns clean.
