### PR TITLE
fix(dify): search the dataset owner's index, not the caller's

### DIFF
--- a/api/apps/restful_apis/dify_retrieval_api.py
+++ b/api/apps/restful_apis/dify_retrieval_api.py
@@ -280,11 +280,11 @@ async def retrieval(tenant_id):
             doc_ids=doc_ids,
             rank_feature=label_question(question, [kb]),
         )
-        ranks["chunks"] = settings.retriever.retrieval_by_children(ranks["chunks"], [tenant_id])
+        ranks["chunks"] = settings.retriever.retrieval_by_children(ranks["chunks"], [kb.tenant_id])
 
         if use_kg:
             model_config = get_tenant_default_model_by_type(kb.tenant_id, LLMType.CHAT)
-            ck = await settings.kg_retriever.retrieval(question, [tenant_id], [kb_id], embd_mdl, LLMBundle(kb.tenant_id, model_config))
+            ck = await settings.kg_retriever.retrieval(question, [kb.tenant_id], [kb_id], embd_mdl, LLMBundle(kb.tenant_id, model_config))
             if ck["content_with_weight"]:
                 ranks["chunks"].insert(0, ck)
 

--- a/test/unit_test/api/apps/sdk/test_dify_retrieval.py
+++ b/test/unit_test/api/apps/sdk/test_dify_retrieval.py
@@ -70,6 +70,7 @@ class _FakeRetriever:
         self._raise_exc = raise_exc
         self.retrieval_calls = []
         self.last_kwargs = None
+        self.by_children_tenant_ids = None
 
     async def retrieval(self, question, embd_mdl, tenant_id, kb_ids, **kwargs):
         if self._raise_exc is not None:
@@ -78,15 +79,18 @@ class _FakeRetriever:
         self.last_kwargs = kwargs
         return {"chunks": list(self._chunks)}
 
-    def retrieval_by_children(self, chunks, _tenant_ids):
+    def retrieval_by_children(self, chunks, tenant_ids):
+        self.by_children_tenant_ids = list(tenant_ids)
         return chunks
 
 
 class _FakeKGRetriever:
     def __init__(self, content=""):
         self._content = content
+        self.tenant_ids = None
 
