### PR TITLE
build: bump office_oxide to v0.1.9 and pdf_oxide to v0.3.73

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ SYSTEM_DEPS="/opt/ragflow-native-libs"
 
 # office_oxide native library settings — static linking
 OFFICE_OXIDE_PREFIX="${HOME}/ragflow-native-libs/office_oxide"
-OFFICE_OXIDE_VERSION="0.1.8"
+OFFICE_OXIDE_VERSION="0.1.9"
 
 # pdfium native library settings — static linking (kognitos/pdfium-static)
 PDFIUM_STATIC_PREFIX="${HOME}/ragflow-native-libs/pdfium-static"
@@ -35,7 +35,7 @@ PDFIUM_STATIC_VERSION="7809"
 
 # pdf_oxide native library settings — static linking (go-ffi tarball)
 PDF_OXIDE_PREFIX="${HOME}/ragflow-native-libs/pdf_oxide"
-PDF_OXIDE_VERSION="0.3.67"
+PDF_OXIDE_VERSION="0.3.73"
 
 # onnxruntime native library settings — static linking for the in-process
 # (Go) DeepDoc backend. libonnxruntime*.a is linked into the server binary
@@ -229,6 +229,28 @@ check_pdf_oxide_deps() {
     local lib_path="${PDF_OXIDE_PREFIX}/lib/${platform_subdir}/libpdf_oxide.a"
 
     if [ -f "$lib_path" ]; then
+        # Verify the on-disk lib matches the pinned version. _seed_from_system
+        # accepts an existing user-cache directory without inspecting it, so a
+        # lib left over from an earlier pin is reused silently and the upgrade
+        # becomes a no-op.
+        #
+        # The marker here differs from office_oxide: instead of a standalone
+        # "0.1.9" line it is "pdf_oxide <version>" merged into Rust's string
+        # constant pool, so a whole-line match cannot be used. Extract the
+        # version and compare it exactly — a substring match would let a pin of
+        # "0.3.7" accept a 0.3.73 lib. The "pdf_oxide " prefix keeps bare
+        # version numbers of vendored dependencies out of the match.
+        local found_version
+        found_version=$(strings "$lib_path" 2>/dev/null \
+            | grep -oE "pdf_oxide [0-9]+\.[0-9]+\.[0-9]+" | head -1 | cut -d' ' -f2)
+        if [ "$found_version" != "$PDF_OXIDE_VERSION" ]; then
+            echo -e "${RED}Error: pdf_oxide native lib version mismatch${NC}"
+            echo "  Required: v${PDF_OXIDE_VERSION}; found: ${found_version:-unknown}"
+            echo "  A stale lib silently reverts PDF parsing fixes. Refresh:"
+            echo "    rm -rf ${PDF_OXIDE_PREFIX} ragflow_deps/pdf_oxide-go-ffi-linux-amd64.tar.gz"
+            echo "    uv run python3 ragflow_deps/download_go_deps.py"
+            return 1
+        fi
         echo "  pdf_oxide (static) → ${PDF_OXIDE_PREFIX}"
         return 0
     fi
@@ -439,7 +461,16 @@ setup_cgo_env() {
             esac
             ;;
     esac
-    export CGO_LDFLAGS="$CGO_LDFLAGS ${PDF_OXIDE_PREFIX}/lib/${pdf_oxide_subdir}/libpdf_oxide.a"
+    # Version-stamp the archive path so an in-place .a upgrade invalidates
+    # Go's build cache. See the office_oxide block above for why the raw path
+    # is not enough: the cache key hashes CGO_LDFLAGS as a string, not the
+    # contents of the archives it names.
+    local pdf_oxide_lib_dir="${PDF_OXIDE_PREFIX}/lib/${pdf_oxide_subdir}"
+    local pdf_oxide_versioned_dir="${pdf_oxide_lib_dir}/v${PDF_OXIDE_VERSION}"
+    mkdir -p "$pdf_oxide_versioned_dir"
+    ln -sf "${pdf_oxide_lib_dir}/libpdf_oxide.a" \
+        "${pdf_oxide_versioned_dir}/libpdf_oxide.a"
+    export CGO_LDFLAGS="$CGO_LDFLAGS ${pdf_oxide_versioned_dir}/libpdf_oxide.a"
 
     # ── onnxruntime (static, resolved via dlopen(NULL)) ────────────────
     # macOS native builds of the in-process DeepDoc backend are not supported:

--- a/go.mod
+++ b/go.mod
@@ -60,8 +60,8 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/ucloud/ucloud-sandbox-sdk-go v0.0.0-20260807065450-08464aef9ed5
 	github.com/xuri/excelize/v2 v2.11.0
-	github.com/yfedoseev/office_oxide/go v0.1.8
-	github.com/yfedoseev/pdf_oxide/go v0.3.67
+	github.com/yfedoseev/office_oxide/go v0.1.9
+	github.com/yfedoseev/pdf_oxide/go v0.3.73
 	github.com/yuin/goldmark v1.7.1
 	github.com/zeebo/xxh3 v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,10 @@ github.com/yargevad/filepathx v1.0.0 h1:SYcT+N3tYGi+NvazubCNlvgIPbzAk7i7y2dwg3I5
 github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGulUIU5tK3tA=
 github.com/yfedoseev/office_oxide/go v0.1.8 h1:Q6aQrrs0pN/B6fBoWN6PN95QSQ7EKGMb5HExh04mJJc=
 github.com/yfedoseev/office_oxide/go v0.1.8/go.mod h1:YLtMlKUkRCp/Q96wsy7D6yoBKDeJnP66UH+c9Bb+E+M=
-github.com/yfedoseev/pdf_oxide/go v0.3.67 h1:Fm1R/KtpmJPNbVmdT1fvYM/Yl41Uu2FdyT7fTo4hqZg=
-github.com/yfedoseev/pdf_oxide/go v0.3.67/go.mod h1:QbJ/nLbez0al2EnqEdEPIlGflFprWmiuUM4mo9rNNOI=
+github.com/yfedoseev/office_oxide/go v0.1.9 h1:gvTMCvJDYEZNF4dKd1cdfvU+9SRDSpnbNhCpZJbZOaE=
+github.com/yfedoseev/office_oxide/go v0.1.9/go.mod h1:YLtMlKUkRCp/Q96wsy7D6yoBKDeJnP66UH+c9Bb+E+M=
+github.com/yfedoseev/pdf_oxide/go v0.3.73 h1:hRad+X4W0ILW3bCQeCvdUKcoy8yMj2TFS6/XtoMk55I=
+github.com/yfedoseev/pdf_oxide/go v0.3.73/go.mod h1:QbJ/nLbez0al2EnqEdEPIlGflFprWmiuUM4mo9rNNOI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.30/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/ragflow_deps/download_deps.py
+++ b/ragflow_deps/download_deps.py
@@ -34,7 +34,6 @@ import argparse
 import os
 import shutil
 import urllib.request
-from typing import Union
 
 import nltk
 from huggingface_hub import snapshot_download
@@ -47,7 +46,7 @@ from huggingface_hub import snapshot_download
 ORT_VERSION = "1.23.2"
 
 
-def get_urls(use_china_mirrors=False) -> list[Union[str, list[str]]]:
+def get_urls(use_china_mirrors=False) -> list[str | list[str]]:
     if use_china_mirrors:
         return [
             "http://mirrors.tuna.tsinghua.edu.cn/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb",
@@ -79,8 +78,8 @@ def get_urls(use_china_mirrors=False) -> list[Union[str, list[str]]]:
             # Used by build.sh's check_*_deps functions — pre-downloaded to avoid
             # network access during CI.
             ["https://github.com/kognitos/pdfium-static/releases/download/chromium%2F7809/pdfium-linux-x64-static.tgz", "pdfium-linux-x64-static.tgz"],
-            ["https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.67/pdf_oxide-go-ffi-linux-amd64.tar.gz", "pdf_oxide-go-ffi-linux-amd64.tar.gz"],
-            ["https://github.com/yfedoseev/office_oxide/releases/download/v0.1.8/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
+            ["https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.73/pdf_oxide-go-ffi-linux-amd64.tar.gz", "pdf_oxide-go-ffi-linux-amd64.tar.gz"],
+            ["https://github.com/yfedoseev/office_oxide/releases/download/v0.1.9/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
             # ONNX Runtime static archives for the Go in-process (DeepDoc)
             # backend. Statically linked into the server binary (see build.sh:
             # ONNX_RUNTIME_STATIC_DIR, --whole-archive + --export-dynamic), so
@@ -125,8 +124,8 @@ def get_urls(use_china_mirrors=False) -> list[Union[str, list[str]]]:
             # Used by build.sh's check_*_deps functions — pre-downloaded to avoid
             # network access during CI.
             ["https://github.com/kognitos/pdfium-static/releases/download/chromium%2F7809/pdfium-linux-x64-static.tgz", "pdfium-linux-x64-static.tgz"],
-            ["https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.67/pdf_oxide-go-ffi-linux-amd64.tar.gz", "pdf_oxide-go-ffi-linux-amd64.tar.gz"],
-            ["https://github.com/yfedoseev/office_oxide/releases/download/v0.1.8/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
+            ["https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.73/pdf_oxide-go-ffi-linux-amd64.tar.gz", "pdf_oxide-go-ffi-linux-amd64.tar.gz"],
+            ["https://github.com/yfedoseev/office_oxide/releases/download/v0.1.9/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
             # ONNX Runtime static archives for the Go in-process (DeepDoc)
             # backend. Statically linked into the server binary (see build.sh:
             # ONNX_RUNTIME_STATIC_DIR, --whole-archive + --export-dynamic), so

--- a/ragflow_deps/download_go_deps.py
+++ b/ragflow_deps/download_go_deps.py
@@ -34,11 +34,11 @@
 import argparse
 import os
 import sys
+
 import requests
-from typing import Union
 
 
-def get_urls(use_china_mirrors=False) -> list[Union[str, list[str]]]:
+def get_urls(use_china_mirrors=False) -> list[str | list[str]]:
     if use_china_mirrors:
         return [
             # stagehand-server-v3 Node.js SEA binaries (used by Browser
@@ -62,7 +62,7 @@ def get_urls(use_china_mirrors=False) -> list[Union[str, list[str]]]:
             # network access during CI.
             ["https://gh-proxy.com/https://github.com/kognitos/pdfium-static/releases/download/chromium%2F7809/pdfium-linux-x64-static.tgz", "pdfium-linux-x64-static.tgz"],
             ["https://gh-proxy.com/https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.73/pdf_oxide-go-ffi-linux-amd64.tar.gz", "pdf_oxide-go-ffi-linux-amd64.tar.gz"],
-            ["https://gh-proxy.com/https://github.com/yfedoseev/office_oxide/releases/download/v0.1.8/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
+            ["https://gh-proxy.com/https://github.com/yfedoseev/office_oxide/releases/download/v0.1.9/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
         ]
     else:
         return [
@@ -87,7 +87,7 @@ def get_urls(use_china_mirrors=False) -> list[Union[str, list[str]]]:
             # network access during CI.
             ["https://github.com/kognitos/pdfium-static/releases/download/chromium%2F7809/pdfium-linux-x64-static.tgz", "pdfium-linux-x64-static.tgz"],
             ["https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.73/pdf_oxide-go-ffi-linux-amd64.tar.gz", "pdf_oxide-go-ffi-linux-amd64.tar.gz"],
-            ["https://github.com/yfedoseev/office_oxide/releases/download/v0.1.8/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
+            ["https://github.com/yfedoseev/office_oxide/releases/download/v0.1.9/native-linux-x86_64.tar.gz", "office_oxide-linux-x86_64.tar.gz"],
         ]
 
 


### PR DESCRIPTION
## Summary

Standalone bump of the two native static libraries linked into the Go server binary, split out from the doc-fidelity work so it can merge independently:

- **office_oxide**: 0.1.8 → 0.1.9
- **pdf_oxide**: 0.3.67 → 0.3.73

Files touched are limited to build infrastructure only (`build.sh`, `go.mod`/`go.sum`, `ragflow_deps/download_deps.py`, `ragflow_deps/download_go_deps.py`) — no parser/doc logic.

## Why separate from doc-fidelity

The published CI runner image already bakes **office_oxide 0.1.9 / pdf_oxide 0.3.73**, but `main` still pins 0.1.8 / 0.3.67. On a fresh runner container, `build.sh`'s version gates then fail (`found 0.1.9 != pinned 0.1.8`, etc.), so CI is currently red against `main`. Merging this PR first brings `main`'s pins in line with the already-shipped runner image and restores green CI; the doc-fidelity changes can follow in their own PR.

## pdf_oxide hardening

Go's build cache keys `CGO_LDFLAGS` as a string rather than hashing the archive it names, so an in-place `.a` upgrade is silently ignored (stale binary). This PR adds:

- a version-mismatch gate in `check_pdf_oxide_deps` that extracts the `pdf_oxide <version>` marker from the archive's constant pool (merged into Rust's string constants, so not a whole-line match) and compares it exactly; and
- a version-stamped symlink (`v<version>/libpdf_oxide.a`) so the cache key changes when the lib changes, forcing a relink.

## Test plan

- [ ] `bash build.sh --go` links against office_oxide 0.1.9 / pdf_oxide 0.3.73
- [ ] `bash build.sh --test ./internal/parser/parser/...` passes
- [ ] CI runner image (0.1.9 / 0.3.73) gates pass against this branch