### PR TITLE
fix(ingestion): defer RUNNING state to worker and handle queued task cancellation

### DIFF
--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -434,7 +434,7 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 		return
 	}
 
-	task, err := e.ingestionTaskSvc.StartRunning(e.ctx, taskMessage.TaskID)
+	task, err := e.ingestionTaskSvc.GetTask(e.ctx, taskMessage.TaskID)
 	if err != nil {
 		if errors.Is(err, common.ErrTaskNotFound) {
 			common.Warn(fmt.Sprintf("task %s not found, skipping", taskMessage.TaskID))
@@ -446,7 +446,7 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 		// Recoverable activation failure (e.g. a DB blip): nack for
 		// redelivery instead of dropping the message or killing the
 		// consumer.
-		common.Error(fmt.Sprintf("error setting task %s to running", taskMessage.TaskID), err)
+		common.Error(fmt.Sprintf("error loading task %s", taskMessage.TaskID), err)
 		if nackErr := handle.Nack(); nackErr != nil {
 			common.Error(fmt.Sprintf("error nack task %s", taskMessage.TaskID), nackErr)
 		}
@@ -467,7 +467,15 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 			common.Error(fmt.Sprintf("error ack task %s", taskMessage.TaskID), ackErr)
 		}
 		return
-	case common.RUNNING:
+	case common.STOPPING:
+		// Task was requested to stop before worker dequeued it. Finalize as STOPPED and ack.
+		common.Info(fmt.Sprintf("task %s is stopping, finalize as STOPPED", taskMessage.TaskID))
+		e.markStopped(e.ctx, task.ID)
+		if ackErr := handle.Ack(); ackErr != nil {
+			common.Error(fmt.Sprintf("error ack task %s", taskMessage.TaskID), ackErr)
+		}
+		return
+	case common.CREATED, common.SCHEDULED, common.RUNNING:
 		// Guard against MQ redelivery: if another worker in this
 		// process is already processing this task, renew the redelivered
 		// message's lease and skip instead of scheduling it again. The
@@ -482,9 +490,6 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 		}
 		claimedTaskID = task.ID
 	default:
-		// Unreachable given StartRunning normalizes every status to
-		// RUNNING/COMPLETED/STOPPED/FAILED, but defensive: ack-skip an
-		// unknown status instead of enqueuing it for execution.
 		common.Warn(fmt.Sprintf("task %s in unexpected status %s, ack-skip", taskMessage.TaskID, task.Status))
 		if ackErr := handle.Ack(); ackErr != nil {
 			common.Error(fmt.Sprintf("error ack task %s", taskMessage.TaskID), ackErr)
@@ -500,12 +505,8 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 	// Push to the task channel. Use a blocking send so backpressure is
 	// applied at the consumer: the consume loop waits for a free worker slot
 	// instead of dropping the message. Dropping on backpressure is unsafe
-	// because StartRunning (above) has already flipped the task — and its
-	// document — to RUNNING in the DB, and there is no scan-and-re-enqueue
-	// path on completion. A Nack that exceeds the broker's MaxDeliver (16,
-	// with no dead-letter in nats.go) would permanently lose the task and
-	// leave the document stuck in RUNNING — the "files get stuck after the
-	// first few parse" defect.
+	// because dropping unhandled tasks would permanently lose them and leave
+	// the document in an unfinished state.
 	//
 	// The in-flight claim (set just above) guards against a redelivery racing
 	// the blocked send: a duplicate delivery sees claimTask fail, renews its
@@ -515,19 +516,17 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 		claimedTaskID = "" // executeTask owns the release now
 		common.Info(fmt.Sprintf("Task %s queued (channel: %d/%d)", task.ID, len(e.taskChan), cap(e.taskChan)))
 	case <-e.ctx.Done():
-		// Shutdown won the race after StartRunning already flipped the task
-		// to RUNNING: finalize it as STOPPED so the row cannot linger in
-		// non-terminal RUNNING with no in-flight worker (the user can
-		// retry). The message is left unsettled - on redelivery the terminal
-		// STOPPED status ack-skips it. Both paths
-		// run with a detached 2s timeout so shutdown is not slowed by a
-		// stalled DB.
+		// Shutdown won the race before the task entered the channel:
+		// finalize as STOPPED so the row cannot linger with no in-flight worker.
+		// The message is left unsettled - on redelivery the terminal
+		// STOPPED status ack-skips it. Both paths run with a detached
+		// 2s timeout so shutdown is not slowed by a stalled DB.
 		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		if e.markStopped(stopCtx, task.ID) {
 			common.Info(fmt.Sprintf("Ingestor shutting down; task %s finalized as STOPPED", task.ID))
 		} else {
-			common.Warn(fmt.Sprintf("Ingestor shutting down; task %s left RUNNING for NATS redelivery", task.ID))
+			common.Warn(fmt.Sprintf("Ingestor shutting down; task %s left for NATS redelivery", task.ID))
 		}
 		return
 	}
