### PR TITLE
fix(web): let the editable description textarea scroll when clamped

### DIFF
--- a/web/src/components/avatar-name-description/editable-textarea.tsx
+++ b/web/src/components/avatar-name-description/editable-textarea.tsx
@@ -115,7 +115,7 @@ export function EditableTextarea({
               onKeyDown={handleKeyDown}
               placeholder={finalPlaceholder}
               className={cn(
-                'min-h-[28px] text-sm text-text-secondary resize-none px-2 py-0.5',
+                'min-h-[28px] text-sm text-text-secondary resize-none px-2 py-0.5 overflow-auto',
                 textareaClassName,
               )}
               autoSize={{ minRows, maxRows }}


### PR DESCRIPTION
### Summary

The shared Textarea applies overflow-hidden whenever resize is 'none', so text past maxRows was clipped with no way to scroll to it.
