### PR TITLE
Support PostgreSQL in the model provider migration

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -282,9 +282,10 @@ if [[ "${INIT_MODEL_PROVIDER_TABLES}" -eq 1 ]]; then
     DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"
     DB_TYPE_NORMALIZED="${DB_TYPE_NORMALIZED,,}"
     if [[ "${DB_TYPE_NORMALIZED}" == "gaussdb" || "${DB_TYPE_NORMALIZED}" == "gauss" ]]; then
-        # This migration script contains MySQL-only SQL and cannot run against
-        # a GaussDB metadata database.
-        echo "Skipping MySQL-specific model provider table migrations for DB_TYPE=${DB_TYPE:-mysql}."
+        # The migration supports MySQL and PostgreSQL. GaussDB needs its own
+        # dialect (empty string is NULL, among other differences) and is still
+        # excluded; see tools/scripts/migration_dialects.py.
+        echo "Skipping model provider table migrations: DB_TYPE=${DB_TYPE:-mysql} has no migration dialect yet."
     else
         tools/scripts/run_migrations.sh
     fi

--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -217,9 +217,10 @@ run_mysql_migrations() {
     local db_type="${DB_TYPE:-mysql}"
     db_type="${db_type,,}"
     if [ "$db_type" = "gaussdb" ] || [ "$db_type" = "gauss" ]; then
-        # This migration script contains MySQL-only SQL and cannot run against
-        # a GaussDB metadata database.
-        echo "Skipping MySQL-specific model provider table migrations for DB_TYPE=${DB_TYPE:-mysql}."
+        # The migration supports MySQL and PostgreSQL. GaussDB needs its own
+        # dialect (empty string is NULL, among other differences) and is still
+        # excluded; see tools/scripts/migration_dialects.py.
+        echo "Skipping model provider table migrations: DB_TYPE=${DB_TYPE:-mysql} has no migration dialect yet."
         return 0
     fi
 

--- a/test/integration/test_model_provider_migration_dialects.py
+++ b/test/integration/test_model_provider_migration_dialects.py
@@ -1,0 +1,321 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Cross-dialect equivalence for the model provider migration.
+
+Builds the same legacy schema and dataset on MySQL and PostgreSQL, runs the
+migration exactly the way tools/scripts/run_migrations.sh does, and asserts the
+two databases end up holding the same rows. A difference is a porting bug in one
+of the dialects.
+
+Requires two live servers and is skipped unless both are configured:
+
+    MIGRATION_TEST_MYSQL_DSN=mysql://root:pw@127.0.0.1:3306/rag_flow_migtest
+    MIGRATION_TEST_POSTGRES_DSN=postgres://user:pw@127.0.0.1:5432/rag_flow_migtest
+
+Both databases are emptied before use, so point them at throwaway instances.
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "tools", "scripts"))
+
+import mysql_migration as mm
+from migration_dialects import MYSQL, POSTGRES
+
+MYSQL_DSN = os.getenv("MIGRATION_TEST_MYSQL_DSN")
+POSTGRES_DSN = os.getenv("MIGRATION_TEST_POSTGRES_DSN")
+
+pytestmark = pytest.mark.skipif(
+    not (MYSQL_DSN and POSTGRES_DSN),
+    reason="set MIGRATION_TEST_MYSQL_DSN and MIGRATION_TEST_POSTGRES_DSN to run",
+)
+
+APOS = chr(39)
+T1 = "t0000000000000000000000000000001"
+T2 = "t0000000000000000000000000000002"
+
+# The two steps in tools/scripts/run_migrations.sh, with the versions it marks.
+MIGRATION_STEPS = [
+    (["tenant_model_provider", "tenant_model_instance", "tenant_model", "model_id_config"], "v0.26.0"),
+    (["tenant_model_seeding", "model_type_merge", "tenant_model_id_migration"], "v0.27.0"),
+]
+
+# Legacy schema, in the logical types the dialect layer maps. tenant_llm_id and
+# tenant_embd_id are INTEGER on purpose: that is the shape the migration has to
+# widen to VARCHAR(32), and the statement doing it is dialect-specific.
+LEGACY_TABLES = [
+    (
+        "tenant_llm",
+        [
+            ("tenant_id", "VARCHAR(32)", "NOT NULL"),
+            ("llm_factory", "VARCHAR(128)", "NOT NULL"),
+            ("model_type", "VARCHAR(128)", ""),
+            ("llm_name", "VARCHAR(128)", ""),
+            ("api_key", "TEXT", ""),
+            ("api_base", "VARCHAR(255)", ""),
+            ("max_tokens", "INT", ""),
+            ("used_tokens", "INT", ""),
+            ("status", "VARCHAR(1)", ""),
+        ],
+        "serial",
+    ),
+    (
+        "system_settings",
+        [
+            ("name", "VARCHAR(255)", "NOT NULL"),
+            ("source", "VARCHAR(64)", ""),
+            ("data_type", "VARCHAR(32)", ""),
+            ("value", "TEXT", ""),
+            ("create_time", "BIGINT", ""),
+            ("create_date", "TIMESTAMP", ""),
+            ("update_time", "BIGINT", ""),
+            ("update_date", "TIMESTAMP", ""),
+        ],
+        "name",
+    ),
+    (
+        "tenant",
+        [
+            ("id", "VARCHAR(32)", "NOT NULL"),
+            ("llm_id", "VARCHAR(255)", ""),
+            ("embd_id", "VARCHAR(255)", ""),
+            ("asr_id", "VARCHAR(255)", ""),
+            ("img2txt_id", "VARCHAR(255)", ""),
+            ("rerank_id", "VARCHAR(255)", ""),
+            ("tts_id", "VARCHAR(255)", ""),
+            ("tenant_llm_id", "INT", ""),
+            ("tenant_embd_id", "INT", ""),
+        ],
+        None,
+    ),
+    (
+        "knowledgebase",
+        [
+            ("id", "VARCHAR(32)", "NOT NULL"),
+            ("tenant_id", "VARCHAR(32)", ""),
+            ("embd_id", "VARCHAR(255)", ""),
+            ("parser_config", "TEXT", ""),
+        ],
+        None,
+    ),
+    (
+        "dialog",
+        [
+            ("id", "VARCHAR(32)", "NOT NULL"),
+            ("tenant_id", "VARCHAR(32)", ""),
+            ("llm_id", "VARCHAR(255)", ""),
+            ("rerank_id", "VARCHAR(255)", ""),
+        ],
+        None,
+    ),
+]
+
+SEED_ROWS = {
+    "tenant_llm": (
+        ["tenant_id", "llm_factory", "model_type", "llm_name", "api_key", "api_base", "max_tokens", "used_tokens", "status"],
+        [
+            (T1, "OpenAI", "chat", "gpt-4o", "sk-aaa", "", 8192, 0, "1"),
+            (T1, "OpenAI", "embedding", "text-embedding-3-large", "sk-aaa", "", 8192, 0, "1"),
+            # status "0" exercises the inactive path.
+            (T1, "OpenAI", "rerank", "rerank-1", "sk-aaa", "", 8192, 0, "0"),
+            (T1, "Ollama", "embedding", "bge-m3", "", "http://ollama:11434", 8192, 0, "1"),
+            (T2, "Ollama", "chat", "qwen3:8b", "", "http://ollama:11434", 8192, 0, "1"),
+            # Apostrophes in a model name and an API key: the batch INSERT
+            # builders embed these as literals, so both dialects must escape.
+            (T2, "LM-Studio", "chat", "weird" + APOS + "name", "sk-b" + APOS + "b", "", 8192, 0, "1"),
+        ],
+    ),
+    "tenant": (
+        ["id", "llm_id", "embd_id", "asr_id", "img2txt_id", "rerank_id", "tts_id"],
+        [
+            (T1, "gpt-4o@OpenAI", "text-embedding-3-large@OpenAI", "", "", "rerank-1@OpenAI", ""),
+            (T2, "qwen3:8b@Ollama", "bge-m3@Ollama", "", "", "", ""),
+        ],
+    ),
+    "knowledgebase": (
+        ["id", "tenant_id", "embd_id", "parser_config"],
+        [
+            ("kb001", T1, "text-embedding-3-large@OpenAI", json.dumps({"raptor": {"use_raptor": False}})),
+            ("kb002", T2, "bge-m3@Ollama", json.dumps({})),
+        ],
+    ),
+    "dialog": (
+        ["id", "tenant_id", "llm_id", "rerank_id"],
+        [("dlg01", T1, "gpt-4o@OpenAI", "rerank-1@OpenAI")],
+    ),
+}
+
+# Compared by value. Generated ids are excluded because they are UUIDs that
+# differ per run by design; they are checked for presence instead, below.
+COMPARED_TABLES = [
+    ("tenant_model_provider", ["provider_name", "tenant_id"]),
+    ("tenant_model_instance", ["instance_name", "api_key", "status", "extra"]),
+    ("tenant_model", ["model_name", "model_type", "status", "extra"]),
+    ("tenant", ["id", "llm_id", "embd_id", "rerank_id"]),
+    ("knowledgebase", ["id", "embd_id", "parser_config"]),
+    ("dialog", ["id", "llm_id", "rerank_id"]),
+    ("system_settings", ["name", "value"]),
+]
+
+# Columns holding references to generated ids: compared as set-or-not.
+RESOLVED_REFERENCE_COLUMNS = [
+    ("tenant", ["tenant_llm_id", "tenant_embd_id"]),
+    ("knowledgebase", ["tenant_embd_id"]),
+    ("dialog", ["tenant_llm_id", "tenant_rerank_id"]),
+]
+
+
+def _config_from_dsn(dsn: str, db_type: str) -> mm.MigrationConfig:
+    parsed = urlparse(dsn)
+    return mm.MigrationConfig(
+        host=parsed.hostname or "127.0.0.1",
+        port=parsed.port,
+        user=parsed.username or "root",
+        password=parsed.password or "",
+        database=(parsed.path or "/rag_flow").lstrip("/"),
+        db_type=db_type,
+    )
+
+
+def _reset_and_seed(db: mm.MigrationDatabase):
+    d = db.dialect
+    created = [spec[0] for spec in LEGACY_TABLES] + [
+        "tenant_model_provider",
+        "tenant_model_instance",
+        "tenant_model",
+        "tenant_model_merge_tmp",
+        "tenant_model_backup",
+    ]
+    for table in created:
+        db.execute_sql(f"DROP TABLE IF EXISTS {d.quote(table)}")
+
+    for table, columns, key in LEGACY_TABLES:
+        parts = []
+        if key == "serial":
+            serial = "BIGINT AUTO_INCREMENT PRIMARY KEY" if d.name == MYSQL else "BIGSERIAL PRIMARY KEY"
+            parts.append(f"{d.quote('id')} {serial}")
+        for name, logical_type, extra in columns:
+            piece = f"{d.quote(name)} {d.render_type(logical_type)}"
+            if extra:
+                piece += f" {extra}"
+            parts.append(piece)
+        if key and key != "serial":
+            parts.append(f"PRIMARY KEY ({d.quote(key)})")
+        db.execute_sql(f"CREATE TABLE {d.quote(table)} (" + ", ".join(parts) + ")" + d.table_options())
+
+    for table, (columns, rows) in SEED_ROWS.items():
+        collist = ", ".join(d.quote(c) for c in columns)
+        marks = ", ".join(["%s"] * len(columns))
+        for row in rows:
+            db.execute_sql(f"INSERT INTO {d.quote(table)} ({collist}) VALUES ({marks})", row)
+    db.db.commit()
+
+
+def _snapshot(db: mm.MigrationDatabase) -> dict:
+    d = db.dialect
+    out = {}
+    for table, columns in COMPARED_TABLES:
+        if not db.table_exists(table):
+            out[table] = "MISSING"
+            continue
+        collist = ", ".join(d.quote(c) for c in columns)
+        cursor = db.execute_sql(f"SELECT {collist} FROM {d.quote(table)} ORDER BY {collist}")
+        out[table] = [tuple("" if v is None else str(v) for v in row) for row in cursor.fetchall()]
+
+    for table, columns in RESOLVED_REFERENCE_COLUMNS:
+        for column in columns:
+            key = f"{table}.{column}"
+            if not db.column_exists(table, column):
+                out[key] = "COLUMN MISSING"
+                continue
+            col = d.quote(column)
+            cursor = db.execute_sql(f"SELECT {d.quote('id')}, ({col} IS NOT NULL AND {col} <> '') FROM {d.quote(table)} ORDER BY {d.quote('id')}")
+            out[key] = [(str(row[0]), bool(row[1])) for row in cursor.fetchall()]
+    return out
+
+
+def _migrate(config: mm.MigrationConfig, boots: int = 1) -> dict:
+    db = mm.MigrationDatabase(config)
+    db.connect()
+    _reset_and_seed(db)
+    db.close()
+
+    for _ in range(boots):
+        for stages, version in MIGRATION_STEPS:
+            mm.run_migration(
+                config,
+                stages=stages,
+                dry_run=False,
+                database_version=version,
+                mark_database_version_on_success=True,
+            )
+
+    db = mm.MigrationDatabase(config)
+    db.connect()
+    try:
+        return _snapshot(db)
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module")
+def mysql_config():
+    return _config_from_dsn(MYSQL_DSN, MYSQL)
+
+
+@pytest.fixture(scope="module")
+def postgres_config():
+    return _config_from_dsn(POSTGRES_DSN, POSTGRES)
+
+
+def test_postgres_and_mysql_migrate_to_the_same_state(mysql_config, postgres_config):
+    mysql_state = _migrate(mysql_config)
+    postgres_state = _migrate(postgres_config)
+
+    assert set(postgres_state) == set(mysql_state)
+    for key in sorted(mysql_state):
+        assert postgres_state[key] == mysql_state[key], f"dialects disagree on {key}"
+
+
+def test_postgres_and_mysql_agree_after_a_second_boot(mysql_config, postgres_config):
+    # run_migrations.sh runs on every container start. The version marker is
+    # what makes the second run a no-op, so a second boot must not change or
+    # duplicate anything, on either dialect.
+    mysql_state = _migrate(mysql_config, boots=2)
+    postgres_state = _migrate(postgres_config, boots=2)
+
+    for key in sorted(mysql_state):
+        assert postgres_state[key] == mysql_state[key], f"dialects disagree on {key} after re-run"
+
+
+def test_legacy_identifiers_are_rewritten_and_resolvable(postgres_config):
+    state = _migrate(postgres_config)
+
+    # The migration normalises model@provider to model@instance@provider, which
+    # is what the application's name-based resolution path expects.
+    assert ("kb001", "text-embedding-3-large@default@OpenAI", '{"raptor": {"use_raptor": false}}') in state["knowledgebase"]
+    assert state["system_settings"] == [("mysql_migration.database.version", "v0.27.0")]
+
+    # An apostrophe in a model name must survive as data, not break the INSERT.
+    assert any(row[0] == "weird" + APOS + "name" for row in state["tenant_model"])
+
+    # tenant_embd_id starts out INTEGER and has to end up holding a 32-char id.
+    assert dict(state["knowledgebase.tenant_embd_id"])["kb001"] is True

