### PR TITLE
refactor(pptx): simplify buildPPTXJSONSections + drop Python-compat wording (Follow-ups 1+2 of #19076)

### DIFF
--- a/internal/parser/parser/pptx_ir.go
+++ b/internal/parser/parser/pptx_ir.go
@@ -43,13 +43,13 @@ func buildPPTXJSONSections(irJSON string) ([]map[string]any, error) {
 	for i, sec := range ir.Sections {
 		var lines []string
 		for _, el := range sec.Elements {
-			// Trim each line and drop blank ones: consecutive hard line
-			// breaks collapse to a single newline, so exactly one newline
-			// survives between two non-empty lines.
-			for _, line := range strings.Split(docxElementText(el), "\n") {
-				if line = strings.TrimSpace(line); line != "" {
-					lines = append(lines, line)
-				}
+			// Each element's full text (paragraphs, table cells, list
+			// items, etc.) becomes a single value; the shared IR walker
+			// already inserts newlines between rows/items, so internal
+			// newlines are preserved as-is. Only the element-level split
+			// is collapsed (one element → one value or none if empty).
+			if text := strings.TrimSpace(docxElementText(el)); text != "" {
+				lines = append(lines, text)
 			}
 		}
 		items = append(items, map[string]any{

--- a/internal/parser/parser/pptx_ir_test.go
+++ b/internal/parser/parser/pptx_ir_test.go
@@ -69,11 +69,13 @@ func TestBuildPPTXJSONSections(t *testing.T) {
 			wantTexts: []string{"before\nafter"},
 		},
 		{
-			// Regression: two consecutive breaks must collapse to exactly
-			// one newline - not zero, and not a preserved blank line. Blank
-			// lines are dropped, keeping one newline between two non-empty
-			// lines.
-			name: "consecutive hard line breaks collapse to one newline",
+			// Internal newlines emitted by the shared IR walker (e.g. between
+			// table rows or list items) are preserved as-is. The element-level
+			// split (one element -> one value or none if empty) is the only
+			// collapse applied at this layer; per-line collapse across
+			// elements happens only at element boundaries, where blank
+			// elements are dropped.
+			name: "consecutive line breaks inside one element stay as newlines",
 			irJSON: `{"sections":[{"elements":[
 				{"type":"paragraph","content":[
 					{"type":"text","text":"before"},
@@ -81,6 +83,18 @@ func TestBuildPPTXJSONSections(t *testing.T) {
 					{"type":"line_break"},
 					{"type":"text","text":"after"}
 				]}
+			]}]}`,
+			wantTexts: []string{"before\n\nafter"},
+		},
+		{
+			// Element-level collapse: a blank element between two text
+			// elements is dropped, leaving a single newline between the
+			// non-empty element values.
+			name: "blank element between two text elements is dropped",
+			irJSON: `{"sections":[{"elements":[
+				{"type":"paragraph","content":[{"type":"text","text":"before"}]},
+				{"type":"paragraph","content":[]},
+				{"type":"paragraph","content":[{"type":"text","text":"after"}]}
 			]}]}`,
 			wantTexts: []string{"before\nafter"},
 		},

--- a/internal/parser/parser/pptx_parser.go
+++ b/internal/parser/parser/pptx_parser.go
@@ -86,8 +86,8 @@ func (p *PPTXParser) ConfigureFromSetup(setup map[string]any) {
 }
 
 // ParseWithResult emits one JSON item per slide with the slide's
-// plain text. Mirrors the python parser.py:slides branch which
-// forces output_format="json" for the slide family.
+// plain text. Forces OutputFormat to "json" and emits one JSON item
+// per slide section.
 func (p *PPTXParser) ParseWithResult(ctx context.Context, filename string, data []byte) ParseResult {
 	// p == nil guard: the struct is embedded by value in PPTParser and
 	// always created via NewPPTXParser or the "ppt"-format constructor in


### PR DESCRIPTION
Implements **PR A** from the 'Suggested split' in #19076.

## Follow-up 1 — Simplify `buildPPTXJSONSections` (remove the split/rejoin round-trip)

The current code in `internal/parser/parser/pptx_ir.go` flattens each slide element with `docxElementText(el)` and then **splits the result on `\\n`**, drops blank lines, and rejoins with `\\n`. The only observable effect of this round-trip is that consecutive hard line breaks inside one paragraph collapse to a single newline.

The replacement: append each element's text once (trimmed, and only if non-empty) as a single value, and join elements with `\\n`. Internal newlines (table rows, list items, hard line breaks within a paragraph) are preserved as-is. Only the element-level collapse applies (drop blank elements between two non-empty elements).

## Follow-up 2 — Drop Python-compat wording in `ParseWithResult` comment

Per the repo's `AGENTS.md` ("do not add new compatibility wording in comments/docs"), reword the comment from

```
// Mirrors the python parser.py:slides branch which forces
// output_format="json" for the slide family.
```

to a factual description of what the function does today:

```
// Forces OutputFormat to "json" and emits one JSON item
// per slide section.
```

Comment-only; no behavior change.

## Test changes

- Replaced the `consecutive hard line breaks collapse to one newline` test case with two new cases that pin the new contract:
  - `consecutive line breaks inside one element stay as newlines` — `before\\n\\nafter` (preserved, was collapsed before)
  - `blank element between two text elements is dropped` — `before\\nafter` (element-level collapse still applies)
- All other test cases (multi-slide, empty slide, bullet list, table cells, hard line break, bare text, image-only, invalid JSON, no sections) still pass with identical expected text. `go test -run TestBuildPPTXJSONSections -v` → 11/11 sub-tests pass. `go test -run TestItemsFromPlainText -v` → 1/1 pass.
- `go vet ./internal/parser/parser/` → clean on the touched files (pre-existing unrelated warning in `paddleocr.go:452` about a `context.WithDeadline` cancel function is not introduced by this change).

## Why I split it into two commits

- Commit 1 (`refactor(pptx): ...`) — code change + the matching test update. Easy to review and revert.
- Commit 2 (`docs(pptx): ...`) — comment-only change, no behavior implication.

Out of scope for this PR (per the issue's split): Follow-up 3 (doc_type_kwd: 'image' alignment) and Follow-up 4 (Go↔Python text-format parity). Both are larger topics and the issue author recommends a separate PR for each.