### PR TITLE
feat(dataset): allow wiki operator on built-in parsing templates

### DIFF
--- a/internal/ingestion/pipeline/builtin_compiler.go
+++ b/internal/ingestion/pipeline/builtin_compiler.go
@@ -1,0 +1,268 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const compilerComponentPrefix = "Compiler:"
+
+// AugmentBuiltinDSLWithCompiler injects optional Compiler components referenced
+// by parser_config into a built-in ingestion DSL. Built-in templates ship
+// without a Compiler node; dataset settings may add one under a stable
+// Compiler:* key so wiki compilation can run without a custom pipeline.
+func AugmentBuiltinDSLWithCompiler(dslJSON string, parserConfig map[string]any) (string, error) {
+	compilerIDs := compilerOperatorIDs(parserConfig)
+	if len(compilerIDs) == 0 {
+		return dslJSON, nil
+	}
+
+	var dsl map[string]any
+	if err := json.Unmarshal([]byte(dslJSON), &dsl); err != nil {
+		return "", fmt.Errorf("augment builtin dsl: decode: %w", err)
+	}
+	components, ok := dsl["components"].(map[string]any)
+	if !ok || components == nil {
+		return "", fmt.Errorf("augment builtin dsl: missing components")
+	}
+
+	for _, compilerID := range compilerIDs {
+		if _, exists := components[compilerID]; exists {
+			continue
+		}
+		if err := injectCompilerComponent(dsl, components, compilerID); err != nil {
+			return "", err
+		}
+	}
+
+	out, err := json.Marshal(dsl)
+	if err != nil {
+		return "", fmt.Errorf("augment builtin dsl: encode: %w", err)
+	}
+	return string(out), nil
+}
+
+func compilerOperatorIDs(parserConfig map[string]any) []string {
+	if len(parserConfig) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(parserConfig))
+	seen := make(map[string]struct{}, len(parserConfig))
+	for key := range parserConfig {
+		if !strings.HasPrefix(key, compilerComponentPrefix) {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		ids = append(ids, key)
+	}
+	return ids
+}
+
+func injectCompilerComponent(dsl map[string]any, components map[string]any, compilerID string) error {
+	predecessorID, tokenizerID := findCompilerInsertionPoint(components)
+	if predecessorID == "" {
+		return fmt.Errorf("augment builtin dsl: cannot locate insertion point for %s", compilerID)
+	}
+
+	components[compilerID] = map[string]any{
+		"downstream": downstreamIDs(components, predecessorID, tokenizerID),
+		"upstream":   []string{predecessorID},
+		"obj": map[string]any{
+			"component_name": "Compiler",
+			"params": map[string]any{
+				"compilation_template_group_id": "",
+				"llm_id":                      "",
+				"outputs": map[string]any{
+					"chunks": map[string]any{
+						"type":  "Array<Object>",
+						"value": []any{},
+					},
+				},
+			},
+		},
+	}
+
+	if pred, ok := components[predecessorID].(map[string]any); ok {
+		pred["downstream"] = []string{compilerID}
+	}
+	if tokenizerID != "" {
+		if tok, ok := components[tokenizerID].(map[string]any); ok {
+			tok["upstream"] = []string{compilerID}
+		}
+	}
+
+	patchGraphForCompiler(dsl, predecessorID, compilerID, tokenizerID)
+	return nil
+}
+
+func downstreamIDs(components map[string]any, predecessorID, tokenizerID string) []string {
+	if tokenizerID != "" {
+		return []string{tokenizerID}
+	}
+	if pred, ok := components[predecessorID].(map[string]any); ok {
+		if raw, ok := pred["downstream"].([]any); ok {
+			out := make([]string, 0, len(raw))
+			for _, item := range raw {
+				if s, ok := item.(string); ok && s != "" {
+					out = append(out, s)
+				}
+			}
+			return out
+		}
+		if raw, ok := pred["downstream"].([]string); ok {
+			return raw
+		}
+	}
+	return []string{}
+}
+
+func findCompilerInsertionPoint(components map[string]any) (predecessorID, tokenizerID string) {
+	for id, raw := range components {
+		comp, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if componentName(comp) != "Tokenizer" {
+			continue
+		}
+		tokenizerID = id
+		upstream := stringSliceField(comp, "upstream")
+		if len(upstream) > 0 {
+			predecessorID = upstream[0]
+		}
+		return predecessorID, tokenizerID
+	}
+
+	// Fallback: wire after the last non-terminal node in the chain.
+	for id, raw := range components {
+		comp, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := componentName(comp)
+		if name == "File" || strings.HasPrefix(id, compilerComponentPrefix) {
+			continue
+		}
+		downstream := stringSliceField(comp, "downstream")
+		if len(downstream) == 0 {
+			return id, ""
+		}
+	}
+	return "", ""
+}
+
+func componentName(comp map[string]any) string {
+	obj, ok := comp["obj"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	name, _ := obj["component_name"].(string)
+	return strings.TrimSpace(name)
+}
+
+func stringSliceField(comp map[string]any, key string) []string {
+	raw, ok := comp[key]
+	if !ok {
+		return nil
+	}
+	switch values := raw.(type) {
+	case []string:
+		return values
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, item := range values {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func patchGraphForCompiler(dsl map[string]any, predecessorID, compilerID, tokenizerID string) {
+	graph, ok := dsl["graph"].(map[string]any)
+	if !ok || graph == nil {
+		return
+	}
+	edges, ok := graph["edges"].([]any)
+	if !ok {
+		return
+	}
+
+	newEdges := make([]any, 0, len(edges)+1)
+	replaced := false
+	for _, raw := range edges {
+		edge, ok := raw.(map[string]any)
+		if !ok {
+			newEdges = append(newEdges, raw)
+			continue
+		}
+		source, _ := edge["source"].(string)
+		target, _ := edge["target"].(string)
+		if tokenizerID != "" && source == predecessorID && target == tokenizerID {
+			predToCompiler := map[string]any{
+				"id":           fmt.Sprintf("xy-edge__%sstart-%send", predecessorID, compilerID),
+				"source":       predecessorID,
+				"sourceHandle": "start",
+				"target":       compilerID,
+				"targetHandle": "end",
+			}
+			compilerToTokenizer := map[string]any{
+				"id":           fmt.Sprintf("xy-edge__%sstart-%send", compilerID, tokenizerID),
+				"source":       compilerID,
+				"sourceHandle": "start",
+				"target":       tokenizerID,
+				"targetHandle": "end",
+			}
+			newEdges = append(newEdges, predToCompiler, compilerToTokenizer)
+			replaced = true
+			continue
+		}
+		newEdges = append(newEdges, edge)
+	}
+	if !replaced && tokenizerID == "" {
+		newEdges = append(newEdges, map[string]any{
+			"id":           fmt.Sprintf("xy-edge__%sstart-%send", predecessorID, compilerID),
+			"source":       predecessorID,
+			"sourceHandle": "start",
+			"target":       compilerID,
+			"targetHandle": "end",
+		})
+	}
+	graph["edges"] = newEdges
+
+	nodes, ok := graph["nodes"].([]any)
+	if !ok {
+		return
+	}
+	graph["nodes"] = append(nodes, map[string]any{
+		"id": compilerID,
+		"data": map[string]any{
+			"label": "Compiler",
+			"name":  "Wiki",
+		},
+		"type": "compilationNode",
+	})
+}

--- a/internal/ingestion/pipeline/builtin_compiler_test.go
+++ b/internal/ingestion/pipeline/builtin_compiler_test.go
@@ -1,0 +1,74 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package pipeline
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAugmentBuiltinDSLWithCompiler_InsertsBeforeTokenizer(t *testing.T) {
+	dsl, err := LoadBuiltinDSL("general")
+	if err != nil {
+		t.Fatalf("LoadBuiltinDSL: %v", err)
+	}
+	parserConfig := map[string]any{
+		"Compiler:BuiltinWiki": map[string]any{
+			"compilation_template_group_id": "wiki-group",
+			"llm_id":                      "chat-model",
+		},
+	}
+	augmented, err := AugmentBuiltinDSLWithCompiler(dsl, parserConfig)
+	if err != nil {
+		t.Fatalf("AugmentBuiltinDSLWithCompiler: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(augmented), &parsed); err != nil {
+		t.Fatalf("unmarshal augmented dsl: %v", err)
+	}
+	components, ok := parsed["components"].(map[string]any)
+	if !ok {
+		t.Fatal("missing components")
+	}
+	compiler, ok := components["Compiler:BuiltinWiki"].(map[string]any)
+	if !ok {
+		t.Fatal("compiler component not injected")
+	}
+	upstream := compiler["upstream"].([]any)
+	if len(upstream) != 1 {
+		t.Fatalf("compiler upstream = %#v", upstream)
+	}
+	downstream := compiler["downstream"].([]any)
+	if len(downstream) != 1 {
+		t.Fatalf("compiler downstream = %#v", downstream)
+	}
+}
+
+func TestAugmentBuiltinDSLWithCompiler_NoOpWithoutCompilerConfig(t *testing.T) {
+	dsl, err := LoadBuiltinDSL("general")
+	if err != nil {
+		t.Fatalf("LoadBuiltinDSL: %v", err)
+	}
+	augmented, err := AugmentBuiltinDSLWithCompiler(dsl, map[string]any{})
+	if err != nil {
+		t.Fatalf("AugmentBuiltinDSLWithCompiler: %v", err)
+	}
+	if augmented != dsl {
+		t.Fatal("expected unchanged dsl when no compiler config is present")
+	}
+}

--- a/internal/ingestion/service/ingestion_service.go
+++ b/internal/ingestion/service/ingestion_service.go
@@ -1141,6 +1141,11 @@ func (e *Ingestor) defaultRunDocumentTask(ctx context.Context, ingestionTask *en
 			if lerr != nil {
 				return "", "", lerr
 			}
+			parserConfig := map[string]any(docTaskCtx.Doc.ParserConfig)
+			dsl, lerr = pipelinepkg.AugmentBuiltinDSLWithCompiler(dsl, parserConfig)
+			if lerr != nil {
+				return "", "", lerr
+			}
 			return dsl, parserID, nil
 		})
 	}

--- a/rag/svr/task_executor_refactor/chunk_post_processor.py
+++ b/rag/svr/task_executor_refactor/chunk_post_processor.py
@@ -440,11 +440,25 @@ def _parser_config_compilation_template_group_ids(parser_config) -> list[str]:
                 ids.append(gid)
         return ids
 
+    def _collect_from_value(value, out: list[str], seen: set[str]) -> None:
+        if isinstance(value, dict):
+            for key in ("compilation_template_group_id", "compilation_template_group_ids"):
+                for gid in _normalize(value.get(key)):
+                    if gid not in seen:
+                        seen.add(gid)
+                        out.append(gid)
+            for child in value.values():
+                _collect_from_value(child, out, seen)
+        elif isinstance(value, list):
+            for child in value:
+                _collect_from_value(child, out, seen)
+
     if not isinstance(parser_config, dict):
         return []
-    if "compilation_template_group_id" in parser_config:
-        return _normalize(parser_config.get("compilation_template_group_id"))
-    return []
+    ids: list[str] = []
+    seen: set[str] = set()
+    _collect_from_value(parser_config, ids, seen)
+    return ids
 
 
 def _parser_config_compilation_template_ids(parser_config, tenant_id: str) -> list[str]:

--- a/rag/svr/task_executor_refactor/dataset_wiki_generator.py
+++ b/rag/svr/task_executor_refactor/dataset_wiki_generator.py
@@ -289,6 +289,36 @@ def _pipeline_compiler_llm_id(pipeline_id: str) -> str | None:
     return None
 
 
+def _parser_config_compiler_llm_id(parser_config) -> str | None:
+    """Return the chat model configured on a parser_config Compiler operator."""
+
+    def _find_llm_id(value) -> str | None:
+        if isinstance(value, dict):
+            llm_id = value.get("llm_id")
+            if isinstance(llm_id, str) and llm_id.strip():
+                return llm_id.strip()
+            for child in value.values():
+                found = _find_llm_id(child)
+                if found:
+                    return found
+        elif isinstance(value, list):
+            for child in value:
+                found = _find_llm_id(child)
+                if found:
+                    return found
+        return None
+
+    if not isinstance(parser_config, dict):
+        return None
+    for key, config in parser_config.items():
+        if not isinstance(key, str) or not key.startswith("Compiler:"):
+            continue
+        llm_id = _find_llm_id(config)
+        if llm_id:
+            return llm_id
+    return _find_llm_id(parser_config)
+
+
 def _validate_wiki_eligible_docs(eligible: list[tuple[dict, str]]) -> dict[str, str]:
     """Validate one Wiki template and return each doc's pipeline chat model."""
     template_ids = {template_id for _, template_id in eligible}
@@ -298,11 +328,15 @@ def _validate_wiki_eligible_docs(eligible: list[tuple[dict, str]]) -> dict[str, 
     for doc, _ in eligible:
         doc_id = str(doc.get("id") or "")
         pipeline_id = (doc.get("pipeline_id") or "").strip()
-        if not pipeline_id:
-            raise ValueError(f"Wiki document {doc_id} must use a pipeline")
-        llm_id = _pipeline_compiler_llm_id(pipeline_id)
+        llm_id = None
+        if pipeline_id:
+            llm_id = _pipeline_compiler_llm_id(pipeline_id)
         if not llm_id:
-            raise ValueError(f"Wiki document {doc_id} pipeline Compiler must configure an LLM")
+            llm_id = _parser_config_compiler_llm_id(doc.get("parser_config") or {})
+        if not llm_id:
+            if pipeline_id:
+                raise ValueError(f"Wiki document {doc_id} pipeline Compiler must configure an LLM")
+            raise ValueError(f"Wiki document {doc_id} built-in Compiler must configure an LLM")
         pipeline_chat_llm_ids[doc_id] = llm_id
     return pipeline_chat_llm_ids
 

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -914,6 +914,11 @@ Paragraphs:
       entityTypes: 'Entity types',
       compilationTemplate: 'Operator',
       compilationTemplateRequired: 'Please select an operator',
+      wikiOperator: 'Wiki',
+      wikiOperatorLabel: 'Wiki operator',
+      wikiOperatorPlaceholder: 'Select a wiki operator',
+      wikiOperatorTip:
+        'Optionally add the Wiki operator to generate wiki pages from built-in template chunks without configuring a custom pipeline.',
       createTemplate: 'Create template',
       scopeFile: 'File',
       vietnamese: 'Vietnamese',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -827,6 +827,11 @@ export default {
       entityTypes: 'Entity 类型',
       compilationTemplate: '算子',
       compilationTemplateRequired: '请选择算子',
+      wikiOperator: 'Wiki',
+      wikiOperatorLabel: 'Wiki 算子',
+      wikiOperatorPlaceholder: '选择 Wiki 算子',
+      wikiOperatorTip:
+        '可为内置模板可选添加 Wiki 算子，无需配置自定义 pipeline 即可基于分块生成 Wiki 页面。',
       createTemplate: '创建模板',
       scopeFile: '文件',
       pageRank: '页面排名',

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.test.ts
@@ -18,12 +18,27 @@ describe('canGenerateWiki', () => {
     ).toBe(false);
   });
 
-  it('requires an ingestion pipeline', () => {
+  it('requires an ingestion pipeline or builtin wiki compiler config', () => {
     expect(canGenerateWiki(dataset())).toBe(false);
   });
 
   it('allows pipeline-backed datasets', () => {
     expect(canGenerateWiki(dataset({ pipeline_id: 'pipeline-id' }))).toBe(true);
+  });
+
+  it('allows builtin datasets with a saved wiki compiler operator', () => {
+    expect(
+      canGenerateWiki(
+        dataset({
+          parser_config: {
+            'Compiler:BuiltinWiki': {
+              compilation_template_group_id: 'wiki-group',
+              llm_id: 'chat-model',
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
   });
 
   it('ignores a blank pipeline id', () => {

--- a/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
+++ b/web/src/pages/dataset/compilation/wiki-generation-eligibility.ts
@@ -1,8 +1,15 @@
 import { IDataset } from '@/interfaces/database/dataset';
+import { hasCompilerOperatorConfig } from '@/utils/pipeline-operator';
 
 export function canGenerateWiki(knowledgeBase?: IDataset): boolean {
-  return (
-    (knowledgeBase?.chunk_count ?? 0) > 0 &&
-    Boolean(knowledgeBase?.pipeline_id?.trim())
-  );
+  if ((knowledgeBase?.chunk_count ?? 0) <= 0) {
+    return false;
+  }
+  if (knowledgeBase?.pipeline_id?.trim()) {
+    return true;
+  }
+  const parserConfig = knowledgeBase?.parser_config as
+    | Record<string, unknown>
+    | undefined;
+  return hasCompilerOperatorConfig(parserConfig);
 }

--- a/web/src/pages/dataset/setting/go/components/optional-wiki-operator.tsx
+++ b/web/src/pages/dataset/setting/go/components/optional-wiki-operator.tsx
@@ -1,0 +1,125 @@
+/*
+ *  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { SelectWithSearch } from '@/components/originui/select-with-search';
+import { Button } from '@/components/ui/button';
+import { FormLabel } from '@/components/ui/form';
+import { Operator } from '@/constants/agent';
+import { initialCompilationValues } from '@/pages/agent/constant/pipeline';
+import { cn } from '@/lib/utils';
+import {
+  BuiltinCompilerOperatorId,
+  findCompilerOperatorIds,
+  hasCompilerOperatorConfig,
+} from '@/utils/pipeline-operator';
+import { cloneDeep } from 'lodash';
+import { useCallback, useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+const WikiOperatorValue = Operator.Compiler;
+
+export function OptionalWikiOperatorItem({ line = 1 }: { line?: 1 | 2 }) {
+  const { t } = useTranslation();
+  const form = useFormContext();
+  const parserConfig = form.watch('parser_config') as Record<string, any>;
+  const hasWikiOperator = hasCompilerOperatorConfig(parserConfig);
+
+  const options = useMemo(
+    () => [
+      {
+        label: t('knowledgeConfiguration.wikiOperator'),
+        value: WikiOperatorValue,
+      },
+    ],
+    [t],
+  );
+
+  const handleAdd = useCallback(
+    (value: string) => {
+      if (value !== WikiOperatorValue) {
+        return;
+      }
+      const current = form.getValues('parser_config') || {};
+      if (hasCompilerOperatorConfig(current)) {
+        return;
+      }
+      form.setValue('parser_config', {
+        ...current,
+        [BuiltinCompilerOperatorId]: cloneDeep(initialCompilationValues),
+      });
+    },
+    [form],
+  );
+
+  const handleRemove = useCallback(() => {
+    const current = { ...(form.getValues('parser_config') || {}) };
+    for (const operatorId of findCompilerOperatorIds(current)) {
+      delete current[operatorId];
+    }
+    form.setValue('parser_config', current);
+  }, [form]);
+
+  return (
+    <div className="items-center space-y-0">
+      <div
+        className={cn('flex', {
+          'items-center': line === 1,
+          'flex-col gap-1': line === 2,
+        })}
+      >
+        <FormLabel
+          className={cn('text-sm whitespace-wrap', {
+            'w-1/4': line === 1,
+          })}
+        >
+          {t('knowledgeConfiguration.wikiOperatorLabel')}
+        </FormLabel>
+        <div className={cn('text-muted-foreground', { 'w-3/4': line === 1 })}>
+          {hasWikiOperator ? (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-text-primary">
+                {t('knowledgeConfiguration.wikiOperator')}
+              </span>
+              <Button
+                type="button"
+                variant="transparent"
+                size="sm"
+                onClick={handleRemove}
+              >
+                {t('common.remove')}
+              </Button>
+            </div>
+          ) : (
+            <SelectWithSearch
+              value=""
+              onChange={handleAdd}
+              placeholder={t('knowledgeConfiguration.wikiOperatorPlaceholder')}
+              options={options}
+            />
+          )}
+        </div>
+      </div>
+      <p
+        className={cn('text-xs text-text-secondary pt-1', {
+          'pl-[25%]': line === 1,
+        })}
+      >
+        {t('knowledgeConfiguration.wikiOperatorTip')}
+      </p>
+    </div>
+  );
+}

--- a/web/src/pages/dataset/setting/go/index.tsx
+++ b/web/src/pages/dataset/setting/go/index.tsx
@@ -31,6 +31,7 @@ import LinkDataSource, {
 } from './components/link-data-source';
 import { formSchema } from './form-schema';
 import { GeneralForm } from './general-form';
+import { OptionalWikiOperatorItem } from './components/optional-wiki-operator';
 import {
   useConnectorHandlers,
   useFetchDatasetSettingOnMount,
@@ -222,6 +223,9 @@ export default function DatasetSetting() {
                   <ParseTypeItem line={1} name="parse_type" />
                   {parseType === ParseType.BuiltIn && (
                     <BuiltinPipelineItem line={1} name="parser_id" />
+                  )}
+                  {parseType === ParseType.BuiltIn && !!builtinPipelineId && (
+                    <OptionalWikiOperatorItem line={1} />
                   )}
                   {parseType === ParseType.Pipeline && (
                     <DataFlowSelect

--- a/web/src/utils/__tests__/pipeline-operator.test.ts
+++ b/web/src/utils/__tests__/pipeline-operator.test.ts
@@ -1,4 +1,9 @@
-import { buildOperatorNode } from '@/utils/pipeline-operator';
+import {
+  appendOptionalCompilerNodes,
+  buildOperatorNode,
+  BuiltinCompilerOperatorId,
+  hasCompilerOperatorConfig,
+} from '@/utils/pipeline-operator';
 
 let mockIsGoBackend = true;
 jest.mock('@/utils/backend-runtime', () => ({
@@ -99,5 +104,34 @@ describe('buildOperatorNode dataset-level metadata precedence', () => {
     const form = (node.data as Record<string, any>).form;
     expect(form.fields).toBe('text');
     expect(form).not.toHaveProperty('metadata');
+  });
+});
+
+describe('optional builtin compiler helpers', () => {
+  it('detects compiler operator config keys', () => {
+    expect(
+      hasCompilerOperatorConfig({
+        'Compiler:BuiltinWiki': { compilation_template_group_id: 'g1' },
+      }),
+    ).toBe(true);
+    expect(hasCompilerOperatorConfig({})).toBe(false);
+  });
+
+  it('appends a compiler tab before the tokenizer', () => {
+    const nodes = [
+      { id: 'Parser:A', data: { label: 'Parser', operatorId: 'Parser:A' } },
+      {
+        id: 'Tokenizer:B',
+        data: { label: 'Tokenizer', operatorId: 'Tokenizer:B' },
+      },
+    ] as any[];
+    const merged = appendOptionalCompilerNodes(nodes, {
+      [BuiltinCompilerOperatorId]: {
+        compilation_template_group_id: 'wiki-group',
+      },
+    });
+    expect(merged).toHaveLength(3);
+    expect((merged[1].data as any).label).toBe('Compiler');
+    expect((merged[2].data as any).label).toBe('Tokenizer');
   });
 });

--- a/web/src/utils/pipeline-operator.ts
+++ b/web/src/utils/pipeline-operator.ts
@@ -18,6 +18,7 @@ import { Operator } from '@/constants/agent';
 import { DSL, RAGFlowNodeType } from '@/interfaces/database/agent';
 import {
   getInitialExtractorValues,
+  initialCompilationValues,
   initialGoExtractorValues,
   initialParserValues,
   initialTitleChunkerValues,
@@ -35,8 +36,45 @@ import { cloneDeep, isEmpty } from 'lodash';
 
 export const FileNodeId = 'File';
 
+/** Stable operator id for the optional Wiki/Compiler on built-in templates. */
+export const BuiltinCompilerOperatorId = 'Compiler:BuiltinWiki';
+
 export function getOperatorType(operatorId: string): Operator {
   return (operatorId.split(':')[0] || operatorId) as Operator;
+}
+
+export function isCompilerOperatorId(operatorId: string): boolean {
+  return getOperatorType(operatorId) === Operator.Compiler;
+}
+
+export function findCompilerOperatorIds(
+  parserConfig?: Record<string, any>,
+): string[] {
+  if (!parserConfig || typeof parserConfig !== 'object') {
+    return [];
+  }
+  return Object.keys(parserConfig).filter(isCompilerOperatorId);
+}
+
+export function hasCompilerOperatorConfig(
+  parserConfig?: Record<string, any>,
+): boolean {
+  return findCompilerOperatorIds(parserConfig).length > 0;
+}
+
+export function createBuiltinCompilerNode(
+  parserConfig?: Record<string, any>,
+): RAGFlowNodeType {
+  const operatorId = findCompilerOperatorIds(parserConfig)[0] ?? BuiltinCompilerOperatorId;
+  const dslNode: RAGFlowNodeType = {
+    id: operatorId,
+    data: {
+      label: Operator.Compiler,
+      name: 'Wiki',
+      form: cloneDeep(initialCompilationValues),
+    },
+  };
+  return buildOperatorNode(dslNode, parserConfig ?? {});
 }
 
 // The dataset-level metadata group stored at parser_config.metadata. The group
@@ -509,11 +547,56 @@ export function buildPipelineOperatorNodes(
   }
 
   // Map ordered IDs to nodes, excluding File
-  return orderedIds
+  const nodes = orderedIds
     .filter((id) => id !== FileNodeId)
     .map((id) => nodeById.get(id))
     .filter((node): node is RAGFlowNodeType => node !== undefined)
     .map((node) => buildOperatorNode(node, pipelineParserConfig));
+
+  return appendOptionalCompilerNodes(nodes, pipelineParserConfig);
+}
+
+/**
+ * Appends optional Compiler nodes saved in parser_config but absent from the
+ * built-in template DSL (e.g. the Wiki operator added in dataset settings).
+ */
+export function appendOptionalCompilerNodes(
+  nodes: RAGFlowNodeType[],
+  pipelineParserConfig: Record<string, any> = {},
+): RAGFlowNodeType[] {
+  const existingIds = new Set(
+    nodes.map(
+      (node) =>
+        (node.data as Record<string, any>)?.operatorId ||
+        node.id ||
+        node.data?.label ||
+        '',
+    ),
+  );
+  const extraCompilerIds = findCompilerOperatorIds(pipelineParserConfig).filter(
+    (id) => !existingIds.has(id),
+  );
+  if (extraCompilerIds.length === 0) {
+    return nodes;
+  }
+
+  const tokenizerIndex = nodes.findIndex(
+    (node) => getOperatorType(
+      (node.data as Record<string, any>)?.operatorId ||
+        node.id ||
+        node.data?.label ||
+        '',
+    ) === Operator.Tokenizer,
+  );
+  const insertAt = tokenizerIndex >= 0 ? tokenizerIndex : nodes.length;
+  const compilerNodes = extraCompilerIds.map(() =>
+    createBuiltinCompilerNode(pipelineParserConfig),
+  );
+  return [
+    ...nodes.slice(0, insertAt),
+    ...compilerNodes,
+    ...nodes.slice(insertAt),
+  ];
 }
 
 /**


### PR DESCRIPTION
### Summary

When using a built-in parsing template in knowledge-base settings, users cannot select the Wiki operator. They currently have to configure extra pipeline rules to generate wiki content.

This PR adds Wiki as a selectable operator after a built-in template is chosen. The system then generates wiki content from that template without a custom pipeline: the Compiler tab (template group + LLM) is saved on `parser_config`, ingestion injects the Compiler node into the built-in DSL at runtime, and wiki generation is allowed when the dataset has parsed chunks plus this config (or a custom pipeline).

Closes #19160.