@@ -678,6 +677,49 @@ func (e *Ingestor) executeTask(ctx context.Context, taskCtx *taskpkg.TaskContext
 	// Release the claim when executeTask returns so that a future
 	// redelivery (after restart) can re-claim the task.
 	defer e.releaseTask(task.ID)
+
+	runningTask, err := e.ingestionTaskSvc.StartRunning(ctx, task.ID)
+	if err != nil {
+		if errors.Is(err, common.ErrTaskNotFound) {
+			common.Warn(fmt.Sprintf("task %s not found, skipping", task.ID))
+			if taskCtx.Handle != nil {
+				if ackErr := taskCtx.Handle.Ack(); ackErr != nil {
+					common.Error(fmt.Sprintf("error ack task %s", task.ID), ackErr)
+				}
+			}
+			return
+		}
+		common.Error(fmt.Sprintf("error setting task %s to running", task.ID), err)
+		if taskCtx.Handle != nil {
+			if nackErr := taskCtx.Handle.Nack(); nackErr != nil {
+				common.Error(fmt.Sprintf("error nack task %s", task.ID), nackErr)
+			}
+		}
+		return
+	}
+	if runningTask == nil {
+		common.Info(fmt.Sprintf("task %s is already removed", task.ID))
+		if taskCtx.Handle != nil {
+			if ackErr := taskCtx.Handle.Ack(); ackErr != nil {
+				common.Error(fmt.Sprintf("error ack task %s", task.ID), ackErr)
+			}
+		}
+		return
+	}
+
+	taskCtx.IngestionTask = runningTask
+	task = runningTask
+
+	switch task.Status {
+	case common.COMPLETED, common.STOPPED, common.FAILED:
+		common.Info(fmt.Sprintf("task %s is already %s, skipping execution", task.ID, task.Status))
+		if taskCtx.Handle != nil {
+			if ackErr := taskCtx.Handle.Ack(); ackErr != nil {
+				common.Error(fmt.Sprintf("error ack task %s", task.ID), ackErr)
+			}
+		}
+		return
+	}
 
 	// Derive a per-task cancelable context so that an external cancel
 	// signal (Redis cancel flag, mirrored from Python's {task_id}-cancel)

--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -470,7 +470,12 @@ func (e *Ingestor) processMessage(handle common.TaskHandle) {
 	case common.STOPPING:
 		// Task was requested to stop before worker dequeued it. Finalize as STOPPED and ack.
 		common.Info(fmt.Sprintf("task %s is stopping, finalize as STOPPED", taskMessage.TaskID))
-		e.markStopped(e.ctx, task.ID)
+		if !e.markStopped(e.ctx, task.ID) {
+			if nackErr := handle.Nack(); nackErr != nil {
+				common.Error(fmt.Sprintf("error nack task %s", taskMessage.TaskID), nackErr)
+			}
+			return
+		}
 		if ackErr := handle.Ack(); ackErr != nil {
 			common.Error(fmt.Sprintf("error ack task %s", taskMessage.TaskID), ackErr)
 		}

--- a/internal/ingestion/service/process_message_test.go
+++ b/internal/ingestion/service/process_message_test.go
@@ -846,3 +846,37 @@ func TestExecuteTask_CancelledWhileQueuedAcksAndSkips(t *testing.T) {
 		t.Fatal("expected task released from currentTasks after executeTask finished")
 	}
 }
+
+// TestProcessMessage_StoppingTaskFinalizesAndAcks verifies that a task in STOPPING
+// status received by processMessage is finalized to STOPPED and Acked.
+func TestProcessMessage_StoppingTaskFinalizesAndAcks(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	cleanup := testutil.ReplaceDBForTest(t, db)
+	defer cleanup()
+	_, _, _, taskID := testutil.SeedTestData(t, db, testutil.WithPipelineID("flow-1"))
+
+	if err := db.Model(&entity.IngestionTask{}).Where("id = ?", taskID).
+		Update("status", common.STOPPING).Error; err != nil {
+		t.Fatalf("set task to STOPPING: %v", err)
+	}
+
+	ingestor := newUnitIngestor("test", 1, []string{"pdf"})
+	handle := newFakeHandle(taskID, common.TaskTypeIngestionTask)
+
+	ingestor.processMessage(handle)
+
+	if handle.acks.Load() != 1 || handle.nacks.Load() != 0 {
+		t.Fatalf("STOPPING task: expected 1 Ack/0 Nack, got acks=%d nacks=%d", handle.acks.Load(), handle.nacks.Load())
+	}
+	if len(ingestor.taskChan) != 0 {
+		t.Fatalf("expected 0 tasks enqueued for STOPPING task, got %d", len(ingestor.taskChan))
+	}
+
+	var task entity.IngestionTask
+	if err := db.Where("id = ?", taskID).First(&task).Error; err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if task.Status != common.STOPPED {
+		t.Fatalf("task status = %q, want %q", task.Status, common.STOPPED)
+	}
+}

--- a/internal/ingestion/service/process_message_test.go
+++ b/internal/ingestion/service/process_message_test.go
@@ -204,8 +204,9 @@ func TestProcessMessage_TaskNotFoundAcks(t *testing.T) {
 	}
 }
 
