### PR TITLE
Fix: restore GraphRAG/mindmap mapping for index type=graph/mindmap

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -53,9 +53,10 @@ _STRUCTURE_INDEX_TYPES = frozenset(_STRUCTURE_INDEX_TYPE_TO_KIND)
 _VALID_INDEX_TYPES = {"graph", "raptor", "mindmap", "wiki", "skill"} | set(_STRUCTURE_INDEX_TYPES)
 
 _INDEX_TYPE_TO_TASK_TYPE = {
-    "graph": "structure_graph",
+    # Public API: type=graph -> GraphRAG (not structure_graph merge).
+    "graph": "graphrag",
     "raptor": "raptor",
-    "mindmap": "structure_mindmap",
+    "mindmap": "mindmap",
     "wiki": "wiki",
     "skill": "skill",
     # Structure merge types carry their own task_type (== index_type) so the


### PR DESCRIPTION
## Summary
- Restore `_INDEX_TYPE_TO_TASK_TYPE` so public `type=graph` / `type=mindmap` map back to `graphrag` / `mindmap`.
- `#17342` accidentally remapped them to `structure_graph` / `structure_mindmap`, so GraphRAG finished instantly with `No doc_graph rows found` and never extracted entities.
- Keep `structure_graph` / `structure_mindmap` as separate merge entrypoints.

## Test plan
- [x] On a dataset with documents, `POST /api/v1/datasets/{id}/index?type=graph` creates a task with `task_type=graphrag` (not `structure_graph`).
- [ ] `POST .../index?type=mindmap` creates `task_type=mindmap`.
- [ ] `POST .../index?type=structure_graph` still queues the structure-merge task.
- [ ] Frontend knowledge-graph generation uses the same `type=graph` path and starts GraphRAG.