### PR TITLE
fix(web): warn about empty Message component content on agent save

### DIFF
--- a/web/src/pages/agent/hooks/use-save-graph.ts
+++ b/web/src/pages/agent/hooks/use-save-graph.ts
@@ -10,12 +10,14 @@ import {
 } from '@/interfaces/database/agent';
 import { formatDate } from '@/utils/date';
 import { useDebounceEffect } from 'ahooks';
+import { t } from 'i18next';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { Operator } from '../constant';
 import { FormSchema as ParserFormSchema } from '../form/parser-form';
 import useGraphStore from '../store';
+import { getEmptyMessageNodeNames } from '../utils';
 import { useBuildDslData } from './use-build-dsl';
 
 /**
@@ -89,6 +91,22 @@ export const useSaveGraph = (
         return;
       }
 
+      // Warn about Message components with empty content at save time; the
+      // canvas only fails on them when the agent runs otherwise (backend
+      // MessageParam.check() rejects empty content). Advisory only — the save
+      // itself proceeds. Autosave/publish (showMessage=false) stay silent to
+      // avoid nagging toasts.
+      if (showMessage) {
+        const emptyMessageNodeNames = getEmptyMessageNodeNames(
+          currentNodes ?? useGraphStore.getState().nodes,
+        );
+        if (emptyMessageNodeNames.length > 0) {
+          message.warning(
+            `${emptyMessageNodeNames.join(', ')}: ${t('flow.messageMsg')}`,
+          );
+        }
+      }
+
       const params: Record<string, any> = {
         id,
         title: data.title,
@@ -101,7 +119,7 @@ export const useSaveGraph = (
 
       return setAgent(params);
     },
-    [id, getInvalidNode, data.title, buildDslData, setAgent],
+    [id, getInvalidNode, showMessage, data.title, buildDslData, setAgent],
   );
 
   return { saveGraph, loading };

--- a/web/src/pages/agent/utils.test.ts
+++ b/web/src/pages/agent/utils.test.ts
@@ -1,4 +1,16 @@
-import { transformTokenChunkerParams } from './utils';
+import { Operator } from './constant';
+import {
+  getEmptyMessageNodeNames,
+  isEmptyMessageContent,
+  transformTokenChunkerParams,
+} from './utils';
+
+const createMessageNode = (name: string, content: unknown) => ({
+  id: `${Operator.Message}:${name}`,
+  type: 'ragNode',
+  position: { x: 0, y: 0 },
+  data: { label: Operator.Message, name, form: { content } },
+});
 
 describe('transformTokenChunkerParams', () => {
   it('keeps overlapped_percent and delimiters when delimiter_mode is one', () => {
@@ -35,5 +47,42 @@ describe('transformTokenChunkerParams', () => {
     expect(result.children_delimiters).toEqual(['|']);
     expect(result.table_context_size).toBe(81);
     expect(result.image_context_size).toBe(81);
+  });
+});
+
+describe('Message component content validation', () => {
+  describe('isEmptyMessageContent', () => {
+    it('treats missing, non-array and blank-only content as empty', () => {
+      expect(isEmptyMessageContent()).toBe(true);
+      expect(isEmptyMessageContent(null)).toBe(true);
+      expect(isEmptyMessageContent('hello')).toBe(true);
+      expect(isEmptyMessageContent([])).toBe(true);
+      expect(isEmptyMessageContent(['', ' \t '])).toBe(true);
+      // Non-string entries never satisfy the backend either.
+      expect(isEmptyMessageContent([123])).toBe(true);
+    });
+
+    it('accepts content with at least one non-blank string entry', () => {
+      expect(isEmptyMessageContent(['hi'])).toBe(false);
+      expect(isEmptyMessageContent(['', '{begin@query}'])).toBe(false);
+      expect(isEmptyMessageContent(['  text  '])).toBe(false);
+    });
+  });
+
+  describe('getEmptyMessageNodeNames', () => {
+    it('flags only Message nodes whose content is empty', () => {
+      const nodes = [
+        createMessageNode('回复消息_0', ['']),
+        createMessageNode('回复消息_1', ['ok']),
+        {
+          id: `${Operator.Agent}:x`,
+          type: 'ragNode',
+          position: { x: 0, y: 0 },
+          data: { label: Operator.Agent, name: '智能体_0', form: {} },
+        },
+      ];
+
+      expect(getEmptyMessageNodeNames(nodes as any)).toEqual(['回复消息_0']);
+    });
   });
 });

--- a/web/src/pages/agent/utils.ts
+++ b/web/src/pages/agent/utils.ts
@@ -934,6 +934,34 @@ export function convertToObjectArray<T extends string | number | boolean>(
 }
 
 /**
+ * Message (回复消息) components keep their texts in form.content (string[]).
+ * The backend rejects the component at canvas run time unless at least one
+ * entry is a non-blank string, so missing/non-array/blank-only content all
+ * count as empty here as well.
+ */
+export function isEmptyMessageContent(content?: unknown): boolean {
+  return (
+    !Array.isArray(content) ||
+    !content.some((item) => typeof item === 'string' && item.trim() !== '')
+  );
+}
+
+/**
+ * Returns the display names of Message nodes whose content is empty, so the
+ * save flow can warn about them up front instead of surfacing the runtime
+ * error only when the user runs the agent.
+ */
+export function getEmptyMessageNodeNames(nodes: RAGFlowNodeType[]): string[] {
+  return nodes
+    .filter(
+      (node) =>
+        node.data?.label === Operator.Message &&
+        isEmptyMessageContent(node.data?.form?.content),
+    )
+    .map((node) => node.data?.name ?? node.id);
+}
+
+/**
    * convert the following object into a list
    *
    * {


### PR DESCRIPTION
### Summary

**Background.** In the agent canvas, a `Message` (回复消息) component whose message content was left empty could be saved without any prompt: the user clicked 保存, got the "更新成功" success toast, and only discovered the problem later when running the agent, where the backend component check fails with `[Message] Content does not support empty value.` (Python: `MessageParam.check()`; the Go runtime treats the node's text as empty as well). The frontend had no save-time validation for this — the message form's zod schema marks `content` as optional, and `saveGraph` PUTs the DSL unconditionally. A locale key `flow.messageMsg` ("Please input message or delete this field." / "请输入消息或删除此字段。") already existed in every locale file but was referenced by no code, showing this validation was intended but never wired up.

**What this PR does.**

- Add `isEmptyMessageContent` / `getEmptyMessageNodeNames` helpers in `web/src/pages/agent/utils.ts`. A Message node counts as empty when `form.content` is missing, not an array, or has no non-blank string entry — mirroring the backend's `_valid_message_content` rule.
- In `useSaveGraph` (`web/src/pages/agent/hooks/use-save-graph.ts`), when an explicit save runs (`showMessage=true`, which covers the Save button, Run, Publish, pipeline run, webhook test and the global-variable sheet), collect Message nodes with empty content and show a warning toast naming them, e.g. `回复消息_0: 请输入消息或删除此字段。`. The save itself is not blocked (the warning is advisory, consistent with other canvas warnings). Background autosave (`showMessage=false`) stays silent so editing is not interrupted by repeated toasts.

**Verification.**

- New unit tests in `web/src/pages/agent/utils.test.ts` (jest): 3/3 pass, covering missing/non-array/blank-only content, non-string entries, variable placeholders like `{begin@query}` being non-empty, and node filtering across Message vs non-Message nodes.
- `oxlint` clean on all touched files (the one exhaustive-deps warning introduced by the change was fixed by adding `showMessage` to the callback deps).
- `npm run type-check`: no errors in the touched files (the repo has 208 pre-existing TS errors elsewhere, unchanged by this PR).
- Boundary: end-to-end browser reproduction was not possible in this environment (the automation browser backend was unavailable, and the service launcher failed in the Go build step because `sudo` is unavailable to install `libpcre2-dev`), so the fix is verified by unit tests, lint and type-check plus code-level alignment with the backend validation, not by a live UI walk-through.
