### PR TITLE
fix(file): classify ancestry authorization failures as data errors

### DIFF
--- a/internal/handler/file.go
+++ b/internal/handler/file.go
@@ -40,6 +40,14 @@ type FileHandler struct {
 	file2DocumentService *document.File2DocumentService
 }
 
+func respondFileServiceError(c *gin.Context, err error) {
+	if errors.Is(err, file.ErrNoAuthorization) {
+		common.ResponseWithCodeData(c, common.CodeDataError, nil, "no authorization")
+		return
+	}
+	jsonInternalError(c, err)
+}
+
 // NewFileHandler create file handler
 func NewFileHandler(fileService *file.FileService, userService *service.UserService) *FileHandler {
 	return &FileHandler{
@@ -172,7 +180,7 @@ func (h *FileHandler) GetParentFolder(c *gin.Context) {
 	// Get parent folder with permission check
 	parentFolder, err := h.fileService.GetParentFolder(ctx, userID, fileID)
 	if err != nil {
-		jsonInternalError(c, err)
+		respondFileServiceError(c, err)
 		return
 	}
 
@@ -207,7 +215,7 @@ func (h *FileHandler) GetAllParentFolders(c *gin.Context) {
 	// Get all parent folders with permission check
 	parentFolders, err := h.fileService.GetAllParentFolders(ctx, userID, fileID)
 	if err != nil {
-		jsonInternalError(c, err)
+		respondFileServiceError(c, err)
 		return
 	}
 
@@ -241,7 +249,7 @@ func (h *FileHandler) GetFileAncestors(c *gin.Context) {
 	// Get all parent folders with permission check
 	parentFolders, err := h.fileService.GetAllParentFolders(ctx, userID, fileID)
 	if err != nil {
-		jsonInternalError(c, err)
+		respondFileServiceError(c, err)
 		return
 	}
 

--- a/internal/handler/file_error_test.go
+++ b/internal/handler/file_error_test.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"ragflow/internal/service/file"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRespondFileServiceError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, tc := range []struct {
+		name string
+		err  error
+		code int
+		msg  string
+	}{{"authorization", file.ErrNoAuthorization, 102, "no authorization"}} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			respondFileServiceError(c, tc.err)
+			if w.Code != 200 {
+				t.Fatalf("HTTP status = %d, want 200", w.Code)
+			}
+			var body struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil || body.Code != tc.code || body.Message != tc.msg {
+				t.Fatalf("body = %s, want code=%d message=%q", w.Body, tc.code, tc.msg)
+			}
+		})
+	}
+}

--- a/internal/service/file/file.go
+++ b/internal/service/file/file.go
@@ -18,10 +18,14 @@ package file
 
 import (
 	"context"
+	"errors"
 	"ragflow/internal/dao"
 	"ragflow/internal/entity"
 	"ragflow/internal/utility"
 )
+
+// ErrNoAuthorization indicates the current user cannot access the target file.
+var ErrNoAuthorization = errors.New("no authorization")
 
 var (
 	// assertURLSafe and pinnedHTTPClient are aliased from utility so tests

--- a/internal/service/file/file_folder.go
+++ b/internal/service/file/file_folder.go
@@ -222,7 +222,7 @@ func (s *FileService) GetParentFolder(ctx context.Context, userID, fileID string
 
 	// Permission check
 	if !s.checkFilePerm(ctx, s.fileDAO, file, userID) {
-		return nil, fmt.Errorf("no authorization")
+		return nil, ErrNoAuthorization
 	}
 
 	// Get parent folder
@@ -244,7 +244,7 @@ func (s *FileService) GetAllParentFolders(ctx context.Context, userID, fileID st
 
 	// Permission check
 	if !s.checkFilePerm(ctx, s.fileDAO, file, userID) {
-		return nil, fmt.Errorf("no authorization")
+		return nil, ErrNoAuthorization
 	}
 
 	// Get all parent folders

--- a/internal/service/file/file_folder_test.go
+++ b/internal/service/file/file_folder_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -92,6 +93,22 @@ func insertFolderTestFile(t *testing.T, id, parentID, name string) {
 	}
 	if err := dao.DB.Create(f).Error; err != nil {
 		t.Fatalf("insert test file: %v", err)
+	}
+}
+
+func TestFileService_AncestryRejectsUnauthorized(t *testing.T) {
+	setupFolderTestDB(t)
+	insertFolderTestFile(t, "file-1", "folder-1", "file.pdf")
+	svc := testFileService()
+	svc.checkFilePerm = func(context.Context, *dao.FileDAO, *entity.File, string) bool { return false }
+
+	for _, call := range []func() error{
+		func() error { _, err := svc.GetParentFolder(t.Context(), "user-2", "file-1"); return err },
+		func() error { _, err := svc.GetAllParentFolders(t.Context(), "user-2", "file-1"); return err },
+	} {
+		if err := call(); !errors.Is(err, ErrNoAuthorization) {
+			t.Fatalf("error = %v, want ErrNoAuthorization", err)
+		}
 	}
 }
 


### PR DESCRIPTION
### Summary

Unauthorized ancestry requests now return code 102 instead of a server error. Unexpected service failures still return the generic internal error.