### PR TITLE
fix(tagging): stop a non-object LLM reply from failing the whole batch

### DIFF
--- a/rag/prompts/generator.py
+++ b/rag/prompts/generator.py
@@ -343,13 +343,19 @@ async def content_tagging(chat_mdl, content, all_tags, examples, topn=3):
         # A model that wraps the object in an array, or emits several objects in a row,
         # parses to a list. The tags are still there, so merge the objects it holds.
         merged = {}
+        found_object = False
         for item in obj:
             if isinstance(item, dict):
+                found_object = True
                 merged.update(item)
+        if not found_object:
+            logging.warning(f"content_tagging: reply parsed to a list of {len(obj)} values holding no object ({len(kwd)} chars).")
+            return {}
         obj = merged
     if not isinstance(obj, dict):
         # A reply holding no JSON object parses to "", which used to reach .items() below.
-        logging.warning(f"content_tagging: expected a JSON object of tags, got {type(obj).__name__}. Response: {kwd[:500]}")
+        # The reply can echo the chunk back, so log its shape rather than its content.
+        logging.warning(f"content_tagging: expected a JSON object of tags, got {type(obj).__name__} ({len(kwd)} chars).")
         return {}
     res = {}
     for k, v in obj.items():

--- a/rag/prompts/generator.py
+++ b/rag/prompts/generator.py
@@ -338,16 +338,19 @@ async def content_tagging(chat_mdl, content, all_tags, examples, topn=3):
     if kwd.find("**ERROR**") >= 0:
         raise Exception(kwd)
 
-    try:
-        obj = json_repair.loads(kwd)
-    except json_repair.JSONDecodeError:
-        try:
-            result = kwd.replace(rendered_prompt[:-1], "").replace("user", "").replace("model", "").strip()
-            result = "{" + result.split("{")[1].split("}")[0] + "}"
-            obj = json_repair.loads(result)
-        except Exception as e:
-            logging.exception(f"JSON parsing error: {result} -> {e}")
-            raise e
+    obj = json_repair.loads(kwd)
+    if isinstance(obj, list):
+        # A model that wraps the object in an array, or emits several objects in a row,
+        # parses to a list. The tags are still there, so merge the objects it holds.
+        merged = {}
+        for item in obj:
+            if isinstance(item, dict):
+                merged.update(item)
+        obj = merged
+    if not isinstance(obj, dict):
+        # A reply holding no JSON object parses to "", which used to reach .items() below.
+        logging.warning(f"content_tagging: expected a JSON object of tags, got {type(obj).__name__}. Response: {kwd[:500]}")
+        return {}
     res = {}
     for k, v in obj.items():
         try:

--- a/test/unit_test/rag/prompts/test_generator_content_tagging.py
+++ b/test/unit_test/rag/prompts/test_generator_content_tagging.py
@@ -1,0 +1,83 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from types import SimpleNamespace
+
+import pytest
+
+from common.constants import TAG_FLD
+from rag.prompts.generator import content_tagging
+
+
+def _chat_model(reply):
+    async def async_chat(_system, _history, _gen_conf=None, **_kwargs):
+        return reply
+
+    return SimpleNamespace(llm_name="test-llm", max_length=8192, async_chat=async_chat)
+
+
+_EXAMPLES = [{"content": "An example chunk", TAG_FLD: {"example": 1}}]
+
+
+class TestContentTagging:
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_json_object_reply_is_parsed(self):
+        res = await content_tagging(_chat_model('{"alpha": 2, "beta": 1}'), "chunk", ["alpha", "beta"], _EXAMPLES)
+
+        assert res == {"alpha": 2, "beta": 1}
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reply",
+        [
+            "I could not identify any tags for this content.",
+            "",
+            '["alpha", "beta"]',
+        ],
+        ids=["prose", "empty", "json_array"],
+    )
+    async def test_reply_without_a_json_object_yields_no_tags(self, reply):
+        """A reply holding no JSON object parses to "" and a bare array of strings to a
+        list. Both used to reach .items() and abort the whole tagging batch through
+        asyncio.gather(return_exceptions=False)."""
+        res = await content_tagging(_chat_model(reply), "chunk", ["alpha", "beta"], _EXAMPLES)
+
+        assert res == {}
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reply",
+        ['[{"alpha": 2, "beta": 1}]', '{"alpha": 2}\n{"beta": 1}'],
+        ids=["array_wrapped", "consecutive_objects"],
+    )
+    async def test_objects_inside_a_list_still_yield_their_tags(self, reply):
+        """json_repair returns a list for both shapes, and the tags are still in it."""
+        res = await content_tagging(_chat_model(reply), "chunk", ["alpha", "beta"], _EXAMPLES)
+
+        assert res == {"alpha": 2, "beta": 1}
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_a_real_parse_failure_still_propagates(self):
+        """Guards against "fix" it by wrapping the whole parse in except Exception.
+
+        json_repair.loads does raise, as ValueError, once nesting passes the parser's
+        recursion limit. That is a genuine failure and must not be swallowed as no tags.
+        """
+        with pytest.raises(ValueError):
+            await content_tagging(_chat_model("[" * 400), "chunk", ["alpha", "beta"], _EXAMPLES)

