### PR TITLE
feat(agent): expose Iteration max_concurrency on the canvas

### DIFF
--- a/agent/component/iteration.py
+++ b/agent/component/iteration.py
@@ -34,6 +34,7 @@ class IterationParam(ComponentParamBase):
         super().__init__()
         self.items_ref = ""
         self.variable = {}
+        self.max_concurrency = 0
 
     def get_input_form(self) -> dict[str, dict]:
         return {"items": {"type": "json", "name": "Items"}}

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -2630,6 +2630,9 @@ Best for: Documents with flowing, contextually connected content — such as boo
       script: 'Script',
       iterationItemDescription:
         'It represents the current element in the iteration, which can be referenced and manipulated in subsequent steps.',
+      maxConcurrency: 'Max concurrency',
+      maxConcurrencyTip:
+        '0 or 1 runs items one by one. Values greater than 1 run that many items at once.',
       guidingQuestion: 'Guidance question',
       onFailure: 'On failure',
       userPromptDefaultValue:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -2248,6 +2248,8 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
       script: '脚本',
       iterationItemDescription:
         '它是迭代过程中的当前元素，可以被后续流程引用和操作。',
+      maxConcurrency: '最大并发数',
+      maxConcurrencyTip: '0 或 1 表示逐项串行。大于 1 时按该数量并行处理。',
       guidingQuestion: '引导问题',
       onFailure: '异常时',
       userPromptDefaultValue:

--- a/web/src/pages/agent/constant/index.tsx
+++ b/web/src/pages/agent/constant/index.tsx
@@ -473,6 +473,7 @@ export const initialEmailValues = {
 
 export const initialIterationValues = {
   items_ref: '',
+  max_concurrency: 0,
   outputs: {},
 };
 

--- a/web/src/pages/agent/form/iteration-form/index.tsx
+++ b/web/src/pages/agent/form/iteration-form/index.tsx
@@ -1,7 +1,10 @@
+import { SliderInputFormField } from '@/components/slider-input-form-field';
 import { Form } from '@/components/ui/form';
+import { FormLayout } from '@/constants/form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { memo, useMemo } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import { ArrayFields } from '../../constant';
 import { INextOperatorForm } from '../../interface';
@@ -23,11 +26,13 @@ const FormSchema = z.object({
       mode: z.string(),
     }),
   ),
+  max_concurrency: z.coerce.number().int().min(0),
   outputs: z.array(z.object({ name: z.string(), value: z.any() })).optional(),
 });
 
 function IterationForm({ node }: INextOperatorForm) {
   const defaultValues = useValues(node);
+  const { t } = useTranslation();
 
   const form = useForm({
     defaultValues: defaultValues,
@@ -52,6 +57,15 @@ function IterationForm({ node }: INextOperatorForm) {
           name="items_ref"
           types={ArrayFields as any[]}
         ></QueryVariable>
+        <SliderInputFormField
+          min={0}
+          max={32}
+          name="max_concurrency"
+          label={t('flow.maxConcurrency')}
+          tooltip={t('flow.maxConcurrencyTip')}
+          layout={FormLayout.Vertical}
+          integer
+        ></SliderInputFormField>
         <DynamicOutput node={node}></DynamicOutput>
         <Output list={outputList}></Output>
       </FormWrapper>

--- a/web/src/pages/agent/form/iteration-form/use-values.ts
+++ b/web/src/pages/agent/form/iteration-form/use-values.ts
@@ -20,7 +20,11 @@ export function useValues(node?: RAGFlowNodeType) {
       return { ...initialIterationValues, outputs: [] };
     }
 
-    return { ...formData, outputs: convertToArray(formData.outputs) };
+    return {
+      ...initialIterationValues,
+      ...formData,
+      outputs: convertToArray(formData.outputs || {}),
+    };
   }, [node?.data?.form]);
 
   return values;


### PR DESCRIPTION
## Summary
- Add an Iteration canvas form field for `max_concurrency` (0–32). Go already honors this DSL field: 0/1 runs serial, >1 runs bounded parallel with order preserved.
- Default remains 0 so existing graphs stay serial.
- Persist `max_concurrency` on Python `IterationParam` so `str(canvas)` does not drop the field when saving DSL. This PR does not change Python Iteration runtime (no clone-based parallel).

## Test plan
- [ ] Open Agent canvas, add Iteration, confirm the slider appears and defaults to 0
- [ ] Set `max_concurrency` to 4, save, reload: the value is still 4 in the form and in DSL
- [ ] Leave the field at 0 on an existing graph: behavior stays serial
- [ ] With Go backend, `max_concurrency > 1` runs bounded parallel as today

Made with [Cursor](https://cursor.com)