### PR TITLE
fix(memory): restore Python-side rules in Go TYPE_INSTRUCTIONS

### DIFF
--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -121,34 +121,45 @@ You are an expert at analyzing conversations to extract structured memory.
 6. Maximum {max_items} items per type
 `
 
-// TYPE_INSTRUCTIONS contains specific instructions for each memory type extraction
+// TYPE_INSTRUCTIONS contains specific instructions for each memory type extraction.
+// Kept in lockstep with Python's memory/utils/prompt_util.py TYPE_INSTRUCTIONS —
+// both implementations drive the same extraction contract, and a rule present on
+// only one side (e.g. the semantic Default line) drifts extraction behavior across
+// languages (see #18415).
 var TYPE_INSTRUCTIONS = map[string]string{
 	"semantic": `
 **EXTRACT SEMANTIC KNOWLEDGE:**
 - Universal facts, definitions, concepts, relationships
 - Time-invariant, generally true information
+- Examples: "The capital of France is Paris", "Water boils at 100°C"
 
-**Timestamp Rules:**
-- valid_at: When the fact became true
-- invalid_at: When it becomes false or empty if still true
+**Timestamp Rules for Semantic Knowledge:**
+- valid_at: When the fact became true (e.g., law enactment, discovery)
+- invalid_at: When it becomes false (e.g., repeal, disproven) or empty if still true
+- Default: valid_at = conversation time, invalid_at = "" for timeless facts
 `,
 	"episodic": `
 **EXTRACT EPISODIC KNOWLEDGE:**
 - Specific experiences, events, personal stories
 - Time-bound, person-specific, contextual
+- Examples: "Yesterday I fixed the bug", "User reported issue last week"
 
-**Timestamp Rules:**
+**Timestamp Rules for Episodic Knowledge:**
 - valid_at: Event start/occurrence time
 - invalid_at: Event end time or empty if instantaneous
+- Extract explicit times: "at 3 PM", "last Monday", "from X to Y"
 `,
 	"procedural": `
 **EXTRACT PROCEDURAL KNOWLEDGE:**
 - Processes, methods, step-by-step instructions
 - Goal-oriented, actionable, often includes conditions
+- Examples: "To reset password, click...", "Debugging steps: 1)..."
 
-**Timestamp Rules:**
+**Timestamp Rules for Procedural Knowledge:**
 - valid_at: When procedure becomes valid/effective
 - invalid_at: When it expires/becomes obsolete or empty if current
