### PR TITLE
fix(web): bound port and max records in the Execute SQL form

### DIFF
--- a/web/src/pages/agent/form/exesql-form/index.tsx
+++ b/web/src/pages/agent/form/exesql-form/index.tsx
@@ -26,7 +26,14 @@ import { buildOutputList } from '../../utils/build-output-list';
 import { FormWrapper } from '../components/form-wrapper';
 import { Output } from '../components/output';
 import { PromptEditor } from '../components/prompt-editor';
-import { FormSchema, useSubmitForm } from './use-submit-form';
+import {
+  FormSchema,
+  MaxMaxRecords,
+  MaxPort,
+  MinMaxRecords,
+  MinPort,
+  useSubmitForm,
+} from './use-submit-form';
 
 const outputList = buildOutputList(initialExeSqlValues.outputs);
 
@@ -98,7 +105,13 @@ export function ExeSQLFormWidgets({ loading }: { loading: boolean }) {
           <FormItem>
             <FormLabel>{t('port')}</FormLabel>
             <FormControl>
-              <NumberInput {...field} className="w-full"></NumberInput>
+              <NumberInput
+                {...field}
+                min={MinPort}
+                max={MaxPort}
+                integer
+                className="w-full"
+              ></NumberInput>
             </FormControl>
             <FormMessage />
           </FormItem>
@@ -125,7 +138,13 @@ export function ExeSQLFormWidgets({ loading }: { loading: boolean }) {
           <FormItem>
             <FormLabel>{t('maxRecords')}</FormLabel>
             <FormControl>
-              <NumberInput {...field} className="w-full"></NumberInput>
+              <NumberInput
+                {...field}
+                min={MinMaxRecords}
+                max={MaxMaxRecords}
+                integer
+                className="w-full"
+              ></NumberInput>
             </FormControl>
             <FormMessage />
           </FormItem>

--- a/web/src/pages/agent/form/exesql-form/use-submit-form.ts
+++ b/web/src/pages/agent/form/exesql-form/use-submit-form.ts
@@ -2,14 +2,24 @@ import { useTestDbConnect } from '@/hooks/use-agent-request';
 import { useCallback } from 'react';
 import { z } from 'zod';
 
+// The backend only checks for a positive integer, so an unbounded value lets a
+// single query pull an entire table into memory. Cap it an order of magnitude
+// above the 1024 default.
+export const MinMaxRecords = 1;
+export const MaxMaxRecords = 10000;
+
+// TCP port range.
+export const MinPort = 1;
+export const MaxPort = 65535;
+
 export const ExeSQLFormSchema = {
   db_type: z.string().min(1),
   database: z.string().min(1),
   username: z.string().min(1),
   host: z.string().min(1),
-  port: z.number(),
+  port: z.number().int().min(MinPort).max(MaxPort),
   password: z.string().optional().or(z.literal('')),
-  max_records: z.number(),
+  max_records: z.number().int().min(MinMaxRecords).max(MaxMaxRecords),
 };
 
 export const FormSchema = z


### PR DESCRIPTION
### Summary

Both fields were plain unbounded numbers. `port` accepted 0 and arbitrarily large values, and `max_records` had no ceiling, so a single query could pull an entire table into memory -- the backend only checks that it is a positive integer.

Constrain `port` to the TCP range and `max_records` to 10000 (10x the 1024 default) in both the zod schema and the NumberInput, and mark them integer so decimals are rejected instead of silently rounded. The node form and the tool form share these widgets, so both are covered.
