### PR TITLE
Fix/final answer streaming phase is not interrupted by the research budget

### DIFF
--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -84,7 +84,7 @@ _REWRITE_TIMEOUT_S = 45.0  # gap → query rewrite call
 def _snip(value: Any, limit: int = 240) -> str:
     try:
         s = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, default=str)
-    except Exception:
+    except Exception:  # noqa: BLE001
         s = str(value)
     s = " ".join(s.split())
     if len(s) > limit:
@@ -141,7 +141,7 @@ def _select_sca_view(chunks: list, focus_terms: list[str], cap: int | None = Non
         fresh = min(i / 20.0, 0.2)  # late arrivals (gap-pursuit evidence) get seen
         return rel * 0.45 + min(cov_ratio, 1.0) * 0.45 + fresh
 
-    ranked = sorted(list(enumerate(chunks)), key=lambda ic: _score(*ic), reverse=True)
+    ranked = sorted(list(enumerate(chunks)), key=lambda ic: _score(*ic), reverse=True)  # noqa: C414
     view = [c for _, c in ranked[:capped]]
     ident = "|".join(sorted((_chunk_id(c) or "") for c in view))
     return view, str(hash(ident))
@@ -373,7 +373,7 @@ def _extract_json_object(text: str):
                     candidate = text[start : j + 1]
                     try:
                         return json.loads(candidate)
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         break  # not a valid object; try the next "{"
         i = start + 1
     return None
@@ -387,12 +387,12 @@ async def _expand_fanouts(tools, question: str, answer_conf: dict) -> list[str]:
     """
     try:
         from rag.advanced_rag.harness.tools.search import _base_chat_mdl
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[rag_agent] could not import _base_chat_mdl for fan-out expansion", exc_info=True)
         return [question] if question else []
     try:
         mdl = _base_chat_mdl(tools)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[rag_agent] could not resolve base chat model for fan-out expansion", exc_info=True)
         return [question] if question else []
     if mdl is None or not question:
@@ -413,7 +413,7 @@ async def _expand_fanouts(tools, question: str, answer_conf: dict) -> list[str]:
         fanouts = list(dict.fromkeys(fanouts))[:5]
         _LOG.info("[Planner] fan-out expansion: %d sub-question(s): %s", len(fanouts), fanouts)
         return fanouts or ([question] if question else [])
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Planner] fan-out expansion failed; falling back to raw question", exc_info=True)
         return [question] if question else []
 
@@ -456,7 +456,7 @@ async def _fanout_search(tools, fanouts: list[str], top_n: int = 8, capacity: in
             bm25_search,
             hybrid_search,
         )
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[rag_agent] could not import fan-out search helpers", exc_info=True)
         return 0
 
@@ -478,7 +478,7 @@ async def _fanout_search(tools, fanouts: list[str], top_n: int = 8, capacity: in
     elif isinstance(fanouts, (list, tuple, set)):
         try:
             fanouts = [f for f in fanouts if isinstance(f, str)]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return 0
     else:
         _LOG.warning("[Prefetch] unexpected queries payload of type %s; skipping fan-out search", type(fanouts).__name__)
@@ -502,7 +502,7 @@ async def _fanout_search(tools, fanouts: list[str], top_n: int = 8, capacity: in
         try:
             res = await bm25_search(tools, fq, kb_ids=kb_ids, top_n=60, keywords=" ".join(keyed or terms))
             candidates = res.get("chunks", []) or []
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOG.warning("[rag_agent] BM25 search failed for %r", fq, exc_info=True)
             candidates = []
 
@@ -519,7 +519,7 @@ async def _fanout_search(tools, fanouts: list[str], top_n: int = 8, capacity: in
                     max_out_total_chars=16000,
                 )
                 kept_a = (narrowed.get("kept", []) or [])[: max(1, top_n)]
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _LOG.warning("[rag_agent] narrowing failed for %r; using raw BM25 head", fq, exc_info=True)
                 kept_a = candidates[: max(1, top_n)]
 
@@ -535,7 +535,7 @@ async def _fanout_search(tools, fanouts: list[str], top_n: int = 8, capacity: in
                 kept_b.append(c)
                 if len(kept_b) >= 4:  # modest semantic quota per query
                     break
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOG.warning("[rag_agent] hybrid channel failed for %r; skipping", fq, exc_info=True)
         return kept_a, kept_b
 
@@ -720,7 +720,7 @@ async def _compose_answer_from_evidence(state: AgenticState, tools, token_queue:
     try:
         async for tok in tools.chat_mdl.async_chat_streamly_delta(msg[0]["content"], msg[1:], answer_conf):
             token_queue.put_nowait(tok)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.exception("formalize_answer: stream failed")
         token_queue.put_nowait("I'm sorry, I encountered an error while composing the answer.")
 
@@ -1257,7 +1257,7 @@ async def _build_slot_table(tools, question: str, fanouts: list, answer_conf: di
             fanouts or [],
             deadline_left_fn() if deadline_left_fn else None,
         )
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[SlotTable] initialize_state failed; building from fanouts", exc_info=True)
         root = None
         first_queries = fanouts or [question]
@@ -1435,7 +1435,7 @@ def _merge_slot_patch(base, branch):
         # best-supported candidate.
         if bv.candidate is None:
             cand, strength = v.candidate, vstr
-        elif v.candidate is None:
+        elif v.candidate is None:  # noqa: SIM114
             cand, strength = bv.candidate, bstr
         elif (bstr or 0.0) > (vstr or 0.0):
             cand, strength = bv.candidate, bstr
@@ -1509,7 +1509,7 @@ async def _compose_fallback_draft(tools, state: AgenticState, answer_conf: dict)
             dict(answer_conf or {}),
         )
         return (str(ans or "").strip() or evidence)[:6000]
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Draft] fallback composition failed; using snippet text", exc_info=True)
         return evidence[:4000]
 
@@ -1531,7 +1531,7 @@ async def _naive_rag(tools, messages: list, gen_conf: dict | None = None):
     _LOG.info("[Naive RAG] single-pass retrieval for question_len=%d", len(question))
     try:
         res = await tools.retrieve(question) if question else {"chunks": [], "doc_aggs": []}
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.exception("[Naive RAG] retrieval failed")
         res = {"chunks": [], "doc_aggs": []}
 
@@ -1563,7 +1563,7 @@ async def _naive_rag(tools, messages: list, gen_conf: dict | None = None):
         if isinstance(ans, tuple):
             ans = ans[0]
         yield str(ans or "").strip() or str(getattr(tools, "empty_response", "") or "")
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.exception("[Naive RAG] composition failed; returning evidence")
         yield evidence[:4000]
 
@@ -1625,7 +1625,7 @@ async def run_agentic_rag(tools, messages: list, max_loops: int = 3, gen_conf: d
         try:
             holder["state"] = await graph.ainvoke(init_state, {"recursion_limit": recursion_limit})
         except Exception:
-            logging.exception("run_agentic_rag: graph execution failed")
+            logging.exception("run_agentic_rag: graph execution failed")  # noqa: LOG015
             holder["error"] = True
         finally:
             token_queue.put_nowait(_SENTINEL)
@@ -1658,7 +1658,7 @@ async def run_agentic_rag(tools, messages: list, max_loops: int = 3, gen_conf: d
             state.get("search_rounds", 0),
             (verdict or {}).get("status") if isinstance(verdict, dict) else verdict,
         )
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.info(
             "[Agentic RAG] Research complete — %d passage(s) gathered.",
             len((state.get("kbinfos") or {}).get("chunks", [])),

--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -881,7 +881,11 @@ def build_agentic_graph(
             return {}
         round_no = int(state.get("search_rounds", 0)) + 1
         pool_before = len(((getattr(tools, "kbinfos", None) or state.get("kbinfos") or {}).get("chunks")) or [])
-        unresolved_ids = [str(getattr(v, "id", "")) for v in getattr(state.get("slot_table"), "state", None) or [] if not getattr(v, "candidate", None)]
+        unresolved_ids = [
+            str(getattr(v, "id", ""))
+            for v in getattr(state.get("slot_table"), "state", None) or []
+            if not getattr(v, "candidate", None)
+        ]
         _LOG.info(
             "[RAGAgent] ROUND %d start (search_rounds=%d, time_left=%.0fs, pool=%d chunks, unresolved slots=%s)",
             round_no,

--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -72,13 +72,13 @@ _LOG = logging.getLogger(__name__)
 # one question's WHOLE pipeline comfortably under that line: when the budget
 # runs out the routing guards steer the graph straight to synthesis with
 # whatever evidence is on hand instead of starting another research round.
-_TOTAL_BUDGET_S = 900.0  # whole-graph wall-clock ceiling per question
-_MIN_ROUND_HEADROOM_S = 90.0  # need at least this much left to start a new round
-_PASS_TIMEOUT_S = 600.0  # slot research pass wall-clock
-_PREFETCH_TIMEOUT_S = 240.0  # programmatic fan-out fetch
-_DRAFT_TIMEOUT_S = 180.0  # fallback draft synthesis
-_SCA_TIMEOUT_S = 180.0  # sufficient-context review call
-_REWRITE_TIMEOUT_S = 120.0  # gap → query rewrite call
+_TOTAL_BUDGET_S = 180.0  # whole-graph wall-clock ceiling per question
+_MIN_ROUND_HEADROOM_S = 50.0  # need at least this much left to start a new round
+_PASS_TIMEOUT_S = 120.0  # slot research pass wall-clock
+_PREFETCH_TIMEOUT_S = 90.0  # programmatic fan-out fetch
+_DRAFT_TIMEOUT_S = 60.0  # fallback draft synthesis
+_SCA_TIMEOUT_S = 60.0  # sufficient-context review call
+_REWRITE_TIMEOUT_S = 45.0  # gap → query rewrite call
 
 
 def _snip(value: Any, limit: int = 240) -> str:

--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -72,13 +72,13 @@ _LOG = logging.getLogger(__name__)
 # one question's WHOLE pipeline comfortably under that line: when the budget
 # runs out the routing guards steer the graph straight to synthesis with
 # whatever evidence is on hand instead of starting another research round.
-_TOTAL_BUDGET_S = 180.0  # whole-graph wall-clock ceiling per question
-_MIN_ROUND_HEADROOM_S = 50.0  # need at least this much left to start a new round
-_PASS_TIMEOUT_S = 120.0  # slot research pass wall-clock
-_PREFETCH_TIMEOUT_S = 90.0  # programmatic fan-out fetch
-_DRAFT_TIMEOUT_S = 60.0  # fallback draft synthesis
-_SCA_TIMEOUT_S = 60.0  # sufficient-context review call
-_REWRITE_TIMEOUT_S = 45.0  # gap → query rewrite call
+_TOTAL_BUDGET_S = 900.0  # whole-graph wall-clock ceiling per question
+_MIN_ROUND_HEADROOM_S = 90.0  # need at least this much left to start a new round
+_PASS_TIMEOUT_S = 300.0  # slot research pass wall-clock
+_PREFETCH_TIMEOUT_S = 240.0  # programmatic fan-out fetch
+_DRAFT_TIMEOUT_S = 180.0  # fallback draft synthesis
+_SCA_TIMEOUT_S = 180.0  # sufficient-context review call
+_REWRITE_TIMEOUT_S = 120.0  # gap → query rewrite call
 
 
 def _snip(value: Any, limit: int = 240) -> str:
@@ -889,6 +889,7 @@ def build_agentic_graph(
             time_left,
             pool_before,
             unresolved_ids or "-",
+
         )
         t = max(20.0, min(_PASS_TIMEOUT_S, time_left - 25.0))
         slot_result = await _bounded(

--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -881,11 +881,7 @@ def build_agentic_graph(
             return {}
         round_no = int(state.get("search_rounds", 0)) + 1
         pool_before = len(((getattr(tools, "kbinfos", None) or state.get("kbinfos") or {}).get("chunks")) or [])
-        unresolved_ids = [
-            str(getattr(v, "id", ""))
-            for v in getattr(state.get("slot_table"), "state", None) or []
-            if not getattr(v, "candidate", None)
-        ]
+        unresolved_ids = [str(getattr(v, "id", "")) for v in getattr(state.get("slot_table"), "state", None) or [] if not getattr(v, "candidate", None)]
         _LOG.info(
             "[RAGAgent] ROUND %d start (search_rounds=%d, time_left=%.0fs, pool=%d chunks, unresolved slots=%s)",
             round_no,
@@ -893,7 +889,6 @@ def build_agentic_graph(
             time_left,
             pool_before,
             unresolved_ids or "-",
-
         )
         t = max(20.0, min(_PASS_TIMEOUT_S, time_left - 25.0))
         slot_result = await _bounded(

--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -1619,16 +1619,11 @@ async def run_agentic_rag(tools, messages: list, max_loops: int = 3, gen_conf: d
     recursion_limit = 60 if use_graph else max(25, max_loops * 8)
 
     async def _drive():
-        # Last-resort wall clock: routing guards steer the graph to synthesis
-        # BEFORE this fires; the hard cancel only trips if a node still hangs
-        # (e.g. an unbounded HTTP read) so the client never hits its 300s
-        # read-timeout and flags the question as an error.
+        # No whole-graph wall clock: research stays bounded by per-node _bounded
+        # timeouts, the routing guards (_MIN_ROUND_HEADROOM_S) and recursion_limit;
+        # the final answer stream runs until the model finishes.
         try:
-            async with asyncio.timeout(_TOTAL_BUDGET_S + 30.0):
-                holder["state"] = await graph.ainvoke(init_state, {"recursion_limit": recursion_limit})
-        except TimeoutError:
-            logging.warning("run_agentic_rag: total research budget (%.0fs) exhausted — cutting off.", _TOTAL_BUDGET_S)
-            holder["error"] = True
+            holder["state"] = await graph.ainvoke(init_state, {"recursion_limit": recursion_limit})
         except Exception:
             logging.exception("run_agentic_rag: graph execution failed")
             holder["error"] = True

--- a/rag/advanced_rag/agentic_rag_graph.py
+++ b/rag/advanced_rag/agentic_rag_graph.py
@@ -74,7 +74,7 @@ _LOG = logging.getLogger(__name__)
 # whatever evidence is on hand instead of starting another research round.
 _TOTAL_BUDGET_S = 900.0  # whole-graph wall-clock ceiling per question
 _MIN_ROUND_HEADROOM_S = 90.0  # need at least this much left to start a new round
-_PASS_TIMEOUT_S = 300.0  # slot research pass wall-clock
+_PASS_TIMEOUT_S = 600.0  # slot research pass wall-clock
 _PREFETCH_TIMEOUT_S = 240.0  # programmatic fan-out fetch
 _DRAFT_TIMEOUT_S = 180.0  # fallback draft synthesis
 _SCA_TIMEOUT_S = 180.0  # sufficient-context review call

--- a/rag/advanced_rag/harness/action_session.py
+++ b/rag/advanced_rag/harness/action_session.py
@@ -35,8 +35,8 @@ from rag.advanced_rag.harness.config import resolve_mode
 
 _LOG = logging.getLogger(__name__)
 
-_INIT_TIMEOUT_S = 45.0
-_ACTION_TIMEOUT_S = 75.0
+_INIT_TIMEOUT_S = 150.0
+_ACTION_TIMEOUT_S = 180.0
 _SNIPPETS_PER_QUERY = 4
 _MAX_TOOL_RESPONSE_CHARS = 12000
 # Dataset-level empty results (reason="no_structure") a compiled-structure tool

--- a/rag/advanced_rag/harness/action_session.py
+++ b/rag/advanced_rag/harness/action_session.py
@@ -1936,6 +1936,7 @@ async def run_nav_prefix(tools, direction: str, deadline_left: float, ctx: _NavC
 _SESSION_GRAPH = _build_session_graph()
 
 
+
 def _extract_relevant_evidence(tools, direction: str, max_chunks: int = 4) -> str:
     """Extract chunks from tools.kbinfos relevant to direction, for seed_user injection."""
     from rag.advanced_rag.harness.tools.search import _chunk_id, _chunk_text
@@ -1949,11 +1950,9 @@ def _extract_relevant_evidence(tools, direction: str, max_chunks: int = 4) -> st
     if not dir_tokens:
         ranked = chunks[-max_chunks:]
     else:
-
         def _rel(c):
             text = (_chunk_text(c) or "").lower()
             return sum(1 for t in dir_tokens if t in text)
-
         ranked = sorted(chunks, key=_rel, reverse=True)
 
     lines = []

--- a/rag/advanced_rag/harness/action_session.py
+++ b/rag/advanced_rag/harness/action_session.py
@@ -1936,7 +1936,6 @@ async def run_nav_prefix(tools, direction: str, deadline_left: float, ctx: _NavC
 _SESSION_GRAPH = _build_session_graph()
 
 
-
 def _extract_relevant_evidence(tools, direction: str, max_chunks: int = 4) -> str:
     """Extract chunks from tools.kbinfos relevant to direction, for seed_user injection."""
     from rag.advanced_rag.harness.tools.search import _chunk_id, _chunk_text
@@ -1950,9 +1949,11 @@ def _extract_relevant_evidence(tools, direction: str, max_chunks: int = 4) -> st
     if not dir_tokens:
         ranked = chunks[-max_chunks:]
     else:
+
         def _rel(c):
             text = (_chunk_text(c) or "").lower()
             return sum(1 for t in dir_tokens if t in text)
+
         ranked = sorted(chunks, key=_rel, reverse=True)
 
     lines = []

--- a/rag/advanced_rag/harness/action_session.py
+++ b/rag/advanced_rag/harness/action_session.py
@@ -485,10 +485,10 @@ def _disable_tool(tools, name: str) -> None:
             disabled = set()
             try:
                 tools._disabled_tools = disabled
-            except Exception:  # tools may be frozen/slots in tests
+            except Exception:  # tools may be frozen/slots in tests  # noqa: BLE001
                 return
         disabled.add(name)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Action Session] could not mark tool %r disabled", name, exc_info=True)
 
 
@@ -536,13 +536,13 @@ def extract_json(text: str):
                     candidate = text[start : j + 1]
                     try:
                         return json.loads(candidate, strict=False)
-                    except Exception:
+                    except Exception:  # noqa: BLE001, S110
                         pass
                     try:
                         import json_repair
 
                         return json_repair.loads(candidate)
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         break  # invalid object; try the next "{"
         i = start + 1
     return None
@@ -566,7 +566,7 @@ def extract_tag(text: str, tag: str):
             want = {"new_states"} if tag == "state" else {"answer", "new_state"}
             if isinstance(obj, dict) and (keys & want):
                 return frag.strip()
-        except Exception:
+        except Exception:  # noqa: BLE001, S112
             continue
     return None
 
@@ -602,7 +602,7 @@ def apply_patch(base: State, branch_patches: list) -> State | None:
             try:
                 nv.candidate_strength = min(max(float(pv["candidate_strength"]), 0.0), 1.0)
                 changed = True
-            except Exception:
+            except Exception:  # noqa: BLE001, S110
                 pass
         if isinstance(pv.get("discovered_clues"), list):
             nv.discovered_clues.extend(str(c)[:160] for c in pv["discovered_clues"][-4:])
@@ -629,7 +629,7 @@ def _seed_evidence(tools):
         kbinfos = {}
         try:
             tools.kbinfos = kbinfos
-        except Exception:
+        except Exception:  # noqa: BLE001, S110
             pass
     kbinfos.setdefault("chunks", [])
     return kbinfos
@@ -699,7 +699,7 @@ async def _run_search(tools, search_fn, queries: list, top_n: int, max_q: int, *
         try:
             res = await search_fn(tools, fq, kb_ids=kb_ids, top_n=top_n, **kw)
             cands = res.get("chunks", []) or []
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOG.warning("[Action Session] %s failed for %r", getattr(search_fn, "__name__", "search"), fq, exc_info=True)
             continue
         for c in cands[:_SNIPPETS_PER_QUERY]:
@@ -794,7 +794,7 @@ async def _exec_web_search(tools, queries: list) -> ToolOutcome:
             web_res = provider.retrieve_chunks(q)
             if asyncio.iscoroutine(web_res) or hasattr(web_res, "__await__"):
                 web_res = await web_res
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOG.warning("[Action Session] web_search failed for %r", q, exc_info=True)
             continue
         for c in ((web_res or {}).get("chunks") or [])[:8]:
@@ -817,7 +817,7 @@ async def _exec_list_chunks(tools, doc_id: str) -> ToolOutcome:
 
     try:
         res = await list_chunks(tools, doc_id)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Action Session] list_chunks failed doc=%r", doc_id, exc_info=True)
         return ToolOutcome(payload=[], status=ERROR, reason="infra")
     out, ids, new_ev = [], [], 0
@@ -854,7 +854,7 @@ def _inject_nav_tools_ref(tools) -> None:
         import rag.advanced_rag.harness.tools.navigation as _nav
 
         _nav._tools_ref["tools"] = tools
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Action Session] could not inject navigation tools ref", exc_info=True)
 
 
@@ -948,7 +948,7 @@ async def _exec_calculate(tools, args: dict) -> ToolOutcome:
         return ToolOutcome(payload=[{"kind": "calculate", "error": "no model"}], status=ERROR, reason="infra")
     try:
         res = await compute_from_facts(mdl, question, facts)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Action Session] calculate failed", exc_info=True)
         res = None
     if not res:
@@ -977,7 +977,7 @@ async def _exec_graph_explore(tools, args: dict) -> ToolOutcome:
     doc_scope = [str(d) for d in (args.get("doc_scope") or []) if str(d).strip()]
     try:
         res = await graph_explore(tools, query, doc_scope=doc_scope or None)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Action Session] graph_explore failed", exc_info=True)
         res = {}
     answer = str(res.get("answer") or "").strip()
@@ -1059,7 +1059,7 @@ async def _acompletion(mdl, messages: list, tools_list=None, temperature: float 
         client = mdl.async_client
         chat_obj = getattr(client, "chat", client)
         completions = getattr(chat_obj, "completions", chat_obj)
-        create = getattr(completions, "create")
+        create = getattr(completions, "create")  # noqa: B009
         kwargs = {"model": mdl.model_name, "messages": oai_messages, "temperature": temperature}
         if tools_list:
             kwargs["tools"] = tools_list
@@ -1117,7 +1117,7 @@ def _parse_tool_calls(msg) -> list:
         raw_args = fn.arguments if fn else "{}"
         try:
             args = json.loads(raw_args) if isinstance(raw_args, str) and raw_args.strip() else (raw_args or {})
-        except Exception:
+        except Exception:  # noqa: BLE001
             args = {}
         if not isinstance(args, dict):
             args = {}
@@ -1491,7 +1491,7 @@ async def _finalize_node(state: _SessionState) -> dict:
             _LOG.info("[Action Session] answer salvaged from exhausted session")
         elif new_states:
             _LOG.info("[Action Session] %d branch(es) salvaged from exhausted session", len(new_states))
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.exception("[Action Session] salvage call failed")
 
     # Loose-clue harvest (deterministic, zero-LLM): even when every JSON
@@ -1706,7 +1706,7 @@ async def _run_drill_merge(tools, ctx: _NavContext, available: set, budget_s: fl
             try:
                 async with asyncio.timeout(max(5.0, budget_s or _NAV_PREFIX_CALL_TIMEOUT_S)):
                     s_oc = await execute_tool(tools, "navigate_structure", {"doc_id": doc_id, "query": ctx.direction, "kind": "catalog"})
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _LOG.warning("[Action Session] drill structure load failed doc=%s", doc_id, exc_info=True)
                 continue
             for d in s_oc.evidence_ids:
@@ -1807,7 +1807,7 @@ def _nav_tool_surface(tools) -> set:
     """Tools this session may call, or an empty set when it cannot be resolved."""
     try:
         return {s["function"]["name"] for s in _active_tool_specs(tools)}
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.warning("[Action Session] could not resolve the tool surface", exc_info=True)
         return set()
 
@@ -1882,7 +1882,7 @@ async def _run_nav_chain(
             else:
                 async with asyncio.timeout(min(_NAV_PREFIX_CALL_TIMEOUT_S, remaining)):
                     oc = await execute_tool(tools, rule.tool, rule.args(ctx))
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOG.warning("[Action Session] nav chain step %r failed", rule_id, exc_info=True)
             break
 
@@ -2009,7 +2009,7 @@ async def run_action_session(
     if _NAV_RULES_ENABLED:
         try:
             prefix_msgs, prefix_ids, prefix_outcomes, pending_rule = await run_nav_prefix(tools, direction, budget_left, ctx=nav_ctx)
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOG.warning("[Action Session] navigation prefix failed; continuing with the plain loop", exc_info=True)
     if prefix_msgs:
         _LOG.info(
@@ -2045,7 +2045,7 @@ async def run_action_session(
     }
     try:
         final = await _SESSION_GRAPH.ainvoke(initial)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.exception("[Action Session] session failed")
         return Result(messages=[], new_states=[])
     return Result(
@@ -2072,7 +2072,7 @@ async def _init_chat(tools, system: str, user: str, tmo: float) -> str:
             return str(ans or "")
     except TimeoutError:
         _LOG.warning("[Action Session:init] timed out (%ds)", tmo)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _LOG.exception("[Action Session:init] failed")
     return ""
 

--- a/rag/advanced_rag/harness/action_session.py
+++ b/rag/advanced_rag/harness/action_session.py
@@ -35,8 +35,8 @@ from rag.advanced_rag.harness.config import resolve_mode
 
 _LOG = logging.getLogger(__name__)
 
-_INIT_TIMEOUT_S = 150.0
-_ACTION_TIMEOUT_S = 180.0
+_INIT_TIMEOUT_S = 45.0
+_ACTION_TIMEOUT_S = 75.0
 _SNIPPETS_PER_QUERY = 4
 _MAX_TOOL_RESPONSE_CHARS = 12000
 # Dataset-level empty results (reason="no_structure") a compiled-structure tool

--- a/rag/advanced_rag/harness/orchestrator/sufficient_context.py
+++ b/rag/advanced_rag/harness/orchestrator/sufficient_context.py
@@ -126,7 +126,6 @@ def _bounded_excerpt(text: str, hints: str, max_chars: int = 300) -> str:
         return ""
     if _is_table_text(text):
         return text
-
     max_chars = max(80, int(max_chars))
     hint_tokens = [t for t in re.findall(r"[A-Za-z0-9_\u4e00-\u9fff]{3,}", str(hints or ""))]
     lower = text.lower()

--- a/rag/advanced_rag/harness/orchestrator/sufficient_context.py
+++ b/rag/advanced_rag/harness/orchestrator/sufficient_context.py
@@ -126,6 +126,7 @@ def _bounded_excerpt(text: str, hints: str, max_chars: int = 300) -> str:
         return ""
     if _is_table_text(text):
         return text
+
     max_chars = max(80, int(max_chars))
     hint_tokens = [t for t in re.findall(r"[A-Za-z0-9_\u4e00-\u9fff]{3,}", str(hints or ""))]
     lower = text.lower()


### PR DESCRIPTION
- Remove the whole-graph timeout around graph.ainvoke() so the final answer streaming phase is not interrupted by the research budget.             
- Keep research-stage safeguards unchanged, including per-node timeouts, the 180-second research deadline, routing guards, and recursion limits.                                                                                                                                                                                                                                                         
                                                                                                                                                        
     The final answer generation can now continue until the model finishes. Retrieval remains bounded by the existing per-node timeouts, research deadline, routing guards, and recursion limit.
<img width="2668" height="924" alt="截图 2026-09-03 15-09-31" src="https://github.com/user-attachments/assets/35266eba-884a-4226-bee3-7591d60cebd5" />
