### PR TITLE
fix(storage): remove S3 dataset buckets correctly

### DIFF
--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -15,13 +15,15 @@
 #
 
 import logging
-import boto3
-from botocore.exceptions import ClientError
-from botocore.config import Config
 import time
 from io import BytesIO
-from common.decorator import singleton
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
 from common import settings
+from common.decorator import singleton
 
 
 @singleton
@@ -232,15 +234,35 @@ class RAGFlowS3:
             logging.exception(f"Fail to move {src_bucket}/{src_path} -> {dest_bucket}/{dest_path}")
             return False
 
-    @use_default_bucket
-    def rm_bucket(self, bucket, *args, **kwargs):
-        for conn in self.conn:
-            try:
-                if not conn.bucket_exists(bucket):
-                    continue
-                for o in conn.list_objects_v2(Bucket=bucket):
-                    conn.delete_object(bucket, o.object_name)
-                conn.delete_bucket(Bucket=bucket)
+    def _delete_objects_by_prefix(self, bucket, prefix):
+        client = self.conn[0]
+        paginator = client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            objects = [{"Key": item["Key"]} for item in page.get("Contents", [])]
+            if not objects:
+                continue
+
+            response = client.delete_objects(Bucket=bucket, Delete={"Objects": objects})
+            errors = (response or {}).get("Errors", [])
+            if errors:
+                details = ", ".join(f"{error.get('Key', '<unknown>')}: {error.get('Code', 'UnknownError')}" for error in errors)
+                raise RuntimeError(f"Failed to delete S3 objects from {bucket}: {details}")
+
+    def remove_bucket(self, bucket):
+        client = self.conn[0]
+        if self.bucket:
+            prefix = f"{self.prefix_path}/" if self.prefix_path else ""
+            self._delete_objects_by_prefix(self.bucket, f"{prefix}{bucket}/")
+            return
+
+        try:
+            client.head_bucket(Bucket=bucket)
+        except ClientError as error:
+            error_code = str(error.response.get("Error", {}).get("Code", ""))
+            status_code = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            if error_code in {"404", "NoSuchBucket", "NotFound"} or status_code == 404:
                 return
-            except Exception as e:
-                logging.error(f"Fail rm {bucket}: " + str(e))
+            raise
+
+        self._delete_objects_by_prefix(bucket, "")
+        client.delete_bucket(Bucket=bucket)

--- a/test/unit_test/rag/utils/test_s3_conn.py
+++ b/test/unit_test/rag/utils/test_s3_conn.py
@@ -15,7 +15,10 @@
 #
 
 import importlib
-from unittest.mock import Mock
+from unittest.mock import Mock, call
+
+import pytest
+from botocore.exceptions import ClientError
 
 # rag.utils.s3_conn and common.settings import each other (s3_conn needs
 # settings.S3; settings re-imports RAGFlowS3). The cycle resolves only when
@@ -63,3 +66,69 @@ def test_s3_health_returns_false_on_client_error(monkeypatch):
     client.head_bucket.side_effect = ConnectionError("unavailable")
 
     assert storage.health() is False
+
+
+def test_s3_remove_bucket_deletes_every_page_before_deleting_bucket(monkeypatch):
+    storage, client, _ = _new_storage(monkeypatch, {})
+    paginator = client.get_paginator.return_value
+    paginator.paginate.return_value = [
+        {"Contents": [{"Key": "first"}, {"Key": "second"}]},
+        {},
+        {"Contents": [{"Key": "third"}]},
+    ]
+    client.delete_objects.side_effect = [{}, {}]
+
+    storage.remove_bucket("dataset-id")
+
+    client.head_bucket.assert_called_once_with(Bucket="dataset-id")
+    client.get_paginator.assert_called_once_with("list_objects_v2")
+    paginator.paginate.assert_called_once_with(Bucket="dataset-id", Prefix="")
+    assert client.delete_objects.call_args_list == [
+        call(Bucket="dataset-id", Delete={"Objects": [{"Key": "first"}, {"Key": "second"}]}),
+        call(Bucket="dataset-id", Delete={"Objects": [{"Key": "third"}]}),
+    ]
+    client.delete_bucket.assert_called_once_with(Bucket="dataset-id")
+
+
+def test_s3_remove_bucket_only_deletes_logical_prefix_in_single_bucket_mode(monkeypatch):
+    storage, client, _ = _new_storage(monkeypatch, {"bucket": "physical-bucket", "prefix_path": "ragflow"})
+    paginator = client.get_paginator.return_value
+    paginator.paginate.return_value = [{"Contents": [{"Key": "ragflow/dataset-id/document"}]}]
+    client.delete_objects.return_value = {}
+
+    storage.remove_bucket("dataset-id")
+
+    client.head_bucket.assert_not_called()
+    paginator.paginate.assert_called_once_with(Bucket="physical-bucket", Prefix="ragflow/dataset-id/")
+    client.delete_objects.assert_called_once_with(Bucket="physical-bucket", Delete={"Objects": [{"Key": "ragflow/dataset-id/document"}]})
+    client.delete_bucket.assert_not_called()
+
+
+def test_s3_remove_bucket_ignores_missing_bucket(monkeypatch):
+    storage, client, _ = _new_storage(monkeypatch, {})
+    client.head_bucket.side_effect = ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadBucket")
+
+    storage.remove_bucket("missing")
+
+    client.get_paginator.assert_not_called()
+    client.delete_bucket.assert_not_called()
+
+
+def test_s3_remove_bucket_propagates_storage_errors(monkeypatch):
+    storage, client, _ = _new_storage(monkeypatch, {})
+    client.head_bucket.side_effect = ClientError({"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadBucket")
+
+    with pytest.raises(ClientError):
+        storage.remove_bucket("dataset-id")
+
+
+def test_s3_remove_bucket_reports_partial_delete_failures(monkeypatch):
+    storage, client, _ = _new_storage(monkeypatch, {})
+    paginator = client.get_paginator.return_value
+    paginator.paginate.return_value = [{"Contents": [{"Key": "blocked"}]}]
+    client.delete_objects.return_value = {"Errors": [{"Key": "blocked", "Code": "AccessDenied"}]}
+
+    with pytest.raises(RuntimeError, match="blocked.*AccessDenied"):
+        storage.remove_bucket("dataset-id")
+
+    client.delete_bucket.assert_not_called()


### PR DESCRIPTION
### Summary

Fix the AWS S3 storage cleanup path used when folders, datasets, or user accounts are deleted.

- replace the unused `rm_bucket` method with the `remove_bucket` contract used by callers
- delete objects through the boto3 paginator and batch API before deleting a dedicated bucket
- in shared-bucket mode, delete only the logical dataset prefix and keep the physical bucket
- treat a genuinely missing bucket as an idempotent success while propagating permission, listing, and partial-delete failures
- add focused unit coverage for pagination, shared-bucket isolation, missing buckets, and error propagation

Closes #19100

### Verification

- `pytest --noconftest test/unit_test/rag/utils/test_s3_conn.py -q` (9 passed, using an isolated `common.settings` stub because the local environment intentionally contains only the dependencies required by this unit)
- `ruff check --select I,F,E rag/utils/s3_conn.py test/unit_test/rag/utils/test_s3_conn.py`
- `ruff format --check rag/utils/s3_conn.py test/unit_test/rag/utils/test_s3_conn.py`
- `git diff --check`