### PR TITLE
fix(go): wire dataflow rerun and honor edited DSL (#19094, #19229)

### DIFF
--- a/internal/dao/ingestion.go
+++ b/internal/dao/ingestion.go
@@ -75,6 +75,10 @@ func (dao *IngestionTaskDAO) UpdateComponentTotal(ctx context.Context, db *gorm.
 	return db.WithContext(ctx).Model(&entity.IngestionTask{}).Where("id = ?", taskID).Update("component_total", total).Error
 }
 
+func (dao *IngestionTaskDAO) UpdateSchema(ctx context.Context, db *gorm.DB, taskID string, schema entity.JSONMap) error {
+	return db.WithContext(ctx).Model(&entity.IngestionTask{}).Where("id = ?", taskID).Update("schema", schema).Error
+}
+
 type TaskInfo struct {
 	TaskID        string   `json:"task_id"`
 	FilesToDelete []string `json:"files_to_delete"`

--- a/internal/entity/ingestion_task_rerun.go
+++ b/internal/entity/ingestion_task_rerun.go
@@ -1,0 +1,82 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package entity
+
+const ingestionTaskRerunSchemaKey = "rerun"
+
+// IngestionTaskRerunInfo carries the edited DSL a dataflow rerun should
+// execute instead of the canvas DSL. It is stored on IngestionTask.Schema
+// under the "rerun" key for traceability.
+type IngestionTaskRerunInfo struct {
+	DSL         JSONMap `json:"dsl"`
+	LogID       string  `json:"log_id"`
+	ComponentID string  `json:"component_id"`
+}
+
+// NewIngestionTaskRerunSchema builds the Schema payload for a rerun task.
+func NewIngestionTaskRerunSchema(dsl JSONMap, logID, componentID string) JSONMap {
+	return JSONMap{
+		ingestionTaskRerunSchemaKey: map[string]interface{}{
+			"dsl":          dsl,
+			"log_id":       logID,
+			"component_id": componentID,
+		},
+	}
+}
+
+// RerunInfo returns rerun metadata when the task was enqueued from a dataflow
+// rerun request.
+func (t *IngestionTask) RerunInfo() (IngestionTaskRerunInfo, bool) {
+	if t == nil || t.Schema == nil {
+		return IngestionTaskRerunInfo{}, false
+	}
+	raw, ok := t.Schema[ingestionTaskRerunSchemaKey]
+	if !ok || raw == nil {
+		return IngestionTaskRerunInfo{}, false
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return IngestionTaskRerunInfo{}, false
+	}
+	info := IngestionTaskRerunInfo{
+		LogID:       stringField(m, "log_id"),
+		ComponentID: stringField(m, "component_id"),
+	}
+	if dsl := jsonMapField(m, "dsl"); dsl != nil {
+		info.DSL = dsl
+		return info, true
+	}
+	return info, info.LogID != "" || info.ComponentID != ""
+}
+
+func jsonMapField(m map[string]interface{}, key string) JSONMap {
+	switch v := m[key].(type) {
+	case JSONMap:
+		return v
+	case map[string]interface{}:
+		return JSONMap(v)
+	default:
+		return nil
+	}
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/internal/entity/ingestion_task_rerun.go
+++ b/internal/entity/ingestion_task_rerun.go
@@ -53,17 +53,17 @@ func (t *IngestionTask) RerunInfo() (IngestionTaskRerunInfo, bool) {
 		return IngestionTaskRerunInfo{}, false
 	}
 	info := IngestionTaskRerunInfo{
-		LogID:       stringField(m, "log_id"),
-		ComponentID: stringField(m, "component_id"),
+		LogID:       rerunStringField(m, "log_id"),
+		ComponentID: rerunStringField(m, "component_id"),
 	}
-	if dsl := jsonMapField(m, "dsl"); dsl != nil {
+	if dsl := rerunJSONMapField(m, "dsl"); dsl != nil {
 		info.DSL = dsl
 		return info, true
 	}
 	return info, info.LogID != "" || info.ComponentID != ""
 }
 
-func jsonMapField(m map[string]interface{}, key string) JSONMap {
+func rerunJSONMapField(m map[string]interface{}, key string) JSONMap {
 	switch v := m[key].(type) {
 	case JSONMap:
 		return v
@@ -74,7 +74,7 @@ func jsonMapField(m map[string]interface{}, key string) JSONMap {
 	}
 }
 
-func stringField(m map[string]interface{}, key string) string {
+func rerunStringField(m map[string]interface{}, key string) string {
 	if v, ok := m[key].(string); ok {
 		return v
 	}

--- a/internal/entity/ingestion_task_rerun_test.go
+++ b/internal/entity/ingestion_task_rerun_test.go
@@ -1,0 +1,27 @@
+package entity
+
+import "testing"
+
+func TestIngestionTaskRerunSchemaRoundTrip(t *testing.T) {
+	dsl := JSONMap{"components": map[string]interface{}{"c1": map[string]interface{}{}}}
+	schema := NewIngestionTaskRerunSchema(dsl, "log-1", "c1")
+
+	task := &IngestionTask{Schema: schema}
+	info, ok := task.RerunInfo()
+	if !ok {
+		t.Fatal("RerunInfo = false, want true")
+	}
+	if info.LogID != "log-1" || info.ComponentID != "c1" {
+		t.Fatalf("info = %+v", info)
+	}
+	if _, ok := info.DSL["components"]; !ok {
+		t.Fatalf("dsl = %v", info.DSL)
+	}
+}
+
+func TestIngestionTaskRerunInfoAbsent(t *testing.T) {
+	task := &IngestionTask{Schema: JSONMap{"other": true}}
+	if _, ok := task.RerunInfo(); ok {
+		t.Fatal("RerunInfo = true, want false")
+	}
+}

--- a/internal/handler/document.go
+++ b/internal/handler/document.go
@@ -78,7 +78,7 @@ type documentServiceIface interface {
 	UpdateDatasetDocument(ctx context.Context, userID, datasetID, documentID string, req *document.UpdateDatasetDocumentRequest, present map[string]bool) (*document.UpdateDatasetDocumentResponse, common.ErrorCode, error)
 	BatchUpdateDocumentMetadatas(ctx context.Context, datasetID string, selector *document.MetadataSelector, updates []document.MetadataUpdate, deletes []document.MetadataDelete) (*document.BatchUpdateMetadatasResponse, common.ErrorCode, error)
 	ListIngestionTasks(ctx context.Context, userID string, datasetID *string, page, pageSize int) ([]*entity.IngestionTask, error)
-	IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string) ([]*service.ParseDocumentResponse, error)
+	IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string, schema entity.JSONMap) ([]*service.ParseDocumentResponse, error)
 	StopIngestionTasks(ctx context.Context, tasks []string, userID string) ([]*entity.IngestionTask, error)
 	Ingest(ctx context.Context, userID string, req *document.IngestDocumentRequest) (common.ErrorCode, error)
 	RemoveIngestionTasks(ctx context.Context, tasks []string, userID string) ([]map[string]string, error)
@@ -1536,7 +1536,7 @@ func (h *DocumentHandler) StartIngestionTask(c *gin.Context) {
 		return
 	}
 
-	parseResult, err := h.documentService.IngestDocuments(ctx, datasetID, userID, req.DocumentIDs)
+	parseResult, err := h.documentService.IngestDocuments(ctx, datasetID, userID, req.DocumentIDs, nil)
 	if err != nil {
 		common.ResponseWithCodeData(c, common.CodeExceptionError, nil, err.Error())
 		return

--- a/internal/handler/document_test.go
+++ b/internal/handler/document_test.go
@@ -249,7 +249,7 @@ func (f *fakeDocumentService) UploadEmptyDocument(ctx context.Context, kb *entit
 func (f *fakeDocumentService) ListIngestionTasks(ctx context.Context, userID string, datasetID *string, page, pageSize int) ([]*entity.IngestionTask, error) {
 	return nil, nil
 }
-func (f *fakeDocumentService) IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string) ([]*service.ParseDocumentResponse, error) {
+func (f *fakeDocumentService) IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string, schema entity.JSONMap) ([]*service.ParseDocumentResponse, error) {
 	return nil, nil
 }
 func (f *fakeDocumentService) StopIngestionTasks(ctx context.Context, tasks []string, userID string) ([]*entity.IngestionTask, error) {

--- a/internal/ingestion/task/pipeline_executor.go
+++ b/internal/ingestion/task/pipeline_executor.go
@@ -174,7 +174,7 @@ func (s *PipelineExecutor) Execute(ctx context.Context) (*PipelineResult, error)
 		return nil, err
 	}
 
-	dsl, correctedID, err := s.loadDSLFunc(ctx, s.canvasID)
+	dsl, correctedID, err := s.resolveDSL(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -203,6 +203,19 @@ func (s *PipelineExecutor) Execute(ctx context.Context) (*PipelineResult, error)
 	}
 
 	return result, nil
+}
+
+func (s *PipelineExecutor) resolveDSL(ctx context.Context) (string, string, error) {
+	if s.taskCtx != nil && s.taskCtx.IngestionTask != nil {
+		if rerun, ok := s.taskCtx.IngestionTask.RerunInfo(); ok && rerun.DSL != nil {
+			raw, err := json.Marshal(rerun.DSL)
+			if err != nil {
+				return "", "", fmt.Errorf("marshal rerun dsl: %w", err)
+			}
+			return string(raw), s.canvasID, nil
+		}
+	}
+	return s.loadDSLFunc(ctx, s.canvasID)
 }
 
 // collectDebugOutput builds a PipelineResult for a debug (dry-run) run.

--- a/internal/ingestion/task/pipeline_run_test.go
+++ b/internal/ingestion/task/pipeline_run_test.go
@@ -17,7 +17,9 @@
 package task
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -52,6 +54,42 @@ func TestPipelineExecutor_DefaultLoadDSL_UsesUserCanvas(t *testing.T) {
 	}
 	if _, ok := decoded["dsl"].(map[string]any); !ok {
 		t.Fatalf("decoded dsl = %v, want top-level dsl map", decoded)
+	}
+}
+
+func TestResolveDSL_UsesRerunSchemaInsteadOfCanvas(t *testing.T) {
+	taskCtx := makeTaskCtx()
+	taskCtx.IngestionTask.Schema = entity.NewIngestionTaskRerunSchema(
+		entity.JSONMap{
+			"components": map[string]interface{}{"rerun-marker": map[string]interface{}{}},
+			"path":       []interface{}{"c1"},
+		},
+		"log-1",
+		"c1",
+	)
+	svc := mustNewPipelineExecutor(t, taskCtx, "canvas-1", 0)
+	canvasCalled := false
+	svc.loadDSLFunc = func(context.Context, string) (string, string, error) {
+		canvasCalled = true
+		return "", "", fmt.Errorf("canvas should not be loaded")
+	}
+
+	gotDSL, correctedID, err := svc.resolveDSL(context.Background())
+	if err != nil {
+		t.Fatalf("resolveDSL: %v", err)
+	}
+	if canvasCalled {
+		t.Fatal("loadDSLFromCanvas was called despite rerun schema")
+	}
+	if correctedID != "canvas-1" {
+		t.Fatalf("correctedID = %q, want canvas-1", correctedID)
+	}
+	var decoded map[string]any
+	if err = json.Unmarshal([]byte(gotDSL), &decoded); err != nil {
+		t.Fatalf("unmarshal dsl: %v", err)
+	}
+	if _, ok := decoded["components"].(map[string]any)["rerun-marker"]; !ok {
+		t.Fatalf("decoded dsl = %v, want rerun-marker component", decoded)
 	}
 }
 

--- a/internal/ingestion/task/pipeline_run_test.go
+++ b/internal/ingestion/task/pipeline_run_test.go
@@ -41,19 +41,19 @@ func TestPipelineExecutor_DefaultLoadDSL_UsesUserCanvas(t *testing.T) {
 
 	taskCtx := makeTaskCtx()
 	svc := mustNewPipelineExecutor(t, taskCtx, "canvas-1", 0)
-	gotDSL, correctedID, err := svc.loadDSLFunc(ctx, "canvas-1")
+	canvasDSL := `{"dsl":{"graph":{"nodes":[],"edges":[]}}}`
+	svc.loadDSLFunc = func(context.Context, string) (string, string, error) {
+		return canvasDSL, "canvas-1", nil
+	}
+	gotDSL, correctedID, err := svc.resolveDSL(ctx)
 	if err != nil {
-		t.Fatalf("loadDSLFunc: %v", err)
+		t.Fatalf("resolveDSL: %v", err)
 	}
 	if correctedID != "canvas-1" {
 		t.Fatalf("correctedID = %q, want canvas-1", correctedID)
 	}
-	var decoded map[string]any
-	if err = json.Unmarshal([]byte(gotDSL), &decoded); err != nil {
-		t.Fatalf("unmarshal dsl: %v", err)
-	}
-	if _, ok := decoded["dsl"].(map[string]any); !ok {
-		t.Fatalf("decoded dsl = %v, want top-level dsl map", decoded)
+	if gotDSL != canvasDSL {
+		t.Fatalf("resolveDSL = %q, want canvas DSL", gotDSL)
 	}
 }
 

--- a/internal/service/document/document.go
+++ b/internal/service/document/document.go
@@ -26,6 +26,7 @@ import (
 
 	"ragflow/internal/dao"
 	"ragflow/internal/engine"
+	"ragflow/internal/entity"
 	"ragflow/internal/ingestion/knowledge_compile"
 )
 
@@ -233,6 +234,14 @@ type StartParseOptions struct {
 	ApplyKB bool
 	// RerunWithDelete clears prior chunks/tasks/counters before reparsing.
 	RerunWithDelete bool
+	// RerunDSL, when set, is the edited pipeline DSL the worker should
+	// execute instead of loading from the canvas.
+	RerunDSL entity.JSONMap
+	// RerunLogID is the pipeline operation log id the rerun originated from.
+	RerunLogID string
+	// RerunComponentID is the component the front-end chose as the rerun
+	// entry point (recorded on the log DSL as path=[component_id]).
+	RerunComponentID string
 }
 
 // GetMetadataSummaryRequest request for metadata summary

--- a/internal/service/document/document_ingest.go
+++ b/internal/service/document/document_ingest.go
@@ -15,8 +15,12 @@ func (s *DocumentService) ListIngestionTasks(ctx context.Context, userID string,
 	return s.ingestionTaskSvc.ListByUser(ctx, userID, datasetID, page, pageSize)
 }
 
-func (s *DocumentService) IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string) ([]*service.ParseDocumentResponse, error) {
-	responses, err := s.ingestionTaskSvc.CreateForDocuments(ctx, datasetID, userID, docIDs)
+func (s *DocumentService) IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string, taskSchema ...entity.JSONMap) ([]*service.ParseDocumentResponse, error) {
+	var schema entity.JSONMap
+	if len(taskSchema) > 0 {
+		schema = taskSchema[0]
+	}
+	responses, err := s.ingestionTaskSvc.CreateForDocuments(ctx, datasetID, userID, docIDs, schema)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/document/document_ingest.go
+++ b/internal/service/document/document_ingest.go
@@ -15,11 +15,7 @@ func (s *DocumentService) ListIngestionTasks(ctx context.Context, userID string,
 	return s.ingestionTaskSvc.ListByUser(ctx, userID, datasetID, page, pageSize)
 }
 
-func (s *DocumentService) IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string, taskSchema ...entity.JSONMap) ([]*service.ParseDocumentResponse, error) {
-	var schema entity.JSONMap
-	if len(taskSchema) > 0 {
-		schema = taskSchema[0]
-	}
+func (s *DocumentService) IngestDocuments(ctx context.Context, datasetID, userID string, docIDs []string, schema entity.JSONMap) ([]*service.ParseDocumentResponse, error) {
 	responses, err := s.ingestionTaskSvc.CreateForDocuments(ctx, datasetID, userID, docIDs, schema)
 	if err != nil {
 		return nil, err

--- a/internal/service/document/document_parse.go
+++ b/internal/service/document/document_parse.go
@@ -75,7 +75,11 @@ func (s *DocumentService) StartParseDocuments(ctx context.Context, doc *entity.D
 		}
 	}
 
-	responses, err := s.IngestDocuments(ctx, doc.KbID, userID, []string{doc.ID})
+	var taskSchema entity.JSONMap
+	if opts.RerunDSL != nil {
+		taskSchema = entity.NewIngestionTaskRerunSchema(opts.RerunDSL, opts.RerunLogID, opts.RerunComponentID)
+	}
+	responses, err := s.IngestDocuments(ctx, doc.KbID, userID, []string{doc.ID}, taskSchema)
 	if err != nil {
 		return err
 	}

--- a/internal/service/document/document_rerun.go
+++ b/internal/service/document/document_rerun.go
@@ -60,13 +60,6 @@ func (e *RerunDocumentProcessingError) Error() string {
 // The Go pipeline has no partial-resume entry point (execution always
 // starts at the graph entry; see pipeline.Pipeline.Run), so the rerun
 // re-executes the whole pipeline instead of resuming from component_id.
-//
-// Known divergence from the Python endpoint: the persisted edited DSL is
-// an audit record only. The Go ingestion worker sources the parse DSL
-// from the canvas (doc.PipelineID -> user_canvas.dsl; see
-// loadDSLFromCanvas) and IngestionTask carries no DSL/log reference, so
-// the edited dsl/component_id currently has no effect on the Go rerun.
-// Plumbing the log DSL through the task to the worker is a follow-up.
 func (s *DocumentService) RerunDocument(ctx context.Context, userID, logID string, dsl map[string]interface{}, componentID string) error {
 	// A missing row is the caller-facing not-found; any other DB error is
 	// an internal failure and must not be collapsed into it.
@@ -114,7 +107,13 @@ func (s *DocumentService) RerunDocument(ctx context.Context, userID, logID strin
 		if err := s.pipelineLogDAO.UpdateDSL(ctx, dao.DB, logID, entity.JSONMap(persisted)); err != nil {
 			return fmt.Errorf("update pipeline log dsl: %w", err)
 		}
+		dsl = persisted
 	}
 
-	return s.StartParseDocuments(ctx, doc, kb, userID, StartParseOptions{RerunWithDelete: true})
+	return s.StartParseDocuments(ctx, doc, kb, userID, StartParseOptions{
+		RerunWithDelete:  true,
+		RerunDSL:         entity.JSONMap(dsl),
+		RerunLogID:       logID,
+		RerunComponentID: componentID,
+	})
 }

--- a/internal/service/document/document_rerun.go
+++ b/internal/service/document/document_rerun.go
@@ -112,8 +112,24 @@ func (s *DocumentService) RerunDocument(ctx context.Context, userID, logID strin
 
 	return s.StartParseDocuments(ctx, doc, kb, userID, StartParseOptions{
 		RerunWithDelete:  true,
-		RerunDSL:         entity.JSONMap(dsl),
+		RerunDSL:         rerunTaskDSL(dsl),
 		RerunLogID:       logID,
 		RerunComponentID: componentID,
 	})
+}
+
+// rerunTaskDSL copies the persisted log DSL for worker execution without
+// the partial-resume "path" marker, which is audit metadata on the log row
+// only and must not reach the execution path until the Go pipeline honors it.
+func rerunTaskDSL(dsl map[string]interface{}) entity.JSONMap {
+	if dsl == nil {
+		return nil
+	}
+	exec := make(map[string]interface{}, len(dsl))
+	for k, v := range dsl {
+		if k != "path" {
+			exec[k] = v
+		}
+	}
+	return entity.JSONMap(exec)
 }

--- a/internal/service/document/document_rerun_e2e_test.go
+++ b/internal/service/document/document_rerun_e2e_test.go
@@ -17,7 +17,7 @@ import (
 // JetStream stream and consumes the task message back. The unit tier's
 // recording publisher only proves the publish call happened; this tier
 // proves the enqueue actually lands on tasks.RAGFLOW with a task id that
-// resolves to a SCHEDULED ingestion task for the document.
+// resolves to a CREATED ingestion task for the document.
 func TestRerunDocument_E2E_EnqueuesThroughRealMessageQueue(t *testing.T) {
 	db := testutil.SetupTestDB(t,
 		&entity.IngestionTask{}, &entity.IngestionTaskLog{}, &entity.Task{},
@@ -99,12 +99,23 @@ func TestRerunDocument_E2E_EnqueuesThroughRealMessageQueue(t *testing.T) {
 		t.Fatalf("message task type = %s, want %s", taskMsg.TaskType, common.TaskTypeIngestionTask)
 	}
 
-	// ...and the referenced task row exists, already SCHEDULED.
+	// ...and the referenced task row exists in CREATED state.
 	task, err := svc.ingestionTaskDAO.GetByID(t.Context(), db, taskMsg.TaskID)
 	if err != nil {
 		t.Fatalf("load enqueued ingestion task %s: %v", taskMsg.TaskID, err)
 	}
-	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.SCHEDULED {
+	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.CREATED {
 		t.Fatalf("ingestion task = %+v", task)
+	}
+	rerun, ok := task.RerunInfo()
+	if !ok {
+		t.Fatal("ingestion task missing rerun schema")
+	}
+	if rerun.LogID != "log-1" || rerun.ComponentID != "c1" {
+		t.Fatalf("rerun info = %+v", rerun)
+	}
+	path, _ = rerun.DSL["path"].([]interface{})
+	if len(path) != 1 || path[0] != "c1" {
+		t.Fatalf("task rerun dsl path = %v, want [c1]", rerun.DSL["path"])
 	}
 }

--- a/internal/service/document/document_rerun_e2e_test.go
+++ b/internal/service/document/document_rerun_e2e_test.go
@@ -99,12 +99,12 @@ func TestRerunDocument_E2E_EnqueuesThroughRealMessageQueue(t *testing.T) {
 		t.Fatalf("message task type = %s, want %s", taskMsg.TaskType, common.TaskTypeIngestionTask)
 	}
 
-	// ...and the referenced task row exists in CREATED state.
+	// ...and the referenced task row exists, already SCHEDULED.
 	task, err := svc.ingestionTaskDAO.GetByID(t.Context(), db, taskMsg.TaskID)
 	if err != nil {
 		t.Fatalf("load enqueued ingestion task %s: %v", taskMsg.TaskID, err)
 	}
-	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.CREATED {
+	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.SCHEDULED {
 		t.Fatalf("ingestion task = %+v", task)
 	}
 	rerun, ok := task.RerunInfo()
@@ -114,8 +114,7 @@ func TestRerunDocument_E2E_EnqueuesThroughRealMessageQueue(t *testing.T) {
 	if rerun.LogID != "log-1" || rerun.ComponentID != "c1" {
 		t.Fatalf("rerun info = %+v", rerun)
 	}
-	path, _ = rerun.DSL["path"].([]interface{})
-	if len(path) != 1 || path[0] != "c1" {
-		t.Fatalf("task rerun dsl path = %v, want [c1]", rerun.DSL["path"])
+	if _, ok := rerun.DSL["path"]; ok {
+		t.Fatalf("task rerun dsl should not include path (audit-only on log row): %v", rerun.DSL)
 	}
 }

--- a/internal/service/document/document_rerun_test.go
+++ b/internal/service/document/document_rerun_test.go
@@ -136,11 +136,24 @@ func TestRerunDocument_RerunsAndPersistsDSL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load ingestion task: %v", err)
 	}
-	// CreateAndEnqueue marks the task SCHEDULED once its queue message has
-	// been published (the publisher here records instead of failing), so the
-	// persisted row is already past CREATED by the time we reload it.
-	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.SCHEDULED {
+	// CreateAndEnqueue leaves the task CREATED once its queue message has
+	// been published (the publisher here records instead of failing).
+	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.CREATED {
 		t.Fatalf("ingestion task = %+v", task)
+	}
+	rerun, ok := task.RerunInfo()
+	if !ok {
+		t.Fatal("ingestion task missing rerun schema")
+	}
+	if rerun.LogID != "log-1" || rerun.ComponentID != "c1" {
+		t.Fatalf("rerun info = %+v", rerun)
+	}
+	if _, ok := rerun.DSL["components"]; !ok {
+		t.Fatalf("task rerun dsl = %v", rerun.DSL)
+	}
+	taskPath, _ := rerun.DSL["path"].([]interface{})
+	if len(taskPath) != 1 || taskPath[0] != "c1" {
+		t.Fatalf("task rerun dsl path = %v, want [c1]", rerun.DSL["path"])
 	}
 
 	// Prior counters are cleared for the rerun.

--- a/internal/service/document/document_rerun_test.go
+++ b/internal/service/document/document_rerun_test.go
@@ -136,8 +136,9 @@ func TestRerunDocument_RerunsAndPersistsDSL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load ingestion task: %v", err)
 	}
-	// CreateAndEnqueue leaves the task CREATED once its queue message has
-	// been published (the publisher here records instead of failing).
+	// CreateAndEnqueue marks the task SCHEDULED once its queue message has
+	// been published (the publisher here records instead of failing), so the
+	// persisted row is already past CREATED by the time we reload it.
 	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.SCHEDULED {
 		t.Fatalf("ingestion task = %+v", task)
 	}

--- a/internal/service/document/document_rerun_test.go
+++ b/internal/service/document/document_rerun_test.go
@@ -138,7 +138,7 @@ func TestRerunDocument_RerunsAndPersistsDSL(t *testing.T) {
 	}
 	// CreateAndEnqueue leaves the task CREATED once its queue message has
 	// been published (the publisher here records instead of failing).
-	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.CREATED {
+	if task.DocumentID != "doc-1" || task.DatasetID != "kb-1" || task.Status != common.SCHEDULED {
 		t.Fatalf("ingestion task = %+v", task)
 	}
 	rerun, ok := task.RerunInfo()
@@ -151,9 +151,8 @@ func TestRerunDocument_RerunsAndPersistsDSL(t *testing.T) {
 	if _, ok := rerun.DSL["components"]; !ok {
 		t.Fatalf("task rerun dsl = %v", rerun.DSL)
 	}
-	taskPath, _ := rerun.DSL["path"].([]interface{})
-	if len(taskPath) != 1 || taskPath[0] != "c1" {
-		t.Fatalf("task rerun dsl path = %v, want [c1]", rerun.DSL["path"])
+	if _, ok := rerun.DSL["path"]; ok {
+		t.Fatalf("task rerun dsl should not include path (audit-only on log row): %v", rerun.DSL)
 	}
 
 	// Prior counters are cleared for the rerun.

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -72,10 +72,15 @@ func (s *IngestionTaskService) ListByUser(ctx context.Context, userID string, da
 	return s.ingestionTaskDAO.ListByUserIDAndDatasetID(ctx, dao.DB, userID, *datasetID, page, pageSize)
 }
 
-func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID, userID string, docIDs []string) ([]*ParseDocumentResponse, error) {
+func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID, userID string, docIDs []string, taskSchema ...entity.JSONMap) ([]*ParseDocumentResponse, error) {
 	uniqueDocIDs := common.Deduplicate(docIDs)
 	if len(uniqueDocIDs) == 0 {
 		return nil, fmt.Errorf("no documents to parse")
+	}
+
+	var schema entity.JSONMap
+	if len(taskSchema) > 0 {
+		schema = taskSchema[0]
 	}
 
 	responses := make([]*ParseDocumentResponse, 0, len(uniqueDocIDs))
@@ -100,7 +105,7 @@ func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID
 			DocumentID: docID,
 			UserID:     userID,
 			DatasetID:  datasetID,
-			Schema:     nil,
+			Schema:     schema,
 			Status:     common.CREATED,
 		}
 		task, err = s.CreateAndEnqueue(ctx, task)
@@ -402,6 +407,12 @@ func (s *IngestionTaskService) CreateAndEnqueue(ctx context.Context, task *entit
 			existing, err = s.transition(ctx, existing.ID, common.CREATED)
 			if err != nil {
 				return nil, err
+			}
+			if task.Schema != nil {
+				if err = s.ingestionTaskDAO.UpdateSchema(ctx, dao.DB, existing.ID, task.Schema); err != nil {
+					return nil, err
+				}
+				existing.Schema = task.Schema
 			}
 			// The previous run is terminal, so any leftover Redis cancel flag
 			// is stale: a genuine cancel of the new run can only come through

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -72,15 +72,10 @@ func (s *IngestionTaskService) ListByUser(ctx context.Context, userID string, da
 	return s.ingestionTaskDAO.ListByUserIDAndDatasetID(ctx, dao.DB, userID, *datasetID, page, pageSize)
 }
 
-func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID, userID string, docIDs []string, taskSchema ...entity.JSONMap) ([]*ParseDocumentResponse, error) {
+func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID, userID string, docIDs []string, schema entity.JSONMap) ([]*ParseDocumentResponse, error) {
 	uniqueDocIDs := common.Deduplicate(docIDs)
 	if len(uniqueDocIDs) == 0 {
 		return nil, fmt.Errorf("no documents to parse")
-	}
-
-	var schema entity.JSONMap
-	if len(taskSchema) > 0 {
-		schema = taskSchema[0]
 	}
 
 	responses := make([]*ParseDocumentResponse, 0, len(uniqueDocIDs))
@@ -404,23 +399,25 @@ func (s *IngestionTaskService) CreateAndEnqueue(ctx context.Context, task *entit
 			return s.markScheduledAfterPublish(ctx, existing.ID)
 		case common.FAILED, common.STOPPED:
 			originalStatus := existing.Status
+			priorSchema := existing.Schema
 			existing, err = s.transition(ctx, existing.ID, common.CREATED)
 			if err != nil {
 				return nil, err
 			}
-			if task.Schema != nil {
-				if err = s.ingestionTaskDAO.UpdateSchema(ctx, dao.DB, existing.ID, task.Schema); err != nil {
-					return nil, err
+			if err = s.ingestionTaskDAO.UpdateSchema(ctx, dao.DB, existing.ID, task.Schema); err != nil {
+				if rollbackErr := s.rollbackRetriedTask(ctx, existing.ID, originalStatus, priorSchema); rollbackErr != nil {
+					return nil, fmt.Errorf("update schema for task %s: %w (rollback failed: %w)", existing.ID, err, rollbackErr)
 				}
-				existing.Schema = task.Schema
+				return nil, err
 			}
+			existing.Schema = task.Schema
 			// The previous run is terminal, so any leftover Redis cancel flag
 			// is stale: a genuine cancel of the new run can only come through
 			// RequestStop once the task is RUNNING again. Clear it so the
 			// re-queued task is not cancelled at the worker's pre-start check.
 			clearCancelFlag(ctx, existing.ID)
 			if err = s.enqueueTask(existing.ID); err != nil {
-				if rollbackErr := s.rollbackRetriedTask(ctx, existing.ID, originalStatus); rollbackErr != nil {
+				if rollbackErr := s.rollbackRetriedTask(ctx, existing.ID, originalStatus, priorSchema); rollbackErr != nil {
 					return nil, fmt.Errorf("enqueue task %s: %w (rollback failed: %w)", existing.ID, err, rollbackErr)
 				}
 				return nil, err
@@ -444,7 +441,7 @@ func (s *IngestionTaskService) CreateAndEnqueue(ctx context.Context, task *entit
 	return s.markScheduledAfterPublish(ctx, created.ID)
 }
 
-func (s *IngestionTaskService) rollbackRetriedTask(ctx context.Context, taskID, status string) error {
+func (s *IngestionTaskService) rollbackRetriedTask(ctx context.Context, taskID, status string, priorSchema entity.JSONMap) error {
 	updated, err := s.ingestionTaskDAO.UpdateStatusIfCurrent(ctx, dao.DB, taskID, common.CREATED, status)
 	if err != nil {
 		return err
@@ -452,7 +449,7 @@ func (s *IngestionTaskService) rollbackRetriedTask(ctx context.Context, taskID, 
 	if !updated {
 		return s.newTaskStatusConflictError(ctx, taskID, common.CREATED, status)
 	}
-	return nil
+	return s.ingestionTaskDAO.UpdateSchema(ctx, dao.DB, taskID, priorSchema)
 }
 
 func (s *IngestionTaskService) rollbackCreatedTask(ctx context.Context, taskID string) error {

--- a/internal/service/ingestion_task_service_test.go
+++ b/internal/service/ingestion_task_service_test.go
@@ -76,7 +76,7 @@ func TestIngestionTaskServiceCreateForDocumentsPublishesTaskMessages(t *testing.
 	svc.taskPublisher = publisher
 
 	ctx := t.Context()
-	resp, err := svc.CreateForDocuments(ctx, "kb-1", "user-1", []string{"doc-1"})
+	resp, err := svc.CreateForDocuments(ctx, "kb-1", "user-1", []string{"doc-1"}, nil)
 	if err != nil {
 		t.Fatalf("CreateForDocuments failed: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestIngestionTaskServiceMarksTaskScheduledOnlyAfterPublish(t *testing.T) {
 	svc := NewIngestionTaskService()
 	svc.taskPublisher = publisher
 
-	responses, err := svc.CreateForDocuments(t.Context(), "kb-1", "user-1", []string{"doc-1"})
+	responses, err := svc.CreateForDocuments(t.Context(), "kb-1", "user-1", []string{"doc-1"}, nil)
 	if err != nil {
 		t.Fatalf("CreateForDocuments failed: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestIngestionTaskServiceAcceptsConsumerWinningPublishRace(t *testing.T) {
 	svc := NewIngestionTaskService()
 	svc.taskPublisher = publisher
 
-	responses, err := svc.CreateForDocuments(t.Context(), "kb-1", "user-1", []string{"doc-1"})
+	responses, err := svc.CreateForDocuments(t.Context(), "kb-1", "user-1", []string{"doc-1"}, nil)
 	if err != nil {
 		t.Fatalf("CreateForDocuments failed: %v", err)
 	}
@@ -646,6 +646,48 @@ func TestIngestionTaskServiceCreateAndEnqueueRetriesTerminalTask(t *testing.T) {
 				t.Fatalf("reloaded status = %q, want %q", reloaded.Status, common.SCHEDULED)
 			}
 		})
+	}
+}
+
+func TestIngestionTaskServiceCreateAndEnqueueClearsRerunSchemaOnNormalRetry(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertTestIngestionTask(t, "task-1", "user-1", "doc-1", "kb-1")
+	rerunSchema := entity.NewIngestionTaskRerunSchema(
+		entity.JSONMap{"components": map[string]interface{}{"c1": map[string]interface{}{}}},
+		"log-1",
+		"c1",
+	)
+	if err := dao.DB.Model(&entity.IngestionTask{}).Where("id = ?", "task-1").Updates(map[string]interface{}{
+		"status": common.FAILED,
+		"schema": rerunSchema,
+	}).Error; err != nil {
+		t.Fatalf("seed failed task with rerun schema: %v", err)
+	}
+
+	publisher := &recordingTaskPublisher{}
+	svc := NewIngestionTaskService()
+	svc.taskPublisher = publisher
+
+	task, err := svc.CreateAndEnqueue(t.Context(), &entity.IngestionTask{
+		DocumentID: "doc-1",
+		UserID:     "user-1",
+		DatasetID:  "kb-1",
+		Status:     common.CREATED,
+		Schema:     nil,
+	})
+	if err != nil {
+		t.Fatalf("CreateAndEnqueue failed: %v", err)
+	}
+	reloaded, err := dao.NewIngestionTaskDAO().GetByID(t.Context(), db, task.ID)
+	if err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if reloaded.Schema != nil {
+		t.Fatalf("schema = %v, want nil after normal retry", reloaded.Schema)
+	}
+	if _, ok := reloaded.RerunInfo(); ok {
+		t.Fatal("RerunInfo should be absent after normal retry")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #19229 and includes the Go rerun wiring from #19094 so the endpoint actually re-enqueues a parse **using the edited DSL** the front-end submits.

Previously on the Go path:
1. `POST /api/v1/agents/rerun` could 500 (document service not wired) — fixed in the first commits here, matching #19094.
2. Even after wiring, the edited DSL was audit-only on the log row; the worker always loaded DSL from the canvas — fixed in the final commit.

## Changes

### Rerun wiring (#19094 parity)
- Wire `DocumentService` into `AgentHandler` and implement `RerunDocument` (log → document, access gate, mid-run guard, persist `dsl.path=[component_id]`, clear prior results, re-enqueue).
- Map domain errors to 102 and internal errors to 500.
- Unit + e2e tests for the rerun endpoint and enqueue path.

### Honor edited DSL on rerun (#19229)
- Store rerun DSL / log id / component id on `IngestionTask.Schema` (`entity.NewIngestionTaskRerunSchema`).
- Thread through `RerunDocument` → `StartParseOptions` → `CreateForDocuments`.
- `PipelineExecutor.resolveDSL()` prefers the task rerun DSL over `loadDSLFromCanvas`.
- Normal (non-rerun) ingests unchanged.

## Acceptance criteria (#19229)

- [x] Rerun re-executes using the edited DSL, not the canvas DSL
- [x] Normal ingest still sources DSL from the canvas
- [x] Rerun DSL recorded on the ingestion task for traceability
- [x] Unit + e2e rerun tests updated

## Tests

```bash
CGO_ENABLED=0 go test ./internal/entity/ -run Rerun
CGO_ENABLED=0 go test ./internal/service/document/ -run Rerun
CGO_ENABLED=0 go test ./internal/ingestion/task/ -run ResolveDSL
CGO_ENABLED=0 go test ./internal/handler/ -run Rerun
```

## Notes

- Stacks the #19094 rerun wiring and #19229 DSL plumbing in one branch rebased onto current `main` (17 files, ~837 lines).
- Partial resume from `dsl.path=[component_id]` remains out of scope; full re-run with edited config is the minimal Python parity fix.
- If #19094 merges separately first, happy to rebase this down to the DSL-only diff.