### PR TITLE
fix(memory): use the shared NumberInput for the temperature field

### DIFF
--- a/web/src/pages/memory/memory-setting/advanced-settings-form.tsx
+++ b/web/src/pages/memory/memory-setting/advanced-settings-form.tsx
@@ -1,6 +1,6 @@
 import { FormFieldType, RenderField } from '@/components/dynamic-form';
+import NumberInput from '@/components/originui/number-input';
 import { SingleFormSlider } from '@/components/ui/dual-range-slider';
-import { NumberInput } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { cn } from '@/lib/utils';
@@ -122,13 +122,13 @@ export const AdvancedSettingsForm = () => {
                     disabled={false}
                   ></SingleFormSlider>
                   <NumberInput
-                    className={cn(
-                      'h-6 w-10 p-1 border border-border-button rounded-sm',
-                    )}
+                    className={cn('h-6 w-16')}
                     max={1}
                     step={0.01}
                     min={0}
+                    precision={2}
                     {...field}
+                    hideIcons
                   ></NumberInput>
                 </div>
               ),


### PR DESCRIPTION
### Summary

The temperature box was a bare `<input type="number">` -- the NumberInput in @/components/ui/input is a thin wrapper that only coerces the value to a number -- so it rendered native spinners and applied no decimal clamping, letting an unclamped float from a slider drag land in the field.

Switch to @/components/originui/number-input and pin `precision={2}` to match the slider's 0.01 step. That component truncates on the decimal string rather than via `Math.trunc(v * 10 ** decimals)`, so a value such as 0.29 survives instead of collapsing through 0.29 * 100 === 28.999...

Hide its stepper icons since the slider already drives adjustment, and widen the box from w-10 to w-16 so two decimals fit. The manual border/padding classes are dropped because the component supplies its own.