### PR TITLE
Fix link folder always use 'add' and use API result to refresh linked datasets

### DIFF
--- a/web/src/hooks/use-file-request.ts
+++ b/web/src/hooks/use-file-request.ts
@@ -338,37 +338,8 @@ export const useConnectToKnowledge = () => {
       });
       if (data.code === 0) {
         message.success(t('message.operated'));
-        const fileIdSet = new Set(params.fileIds);
-        queryClient.setQueriesData<IFetchFileListResult>(
-          {
-            queryKey: [FileApiAction.FetchFileList],
-          },
-          (oldData) => {
-            if (!oldData?.files) return oldData;
-            return {
-              ...oldData,
-              files: oldData.files.map((file) => {
-                if (!fileIdSet.has(file.id)) return file;
-                const kbsInfo =
-                  params.mode === 'replace'
-                    ? params.kbsInfo
-                    : [
-                        ...(file.kbs_info ?? []),
-                        ...params.kbsInfo.filter(
-                          (kb) =>
-                            !(file.kbs_info ?? []).some(
-                              (item) => item.kb_id === kb.kb_id,
-                            ),
-                        ),
-                      ];
-                return { ...file, kbs_info: kbsInfo };
-              }),
-            };
-          },
-        );
-        queryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
           queryKey: [FileApiAction.FetchFileList],
-          refetchType: 'none',
         });
       }
       return data.code;

--- a/web/src/pages/files/hooks.ts
+++ b/web/src/pages/files/hooks.ts
@@ -5,6 +5,7 @@ import { IFile } from '@/interfaces/database/file-manager';
 import { ConnectFileToKnowledgeMode } from '@/interfaces/request/file-manager';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
+import { isFolderType } from './util';
 
 export const useGetFolderId = () => {
   const [searchParams] = useSearchParams();
@@ -118,7 +119,7 @@ export const useHandleConnectToKnowledge = () => {
       } else {
         setRecord(documents);
         setDocumentIds([documents.id]);
-        setMode('replace');
+        setMode(isFolderType(documents.type) ? 'add' : 'replace');
       }
 
       showConnectToKnowledgeModal();


### PR DESCRIPTION
1. link folder always use add
2. show linked dataset always use API result.