### PR TITLE
fix(parser): decode legacy Chinese text before chunking

### DIFF
--- a/internal/parser/parser/charset.go
+++ b/internal/parser/parser/charset.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"golang.org/x/text/encoding"
@@ -123,4 +124,26 @@ func decodeFirstCharsetMatch(data []byte, labels []string) (string, string, bool
 		}
 	}
 	return "", "", false
+}
+
+var xmlEncodingRe = regexp.MustCompile(`(?i)^\s*<\?xml[^>]*\bencoding\s*=\s*["']\s*([^"'\s?]+)`)
+
+// decodeLegacyTextToUTF8 accepts UTF-8 first, then the GB18030 family used by
+// legacy Chinese text files. An XML declaration is authoritative for EPUB
+// XHTML; undecodable input remains an error instead of being reinterpreted as
+// arbitrary binary text.
+func decodeLegacyTextToUTF8(data []byte) (string, string, error) {
+	if utf8Valid(data) {
+		return string(data), "utf-8", nil
+	}
+	if match := xmlEncodingRe.FindSubmatch(data); len(match) == 2 {
+		label := string(match[1])
+		if decoded, err := decodeWithCharset(data, label); err == nil {
+			return decoded, label, nil
+		}
+	}
+	if decoded, err := decodeWithCharset(data, "gb18030"); err == nil {
+		return decoded, "gb18030", nil
+	}
+	return "", "", fmt.Errorf("text input is neither valid UTF-8 nor decodable GB18030")
 }

--- a/internal/parser/parser/csv_parser.go
+++ b/internal/parser/parser/csv_parser.go
@@ -125,14 +125,17 @@ func (p *CSVParser) ParseWithResult(ctx context.Context, filename string, data [
 		// for CSV processing.
 	}
 
-	text := string(data)
+	text, encoding, err := decodeLegacyTextToUTF8(data)
+	if err != nil {
+		return ParseResult{Err: fmt.Errorf("csv decode: %w", err)}
+	}
 	if strings.TrimSpace(text) == "" {
 		return ParseResult{
 			OutputFormat: "html",
 			File: map[string]any{
 				"name":     filename,
 				"size":     len(data),
-				"encoding": "utf-8",
+				"encoding": encoding,
 			},
 			HTML: "<table><caption>" + csvSheetName + "</caption><tr><td></td></tr></table>",
 		}
@@ -161,7 +164,7 @@ func (p *CSVParser) ParseWithResult(ctx context.Context, filename string, data [
 		File: map[string]any{
 			"name":     filename,
 			"size":     len(data),
-			"encoding": "utf-8",
+			"encoding": encoding,
 		},
 		HTML: recordsToHTMLTableChunks(records, chunkRows, csvSheetName),
 	}

--- a/internal/parser/parser/epub_parser.go
+++ b/internal/parser/parser/epub_parser.go
@@ -238,7 +238,11 @@ func readEPUBContentFile(r *zip.Reader, opfDir, href string) string {
 	if err != nil {
 		return ""
 	}
-	return stripHTMLTags(string(raw))
+	text, _, err := decodeLegacyTextToUTF8(raw)
+	if err != nil {
+		return ""
+	}
+	return stripHTMLTags(text)
 }
 
 // stripHTMLTags removes HTML markup and returns normalized plain text.

--- a/internal/parser/parser/text_parser.go
+++ b/internal/parser/parser/text_parser.go
@@ -57,10 +57,11 @@ func NewTextParser() *TextParser {
 // non-empty JSON payload even for an empty input (mirrors the
 // MarkdownParser convention at markdown_parser.go:71-76).
 func (p *TextParser) ParseWithResult(ctx context.Context, filename string, data []byte) ParseResult {
-	if !utf8Valid(data) {
-		return ParseResult{Err: errInvalidUTF8}
+	text, encoding, err := decodeLegacyTextToUTF8(data)
+	if err != nil {
+		return ParseResult{Err: err}
 	}
-	items := textParserItems(data)
+	items := textParserItems([]byte(text))
 	if items == nil {
 		items = []map[string]any{{"text": "", "doc_type_kwd": "text"}}
 	}
@@ -69,7 +70,7 @@ func (p *TextParser) ParseWithResult(ctx context.Context, filename string, data 
 		File: map[string]any{
 			"name":     filename,
 			"size":     len(data),
-			"encoding": "utf-8",
+			"encoding": encoding,
 		},
 		JSON: items,
 	}


### PR DESCRIPTION
GBK and GB18030 text now decodes before chunks are created. UTF-8 files keep their current behavior.