### PR TITLE
docs(api): use the memory update field names the route reads

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -5572,13 +5572,13 @@ Updates configurations for a specified memory.
 - Body:
   - `"name"`: `string`
   - `"avatar"`: `string`
-  - `"permission"`: `string`
+  - `"permissions"`: `string`
   - `"llm_id"`: `string`
   - `"description"`: `string`
   - `"memory_size"`: `int`
   - `"forgetting_policy"`: `string`
   - `"temperature"`: `float`
-  - `"system_promot"`: `string`
+  - `"system_prompt"`: `string`
   - `"user_prompt"`: `string`
 
 ##### Request example
@@ -5611,7 +5611,7 @@ curl --location --request PUT 'http://{address}/api/v1/memories/d6775d4eeada11f0
 
   - Maximum 65535 characters
 
-- `permission`: (*Body parameter*), `enum<string>`, *Optional*
+- `permissions`: (*Body parameter*), `enum<string>`, *Optional*
 
   The updated memory permission. Available options:
 

--- a/docs/references/python_api_reference.md
+++ b/docs/references/python_api_reference.md
@@ -2318,7 +2318,7 @@ Configurations to update. Available configurations:
 
   - Maximum 65535 characters
 
-- `permission`:  `enum<string>`, *Optional*
+- `permissions`:  `enum<string>`, *Optional*
 
   The updated memory permission. Available options:
 


### PR DESCRIPTION
### Summary

The Update Memory sections of both API references name two body fields that the route does not read.

`docs/references/http_api_reference.md:5575` and `:5581` list the request body:

```
  - `"permission"`: `string`
  - `"system_promot"`: `string`
```

and `:5614` repeats the first one in the parameter list:

```
- `permission`: (*Body parameter*), `enum<string>`, *Optional*
```

`docs/references/python_api_reference.md:2321` carries the same `permission` entry.

The route builds its update from a fixed key list. `api/apps/restful_apis/memory_api.py:88-107`:

```python
    new_settings = {
        k: req[k]
        for k in [
            "name",
            "permissions",
            ...
            "system_prompt",
            ...
        ]
        if k in req
    }
```

`permissions` is at `:92` and `system_prompt` is at `:101`. Neither `permission` nor `system_promot` is in that list.

So a request built from the reference does not update either field. `PUT /api/v1/memories/{memory_id}` with `{"permission": "team"}` leaves `new_settings` empty. `api/apps/services/memory_api_service.py:226-227` then returns early:

```python
    if not to_update:
        return True, memory_dict
```

The route turns that into `get_json_result(message=True, data=res)` at `memory_api.py:111`. The response is `code 0` and the memory is unchanged. Nothing tells the caller the field was ignored.

The rest of the project already agrees on `permissions`:

- `api/db/db_models.py:1822`, on `class Memory`: `permissions = CharField(max_length=16, null=False, index=True, help_text="me|team", default="me")`
- `api/apps/services/memory_api_service.py:164`: `if new_memory_setting.get("permissions"):`
- `internal/handler/memory.go:181`: `permissions (optional): Permission setting ["me", "team", "all"]`
- `web/src/pages/memory/memory-setting/advanced-settings-form.tsx:49`: `name: 'permissions'`
- `test/testcases/test_sdk_api/test_memory_management/test_update_memory.py:123`: `update_dict = {"permissions": permission}`

The HTTP reference also disagrees with itself on the second field. The body list at `:5581` says `system_promot`, while the parameter entry for that same field at `:5650` already says `system_prompt`.

This PR changes four lines, all in the Update Memory sections:

- `permission` to `permissions` at `http_api_reference.md:5575` and `:5614`, and at `python_api_reference.md:2321`
- `system_promot` to `system_prompt` at `http_api_reference.md:5581`

Four lines in two files, no code change.

The dataset sections keep `permission`, which is the right name there. The dataset column is `permission` at `api/db/db_models.py:1270` on `class Knowledgebase`, and the dataset docs match it at `http_api_reference.md:492`, `:549`, `:772` and `:807`. The memory Create sections name neither field, so they are untouched.

The lines came from #12499 (memory HTTP docs, merged 2026-01-08) and #12554 (Python SDK docs, merged 2026-01-12). The `permissions` column landed a month before either of them, in #11812 on 2025-12-10, so the column was already spelled `permissions` when both documents were written.
