### PR TITLE
fix(web): default NumberInput precision to 2

### DIFF
--- a/web/src/components/originui/number-input.tsx
+++ b/web/src/components/originui/number-input.tsx
@@ -59,7 +59,7 @@ const NumberInput = forwardRef<
     hideIcons = false,
     integer = false,
     inputClassName,
-    precision,
+    precision = 2,
     ...props
   },
   ref,


### PR DESCRIPTION
### Summary

Without a default, an undefined precision let inputs accept arbitrary decimal places, so values rendered inconsistently across forms.
