### PR TITLE
fix(agent): reject empty message rows when saving canvas

### DIFF
--- a/internal/agent/component/dynamic_params.go
+++ b/internal/agent/component/dynamic_params.go
@@ -53,6 +53,10 @@ func validateDynamicParams(component string, params map[string]any) error {
 		}
 	}
 	switch strings.ToLower(component) {
+	case "message":
+		if err := validateMessageContent(params); err != nil {
+			return fmt.Errorf("[%s] %w", component, err)
+		}
 	case "dataoperations":
 		for _, field := range []string{"select_keys", "remove_keys"} {
 			if values, ok := params[field].([]any); ok && containsBlank(values) {
@@ -88,6 +92,43 @@ func validateDynamicParams(component string, params map[string]any) error {
 		return validateVariableAggregatorGroups(component, params)
 	case "userfillup":
 		return validateInputOptions(component, params)
+	}
+	return nil
+}
+
+func validateMessageContent(params map[string]any) error {
+	if text, ok := params["text"]; ok {
+		if !isNonBlankString(text) {
+			return fmt.Errorf("content does not support empty value")
+		}
+		return nil
+	}
+	content, ok := params["content"]
+	if !ok {
+		return fmt.Errorf("content does not support empty value")
+	}
+	switch values := content.(type) {
+	case string:
+		if !isNonBlankString(values) {
+			return fmt.Errorf("content does not support empty value")
+		}
+	case []string:
+		for _, value := range values {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("content does not support empty entries")
+			}
+		}
+	case []any:
+		if len(values) == 0 {
+			return fmt.Errorf("content does not support empty value")
+		}
+		for _, value := range values {
+			if !isNonBlankString(value) {
+				return fmt.Errorf("content does not support empty entries")
+			}
+		}
+	default:
+		return fmt.Errorf("content does not support empty value")
 	}
 	return nil
 }

--- a/internal/agent/component/dynamic_params_test.go
+++ b/internal/agent/component/dynamic_params_test.go
@@ -28,6 +28,7 @@ func TestValidateDynamicEntries(t *testing.T) {
 		componentDSL("Iteration", map[string]any{"outputs": map[string]any{
 			"result": map[string]any{"type": "string", "ref": "Iteration@result"},
 		}}),
+		componentDSL("Message", map[string]any{"text": "hello"}),
 		// Whitespace-only delimiters are legitimate split tokens: the web
 		// form's default row is "\n" (a real newline) and the delimiter
 		// input converts a typed "\n"/"\t" into the raw control character
@@ -61,6 +62,10 @@ func TestValidateDynamicEntries(t *testing.T) {
 		{"input option", componentDSL("UserFillUp", map[string]any{"inputs": map[string]any{"choice": map[string]any{"options": []any{"one", ""}}}}), "inputs.choice.options"},
 		{"empty delimiter entry", componentDSL("TokenChunker", map[string]any{"delimiters": []any{"ok", ""}}), "delimiters"},
 		{"empty children delimiter entry", componentDSL("TokenChunker", map[string]any{"children_delimiters": []any{""}}), "children_delimiters"},
+		{"empty message text", componentDSL("Message", map[string]any{"text": " \t "}), "Message"},
+		{"empty message content", componentDSL("Message", map[string]any{"content": []any{""}}), "Message"},
+		{"missing message content", componentDSL("Message", map[string]any{}), "Message"},
+		{"blank message row after valid row", componentDSL("Message", map[string]any{"content": []any{"hello", " "}}), "Message"},
 	}
 
 	for _, test := range tests {

--- a/web/src/pages/agent/hooks/use-save-graph.ts
+++ b/web/src/pages/agent/hooks/use-save-graph.ts
@@ -119,6 +119,7 @@ export const useSaveGraph = (
           message.warning(
             `${emptyMessageNodeNames.join(', ')}: ${t('flow.messageMsg')}`,
           );
+          return;
         }
       }
 

--- a/web/src/pages/agent/utils.test.ts
+++ b/web/src/pages/agent/utils.test.ts
@@ -64,7 +64,7 @@ describe('Message component content validation', () => {
 
     it('accepts content with at least one non-blank string entry', () => {
       expect(isEmptyMessageContent(['hi'])).toBe(false);
-      expect(isEmptyMessageContent(['', '{begin@query}'])).toBe(false);
+      expect(isEmptyMessageContent(['', '{begin@query}'])).toBe(true);
       expect(isEmptyMessageContent(['  text  '])).toBe(false);
     });
   });

--- a/web/src/pages/agent/utils.ts
+++ b/web/src/pages/agent/utils.ts
@@ -942,7 +942,8 @@ export function convertToObjectArray<T extends string | number | boolean>(
 export function isEmptyMessageContent(content?: unknown): boolean {
   return (
     !Array.isArray(content) ||
-    !content.some((item) => typeof item === 'string' && item.trim() !== '')
+    content.length === 0 ||
+    content.some((item) => typeof item !== 'string' || item.trim() === '')
   );
 }
 


### PR DESCRIPTION
### Summary

Empty Message rows can still be saved when another row has content. This change blocks saving and returns a clear validation error. completes #18979