--- a/test/unit_test/api/db/test_gaussdb_adaptation_points.py
+++ b/test/unit_test/api/db/test_gaussdb_adaptation_points.py
@@ -390,8 +390,8 @@ def test_docker_launch_scripts_skip_mysql_migration_for_gaussdb():
 
     assert 'DB_TYPE_NORMALIZED="${DB_TYPE:-mysql}"' in entrypoint
     assert 'if [[ "${DB_TYPE_NORMALIZED}" == "gaussdb" || "${DB_TYPE_NORMALIZED}" == "gauss" ]]; then' in entrypoint
-    assert "Skipping MySQL-specific model provider table migrations" in entrypoint
+    assert "Skipping model provider table migrations" in entrypoint
 
     assert 'local db_type="${DB_TYPE:-mysql}"' in launcher
     assert 'if [ "$db_type" = "gaussdb" ] || [ "$db_type" = "gauss" ]; then' in launcher
-    assert "Skipping MySQL-specific model provider table migrations" in launcher
+    assert "Skipping model provider table migrations" in launcher

--- a/test/unit_test/tools/test_migration_dialects.py
+++ b/test/unit_test/tools/test_migration_dialects.py
@@ -28,6 +28,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "tools", "scripts"))
 
 from migration_dialects import (
+    CONNECT_OPTION_KEYS,
     MYSQL,
     POSTGRES,
     Column,
@@ -194,3 +195,127 @@ def test_catalog_scope_is_the_database_on_mysql_and_the_schema_on_postgres():
     # information_schema.table_schema means the namespace in PostgreSQL, so
     # filtering by database name would match nothing.
     assert PostgresDialect().catalog_scope(Config()) == "public"
+
+
+class _RecordingDB:
+    def __init__(self):
+        self.statements = []
+
+    def execute_sql(self, sql, params=None):
+        self.statements.append(sql)
+
+
+class _Config:
+    def __init__(self, schema="public"):
+        self.schema = schema
+        self.database = "rag_flow"
+
+
+def test_mysql_session_needs_no_preparation():
+    db = _RecordingDB()
+    MySQLDialect().prepare_session(db, _Config())
+    assert db.statements == []
+
+
+@pytest.mark.parametrize("schema", ["public", "ragflow", "Mixed_Case"])
+def test_postgres_binds_the_session_to_the_configured_schema(schema):
+    """Catalog lookups scope to config.schema, so unqualified DDL must land there
+    too - otherwise a non-public deployment inspects one namespace and writes
+    to another."""
+    db = _RecordingDB()
+    PostgresDialect().prepare_session(db, _Config(schema))
+    assert db.statements == [f'SET search_path TO "{schema}"']
+
+
+def test_postgres_search_path_rejects_a_quoted_schema_name():
+    with pytest.raises(ValueError):
+        PostgresDialect().prepare_session(_RecordingDB(), _Config('pub"lic'))
+
+
+def test_connection_options_cover_each_driver_tls_settings():
+    assert "sslmode" in CONNECT_OPTION_KEYS[POSTGRES]
+    assert "sslrootcert" in CONNECT_OPTION_KEYS[POSTGRES]
+    assert "ssl_ca" in CONNECT_OPTION_KEYS[MYSQL]
+
+
+# --- config-block selection ------------------------------------------------
+
+
+def _write_conf(tmp_path, text):
+    path = tmp_path / "service_conf.yaml"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+def _load(monkeypatch, tmp_path, text, db_type):
+    import mysql_migration
+
+    monkeypatch.setenv("DB_TYPE", db_type)
+    return mysql_migration.MigrationConfig.from_config_file(_write_conf(tmp_path, text))
+
+
+MYSQL_BLOCK = "mysql:\n  host: mysql-host\n  port: 3306\n  name: rag_flow\n"
+PG_BLOCK = "postgres:\n  host: pg-host\n  port: 5432\n  name: rag_flow\n  sslmode: verify-full\n"
+
+
+def test_postgres_reads_its_own_block(monkeypatch, tmp_path):
+    cfg = _load(monkeypatch, tmp_path, MYSQL_BLOCK + PG_BLOCK, "postgres")
+    assert (cfg.db_type, cfg.host, cfg.port) == (POSTGRES, "pg-host", 5432)
+
+
+def test_postgres_never_falls_back_to_the_mysql_block(monkeypatch, tmp_path):
+    """The dangerous case: `postgres:` still commented out in service_conf.yaml.
+    Reading `mysql:` would point --execute at a different server."""
+    with pytest.raises(KeyError):
+        _load(monkeypatch, tmp_path, MYSQL_BLOCK, "postgres")
+
+
+def test_mysql_keeps_the_legacy_block_lookup(monkeypatch, tmp_path):
+    cfg = _load(monkeypatch, tmp_path, "database:\n  host: legacy-host\n  name: rag_flow\n", "mysql")
+    assert (cfg.db_type, cfg.host) == (MYSQL, "legacy-host")
+
+
+def test_missing_config_file_is_not_swallowed_into_defaults(monkeypatch, tmp_path):
+    import mysql_migration
+
+    monkeypatch.setenv("DB_TYPE", "postgres")
+    with pytest.raises(OSError):
+        mysql_migration.MigrationConfig.from_config_file(str(tmp_path / "nope.yaml"))
+
+
+def test_tls_settings_are_carried_over_from_the_config_block(monkeypatch, tmp_path):
+    cfg = _load(monkeypatch, tmp_path, PG_BLOCK, "postgres")
+    assert cfg.connect_options == {"sslmode": "verify-full"}
+
+
+def test_unknown_block_keys_are_not_forwarded_to_the_driver(monkeypatch, tmp_path):
+    cfg = _load(monkeypatch, tmp_path, PG_BLOCK + "  max_connections: 100\n  stale_timeout: 30\n", "postgres")
+    assert "max_connections" not in cfg.connect_options
+    assert "stale_timeout" not in cfg.connect_options
+
+
+# --- information_schema type normalization ---------------------------------
+
+
+@pytest.mark.parametrize(
+    ("reported", "expected"),
+    [("integer", "int"), ("INTEGER", "int"), ("int", "int"), ("bigint", "bigint"), ("character varying", "character varying")],
+)
+def test_column_type_is_normalized_to_the_mysql_spelling(reported, expected):
+    """PostgreSQL reports INT as "integer". The merge/seeding stages compare
+    against "int", and missing that makes them run again on an already-migrated
+    table - the merge then re-maps ints through a string-keyed lookup and writes
+    model_type=0."""
+    import mysql_migration
+
+    class _Cursor:
+        @staticmethod
+        def fetchone():
+            return (reported,)
+
+    db = mysql_migration.MigrationDatabase.__new__(mysql_migration.MigrationDatabase)
+    db.config = _Config()
+    db.dialect = PostgresDialect()
+    db.execute_sql = lambda *_a, **_k: _Cursor()
+
+    assert db.get_column_type("tenant_model", "model_type") == expected

--- a/test/unit_test/tools/test_migration_dialects.py
+++ b/test/unit_test/tools/test_migration_dialects.py
@@ -1,0 +1,196 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Per-dialect rendering tests for the model provider migration.
+
+These assert the SQL each dialect emits, so a regression in one dialect cannot
+hide behind the other. End-to-end equivalence against live servers lives in
+test/integration/test_model_provider_migration_dialects.py.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "tools", "scripts"))
+
+from migration_dialects import (
+    MYSQL,
+    POSTGRES,
+    Column,
+    Index,
+    MySQLDialect,
+    PostgresDialect,
+    TableSpec,
+    get_dialect,
+    normalize_db_type,
+)
+
+SPEC = TableSpec(
+    name="tenant_model_provider",
+    columns=[
+        Column("id", "VARCHAR(32)", null=False, primary_key=True),
+        Column("provider_name", "VARCHAR(128)", null=False),
+        Column("status", "VARCHAR(32)", default="'active'"),
+        Column("model_type", "INT", null=False),
+        Column("create_date", "TIMESTAMP"),
+    ],
+    indexes=[
+        Index("idx_provider_name", ["provider_name"]),
+        Index("idx_tenant_provider_unique", ["tenant_id", "provider_name"], unique=True),
+    ],
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("mysql", MYSQL),
+        ("MySQL", MYSQL),
+        ("  mariadb ", MYSQL),
+        ("oceanbase", MYSQL),
+        ("postgres", POSTGRES),
+        ("PostgreSQL", POSTGRES),
+        ("serenedb", POSTGRES),
+        # Anything unrecognised keeps the behaviour this script had before
+        # PostgreSQL support existed, rather than raising at import time.
+        ("gaussdb", MYSQL),
+        (None, MYSQL),
+        ("", MYSQL),
+    ],
+)
+def test_normalize_db_type(raw, expected):
+    assert normalize_db_type(raw) == expected
+
+
+def test_get_dialect_returns_matching_implementation():
+    assert isinstance(get_dialect("postgres"), PostgresDialect)
+    assert isinstance(get_dialect("mysql"), MySQLDialect)
+
+
+def test_quoting_is_dialect_specific():
+    assert MySQLDialect().quote("value") == "`value`"
+    assert PostgresDialect().quote("value") == '"value"'
+
+
+@pytest.mark.parametrize("dialect", [MySQLDialect(), PostgresDialect()])
+def test_quote_rejects_its_own_quote_character(dialect):
+    # Identifiers are fixed schema names, so a quote character means a caller
+    # bug. Failing loudly beats emitting SQL that silently means something else.
+    with pytest.raises(ValueError):
+        dialect.quote(f"a{dialect.quote_char}b")
+
+
+def test_type_mapping_keeps_length_suffix():
+    assert MySQLDialect().render_type("VARCHAR(32)") == "VARCHAR(32)"
+    assert PostgresDialect().render_type("VARCHAR(32)") == "VARCHAR(32)"
+    # Only the base name is mapped.
+    assert MySQLDialect().render_type("TIMESTAMP") == "DATETIME"
+    assert PostgresDialect().render_type("TIMESTAMP") == "TIMESTAMP"
+    assert MySQLDialect().render_type("INT") == "INT"
+    assert PostgresDialect().render_type("INT") == "INTEGER"
+
+
+def test_mysql_creates_table_with_inline_indexes():
+    statements = MySQLDialect().create_table_statements(SPEC)
+
+    assert len(statements) == 1, "MySQL declares indexes inside CREATE TABLE"
+    sql = statements[0]
+    assert "CREATE TABLE IF NOT EXISTS `tenant_model_provider`" in sql
+    assert "`id` VARCHAR(32) NOT NULL PRIMARY KEY" in sql
+    assert "`status` VARCHAR(32) DEFAULT 'active'" in sql
+    assert "`create_date` DATETIME" in sql
+    assert "INDEX `idx_provider_name` (`provider_name`)" in sql
+    assert "UNIQUE INDEX `idx_tenant_provider_unique` (`tenant_id`, `provider_name`)" in sql
+    assert sql.endswith("ENGINE=InnoDB DEFAULT CHARSET=utf8mb4")
+
+
+def test_postgres_creates_table_then_indexes_separately():
+    statements = PostgresDialect().create_table_statements(SPEC)
+
+    # PostgreSQL has no inline index syntax, so each index is its own statement.
+    assert len(statements) == 3
+    create, *indexes = statements
+    assert 'CREATE TABLE IF NOT EXISTS "tenant_model_provider"' in create
+    assert '"create_date" TIMESTAMP' in create
+    assert '"model_type" INTEGER NOT NULL' in create
+    assert "ENGINE" not in create and "CHARSET" not in create
+    assert "INDEX" not in create
+
+    assert indexes[0] == 'CREATE INDEX IF NOT EXISTS "idx_provider_name" ON "tenant_model_provider" ("provider_name")'
+    assert indexes[1] == 'CREATE UNIQUE INDEX IF NOT EXISTS "idx_tenant_provider_unique" ON "tenant_model_provider" ("tenant_id", "provider_name")'
+
+
+@pytest.mark.parametrize("dialect", [MySQLDialect(), PostgresDialect()])
+def test_create_table_statements_are_all_idempotent(dialect):
+    # run_migrations.sh can be re-entered on any container boot, so every
+    # statement has to tolerate the objects already existing.
+    for sql in dialect.create_table_statements(SPEC):
+        assert "IF NOT EXISTS" in sql
+
+
+def test_epoch_conversion_is_dialect_specific():
+    assert MySQLDialect().epoch_to_timestamp("%s") == "FROM_UNIXTIME(%s)"
+    assert PostgresDialect().epoch_to_timestamp("%s") == "to_timestamp(%s)"
+
+
+def test_upsert_uses_each_dialect_own_conflict_clause():
+    mysql_sql = MySQLDialect().upsert_system_setting_sql()
+    assert "ON DUPLICATE KEY UPDATE" in mysql_sql
+    assert "VALUES(`value`)" in mysql_sql
+
+    pg_sql = PostgresDialect().upsert_system_setting_sql()
+    assert 'ON CONFLICT ("name") DO UPDATE SET' in pg_sql
+    assert 'EXCLUDED."value"' in pg_sql
+    assert "ON DUPLICATE KEY" not in pg_sql
+
+    # Both take the same eight bind parameters, so callers stay dialect-blind.
+    assert mysql_sql.count("%s") == pg_sql.count("%s") == 8
+
+
+def test_surrogate_id_column_is_unique_and_backfilled():
+    (mysql_sql,) = MySQLDialect().add_surrogate_id_statements("tenant_llm", "id")
+    assert mysql_sql == "ALTER TABLE `tenant_llm` ADD COLUMN `id` BIGINT AUTO_INCREMENT UNIQUE"
+
+    pg_statements = PostgresDialect().add_surrogate_id_statements("tenant_llm", "id")
+    # BIGSERIAL back-fills existing rows; PostgreSQL needs the UNIQUE
+    # constraint as a second statement rather than a column modifier.
+    assert pg_statements == [
+        'ALTER TABLE "tenant_llm" ADD COLUMN "id" BIGSERIAL',
+        'ALTER TABLE "tenant_llm" ADD CONSTRAINT "tenant_llm_id_key" UNIQUE ("id")',
+    ]
+
+
+def test_relaxing_a_column_splits_into_type_and_nullability_on_postgres():
+    (mysql_sql,) = MySQLDialect().relax_to_nullable_varchar_statements("tenant", "tenant_llm_id", 32)
+    assert mysql_sql == "ALTER TABLE `tenant` MODIFY COLUMN `tenant_llm_id` VARCHAR(32) NULL"
+
+    pg_statements = PostgresDialect().relax_to_nullable_varchar_statements("tenant", "tenant_llm_id", 32)
+    assert len(pg_statements) == 2
+    # The USING cast is required: these columns start out INTEGER.
+    assert "TYPE VARCHAR(32) USING" in pg_statements[0]
+    assert pg_statements[1].endswith("DROP NOT NULL")
+
+
+def test_catalog_scope_is_the_database_on_mysql_and_the_schema_on_postgres():
+    class Config:
+        database = "rag_flow"
+        schema = "public"
+
+    assert MySQLDialect().catalog_scope(Config()) == "rag_flow"
+    # information_schema.table_schema means the namespace in PostgreSQL, so
+    # filtering by database name would match nothing.
+    assert PostgresDialect().catalog_scope(Config()) == "public"

