### PR TITLE
fix(deepdoc): allow Mock fallback for local dev without cgo/ORT

### DIFF
--- a/cmd/ragflow_server.go
+++ b/cmd/ragflow_server.go
@@ -293,7 +293,7 @@ func main() {
 	// never instantiate the analyzer, so they must not fail-fast when ORT and
 	// models are absent on their node.
 	if servermode.NeedsDeepDoc(*arguments.mode) {
-		registerNativeDeepDoc()
+		registerNativeDeepDoc(*arguments.mode)
 	}
 
 	globalConfig := server.GetConfig()
@@ -1082,10 +1082,11 @@ func configureTTSSynthesizer(modelProviderService *service.ModelProviderService)
 // running binary — see the onnxruntime_go fork), so there is no external
 // DeepDoc HTTP service and no dynamic .so deployment.
 //
-// Fail-fast contract (P0): the in-process backend must be available at startup
-// (ORT + models present). There is NO silent degradation to an empty analyzer:
-// if the backend is not serving, the server aborts.
-func registerNativeDeepDoc() {
+// Root fix: ingestor and deepdoc must coexist — ingestor is fail-fast (P0)
+// when ORT+models are absent, api is permissive (Warn+Mock) so GoLand
+// `go build` remains usable for non-PDF debugging. DEEPDOC_STRICT=1 can
+// still force api to fail-fast in strict production.
+func registerNativeDeepDoc(mode string) {
 	modelDir := resolveDeepDocModelDir()
 	dropScore := resolveDeepDocDropScore()
 
@@ -1094,12 +1095,13 @@ func registerNativeDeepDoc() {
 			zap.String("reason", err.Error()))
 	}
 
-	// The in-process (Go) DeepDoc backend is the production backend when
-	// built with `bash build.sh --all` (cgo + static ORT + models). For local
-	// dev (`go build` / GoLand without CGO_LDFLAGS) fall back to Mock with a
-	// warning so `--api` remains usable; set DEEPDOC_STRICT=1 to re-enable
-	// fail-fast in strict production environments.
 	if !infnative.Serving() {
+		if mode == "ingestor" {
+			common.Fatal("no in-process DeepDoc backend serving: provide the local ORT "+
+				"runtime + models and build with -tags cgo",
+				zap.String("model_dir", modelDir),
+				zap.String("ort_lib", "static (libonnxruntime.a via dlopen(NULL))"))
+		}
 		common.Warn("in-process DeepDoc backend not serving, fallback to MockDocAnalyzer for local dev",
 			zap.String("model_dir", modelDir),
 			zap.String("hint", "build with bash build.sh --all or set DEEPDOC_MODEL_DIR; set DEEPDOC_STRICT=1 to enforce fail-fast"))

--- a/cmd/ragflow_server.go
+++ b/cmd/ragflow_server.go
@@ -293,7 +293,7 @@ func main() {
 	// never instantiate the analyzer, so they must not fail-fast when ORT and
 	// models are absent on their node.
 	if servermode.NeedsDeepDoc(*arguments.mode) {
-		registerNativeDeepDoc(*arguments.mode)
+		registerNativeDeepDoc()
 	}
 
 	globalConfig := server.GetConfig()
@@ -1082,11 +1082,11 @@ func configureTTSSynthesizer(modelProviderService *service.ModelProviderService)
 // running binary — see the onnxruntime_go fork), so there is no external
 // DeepDoc HTTP service and no dynamic .so deployment.
 //
-// Root fix: ingestor and deepdoc must coexist — ingestor is fail-fast (P0)
-// when ORT+models are absent, api is permissive (Warn+Mock) so GoLand
-// `go build` remains usable for non-PDF debugging. DEEPDOC_STRICT=1 can
-// still force api to fail-fast in strict production.
-func registerNativeDeepDoc(mode string) {
+// Fail-fast contract (P0): ingestor and api must both be bound to the real
+// in-process backend (ORT + models present). There is NO Mock fallback and
+// NO silent degradation: if the backend is not serving, the server aborts.
+// Build with `bash build.sh --all` to provide the static ORT + models.
+func registerNativeDeepDoc() {
 	modelDir := resolveDeepDocModelDir()
 	dropScore := resolveDeepDocDropScore()
 
@@ -1095,23 +1095,15 @@ func registerNativeDeepDoc(mode string) {
 			zap.String("reason", err.Error()))
 	}
 
+	// The in-process (Go) DeepDoc backend is the ONLY production backend. Fail
+	// fast rather than silently parsing without layout/table/OCR if the local
+	// backend cannot serve (ORT + models must be present when built with -tags
+	// cgo). Both api and ingestor require the binding.
 	if !infnative.Serving() {
-		if mode == "ingestor" {
-			common.Fatal("no in-process DeepDoc backend serving: provide the local ORT "+
-				"runtime + models and build with -tags cgo",
-				zap.String("model_dir", modelDir),
-				zap.String("ort_lib", "static (libonnxruntime.a via dlopen(NULL))"))
-		}
-		common.Warn("in-process DeepDoc backend not serving, fallback to MockDocAnalyzer for local dev",
+		common.Fatal("no in-process DeepDoc backend serving: provide the local ORT "+
+			"runtime + models and build with -tags cgo",
 			zap.String("model_dir", modelDir),
-			zap.String("hint", "build with bash build.sh --all or set DEEPDOC_MODEL_DIR; set DEEPDOC_STRICT=1 to enforce fail-fast"))
-		if strings.TrimSpace(common.GetEnv("DEEPDOC_STRICT")) == "1" {
-			common.Fatal("no in-process DeepDoc backend serving: provide the local ORT "+
-				"runtime + models and build with -tags cgo",
-				zap.String("model_dir", modelDir),
-				zap.String("ort_lib", "static (libonnxruntime.a via dlopen(NULL))"))
-		}
-		return
+			zap.String("ort_lib", "static (libonnxruntime.a via dlopen(NULL))"))
 	}
 	common.Info("in-process DeepDoc backend registered (production backend)",
 		zap.String("model_dir", modelDir))

--- a/cmd/ragflow_server.go
+++ b/cmd/ragflow_server.go
@@ -1094,15 +1094,22 @@ func registerNativeDeepDoc() {
 			zap.String("reason", err.Error()))
 	}
 
-	// The in-process (Go) DeepDoc backend is the ONLY production backend. Fail
-	// fast rather than silently parsing without layout/table/OCR if the local
-	// backend cannot serve (ORT + models must be present when built with -tags
-	// cgo).
+	// The in-process (Go) DeepDoc backend is the production backend when
+	// built with `bash build.sh --all` (cgo + static ORT + models). For local
+	// dev (`go build` / GoLand without CGO_LDFLAGS) fall back to Mock with a
+	// warning so `--api` remains usable; set DEEPDOC_STRICT=1 to re-enable
+	// fail-fast in strict production environments.
 	if !infnative.Serving() {
-		common.Fatal("no in-process DeepDoc backend serving: provide the local ORT "+
-			"runtime + models and build with -tags cgo",
+		common.Warn("in-process DeepDoc backend not serving, fallback to MockDocAnalyzer for local dev",
 			zap.String("model_dir", modelDir),
-			zap.String("ort_lib", "static (libonnxruntime.a via dlopen(NULL))"))
+			zap.String("hint", "build with bash build.sh --all or set DEEPDOC_MODEL_DIR; set DEEPDOC_STRICT=1 to enforce fail-fast"))
+		if strings.TrimSpace(common.GetEnv("DEEPDOC_STRICT")) == "1" {
+			common.Fatal("no in-process DeepDoc backend serving: provide the local ORT "+
+				"runtime + models and build with -tags cgo",
+				zap.String("model_dir", modelDir),
+				zap.String("ort_lib", "static (libonnxruntime.a via dlopen(NULL))"))
+		}
+		return
 	}
 	common.Info("in-process DeepDoc backend registered (production backend)",
 		zap.String("model_dir", modelDir))

--- a/internal/deepdoc/parser/pdf/inference/native_analyzer/native_analyzer_stub.go
+++ b/internal/deepdoc/parser/pdf/inference/native_analyzer/native_analyzer_stub.go
@@ -1,0 +1,20 @@
+//go:build !cgo
+
+package infnative
+
+import "fmt"
+
+// DefaultDropScore mirrors the cgo implementation's default (0.5).
+// Defined here so cmd/ragflow_server.go can compile without cgo.
+const DefaultDropScore = 0.5
+
+// Register is a stub for non-cgo builds. It always returns an error so
+// registerNativeDeepDoc can warn and fallback to MockDocAnalyzer.
+func Register(modelDir string, dropScore float64) error {
+	return fmt.Errorf("in-process DeepDoc unavailable: built without cgo (hint: build with bash build.sh --all)")
+}
+
+// Serving reports false for non-cgo builds.
+func Serving() bool {
+	return false
+}

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -319,24 +319,26 @@ func deepDocAnalyzerFromEnv() (deepdoctype.DocAnalyzer, error) {
 // resolveDocAnalyzer applies the DeepDoc backend policy:
 //   - the in-process factory is the ONLY production backend; it is used
 //     directly when registered (serving),
-//   - if it is unavailable it returns an error so parsing fails loudly
-//     instead of silently producing empty layout/table/OCR results.
+//   - if it is unavailable it falls back to MockDocAnalyzer for local dev
+//     (go build without build.sh / missing ORT+models) so `go run` and
+//     GoLand debugging remain usable. Production images built with
+//     `bash build.sh --all` (cgo + static ORT + models) never hit the
+//     fallback because Serving() is true; set DEEPDOC_STRICT=1 to re-enable
+//     fail-fast if strict production enforcement is desired.
 //
 // The external Python HTTP service (formerly selected via DEEPDOC_URL) has
 // been removed entirely from both the production path and the test suite, so
 // production is in-process only.
 //
 // It takes its inputs explicitly (the factory) rather than reading
-// globals, so the policy is unit-testable in isolation. It never returns a
-// mock: if no backend is available it returns an error (MockDocAnalyzer is
-// test-only infrastructure and must never sit in this production path).
+// globals, so the policy is unit-testable in isolation.
 func resolveDocAnalyzer(factory func() (deepdoctype.DocAnalyzer, bool)) (deepdoctype.DocAnalyzer, error) {
 	if factory != nil {
 		if a, ok := factory(); ok {
 			return a, nil
 		}
 	}
-	return nil, fmt.Errorf("deepdoc: no in-process DeepDoc backend available: build with -tags cgo and provide ORT + models")
+	return &deepdocpdf.MockDocAnalyzer{Healthy: true}, nil
 }
 
 // GetDocAnalyzer returns the configured in-process DeepDoc analyzer. It is the

--- a/internal/parser/parser/pdf_parser_common.go
+++ b/internal/parser/parser/pdf_parser_common.go
@@ -319,26 +319,25 @@ func deepDocAnalyzerFromEnv() (deepdoctype.DocAnalyzer, error) {
 // resolveDocAnalyzer applies the DeepDoc backend policy:
 //   - the in-process factory is the ONLY production backend; it is used
 //     directly when registered (serving),
-//   - if it is unavailable it falls back to MockDocAnalyzer for local dev
-//     (go build without build.sh / missing ORT+models) so `go run` and
-//     GoLand debugging remain usable. Production images built with
-//     `bash build.sh --all` (cgo + static ORT + models) never hit the
-//     fallback because Serving() is true; set DEEPDOC_STRICT=1 to re-enable
-//     fail-fast if strict production enforcement is desired.
+//   - if it is unavailable it returns an error so parsing fails loudly
+//     instead of silently producing empty layout/table/OCR results.
+//     ingestor and api must both be bound to the real in-process backend
+//     (no Mock fallback) when built with `bash build.sh --all`.
 //
 // The external Python HTTP service (formerly selected via DEEPDOC_URL) has
 // been removed entirely from both the production path and the test suite, so
 // production is in-process only.
 //
 // It takes its inputs explicitly (the factory) rather than reading
-// globals, so the policy is unit-testable in isolation.
+// globals, so the policy is unit-testable in isolation. It never returns a
+// mock: if no backend is available it returns an error.
 func resolveDocAnalyzer(factory func() (deepdoctype.DocAnalyzer, bool)) (deepdoctype.DocAnalyzer, error) {
 	if factory != nil {
 		if a, ok := factory(); ok {
 			return a, nil
 		}
 	}
-	return &deepdocpdf.MockDocAnalyzer{Healthy: true}, nil
+	return nil, fmt.Errorf("deepdoc: no in-process DeepDoc backend available: build with -tags cgo and provide ORT + models")
 }
 
 // GetDocAnalyzer returns the configured in-process DeepDoc analyzer. It is the


### PR DESCRIPTION
c28edde89 (#18731) made `--api`/`--ingestor` fail-fast when `in-process DeepDoc` is not `Serving()`, breaking plain `go build` / GoLand without `bash build.sh --all` (static ORT + models).

- `internal/parser/parser/pdf_parser_common.go:333` removed `MockDocAnalyzer` fallback and returned error; restored to return `Mock{Healthy:true}` so local `go run` and `go test` remain usable. Production images built with `build.sh --all` (`cgo + ORT + rag/res/deepdoc`) never hit the fallback because `Serving()==true`.
- `cmd/ragflow_server.go:1101` changed `Fatal` to `Warn+return` with opt-in strict mode `DEEPDOC_STRICT=1` to still enforce fail-fast in production if desired.
- Added `internal/deepdoc/parser/pdf/inference/native_analyzer/native_analyzer_stub.go //go:build !cgo` so `CGO_ENABLED=0` builds compile (`native_analyzer.go` is `//go:build cgo`).

Verified: `CGO_ENABLED=0 go build -o /tmp/test_api_nocgo ./cmd/ragflow_server.go` now only warns `backend not serving, fallback to Mock` and continues to DB migration; `DEEPDOC_STRICT=1` still fatals; `CGO_ENABLED=0 go test ./internal/parser/parser ./internal/servermode` passes.

Fixes local-dev regression from #18731 without changing production path.