### PR TITLE
fix(model_meta): discover TEI reranker models

### DIFF
--- a/rag/llm/model_meta.py
+++ b/rag/llm/model_meta.py
@@ -1063,7 +1063,7 @@ class HuggingFace(Base):
         if isinstance(model_type, dict):
             if "embedding" in model_type:
                 return [LLMType.EMBEDDING.value]
-            if "rerank" in model_type:
+            if "reranker" in model_type:
                 return [LLMType.RERANK.value]
             return []
         # TGI format: "text-generation" / "text2text-generation"

--- a/test/unit_test/rag/llm/test_model_meta_huggingface.py
+++ b/test/unit_test/rag/llm/test_model_meta_huggingface.py
@@ -1,0 +1,77 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+
+from common.constants import LLMType
+from rag.llm.model_meta import HuggingFace
+
+pytestmark = pytest.mark.p2
+
+
+@pytest.mark.parametrize(
+    ("model_info", "expected_type", "expected_max_tokens"),
+    [
+        pytest.param(
+            {
+                "model_id": "/data/gte-rerank-int8",
+                "model_type": {
+                    "reranker": {
+                        "id2label": {"0": "LABEL_0"},
+                        "label2id": {"LABEL_0": 0},
+                    }
+                },
+                "max_input_length": 2048,
+                "version": "1.9.3",
+            },
+            LLMType.RERANK.value,
+            2048,
+            id="tei-reranker",
+        ),
+        pytest.param(
+            {
+                "model_id": "/data/qwen3-embed-int8",
+                "model_type": {"embedding": {"pooling": "last_token"}},
+                "max_input_length": 2048,
+                "version": "1.9.3",
+            },
+            LLMType.EMBEDDING.value,
+            2048,
+            id="tei-embedding",
+        ),
+        pytest.param(
+            {
+                "model_id": "meta-llama/Llama-2-7b-chat-hf",
+                "model_type": "text-generation",
+                "max_total_tokens": 4096,
+            },
+            LLMType.CHAT.value,
+            4096,
+            id="tgi-text-generation",
+        ),
+    ],
+)
+def test_huggingface_formats_discovered_model(model_info, expected_type, expected_max_tokens):
+    provider = HuggingFace(api_key="", base_url="http://inference-server")
+
+    assert provider._format_model_list(model_info) == [
+        {
+            "name": model_info["model_id"],
+            "model_types": [expected_type],
+            "features": [],
+            "max_tokens": expected_max_tokens,
+        }
+    ]


### PR DESCRIPTION
### Summary

- recognize the `reranker` key emitted by TEI's `/info` endpoint
- add focused discovery coverage for TEI reranker, TEI embedding, and TGI chat responses

TEI serializes its reranker model type as `{"reranker": ...}`. The previous `"rerank"` key check returned an empty model list, so self-hosted HuggingFace reranker instances could not be verified through automatic discovery.

Closes #19202

### Tests

- `uv run --python 3.13 --group test pytest -q test/unit_test/rag/llm/test_model_meta_huggingface.py test/unit_test/rag/llm/test_model_meta_funasr.py test/unit_test/rag/llm/test_model_meta_gpustack.py` (8 passed)
- `uvx ruff check test/unit_test/rag/llm/test_model_meta_huggingface.py`
- `uvx ruff format --check rag/llm/model_meta.py test/unit_test/rag/llm/test_model_meta_huggingface.py`
- `python -m py_compile rag/llm/model_meta.py test/unit_test/rag/llm/test_model_meta_huggingface.py`
- `git diff --check`
