### PR TITLE
fix(ingestion): preserve run input on resume and detach context for terminal cleanup

### DIFF
--- a/internal/ingestion/pipeline/pipeline.go
+++ b/internal/ingestion/pipeline/pipeline.go
@@ -554,6 +554,14 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 	cpID := compiled.CheckPointID
 	var localInterruptID string // in-process resume fallback when tracker is nil
 
+	// All terminal-state Redis writes (success cleanup, failure, cancel)
+	// must survive a ctx that gets cancelled around the Invoke boundary.
+	// Detach cancellation once here, bounded by a short timeout so a hung
+	// Redis cannot stall the terminal path indefinitely — mirrors the
+	// WithoutCancel+WithTimeout convention used across ingestion_service.go.
+	stateCtx, stateCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer stateCancel()
+
 	const maxResumeRounds = 1000
 	for round := 0; round < maxResumeRounds; round++ {
 		// TOP: recover the pending interrupt (crash recovery or in-process).
@@ -582,38 +590,29 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 		out, invokeErr := compiled.Workflow.Invoke(runCtx, current, compose.WithCheckPointID(cpID))
 		if invokeErr == nil {
 			if tracker != nil {
-				utility.BestEffort(fmt.Sprintf("ClearInterruptID for %s", p.taskID), func() error { return tracker.ClearInterruptID(ctx, cpID) })
-				utility.BestEffort(fmt.Sprintf("MarkSucceeded for %s", p.taskID), func() error { return tracker.MarkSucceeded(ctx, cpID) })
+				utility.BestEffort(fmt.Sprintf("ClearInterruptID for %s", p.taskID), func() error { return tracker.ClearInterruptID(stateCtx, cpID) })
+				utility.BestEffort(fmt.Sprintf("MarkSucceeded for %s", p.taskID), func() error { return tracker.MarkSucceeded(stateCtx, cpID) })
 			}
 			if store != nil {
-				utility.BestEffort(fmt.Sprintf("delete checkpoint for %s", p.taskID), func() error { return store.Delete(ctx, cpID) })
-				utility.BestEffort(fmt.Sprintf("delete DSL fingerprint for %s", p.taskID), func() error { return store.Delete(ctx, cpID+dslKeySuffix) })
-				utility.BestEffort(fmt.Sprintf("delete override fingerprint for %s", p.taskID), func() error { return store.Delete(ctx, cpID+ovfKeySuffix) })
+				utility.BestEffort(fmt.Sprintf("delete checkpoint for %s", p.taskID), func() error { return store.Delete(stateCtx, cpID) })
+				utility.BestEffort(fmt.Sprintf("delete DSL fingerprint for %s", p.taskID), func() error { return store.Delete(stateCtx, cpID+dslKeySuffix) })
+				utility.BestEffort(fmt.Sprintf("delete override fingerprint for %s", p.taskID), func() error { return store.Delete(stateCtx, cpID+ovfKeySuffix) })
 			}
 			return finalizeResult(current, out, runState), nil
 		}
 
 		// Cancellation (plan §4.3.b): wipe the checkpoint and mark cancelled.
 		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			// The run ctx is already cancelled, so the Redis writes below
-			// would fail immediately if we used it. Detach cancellation so
-			// the cleanup + MarkCancelled actually land; otherwise a
-			// cancelled run leaks its checkpoint and interrupt id, and the
-			// next attempt misreads "interrupt pending + checkpoint missing"
-			// as a fresh run with nil input. Bound the detached ctx so a
-			// hung Redis cannot stall the cancel path indefinitely.
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-			defer cleanupCancel()
-			p.cleanupCheckpoint(cleanupCtx, store, tracker, cpID)
+			p.cleanupCheckpoint(stateCtx, store, tracker, cpID)
 			if tracker != nil {
-				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(cleanupCtx, cpID) })
+				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(stateCtx, cpID) })
 			}
 			return current, fmt.Errorf("pipeline: run cancelled: %w", ctx.Err())
 		}
 
 		if !canvas.IsInterruptError(invokeErr) {
 			if tracker != nil {
-				utility.BestEffort(fmt.Sprintf("MarkFailed for %s", p.taskID), func() error { return tracker.MarkFailed(ctx, cpID, invokeErr.Error()) })
+				utility.BestEffort(fmt.Sprintf("MarkFailed for %s", p.taskID), func() error { return tracker.MarkFailed(stateCtx, cpID, invokeErr.Error()) })
 			}
 			return current, fmt.Errorf("pipeline: run canvas workflow: %w", invokeErr)
 		}

