### PR TITLE
fix(ingestion): mark document RUNNING when a parse task is enqueued

### DIFF
--- a/internal/service/document/document_ingest.go
+++ b/internal/service/document/document_ingest.go
@@ -84,9 +84,9 @@ func (s *DocumentService) Ingest(ctx context.Context, userID string, req *Ingest
 		kb := vd.kb
 
 		// Start parsing: delegates to the shared start-parse flow. The
-		// document run status is set by service.IngestionTaskService.StartRunning
-		// when the task transitions from CREATED or SCHEDULED,
-		// not here.
+		// document run status is set to RUNNING when the task is enqueued
+		// (IngestionTaskService.CreateForDocuments), and StartRunning plus
+		// the worker's progress sink keep it in sync from there.
 		if run == string(entity.TaskStatusRunning) {
 			if err = s.StartParseDocuments(ctx, doc, kb, userID, StartParseOptions{
 				ApplyKB:         req.ApplyKB,

--- a/internal/service/document/document_parse.go
+++ b/internal/service/document/document_parse.go
@@ -54,9 +54,10 @@ func lockDocumentParse(docID string) func() {
 // StartParseDocuments starts parsing a document via the DSL ingestion
 // pipeline. It optionally clears prior results (RerunWithDelete), applies
 // KB config (ApplyKB), validates storage, and enqueues an ingestion task.
-// The document run status is NOT set here; service.IngestionTaskService.StartRunning
-// sets it to RUNNING when the worker picks up the task and transitions it from
-// CREATED or SCHEDULED. Extracted from Ingest so
+// The document run status is set to RUNNING when the task is enqueued
+// (service.IngestionTaskService.CreateForDocuments); StartRunning and the
+// worker's progress sink keep run/progress in sync as the task advances.
+// Extracted from Ingest so
 // other entry points (e.g. ChunkService.Parse)
 // can reuse the same start-parse flow.
 func (s *DocumentService) StartParseDocuments(ctx context.Context, doc *entity.Document, kb *entity.Knowledgebase, userID string, opts StartParseOptions) error {

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -96,6 +96,24 @@ func (s *IngestionTaskService) CreateForDocuments(ctx context.Context, datasetID
 			continue
 		}
 
+		// Mirror the Python run endpoint (DocumentService.update_by_id with
+		// run=RUNNING and progress=0 before queueing): accepting a parse
+		// request flips the document to RUNNING right away so the document
+		// list/detail reflects the newly queued run instead of a stale
+		// terminal status (e.g. CANCEL left by a previous run). The worker's
+		// StartRunning and the progress sink keep run/progress in sync as the
+		// task advances.
+		if err := s.documentDAO.UpdateByID(ctx, dao.DB, docID, map[string]interface{}{
+			"run":      string(entity.TaskStatusRunning),
+			"progress": float64(0),
+		}); err != nil {
+			responses = append(responses, &ParseDocumentResponse{
+				DocumentID: docID,
+				Result:     fmt.Sprintf("mark document running: %v", err),
+			})
+			continue
+		}
+
 		task := &entity.IngestionTask{
 			DocumentID: docID,
 			UserID:     userID,

--- a/internal/service/ingestion_task_service_test.go
+++ b/internal/service/ingestion_task_service_test.go
@@ -102,6 +102,44 @@ func TestIngestionTaskServiceCreateForDocumentsPublishesTaskMessages(t *testing.
 	}
 }
 
+func TestIngestionTaskServiceCreateForDocumentsMarksDocumentRunning(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertTestKB(t, "kb-1", "tenant-1", 1, 0, 0)
+	insertTestDoc(t, "doc-1", "kb-1", 0, 0)
+	insertTestIngestionTaskWithStatus(t, "task-1", "user-1", "doc-1", "kb-1", common.STOPPED)
+
+	// A previously cancelled parse leaves the legacy run field terminal.
+	// Re-parsing must flip it back to RUNNING when the run is accepted so
+	// the file list and the detail dialog agree a new run is queued.
+	if err := db.Model(&entity.Document{}).Where("id = ?", "doc-1").
+		Updates(map[string]interface{}{"run": string(entity.TaskStatusCancel), "progress": float64(0)}).Error; err != nil {
+		t.Fatalf("seed cancelled document: %v", err)
+	}
+
+	svc := NewIngestionTaskService()
+	svc.taskPublisher = &recordingTaskPublisher{}
+
+	responses, err := svc.CreateForDocuments(t.Context(), "kb-1", "user-1", []string{"doc-1"})
+	if err != nil {
+		t.Fatalf("CreateForDocuments failed: %v", err)
+	}
+	if len(responses) != 1 || !strings.HasPrefix(responses[0].Result, "task_id: ") {
+		t.Fatalf("unexpected parse response: %+v", responses)
+	}
+
+	var doc entity.Document
+	if err := db.First(&doc, "id = ?", "doc-1").Error; err != nil {
+		t.Fatalf("reload document: %v", err)
+	}
+	if doc.Run == nil || *doc.Run != string(entity.TaskStatusRunning) {
+		t.Fatalf("document run = %v, want %q (RUNNING)", doc.Run, string(entity.TaskStatusRunning))
+	}
+	if doc.Progress != 0 {
+		t.Fatalf("document progress = %v, want 0", doc.Progress)
+	}
+}
+
 func TestIngestionTaskServiceMarksTaskScheduledOnlyAfterPublish(t *testing.T) {
 	db := setupServiceTestDB(t)
 	pushServiceDB(t, db)


### PR DESCRIPTION
### Summary

**Problem.** On the Go backend, re-parsing a previously cancelled document showed
contradictory UI state: the dataset file list badge said **Queued** (derived from
`ingestion_status` = CREATED/SCHEDULED) while the file detail dialog said
**Cancel** with `Duration 0s` (derived from the legacy `document.run` = "2").

**Root cause.** When the Go backend accepts a parse request (parse button,
re-parse, chunk parse, agent rerun, connector sync — all funnel through
`IngestionTaskService.CreateForDocuments`), it only created and enqueued the
ingestion task. The document's legacy `run` field kept whatever value the
previous run left behind (e.g. "2"/CANCEL) and was only rewritten when a worker
picked the task up (`StartRunning`). While the task sat in the queue the two
status sources disagreed. The Python backend does not have this bug: its run
endpoint (`api/apps/restful_apis/document_api.py`, `_run_sync`) writes
`run = RUNNING`, `progress = 0` per document as soon as the request is accepted,
before queueing.

**Fix.** Mirror the Python behavior in `CreateForDocuments`: once a document is
validated for parsing, immediately update `run` to RUNNING ("1") and reset
`progress` to 0, before enqueueing the ingestion task. `StartRunning` and the
worker progress sink keep `run`/`progress` in sync as the task advances, and the
cancel path still overwrites `run` with CANCEL, so every state visible while a
task is queued/running/cancelled is now consistent between the list badge and
the detail dialog. Updated the now-stale comments on `StartParseDocuments` /
`Ingest` that claimed the run status is only set by the worker.

Relationship to prior work: #19137 and #19249 surfaced the ingestion-side
queued status on the frontend; neither touched the backend `document.run`
sync, so the stale-`run` contradiction remained. This PR is the backend
complement.

### Verification

- New regression test `TestIngestionTaskServiceCreateForDocumentsMarksDocumentRunning`
  seeds the exact reported scenario (terminal STOPPED ingestion task +
  `run = CANCEL`) and asserts `CreateForDocuments` flips the document to
  `run = RUNNING` / `progress = 0` while re-queueing the task.
- `bash build.sh --test ./internal/service/...` — all packages pass
  (`internal/service`, `internal/service/document`, `internal/service/chunk`,
  `internal/service/dataset`, ...), 0 failures.
- Python-parity check: `document_api.py::_run_sync` sets the same fields at the
  same point in the flow (accept-time, pre-queue).
- Verification boundary: end-to-end UI verification was not possible in this
  environment — the browser automation MCP session was dead ("Target closed",
  unrecoverable from the task sandbox) and the Python API stack could not start
  (its venv interpreter was lost and PyPI is unreachable), so the seed login
  account does not exist. Evidence is therefore Python alignment + unit tests
  (backend-only change; no frontend surface modified).
