### PR TITLE
fix(web): default Textarea resize to vertical

### DIFF
--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -21,7 +21,7 @@ interface TextareaProps extends Omit<
   resize?: 'none' | 'vertical' | 'horizontal' | 'both';
 }
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, autoSize, resize = 'none', ...props }, ref) => {
+  ({ className, autoSize, resize = 'vertical', ...props }, ref) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const manualHeightRef = useRef<number | null>(null);
     const isAdjustingRef = useRef(false);


### PR DESCRIPTION
### Summary

Change the shared Textarea default so users can grow it vertically unless a component explicitly opts out.