--- a/test/unit_test/rag/prompts/test_generator_content_tagging.py
+++ b/test/unit_test/rag/prompts/test_generator_content_tagging.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -70,6 +71,28 @@ class TestContentTagging:
         res = await content_tagging(_chat_model(reply), "chunk", ["alpha", "beta"], _EXAMPLES)
 
         assert res == {"alpha": 2, "beta": 1}
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_a_list_holding_no_object_is_reported_not_silently_empty(self, caplog):
+        """An empty result from a malformed reply must stay distinguishable from real
+        empty tags, so the list branch warns when it merged nothing."""
+        with caplog.at_level(logging.WARNING):
+            res = await content_tagging(_chat_model("[1, 2, 3]"), "chunk", ["alpha", "beta"], _EXAMPLES)
+
+        assert res == {}
+        assert "holding no object" in caplog.text
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_the_warning_does_not_carry_the_model_reply(self, caplog):
+        """The reply can echo the chunk back, so the log records shape, not content."""
+        secret = "PATIENT NAME REDACTED EXAMPLE STRING"
+        with caplog.at_level(logging.WARNING):
+            await content_tagging(_chat_model(secret), "chunk", ["alpha", "beta"], _EXAMPLES)
+
+        assert secret not in caplog.text
+        assert "content_tagging" in caplog.text
 
     @pytest.mark.p2
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

One chunk whose LLM reply contains no JSON object fails the whole document's parse task and throws away the chunking work already done.

`content_tagging` in `rag/prompts/generator.py` guarded its parse with `except json_repair.JSONDecodeError`. `json_repair` has no such attribute, so evaluating that clause raises `AttributeError` and masks whatever it was meant to handle.

Reported twice already, both times against a real model: [#14942](https://github.com/infiniflow/ragflow/issues/14942) carries the exact traceback down to `for k, v in obj.items()`, and [#12542](https://github.com/infiniflow/ragflow/issues/12542) shows `[ERROR][Exception]: 'str' object has no attribute 'items'` after keywords and questions both completed. Neither was closed on the merits. The reporter closed #14942 himself, and a maintainer closed #12542 under the non-English-title policy.

### What actually happens

`loads()` returns a repaired value for every reply a model realistically produces, so the handler was never entered. Text holding no JSON object parses to `""`, and a bare array parses to a list. Both reached `obj.items()`.

From there nothing catches it. `doc_content_tagging` swallows nothing, both callers gather with `return_exceptions=False`, cancel every sibling task and re-raise, and `handle_task` ends at `set_progress(prog=-1)`. Tagging runs before embedding and indexing, so the whole document's chunking work is discarded. The refactored executor is the default path (`TE_RUN_MODE` defaults to `"0"`), and the older one has the same shape, so both are affected.

`loads()` is not incapable of raising, for the record. It raises `ValueError` for input nested past the parser's recursion limit, measured at 260 to 340 unterminated brackets on the pinned `json-repair==0.60.1`. That is a real failure and this change leaves it uncaught.

### The change

Check the parsed value and return no tags for that chunk. `{}` is falsy at both call sites, so `set_llm_cache` is skipped and nothing poisons the cache. A chunk ending up untagged is already normal here, since the scoring loop below drops every tag whose value is not greater than zero.

Objects inside a list are merged rather than discarded. A model that wraps its object in an array, or emits two objects in a row, parses to a list and its tags are still in it. The salvage branch this change removes was trying to recover exactly that, so dropping those replies would have been a step back.

### On making a hard failure quiet

Worth stating, because it is the fair objection. The crash is what made #12542's reporter investigate, and he found his model connection misconfigured after a server IP change. Under this change that document reports success with every chunk untagged, and a `logging.warning` is not something an operator watches.

What limits it: a genuinely broken model still fails loudly, because provider exceptions propagate through `LLMBundle.async_chat`, and providers that swallow into `ERROR_PREFIX` are still caught by the `if kwd.find("**ERROR**") >= 0: raise` above. The only newly quiet case is an HTTP 200 reply that is not a JSON object, which is a model quality problem rather than a configuration one.

If you would rather surface it, the natural place is a count threaded into the existing `Tagging N chunks completed` callback in both executors. I left that out because it changes two task executors and the shape of that message is your call. Happy to add it.

### One more site

`rag/graphrag/search.py:55` has the byte-identical broken handler, and there it is reachable, so it masks a real `AttributeError` with a confusing one about `json_repair`. Different function and different correct return value, so I have kept it out of this PR. Say the word and I will send it separately.

### Testing

New file `test/unit_test/rag/prompts/test_generator_content_tagging.py`, 7 tests. The parse-failure case exists so that wrapping the whole thing in `except Exception` does not pass.

| source under test | result |
| --- | --- |
| this PR | 7 passed |
| `main` | 6 failed |
| whole parse and loop wrapped in `except Exception: return {}` | 1 failed |
| `json_repair.loads(kwd) or {}` | 2 failed |

```
$ pytest test/unit_test/rag/prompts/
25 passed

$ ruff check .          # All checks passed
$ ruff format --check   # already formatted
```
