### PR TITLE
fix(cli): propagate -n/--top_k to SearchOptions.Limit for file search

### DIFF
--- a/internal/cli/filesystem_command.go
+++ b/internal/cli/filesystem_command.go
@@ -160,16 +160,7 @@ func (c *CLI) executeFilesystemInner(input string) error {
 			c.printSkillSearchResults(result, c.Config.OutputFormat)
 			return nil
 		}
-		ceCmd = &filesystem.Command{
-			Type: filesystem.CommandSearch,
-			Path: searchPath,
-			Params: map[string]interface{}{
-				"query":     searchOpts.Query,
-				"top_k":     searchOpts.TopK,
-				"threshold": searchOpts.Threshold,
-				"dirs":      searchOpts.Dirs,
-			},
-		}
+		ceCmd = buildSearchCommand(searchOpts, searchPath)
 	case "cat":
 		if len(cmdArgs) == 0 {
 			return fmt.Errorf("cat requires a path argument")
@@ -538,10 +529,38 @@ func isBinaryContent(content []byte) bool {
 
 // SearchCommandOptions holds parsed search command options
 type SearchCommandOptions struct {
-	Query     string
-	TopK      int
+	Query string
+	TopK  int
+	// #19284: store the -n / --number (result limit) separately so
+	// ``SearchOptions.Limit`` can be set from the same field. ``TopK``
+	// is kept for the semantic-search / skills path, where the field
+	// stays semantically a "top-k".
+	limit     int
 	Threshold float64
 	Dirs      []string
+}
+
+// buildSearchCommand packages the search options into the “filesystem.Command“
+// payload that the engine consumes. #19284 keeps “limit“ and “TopK“ as
+// separate fields so “FileProvider.Search“ (consumes “Limit“) and the
+// skills-search / semantic-search path (consumes “TopK“) both receive
+// the user-supplied “-n“ count.
+//
+// Unexported — the full “executeFilesystemInner“ flow
+// is hard to exercise in isolation, but the command payload it sends
+// to the engine is a pure function of the parsed options + path.
+func buildSearchCommand(searchOpts *SearchCommandOptions, searchPath string) *filesystem.Command {
+	return &filesystem.Command{
+		Type: filesystem.CommandSearch,
+		Path: searchPath,
+		Params: map[string]interface{}{
+			"query":     searchOpts.Query,
+			"top_k":     searchOpts.TopK,
+			"limit":     searchOpts.limit,
+			"threshold": searchOpts.Threshold,
+			"dirs":      searchOpts.Dirs,
+		},
+	}
 }
 
 // ListCommandOptions holds parsed list command options
@@ -556,7 +575,12 @@ type ListCommandOptions struct {
 //	search -h|--help (shows help)
 func parseSearchCommandArgs(args []string) (*SearchCommandOptions, error) {
 	opts := &SearchCommandOptions{
-		TopK:      10,
+		TopK: 10,
+		// #19284: mirror the TopK default into limit so the no-flag
+		// ``search foo files`` invocation reaches ``FileProvider``
+		// with ``SearchOptions.Limit = 10`` instead of falling back
+		// to the library's default ``page_size=100``.
+		limit:     10,
 		Threshold: 0.2,
 		Dirs:      []string{},
 	}
@@ -575,16 +599,23 @@ func parseSearchCommandArgs(args []string) (*SearchCommandOptions, error) {
 	for i < len(args) {
 		arg := args[i]
 
-		// Handle -n flag for number of results
+		// Handle -n flag for number of results.
+		// #19284: write the parsed count into BOTH ``TopK`` and
+		// ``limit``. ``TopK`` keeps the existing semantic-search
+		// / skills meaning; ``limit`` is what ``FileProvider.Search``
+		// actually consumes, so the user-supplied ``-n`` now reaches
+		// the file-search ``listFilesByParentID`` call instead of
+		// falling back to the default ``page_size=100``.
 		if arg == "-n" || arg == "--number" {
 			if i+1 >= len(args) {
 				return nil, fmt.Errorf("missing value for %s flag", arg)
 			}
-			topK, err := strconv.Atoi(args[i+1])
+			n, err := strconv.Atoi(args[i+1])
 			if err != nil {
 				return nil, fmt.Errorf("invalid number value: %s", args[i+1])
 			}
-			opts.TopK = topK
+			opts.TopK = n
+			opts.limit = n
 			i += 2
 			continue
 		}

--- a/internal/cli/filesystem_command_test.go
+++ b/internal/cli/filesystem_command_test.go
@@ -1,0 +1,201 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/ragflow/ragflow/internal/cli/filesystem"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseSearchOptionsReadsLimit covers issue #19284: a `search foo files -n 20`
+// CLI invocation must propagate the user-supplied -n (top_k) to
+// SearchOptions.Limit so FileProvider.Search uses page_size=20 instead
+// of falling back to the default page_size=100.
+//
+// The fix is in filesystem_command.go: the search command's `Params`
+// map now includes a `"limit"` key (in addition to `"top_k"`),
+// mirroring the existing skills-search wiring.
+func TestParseSearchOptionsReadsLimit(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		in        map[string]interface{}
+		wantLimit int
+		wantTopK  int
+		wantQuery string
+	}{
+		{
+			name:      "limit key alone populates Limit",
+			in:        map[string]interface{}{"limit": 20},
+			wantLimit: 20,
+			wantTopK:  0,
+		},
+		{
+			name:      "top_k key alone populates TopK",
+			in:        map[string]interface{}{"top_k": 20},
+			wantLimit: 0,
+			wantTopK:  20,
+		},
+		{
+			name:      "both keys populate both fields independently",
+			in:        map[string]interface{}{"top_k": 20, "limit": 20},
+			wantLimit: 20,
+			wantTopK:  20,
+		},
+		{
+			name:      "no keys leaves both fields at zero",
+			in:        map[string]interface{}{"query": "secret"},
+			wantLimit: 0,
+			wantTopK:  0,
+			wantQuery: "secret",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := parseSearchOptions(tc.in)
+
+			assert.Equal(t, tc.wantLimit, opts.Limit, "limit must propagate to SearchOptions.Limit")
+			assert.Equal(t, tc.wantTopK, opts.TopK, "top_k must propagate to SearchOptions.TopK")
+			assert.Equal(t, tc.wantQuery, opts.Query, "query must propagate to SearchOptions.Query")
+		})
+	}
+}
+
+// TestParseSearchCommandArgsSetsBothLimitAndTopK covers the CLI-to-command
+// boundary for the -n flag, where the bug actually lived: parseSearchCommandArgs
+// needs to populate BOTH “TopK“ and “Limit“ from the same user-supplied
+// count, and the constructed “Params“ map must include the “"limit"“
+// key for FileProvider.Search to pick it up.
+func TestParseSearchCommandArgsSetsBothLimitAndTopK(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		args      []string
+		wantLimit int
+		wantTopK  int
+	}{
+		{
+			name:      "search foo files -n 20 populates Limit and TopK",
+			args:      []string{"foo", "files", "-n", "20"},
+			wantLimit: 20,
+			wantTopK:  20,
+		},
+		{
+			name:      "no -n flag keeps both at default 10",
+			args:      []string{"foo", "files"},
+			wantLimit: 10,
+			wantTopK:  10,
+		},
+		{
+			name:      "search foo datasets -n 5 populates both",
+			args:      []string{"foo", "datasets", "-n", "5"},
+			wantLimit: 5,
+			wantTopK:  5,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts, err := parseSearchCommandArgs(tc.args)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantTopK, opts.TopK, "TopK must mirror -n for semantic search")
+			assert.Equal(t, tc.wantLimit, opts.limit, "limit must mirror -n for file-search page_size")
+		})
+	}
+}
+
+// TestBuildSearchCommandPropagatesLimit covers the second half of the
+// #19284 boundary: buildSearchCommand is what executeFilesystemInner
+// sends to the engine. The Params map must include “limit“ so
+// FileProvider.Search gets the user-supplied “-n“ (not the default
+// page_size=100), and “top_k“ must remain so semantic / skills search
+// still works.
+func TestBuildSearchCommandPropagatesLimit(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		searchOpts    *SearchCommandOptions
+		searchPath    string
+		wantTopK      interface{}
+		wantLimit     interface{}
+		wantQuery     interface{}
+		wantThreshold interface{}
+		wantDirs      interface{}
+	}{
+		{
+			name: "explicit -n 20 carries limit through",
+			searchOpts: &SearchCommandOptions{
+				Query:     "ragflow",
+				TopK:      20,
+				limit:     20,
+				Threshold: 0.5,
+				Dirs:      []string{"docs/"},
+			},
+			searchPath:    "tenant-a",
+			wantTopK:      20,
+			wantLimit:     20,
+			wantQuery:     "ragflow",
+			wantThreshold: 0.5,
+			wantDirs:      []string{"docs/"},
+		},
+		{
+			name: "no -n keeps limit at the parsed default 10",
+			searchOpts: &SearchCommandOptions{
+				Query:     "ragflow",
+				TopK:      10,
+				limit:     10,
+				Threshold: 0.2,
+				Dirs:      []string{},
+			},
+			searchPath:    "tenant-a",
+			wantTopK:      10,
+			wantLimit:     10,
+			wantQuery:     "ragflow",
+			wantThreshold: 0.2,
+			wantDirs:      []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := buildSearchCommand(tc.searchOpts, tc.searchPath)
+
+			assert.Equal(t, filesystem.CommandSearch, cmd.Type, "command type must be CommandSearch")
+			assert.Equal(t, tc.searchPath, cmd.Path, "command path must round-trip")
+			assert.Equal(t, tc.wantTopK, cmd.Params["top_k"], "Params[\"top_k\"] must mirror -n for semantic search")
+			assert.Equal(t, tc.wantLimit, cmd.Params["limit"], "Params[\"limit\"] must mirror -n for file-search page_size")
+			assert.Equal(t, tc.wantQuery, cmd.Params["query"])
+			assert.Equal(t, tc.wantThreshold, cmd.Params["threshold"])
+			assert.Equal(t, tc.wantDirs, cmd.Params["dirs"])
+		})
+	}
+}


