### PR TITLE
feat(ingestor): raise default max_concurrent_workers from 1 to 2

### DIFF
--- a/conf/service_conf.yaml
+++ b/conf/service_conf.yaml
@@ -68,7 +68,7 @@ otel:
   enable: false
 ingestor:
   mq_type: 'nats'
-  max_concurrent_workers: 1
+  max_concurrent_workers: 2
   compiler_pool_size: 0
 file_syncer:
   max_concurrent_syncs: 5

--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -93,7 +93,7 @@ otel:
   enable: false
 ingestor:
   mq_type: 'nats'
-  max_concurrent_workers: 1
+  max_concurrent_workers: 2
   compiler_pool_size: 0
 file_syncer:
   max_concurrent_syncs: 5

--- a/internal/server/config/ingestor_config.go
+++ b/internal/server/config/ingestor_config.go
@@ -30,7 +30,7 @@ type IngestorConfig struct {
 
 func (c *Config) ParseIngestorConfig(v *viper.Viper) error {
 	// Default Ingestor config
-	c.ingestor.MaxConcurrentWorkers = 1
+	c.ingestor.MaxConcurrentWorkers = 2
 	c.ingestor.CompilerPoolSize = 0
 
 	if !v.IsSet("ingestor") {


### PR DESCRIPTION
## Summary

Raise the ingestor's default `max_concurrent_workers` from 1 to 2 so a single ingestor process runs ingestion tasks with more parallelism out of the box.

## Changes

- `conf/service_conf.yaml`: `ingestor.max_concurrent_workers: 1 -> 2`
- `docker/service_conf.yaml.template`: same change for the Docker template
- `internal/server/config/ingestor_config.go`: code default in `ParseIngestorConfig` bumped to match

## Notes

`go build ./internal/server/config/...` passes. This changes the shipped default; operators who pinned `max_concurrent_workers: 1` explicitly are unaffected.