### PR TITLE
fix(agent): reject only truly-empty delimiter entries on canvas save

### DIFF
--- a/internal/agent/component/dynamic_params.go
+++ b/internal/agent/component/dynamic_params.go
@@ -38,9 +38,17 @@ func validateDynamicEntries(value any) error {
 func validateDynamicParams(component string, params map[string]any) error {
 	for _, field := range []string{
 		"include_domains", "exclude_domains", "site_include", "site_exclude",
-		"country_include", "language_include", "delimiters", "children_delimiters",
+		"country_include", "language_include",
 	} {
 		if values, ok := params[field].([]any); ok && containsBlank(values) {
+			return fmt.Errorf("[%s] %s does not support empty entries", component, field)
+		}
+	}
+	// Delimiter entries are split tokens, not names: whitespace-only values
+	// ("\n", "\t") are valid delimiters — the chunker form's default row is a
+	// real newline — so only a zero-length string marks an incomplete row.
+	for _, field := range []string{"delimiters", "children_delimiters"} {
+		if values, ok := params[field].([]any); ok && containsEmpty(values) {
 			return fmt.Errorf("[%s] %s does not support empty entries", component, field)
 		}
 	}
@@ -170,6 +178,18 @@ func isNonBlankString(value any) bool {
 func containsBlank(values []any) bool {
 	for _, value := range values {
 		if isBlank(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsEmpty reports whether any entry is a zero-length string. Unlike
+// containsBlank it keeps whitespace-only entries, which are meaningful
+// delimiter values.
+func containsEmpty(values []any) bool {
+	for _, value := range values {
+		if s, ok := value.(string); ok && s == "" {
 			return true
 		}
 	}

--- a/internal/agent/component/dynamic_params_test.go
+++ b/internal/agent/component/dynamic_params_test.go
@@ -28,6 +28,15 @@ func TestValidateDynamicEntries(t *testing.T) {
 		componentDSL("Iteration", map[string]any{"outputs": map[string]any{
 			"result": map[string]any{"type": "string", "ref": "Iteration@result"},
 		}}),
+		// Whitespace-only delimiters are legitimate split tokens: the web
+		// form's default row is "\n" (a real newline) and the delimiter
+		// input converts a typed "\n"/"\t" into the raw control character
+		// before saving. They must not be rejected as empty entries.
+		componentDSL("TokenChunker", map[string]any{
+			"delimiter_mode":      "delimiter",
+			"delimiters":          []any{"\n"},
+			"children_delimiters": []any{"\t"},
+		}),
 	)
 
 	if err := ValidateDynamicEntries(valid); err != nil {
@@ -50,6 +59,8 @@ func TestValidateDynamicEntries(t *testing.T) {
 		{"loop operator", componentDSL("Loop", map[string]any{"loop_termination_condition": []any{map[string]any{"variable": "count", "operator": "", "value": 3}}}), "loop_termination_condition[0]"},
 		{"iteration output", componentDSL("Iteration", map[string]any{"outputs": map[string]any{"result": map[string]any{"ref": ""}}}), "outputs.result"},
 		{"input option", componentDSL("UserFillUp", map[string]any{"inputs": map[string]any{"choice": map[string]any{"options": []any{"one", ""}}}}), "inputs.choice.options"},
+		{"empty delimiter entry", componentDSL("TokenChunker", map[string]any{"delimiters": []any{"ok", ""}}), "delimiters"},
+		{"empty children delimiter entry", componentDSL("TokenChunker", map[string]any{"children_delimiters": []any{""}}), "children_delimiters"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Summary

Saving an agent canvas that contains a TokenChunker node failed on the Go backend with `[TokenChunker] delimiters does not support empty entries` whenever any separator was configured; users had to delete all delimiters to save. Reported with a screenshot showing the toast `update agent … [TokenChunker] delimiters does not support empty entries` on a node whose only delimiter row is `\n`.

**Root cause.** The web delimiter input converts a typed `\n`/`\t` into the raw control character before saving, and the chunker form's default row is `{ value: '\n' }` (a real newline), so a default-configured TokenChunker always submits `delimiters: ["\n"]`. The Go save-path guard `internal/agent/component/dynamic_params.go` (wired into create/update/publish agent in `internal/service/agent.go`) checked `delimiters`/`children_delimiters` with a `strings.TrimSpace`-based blank test, so the legitimate whitespace-only delimiter was classified as an "empty entry" and the whole save was rejected. The Python backend has no such save-time check, and its runtime (`rag/flow/chunker/token_chunker.py`) explicitly keeps whitespace delimiters and defaults to `["\n"]` — this was a Go-only divergence.

**Fix.** `validateDynamicParams` now treats `delimiters` and `children_delimiters` as split tokens: only a zero-length string marks an incomplete row (parity with the Python runtime's `if d` filter). Name-like repeatable fields (`include_domains`, `site_include`, `tools`, `select_keys`, option lists, …) keep the stricter whitespace-blank rule. The error message for genuinely empty rows is unchanged.

**Tests.** Extended `TestValidateDynamicEntries` in `internal/agent/component/dynamic_params_test.go`:
- valid DSL now includes a TokenChunker with `delimiters: ["\n"]` and `children_delimiters: ["\t"]` — this case reproduced the reported failure verbatim against the pre-fix code (`valid DSL rejected: [TokenChunker] delimiters does not support empty entries`);
- new guard cases assert `delimiters: ["ok", ""]` and `children_delimiters: [""]` are still rejected.

**Verification boundary.** Unit-verified with `CGO_ENABLED=0 go test ./internal/agent/component/` (repro fails pre-fix, all 13 subtests + full package suite pass post-fix). In this sandbox `bash build.sh --test` binaries crash at process init in the statically linked CGO chain (`__cxa_guard_release` SIGSEGV before any test executes — also reproduces with `ragflow_server --help`, i.e. unrelated to this change), so the canonical command and a live browser save-through-the-UI walkthrough could not be run here; the fix is one self-contained pure-Go validation change with no new dependencies.
