### PR TITLE
fix(doc-store): round minimum_should_match instead of truncating it

### DIFF
--- a/common/float_utils.py
+++ b/common/float_utils.py
@@ -69,6 +69,11 @@ def minimum_should_match_percent(fraction):
     int(fraction * 100) silently sends a stricter-than-requested threshold for
     many two-decimal fractions (0.29 -> "28%", not "29%").
 
+    Exact midpoints use Python's round()-to-even, so they land on the nearer
+    even percent rather than always rounding up: 0.005 -> "0%", 0.015 -> "2%".
+    That is the intended contract here; a caller-facing search threshold does
+    not need half-up tie-breaking.
+
     Examples:
         >>> minimum_should_match_percent(0.29)
         '29%'

--- a/common/float_utils.py
+++ b/common/float_utils.py
@@ -56,3 +56,23 @@ def normalize_overlapped_percent(overlapped_percent):
         value *= 100
     value = int(value)
     return max(0, min(value, 90))
+
+
+def minimum_should_match_percent(fraction):
+    """
+    Convert a 0..1 minimum_should_match fraction to the percent-string the
+    full-text doc-store connectors (es_conn/opensearch_conn/ob_conn/infinity_conn)
+    pass through to their query engine, e.g. 0.57 -> "57%".
+
+    Rounds rather than truncates: a base-10 fraction like 0.29 is not exactly
+    representable in IEEE-754 (it is stored as 0.28999999999999998...), so
+    int(fraction * 100) silently sends a stricter-than-requested threshold for
+    many two-decimal fractions (0.29 -> "28%", not "29%").
+
+    Examples:
+        >>> minimum_should_match_percent(0.29)
+        '29%'
+        >>> minimum_should_match_percent(0.5)
+        '50%'
+    """
+    return f"{round(fraction * 100)}%"

--- a/memory/utils/es_conn.py
+++ b/memory/utils/es_conn.py
@@ -25,7 +25,7 @@ from elastic_transport import ConnectionTimeout
 from common.decorator import singleton
 from common.doc_store.doc_store_base import MatchExpr, OrderByExpr, MatchTextExpr, MatchDenseExpr, FusionExpr
 from common.doc_store.es_conn_base import ESConnectionBase
-from common.float_utils import get_float
+from common.float_utils import get_float, minimum_should_match_percent
 from common.constants import PAGERANK_FLD, TAG_FLD
 from rag.nlp.rag_tokenizer import tokenize, fine_grained_tokenize
 
@@ -171,7 +171,7 @@ class ESConnection(ESConnectionBase):
             if isinstance(m, MatchTextExpr):
                 minimum_should_match = m.extra_options.get("minimum_should_match", 0.0)
                 if isinstance(minimum_should_match, float):
