### PR TITLE
refactor(dao): isolate database migrations from runtime startup

### DIFF
--- a/Dockerfile_go
+++ b/Dockerfile_go
@@ -218,6 +218,7 @@ RUN rm -f /etc/nginx/sites-enabled/default
 
 COPY conf conf
 COPY agent/templates agent/templates
+COPY internal/ingestion/pipeline/template internal/ingestion/pipeline/template
 
 # Wiki page-structure presets read at runtime by the Go backend
 # (CompilationTemplateService.LoadWikiPresets).

--- a/api/ragflow_server.py
+++ b/api/ragflow_server.py
@@ -53,6 +53,10 @@ chat_channel_thread = None
 RAGFLOW_DEBUGPY_LISTEN = int(os.environ.get("RAGFLOW_DEBUGPY_LISTEN", "0"))
 
 
+def _should_skip_db_init():
+    return os.environ.get("SKIP_DB_INIT") in {"1", "true"}
+
+
 def update_progress():
     lock_value = str(uuid.uuid4())
     redis_lock = RedisDistributedLock("update_progress", lock_value=lock_value, timeout=60)
@@ -110,9 +114,11 @@ if __name__ == "__main__":
 
         debugpy.listen(("0.0.0.0", RAGFLOW_DEBUGPY_LISTEN))
 
-    # init db
-    init_web_db()
-    init_web_data()
+    if _should_skip_db_init():
+        logging.info("Skipping database initialization (SKIP_DB_INIT is enabled).")
+    else:
+        init_web_db()
+        init_web_data()
     # init runtime config
     import argparse
 

