### PR TITLE
fix: allow special tokens in token counting

### DIFF
--- a/common/token_utils.py
+++ b/common/token_utils.py
@@ -126,7 +126,7 @@ def usage_from_response(resp) -> dict:
 def num_tokens_from_string(string: str) -> int:
     """Returns the number of tokens in a text string."""
     try:
-        code_list = encoder.encode(string)
+        code_list = encoder.encode(string, disallowed_special=())
         return len(code_list)
     except Exception:
         return 0
@@ -182,4 +182,4 @@ def total_token_count_from_response(resp):
 
 def truncate(string: str, max_len: int) -> str:
     """Returns truncated text if the length of text exceed max_len."""
-    return encoder.decode(encoder.encode(string)[:max_len])
+    return encoder.decode(encoder.encode(string, disallowed_special=())[:max_len])


### PR DESCRIPTION
### What problem does this PR solve?

Embedding text containing special tokens such as `<|endoftext|>` caused token counting and truncation to fail.

This change disables special-token rejection during local token counting and truncation.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
