### PR TITLE
fix(agentic_rag): return calculate tool result

### DIFF
--- a/rag/advanced_rag/harness/action_session.py
+++ b/rag/advanced_rag/harness/action_session.py
@@ -824,7 +824,7 @@ async def _exec_calculate(tools, args: dict) -> tuple:
     if not res:
         # nothing derivable -> tell the model so it doesn't loop on it
         return [{"kind": "calculate", "expression": None, "note": "no numeric answer derivable from given facts; answer directly or retrieve more numbers."}], []
-    return [{"kind": "calculate", "expression": res.get("expression"), "result": res.get("result"), "computed": res.get("computed_value")}], []
+    return [{"kind": "calculate", "expression": res.get("expression"), "result": res.get("value")}], []
 
 
 async def _exec_graph_explore(tools, args: dict) -> tuple:

--- a/test/unit_test/rag/advanced_rag/test_action_session.py
+++ b/test/unit_test/rag/advanced_rag/test_action_session.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+from rag.advanced_rag.harness.action_session import _exec_calculate
+
+
+@pytest.mark.asyncio
+async def test_exec_calculate_returns_computed_value(monkeypatch):
+    async def fake_compute_from_facts(model, question, facts):
+        assert model is tools.chat_mdl
+        assert question == "What is the total?"
+        assert facts == ["First value: 2", "Second value: 3"]
+        return {
+            "needed": True,
+            "label": "Total",
+            "value": "5",
+            "expression": "2 + 3",
+            "uses": [0, 1],
+        }
+
+    monkeypatch.setattr("rag.advanced_rag.harness.arithmetic.compute_from_facts", fake_compute_from_facts)
+    tools = SimpleNamespace(chat_mdl=object())
+
+    results, evidence_ids = await _exec_calculate(
+        tools,
+        {
+            "question": "What is the total?",
+            "facts": ["First value: 2", "Second value: 3"],
+        },
+    )
+
+    assert results == [{"kind": "calculate", "expression": "2 + 3", "result": "5"}]
+    assert evidence_ids == []


### PR DESCRIPTION
## Summary

- return the `value` produced by `compute_from_facts` as the calculate tool result
- remove response fields backed by keys that the arithmetic helper never returns
- add an async regression test for the action-session result contract

## Problem

`compute_from_facts` returns successful calculations under its documented `value` key. `_exec_calculate` instead read `result` and `computed_value`, so every successful calculation was sent back to the action model with null result fields.

This is a focused follow-up to the agentic search refactor in #19000.

## Test plan

- `uv run --no-project --python 3.13 --with pytest --with pytest-asyncio --with langchain-core --with langgraph --with json-repair pytest --confcutdir=test/unit_test/rag/advanced_rag test/unit_test/rag/advanced_rag/test_action_session.py -q`
- `uvx ruff check test/unit_test/rag/advanced_rag/test_action_session.py`
- `uvx ruff check --select E9,F63,F7,F82 rag/advanced_rag/harness/action_session.py`
- `uvx ruff format --check rag/advanced_rag/harness/action_session.py test/unit_test/rag/advanced_rag/test_action_session.py`