### PR TITLE
fix(agentic_rag): normalize structure answers

### DIFF
--- a/rag/advanced_rag/harness/structure_qa.py
+++ b/rag/advanced_rag/harness/structure_qa.py
@@ -88,7 +88,8 @@ async def _ask_structure(tools, topic: str, entities: list[dict], relations: lis
         _LOG.exception(f"[{label}] Could not read the outline with the model.")
 
     is_sufficient = bool(verdict.get("is_sufficient"))
-    answer = (verdict.get("answer") or "").strip() if is_sufficient else ""
+    raw_answer = verdict.get("answer")
+    answer = str(raw_answer).strip() if is_sufficient and raw_answer is not None else ""
     relevant = [n for n in (verdict.get("relevant_entities") or []) if isinstance(n, str)]
     _LOG.info(
         "[%s] The %s %s the question; %d relevant entity(ies): %s",

--- a/test/unit_test/rag/advanced_rag/test_structure_qa.py
+++ b/test/unit_test/rag/advanced_rag/test_structure_qa.py
@@ -1,0 +1,45 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from rag.advanced_rag.harness.structure_qa import _ask_structure
+
+
+@pytest.mark.asyncio
+async def test_ask_structure_normalizes_non_string_answer(monkeypatch):
+    generator = ModuleType("rag.prompts.generator")
+    generator.form_message = lambda system, user: [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    generator.message_fit_in = lambda messages, _budget: (0, messages)
+
+    prompts = ModuleType("rag.prompts")
+    prompts.__path__ = []
+    prompts.generator = generator
+    monkeypatch.setitem(sys.modules, "rag.prompts", prompts)
+    monkeypatch.setitem(sys.modules, "rag.prompts.generator", generator)
+
+    class FakeChatModel:
+        max_length = 8192
+
+        async def async_chat(self, system, messages, config):
+            assert system
+            assert messages
+            assert config == {"temperature": 0.2}
+            return '{"is_sufficient": true, "answer": 42, "relevant_entities": ["Revenue", 7]}'
+
+    tools = SimpleNamespace(chat_mdl=FakeChatModel())
+
+    answer, relevant = await _ask_structure(
+        tools,
+        "What is the revenue?",
+        [{"name": "Revenue", "type": "metric", "description": "Annual revenue is 42."}],
+        [],
+        "outline",
+        "Structure test",
+    )
+
+    assert answer == "42"
+    assert relevant == ["Revenue"]


### PR DESCRIPTION
## Summary

- normalize a sufficient structure answer to text before trimming it
- preserve the existing empty-answer behavior for missing or insufficient verdicts
- add an async regression test for a valid JSON numeric answer

## Problem

`_ask_structure` parses model output as arbitrary JSON but calls `.strip()` directly on `verdict["answer"]` after the protected parsing block. If the model returns a valid non-string JSON answer such as `42`, the resulting `AttributeError` escapes and aborts the knowledge-graph/compiled-structure exploration turn instead of returning the answer and relevant entities.

This is a focused follow-up to the agentic search refactor in #19000.

## Test plan

- `uv run --no-project --python 3.13 --with pytest --with pytest-asyncio --with json-repair pytest --confcutdir=test/unit_test/rag/advanced_rag test/unit_test/rag/advanced_rag/test_structure_qa.py -q`
- `uvx ruff check test/unit_test/rag/advanced_rag/test_structure_qa.py`
- `uvx ruff check --select E9,F63,F7,F82 rag/advanced_rag/harness/structure_qa.py`
- `uvx ruff format --check rag/advanced_rag/harness/structure_qa.py test/unit_test/rag/advanced_rag/test_structure_qa.py`