### PR TITLE
fix(dataset): surface Go ingestion QUEUED status and honor terminal run state

### DIFF
--- a/web/src/components/file-status-badge.tsx
+++ b/web/src/components/file-status-badge.tsx
@@ -1,4 +1,3 @@
-
 /*
  *  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
  *
@@ -48,6 +47,7 @@ const FileStatusBadge: FC<StatusBadgeProps> = ({ status, name, className }) => {
         return `bg-[rgba(0,190,180,0.1)] text-accent-primary`;
       case RunningStatus.UNSTART:
       case RunningStatusOld.UNSTART:
+      case RunningStatus.QUEUED:
         return `bg-[rgba(250,173,20,0.1)] text-state-warning`;
       default:
         return 'bg-gray-500/10 text-text-secondary';
@@ -71,6 +71,7 @@ const FileStatusBadge: FC<StatusBadgeProps> = ({ status, name, className }) => {
         return `bg-[rgba(0,190,180,1)] text-accent-primary`;
       case RunningStatus.UNSTART:
       case RunningStatusOld.UNSTART:
+      case RunningStatus.QUEUED:
         return `bg-[rgba(250,173,20,1)] text-state-warning`;
       default:
         return `bg-[rgba(117,120,122,1)] text-text-secondary`;

--- a/web/src/constants/knowledge.ts
+++ b/web/src/constants/knowledge.ts
@@ -30,6 +30,9 @@ export enum RunningStatus {
   DONE = 'DONE', // need to refresh
   FAIL = 'FAIL', // need to refresh
   SCHEDULE = 'SCHEDULE',
+  // Go ingestion only: the task is enqueued but not started yet
+  // (ingestion_status CREATED / SCHEDULED).
+  QUEUED = 'QUEUED',
 }
 
 export enum RunningStatusOld {
@@ -58,6 +61,7 @@ export const RunningStatusMap = {
   [RunningStatus.DONE]: 'Success',
   [RunningStatus.FAIL]: 'Failed',
   [RunningStatus.SCHEDULE]: 'Schedule',
+  [RunningStatus.QUEUED]: 'Queued',
 
   [RunningStatusOld.UNSTART]: 'Pending',
   [RunningStatusOld.RUNNING]: 'Running',

--- a/web/src/pages/dataset/dataset/hooks.ts
+++ b/web/src/pages/dataset/dataset/hooks.ts
@@ -1,11 +1,13 @@
 import { useSetModalState } from '@/hooks/common-hooks';
 import { IDocumentInfo } from '@/interfaces/database/document';
+import { pickByBackend } from '@/utils/backend-variant';
 import { formatDate, formatSecondsToHumanReadable } from '@/utils/date';
 import { formatBytes } from '@/utils/file-util';
 import { useCallback, useMemo, useState } from 'react';
 import { ILogInfo } from '../process-log-modal';
 import { RunningStatus } from './constant';
 import { useFetchDocumentsByIds } from '@/hooks/use-document-request';
+import { isDocumentQueued } from './utils';
 
 const PollIntervalMs = 5000;
 
@@ -43,7 +45,14 @@ export const useShowLog = (documents: IDocumentInfo[]) => {
         processBeginAt: formatDate(source.process_begin_at),
         chunkNumber: source.chunk_count,
         duration: formatSecondsToHumanReadable(source.process_duration || 0),
-        status: source.run as RunningStatus,
+        status: pickByBackend({
+          // The Go backend reports a queued document via ingestion_status
+          // while the legacy run field stays UNSTART; surface it as QUEUED.
+          go: isDocumentQueued(source)
+            ? RunningStatus.QUEUED
+            : (source.run as RunningStatus),
+          python: source.run as RunningStatus,
+        }),
         details: source.progress_msg,
       };
     }

--- a/web/src/pages/dataset/dataset/utils.ts
+++ b/web/src/pages/dataset/dataset/utils.ts
@@ -6,13 +6,32 @@ export const isParserRunning = (text: RunningStatus) => {
   return isRunning;
 };
 
+export const isDocumentQueued = (
+  document: Pick<IDocumentInfo, 'ingestion_status'>,
+) =>
+  document.ingestion_status === IngestionTaskStatus.CREATED ||
+  document.ingestion_status === IngestionTaskStatus.SCHEDULED;
+
 // Go ingestion status can advance before the legacy document run field. The
 // Python endpoint omits ingestion_status, so run remains the compatibility path.
+// A terminal legacy run status is authoritative: the Go backend may leave
+// ingestion_status at STOPPING after a cancel completes, and the document must
+// then be treated as not running so its parsing style and restart action work.
 export const isDocumentProcessing = (
   document: Pick<IDocumentInfo, 'run' | 'ingestion_status'>,
-) =>
-  isParserRunning(document.run) ||
-  document.ingestion_status === IngestionTaskStatus.CREATED ||
-  document.ingestion_status === IngestionTaskStatus.SCHEDULED ||
-  document.ingestion_status === IngestionTaskStatus.RUNNING ||
-  document.ingestion_status === IngestionTaskStatus.STOPPING;
+) => {
+  if (isParserRunning(document.run)) return true;
+  if (
+    document.run === RunningStatus.CANCEL ||
+    document.run === RunningStatus.DONE ||
+    document.run === RunningStatus.FAIL
+  ) {
+    return false;
+  }
+  return (
+    document.ingestion_status === IngestionTaskStatus.CREATED ||
+    document.ingestion_status === IngestionTaskStatus.SCHEDULED ||
+    document.ingestion_status === IngestionTaskStatus.RUNNING ||
+    document.ingestion_status === IngestionTaskStatus.STOPPING
+  );
+};


### PR DESCRIPTION
### Summary

- Add `RunningStatus.QUEUED` for Go-backend documents whose `ingestion_status` is CREATED/SCHEDULED while the legacy `run` field still reports UNSTART, and render it with the pending/warning style in FileStatusBadge.
- Map queued documents to QUEUED in `useShowLog` via `pickByBackend`, keeping the Python backend behavior unchanged.
- Make `isDocumentProcessing` treat terminal legacy run statuses (CANCEL, DONE, FAIL) as authoritative, so a stale STOPPING `ingestion_status` no longer blocks parsing style and restart actions.
