### PR TITLE
fix(url_utils): strip trailing OpenAI endpoint in ensure_v1 to avoid path doubling (#18965)

### DIFF
--- a/rag/utils/url_utils.py
+++ b/rag/utils/url_utils.py
@@ -25,6 +25,14 @@ def ensure_v1(url: str) -> str:
     returned unchanged.  Otherwise the base host is kept and ``/v1`` is
     appended.
 
+    If the path ends with a known OpenAI-compatible endpoint segment
+    (``/chat/completions``, ``/embeddings``, ``/completions``), the
+    endpoint segment is stripped first so the OpenAI client does not
+    double the path when it re-appends the same segment on the request.
+    This is what happens when a user pastes a full endpoint URL
+    (``https://api.pzero.studio/v1/chat/completions``) into the base-URL
+    field instead of just the host.
+
     Examples::
 
         >>> ensure_v1("https://api.example.com")
@@ -37,6 +45,10 @@ def ensure_v1(url: str) -> str:
         'https://api.example.com/api/v3'
         >>> ensure_v1("https://generativelanguage.googleapis.com/v1beta/openai/")
         'https://generativelanguage.googleapis.com/v1beta/openai/'
+        >>> ensure_v1("https://api.pzero.studio/v1/chat/completions")
+        'https://api.pzero.studio/v1'
+        >>> ensure_v1("https://api.openai.com/v1/embeddings")
+        'https://api.openai.com/v1'
     """
     if not url:
         return url
@@ -44,10 +56,29 @@ def ensure_v1(url: str) -> str:
     parsed = urlparse(url)
     path = parsed.path.rstrip("/")
 
+    # Strip a trailing OpenAI-compatible endpoint if the user pasted a full
+    # endpoint URL. The OpenAI client will re-append the same segment on the
+    # request, so leaving it in place would double the path. See issue #18965.
+    endpoint_stripped = False
+    for endpoint in ("/chat/completions", "/embeddings", "/completions"):
+        if path.endswith(endpoint):
+            path = path[: -len(endpoint)].rstrip("/")
+            endpoint_stripped = True
+            break
+
     # Check if any path segment starts with v{digit}, e.g. v1, v2beta, v1alpha1
     segments = path.split("/")
-    if any(re.match(r"^v\d+", segment) for segment in segments):
+    has_version_segment = any(re.match(r"^v\d+", segment) for segment in segments)
+
+    if has_version_segment and not endpoint_stripped:
+        # Preserve the original URL (including any trailing slash) so callers
+        # round-trip exactly.
         return url
+
+    # Either the original URL had no version segment (append /v1) or we
+    # stripped an endpoint (drop the doubled segment and reuse the version).
+    if has_version_segment:
+        return urlunparse((parsed.scheme, parsed.netloc, path, parsed.params, parsed.query, parsed.fragment))
 
     # No versioned segment found – append /v1
     new_path = (path + "/v1") if path else "/v1"

--- a/test/unit_test/rag/utils/test_url_utils.py
+++ b/test/unit_test/rag/utils/test_url_utils.py
@@ -57,3 +57,25 @@ class TestEnsureV1:
         no digit right after) is not a version segment - /v1 must still be
         appended."""
         assert ensure_v1("https://api.example.com/vendors/list") == "https://api.example.com/vendors/list/v1"
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            # Issue #18965: a user pasting a full OpenAI-compatible endpoint
+            # URL must not have the path doubled by the OpenAI client.
+            ("https://api.pzero.studio/v1/chat/completions", "https://api.pzero.studio/v1"),
+            ("https://api.openai.com/v1/embeddings", "https://api.openai.com/v1"),
+            ("https://api.openai.com/v1/completions", "https://api.openai.com/v1"),
+            # No version segment + endpoint: strip the endpoint, then add /v1.
+            ("https://api.pzero.studio/chat/completions", "https://api.pzero.studio/v1"),
+            # Trailing slash on the input is preserved when no endpoint is
+            # stripped.
+            ("https://generativelanguage.googleapis.com/v1beta/openai/", "https://generativelanguage.googleapis.com/v1beta/openai/"),
+        ],
+    )
+    def test_trailing_openai_endpoint_is_stripped(self, url, expected):
+        """A user pasting ``<base>/v1/chat/completions`` (or ``/embeddings`` /
+        ``/completions``) gets the endpoint stripped so the OpenAI client
+        can re-append it on the request without doubling the path. See
+        issue #18965."""
+        assert ensure_v1(url) == expected


### PR DESCRIPTION
## Summary

Fixes #18965.

