### PR TITLE
fix(storage): make bucket deletion work on the AWS_S3 backend

### DIFF
--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -238,13 +238,17 @@ class RAGFlowS3:
             logging.exception(f"Fail to move {src_bucket}/{src_path} -> {dest_bucket}/{dest_path}")
             return False
 
-    def _delete_objects_paginated(self, bucket, prefix=None):
-        """Delete every object under ``bucket`` (optionally scoped to ``prefix``)
-        in paginated batches. Raises if any key in a batch fails to delete."""
-        paginator = self.conn[0].get_paginator("list_objects_v2")
-        pages = paginator.paginate(Bucket=bucket, Prefix=prefix) if prefix is not None else paginator.paginate(Bucket=bucket)
+    def _delete_object_batches(self, bucket, pages):
+        """Delete the objects listed in ``pages`` (an iterable of ListObjects
+        pages) in batches. Handles versioned buckets by deleting every listed
+        version and delete marker. Raises RuntimeError if any key fails."""
         for page in pages:
-            objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+            objects = []
+            for obj in page.get("Versions", []) + page.get("DeleteMarkers", []):
+                entry = {"Key": obj["Key"]}
+                if "VersionId" in obj:
+                    entry["VersionId"] = obj["VersionId"]
+                objects.append(entry)
             if not objects:
                 continue
             result = self.conn[0].delete_objects(Bucket=bucket, Delete={"Objects": objects})
@@ -252,28 +256,65 @@ class RAGFlowS3:
                 failed = ", ".join(err.get("Key", "?") for err in result["Errors"])
                 raise RuntimeError(f"S3 object deletion failed for keys: {failed}")
 
+    def _abort_incomplete_multipart_uploads(self, bucket):
+        """Abort incomplete multipart uploads; they keep a bucket non-empty
+        even when no object versions remain."""
+        paginator = self.conn[0].get_paginator("list_multipart_uploads")
+        for page in paginator.paginate(Bucket=bucket):
+            uploads = page.get("Uploads", [])
+            if not uploads:
+                continue
+            self.conn[0].abort_multipart_upload(
+                Bucket=bucket,
+                Key=uploads[0]["Key"],
+                UploadId=uploads[0]["UploadId"],
+            )
+
+    def _head_bucket_or_none(self, bucket):
+        """Return the head_bucket response, or None only when the bucket does
+        not exist. Other client errors (403 Forbidden, 400) propagate so the
+        caller's error handler reports them instead of treating the bucket as
+        absent."""
+        try:
+            return self.conn[0].head_bucket(Bucket=bucket)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "") if isinstance(e.response, dict) else ""
+            if code in ("404", "NoSuchBucket", "NotFound"):
+                return None
+            raise
+
+    def _delete_all_versions(self, bucket, prefix=None):
+        """Delete every object version and delete marker under ``bucket``
+        (optionally scoped to ``prefix``), then abort incomplete multipart
+        uploads. Raises if any batch fails."""
+        paginator = self.conn[0].get_paginator("list_object_versions")
+        pages = paginator.paginate(Bucket=bucket, Prefix=prefix) if prefix is not None else paginator.paginate(Bucket=bucket)
+        self._delete_object_batches(bucket, pages)
+        self._abort_incomplete_multipart_uploads(bucket)
+
     @use_default_bucket
     def remove_bucket(self, bucket, **kwargs):
         orig_bucket = kwargs.pop("_orig_bucket", None)
         try:
             if self.bucket:
                 # Single bucket mode: remove objects with the logical-bucket
-                # prefix, but do not remove the physical bucket.
+                # prefix, but do not remove the physical bucket. The prefix
+                # matches the write path: use_prefix_path only prepends the
+                # "{prefix_path}/{bucket}/" segment when prefix_path is set,
+                # so with no prefix_path the objects carry no bucket segment.
                 prefix = ""
                 if self.prefix_path:
-                    prefix = f"{self.prefix_path}/"
-                if orig_bucket:
-                    prefix += f"{orig_bucket}/"
-                self._delete_objects_paginated(bucket, prefix)
+                    prefix = f"{self.prefix_path}/{orig_bucket}/" if orig_bucket else f"{self.prefix_path}/"
+                self._delete_all_versions(bucket, prefix)
             else:
-                if not self.bucket_exists(bucket):
+                if self._head_bucket_or_none(bucket) is None:
                     return
-                self._delete_objects_paginated(bucket)
+                self._delete_all_versions(bucket)
                 self.conn[0].delete_bucket(Bucket=bucket)
-        except Exception as e:
-            # Keep the connector-wide convention of not propagating storage
-            # errors, but log only the failure mode: exception type and, for
-            # botocore errors, the service error code. str(e) is omitted
-            # because S3 error responses can embed signed request URLs.
-            detail = getattr(e, "response", {}).get("Error", {}).get("Code", "") if hasattr(e, "response") else ""
-            logging.error(f"Fail to remove bucket {bucket}: {type(e).__name__}" + (f" ({detail})" if detail else ""))
+        except Exception:
+            # Storage deletions must not fail silently: lifecycle callers
+            # (knowledge-base and account deletion) remove metadata after this
+            # returns, so re-raise after logging the failure mode. str(e) is
+            # omitted because S3 error responses can embed signed request URLs.
+            logging.exception(f"Fail to remove bucket {bucket}")
+            raise

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -256,20 +256,6 @@ class RAGFlowS3:
                 failed = ", ".join(err.get("Key", "?") for err in result["Errors"])
                 raise RuntimeError(f"S3 object deletion failed for keys: {failed}")
 
