### PR TITLE
fix(graphrag): stop query_rewrite masking a parse failure with json_repair

### DIFF
--- a/rag/graphrag/search.py
+++ b/rag/graphrag/search.py
@@ -32,6 +32,36 @@ from common import settings
 from common.doc_store.doc_store_base import OrderByExpr
 
 
+def keywords_from_query_rewrite(result: str) -> dict:
+    """Return the keyword object a query-rewrite reply carries.
+
+    json_repair.loads returns "" for a reply holding no JSON object, so the value has to be
+    checked before it is read. It was not: query_rewrite read .get straight off it, and the
+    resulting AttributeError met `except json_repair.JSONDecodeError`. json_repair has no
+    such attribute, so evaluating that clause raised a second AttributeError that propagated
+    in place of the first and named json_repair as the problem.
+
+    Raising on an unusable reply is deliberate. KGSearch.retrieval catches it and falls back
+    to searching on the question, which keeps entity, n-hop and community retrieval running.
+    Returning empty keywords would skip that fallback and lose all three.
+    """
+    keywords_data = json_repair.loads(result)
+    if isinstance(keywords_data, dict):
+        return keywords_data
+    if isinstance(keywords_data, list):
+        # A model that wraps its object in an array parses to a list. Merge the objects it
+        # holds, the same way content_tagging treats this shape.
+        merged = {}
+        for item in keywords_data:
+            if isinstance(item, dict):
+                merged.update(item)
+        if merged:
+            return merged
+    # The reply can echo the question and the entity samples in the prompt, so report its
+    # shape rather than its content.
+    raise ValueError(f"query_rewrite expected a JSON object of keywords, got {type(keywords_data).__name__} from a {len(result)} character reply")
+
+
 class KGSearch(Dealer):
     async def _chat(self, llm_bdl, system, history, gen_conf):
         response = get_llm_cache(llm_bdl.llm_name, system, history, gen_conf)
@@ -47,23 +77,10 @@ class KGSearch(Dealer):
         ty2ents = await get_entity_type2samples(idxnms, kb_ids)
         hint_prompt = PROMPTS["minirag_query2kwd"].format(query=question, TYPE_POOL=json.dumps(ty2ents, ensure_ascii=False, indent=2))
         result = await self._chat(llm, hint_prompt, [{"role": "user", "content": "Output:"}], {})
-        try:
-            keywords_data = json_repair.loads(result)
-            type_keywords = keywords_data.get("answer_type_keywords", [])
-            entities_from_query = keywords_data.get("entities_from_query", [])[:5]
-            return type_keywords, entities_from_query
-        except json_repair.JSONDecodeError:
-            try:
-                result = result.replace(hint_prompt[:-1], "").replace("user", "").replace("model", "").strip()
-                result = "{" + result.split("{")[1].split("}")[0] + "}"
-                keywords_data = json_repair.loads(result)
-                type_keywords = keywords_data.get("answer_type_keywords", [])
-                entities_from_query = keywords_data.get("entities_from_query", [])[:5]
-                return type_keywords, entities_from_query
-            # Handle parsing error
-            except Exception as e:
-                logging.exception(f"JSON parsing error: {result} -> {e}")
-                raise e
+        keywords_data = keywords_from_query_rewrite(result)
+        type_keywords = keywords_data.get("answer_type_keywords", [])
+        entities_from_query = keywords_data.get("entities_from_query", [])[:5]
+        return type_keywords, entities_from_query
 
     def _ent_info_from_(self, es_res, sim_thr=0.3):
         res = {}

--- a/test/unit_test/rag/graphrag/test_query_rewrite_parse.py
+++ b/test/unit_test/rag/graphrag/test_query_rewrite_parse.py
@@ -1,0 +1,83 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Parsing of the query-rewrite reply in rag/graphrag/search.py."""
+
+import pytest
+
+from rag.graphrag.search import keywords_from_query_rewrite
+
+_OBJECT = '{"answer_type_keywords": ["PERSON"], "entities_from_query": ["ada"]}'
+_PARSED = {"answer_type_keywords": ["PERSON"], "entities_from_query": ["ada"]}
+
+
+class TestKeywordsFromQueryRewrite:
+    @pytest.mark.p2
+    @pytest.mark.parametrize(
+        "reply",
+        [_OBJECT, "Output:\n" + _OBJECT, "```json\n" + _OBJECT + "\n```"],
+        ids=["bare", "preamble", "fenced"],
+    )
+    def test_a_reply_carrying_the_object_is_parsed(self, reply):
+        assert keywords_from_query_rewrite(reply) == _PARSED
+
+    @pytest.mark.p2
+    @pytest.mark.parametrize(
+        "reply",
+        ["[" + _OBJECT + "]", '{"answer_type_keywords": ["PERSON"]}\n{"entities_from_query": ["ada"]}'],
+        ids=["array_wrapped", "consecutive_objects"],
+    )
+    def test_objects_inside_a_list_are_merged(self, reply):
+        """json_repair returns a list for both shapes and the keywords are still in it."""
+        assert keywords_from_query_rewrite(reply) == _PARSED
+
+    @pytest.mark.p2
+    @pytest.mark.parametrize(
+        "reply",
+        ["I cannot answer that.", "", "[1, 2, 3]", '"PERSON"'],
+        ids=["prose", "empty", "list_of_scalars", "bare_string"],
+    )
+    def test_an_unusable_reply_raises_value_error(self, reply):
+        """Raising is the useful outcome here, not a shortcoming.
+
+        KGSearch.retrieval catches this and falls back to searching on the question, which
+        keeps entity, n-hop and community retrieval running. Returning empty keywords would
+        skip that fallback, so a fix that swallows the failure is worse than the bug.
+
+        The type matters as much as the raise. Before this change these replies produced an
+        AttributeError blaming json_repair, and a parse that strips to the first brace pair
+        produces IndexError. Neither tells an operator what the model sent.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            keywords_from_query_rewrite(reply)
+
+        assert "expected a JSON object of keywords" in str(excinfo.value)
+
+    @pytest.mark.p2
+    def test_the_failure_does_not_carry_the_model_reply(self):
+        """The reply can echo the question and the prompt's entity samples."""
+        secret = "PATIENT NAME REDACTED EXAMPLE STRING"
+
+        with pytest.raises(ValueError) as excinfo:
+            keywords_from_query_rewrite(secret)
+
+        assert secret not in str(excinfo.value)
+
+    @pytest.mark.p2
+    def test_a_reply_nested_past_the_parser_limit_propagates(self):
+        """json_repair.loads does raise, as ValueError, once nesting passes its recursion
+        limit. Documented here so nobody re-adds a handler claiming it never raises."""
+        with pytest.raises(ValueError):
+            keywords_from_query_rewrite("[" * 400)


