### PR TITLE
fix(dify): return the custom document metadata the handler already fetches

### DIFF
--- a/internal/handler/dify_retrieval_handler.go
+++ b/internal/handler/dify_retrieval_handler.go
@@ -364,6 +364,11 @@ func (h *DifyRetrievalHandler) Retrieval(c *gin.Context) {
 		delete(ch, "vector")
 
 		meta := make(map[string]interface{})
+		if metaFields := metaMap[docID]; metaFields != nil {
+			for k, v := range metaFields {
+				meta[k] = v
+			}
+		}
 
 		meta["doc_id"] = docID
 		meta["document_id"] = docID

--- a/internal/handler/dify_retrieval_handler_test.go
+++ b/internal/handler/dify_retrieval_handler_test.go
@@ -238,6 +238,90 @@ func TestDifyRetrieval_Basic(t *testing.T) {
 	}
 }
 
+func TestDifyRetrieval_IncludesCustomDocumentMetadata(t *testing.T) {
+	h, r := setupDifyTest("user1")
+	h.metadataSvc = &mockMetadataService{
+		searchMetadataByKBs: func(ctx context.Context, kbIDs []string, size int) (*service.SearchMetadataResponse, error) {
+			return &service.SearchMetadataResponse{
+				MetadataRecords: []map[string]interface{}{
+					{"id": "doc1", "meta_fields": map[string]interface{}{"author": "Zhang San"}},
+				},
+			}, nil
+		},
+	}
+	body := `{"knowledge_id": "kb1", "query": "test question"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/dify/retrieval", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	meta := firstRecordMetadata(t, w.Body.Bytes())
+
+	if got := meta["author"]; got != "Zhang San" {
+		t.Errorf("custom metadata field author = %v, want %q", got, "Zhang San")
+	}
+	if got := meta["doc_id"]; got != "doc1" {
+		t.Errorf("doc_id = %v, want %q", got, "doc1")
+	}
+	if got := meta["document_id"]; got != "doc1" {
+		t.Errorf("document_id = %v, want %q", got, "doc1")
+	}
+}
+
+// A custom metadata key named doc_id or document_id must not replace the
+// identifiers the handler sets.
+func TestDifyRetrieval_DocumentIDsOverrideCustomMetadata(t *testing.T) {
+	h, r := setupDifyTest("user1")
+	h.metadataSvc = &mockMetadataService{
+		searchMetadataByKBs: func(ctx context.Context, kbIDs []string, size int) (*service.SearchMetadataResponse, error) {
+			return &service.SearchMetadataResponse{
+				MetadataRecords: []map[string]interface{}{
+					{"id": "doc1", "meta_fields": map[string]interface{}{
+						"doc_id":      "spoofed",
+						"document_id": "spoofed",
+					}},
+				},
+			}, nil
+		},
+	}
+	body := `{"knowledge_id": "kb1", "query": "test question"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/dify/retrieval", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	meta := firstRecordMetadata(t, w.Body.Bytes())
+
+	if got := meta["doc_id"]; got != "doc1" {
+		t.Errorf("doc_id = %v, want %q", got, "doc1")
+	}
+	if got := meta["document_id"]; got != "doc1" {
+		t.Errorf("document_id = %v, want %q", got, "doc1")
+	}
+}
+
+func firstRecordMetadata(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var resp struct {
+		Records []struct {
+			Metadata map[string]interface{} `json:"metadata"`
+		} `json:"records"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Records) == 0 {
+		t.Fatalf("expected at least one record, got %s", body)
+	}
+	return resp.Records[0].Metadata
+}
+
 func TestDifyRetrieval_GET(t *testing.T) {
 	_, r := setupDifyTest("user1")
 	w := httptest.NewRecorder()


### PR DESCRIPTION
### Summary

`DifyRetrievalHandler.Retrieval` fetches per-document metadata and then throws it away.

It builds `metaMap` from `SearchMetadataByKBs`:

```go
metaMap := make(map[string]map[string]interface{})
metaResult, err := h.metadataSvc.SearchMetadataByKBs(ctx, []string{kb.ID}, 10000)
```

but the response loop starts a fresh map and only ever writes the identifiers into it:

```go
meta := make(map[string]interface{})

meta["doc_id"] = docID
meta["document_id"] = docID
```

`metaMap` has one write site and no reader, so a Dify external knowledge base gets records whose `metadata` holds `doc_id` and `document_id` and nothing else. Custom fields such as `author` or `department` never arrive, which removes them from Dify-side metadata filtering and from citation display. The KB-wide fetch still runs on every request and its result is discarded.

### How the reader went missing

#16976 added the `SearchMetadataByKBs` fetch and re-pointed the existing merge loop at `metaMap`. #16983 was branched from a commit that predated that merge and removed the older `doc.MetaFields` loop; its merge resolution kept the deletion next to the new fetch, which left the lookup with nothing reading it. CodeRabbit noted on #16983 that `metaMap` had become unread.

This restores the merge exactly as #16976 had it. The identifiers are written after it, so a document whose own metadata carries a `doc_id` key cannot replace the one the handler sets. Neither backend reserves that key, so the ordering is load bearing rather than theoretical.

### Scope

Only `API_PROXY_SCHEME=go` deployments are affected. `docker/.env` ships `python`, and the `hybrid` nginx config sends `^/(v1|api)` to the Python server on 9380, so this endpoint reaches the Go handler in pure-Go mode only. The commit that removed the reader is an ancestor of v0.27.0, v0.27.1 and nightly, and is not an ancestor of v0.26.4.

The Python handler returns the same two keys for a different reason: `getattr(doc, "meta_fields", {})` reads an attribute the model does not define, so it yields `{}`. That is #15105, and #15111 proposes a Python fix against `api/apps/sdk/dify_retrieval.py`, a path that has since moved. This change is Go only and does not overlap it.

### Tests

Two tests in the existing `dify_retrieval_handler_test.go`. Three implementations, three outcomes:

| implementation | result |
| --- | --- |
| this change | 15 of 15 pass |
| current code | `IncludesCustomDocumentMetadata` fails, `author = <nil>` |
| merge written after the identifiers | `DocumentIDsOverrideCustomMetadata` fails, `doc_id = spoofed` |

The second test passes on current code as well as on this change. It is there to fail the wrong fix in row three rather than to fail today's behaviour, so the two tests pin different things.

### What was and was not run

`internal/handler` does not build on macOS: `internal/agent/sandbox/local.go:307` sets `SysProcAttr.Pdeathsig`, which exists only on Linux. The runs above used `CGO_ENABLED=0` with a `go test -overlay` that removes that one field, and were repeated with a `GOOS=linux GOARCH=arm64` static test binary in an `ubuntu:24.04` container with no overlay. Both environments gave the same three results. These handler tests are mock driven and never reach the cgo tokenizer.

Whole package on this branch: 483 results, 482 pass, 1 failure. The failure is `TestDownloadAttachment_OK` (`bot_test.go:667`, a `Content-Disposition` assertion). I ran it against the unmodified handler under the same overlay and it fails with the identical message, so it predates this change and is unrelated to it.

Worth knowing: `.github/workflows/tests.yml:248` filters `internal/handler` out of the Go unit test step, so CI will not run either new test. I have not claimed a CI result for them.

