### PR TITLE
fix(web): honor webhook trace terminal status

### DIFF
--- a/web/src/pages/agent/webhook-sheet/__tests__/status.test.ts
+++ b/web/src/pages/agent/webhook-sheet/__tests__/status.test.ts
@@ -1,0 +1,64 @@
+import { getWebhookTraceStatus } from '../status';
+
+describe('getWebhookTraceStatus', () => {
+  test('keeps loading and unfinished traces in the running state', () => {
+    expect(getWebhookTraceStatus()).toEqual({ status: 'running' });
+    expect(
+      getWebhookTraceStatus({
+        events: [],
+        finished: false,
+      }),
+    ).toEqual({ status: 'running' });
+  });
+
+  test('reports success only for an explicit successful finished event', () => {
+    expect(
+      getWebhookTraceStatus({
+        events: [{ event: 'finished', data: { success: true } }],
+        finished: true,
+      }),
+    ).toEqual({ status: 'success' });
+
+    expect(
+      getWebhookTraceStatus({
+        events: [],
+        finished: true,
+      }),
+    ).toEqual({ status: 'fail', message: undefined });
+  });
+
+  test.each([
+    ['error', { event: 'error', message: 'LLM failed' }, 'LLM failed'],
+    [
+      'cancelled',
+      { event: 'cancelled', data: { message: 'Run cancelled' } },
+      'Run cancelled',
+    ],
+    [
+      'waiting for user',
+      { event: 'waiting_for_user', data: { tips: 'Choose an option' } },
+      'Choose an option',
+    ],
+    [
+      'node failure',
+      { event: 'node_finished', data: { error: 'Node failed' } },
+      'Node failed',
+    ],
+  ])('reports %s terminal traces as failed', (_name, event, message) => {
+    expect(
+      getWebhookTraceStatus({
+        events: [event, { event: 'finished', data: { success: false } }],
+        finished: true,
+      }),
+    ).toEqual({ status: 'fail', message });
+  });
+
+  test('honors an unsuccessful finished event without a separate error', () => {
+    expect(
+      getWebhookTraceStatus({
+        events: [{ event: 'finished', data: { success: false } }],
+        finished: true,
+      }),
+    ).toEqual({ status: 'fail', message: undefined });
+  });
+});

--- a/web/src/pages/agent/webhook-sheet/index.tsx
+++ b/web/src/pages/agent/webhook-sheet/index.tsx
@@ -11,11 +11,11 @@ import { MessageEventType } from '@/hooks/use-send-message';
 import { IModalProps } from '@/interfaces/common';
 import { cn } from '@/lib/utils';
 import { upperFirst } from 'lodash';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { BeginId } from '../constant';
 import { JsonViewer } from '../form/components/json-viewer';
+import { getWebhookTraceStatus } from './status';
 import { WorkFlowTimeline } from './timeline';
 
 type RunSheetProps = IModalProps<any>;
@@ -38,28 +38,15 @@ const WebhookSheet = ({ hideModal }: RunSheetProps) => {
       event.data.component_id === BeginId,
   )?.data.inputs;
 
-  const latestOutput = data?.events?.findLast(
-    (event) =>
-      event.event === MessageEventType.NodeFinished &&
-      event.data.component_id !== BeginId,
-  )?.data.outputs;
+  const latestOutput = [...(data?.events ?? [])]
+    .reverse()
+    .find(
+      (event) =>
+        event.event === MessageEventType.NodeFinished &&
+        event.data.component_id !== BeginId,
+    )?.data.outputs;
 
-  const statusInfo = useMemo(() => {
-    if (data?.finished === false) {
-      return { status: 'running' };
-    }
-
-    const errorItem = data?.events.find(
-      (x) => x.event === 'error' || x.data?.error,
-    );
-    if (errorItem) {
-      return {
-        status: 'fail',
-        message: errorItem.data?.error || errorItem.message,
-      };
-    }
-    return { status: 'success' };
-  }, [data?.events, data?.finished]);
+  const statusInfo = getWebhookTraceStatus(data);
 
   return (
     <Sheet onOpenChange={hideModal} open modal={false}>

--- a/web/src/pages/agent/webhook-sheet/status.ts
+++ b/web/src/pages/agent/webhook-sheet/status.ts
@@ -1,0 +1,43 @@
+import type { IWebhookTrace } from '@/interfaces/database/agent';
+
+type WebhookTraceStatus = {
+  status: 'running' | 'success' | 'fail';
+  message?: string;
+};
+
+const FailedTerminalEvents = new Set([
+  'error',
+  'cancelled',
+  'waiting_for_user',
+]);
+
+const getFailureMessage = (event: any) =>
+  event?.data?.error ||
+  event?.data?.message ||
+  event?.data?.tips ||
+  event?.message;
+
+export const getWebhookTraceStatus = (
+  trace?: Pick<IWebhookTrace, 'events' | 'finished'>,
+): WebhookTraceStatus => {
+  if (trace?.finished !== true) {
+    return { status: 'running' };
+  }
+
+  const events = trace.events ?? [];
+  const failureEvent = events.find(
+    (event) => FailedTerminalEvents.has(event.event) || event.data?.error,
+  );
+  const finishedEvent = [...events]
+    .reverse()
+    .find((event) => event.event === 'finished');
+
+  if (failureEvent || finishedEvent?.data?.success !== true) {
+    return {
+      status: 'fail',
+      message: getFailureMessage(failureEvent),
+    };
+  }
+
+  return { status: 'success' };
+};


### PR DESCRIPTION
### Summary

Webhook trace polling marks a response as finished after any terminal event, but the sheet previously treated every finished trace without a node error as successful. This made cancelled runs, wait-for-user terminations, unsuccessful finished events, and the initial loading state appear successful.

This change:
- keeps loading and unfinished traces in the running state;
- reports error, cancelled, waiting-for-user, node-error, and success=false traces as failed;
- reports success only when the trace contains an explicit successful finished event;
- avoids findLast so the touched component remains compatible with the current TypeScript target;
- adds focused status regression tests.

Validation:
- 7 focused Jest tests passed;
- formatting and lint checks passed for all touched files;
- the touched files produce no TypeScript diagnostics. The repository-wide type check still reports existing errors in unrelated files.