### PR TITLE
fix(ingestion): route xlsx QA JSON table items to extractQATable

### DIFF
--- a/internal/ingestion/component/chunker/qa.go
+++ b/internal/ingestion/component/chunker/qa.go
@@ -19,7 +19,7 @@
 // Input formats and extraction strategies:
 //   - Text (txt, csv)  → delimiter-based Q&A (comma or tab)
 //   - Markdown (md)    → heading-based Q&A
-//   - HTML (xls, legacy xlsx) → table-based Q&A (first two columns)
+//   - HTML (xls, xlsx) → table-based Q&A (first two columns)
 //   - JSON (pdf, docx, xlsx) → text sections via delimiter; table items via extractQATable
 //
 // Every Q&A pair becomes a single chunk with content_with_weight

--- a/internal/ingestion/component/chunker/qa.go
+++ b/internal/ingestion/component/chunker/qa.go
@@ -19,8 +19,8 @@
 // Input formats and extraction strategies:
 //   - Text (txt, csv)  → delimiter-based Q&A (comma or tab)
 //   - Markdown (md)    → heading-based Q&A
-//   - HTML (xlsx/xls)  → table-based Q&A (first two columns)
-//   - JSON (pdf, docx) → delimiter-based on structured text sections
+//   - HTML (xls, legacy xlsx) → table-based Q&A (first two columns)
+//   - JSON (pdf, docx, xlsx) → text sections via delimiter; table items via extractQATable
 //
 // Every Q&A pair becomes a single chunk with content_with_weight
 // formatted as "Question: {q}\tAnswer: {a}".
@@ -430,7 +430,16 @@ func extractQAJSON(items []schema.ChunkDoc) []qaPair {
 		if txt == "" {
 			continue
 		}
-		tmp := extractQAText(txt)
+		// XLSX (#18800) emits OutputFormat json with HTML tables in item
+		// text and doc_type_kwd=table. Route those through extractQATable
+		// so spreadsheet QA keeps working; plain text items stay on the
+		// delimiter path used by pdf/docx.
+		var tmp []qaPair
+		if itemDocType(item) == "table" {
+			tmp = extractQATable(txt, false)
+		} else {
+			tmp = extractQAText(txt)
+		}
 		// Preserve the source item's image id and coordinates on each
 		// extracted pair
 		for _, p := range tmp {

--- a/internal/ingestion/component/chunker/xlsx_qa_regression_test.go
+++ b/internal/ingestion/component/chunker/xlsx_qa_regression_test.go
@@ -1,0 +1,60 @@
+package chunker
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/xuri/excelize/v2"
+	"ragflow/internal/parser/parser"
+)
+
+func TestXLSXQARegression(t *testing.T) {
+	f := excelize.NewFile()
+	sh := f.GetSheetName(0)
+	for i, r := range [][]string{
+		{"question", "answer"},
+		{"What is RAGFlow?", "A RAG engine."},
+		{"Where are the docs?", "On the website."},
+	} {
+		for j, c := range r {
+			cell, _ := excelize.CoordinatesToCellName(j+1, i+1)
+			_ = f.SetCellValue(sh, cell, c)
+		}
+	}
+	var buf bytes.Buffer
+	if err := f.Write(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := parser.NewXLSXParser("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := p.ParseWithResult(context.Background(), "qa.xlsx", buf.Bytes())
+	if res.Err != nil {
+		t.Fatal(res.Err)
+	}
+
+	inputs := map[string]any{"name": "qa.xlsx", "output_format": res.OutputFormat}
+	switch res.OutputFormat {
+	case "json":
+		inputs["json"] = res.JSON
+	case "html":
+		inputs["html"] = res.HTML
+	}
+
+	comp, err := NewQAChunker(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := comp.Invoke(t.Context(), nil, inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunks, _ := out["chunks"].([]map[string]any)
+	t.Logf("format=%q QA chunks=%d", res.OutputFormat, len(chunks))
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(chunks))
+	}
+}


### PR DESCRIPTION
### Summary

Since #18800, `xlsx_parser` returns `OutputFormat: "json"` with the HTML table in each item's `text` and `doc_type_kwd: "table"`. `extractQAJSON` still sent that HTML through `extractQAText` (CSV/TSV), so QA chunking produced zero chunks for every `.xlsx`.

Route JSON items with `doc_type_kwd=table` through the existing `extractQATable` path (option 1 from the issue). Keeps the #18800 image envelope intact. Adds the issue's `xlsx_qa_regression_test.go`.

Fixes #19174

Evidence: `CGO_ENABLED=0 go test ./internal/ingestion/component/chunker/ -run 'TestQA|TestXLSXQA' -count=1` → pass (`TestXLSXQARegression` → format=`json`, 3 chunks).