### PR TITLE
fix(test): expect the bare attachment disposition the download path emits

### DIFF
--- a/internal/handler/bot_test.go
+++ b/internal/handler/bot_test.go
@@ -661,9 +661,7 @@ func TestDownloadAttachment_OK(t *testing.T) {
 	}
 	cd := w.Header().Get("Content-Disposition")
 	// Mirrors Python apply_download_file_response_headers: with no
-	// explicit ?filename= the disposition is a bare attachment. The
-	// "file" fallback lives inside format_content_disposition, which
-	// both languages skip entirely when no filename was supplied.
+	// explicit ?filename= the disposition is a plain attachment.
 	if cd != "attachment" {
 		t.Errorf("Content-Disposition = %q, want attachment", cd)
 	}

--- a/internal/handler/bot_test.go
+++ b/internal/handler/bot_test.go
@@ -661,10 +661,11 @@ func TestDownloadAttachment_OK(t *testing.T) {
 	}
 	cd := w.Header().Get("Content-Disposition")
 	// Mirrors Python apply_download_file_response_headers: with no
-	// explicit ?filename= the disposition is a plain attachment (Go
-	// backfills the empty name with "file" via SanitizeContentDispositionFilename).
-	if !strings.Contains(cd, "attachment") || !strings.Contains(cd, `filename="file"`) {
-		t.Errorf("Content-Disposition = %q, want attachment; filename=\"file\"", cd)
+	// explicit ?filename= the disposition is a bare attachment. The
+	// "file" fallback lives inside format_content_disposition, which
+	// both languages skip entirely when no filename was supplied.
+	if cd != "attachment" {
+		t.Errorf("Content-Disposition = %q, want attachment", cd)
 	}
 }
 


### PR DESCRIPTION
### Summary

`TestDownloadAttachment_OK` in `internal/handler/bot_test.go` fails on `main`. It asserts a `Content-Disposition` value that the download path deliberately stopped emitting in #17105, so the test now pins a contract the code no longer has.

```
--- FAIL: TestDownloadAttachment_OK (0.00s)
    bot_test.go:667: Content-Disposition = "attachment", want attachment; filename="file"
```

### The test is the stale side, not the handler

`GET /api/v1/agents/attachments/<id>/download` reaches `SetDownloadFileResponseHeaders`, which mirrors Python `apply_download_file_response_headers`. Neither emits a filename when the caller supplies none.

`api/utils/file_response.py:153-156`
```python
    if filename:
        response.headers.set("Content-Disposition", format_content_disposition("attachment", filename))
    else:
        response.headers.set("Content-Disposition", "attachment")
```

`internal/utility/file.go:481-485`
```go
	if filename != "" {
		h.Set("Content-Disposition", FormatContentDisposition("attachment", filename))
	} else {
		h.Set("Content-Disposition", "attachment")
	}
```

The two agree. Before #17105 the Go side, on the non-force-attachment path, called `SanitizeContentDispositionFilename(filename)` without checking for an empty name, and that function returns `"file"` for an empty input, so the header really was `attachment; filename="file"`. #17105 replaced it with the branch above, the same shape as the Python side. It updated three Python test files and no Go test file, and `bot_test.go` is the only Go test that reaches this header, so it kept asserting the old shape.

The comment above the assertion describes a path the handler does not take:

> Go backfills the empty name with "file" via SanitizeContentDispositionFilename

The `"file"` fallback is in `format_content_disposition` (`api/utils/file_response.py:104`) and, on the Go side, in `SanitizeContentDispositionFilename` (`internal/utility/file.go:367`), whose only caller is `FormatContentDisposition` (`file.go:435`). Both formatters return the bare disposition on an empty name before reaching it (`file_response.py:99-103`, `file.go:432-433`), and the download path never calls them without a filename, so the fallback applies only when a caller-supplied filename sanitizes down to nothing. Left in place, that comment invites a change to the handler that would re-diverge Go from Python.

### Change

One assertion and its comment. Equality replaces the two substring checks, because `strings.Contains(cd, "attachment")` is true for both the current output and the pre-#17105 output and so guards nothing.

### Why it went unnoticed

Both `build.sh --test` jobs in `sep-tests.yml` skip the package, at `:390` in `ragflow_tests_infinity` and `:1021` in `ragflow_tests_elasticsearch`:

```
          PKGS=$(go list ./... 2>/dev/null \
            | grep -v '/internal/storage$' \
            | grep -v '/internal/handler$' || true)
```

`tests.yml` has one job without that filter, but the workflow is disabled and its most recent run is 2026-07-02, before #17105. Nothing in CI has run this test since. This PR changes no workflow; it only makes the package pass for anyone who runs it locally.

### Verification

Run on macOS with `CGO_ENABLED=0` and a `-overlay` that swaps only `internal/agent/sandbox/local.go`, which uses the Linux-only `SysProcAttr.Pdeathsig`. No file involved in this change is overlaid.

| state | `internal/handler` |
|---|---|
| `main` (2132798f1) | 401 pass, **1 fail** (`TestDownloadAttachment_OK`) |
| this PR | **402 pass, 0 fail** |
| this PR's assertion against a restored pre-#17105 handler | **fails**, as it should |

The third row is the one that matters. Reverting the non-force-attachment path of `SetDownloadFileResponseHeaders` to the old backfill and running the new assertion against it gives:

```
    bot_test.go:666: Content-Disposition = "attachment; filename=\"file\"", want attachment
--- FAIL: TestDownloadAttachment_OK (0.00s)
```

So the assertion still pins the behavior rather than having been loosened until it passed.

`gofmt -l` and `go vet` are clean on the changed file.
