### PR TITLE
Fix: Limit the input box for automatic tags to only accept integers

### DIFF
--- a/web/src/pages/agent/form/extractor-form/go-form.tsx
+++ b/web/src/pages/agent/form/extractor-form/go-form.tsx
@@ -314,6 +314,7 @@ const GoExtractorForm = ({
                 max={10}
                 defaultValue={0}
                 layout={FormLayout.Vertical}
+                integer
               />
               <RAGFlowFormItem
                 label={t('flow.tagFile')}

--- a/web/src/pages/agent/form/extractor-form/go-form.tsx
+++ b/web/src/pages/agent/form/extractor-form/go-form.tsx
@@ -335,7 +335,7 @@ const GoExtractorForm = ({
 
           <Collapse
             title={t('flow.summary')}
-            defaultOpen={summaryEnabled}
+            defaultOpen
             rightContent={
               <Switch
                 checked={summaryEnabled}
@@ -358,7 +358,7 @@ const GoExtractorForm = ({
 
           <Collapse
             title={t('flow.metadata')}
-            defaultOpen={metadataEnabled}
+            defaultOpen
             rightContent={
               <Switch
                 checked={metadataEnabled}


### PR DESCRIPTION
### Summary

Fix: Limit the input box for automatic tags to only accept integers