### PR DESCRIPTION
### Summary

`query_rewrite` reads `.get` straight off whatever `json_repair.loads` returns. `loads` returns `""` for a reply holding no JSON object, so that raises `AttributeError: 'str' object has no attribute 'get'`. The handler below catches `json_repair.JSONDecodeError`, an attribute `json_repair` does not have, so evaluating that clause raises a second `AttributeError` that propagates in place of the first and names `json_repair` as the problem.

```
AttributeError: 'str' object has no attribute 'get'

During handling of the above exception, another exception occurred:

AttributeError: module 'json_repair' has no attribute 'JSONDecodeError'
```

The masking covers everything the `try` can raise. `loads` also raises `ValueError` once nesting passes the parser's recursion limit, measured here at 332 unterminated brackets on the pinned `json-repair==0.60.1`, and today that is replaced by the same `AttributeError`.

Present from v0.16.0 through v0.27.1. Verified by reading the file at each tag rather than with `git tag --contains`, which under-reports in a shallow clone. The path was `graphrag/search.py` before it moved under `rag/`.

### What it costs

This degrades a query, it does not fail one. `KGSearch.retrieval` is the only caller, and it catches the exception and falls back to `ents = [qst]`. So the search loses its entity lookup, the n-hop expansion built from those entities, and the community grounding. Relations found from the question text still run either way, so this is a quality loss rather than an outage.

### Why it keeps raising

Returning empty keywords would be worse than the bug. `get_relevant_ents_by_keywords` short-circuits on `if not keywords: return {}`, so `([], [])` skips retrieval's fallback and drops all three of those. Raising hands control back to the caller, which already knows what to do.

### Why the retry branch goes rather than gets repaired

It has never run since it was written. Repairing it would activate a path that has had no production exposure, and that path runs `.replace("user", "").replace("model", "")` across the whole reply. A reply carrying `["user manual"]` and `["model T"]` would come back as `[" manual"]` and `[" T"]`, which then goes into a vector search. That is a worse outcome than the fallback it would be replacing.

Objects inside a list are merged instead, which is the shape the branch was really there to catch. A model that wraps its object in an array, or emits two objects in a row, parses to a list with the keywords still in it. This matches how `content_tagging` handles the same shape in #18991.

### Relationship to #18991

Same broken construct, different consequence, so the fixes differ on purpose. In `content_tagging` the `.items()` call sits outside the `try`, so the clause is merely dead and the failure is a clean `AttributeError`. Here the `.get` is inside, so it masks. There, `{}` means "no tags for this chunk" and the caller expects it; here, empty keywords would suppress a useful fallback, so this raises.

They agree on the parts that should agree. Neither logs the model reply, because it can echo the question and the entity samples the prompt carries. Both merge objects out of a list rather than discarding them.

On #18991 I said I would send this separately if a maintainer asked, and nobody has. Sending it anyway because the two are easier to judge together than weeks apart. Close it if you would rather it waited.

### Testing

`keywords_from_query_rewrite` is a module-level function so it can be tested at all. `KGSearch` subclasses `Dealer`, which `test/unit_test/rag/graphrag/conftest.py` mocks, so under that conftest `KGSearch` is a `MagicMock` and `isinstance(KGSearch, type)` is `False`.

| source under test | result |
| --- | --- |
| this PR | 11 passed |
| the current handler | 8 failed |
| returns `{}` instead of raising | 7 failed |
| list handling removed | 2 failed |
| retry branch kept, wrapped in `except Exception` | 1 failed |

```
$ pytest test/unit_test/rag/graphrag/
123 passed

$ ruff check .          # All checks passed
$ ruff format --check   # already formatted
```
