### PR TITLE
fix(security): generate random UUIDv4 identifiers

### DIFF
--- a/api/db/joint_services/user_account_service.py
+++ b/api/db/joint_services/user_account_service.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 import logging
-import uuid
+from common.misc_utils import get_uuid
 
 from api.utils.api_utils import group_by
 from api.db import FileType, UserTenantRole
@@ -56,9 +56,9 @@ def create_new_user(user_info: dict) -> dict:
     }
     """
     # generate user_id and access_token for user
-    user_id = uuid.uuid1().hex
+    user_id = get_uuid()
     user_info["id"] = user_id
-    user_info["access_token"] = uuid.uuid1().hex
+    user_info["access_token"] = get_uuid()
     # construct tenant info
     tenant = {
         "id": user_id,
@@ -77,7 +77,7 @@ def create_new_user(user_info: dict) -> dict:
         "role": UserTenantRole.OWNER,
     }
     # construct file folder info
-    file_id = uuid.uuid1().hex
+    file_id = get_uuid()
     file = {
         "id": file_id,
         "parent_id": file_id,

--- a/api/db/joint_services/user_account_service.py
+++ b/api/db/joint_services/user_account_service.py
@@ -14,6 +14,8 @@
 #  limitations under the License.
 #
 import logging
+import uuid
+
 from common.misc_utils import get_uuid
 
 from api.utils.api_utils import group_by
@@ -58,7 +60,7 @@ def create_new_user(user_info: dict) -> dict:
     # generate user_id and access_token for user
     user_id = get_uuid()
     user_info["id"] = user_id
-    user_info["access_token"] = get_uuid()
+    user_info["access_token"] = uuid.uuid4().hex
     # construct tenant info
     tenant = {
         "id": user_id,

--- a/common/misc_utils.py
+++ b/common/misc_utils.py
@@ -34,7 +34,7 @@ _LONG_TIME_THREAD_POOL_EXECUTOR = ThreadPoolExecutor(max_workers=int(os.getenv("
 
 
 def get_uuid():
-    return uuid.uuid4().hex
+    return uuid.uuid1().hex
 
 
 # OAuth avatar fetch: bounded size; each redirect hop is SSRF-checked and DNS-pinned

--- a/common/misc_utils.py
+++ b/common/misc_utils.py
@@ -34,7 +34,7 @@ _LONG_TIME_THREAD_POOL_EXECUTOR = ThreadPoolExecutor(max_workers=int(os.getenv("
 
 
 def get_uuid():
-    return uuid.uuid1().hex
+    return uuid.uuid4().hex
 
 
 # OAuth avatar fetch: bounded size; each redirect hop is SSRF-checked and DNS-pinned

--- a/test/unit_test/common/test_misc_utils.py
+++ b/test/unit_test/common/test_misc_utils.py
@@ -214,11 +214,11 @@ class TestGetUuid:
         # The hex representation should match the original
         assert reconstructed_uuid.hex == result
 
-    def test_uuid4_characteristics(self):
-        """Generated identifiers are random RFC 4122 UUIDv4 values."""
+    def test_uuid1_characteristics(self):
+        """Generated identifiers are RFC 4122 UUIDv1 values."""
         result = get_uuid()
         uuid_obj = uuid.UUID(hex=result)
-        assert uuid_obj.version == 4
+        assert uuid_obj.version == 1
         assert uuid_obj.variant == "specified in RFC 4122"
 
     def test_result_length_consistency(self):

--- a/test/unit_test/common/test_misc_utils.py
+++ b/test/unit_test/common/test_misc_utils.py
@@ -181,7 +181,7 @@ class TestGetUuid:
     def test_hex_format(self):
         """Test that returned string is in hex format"""
         result = get_uuid()
-        # UUID v1 hex should be 32 characters (without dashes)
+        # UUID hex should be 32 characters (without dashes)
         assert len(result) == 32
         # Should only contain hexadecimal characters
         assert all(c in "0123456789abcdef" for c in result)
@@ -214,15 +214,11 @@ class TestGetUuid:
         # The hex representation should match the original
         assert reconstructed_uuid.hex == result
 
-    def test_uuid1_specific_characteristics(self):
-        """Test that UUID v1 characteristics are present"""
+    def test_uuid4_characteristics(self):
+        """Generated identifiers are random RFC 4122 UUIDv4 values."""
         result = get_uuid()
         uuid_obj = uuid.UUID(hex=result)
-
-        # UUID v1 should have version 1
-        assert uuid_obj.version == 1
-
-        # Variant should be RFC 4122
+        assert uuid_obj.version == 4
         assert uuid_obj.variant == "specified in RFC 4122"
 
     def test_result_length_consistency(self):
@@ -235,8 +231,8 @@ class TestGetUuid:
         """Test that only valid hex characters are used"""
         for _ in range(100):
             result = get_uuid()
-            # Should only contain lowercase hex characters (UUID hex is lowercase)
-            assert result.islower()
+            # Should only contain lowercase hexadecimal characters
+            assert result == result.lower()
             assert all(c in "0123456789abcdef" for c in result)
 
 


### PR DESCRIPTION
### Summary

get_uuid() now generates random UUIDv4 values instead of predictable UUIDv1 values. This keeps the same 32-character hexadecimal format