### PR TITLE
fix(go): align dataset tag APIs with Python behavior

### DIFF
--- a/internal/handler/dataset.go
+++ b/internal/handler/dataset.go
@@ -40,6 +40,7 @@ type DatasetsHandler struct {
 	metadataService       *service.MetadataService
 	searchDatasetsService searchDatasetsService
 	searchDatasetService  searchDatasetService
+	datasetTagsService    datasetTagsService
 }
 
 type searchDatasetsService interface {
@@ -65,6 +66,7 @@ func NewDatasetsHandler(datasetsService *dataset.DatasetService, metadataService
 	if datasetsService != nil {
 		h.searchDatasetsService = datasetsService
 		h.searchDatasetService = datasetsService
+		h.datasetTagsService = datasetsService
 	}
 	return h
 }
@@ -735,81 +737,6 @@ func (h *DatasetsHandler) GetKnowledgeGraph(c *gin.Context) {
 	common.SuccessWithData(c, result, "success")
 }
 
-// ListTags handles GET /api/v1/datasets/:dataset_id/tags.
-// @Summary List dataset tags
-// @Description List tags for a dataset
-// @Tags datasets
-// @Produce json
-// @Security ApiKeyAuth
-// @Param dataset_id path string true "Dataset ID"
-// @Success 200 {object} map[string]interface{}
-// @Router /api/v1/datasets/{dataset_id}/tags [get]
-func (h *DatasetsHandler) ListTags(c *gin.Context) {
-	user, errorCode, errorMessage := GetUser(c)
-	if errorCode != common.CodeSuccess {
-		common.ErrorWithCode(c, errorCode, errorMessage)
-		return
-	}
-
-	ctx := c.Request.Context()
-
-	datasetID := strings.TrimSpace(c.Param("dataset_id"))
-	result, code, err := h.datasetsService.ListTags(ctx, datasetID, user.ID)
-	if err != nil {
-		common.ErrorWithCode(c, code, err.Error())
-		return
-	}
-
-	common.SuccessWithData(c, result, "success")
-}
-
-type renameTagRequest struct {
-	FromTag string `json:"from_tag"`
-	ToTag   string `json:"to_tag"`
-}
-
-func (h *DatasetsHandler) RenameTag(c *gin.Context) {
-	user, errorCode, errorMessage := GetUser(c)
-	if errorCode != common.CodeSuccess {
-		common.ErrorWithCode(c, errorCode, errorMessage)
-		return
-	}
-	datasetID := strings.TrimSpace(c.Param("dataset_id"))
-
-	var payload map[string]interface{}
-	if err := c.ShouldBindJSON(&payload); err != nil {
-		common.ResponseWithCodeData(c, common.CodeDataError, nil, "Lack of from_tag or to_tag in request body")
-		return
-	}
-	fromTagValue, hasFrom := payload["from_tag"]
-	toTagValue, hasTo := payload["to_tag"]
-	if !hasFrom || !hasTo {
-		common.ResponseWithCodeData(c, common.CodeDataError, nil, "Lack of from_tag or to_tag in request body")
-		return
-	}
-	fromTag, okFrom := fromTagValue.(string)
-	toTag, okTo := toTagValue.(string)
-	if !okFrom || !okTo {
-		common.ResponseWithCodeData(c, common.CodeArgumentError, nil, "from_tag and to_tag must be strings")
-		return
-	}
-	req := renameTagRequest{FromTag: fromTag, ToTag: toTag}
-	if strings.TrimSpace(req.FromTag) == "" || strings.TrimSpace(req.ToTag) == "" {
-		common.ResponseWithCodeData(c, common.CodeArgumentError, nil, "from_tag and to_tag must not be empty")
-		return
-	}
-
-	ctx := c.Request.Context()
-
-	result, code, err := h.datasetsService.RenameTag(ctx, datasetID, user.ID, req.FromTag, req.ToTag)
-	if err != nil {
-		common.ErrorWithCode(c, code, err.Error())
-		return
-	}
-
-	common.SuccessWithData(c, result, "success")
-}
-
 // DeleteKnowledgeGraph handles DELETE /api/v1/datasets/:dataset_id/graph.
 func (h *DatasetsHandler) DeleteKnowledgeGraph(c *gin.Context) {
 	user, errorCode, errorMessage := GetUser(c)
@@ -966,46 +893,6 @@ func (h *DatasetsHandler) CheckEmbedding(c *gin.Context) {
 		return
 	}
 	common.SuccessWithData(c, data, "success")
-}
-
-// AggregateTags handles GET /api/v1/datasets/tags/aggregation.
-// @Summary Aggregate dataset tags
-// @Description Aggregate tags across multiple datasets
-// @Tags datasets
-// @Produce json
-// @Security ApiKeyAuth
-// @Param dataset_ids query string true "Comma-separated dataset IDs"
-// @Success 200 {object} map[string]interface{}
-// @Router /api/v1/datasets/tags/aggregation [get]
-func (h *DatasetsHandler) AggregateTags(c *gin.Context) {
-	user, errorCode, errorMessage := GetUser(c)
-	if errorCode != common.CodeSuccess {
-		common.ErrorWithCode(c, errorCode, errorMessage)
-		return
-	}
-
-	rawIDs := strings.Split(c.Query("dataset_ids"), ",")
-	datasetIDs := make([]string, 0, len(rawIDs))
-
-	for _, rawID := range rawIDs {
-		tempID := strings.TrimSpace(rawID)
-		if tempID != "" {
-			datasetIDs = append(datasetIDs, tempID)
-		}
-	}
-	if len(datasetIDs) == 0 {
-		common.ResponseWithCodeData(c, common.CodeDataError, nil, "Lack of dataset_ids in query parameters")
-		return
-	}
-
-	ctx := c.Request.Context()
-
-	result, code, err := h.datasetsService.AggregateTags(ctx, datasetIDs, user.ID)
-	if err != nil {
-		common.ErrorWithCode(c, code, err.Error())
-		return
-	}
-	common.SuccessWithData(c, result, "success")
 }
 
 // GetCompilationStatus returns the dataset-level knowledge-compile lifecycle

--- a/internal/handler/dataset_aggregate_tags_test.go
+++ b/internal/handler/dataset_aggregate_tags_test.go
@@ -1,78 +1,89 @@
 package handler
 
 import (
-	"encoding/json"
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
 	"testing"
 
-	"github.com/gin-gonic/gin"
-
 	"ragflow/internal/common"
-	"ragflow/internal/entity"
 )
 
-func newAggregateTagsHandlerRouter(authenticated bool) *gin.Engine {
-	gin.SetMode(gin.TestMode)
-	h := &DatasetsHandler{}
-	r := gin.New()
-	r.GET("/api/v1/datasets/tags/aggregation", func(c *gin.Context) {
-		if authenticated {
-			c.Set("user", &entity.User{ID: "user-1"})
-		}
-		h.AggregateTags(c)
-	})
-	return r
+func TestDatasetsHandlerAggregateTags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data []map[string]interface{}
+	}{
+		{"tags", []map[string]interface{}{{"value": "alpha", "count": 2}}},
+		{"empty", []map[string]interface{}{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeDatasetTagsService{tags: tc.data}
+			r := newDatasetTagsRouter(fake, true)
+			rec := httptest.NewRecorder()
+			ids := "," + tagDatasetID + ",, " + tagDatasetID + " ,"
+			r.ServeHTTP(rec, datasetTagRequest(context.Background(), http.MethodGet,
+				"/api/v1/datasets/tags/aggregation?dataset_ids="+url.QueryEscape(ids), ""))
+			assertDatasetTagResponse(t, rec, map[string]interface{}{"code": common.CodeSuccess, "data": tc.data})
+			if fake.calls != 1 || fake.userID != "user-1" || !reflect.DeepEqual(fake.datasetIDs, []string{tagDatasetID, " " + tagDatasetID + " "}) {
+				t.Fatalf("service calls = %d, user = %q, dataset IDs = %v", fake.calls, fake.userID, fake.datasetIDs)
+			}
+		})
+	}
 }
 
 func TestDatasetsHandlerAggregateTagsRequiresDatasetIDs(t *testing.T) {
-	r := newAggregateTagsHandlerRouter(true)
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/tags/aggregation", nil)
-	r.ServeHTTP(resp, req)
-
-	if resp.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
-	}
-
-	var body struct {
-		Code    int         `json:"code"`
-		Data    interface{} `json:"data"`
-		Message string      `json:"message"`
-	}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
-	}
-	if body.Code != int(common.CodeDataError) {
-		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeDataError, resp.Body.String())
-	}
-	if body.Message != "Lack of dataset_ids in query parameters" {
-		t.Fatalf("message=%q want=%q", body.Message, "Lack of dataset_ids in query parameters")
-	}
-	if body.Data != nil {
-		t.Fatalf("data=%v want nil", body.Data)
+	for _, query := range []string{"", "?dataset_ids=,,,"} {
+		t.Run(query, func(t *testing.T) {
+			fake := &fakeDatasetTagsService{}
+			r := newDatasetTagsRouter(fake, true)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, datasetTagRequest(context.Background(), http.MethodGet,
+				"/api/v1/datasets/tags/aggregation"+query, ""))
+			assertDatasetTagResponse(t, rec, map[string]interface{}{
+				"code": common.CodeDataError, "message": "Lack of dataset_ids in query parameters",
+			})
+			if fake.calls != 0 {
+				t.Fatalf("invalid request called service %d times", fake.calls)
+			}
+		})
 	}
 }
 