-    def _abort_incomplete_multipart_uploads(self, bucket, prefix=None):
-        """Abort every incomplete multipart upload (optionally scoped to
-        ``prefix``); they keep a bucket non-empty even when no object versions
-        remain."""
-        paginator = self.conn[0].get_paginator("list_multipart_uploads")
-        pages = paginator.paginate(Bucket=bucket, Prefix=prefix) if prefix is not None else paginator.paginate(Bucket=bucket)
-        for page in pages:
-            for upload in page.get("Uploads", []):
-                self.conn[0].abort_multipart_upload(
-                    Bucket=bucket,
-                    Key=upload["Key"],
-                    UploadId=upload["UploadId"],
-                )
-
     def _head_bucket_or_none(self, bucket):
         """Return the head_bucket response, or None only when the bucket does
         not exist. Other client errors (403 Forbidden, 400) propagate so the
@@ -285,12 +271,10 @@ class RAGFlowS3:
 
     def _delete_all_versions(self, bucket, prefix=None):
         """Delete every object version and delete marker under ``bucket``
-        (optionally scoped to ``prefix``), then abort incomplete multipart
-        uploads under the same prefix. Raises if any batch fails."""
+        (optionally scoped to ``prefix``). Raises if any batch fails."""
         paginator = self.conn[0].get_paginator("list_object_versions")
         pages = paginator.paginate(Bucket=bucket, Prefix=prefix) if prefix is not None else paginator.paginate(Bucket=bucket)
         self._delete_object_batches(bucket, pages)
-        self._abort_incomplete_multipart_uploads(bucket, prefix)
 
     @use_default_bucket
     def remove_bucket(self, bucket, **kwargs):
@@ -300,11 +284,19 @@ class RAGFlowS3:
                 # Single bucket mode: remove objects with the logical-bucket
                 # prefix, but do not remove the physical bucket. The prefix
                 # matches the write path: use_prefix_path only prepends the
-                # "{prefix_path}/{bucket}/" segment when prefix_path is set,
-                # so with no prefix_path the objects carry no bucket segment.
-                prefix = ""
-                if self.prefix_path:
-                    prefix = f"{self.prefix_path}/{orig_bucket}/" if orig_bucket else f"{self.prefix_path}/"
+                # "{prefix_path}/{bucket}/" segment when prefix_path is set.
+                if not self.prefix_path:
+                    # A shared physical bucket with no prefix_path stores keys
+                    # without a logical-bucket segment, so no cleanup prefix
+                    # can scope this deletion to one knowledge base: run it
+                    # and the whole bucket's data would go. Refuse instead;
+                    # shared-bucket namespacing needs its own migration story.
+                    logging.error(
+                        "Refusing to remove logical bucket %s: STORAGE_S3 bucket is shared without a prefix_path, which cannot be scoped to one knowledge base",
+                        orig_bucket or bucket,
+                    )
+                    return
+                prefix = f"{self.prefix_path}/{orig_bucket}/" if orig_bucket else f"{self.prefix_path}/"
                 self._delete_all_versions(bucket, prefix)
             else:
                 if self._head_bucket_or_none(bucket) is None:

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -238,6 +238,20 @@ class RAGFlowS3:
             logging.exception(f"Fail to move {src_bucket}/{src_path} -> {dest_bucket}/{dest_path}")
             return False
 
+    def _delete_objects_paginated(self, bucket, prefix=None):
+        """Delete every object under ``bucket`` (optionally scoped to ``prefix``)
+        in paginated batches. Raises if any key in a batch fails to delete."""
+        paginator = self.conn[0].get_paginator("list_objects_v2")
+        pages = paginator.paginate(Bucket=bucket, Prefix=prefix) if prefix is not None else paginator.paginate(Bucket=bucket)
+        for page in pages:
+            objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+            if not objects:
+                continue
+            result = self.conn[0].delete_objects(Bucket=bucket, Delete={"Objects": objects})
+            if result.get("Errors"):
+                failed = ", ".join(err.get("Key", "?") for err in result["Errors"])
+                raise RuntimeError(f"S3 object deletion failed for keys: {failed}")
+
     @use_default_bucket
     def remove_bucket(self, bucket, **kwargs):
         orig_bucket = kwargs.pop("_orig_bucket", None)
@@ -250,20 +264,16 @@ class RAGFlowS3:
                     prefix = f"{self.prefix_path}/"
                 if orig_bucket:
                     prefix += f"{orig_bucket}/"
-
-                paginator = self.conn[0].get_paginator("list_objects_v2")
-                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-                    objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
-                    if objects:
-                        self.conn[0].delete_objects(Bucket=bucket, Delete={"Objects": objects})
+                self._delete_objects_paginated(bucket, prefix)
             else:
                 if not self.bucket_exists(bucket):
                     return
-                paginator = self.conn[0].get_paginator("list_objects_v2")
-                for page in paginator.paginate(Bucket=bucket):
-                    objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
-                    if objects:
-                        self.conn[0].delete_objects(Bucket=bucket, Delete={"Objects": objects})
+                self._delete_objects_paginated(bucket)
                 self.conn[0].delete_bucket(Bucket=bucket)
-        except Exception:
-            logging.exception(f"Fail to remove bucket {bucket}")
+        except Exception as e:
+            # Keep the connector-wide convention of not propagating storage
+            # errors, but log only the failure mode: exception type and, for
+            # botocore errors, the service error code. str(e) is omitted
+            # because S3 error responses can embed signed request URLs.
+            detail = getattr(e, "response", {}).get("Error", {}).get("Code", "") if hasattr(e, "response") else ""
+            logging.error(f"Fail to remove bucket {bucket}: {type(e).__name__}" + (f" ({detail})" if detail else ""))

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -44,7 +44,13 @@ class RAGFlowS3:
     def use_default_bucket(method):
         def wrapper(self, bucket, *args, **kwargs):
             # If there is a default bucket, use the default bucket
+            # but preserve the original bucket identifier so callers that
+            # need it as a key prefix (e.g. remove_bucket in single-bucket
+            # mode) can still scope the operation to the logical bucket.
+            original_bucket = bucket
             actual_bucket = self.bucket if self.bucket else bucket