--- a/cmd/ragflow_server.go
+++ b/cmd/ragflow_server.go
@@ -68,7 +68,7 @@ import (
 )
 
 type serverArgs struct {
-	mode          *string // admin | api | ingestor | syncer
+	mode          *string // admin | api | ingestor | syncer | migrate
 	helpFlag      bool
 	versionFlag   bool
 	debugLog      bool
@@ -168,15 +168,16 @@ func parseArgs() (*serverArgs, error) {
 func printHelp(args *serverArgs) {
 	switch {
 	case args.mode == nil:
-		fmt.Fprintf(os.Stderr, "Usage: %s --api|--admin|--ingestor|--syncer [OPTIONS]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s --api|--admin|--ingestor|--syncer|--migrate [OPTIONS]\n\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "RAGFlow Server - Open-source RAG engine based on deep document understanding\n\n")
-		fmt.Fprintf(os.Stderr, "Mode selection (default: --api):\n")
+		fmt.Fprintf(os.Stderr, "Mode selection:\n")
 		fmt.Fprintf(os.Stderr, "  --api          \tRun as API server\n")
 		fmt.Fprintf(os.Stderr, "  --admin        \tRun as admin server\n")
 		fmt.Fprintf(os.Stderr, "  --ingestor     \tRun as ingestion worker\n")
 		fmt.Fprintf(os.Stderr, "  --syncer       \tRun as file sync service\n\n")
 		fmt.Fprintf(os.Stderr, "Common options:\n")
 		fmt.Fprintf(os.Stderr, "  --config string\tPath to configuration file\n")
+		fmt.Fprintf(os.Stderr, "  --migrate      \tRun database schema migrations and exit\n")
 		fmt.Fprintf(os.Stderr, "  -v, --version  \tPrint version information and exit\n")
 		fmt.Fprintf(os.Stderr, "  --debug        \tEnable debug-level logging\n")
 		fmt.Fprintf(os.Stderr, "  -h, --help     \tShow this help message and exit\n\n")
@@ -236,9 +237,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	if arguments.helpFlag || arguments.mode == nil {
+	if arguments.helpFlag || (arguments.mode == nil && !arguments.migrateDB) {
 		printHelp(arguments)
 		os.Exit(1)
+	}
+
+	if arguments.migrateDB && arguments.mode != nil && *arguments.mode != "admin" {
+		fmt.Fprintf(os.Stderr, "Error: --migrate cannot be combined with --%s. Run '%s --migrate' standalone or with '--admin'.\n\n", *arguments.mode, os.Args[0])
+		printHelp(arguments)
+		os.Exit(1)
+	}
+
+	if arguments.mode == nil && arguments.migrateDB {
+		migrateMode := "migrate"
+		arguments.mode = &migrateMode
 	}
 
 	if arguments.versionFlag {
@@ -330,6 +342,10 @@ func main() {
 			uuid := utility.GenerateUUID()
 			serverName = fmt.Sprintf("syncer_server_%s", uuid)
 		}
+	case "migrate":
+		if arguments.name == nil {
+			serverName = "migrate_server"
+		}
 	default:
 		err = errors.New(*arguments.mode)
 		common.Error("invalid server mode", err)
@@ -377,6 +393,11 @@ func main() {
 	// Initialize database
 	if err = dao.InitDB(ctx, arguments.migrateDB); err != nil {
 		common.Fatal("Failed to initialize database", zap.Error(err))
+	}
+
+	if *arguments.mode == "migrate" {
+		common.Info("Database migration completed successfully")
+		return
 	}
 
 	// Initialize doc engine

--- a/docker/entrypoint-go.sh
+++ b/docker/entrypoint-go.sh
@@ -254,8 +254,12 @@ function ensure_docling() {
 }
 
 function ensure_db_init() {
-    echo "Initializing database tables..."
-    "$PY" -c "from api.db.db_models import init_database_tables as init_web_db; init_web_db()"
+    if [[ "${SKIP_DB_INIT:-0}" == "1" || "${SKIP_DB_INIT:-false}" == "true" ]]; then
+        echo "Skipping database initialization (SKIP_DB_INIT is enabled)."
+        return 0
+    fi
+    echo "Running Go database migrations..."
+    bin/ragflow_server --migrate
     echo "Database tables initialized."
 }
 
@@ -263,7 +267,7 @@ function ensure_db_init() {
 # Start components based on flags
 # -----------------------------------------------------------------------------
 #ensure_docling
-#ensure_db_init
+ensure_db_init
 
 run_with_restart() {
   local process_name="$1"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -254,8 +254,16 @@ function ensure_docling() {
 }
 
 function ensure_db_init() {
+    if [[ "${SKIP_DB_INIT:-0}" == "1" || "${SKIP_DB_INIT:-false}" == "true" ]]; then
+        echo "Skipping database initialization (SKIP_DB_INIT is enabled)."
+        return 0
+    fi
     echo "Initializing database tables..."
     "$PY" -c "from api.db.db_models import init_database_tables as init_web_db; init_web_db()"
+    if [[ "${API_PROXY_SCHEME}" == "go" || "${API_PROXY_SCHEME}" == "hybrid" ]]; then
+        echo "Running Go database migrations..."
+        bin/ragflow_server --migrate
+    fi
     echo "Database tables initialized."
 }
 

--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -235,6 +235,11 @@ ensure_db_init() {
 }
 
 run_mysql_migrations() {
+    if [[ "${SKIP_DB_INIT:-0}" == "1" || "${SKIP_DB_INIT:-false}" == "true" ]]; then
+        echo "Skipping model provider table migrations (SKIP_DB_INIT is enabled)."
+        return 0
+    fi
+
     local db_type="${DB_TYPE:-mysql}"
     db_type="${db_type,,}"
     if [ "$db_type" = "gaussdb" ] || [ "$db_type" = "gauss" ]; then

--- a/docker/launch_backend_service.sh
+++ b/docker/launch_backend_service.sh
@@ -208,8 +208,16 @@ run_data_sync(){
 }
 
 ensure_db_init() {
+    if [[ "${SKIP_DB_INIT:-0}" == "1" || "${SKIP_DB_INIT:-false}" == "true" ]]; then
+        echo "Skipping database initialization (SKIP_DB_INIT is enabled)."
+        return 0
+    fi
     echo "Initializing database tables..."
     "$PY" -c "from api.db.db_models import init_database_tables as init_web_db; init_web_db()"
+    if [[ "${API_PROXY_SCHEME}" == "go" || "${API_PROXY_SCHEME}" == "hybrid" ]]; then
+        echo "Running Go database migrations..."
+        bin/ragflow_server --migrate
+    fi
     echo "Database tables initialized."
 }
 

--- a/internal/dao/canvas_template_seed.go
+++ b/internal/dao/canvas_template_seed.go
@@ -155,8 +155,11 @@ func parseCanvasTemplateFile(raw []byte) (*entity.CanvasTemplate, error) {
 		CanvasCategory: "agent_canvas",
 	}
 
-	if v, ok := data["id"]; ok {
-		tmpl.ID = strings.TrimSpace(fmt.Sprint(v))
+	switch v := data["id"].(type) {
+	case string:
+		tmpl.ID = strings.TrimSpace(v)
+	case json.Number:
+		tmpl.ID = strings.TrimSpace(v.String())
 	}
 	if tmpl.ID == "" {
 		return nil, fmt.Errorf("canvas template missing or empty id")

--- a/internal/dao/canvas_template_seed.go
+++ b/internal/dao/canvas_template_seed.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -37,10 +38,6 @@ import (
 // SeedCanvasTemplates seeds the canvas_template table from the built-in
 // agent/templates/*.json and internal/ingestion/pipeline/template/*.json files.
 func SeedCanvasTemplates(ctx context.Context, db *gorm.DB) error {
-	if err := addColumnIfNotExists(ctx, db, "canvas_template", "parser_ids", "LONGTEXT NULL"); err != nil {
-		return fmt.Errorf("failed to ensure canvas_template.parser_ids column: %w", err)
-	}
-
 	var allTemplates []*entity.CanvasTemplate
 	var allIDs []string
 	for _, dir := range findTemplateDirs() {
@@ -49,18 +46,19 @@ func SeedCanvasTemplates(ctx context.Context, db *gorm.DB) error {
 		}
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			common.Warn("Failed to read template directory", zap.String("dir", dir), zap.Error(err))
-			continue
+			return fmt.Errorf("failed to read template directory %s: %w", dir, err)
 		}
 		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
-		templates, ids := loadTemplatesFromDir(dir, entries)
+		templates, ids, err := loadTemplatesFromDir(dir, entries)
+		if err != nil {
+			return err
+		}
 		allTemplates = append(allTemplates, templates...)
 		allIDs = append(allIDs, ids...)
 	}
 
 	if len(allTemplates) == 0 {
-		common.Warn("No template directories found, skipping canvas template seeding")
-		return nil
+		return fmt.Errorf("no canvas templates found to seed")
 	}
 
 	err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -86,7 +84,7 @@ func SeedCanvasTemplates(ctx context.Context, db *gorm.DB) error {
 	return nil
 }
 
-func loadTemplatesFromDir(dir string, entries []os.DirEntry) ([]*entity.CanvasTemplate, []string) {
+func loadTemplatesFromDir(dir string, entries []os.DirEntry) ([]*entity.CanvasTemplate, []string, error) {
 	templates := make([]*entity.CanvasTemplate, 0, len(entries))
 	ids := make([]string, 0, len(entries))
 	for _, entry := range entries {
@@ -96,71 +94,27 @@ func loadTemplatesFromDir(dir string, entries []os.DirEntry) ([]*entity.CanvasTe
 		path := filepath.Join(dir, entry.Name())
 		raw, err := os.ReadFile(path)
 		if err != nil {
-			common.Warn("Failed to read agent template", zap.String("file", path), zap.Error(err))
-			continue
+			return nil, nil, fmt.Errorf("failed to read agent template %s: %w", path, err)
 		}
 		tmpl, err := parseCanvasTemplateFile(raw)
 		if err != nil {
-			common.Warn("Failed to parse agent template", zap.String("file", path), zap.Error(err))
-			continue
+			return nil, nil, fmt.Errorf("failed to parse agent template %s: %w", path, err)
 		}
 		templates = append(templates, tmpl)
 		ids = append(ids, tmpl.ID)
 	}
-	return templates, ids
-}
-
-func findTemplateDirs() []string {
-	var dirs []string
-	if d := findAgentTemplatesDir(); d != "" {
-		dirs = append(dirs, d)
-	}
-	if d := findIngestionTemplatesDir(); d != "" {
-		dirs = append(dirs, d)
-	}
-	return dirs
-}
-
-func findIngestionTemplatesDir() string {
-	candidates := []string{
-		"internal/ingestion/pipeline/template",
-		filepath.Join("..", "internal", "ingestion", "pipeline", "template"),
-		filepath.Join("..", "..", "internal", "ingestion", "pipeline", "template"),
-		filepath.Join("..", "..", "..", "internal", "ingestion", "pipeline", "template"),
-	}
-	for _, candidate := range candidates {
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			return candidate
-		}
-	}
-	return ""
+	return templates, ids, nil
 }
 
 func seedCanvasTemplates(ctx context.Context, db *gorm.DB, dir string, entries []os.DirEntry) (int, error) {
-	templates := make([]*entity.CanvasTemplate, 0, len(entries))
-	ids := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
-			continue
-		}
-		path := filepath.Join(dir, entry.Name())
-		raw, err := os.ReadFile(path)
-		if err != nil {
-			common.Warn("Failed to read agent template", zap.String("file", path), zap.Error(err))
-			continue
-		}
-		tmpl, err := parseCanvasTemplateFile(raw)
-		if err != nil {
-			common.Warn("Failed to parse agent template", zap.String("file", path), zap.Error(err))
-			continue
-		}
-		templates = append(templates, tmpl)
-		ids = append(ids, tmpl.ID)
+	templates, ids, err := loadTemplatesFromDir(dir, entries)
+	if err != nil {
+		return 0, err
 	}
 	if len(templates) == 0 {
 		return 0, nil
 	}
-	err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, tmpl := range templates {
 			if err := tx.WithContext(ctx).Clauses(clause.OnConflict{
 				Columns: []clause.Column{{Name: "id"}},
@@ -189,13 +143,23 @@ func parseCanvasTemplateFile(raw []byte) (*entity.CanvasTemplate, error) {
 	if err := decoder.Decode(&data); err != nil {
 		return nil, err
 	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("unexpected trailing data in canvas template")
+		}
+		return nil, fmt.Errorf("invalid trailing data in canvas template: %w", err)
+	}
 
 	tmpl := &entity.CanvasTemplate{
 		CanvasCategory: "agent_canvas",
 	}
 
 	if v, ok := data["id"]; ok {
-		tmpl.ID = fmt.Sprint(v)
+		tmpl.ID = strings.TrimSpace(fmt.Sprint(v))
+	}
+	if tmpl.ID == "" {
+		return nil, fmt.Errorf("canvas template missing or empty id")
 	}
 	if v, ok := data["title"].(map[string]any); ok {
 		tmpl.Title = v
@@ -261,6 +225,32 @@ func collectCanvasTypes(rawType, rawTypes any) entity.JSONSlice {
 	}
 
 	return result
+}
+
+func findTemplateDirs() []string {
+	var dirs []string
+	if d := findAgentTemplatesDir(); d != "" {
+		dirs = append(dirs, d)
+	}
+	if d := findIngestionTemplatesDir(); d != "" {
+		dirs = append(dirs, d)
+	}
+	return dirs
+}
+
+func findIngestionTemplatesDir() string {
+	candidates := []string{
+		"internal/ingestion/pipeline/template",
+		filepath.Join("..", "internal", "ingestion", "pipeline", "template"),
+		filepath.Join("..", "..", "internal", "ingestion", "pipeline", "template"),
+		filepath.Join("..", "..", "..", "internal", "ingestion", "pipeline", "template"),
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func findAgentTemplatesDir() string {

--- a/internal/dao/database.go
+++ b/internal/dao/database.go
@@ -179,26 +179,23 @@ func InitDB(ctx context.Context, migrateDB bool) error {
 		if err = RunMigrations(ctx, DB); err != nil {
 			return fmt.Errorf("failed to run manual migrations: %w", err)
 		}
-		common.Info("Database schema migrated successfully")
-	} else {
-		// Ensure Go-exclusive runtime tables exist even if the server starts without --migrate
-		if err = autoMigrateRuntimeModels(ctx, DB); err != nil {
-			common.Warn("Failed to auto-migrate runtime models", zap.Error(err))
+
+		// Seed built-in agent templates so the Go backend can serve the
+		// "create agent from template" catalogue without relying on Python-side
+		// initialization.
+		if err = SeedCanvasTemplates(ctx, DB); err != nil {
+			return fmt.Errorf("failed to seed canvas templates: %w", err)
 		}
-	}
-	// Seed built-in agent templates so the Go backend can serve the
-	// "create agent from template" catalogue without relying on Python-side
-	// initialization.
-	if err = SeedCanvasTemplates(ctx, DB); err != nil {
-		common.Warn("Failed to seed canvas templates", zap.Error(err))
-	}
-	// Seed the built-in compilation template group (c3aa748c...) for every
-	// tenant so compiler.json's default group resolves out of the box.
-	if err = SeedBuiltinCompilationTemplates(ctx, DB); err != nil {
-		common.Warn("Failed to seed built-in compilation templates", zap.Error(err))
+		// Seed the built-in compilation template group (c3aa748c...) for every
+		// tenant so compiler.json's default group resolves out of the box.
+		if err = SeedBuiltinCompilationTemplates(ctx, DB); err != nil {
+			return fmt.Errorf("failed to seed built-in compilation templates: %w", err)
+		}
+
+		common.Info("Database schema migrated successfully")
 	}
 
-	common.Info("Database connected and migrated successfully")
+	common.Info("Database connected successfully")
 
 	err = models.InitProviderManager("conf/models")
 	if err != nil {
@@ -293,19 +290,4 @@ func autoMigrateSafely(ctx context.Context, db *gorm.DB, model interface{}) erro
 	}
 
 	return err
-}
-
-// autoMigrateRuntimeModels ensures Go-exclusive runtime tables exist even if
-// the server starts without --migrate.
-func autoMigrateRuntimeModels(ctx context.Context, db *gorm.DB) error {
-	goRuntimeModels := []interface{}{
-		&entity.IngestionTask{},
-		&entity.IngestionTaskLog{},
-	}
-	for _, m := range goRuntimeModels {
-		if err := autoMigrateSafely(ctx, db, m); err != nil {
-			return fmt.Errorf("failed to auto-migrate runtime model %T: %w", m, err)
-		}
-	}
-	return nil
 }

--- a/internal/dao/database_test.go
+++ b/internal/dao/database_test.go
@@ -18,6 +18,8 @@ package dao
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"ragflow/internal/entity"
@@ -26,7 +28,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestAutoMigrateRuntimeModelsCreatesIngestionTaskTables(t *testing.T) {
+func TestAutoMigrateSafelyCreatesIngestionTaskTables(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -41,20 +43,91 @@ func TestAutoMigrateRuntimeModelsCreatesIngestionTaskTables(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err = autoMigrateRuntimeModels(ctx, db); err != nil {
-		t.Fatalf("autoMigrateRuntimeModels failed: %v", err)
+	for _, m := range []interface{}{&entity.IngestionTask{}, &entity.IngestionTaskLog{}} {
+		if err = autoMigrateSafely(ctx, db, m); err != nil {
+			t.Fatalf("autoMigrateSafely failed for %T: %v", m, err)
+		}
 	}
 
 	// Verify tables exist after auto migration
 	if !db.Migrator().HasTable(&entity.IngestionTask{}) {
-		t.Fatal("expected ingestion_task to exist after autoMigrateRuntimeModels")
+		t.Fatal("expected ingestion_task to exist after autoMigrateSafely")
 	}
 	if !db.Migrator().HasTable(&entity.IngestionTaskLog{}) {
-		t.Fatal("expected ingestion_task_log to exist after autoMigrateRuntimeModels")
+		t.Fatal("expected ingestion_task_log to exist after autoMigrateSafely")
 	}
 
 	// Verify idempotency
-	if err = autoMigrateRuntimeModels(ctx, db); err != nil {
-		t.Fatalf("second autoMigrateRuntimeModels failed: %v", err)
+	for _, m := range []interface{}{&entity.IngestionTask{}, &entity.IngestionTaskLog{}} {
+		if err = autoMigrateSafely(ctx, db, m); err != nil {
+			t.Fatalf("second autoMigrateSafely failed for %T: %v", m, err)
+		}
+	}
+}
+
+func TestLoadTemplatesFromDirErrorHandling(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// 1. Valid JSON template
+	validPath := filepath.Join(tmpDir, "valid.json")
+	validContent := `{"id": "test_1", "title": {"en": "Test"}, "description": {"en": "Desc"}}`
+	if err := os.WriteFile(validPath, []byte(validContent), 0644); err != nil {
+		t.Fatalf("write valid file: %v", err)
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("read tmp dir: %v", err)
+	}
+	tmpls, ids, err := loadTemplatesFromDir(tmpDir, entries)
+	if err != nil {
+		t.Fatalf("unexpected error loading valid template: %v", err)
+	}
+	if len(tmpls) != 1 || ids[0] != "test_1" {
+		t.Fatalf("expected 1 template with id test_1, got %v", ids)
+	}
+
+	// 2. Corrupt JSON template
+	corruptPath := filepath.Join(tmpDir, "corrupt.json")
+	if err := os.WriteFile(corruptPath, []byte("invalid json"), 0644); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	entries, err = os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("read tmp dir: %v", err)
+	}
+	_, _, err = loadTemplatesFromDir(tmpDir, entries)
+	if err == nil {
+		t.Fatal("expected error loading corrupt template, got nil")
+	}
+	_ = os.Remove(corruptPath)
+
+	// 3. Template with missing/empty ID
+	emptyIDPath := filepath.Join(tmpDir, "empty_id.json")
+	if err := os.WriteFile(emptyIDPath, []byte(`{"title": {"en": "No ID"}}`), 0644); err != nil {
+		t.Fatalf("write empty ID file: %v", err)
+	}
+	entries, err = os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("read tmp dir: %v", err)
+	}
+	_, _, err = loadTemplatesFromDir(tmpDir, entries)
+	if err == nil {
+		t.Fatal("expected error loading template with missing ID, got nil")
+	}
+	_ = os.Remove(emptyIDPath)
+
+	// 4. Template with trailing data
+	trailingPath := filepath.Join(tmpDir, "trailing.json")
+	if err := os.WriteFile(trailingPath, []byte(`{"id": "t1"} trailing content`), 0644); err != nil {
+		t.Fatalf("write trailing file: %v", err)
+	}
+	entries, err = os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("read tmp dir: %v", err)
+	}
+	_, _, err = loadTemplatesFromDir(tmpDir, entries)
+	if err == nil {
+		t.Fatal("expected error loading template with trailing content, got nil")
 	}
 }

--- a/internal/dao/database_test.go
+++ b/internal/dao/database_test.go
@@ -131,3 +131,26 @@ func TestLoadTemplatesFromDirErrorHandling(t *testing.T) {
 		t.Fatal("expected error loading template with trailing content, got nil")
 	}
 }
+
+func TestParseCanvasTemplateFileRejectsInvalidIDTypes(t *testing.T) {
+	for _, raw := range []string{
+		`{"id": null}`,
+		`{"id": true}`,
+		`{"id": {"value": "template"}}`,
+		`{"id": ["template"]}`,
+	} {
+		if _, err := parseCanvasTemplateFile([]byte(raw)); err == nil {
+			t.Fatalf("parseCanvasTemplateFile(%s) succeeded for an invalid ID type", raw)
+		}
+	}
+}
+
+func TestParseCanvasTemplateFileAcceptsNumericID(t *testing.T) {
+	tmpl, err := parseCanvasTemplateFile([]byte(`{"id": 45}`))
+	if err != nil {
+		t.Fatalf("parseCanvasTemplateFile returned error for numeric ID: %v", err)
+	}
+	if tmpl.ID != "45" {
+		t.Fatalf("template ID = %q, want 45", tmpl.ID)
+	}
+}

--- a/internal/dao/migration.go
+++ b/internal/dao/migration.go
@@ -84,7 +84,7 @@ func migrateTenantLLMPrimaryKey(ctx context.Context, db *gorm.DB) error {
 	var idColumnExists int64
 	err := db.WithContext(ctx).Raw(`
 		SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_NAME = 'tenant_llm' AND COLUMN_NAME = 'id'
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tenant_llm' AND COLUMN_NAME = 'id'
 	`).Scan(&idColumnExists).Error
 	if err != nil {
 		return err
@@ -95,7 +95,8 @@ func migrateTenantLLMPrimaryKey(ctx context.Context, db *gorm.DB) error {
 		var count int64
 		err = db.WithContext(ctx).Raw(`
 			SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME = 'tenant_llm'
+			WHERE TABLE_SCHEMA = DATABASE()
+			AND TABLE_NAME = 'tenant_llm'
 			AND COLUMN_NAME = 'id'
 			AND EXTRA LIKE '%auto_increment%'
 		`).Scan(&count).Error
@@ -115,7 +116,7 @@ func migrateTenantLLMPrimaryKey(ctx context.Context, db *gorm.DB) error {
 		// Check for temp_id column and drop it if exists
 		var tempIdExists int64
 		tx.Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME = 'tenant_llm' AND COLUMN_NAME = 'temp_id'`).Scan(&tempIdExists)
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tenant_llm' AND COLUMN_NAME = 'temp_id'`).Scan(&tempIdExists)
 		if tempIdExists > 0 {
 			if err = tx.Exec("ALTER TABLE tenant_llm DROP COLUMN temp_id").Error; err != nil {
 				common.Warn("Failed to drop temp_id column", zap.Error(err))
@@ -385,7 +386,7 @@ func modifyColumnTypes(ctx context.Context, db *gorm.DB) error {
 	columnExists := func(table, column string) bool {
 		var count int64
 		db.WithContext(ctx).Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME = ? AND COLUMN_NAME = ?`, table, column).Scan(&count)
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`, table, column).Scan(&count)
 		return count > 0
 	}
 
@@ -423,6 +424,9 @@ func modifyColumnTypes(ctx context.Context, db *gorm.DB) error {
 				common.Warn("Failed to modify canvas_template.description", zap.Error(err))
 			}
 		}
+		if err := addColumnIfNotExists(ctx, db, "canvas_template", "parser_ids", "LONGTEXT NULL"); err != nil {
+			return fmt.Errorf("failed to add parser_ids column to canvas_template: %w", err)
+		}
 	}
 
 	// system_settings.value: ensure it's LONGTEXT
@@ -459,7 +463,7 @@ func renameColumnIfExists(ctx context.Context, db *gorm.DB, tableName, oldName, 
 	columnExists := func(column string) bool {
 		var count int64
 		db.WithContext(ctx).Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME = ? AND COLUMN_NAME = ?`, tableName, column).Scan(&count)
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`, tableName, column).Scan(&count)
 		return count > 0
 	}
 
@@ -494,7 +498,7 @@ func addColumnIfNotExists(ctx context.Context, db *gorm.DB, tableName, columnNam
 	// Check if column exists using raw SQL
 	var count int64
 	db.WithContext(ctx).Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_NAME = ? AND COLUMN_NAME = ?`, tableName, columnName).Scan(&count)
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`, tableName, columnName).Scan(&count)
 	if count > 0 {
 		return nil
 	}

--- a/internal/dao/migration.go
+++ b/internal/dao/migration.go
@@ -145,7 +145,7 @@ func migrateTenantLLMPrimaryKey(ctx context.Context, db *gorm.DB) error {
 		// Add unique index on (tenant_id, llm_factory, llm_name)
 		var idxExists int64
 		tx.Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-			WHERE TABLE_NAME = 'tenant_llm' AND INDEX_NAME = 'idx_tenant_llm_unique'`).Scan(&idxExists)
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tenant_llm' AND INDEX_NAME = 'idx_tenant_llm_unique'`).Scan(&idxExists)
 		if idxExists == 0 {
 			if err = tx.Exec(`
 				ALTER TABLE tenant_llm
@@ -169,7 +169,7 @@ func migrateAddUniqueEmail(ctx context.Context, db *gorm.DB) error {
 	// Check if unique index already exists using raw SQL
 	var count int64
 	db.WithContext(ctx).Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-		WHERE TABLE_NAME = 'user' AND INDEX_NAME = 'idx_user_email_unique'`).Scan(&count)
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user' AND INDEX_NAME = 'idx_user_email_unique'`).Scan(&count)
 	if count > 0 {
 		return nil
 	}
@@ -215,7 +215,8 @@ func migrateIngestionTaskDocumentIDUnique(ctx context.Context, db *gorm.DB) erro
 	var uniqueCount int64
 	if err := db.WithContext(ctx).Raw(`
 		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-		WHERE TABLE_NAME = 'ingestion_task'
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'ingestion_task'
 		  AND INDEX_NAME = ?
 		  AND COLUMN_NAME = 'document_id'
 		  AND NON_UNIQUE = 0
@@ -242,7 +243,8 @@ func migrateIngestionTaskDocumentIDUnique(ctx context.Context, db *gorm.DB) erro
 	var existingIndexCount int64
 	if err := db.WithContext(ctx).Raw(`
 		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-		WHERE TABLE_NAME = 'ingestion_task'
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'ingestion_task'
 		  AND INDEX_NAME = ?
 	`, indexName).Scan(&existingIndexCount).Error; err != nil {
 		return err
@@ -567,7 +569,7 @@ func migrateSkillSearchTables(ctx context.Context, db *gorm.DB) error {
 		// Drop legacy unique index (tenant_id, embd_id) to allow per-space configs.
 		var legacyIndexExists int64
 		db.WithContext(ctx).Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-			WHERE TABLE_NAME = 'skill_search_configs' AND INDEX_NAME = 'idx_tenant_embd'`).Scan(&legacyIndexExists)
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'skill_search_configs' AND INDEX_NAME = 'idx_tenant_embd'`).Scan(&legacyIndexExists)
 		if legacyIndexExists > 0 {
 			common.Info("Dropping legacy unique index idx_tenant_embd from skill_search_configs...")
 			if err := db.WithContext(ctx).Exec(`ALTER TABLE skill_search_configs DROP INDEX idx_tenant_embd`).Error; err != nil {
@@ -578,7 +580,7 @@ func migrateSkillSearchTables(ctx context.Context, db *gorm.DB) error {
 		// Table exists, check if unique index exists
 		var indexExists int64
 		db.WithContext(ctx).Raw(`SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-			WHERE TABLE_NAME = 'skill_search_configs' AND INDEX_NAME = 'idx_tenant_space_embd'`).Scan(&indexExists)
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'skill_search_configs' AND INDEX_NAME = 'idx_tenant_space_embd'`).Scan(&indexExists)
 		if indexExists == 0 {
 			common.Info("Adding unique index idx_tenant_space_embd to skill_search_configs...")
 			if err := db.WithContext(ctx).Exec(`ALTER TABLE skill_search_configs
@@ -655,7 +657,7 @@ func migrateSkillSpaceIndex(ctx context.Context, db *gorm.DB) error {
 	var oldIndexExists int64
 	db.WithContext(ctx).Raw(`
 		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-		WHERE TABLE_NAME = 'skill_spaces' AND INDEX_NAME = 'idx_tenant_name'
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'skill_spaces' AND INDEX_NAME = 'idx_tenant_name'
 	`).Scan(&oldIndexExists)
 
 	if oldIndexExists > 0 {
@@ -669,7 +671,7 @@ func migrateSkillSpaceIndex(ctx context.Context, db *gorm.DB) error {
 	var newIndexExists int64
 	db.WithContext(ctx).Raw(`
 		SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-		WHERE TABLE_NAME = 'skill_spaces' AND INDEX_NAME = 'idx_tenant_name_status'
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'skill_spaces' AND INDEX_NAME = 'idx_tenant_name_status'
 	`).Scan(&newIndexExists)
 
 	if newIndexExists == 0 {

--- a/internal/dao/migration_test.go
+++ b/internal/dao/migration_test.go
@@ -1,0 +1,69 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package dao
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func TestMigrateTenantLLMPrimaryKeyScopesUniqueIndexLookup(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatal(err)
+		}
+		_ = sqlDB.Close()
+	})
+
+	db, err := gorm.Open(mysql.New(mysql.Config{Conn: sqlDB, SkipInitializeWithVersion: true}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT DATABASE()")).
+		WillReturnRows(sqlmock.NewRows([]string{"DATABASE()"}).AddRow("ragflow"))
+	mock.ExpectQuery("SELECT SCHEMA_NAME from Information_schema.SCHEMATA").
+		WithArgs("ragflow%", "ragflow").
+		WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}).AddRow("ragflow"))
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM information_schema.tables").
+		WithArgs("ragflow", "tenant_llm", "BASE TABLE").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM INFORMATION_SCHEMA.COLUMNS").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM INFORMATION_SCHEMA.COLUMNS").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+	mock.ExpectExec("ALTER TABLE tenant_llm ADD COLUMN id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM INFORMATION_SCHEMA.STATISTICS\\s+WHERE TABLE_SCHEMA = DATABASE\\(\\)\\s+AND TABLE_NAME = 'tenant_llm' AND INDEX_NAME = 'idx_tenant_llm_unique'").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+	mock.ExpectExec("ALTER TABLE tenant_llm ADD UNIQUE INDEX idx_tenant_llm_unique \\(tenant_id, llm_factory, llm_name\\)").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	if err := migrateTenantLLMPrimaryKey(t.Context(), db); err != nil {
+		t.Fatalf("migrateTenantLLMPrimaryKey: %v", err)
+	}
+}

--- a/internal/ingestion/knowledge_compile/scheduler.go
+++ b/internal/ingestion/knowledge_compile/scheduler.go
@@ -85,9 +85,6 @@ type ClaimResult struct {
 // single producer entry point so a publisher never forgets to Notify after
 // enqueue (the two are now one atomic call site).
 type Publisher interface {
-	// Provision verifies that external database schema migrations have initialized the backing store.
-	Provision(ctx context.Context) error
-
 	// Publish records one doc event in the dataset's durable backlog and wakes
 	// idle workers. It is transactional so concurrent publishers do not clobber
 	// each other's backlog, and it always pairs the append with a notify.
@@ -204,10 +201,6 @@ type mysqlScheduler struct {
 // defaultClaimBatch is the closed-batch boundary when Claim is invoked without
 // an explicit size (the previous batchSize argument).
 const defaultClaimBatch = 32
-
-func (s *mysqlScheduler) Provision(_ context.Context) error {
-	return nil
-}
 
 // Publish appends one doc event to the dataset's durable backlog and wakes idle
 // workers. The append is transactional (concurrent publishers do not clobber
@@ -776,8 +769,6 @@ func NewFakeScheduler() *FakeScheduler {
 		leaseTTL: 2 * time.Minute,
 	}
 }
-
-func (f *FakeScheduler) Provision(_ context.Context) error { return nil }
 
 // Publish appends one doc event and pushes a notify (same contract as MySQL).
 func (f *FakeScheduler) Publish(_ context.Context, tenantID, datasetID, docID, eventType string, variants []string) error {

--- a/internal/ingestion/knowledge_compile/scheduler.go
+++ b/internal/ingestion/knowledge_compile/scheduler.go
@@ -85,7 +85,7 @@ type ClaimResult struct {
 // single producer entry point so a publisher never forgets to Notify after
 // enqueue (the two are now one atomic call site).
 type Publisher interface {
-	// Provision ensures the backing store (table + notify subject) exists.
+	// Provision verifies that external database schema migrations have initialized the backing store.
 	Provision(ctx context.Context) error
 
 	// Publish records one doc event in the dataset's durable backlog and wakes
@@ -205,11 +205,8 @@ type mysqlScheduler struct {
 // an explicit size (the previous batchSize argument).
 const defaultClaimBatch = 32
 
-func (s *mysqlScheduler) Provision(ctx context.Context) error {
-	if s.db == nil {
-		return nil
-	}
-	return s.db.WithContext(ctx).AutoMigrate(&entity.KnowledgeCompileDataset{})
+func (s *mysqlScheduler) Provision(_ context.Context) error {
+	return nil
 }
 
 // Publish appends one doc event to the dataset's durable backlog and wakes idle

--- a/internal/ingestion/knowledge_compile/service.go
+++ b/internal/ingestion/knowledge_compile/service.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"ragflow/internal/engine"
-	"ragflow/internal/entity"
 	kccommon "ragflow/internal/ingestion/component/knowledge_compiler/common"
 
 	"gorm.io/gorm"
@@ -143,19 +142,7 @@ func Provision(ctx context.Context, mq engine.MessageQueue, db *gorm.DB) error {
 	}
 	kcDB = db
 	s := newScheduler(db, mq, generateHolder(), 2*time.Minute)
-	// Bound the startup AutoMigrate so a slow/unreachable DB cannot block
-	// startup indefinitely. The caller's ctx is also honoured (cancelled on
-	// shutdown).
-	runCtx := ctx
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	if err := s.Provision(ctx); err != nil {
-		return err
-	}
-	if err := db.WithContext(ctx).AutoMigrate(&entity.WikiDocumentDirty{}); err != nil {
-		return err
-	}
 	SetScheduler(s)
-	go runWikiDirtyWorker(runCtx, db, s.holder)
+	go runWikiDirtyWorker(ctx, db, s.holder)
 	return nil
 }

--- a/test/unit_test/api/test_ragflow_server.py
+++ b/test/unit_test/api/test_ragflow_server.py
@@ -1,0 +1,31 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import pytest
+
+from api.ragflow_server import _should_skip_db_init
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, False), ("0", False), ("false", False), ("1", True), ("true", True)],
+)
+def test_should_skip_db_init(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("SKIP_DB_INIT", raising=False)
+    else:
+        monkeypatch.setenv("SKIP_DB_INIT", value)
+
+    assert _should_skip_db_init() is expected

--- a/test/unit_test/deploy/test_gaussdb_docengine_config.py
+++ b/test/unit_test/deploy/test_gaussdb_docengine_config.py
@@ -13,8 +13,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 from unittest.mock import patch
 
@@ -209,3 +211,43 @@ def test_tc_cfg_808_rendered_artifacts_stay_under_tmp_path_and_git_status_is_sta
         check=True,
     ).stdout
     assert after == before
+
+
+def test_launch_backend_service_skips_all_migrations_when_db_init_is_skipped(tmp_path):
+    root = tmp_path / "ragflow"
+    docker_dir = root / "docker"
+    tools_dir = root / "tools" / "scripts"
+    bin_dir = root / "bin"
+    docker_dir.mkdir(parents=True)
+    tools_dir.mkdir(parents=True)
+    bin_dir.mkdir()
+
+    launcher = docker_dir / "launch_backend_service.sh"
+    shutil.copy2(ROOT / "docker" / "launch_backend_service.sh", launcher)
+
+    sentinel = root / "migration-ran"
+    migration_script = tools_dir / "run_migrations.sh"
+    migration_script.write_text('#!/bin/sh\ntouch "$MIGRATION_SENTINEL"\n', encoding="utf-8")
+    migration_script.chmod(0o755)
+
+    for command in ("python3", "pkg-config"):
+        stub = bin_dir / command
+        stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        stub.chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", str(launcher), "ragflow"],
+        cwd=root,
+        env={
+            "API_PROXY_SCHEME": "python",
+            "MIGRATION_SENTINEL": str(sentinel),
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "SKIP_DB_INIT": "1",
+        },
+        encoding="utf-8",
+        capture_output=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not sentinel.exists(), result.stdout


### PR DESCRIPTION
### Summary / Motivation

This PR moves schema changes and built-in template seeding out of application runtime paths. Runtime services can run with DML-only database credentials, while local and Docker Compose deployments retain automatic bootstrap at the entrypoint layer.

It also makes the opt-out path complete: `SKIP_DB_INIT=1` now prevents shell migrations and Python database initialization, so Kubernetes workers can rely on a separately run privileged migration job.

Fixes #

### Key Changes

- Centralizes schema creation, migrations, and built-in template seeding in the Go migration path invoked by `ragflow_server --migrate`.
- Removes runtime DDL from DAO initialization and knowledge-compile startup, and deletes the unused scheduler provisioning contract.
- Validates migration template JSON strictly: IDs must be non-empty strings or numbers; malformed JSON and trailing content fail the migration.
- Scopes index metadata lookups to the active database schema to avoid false positives from other schemas on shared MySQL instances.
- Keeps automatic bootstrap for single-node environments, while making `SKIP_DB_INIT=1` skip both the model-provider migration script and Python database initialization.
- Packages ingestion pipeline templates in the Go image so migration seeds every built-in template source.

### Implementation Details

- `--migrate` is the dedicated Go execution mode for schema work and seeding; runtime worker modes do not issue DDL themselves.
- Entrypoints retain developer-friendly initialization by default. Production operators can set `SKIP_DB_INIT=1` on application pods and execute `ragflow_server --migrate` separately with migration credentials.
- All affected `INFORMATION_SCHEMA.STATISTICS` checks include `TABLE_SCHEMA = DATABASE()`.
- Template parsing uses `json.Number` for numeric IDs and rejects unsupported JSON value types instead of stringifying them.

### How to Test

```bash
GOTOOLCHAIN=auto CGO_ENABLED=0 go test ./internal/dao ./internal/ingestion/knowledge_compile -count=1

uv run --group test --python 3.13 python -m pytest --noconftest \
  test/unit_test/deploy/test_gaussdb_docengine_config.py \
  -k skips_all_migrations -q

LITELLM_LOCAL_MODEL_COST_MAP=True uv run --group test --python 3.13 \
  python -m pytest --noconftest test/unit_test/api/test_ragflow_server.py -q

bash -n docker/entrypoint.sh docker/entrypoint-go.sh docker/launch_backend_service.sh
```