--- a/internal/ingestion/pipeline/pipeline.go
+++ b/internal/ingestion/pipeline/pipeline.go
@@ -568,8 +568,21 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 			resumeID = localInterruptID
 		}
 		if resumeID != "" {
-			runCtx = compose.ResumeWithData(runCtx, resumeID, nil)
-			invokeInput = nil // resume restores the graph input from checkpoint
+			// Only null out the input when the checkpoint this resume would
+			// rely on actually exists. eino silently starts a FRESH run from
+			// the entry node when the checkpoint is missing (load failure is
+			// not an error), so nil input would re-execute the source node
+			// (File) without doc_id / file[0].name and fail with "inputs
+			// missing". This can happen when a cancel raced the checkpoint
+			// save/delete, leaving the interrupt id behind but the payload
+			// gone. Fall back to a plain run with the full original input.
+			if _, ok, _ := store.Get(ctx, cpID); ok {
+				runCtx = compose.ResumeWithData(runCtx, resumeID, nil)
+				invokeInput = nil // resume restores the graph input from checkpoint
+			} else {
+				resumeID = ""
+				invokeInput = current
+			}
 		}
 
 		out, invokeErr := compiled.Workflow.Invoke(runCtx, invokeInput, compose.WithCheckPointID(cpID))
@@ -588,9 +601,16 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 
 		// Cancellation (plan §4.3.b): wipe the checkpoint and mark cancelled.
 		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			p.cleanupCheckpoint(ctx, store, tracker, cpID)
+			// The run ctx is already cancelled, so the Redis writes below
+			// would fail immediately if we used it. Detach cancellation so
+			// the cleanup + MarkCancelled actually land; otherwise a
+			// cancelled run leaks its checkpoint and interrupt id, and the
+			// next attempt misreads "interrupt pending + checkpoint missing"
+			// as a fresh run with nil input.
+			cleanupCtx := context.WithoutCancel(ctx)
+			p.cleanupCheckpoint(cleanupCtx, store, tracker, cpID)
 			if tracker != nil {
-				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(ctx, cpID) })
+				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(cleanupCtx, cpID) })
 			}
 			return current, fmt.Errorf("pipeline: run cancelled: %w", ctx.Err())
 		}

--- a/internal/ingestion/pipeline/pipeline.go
+++ b/internal/ingestion/pipeline/pipeline.go
@@ -524,21 +524,35 @@ func (p *Pipeline) resolveTracker() *canvas.RunTracker {
 // runPlain executes a single Invoke with no checkpoint/resume. Used when no
 // checkpoint store is available; progress is still recorded via the sink.
 func (p *Pipeline) runPlain(runCtx context.Context, current map[string]any, compiled *canvas.CompiledCanvas, tracker *canvas.RunTracker, runState *canvas.CanvasState) (map[string]any, error) {
+	// Terminal tracker writes must survive a run ctx that gets cancelled
+	// (the common failure/cancel path). Derive a fresh detached ctx per
+	// terminal branch, bounded so a hung Redis cannot stall — mirrors
+	// markStopped/markFailed in ingestion_service.go.
+	detached := func() (context.Context, context.CancelFunc) {
+		return context.WithTimeout(context.WithoutCancel(runCtx), 5*time.Second)
+	}
+
 	out, err := compiled.Workflow.Invoke(runCtx, current)
 	if err != nil {
 		if errors.Is(runCtx.Err(), context.Canceled) || errors.Is(runCtx.Err(), context.DeadlineExceeded) {
 			if tracker != nil {
-				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(runCtx, p.taskID) })
+				stateCtx, cancel := detached()
+				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(stateCtx, p.taskID) })
+				cancel()
 			}
 			return current, fmt.Errorf("pipeline: run cancelled: %w", runCtx.Err())
 		}
 		if tracker != nil {
-			utility.BestEffort(fmt.Sprintf("MarkFailed for %s", p.taskID), func() error { return tracker.MarkFailed(runCtx, p.taskID, err.Error()) })
+			stateCtx, cancel := detached()
+			utility.BestEffort(fmt.Sprintf("MarkFailed for %s", p.taskID), func() error { return tracker.MarkFailed(stateCtx, p.taskID, err.Error()) })
+			cancel()
 		}
 		return current, fmt.Errorf("pipeline: run canvas workflow: %w", err)
 	}
 	if tracker != nil {
-		utility.BestEffort(fmt.Sprintf("MarkSucceeded for %s", p.taskID), func() error { return tracker.MarkSucceeded(runCtx, p.taskID) })
+		stateCtx, cancel := detached()
+		utility.BestEffort(fmt.Sprintf("MarkSucceeded for %s", p.taskID), func() error { return tracker.MarkSucceeded(stateCtx, p.taskID) })
+		cancel()
 	}
 	return finalizeResult(current, out, runState), nil
 }
