### PR TITLE
fix(agent): avoid shared StringTransform merge arguments

### DIFF
--- a/agent/component/string_transform.py
+++ b/agent/component/string_transform.py
@@ -82,10 +82,12 @@ class StringTransform(Message, ABC):
             res.append(s)
         self.set_output("result", res)
 
-    def _merge(self, kwargs: dict[str, str] = {}):
+    def _merge(self, kwargs: dict[str, str] | None = None):
         if self.check_if_canceled("StringTransform merge processing"):
             return
 
+        if kwargs is None:
+            kwargs = {}
         script = self._param.script
         script, kwargs = self.get_kwargs(script, kwargs, self._param.delimiters[0])
 


### PR DESCRIPTION


### Summary


StringTransform._merge used a dictionary as a default argument and passed it to get_kwargs, which adds missing template inputs to that mapping. Use None and create a fresh dictionary per call so merge invocations cannot share accumulated state.

