### PR TITLE
fix(dynamic-form): allow non-string values in Segmented fields (#15106)

### DIFF
--- a/web/src/components/dynamic-form.tsx
+++ b/web/src/components/dynamic-form.tsx
@@ -194,7 +194,11 @@ export const generateSchema = (fields: FormFieldConfig[]): ZodSchema<any> => {
           }
           break;
         case FormFieldType.Segmented:
-          fieldSchema = z.string();
+          fieldSchema = field.options?.every(
+            (option) => typeof option.value === 'string',
+          )
+            ? z.string()
+            : z.union([z.string(), z.boolean(), z.number()]);
           break;
         case FormFieldType.Number:
           fieldSchema = z.coerce.number();


### PR DESCRIPTION
### Summary

The generated Zod schema for Segmented fields assumed string option values, so a Segmented field backed by boolean options failed validation on submit with "Expected string, received boolean" (e.g. the Jira data source cloud/server mode). Derive the schema from the option value types: keep z.string() when all options are strings, otherwise accept string | boolean | number.