A user configuring the OpenAI-API-Compatible (or VLLM) factory with a base URL that already includes the full OpenAI endpoint path (e.g. `https://api.pzero.studio/v1/chat/completions`) gets a 404 because the OpenAI client appends another `chat/completions` to a URL that already ends with it. The final request URL becomes `https://api.pzero.studio/v1/chat/completions/chat/completions`. The same shape of bug applies to `/embeddings` and `/completions`. The reporter's workaround is to paste only the host part of the URL; the fix should make RAGFlow tolerate a full endpoint URL.

## Root cause

`rag/utils/url_utils.py::ensure_v1` — the URL normalizer the chat/embedding/sequence2txt/tts providers call before handing the URL to the OpenAI client — only checks whether a path segment starts with `v{digit}`. If the path ends with `/chat/completions` (or `/embeddings` or `/completions`), the function returns the URL unchanged, so the OpenAI client appends the same segment again and the path doubles.

## Changes

**`rag/utils/url_utils.py`** — 32 insertions, 1 deletion.

After the existing `path.rstrip("/")`, strip a trailing `/chat/completions`, `/embeddings` or `/completions` from the path. Then run the existing version-segment check on the (possibly trimmed) path. Three new lines of logic, plus a small refactor of the early-return branch:

- If a trailing OpenAI endpoint was stripped AND the path already has a version segment: return `urlunparse(...)` of the trimmed path so the OpenAI client re-appends the same segment and the final URL is correct.
- If a trailing OpenAI endpoint was stripped AND the path has no version segment: fall through to the existing `/v1` append, so `https://api.pzero.studio/chat/completions` becomes `https://api.pzero.studio/v1`.
- If no endpoint was stripped: return the original URL byte-for-byte (query strings, trailing slashes, and the v1beta/v1alpha1 segment shapes from the recent #16916 fix all round-trip exactly).

**`test/unit_test/rag/utils/test_url_utils.py`** — 22 insertions, 5 new parametrized cases on `TestEnsureV1.test_trailing_openai_endpoint_is_stripped`:

1. `https://api.pzero.studio/v1/chat/completions` → `https://api.pzero.studio/v1` (the issue repro)
2. `https://api.openai.com/v1/embeddings` → `https://api.openai.com/v1` (embeddings shape)
3. `https://api.openai.com/v1/completions` → `https://api.openai.com/v1` (completions shape)
4. `https://api.pzero.studio/chat/completions` → `https://api.pzero.studio/v1` (no version segment: strip endpoint first, then add `/v1`)
5. `https://generativelanguage.googleapis.com/v1beta/openai/` → unchanged (regression guard: a versioned URL with a non-OpenAI trailing path round-trips exactly, trailing slash preserved)

Pre-fix: 4/5 new cases fail (1 passes because the v1beta case is unchanged by the patch). The 9 pre-existing `TestEnsureV1` cases all still pass both pre- and post-fix. Post-fix: 14/14 pass. `ruff check` + `ruff format --check` clean.

## /consult-kiro

The local OpenCode Tier A panel timed out twice (5 minutes and 90 seconds, no output) when run with `--timeout 180 --idle-timeout 90 --min-success 2`. The PR relies on the in-session review of the diff and tests. Per the established pattern documented in the user's workflow memory, consult-kiro timeouts on ragflow have been consistently treated as "document and proceed" rather than as a hard blocker; the diff is small, the fix matches the pattern from the related PRs that have been merged (the recent #16916 `ensure_v1` fix for Gemini v1beta endpoints, and the related #18712 / #18759 series for empty-binary parsers), and the test coverage is explicit.

## Testing

```bash
.venv/bin/python -m pytest test/unit_test/rag/utils/test_url_utils.py -v
# 14 passed in 0.18s

ruff check rag/utils/url_utils.py test/unit_test/rag/utils/test_url_utils.py
# All checks passed!

ruff format --check rag/utils/url_utils.py test/unit_test/rag/utils/test_url_utils.py
# 2 files already formatted
```

## Risks

- **Aggressive endpoint stripping.** The fix only strips `/chat/completions`, `/embeddings`, and `/completions` — the three OpenAI endpoints that the OpenAI client re-appends on the request. A custom OpenAI-compatible provider whose actual endpoint is at some other path (e.g. `/api/chat` or `/v1/chat/completions-v2`) would not have the wrong segment stripped, so the existing pre-fix behavior is preserved for those.
- **Other backends unaffected.** The fix is purely additive: the new branch only activates when the path ends with one of the three known OpenAI endpoints, and the original URL is still returned byte-for-byte when no endpoint was stripped. The 9 pre-existing `TestEnsureV1` cases all still pass, including the v1beta and trailing-slash shapes from the recent #16916 fix.
- **Other call sites.** `ensure_v1` is the single normalization entry point for `rag/llm/chat_model.py`, `rag/llm/embedding_model.py`, `rag/llm/tts_model.py`, and `rag/llm/sequence2txt_model.py`. All ~30 call sites already pass through it; the fix takes effect uniformly without per-site changes.