--- a/tools/scripts/migration_dialects.py
+++ b/tools/scripts/migration_dialects.py
@@ -1,0 +1,334 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""SQL dialect adapters for the model provider migration.
+
+The migration itself is dialect-agnostic Python: it reads rows, rewrites model
+identifiers, and writes rows back. Only a small, enumerable set of statements
+is dialect-specific — identifier quoting, catalog lookups, upserts, epoch-to-
+timestamp conversion, and DDL. Those live here so the stage classes can stay
+declarative and so each dialect's rendering is unit-testable without a server.
+
+Adding a dialect means implementing one subclass, not touching the stages.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from peewee import MySQLDatabase, PostgresqlDatabase
+from playhouse.migrate import MySQLMigrator, PostgresqlMigrator
+
+MYSQL = "mysql"
+POSTGRES = "postgres"
+
+# DB_TYPE values that are wire-compatible with a dialect we already implement.
+# OceanBase speaks the MySQL protocol; SereneDB speaks the PostgreSQL one.
+DB_TYPE_ALIASES: dict[str, str] = {
+    "mysql": MYSQL,
+    "mariadb": MYSQL,
+    "oceanbase": MYSQL,
+    "postgres": POSTGRES,
+    "postgresql": POSTGRES,
+    "serenedb": POSTGRES,
+}
+
+DEFAULT_PORTS = {MYSQL: 3306, POSTGRES: 5432}
+
+
+def normalize_db_type(db_type: str | None) -> str:
+    """Map a DB_TYPE / service_conf key onto a dialect name.
+
+    Unknown values fall back to MySQL, preserving the behaviour this script had
+    before PostgreSQL support existed.
+    """
+    if not db_type:
+        return MYSQL
+    return DB_TYPE_ALIASES.get(db_type.strip().lower(), MYSQL)
+
+
+@dataclass
+class Column:
+    """One column in a table this migration creates."""
+
+    name: str
+    type: str  # logical type; see SqlDialect.render_type
+    null: bool = True
+    default: str | None = None  # rendered verbatim, so quote string literals
+    primary_key: bool = False
+
+
+@dataclass
+class Index:
+    """One index on a table this migration creates."""
+
+    name: str
+    columns: list[str]
+    unique: bool = False
+
+
+@dataclass
+class TableSpec:
+    """A table this migration creates, described once for every dialect."""
+
+    name: str
+    columns: list[Column]
+    indexes: list[Index] = field(default_factory=list)
+
+
+class SqlDialect:
+    """Renders the dialect-specific statements the migration needs."""
+
+    name: str = ""
+    quote_char: str = '"'
+    # Logical type -> physical type. Only types this migration actually uses.
+    type_map: ClassVar[dict[str, str]] = {}
+
+    def make_database(self, config):
+        raise NotImplementedError
+
+    def make_migrator(self, db):
+        raise NotImplementedError
+
+    # --- identifiers -----------------------------------------------------
+
+    def quote(self, identifier: str) -> str:
+        """Quote one identifier.
+
+        Rejects the quote character instead of escaping it: every identifier
+        this migration touches is a fixed table or column name from the schema,
+        so a quote character in one means a caller bug, not user input.
+        """
+        if self.quote_char in identifier:
+            raise ValueError(f"Refusing to quote identifier containing {self.quote_char!r}: {identifier!r}")
+        return f"{self.quote_char}{identifier}{self.quote_char}"
+
+    # --- catalog ---------------------------------------------------------
+
+    def catalog_scope(self, config) -> str:
+        """Value to compare against information_schema.*.table_schema.
+
+        MySQL's table_schema is the database; PostgreSQL's is the namespace.
+        """
+        raise NotImplementedError
+
+    # --- expressions -----------------------------------------------------
+
+    def epoch_to_timestamp(self, seconds_expr: str) -> str:
+        """Wrap an epoch-seconds expression so it lands in a timestamp column."""
+        raise NotImplementedError
+
+    def upsert_system_setting_sql(self) -> str:
+        """INSERT ... ON CONFLICT/DUPLICATE for the migration version marker.
+
+        Takes eight parameters: name, source, data_type, value, create_time,
+        create_date (epoch seconds), update_time, update_date (epoch seconds).
+        """
+        raise NotImplementedError
+
+    # --- DDL -------------------------------------------------------------
+
+    def render_type(self, logical_type: str) -> str:
+        """Map a logical type onto this dialect, keeping any length suffix.
+
+        "VARCHAR(32)" is looked up as VARCHAR and re-rendered with its "(32)",
+        so specs stay readable and only the base name needs a mapping.
+        """
+        base, _, rest = logical_type.partition("(")
+        mapped = self.type_map.get(base.strip().upper(), base.strip())
+        return f"{mapped}({rest}" if rest else mapped
+
+    def table_options(self) -> str:
+        return ""
+
+    def supports_inline_index(self) -> bool:
+        """Whether CREATE TABLE accepts index definitions in the column list."""
+        raise NotImplementedError
+
+    def create_table_statements(self, spec: TableSpec) -> list[str]:
+        """Render CREATE TABLE (+ CREATE INDEX where indexes can't be inline).
+
+        Always idempotent: every statement carries IF NOT EXISTS, so a partially
+        completed migration can be re-run.
+        """
+        parts = []
+        for col in spec.columns:
+            piece = f"{self.quote(col.name)} {self.render_type(col.type)}"
+            if not col.null:
+                piece += " NOT NULL"
+            if col.default is not None:
+                piece += f" DEFAULT {col.default}"
+            if col.primary_key:
+                piece += " PRIMARY KEY"
+            parts.append(piece)
+
+        statements = []
+        if self.supports_inline_index():
+            for idx in spec.indexes:
+                cols = ", ".join(self.quote(c) for c in idx.columns)
+                kind = "UNIQUE INDEX" if idx.unique else "INDEX"
+                parts.append(f"{kind} {self.quote(idx.name)} ({cols})")
+        body = ",\n    ".join(parts)
+        statements.append(f"CREATE TABLE IF NOT EXISTS {self.quote(spec.name)} (\n    {body}\n){self.table_options()}")
+
+        if not self.supports_inline_index():
+            for idx in spec.indexes:
+                cols = ", ".join(self.quote(c) for c in idx.columns)
+                kind = "CREATE UNIQUE INDEX" if idx.unique else "CREATE INDEX"
+                statements.append(f"{kind} IF NOT EXISTS {self.quote(idx.name)} ON {self.quote(spec.name)} ({cols})")
+        return statements
+
+    def add_surrogate_id_statements(self, table: str, column: str) -> list[str]:
+        """Add a unique auto-incrementing column, back-filling existing rows.
+
+        UNIQUE rather than PRIMARY KEY: the tables this runs against are old
+        enough to predate the column but may already have a primary key.
+        """
+        raise NotImplementedError
+
+    def relax_to_nullable_varchar_statements(self, table: str, column: str, length: int) -> list[str]:
+        """Widen a column to a nullable VARCHAR(length), whatever it was before."""
+        raise NotImplementedError
+
+
+class MySQLDialect(SqlDialect):
+    name = MYSQL
+    quote_char = "`"
+    type_map: ClassVar[dict[str, str]] = {
+        "VARCHAR": "VARCHAR",
+        "TEXT": "TEXT",
+        "INT": "INT",
+        "BIGINT": "BIGINT",
+        "TIMESTAMP": "DATETIME",
+    }
+
+    def make_database(self, config):
+        return MySQLDatabase(
+            config.database,
+            host=config.host,
+            port=config.port,
+            user=config.user,
+            password=config.password,
+            charset="utf8mb4",
+        )
+
+    def make_migrator(self, db):
+        return MySQLMigrator(db)
+
+    def catalog_scope(self, config) -> str:
+        return config.database
+
+    def epoch_to_timestamp(self, seconds_expr: str) -> str:
+        return f"FROM_UNIXTIME({seconds_expr})"
+
+    def upsert_system_setting_sql(self) -> str:
+        return """
+        INSERT INTO `system_settings`
+        (`name`, `source`, `data_type`, `value`, `create_time`, `create_date`, `update_time`, `update_date`)
+        VALUES (%s, %s, %s, %s, %s, FROM_UNIXTIME(%s), %s, FROM_UNIXTIME(%s))
+        ON DUPLICATE KEY UPDATE
+          `source` = VALUES(`source`),
+          `data_type` = VALUES(`data_type`),
+          `value` = VALUES(`value`),
+          `update_time` = VALUES(`update_time`),
+          `update_date` = VALUES(`update_date`)
+        """
+
+    def table_options(self) -> str:
+        return " ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+
+    def supports_inline_index(self) -> bool:
+        return True
+
+    def add_surrogate_id_statements(self, table: str, column: str) -> list[str]:
+        # MySQL back-fills existing rows with sequential values automatically.
+        return [f"ALTER TABLE {self.quote(table)} ADD COLUMN {self.quote(column)} BIGINT AUTO_INCREMENT UNIQUE"]
+
+    def relax_to_nullable_varchar_statements(self, table: str, column: str, length: int) -> list[str]:
+        return [f"ALTER TABLE {self.quote(table)} MODIFY COLUMN {self.quote(column)} VARCHAR({length}) NULL"]
+
+
+class PostgresDialect(SqlDialect):
+    name = POSTGRES
+    quote_char = '"'
+    type_map: ClassVar[dict[str, str]] = {
+        "VARCHAR": "VARCHAR",
+        "TEXT": "TEXT",
+        "INT": "INTEGER",
+        "BIGINT": "BIGINT",
+        "TIMESTAMP": "TIMESTAMP",
+    }
+
+    def make_database(self, config):
+        return PostgresqlDatabase(
+            config.database,
+            host=config.host,
+            port=config.port,
+            user=config.user,
+            password=config.password,
+        )
+
+    def make_migrator(self, db):
+        return PostgresqlMigrator(db)
+
+    def catalog_scope(self, config) -> str:
+        # information_schema.table_schema is the namespace, not the database.
+        return config.schema
+
+    def epoch_to_timestamp(self, seconds_expr: str) -> str:
+        return f"to_timestamp({seconds_expr})"
+
+    def upsert_system_setting_sql(self) -> str:
+        # ON CONFLICT needs a unique constraint on "name". system_settings is
+        # created by peewee from db_models.SystemSettings, where name is the
+        # primary key, so the inference target is always present.
+        return """
+        INSERT INTO "system_settings"
+        ("name", "source", "data_type", "value", "create_time", "create_date", "update_time", "update_date")
+        VALUES (%s, %s, %s, %s, %s, to_timestamp(%s), %s, to_timestamp(%s))
+        ON CONFLICT ("name") DO UPDATE SET
+          "source" = EXCLUDED."source",
+          "data_type" = EXCLUDED."data_type",
+          "value" = EXCLUDED."value",
+          "update_time" = EXCLUDED."update_time",
+          "update_date" = EXCLUDED."update_date"
+        """
+
+    def supports_inline_index(self) -> bool:
+        return False
+
+    def add_surrogate_id_statements(self, table: str, column: str) -> list[str]:
+        # Adding a BIGSERIAL column rewrites the table and assigns nextval() per
+        # existing row, which is the back-fill MySQL gives us for free.
+        return [
+            f"ALTER TABLE {self.quote(table)} ADD COLUMN {self.quote(column)} BIGSERIAL",
+            f"ALTER TABLE {self.quote(table)} ADD CONSTRAINT {self.quote(f'{table}_{column}_key')} UNIQUE ({self.quote(column)})",
+        ]
+
+    def relax_to_nullable_varchar_statements(self, table: str, column: str, length: int) -> list[str]:
+        # PostgreSQL splits MySQL's MODIFY COLUMN into a type change and a
+        # nullability change, and needs an explicit cast off non-text types.
+        return [
+            f"ALTER TABLE {self.quote(table)} ALTER COLUMN {self.quote(column)} TYPE VARCHAR({length}) USING {self.quote(column)}::VARCHAR({length})",
+            f"ALTER TABLE {self.quote(table)} ALTER COLUMN {self.quote(column)} DROP NOT NULL",
+        ]
+
+
+DIALECTS = {MYSQL: MySQLDialect, POSTGRES: PostgresDialect}
+
+
+def get_dialect(db_type: str | None) -> SqlDialect:
+    return DIALECTS[normalize_db_type(db_type)]()

