### PR TITLE
Fix: The select-all option in the dataset file list and file management now only applies to the current page; switching pages will clear the previous selection.

### DIFF
--- a/web/src/hooks/logic-hooks/use-clear-selection-on-page-change.ts
+++ b/web/src/hooks/logic-hooks/use-clear-selection-on-page-change.ts
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { useEffect, useRef } from 'react';
+
+// Items are selected per page, so the selection is meaningless once another
+// page or another page size is displayed. Watching the pagination values
+// instead of wrapping onChange also covers page changes triggered elsewhere,
+// e.g. by the URL search params or by a search resetting to the first page.
+export function useClearSelectionOnPageChange(
+  pagination: { current?: number; pageSize?: number },
+  clearSelection: () => void,
+) {
+  const { current, pageSize } = pagination;
+  const displayedPageRef = useRef({ current, pageSize });
+
+  useEffect(() => {
+    const displayedPage = displayedPageRef.current;
+    if (
+      displayedPage.current === current &&
+      displayedPage.pageSize === pageSize
+    ) {
+      return;
+    }
+
+    displayedPageRef.current = { current, pageSize };
+    clearSelection();
+  }, [current, pageSize, clearSelection]);
+}

--- a/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/index.tsx
+++ b/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/index.tsx
@@ -25,10 +25,7 @@ import { PageHeader } from '@/components/page-header';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import message from '@/components/ui/message';
-import {
-  RAGFlowPagination,
-  RAGFlowPaginationType,
-} from '@/components/ui/ragflow-pagination';
+import { RAGFlowPagination } from '@/components/ui/ragflow-pagination';
 import {
   ResizableHandle,
   ResizablePanel,
@@ -39,6 +36,7 @@ import {
   QueryStringMap,
   useNavigatePage,
 } from '@/hooks/logic-hooks/navigate-hooks';
+import { useClearSelectionOnPageChange } from '@/hooks/logic-hooks/use-clear-selection-on-page-change';
 import { getExtension } from '@/utils/document-util';
 import { LucideArrowBigLeft } from 'lucide-react';
 
@@ -76,13 +74,12 @@ function Chunk() {
   useEffect(() => {
     setChunkList(data);
   }, [data]);
-  const onPaginationChange: RAGFlowPaginationType['onChange'] = (
-    page,
-    size,
-  ) => {
+
+  const clearSelectedChunkIds = useCallback(() => {
     setSelectedChunkIds([]);
-    pagination.onChange?.(page, size);
-  };
+  }, []);
+
+  useClearSelectionOnPageChange(pagination, clearSelectedChunkIds);
 
   const selectAllChunk = useCallback(
     (checked: boolean) => {
@@ -125,12 +122,18 @@ function Chunk() {
     if (selectedChunkIds.length > 0) {
       const resCode: number = await removeChunk(selectedChunkIds, documentId);
       if (resCode === 0) {
-        setSelectedChunkIds([]);
+        clearSelectedChunkIds();
       }
     } else {
       showSelectedChunkWarning();
     }
-  }, [selectedChunkIds, documentId, removeChunk, showSelectedChunkWarning]);
+  }, [
+    selectedChunkIds,
+    documentId,
+    removeChunk,
+    showSelectedChunkWarning,
+    clearSelectedChunkIds,
+  ]);
 
   const handleSwitchChunk = useCallback(
     async (available?: number, chunkIds?: string[]) => {
@@ -292,9 +295,7 @@ function Chunk() {
                         pageSize={pagination.pageSize}
                         current={pagination.current}
                         total={total}
-                        onChange={(page, pageSize) => {
-                          onPaginationChange(page, pageSize);
-                        }}
+                        onChange={pagination.onChange}
                       />
                     </footer>
                   </div>

--- a/web/src/pages/dataset/dataset/index.tsx
+++ b/web/src/pages/dataset/dataset/index.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useGoToPreviousPageOnEmpty } from '@/hooks/logic-hooks';
+import { useClearSelectionOnPageChange } from '@/hooks/logic-hooks/use-clear-selection-on-page-change';
 import {
   useRowSelection,
   useSelectedIds,
@@ -80,8 +81,15 @@ export default function Dataset() {
     checkValue(filters);
   }, [filters]);
 
-  const { rowSelection, rowSelectionIsEmpty, setRowSelection, selectedCount } =
-    useRowSelection();
+  const {
+    rowSelection,
+    rowSelectionIsEmpty,
+    setRowSelection,
+    selectedCount,
+    clearRowSelection,
+  } = useRowSelection();
+
+  useClearSelectionOnPageChange(pagination, clearRowSelection);
 
   const {
     chunkNum,

--- a/web/src/pages/files/index.tsx
+++ b/web/src/pages/files/index.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useClearSelectionOnPageChange } from '@/hooks/logic-hooks/use-clear-selection-on-page-change';
 import { useRowSelection } from '@/hooks/logic-hooks/use-row-selection';
 import { useFetchFileList } from '@/hooks/use-file-request';
 import { LucidePlus } from 'lucide-react';
@@ -62,6 +63,8 @@ export default function Files() {
     clearRowSelection,
     selectedCount,
   } = useRowSelection();
+
+  useClearSelectionOnPageChange(pagination, clearRowSelection);
 
   const {
     showMoveFileModal,

--- a/web/src/pages/user-setting/mcp/index.tsx
+++ b/web/src/pages/user-setting/mcp/index.tsx
@@ -25,6 +25,7 @@ import { SearchInput } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RAGFlowPagination } from '@/components/ui/ragflow-pagination';
 import { useGoToPreviousPageOnEmpty } from '@/hooks/logic-hooks';
+import { useClearSelectionOnPageChange } from '@/hooks/logic-hooks/use-clear-selection-on-page-change';
 import { useListMcpServer } from '@/hooks/use-mcp-request';
 import { pick } from 'lodash';
 import {
@@ -65,6 +66,7 @@ export default function McpServer() {
     handleSelectAll,
     resetSelection,
   } = useBulkOperateMCP(data.mcp_servers);
+  useClearSelectionOnPageChange(pagination, resetSelection);
   const { t } = useTranslation();
   const {
     importVisible,


### PR DESCRIPTION
### Summary

### Summary

Fix: The 'select all' for the dataset file list and file management used to accumulate page by page. Now, 'select all' only applies to the current page, and changing pages clears the previous selection.