@@ -553,14 +567,6 @@ func (p *Pipeline) runPlain(runCtx context.Context, current map[string]any, comp
 func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, current map[string]any, compiled *canvas.CompiledCanvas, store canvas.CheckPointStore, tracker *canvas.RunTracker, runState *canvas.CanvasState) (map[string]any, error) {
 	cpID := compiled.CheckPointID
 	var localInterruptID string // in-process resume fallback when tracker is nil
-
-	// All terminal-state Redis writes (success cleanup, failure, cancel)
-	// must survive a ctx that gets cancelled around the Invoke boundary.
-	// Detach cancellation once here, bounded by a short timeout so a hung
-	// Redis cannot stall the terminal path indefinitely — mirrors the
-	// WithoutCancel+WithTimeout convention used across ingestion_service.go.
-	stateCtx, stateCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer stateCancel()
 
 	const maxResumeRounds = 1000
 	for round := 0; round < maxResumeRounds; round++ {
@@ -589,6 +595,13 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 
 		out, invokeErr := compiled.Workflow.Invoke(runCtx, current, compose.WithCheckPointID(cpID))
 		if invokeErr == nil {
+			// Terminal-state writes must survive a ctx cancelled around the
+			// Invoke boundary. Derive a fresh detached ctx here — bounded by
+			// a short timeout so a hung Redis cannot stall completion — so
+			// the 5s window covers only the cleanup, not the whole run
+			// (mirrors markStopped/markFailed in ingestion_service.go).
+			stateCtx, stateCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer stateCancel()
 			if tracker != nil {
 				utility.BestEffort(fmt.Sprintf("ClearInterruptID for %s", p.taskID), func() error { return tracker.ClearInterruptID(stateCtx, cpID) })
 				utility.BestEffort(fmt.Sprintf("MarkSucceeded for %s", p.taskID), func() error { return tracker.MarkSucceeded(stateCtx, cpID) })
@@ -603,16 +616,26 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 
 		// Cancellation (plan §4.3.b): wipe the checkpoint and mark cancelled.
 		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			p.cleanupCheckpoint(stateCtx, store, tracker, cpID)
+			// The run ctx is already cancelled, so Redis writes with it would
+			// fail immediately. Derive a fresh detached ctx so cleanup +
+			// MarkCancelled actually land; the 5s window covers the cleanup
+			// only, regardless of how long the run itself took.
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer cleanupCancel()
+			p.cleanupCheckpoint(cleanupCtx, store, tracker, cpID)
 			if tracker != nil {
-				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(stateCtx, cpID) })
+				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(cleanupCtx, cpID) })
 			}
 			return current, fmt.Errorf("pipeline: run cancelled: %w", ctx.Err())
 		}
 
 		if !canvas.IsInterruptError(invokeErr) {
+			// Same detached-ctx guarantee as the success/cancel paths: the
+			// run ctx may be cancelled by the time the failure surfaces.
+			failCtx, failCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer failCancel()
 			if tracker != nil {
-				utility.BestEffort(fmt.Sprintf("MarkFailed for %s", p.taskID), func() error { return tracker.MarkFailed(stateCtx, cpID, invokeErr.Error()) })
+				utility.BestEffort(fmt.Sprintf("MarkFailed for %s", p.taskID), func() error { return tracker.MarkFailed(failCtx, cpID, invokeErr.Error()) })
 			}
 			return current, fmt.Errorf("pipeline: run canvas workflow: %w", invokeErr)
 		}