-func TestDatasetsHandlerAggregateTagsRequiresAuth(t *testing.T) {
-	r := newAggregateTagsHandlerRouter(false)
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/tags/aggregation?dataset_ids=123e4567-e89b-12d3-a456-426614174000", nil)
-	r.ServeHTTP(resp, req)
-
-	var body struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
-	}
-	if body.Code != int(common.CodeUnauthorized) {
-		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeUnauthorized, resp.Body.String())
-	}
-	if body.Message != "User not found" {
-		t.Fatalf("message=%q want=%q", body.Message, "User not found")
+func TestDatasetsHandlerAggregateTagsIDLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		count int
+	}{
+		{"maximum accepted", 100},
+		{"maximum exceeded", 101},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ids := make([]string, tc.count)
+			for i := range ids {
+				ids[i] = tagDatasetID
+			}
+			fake := &fakeDatasetTagsService{tags: []map[string]interface{}{}}
+			r := newDatasetTagsRouter(fake, true)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, datasetTagRequest(context.Background(), http.MethodGet,
+				"/api/v1/datasets/tags/aggregation?dataset_ids="+strings.Join(ids, ","), ""))
+			if tc.count == 100 {
+				assertDatasetTagResponse(t, rec, map[string]interface{}{"code": common.CodeSuccess, "data": fake.tags})
+				if fake.calls != 1 || !reflect.DeepEqual(fake.datasetIDs, ids) {
+					t.Fatalf("service calls = %d, dataset IDs = %v", fake.calls, fake.datasetIDs)
+				}
+			} else {
+				assertDatasetTagResponse(t, rec, map[string]interface{}{
+					"code": common.CodeArgumentError, "message": "dataset_ids must contain at most 100 IDs",
+				})
+				if fake.calls != 0 {
+					t.Fatalf("oversized request called service %d times", fake.calls)
+				}
+			}
+		})
 	}
 }

--- a/internal/handler/dataset_list_tags_test.go
+++ b/internal/handler/dataset_list_tags_test.go
@@ -1,39 +1,32 @@
 package handler
 
 import (
-	"encoding/json"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
-
 	"ragflow/internal/common"
 )
 
-func TestDatasetsHandlerListTagsRequiresAuth(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	h := &DatasetsHandler{}
-	r := gin.New()
-	r.GET("/api/v1/datasets/:dataset_id/tags", func(c *gin.Context) {
-		h.ListTags(c)
-	})
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/123e4567-e89b-12d3-a456-426614174000/tags", nil)
-	r.ServeHTTP(resp, req)
-
-	var body struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
-	}
-	if body.Code != int(common.CodeUnauthorized) {
-		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeUnauthorized, resp.Body.String())
-	}
-	if body.Message != "User not found" {
-		t.Fatalf("message=%q want=%q", body.Message, "User not found")
+func TestDatasetsHandlerListTags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data [][2]interface{}
+	}{
+		{"pairs", [][2]interface{}{{"beta", 5}, {"alpha", 2}}},
+		{"empty", [][2]interface{}{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeDatasetTagsService{pairs: tc.data}
+			r := newDatasetTagsRouter(fake, true)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, datasetTagRequest(context.Background(), http.MethodGet,
+				"/api/v1/datasets/"+tagDatasetID+"/tags", ""))
+			assertDatasetTagResponse(t, rec, map[string]interface{}{"code": common.CodeSuccess, "data": tc.data})
+			if fake.calls != 1 || fake.datasetID != tagDatasetID || fake.userID != "user-1" {
+				t.Fatalf("service calls = %d, dataset = %q, user = %q", fake.calls, fake.datasetID, fake.userID)
+			}
+		})
 	}
 }

--- a/internal/handler/dataset_rename_tag_test.go
+++ b/internal/handler/dataset_rename_tag_test.go
@@ -1,126 +1,54 @@
 package handler
 
 import (
-	"bytes"
-	"encoding/json"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
-
 	"ragflow/internal/common"
-	"ragflow/internal/entity"
 )
 
-func TestDatasetsHandlerRenameTagRequiresAuth(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	h := &DatasetsHandler{}
-	r := gin.New()
-	r.PUT("/api/v1/datasets/:dataset_id/tags", func(c *gin.Context) {
-		h.RenameTag(c)
-	})
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/datasets/123e4567-e89b-12d3-a456-426614174000/tags", bytes.NewBufferString(`{"from_tag":"a","to_tag":"b"}`))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(resp, req)
-
-	var body struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
-	}
-	if body.Code != int(common.CodeUnauthorized) {
-		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeUnauthorized, resp.Body.String())
-	}
-	if body.Message != "User not found" {
-		t.Fatalf("message=%q want=%q", body.Message, "User not found")
-	}
-}
-
-func TestDatasetsHandlerRenameTagRejectsMissingFields(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	h := &DatasetsHandler{}
-	r := gin.New()
-	r.PUT("/api/v1/datasets/:dataset_id/tags", func(c *gin.Context) {
-		c.Set("user", &entity.User{ID: "user-1"})
-		h.RenameTag(c)
-	})
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/datasets/123e4567-e89b-12d3-a456-426614174000/tags", bytes.NewBufferString(`{"from_tag":"a"}`))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(resp, req)
-
-	var body struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
-	}
-	if body.Code != int(common.CodeDataError) {
-		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeDataError, resp.Body.String())
+func TestDatasetsHandlerRenameTagValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name, payload string
+		code          common.ErrorCode
+		message       string
+	}{
+		{"missing body", "", common.CodeDataError, "Lack of from_tag or to_tag in request body"},
+		{"malformed JSON", `{"from_tag":`, common.CodeDataError, "Lack of from_tag or to_tag in request body"},
+		{"null body", `null`, common.CodeDataError, "Lack of from_tag or to_tag in request body"},
+		{"array body", `[]`, common.CodeDataError, "Lack of from_tag or to_tag in request body"},
+		{"missing from", `{"to_tag":"new"}`, common.CodeDataError, "Lack of from_tag or to_tag in request body"},
+		{"missing to", `{"from_tag":"old"}`, common.CodeDataError, "Lack of from_tag or to_tag in request body"},
+		{"numeric from", `{"from_tag":1,"to_tag":"new"}`, common.CodeArgumentError, "from_tag and to_tag must be strings"},
+		{"null to", `{"from_tag":"old","to_tag":null}`, common.CodeArgumentError, "from_tag and to_tag must be strings"},
+		{"empty from", `{"from_tag":"","to_tag":"new"}`, common.CodeArgumentError, "from_tag and to_tag must not be empty"},
+		{"whitespace to", `{"from_tag":"old","to_tag":" \t "}`, common.CodeArgumentError, "from_tag and to_tag must not be empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeDatasetTagsService{}
+			r := newDatasetTagsRouter(fake, true)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, datasetTagRequest(context.Background(), http.MethodPut,
+				"/api/v1/datasets/"+tagDatasetID+"/tags", tc.payload))
+			assertDatasetTagResponse(t, rec, map[string]interface{}{"code": tc.code, "message": tc.message})
+			if fake.calls != 0 {
+				t.Fatalf("invalid request called service %d times", fake.calls)
+			}
+		})
 	}
 }
 
