### PR TITLE
fix(parser): stop the .msg date test depending on the host timezone

### DIFF
--- a/internal/parser/parser/email_parser_test.go
+++ b/internal/parser/parser/email_parser_test.go
@@ -247,8 +247,14 @@ func TestEmailParser_MsgSupported(t *testing.T) {
 	if v, ok := item["subject"].(string); !ok || v != "asdf" {
 		t.Errorf("subject: got %q", v)
 	}
-	if v, ok := item["date"].(string); !ok || v != "2018-03-24 00:06:29+0800" {
-		t.Errorf("date: got %q, want 2018-03-24 00:06:29+0800", v)
+	// The rendered offset follows the host timezone, so assert the layout and the
+	// instant instead of one host's spelling.
+	if v, ok := item["date"].(string); !ok {
+		t.Errorf("date: got %T, want string", item["date"])
+	} else if got, err := time.Parse("2006-01-02 15:04:05-0700", v); err != nil {
+		t.Errorf("date %q: %v", v, err)
+	} else if want := time.Date(2018, 3, 23, 16, 6, 29, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("date: got %q = %v, want %v", v, got.UTC(), want)
 	}
 	if v, ok := item["text"].(string); !ok || v != " \r\n\r\n" {
 		t.Errorf("text: got %q", v)


### PR DESCRIPTION
### Summary

`TestEmailParser_MsgSupported` asserts the literal string `2018-03-24 00:06:29+0800`. The test only passes on a host at +0800.

`formatMsgDate` renders `msg.Date` with the `-0700` layout. `gomsg` builds that time in `filetimeToTime` with `time.Unix`, which returns a `time.Time` in the local location. The rendered offset follows `TZ`, so the correct expected string does too.

Measured on `4168b3f9d`, one run per zone:

| TZ | result |
|---|---|
| `Asia/Shanghai` | ok |
| `America/New_York` | FAIL, got `"2018-03-23 12:06:29-0400"` |
| `UTC` | FAIL, got `"2018-03-23 16:06:29+0000"` |
| `Europe/Berlin` | FAIL, got `"2018-03-23 17:06:29+0100"` |

All four strings are the same instant. `docker/.env` line 291 sets `TZ=Asia/Shanghai`, so CI stays green. A contributor in another zone gets a red package on a clean checkout.

The parser is correct, so this PR does not touch it. The test now parses the value with the same layout and compares the instant.

```go
if v, ok := item["date"].(string); !ok {
	t.Errorf("date: got %T, want string", item["date"])
} else if got, err := time.Parse("2006-01-02 15:04:05-0700", v); err != nil {
	t.Errorf("date %q: %v", v, err)
} else if want := time.Date(2018, 3, 23, 16, 6, 29, 0, time.UTC); !got.Equal(want) {
	t.Errorf("date: got %q = %v, want %v", v, got.UTC(), want)
}
```

The new assertion passes under `Asia/Shanghai`, `America/New_York`, `UTC`, `Europe/Berlin`, `Australia/Sydney`, `Asia/Kolkata` and `Pacific/Kiritimati`.

It still catches a broken `formatMsgDate`. I applied each mutation to the parser and ran the test under `America/New_York`:

| mutation | failure |
|---|---|
| layout `-07:00` instead of `-0700` | `cannot parse "-04:00" as "-0700"` |
| `t.Add(time.Hour)` before the format | `got "2018-03-23 13:06:29-0400" = 2018-03-23 17:06:29 +0000 UTC, want 2018-03-23 16:06:29 +0000 UTC` |
| zone dropped from the layout | `cannot parse "" as "-0700"` |