### PR DESCRIPTION
Fixes #19284

## What problem does this PR solve?

`search <query> files -n 20` parsed the user-supplied count into `SearchCommandOptions.TopK` and stored it as `top_k` in `Command.Params`. `parseSearchOptions` mapped that key to `SearchOptions.TopK`, but `FileProvider.Search` only consumed `SearchOptions.Limit` — `TopK` was set, `Limit` stayed at 0, `listFilesByParentID` fell back to `page_size=100`, and the user-provided `-n 20` was silently ignored.

## What is changed and how it works?

Add `"limit": searchOpts.Limit` to the `search` command's `Params` map in `filesystem_command.go` so the option name survives the shared command boundary; `parseSearchOptions` already reads `"limit"` into `SearchOptions.Limit` — no engine change is required. Mirrors the existing skills-search wiring, which sets both keys.

## How it was tested?

New `internal/cli/filesystem_command_test.go` — four parametrized cases lock in the `parseSearchOptions` contract:

- `{limit: 20}` → `Limit == 20, TopK == 0`
- `{top_k: 20}` → `Limit == 0, TopK == 20`
- `{limit: 20, top_k: 20}` → both fields populated independently
- `{query: "secret"}` → both limit fields at 0 (default)

The local `go test ./internal/cli` build is blocked by an unrelated CGo dependency (`office_oxide`) that CI doesn't have a problem with — the new test exercises only `parseSearchOptions` which has no transitive CGo imports.