-func TestDatasetsHandlerRenameTagRejectsEmptyFields(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	h := &DatasetsHandler{}
-	r := gin.New()
-	r.PUT("/api/v1/datasets/:dataset_id/tags", func(c *gin.Context) {
-		c.Set("user", &entity.User{ID: "user-1"})
-		h.RenameTag(c)
-	})
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/datasets/123e4567-e89b-12d3-a456-426614174000/tags", bytes.NewBufferString(`{"from_tag":" ","to_tag":"x"}`))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(resp, req)
-
-	var body struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
-	}
-	if body.Code != int(common.CodeArgumentError) {
-		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeArgumentError, resp.Body.String())
-	}
-	if body.Message != "from_tag and to_tag must not be empty" {
-		t.Fatalf("message=%q want=%q", body.Message, "from_tag and to_tag must not be empty")
-	}
-}
-
-func TestDatasetsHandlerRenameTagRejectsNonStringFields(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	h := &DatasetsHandler{}
-	r := gin.New()
-	r.PUT("/api/v1/datasets/:dataset_id/tags", func(c *gin.Context) {
-		c.Set("user", &entity.User{ID: "user-1"})
-		h.RenameTag(c)
-	})
-
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/datasets/123e4567-e89b-12d3-a456-426614174000/tags", bytes.NewBufferString(`{"from_tag":1,"to_tag":"x"}`))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(resp, req)
-
-	var body struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v body=%s", err, resp.Body.String())
-	}
-	if body.Code != int(common.CodeArgumentError) {
-		t.Fatalf("code=%d want=%d body=%s", body.Code, common.CodeArgumentError, resp.Body.String())
-	}
-	if body.Message != "from_tag and to_tag must be strings" {
-		t.Fatalf("message=%q want=%q", body.Message, "from_tag and to_tag must be strings")
+func TestDatasetsHandlerRenameTagPreservesWhitespace(t *testing.T) {
+	expected := map[string]interface{}{"from": " old ", "to": " new "}
+	fake := &fakeDatasetTagsService{rename: expected}
+	r := newDatasetTagsRouter(fake, true)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, datasetTagRequest(context.Background(), http.MethodPut,
+		"/api/v1/datasets/"+tagDatasetID+"/tags", `{"from_tag":" old ","to_tag":" new "}`))
+	assertDatasetTagResponse(t, rec, map[string]interface{}{"code": common.CodeSuccess, "data": expected})
+	if fake.calls != 1 || fake.datasetID != tagDatasetID || fake.userID != "user-1" || fake.fromTag != " old " || fake.toTag != " new " {
+		t.Fatalf("unexpected service arguments: %#v", fake)
 	}
 }

--- a/internal/handler/dataset_tags.go
+++ b/internal/handler/dataset_tags.go
@@ -1,0 +1,138 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"ragflow/internal/common"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+type datasetTagsService interface {
+	AggregateTags(ctx context.Context, datasetIDs []string, userID string) ([]map[string]interface{}, common.ErrorCode, error)
+	ListTags(ctx context.Context, datasetID, userID string) ([][2]interface{}, common.ErrorCode, error)
+	RenameTag(ctx context.Context, datasetID, userID, fromTag, toTag string) (map[string]interface{}, common.ErrorCode, error)
+}
+
+// ListTags handles GET /api/v1/datasets/:dataset_id/tags.
+// @Summary List dataset tags
+// @Description List tags for a dataset
+// @Tags datasets
+// @Produce json
+// @Security ApiKeyAuth
+// @Param dataset_id path string true "Dataset ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/datasets/{dataset_id}/tags [get]
+func (h *DatasetsHandler) ListTags(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		common.ErrorWithCode(c, errorCode, errorMessage)
+		return
+	}
+
+	datasetID := strings.TrimSpace(c.Param("dataset_id"))
+	result, code, err := h.datasetTagsService.ListTags(c.Request.Context(), datasetID, user.ID)
+	if err != nil {
+		datasetTagsError(c, code, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": result})
+}
+
+func (h *DatasetsHandler) RenameTag(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		common.ErrorWithCode(c, errorCode, errorMessage)
+		return
+	}
+
+	var payload map[string]interface{}
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		common.ErrorWithCode(c, common.CodeDataError, "Lack of from_tag or to_tag in request body")
+		return
+	}
+	fromValue, hasFrom := payload["from_tag"]
+	toValue, hasTo := payload["to_tag"]
+	if !hasFrom || !hasTo {
+		common.ErrorWithCode(c, common.CodeDataError, "Lack of from_tag or to_tag in request body")
+		return
+	}
+	fromTag, okFrom := fromValue.(string)
+	toTag, okTo := toValue.(string)
+	if !okFrom || !okTo {
+		common.ErrorWithCode(c, common.CodeArgumentError, "from_tag and to_tag must be strings")
+		return
+	}
+	if strings.TrimSpace(fromTag) == "" || strings.TrimSpace(toTag) == "" {
+		common.ErrorWithCode(c, common.CodeArgumentError, "from_tag and to_tag must not be empty")
+		return
+	}
+
+	datasetID := strings.TrimSpace(c.Param("dataset_id"))
+	result, code, err := h.datasetTagsService.RenameTag(c.Request.Context(), datasetID, user.ID, fromTag, toTag)
+	if err != nil {
+		datasetTagsError(c, code, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": result})
+}
+
+// AggregateTags handles GET /api/v1/datasets/tags/aggregation.
+// @Summary Aggregate dataset tags
+// @Description Aggregate tags across multiple datasets
+// @Tags datasets
+// @Produce json
+// @Security ApiKeyAuth
+// @Param dataset_ids query string true "Comma-separated dataset IDs"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/datasets/tags/aggregation [get]
+func (h *DatasetsHandler) AggregateTags(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		common.ErrorWithCode(c, errorCode, errorMessage)
+		return
+	}
+
+	rawIDs := strings.Split(c.Query("dataset_ids"), ",")
+	datasetIDs := make([]string, 0, len(rawIDs))
+	for _, rawID := range rawIDs {
+		if rawID != "" {
+			datasetIDs = append(datasetIDs, rawID)
+		}
+	}
+	if len(datasetIDs) == 0 {
+		common.ErrorWithCode(c, common.CodeDataError, "Lack of dataset_ids in query parameters")
+		return
+	}
+	if len(datasetIDs) > 100 {
+		common.ErrorWithCode(c, common.CodeArgumentError, "dataset_ids must contain at most 100 IDs")
+		return
+	}
+
+	result, code, err := h.datasetTagsService.AggregateTags(c.Request.Context(), datasetIDs, user.ID)
+	if err != nil {
+		datasetTagsError(c, code, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"code": common.CodeSuccess, "data": result})
+}
+
+func datasetTagsError(c *gin.Context, code common.ErrorCode, err error) {
+	message := err.Error()
+	if code == common.CodeServerError {
+		common.Warn("dataset tags request failed",
+			zap.Error(err),
+			zap.String("method", c.Request.Method),
+			zap.String("path", c.Request.URL.Path),
+		)
+		code = common.CodeDataError
+		message = "Internal server error"
+	}
+	common.ErrorWithCode(c, code, message)
+}

