### PR TITLE
fix(memory): persist unparseable invalid_at as empty, aligning Go with Python

### DIFF
--- a/internal/service/memory_extractor.go
+++ b/internal/service/memory_extractor.go
@@ -223,7 +223,14 @@ func (s *MemoryMessageService) extractByLLM(ctx context.Context, mem *CreateMemo
 func buildExtractedMessage(messageID, sourceID int64, memoryID string, msg MemoryMessage, item extractedMemory, now time.Time) map[string]any {
 	var invalidAt any
 	if strings.TrimSpace(item.InvalidAt) != "" {
-		invalidAt = formatMemoryTime(item.InvalidAt, now)
+		// Python's decided semantics (api/db/joint_services/memory_message_service.py)
+		// persist an unparseable end time as empty — "not invalidated" — while only
+		// valid_at falls back to the extraction run time. Stamping the run time here
+		// would mark still-true memories expired, so an unparseable invalid_at stays
+		// nil, same as an absent one.
+		if parsed, ok := parseMemoryTime(item.InvalidAt); ok {
+			invalidAt = parsed
+		}
 	}
 	return map[string]any{
 		"message_id":   messageID,
@@ -282,19 +289,40 @@ func parseMemoryExtraction(answer string, extractTypes []string) []extractedMemo
 	return out
 }
 
-// formatMemoryTime normalizes an LLM-supplied timestamp (ISO 8601 or
-// already-formatted) into memoryTimeLayout. The parsed timestamp keeps its
-// own wall clock (no zone conversion). Unparseable or empty input falls
-// back to the supplied time formatted in its own location (server-local
-// when callers pass time.Now()).
-func formatMemoryTime(value string, fallback time.Time) string {
+// parseMemoryTime normalizes an LLM-supplied timestamp (ISO 8601 or
+// already-formatted) into memoryTimeLayout, reporting whether the value
+// parsed at all. The layout set mirrors what Python's
+// dateutil.parser.isoparse accepts for extraction timestamps — including
+// reduced-precision forms ("2026-01-02T15:04") — so identical LLM output
+// takes the same path in both implementations.
+func parseMemoryTime(value string) (string, bool) {
 	v := strings.TrimSpace(value)
 	if v != "" {
-		for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02 15:04:05", "2006-01-02"} {
+		for _, layout := range []string{
+			time.RFC3339,
+			"2006-01-02T15:04:05",
+			"2006-01-02 15:04:05",
+			"2006-01-02",
+			"2006-01-02T15:04",
+			"2006-01-02 15:04",
+		} {
 			if t, err := time.Parse(layout, v); err == nil {
-				return t.Format(memoryTimeLayout)
+				return t.Format(memoryTimeLayout), true
 			}
 		}
+	}
+	return "", false
+}
+
+// formatMemoryTime normalizes an LLM-supplied timestamp into
+// memoryTimeLayout, falling back to the supplied time formatted in its own
+// location (server-local when callers pass time.Now()) when the value is
+// empty or unparseable. Callers that need to distinguish "unparseable" —
+// e.g. invalid_at, which persists as empty rather than the run time — use
+// parseMemoryTime directly.
+func formatMemoryTime(value string, fallback time.Time) string {
+	if parsed, ok := parseMemoryTime(value); ok {
+		return parsed
 	}
 	return fallback.Format(memoryTimeLayout)
 }

--- a/internal/service/memory_extractor_test.go
+++ b/internal/service/memory_extractor_test.go
@@ -49,6 +49,10 @@ func TestFormatMemoryTimeKeepsParsedWallClock(t *testing.T) {
 		{name: "naive iso", value: "2026-08-20T10:05:00", want: "2026-08-20 10:05:00"},
 		{name: "storage layout", value: "2026-08-20 10:05:00", want: "2026-08-20 10:05:00"},
 		{name: "date only", value: "2026-08-20", want: "2026-08-20 00:00:00"},
+		// Reduced-precision ISO 8601: Python's dateutil.parser.isoparse accepts
+		// these, so identical LLM output must not fall back on the Go side.
+		{name: "naive iso without seconds", value: "2026-08-20T10:05", want: "2026-08-20 10:05:00"},
+		{name: "storage layout without seconds", value: "2026-08-20 10:05", want: "2026-08-20 10:05:00"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := formatMemoryTime(test.value, fallback); got != test.want {
@@ -91,5 +95,39 @@ func TestBuildExtractedMessageValidAtSemantics(t *testing.T) {
 	}, now)
 	if got := fallbackOnly["valid_at"]; got != now.Format(memoryTimeLayout) {
 		t.Fatalf("valid_at = %v, want fallback %q", got, now.Format(memoryTimeLayout))
+	}
+}
+
+// TestBuildExtractedMessageInvalidAtSemantics pins the Python-side policy for
+// invalid_at (api/db/joint_services/memory_message_service.py): an empty or
+// unparseable end time means "not invalidated" and persists as empty — never
+// as the extraction run time, which would mark still-true memories expired.
+func TestBuildExtractedMessageInvalidAtSemantics(t *testing.T) {
+	msg := MemoryMessage{UserID: "u1", AgentID: "a1", SessionID: "s1"}
+	now := time.Date(2026, 8, 20, 10, 5, 0, 0, time.Local)
+
+	parsed := buildExtractedMessage(10, 42, "mem-1", msg, extractedMemory{
+		MessageType: "fact",
+		Content:     "likes coffee",
+		InvalidAt:   "2026-08-21T09:00:00+08:00",
+	}, now)
+	if got := parsed["invalid_at"]; got != "2026-08-21 09:00:00" {
+		t.Fatalf("invalid_at = %v, want parsed wall clock %q", got, "2026-08-21 09:00:00")
+	}
+
+	for name, invalidAt := range map[string]string{
+		"empty":       "",
+		"unparseable": "when the user gets tired of coffee",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := buildExtractedMessage(11, 42, "mem-1", msg, extractedMemory{
+				MessageType: "fact",
+				Content:     "likes coffee",
+				InvalidAt:   invalidAt,
+			}, now)
+			if invalidAt, ok := got["invalid_at"]; ok && invalidAt != nil {
+				t.Fatalf("invalid_at = %v (%T), want nil for %s end time", invalidAt, invalidAt, name)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

While comparing the Python memory pipeline against its Go port line by line, I found one semantic divergence in how an **unparseable `invalid_at`** is persisted, plus a small timestamp-grammar gap. This PR aligns the Go side with the semantics Python has already committed to.

### The divergence (same LLM output, different stored memory)

Python (`api/db/joint_services/memory_message_service.py`, `extract_by_llm`):

```python
"valid_at": format_iso_8601_to_ymd_hms(extracted_content.get("valid_at", ""), fallback=conversation_time),
"invalid_at": format_iso_8601_to_ymd_hms(extracted_content["invalid_at"], fallback="") if extracted_content.get("invalid_at") else "",
```

- `valid_at` unparseable → falls back to the extraction run time
- `invalid_at` unparseable → falls back to **`""`** ("not invalidated")

Go (`internal/service/memory_extractor.go`, before this PR):

```go
var invalidAt any
if strings.TrimSpace(item.InvalidAt) != "" {
    invalidAt = formatMemoryTime(item.InvalidAt, now) // unparseable -> now
}
```

An `invalid_at` the parser rejects (LLM prose, or an ISO form outside the layout set — e.g. reduced-precision `2026-08-20T10:05`, which `dateutil.parser.isoparse` accepts) became **the extraction run time** — i.e. a still-true memory got persisted as *expired at extraction time*. Python keeps it empty.

### Changes

- `buildExtractedMessage`: parse `invalid_at` first; only a successfully parsed end time is persisted, otherwise it stays `nil` — same as an absent one. `valid_at` keeps its run-time fallback (both the code and `TestBuildExtractedMessageValidAtSemantics` unchanged).
- `formatMemoryTime` is split into a `parseMemoryTime(value) (string, bool)` helper so callers can distinguish "unparseable" from "parsed"; its contract is unchanged (covered by the existing tests).
- The layout set gains the reduced-precision ISO 8601 forms `YYYY-MM-DDTHH:MM` and `YYYY-MM-DD HH:MM` — `dateutil.parser.isoparse` accepts both, so identical LLM output takes the same path on both sides instead of silently falling back on Go.

### Verification

- New/extended tests in `memory_extractor_test.go`: parsed wall clock kept; empty/unparseable `invalid_at` persist as `nil`; reduced-precision forms parse.
- One honest caveat: I could not run the package tests locally — on macOS the build fails for pre-existing environment reasons unrelated to this change (`office_oxide` cgo header lookup, and `syscall.SysProcAttr.Pdeathsig` which is Linux-only in `internal/agent/sandbox`). I verified the touched functions by extracting them verbatim into an isolated package and running the same test cases there (3 failures before the fix, all green after). CI should exercise the real package.

### A question on the Go/Python prompt parity itself

While diffing this subsystem I also noticed the Go extraction prompt (`internal/service/memory.go` `TYPE_INSTRUCTIONS` / `AssembleSystemPrompt`) looks like a port of an older Python revision: the per-type `Examples:` lines, the `Default: valid_at = conversation time, invalid_at = "" for timeless facts` rule, the episodic "extract explicit times" guidance, the procedural fine-print, and Python's whole `**EXAMPLES:**` few-shot block are all absent on the Go side.

So, same question as #18752 left open: **is Python↔Go prompt/semantic sync something you want to track as a property of the memory subsystem (in which case I'm happy to follow up with a parity PR for the template block), or is the Go implementation expected to diverge over time?** If drift is acceptable by design, knowing that would save reviewers future parity PRs.

Refs #18752, #18415.
