### PR TITLE
fix(document-preview): keep xlsx sheet tabs on one row, drop duplicate fetch

### DIFF
--- a/web/src/components/document-preview/hooks.ts
+++ b/web/src/components/document-preview/hooks.ts
@@ -100,24 +100,6 @@ export const useGetDocumentUrl = (isAgent: boolean) => {
   return url;
 };
 
-export const useCatchError = (api: string) => {
-  const [error, setError] = useState('');
-  const fetchDocument = useCallback(async () => {
-    const ret = await axios.get(api);
-    const { data } = ret;
-    if (!(data instanceof ArrayBuffer) && data.code !== 0) {
-      setError(data.message);
-    }
-    return ret;
-  }, [api]);
-
-  useEffect(() => {
-    fetchDocument();
-  }, [fetchDocument]);
-
-  return { fetchDocument, error };
-};
-
 export const useFetchDocument = () => {
   const fetchDocument = useCallback(async (api: string) => {
     const ret = await axios.get(api, {
@@ -156,15 +138,9 @@ async function stripWpsDispImg(data: ArrayBuffer): Promise<ArrayBuffer> {
     modified = true;
     let cleaned = xml;
     // Remove <f> formula tags that reference DISPIMG
-    cleaned = cleaned.replace(
-      /<f\b[^>]*>[\s\S]*?DISPIMG[\s\S]*?<\/f>/g,
-      '',
-    );
+    cleaned = cleaned.replace(/<f\b[^>]*>[\s\S]*?DISPIMG[\s\S]*?<\/f>/g, '');
     // Replace cached <v> values that reference DISPIMG with a placeholder
-    cleaned = cleaned.replace(
-      /<v>[^<]*DISPIMG[^<]*<\/v>/g,
-      '<v>[图片]</v>',
-    );
+    cleaned = cleaned.replace(/<v>[^<]*DISPIMG[^<]*<\/v>/g, '<v>[图片]</v>');
     zip.file(path, cleaned);
   }
 
@@ -187,7 +163,9 @@ async function stripWpsDispImg(data: ArrayBuffer): Promise<ArrayBuffer> {
  * When such a prefix is detected, re-serialize the file with SheetJS (which
  * always emits a standard, prefix-free xlsx) so ExcelJS can parse it.
  */
-async function normalizeXlsxForExcelJS(data: ArrayBuffer): Promise<ArrayBuffer> {
+async function normalizeXlsxForExcelJS(
+  data: ArrayBuffer,
+): Promise<ArrayBuffer> {
   try {
     const zip = await JSZip.loadAsync(data);
     const workbookFile = zip.file('xl/workbook.xml');
@@ -221,10 +199,7 @@ type XsData = {
       cell: { style?: number; text?: string },
       type?: 'all' | 'text' | 'format',
     ) => void;
-    getCellOrNew: (
-      ri: number,
-      ci: number,
-    ) => { style?: number; text?: string };
+    getCellOrNew: (ri: number, ci: number) => { style?: number; text?: string };
     getHeight?: (ri: number) => number;
     len?: number;
   };
@@ -295,6 +270,9 @@ export function applyExcelSourceLocate(
     }
   }
 
+  // clickSwap2 must run even when the target sheet is already on screen: it is
+  // the library's only hook that redraws images embedded in the sheet, and the
+  // reRender/render/reload calls below each clear the canvas first.
   const tab = xs.bottombar?.items?.[sheetIdx];
   if (tab && typeof xs.bottombar?.clickSwap2 === 'function') {
     xs.bottombar.clickSwap2(tab);
@@ -302,29 +280,30 @@ export function applyExcelSourceLocate(
     xs.sheet.resetData(data);
   }
 
-  const rowHeight = data.rows.getHeight?.(0) || xs.sheet.data?.row?.height || 24;
+  const rowHeight =
+    data.rows.getHeight?.(0) || xs.sheet.data?.row?.height || 24;
   let y = 0;
   for (let r = 0; r < r1; r++) {
     y += data.rows.getHeight?.(r) ?? rowHeight;
   }
   data.scroll = { ...(data.scroll || { x: 0, y: 0 }), x: 0, y };
   if (xs.sheet.data && xs.sheet.data !== data) {
-    xs.sheet.data.scroll = { ...(xs.sheet.data.scroll || { x: 0, y: 0 }), x: 0, y };
+    xs.sheet.data.scroll = {
+      ...(xs.sheet.data.scroll || { x: 0, y: 0 }),
+      x: 0,
+      y,
+    };
   }
   xs.reRender?.();
   xs.sheet.table?.render?.();
   xs.sheet.reload?.();
 }
 
-export const useFetchExcel = (
-  filePath: string,
-  positions?: number[][],
-) => {
+export const useFetchExcel = (filePath: string, positions?: number[][]) => {
   const [status, setStatus] = useState(true);
   const { fetchDocument } = useFetchDocument();
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
   const size = useSize(containerEl);
-  const { error } = useCatchError(filePath);
 
   const previewerRef = useRef<ReturnType<typeof jsPreviewExcel.init> | null>(
     null,
@@ -462,7 +441,7 @@ export const useFetchExcel = (
     };
   }, []);
 
-  return { status, containerRef: setContainerEl, error };
+  return { status, containerRef: setContainerEl };
 };
 
 export const useCatchDocumentError = (url: string) => {

--- a/web/src/global.less
+++ b/web/src/global.less
@@ -43,6 +43,26 @@ body,
   height: 100%;
 }
 
+/* @js-preview/excel gives the sheet tab bar a fixed 40px height but floats the
+   tabs (`.x-spreadsheet-menu > li { float: left }`) with no horizontal overflow
+   handling. A workbook with several sheets therefore wraps the tabs onto a
+   second row that spills past the bar, which pushes a vertical scrollbar onto
+   the previewer container and steals 10px of its width. Keep the tabs on one
+   scrollable row instead, the way Excel does. */
+.x-spreadsheet-bottombar {
+  overflow-x: auto;
+  overflow-y: hidden;
+
+  .x-spreadsheet-menu {
+    display: flex;
+    flex-wrap: nowrap;
+  }
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+}
+
 /* Scroll bar stylings */
 ::-webkit-scrollbar {
   width: 10px;


### PR DESCRIPTION
### Summary

@js-preview/excel gives the sheet tab bar a fixed 40px height but floats the tabs (`.x-spreadsheet-menu > li { float: left }`) with no horizontal overflow handling. A workbook with several sheets therefore wraps the tabs onto a second row that spills past the bar, and that overflow pushed a vertical scrollbar onto the previewer container, stealing 10px of its width. Constrain the bar to a single horizontally scrollable row, the way Excel does.

Measured on a 7-sheet workbook in a 487px panel: tabs went from 2 rows to 1, the container's spurious vertical scrollbar disappeared, and its client width recovered from 509px to 519px.

Also drop useFetchExcel's useCatchError call. It re-downloaded the entire workbook through a bare axios.get -- no responseType, no Authorization header -- purely to sniff an error code that no consumer ever read, doubling the bytes transferred on every mount of the Excel previewer.