--- a/internal/handler/dataset_tags_test.go
+++ b/internal/handler/dataset_tags_test.go
@@ -1,0 +1,172 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"ragflow/internal/common"
+	"ragflow/internal/entity"
+
+	"github.com/gin-gonic/gin"
+)
+
+const tagDatasetID = "123e4567-e89b-12d3-a456-426614174000"
+
+type fakeDatasetTagsService struct {
+	ctx        context.Context
+	calls      int
+	datasetID  string
+	datasetIDs []string
+	userID     string
+	fromTag    string
+	toTag      string
+	pairs      [][2]interface{}
+	tags       []map[string]interface{}
+	rename     map[string]interface{}
+	code       common.ErrorCode
+	err        error
+}
+
+func (f *fakeDatasetTagsService) ListTags(ctx context.Context, datasetID, userID string) ([][2]interface{}, common.ErrorCode, error) {
+	f.ctx, f.datasetID, f.userID = ctx, datasetID, userID
+	f.calls++
+	return f.pairs, f.code, f.err
+}
+
+func (f *fakeDatasetTagsService) AggregateTags(ctx context.Context, datasetIDs []string, userID string) ([]map[string]interface{}, common.ErrorCode, error) {
+	f.ctx, f.datasetIDs, f.userID = ctx, datasetIDs, userID
+	f.calls++
+	return f.tags, f.code, f.err
+}
+
+func (f *fakeDatasetTagsService) RenameTag(ctx context.Context, datasetID, userID, fromTag, toTag string) (map[string]interface{}, common.ErrorCode, error) {
+	f.ctx, f.datasetID, f.userID = ctx, datasetID, userID
+	f.fromTag, f.toTag = fromTag, toTag
+	f.calls++
+	return f.rename, f.code, f.err
+}
+
+func newDatasetTagsRouter(fake datasetTagsService, authenticated bool) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewDatasetsHandler(nil, nil)
+	h.datasetTagsService = fake
+	r := gin.New()
+	if authenticated {
+		r.Use(func(c *gin.Context) {
+			c.Set("user", &entity.User{ID: "user-1"})
+		})
+	}
+	r.GET("/api/v1/datasets/:dataset_id/tags", h.ListTags)
+	r.PUT("/api/v1/datasets/:dataset_id/tags", h.RenameTag)
+	r.GET("/api/v1/datasets/tags/aggregation", h.AggregateTags)
+	return r
+}
+
+func datasetTagRequest(ctx context.Context, method, target, payload string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(payload)).WithContext(ctx)
+	if payload != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req
+}
+
+func assertDatasetTagResponse(t *testing.T, rec *httptest.ResponseRecorder, expected map[string]interface{}) {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HTTP status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v, body = %s", err, rec.Body.String())
+	}
+	wantJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("encode expected response: %v", err)
+	}
+	var want interface{}
+	if err := json.Unmarshal(wantJSON, &want); err != nil {
+		t.Fatalf("decode expected response: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("response = %s, want %s", rec.Body.String(), wantJSON)
+	}
+}
+
+func datasetTagEndpoints() []struct{ name, method, target, payload string } {
+	return []struct{ name, method, target, payload string }{
+		{"list", http.MethodGet, "/api/v1/datasets/" + tagDatasetID + "/tags", ""},
+		{"aggregate", http.MethodGet, "/api/v1/datasets/tags/aggregation?dataset_ids=" + tagDatasetID, ""},
+		{"rename", http.MethodPut, "/api/v1/datasets/" + tagDatasetID + "/tags", `{"from_tag":"old","to_tag":"new"}`},
+	}
+}
+
+func TestDatasetsHandlerTagsRequiresAuth(t *testing.T) {
+	for _, endpoint := range datasetTagEndpoints() {
+		t.Run(endpoint.name, func(t *testing.T) {
+			fake := &fakeDatasetTagsService{}
+			r := newDatasetTagsRouter(fake, false)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, datasetTagRequest(context.Background(), endpoint.method, endpoint.target, endpoint.payload))
+			assertDatasetTagResponse(t, rec, map[string]interface{}{
+				"code": common.CodeUnauthorized, "message": "User not found",
+			})
+			if fake.calls != 0 {
+				t.Fatalf("unauthenticated request called service %d times", fake.calls)
+			}
+		})
+	}
+}
+
+func TestDatasetsHandlerTagsServiceErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		code    common.ErrorCode
+		err     error
+		want    common.ErrorCode
+		message string
+	}{
+		{"unauthorized dataset", common.CodeDataError, errors.New("no authorization"), common.CodeDataError, "no authorization"},
+		{"invalid dataset", common.CodeDataError, errors.New("invalid Dataset ID"), common.CodeDataError, "invalid Dataset ID"},
+		{"invalid argument", common.CodeArgumentError, errors.New("invalid tag"), common.CodeArgumentError, "invalid tag"},
+		{"store failure", common.CodeServerError, errors.New("private database connection details"), common.CodeDataError, "Internal server error"},
+	}
+	for _, endpoint := range datasetTagEndpoints() {
+		for _, tc := range cases {
+			t.Run(endpoint.name+"/"+tc.name, func(t *testing.T) {
+				fake := &fakeDatasetTagsService{code: tc.code, err: tc.err}
+				r := newDatasetTagsRouter(fake, true)
+				rec := httptest.NewRecorder()
+				r.ServeHTTP(rec, datasetTagRequest(context.Background(), endpoint.method, endpoint.target, endpoint.payload))
+				assertDatasetTagResponse(t, rec, map[string]interface{}{"code": tc.want, "message": tc.message})
+				if fake.calls != 1 || fake.userID != "user-1" {
+					t.Fatalf("service calls = %d, user = %q", fake.calls, fake.userID)
+				}
+			})
+		}
+	}
+}
+
+func TestDatasetsHandlerTagsForwardsCanceledContext(t *testing.T) {
+	for _, endpoint := range datasetTagEndpoints() {
+		t.Run(endpoint.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			fake := &fakeDatasetTagsService{code: common.CodeServerError, err: context.Canceled}
+			r := newDatasetTagsRouter(fake, true)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, datasetTagRequest(ctx, endpoint.method, endpoint.target, endpoint.payload))
+			assertDatasetTagResponse(t, rec, map[string]interface{}{
+				"code": common.CodeDataError, "message": "Internal server error",
+			})
+			if fake.calls != 1 || fake.ctx != ctx || !errors.Is(fake.ctx.Err(), context.Canceled) {
+				t.Fatalf("request context was not forwarded: calls = %d, ctx = %v", fake.calls, fake.ctx)
+			}
+		})
+	}
+}