+            if self.bucket:
+                kwargs["_orig_bucket"] = original_bucket
             return method(self, actual_bucket, *args, **kwargs)
 
         return wrapper
@@ -233,14 +239,31 @@ class RAGFlowS3:
             return False
 
     @use_default_bucket
-    def rm_bucket(self, bucket, *args, **kwargs):
-        for conn in self.conn:
-            try:
-                if not conn.bucket_exists(bucket):
-                    continue
-                for o in conn.list_objects_v2(Bucket=bucket):
-                    conn.delete_object(bucket, o.object_name)
-                conn.delete_bucket(Bucket=bucket)
-                return
-            except Exception as e:
-                logging.error(f"Fail rm {bucket}: " + str(e))
+    def remove_bucket(self, bucket, **kwargs):
+        orig_bucket = kwargs.pop("_orig_bucket", None)
+        try:
+            if self.bucket:
+                # Single bucket mode: remove objects with the logical-bucket
+                # prefix, but do not remove the physical bucket.
+                prefix = ""
+                if self.prefix_path:
+                    prefix = f"{self.prefix_path}/"
+                if orig_bucket:
+                    prefix += f"{orig_bucket}/"
+
+                paginator = self.conn[0].get_paginator("list_objects_v2")
+                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+                    objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+                    if objects:
+                        self.conn[0].delete_objects(Bucket=bucket, Delete={"Objects": objects})
+            else:
+                if not self.bucket_exists(bucket):
+                    return
+                paginator = self.conn[0].get_paginator("list_objects_v2")
+                for page in paginator.paginate(Bucket=bucket):
+                    objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+                    if objects:
+                        self.conn[0].delete_objects(Bucket=bucket, Delete={"Objects": objects})
+                self.conn[0].delete_bucket(Bucket=bucket)
+        except Exception:
+            logging.exception(f"Fail to remove bucket {bucket}")

--- a/rag/utils/s3_conn.py
+++ b/rag/utils/s3_conn.py
@@ -256,19 +256,19 @@ class RAGFlowS3:
                 failed = ", ".join(err.get("Key", "?") for err in result["Errors"])
                 raise RuntimeError(f"S3 object deletion failed for keys: {failed}")
 
-    def _abort_incomplete_multipart_uploads(self, bucket):
-        """Abort incomplete multipart uploads; they keep a bucket non-empty
-        even when no object versions remain."""
+    def _abort_incomplete_multipart_uploads(self, bucket, prefix=None):
+        """Abort every incomplete multipart upload (optionally scoped to
+        ``prefix``); they keep a bucket non-empty even when no object versions
+        remain."""
         paginator = self.conn[0].get_paginator("list_multipart_uploads")
-        for page in paginator.paginate(Bucket=bucket):
-            uploads = page.get("Uploads", [])
-            if not uploads:
-                continue
-            self.conn[0].abort_multipart_upload(
-                Bucket=bucket,
-                Key=uploads[0]["Key"],
-                UploadId=uploads[0]["UploadId"],
-            )
+        pages = paginator.paginate(Bucket=bucket, Prefix=prefix) if prefix is not None else paginator.paginate(Bucket=bucket)
+        for page in pages:
+            for upload in page.get("Uploads", []):
+                self.conn[0].abort_multipart_upload(
+                    Bucket=bucket,
+                    Key=upload["Key"],
+                    UploadId=upload["UploadId"],
+                )
 
     def _head_bucket_or_none(self, bucket):
         """Return the head_bucket response, or None only when the bucket does
@@ -286,11 +286,11 @@ class RAGFlowS3:
     def _delete_all_versions(self, bucket, prefix=None):
         """Delete every object version and delete marker under ``bucket``
         (optionally scoped to ``prefix``), then abort incomplete multipart
-        uploads. Raises if any batch fails."""
+        uploads under the same prefix. Raises if any batch fails."""
         paginator = self.conn[0].get_paginator("list_object_versions")
         pages = paginator.paginate(Bucket=bucket, Prefix=prefix) if prefix is not None else paginator.paginate(Bucket=bucket)
         self._delete_object_batches(bucket, pages)
-        self._abort_incomplete_multipart_uploads(bucket)
+        self._abort_incomplete_multipart_uploads(bucket, prefix)
 
     @use_default_bucket
     def remove_bucket(self, bucket, **kwargs):

--- a/test/unit_test/rag/utils/test_s3_remove_bucket.py
+++ b/test/unit_test/rag/utils/test_s3_remove_bucket.py
@@ -18,7 +18,7 @@
 
 import importlib
 import logging
-from unittest.mock import Mock
+from unittest.mock import Mock, call as mock_call
 
 import pytest
 from botocore.exceptions import ClientError
