### PR TITLE
fix(graphrag): accept an integer community report rating

### DIFF
--- a/rag/graphrag/general/community_reports_extractor.py
+++ b/rag/graphrag/general/community_reports_extractor.py
@@ -141,16 +141,22 @@ class CommunityReportsExtractor(Extractor):
                 logging.error(f"Failed to parse JSON response: {e}")
                 logging.error(f"Response content: {response}")
                 return
+            # JSON has a single number type, so a model that complies with the prompt's
+            # 0-10 severity score can still write 5 rather than 5.0. json.loads yields an
+            # int for that, and isinstance(5, float) is False, so requiring float alone
+            # discarded the report.
             if not dict_has_keys_with_types(
                 response,
                 [
                     ("title", str),
                     ("summary", str),
                     ("findings", list),
-                    ("rating", float),
+                    ("rating", (int, float)),
                     ("rating_explanation", str),
                 ],
             ):
+                field_types = {k: type(v).__name__ for k, v in response.items()}
+                logging.error(f"Community report does not match the expected schema, skipping. Field types: {field_types}")
                 return
             response["weight"] = weight
             response["entities"] = ents

--- a/rag/graphrag/utils.py
+++ b/rag/graphrag/utils.py
@@ -155,8 +155,10 @@ def clean_str(input: Any) -> str:
     return re.sub(r"[\"\x00-\x1f\x7f-\x9f]", "", result)
 
 
-def dict_has_keys_with_types(data: dict, expected_fields: list[tuple[str, type]]) -> bool:
-    """Return True if the given dictionary has the given keys with the given types."""
+def dict_has_keys_with_types(data: dict, expected_fields: list[tuple[str, type | tuple[type, ...]]]) -> bool:
+    """Return True if the given dictionary has the given keys with the given types.
+
+    A field may name a tuple of acceptable types, as ``isinstance`` accepts."""
     for field, field_type in expected_fields:
         if field not in data:
             return False

--- a/test/unit_test/rag/graphrag/test_graphrag_extractors.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_extractors.py
@@ -94,13 +94,18 @@ class TestCommunityReportsExtractor:
 
     @staticmethod
     def _extract_with_rating(monkeypatch, extractor, rating_literal):
+        report = '{"title":"Community","summary":"Summary","findings":[],"rating":' + rating_literal + ',"rating_explanation":"Clear"}'
+        return TestCommunityReportsExtractor._extract_with_response(monkeypatch, extractor, report)
+
+    @staticmethod
+    def _extract_with_response(monkeypatch, extractor, response):
         graph = nx.Graph()
         graph.add_node("A", description="alpha")
         graph.add_node("B", description="beta")
         graph.add_edge("A", "B", description="related")
 
         async def fake_async_chat(*_args, **_kwargs):