--- a/internal/service/dataset/tags.go
+++ b/internal/service/dataset/tags.go
@@ -23,9 +23,10 @@ func (d *DatasetService) AggregateTags(ctx context.Context, datasetIDs []string,
 
 	datasetIDsByTenant := make(map[string][]string)
 	for _, rawID := range datasetIDs {
+		inputID := rawID
 		rawID = strings.TrimSpace(rawID)
 		if rawID == "" {
-			continue
+			return nil, common.CodeDataError, fmt.Errorf("No authorization for dataset '%s'", inputID)
 		}
 		datasetID, err := normalizeDatasetID(rawID)
 		if err != nil {

--- a/internal/service/dataset/tags.go
+++ b/internal/service/dataset/tags.go
@@ -41,18 +41,29 @@ func (d *DatasetService) AggregateTags(ctx context.Context, datasetIDs []string,
 			}
 			return nil, common.CodeServerError, errors.New("Database operation failed")
 		}
-		if kb.DocNum <= 0 {
-			continue
-		}
 		datasetIDsByTenant[kb.TenantID] = append(datasetIDsByTenant[kb.TenantID], datasetID)
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	const pageSize = 10000
 	merged := make(map[string]int)
 	for tenantID, kbIDs := range datasetIDsByTenant {
+		indexName := fmt.Sprintf("ragflow_%s", tenantID)
+		// Python retriever.all_tags checks the first dataset's store before querying the group.
+		exists, err := d.docEngine.ChunkStoreExists(ctx, indexName, kbIDs[0])
+		if err != nil {
+			return nil, common.CodeServerError, fmt.Errorf("failed to inspect chunk store: %w", err)
+		}
+		if !exists {
+			continue
+		}
 		for offset := 0; ; offset += pageSize {
+			if err := ctx.Err(); err != nil {
+				return nil, common.CodeServerError, err
+			}
 			searchResp, err := d.docEngine.Search(ctx, &enginetypes.SearchRequest{
-				IndexNames:   []string{fmt.Sprintf("ragflow_%s", tenantID)},
+				IndexNames:   []string{indexName},
 				KbIDs:        kbIDs,
 				Offset:       offset,
 				Limit:        pageSize,
@@ -60,6 +71,9 @@ func (d *DatasetService) AggregateTags(ctx context.Context, datasetIDs []string,
 			})
 			if err != nil {
 				return nil, common.CodeServerError, fmt.Errorf("failed to aggregate tags: %w", err)
+			}
+			if searchResp == nil {
+				return nil, common.CodeServerError, errors.New("document engine returned no search result")
 			}
 			for _, agg := range d.docEngine.GetAggregation(searchResp.Chunks, "tag_kwd") {
 				tag, _ := agg["key"].(string)
@@ -96,7 +110,7 @@ func (d *DatasetService) AggregateTags(ctx context.Context, datasetIDs []string,
 	return result, common.CodeSuccess, nil
 }
 
-func (d *DatasetService) ListTags(ctx context.Context, datasetID, userID string) ([]map[string]interface{}, common.ErrorCode, error) {
+func (d *DatasetService) ListTags(ctx context.Context, datasetID, userID string) ([][2]interface{}, common.ErrorCode, error) {
 	datasetID = strings.TrimSpace(datasetID)
 	if datasetID == "" {
 		return nil, common.CodeDataError, errors.New("lack of \"Dataset ID\"")
@@ -113,7 +127,10 @@ func (d *DatasetService) ListTags(ctx context.Context, datasetID, userID string)
 		return nil, common.CodeServerError, errors.New("document engine is not initialized")
 	}
 	kb, err := d.kbDAO.GetByID(ctx, dao.DB, datasetID)
-	if err != nil || kb == nil {
+	if err != nil && !dao.IsNotFoundErr(err) {
+		return nil, common.CodeServerError, fmt.Errorf("failed to load dataset: %w", err)
+	}
+	if kb == nil || err != nil {
 		return nil, common.CodeDataError, errors.New("invalid Dataset ID")
 	}
 	indexName := fmt.Sprintf("ragflow_%s", kb.TenantID)
@@ -124,7 +141,7 @@ func (d *DatasetService) ListTags(ctx context.Context, datasetID, userID string)
 		return nil, common.CodeServerError, fmt.Errorf("failed to inspect chunk store: %w", err)
 	}
 	if !exists {
-		return []map[string]interface{}{}, common.CodeSuccess, nil
+		return [][2]interface{}{}, common.CodeSuccess, nil
 	}
 	const pageSize = 10000
 	counts := make(map[string]int)
@@ -141,6 +158,9 @@ func (d *DatasetService) ListTags(ctx context.Context, datasetID, userID string)
 		})
 		if err != nil {
 			return nil, common.CodeServerError, fmt.Errorf("failed to list tags: %w", err)
+		}
+		if searchResp == nil {
+			return nil, common.CodeServerError, errors.New("document engine returned no search result")
 		}
 		for _, agg := range d.docEngine.GetAggregation(searchResp.Chunks, "tag_kwd") {
 			tag, _ := agg["key"].(string)
@@ -167,7 +187,7 @@ func (d *DatasetService) ListTags(ctx context.Context, datasetID, userID string)
 		}
 	}
 	if len(counts) == 0 {
-		return []map[string]interface{}{}, common.CodeSuccess, nil
+		return [][2]interface{}{}, common.CodeSuccess, nil
 	}
 	tags := make([]string, 0, len(counts))
 	for tag := range counts {
@@ -179,19 +199,14 @@ func (d *DatasetService) ListTags(ctx context.Context, datasetID, userID string)
 		}
 		return tags[i] < tags[j]
 	})
-	result := make([]map[string]interface{}, 0, len(tags))
+	result := make([][2]interface{}, 0, len(tags))
 	for _, tag := range tags {
-		result = append(result, map[string]interface{}{
-			"key":   tag,
-			"count": counts[tag],
-		})
+		result = append(result, [2]interface{}{tag, counts[tag]})
 	}
 	return result, common.CodeSuccess, nil
 }
 
 func (d *DatasetService) RenameTag(ctx context.Context, datasetID, userID, fromTag, toTag string) (map[string]interface{}, common.ErrorCode, error) {
-	fromTag = strings.TrimSpace(fromTag)
-	toTag = strings.TrimSpace(toTag)
 	datasetID, err := normalizeDatasetID(datasetID)
 	if err != nil {
 		return nil, common.CodeDataError, err
@@ -206,7 +221,10 @@ func (d *DatasetService) RenameTag(ctx context.Context, datasetID, userID, fromT
 		return nil, common.CodeServerError, errors.New("document engine is not initialized")
 	}
 	kb, err := d.kbDAO.GetByID(ctx, dao.DB, datasetID)
-	if err != nil || kb == nil {
+	if err != nil && !dao.IsNotFoundErr(err) {
+		return nil, common.CodeServerError, fmt.Errorf("failed to load dataset: %w", err)
+	}
+	if kb == nil || err != nil {
 		return nil, common.CodeDataError, errors.New("invalid Dataset ID")
 	}
 	indexName := fmt.Sprintf("ragflow_%s", kb.TenantID)
@@ -216,7 +234,7 @@ func (d *DatasetService) RenameTag(ctx context.Context, datasetID, userID, fromT
 	}
 	newValue := map[string]interface{}{
 		"remove": map[string]interface{}{
-			"tag_kwd": fromTag,
+			"tag_kwd": strings.TrimSpace(fromTag),
 		},
 		"add": map[string]interface{}{
 			"tag_kwd": toTag,

--- a/internal/service/dataset/tags_aggregate_test.go
+++ b/internal/service/dataset/tags_aggregate_test.go
@@ -19,6 +19,12 @@ type aggregateTagsMockEngine struct {
 	pagedSearchResults map[string]map[int]*types.SearchResult
 	searchErr          error
 	requests           []*types.SearchRequest
+	missingStores      map[string]bool
+	chunkStoreErr      error
+}
+
+func (m *aggregateTagsMockEngine) ChunkStoreExists(ctx context.Context, baseName, datasetID string) (bool, error) {
+	return !m.missingStores[datasetID], m.chunkStoreErr
 }
 
 func (m *aggregateTagsMockEngine) Search(ctx context.Context, req *types.SearchRequest) (*types.SearchResult, error) {
@@ -317,7 +323,7 @@ func TestDatasetServiceAggregateTagsRequiresDocumentEngine(t *testing.T) {
 	}
 }
 
-func TestDatasetServiceAggregateTagsSkipsDatasetsWithoutDocuments(t *testing.T) {
+func TestDatasetServiceAggregateTagsIncludesZeroDocumentCount(t *testing.T) {
 	db := setupServiceTestDB(t)
 	pushServiceDB(t, db)
 
@@ -350,8 +356,8 @@ func TestDatasetServiceAggregateTagsSkipsDatasetsWithoutDocuments(t *testing.T) 
 	if len(docEngine.requests) != 1 {
 		t.Fatalf("search requests=%d want=1", len(docEngine.requests))
 	}
-	if len(docEngine.requests[0].KbIDs) != 1 || docEngine.requests[0].KbIDs[0] != liveID {
-		t.Fatalf("KbIDs=%v want [%s]", docEngine.requests[0].KbIDs, liveID)
+	if len(docEngine.requests[0].KbIDs) != 2 || docEngine.requests[0].KbIDs[0] != emptyID || docEngine.requests[0].KbIDs[1] != liveID {
+		t.Fatalf("KbIDs=%v want [%s %s]", docEngine.requests[0].KbIDs, emptyID, liveID)
 	}
 
 	got := aggregateTagsResultMap(result)
@@ -379,5 +385,50 @@ func TestDatasetServiceAggregateTagsReturnsSearchError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to aggregate tags: boom") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDatasetServiceAggregateTagsMissingStores(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	missingID := "423e4567e89b12d3a456426614174003"
+	liveID := "523e4567e89b12d3a456426614174004"
+	insertAggregateTagsKB(t, missingID, "user-1", string(entity.TenantPermissionMe), 3)
+	insertAggregateTagsKB(t, liveID, "user-1", string(entity.TenantPermissionMe), 0)
+	docEngine := &aggregateTagsMockEngine{
+		missingStores: map[string]bool{missingID: true},
+		searchResults: map[string]*types.SearchResult{
+			"ragflow_user-1": {Chunks: []map[string]interface{}{{"tag_kwd": "live"}}},
+		},
+	}
+	svc := testDatasetServiceForAggregateTags(t, docEngine)
+	result, code, err := svc.AggregateTags(t.Context(), []string{missingID, liveID}, "user-1")
+	if err != nil || code != common.CodeSuccess || result == nil || len(result) != 0 || len(docEngine.requests) != 0 {
+		t.Fatalf("result=%v code=%d err=%v requests=%v; want Python empty result for missing first store", result, code, err, docEngine.requests)
+	}
+	result, code, err = svc.AggregateTags(t.Context(), []string{liveID}, "user-1")
+	if err != nil || code != common.CodeSuccess || aggregateTagsResultMap(result)["live"] != 1 {
+		t.Fatalf("result=%v code=%d err=%v; want zero-doc-count dataset tags", result, code, err)
+	}
+}
+
+func TestDatasetServiceAggregateTagsBackendFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		engine *aggregateTagsMockEngine
+	}{
+		{"store error", &aggregateTagsMockEngine{chunkStoreErr: errors.New("backend unavailable")}},
+		{"nil result", &aggregateTagsMockEngine{searchResults: map[string]*types.SearchResult{"ragflow_user-1": nil}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupServiceTestDB(t)
+			pushServiceDB(t, db)
+			kbID := "123e4567e89b12d3a456426614174000"
+			insertAggregateTagsKB(t, kbID, "user-1", string(entity.TenantPermissionMe), 1)
+			result, code, err := testDatasetServiceForAggregateTags(t, tc.engine).AggregateTags(t.Context(), []string{kbID}, "user-1")
+			if err == nil || code != common.CodeServerError || result != nil {
+				t.Fatalf("result=%v code=%d err=%v; want server error without partial data", result, code, err)
+			}
+		})
 	}
 }

--- a/internal/service/dataset/tags_aggregate_test.go
+++ b/internal/service/dataset/tags_aggregate_test.go
@@ -432,3 +432,20 @@ func TestDatasetServiceAggregateTagsBackendFailures(t *testing.T) {
 		})
 	}
 }
+
+func TestDatasetServiceAggregateTagsRejectsWhitespaceOnlyID(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	kbID := "123e4567e89b12d3a456426614174000"
+	insertAggregateTagsKB(t, kbID, "user-1", string(entity.TenantPermissionMe), 1)
+	for _, ids := range [][]string{{" "}, {kbID, " "}} {
+		docEngine := &aggregateTagsMockEngine{}
+		result, code, err := testDatasetServiceForAggregateTags(t, docEngine).AggregateTags(t.Context(), ids, "user-1")
+		if err == nil || code != common.CodeDataError || err.Error() != "No authorization for dataset ' '" || result != nil {
+			t.Fatalf("ids=%q result=%v code=%d err=%v; want Python authorization error", ids, result, code, err)
+		}
+		if len(docEngine.requests) != 0 {
+			t.Fatal("invalid dataset list must not query the document engine")
+		}
+	}
+}

--- a/internal/service/dataset/tags_list_test.go
+++ b/internal/service/dataset/tags_list_test.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -149,11 +150,9 @@ func TestDatasetServiceListTagsSuccess(t *testing.T) {
 	if len(result) != 2 {
 		t.Fatalf("len(result)=%d want=2 result=%v", len(result), result)
 	}
-	if result[0]["key"] != "finance" || result[0]["count"] != 2 {
-		t.Fatalf("first row=%v want finance/2", result[0])
-	}
-	if result[1]["key"] != "urgent" || result[1]["count"] != 1 {
-		t.Fatalf("second row=%v want urgent/1", result[1])
+	encoded, err := json.Marshal(result)
+	if err != nil || string(encoded) != `[["finance",2],["urgent",1]]` {
+		t.Fatalf("JSON=%s err=%v; want Python tag/count pairs", encoded, err)
 	}
 	if len(docEngine.requests) != 1 {
 		t.Fatalf("search requests=%d want=1", len(docEngine.requests))
@@ -188,6 +187,10 @@ func TestDatasetServiceListTagsReturnsEmptyWhenChunkStoreMissing(t *testing.T) {
 	}
 	if len(result) != 0 {
 		t.Fatalf("len(result)=%d want=0 result=%v", len(result), result)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil || string(encoded) != `[]` {
+		t.Fatalf("JSON=%s err=%v; want empty array", encoded, err)
 	}
 	if len(docEngine.requests) != 0 {
 		t.Fatalf("search requests=%d want=0", len(docEngine.requests))
@@ -241,5 +244,26 @@ func TestDatasetServiceListTagsReturnsChunkStoreError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to inspect chunk store: boom") {
 		t.Fatalf("err=%q want contains %q", err.Error(), "failed to inspect chunk store: boom")
+	}
+}
+
+func TestDatasetServiceListTagsSearchFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		engine *listTagsMockEngine
+	}{
+		{"search error", &listTagsMockEngine{chunkStoreExists: true, searchErr: errors.New("backend unavailable")}},
+		{"nil result", &listTagsMockEngine{chunkStoreExists: true, searchResults: map[string]*types.SearchResult{"ragflow_user-1": nil}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupServiceTestDB(t)
+			pushServiceDB(t, db)
+			kbID := "123e4567e89b12d3a456426614174000"
+			insertListTagsKB(t, kbID, "user-1", string(entity.TenantPermissionMe), 1)
+			result, code, err := testDatasetServiceForListTags(t, tc.engine).ListTags(t.Context(), kbID, "user-1")
+			if err == nil || code != common.CodeServerError || result != nil {
+				t.Fatalf("result=%v code=%d err=%v; want server error without partial data", result, code, err)
+			}
+		})
 	}
 }

--- a/internal/service/dataset/tags_rename_test.go
+++ b/internal/service/dataset/tags_rename_test.go
@@ -76,14 +76,14 @@ func TestDatasetServiceRenameTagSuccess(t *testing.T) {
 	docEngine := &renameTagMockEngine{}
 	ctx := t.Context()
 
-	result, code, err := testDatasetServiceForRenameTag(t, docEngine).RenameTag(ctx, kbInput, "user-1", "old-tag ", "new-tag")
+	result, code, err := testDatasetServiceForRenameTag(t, docEngine).RenameTag(ctx, kbInput, "user-1", "old-tag ", " new-tag ")
 	if err != nil {
 		t.Fatalf("RenameTag failed: %v", err)
 	}
 	if code != common.CodeSuccess {
 		t.Fatalf("code=%d want=%d", code, common.CodeSuccess)
 	}
-	if result["from"] != "old-tag" || result["to"] != "new-tag" {
+	if result["from"] != "old-tag " || result["to"] != " new-tag " {
 		t.Fatalf("result=%v", result)
 	}
 	if len(docEngine.updateCalls) != 1 {
@@ -97,8 +97,8 @@ func TestDatasetServiceRenameTagSuccess(t *testing.T) {
 	if call.DatasetID != kbID {
 		t.Fatalf("datasetID=%q want=%q", call.DatasetID, kbID)
 	}
-	if got := call.Condition["tag_kwd"]; got != "old-tag" {
-		t.Fatalf("condition tag_kwd=%v want=%q", got, "old-tag")
+	if got := call.Condition["tag_kwd"]; got != "old-tag " {
+		t.Fatalf("condition tag_kwd=%v want=%q", got, "old-tag ")
 	}
 	if got := call.Condition["kb_id"]; got != kbID {
 		t.Fatalf("condition kb_id=%v want=%q", got, kbID)
@@ -109,8 +109,8 @@ func TestDatasetServiceRenameTagSuccess(t *testing.T) {
 	if got := remove["tag_kwd"]; got != "old-tag" {
 		t.Fatalf("remove tag_kwd=%v want=%q", got, "old-tag")
 	}
-	if got := add["tag_kwd"]; got != "new-tag" {
-		t.Fatalf("add tag_kwd=%v want=%q", got, "new-tag")
+	if got := add["tag_kwd"]; got != " new-tag " {
+		t.Fatalf("add tag_kwd=%v want=%q", got, " new-tag ")
 	}
 }
 

--- a/internal/service/dataset/testdata/README.md
+++ b/internal/service/dataset/testdata/README.md
@@ -4,7 +4,7 @@ These checks cover the existing Go routes listed in #15240:
 
 - `GET /api/v1/datasets/{dataset_id}/tags`: JSON tag/count pairs, including an empty array when no tags exist.
 - `GET /api/v1/datasets/tags/aggregation`: query actual stores even when `doc_num` is zero; preserve tenant grouping and access checks; reject more than 100 nonempty IDs.
-- `PUT /api/v1/datasets/{dataset_id}/tags`: preserve the original match, replacement, and response strings. Python strips only the removal operand.
+- `PUT /api/v1/datasets/{dataset_id}/tags`: preserve the original match, replacement, and response strings at the service boundary. Python strips only the removal operand there; the selected document engine may normalize values further.
 
 All three use the Python success envelope (`code`, `data`) and error envelope (`code`, `message`). Internal failures return code 102 and `Internal server error`; the Go server retains details in its log.
 
@@ -52,4 +52,4 @@ curl --fail-with-body -sS -H "Authorization: Bearer $RAGFLOW_TOKEN" \
 # Expected: {"code":102,"message":"Lack of dataset_ids in query parameters"}.
 ```
 
-Repeat listing with a user who cannot access the disposable dataset: the response must contain `no authorization`, with no tags. Verify list and aggregate responses for a dataset with an absent chunk store, and verify the exact renamed values in the document engine. Application errors use HTTP 200, so inspect the JSON `code` as well as curl's exit status.
+Repeat listing with a user who cannot access the disposable dataset: the response must contain `no authorization`, with no tags. Verify list and aggregate responses for a dataset with an absent chunk store. Compare persisted renamed tags with Python using the same document engine: Elasticsearch trims added tag whitespace in both implementations. Application errors use HTTP 200, so inspect the JSON `code` as well as curl's exit status.

--- a/internal/service/dataset/testdata/README.md
+++ b/internal/service/dataset/testdata/README.md
@@ -1,0 +1,55 @@
+# Dataset Tag API Contract Checks
+
+These checks cover the existing Go routes listed in #15240:
+
+- `GET /api/v1/datasets/{dataset_id}/tags`: JSON tag/count pairs, including an empty array when no tags exist.
+- `GET /api/v1/datasets/tags/aggregation`: query actual stores even when `doc_num` is zero; preserve tenant grouping and access checks; reject more than 100 nonempty IDs.
+- `PUT /api/v1/datasets/{dataset_id}/tags`: preserve the original match, replacement, and response strings. Python strips only the removal operand.
+
+All three use the Python success envelope (`code`, `data`) and error envelope (`code`, `message`). Internal failures return code 102 and `Internal server error`; the Go server retains details in its log.
+
+## Local Regression Tests
+
+With the native dependencies described in `internal/development.md` installed:
+
+```bash
+bash build.sh --test -run 'TestDatasetService(ListTags|AggregateTags|RenameTag)|TestDatasetsHandler.*Tags|TestDatasetsHandlerRenameTag' ./internal/service/dataset ./internal/handler
+```
+
+The service tests use SQLite and fake document engines. The handler tests send HTTP requests through Gin with fake service boundaries. These unit tests do not require a running backend service.
+
+The reference check executes the original Python functions extracted with `ast`, replacing database and network I/O with fakes. It does not import or start the full Python server:
+
+```bash
+python internal/service/dataset/testdata/python_tags_contract.py
+```
+
+References: `api/apps/restful_apis/dataset_api.py`, `api/apps/services/dataset_api_service.py`, `rag/nlp/search.py:all_tags`, and `api/utils/pagination_utils.py:validate_rest_api_ids`.
+
+The existing Go dataset-ID normalization remains in place. Result ordering across tenant groups is not guaranteed. The native document-engine queries still need real-service integration testing.
+
+## API Smoke Checks
+
+Use a running Go server, an authorized test user, and a disposable dataset with a tagged chunk. Set `RAGFLOW_URL`, `RAGFLOW_TOKEN`, and `DATASET_ID` before running these commands:
+
+```bash
+curl --fail-with-body -sS -H "Authorization: Bearer $RAGFLOW_TOKEN" \
+  "$RAGFLOW_URL/api/v1/datasets/$DATASET_ID/tags"
+# Expected data shape: [["finance",2],["urgent",1]]. Counts depend on the fixture.
+
+curl --fail-with-body -sS -H "Authorization: Bearer $RAGFLOW_TOKEN" \
+  "$RAGFLOW_URL/api/v1/datasets/tags/aggregation?dataset_ids=$DATASET_ID"
+# Expected data shape: [{"value":"finance","count":2}, ...].
+
+curl --fail-with-body -sS -X PUT -H "Authorization: Bearer $RAGFLOW_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"from_tag":"old-tag ","to_tag":" new-tag "}' \
+  "$RAGFLOW_URL/api/v1/datasets/$DATASET_ID/tags"
+# Expected: {"code":0,"data":{"from":"old-tag ","to":" new-tag "}}.
+
+curl --fail-with-body -sS -H "Authorization: Bearer $RAGFLOW_TOKEN" \
+  "$RAGFLOW_URL/api/v1/datasets/tags/aggregation"
+# Expected: {"code":102,"message":"Lack of dataset_ids in query parameters"}.
+```
+
+Repeat listing with a user who cannot access the disposable dataset: the response must contain `no authorization`, with no tags. Verify list and aggregate responses for a dataset with an absent chunk store, and verify the exact renamed values in the document engine. Application errors use HTTP 200, so inspect the JSON `code` as well as curl's exit status.

--- a/internal/service/dataset/testdata/python_tags_contract.py
+++ b/internal/service/dataset/testdata/python_tags_contract.py
@@ -18,7 +18,8 @@ def load_functions(path, names, namespace):
     assert {node.name for node in selected} == set(names)
     for node in selected:
         node.decorator_list = []
-    exec(compile(ast.Module(body=selected, type_ignores=[]), path, "exec"), namespace)
+    # Execute selected repository functions with fake I/O instead of importing the full server.
+    exec(compile(ast.Module(body=selected, type_ignores=[]), path, "exec"), namespace)  # noqa: S102
 
 
 def main():
@@ -83,11 +84,13 @@ def main():
         raise RuntimeError("private backend address")
 
     routes = dict(response)
-    routes.update({
-        "dataset_api_service": SimpleNamespace(list_tags=failing_service, aggregate_tags=failing_service, rename_tag=failing_service),
-        "logging": SimpleNamespace(exception=lambda *_: None),
-        "request": SimpleNamespace(args={"dataset_ids": kb_id}),
-    })
+    routes.update(
+        {
+            "dataset_api_service": SimpleNamespace(list_tags=failing_service, aggregate_tags=failing_service, rename_tag=failing_service),
+            "logging": SimpleNamespace(exception=lambda *_: None),
+            "request": SimpleNamespace(args={"dataset_ids": kb_id}),
+        }
+    )
     load_functions("api/apps/restful_apis/dataset_api.py", ["list_tags", "aggregate_tags", "rename_tag"], routes)
     expected_error = {"code": 102, "message": "Internal server error"}
     assert routes["list_tags"]("user-1", kb_id) == expected_error

--- a/internal/service/dataset/testdata/python_tags_contract.py
+++ b/internal/service/dataset/testdata/python_tags_contract.py
@@ -61,6 +61,9 @@ def main():
     assert change == {"remove": {"tag_kwd": "old-tag"}, "add": {"tag_kwd": " new-tag "}}
     assert index == "ragflow_user-1" and dataset == kb_id
 
+    namespace["KnowledgebaseService"].accessible = lambda dataset_id, _: dataset_id == kb_id
+    assert namespace["aggregate_tags"]([" "], "user-1") == (False, "No authorization for dataset ' '")
+
     ret_code = SimpleNamespace(SUCCESS=0, DATA_ERROR=102, ARGUMENT_ERROR=101)
     response = {"RetCode": ret_code, "_safe_jsonify": lambda value: value}
     load_functions("api/utils/api_utils.py", ["get_result", "get_error_data_result", "get_error_argument_result"], response)

--- a/internal/service/dataset/testdata/python_tags_contract.py
+++ b/internal/service/dataset/testdata/python_tags_contract.py
@@ -1,0 +1,102 @@
+"""Check tag API contracts using the original Python functions and fake I/O.
+
+Run from the repository root: python internal/service/dataset/testdata/python_tags_contract.py
+This checks source behavior without importing the full Python server or services.
+"""
+
+import ast
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def load_functions(path, names, namespace):
+    tree = ast.parse(Path(path).read_text(encoding="utf-8"), filename=path)
+    selected = [node for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in names]
+    assert {node.name for node in selected} == set(names)
+    for node in selected:
+        node.decorator_list = []
+    exec(compile(ast.Module(body=selected, type_ignores=[]), path, "exec"), namespace)
+
+
+def main():
+    kb_id = "123e4567e89b12d3a456426614174000"
+    kb = SimpleNamespace(tenant_id="user-1", doc_num=0)
+    tags = [("finance", 2), ("urgent", 1)]
+    updates = []
+    queried = []
+
+    def all_tags(tenant_id, ids):
+        queried.append((tenant_id, ids))
+        return tags
+
+    search = ModuleType("rag.nlp.search")
+    search.index_name = lambda tenant_id: "ragflow_" + tenant_id
+    nlp = ModuleType("rag.nlp")
+    nlp.search = search
+    sys.modules["rag"] = ModuleType("rag")
+    sys.modules["rag.nlp"] = nlp
+    sys.modules["rag.nlp.search"] = search
+    namespace = {
+        "KnowledgebaseService": SimpleNamespace(accessible=lambda *_: True, get_by_id=lambda _: (True, kb)),
+        "UserTenantService": SimpleNamespace(get_tenants_by_user_id=lambda _: [{"tenant_id": "user-1"}]),
+        "settings": SimpleNamespace(
+            retriever=SimpleNamespace(all_tags=all_tags),
+            docStoreConn=SimpleNamespace(update=lambda *args: updates.append(args) or True),
+        ),
+    }
+    load_functions("api/apps/services/dataset_api_service.py", ["list_tags", "aggregate_tags", "rename_tag"], namespace)
+    ok, listed = namespace["list_tags"](kb_id, "user-1")
+    assert ok and json.loads(json.dumps(listed)) == [["finance", 2], ["urgent", 1]]
+    queried.clear()
+    ok, aggregated = namespace["aggregate_tags"]([kb_id], "user-1")
+    assert ok and queried == [("user-1", [kb_id])]
+    assert aggregated == [{"value": "finance", "count": 2}, {"value": "urgent", "count": 1}]
+    ok, renamed = namespace["rename_tag"](kb_id, "user-1", "old-tag ", " new-tag ")
+    assert ok and renamed == {"from": "old-tag ", "to": " new-tag "}
+    condition, change, index, dataset = updates[0]
+    assert condition == {"tag_kwd": "old-tag ", "kb_id": [kb_id]}
+    assert change == {"remove": {"tag_kwd": "old-tag"}, "add": {"tag_kwd": " new-tag "}}
+    assert index == "ragflow_user-1" and dataset == kb_id
+
+    ret_code = SimpleNamespace(SUCCESS=0, DATA_ERROR=102, ARGUMENT_ERROR=101)
+    response = {"RetCode": ret_code, "_safe_jsonify": lambda value: value}
+    load_functions("api/utils/api_utils.py", ["get_result", "get_error_data_result", "get_error_argument_result"], response)
+    load_functions("api/utils/pagination_utils.py", ["validate_rest_api_ids"], response)
+    response["REST_API_MAX_IDS"] = 100
+    response["validate_rest_api_ids"]([kb_id] * 100, "dataset_ids")
+    try:
+        response["validate_rest_api_ids"]([kb_id] * 101, "dataset_ids")
+    except ValueError as exc:
+        assert str(exc) == "dataset_ids must contain at most 100 IDs"
+    else:
+        raise AssertionError("101 IDs must fail")
+    assert response["get_result"](data=listed) == {"code": 0, "data": listed}
+    assert response["get_error_data_result"](message="Internal server error") == {"code": 102, "message": "Internal server error"}
+
+    def failing_service(*_):
+        raise RuntimeError("private backend address")
+
+    routes = dict(response)
+    routes.update({
+        "dataset_api_service": SimpleNamespace(list_tags=failing_service, aggregate_tags=failing_service, rename_tag=failing_service),
+        "logging": SimpleNamespace(exception=lambda *_: None),
+        "request": SimpleNamespace(args={"dataset_ids": kb_id}),
+    })
+    load_functions("api/apps/restful_apis/dataset_api.py", ["list_tags", "aggregate_tags", "rename_tag"], routes)
+    expected_error = {"code": 102, "message": "Internal server error"}
+    assert routes["list_tags"]("user-1", kb_id) == expected_error
+    assert routes["aggregate_tags"]("user-1") == expected_error
+
+    async def get_json():
+        return {"from_tag": "old", "to_tag": "new"}
+
+    routes["request"].get_json = get_json
+    assert asyncio.run(routes["rename_tag"]("user-1", kb_id)) == expected_error
+    print(json.dumps({"list_tags": listed, "aggregate_tags_zero_doc_num": aggregated, "rename_tag": renamed, "error": expected_error, "max_ids": 100}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

Complete Python behavior parity for three existing Go dataset-tag APIs in #15240, following the [claim comment](https://github.com/infiniflow/ragflow/issues/15240#issuecomment-5558957641).

- `GET /datasets/{dataset_id}/tags` returns tag/count pairs such as `[["finance",2]]`, matching Python and the frontend consumer.
- `GET /datasets/tags/aggregation` includes accessible datasets with a zero metadata document count, checks the actual store, enforces the Python 100-ID limit, and rejects whitespace-only IDs.
- `PUT /datasets/{dataset_id}/tags` preserves the original match, replacement, and response strings at the service boundary. Only the removal operand is stripped there, as in Python; engine-specific normalization remains in the engine.
- All three return the Python `code/data` success envelope and `code/message` error envelope. Internal errors are logged and returned as `102 / Internal server error`.

Tenant access checks and grouping remain before document queries. Existing Go dataset-ID normalization is retained. The three handlers share a private service interface so their HTTP contracts can be tested without external services.

### Validation

- Regression tests fail on the original source for all three primary behavior differences and pass after the fixes.
- 26 top-level tests and 40 subtests pass locally, covering service behavior, HTTP responses, authorization, empty/missing stores, malformed requests, 100/101 IDs, cancellation propagation, and backend failures. Affected-package `go vet` also passes.
- Local Windows checks used `CGO_ENABLED=0` with isolated workarounds for two unrelated pre-existing platform compilation issues. These workarounds are outside this PR and are not a native-build acceptance claim.
- The source oracle executes the original Python service and route functions with fake I/O. Run `python internal/service/dataset/testdata/python_tags_contract.py`.
- [Independent Linux verification](https://github.com/ltyfulan9/ragflow/actions/runs/34031636842) passed the Python oracle, all focused Go tests, and affected-package `go vet` on `d526165cff8ce7e6ef84ae6bdf684d349eab54d7`, without Windows workarounds.
- [Final-source Linux and native verification](https://github.com/ltyfulan9/ragflow/actions/runs/34032081092) passed on exact source `45a347755a1bb410979af11c8c1c98db3e72bd1b`. The Linux job passes Ruff, the Python oracle, focused tests, and `go vet`. The native job builds the tokenizer library, links the repository-pinned native dependencies, and passes the supported `build.sh --test` path, including its additional native unit tests.

Test commands, source references, and curl smoke checks are in `internal/service/dataset/testdata/README.md`. Real-service API smoke checks and document-engine persistence tests remain pending, so this PR is a draft. This does not claim full-repository `go build ./...`, `go test ./...`, or production acceptance.

### Review

AI tools assisted implementation, tests, and independent Standards/Spec reviews. Source comparisons and regression evidence were checked; the review caught and fixed the whitespace-only-ID case and clarified the service-versus-engine whitespace contract. No claim of human or maintainer approval is made.
