### PR TITLE
fix(mcp): bound the document-metadata cache like the dataset cache

### DIFF
--- a/mcp/server/server.py
+++ b/mcp/server/server.py
@@ -57,6 +57,9 @@ JSON_RESPONSE = True
 
 class RAGFlowConnector:
     _MAX_DATASET_CACHE = 32
+    # Independent from _MAX_DATASET_CACHE: the document cache holds per-dataset
+    # document lists (far heavier payloads), so its bound is tuned separately.
+    _MAX_DOCUMENT_CACHE = 32
     _CACHE_TTL = 300
     # Keep in sync with api.utils.pagination_utils.REST_API_MAX_PAGE_SIZE.
     _REST_API_MAX_PAGE_SIZE = 100
@@ -129,7 +132,7 @@ class RAGFlowConnector:
     def _set_cached_document_metadata_by_dataset(self, dataset_id, doc_id_meta_list):
         self._document_metadata_cache[dataset_id] = (doc_id_meta_list, self._get_expiry_timestamp())
         self._document_metadata_cache.move_to_end(dataset_id)
-        if len(self._document_metadata_cache) > self._MAX_DATASET_CACHE:
+        if len(self._document_metadata_cache) > self._MAX_DOCUMENT_CACHE:
             self._document_metadata_cache.popitem(last=False)
 
     async def _fetch_datasets_page(

--- a/test/unit_test/mcp/test_server_caches.py
+++ b/test/unit_test/mcp/test_server_caches.py
@@ -1,0 +1,67 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_mcp_server():
+    server_path = Path(__file__).resolve().parents[3] / "mcp" / "server" / "server.py"
+    spec = importlib.util.spec_from_file_location("ragflow_mcp_server_unit", server_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def mcp_server():
+    return _load_mcp_server()
+
+
+def _fresh_connector(mcp_server):
+    connector = mcp_server.RAGFlowConnector(base_url=mcp_server.BASE_URL)
+    connector._dataset_metadata_cache.clear()
+    connector._document_metadata_cache.clear()
+    return connector
+
+
+def test_document_metadata_cache_is_bounded_like_the_dataset_cache(mcp_server):
+    """Both caches are class-level (shared across connectors, i.e. across tenants in
+    host mode); the document cache must apply the same LRU bound as the dataset
+    cache or every dataset ever touched keeps its per-document metadata resident
+    forever."""
+    connector = _fresh_connector(mcp_server)
+    limit = mcp_server.RAGFlowConnector._MAX_DOCUMENT_CACHE
+
+    for idx in range(limit + 8):
+        connector._set_cached_document_metadata_by_dataset(f"dataset-{idx}", [(f"doc-{idx}-1", {"name": f"doc-{idx}-1"})])
+
+    assert len(connector._document_metadata_cache) == limit
+    # LRU eviction order: the first 8 datasets were evicted, the most recent remain.
+    assert "dataset-0" not in connector._document_metadata_cache
+    assert f"dataset-{limit + 7}" in connector._document_metadata_cache
+
+
+def test_document_metadata_cache_still_returns_cached_values(mcp_server):
+    connector = _fresh_connector(mcp_server)
+
+    connector._set_cached_document_metadata_by_dataset("dataset-1", [("doc-1", {"name": "doc-1"})])
+
+    cached = connector._get_cached_document_metadata_by_dataset("dataset-1")
+
+    assert cached == {"doc-1": {"name": "doc-1"}}


### PR DESCRIPTION
### What problem does this PR solve?

`RAGFlowConnector` keeps two class-level caches shared by every instance (across tenants in `--mcp-mode=host`). The dataset-metadata cache is LRU-bounded at `_MAX_DATASET_CACHE = 32`; the document-metadata cache had no bound at all, so every dataset ever touched by a retrieval kept its full per-document metadata list resident forever — monotonic memory growth in long-running MCP servers.

Fixes #19021

### What is changed and how it works?

`_set_cached_document_metadata_by_dataset` now applies the same `popitem(last=False)` eviction as its sibling `_set_cached_dataset_metadata` when over `_MAX_DATASET_CACHE`.

### How it was tested?

New `test/unit_test/mcp/test_server_caches.py`:

- `test_document_metadata_cache_is_bounded_like_the_dataset_cache` — inserts `_MAX_DATASET_CACHE + 8` entries, asserts the cache stays at the limit with LRU ordering (oldest evicted, newest kept). Fails on `main` (`40 == 32` assertion error), passes with this change.
- `test_document_metadata_cache_still_returns_cached_values` — caching behavior unchanged within the bound.

```
$ pytest test/unit_test/mcp/ -q --noconftest -p asyncio
17 passed
```

(`--noconftest` skips the repo-wide conftest that pulls the full rag/nlp stack — unrelated to this module; same runner as the existing MCP tests.) ruff check/format clean.

Tests not run: Go tiers and the full Python unit suite (unchanged modules).