### PR TITLE
fix(sdk): reject conflicting dataset ID filters

### DIFF
--- a/sdk/python/ragflow_sdk/ragflow.py
+++ b/sdk/python/ragflow_sdk/ragflow.py
@@ -98,6 +98,9 @@ class RAGFlow:
     def list_datasets(
         self, page: int = 1, page_size: int = 30, orderby: str = "create_time", desc: bool = True, id: str | None = None, ids: list[str] | None = None, name: str | None = None
     ) -> list[DataSet]:
+        if id and ids:
+            raise ValueError("Cannot use both 'id' and 'ids' parameters at the same time.")
+
         res = self.get(
             "/datasets",
             {

--- a/test/testcases/test_sdk_api/test_dataset_mangement/test_list_datasets.py
+++ b/test/testcases/test_sdk_api/test_dataset_mangement/test_list_datasets.py
@@ -21,6 +21,55 @@ from configs import HOST_ADDRESS, INVALID_API_TOKEN, SDK_UNAUTHORIZED_ERROR_MESS
 from ragflow_sdk import RAGFlow
 
 
+class _ListDatasetsResponse:
+    def json(self):
+        return {"code": 0, "data": []}
+
+
+class TestListDatasetsArgumentValidation:
+    @pytest.fixture(autouse=True)
+    def set_tenant_info(self):
+        return None
+
+    @pytest.mark.p2
+    @pytest.mark.parametrize(
+        "params",
+        [{"id": "dataset-id", "ids": ["dataset-id"]}, {"id": "dataset-id", "ids": [""]}],
+    )
+    def test_rejects_conflicting_id_and_ids_before_get(self, monkeypatch, params):
+        client = RAGFlow("token", HOST_ADDRESS)
+        get_calls = []
+        monkeypatch.setattr(client, "get", lambda *_args, **_kwargs: get_calls.append((_args, _kwargs)))
+
+        with pytest.raises(ValueError, match="^Cannot use both 'id' and 'ids' parameters at the same time\\.$"):
+            client.list_datasets(**params)
+
+        assert get_calls == []
+
+    @pytest.mark.p2
+    @pytest.mark.parametrize(
+        "params",
+        [{"id": "dataset-id"}, {"ids": ["dataset-id"]}, {"id": None, "ids": None}, {"id": "dataset-id", "ids": []}, {"id": "", "ids": ["dataset-id"]}],
+    )
+    def test_preserves_nonconflicting_id_and_ids(self, monkeypatch, params):
+        client = RAGFlow("token", HOST_ADDRESS)
+        get_calls = []
+
+        def _get(path, params=None, json=None):
+            get_calls.append((path, params, json))
+            return _ListDatasetsResponse()
+
+        monkeypatch.setattr(client, "get", _get)
+        assert client.list_datasets(**params) == []
+        assert get_calls == [
+            (
+                "/datasets",
+                {"page": 1, "page_size": 30, "orderby": "create_time", "desc": True, "id": params.get("id"), "ids": params.get("ids"), "name": None},
+                None,
+            )
+        ]
+
+
 class TestAuthorization:
     @pytest.mark.p2
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary

Reject simultaneous non-empty `id` and `ids` arguments in the Python SDK's `list_datasets` method before issuing an HTTP request. This mirrors server-side dataset-list validation and the SDK's existing `list_documents` behavior while preserving empty and unset filter behavior.

### Tests

- Focused `TestListDatasetsArgumentValidation`: 7 passed
- Independent 9-case argument matrix: passed
- Ruff 0.16.5 format check: passed
- Ruff lint: no changed-line findings
- AST, import, and diff hygiene checks: passed
