### PR TITLE
fix(test): give the rag_agent dialog stub the retrieval settings it now reads

### DIFF
--- a/test/unit_test/api/db/services/test_dialog_service_rag_agent_image_routing.py
+++ b/test/unit_test/api/db/services/test_dialog_service_rag_agent_image_routing.py
@@ -103,6 +103,14 @@ def _dialog(llm_id="qwen3-vl-plus@Tongyi-Qianwen"):
         llm_setting={"temperature": 0.1},
         prompt_config={},
         meta_data_filter=None,
+        # rag_agent forwards the assistant's retrieval settings to RAGTools, so a
+        # dialog stub without them raises AttributeError before reaching anything
+        # these tests assert on. Values are the Dialog model's own defaults.
+        similarity_threshold=0.2,
+        vector_similarity_weight=0.3,
+        top_n=6,
+        rerank_candidates_count=64,
+        top_k=1024,
     )
 
 


### PR DESCRIPTION
### Summary

`main` is currently red. Two tests in `test/unit_test/api/db/services/test_dialog_service_rag_agent_image_routing.py` fail on a clean checkout:

```
E   AttributeError: 'types.SimpleNamespace' object has no attribute 'similarity_threshold'
api/db/services/dialog_service.py:2136: in rag_agent
```

I reproduced it on `092b2744` with no other changes: `2 failed, 5 passed`.

Two changes landed 32 minutes apart on 2026-08-31 and each was green on its own branch:

- **#19016** (`17574259`, 11:03 UTC) made `rag_agent` forward the assistant's retrieval settings to `RAGTools`, adding five new reads off `dialog`: `similarity_threshold`, `vector_similarity_weight`, `top_n`, `rerank_candidates_count`, `top_k`.
- **#18884** (`2af732d6`, 11:35 UTC) added this test file. Its `_dialog()` stub carries seven attributes and none of those five.

So the `SimpleNamespace` raises inside the `RAGTools` construction, before either test reaches the behaviour it is actually asserting on. Neither PR was wrong in isolation, and neither run would have caught it.

The production code is right: a real `Dialog` row has all five columns. Only the stub is behind, so this adds them using the model's own defaults from `api/db/db_models.py:1474-1480` (`0.2`, `0.3`, `6`, `64`, `1024`).

Both introducing commits were confirmed through the API rather than from local history, since this checkout is shallow:

```
$ gh api repos/infiniflow/ragflow/commits/175742590 --jq '.files[] | select(.filename=="api/db/services/dialog_service.py") | .patch'
+        similarity_threshold=dialog.similarity_threshold,
+        vector_similarity_weight=dialog.vector_similarity_weight,
+        top_n=dialog.top_n,
+        rerank_candidates_count=dialog.rerank_candidates_count,
+        top_k=dialog.top_k,
```

### Testing

```
# on 092b2744, unmodified
$ pytest test/unit_test/api/db/services/test_dialog_service_rag_agent_image_routing.py -q
2 failed, 5 passed

# on this branch
$ pytest test/unit_test/api/db/services/test_dialog_service_rag_agent_image_routing.py -q
7 passed
```

Full unit suite on this branch: `3981 passed, 26 skipped`, with 4 failures that are identical on unmodified `main` in this environment and unrelated to the change: three in `test/unit_test/agent/sandbox/test_local_provider.py` that need Linux (`preexec_fn`), and `test_time_utils.py::test_different_timezones_handled`, which assumes a particular local timezone. CI's own run of `main` merged with a PR head reported `2 failed, 3990 passed`, and those 2 are the ones this fixes.
