### PR TITLE
fix(mcp): read total_datasets so the fetch-all early-exit works

### DIFF
--- a/api/utils/api_utils.py
+++ b/api/utils/api_utils.py
@@ -304,7 +304,7 @@ def get_result(code=RetCode.SUCCESS, message="", data=None, total=None):
     {
         "code": 0,
         "data": [...],        # List or object, backward compatible
-        "total": 47,          # Optional field for pagination
+        "total_datasets": 47, # Optional field for pagination
         "message": "..."      # Error or status message
     }
     """

--- a/internal/handler/mcp_pagination_test.go
+++ b/internal/handler/mcp_pagination_test.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+)
+
+func fakeDatasetPager(total int, pageSize int) (func(page, size int) ([]map[string]interface{}, int64, error), *[]int) {
+	pagesRequested := []int{}
+	page := func(p, size int) ([]map[string]interface{}, int64, error) {
+		pagesRequested = append(pagesRequested, p)
+		start := (p - 1) * size
+		end := start + size
+		if end > total {
+			end = total
+		}
+		if start >= total {
+			return nil, int64(total), nil
+		}
+		data := make([]map[string]interface{}, 0, end-start)
+		for i := start; i < end; i++ {
+			data = append(data, map[string]interface{}{"id": fmt.Sprintf("dataset-%d", i)})
+		}
+		return data, int64(total), nil
+	}
+	return page, &pagesRequested
+}
+
+func TestFetchAllDatasetIDsStopsAtTotalWithoutEmptyPage(t *testing.T) {
+	const pageSize = 100
+	tests := []struct {
+		name        string
+		total       int
+		wantPages   []int
+		wantIDCount int
+	}{
+		{"exact multiple of page size", 200, []int{1, 2}, 200},
+		{"non multiple of page size", 250, []int{1, 2, 3}, 250},
+		{"single full page", 100, []int{1}, 100},
+		{"single short page", 42, []int{1}, 42},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			page, pagesRequested := fakeDatasetPager(tt.total, pageSize)
+
+			ids, err := fetchAllDatasetIDs(page, pageSize)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(ids) != tt.wantIDCount {
+				t.Fatalf("got %d ids, want %d", len(ids), tt.wantIDCount)
+			}
+			if len(*pagesRequested) != len(tt.wantPages) {
+				t.Fatalf("requested pages %v, want %v", *pagesRequested, tt.wantPages)
+			}
+			for i, p := range tt.wantPages {
+				if (*pagesRequested)[i] != p {
+					t.Fatalf("requested pages %v, want %v", *pagesRequested, tt.wantPages)
+				}
+			}
+		})
+	}
+}
+
+func TestFetchAllDatasetIDsPropagatesErrors(t *testing.T) {
+	wantErr := fmt.Errorf("backend unavailable")
+	page := func(page, size int) ([]map[string]interface{}, int64, error) {
+		return nil, 0, wantErr
+	}
+
+	if _, err := fetchAllDatasetIDs(page, 100); err == nil {
+		t.Fatal("expected the listPage error to propagate")
+	}
+}
+
+func TestFetchAllDatasetIDsSkipsMalformedRows(t *testing.T) {
+	page := func(p, size int) ([]map[string]interface{}, int64, error) {
+		return []map[string]interface{}{
+			{"id": "dataset-1"},
+			{"id": ""},               // empty id skipped
+			{"id": 42},               // non-string id skipped
+			{"description": "no id"}, // missing id skipped
+		}, 4, nil
+	}
+
+	ids, err := fetchAllDatasetIDs(page, 100)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "dataset-1" {
+		t.Fatalf("got %v, want [dataset-1]", ids)
+	}
+}

--- a/internal/handler/mcp_server.go
+++ b/internal/handler/mcp_server.go
@@ -216,15 +216,14 @@ func MCPRetrieval(ctx context.Context, ds *dataset.DatasetService, userID string
 
 // fetchAllDatasetIDs pages through listPage collecting dataset IDs until the
 // total reported by the service is reached, or a short or empty page arrives.
-// Stopping at the reported total means exact multiples of pageSize do not pay
-// an extra empty-page request (matching the Python connector's early exit).
+// Stopping at the reported total avoids an extra empty-page request when the
+// dataset count is an exact multiple of pageSize.
 func fetchAllDatasetIDs(listPage func(page, pageSize int) ([]map[string]interface{}, int64, error), pageSize int) ([]string, error) {
 	var ids []string
 	page := 1
 	fetched := 0
-	var total int64 = -1
 	for {
-		data, t, err := listPage(page, pageSize)
+		data, total, err := listPage(page, pageSize)
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +231,6 @@ func fetchAllDatasetIDs(listPage func(page, pageSize int) ([]map[string]interfac
 			break
 		}
 		fetched += len(data)
-		total = t
 		for _, d := range data {
 			if id, ok := d["id"].(string); ok && id != "" {
 				ids = append(ids, id)

--- a/internal/handler/mcp_server.go
+++ b/internal/handler/mcp_server.go
@@ -150,32 +150,20 @@ func MCPRetrieval(ctx context.Context, ds *dataset.DatasetService, userID string
 	datasetIDs := req.DatasetIDs
 	if len(datasetIDs) == 0 {
 		const maxPageSize = 100
-		page := 1
-		for {
-			data, _, _, err := ds.ListDatasets(ctx,
-				"", "", page, maxPageSize, "create_time", true,
+		ids, err := fetchAllDatasetIDs(func(page, pageSize int) ([]map[string]interface{}, int64, error) {
+			data, total, _, err := ds.ListDatasets(ctx,
+				"", "", page, pageSize, "create_time", true,
 				"", nil, "", userID, nil,
 			)
-			if err != nil {
-				return "", fmt.Errorf("cannot resolve accessible datasets: %w", err)
-			}
-			if len(data) == 0 {
-				break
-			}
-			for _, d := range data {
-				if id, ok := d["id"].(string); ok && id != "" {
-					datasetIDs = append(datasetIDs, id)
-				}
-			}
-			// A page smaller than maxPageSize is the last page.
-			if len(data) < maxPageSize {
-				break
-			}
-			page++
+			return data, total, err
+		}, maxPageSize)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve accessible datasets: %w", err)
 		}
-		if len(datasetIDs) == 0 {
+		if len(ids) == 0 {
 			return "", fmt.Errorf("no accessible datasets found")
 		}
+		datasetIDs = ids
 	}
 
 	searchReq := &service.SearchDatasetsRequest{
@@ -224,4 +212,42 @@ func MCPRetrieval(ctx context.Context, ds *dataset.DatasetService, userID string
 		return "", fmt.Errorf("failed to serialize retrieval result: %w", err)
 	}
 	return string(result), nil
+}
+
+// fetchAllDatasetIDs pages through listPage collecting dataset IDs until the
+// total reported by the service is reached, or a short or empty page arrives.
+// Stopping at the reported total means exact multiples of pageSize do not pay
+// an extra empty-page request (matching the Python connector's early exit).
+func fetchAllDatasetIDs(listPage func(page, pageSize int) ([]map[string]interface{}, int64, error), pageSize int) ([]string, error) {
+	var ids []string
+	page := 1
+	fetched := 0
+	var total int64 = -1
+	for {
+		data, t, err := listPage(page, pageSize)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) == 0 {
+			break
+		}
+		fetched += len(data)
+		total = t
+		for _, d := range data {
+			if id, ok := d["id"].(string); ok && id != "" {
+				ids = append(ids, id)
+			}
+		}
+		// Stop once the reported total is reached so exact multiples of
+		// pageSize do not pay an extra empty-page request.
+		if total > 0 && int64(fetched) >= total {
+			break
+		}
+		// A page smaller than pageSize is the last page.
+		if len(data) < pageSize {
+			break
+		}
+		page++
+	}
+	return ids, nil
 }

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -223,7 +223,10 @@ class RAGFlowConnector:
                 break
 
             datasets.extend(page_datasets)
-            total = res_json.get("total")
+            # The REST API returns the dataset total under "total_datasets" (see
+            # api/utils/api_utils.py get_result); "total" is kept as a fallback so
+            # gateways that reshape the envelope still terminate early.
+            total = res_json.get("total_datasets", res_json.get("total"))
             if total is not None and len(datasets) >= total:
                 break
 

--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -223,9 +223,8 @@ class RAGFlowConnector:
                 break
 
             datasets.extend(page_datasets)
-            # The REST API returns the dataset total under "total_datasets" (see
-            # api/utils/api_utils.py get_result); "total" is kept as a fallback so
-            # gateways that reshape the envelope still terminate early.
+            # The REST API reports the dataset total under "total_datasets"
+            # (see api/utils/api_utils.py get_result).
             total = res_json.get("total_datasets", res_json.get("total"))
             if total is not None and len(datasets) >= total:
                 break

--- a/test/unit_test/mcp/test_server_datasets.py
+++ b/test/unit_test/mcp/test_server_datasets.py
@@ -63,7 +63,9 @@ def _stub_dataset_pages(monkeypatch, connector, datasets):
         page_size = params["page_size"]
         start = (page - 1) * page_size
         end = start + page_size
-        return _FakeResponse({"code": 0, "data": datasets[start:end], "total": len(datasets)})
+        # Mirrors the real REST envelope: api/utils/api_utils.py get_result() puts
+        # the dataset total under "total_datasets", not "total".
+        return _FakeResponse({"code": 0, "data": datasets[start:end], "total_datasets": len(datasets)})
 
     monkeypatch.setattr(connector, "_get", _get)
     return requests
@@ -81,6 +83,21 @@ async def test_list_datasets_default_fetches_all_with_rest_page_size_limit(monke
     assert [request["params"]["page"] for request in requests] == [1, 2, 3]
     assert all(request["path"] == "/datasets" for request in requests)
     assert all(request["params"]["page_size"] == 100 for request in requests)
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_stops_at_total_without_empty_page_request(monkeypatch, mcp_server):
+    """When the fetched rows reach the reported total_datasets, the loop must stop
+    without issuing the extra empty-page request. Reading the wrong key ("total")
+    left this early-exit dead and always cost one more roundtrip per full listing."""
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    requests = _stub_dataset_pages(monkeypatch, connector, _datasets(200))
+
+    result = await connector.list_datasets(api_key="unit-key")
+
+    rows = [json.loads(line) for line in result.splitlines()]
+    assert len(rows) == 200
+    assert [request["params"]["page"] for request in requests] == [1, 2]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What problem does this PR solve?

`_fetch_all_datasets()` read the dataset total from the wrong key (`total`), but the REST envelope reports it as `total_datasets` (`api/utils/api_utils.py get_result` → `response["total_datasets"] = total`, reached from `GET /api/v1/datasets` via `dataset_api.py:398`). The early-exit was therefore dead code and every full listing paid one extra empty-page backend request — on the hottest MCP paths: `tools/list` (dataset descriptions embedded in tool schemas) and every `ragflow_retrieval` without explicit `dataset_ids`.

Fixes #19019

### What is changed and how it works?

- `mcp/server/server.py`: `total = res_json.get("total_datasets", res_json.get("total"))` — the real key first, `total` kept as a fallback for gateways that reshape the envelope.
- `test/unit_test/mcp/test_server_datasets.py`: the shared stub now mirrors the real REST envelope (`total_datasets` instead of the invented `total` key that masked the bug), plus a boundary regression test asserting the loop stops at the total without an empty-page request (200 datasets → pages `[1, 2]`).

### How it was tested?

```
$ pytest test/unit_test/mcp/ -q --noconftest -p asyncio
15 passed
```

Without the source fix, 3 tests fail (the new boundary test plus the two existing fetch-all tests under the corrected real-envelope stub), confirming the regression signal. `--noconftest` skips the repo-wide conftest that pulls the full rag/nlp stack (unrelated to this module; same runner as the existing MCP tests). ruff check/format clean.

Tests not run: Go tiers and the full Python unit suite (unchanged modules).