-            return '{"title":"Community","summary":"Summary","findings":[],"rating":' + rating_literal + ',"rating_explanation":"Clear"}'
+            return response
 
         monkeypatch.setattr(
             community_reports_module.leiden,
@@ -127,6 +132,40 @@ class TestCommunityReportsExtractor:
 
         assert len(result.structured_output) == 1
         assert result.structured_output[0]["title"] == "Community"
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("response", ["[]", '["a","b"]', "5", "null"], ids=["array", "string_array", "number", "null"])
+    async def test_json_that_is_not_an_object_never_reaches_the_schema_check(self, monkeypatch, response):
+        """The two re.sub calls above strip everything outside the outermost braces.
+
+        A reply with no braces is reduced to "" and json.loads rejects it, so the
+        schema check and the logging below only ever see a dict. Pinning that, because
+        it is what makes the field-type log safe.
+        """
+        extractor = CommunityReportsExtractor(_build_llm_stub())
+        graph = self._extract_with_response(monkeypatch, extractor, response)
+
+        result = await extractor(graph)
+
+        assert result.structured_output == []
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_a_boolean_rating_is_accepted_rather_than_costing_the_report(self, monkeypatch):
+        """isinstance(True, int) is True, so "rating": true passes the widened check.
+
+        Deliberate. Nothing reads the rating, so rejecting the value would discard a
+        usable title, summary and findings, which is the loss this check caused in the
+        first place. dict_has_keys_with_types treats bool as int elsewhere too, pinned
+        by test_graphrag_utils.py.
+        """
+        extractor = CommunityReportsExtractor(_build_llm_stub())
+        graph = self._extract_with_rating(monkeypatch, extractor, "true")
+
+        result = await extractor(graph)
+
+        assert len(result.structured_output) == 1
 
     @pytest.mark.p2
     @pytest.mark.asyncio

--- a/test/unit_test/rag/graphrag/test_graphrag_extractors.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_extractors.py
@@ -15,6 +15,7 @@
 #
 
 import asyncio
+import logging
 from types import SimpleNamespace
 
 import networkx as nx
@@ -169,15 +170,19 @@ class TestCommunityReportsExtractor:
 
     @pytest.mark.p2
     @pytest.mark.asyncio
-    async def test_report_with_a_non_numeric_rating_is_still_rejected(self, monkeypatch):
+    async def test_report_with_a_non_numeric_rating_is_still_rejected(self, monkeypatch, caplog):
         """The rating check must be widened, not switched off.
 
         Without this case the suite also passes against ("rating", object) and against
-        deleting the rating check outright, so it would guard nothing.
+        deleting the rating check outright, so it would guard nothing. The log assertion
+        holds the diagnostic too, since dropping it leaves no trace of why a report went
+        missing.
         """
         extractor = CommunityReportsExtractor(_build_llm_stub())
         graph = self._extract_with_rating(monkeypatch, extractor, '"high"')
 
-        result = await extractor(graph)
+        with caplog.at_level(logging.ERROR):
+            result = await extractor(graph)
 
         assert result.structured_output == []
+        assert "'rating': 'str'" in caplog.text

--- a/test/unit_test/rag/graphrag/test_graphrag_extractors.py
+++ b/test/unit_test/rag/graphrag/test_graphrag_extractors.py
@@ -91,3 +91,54 @@ class TestCommunityReportsExtractor:
 
         assert len(result.structured_output) == 1
         assert result.structured_output[0]["title"] == "Community"
+
+    @staticmethod
+    def _extract_with_rating(monkeypatch, extractor, rating_literal):
+        graph = nx.Graph()
+        graph.add_node("A", description="alpha")
+        graph.add_node("B", description="beta")
+        graph.add_edge("A", "B", description="related")
+
+        async def fake_async_chat(*_args, **_kwargs):
+            return '{"title":"Community","summary":"Summary","findings":[],"rating":' + rating_literal + ',"rating_explanation":"Clear"}'
+
+        monkeypatch.setattr(
+            community_reports_module.leiden,
+            "run",
+            lambda *_args, **_kwargs: {0: {"0": {"weight": 1.0, "nodes": ["A", "B"]}}},
+        )
+        monkeypatch.setattr(community_reports_module, "add_community_info2graph", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(extractor, "_async_chat", fake_async_chat)
+        return graph
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("rating", ["5", "5.0"], ids=["int", "float"])
+    async def test_report_is_kept_whatever_json_number_the_rating_uses(self, monkeypatch, rating):
+        """JSON has one number type, so a compliant 0-10 score may arrive as 5 or 5.0.
+
+        json.loads yields an int for the first, and isinstance(5, float) is False, so
+        requiring float alone dropped the report on a bare return.
+        """
+        extractor = CommunityReportsExtractor(_build_llm_stub())
+        graph = self._extract_with_rating(monkeypatch, extractor, rating)
+
+        result = await extractor(graph)
+
+        assert len(result.structured_output) == 1
+        assert result.structured_output[0]["title"] == "Community"
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_report_with_a_non_numeric_rating_is_still_rejected(self, monkeypatch):
+        """The rating check must be widened, not switched off.
+
+        Without this case the suite also passes against ("rating", object) and against
+        deleting the rating check outright, so it would guard nothing.
+        """
+        extractor = CommunityReportsExtractor(_build_llm_stub())
+        graph = self._extract_with_rating(monkeypatch, extractor, '"high"')
+
+        result = await extractor(graph)
+
+        assert result.structured_output == []


### PR DESCRIPTION
### Summary

A community report whose `rating` is a whole number is thrown away, silently.

`rag/graphrag/general/community_reports_extractor.py` validated the parsed report with `dict_has_keys_with_types` and required `("rating", float)`. That helper hands the type straight to `isinstance`, and `isinstance(5, float)` is `False`.

JSON has a single number type. A model that complies with the prompt's "a float score between 0-10" can still write the token `5`, and `json.loads` yields a Python `int` for it. The check then fails and a bare `return` discards the report. This is a contract problem, not a claim about how often any particular model does it.

### Why it is hard to notice

Nothing is logged. `over` never increments, so `callback(msg=f"Communities: {over}/{total}")` reports a smaller number, and that is the only trace.

Re-running does not help either. `_async_chat` reads `get_llm_cache` first, and `set_llm_cache` writes with a 24 hour TTL (`rag/graphrag/utils.py:187`). A rerun inside that window replays the identical response and drops the identical report.

### What the rating is used for

Nothing. `rag/graphrag/general/index.py` copies `title`, `weight`, `entities` and `findings` out of the structured output and never touches `rating`. It does not reach the doc store, no mapping in `conf/` declares it, retrieval orders by `weight_flt`, and no frontend or API code reads it. So there is no downstream consumer that needs a float, which is why this widens the check rather than coercing the value.

Coercing is the other option, and I decided against it. Coercion in this helper would have to apply to every field, and `str({})` succeeds, so `("title", str)` would start accepting a dict and pass it to `rag_tokenizer.tokenize`. Widening one field is the smaller change.

### What widening also admits

`isinstance(True, int)` is `True`, so `"rating": true` now passes where it did not before. I do not think this matters, since nothing reads the value, and `test/unit_test/rag/graphrag/test_graphrag_utils.py` already pins the helper's bool-as-int behaviour. Saying it out loud rather than leaving it to be found.

### Logging

The rejection now logs the field types rather than the response body. A report can run to `_max_report_length`, and this branch is exactly the one that fires for every community when a model's output shape is slightly off, so dumping full reports at ERROR would produce megabytes on a large knowledge base. The adjacent JSON-decode branch logs the whole response, which is right there because malformed text needs reading in full.

### Testing

One test keeps a report with `"rating": 5` and `"rating": 5.0`. Another asserts `"rating": "high"` is still rejected, because without it the suite is worthless. I checked:

| source under test | result |
| --- | --- |
| this PR, `("rating", (int, float))` | 10 passed |
| `main`, `("rating", float)` | 2 failed |
| `("rating", object)` | 1 failed |
| rating check deleted | 1 failed |

Two more came out of review. One pins that a reply which is not a JSON object never reaches the schema check, since the `re.sub` pair above the parse reduces it to `""` and `json.loads` rejects it first. That is what makes the new field-type log safe, so a test holds it rather than a comment. The other pins the bool decision above.

```
$ pytest test/unit_test/rag/graphrag/
120 passed

$ ruff check .          # All checks passed
$ ruff format --check   # already formatted
```
