### PR TITLE
fix(graphrag): keep string findings from crashing community indexing

### DIFF
--- a/rag/graphrag/general/index.py
+++ b/rag/graphrag/general/index.py
@@ -936,13 +936,17 @@ async def extract_community(
 
     chunks = []
     for stru, rep in zip(community_structure, community_reports):
+        # A finding may be a plain string rather than a dict, which the schema check allows
+        # because it only requires ("findings", list). CommunityReportsExtractor
+        # ._get_text_output handles both shapes. A string finding carries no separate
+        # explanation, and its text still reaches content_ltks through the report.
+        dict_findings = [f for f in stru["findings"] if isinstance(f, dict)]
+        skipped_findings = len(stru["findings"]) - len(dict_findings)
+        if skipped_findings:
+            logging.debug("Omitted %d non-dict findings from community evidences", skipped_findings)
         obj = {
             "report": rep,
-            # A finding may be a plain string rather than a dict, which the schema check
-            # allows because it only requires ("findings", list). CommunityReportsExtractor
-            # ._get_text_output handles both shapes. A string finding carries no separate
-            # explanation, and its text still reaches content_ltks through the report.
-            "evidences": "\n".join([f.get("explanation", "") for f in stru["findings"] if isinstance(f, dict)]),
+            "evidences": "\n".join([f.get("explanation", "") for f in dict_findings]),
         }
         # Deterministic id derived from (kb_id, community title) so reruns of
         # extract_community produce stable ids.  Combined with insert-then-

--- a/rag/graphrag/general/index.py
+++ b/rag/graphrag/general/index.py
@@ -938,7 +938,11 @@ async def extract_community(
     for stru, rep in zip(community_structure, community_reports):
         obj = {
             "report": rep,
-            "evidences": "\n".join([f.get("explanation", "") for f in stru["findings"]]),
+            # A finding may be a plain string rather than a dict, which the schema check
+            # allows because it only requires ("findings", list). CommunityReportsExtractor
+            # ._get_text_output handles both shapes. A string finding carries no separate
+            # explanation, and its text still reaches content_ltks through the report.
+            "evidences": "\n".join([f.get("explanation", "") for f in stru["findings"] if isinstance(f, dict)]),
         }
         # Deterministic id derived from (kb_id, community title) so reruns of
         # extract_community produce stable ids.  Combined with insert-then-

--- a/test/unit_test/rag/graphrag/conftest.py
+++ b/test/unit_test/rag/graphrag/conftest.py
@@ -29,6 +29,7 @@ _modules_to_mock = [
     "common.doc_store",
     "common.doc_store.doc_store_base",
     "api.db.services",
+    "api.db.services.document_service",
     "api.db.services.task_service",
     "rag.graphrag.general.leiden",
     "rag.llm.chat_model",

--- a/test/unit_test/rag/graphrag/test_community_chunk_findings.py
+++ b/test/unit_test/rag/graphrag/test_community_chunk_findings.py
@@ -1,0 +1,107 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Community report chunks must tolerate findings that are plain strings.
+
+``CommunityReportsExtractor._get_text_output`` has handled that shape since it was
+written, and the schema check only requires ``("findings", list)``, so a list of
+strings reaches ``extract_community`` intact.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import networkx as nx
+import pytest
+
+import rag.graphrag.general.index as index_module
+from rag.graphrag.general.community_reports_extractor import CommunityReportsExtractor, CommunityReportsResult
+
+
+def _stub_extractor(structure, reports):
+    class _Extractor:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __call__(self, *_args, **_kwargs):
+            return CommunityReportsResult(output=reports, structured_output=structure)
+
+    return _Extractor
+
+
+async def _noop(*_args, **_kwargs):
+    return {}
+
+
+async def _run_extract_community(monkeypatch, structure, reports):
+    """Drive extract_community far enough to build its chunks, capturing them."""
+    captured = {}
+
+    async def fake_insert(chunks, *_args, **_kwargs):
+        captured["chunks"] = chunks
+
+    graph = nx.Graph()
+    graph.graph["source_id"] = ["doc-1"]
+
+    monkeypatch.setattr(index_module, "load_checkpoints", _noop)
+    monkeypatch.setattr(index_module, "cleanup_checkpoints", _noop)
+    monkeypatch.setattr(index_module, "save_checkpoint", _noop)
+    monkeypatch.setattr(index_module, "CommunityReportsExtractor", _stub_extractor(structure, reports))
+    monkeypatch.setattr(index_module, "insert_chunks_bounded", fake_insert)
+    monkeypatch.setattr(index_module.settings, "docStoreConn", MagicMock(**{"get_fields.return_value": {}}))
+
+    await index_module.extract_community(graph, "tenant-1", "kb-1", None, object(), object(), lambda **_kwargs: None)
+    return captured["chunks"]
+
+
+_DICT_FINDING = {"summary": "Alpha matters", "explanation": "Because of beta"}
+
+
+class TestCommunityChunkFindings:
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_string_findings_do_not_break_chunk_building(self, monkeypatch):
+        structure = [{"title": "Community", "weight": 1.0, "entities": ["A"], "findings": ["Alpha matters", _DICT_FINDING]}]
+
+        chunks = await _run_extract_community(monkeypatch, structure, ["report text"])
+
+        assert len(chunks) == 1
+        assert json.loads(chunks[0]["content_with_weight"])["evidences"] == "Because of beta"
+
+    @pytest.mark.p2
+    @pytest.mark.asyncio
+    async def test_dict_findings_still_contribute_their_explanations(self, monkeypatch):
+        """Guards against a fix that simply drops the evidences field or empties it."""
+        structure = [{"title": "Community", "weight": 1.0, "entities": ["A"], "findings": [_DICT_FINDING, {"explanation": "And gamma"}]}]
+
+        chunks = await _run_extract_community(monkeypatch, structure, ["report text"])
+
+        assert json.loads(chunks[0]["content_with_weight"])["evidences"] == "Because of beta\nAnd gamma"
+
+    @pytest.mark.p2
+    def test_a_string_finding_still_reaches_the_indexed_text(self):
+        """Why skipping them in evidences is not data loss.
+
+        _get_text_output renders a string finding as its own section of the report, and
+        the chunk tokenizes report + evidences into content_ltks, so the text is indexed
+        either way. Adding it to evidences as well would only duplicate it.
+        """
+        extractor = CommunityReportsExtractor(SimpleNamespace(llm_name="test-llm", max_length=4096))
+
+        report = extractor._get_text_output({"title": "T", "summary": "S", "findings": ["Alpha matters", _DICT_FINDING]})
+
+        assert "Alpha matters" in report
+        assert "Because of beta" in report

--- a/test/unit_test/rag/graphrag/test_community_chunk_findings.py
+++ b/test/unit_test/rag/graphrag/test_community_chunk_findings.py
@@ -21,6 +21,7 @@ strings reaches ``extract_community`` intact.
 """
 
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -73,13 +74,15 @@ _DICT_FINDING = {"summary": "Alpha matters", "explanation": "Because of beta"}
 class TestCommunityChunkFindings:
     @pytest.mark.p2
     @pytest.mark.asyncio
-    async def test_string_findings_do_not_break_chunk_building(self, monkeypatch):
+    async def test_string_findings_do_not_break_chunk_building(self, monkeypatch, caplog):
         structure = [{"title": "Community", "weight": 1.0, "entities": ["A"], "findings": ["Alpha matters", _DICT_FINDING]}]
 
-        chunks = await _run_extract_community(monkeypatch, structure, ["report text"])
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            chunks = await _run_extract_community(monkeypatch, structure, ["report text"])
 
         assert len(chunks) == 1
         assert json.loads(chunks[0]["content_with_weight"])["evidences"] == "Because of beta"
+        assert "Omitted 1 non-dict findings" in caplog.text
 
     @pytest.mark.p2
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`extract_community` builds a community report chunk with

```python
"evidences": "\n".join([f.get("explanation", "") for f in stru["findings"]]),
```

A finding may be a plain string rather than a dict. The schema check only requires `("findings", list)` and says nothing about the element type, so a list of strings passes validation and reaches this line, where `f.get` raises `AttributeError: 'str' object has no attribute 'get'`.

`CommunityReportsExtractor._get_text_output` handles both shapes, in both of its helpers. One part of the pipeline accepts string findings and the next part crashes on them.

Present since v0.16.0 (`dd0ebbea3`, #4585) and still in v0.27.1. Before v0.18.0 the expression was `f["explanation"]`, so it raised `TypeError` instead.

### How solid the premise is

Worth being straight about this. I have no report of a model emitting a string finding, and the community report prompt asks for objects. The `_get_text_output` guard arrived with the initial GraphRAG import in #1793 rather than in response to a failure, so read it as inherited defensiveness, not as proof the shape occurs.

What makes it worth fixing anyway is the precedent one line up. #7053 is a user hitting `KeyError: 'explanation'` on this exact expression, and #7127 hardened it with `.get(...)` for that. So this line has already malformed once in the field, a maintainer already accepted a defensive one-liner on it, and the sibling method in the extractor guards a second malformation that this one does not.

### What happens when it fires

Nothing swallows it. `_run_with_retry` re-raises after exhausting its attempts, and neither `task_executor.py` nor `task_handler.py` catches around `run_graphrag_for_kb`, so the KB-level GraphRAG task fails at progress -1 and no community reports are written for that dataset.

Retrying makes it worse rather than better. `extract_community_report` writes `{"structured_output": response, "output": output}` to a Redis checkpoint with a 7 day TTL, and `cleanup_checkpoints` only runs after the chunk loop. A crash in the loop leaves the checkpoint behind, so the next attempt replays the same `structured_output` and short-circuits before calling the model.

### Why skipping loses nothing

`_get_text_output` renders a string finding as its own section of the report, and the chunk tokenizes `report + evidences` into `content_ltks`, so the text is indexed either way. Retrieval also formats `obj["report"]` for the answering model. Adding the string to `evidences` as well would only duplicate it. There is a test asserting this, so the alternative is rejected for a stated reason.

### One thing to know about CI

`rag/graphrag/general/index.py` already fails `ruff format --check` on `main`, one of four such files. `ragflow_preflight` only runs once the `ci` label is applied, so it will not fire on this PR as it stands, but labelling it will make lefthook's ruff-format job fail on that file whether or not this PR exists.

I had a `ruff format` commit here and dropped it, because it rewrites a regex list and two logging calls 200 lines from the change and that churn does not belong in a bug fix. Happy to put it back, or send it separately.

### Testing

The test drives the real `extract_community` with the doc store stubbed out. `test_checkpoint_resume.py` in the same directory is commented out entirely, but `rag.graphrag.general.index` imports fine today, so that file is just stale.

| source under test | result |
| --- | --- |
| this PR | 3 passed |
| `main` | 1 failed |
| `"evidences": ""` | 2 failed |
| `str(f)` for every finding | 2 failed |

`test/unit_test/rag/graphrag/conftest.py` gains one entry, `api.db.services.document_service`. Without it the module cannot be imported at all, because the conftest already mocks `api.db.services` wholesale.

```
$ pytest test/unit_test/rag/graphrag/
115 passed

$ ruff check .   # All checks passed
```
