### PR TITLE
Refactor: go default template no more _0

### DIFF
--- a/internal/ingestion/pipeline/template/ingestion_pipeline_audio.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_audio.json
@@ -233,7 +233,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_audio_0"
+                        "name": "Parser_audio"
                     },
                     "dragging": false,
                     "id": "Parser:SongsFillAir",
@@ -261,7 +261,7 @@
                             }
                         },
                         "label": "OneChunker",
-                        "name": "OneChunker_audio_0"
+                        "name": "OneChunker_audio"
                     },
                     "id": "TokenChunker:BlueSkiesLaugh",
                     "measured": {
@@ -289,7 +289,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_audio_0"
+                        "name": "Indexer_audio"
                     },
                     "id": "Tokenizer:KindEyesWatch",
                     "measured": {
@@ -313,7 +313,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_book.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_book.json
@@ -330,7 +330,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -452,7 +452,7 @@
                             ]
                         },
                         "label": "TitleChunker",
-                        "name": "Title Chunker_0"
+                        "name": "Title Chunker"
                     },
                     "id": "TitleChunker:GrumpyGarlicsBake",
                     "measured": {
@@ -480,7 +480,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:HotDonutsRing",
                     "measured": {
@@ -504,7 +504,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_email.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_email.json
@@ -248,7 +248,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_email_0"
+                        "name": "Parser_email"
                     },
                     "dragging": false,
                     "id": "Parser:BirdsFlutterHigh",
@@ -298,7 +298,7 @@
                             "overlapped_percent": 0
                         },
                         "label": "TokenChunker",
-                        "name": "Token Chunker_email_0"
+                        "name": "Token Chunker_email"
                     },
                     "id": "TokenChunker:WarmBreadSmells",
                     "measured": {
@@ -326,7 +326,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_email_0"
+                        "name": "Indexer_email"
                     },
                     "id": "Tokenizer:NiceWordsSpoken",
                     "measured": {
@@ -350,7 +350,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_general.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_general.json
@@ -374,7 +374,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -430,7 +430,7 @@
                             "overlapped_percent": 0
                         },
                         "label": "TokenChunker",
-                        "name": "Token Chunker_0"
+                        "name": "Token Chunker"
                     },
                     "id": "TokenChunker:SixApplesFall",
                     "measured": {
@@ -458,7 +458,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:LegalReadersDecide",
                     "measured": {
@@ -482,7 +482,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_laws.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_laws.json
@@ -349,7 +349,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -471,7 +471,7 @@
                             ]
                         },
                         "label": "TitleChunker",
-                        "name": "Title Chunker_0"
+                        "name": "Title Chunker"
                     },
                     "id": "TitleChunker:SpicyKeysKick",
                     "measured": {
@@ -499,7 +499,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:PublicJobsTake",
                     "measured": {
@@ -524,7 +524,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_manual.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_manual.json
@@ -291,7 +291,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -413,7 +413,7 @@
                             ]
                         },
                         "label": "ManualChunker",
-                        "name": "Manual Chunker_0"
+                        "name": "Manual Chunker"
                     },
                     "id": "ManualChunker:NineInsectsFind",
                     "measured": {
@@ -441,7 +441,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:FunnyBalloonsGrin",
                     "measured": {
@@ -465,7 +465,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_one.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_one.json
@@ -335,7 +335,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -363,7 +363,7 @@
                             }
                         },
                         "label": "OneChunker",
-                        "name": "One Chunker_0"
+                        "name": "One Chunker"
                     },
                     "id": "OneChunker:DryDrinksVisit",
                     "measured": {
@@ -391,7 +391,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:FrankWeeksListen",
                     "measured": {
@@ -415,7 +415,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_paper.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_paper.json
@@ -262,7 +262,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -384,7 +384,7 @@
                             ]
                         },
                         "label": "TitleChunker",
-                        "name": "Title Chunker_0"
+                        "name": "Title Chunker"
                     },
                     "id": "TitleChunker:SparklySchoolsTravel",
                     "measured": {
@@ -412,7 +412,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:GreatCarsWash",
                     "measured": {
@@ -437,7 +437,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_picture.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_picture.json
@@ -255,7 +255,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_picture_0"
+                        "name": "Parser_picture"
                     },
                     "dragging": false,
                     "id": "Parser:ViewsCaptureLight",
@@ -283,7 +283,7 @@
                             }
                         },
                         "label": "OneChunker",
-                        "name": "OneChunker_picture_0"
+                        "name": "OneChunker_picture"
                     },
                     "id": "TokenChunker:BrightColorsGlow",
                     "measured": {
@@ -311,7 +311,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_picture_0"
+                        "name": "Indexer_picture"
                     },
                     "id": "Tokenizer:SharpLensFocus",
                     "measured": {
@@ -335,7 +335,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_presentation.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_presentation.json
@@ -244,7 +244,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -272,7 +272,7 @@
                             }
                         },
                         "label": "PageChunker",
-                        "name": "Presentation Chunker_0"
+                        "name": "Presentation Chunker"
                     },
                     "id": "PageChunker:HappyHillsGlow",
                     "measured": {
@@ -300,7 +300,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:TallTreesDance",
                     "measured": {
@@ -324,7 +324,7 @@
                     },
                     "data": {
                         "label": "Extractor",
-                        "name": "Extractor_0"
+                        "name": "Extractor"
                     }
                 }
             ]

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_qa.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_qa.json
@@ -268,7 +268,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -296,7 +296,7 @@
                             }
                         },
                         "label": "QAChunker",
-                        "name": "QA Chunker_0"
+                        "name": "QA Chunker"
                     },
                     "id": "QAChunker:TidyCloudsThink",
                     "measured": {
@@ -324,7 +324,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:ColdCloudsDream",
                     "measured": {

--- a/internal/ingestion/pipeline/template/ingestion_pipeline_table.json
+++ b/internal/ingestion/pipeline/template/ingestion_pipeline_table.json
@@ -207,7 +207,7 @@
                             ]
                         },
                         "label": "Parser",
-                        "name": "Parser_0"
+                        "name": "Parser"
                     },
                     "dragging": false,
                     "id": "Parser:HipSignsRhyme",
@@ -235,7 +235,7 @@
                             }
                         },
                         "label": "TableChunker",
-                        "name": "Table Chunker_0"
+                        "name": "Table Chunker"
                     },
                     "id": "TableChunker:FastFoxesJump",
                     "measured": {
@@ -263,7 +263,7 @@
                             ]
                         },
                         "label": "Tokenizer",
-                        "name": "Indexer_0"
+                        "name": "Indexer"
                     },
                     "id": "Tokenizer:DeepLakesShine",
                     "measured": {


### PR DESCRIPTION
### After
<img width="1183" height="636" alt="image" src="https://github.com/user-attachments/assets/b00a688e-c186-46b1-99fd-ec71f0a0f20d" />

### Before
<img width="1183" height="636" alt="image" src="https://github.com/user-attachments/assets/f658f531-1a6b-43a9-8c36-494069d49b55" />