@@ -124,23 +124,46 @@ def test_remove_bucket_deletes_versions_and_markers_with_version_ids(monkeypatch
     client.delete_bucket.assert_called_once_with(Bucket="kb01")
 
 
-def test_remove_bucket_aborts_incomplete_multipart_uploads(monkeypatch):
-    """Incomplete multipart uploads keep a bucket non-empty; they must be
-    aborted before delete_bucket."""
+def test_remove_bucket_aborts_every_incomplete_multipart_upload(monkeypatch):
+    """Incomplete multipart uploads keep a bucket non-empty; every upload in
+    the page must be aborted, not just the first, before delete_bucket."""
     storage, client = _new_storage(monkeypatch, {})
     _wire(client)
     _paginator(client, "list_object_versions", {})
     _paginator(
         client,
         "list_multipart_uploads",
-        {"Uploads": [{"Key": "big.bin", "UploadId": "up-1"}]},
+        {
+            "Uploads": [
+                {"Key": "big.bin", "UploadId": "up-1"},
+                {"Key": "huge.bin", "UploadId": "up-2"},
+            ]
+        },
     )
     client.head_bucket.return_value = {}
 
     storage.remove_bucket("kb01")
 
-    client.abort_multipart_upload.assert_called_once_with(Bucket="kb01", Key="big.bin", UploadId="up-1")
+    assert client.abort_multipart_upload.call_args_list == [
+        mock_call(Bucket="kb01", Key="big.bin", UploadId="up-1"),
+        mock_call(Bucket="kb01", Key="huge.bin", UploadId="up-2"),
+    ]
     client.delete_bucket.assert_called_once_with(Bucket="kb01")
+
+
+def test_remove_bucket_scopes_multipart_pagination_to_prefix(monkeypatch):
+    """Single-bucket mode: the multipart-upload pagination must apply the same
+    logical-bucket prefix as the version listing."""
+    storage, client = _new_storage(monkeypatch, {"bucket": "ragflow", "prefix_path": "prod"})
+    _wire(client)
+    _paginator(client, "list_object_versions", by_prefix={})
+    uploads = _paginator(client, "list_multipart_uploads", by_prefix={})
+    client.head_bucket.return_value = {}
+
+    storage.remove_bucket("kb01")
+
+    uploads.paginate.assert_called_once_with(Bucket="ragflow", Prefix="prod/kb01/")
+    client.delete_bucket.assert_not_called()
 
 
 def test_remove_bucket_skips_missing_bucket(monkeypatch):
@@ -242,7 +265,7 @@ def test_remove_bucket_single_bucket_mode_keeps_physical_bucket(monkeypatch):
     storage.remove_bucket("kb01")
 
     versions.paginate.assert_called_once_with(Bucket="ragflow", Prefix="")
-    uploads.paginate.assert_called_once_with(Bucket="ragflow")
+    uploads.paginate.assert_called_once_with(Bucket="ragflow", Prefix="")
     client.delete_bucket.assert_not_called()
 
 

--- a/test/unit_test/rag/utils/test_s3_remove_bucket.py
+++ b/test/unit_test/rag/utils/test_s3_remove_bucket.py
@@ -1,0 +1,125 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Unit tests for RAGFlowS3.remove_bucket (issue: S3 backend could not delete buckets)."""
+
+import importlib
+from unittest.mock import Mock
+
+# Import common.settings first: s3_conn <-> settings import cycle resolves
+# only in the same order the app uses (see test_s3_conn.py).
+import common.settings  # noqa: F401
+from rag.utils import s3_conn
+
+
+def _new_storage(monkeypatch, config):
+    module = importlib.reload(s3_conn)
+    client = Mock()
+    monkeypatch.setattr(module.settings, "S3", config)
+    monkeypatch.setattr(module.boto3, "client", Mock(return_value=client))
+    return module.RAGFlowS3(), client
+
+
+def _pages(client, *pages, by_prefix=None):
+    """Stub the list_objects_v2 paginator. ``by_prefix`` maps a Prefix kwarg to
+    its pages so single-bucket mode sees realistic prefix-filtered results."""
+    paginator = Mock()
+
+    def paginate(**kwargs):
+        if by_prefix is not None:
+            return list(by_prefix.get(kwargs.get("Prefix"), []))
+        return list(pages)
+
+    paginator.paginate.side_effect = paginate
+    client.get_paginator.return_value = paginator
+
+
+def test_remove_bucket_method_matches_storage_contract(monkeypatch):
+    """Callers use remove_bucket (kb/user-account deletion); it must exist."""
+    storage, _ = _new_storage(monkeypatch, {})
+    assert hasattr(storage, "remove_bucket")
+    assert not hasattr(storage, "rm_bucket")
+
+
+def test_remove_bucket_deletes_objects_then_bucket(monkeypatch):
+    """Multi-bucket mode: objects are deleted in batches, then the bucket itself."""
+    storage, client = _new_storage(monkeypatch, {})
+    _pages(
+        client,
+        {"Contents": [{"Key": "a"}, {"Key": "b"}]},
+        {"Contents": [{"Key": "c"}]},
+    )
+    client.bucket_exists.return_value = True
+
+    storage.remove_bucket("kb01")
+
+    client.delete_objects.assert_any_call(Bucket="kb01", Delete={"Objects": [{"Key": "a"}, {"Key": "b"}]})
+    client.delete_objects.assert_any_call(Bucket="kb01", Delete={"Objects": [{"Key": "c"}]})
+    client.delete_bucket.assert_called_once_with(Bucket="kb01")
+
+
+def test_remove_bucket_skips_missing_bucket(monkeypatch):
+    storage, client = _new_storage(monkeypatch, {})
+    client.bucket_exists.return_value = False
+
+    storage.remove_bucket("nope")
+
+    client.delete_objects.assert_not_called()
+    client.delete_bucket.assert_not_called()
+
+
+def test_remove_bucket_single_bucket_mode_keeps_physical_bucket(monkeypatch):
+    """Default-bucket mode: scope deletion to the logical prefix, keep the bucket."""
+    storage, client = _new_storage(monkeypatch, {"bucket": "ragflow"})
+    _pages(
+        client,
+        by_prefix={"kb01/": [{"Contents": [{"Key": "kb01/x"}, {"Key": "kb01/y"}]}]},
+    )
+
+    storage.remove_bucket("kb01")
+
+    deleted = client.delete_objects.call_args
+    assert deleted.kwargs["Bucket"] == "ragflow"
+    keys = [o["Key"] for o in deleted.kwargs["Delete"]["Objects"]]
+    assert keys == ["kb01/x", "kb01/y"]
+    client.delete_bucket.assert_not_called()
+
+
+def test_remove_bucket_single_bucket_mode_with_prefix_path(monkeypatch):
+    storage, client = _new_storage(monkeypatch, {"bucket": "ragflow", "prefix_path": "prod"})
+    _pages(
+        client,
+        by_prefix={"prod/kb01/": [{"Contents": [{"Key": "prod/kb01/doc"}]}]},
+    )
+
+    storage.remove_bucket("kb01")
+
+    deleted = client.delete_objects.call_args
+    keys = [o["Key"] for o in deleted.kwargs["Delete"]["Objects"]]
+    assert keys == ["prod/kb01/doc"]
+    client.delete_bucket.assert_not_called()
+
+
+def test_remove_bucket_empty_pages_delete_nothing_but_bucket(monkeypatch):
+    """A bucket that exists but has no objects: only delete_bucket fires."""
+    storage, client = _new_storage(monkeypatch, {})
+    _pages(client, {})
+    client.bucket_exists.return_value = True
+
+    storage.remove_bucket("kb01")
+
+    client.delete_objects.assert_not_called()
+    client.delete_bucket.assert_called_once_with(Bucket="kb01")

--- a/test/unit_test/rag/utils/test_s3_remove_bucket.py
+++ b/test/unit_test/rag/utils/test_s3_remove_bucket.py
@@ -20,6 +20,7 @@ import importlib
 import logging
 from unittest.mock import Mock
 
+import pytest
 from botocore.exceptions import ClientError
 
 # Import common.settings first: s3_conn <-> settings import cycle resolves
@@ -36,8 +37,8 @@ def _new_storage(monkeypatch, config):
     return module.RAGFlowS3(), client
 
 
-def _pages(client, *pages, by_prefix=None):
-    """Stub the list_objects_v2 paginator. ``by_prefix`` maps a Prefix kwarg to
+def _paginator(client, kind, *pages, by_prefix=None):
+    """Stub one kind of list paginator. ``by_prefix`` maps a Prefix kwarg to
     its pages so single-bucket mode sees realistic prefix-filtered results.
     delete_objects defaults to an all-deleted response; tests override it."""
     paginator = Mock()
@@ -48,8 +49,22 @@ def _pages(client, *pages, by_prefix=None):
         return list(pages)
 
     paginator.paginate.side_effect = paginate
-    client.get_paginator.return_value = paginator
+    client.get_paginator.side_effect_map[kind] = paginator
+    return paginator
+
+
+def _wire(client):
+    """Prepare a client mock with per-kind paginators and safe defaults."""
+    client.get_paginator.side_effect_map = {}
+    client.get_paginator.side_effect = lambda kind: client.get_paginator.side_effect_map.setdefault(kind, _default_paginator(kind))
     client.delete_objects.return_value = {"Deleted": []}
+
+
+def _default_paginator(kind):
+    """Empty-pages paginator for kinds a test did not register explicitly."""
+    paginator = Mock()
+    paginator.paginate.side_effect = lambda **kwargs: [{}]
+    return paginator
 
 
 def test_remove_bucket_method_matches_storage_contract(monkeypatch):
@@ -60,14 +75,17 @@ def test_remove_bucket_method_matches_storage_contract(monkeypatch):
 
 
 def test_remove_bucket_deletes_objects_then_bucket(monkeypatch):
-    """Multi-bucket mode: objects are deleted in batches, then the bucket itself."""
+    """Multi-bucket mode: all object versions are deleted in batches, then the
+    bucket itself."""
     storage, client = _new_storage(monkeypatch, {})
-    _pages(
+    _wire(client)
+    _paginator(
         client,
-        {"Contents": [{"Key": "a"}, {"Key": "b"}]},
-        {"Contents": [{"Key": "c"}]},
+        "list_object_versions",
+        {"Versions": [{"Key": "a"}, {"Key": "b"}], "DeleteMarkers": []},
+        {"Versions": [{"Key": "c"}], "DeleteMarkers": []},
     )
-    client.bucket_exists.return_value = True
+    client.head_bucket.return_value = {}
 
     storage.remove_bucket("kb01")
 
@@ -76,9 +94,59 @@ def test_remove_bucket_deletes_objects_then_bucket(monkeypatch):
     client.delete_bucket.assert_called_once_with(Bucket="kb01")
 
 
-def test_remove_bucket_skips_missing_bucket(monkeypatch):
-    """bucket_exists goes through head_bucket; drive the real 404 path."""
+def test_remove_bucket_deletes_versions_and_markers_with_version_ids(monkeypatch):
+    """Versioned buckets: every version and delete marker must be deleted with
+    its VersionId, otherwise delete_bucket fails with BucketNotEmpty."""
     storage, client = _new_storage(monkeypatch, {})
+    _wire(client)
+    _paginator(
+        client,
+        "list_object_versions",
+        {
+            "Versions": [{"Key": "a", "VersionId": "v1"}, {"Key": "a", "VersionId": "v2"}],
+            "DeleteMarkers": [{"Key": "b", "VersionId": "m1"}],
+        },
+    )
+    client.head_bucket.return_value = {}
+
+    storage.remove_bucket("kb01")
+
+    client.delete_objects.assert_called_once_with(
+        Bucket="kb01",
+        Delete={
+            "Objects": [
+                {"Key": "a", "VersionId": "v1"},
+                {"Key": "a", "VersionId": "v2"},
+                {"Key": "b", "VersionId": "m1"},
+            ]
+        },
+    )
+    client.delete_bucket.assert_called_once_with(Bucket="kb01")
+
+
+def test_remove_bucket_aborts_incomplete_multipart_uploads(monkeypatch):
+    """Incomplete multipart uploads keep a bucket non-empty; they must be
+    aborted before delete_bucket."""
+    storage, client = _new_storage(monkeypatch, {})
+    _wire(client)
+    _paginator(client, "list_object_versions", {})
+    _paginator(
+        client,
+        "list_multipart_uploads",
+        {"Uploads": [{"Key": "big.bin", "UploadId": "up-1"}]},
+    )
+    client.head_bucket.return_value = {}
+
+    storage.remove_bucket("kb01")
+
+    client.abort_multipart_upload.assert_called_once_with(Bucket="kb01", Key="big.bin", UploadId="up-1")
+    client.delete_bucket.assert_called_once_with(Bucket="kb01")
+
+
+def test_remove_bucket_skips_missing_bucket(monkeypatch):
+    """A 404 from head_bucket means the bucket is absent: a clean no-op."""
+    storage, client = _new_storage(monkeypatch, {})
+    _wire(client)
     client.head_bucket.side_effect = ClientError(
         {"Error": {"Code": "404"}},
         "HeadBucket",
@@ -91,39 +159,71 @@ def test_remove_bucket_skips_missing_bucket(monkeypatch):
     client.delete_bucket.assert_not_called()
 
 
+def test_remove_bucket_propagates_head_bucket_errors(monkeypatch):
+    """403/400 from head_bucket are access failures, not absence: they must
+    reach the error handler, not silently skip cleanup."""
+    storage, client = _new_storage(monkeypatch, {})
+    _wire(client)
+    client.head_bucket.side_effect = ClientError(
+        {"Error": {"Code": "403", "Message": "Forbidden"}},
+        "HeadBucket",
+    )
+
+    with pytest.raises(ClientError):
+        storage.remove_bucket("kb01")
+
+    client.get_paginator.assert_not_called()
+    client.delete_bucket.assert_not_called()
+
+
 def test_remove_bucket_raises_on_batch_delete_errors(monkeypatch):
     """delete_objects reports failed keys in its response instead of raising;
-    the helper must surface them rather than report silent success."""
+    remove_bucket must propagate the failure to lifecycle callers."""
     storage, client = _new_storage(monkeypatch, {})
-    _pages(
+    _wire(client)
+    _paginator(
         client,
-        {"Contents": [{"Key": "a"}]},
-        {"Contents": [{"Key": "c"}]},
+        "list_object_versions",
+        {"Versions": [{"Key": "a"}], "DeleteMarkers": []},
+        {"Versions": [{"Key": "c"}], "DeleteMarkers": []},
     )
     client.delete_objects.side_effect = [
         {"Deleted": [{"Key": "a"}]},
         {"Errors": [{"Key": "c", "Code": "InternalError", "Message": "boom"}]},
     ]
-    client.bucket_exists.return_value = True
+    client.head_bucket.return_value = {}
 
-    storage.remove_bucket("kb01")
-
-    client.delete_bucket.assert_not_called()
-
-
-def test_remove_bucket_log_omits_request_urls(monkeypatch, caplog):
-    """S3 error responses can embed signed query strings; the log line must
-    carry the failure mode, not a verbatim request URL."""
-    storage, client = _new_storage(monkeypatch, {})
-    # A non-ClientError escapes bucket_exists and reaches remove_bucket's
-    # handler; botocore wraps such failures with the request URL attached.
-    client.head_bucket.side_effect = ConnectionError("GET https://s3.example.com/bucket?X-Amz-Signature=SECRET failed")
-
-    with caplog.at_level(logging.ERROR):
+    with pytest.raises(RuntimeError, match="S3 object deletion failed for keys: c"):
         storage.remove_bucket("kb01")
 
     client.delete_bucket.assert_not_called()
-    client.get_paginator.assert_not_called()
+
+
+def test_remove_bucket_handles_null_error_response(monkeypatch, caplog):
+    """botocore HTTPClientError can carry response=None; the failure path must
+    complete without AttributeError and still log the failure."""
+    storage, client = _new_storage(monkeypatch, {})
+    _wire(client)
+    err = ClientError({"Error": {}}, "HeadBucket")
+    err.response = None  # HTTPClientError can surface with a null response
+    client.head_bucket.side_effect = err
+
+    with caplog.at_level(logging.ERROR), pytest.raises(ClientError):
+        storage.remove_bucket("kb01")
+
+    assert any("Fail to remove bucket kb01" in r.getMessage() for r in caplog.records)
+
+
+def test_remove_bucket_re_raises_to_callers(monkeypatch, caplog):
+    """Lifecycle callers delete metadata after remove_bucket returns; a
+    storage failure must propagate, not report silent success."""
+    storage, client = _new_storage(monkeypatch, {})
+    _wire(client)
+    client.head_bucket.side_effect = ConnectionError("network down")
+
+    with caplog.at_level(logging.ERROR), pytest.raises(ConnectionError):
+        storage.remove_bucket("kb01")
+
     messages = [r.getMessage() for r in caplog.records]
     assert any("Fail to remove bucket kb01" in m for m in messages), messages
     for m in messages:
@@ -131,42 +231,47 @@ def test_remove_bucket_log_omits_request_urls(monkeypatch, caplog):
 
 
 def test_remove_bucket_single_bucket_mode_keeps_physical_bucket(monkeypatch):
-    """Default-bucket mode: scope deletion to the logical prefix, keep the bucket."""
+    """Default-bucket mode: scope deletion to the logical prefix, keep the
+    bucket. With no prefix_path the write path stores keys without a bucket
+    segment, so the cleanup prefix must also be empty."""
     storage, client = _new_storage(monkeypatch, {"bucket": "ragflow"})
-    _pages(
-        client,
-        by_prefix={"kb01/": [{"Contents": [{"Key": "kb01/x"}, {"Key": "kb01/y"}]}]},
-    )
+    _wire(client)
+    versions = _paginator(client, "list_object_versions", by_prefix={})
+    uploads = _paginator(client, "list_multipart_uploads", by_prefix={})
 
     storage.remove_bucket("kb01")
 
-    deleted = client.delete_objects.call_args
-    assert deleted.kwargs["Bucket"] == "ragflow"
-    keys = [o["Key"] for o in deleted.kwargs["Delete"]["Objects"]]
-    assert keys == ["kb01/x", "kb01/y"]
+    versions.paginate.assert_called_once_with(Bucket="ragflow", Prefix="")
+    uploads.paginate.assert_called_once_with(Bucket="ragflow")
     client.delete_bucket.assert_not_called()
 
 
 def test_remove_bucket_single_bucket_mode_with_prefix_path(monkeypatch):
     storage, client = _new_storage(monkeypatch, {"bucket": "ragflow", "prefix_path": "prod"})
-    _pages(
+    _wire(client)
+    versions = _paginator(
         client,
-        by_prefix={"prod/kb01/": [{"Contents": [{"Key": "prod/kb01/doc"}]}]},
+        "list_object_versions",
+        by_prefix={"prod/kb01/": [{"Versions": [{"Key": "prod/kb01/doc"}], "DeleteMarkers": []}]},
     )
+    _paginator(client, "list_multipart_uploads", by_prefix={"prod/kb01/": []})
 
     storage.remove_bucket("kb01")
 
+    versions.paginate.assert_called_once_with(Bucket="ragflow", Prefix="prod/kb01/")
     deleted = client.delete_objects.call_args
     keys = [o["Key"] for o in deleted.kwargs["Delete"]["Objects"]]
     assert keys == ["prod/kb01/doc"]
     client.delete_bucket.assert_not_called()
 
 
-def test_remove_bucket_empty_pages_delete_nothing_but_bucket(monkeypatch):
+def test_remove_bucket_empty_bucket_deletes_only_bucket(monkeypatch):
     """A bucket that exists but has no objects: only delete_bucket fires."""
     storage, client = _new_storage(monkeypatch, {})
-    _pages(client, {})
-    client.bucket_exists.return_value = True
+    _wire(client)
+    _paginator(client, "list_object_versions", {})
+    _paginator(client, "list_multipart_uploads", {})
+    client.head_bucket.return_value = {}
 
     storage.remove_bucket("kb01")
 

--- a/test/unit_test/rag/utils/test_s3_remove_bucket.py
+++ b/test/unit_test/rag/utils/test_s3_remove_bucket.py
@@ -17,7 +17,10 @@
 """Unit tests for RAGFlowS3.remove_bucket (issue: S3 backend could not delete buckets)."""
 
 import importlib
+import logging
 from unittest.mock import Mock
+
+from botocore.exceptions import ClientError
 
 # Import common.settings first: s3_conn <-> settings import cycle resolves
 # only in the same order the app uses (see test_s3_conn.py).
@@ -35,7 +38,8 @@ def _new_storage(monkeypatch, config):
 
 def _pages(client, *pages, by_prefix=None):
     """Stub the list_objects_v2 paginator. ``by_prefix`` maps a Prefix kwarg to
-    its pages so single-bucket mode sees realistic prefix-filtered results."""
+    its pages so single-bucket mode sees realistic prefix-filtered results.
+    delete_objects defaults to an all-deleted response; tests override it."""
     paginator = Mock()
 
     def paginate(**kwargs):
@@ -45,6 +49,7 @@ def _pages(client, *pages, by_prefix=None):
 
     paginator.paginate.side_effect = paginate
     client.get_paginator.return_value = paginator
+    client.delete_objects.return_value = {"Deleted": []}
 
 
 def test_remove_bucket_method_matches_storage_contract(monkeypatch):
@@ -72,13 +77,57 @@ def test_remove_bucket_deletes_objects_then_bucket(monkeypatch):
 
 
 def test_remove_bucket_skips_missing_bucket(monkeypatch):
+    """bucket_exists goes through head_bucket; drive the real 404 path."""
     storage, client = _new_storage(monkeypatch, {})
-    client.bucket_exists.return_value = False
+    client.head_bucket.side_effect = ClientError(
+        {"Error": {"Code": "404"}},
+        "HeadBucket",
+    )
 
     storage.remove_bucket("nope")
 
+    client.get_paginator.assert_not_called()
     client.delete_objects.assert_not_called()
     client.delete_bucket.assert_not_called()
+
+
+def test_remove_bucket_raises_on_batch_delete_errors(monkeypatch):
+    """delete_objects reports failed keys in its response instead of raising;
+    the helper must surface them rather than report silent success."""
+    storage, client = _new_storage(monkeypatch, {})
+    _pages(
+        client,
+        {"Contents": [{"Key": "a"}]},
+        {"Contents": [{"Key": "c"}]},
+    )
+    client.delete_objects.side_effect = [
+        {"Deleted": [{"Key": "a"}]},
+        {"Errors": [{"Key": "c", "Code": "InternalError", "Message": "boom"}]},
+    ]
+    client.bucket_exists.return_value = True
+
+    storage.remove_bucket("kb01")
+
+    client.delete_bucket.assert_not_called()
+
+
+def test_remove_bucket_log_omits_request_urls(monkeypatch, caplog):
+    """S3 error responses can embed signed query strings; the log line must
+    carry the failure mode, not a verbatim request URL."""
+    storage, client = _new_storage(monkeypatch, {})
+    # A non-ClientError escapes bucket_exists and reaches remove_bucket's
+    # handler; botocore wraps such failures with the request URL attached.
+    client.head_bucket.side_effect = ConnectionError("GET https://s3.example.com/bucket?X-Amz-Signature=SECRET failed")
+
+    with caplog.at_level(logging.ERROR):
+        storage.remove_bucket("kb01")
+
+    client.delete_bucket.assert_not_called()
+    client.get_paginator.assert_not_called()
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("Fail to remove bucket kb01" in m for m in messages), messages
+    for m in messages:
+        assert "X-Amz-Signature" not in m
 
 
 def test_remove_bucket_single_bucket_mode_keeps_physical_bucket(monkeypatch):

--- a/test/unit_test/rag/utils/test_s3_remove_bucket.py
+++ b/test/unit_test/rag/utils/test_s3_remove_bucket.py
@@ -18,7 +18,7 @@
 
 import importlib
 import logging
-from unittest.mock import Mock, call as mock_call
+from unittest.mock import Mock
 
 import pytest
 from botocore.exceptions import ClientError
@@ -124,48 +124,6 @@ def test_remove_bucket_deletes_versions_and_markers_with_version_ids(monkeypatch
     client.delete_bucket.assert_called_once_with(Bucket="kb01")
 
 
-def test_remove_bucket_aborts_every_incomplete_multipart_upload(monkeypatch):
-    """Incomplete multipart uploads keep a bucket non-empty; every upload in
-    the page must be aborted, not just the first, before delete_bucket."""
-    storage, client = _new_storage(monkeypatch, {})
-    _wire(client)
-    _paginator(client, "list_object_versions", {})
-    _paginator(
-        client,
-        "list_multipart_uploads",
-        {
-            "Uploads": [
-                {"Key": "big.bin", "UploadId": "up-1"},
-                {"Key": "huge.bin", "UploadId": "up-2"},
-            ]
-        },
-    )
-    client.head_bucket.return_value = {}
-
-    storage.remove_bucket("kb01")
-
-    assert client.abort_multipart_upload.call_args_list == [
-        mock_call(Bucket="kb01", Key="big.bin", UploadId="up-1"),
-        mock_call(Bucket="kb01", Key="huge.bin", UploadId="up-2"),
-    ]
-    client.delete_bucket.assert_called_once_with(Bucket="kb01")
-
-
-def test_remove_bucket_scopes_multipart_pagination_to_prefix(monkeypatch):
-    """Single-bucket mode: the multipart-upload pagination must apply the same
-    logical-bucket prefix as the version listing."""
-    storage, client = _new_storage(monkeypatch, {"bucket": "ragflow", "prefix_path": "prod"})
-    _wire(client)
-    _paginator(client, "list_object_versions", by_prefix={})
-    uploads = _paginator(client, "list_multipart_uploads", by_prefix={})
-    client.head_bucket.return_value = {}
-
-    storage.remove_bucket("kb01")
-
-    uploads.paginate.assert_called_once_with(Bucket="ragflow", Prefix="prod/kb01/")
-    client.delete_bucket.assert_not_called()
-
-
 def test_remove_bucket_skips_missing_bucket(monkeypatch):
     """A 404 from head_bucket means the bucket is absent: a clean no-op."""
     storage, client = _new_storage(monkeypatch, {})
@@ -253,20 +211,19 @@ def test_remove_bucket_re_raises_to_callers(monkeypatch, caplog):
         assert "X-Amz-Signature" not in m
 
 
-def test_remove_bucket_single_bucket_mode_keeps_physical_bucket(monkeypatch):
-    """Default-bucket mode: scope deletion to the logical prefix, keep the
-    bucket. With no prefix_path the write path stores keys without a bucket
-    segment, so the cleanup prefix must also be empty."""
+def test_remove_bucket_refuses_shared_bucket_without_prefix_path(monkeypatch, caplog):
+    """A shared physical bucket without prefix_path hosts keys without a
+    logical-bucket segment; no cleanup prefix could scope the deletion, so it
+    must refuse rather than wipe the whole bucket."""
     storage, client = _new_storage(monkeypatch, {"bucket": "ragflow"})
     _wire(client)
-    versions = _paginator(client, "list_object_versions", by_prefix={})
-    uploads = _paginator(client, "list_multipart_uploads", by_prefix={})
 
-    storage.remove_bucket("kb01")
+    with caplog.at_level(logging.ERROR):
+        storage.remove_bucket("kb01")
 
-    versions.paginate.assert_called_once_with(Bucket="ragflow", Prefix="")
-    uploads.paginate.assert_called_once_with(Bucket="ragflow", Prefix="")
+    client.get_paginator.assert_not_called()
     client.delete_bucket.assert_not_called()
+    assert any("Refusing to remove logical bucket kb01" in r.getMessage() for r in caplog.records)
 
 
 def test_remove_bucket_single_bucket_mode_with_prefix_path(monkeypatch):


### PR DESCRIPTION
## Problem

With `STORAGE_IMPL=AWS_S3`, deleting a knowledge base or a user account silently fails to remove the underlying storage: the storage layer either raises `AttributeError` or swallows the error, and the objects leak indefinitely. Three defects compound:

1. Callers (`api/db/joint_services/user_account_service.py:164`, `api/apps/services/file_api_service.py:425`) invoke `remove_bucket`, but `RAGFlowS3` only defines `rm_bucket` — every other connector (MinIO, GCS, encrypted wrapper) exposes `remove_bucket`.
2. The old `rm_bucket` implementation called MinIO-SDK signatures (`conn.bucket_exists(bucket)`, `conn.delete_object(bucket, o.object_name)`) on a **boto3** client, and wrapped it in a bare `except` that only logged.
3. In single-bucket mode there was no prefix-scoped deletion at all — the semantics that `RAGFlowMinio.remove_bucket` implements (delete objects under the logical prefix, keep the physical bucket).

Present since at least v0.24.0 through v0.27.1.

## Changes

`rag/utils/s3_conn.py`:

- Rename `rm_bucket` → `remove_bucket` to match the storage-layer contract used by every caller and connector. (`rm_bucket` had no other references in the repo.)
- Rewrite the implementation with boto3 APIs: `get_paginator("list_objects_v2")` + batch `delete_objects`, then `delete_bucket` in multi-bucket mode.
- Single-bucket mode now mirrors `RAGFlowMinio.remove_bucket`: objects are deleted under the logical-bucket prefix (`prefix_path` + original bucket id) and the physical bucket is kept.
- `use_default_bucket` now forwards the original bucket id as `_orig_bucket` in default-bucket mode, same contract as the MinIO connector. All decorated methods accept `**kwargs`, so the extra key is inert everywhere else.

## Testing

- New `test/unit_test/rag/utils/test_s3_remove_bucket.py` (follows the existing `test_s3_conn.py` mock style): contract method presence, multi-bucket delete-then-bucket flow, missing-bucket no-op, single-bucket prefix scoping (with and without `prefix_path`), empty-bucket flow.
- `ruff check`: no new findings on the touched file (baseline findings unchanged).

Fixes #19100