-                    minimum_should_match = str(int(minimum_should_match * 100)) + "%"
+                    minimum_should_match = minimum_should_match_percent(minimum_should_match)
                 bool_query.must.append(
                     Q(
                         "query_string",

--- a/memory/utils/infinity_conn.py
+++ b/memory/utils/infinity_conn.py
@@ -24,6 +24,7 @@ from common.decorator import singleton
 import pandas as pd
 from common.doc_store.doc_store_base import MatchExpr, MatchTextExpr, MatchDenseExpr, FusionExpr, OrderByExpr
 from common.doc_store.infinity_conn_base import InfinityConnectionBase
+from common.float_utils import minimum_should_match_percent
 from common.time_utils import date_string_to_timestamp
 
 
@@ -187,7 +188,7 @@ class InfinityConnection(InfinityConnectionBase):
                         filter_fulltext = f"({filter_cond}) AND {filter_fulltext}"
                     minimum_should_match = matchExpr.extra_options.get("minimum_should_match", 0.0)
                     if isinstance(minimum_should_match, float):
-                        str_minimum_should_match = str(int(minimum_should_match * 100)) + "%"
+                        str_minimum_should_match = minimum_should_match_percent(minimum_should_match)
                         matchExpr.extra_options["minimum_should_match"] = str_minimum_should_match
 
                     for k, v in matchExpr.extra_options.items():

--- a/rag/utils/es_conn.py
+++ b/rag/utils/es_conn.py
@@ -26,7 +26,7 @@ from common.constants import PAGERANK_FLD, TAG_FLD
 from common.decorator import singleton
 from common.doc_store.doc_store_base import FusionExpr, MatchDenseExpr, MatchExpr, MatchTextExpr, OrderByExpr
 from common.doc_store.es_conn_base import ESConnectionBase
-from common.float_utils import get_float
+from common.float_utils import get_float, minimum_should_match_percent
 
 ATTEMPT_TIME = 2
 MAX_RESULT_WINDOW = 10000
@@ -246,7 +246,7 @@ class ESConnection(ESConnectionBase):
             if isinstance(m, MatchTextExpr):
                 minimum_should_match = (m.extra_options or {}).get("minimum_should_match", 0.0)
                 if isinstance(minimum_should_match, float):
-                    minimum_should_match = str(int(minimum_should_match * 100)) + "%"
+                    minimum_should_match = minimum_should_match_percent(minimum_should_match)
                 bool_query.must.append(Q("query_string", fields=m.fields, type="best_fields", query=m.matching_text, minimum_should_match=minimum_should_match, boost=1))
                 bool_query.boost = 1.0 - vector_similarity_weight
 

--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -24,7 +24,7 @@ import pandas as pd
 from common.constants import PAGERANK_FLD, TAG_FLD
 from common.doc_store.doc_store_base import MatchExpr, MatchTextExpr, MatchDenseExpr, FusionExpr, OrderByExpr
 from common.doc_store.infinity_conn_base import InfinityConnectionBase
-from common.float_utils import get_float
+from common.float_utils import get_float, minimum_should_match_percent
 
 
 DENSE_FILTER_FULLTEXT_WEIGHT_THRESHOLD = 0.8
@@ -227,7 +227,7 @@ class InfinityConnection(InfinityConnectionBase):
                         filter_fulltext = f"({filter_cond}) AND {filter_fulltext}"
                     minimum_should_match = matchExpr.extra_options.get("minimum_should_match", 0.0)
                     if isinstance(minimum_should_match, float):
-                        str_minimum_should_match = str(int(minimum_should_match * 100)) + "%"
+                        str_minimum_should_match = minimum_should_match_percent(minimum_should_match)
                         matchExpr.extra_options["minimum_should_match"] = str_minimum_should_match
 
                     # Add rank_feature support

--- a/rag/utils/ob_conn.py
+++ b/rag/utils/ob_conn.py
@@ -31,6 +31,7 @@ from sqlalchemy.sql.type_api import TypeEngine
 from common.constants import PAGERANK_FLD, TAG_FLD
 from common.decorator import singleton
 from common.doc_store.doc_store_base import MatchExpr, OrderByExpr, FusionExpr, MatchTextExpr, MatchDenseExpr
+from common.float_utils import minimum_should_match_percent
 from common.doc_store.ob_conn_base import (
     OBConnectionBase,
     get_value_str,
@@ -635,7 +636,7 @@ class OBConnection(OBConnectionBase):
                 if isinstance(m, MatchTextExpr):
                     minimum_should_match = m.extra_options.get("minimum_should_match", 0.0)
                     if isinstance(minimum_should_match, float):
-                        minimum_should_match = str(int(minimum_should_match * 100)) + "%"
+                        minimum_should_match = minimum_should_match_percent(minimum_should_match)
                     bqry.must.append(Q("query_string", fields=FTS_COLUMNS_TKS, type="best_fields", query=m.matching_text, minimum_should_match=minimum_should_match, boost=1))
                     bqry.boost = 1.0 - vector_similarity_weight
 

--- a/rag/utils/opensearch_conn.py
+++ b/rag/utils/opensearch_conn.py
@@ -27,6 +27,7 @@ from opensearchpy import ConnectionTimeout
 from common.decorator import singleton
 from common.file_utils import get_project_base_directory
 from common.doc_store.doc_store_base import DocStoreConnection, MatchExpr, OrderByExpr, MatchTextExpr, MatchDenseExpr, FusionExpr
+from common.float_utils import minimum_should_match_percent
 from rag.nlp import is_english, rag_tokenizer
 from common.constants import PAGERANK_FLD, TAG_FLD
 from common import settings
@@ -385,7 +386,7 @@ class OSConnection(DocStoreConnection):
                 use_text = True
                 minimum_should_match = m.extra_options.get("minimum_should_match", 0.0)
                 if isinstance(minimum_should_match, float):
-                    minimum_should_match = str(int(minimum_should_match * 100)) + "%"
+                    minimum_should_match = minimum_should_match_percent(minimum_should_match)
                 bqry.must.append(Q("query_string", fields=m.fields, type="best_fields", query=m.matching_text, minimum_should_match=minimum_should_match, boost=1))
                 bqry.boost = 1.0 - vector_similarity_weight
 

--- a/test/unit_test/common/test_float_utils.py
+++ b/test/unit_test/common/test_float_utils.py
@@ -15,7 +15,7 @@
 #
 
 import math
-from common.float_utils import get_float
+from common.float_utils import get_float, minimum_should_match_percent
 
 
 class TestGetFloat:
@@ -86,3 +86,23 @@ class TestGetFloat:
         result = get_float("  invalid  ")
         assert math.isinf(result)
         assert result < 0
+
+
+class TestMinimumShouldMatchPercent:
+    def test_rounds_ieee754_representation_error_up(self):
+        """0.29 * 100 == 28.999999999999996 in IEEE-754; the old int() truncation
+        sent "28%" instead of the requested "29%". These are the exact fractions
+        the issue reproduced against (old buggy output in parens)."""
+        assert minimum_should_match_percent(0.29) == "29%"  # was "28%"
+        assert minimum_should_match_percent(0.57) == "57%"  # was "56%"
+        assert minimum_should_match_percent(0.58) == "58%"  # was "57%"
+
+    def test_all_two_decimal_fractions_round_to_nearest_percent(self):
+        for hundredths in range(1, 100):
+            fraction = hundredths / 100
+            assert minimum_should_match_percent(fraction) == f"{hundredths}%"
+
+    def test_exact_boundaries(self):
+        assert minimum_should_match_percent(0.0) == "0%"
+        assert minimum_should_match_percent(1.0) == "100%"
+        assert minimum_should_match_percent(0.5) == "50%"

--- a/test/unit_test/common/test_float_utils.py
+++ b/test/unit_test/common/test_float_utils.py
@@ -106,3 +106,10 @@ class TestMinimumShouldMatchPercent:
         assert minimum_should_match_percent(0.0) == "0%"
         assert minimum_should_match_percent(1.0) == "100%"
         assert minimum_should_match_percent(0.5) == "50%"
+
+    def test_midpoint_ties_round_to_even(self):
+        """Documents the intended tie-breaking contract: an exact half-percent
+        rounds to the nearer even percent, matching Python's round(), not
+        always up."""
+        assert minimum_should_match_percent(0.005) == "0%"
+        assert minimum_should_match_percent(0.015) == "2%"


### PR DESCRIPTION
### Summary

All six full-text doc-store connectors convert a `minimum_should_match` fraction to a percent string with `str(int(fraction * 100)) + "%"`. Because most two-decimal fractions are not exact in IEEE-754 (0.29 is stored as 0.28999999999999998...), `int()` truncates toward zero and always rounds the caller's requested threshold down, never up: `0.29 -> "28%"`, `0.57 -> "56%"`, `0.58 -> "57%"`. This silently sends the query engine a stricter-than-requested match threshold.

Fixes #19027.

### Change

Added `minimum_should_match_percent()` to `common/float_utils.py` (rounds instead of truncating) and routed all six sites through it: `rag/utils/{es,opensearch,ob,infinity}_conn.py` and `memory/utils/{es,infinity}_conn.py`. The issue named the four `rag/utils/` sites; grepping the exact expression across the repo turned up the identical bug at the two `memory/utils/` sites as well, so this covers all six rather than four.

This is a distinct code path from `normalize_overlapped_percent` (also in `common/float_utils.py`), which backs the chunk-overlap-percent config field and was left untouched: #17667 proposed rounding it and was closed in favor of restricting that field's UI to integers instead. These six sites back full-text search recall, have no such clamp, and are not part of that discussion.

### Verification

- Added `TestMinimumShouldMatchPercent` to `test/unit_test/common/test_float_utils.py`: covers the three fractions from the issue, all 99 two-decimal fractions in (0, 1), and the 0/0.5/1.0 boundaries. Confirmed the new test fails on main (`minimum_should_match_percent` does not exist there) and passes on this branch, both in a clean `python:3.13-slim` container.
- Grepped the fixed expression across the repo after the change: no remaining `int(minimum_should_match * 100)` site.
- `ruff check` and `ruff format --check` on every changed line: clean (verified via `check_files.py`'s staged-file eof/trailing-whitespace/mixed-line-ending hooks too).
- Not run: the full `ragflow_tests_elasticsearch` / `ragflow_tests_infinity` suites, which need a full `uv sync` plus live doc-store services this environment doesn't have set up. The four `rag/utils/` connectors' `search()` builds the query as a plain dict before any network call, so behaviorally this is the same code path those CI legs already exercise; I didn't verify that behaviorally against a running Elasticsearch/Infinity instance myself.
