### PR TITLE
fix(web): disallow folder upload in chunk creating modal

### DIFF
--- a/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-creating-modal/index.tsx
+++ b/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-creating-modal/index.tsx
@@ -202,6 +202,7 @@ const ChunkCreatingModal: React.FC<IModalProps<any> & kFProps> = ({
                           }}
                           maxFileCount={1}
                           hideDropzoneOnMaxFileCount
+                          showFolderTab={false}
                           title={t('chunk.imageUploaderTitle')}
                           description={<></>}
                         />


### PR DESCRIPTION
### Summary

Hide the folder tab of the image uploader in the chunk creating modal so folders cannot be uploaded when creating or editing a chunk.