--- a/tools/scripts/migration_dialects.py
+++ b/tools/scripts/migration_dialects.py
@@ -48,6 +48,16 @@ DB_TYPE_ALIASES: dict[str, str] = {
 
 DEFAULT_PORTS = {MYSQL: 3306, POSTGRES: 5432}
 
+# Connection settings carried over from the deployment's config block, so the
+# migration connects on the same terms as the application (which forwards its
+# whole block to the driver). TLS is not forced here: the application does not
+# require it either, and doing so would break every deployment that does not
+# already run TLS.
+CONNECT_OPTION_KEYS: dict[str, tuple[str, ...]] = {
+    MYSQL: ("ssl_ca", "ssl_cert", "ssl_key", "ssl_verify_cert", "ssl_verify_identity", "connect_timeout"),
+    POSTGRES: ("sslmode", "sslrootcert", "sslcert", "sslkey", "connect_timeout"),
+}
+
 
 def normalize_db_type(db_type: str | None) -> str:
     """Map a DB_TYPE / service_conf key onto a dialect name.
@@ -102,6 +112,9 @@ class SqlDialect:
 
     def make_migrator(self, db):
         raise NotImplementedError
+
+    def prepare_session(self, db, config) -> None:
+        """Configure a freshly opened connection. No-op unless overridden."""
 
     # --- identifiers -----------------------------------------------------
 
@@ -223,6 +236,7 @@ class MySQLDialect(SqlDialect):
             user=config.user,
             password=config.password,
             charset="utf8mb4",
+            **config.connect_options,
         )
 
     def make_migrator(self, db):
@@ -279,10 +293,20 @@ class PostgresDialect(SqlDialect):
             port=config.port,
             user=config.user,
             password=config.password,
+            **config.connect_options,
         )
 
     def make_migrator(self, db):
         return PostgresqlMigrator(db)
+
+    def prepare_session(self, db, config) -> None:
+        """Bind the session to the schema the catalog lookups inspect.
+
+        Unqualified DDL otherwise lands in whatever the server's default
+        search_path resolves to, so a non-public deployment would check one
+        namespace and create tables in another.
+        """
+        db.execute_sql(f"SET search_path TO {self.quote(config.schema)}")
 
     def catalog_scope(self, config) -> str:
         # information_schema.table_schema is the namespace, not the database.

--- a/tools/scripts/mysql_migration.py
+++ b/tools/scripts/mysql_migration.py
@@ -55,7 +55,9 @@ sys.path.insert(0, PROJECT_BASE)
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from migration_dialects import (
+    CONNECT_OPTION_KEYS,
     DEFAULT_PORTS,
+    MYSQL,
     Column,
     Index,
     TableSpec,
@@ -70,6 +72,10 @@ logger = logging.getLogger(__name__)
 
 MIGRATION_DB_VERSION_MARKER = "mysql_migration.database.version"
 
+# information_schema type names normalized to the spelling the stage predicates
+# use. PostgreSQL reports INT as "integer"; MySQL reports "int".
+COLUMN_TYPE_ALIASES = {"integer": "int"}
+
 
 class MigrationConfig:
     """Connection settings for the metadata database being migrated."""
@@ -83,6 +89,7 @@ class MigrationConfig:
         database: str = "rag_flow",
         db_type: str = "mysql",
         schema: str = "public",
+        connect_options: dict | None = None,
     ):
         self.db_type = normalize_db_type(db_type)
         self.host = host
@@ -93,6 +100,9 @@ class MigrationConfig:
         # PostgreSQL only: the namespace holding the tables. Ignored on MySQL,
         # where information_schema.table_schema is the database instead.
         self.schema = schema
+        # TLS and timeout settings carried over from the deployment's own config
+        # block, so the migration connects the way the application does.
+        self.connect_options = connect_options or {}
 
     @classmethod
     def from_config_file(cls, config_path: str) -> "MigrationConfig":
@@ -103,48 +113,50 @@ class MigrationConfig:
         so a deployment with a `postgres:` block and DB_TYPE=postgres is read
         without any migration-specific configuration.
 
-        Falls back to the legacy `database:`/`mysql:` block lookup so existing
-        MySQL deployments keep working unchanged.
+        The legacy `database:`/`mysql:` lookup is kept for MySQL only, because it
+        is what MySQL deployments already have. Any other dialect must have its
+        own block: silently reading the `mysql:` block would point the migration
+        at a different server than the one being migrated.
         """
         raw_db_type = os.getenv("DB_TYPE", "mysql")
         db_type = normalize_db_type(raw_db_type)
-        try:
-            from ruamel.yaml import YAML
 
-            yaml = YAML(typ="safe", pure=True)
+        from ruamel.yaml import YAML
 
-            with open(config_path, "r") as f:
-                config = yaml.load(f) or {}
+        yaml = YAML(typ="safe", pure=True)
 
-            # Prefer the block named by DB_TYPE, then the raw DB_TYPE spelling
-            # (so `serenedb:` or `postgresql:` are found), then the legacy keys.
-            db_config = None
-            for key in (db_type, raw_db_type.strip().lower(), "database", "mysql"):
-                candidate = config.get(key)
-                if isinstance(candidate, dict) and candidate:
-                    db_config = candidate
-                    if key not in (db_type, raw_db_type.strip().lower()):
-                        logger.info("Using legacy '%s' config block for DB_TYPE=%s", key, raw_db_type)
-                    break
+        with open(config_path, "r") as f:
+            config = yaml.load(f) or {}
 
-            if db_config is None:
-                raise KeyError(f"no database config block found for DB_TYPE={raw_db_type} in {config_path}")
+        # The block named by DB_TYPE, then the raw DB_TYPE spelling (so
+        # `serenedb:` or `postgresql:` are found), then - on MySQL only - the
+        # legacy keys, in the order the script used before it knew dialects.
+        keys = [db_type, raw_db_type.strip().lower()]
+        if db_type == MYSQL:
+            keys += ["database", "mysql"]
 
-            return cls(
-                host=db_config.get("host", "localhost"),
-                port=db_config.get("port", DEFAULT_PORTS[db_type]),
-                user=db_config.get("user", "root"),
-                password=db_config.get("password", ""),
-                database=db_config.get("name", db_config.get("database", "rag_flow")),
-                db_type=raw_db_type,
-                schema=db_config.get("schema", "public"),
-            )
-        except Exception as e:
-            # Defaults are MySQL-shaped and almost certainly wrong for any other
-            # dialect, so say which dialect was expected rather than failing
-            # later with a connection refused to port 3306.
-            logger.warning("Failed to load config file %s: %s; falling back to %s defaults", config_path, e, db_type)
-            return cls(db_type=raw_db_type)
+        db_config = None
+        for key in keys:
+            candidate = config.get(key)
+            if isinstance(candidate, dict) and candidate:
+                db_config = candidate
+                break
+
+        if db_config is None:
+            # Falling back to defaults here would migrate whatever happens to be
+            # reachable on localhost, so stop instead.
+            raise KeyError(f"No '{db_type}' database config block found in {config_path} for DB_TYPE={raw_db_type}")
+
+        return cls(
+            host=db_config.get("host", "localhost"),
+            port=db_config.get("port", DEFAULT_PORTS[db_type]),
+            user=db_config.get("user", "root"),
+            password=db_config.get("password", ""),
+            database=db_config.get("name", db_config.get("database", "rag_flow")),
+            db_type=raw_db_type,
+            schema=db_config.get("schema", "public"),
+            connect_options={k: db_config[k] for k in CONNECT_OPTION_KEYS[db_type] if k in db_config},
+        )
 
 
 class MigrationStats:
@@ -199,6 +211,7 @@ class MigrationDatabase:
 
     def connect(self):
         self.db.connect()
+        self.dialect.prepare_session(self.db, self.config)
         logger.info("Connected to %s database: %s", self.dialect.name, self.config.database)
 
     def close(self):
@@ -249,10 +262,16 @@ class MigrationDatabase:
         The column is spelled data_type in lower case: PostgreSQL folds unquoted
         identifiers to lower case, so MySQL's conventional DATA_TYPE would not
         resolve there.
+
+        The type name is normalized to the MySQL spelling the stage predicates
+        compare against - PostgreSQL reports an INT column as "integer", and a
+        stage that misses that runs a second time on an already-migrated table.
         """
         cursor = self.execute_sql("SELECT data_type FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self._catalog_scope, table_name, column_name))
         row = cursor.fetchone()
-        return row[0] if row else None
+        if not row or row[0] is None:
+            return None
+        return COLUMN_TYPE_ALIASES.get(str(row[0]).strip().lower(), row[0])
 
     def get_system_setting_value(self, name: str) -> str | None:
         if not self.table_exists("system_settings"):
@@ -2284,7 +2303,11 @@ Examples:
 
     # Load configuration: command line args take precedence over config file
     if args.config:
-        config = MigrationConfig.from_config_file(args.config)
+        try:
+            config = MigrationConfig.from_config_file(args.config)
+        except Exception as e:
+            logger.error("Cannot load the database configuration: %s", e)
+            sys.exit(1)
         # Override with command line args if provided
         if args.host != "localhost":
             config.host = args.host

--- a/tools/scripts/mysql_migration.py
+++ b/tools/scripts/mysql_migration.py
@@ -14,13 +14,20 @@
 #  limitations under the License.
 #
 """
-MySQL Data Migration Script
+Model provider table migration script.
 
-This script provides a flexible MySQL data migration tool that supports:
-1. MySQL configuration via config file or command line arguments
-2. Direct peewee operations without importing api.db.services
-3. Configurable migration stages via command line
-4. Migration logging with table names, row counts, and duration
+Migrates legacy per-tenant model configuration (tenant_llm) into the model
+provider / instance / model tables, and rewrites the model identifiers that
+reference them.
+
+Supports:
+1. MySQL and PostgreSQL metadata databases, selected by DB_TYPE the same way
+   the application selects it (see common.settings.DATABASE_TYPE); dialect
+   differences live in tools/scripts/migration_dialects.py
+2. Connection settings from a config file or command line arguments
+3. Direct peewee operations without importing api.db.services
+4. Configurable migration stages via command line
+5. Migration logging with table names, row counts, and duration
 """
 
 import argparse
@@ -38,15 +45,23 @@ from peewee import (
     DateTimeField,
     IntegerField,
     Model,
-    MySQLDatabase,
     PrimaryKeyField,
     TextField,
 )
-from playhouse.migrate import MySQLMigrator
 
 # Add project root to path for imports
 PROJECT_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_BASE)
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from migration_dialects import (
+    DEFAULT_PORTS,
+    Column,
+    Index,
+    TableSpec,
+    get_dialect,
+    normalize_db_type,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -57,39 +72,79 @@ MIGRATION_DB_VERSION_MARKER = "mysql_migration.database.version"
 
 
 class MigrationConfig:
-    """Configuration for MySQL connection"""
+    """Connection settings for the metadata database being migrated."""
 
-    def __init__(self, host: str = "localhost", port: int = 3306, user: str = "root", password: str = "", database: str = "rag_flow"):
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int | None = None,
+        user: str = "root",
+        password: str = "",
+        database: str = "rag_flow",
+        db_type: str = "mysql",
+        schema: str = "public",
+    ):
+        self.db_type = normalize_db_type(db_type)
         self.host = host
-        self.port = port
+        self.port = port if port is not None else DEFAULT_PORTS[self.db_type]
         self.user = user
         self.password = password
         self.database = database
+        # PostgreSQL only: the namespace holding the tables. Ignored on MySQL,
+        # where information_schema.table_schema is the database instead.
+        self.schema = schema
 
     @classmethod
     def from_config_file(cls, config_path: str) -> "MigrationConfig":
-        """Load configuration from YAML config file"""
+        """Load connection settings from service_conf.yaml.
+
+        Resolves the config block the same way the application does: DB_TYPE
+        names the block (common.settings reads DB_TYPE, defaulting to mysql),
+        so a deployment with a `postgres:` block and DB_TYPE=postgres is read
+        without any migration-specific configuration.
+
+        Falls back to the legacy `database:`/`mysql:` block lookup so existing
+        MySQL deployments keep working unchanged.
+        """
+        raw_db_type = os.getenv("DB_TYPE", "mysql")
+        db_type = normalize_db_type(raw_db_type)
         try:
             from ruamel.yaml import YAML
 
             yaml = YAML(typ="safe", pure=True)
 
             with open(config_path, "r") as f:
-                config = yaml.load(f)
+                config = yaml.load(f) or {}
 
-            # Try to get database config
-            db_config = config.get("database", config.get("mysql", {}))
+            # Prefer the block named by DB_TYPE, then the raw DB_TYPE spelling
+            # (so `serenedb:` or `postgresql:` are found), then the legacy keys.
+            db_config = None
+            for key in (db_type, raw_db_type.strip().lower(), "database", "mysql"):
+                candidate = config.get(key)
+                if isinstance(candidate, dict) and candidate:
+                    db_config = candidate
+                    if key not in (db_type, raw_db_type.strip().lower()):
+                        logger.info("Using legacy '%s' config block for DB_TYPE=%s", key, raw_db_type)
+                    break
+
+            if db_config is None:
+                raise KeyError(f"no database config block found for DB_TYPE={raw_db_type} in {config_path}")
 
             return cls(
                 host=db_config.get("host", "localhost"),
-                port=db_config.get("port", 3306),
+                port=db_config.get("port", DEFAULT_PORTS[db_type]),
                 user=db_config.get("user", "root"),
                 password=db_config.get("password", ""),
                 database=db_config.get("name", db_config.get("database", "rag_flow")),
+                db_type=raw_db_type,
+                schema=db_config.get("schema", "public"),
             )
         except Exception as e:
-            logger.warning(f"Failed to load config file: {e}, using defaults")
-            return cls()
+            # Defaults are MySQL-shaped and almost certainly wrong for any other
+            # dialect, so say which dialect was expected rather than failing
+            # later with a connection refused to port 3306.
+            logger.warning("Failed to load config file %s: %s; falling back to %s defaults", config_path, e, db_type)
+            return cls(db_type=raw_db_type)
 
 
 class MigrationStats:
@@ -129,16 +184,22 @@ class MigrationStats:
 
 
 class MigrationDatabase:
-    """Database wrapper for migrations"""
+    """Database wrapper for migrations.
+
+    Every dialect-specific statement is delegated to self.dialect, so the stage
+    classes below stay portable and only this file's helpers need to know which
+    database they are talking to.
+    """
 
     def __init__(self, config: MigrationConfig):
         self.config = config
-        self.db = MySQLDatabase(config.database, host=config.host, port=config.port, user=config.user, password=config.password, charset="utf8mb4")
-        self.migrator = MySQLMigrator(self.db)
+        self.dialect = get_dialect(config.db_type)
+        self.db = self.dialect.make_database(config)
+        self.migrator = self.dialect.make_migrator(self.db)
 
     def connect(self):
         self.db.connect()
-        logger.info(f"Connected to MySQL database: {self.config.database}")
+        logger.info("Connected to %s database: %s", self.dialect.name, self.config.database)
 
     def close(self):
         if not self.db.is_closed():
@@ -148,17 +209,48 @@ class MigrationDatabase:
     def execute_sql(self, sql: str, params=None):
         return self.db.execute_sql(sql, params)
 
+    def q(self, identifier: str) -> str:
+        """Quote one identifier for the active dialect."""
+        return self.dialect.quote(identifier)
+
+    def epoch_to_timestamp(self, seconds_expr: str) -> str:
+        """Render an epoch-seconds expression as a timestamp for this dialect."""
+        return self.dialect.epoch_to_timestamp(seconds_expr)
+
+    def create_table(self, spec: TableSpec):
+        """Create a table and its indexes, idempotently."""
+        for statement in self.dialect.create_table_statements(spec):
+            self.execute_sql(statement)
+        logger.info("Created %s table", spec.name)
+
+    def add_surrogate_id(self, table_name: str, column_name: str = "id"):
+        for statement in self.dialect.add_surrogate_id_statements(table_name, column_name):
+            self.execute_sql(statement)
+
+    def relax_to_nullable_varchar(self, table_name: str, column_name: str, length: int):
+        for statement in self.dialect.relax_to_nullable_varchar_statements(table_name, column_name, length):
+            self.execute_sql(statement)
+
+    @property
+    def _catalog_scope(self) -> str:
+        return self.dialect.catalog_scope(self.config)
+
     def table_exists(self, table_name: str) -> bool:
-        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s", (self.config.database, table_name))
+        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s AND table_name = %s", (self._catalog_scope, table_name))
         return cursor.fetchone()[0] > 0
 
     def column_exists(self, table_name: str, column_name: str) -> bool:
-        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self.config.database, table_name, column_name))
+        cursor = self.execute_sql("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self._catalog_scope, table_name, column_name))
         return cursor.fetchone()[0] > 0
 
     def get_column_type(self, table_name: str, column_name: str) -> str | None:
-        """Get the DATA_TYPE of a column from information_schema, returns None if column does not exist"""
-        cursor = self.execute_sql("SELECT DATA_TYPE FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self.config.database, table_name, column_name))
+        """Get the data type of a column from information_schema, or None if it does not exist.
+
+        The column is spelled data_type in lower case: PostgreSQL folds unquoted
+        identifiers to lower case, so MySQL's conventional DATA_TYPE would not
+        resolve there.
+        """
+        cursor = self.execute_sql("SELECT data_type FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s", (self._catalog_scope, table_name, column_name))
         row = cursor.fetchone()
         return row[0] if row else None
 
@@ -167,7 +259,7 @@ class MigrationDatabase:
             logger.info("Table 'system_settings' does not exist, migration marker is unavailable")
             return None
         cursor = self.execute_sql(
-            "SELECT `value` FROM `system_settings` WHERE `name` = %s",
+            f"SELECT {self.q('value')} FROM {self.q('system_settings')} WHERE {self.q('name')} = %s",
             (name,),
         )
         row = cursor.fetchone()
@@ -180,17 +272,7 @@ class MigrationDatabase:
 
         current_ts = int(time.time())
         self.execute_sql(
-            """
-            INSERT INTO `system_settings`
-            (`name`, `source`, `data_type`, `value`, `create_time`, `create_date`, `update_time`, `update_date`)
-            VALUES (%s, %s, %s, %s, %s, FROM_UNIXTIME(%s), %s, FROM_UNIXTIME(%s))
-            ON DUPLICATE KEY UPDATE
-              `source` = VALUES(`source`),
-              `data_type` = VALUES(`data_type`),
-              `value` = VALUES(`value`),
-              `update_time` = VALUES(`update_time`),
-              `update_date` = VALUES(`update_date`)
-            """,
+            self.dialect.upsert_system_setting_sql(),
             (
                 name,
                 source,
@@ -229,6 +311,77 @@ def should_skip_migration(current_db_version: str | None, target_version: str) -
     if current is None or target is None:
         return False
     return current >= target
+
+
+# --- Tables this migration creates ---------------------------------------
+#
+# Described once, rendered per dialect by migration_dialects. The audit columns
+# are identical everywhere, so they are shared rather than repeated five times.
+
+
+def _audit_columns() -> list:
+    return [
+        Column("create_time", "BIGINT"),
+        Column("create_date", "TIMESTAMP"),
+        Column("update_time", "BIGINT"),
+        Column("update_date", "TIMESTAMP"),
+    ]
+
+
+TENANT_MODEL_PROVIDER_TABLE = TableSpec(
+    name="tenant_model_provider",
+    columns=[
+        Column("id", "VARCHAR(32)", null=False, primary_key=True),
+        Column("provider_name", "VARCHAR(128)", null=False),
+        Column("tenant_id", "VARCHAR(32)", null=False),
+        *_audit_columns(),
+    ],
+    indexes=[
+        Index("idx_provider_name", ["provider_name"]),
+        Index("idx_tenant_id", ["tenant_id"]),
+        Index("idx_tenant_provider_unique", ["tenant_id", "provider_name"], unique=True),
+    ],
+)
+
+TENANT_MODEL_INSTANCE_TABLE = TableSpec(
+    name="tenant_model_instance",
+    columns=[
+        Column("id", "VARCHAR(32)", null=False, primary_key=True),
+        Column("instance_name", "VARCHAR(128)", null=False),
+        Column("provider_id", "VARCHAR(32)", null=False),
+        Column("api_key", "VARCHAR(512)", null=False),
+        Column("status", "VARCHAR(32)", default="'active'"),
+        Column("extra", "VARCHAR(512)", default="'{}'"),
+        *_audit_columns(),
+    ],
+    indexes=[Index("idx_provider_id", ["provider_id"])],
+)
+
+
+def _tenant_model_table(name: str, model_type: str) -> TableSpec:
+    """tenant_model and its merge scratch table differ only in model_type.
+
+    model_type is VARCHAR in tenant_model and INT in the scratch table, because
+    the merge stage is what converts the type to a bitmask.
+    """
+    return TableSpec(
+        name=name,
+        columns=[
+            Column("id", "VARCHAR(32)", null=False, primary_key=True),
+            Column("model_name", "VARCHAR(128)"),
+            Column("provider_id", "VARCHAR(32)", null=False),
+            Column("instance_id", "VARCHAR(32)", null=False),
+            Column("model_type", model_type, null=False),
+            Column("status", "VARCHAR(32)", default="'active'"),
+            Column("extra", "VARCHAR(1024)", default="'{}'"),
+            *_audit_columns(),
+        ],
+        indexes=[Index("idx_instance_id", ["instance_id"])],
+    )
+
+
+TENANT_MODEL_TABLE = _tenant_model_table("tenant_model", "VARCHAR(32)")
+TENANT_MODEL_MERGE_TMP_TABLE = _tenant_model_table("tenant_model_merge_tmp", "INT")
 
 
 # Define model classes for migration (not importing from api.db.db_models)
@@ -399,7 +552,8 @@ class TenantModelProviderStage(MigrationStage):
             params = []
             for tenant_id, llm_factory in batch:
                 record_id = self.generate_uuid()
-                placeholders.append("(%s, %s, %s, %s, FROM_UNIXTIME(%s), %s, FROM_UNIXTIME(%s))")
+                ts = self.db.epoch_to_timestamp("%s")
+                placeholders.append(f"(%s, %s, %s, %s, {ts}, %s, {ts})")
                 params.extend(
                     [
                         record_id,
@@ -424,22 +578,7 @@ class TenantModelProviderStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model_provider table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_provider (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            provider_name VARCHAR(128) NOT NULL,
-            tenant_id VARCHAR(32) NOT NULL,
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_provider_name (provider_name),
-            INDEX idx_tenant_id (tenant_id),
-            UNIQUE INDEX idx_tenant_provider_unique (tenant_id, provider_name)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
-        logger.info("Created tenant_model_provider table")
+        self.db.create_table(TENANT_MODEL_PROVIDER_TABLE)
 
 
 class TenantModelInstanceStage(MigrationStage):
@@ -506,6 +645,7 @@ class TenantModelInstanceStage(MigrationStage):
     def execute(self) -> tuple[int, list]:
         """Execute migration"""
         current_ts = self.current_timestamp()
+        current_date_sql = self.db.epoch_to_timestamp(str(current_ts))
         rows_inserted = 0
 
         # Check if tenant_model_provider exists (dependency)
@@ -573,10 +713,7 @@ class TenantModelInstanceStage(MigrationStage):
                 api_key_escaped = api_key.replace("'", "''") if api_key else ""
                 status_val = "active" if status in ["1", "active", "enable"] else "inactive"
                 values.append(
-                    f"('{record_id}', '{instance_name}', '{provider_id}', "
-                    f"'{api_key_escaped}', '{status_val}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"('{record_id}', '{instance_name}', '{provider_id}', '{api_key_escaped}', '{status_val}', {current_ts * 1000}, {current_date_sql}, {current_ts * 1000}, {current_date_sql})"
                 )
 
             insert_sql = f"""
@@ -677,23 +814,7 @@ class TenantModelInstanceStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model_instance table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_instance (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            instance_name VARCHAR(128) NOT NULL,
-            provider_id VARCHAR(32) NOT NULL,
-            api_key VARCHAR(512) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(512) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_provider_id (provider_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
-        logger.info("Created tenant_model_instance table")
+        self.db.create_table(TENANT_MODEL_INSTANCE_TABLE)
 
 
 class TenantModelStage(MigrationStage):
@@ -795,6 +916,7 @@ class TenantModelStage(MigrationStage):
     def execute(self) -> tuple[int, list]:
         """Execute migration"""
         current_ts = self.current_timestamp()
+        current_date_sql = self.db.epoch_to_timestamp(str(current_ts))
         rows_inserted = 0
 
         # Check if tenant_model_provider exists (dependency)
@@ -890,8 +1012,8 @@ class TenantModelStage(MigrationStage):
                     f"('{record_id}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', '{model_type_escaped}', '{status_val}', "
                     f"'{extra_escaped}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {current_date_sql}, "
+                    f"{current_ts * 1000}, {current_date_sql})"
                 )
 
             insert_sql = f"""
@@ -911,10 +1033,11 @@ class TenantModelStage(MigrationStage):
 
         Very old tenant_llm tables may predate the id column, while the migration
         SELECT relies on it (tl.id is carried as source_id for audit logging).
-        The id is only used as a unique audit key, so it is added as an
-        AUTO_INCREMENT UNIQUE column rather than PRIMARY KEY: old tables may
-        already have another primary key. MySQL back-fills existing rows with
-        sequential values when adding an AUTO_INCREMENT column.
+        The id is only used as a unique audit key, so it is added as a unique
+        auto-incrementing column rather than a PRIMARY KEY: old tables may
+        already have another primary key. Both supported dialects back-fill
+        existing rows with sequential values (MySQL via AUTO_INCREMENT,
+        PostgreSQL via the table rewrite that adding a BIGSERIAL triggers).
 
         Returns:
             True if the column exists (or was added successfully), False otherwise.
@@ -928,7 +1051,7 @@ class TenantModelStage(MigrationStage):
             return False
 
         try:
-            self.db.execute_sql("ALTER TABLE tenant_llm ADD COLUMN id BIGINT AUTO_INCREMENT UNIQUE")
+            self.db.add_surrogate_id("tenant_llm", "id")
         except Exception as e:
             logger.error(f"Failed to add auto-increment id column to tenant_llm: {e}")
             return False
@@ -1014,24 +1137,7 @@ class TenantModelStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type VARCHAR(32) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
-        logger.info("Created tenant_model table")
+        self.db.create_table(TENANT_MODEL_TABLE)
 
 
 class ModelIdConfigStage(MigrationStage):
@@ -1159,7 +1265,7 @@ class ModelIdConfigStage(MigrationStage):
     def iter_string_changes(self):
         for table_name, column_name in self.existing_columns(self.string_columns):
             cursor = self.db.execute_sql(
-                f"SELECT id, `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL AND `{column_name}` != '' AND `{column_name}` LIKE %s",
+                f"SELECT id, {self.db.q(column_name)} FROM {self.db.q(table_name)} WHERE {self.db.q(column_name)} IS NOT NULL AND {self.db.q(column_name)} != '' AND {self.db.q(column_name)} LIKE %s",
                 ("%@%",),
             )
             while True:
@@ -1174,7 +1280,7 @@ class ModelIdConfigStage(MigrationStage):
     def iter_json_changes(self):
         for table_name, column_name in self.existing_columns(self.json_columns):
             cursor = self.db.execute_sql(
-                f"SELECT id, `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL AND `{column_name}` != '' AND `{column_name}` LIKE %s",
+                f"SELECT id, {self.db.q(column_name)} FROM {self.db.q(table_name)} WHERE {self.db.q(column_name)} IS NOT NULL AND {self.db.q(column_name)} != '' AND {self.db.q(column_name)} LIKE %s",
                 ("%@%",),
             )
             while True:
@@ -1240,7 +1346,7 @@ class ModelIdConfigStage(MigrationStage):
                 )
             if not self.dry_run:
                 self.db.execute_sql(
-                    f"UPDATE `{table_name}` SET `{column_name}` = %s WHERE id = %s",
+                    f"UPDATE {self.db.q(table_name)} SET {self.db.q(column_name)} = %s WHERE id = %s",
                     (normalized, row_id),
                 )
 
@@ -1257,7 +1363,7 @@ class ModelIdConfigStage(MigrationStage):
                 )
             if not self.dry_run:
                 self.db.execute_sql(
-                    f"UPDATE `{table_name}` SET `{column_name}` = %s WHERE id = %s",
+                    f"UPDATE {self.db.q(table_name)} SET {self.db.q(column_name)} = %s WHERE id = %s",
                     (normalized_json, row_id),
                 )
 
@@ -1378,6 +1484,7 @@ class TenantModelSeedingStage(MigrationStage):
     def execute(self) -> tuple[int, list]:
         """Execute migration"""
         current_ts = self.current_timestamp()
+        current_date_sql = self.db.epoch_to_timestamp(str(current_ts))
         rows_inserted = 0
 
         if not self.db.table_exists("tenant_model_provider"):
@@ -1522,8 +1629,8 @@ class TenantModelSeedingStage(MigrationStage):
                     f"('{record_id}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', '{mt_escaped}', '{status_escaped}', "
                     f"'{extra_escaped}', "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}), "
-                    f"{current_ts * 1000}, FROM_UNIXTIME({current_ts}))"
+                    f"{current_ts * 1000}, {current_date_sql}, "
+                    f"{current_ts * 1000}, {current_date_sql})"
                 )
 
             insert_sql = f"""
@@ -1540,24 +1647,7 @@ class TenantModelSeedingStage(MigrationStage):
 
     def create_target_table(self):
         """Create tenant_model table"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type VARCHAR(32) NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
-        logger.info("Created tenant_model table")
+        self.db.create_table(TENANT_MODEL_TABLE)
 
 
 class ModelTypeMergeStage(MigrationStage):
@@ -1692,8 +1782,8 @@ class ModelTypeMergeStage(MigrationStage):
                 # Handle NULL date fields
                 create_time_val = create_time if create_time is not None else current_ts * 1000
                 update_time_val = update_time if update_time is not None else current_ts * 1000
-                create_date_sql = f"FROM_UNIXTIME({int(create_time_val / 1000)})" if create_time_val else "NULL"
-                update_date_sql = f"FROM_UNIXTIME({int(update_time_val / 1000)})" if update_time_val else "NULL"
+                create_date_sql = self.db.epoch_to_timestamp(str(int(create_time_val / 1000))) if create_time_val else "NULL"
+                update_date_sql = self.db.epoch_to_timestamp(str(int(update_time_val / 1000))) if update_time_val else "NULL"
                 values.append(
                     f"('{id_}', '{model_name_escaped}', '{provider_id}', "
                     f"'{instance_id}', {merged_type}, '{status_escaped}', "
@@ -1723,24 +1813,7 @@ class ModelTypeMergeStage(MigrationStage):
 
     def create_target_table(self):
         """Create temporary table tenant_model_merge_tmp with model_type as INTEGER"""
-        create_sql = """
-        CREATE TABLE IF NOT EXISTS tenant_model_merge_tmp (
-            id VARCHAR(32) NOT NULL PRIMARY KEY,
-            model_name VARCHAR(128),
-            provider_id VARCHAR(32) NOT NULL,
-            instance_id VARCHAR(32) NOT NULL,
-            model_type INT NOT NULL,
-            status VARCHAR(32) DEFAULT 'active',
-            extra VARCHAR(1024) DEFAULT '{}',
-            create_time BIGINT,
-            create_date DATETIME,
-            update_time BIGINT,
-            update_date DATETIME,
-            INDEX idx_instance_id (instance_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        """
-        self.db.execute_sql(create_sql)
-        logger.info("Created tenant_model_merge_tmp table")
+        self.db.create_table(TENANT_MODEL_MERGE_TMP_TABLE)
 
 
 class TenantModelIdMigrationStage(MigrationStage):
@@ -1820,7 +1893,9 @@ class TenantModelIdMigrationStage(MigrationStage):
                     has_work = True
                     break
                 # Check if there are NULL values that should be populated
-                cursor = self.db.execute_sql(f"SELECT COUNT(*) FROM `{table_name}` WHERE `{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32")
+                cursor = self.db.execute_sql(
+                    f"SELECT COUNT(*) FROM {self.db.q(table_name)} WHERE {self.db.q(tenant_id_col)} IS NULL OR {self.db.q(tenant_id_col)} = '' OR LENGTH({self.db.q(tenant_id_col)}) <> 32"
+                )
                 null_count = cursor.fetchone()[0]
                 if null_count > 0:
                     has_work = True
@@ -1853,14 +1928,14 @@ class TenantModelIdMigrationStage(MigrationStage):
                     # Column does not exist yet — add it as VARCHAR(32)
                     logger.info(f"Adding column {table_name}.{tenant_id_col} as VARCHAR(32) NULL")
                     if not self.dry_run:
-                        self.db.execute_sql(f"ALTER TABLE `{table_name}` ADD COLUMN `{tenant_id_col}` VARCHAR(32) NULL")
+                        self.db.execute_sql(f"ALTER TABLE {self.db.q(table_name)} ADD COLUMN {self.db.q(tenant_id_col)} VARCHAR(32) NULL")
                     tables_operated.add(table_name)
                     continue
                 col_type = self.db.get_column_type(table_name, tenant_id_col)
                 if col_type and col_type.lower() in ("int", "bigint", "integer"):
                     logger.info(f"Converting {table_name}.{tenant_id_col} from {col_type} to VARCHAR(32)")
                     if not self.dry_run:
-                        self.db.execute_sql(f"ALTER TABLE `{table_name}` MODIFY COLUMN `{tenant_id_col}` VARCHAR(32) NULL")
+                        self.db.relax_to_nullable_varchar(table_name, tenant_id_col, 32)
                     tables_operated.add(table_name)
 
         # Step 2: Build lookup cache from tenant_model joined with provider + instance
@@ -1885,7 +1960,7 @@ class TenantModelIdMigrationStage(MigrationStage):
                 # For knowledgebase, dialog, memory we also need tenant_id
                 if table_name == "tenant":
                     cursor = self.db.execute_sql(
-                        f"SELECT id, `{legacy_col}` FROM `{table_name}` WHERE (`{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32) AND `{legacy_col}` IS NOT NULL AND `{legacy_col}` != ''"
+                        f"SELECT id, {self.db.q(legacy_col)} FROM {self.db.q(table_name)} WHERE ({self.db.q(tenant_id_col)} IS NULL OR {self.db.q(tenant_id_col)} = '' OR LENGTH({self.db.q(tenant_id_col)}) <> 32) AND {self.db.q(legacy_col)} IS NOT NULL AND {self.db.q(legacy_col)} != ''"
                     )
                     while True:
                         rows = cursor.fetchmany(self.scan_batch_size)
@@ -1897,20 +1972,20 @@ class TenantModelIdMigrationStage(MigrationStage):
                             if resolved_id:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = %s WHERE id = %s",
+                                        f"UPDATE {self.db.q(table_name)} SET {self.db.q(tenant_id_col)} = %s WHERE id = %s",
                                         (resolved_id, row_id),
                                     )
                             else:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = '' WHERE id = %s",
+                                        f"UPDATE {self.db.q(table_name)} SET {self.db.q(tenant_id_col)} = '' WHERE id = %s",
                                         (row_id,),
                                     )
                             rows_updated += 1
                             tables_operated.add(table_name)
                 else:
                     cursor = self.db.execute_sql(
-                        f"SELECT id, tenant_id, `{legacy_col}` FROM `{table_name}` WHERE (`{tenant_id_col}` IS NULL OR `{tenant_id_col}` = '' OR LENGTH(`{tenant_id_col}`) <> 32) AND `{legacy_col}` IS NOT NULL AND `{legacy_col}` != ''"
+                        f"SELECT id, tenant_id, {self.db.q(legacy_col)} FROM {self.db.q(table_name)} WHERE ({self.db.q(tenant_id_col)} IS NULL OR {self.db.q(tenant_id_col)} = '' OR LENGTH({self.db.q(tenant_id_col)}) <> 32) AND {self.db.q(legacy_col)} IS NOT NULL AND {self.db.q(legacy_col)} != ''"
                     )
                     while True:
                         rows = cursor.fetchmany(self.scan_batch_size)
@@ -1921,13 +1996,13 @@ class TenantModelIdMigrationStage(MigrationStage):
                             if resolved_id:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = %s WHERE id = %s",
+                                        f"UPDATE {self.db.q(table_name)} SET {self.db.q(tenant_id_col)} = %s WHERE id = %s",
                                         (resolved_id, row_id),
                                     )
                             else:
                                 if not self.dry_run:
                                     self.db.execute_sql(
-                                        f"UPDATE `{table_name}` SET `{tenant_id_col}` = '' WHERE id = %s",
+                                        f"UPDATE {self.db.q(table_name)} SET {self.db.q(tenant_id_col)} = '' WHERE id = %s",
                                         (row_id,),
                                     )
                             rows_updated += 1
@@ -2180,12 +2255,12 @@ Examples:
 """,
     )
 
-    # MySQL connection options
-    parser.add_argument("--host", type=str, default="localhost", help="MySQL host (default: localhost)")
-    parser.add_argument("--port", type=int, default=3306, help="MySQL port (default: 3306)")
-    parser.add_argument("--user", type=str, default="root", help="MySQL user (default: root)")
-    parser.add_argument("--password", type=str, default="", help="MySQL password (default: empty)")
-    parser.add_argument("--database", type=str, default="rag_flow", help="MySQL database name (default: rag_flow)")
+    # Database connection options
+    parser.add_argument("--host", type=str, default="localhost", help="Database host (default: localhost)")
+    parser.add_argument("--port", type=int, help="Database port (default: 3306 on MySQL, 5432 on PostgreSQL)")
+    parser.add_argument("--user", type=str, default="root", help="Database user (default: root)")
+    parser.add_argument("--password", type=str, default="", help="Database password (default: empty)")
+    parser.add_argument("--database", type=str, default="rag_flow", help="Database name (default: rag_flow)")
 
     # Configuration options
     parser.add_argument("--config", "-c", type=str, help="Path to YAML config file")
@@ -2213,7 +2288,7 @@ Examples:
         # Override with command line args if provided
         if args.host != "localhost":
             config.host = args.host
-        if args.port != 3306:
+        if args.port is not None:
             config.port = args.port
         if args.user != "root":
             config.user = args.user
@@ -2223,9 +2298,9 @@ Examples:
             config.database = args.database
     else:
         # Use command line args directly
-        config = MigrationConfig(host=args.host, port=args.port, user=args.user, password=args.password, database=args.database)
+        config = MigrationConfig(host=args.host, port=args.port, user=args.user, password=args.password, database=args.database, db_type=os.getenv("DB_TYPE", "mysql"))
 
-    logger.info(f"MySQL Configuration: host={config.host}, port={config.port}, user={config.user}, database={config.database}")
+    logger.info(f"Configuration: db_type={config.db_type}, host={config.host}, port={config.port}, user={config.user}, database={config.database}")
 
     if args.check_database_version and args.mark_database_version:
         logger.error("--check-database-version and --mark-database-version are mutually exclusive")


### PR DESCRIPTION
### What

`tools/scripts/mysql_migration.py` is MySQL-only, so a PostgreSQL deployment has no working path to the model provider / instance / model tables:

- it builds a `MySQLDatabase` and a `MySQLMigrator` unconditionally;
- its SQL uses backtick identifiers, `ENGINE=InnoDB`, inline `INDEX` clauses, `ON DUPLICATE KEY UPDATE`, `FROM_UNIXTIME()`, `AUTO_INCREMENT` and `MODIFY COLUMN`;
- its config loader reads only the `database:`/`mysql:` blocks, so a deployment configured with `postgres:` silently falls back to localhost:3306.

Skipping the migration is not an alternative: `llm_service` resolves every model through the new tables, so leaving them empty makes each embedding, rerank and chat lookup raise `LookupError`.

### Approach

The migration logic itself is dialect-agnostic Python — it reads rows, rewrites model identifiers and writes them back — and the dialect-specific surface turned out to be small and enumerable. It now lives in `tools/scripts/migration_dialects.py` as one subclass per dialect, covering identifier quoting, `information_schema` scope (MySQL compares the database, PostgreSQL the namespace), epoch-to-timestamp conversion, the upsert, and DDL rendering.

The five `CREATE TABLE` statements became declarative `TableSpec`s rendered per dialect, which also removes the duplicated `tenant_model` DDL. Stage classes are otherwise unchanged. `DB_TYPE` selects the dialect exactly as the application selects its database, so a deployment with a `postgres:` block needs no migration-specific configuration.

GaussDB has no dialect yet and is still skipped, as before.

### Tests

- `test/unit_test/tools/test_migration_dialects.py` — per-dialect SQL rendering, 24 tests, unit tier.
- `test/integration/test_model_provider_migration_dialects.py` — builds the same legacy schema and dataset on MySQL and PostgreSQL, runs the migration the way `run_migrations.sh` does, and asserts both databases end up holding the same rows. Skipped unless `MIGRATION_TEST_MYSQL_DSN` and `MIGRATION_TEST_POSTGRES_DSN` are set.
