### PR TITLE
fix(dataset): fail closed on unknown permissions

### DIFF
--- a/internal/dao/kb.go
+++ b/internal/dao/kb.go
@@ -337,8 +337,8 @@ func (dao *KnowledgebaseDAO) GetDetail(ctx context.Context, db *gorm.DB, kbID st
 // This matches the Python accessible method:
 // 1. KB must exist and be VALID
 // 2. If user is the owner tenant, return true
-// 3. If permission is "me", only owner tenant can access
-// 4. If permission is "team", user must be a member of the tenant
+// 3. Non-owners require the explicit "team" permission
+// 4. Team members must have a valid user_tenant relationship
 func (dao *KnowledgebaseDAO) Accessible(ctx context.Context, db *gorm.DB, datasetID, userID string) bool {
 	var kb entity.Knowledgebase
 	err := db.WithContext(ctx).Where("id = ? AND status = ?", datasetID, string(entity.StatusValid)).First(&kb).Error
@@ -351,14 +351,14 @@ func (dao *KnowledgebaseDAO) Accessible(ctx context.Context, db *gorm.DB, datase
 		return true
 	}
 
-	// If permission is "me", only the owner can access
-	if kb.Permission == string(entity.TenantPermissionMe) {
+	// Fail closed for unknown, missing, or private permissions.
+	if kb.Permission != string(entity.TenantPermissionTeam) {
 		return false
 	}
 
 	var count int64
 	err = db.WithContext(ctx).Table("user_tenant").
-		Where("tenant_id = ? AND user_id = ? AND status = ?", kb.TenantID, userID, "1").
+		Where("tenant_id = ? AND user_id = ? AND status = ?", kb.TenantID, userID, string(entity.StatusValid)).
 		Count(&count).Error
 
 	if err != nil {

--- a/internal/dao/kb_test.go
+++ b/internal/dao/kb_test.go
@@ -40,6 +40,9 @@ func setupKBTestDB(t *testing.T) *gorm.DB {
 	if err := db.AutoMigrate(&entity.Knowledgebase{}); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
+	if err := db.AutoMigrate(&entity.UserTenant{}); err != nil {
+		t.Fatalf("failed to migrate user_tenant: %v", err)
+	}
 
 	return db
 }
@@ -64,6 +67,56 @@ func testKnowledgebase(t *testing.T, db *gorm.DB, id string, docNum, tokenNum, c
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+func createKBAccessFixture(t *testing.T, db *gorm.DB, id, permission, status string) {
+	t.Helper()
+	kb := &entity.Knowledgebase{ID: id, TenantID: "owner", CreatedBy: "owner", Name: id, EmbdID: "embd", Permission: permission, Status: stringPtr(status)}
+	if err := db.Create(kb).Error; err != nil {
+		t.Fatalf("failed to create KB: %v", err)
+	}
+}
+
+func createUserTenant(t *testing.T, db *gorm.DB, userID, tenantID, status string) {
+	t.Helper()
+	row := &entity.UserTenant{ID: userID + "-" + tenantID, UserID: userID, TenantID: tenantID, Role: "normal", InvitedBy: "owner", Status: stringPtr(status)}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("failed to create user_tenant: %v", err)
+	}
+}
+
+func TestKnowledgebaseDAO_Accessible(t *testing.T) {
+	db := setupKBTestDB(t)
+	dao := NewKnowledgebaseDAO()
+	ctx := t.Context()
+
+	createKBAccessFixture(t, db, "private", string(entity.TenantPermissionMe), string(entity.StatusValid))
+	createKBAccessFixture(t, db, "team", string(entity.TenantPermissionTeam), string(entity.StatusValid))
+	createKBAccessFixture(t, db, "unknown", "", string(entity.StatusValid))
+	createKBAccessFixture(t, db, "invalid", string(entity.TenantPermissionTeam), string(entity.StatusInvalid))
+	createUserTenant(t, db, "member", "owner", string(entity.StatusValid))
+	createUserTenant(t, db, "revoked", "owner", string(entity.StatusInvalid))
+
+	tests := []struct {
+		name, kbID, userID string
+		want               bool
+	}{
+		{"owner private", "private", "owner", true},
+		{"member private", "private", "member", false},
+		{"member team", "team", "member", true},
+		{"revoked member team", "team", "revoked", false},
+		{"unrelated team", "team", "other", false},
+		{"member unknown permission", "unknown", "member", false},
+		{"invalid KB", "invalid", "owner", false},
+		{"missing KB", "missing", "owner", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dao.Accessible(ctx, db, tt.kbID, tt.userID); got != tt.want {
+				t.Fatalf("Accessible(%q, %q) = %v, want %v", tt.kbID, tt.userID, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestKnowledgebaseDAO_DecreaseDocumentNum(t *testing.T) {


### PR DESCRIPTION
Go now requires non-owners to have explicit team permission. Revoked memberships remain denied.