### PR TITLE
fix(confluence): stop passing start/end to _retrieve_all_slim_docs

### DIFF
--- a/common/data_source/confluence_connector.py
+++ b/common/data_source/confluence_connector.py
@@ -1761,9 +1761,10 @@ class ConfluenceConnector(
         end: SecondsSinceUnixEpoch | None = None,
         callback: IndexingHeartbeatInterface | None = None,
     ) -> GenerateSlimDocumentOutput:
+        # ``start``/``end`` are accepted for interface compatibility, but the
+        # Confluence slim-doc CQL query is not time-filtered, so they are not
+        # forwarded -- same as ``retrieve_all_slim_docs_perm_sync`` below.
         return self._retrieve_all_slim_docs(
-            start=start,
-            end=end,
             callback=callback,
             include_permissions=False,
         )


### PR DESCRIPTION
### Summary

`ConfluenceConnector.retrieve_all_slim_docs()` cannot be called — it raises `TypeError` before issuing a single Confluence request.

The public method forwards four keyword arguments to a private helper that only accepts two:

```python
# common/data_source/confluence_connector.py

@override
def retrieve_all_slim_docs(
    self,
    start: SecondsSinceUnixEpoch | None = None,
    end: SecondsSinceUnixEpoch | None = None,
    callback: IndexingHeartbeatInterface | None = None,
) -> GenerateSlimDocumentOutput:
    return self._retrieve_all_slim_docs(
        start=start,          # <-- not a parameter
        end=end,              # <-- not a parameter
        callback=callback,
        include_permissions=False,
    )

def _retrieve_all_slim_docs(
    self,
    callback: IndexingHeartbeatInterface | None = None,
    include_permissions: bool = True,
) -> GenerateSlimDocumentOutput:
```

Result:

```
TypeError: _retrieve_all_slim_docs() got an unexpected keyword argument 'start'
```

### Why `start`/`end` are dropped rather than plumbed through

Three things agree that the helper is right and the call is wrong:

1. **The sibling method in the same class is already correct.** `retrieve_all_slim_docs_perm_sync()` calls the very same helper with only `callback` and `include_permissions`.
2. **The base contract has no time window.** `SlimConnector.retrieve_all_slim_docs()` in `common/data_source/interfaces.py` is declared as `(self)` — no `start`, no `end`.
3. **There is nothing for them to do.** `_retrieve_all_slim_docs` builds its CQL from `self.base_cql_page_query + self.cql_label_filter`; the slim-doc query is not time-filtered, so a forwarded `start`/`end` would have had no effect even if the parameters had existed.

`start`/`end` stay on the public signature so existing callers that pass them keep working, and a comment now records that they are intentionally ignored. Adding real time-filtering to the slim-doc query would be a feature change and is deliberately out of scope here.

### Verification

Argument binding was replayed against the **real** AST of `confluence_connector.py` — the actual `_retrieve_all_slim_docs` signature and the actual `Call` nodes — rather than a hand-copied snippet, so it cannot drift from the file:

| call site | before | after |
|---|---|---|
| `retrieve_all_slim_docs` (L1758) | `TypeError: ... unexpected keyword argument 'start'` | binds |
| `retrieve_all_slim_docs_perm_sync` (L1771) | binds | binds |

`ruff check` and `ruff format` pass with the repo's `pyproject.toml` (line-length 200).

Diff is +3 / −2 in one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
