### PR TITLE
fix(searchbots): enforce KB authorization before retrieval

### DIFF
--- a/api/apps/restful_apis/bot_api.py
+++ b/api/apps/restful_apis/bot_api.py
@@ -54,6 +54,19 @@ from api.utils.pagination_utils import DEFAULT_PAGE, DEFAULT_PAGE_SIZE, validate
 logger = logging.getLogger(__name__)
 
 
+async def _accessible_kbs(kb_ids, tenant_id):
+    """Return whether every requested KB is accessible to the caller."""
+    if isinstance(kb_ids, str):
+        kb_ids = [kb_ids]
+    if not kb_ids:
+        return False
+    for kb_id in kb_ids:
+        if not await thread_pool_exec(KnowledgebaseService.accessible, kb_id, tenant_id):
+            logger.warning("Denied KB access: user_id=%s kb_id=%s", tenant_id, kb_id)
+            return False
+    return True
+
+
 @manager.route("/chatbots/<dialog_id>/completions", methods=["POST"])  # noqa: F821
 @login_required(auth_types=AUTH_BETA)
 @add_tenant_id_to_kwargs
@@ -308,6 +321,10 @@ async def ask_about_embedded(tenant_id=None):
         if search_app := await thread_pool_exec(SearchService.get_detail, search_id):
             search_config = search_app.get("search_config", {})
 
+    effective_kb_ids = search_config.get("kb_ids", req["kb_ids"])
+    if not await _accessible_kbs(effective_kb_ids, uid):
+        return get_error_data_result(message="You don't own the requested dataset")
+
     chat_llm_name = ""
     if not search_config or not search_config.get("chat_id"):
         _, tenant_info = TenantService.get_by_id(uid)
@@ -407,14 +424,12 @@ async def retrieval_test_embedded(tenant_id=None):
                 metas_loader=lambda: DocMetadataService.get_flatted_meta_by_kbs(kb_ids),
             )
 
-        tenants = await thread_pool_exec(UserTenantService.query, user_id=tenant_id)
         for kb_id in kb_ids:
-            for tenant in tenants:
-                if await thread_pool_exec(KnowledgebaseService.query, tenant_id=tenant.tenant_id, id=kb_id):
-                    tenant_ids.append(tenant.tenant_id)
-                    break
-            else:
+            if not await thread_pool_exec(KnowledgebaseService.accessible, kb_id, tenant_id):
                 return get_json_result(data=False, message="Only owner of dataset authorized for this operation.", code=RetCode.OPERATING_ERROR)
+            exists, kb = await thread_pool_exec(KnowledgebaseService.get_by_id, kb_id)
+            if exists:
+                tenant_ids.append(kb.tenant_id)
 
         e, kb = await thread_pool_exec(KnowledgebaseService.get_by_id, kb_ids[0])
         if not e:
@@ -548,6 +563,9 @@ async def detail_share_embedded(tenant_id=None):
 @validate_request("question", "kb_ids")
 async def mindmap(tenant_id=None):
     req = await get_request_json()
+
+    if not await _accessible_kbs(req["kb_ids"], tenant_id):
+        return get_error_data_result(message="You don't own the requested dataset")
 
     search_id = req.get("search_id", "")
     search_app = await thread_pool_exec(SearchService.get_detail, search_id) if search_id else {}

