### PR TITLE
Fix NameError in audio chunker when file extension is missing or unsupported

### DIFF
--- a/rag/app/audio.py
+++ b/rag/app/audio.py
@@ -30,6 +30,7 @@ def chunk(filename, binary, tenant_id, lang, callback=None, **kwargs):
 
     # is it English
     is_english = lang.lower() == "english"  # is_english(sections)
+    tmp_path = ""
     try:
         _, ext = os.path.splitext(filename)
         if not ext:
@@ -38,7 +39,6 @@ def chunk(filename, binary, tenant_id, lang, callback=None, **kwargs):
         if ext not in [".da", ".wave", ".wav", ".mp3", ".aac", ".flac", ".ogg", ".aiff", ".au", ".midi", ".wma", ".realaudio", ".vqf", ".oggvorbis", ".ape"]:
             raise RuntimeError(f"Extension {ext} is not supported yet.")
 
-        tmp_path = ""
         with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmpf:
             tmpf.write(binary)
             tmpf.flush()

--- a/test/unit_test/rag/app/test_audio_invalid_extension.py
+++ b/test/unit_test/rag/app/test_audio_invalid_extension.py
@@ -22,14 +22,8 @@ from rag.app import audio
 
 
 @pytest.mark.p2
-def test_missing_extension_reports_error_instead_of_name_error():
-    """A file without an extension must be reported via the failure callback.
-
-    Regression: ``tmp_path`` used to be initialized inside the ``try`` block
-    after the extension checks, so the ``finally`` clause raised
-    ``NameError: name 'tmp_path' is not defined`` and masked the graceful
-    error handling.
-    """
+def test_missing_extension_reports_error():
+    """A file without an extension is reported via the failure callback."""
     messages: list[tuple] = []
 
     def callback(prog=None, msg=""):
@@ -43,7 +37,7 @@ def test_missing_extension_reports_error_instead_of_name_error():
 
 
 @pytest.mark.p2
-def test_unsupported_extension_reports_error_instead_of_name_error():
+def test_unsupported_extension_reports_error():
     messages: list[tuple] = []
 
     def callback(prog=None, msg=""):

--- a/test/unit_test/rag/app/test_audio_invalid_extension.py
+++ b/test/unit_test/rag/app/test_audio_invalid_extension.py
@@ -1,0 +1,56 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from rag.app import audio
+
+
+@pytest.mark.p2
+def test_missing_extension_reports_error_instead_of_name_error():
+    """A file without an extension must be reported via the failure callback.
+
+    Regression: ``tmp_path`` used to be initialized inside the ``try`` block
+    after the extension checks, so the ``finally`` clause raised
+    ``NameError: name 'tmp_path' is not defined`` and masked the graceful
+    error handling.
+    """
+    messages: list[tuple] = []
+
+    def callback(prog=None, msg=""):
+        messages.append((prog, msg))
+
+    res = audio.chunk("no_extension_file", b"data", tenant_id="t", lang="english", callback=callback)
+
+    assert res == []
+    assert messages and messages[-1][0] == -1
+    assert "No extension detected" in messages[-1][1]
+
+
+@pytest.mark.p2
+def test_unsupported_extension_reports_error_instead_of_name_error():
+    messages: list[tuple] = []
+
+    def callback(prog=None, msg=""):
+        messages.append((prog, msg))
+
+    res = audio.chunk("song.xyz", b"data", tenant_id="t", lang="english", callback=callback)
+
+    assert res == []
+    assert messages and messages[-1][0] == -1
+    assert "not supported yet" in messages[-1][1]


### PR DESCRIPTION
### What
`rag/app/audio.py` `chunk()`: `tmp_path` was initialized inside the `try` block, after the extension checks. When a filename has no extension or an unsupported one, the `RuntimeError` is caught and passed to the callback, but the `finally` clause then hits `NameError: name 'tmp_path' is not defined`, which masks the graceful error handling.

Moved the `tmp_path = ""` initialization above the `try` so `finally` always sees a defined variable.

### Testing
Added `test/unit_test/rag/app/test_audio_invalid_extension.py` covering both cases (no extension, unsupported extension); both now expect the error message through the callback instead of a NameError.

Not run locally (missing full dev env), but change is a one-line move and covered by the new tests.