+- For version-specific: use release dates
+- For best practices: invalid_at = ""
 `,
 }
 

--- a/internal/service/memory_extractor_test.go
+++ b/internal/service/memory_extractor_test.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -91,5 +92,45 @@ func TestBuildExtractedMessageValidAtSemantics(t *testing.T) {
 	}, now)
 	if got := fallbackOnly["valid_at"]; got != now.Format(memoryTimeLayout) {
 		t.Fatalf("valid_at = %v, want fallback %q", got, now.Format(memoryTimeLayout))
+	}
+}
+
+// TestTypeInstructionsStayInLockstepWithPython pins the rules that
+// memory/utils/prompt_util.py carries and the Go map historically dropped:
+// per-type Examples lines, the full "Timestamp Rules for <Type> Knowledge:"
+// titles, and the semantic Default line. If a substring fails here, the two
+// implementations are handing the extracting LLM different contracts (the
+// drift this map was merged with — see #18415).
+func TestTypeInstructionsStayInLockstepWithPython(t *testing.T) {
+	want := map[string][]string{
+		"semantic": {
+			"- Examples: \"The capital of France is Paris\", \"Water boils at 100°C\"",
+			"**Timestamp Rules for Semantic Knowledge:**",
+			"- valid_at: When the fact became true (e.g., law enactment, discovery)",
+			"- invalid_at: When it becomes false (e.g., repeal, disproven) or empty if still true",
+			"- Default: valid_at = conversation time, invalid_at = \"\" for timeless facts",
+		},
+		"episodic": {
+			"- Examples: \"Yesterday I fixed the bug\", \"User reported issue last week\"",
+			"**Timestamp Rules for Episodic Knowledge:**",
+			"- Extract explicit times: \"at 3 PM\", \"last Monday\", \"from X to Y\"",
+		},
+		"procedural": {
+			"- Examples: \"To reset password, click...\", \"Debugging steps: 1)...\"",
+			"**Timestamp Rules for Procedural Knowledge:**",
+			"- For version-specific: use release dates",
+			"- For best practices: invalid_at = \"\"",
+		},
+	}
+	for memoryType, lines := range want {
+		got, ok := TYPE_INSTRUCTIONS[memoryType]
+		if !ok {
+			t.Fatalf("TYPE_INSTRUCTIONS has no entry for %q", memoryType)
+		}
+		for _, line := range lines {
+			if !strings.Contains(got, line) {
+				t.Errorf("TYPE_INSTRUCTIONS[%q] is missing the Python-side rule: %s", memoryType, line)
+			}
+		}
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Parity fix for the Python/Go memory implementations tracked in #18415 (same line of work as #18752).

The Go `TYPE_INSTRUCTIONS` map dropped several rules that Python's `memory/utils/prompt_util.py` carries, so the two implementations hand the extracting LLM different contracts:

| missing in Go | where Python has it |
|---|---|
| semantic Examples line (`"The capital of France is Paris", "Water boils at 100°C"`) | `prompt_util.py:46` |
| semantic `(e.g., law enactment, discovery)` / `(e.g., repeal, disproven)` parentheticals | `prompt_util.py:47-48` |
| **semantic `- Default: valid_at = conversation time, invalid_at = "" for timeless facts`** | `prompt_util.py:49` |
| episodic Examples line + `Extract explicit times:` rule | `prompt_util.py:57,60` |
| procedural Examples line + version-specific / best-practices rules | `prompt_util.py:68,71-72` |
| full titles (`Timestamp Rules for Semantic/Episodic/Procedural Knowledge:`) | `prompt_util.py:47,56,65` |

The semantic **Default** line is the load-bearing one: it tells the model what to do for timeless facts, and the Go side has been extracting without it.

### How was this PR solved?

Restore the missing rules verbatim from `prompt_util.py` (content parity; each side keeps its own indentation style). Added `TestTypeInstructionsStayInLockstepWithPython`, which pins the previously-dropped lines so the map cannot silently diverge again.

### Behavior change surface

Only the system prompt assembled for memory extraction (`PromptAssembler.AssembleSystemPrompt`) when no custom system prompt is configured: the instructions now carry the same rules/examples as the Python implementation. No storage, API, or parsing changes.

### Tests

- New `TestTypeInstructionsStayInLockstepWithPython` fails against the previous map (verified: the pinned lines are absent from `upstream/main`) and passes with this change.
- Note: `go test ./internal/service/` cannot compile on macOS hosts because `internal/agent/sandbox` uses the Linux-only `syscall.SysProcAttr.Pdeathsig` (pre-existing, unrelated to this change); `gofmt` is clean and CI is the arbiter.

`git diff --stat upstream/main...HEAD` touches only `internal/service/memory.go` and `internal/service/memory_extractor_test.go`.

### One question alongside this (parity cadence)

Context: as part of #18415's follow-up we ran a module-by-module Python/Go comparison over the memory subsystem (prompt assembly, extraction pipeline, time handling, message storage, retrieval) and collected ~41 drift points, 9 of them bug-shaped — this map is one of them, and #19001 (sibling PR) is another. The Go port is otherwise a remarkably faithful line-by-line port, so the drift reads like "not synced yet" rather than "intentionally diverged".

Which of these is the intended workflow for this class of finding?

1. Keep the two implementations aligned and accept parity PRs like this one (we can send them in small, per-module batches with tests); or
2. the Go side is expected to gradually replace Python, and drift in the interim is accepted (in which case we'd stop proposing parity fixes and close out the effort).

Happy to align with whichever — no hard feelings either way.
