### PR TITLE
Restore visible Markdown list styling in chat

### DIFF
--- a/web/src/components/markdown-content/index.module.less
+++ b/web/src/components/markdown-content/index.module.less
@@ -53,6 +53,23 @@
     padding-inline-start: 10px;
     border-inline-start: 4px solid #ccc;
   }
+  :global(ul),
+  :global(ol) {
+    margin: 0.5em 0;
+    padding-inline-start: 1.5em;
+  }
+  :global(ul) {
+    list-style-type: disc;
+  }
+  :global(ol) {
+    list-style-type: decimal;
+  }
+  :global(li) {
+    margin: 0.25em 0;
+  }
+  :global(li > p) {
+    margin: 0.15em 0;
+  }
 
   // RTL Support
   &[dir='rtl'] {

--- a/web/src/components/next-markdown-content/index.module.less
+++ b/web/src/components/next-markdown-content/index.module.less
@@ -54,6 +54,23 @@
     padding-inline-start: 10px;
     border-inline-start: 4px solid #ccc;
   }
+  :global(ul),
+  :global(ol) {
+    margin: 0.5em 0;
+    padding-inline-start: 1.5em;
+  }
+  :global(ul) {
+    list-style-type: disc;
+  }
+  :global(ol) {
+    list-style-type: decimal;
+  }
+  :global(li) {
+    margin: 0.25em 0;
+  }
+  :global(li > p) {
+    margin: 0.15em 0;
+  }
 
   // RTL Support
   &[dir='rtl'] {


### PR DESCRIPTION
## Summary

- Restore visible unordered and ordered list markers in both chat Markdown renderers.
- Add logical indentation and compact spacing for list items and nested paragraphs.
- Keep the legacy and next Markdown renderers visually consistent.

## Test plan

- [x] `npm --prefix web run build`
- [ ] Manually verify unordered, ordered, and nested lists in the chat UI.

This is a CSS-only change; no backend or data behavior is modified.
