### PR TITLE
fix(agentic_rag): align answer variable prompt

### DIFF
--- a/rag/prompts/action_initialize_state.md
+++ b/rag/prompts/action_initialize_state.md
@@ -11,13 +11,13 @@ Output ONLY a JSON object:
     {"id": 0, "type": "<entity|person|date|duration|count|number|place|web|dataset>", "clues": ["<what identifies this slot from the question>", "..."], "source": "<dataset name or 'web'>"},
     ...
   ],
-  "answer_slot": <id of the slot the FINAL answer goes to>,
+  "answer_variable": <id of the slot the FINAL answer goes to>,
   "first_queries": ["<concrete searchable query for the first retrieval round>", ...]
 }
 
 Rules:
 - 2-6 slots; each slot ONE fact (a name, a date, a count...), never a clause.
-- "answer_slot" holds the top-level requested fact; other slots are its dependencies.
+- "answer_variable" holds the top-level requested fact; other slots are its dependencies.
 - Cover EVERY listed source: one or more slots per dataset, plus a "web" slot when Web is available and the question touches world knowledge or recent events.
 - clues must be self-contained phrases usable as retrieval hints.
 - 1-4 first_queries: direct keyword-style searches against the listed sources.

--- a/rag/prompts/action_initialize_state.md
+++ b/rag/prompts/action_initialize_state.md
@@ -11,13 +11,13 @@ Output ONLY a JSON object:
     {"id": 0, "type": "<entity|person|date|duration|count|number|place|web|dataset>", "clues": ["<what identifies this slot from the question>", "..."], "source": "<dataset name or 'web'>"},
     ...
   ],
-  "answer_variable": <id of the slot the FINAL answer goes to>,
+  "answer_variable": <zero-based index in "slots" of the slot the FINAL answer goes to>,
   "first_queries": ["<concrete searchable query for the first retrieval round>", ...]
 }
 
 Rules:
 - 2-6 slots; each slot ONE fact (a name, a date, a count...), never a clause.
-- "answer_variable" holds the top-level requested fact; other slots are its dependencies.
+- "answer_variable" is the zero-based index of the top-level requested fact; other slots are its dependencies.
 - Cover EVERY listed source: one or more slots per dataset, plus a "web" slot when Web is available and the question touches world knowledge or recent events.
 - clues must be self-contained phrases usable as retrieval hints.
 - 1-4 first_queries: direct keyword-style searches against the listed sources.

--- a/test/unit_test/rag/advanced_rag/test_action_session.py
+++ b/test/unit_test/rag/advanced_rag/test_action_session.py
@@ -41,3 +41,4 @@ def test_initialize_state_prompt_uses_runtime_answer_variable():
 
     assert '"answer_variable"' in prompt
     assert '"answer_slot"' not in prompt
+    assert "zero-based index" in prompt

--- a/test/unit_test/rag/advanced_rag/test_action_session.py
+++ b/test/unit_test/rag/advanced_rag/test_action_session.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -32,3 +33,11 @@ async def test_exec_calculate_returns_computed_value(monkeypatch):
 
     assert results == [{"kind": "calculate", "expression": "2 + 3", "result": "5"}]
     assert evidence_ids == []
+
+
+def test_initialize_state_prompt_uses_runtime_answer_variable():
+    prompt_path = Path(__file__).resolve().parents[4] / "rag" / "prompts" / "action_initialize_state.md"
+    prompt = prompt_path.read_text(encoding="utf-8")
+
+    assert '"answer_variable"' in prompt
+    assert '"answer_slot"' not in prompt


### PR DESCRIPTION
## Summary

- make the action-state initialization prompt emit the `answer_variable` field consumed by the runtime
- remove the unused `answer_slot` prompt contract
- add a regression test that keeps the prompt and runtime field aligned

## Problem

`action_initialize_state.md` instructs the model to return the final slot under `answer_slot`, while `initialize_state` reads only `data.get("answer_variable")`. A compliant model response therefore leaves `ans_var` unset and silently falls back to slot 0, even when a different slot is the final answer in a multi-hop plan.

This is a focused follow-up to the agentic search refactor in #19000.

## Test plan

- `uv run --no-project --python 3.13 --with pytest --with pytest-asyncio --with langchain-core --with langgraph --with json-repair pytest --confcutdir=test/unit_test/rag/advanced_rag test/unit_test/rag/advanced_rag/test_action_session.py -q`
- `uvx ruff check test/unit_test/rag/advanced_rag/test_action_session.py`
- `uvx ruff format --check test/unit_test/rag/advanced_rag/test_action_session.py`