### PR TITLE
fix(cli): pass search number as file limit

### DIFF
--- a/internal/cli/filesystem_command.go
+++ b/internal/cli/filesystem_command.go
@@ -165,6 +165,7 @@ func (c *CLI) executeFilesystemInner(input string) error {
 			Path: searchPath,
 			Params: map[string]interface{}{
 				"query":     searchOpts.Query,
+				"limit":     searchOpts.TopK,
 				"top_k":     searchOpts.TopK,
 				"threshold": searchOpts.Threshold,
 				"dirs":      searchOpts.Dirs,

--- a/internal/cli/filesystem_command_test.go
+++ b/internal/cli/filesystem_command_test.go
@@ -1,0 +1,69 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"ragflow/internal/cli/filesystem"
+)
+
+type recordingFileProvider struct {
+	searchOptions *filesystem.SearchOptions
+}
+
+func (p *recordingFileProvider) Name() string        { return "files" }
+func (p *recordingFileProvider) Description() string { return "test file provider" }
+func (p *recordingFileProvider) Supports(path string) bool {
+	return path == "files"
+}
+func (p *recordingFileProvider) List(context.Context, string, *filesystem.ListOptions) (*filesystem.Result, error) {
+	return &filesystem.Result{}, nil
+}
+func (p *recordingFileProvider) Search(_ context.Context, _ string, opts *filesystem.SearchOptions) (*filesystem.Result, error) {
+	p.searchOptions = opts
+	return &filesystem.Result{}, nil
+}
+func (p *recordingFileProvider) Cat(context.Context, string) ([]byte, error) {
+	return nil, nil
+}
+
+func TestSearchFilesPassesNumberAsLimit(t *testing.T) {
+	provider := &recordingFileProvider{}
+	engine := filesystem.NewEngine()
+	engine.RegisterProvider(provider)
+	cli := &CLI{
+		ContextEngine: engine,
+		Config: &CommandLineConfig{
+			OutputFormat: OutputFormatJSON,
+		},
+	}
+
+	if err := cli.executeFilesystemInner("search foo files -n 20"); err != nil {
+		t.Fatalf("executeFilesystemInner() error = %v", err)
+	}
+	if provider.searchOptions == nil {
+		t.Fatal("file provider Search() was not called")
+	}
+	if provider.searchOptions.Limit != 20 {
+		t.Errorf("SearchOptions.Limit = %d, want 20", provider.searchOptions.Limit)
+	}
+	if provider.searchOptions.TopK != 20 {
+		t.Errorf("SearchOptions.TopK = %d, want 20", provider.searchOptions.TopK)
+	}
+}


### PR DESCRIPTION
### Summary

The Go CLI parses `search foo files -n 20` into `SearchCommandOptions.TopK`, but only forwards the value as `top_k`. File search reads the independent `SearchOptions.Limit` field, so it receives zero and falls back to the default page size.

This change forwards the parsed number as both `limit` and `top_k`. File search can consume `Limit`, while semantic dataset search continues to consume `TopK`.

A focused regression test covers the full CLI command-to-provider parameter path.

Fixes #19284

### Testing

- `CGO_ENABLED=0 go test ./internal/cli -count=1`
- `git diff --check`