-// TestProcessMessage_CreatedTaskStartsRunning verifies that a worker can claim
-// a task after NATS accepts its message but before the API records SCHEDULED.
+// TestProcessMessage_CreatedTaskStartsRunning verifies that a task remains in its
+// queued status (CREATED) while sitting in the channel, and only transitions to
+// RUNNING when the worker actually starts executing it.
 func TestProcessMessage_CreatedTaskStartsRunning(t *testing.T) {
 	db := testutil.SetupTestDB(t)
 	cleanup := testutil.ReplaceDBForTest(t, db)
@@ -232,8 +233,23 @@ func TestProcessMessage_CreatedTaskStartsRunning(t *testing.T) {
 	if err := db.Where("id = ?", taskID).First(&task).Error; err != nil {
 		t.Fatalf("reload task: %v", err)
 	}
-	if task.Status != common.RUNNING {
-		t.Fatalf("status = %q, want %q", task.Status, common.RUNNING)
+	if task.Status != common.CREATED {
+		t.Fatalf("status = %q, want %q (must remain CREATED while queued in channel)", task.Status, common.CREATED)
+	}
+
+	// Worker picks up task and executes it: should transition to RUNNING.
+	taskCtx := <-ingestor.taskChan
+	var ranWithRunningStatus bool
+	ingestor.runDocumentTask = func(ctx context.Context, it *entity.IngestionTask) error {
+		var current entity.IngestionTask
+		if err := db.Where("id = ?", taskID).First(&current).Error; err == nil {
+			ranWithRunningStatus = current.Status == common.RUNNING
+		}
+		return nil
+	}
+	ingestor.executeTask(context.Background(), taskCtx)
+	if !ranWithRunningStatus {
+		t.Fatalf("expected task status to be RUNNING during execution")
 	}
 }
 
@@ -437,16 +453,17 @@ func TestProcessMessage_ShutdownRaceMarksStopped(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait until StartRunning flipped the task RUNNING and processMessage
-	// is blocked on the full channel.
+	// Wait until processMessage claimed the task and is blocked on the full channel.
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		var task entity.IngestionTask
-		if err := db.Where("id = ?", taskID).First(&task).Error; err == nil && task.Status == common.RUNNING {
+		ingestor.tasksMu.Lock()
+		_, claimed := ingestor.currentTasks[taskID]
+		ingestor.tasksMu.Unlock()
+		if claimed {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("task never reached RUNNING; processMessage did not reach the blocking send")
+			t.Fatal("task was never claimed; processMessage did not reach the blocking send")
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
@@ -761,5 +778,71 @@ func TestExecuteMemoryTaskAlreadyCompletedAcks(t *testing.T) {
 	ingestor.executeMemoryTask(context.Background(), taskCtx)
 	if handle.acks.Load() != 1 || handle.nacks.Load() != 0 {
 		t.Fatalf("already-completed memory task: expected 1 Ack/0 Nack, got acks=%d nacks=%d", handle.acks.Load(), handle.nacks.Load())
+	}
+}
+
+// TestExecuteTask_CancelledWhileQueuedAcksAndSkips verifies that when a task is
+// cancelled while queued in the worker channel (before a worker starts it),
+// RequestStop transitions it to STOPPED, and executeTask skips execution and
+// acks the message.
+func TestExecuteTask_CancelledWhileQueuedAcksAndSkips(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	cleanup := testutil.ReplaceDBForTest(t, db)
+	defer cleanup()
+	_, _, _, taskID := testutil.SeedTestData(t, db, testutil.WithPipelineID("flow-1"))
+
+	if err := db.Model(&entity.IngestionTask{}).Where("id = ?", taskID).
+		Update("status", common.SCHEDULED).Error; err != nil {
+		t.Fatalf("set task to SCHEDULED: %v", err)
+	}
+
+	ingestor := newUnitIngestor("test", 1, []string{"pdf"})
+	var runDocumentTaskCalled bool
+	ingestor.runDocumentTask = func(ctx context.Context, it *entity.IngestionTask) error {
+		runDocumentTaskCalled = true
+		return nil
+	}
+
+	handle := newFakeHandle(taskID, common.TaskTypeIngestionTask)
+	ingestor.processMessage(handle)
+
+	if len(ingestor.taskChan) != 1 {
+		t.Fatalf("expected 1 task enqueued, got %d", len(ingestor.taskChan))
+	}
+
+	// Task should still be SCHEDULED while queued.
+	var task entity.IngestionTask
+	if err := db.Where("id = ?", taskID).First(&task).Error; err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if task.Status != common.SCHEDULED {
+		t.Fatalf("task status = %q, want %q", task.Status, common.SCHEDULED)
+	}
+
+	// User cancels the task while it is still queued.
+	if _, err := ingestor.ingestionTaskSvc.RequestStop(context.Background(), taskID); err != nil {
+		t.Fatalf("RequestStop failed: %v", err)
+	}
+
+	// RequestStop on a SCHEDULED task transitions directly to STOPPED.
+	if err := db.Where("id = ?", taskID).First(&task).Error; err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if task.Status != common.STOPPED {
+		t.Fatalf("task status after cancel = %q, want %q", task.Status, common.STOPPED)
+	}
+
+	// Worker now picks up the task context from the channel and executes it.
+	taskCtx := <-ingestor.taskChan
+	ingestor.executeTask(context.Background(), taskCtx)
+
+	if runDocumentTaskCalled {
+		t.Fatal("expected runDocumentTask NOT to be called for cancelled task")
+	}
+	if handle.acks.Load() != 1 || handle.nacks.Load() != 0 {
+		t.Fatalf("cancelled queued task: expected 1 Ack/0 Nack, got acks=%d nacks=%d", handle.acks.Load(), handle.nacks.Load())
+	}
+	if _, stillClaimed := ingestor.currentTasks[taskID]; stillClaimed {
+		t.Fatal("expected task released from currentTasks after executeTask finished")
 	}
 }

--- a/internal/service/document/document_parse.go
+++ b/internal/service/document/document_parse.go
@@ -416,7 +416,10 @@ func (s *DocumentService) CancelDocParse(ctx context.Context, doc *entity.Docume
 		}
 	}
 
-	if upErr := s.documentDAO.UpdateByID(ctx, dao.DB, doc.ID, map[string]interface{}{"run": string(entity.TaskStatusCancel)}); upErr != nil {
+	if upErr := s.documentDAO.UpdateByID(ctx, dao.DB, doc.ID, map[string]interface{}{
+		"run":      string(entity.TaskStatusCancel),
+		"progress": 0,
+	}); upErr != nil {
 		return fmt.Errorf("failed to update document %s: %w", doc.ID, upErr)
 	}
 	return nil

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -267,8 +267,12 @@ func (s *IngestionTaskService) RequestStop(ctx context.Context, taskID string) (
 	case common.STOPPING:
 		// User requested stop again on an already-stopping task: finalize to STOPPED
 		// and clean up the cancel flag so the task does not remain stuck.
+		task, err = s.transition(ctx, taskID, common.STOPPED)
+		if err != nil {
+			return nil, err
+		}
 		clearCancelFlag(ctx, taskID)
-		return s.transition(ctx, taskID, common.STOPPED)
+		return task, nil
 	default:
 		return task, nil
 	}
@@ -486,18 +490,22 @@ func (s *IngestionTaskService) ScheduleCreatedTasks(ctx context.Context) error {
 	// Clean up orphaned STOPPING tasks on startup: since the previous worker process
 	// exited, no worker is running them. Finalize them as STOPPED.
 	stoppingTasks, err := s.ingestionTaskDAO.ListByStatus(ctx, dao.DB, common.STOPPING)
-	if err == nil {
-		for _, task := range stoppingTasks {
-			_ = s.MarkStopped(ctx, task.ID)
-			clearCancelFlag(ctx, task.ID)
+	if err != nil {
+		return err
+	}
+	var recoveryErr error
+	for _, task := range stoppingTasks {
+		if stopErr := s.MarkStopped(ctx, task.ID); stopErr != nil {
+			recoveryErr = errors.Join(recoveryErr, fmt.Errorf("finalize stopping task %s: %w", task.ID, stopErr))
+			continue
 		}
+		clearCancelFlag(ctx, task.ID)
 	}
 
 	tasks, err := s.ingestionTaskDAO.ListByStatus(ctx, dao.DB, common.CREATED)
 	if err != nil {
 		return err
 	}
-	var recoveryErr error
 	for _, task := range tasks {
 		if err := s.enqueueTask(task.ID); err != nil {
 			recoveryErr = errors.Join(recoveryErr, fmt.Errorf("schedule created task %s: %w", task.ID, err))

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -264,6 +264,11 @@ func (s *IngestionTaskService) RequestStop(ctx context.Context, taskID string) (
 			rc.Set(ctx, fmt.Sprintf("%s-cancel", taskID), "x", 1*time.Hour)
 		}
 		return task, nil
+	case common.STOPPING:
+		// User requested stop again on an already-stopping task: finalize to STOPPED
+		// and clean up the cancel flag so the task does not remain stuck.
+		clearCancelFlag(ctx, taskID)
+		return s.transition(ctx, taskID, common.STOPPED)
 	default:
 		return task, nil
 	}
@@ -478,6 +483,16 @@ func (s *IngestionTaskService) markScheduledAfterPublish(ctx context.Context, ta
 // single startup recovery pass; a publish error leaves the task CREATED for a
 // future startup or explicit parse request to retry.
 func (s *IngestionTaskService) ScheduleCreatedTasks(ctx context.Context) error {
+	// Clean up orphaned STOPPING tasks on startup: since the previous worker process
+	// exited, no worker is running them. Finalize them as STOPPED.
+	stoppingTasks, err := s.ingestionTaskDAO.ListByStatus(ctx, dao.DB, common.STOPPING)
+	if err == nil {
+		for _, task := range stoppingTasks {
+			_ = s.MarkStopped(ctx, task.ID)
+			clearCancelFlag(ctx, task.ID)
+		}
+	}
+
 	tasks, err := s.ingestionTaskDAO.ListByStatus(ctx, dao.DB, common.CREATED)
 	if err != nil {
 		return err

--- a/internal/service/ingestion_task_service_test.go
+++ b/internal/service/ingestion_task_service_test.go
@@ -492,6 +492,50 @@ func TestIngestionTaskServiceRequestStopTransitionsCreatedTaskToStopped(t *testi
 	}
 }
 
+func TestIngestionTaskServiceRequestStopFinalizesStoppingTask(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertTestIngestionTask(t, "task-1", "user-1", "doc-1", "kb-1")
+	if err := db.Model(&entity.IngestionTask{}).Where("id = ?", "task-1").
+		Update("status", common.STOPPING).Error; err != nil {
+		t.Fatalf("set STOPPING: %v", err)
+	}
+	ctx := t.Context()
+
+	svc := NewIngestionTaskService()
+	task, err := svc.RequestStop(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("RequestStop failed: %v", err)
+	}
+	if task.Status != common.STOPPED {
+		t.Fatalf("status = %q, want %q", task.Status, common.STOPPED)
+	}
+}
+
+func TestScheduleCreatedTasksRecoversOrphanedStoppingTasks(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertTestIngestionTask(t, "task-stopping", "user-1", "doc-1", "kb-1")
+	if err := db.Model(&entity.IngestionTask{}).Where("id = ?", "task-stopping").
+		Update("status", common.STOPPING).Error; err != nil {
+		t.Fatalf("set STOPPING: %v", err)
+	}
+	ctx := t.Context()
+
+	svc := NewIngestionTaskService()
+	if err := svc.ScheduleCreatedTasks(ctx); err != nil {
+		t.Fatalf("ScheduleCreatedTasks failed: %v", err)
+	}
+
+	task, err := dao.NewIngestionTaskDAO().GetByID(ctx, db, "task-stopping")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.Status != common.STOPPED {
+		t.Fatalf("status = %q, want %q", task.Status, common.STOPPED)
+	}
+}
+
 func TestIngestionTaskServiceMarkCompletedRejectsNonRunningTask(t *testing.T) {
 	db := setupServiceTestDB(t)
 	pushServiceDB(t, db)

--- a/web/src/pages/dataset/dataset/parsing-status-cell.test.tsx
+++ b/web/src/pages/dataset/dataset/parsing-status-cell.test.tsx
@@ -65,7 +65,7 @@ describe('ParsingStatusCell', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not expose cancelling as a document status', () => {
+  it('shows spinner and cancel text when ingestion task is stopping', () => {
     const { container } = render(
       React.createElement(ParsingStatusCell, {
         record: {
@@ -105,7 +105,60 @@ describe('ParsingStatusCell', () => {
     expect(
       screen.queryByText('knowledgeDetails.runningStatusStopping'),
     ).not.toBeInTheDocument();
+    expect(screen.getByText('common.cancel...')).toBeInTheDocument();
+    expect(container.querySelector('svg.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector('section')).toHaveAttribute(
+      'data-state',
+      'stopping',
+    );
     expect(container.querySelector('svg.lucide-circle-x')).toBeInTheDocument();
     expect(container.querySelector('button[disabled]')).toBeInTheDocument();
+  });
+
+  it('shows queued state with clock icon when ingestion status is SCHEDULED or CREATED', () => {
+    const { container } = render(
+      React.createElement(ParsingStatusCell, {
+        record: {
+          id: 'doc-2',
+          dataset_id: 'dataset-1',
+          name: 'doc2.pdf',
+          type: 'document',
+          run: RunningStatus.RUNNING,
+          ingestion_status: IngestionTaskStatus.SCHEDULED,
+          progress: 0,
+          chunk_count: 0,
+          parser_config: {},
+          create_date: '',
+          create_time: 0,
+          created_by: 'user-1',
+          nickname: '',
+          location: '',
+          pipeline_id: '',
+          pipeline_name: '',
+          process_duration: 0,
+          progress_msg: '',
+          size: 0,
+          source_type: 'local',
+          status: '1',
+          suffix: 'pdf',
+          thumbnail: '',
+          token_num: 0,
+          update_date: '',
+          update_time: 0,
+          chunk_method: 'naive',
+        },
+        showLog: jest.fn(),
+        showChangeParserModal: jest.fn(),
+      }),
+    );
+
+    expect(
+      screen.getByText('knowledgeDetails.runningStatusQueued'),
+    ).toBeInTheDocument();
+    expect(container.querySelector('svg.lucide-clock-3')).toBeInTheDocument();
+    expect(container.querySelector('section')).toHaveAttribute(
+      'data-state',
+      'queued',
+    );
   });
 });

--- a/web/src/pages/dataset/dataset/parsing-status-cell.tsx
+++ b/web/src/pages/dataset/dataset/parsing-status-cell.tsx
@@ -14,7 +14,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { IDocumentInfo } from '@/interfaces/database/document';
-import { CircleQuestionMark, CircleX, Clock3 } from 'lucide-react';
+import { CircleQuestionMark, CircleX, Clock3, Loader2 } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DocumentType, IngestionTaskStatus, RunningStatus } from './constant';
@@ -144,7 +144,13 @@ export function ParsingStatusCell({
     <section
       className="flex gap-8 items-center"
       data-testid="document-parse-status"
-      data-state={isQueued ? 'queued' : (ParseStatusStateMap[run] ?? 'unknown')}
+      data-state={
+        isStopping
+          ? 'stopping'
+          : isQueued
+            ? 'queued'
+            : (ParseStatusStateMap[run] ?? 'unknown')
+      }
     >
       {showParse && (
         <div className="flex items-center gap-2">
@@ -152,7 +158,16 @@ export function ParsingStatusCell({
 
           {isRunning ? (
             <>
-              {isQueued ? (
+              {isStopping ? (
+                <Button
+                  size="auto"
+                  variant="static"
+                  onClick={() => handleShowLog(record)}
+                >
+                  <Loader2 className="size-[1em] animate-spin" />
+                  {t('common.cancel')}...
+                </Button>
+              ) : isQueued ? (
                 <Button
                   size="auto"
                   variant="static"


### PR DESCRIPTION
### Summary

Fixes two related issues in the Go ingestion pipeline and frontend:
1. **Premature `RUNNING` status and fake progress bars**: When ingestion tasks are pulled from MQ in `processMessage`, they were immediately transitioned to `RUNNING` (progress: 0%) before being enqueued into the worker channel buffer (`taskChan`). When worker width is limited (e.g. 2 workers), all buffered tasks appeared as active parsing tasks with 0% progress bars instead of queued status.
2. **Cancellation hanging at 0% for queued tasks**: If a user cancels a task waiting in the buffer, `RequestStop` transitioned it from `RUNNING` to `STOPPING`, waiting for an executing worker to finalize it. But because no worker was running it yet, it remained stuck in `STOPPING`. The frontend treats `STOPPING` as in-progress while disabling the cancel button, leaving the UI permanently frozen at 0%.

### Changes

- **Ingestion Service ([`internal/ingestion/service/ingestion_service.go`](file:///home/jay/Code/ragflow/internal/ingestion/service/ingestion_service.go))**:
  - In `processMessage`, use `GetTask` instead of `StartRunning`. Queued tasks retain their `SCHEDULED`/`CREATED` status while waiting in `taskChan`.
  - In `executeTask`, call `StartRunning` right when a worker goroutine dequeues and begins executing the task.
  - If a task in `taskChan` was cancelled while queued, `executeTask` detects the terminal/`STOPPED` status, immediately Acks the MQ message, and skips execution.
- **Task Service ([`internal/service/ingestion_task_service.go`](file:///home/jay/Code/ragflow/internal/service/ingestion_task_service.go))**:
  - In `RequestStop`, allow an already-`STOPPING` task to transition directly to `STOPPED` and clear the cancel flag.
  - In `ScheduleCreatedTasks`, clean up any orphaned `STOPPING` tasks on server startup.
- **Document Service ([`internal/service/document/document_parse.go`](file:///home/jay/Code/ragflow/internal/service/document/document_parse.go))**:
  - In `CancelDocParse`, explicitly reset `progress: 0` alongside `run: TaskStatusCancel`.
- **Frontend ([`web/src/pages/dataset/dataset/parsing-status-cell.tsx`](file:///home/jay/Code/ragflow/web/src/pages/dataset/dataset/parsing-status-cell.tsx))**:
  - When `isStopping` is true, render an animated spinner (`Loader2`) with `{t('common.cancel')}...` instead of a 0% progress bar, with `data-state="stopping"`.
  - Queued tasks continue to display the clock icon and "queued" text.
- **Tests**:
  - Updated existing ingestion service tests and added `TestExecuteTask_CancelledWhileQueuedAcksAndSkips` in [`internal/ingestion/service/process_message_test.go`](file:///home/jay/Code/ragflow/internal/ingestion/service/process_message_test.go).
  - Updated frontend [`web/src/pages/dataset/dataset/parsing-status-cell.test.tsx`](file:///home/jay/Code/ragflow/web/src/pages/dataset/dataset/parsing-status-cell.test.tsx) with assertions for stopping spinner and queued state.