--- a/internal/ingestion/pipeline/pipeline.go
+++ b/internal/ingestion/pipeline/pipeline.go
@@ -553,7 +553,6 @@ func (p *Pipeline) runPlain(runCtx context.Context, current map[string]any, comp
 func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, current map[string]any, compiled *canvas.CompiledCanvas, store canvas.CheckPointStore, tracker *canvas.RunTracker, runState *canvas.CanvasState) (map[string]any, error) {
 	cpID := compiled.CheckPointID
 	var localInterruptID string // in-process resume fallback when tracker is nil
-	invokeInput := current
 
 	const maxResumeRounds = 1000
 	for round := 0; round < maxResumeRounds; round++ {
@@ -568,24 +567,19 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 			resumeID = localInterruptID
 		}
 		if resumeID != "" {
-			// Only null out the input when the checkpoint this resume would
-			// rely on actually exists. eino silently starts a FRESH run from
-			// the entry node when the checkpoint is missing (load failure is
-			// not an error), so nil input would re-execute the source node
+			// Mark the resume target. Keep passing the full original input
+			// instead of nil: when eino loads the checkpoint it ignores the
+			// passed input entirely (restoreCheckPointState only restores
+			// channels/state, restoreTasks replays cp.Inputs), and when the
+			// checkpoint is missing it silently starts a FRESH run from the
+			// entry node — so nil input would re-execute the source node
 			// (File) without doc_id / file[0].name and fail with "inputs
-			// missing". This can happen when a cancel raced the checkpoint
-			// save/delete, leaving the interrupt id behind but the payload
-			// gone. Fall back to a plain run with the full original input.
-			if _, ok, _ := store.Get(ctx, cpID); ok {
-				runCtx = compose.ResumeWithData(runCtx, resumeID, nil)
-				invokeInput = nil // resume restores the graph input from checkpoint
-			} else {
-				resumeID = ""
-				invokeInput = current
-			}
+			// missing". Passing `current` covers both cases with no
+			// check-then-use race.
+			runCtx = compose.ResumeWithData(runCtx, resumeID, nil)
 		}
 
-		out, invokeErr := compiled.Workflow.Invoke(runCtx, invokeInput, compose.WithCheckPointID(cpID))
+		out, invokeErr := compiled.Workflow.Invoke(runCtx, current, compose.WithCheckPointID(cpID))
 		if invokeErr == nil {
 			if tracker != nil {
 				utility.BestEffort(fmt.Sprintf("ClearInterruptID for %s", p.taskID), func() error { return tracker.ClearInterruptID(ctx, cpID) })
@@ -606,8 +600,10 @@ func (p *Pipeline) runResumable(ctx context.Context, runCtx context.Context, cur
 			// the cleanup + MarkCancelled actually land; otherwise a
 			// cancelled run leaks its checkpoint and interrupt id, and the
 			// next attempt misreads "interrupt pending + checkpoint missing"
-			// as a fresh run with nil input.
-			cleanupCtx := context.WithoutCancel(ctx)
+			// as a fresh run with nil input. Bound the detached ctx so a
+			// hung Redis cannot stall the cancel path indefinitely.
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer cleanupCancel()
 			p.cleanupCheckpoint(cleanupCtx, store, tracker, cpID)
 			if tracker != nil {
 				utility.BestEffort(fmt.Sprintf("MarkCancelled for %s", p.taskID), func() error { return tracker.MarkCancelled(cleanupCtx, cpID) })

--- a/internal/ingestion/pipeline/pipeline_test.go
+++ b/internal/ingestion/pipeline/pipeline_test.go
@@ -455,6 +455,119 @@ func TestPipelineRunResumableCrossRunResume(t *testing.T) {
 	}
 }
 
+// docIDGuardStage mirrors the File component's contract: it requires
+// doc_id (or an explicit file descriptor) in its input and fails otherwise.
+// It lets the resume tests observe whether the graph was re-entered with the
+// original run input or with a nil input (the "inputs missing" failure).
+type docIDGuardStage struct {
+	mockCanvasStage
+	mu            sync.Mutex
+	guardCalls    int
+	missingInputs int
+}
+
+func (m *docIDGuardStage) Invoke(ctx context.Context, db *gorm.DB, inputs map[string]any) (map[string]any, error) {
+	m.mu.Lock()
+	m.guardCalls++
+	m.mu.Unlock()
+	if inputs == nil || inputs["doc_id"] == nil {
+		m.mu.Lock()
+		m.missingInputs++
+		m.mu.Unlock()
+		return nil, errors.New("file: inputs missing doc_id or file[0].name")
+	}
+	return m.mockCanvasStage.Invoke(ctx, db, inputs)
+}
+
+func (m *docIDGuardStage) snapshot() (calls, missing int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.guardCalls, m.missingInputs
+}
+
+// TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint covers the
+// cancel-race state: the interrupt id survives in the RunTracker but the
+// checkpoint payload is gone. Before the fix, runResumable treated the
+// orphaned id as "resume" and invoked the graph with nil input, which
+// re-entered the source node (docIDGuardStage) and failed with
+// "inputs missing doc_id". The fix must detect the missing checkpoint and
+// fall back to a plain run with the full original input.
+func TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint(t *testing.T) {
+	guard := &docIDGuardStage{mockCanvasStage: mockCanvasStage{output: map[string]any{"a": 1}}}
+	termStage := &oneShotErrStage{mockCanvasStage: mockCanvasStage{output: map[string]any{"b": 2}}}
+
+	const (
+		nameA = "p.OrphanA"
+		nameB = "p.OrphanB"
+	)
+	runtime.MustRegister(nameA, runtime.CategoryIngestion,
+		func(_ string, _ map[string]any) (runtime.Component, error) { return guard, nil },
+		runtime.Metadata{Version: "1.0.0"})
+	runtime.MustRegister(nameB, runtime.CategoryIngestion,
+		func(_ string, _ map[string]any) (runtime.Component, error) { return termStage, nil },
+		runtime.Metadata{Version: "1.0.0"})
+
+	const taskID = "task-orphan-interrupt"
+
+	store := newMemCheckpointStore()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { client.Close() })
+	tracker := canvas.NewRunTrackerWithClient(client, time.Hour)
+
+	newPipe := func() *Pipeline {
+		pipe, err := NewPipelineFromDSL([]byte(`{
+			"dsl": {
+				"components": {
+					"begin": {"obj": {"component_name": "Begin", "params": {}}, "downstream": ["a"]},
+					"a": {"obj": {"component_name": "`+nameA+`", "params": {}}, "upstream": ["begin"], "downstream": ["b"]},
+					"b": {"obj": {"component_name": "`+nameB+`", "params": {}}, "upstream": ["a"]}
+				},
+				"path": ["begin", "a", "b"],
+				"graph": {"nodes": []}
+			}
+		}`), taskID, WithCheckPointStore(store), WithRunTracker(tracker))
+		if err != nil {
+			t.Fatalf("NewPipelineFromDSL: %v", err)
+		}
+		return pipe
+	}
+
+	// Run 1: terminal B errors, leaving a checkpoint + interrupt id.
+	pipe1 := newPipe()
+	_, err := pipe1.Run(context.Background(), map[string]any{"doc_id": "d1"}, nil)
+	if err == nil {
+		t.Fatal("Run 1: expected error from simulated crash, got nil")
+	}
+	if calls, missing := guard.snapshot(); calls != 1 || missing != 0 {
+		t.Fatalf("Run 1: guard.calls=%d missing=%d, want 1/0", calls, missing)
+	}
+
+	// Simulate the cancel-race: the checkpoint payload vanishes but the
+	// interrupt id stays behind (cleanup used a cancelled ctx and failed).
+	if err := store.Delete(context.Background(), taskID); err != nil {
+		t.Fatalf("store.Delete: %v", err)
+	}
+	if _, ok, _ := tracker.GetInterruptID(context.Background(), taskID); !ok {
+		t.Fatal("precondition: interrupt id must still be present after checkpoint deletion")
+	}
+
+	// Run 2: must fall back to a plain run with the full input. The guard
+	// stage must see doc_id on every invocation (no "inputs missing").
+	pipe2 := newPipe()
+	_, err = pipe2.Run(context.Background(), map[string]any{"doc_id": "d1"}, nil)
+	if err != nil {
+		t.Fatalf("Run 2: expected success after checkpoint loss, got: %v", err)
+	}
+	calls, missing := guard.snapshot()
+	if missing != 0 {
+		t.Fatalf("Run 2: source stage ran %d times with missing doc_id, want 0 (orphan interrupt id must not nil the input)", missing)
+	}
+	if calls != 2 {
+		t.Fatalf("Run 2: source stage calls=%d, want 2 (fresh run after checkpoint loss)", calls)
+	}
+}
+
 // TestPipelineRunResumableDSLChanged discards a stale checkpoint when the DSL
 // is edited between the failed run and the resume. Run 1 fails on the terminal
 // stage, persisting a checkpoint keyed by taskID. Run 2 re-runs the SAME

--- a/internal/ingestion/pipeline/pipeline_test.go
+++ b/internal/ingestion/pipeline/pipeline_test.go
@@ -574,6 +574,107 @@ func TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint(t *testing.T) {
 	}
 }
 
+// longRunCancelStage simulates a long-running component (e.g. a PDF parser):
+// it blocks until the run ctx is cancelled, then returns a cancellation error
+// so runResumable takes the cancel branch. The started channel lets the test
+// coordinate the cancel so it lands AFTER the entry-derived stateCtx's 5s
+// window would have expired — reproducing the "run took longer than the
+// detached-cleanup budget" failure mode.
+type longRunCancelStage struct {
+	started chan struct{}
+}
+
+func (m *longRunCancelStage) Invoke(ctx context.Context, _ *gorm.DB, inputs map[string]any) (map[string]any, error) {
+	if m.started != nil {
+		close(m.started)
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+func (m *longRunCancelStage) Inputs() map[string]string  { return map[string]string{"name": "string"} }
+func (m *longRunCancelStage) Outputs() map[string]string { return map[string]string{"output": "any"} }
+
+// TestPipelineRunResumableCancelCleanupAfterLongRun covers the detached-ctx
+// timing defect: the previous "unified" stateCtx was derived once at the top
+// of runResumable with a 5s timeout, so any run lasting longer than 5s
+// reached the cancel branch with an already-expired ctx and the cleanup
+// (checkpoint delete + ClearInterruptID + MarkCancelled) silently failed —
+// reintroducing the exact leak this PR fixes. Each terminal branch must
+// derive its own detached ctx at the point of cleanup.
+func TestPipelineRunResumableCancelCleanupAfterLongRun(t *testing.T) {
+	started := make(chan struct{})
+	longStage := &longRunCancelStage{started: started}
+	termStage := &mockCanvasStage{output: map[string]any{"b": 2}}
+
+	const (
+		nameA = "p.LongCancelA"
+		nameB = "p.LongCancelB"
+	)
+	runtime.MustRegister(nameA, runtime.CategoryIngestion,
+		func(_ string, _ map[string]any) (runtime.Component, error) { return longStage, nil },
+		runtime.Metadata{Version: "1.0.0"})
+	runtime.MustRegister(nameB, runtime.CategoryIngestion,
+		func(_ string, _ map[string]any) (runtime.Component, error) { return termStage, nil },
+		runtime.Metadata{Version: "1.0.0"})
+
+	const taskID = "task-long-run-cancel"
+
+	store := newMemCheckpointStore()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("client.Close: %v", err)
+		}
+	})
+	tracker := canvas.NewRunTrackerWithClient(client, time.Hour)
+
+	pipe, err := NewPipelineFromDSL([]byte(`{
+		"dsl": {
+			"components": {
+				"begin": {"obj": {"component_name": "Begin", "params": {}}, "downstream": ["a"]},
+				"a": {"obj": {"component_name": "`+nameA+`", "params": {}}, "upstream": ["begin"], "downstream": ["b"]},
+				"b": {"obj": {"component_name": "`+nameB+`", "params": {}}, "upstream": ["a"]}
+			},
+			"path": ["begin", "a", "b"],
+			"graph": {"nodes": []}
+		}
+	}`), taskID, WithCheckPointStore(store), WithRunTracker(tracker))
+	if err != nil {
+		t.Fatalf("NewPipelineFromDSL: %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-started
+		// Simulate a long parse: cancel only after the entry-derived 5s
+		// cleanup window would have expired. 6s > 5s. Keep the test fast by
+		// timing the sleep from component start rather than from Run entry.
+		time.Sleep(6 * time.Second)
+		cancel()
+	}()
+
+	_, err = pipe.Run(runCtx, map[string]any{"doc_id": "d1"}, nil)
+	if err == nil {
+		t.Fatal("expected cancellation error, got nil")
+	}
+
+	// The cancel branch must have cleaned up with a fresh detached ctx.
+	if _, ok, _ := store.Get(context.Background(), taskID); ok {
+		t.Error("checkpoint was not deleted after cancellation (detached-ctx cleanup failed)")
+	}
+	if _, ok, _ := tracker.GetInterruptID(context.Background(), taskID); ok {
+		t.Error("interrupt id was not cleared after cancellation (detached-ctx cleanup failed)")
+	}
+	fields, err := tracker.Get(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("tracker.Get: %v", err)
+	}
+	if status := fields["status"]; status != "3" {
+		t.Errorf("tracker status = %q, want %q (cancelled)", status, "3")
+	}
+}
+
 // TestPipelineRunResumableDSLChanged discards a stale checkpoint when the DSL
 // is edited between the failed run and the resume. Run 1 fails on the terminal
 // stage, persisting a checkpoint keyed by taskID. Run 2 re-runs the SAME

--- a/internal/ingestion/pipeline/pipeline_test.go
+++ b/internal/ingestion/pipeline/pipeline_test.go
@@ -490,8 +490,9 @@ func (m *docIDGuardStage) snapshot() (calls, missing int) {
 // checkpoint payload is gone. Before the fix, runResumable treated the
 // orphaned id as "resume" and invoked the graph with nil input, which
 // re-entered the source node (docIDGuardStage) and failed with
-// "inputs missing doc_id". The fix must detect the missing checkpoint and
-// fall back to a plain run with the full original input.
+// "inputs missing doc_id". The fix keeps passing the full original input on
+// resume rounds, so the graph starts fresh with doc_id intact instead of
+// re-entering the source node with nil input.
 func TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint(t *testing.T) {
 	guard := &docIDGuardStage{mockCanvasStage: mockCanvasStage{output: map[string]any{"a": 1}}}
 	termStage := &oneShotErrStage{mockCanvasStage: mockCanvasStage{output: map[string]any{"b": 2}}}
@@ -512,7 +513,11 @@ func TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint(t *testing.T) {
 	store := newMemCheckpointStore()
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("client.Close: %v", err)
+		}
+	})
 	tracker := canvas.NewRunTrackerWithClient(client, time.Hour)
 
 	newPipe := func() *Pipeline {
@@ -552,8 +557,9 @@ func TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint(t *testing.T) {
 		t.Fatal("precondition: interrupt id must still be present after checkpoint deletion")
 	}
 
-	// Run 2: must fall back to a plain run with the full input. The guard
-	// stage must see doc_id on every invocation (no "inputs missing").
+	// Run 2: must start fresh with the full input preserved (no nil-input
+	// re-entry). The guard stage must see doc_id on every invocation
+	// (no "inputs missing").
 	pipe2 := newPipe()
 	_, err = pipe2.Run(context.Background(), map[string]any{"doc_id": "d1"}, nil)
 	if err != nil {


### PR DESCRIPTION
### Summary / Motivation

In the ingestion resumable pipeline (`runResumable`) and plain pipeline (`runPlain`), a combination of context cancellation races and nil input handling led to production failures with the following error signature:

```text
error  ingestor_server best-effort MarkCancelled ... failed: context canceled
info   ingestor_server Task ... cancelled during pipeline
error  ingestor_server Task ... failed, pipeline: run canvas workflow: [NodeRunError] canvas: component "File" invoke: file: inputs missing doc_id or file[0].name
```

Two primary defects caused this behavior:
1. **Terminal cleanup ran with an expired or canceled context:** In both `runResumable` and `runPlain`, terminal cleanup operations (deleting checkpoints and fingerprints, clearing interrupt IDs, marking task status as cancelled or failed) were attempted using the already-canceled `ctx`. Redis operations failed immediately with `context canceled`, or with `DeadlineExceeded` when a single upfront timeout context was used for runs exceeding 5 seconds (such as lengthy PDF parsing). As a result, interrupt IDs and checkpoints leaked into storage.
2. **Resumption re-entered source components with `nil` input:** When an interrupt ID was present in the tracker without a corresponding checkpoint payload (leftover from failed cancel cleanup or a save/delete race), eino silently initiated a fresh run from the root/entry node rather than failing. Because `invokeInput` was reset to `nil` on resume rounds, the entry component (`File`) re-executed without inputs and failed with `file: inputs missing doc_id or file[0].name`.

Fixes # <!-- Issue number placeholder -->

### Key Changes

- **Preserve original input on resume rounds (`runResumable`)**: Always pass the original run input (`current`) to `Workflow.Invoke` instead of resetting it to `nil`. When eino successfully loads a checkpoint, the passed input is ignored (tasks and channels are restored from the checkpoint payload). When the checkpoint payload is missing, eino safely executes a fresh run with all required inputs (such as `doc_id`) intact.
- **Derive fresh detached contexts per terminal branch (`runResumable` & `runPlain`)**: Derive a separate, bounded detached context (`context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)`) immediately before terminal operations in each branch (success cleanup, cancellation cleanup, and failure status updates). This ensures terminal writes succeed even if the parent execution context was canceled or if the workflow was long-running.
- **Add comprehensive regression tests**:
  - `docIDGuardStage`: Simulates an entry component requiring `doc_id` to detect invalid re-entry.
  - `TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint`: Asserts that an orphaned interrupt ID without a checkpoint payload gracefully performs a clean run with full inputs without error.
  - `TestPipelineRunResumableCancelCleanupAfterLongRun`: Asserts that cancellation cleanup succeeds after long-running tasks (>5s) and verifies proper cleanup of checkpoints, interrupt IDs, and task cancellation state in Redis.

### Implementation Details

- **Elimination of TOCTOU pre-check race**: Passing `current` directly on resume rounds avoids adding a separate Redis read to verify checkpoint existence prior to invocation, eliminating time-of-check to time-of-use (TOCTOU) races and preserving zero-overhead execution.
- **Terminal-time context detachment**: Rather than creating a single detached timeout context at the start of `runResumable` (which would expire during long ingestion steps like OCR or document parsing), `context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)` is created lazily at the point of terminal execution. This mirrors the `markStopped` / `markFailed` pattern established in `internal/ingestion/service/ingestion_service.go`.

### How to Test

Run the newly added regression and stress tests in `internal/ingestion/pipeline`:
```bash
bash build.sh --test ./internal/ingestion/pipeline/... -run "TestPipelineRunResumableOrphanInterruptIDWithoutCheckpoint|TestPipelineRunResumableCancelCleanupAfterLongRun"
```

Verify that all existing resumable pipeline tests and surrounding ingestion packages pass:
```bash
bash build.sh --test ./internal/ingestion/pipeline/...
```