--- a/internal/service/chunk/chunk.go
+++ b/internal/service/chunk/chunk.go
@@ -177,6 +177,9 @@ func (s *ChunkService) RetrievalTest(ctx context.Context, req *service.Retrieval
 		for _, tenant := range tenants {
 			kb, err := s.kbDAO.GetByIDAndTenantID(ctx, dao.DB, datasetID, tenant.TenantID)
 			if err == nil && kb != nil {
+				if kb.TenantID != userID && kb.Permission != string(entity.TenantPermissionTeam) {
+					continue
+				}
 				common.Debug("Found knowledge base in database",
 					zap.String("datasetID", datasetID),
 					zap.String("tenantID", tenant.TenantID),

--- a/test/unit_test/api/apps/restful_apis/test_agentbots_access_control.py
+++ b/test/unit_test/api/apps/restful_apis/test_agentbots_access_control.py
@@ -49,7 +49,7 @@ async def _passthrough_thread_pool_exec(fn, *args, **kwargs):
     return fn(*args, **kwargs)
 
 
-def _load_bot_api(monkeypatch, *, accessible, calls):
+def _load_bot_api(monkeypatch, *, accessible, calls, kb_accessible=True, search_config=None):
     """Load bot_api.py with the minimum stubs required.
 
     `accessible` is what the stubbed `UserCanvasService.accessible` returns.
@@ -79,9 +79,22 @@ def _load_bot_api(monkeypatch, *, accessible, calls):
     _stub(monkeypatch, "api.db.services.canvas_service", UserCanvasService=user_canvas_service, completion=_completion)
     _stub(monkeypatch, "api.db.services.user_canvas_version", UserCanvasVersionService=SimpleNamespace())
     _stub(monkeypatch, "api.db.services.conversation_service", async_iframe_completion=lambda *_a, **_k: None)
-    _stub(monkeypatch, "api.db.services.dialog_service", DialogService=SimpleNamespace(), async_ask=lambda *_a, **_k: None, gen_mindmap=lambda *_a, **_k: None)
+    async def _ask(*_a, **_k):
+        calls["async_ask"] = _k
+        if False:
+            yield None
+
+    async def _mindmap(*_a, **_k):
+        calls["gen_mindmap"] = True
+        return {}
+
+    _stub(monkeypatch, "api.db.services.dialog_service", DialogService=SimpleNamespace(), async_ask=_ask, gen_mindmap=_mindmap)
     _stub(monkeypatch, "api.db.services.doc_metadata_service", DocMetadataService=SimpleNamespace())
-    _stub(monkeypatch, "api.db.services.knowledgebase_service", KnowledgebaseService=SimpleNamespace())
+    _stub(
+        monkeypatch,
+        "api.db.services.knowledgebase_service",
+        KnowledgebaseService=SimpleNamespace(accessible=lambda kb_id, user_id: kb_accessible),
+    )
     _stub(
         monkeypatch,
         "api.db.services.llm_service",
@@ -89,7 +102,7 @@ def _load_bot_api(monkeypatch, *, accessible, calls):
         resolve_llm_setting=lambda s: s or {"temperature": 0.1, "top_p": 0.3, "frequency_penalty": 0.7, "presence_penalty": 0.4},
     )
     _stub(monkeypatch, "common.metadata_utils", apply_meta_data_filter=lambda *_a, **_k: None)
-    _stub(monkeypatch, "api.db.services.search_service", SearchService=SimpleNamespace())
+    _stub(monkeypatch, "api.db.services.search_service", SearchService=SimpleNamespace(get_detail=lambda _id: {"search_config": search_config or {}}))
     _stub(
         monkeypatch,
         "api.db.services.user_service",
@@ -120,6 +133,7 @@ def _load_bot_api(monkeypatch, *, accessible, calls):
     _stub(monkeypatch, "rag.app.tag", label_question=lambda *_a, **_k: None)
     _stub(monkeypatch, "rag.prompts.template", load_prompt=lambda *_a, **_k: "")
     _stub(monkeypatch, "rag.prompts.generator", cross_languages=lambda *_a, **_k: None, keyword_extraction=lambda *_a, **_k: None)
+    _stub(monkeypatch, "rag.utils.web_search_conn", has_web_search_provider=lambda *_a, **_k: False)
     _stub(monkeypatch, "common.constants", RetCode=SimpleNamespace(), LLMType=SimpleNamespace(), StatusEnum=SimpleNamespace())
     _stub(monkeypatch, "common", settings=SimpleNamespace())
     _stub(monkeypatch, "common.settings", retriever=SimpleNamespace(), kg_retriever=SimpleNamespace())
@@ -184,3 +198,37 @@ class TestAgentBotAccessControl:
 
         assert calls.get("completion") is True
         assert result["code"] == 0
+
+    @pytest.mark.p1
+    def test_searchbots_reject_inaccessible_kbs_before_retrieval(self, monkeypatch):
+        calls = {}
+        module = _load_bot_api(monkeypatch, accessible=True, calls=calls, kb_accessible=False)
+        module.get_request_json = lambda: None
+
+        async def request_json():
+            return {"question": "q", "kb_ids": ["victim"]}
+
+        module.get_request_json = request_json
+        assert asyncio.run(module.ask_about_embedded(tenant_id="attacker"))["code"] == 102
+        assert "async_ask" not in calls
+
+        assert asyncio.run(module.mindmap(tenant_id="attacker"))["code"] == 102
+        assert "gen_mindmap" not in calls
+
+    @pytest.mark.p1
+    def test_searchbots_ask_authorizes_search_config_kbs(self, monkeypatch):
+        calls = {}
+        module = _load_bot_api(
+            monkeypatch,
+            accessible=True,
+            calls=calls,
+            kb_accessible=False,
+            search_config={"kb_ids": ["victim"]},
+        )
+
+        async def request_json():
+            return {"question": "q", "kb_ids": ["attacker"], "search_id": "saved"}
+
+        module.get_request_json = request_json
+        assert asyncio.run(module.ask_about_embedded(tenant_id="attacker"))["code"] == 102
+        assert "async_ask" not in calls

--- a/test/unit_test/api/apps/restful_apis/test_agentbots_access_control.py
+++ b/test/unit_test/api/apps/restful_apis/test_agentbots_access_control.py
@@ -79,6 +79,7 @@ def _load_bot_api(monkeypatch, *, accessible, calls, kb_accessible=True, search_
     _stub(monkeypatch, "api.db.services.canvas_service", UserCanvasService=user_canvas_service, completion=_completion)
     _stub(monkeypatch, "api.db.services.user_canvas_version", UserCanvasVersionService=SimpleNamespace())
     _stub(monkeypatch, "api.db.services.conversation_service", async_iframe_completion=lambda *_a, **_k: None)
+
     async def _ask(*_a, **_k):
         calls["async_ask"] = _k
         if False:


### PR DESCRIPTION
Searchbot endpoints now verify every effective KB ID before retrieval. Private datasets remain inaccessible to unauthorized tenant members.