### PR TITLE
fix(docker): disable stale macOS nginx mount

### DIFF
--- a/docker/docker-compose-macos.yml
+++ b/docker/docker-compose-macos.yml
@@ -17,7 +17,7 @@ services:
       - 443:443
     volumes:
       - ./ragflow-logs:/ragflow/logs
-      - ./nginx/ragflow.conf:/etc/nginx/conf.d/ragflow.conf
+      # - ./nginx/ragflow.conf:/etc/nginx/conf.d/ragflow.conf
       - ./nginx/proxy.conf:/etc/nginx/proxy.conf
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
     env_file: .env


### PR DESCRIPTION
### Summary

The `docker/nginx/ragflow.conf` path no longer exists in the repository, but `docker-compose-macos.yml` still attempts to bind-mount it.

On macOS, Docker treats the missing source path as a directory and mounts it to `/etc/nginx/conf.d/ragflow.conf`. The container entrypoint then fails when attempting to generate the Nginx configuration at that path. Because the service uses `restart: unless-stopped`, the container and Nginx enter an infinite restart loop.

This PR disables the stale bind mount in `docker-compose-macos.yml`, allowing the container entrypoint to generate `ragflow.conf` from the bundled deployment-specific Nginx configuration and start normally.