### PR TITLE
fix(ingestion): show data pipeline on failed parse log entries

### DIFF
--- a/internal/ingestion/task/pipeline_executor.go
+++ b/internal/ingestion/task/pipeline_executor.go
@@ -756,13 +756,16 @@ func recordPipelineLog(
 	// selection runs on a builtin registry pipeline: its canvasID is the
 	// parser_id, not a canvas row, so the log is titled with the document's
 	// parser_id, reuses the document thumbnail as avatar, and leaves
-	// pipeline_id empty.
+	// pipeline_id empty. The canvas lookup must not depend on the DSL: terminal
+	// failure/cancel logs are recorded without a DSL, and their pipeline title
+	// and avatar must still resolve from the canvas row (mirrors the Python
+	// operation-log creation path).
 	pipelineTitle := doc.ParserID
 	pipelineAvatar := doc.Thumbnail
 	var pipelineID *string
 	if input.PipelineID != "" {
 		pipelineID = &input.PipelineID
-		if db != nil && strings.TrimSpace(input.DSL) != "" {
+		if db != nil {
 			if canvas, err := dao.NewUserCanvasDAO().GetByID(ctx, db, input.PipelineID); err == nil && canvas != nil {
 				if canvas.Title != nil {
 					pipelineTitle = *canvas.Title

--- a/internal/ingestion/task/pipeline_executor_test.go
+++ b/internal/ingestion/task/pipeline_executor_test.go
@@ -487,6 +487,69 @@ func TestRecordPipelineLog_CustomCanvasMissingFallsBackToParserID(t *testing.T) 
 	}
 }
 
+func TestRecordPipelineLog_TerminalWithoutDSLResolvesCanvasTitle(t *testing.T) {
+	cleanup := setupPipelineExecutorTestDB(t)
+	defer cleanup()
+
+	if err := dao.DB.Create(&entity.UserCanvas{
+		ID:     "canvas-1",
+		UserID: "tenant-1",
+		Title:  strPtr("My Pipeline"),
+		Avatar: strPtr("a.png"),
+	}).Error; err != nil {
+		t.Fatalf("seed canvas: %v", err)
+	}
+	if err := dao.DB.AutoMigrate(&entity.Knowledgebase{}); err != nil {
+		t.Fatalf("migrate knowledgebase: %v", err)
+	}
+	if err := dao.DB.Create(&entity.Knowledgebase{
+		ID:       "kb-1",
+		TenantID: "tenant-1",
+	}).Error; err != nil {
+		t.Fatalf("seed knowledgebase: %v", err)
+	}
+	docName := "sample.avi"
+	run := "1"
+	if err := dao.DB.Create(&entity.Document{
+		ID:           "doc-1",
+		KbID:         "kb-1",
+		PipelineID:   strPtr("canvas-1"),
+		ParserID:     "naive",
+		ParserConfig: entity.JSONMap{},
+		Name:         &docName,
+		Run:          &run,
+	}).Error; err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+
+	// Mirrors Ingestor.recordTerminalPipelineLog: only the terminal status is
+	// known; pipeline_id and DSL are absent and must come from the document.
+	if err := RecordPipelineLog(t.Context(), dao.DB, PipelineLogInput{
+		KbID:       "kb-1",
+		DocumentID: "doc-1",
+		Status:     "3",
+	}); err != nil {
+		t.Fatalf("RecordPipelineLog: %v", err)
+	}
+
+	var log entity.PipelineOperationLog
+	if err := dao.DB.First(&log, "document_id = ?", "doc-1").Error; err != nil {
+		t.Fatalf("load pipeline log: %v", err)
+	}
+	if log.OperationStatus != "3" {
+		t.Fatalf("OperationStatus = %q, want terminal status", log.OperationStatus)
+	}
+	if log.PipelineID == nil || *log.PipelineID != "canvas-1" {
+		t.Fatalf("PipelineID = %v, want \"canvas-1\"", log.PipelineID)
+	}
+	if log.PipelineTitle == nil || *log.PipelineTitle != "My Pipeline" {
+		t.Fatalf("PipelineTitle = %v, want \"My Pipeline\"", log.PipelineTitle)
+	}
+	if log.Avatar == nil || *log.Avatar != "a.png" {
+		t.Fatalf("Avatar = %v, want \"a.png\"", log.Avatar)
+	}
+}
+
 func TestRecordPipelineLog_SourceFrom(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
### Summary

On the dataset **Logs** page (文件日志 tab), log rows whose status is **Failed** (or **Cancelled**) showed an empty **Data pipeline** cell when the dataset's parse method was a user pipeline, while successful rows displayed the pipeline name correctly.

**Root cause (Go stack):** when a document parse task ends in a terminal state, `Ingestor.recordTerminalPipelineLog` records the `pipeline_operation_log` row through the shared writer `recordPipelineLog` with only `KbID/DocumentID/Status` — no DSL snapshot. Commit a33ee7d4 (#18605) made the canvas lookup that fills `pipeline_title`/`avatar` conditional on a non-empty DSL, so terminal rows written without a DSL fell back to `document.parser_id` (empty for pipeline-parsed documents) and the document thumbnail (empty). The Python implementation (`PipelineOperationLogService.create`) resolves the canvas unconditionally whenever `pipeline_id` is set, which is why only the Go stack shows the regression.

**Fix:** in `internal/ingestion/task/pipeline_executor.go`, the `UserCanvas` lookup now runs whenever the pipeline id is known (task input or the document row), regardless of the DSL. If the canvas is missing the writer still falls back to `parser_id`/thumbnail, matching the previous behavior. A regression test (`TestRecordPipelineLog_TerminalWithoutDSLResolvesCanvasTitle`) seeds a canvas + document and records a terminal log without a DSL, asserting the row keeps `pipeline_id`, `pipeline_title` and `avatar` from the canvas.

### Verification

- `bash build.sh --test ./internal/ingestion/task/...` — all packages pass, including the new regression test `TestRecordPipelineLog_TerminalWithoutDSLResolvesCanvasTitle`, which seeds a user canvas plus a pipeline-linked document and records a terminal log exactly the way `Ingestor.recordTerminalPipelineLog` does (only `KbID/DocumentID/Status`, no DSL, no pipeline id), then asserts the stored row keeps `pipeline_id`, `pipeline_title` and `avatar` resolved from the canvas.
- Python alignment: `PipelineOperationLogService.create` (`api/db/services/pipeline_operation_log_service.py`) resolves the canvas title/avatar unconditionally whenever `pipeline_id` is set; after this change the Go writer matches that behavior.
- UI end-to-end verification could not be completed in this run: the browser automation tool (chrome-devtools MCP) died from an environment fault mid-session and could not be restarted, so no UI screenshots are attached. The fix is covered by the regression test above, which exercises the exact production write path used for failed/cancelled parses.
