### PR TITLE
Require exactly two cells for a CSV QA pair

### DIFF
--- a/internal/ingestion/component/chunker/qa.go
+++ b/internal/ingestion/component/chunker/qa.go
@@ -111,7 +111,7 @@ func (c *QAChunkerComponent) invoke(_ context.Context, inputs map[string]any) (m
 	var isMarkdown bool
 	switch upstream.OutputFormat {
 	case schema.PayloadFormatHTML:
-		qaPairs = extractQATable(stringPtrVal(upstream.HTMLResult))
+		qaPairs = extractQATable(stringPtrVal(upstream.HTMLResult), isCSV(upstream.Name))
 	case schema.PayloadFormatMarkdown:
 		qaPairs = extractQAMarkdown(stringPtrVal(upstream.MarkdownResult))
 		isMarkdown = true
@@ -193,6 +193,10 @@ func stringPtrVal(s *string) string {
 	return *s
 }
 
+func isCSV(name string) bool {
+	return strings.HasSuffix(strings.ToLower(name), ".csv")
+}
+
 // ---------------------------------------------------------------------------
 // HTML / spreadsheet QA extraction
 // ---------------------------------------------------------------------------
@@ -201,7 +205,7 @@ var htmlTR = regexp.MustCompile(`(?i)<tr[^>]*>(.*?)</tr>`)
 var htmlTD = regexp.MustCompile(`(?i)<t[dh][^>]*>(.*?)</t[dh]>`)
 var htmlTag = regexp.MustCompile(`<[^>]+>`)
 
-func extractQATable(htmlStr string) []qaPair {
+func extractQATable(htmlStr string, strictPairs bool) []qaPair {
 	if htmlStr == "" {
 		return nil
 	}
@@ -209,6 +213,10 @@ func extractQATable(htmlStr string) []qaPair {
 	pairs := make([]qaPair, 0, len(rows))
 	for _, row := range rows {
 		cells := htmlTD.FindAllStringSubmatch(row[1], -1)
+		// Python qa.py:365 requires exactly two fields for CSV pairs.
+		if strictPairs && len(cells) != 2 {
+			continue
+		}
 		var texts []string
 		for _, cell := range cells {
 			t := html.UnescapeString(htmlTag.ReplaceAllString(cell[1], ""))

--- a/internal/ingestion/component/chunker/qa_test.go
+++ b/internal/ingestion/component/chunker/qa_test.go
@@ -128,6 +128,74 @@ func TestQAChunker_HTMLTable(t *testing.T) {
 	}
 }
 
+func TestQAChunker_CSVStrictPairRejectsThreeCells(t *testing.T) {
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "test.CSV",
+		"output_format": "html",
+		"html":          "<table><tr><td>question</td><td></td><td>extra</td></tr></table>",
+	}
+	out, err := comp.Invoke(context.Background(), nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks, got %d", len(chunks))
+	}
+}
+
+func TestQAChunker_CSVStrictPairAcceptsTwoCells(t *testing.T) {
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "test.csv",
+		"output_format": "html",
+		"html":          "<table><tr><td>question</td><td>answer</td></tr></table>",
+	}
+	out, err := comp.Invoke(context.Background(), nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	cww, _ := chunks[0]["content_with_weight"].(string)
+	if cww != "Question: question\tAnswer: answer" {
+		t.Fatalf("unexpected content: %q", cww)
+	}
+}
+
+func TestQAChunker_XLSXThreeCellsKeepsFirstTwoNonEmpty(t *testing.T) {
+	comp, err := NewQAChunker(map[string]any{"lang": "english"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string]any{
+		"name":          "test.xlsx",
+		"output_format": "html",
+		"html":          "<table><tr><td>question</td><td></td><td>extra</td></tr></table>",
+	}
+	out, err := comp.Invoke(context.Background(), nil, inputs)
+	if err != nil {
+		t.Fatalf("Invoke failed: %v", err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	cww, _ := chunks[0]["content_with_weight"].(string)
+	if cww != "Question: question\tAnswer: extra" {
+		t.Fatalf("unexpected content: %q", cww)
+	}
+}
+
 func TestQAChunker_RmQAPrefix(t *testing.T) {
 	comp, err := NewQAChunker(map[string]any{"lang": "english"})
 	if err != nil {

--- a/internal/ingestion/component/chunker/qa_test.go
+++ b/internal/ingestion/component/chunker/qa_test.go
@@ -172,13 +172,16 @@ func TestQAChunker_CSVStrictPairAcceptsTwoCells(t *testing.T) {
 	}
 }
 
-func TestQAChunker_XLSXThreeCellsKeepsFirstTwoNonEmpty(t *testing.T) {
+// Non-CSV names keep the old "first two non-empty cells" rule on the HTML
+// table path. Since #18800 an .xlsx file reaches the chunker as "json", not
+// "html", so this covers the shared HTML branch and not the XLSX pipeline.
+func TestQAChunker_NonCSVHTMLThreeCellsKeepsFirstTwo(t *testing.T) {
 	comp, err := NewQAChunker(map[string]any{"lang": "english"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	inputs := map[string]any{
-		"name":          "test.xlsx",
+		"name":          "test.xls",
 		"output_format": "html",
 		"html":          "<table><tr><td>question</td><td></td><td>extra</td></tr></table>",
 	}

--- a/internal/ingestion/component/chunker/qa_test.go
+++ b/internal/ingestion/component/chunker/qa_test.go
@@ -138,7 +138,7 @@ func TestQAChunker_CSVStrictPairRejectsThreeCells(t *testing.T) {
 		"output_format": "html",
 		"html":          "<table><tr><td>question</td><td></td><td>extra</td></tr></table>",
 	}
-	out, err := comp.Invoke(context.Background(), nil, inputs)
+	out, err := comp.Invoke(t.Context(), nil, inputs)
 	if err != nil {
 		t.Fatalf("Invoke failed: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestQAChunker_CSVStrictPairAcceptsTwoCells(t *testing.T) {
 		"output_format": "html",
 		"html":          "<table><tr><td>question</td><td>answer</td></tr></table>",
 	}
-	out, err := comp.Invoke(context.Background(), nil, inputs)
+	out, err := comp.Invoke(t.Context(), nil, inputs)
 	if err != nil {
 		t.Fatalf("Invoke failed: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestQAChunker_NonCSVHTMLThreeCellsKeepsFirstTwo(t *testing.T) {
 		"output_format": "html",
 		"html":          "<table><tr><td>question</td><td></td><td>extra</td></tr></table>",
 	}
-	out, err := comp.Invoke(context.Background(), nil, inputs)
+	out, err := comp.Invoke(t.Context(), nil, inputs)
 	if err != nil {
 		t.Fatalf("Invoke failed: %v", err)
 	}


### PR DESCRIPTION
### Summary

Closes part of #19006. Follows the review on #17902.

## Problem

`extractQATable` drops empty cells, then pairs `texts[0]` with `texts[1]`:

```go
if t != "" {
    texts = append(texts, t)
}
...
if len(texts) >= 2 {
    pairs = append(pairs, qaPair{Question: texts[0], Answer: texts[1]})
}
```

A CSV row `question,,extra` renders as `<td>question</td><td></td><td>extra</td>`, because `office_table_render.go:238` writes one cell per field and keeps the empty ones. The pair becomes `question` and `extra`. The empty middle column is skipped without notice.

Python does not apply one rule to every format:

| source | Python | rule |
|---|---|---|
| `.csv` | `rag/app/qa.py:365` | the row must hold exactly two fields |
| `.xls`, `.xlsx` | `rag/app/qa.py:53` | skip empty cells, take the first two values |

## Which formats reach this function

`csv_parser.go` and `xls_parser.go` emit `OutputFormat: "html"`, so they reach `extractQATable`. `xlsx_parser.go` no longer does. #18800 changed its return from `"html"` to `"json"` on 2026-08-27, so an `.xlsx` file now reaches `extractQAJSON`.

This change is therefore CSV-only in effect, plus `.xls`, which keeps its current behaviour. It is a no-op for `.xlsx`.

## Change

`extractQATable` takes a `strictPairs` flag. When it is set, a row makes a pair only if it holds exactly two cells. The call site sets it from the source document name, the same signal Python dispatches on.

`.xls` behaviour does not change.

## Scope

This stops the incorrect pairing on the HTML table path. Two things stay out:

- Python's continuation handling, where a row without exactly two fields appends to the previous answer (`qa.py:366-369`). The Go text paths already do this; the table path does not.
- The `.xlsx` JSON path. It is broken in a different way, reported separately in #19174.

## Tests

Three tests in `qa_test.go`, all driving the component through `Invoke`:

- `TestQAChunker_CSVStrictPairRejectsThreeCells` - a `.CSV` source with `question`, empty, `extra` produces no chunk. The name is uppercase on purpose, to cover the case-insensitive match.
- `TestQAChunker_CSVStrictPairAcceptsTwoCells` - a normal two-column CSV row still pairs.
- `TestQAChunker_NonCSVHTMLThreeCellsKeepsFirstTwo` - the same three-cell row on an `.xls` source still pairs `question` with `extra`, so the non-CSV path is unchanged.

Results:

```
CGO_ENABLED=0 go test ./internal/ingestion/component/chunker/
ok  	ragflow/internal/ingestion/component/chunker	1.124s

CGO_ENABLED=0 go vet ./internal/ingestion/component/chunker/
(no output)
```

Reverting only the source guard and keeping the tests fails one test, and only the intended one:

```
--- FAIL: TestQAChunker_CSVStrictPairRejectsThreeCells
    qa_test.go:147: expected 0 chunks, got 1
--- PASS: TestQAChunker_CSVStrictPairAcceptsTwoCells
--- PASS: TestQAChunker_NonCSVHTMLThreeCellsKeepsFirstTwo
```

## Note on the local build

`go build ./internal/...` needs `CGO_ENABLED=0` on macOS, or it stops on a missing `office_oxide.h`. With cgo off, one unrelated package still fails on this platform:

```
internal/agent/sandbox/local.go:307:3: unknown field Pdeathsig in struct literal of type "syscall".SysProcAttr
```

`Pdeathsig` is Linux only and that file carries `//go:build !windows`. The same failure appears on a clean `main`, so it is not from this change.
