### PR TITLE
fix(agent): allow whitespace-only chunker delimiters on agent save

### DIFF
--- a/internal/agent/component/dynamic_params.go
+++ b/internal/agent/component/dynamic_params.go
@@ -5,7 +5,11 @@ import (
 	"strings"
 )
 
-// ValidateDynamicEntries rejects blank values in repeatable Agent parameters.
+// ValidateDynamicEntries rejects empty values in repeatable Agent parameters.
+// Whitespace-only entries stay valid for delimiter lists: the TokenChunker
+// default delimiter is "\n", and "\t"/"\r"/" " are ordinary custom delimiters
+// (Python keeps every non-empty string there — rag/flow/chunker/token_chunker.py
+// drops only "" entries).
 func ValidateDynamicEntries(dsl map[string]any) error {
 	return validateDynamicEntries(dsl)
 }
@@ -36,9 +40,17 @@ func validateDynamicEntries(value any) error {
 }
 
 func validateDynamicParams(component string, params map[string]any) error {
+	// Delimiter lists keep whitespace-only entries: they are semantic split
+	// tokens (the TokenChunker default is "\n"). Only truly empty strings are
+	// user-added blank rows and must fail the save.
+	for _, field := range []string{"delimiters", "children_delimiters"} {
+		if values, ok := params[field].([]any); ok && containsEmptyString(values) {
+			return fmt.Errorf("[%s] %s does not support empty entries", component, field)
+		}
+	}
 	for _, field := range []string{
 		"include_domains", "exclude_domains", "site_include", "site_exclude",
-		"country_include", "language_include", "delimiters", "children_delimiters",
+		"country_include", "language_include",
 	} {
 		if values, ok := params[field].([]any); ok && containsBlank(values) {
 			return fmt.Errorf("[%s] %s does not support empty entries", component, field)
@@ -162,6 +174,14 @@ func isBlank(value any) bool {
 	return ok && strings.TrimSpace(s) == ""
 }
 
+// isEmptyString reports a truly empty string. Unlike isBlank it does not
+// trim: "\n", "\t" or " " are valid delimiter entries (the TokenChunker
+// default is "\n"), so only "" counts as a user-added blank row.
+func isEmptyString(value any) bool {
+	s, ok := value.(string)
+	return ok && s == ""
+}
+
 func isNonBlankString(value any) bool {
 	s, ok := value.(string)
 	return ok && strings.TrimSpace(s) != ""
@@ -170,6 +190,15 @@ func isNonBlankString(value any) bool {
 func containsBlank(values []any) bool {
 	for _, value := range values {
 		if isBlank(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEmptyString(values []any) bool {
+	for _, value := range values {
+		if isEmptyString(value) {
 			return true
 		}
 	}

--- a/internal/agent/component/dynamic_params_test.go
+++ b/internal/agent/component/dynamic_params_test.go
@@ -28,6 +28,12 @@ func TestValidateDynamicEntries(t *testing.T) {
 		componentDSL("Iteration", map[string]any{"outputs": map[string]any{
 			"result": map[string]any{"type": "string", "ref": "Iteration@result"},
 		}}),
+		componentDSL("TokenChunker", map[string]any{
+			// The canvas default chunker: whitespace-only delimiters are
+			// semantic split tokens and must save cleanly (#18979 follow-up).
+			"delimiters":          []any{"\n"},
+			"children_delimiters": []any{"\t"},
+		}),
 	)
 
 	if err := ValidateDynamicEntries(valid); err != nil {
@@ -40,6 +46,8 @@ func TestValidateDynamicEntries(t *testing.T) {
 		want      string
 	}{
 		{"string array", componentDSL("DataOperations", map[string]any{"select_keys": []any{"title", " "}}), "select_keys"},
+		{"empty delimiter entry", componentDSL("TokenChunker", map[string]any{"delimiters": []any{"\n", ""}}), "delimiters"},
+		{"empty children delimiter entry", componentDSL("TokenChunker", map[string]any{"children_delimiters": []any{""}}), "children_delimiters"},
 		{"tool name", componentDSL("Agent", map[string]any{"tools": []any{"web_search", ""}}), "tools"},
 		{"filter operator", componentDSL("DataOperations", map[string]any{"filter_values": []any{map[string]any{"key": "status", "operator": "", "value": "published"}}}), "filter_values[0]"},
 		{"invoke variable", componentDSL("Invoke", map[string]any{"variables": []any{map[string]any{"key": "", "ref": "Begin@query", "value": "query"}}}), "variables[0]"},

--- a/internal/service/agent_test.go
+++ b/internal/service/agent_test.go
@@ -1688,6 +1688,72 @@ func TestUpdateAgentPersistsDSLAsJSONMap(t *testing.T) {
 	}
 }
 
+func TestUpdateAgentAcceptsDefaultTokenChunkerDelimiters(t *testing.T) {
+	setupAgentSessionServiceTest(t)
+
+	ctx := t.Context()
+	if err := dao.DB.WithContext(ctx).Create(&entity.UserCanvas{
+		ID:             "canvas-default-chunker",
+		UserID:         "user-1",
+		Title:          sptr("Default Chunker Agent"),
+		CanvasCategory: "agent_canvas",
+		DSL:            entity.JSONMap{},
+	}).Error; err != nil {
+		t.Fatalf("failed to seed canvas: %v", err)
+	}
+
+	// The canvas-default Chunker node ("按 Token 分块"): its delimiters list
+	// ships as ["\n"] (web/src/pages/agent/constant/pipeline.tsx). Saving the
+	// freshly added node must succeed — "\n" is a semantic split token, not an
+	// empty user-added row.
+	defaultChunkerDSL := func(delimiters []interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"graph": map[string]interface{}{
+				"nodes": []interface{}{map[string]interface{}{"id": "chunker"}},
+				"edges": []interface{}{},
+			},
+			"components": map[string]interface{}{
+				"chunker": map[string]interface{}{
+					"obj": map[string]interface{}{
+						"component_name": "TokenChunker",
+						"params": map[string]interface{}{
+							"delimiter_mode":      "delimiter",
+							"chunk_token_size":    512,
+							"overlapped_percent":  0,
+							"delimiters":          delimiters,
+							"enable_children":     false,
+							"children_delimiters": []interface{}{},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	if err := NewAgentService().UpdateAgent(ctx, "user-1", "canvas-default-chunker", map[string]interface{}{
+		"dsl": defaultChunkerDSL([]interface{}{"\n"}),
+	}); err != nil {
+		t.Fatalf("UpdateAgent rejected the default TokenChunker delimiters: %v", err)
+	}
+
+	persisted, err := dao.NewUserCanvasDAO().GetByID(ctx, dao.DB, "canvas-default-chunker")
+	if err != nil {
+		t.Fatalf("failed to reload canvas: %v", err)
+	}
+	if _, ok := persisted.DSL["components"]; !ok {
+		t.Fatalf("DSL components were not persisted: %#v", persisted.DSL)
+	}
+
+	// A genuinely empty delimiter row (user clicked "+ 添加" and left it blank)
+	// must still fail the save, preserving the intent of #18979.
+	err = NewAgentService().UpdateAgent(ctx, "user-1", "canvas-default-chunker", map[string]interface{}{
+		"dsl": defaultChunkerDSL([]interface{}{"\n", ""}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "[TokenChunker] delimiters does not support empty entries") {
+		t.Fatalf("UpdateAgent error = %v, want [TokenChunker] delimiters does not support empty entries", err)
+	}
+}
+
 func TestUpdateAgentDSLCreatesAndReplacesDraftVersion(t *testing.T) {
 	setupAgentSessionServiceTest(t)
 


### PR DESCRIPTION
### Summary

Saving an agent that contains a freshly added, default-configured Chunker node failed with:

```
102 update agent <canvas_id>: [TokenChunker] delimiters does not support empty entries
```

**Root cause.** The dynamic-entry validation introduced in #18979 (`internal/agent/component/dynamic_params.go`) screened every repeatable string list with `strings.TrimSpace(s) == ""`. That trimmed check is wrong for delimiter lists: the TokenChunker canvas default is `delimiters: ["\n"]` (the panel literally shows `\n`), and whitespace-only entries such as `"\t"`, `"\r"` or `" "` are perfectly ordinary custom delimiters. Every whitespace-only delimiter was therefore rejected as an "empty entry", which made the *default* Chunker node unsavable. Python does not behave this way — `rag/flow/chunker/token_chunker.py` only drops truly empty strings (`[d for d in self.delimiters if d]`).

**Fix.** `delimiters` and `children_delimiters` are now validated with a strict empty-string check (`s == ""`), so only genuinely empty user-added rows fail the save. All other repeatable fields (`include_domains`, `exclude_domains`, `site_include`, `site_exclude`, `country_include`, `language_include`, `select_keys`, `remove_keys`, `tools`, `inputs.*.options`, row/group validations) keep the stricter trimmed-blank rejection from #18979, so its original intent is preserved.

**Verification.**
- `internal/service/agent_test.go` gained `TestUpdateAgentAcceptsDefaultTokenChunkerDelimiters`, which drives the real `UpdateAgent` path with the canvas-default chunker DSL. Before the fix it failed with exactly the reported error (`update agent …: [TokenChunker] delimiters does not support empty entries`); after the fix the default `["\n"]` saves, while a user-added blank row (`["\n", ""]`) is still rejected.
- Unit tests in `internal/agent/component/dynamic_params_test.go`:
  - the valid DSL fixture now includes a default TokenChunker (`delimiters: ["\n"]`, `children_delimiters: ["\t"]`) and passes;
  - new rejection cases cover `delimiters: ["\n", ""]` and `children_delimiters: [""]`;
  - all pre-existing rejection cases (including `select_keys: [" ", ...]`) still pass.
- Both packages pass via `bash build.sh --test ./internal/agent/component/... ./internal/service/`.

Verification boundary: no browser end-to-end run was possible in this environment — the local Go API cannot start (missing native tokenizer resource under `/usr/share/infinity/resource`) and the local vite proxy routes `/api` to the Python backend, where this Go-only validation does not exist. Evidence is the service-level before/after test above, the component unit suite, and Python-parity analysis (`rag/flow/chunker/token_chunker.py` keeps every non-empty delimiter).
