### PR TITLE
fix(agent): prevent duplicate tools on one Agent node at creation

### DIFF
--- a/web/src/pages/agent/form/agent-form/tool-popover/tool-command.tsx
+++ b/web/src/pages/agent/form/agent-form/tool-popover/tool-command.tsx
@@ -12,7 +12,6 @@ import { Operator } from '@/pages/agent/constant';
 import OperatorIcon from '@/components/operator-icon';
 import { t } from 'i18next';
 import { lowerFirst } from 'lodash';
-import { LucidePlus } from 'lucide-react';
 import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGetNodeTools, useUpdateAgentNodeTools } from './use-update-tools';
@@ -73,13 +72,7 @@ function ToolCommandItem({
 }: ToolCommandItemProps & PropsWithChildren) {
   return (
     <CommandItem className="cursor-pointer" onSelect={() => toggleOption(id)}>
-      {id === Operator.Retrieval ? (
-        <span>
-          <LucidePlus className="size-4" />
-        </span>
-      ) : (
-        <Checkbox checked={isSelected} />
-      )}
+      <Checkbox checked={isSelected} />
       {children}
     </CommandItem>
   );

--- a/web/src/pages/agent/form/agent-form/tool-popover/use-update-tools.test.tsx
+++ b/web/src/pages/agent/form/agent-form/tool-popover/use-update-tools.test.tsx
@@ -1,0 +1,97 @@
+import { AgentFormContext } from '@/pages/agent/context';
+import { Operator } from '@/pages/agent/constant';
+import useGraphStore from '@/pages/agent/store';
+import { act, renderHook } from '@testing-library/react';
+import { useUpdateAgentNodeTools } from './use-update-tools';
+
+// The initial-values hook pulls in the whole operator-params catalog; the
+// params payload is irrelevant to duplicate-guard behavior.
+jest.mock('@/pages/agent/hooks/use-agent-tool-initial-values', () => ({
+  useAgentToolInitialValues: () => ({
+    initializeAgentToolValues: () => ({}),
+  }),
+}));
+
+type Tool = {
+  component_name: string;
+  name: string;
+  params: object;
+  id?: string;
+};
+
+const agentNode = (tools: Tool[]) =>
+  ({
+    id: 'agent:0',
+    type: 'ragNode',
+    position: { x: 0, y: 0 },
+    data: { label: Operator.Agent, name: 'agent:0', form: { tools } },
+  }) as any;
+
+function seedStore(tools: Tool[]) {
+  useGraphStore.setState({ nodes: [agentNode(tools)], edges: [] });
+}
+
+// Mirror the real tree: the context node always comes from the live store,
+// so a toggle re-reads the tools written by the previous toggle.
+function Wrapper({ children }: any) {
+  const node = useGraphStore((s) => s.nodes.find((n) => n.id === 'agent:0'));
+  return (
+    <AgentFormContext.Provider value={node as any}>
+      {children}
+    </AgentFormContext.Provider>
+  );
+}
+
+const currentTools = () =>
+  (useGraphStore.getState().nodes[0].data.form as any).tools as Tool[];
+
+describe('useUpdateAgentNodeTools (creation-time duplicate guard)', () => {
+  beforeEach(() => seedStore([]));
+
+  const renderTools = () =>
+    renderHook(() => useUpdateAgentNodeTools(), { wrapper: Wrapper });
+
+  it('adds a tool that is not present yet, named after the component', () => {
+    const { result } = renderTools();
+    act(() => result.current.updateNodeTools(Operator.Retrieval));
+    expect(currentTools().map((x) => x.component_name)).toEqual([
+      Operator.Retrieval,
+    ]);
+    expect(currentTools()[0].name).toBe(Operator.Retrieval);
+  });
+
+  it('selecting an already-added tool removes it instead of appending a duplicate', () => {
+    seedStore([
+      { component_name: Operator.Retrieval, name: Operator.Retrieval, params: {} },
+    ]);
+    const { result } = renderTools();
+    act(() => result.current.updateNodeTools(Operator.Retrieval));
+    expect(currentTools()).toEqual([]);
+  });
+
+  it('never holds two copies of the same tool, Retrieval included', () => {
+    const { result } = renderTools();
+    act(() => result.current.updateNodeTools(Operator.Retrieval));
+    // A second select toggles it off — previously this appended a second
+    // Retrieval tool, which later crashed the Go runtime with
+    // "duplicate agent tool name \"search_my_dateset\"".
+    act(() => result.current.updateNodeTools(Operator.Retrieval));
+    act(() => result.current.updateNodeTools(Operator.Retrieval));
+    const copies = currentTools().filter(
+      (x) => x.component_name === Operator.Retrieval,
+    );
+    expect(copies).toHaveLength(1);
+  });
+
+  it('cleans up a legacy canvas that already carries duplicates', () => {
+    seedStore([
+      { component_name: Operator.Retrieval, name: 'Retrieval', params: {} },
+      { component_name: Operator.Retrieval, name: 'Retrieval_0', params: {} },
+    ]);
+    const { result } = renderTools();
+    act(() => result.current.updateNodeTools(Operator.Retrieval));
+    expect(
+      currentTools().filter((x) => x.component_name === Operator.Retrieval),
+    ).toHaveLength(0);
+  });
+});

--- a/web/src/pages/agent/form/agent-form/tool-popover/use-update-tools.ts
+++ b/web/src/pages/agent/form/agent-form/tool-popover/use-update-tools.ts
@@ -16,8 +16,9 @@ export function useGetNodeTools() {
 }
 
 export function useUpdateAgentNodeTools() {
-  const { generateAgentToolName, generateAgentToolId, updateNodeForm } =
-    useGraphStore((state) => state);
+  const { generateAgentToolId, updateNodeForm } = useGraphStore(
+    (state) => state,
+  );
   const node = useContext(AgentFormContext)!;
   const tools = useGetNodeTools();
   const { initializeAgentToolValues } = useAgentToolInitialValues();
@@ -26,43 +27,26 @@ export function useUpdateAgentNodeTools() {
     (value: string) => {
       if (!node?.id) return;
 
-      // Append
-      if (value === Operator.Retrieval) {
-        updateNodeForm(
-          node.id,
-          [
-            ...tools,
-            {
-              component_name: value,
-              name: generateAgentToolName(node.id, value),
-              params: initializeAgentToolValues(value as Operator),
-              id: generateAgentToolId(value),
-            },
-          ],
-          ['tools'],
-        );
-      }
-      // Toggle
-      else {
-        updateNodeForm(
-          node.id,
-          tools.some((x) => x.component_name === value)
-            ? tools.filter((x) => x.component_name !== value)
-            : [
-                ...tools,
-                {
-                  component_name: value,
-                  name: value,
-                  params: initializeAgentToolValues(value as Operator),
-                  id: generateAgentToolId(value),
-                },
-              ],
-          ['tools'],
-        );
-      }
+      // Toggle — every tool (Retrieval included) is single-instance: the
+      // same tool can never be added to one Agent node twice. Selecting an
+      // already-added tool removes it.
+      updateNodeForm(
+        node.id,
+        tools.some((x) => x.component_name === value)
+          ? tools.filter((x) => x.component_name !== value)
+          : [
+              ...tools,
+              {
+                component_name: value,
+                name: value,
+                params: initializeAgentToolValues(value as Operator),
+                id: generateAgentToolId(value),
+              },
+            ],
+        ['tools'],
+      );
     },
     [
-      generateAgentToolName,
       generateAgentToolId,
       initializeAgentToolValues,
       node?.id,

--- a/web/src/pages/agent/store.ts
+++ b/web/src/pages/agent/store.ts
@@ -194,7 +194,6 @@ export type RFState = {
   getParentIdById: (id?: string | null) => string | undefined;
   updateNodeName: (id: string, name: string) => void;
   generateNodeName: (name: string) => string;
-  generateAgentToolName: (id: string, name: string) => string;
   generateAgentToolId: (prefix: string) => string;
   getAllAgentTools: () => IAgentTool[];
   getAgentToolById: GetAgentToolByIdFunc;
@@ -640,28 +639,6 @@ const useGraphStore = create<RFState>()(
         const { nodes } = get();
 
         return generateNodeNamesWithIncreasingIndex(name, nodes);
-      },
-      generateAgentToolName: (id: string, name: string) => {
-        const node = get().nodes.find((x) => x.id === id) as RAGFlowNodeType;
-
-        if (!node) {
-          return '';
-        }
-
-        const tools = (node.data.form!.tools as any[]).filter(
-          (x) => x.component_name === name,
-        );
-        const lastIndex = tools.length
-          ? (tools
-              .map((x) => {
-                const idx = x.name.match(/(\d+)$/)?.[1];
-                return idx && isNaN(idx) ? -1 : Number(idx);
-              })
-              .sort((a, b) => a - b)
-              .at(-1) ?? -1)
-          : -1;
-
-        return `${name}_${lastIndex + 1}`;
       },
       generateAgentToolId: (prefix: string) => {
         const allAgentToolIds = get()


### PR DESCRIPTION
### Summary

An Agent canvas with **two knowledge-retrieval (Retrieval) tools** failed on every user question with:

```
canvas invoke: [NodeRunError] ... Message: consume deferred Agent stream: component: Agent.Invoke: build tools: duplicate agent tool name "search_my_dateset"
```

Reported from the field with screenshots: the agent ("Docs QA Agent") had two retrieval tools attached; the chat panel answered with the raw `NodeRunError`, and the second tool had been auto-named `Retrieval_NaN`.

**Root cause**

The Agent tool picker **appended Retrieval unconditionally** while every other tool toggled (`use-update-tools.ts`), so a user could attach the same tool twice. Every Retrieval instance reports the same constant function name (`search_my_dateset`, `internal/agent/tool/retrieval.go`), and the Go runtime's `buildAgentTools` rejects duplicate tool names — aborting the whole canvas run before any model call. The `generateAgentToolName` helper additionally mis-computed the second tool's display name as `Retrieval_NaN` (`Number(undefined)` slipping through the index guard).

## Fix

Per review feedback, the correct behavior is to **prevent the duplicate at creation time** rather than make the runtime tolerate it:

- `web/.../tool-popover/use-update-tools.ts`: the Retrieval special case is removed; every tool now toggles — selecting an already-added tool removes it, so one Agent node can never hold two copies of the same tool.
- `web/.../tool-popover/tool-command.tsx`: the Retrieval menu row shows the same selection checkbox as every other tool instead of a plus icon.
- `web/src/pages/agent/store.ts`: `generateAgentToolName` loses its only caller and is removed (dead code).
- The Go runtime **keeps rejecting duplicate tool names** (`duplicate agent tool name %q`) as the last-resort guard for canvases constructed outside the UI or saved before this guard — such a canvas should fail loudly, not silently rename.

**Legacy canvases**: a canvas already saved with duplicate tools still fails at run time; opening the tool picker and selecting the duplicated tool once removes every copy, returning the canvas to a valid state.

## Verification

- New hook tests (`use-update-tools.test.tsx`, 4 cases): add-when-absent, toggle-off-when-present, never two copies across repeated selects, and cleanup of a legacy canvas that already carries duplicates.
- `jest src/pages/agent/form/agent-form/tool-popover src/pages/agent/store.test.ts`: 10/10 pass.
- `bash build.sh --test ./internal/agent/component/...`: pass (runtime behavior unchanged from main).
- `oxlint` clean on touched files; `tsc --noEmit` reports no new errors in touched files (remaining errors are pre-existing on main).