-    async def retrieval(self, *_a, **_k):
+    async def retrieval(self, _question, tenant_ids, *_a, **_k):
+        self.tenant_ids = list(tenant_ids)
         if not self._content:
             return {"content_with_weight": ""}
         return {
@@ -180,11 +184,13 @@ def _load_dify_retrieval(
     _stub(monkeypatch, "rag.app.tag", label_question=lambda *_a, **_k: {})
 
     fake_retriever = _FakeRetriever(chunks=chunks)
+
+    fake_kg = _FakeKGRetriever(kg_content)
     _stub(
         monkeypatch,
         "common.settings",
         retriever=fake_retriever,
-        kg_retriever=_FakeKGRetriever(kg_content),
+        kg_retriever=fake_kg,
     )
 
     quart_stub = ModuleType("quart")
@@ -200,6 +206,7 @@ def _load_dify_retrieval(
     monkeypatch.setitem(sys.modules, "test_dify_retrieval_module", module)
     spec.loader.exec_module(module)
     module._fake_retriever = fake_retriever
+    module._fake_kg = fake_kg
     return module
 
 
@@ -278,6 +285,46 @@ class TestDifyRetrievalTenantCheck:
         assert module._fake_retriever.retrieval_calls, "retriever was not called on legitimate request"
 
     @pytest.mark.p1
+    def test_team_member_searches_the_owner_index_not_their_own(self, monkeypatch):
+        """A permitted cross-tenant caller must search the KB owner's index.
+
+        ``KnowledgebaseService.accessible`` admits two callers: the owning tenant,
+        and a member of that tenant when the KB is ``TEAM``. In the second case the
+        caller's tenant is not the KB's, and every index lookup has to name the
+        owner or it searches a tenant that holds none of the KB's chunks.
+
+        Every sibling call site already does this -- ``agent/tools/retrieval.py``
+        passes ``[kb.tenant_id for kb in kbs]`` and ``chunk_api.py`` passes
+        ``[k.tenant_id for k in kbs]`` -- and the surrounding lines here already
+        build ``LLMBundle(kb.tenant_id, ...)``.
+        """
+        team_kb = SimpleNamespace(id="kb-shared", tenant_id="tenant-owner", tenant_embd_id="", embd_id="bge")
+        module = _load_dify_retrieval(
+            monkeypatch,
+            kb=(True, team_kb),
+            accessible=lambda _id, _u: True,
+            request_body={
+                "knowledge_id": "kb-shared",
+                "query": "shared question",
+                "use_kg": True,
+                "retrieval_setting": {"top_k": 5, "score_threshold": 0.0},
+            },
+            tenant_id="tenant-member",
+            chunks=[{"doc_id": "d1", "content_with_weight": "chunk", "similarity": 0.9, "docnm_kwd": "doc.txt"}],
+            kg_content="graph answer",
+        )
+
+        asyncio.run(module.retrieval())
+
+        assert module._fake_retriever.retrieval_calls, "retriever was not called"
+        assert module._fake_retriever.retrieval_calls[0]["tenant_id"] == "tenant-owner"
+        assert module._fake_retriever.by_children_tenant_ids == ["tenant-owner"], (
+            "retrieval_by_children searched the caller's tenant instead of the KB owner's"
+        )
+        assert module._fake_kg.tenant_ids == ["tenant-owner"], (
+            "kg_retriever searched the caller's tenant instead of the KB owner's"
+        )
+
     def test_missing_knowledge_base_returns_not_found(self, monkeypatch):
         """KB id that does not exist returns 404 before the access check fires."""
         request_body = {"knowledge_id": "kb-does-not-exist", "query": "hello"}

--- a/test/unit_test/api/apps/sdk/test_dify_retrieval.py
+++ b/test/unit_test/api/apps/sdk/test_dify_retrieval.py
@@ -288,15 +288,9 @@ class TestDifyRetrievalTenantCheck:
     def test_team_member_searches_the_owner_index_not_their_own(self, monkeypatch):
         """A permitted cross-tenant caller must search the KB owner's index.
 
-        ``KnowledgebaseService.accessible`` admits two callers: the owning tenant,
-        and a member of that tenant when the KB is ``TEAM``. In the second case the
-        caller's tenant is not the KB's, and every index lookup has to name the
-        owner or it searches a tenant that holds none of the KB's chunks.
-
-        Every sibling call site already does this -- ``agent/tools/retrieval.py``
-        passes ``[kb.tenant_id for kb in kbs]`` and ``chunk_api.py`` passes
-        ``[k.tenant_id for k in kbs]`` -- and the surrounding lines here already
-        build ``LLMBundle(kb.tenant_id, ...)``.
+        ``KnowledgebaseService.accessible`` admits the owning tenant and, for a
+        ``TEAM`` KB, a member of that tenant. In the second case the caller's tenant
+        is not the KB's, so an index named after the caller holds none of its chunks.
         """
         team_kb = SimpleNamespace(id="kb-shared", tenant_id="tenant-owner", tenant_embd_id="", embd_id="bge")
         module = _load_dify_retrieval(
@@ -318,13 +312,10 @@ class TestDifyRetrievalTenantCheck:
 
         assert module._fake_retriever.retrieval_calls, "retriever was not called"
         assert module._fake_retriever.retrieval_calls[0]["tenant_id"] == "tenant-owner"
-        assert module._fake_retriever.by_children_tenant_ids == ["tenant-owner"], (
-            "retrieval_by_children searched the caller's tenant instead of the KB owner's"
-        )
-        assert module._fake_kg.tenant_ids == ["tenant-owner"], (
-            "kg_retriever searched the caller's tenant instead of the KB owner's"
-        )
+        assert module._fake_retriever.by_children_tenant_ids == ["tenant-owner"], "retrieval_by_children searched the caller's tenant instead of the KB owner's"
+        assert module._fake_kg.tenant_ids == ["tenant-owner"], "kg_retriever searched the caller's tenant instead of the KB owner's"
 
+    @pytest.mark.p1
     def test_missing_knowledge_base_returns_not_found(self, monkeypatch):
         """KB id that does not exist returns 404 before the access check fires."""
         request_body = {"knowledge_id": "kb-does-not-exist", "query": "hello"}


### PR DESCRIPTION
### The bug

`KnowledgebaseService.accessible` admits two kinds of caller:

```python
if kb.tenant_id == user_id:
    return True
if kb.permission != TenantPermission.TEAM.value:
    return False
joined_tenants = TenantService.get_joined_tenants_by_user_id(user_id)
return any(tenant["tenant_id"] == kb.tenant_id for tenant in joined_tenants)
```

The owner, and a member of the owning tenant when the dataset is `TEAM`. In the second case the caller's `tenant_id` is **not** the dataset's, and two lines in `dify_retrieval_api.py` then look up chunks under the caller's tenant instead of the owner's:

```python
ranks["chunks"] = settings.retriever.retrieval_by_children(ranks["chunks"], [tenant_id])

if use_kg:
    model_config = get_tenant_default_model_by_type(kb.tenant_id, LLMType.CHAT)
    ck = await settings.kg_retriever.retrieval(question, [tenant_id], [kb_id], embd_mdl, LLMBundle(kb.tenant_id, model_config))
```

A tenant holds none of another tenant's chunks, so the child lookup and the knowledge-graph lookup search an index that cannot contain the requested dataset.

### Why `kb.tenant_id` is the right value

Every other call site in the repository already passes the dataset owners, and the same two statements here already do it for the model bundles:

| call site | tenants passed |
| --- | --- |
| `agent/tools/retrieval.py:211` | `[kb.tenant_id for kb in kbs]` |
| `agent/tools/retrieval.py:215,225` | `[kb.tenant_id for kb in kbs]` |
| `api/apps/restful_apis/chunk_api.py:453,456` | `[k.tenant_id for k in kbs]` |
| `api/apps/services/dataset_api_service.py:1187,1590` | `tenant_ids` from the datasets |
| `dify_retrieval_api.py:283,287` | **the caller** |

The primary retrieval on line 273 already passes `kb.tenant_id`, so the endpoint currently disagrees with itself inside one request. This is the same shape as #18932, which corrected `tenant_id` to `kb.tenant_id` in the dataset owner index.

### The change

Two tokens.

```diff
-ranks["chunks"] = settings.retriever.retrieval_by_children(ranks["chunks"], [tenant_id])
+ranks["chunks"] = settings.retriever.retrieval_by_children(ranks["chunks"], [kb.tenant_id])

-ck = await settings.kg_retriever.retrieval(question, [tenant_id], [kb_id], embd_mdl, LLMBundle(kb.tenant_id, model_config))
+ck = await settings.kg_retriever.retrieval(question, [kb.tenant_id], [kb_id], embd_mdl, LLMBundle(kb.tenant_id, model_config))
```

Nothing changes for an owner calling their own dataset, where the two values are equal. Authorization is untouched: `accessible()` still decides who may call, and this only corrects which index the permitted call reads.

### Test

`test_team_member_searches_the_owner_index_not_their_own` in the existing `test/unit_test/api/apps/sdk/test_dify_retrieval.py`, which was added for the cross-tenant fix in #15027. Its `_FakeRetriever.retrieval_by_children` previously discarded the tenant list; it now records it, and `_FakeKGRetriever` records its own.

Checked against the wrong fixes rather than only against `main`:

| variant | result |
| --- | --- |
| `main` | fails: `retrieval_by_children searched the caller's tenant` |
| only `retrieval_by_children` corrected | fails: `kg_retriever searched the caller's tenant` |
| both corrected | 23 passed |

`test/unit_test/api/apps/sdk/test_dify_retrieval.py` passes in full and `ruff check` is clean. I could not run `test/testcases/restful_api/test_dify_retrieval_routes_unit.py` locally because `test/testcases/configs.py` exits unless `ZHIPU_AI_API_KEY` is set.

### Scope

#9643 also reports empty results from this endpoint, but its cause is different: a `page_size` default of 1024 driving `RERANK_LIMIT` in `rag/nlp/search.py`. This change does not address that, and should not be read as closing it.
