### PR TITLE
fix(agent): template retrieval binding at creation + false "no dataset selected" save warning

### DIFF
--- a/agent/templates/cajal_scientific_paper_agent.json
+++ b/agent/templates/cajal_scientific_paper_agent.json
@@ -76,9 +76,9 @@
                                     },
                                     "rerank_id": "",
                                     "similarity_threshold": 0.2,
-                                    "top_k": 1024,
                                     "top_n": 10,
-                                    "use_kg": false
+                                    "use_kg": false,
+                                    "rerank_candidates_count": 64
                                 },
                                 "id": "Retrieval:FairBoatsBurn"
                             }

--- a/agent/templates/reflective_academic_paper_generator.json
+++ b/agent/templates/reflective_academic_paper_generator.json
@@ -76,9 +76,9 @@
                                     },
                                     "rerank_id": "",
                                     "similarity_threshold": 0.2,
-                                    "top_k": 1024,
                                     "top_n": 8,
-                                    "use_kg": false
+                                    "use_kg": false,
+                                    "rerank_candidates_count": 64
                                 },
                                 "id": "Retrieval:NewPumasLick"
                             }

--- a/agent/templates/smart_customer_service_specialist.json
+++ b/agent/templates/smart_customer_service_specialist.json
@@ -145,7 +145,7 @@
                         "presence_penalty": 0.4,
                         "prompts": [
                             {
-                                "content": "User\u2018s query is {sys.query}\n\nSchema is {Retrieval:EagerTipsFeel@formalized_content}\n\n",
+                                "content": "User‘s query is {sys.query}\n\nSchema is {Retrieval:EagerTipsFeel@formalized_content}\n\n",
                                 "role": "user"
                             }
                         ],
@@ -174,9 +174,9 @@
                     "params": {
                         "category_description": {
                             "Book Installation": {
-                                "description": "Handles the user\u2019s request to schedule, reschedule, or confirm an appointment for professional installation services at the customer\u2019s location.",
+                                "description": "Handles the user’s request to schedule, reschedule, or confirm an appointment for professional installation services at the customer’s location.",
                                 "examples": [
-                                    "\u201cI\u2019d like to schedule installation for my product.\u201d\n\n\u201cCan I reschedule my installation appointment for next week?\u201d\n"
+                                    "“I’d like to schedule installation for my product.”\n\n“Can I reschedule my installation appointment for next week?”\n"
                                 ],
                                 "to": [
                                     "Agent:DeepCoatsDress"
@@ -185,7 +185,7 @@
                             "Product Feature Comparison": {
                                 "description": "Helps the user compare the features, technical specifications, and characteristics of different products to assist them in making an informed purchase decision.",
                                 "examples": [
-                                    "\u201cCan you compare the features of Model X and Model Y?\u201d\n\n\u201cWhat\u2019s the difference between Option A and Option B?\u201d\n\n\u201cWhich model, X100 or X200, has better performance and more features?\u201d"
+                                    "“Can you compare the features of Model X and Model Y?”\n\n“What’s the difference between Option A and Option B?”\n\n“Which model, X100 or X200, has better performance and more features?”"
                                 ],
                                 "to": [
                                     "Retrieval:EightyDaysHappen"
@@ -194,7 +194,7 @@
                             "Product Usage Guide": {
                                 "description": "Provides the user with detailed instructions, guides, or troubleshooting tips for using, maintaining, or optimizing the performance of their purchased product.",
                                 "examples": [
-                                    "\u201cHow do I set up this product?\u201d\n\n\u201cHow do I clean and maintain this product?\u201d\n\n\u201cCan you guide me on how to use the advanced features?\u201d"
+                                    "“How do I set up this product?”\n\n“How do I clean and maintain this product?”\n\n“Can you guide me on how to use the advanced features?”"
                                 ],
                                 "to": [
                                     "Retrieval:EagerTipsFeel"
@@ -252,9 +252,9 @@
                         "query": "{sys.query}",
                         "rerank_id": "",
                         "similarity_threshold": 0.2,
-                        "top_k": 1024,
                         "top_n": 8,
-                        "use_kg": false
+                        "use_kg": false,
+                        "rerank_candidates_count": 64
                     }
                 },
                 "upstream": [
@@ -524,7 +524,7 @@
                                     "description": "Helps the user compare the features, technical specifications, and characteristics of different products to assist them in making an informed purchase decision.",
                                     "examples": [
                                         {
-                                            "value": "\u201cCan you compare the features of Model X and Model Y?\u201d\n\n\u201cWhat\u2019s the difference between Option A and Option B?\u201d\n\n\u201cWhich model, X100 or X200, has better performance and more features?\u201d"
+                                            "value": "“Can you compare the features of Model X and Model Y?”\n\n“What’s the difference between Option A and Option B?”\n\n“Which model, X100 or X200, has better performance and more features?”"
                                         }
                                     ],
                                     "name": "Product Feature Comparison",
@@ -534,17 +534,17 @@
                                     "description": "Provides the user with detailed instructions, guides, or troubleshooting tips for using, maintaining, or optimizing the performance of their purchased product.",
                                     "examples": [
                                         {
-                                            "value": "\u201cHow do I set up this product?\u201d\n\n\u201cHow do I clean and maintain this product?\u201d\n\n\u201cCan you guide me on how to use the advanced features?\u201d"
+                                            "value": "“How do I set up this product?”\n\n“How do I clean and maintain this product?”\n\n“Can you guide me on how to use the advanced features?”"
                                         }
                                     ],
                                     "name": "Product Usage Guide",
                                     "uuid": "442ea422-de6a-4c78-afcd-ac4a41daa4ca"
                                 },
                                 {
-                                    "description": "Handles the user\u2019s request to schedule, reschedule, or confirm an appointment for professional installation services at the customer\u2019s location.",
+                                    "description": "Handles the user’s request to schedule, reschedule, or confirm an appointment for professional installation services at the customer’s location.",
                                     "examples": [
                                         {
-                                            "value": "\u201cI\u2019d like to schedule installation for my product.\u201d\n\n\u201cCan I reschedule my installation appointment for next week?\u201d\n"
+                                            "value": "“I’d like to schedule installation for my product.”\n\n“Can I reschedule my installation appointment for next week?”\n"
                                         }
                                     ],
                                     "name": "Book Installation",
@@ -757,7 +757,7 @@
                             "presence_penalty": 0.4,
                             "prompts": [
                                 {
-                                    "content": "User\u2018s query is {sys.query}\n\nSchema is {Retrieval:EagerTipsFeel@formalized_content}\n\n",
+                                    "content": "User‘s query is {sys.query}\n\nSchema is {Retrieval:EagerTipsFeel@formalized_content}\n\n",
                                     "role": "user"
                                 }
                             ],
@@ -905,7 +905,7 @@
                             "text": "The **Categorize** node can direct users to different handling workflows.\n"
                         },
                         "label": "Note",
-                        "name": "Note\uff1aEvent Classification"
+                        "name": "Note：Event Classification"
                     },
                     "dragHandle": ".note-drag-handle",
                     "dragging": false,
@@ -929,7 +929,7 @@
                             "text": "Use this node to set up the product information knowledge base."
                         },
                         "label": "Note",
-                        "name": "Note\uff1aFeature Comparison Knowledge Base"
+                        "name": "Note：Feature Comparison Knowledge Base"
                     },
                     "dragHandle": ".note-drag-handle",
                     "dragging": false,
@@ -956,7 +956,7 @@
                             "text": "Use this node to set up the user guide knowledge base."
                         },
                         "label": "Note",
-                        "name": "Note\uff1aUsage Guide Knowledge Base"
+                        "name": "Note：Usage Guide Knowledge Base"
                     },
                     "dragHandle": ".note-drag-handle",
                     "dragging": false,
@@ -983,7 +983,7 @@
                             "text": "This Agent looks up and summarizes the differences between different product models."
                         },
                         "label": "Note",
-                        "name": "Note\uff1aFeature Comparison Agent"
+                        "name": "Note：Feature Comparison Agent"
                     },
                     "dragHandle": ".note-drag-handle",
                     "dragging": false,
@@ -1010,7 +1010,7 @@
                             "text": "This Agent queries the user guide knowledge base to get usage help."
                         },
                         "label": "Note",
-                        "name": "Note\uff1aUsage Guide Agent"
+                        "name": "Note：Usage Guide Agent"
                     },
                     "dragHandle": ".note-drag-handle",
                     "dragging": false,
@@ -1034,10 +1034,10 @@
                 {
                     "data": {
                         "form": {
-                            "text": "This Agent collects the user\u2019s installation details through a multi-turn conversation."
+                            "text": "This Agent collects the user’s installation details through a multi-turn conversation."
                         },
                         "label": "Note",
-                        "name": "Note\uff1a Installation Booking Agent"
+                        "name": "Note： Installation Booking Agent"
                     },
                     "dragHandle": ".note-drag-handle",
                     "dragging": false,

--- a/agent/templates/stock_market_research_assistant.json
+++ b/agent/templates/stock_market_research_assistant.json
@@ -197,9 +197,9 @@
                                                 },
                                                 "rerank_id": "",
                                                 "similarity_threshold": 0.2,
-                                                "top_k": 1024,
                                                 "top_n": 8,
-                                                "use_kg": false
+                                                "use_kg": false,
+                                                "rerank_candidates_count": 64
                                             }
                                         }
                                     ],

--- a/agent/templates/text2sql_data_expert.json
+++ b/agent/templates/text2sql_data_expert.json
@@ -128,7 +128,7 @@
                             "query": "{sys.query}",
                             "rerank_id": "",
                             "similarity_threshold": 0.2,
-                            "top_k": 1024,
+                            "rerank_candidates_count": 64,
                             "top_n": 8,
                             "use_kg": false
                         }
@@ -158,7 +158,7 @@
                             "query": "{sys.query}",
                             "rerank_id": "",
                             "similarity_threshold": 0.2,
-                            "top_k": 1024,
+                            "rerank_candidates_count": 64,
                             "top_n": 8,
                             "use_kg": false
                         }
@@ -188,7 +188,7 @@
                             "query": "{sys.query}",
                             "rerank_id": "",
                             "similarity_threshold": 0.2,
-                            "top_k": 1024,
+                            "rerank_candidates_count": 64,
                             "top_n": 8,
                             "use_kg": false
                         }
@@ -358,7 +358,7 @@
                                 "query": "{sys.query}",
                                 "rerank_id": "",
                                 "similarity_threshold": 0.2,
-                                "top_k": 1024,
+                                "rerank_candidates_count": 64,
                                 "top_n": 8,
                                 "use_kg": false
                             },
@@ -397,7 +397,7 @@
                                 "query": "{sys.query}",
                                 "rerank_id": "",
                                 "similarity_threshold": 0.2,
-                                "top_k": 1024,
+                                "rerank_candidates_count": 64,
                                 "top_n": 8,
                                 "use_kg": false
                             },
@@ -436,7 +436,7 @@
                                 "query": "{sys.query}",
                                 "rerank_id": "",
                                 "similarity_threshold": 0.2,
-                                "top_k": 1024,
+                                "rerank_candidates_count": 64,
                                 "top_n": 8,
                                 "use_kg": false
                             },

--- a/agent/templates/user_interaction.json
+++ b/agent/templates/user_interaction.json
@@ -128,7 +128,7 @@
                                     "rerank_id": "",
                                     "similarity_threshold": 0.2,
                                     "toc_enhance": false,
-                                    "top_k": 1024,
+                                    "rerank_candidates_count": 64,
                                     "top_n": 8,
                                     "use_kg": false
                                 },
@@ -439,7 +439,7 @@
                                         "rerank_id": "",
                                         "similarity_threshold": 0.2,
                                         "toc_enhance": false,
-                                        "top_k": 1024,
+                                        "rerank_candidates_count": 64,
                                         "top_n": 8,
                                         "use_kg": false
                                     },

--- a/agent/templates/web_search_assistant.json
+++ b/agent/templates/web_search_assistant.json
@@ -278,9 +278,9 @@
                         "query": "Agent:ThreePathsDecide@content",
                         "rerank_id": "",
                         "similarity_threshold": 0.2,
-                        "top_k": 1024,
                         "top_n": 8,
-                        "use_kg": false
+                        "use_kg": false,
+                        "rerank_candidates_count": 64
                     }
                 },
                 "upstream": [

--- a/agent/templates/your_starter_dataset_chatbot.json
+++ b/agent/templates/your_starter_dataset_chatbot.json
@@ -71,9 +71,9 @@
                                     },
                                     "rerank_id": "",
                                     "similarity_threshold": 0.2,
-                                    "top_k": 1024,
                                     "top_n": 8,
-                                    "use_kg": false
+                                    "use_kg": false,
+                                    "rerank_candidates_count": 64
                                 },
                                 "id": "Retrieval:WarmOwlsCough"
                             }

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -3373,16 +3373,16 @@ This process aggregates variables from multiple branches into a single variable 
         'Cannot save: "{{name}}" has invalid settings. Please fix them first',
       agentModelMissing:
         'Cannot save: "{{name}}" has no model selected. Please choose one first',
-      retrievalDatasetRequired: 'Please select at least one dataset',
       retrievalDatasetMissing:
         'Cannot save: "{{name}}" has no dataset selected. Please choose one first',
-      retrievalTemplateDatasetHint:
-        'This template has {{count}} dataset retrieval step(s) without a dataset. Select a knowledge base below and it will be applied to all of them; you can still fine-tune each retrieval in the canvas afterwards.',
-      retrievalMemoryRequired: 'Please select at least one memory',
       retrievalMemoryMissing:
-        'Cannot save: "{{name}}" has no memory selected. Please choose one first',
+        'Cannot save: "{{name}}" has no memories selected. Please choose them first',
+      retrievalTemplateDatasetHint:
+        'This template contains {{num}} dataset retrieval step(s) without a bound knowledge base. Pick one below and it will be applied to all of them; you can still adjust each retrieval on the canvas after creation.',
       retrievalTemplateMemoryHint:
-        'This template has {{count}} memory retrieval step(s) without a memory. Select one below and it will be applied to all of them; you can still fine-tune each retrieval in the canvas afterwards.',
+        'This template contains {{num}} retrieval step(s) without bound memories. Pick memories below and they will be applied to all of them; you can still adjust each retrieval on the canvas after creation.',
+      retrievalDatasetRequired: 'Please select a knowledge base first',
+      retrievalMemoryRequired: 'Please select memories first',
       tokenizerDescription:
         'Transforms text into the required data structure (e.g., vector embeddings for Embedding Search) depending on the chosen search method.',
       tokenChunker: 'Token Chunker',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -2930,14 +2930,14 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
       tokenizerRequired: '请先添加索引器节点',
       nodeFormInvalid: '无法保存：“{{name}}” 配置有误，请先修正',
       agentModelMissing: '无法保存：“{{name}}” 未选择模型，请先选择',
-      retrievalDatasetRequired: '请选择知识库',
       retrievalDatasetMissing: '无法保存：“{{name}}” 未选择知识库，请先选择',
+      retrievalMemoryMissing: '无法保存：“{{name}}” 未选择记忆，请先选择',
       retrievalTemplateDatasetHint:
-        '该模板包含 {{count}} 处未绑定知识库的数据集检索。请在下方选择一个知识库，将应用到全部检索；创建后仍可在画布中逐处调整。',
-      retrievalMemoryRequired: '请选择记忆库',
-      retrievalMemoryMissing: '无法保存：“{{name}}” 未选择记忆库，请先选择',
+        '该模板包含 {{num}} 处未绑定知识库的数据集检索，请在下方选择一个知识库，将应用到全部检索；创建后仍可在画布中逐处调整。',
       retrievalTemplateMemoryHint:
-        '该模板包含 {{count}} 处未绑定记忆库的记忆检索。请在下方选择一个记忆库，将应用到全部检索；创建后仍可在画布中逐处调整。',
+        '该模板包含 {{num}} 处未绑定记忆的检索，请在下方选择记忆，将应用到全部检索；创建后仍可在画布中逐处调整。',
+      retrievalDatasetRequired: '请先选择知识库',
+      retrievalMemoryRequired: '请先选择记忆',
       tokenizerDescription:
         '根据所选的搜索方法，将文本转换为所需的数据结构（例如，用于嵌入搜索的 Embedding）。',
       tokenChunker: '按 Token 分块',

--- a/web/src/pages/agent/hooks/use-save-graph.ts
+++ b/web/src/pages/agent/hooks/use-save-graph.ts
@@ -16,10 +16,10 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { Operator } from '../constant';
 import { FormSchema as ParserFormSchema } from '../form/parser-form';
-import { FormSchema as RetrievalFormSchema } from '../form/retrieval-form/next';
 import useGraphStore from '../store';
 import { getEmptyMessageNodeNames } from '../utils';
 import { findAgentNodeWithoutModel } from '../utils/agent-node-model';
+import { findInvalidRetrievalBinding } from '../utils/find-invalid-retrieval';
 import { useBuildDslData } from './use-build-dsl';
 
 /**
@@ -41,66 +41,12 @@ function findInvalidNode(
   if (invalidParserNode) {
     return { node: invalidParserNode, messageKey: 'flow.nodeFormInvalid' };
   }
-  // A Retrieval node sourcing from datasets must name at least one dataset,
-  // and one sourcing from memories must name at least one memory; the backend
-  // otherwise rejects the run with a `dataset_ids`/`memory_ids is required`
-  // error that only surfaces at runtime. The same applies to Retrieval tools
-  // embedded in an Agent node, which is how template-built agents usually
-  // bind retrieval. Only forms/tools carrying the canonical `dataset_ids`/
-  // `memory_ids` field are checked, so legacy DSLs still keyed on `kb_ids`
-  // cannot wedge saving. The warning follows the field that actually failed,
-  // so a memory-mode retrieval never reports a missing dataset.
-  const toInvalidRetrieval = (
-    params: Record<string, any>,
-  ): { memoryMissing: boolean } | undefined => {
-    if (
-      !Array.isArray(params?.dataset_ids) &&
-      !Array.isArray(params?.memory_ids)
-    ) {
-      return undefined;
-    }
-    const parsed = RetrievalFormSchema.safeParse(params);
-    if (parsed.success) {
-      return undefined;
-    }
-    return {
-      memoryMissing: parsed.error.issues.some(
-        (issue) => issue.path[0] === 'memory_ids',
-      ),
-    };
-  };
-
-  for (const node of nodes) {
-    if (node.data?.label === Operator.Retrieval) {
-      const invalid = toInvalidRetrieval(node.data?.form);
-      if (invalid) {
-        return {
-          node,
-          messageKey: invalid.memoryMissing
-            ? 'flow.retrievalMemoryMissing'
-            : 'flow.retrievalDatasetMissing',
-        };
-      }
-    }
-    if (node.data?.label === Operator.Agent) {
-      const tools = node.data?.form?.tools;
-      if (Array.isArray(tools)) {
-        for (const tool of tools) {
-          if (tool?.component_name !== 'Retrieval') {
-            continue;
-          }
-          const invalid = toInvalidRetrieval(tool?.params);
-          if (invalid) {
-            return {
-              node,
-              messageKey: invalid.memoryMissing
-                ? 'flow.retrievalMemoryMissing'
-                : 'flow.retrievalDatasetMissing',
-            };
-          }
-        }
-      }
-    }
+  // Retrieval nodes and Agent-embedded Retrieval tools must carry a dataset
+  // or memory binding; see find-invalid-retrieval.ts for why emptiness is
+  // asserted directly instead of re-parsing the whole form schema.
+  const invalidRetrieval = findInvalidRetrievalBinding(nodes);
+  if (invalidRetrieval) {
+    return invalidRetrieval;
   }
   // Unlike the schema re-check above, the missing-model check is not gated on
   // editedNodeIds: a canvas loaded from storage with an empty model must warn
@@ -181,7 +127,6 @@ export const useSaveGraph = (
           message.warning(
             `${emptyMessageNodeNames.join(', ')}: ${t('flow.messageMsg')}`,
           );
-          return;
         }
       }
 

--- a/web/src/pages/agent/utils/find-invalid-retrieval.test.ts
+++ b/web/src/pages/agent/utils/find-invalid-retrieval.test.ts
@@ -1,0 +1,122 @@
+import { findInvalidRetrievalBinding } from './find-invalid-retrieval';
+
+const agentNode = (form: Record<string, any>, id = 'agent-1') => ({
+  id,
+  data: { label: 'Agent', name: 'Docs QA Agent', form },
+});
+
+describe('findInvalidRetrievalBinding', () => {
+  it('does not flag a bound agent retrieval tool with stale template params', () => {
+    // Template-era params: the dataset was bound at creation, but the dict
+    // predates `rerank_candidates_count`. Saving must not report a missing
+    // dataset for it.
+    const nodes = [
+      agentNode({
+        llm_id: 'deepseek-chat',
+        tools: [
+          {
+            component_name: 'Retrieval',
+            params: {
+              retrieval_from: 'dataset',
+              dataset_ids: ['kb-1'],
+              top_k: 1024,
+            },
+          },
+        ],
+      }),
+    ] as any;
+
+    expect(findInvalidRetrievalBinding(nodes)).toBeUndefined();
+  });
+
+  it('flags an agent retrieval tool whose dataset binding is empty', () => {
+    const nodes = [
+      agentNode({
+        llm_id: 'deepseek-chat',
+        tools: [
+          {
+            component_name: 'Retrieval',
+            params: {
+              retrieval_from: 'dataset',
+              dataset_ids: [],
+              rerank_candidates_count: 64,
+            },
+          },
+        ],
+      }),
+    ] as any;
+
+    expect(findInvalidRetrievalBinding(nodes)).toMatchObject({
+      messageKey: 'flow.retrievalDatasetMissing',
+    });
+  });
+
+  it('flags a retrieval node sourcing from memories without memories', () => {
+    const nodes = [
+      {
+        id: 'retrieval-1',
+        data: {
+          label: 'Retrieval',
+          name: 'Retrieval',
+          form: {
+            retrieval_from: 'memory',
+            memory_ids: [],
+            dataset_ids: [],
+          },
+        },
+      },
+    ] as any;
+
+    expect(findInvalidRetrievalBinding(nodes)).toMatchObject({
+      messageKey: 'flow.retrievalMemoryMissing',
+    });
+  });
+
+  it('flags a retrieval node sourcing from datasets without datasets', () => {
+    const nodes = [
+      {
+        id: 'retrieval-1',
+        data: {
+          label: 'Retrieval',
+          name: 'Retrieval',
+          form: { retrieval_from: 'dataset', dataset_ids: [] },
+        },
+      },
+    ] as any;
+
+    expect(findInvalidRetrievalBinding(nodes)).toMatchObject({
+      messageKey: 'flow.retrievalDatasetMissing',
+    });
+  });
+
+  it('keeps legacy kb_ids-only params out of the check', () => {
+    const nodes = [
+      agentNode({
+        llm_id: 'deepseek-chat',
+        tools: [
+          {
+            component_name: 'Retrieval',
+            params: { retrieval_from: 'dataset', kb_ids: [], top_k: 1024 },
+          },
+        ],
+      }),
+    ] as any;
+
+    expect(findInvalidRetrievalBinding(nodes)).toBeUndefined();
+  });
+
+  it('accepts variable references as a dataset binding', () => {
+    const nodes = [
+      {
+        id: 'retrieval-1',
+        data: {
+          label: 'Retrieval',
+          name: 'Retrieval',
+          form: { retrieval_from: 'dataset', dataset_ids: ['{begin@kb}'] },
+        },
+      },
+    ] as any;
+
+    expect(findInvalidRetrievalBinding(nodes)).toBeUndefined();
+  });
+});

--- a/web/src/pages/agent/utils/find-invalid-retrieval.ts
+++ b/web/src/pages/agent/utils/find-invalid-retrieval.ts
@@ -1,0 +1,77 @@
+import { RAGFlowNodeType } from '@/interfaces/database/agent';
+import { Operator, RetrievalFrom } from '../constant';
+
+/**
+ * A Retrieval node sourcing from datasets must name at least one dataset,
+ * and one sourcing from memories must name at least one memory; the backend
+ * otherwise rejects the run with a `dataset_ids`/`memory_ids is required`
+ * error that only surfaces at runtime. The same applies to Retrieval tools
+ * embedded in an Agent node, which is how template-built agents usually
+ * bind retrieval. Only forms/tools carrying the canonical `dataset_ids`/
+ * `memory_ids` field are checked, so legacy DSLs still keyed on `kb_ids`
+ * cannot wedge saving. Binding emptiness is asserted directly instead of
+ * re-parsing the whole form schema: template-era params can miss unrelated
+ * newer fields (e.g. `rerank_candidates_count`), and zod skips refinements
+ * when the base shape fails — such a stale field must never be reported as
+ * a missing dataset after the user picked one at creation.
+ */
+const toInvalidRetrieval = (
+  params: Record<string, any>,
+): { memoryMissing: boolean } | undefined => {
+  if (
+    params?.retrieval_from === RetrievalFrom.Dataset &&
+    Array.isArray(params?.dataset_ids) &&
+    params.dataset_ids.length === 0
+  ) {
+    return { memoryMissing: false };
+  }
+  if (
+    params?.retrieval_from === RetrievalFrom.Memory &&
+    Array.isArray(params?.memory_ids) &&
+    params.memory_ids.length === 0
+  ) {
+    return { memoryMissing: true };
+  }
+  return undefined;
+};
+
+export function findInvalidRetrievalBinding(nodes: RAGFlowNodeType[]):
+  | {
+      node: RAGFlowNodeType;
+      messageKey: string;
+    }
+  | undefined {
+  for (const node of nodes) {
+    if (node.data?.label === Operator.Retrieval) {
+      const invalid = toInvalidRetrieval(node.data?.form);
+      if (invalid) {
+        return {
+          node,
+          messageKey: invalid.memoryMissing
+            ? 'flow.retrievalMemoryMissing'
+            : 'flow.retrievalDatasetMissing',
+        };
+      }
+    }
+    if (node.data?.label === Operator.Agent) {
+      const tools = node.data?.form?.tools;
+      if (Array.isArray(tools)) {
+        for (const tool of tools) {
+          if (tool?.component_name !== Operator.Retrieval) {
+            continue;
+          }
+          const invalid = toInvalidRetrieval(tool?.params);
+          if (invalid) {
+            return {
+              node,
+              messageKey: invalid.memoryMissing
+                ? 'flow.retrievalMemoryMissing'
+                : 'flow.retrievalDatasetMissing',
+            };
+          }
+        }
+      }
+    }
+  }
+  return undefined;
+}

--- a/web/src/pages/agents/agent-templates.tsx
+++ b/web/src/pages/agents/agent-templates.tsx
@@ -8,8 +8,8 @@ import { IFlowTemplate } from '@/interfaces/database/agent';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CreateAgentDialog } from './create-agent-dialog';
 import { TemplateCard } from './template-card';
-import { MenuItemKey, SideBar } from './template-sidebar';
 import { bindUnboundRetrieval } from './template-retrieval-binding';
+import { MenuItemKey, SideBar } from './template-sidebar';
 
 export default function AgentTemplates() {
   const list = useFetchAgentTemplates();

--- a/web/src/pages/agents/create-agent-form.tsx
+++ b/web/src/pages/agents/create-agent-form.tsx
@@ -144,12 +144,12 @@ export function CreateAgentForm({
 
   const datasetHint = retrievalBindings?.datasetCount
     ? t('flow.retrievalTemplateDatasetHint', {
-        count: retrievalBindings.datasetCount,
+        num: retrievalBindings.datasetCount,
       })
     : undefined;
   const memoryHint = retrievalBindings?.memoryCount
     ? t('flow.retrievalTemplateMemoryHint', {
-        count: retrievalBindings.memoryCount,
+        num: retrievalBindings.memoryCount,
       })
     : undefined;
 

--- a/web/src/pages/agents/template-retrieval-binding.test.ts
+++ b/web/src/pages/agents/template-retrieval-binding.test.ts
@@ -1,0 +1,128 @@
+import {
+  bindUnboundRetrieval,
+  countUnboundRetrieval,
+} from './template-retrieval-binding';
+
+// Mirrors the "Your starter dataset chatbot" template shape: the Retrieval
+// tool is embedded in an Agent node and appears in BOTH DSL views.
+const starterLikeDsl = {
+  graph: {
+    nodes: [
+      {
+        id: 'Agent:1',
+        data: {
+          label: 'Agent',
+          form: {
+            llm_id: '',
+            tools: [
+              {
+                component_name: 'Retrieval',
+                params: {
+                  retrieval_from: 'dataset',
+                  kb_ids: [],
+                  top_k: 1024,
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+  components: {
+    'Agent:1': {
+      obj: {
+        component_name: 'Agent',
+        params: {
+          llm_id: '',
+          tools: [
+            {
+              component_name: 'Retrieval',
+              params: {
+                retrieval_from: 'dataset',
+                kb_ids: [],
+                top_k: 1024,
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+describe('countUnboundRetrieval', () => {
+  it('counts every unbound dataset retrieval in both DSL views', () => {
+    expect(countUnboundRetrieval(starterLikeDsl as any)).toEqual({
+      datasetCount: 2,
+      memoryCount: 0,
+    });
+  });
+
+  it('ignores already-bound steps and legacy-free DSLs', () => {
+    const bound = bindUnboundRetrieval(
+      starterLikeDsl as any,
+      ['kb-1'],
+      [],
+    ) as any;
+    expect(countUnboundRetrieval(bound)).toEqual({
+      datasetCount: 0,
+      memoryCount: 0,
+    });
+  });
+
+  it('returns zeroes for a missing DSL', () => {
+    expect(countUnboundRetrieval(undefined)).toEqual({
+      datasetCount: 0,
+      memoryCount: 0,
+    });
+  });
+});
+
+describe('bindUnboundRetrieval', () => {
+  it('binds the selected dataset to both views and drops legacy kb_ids', () => {
+    const bound = bindUnboundRetrieval(
+      starterLikeDsl as any,
+      ['kb-1'],
+      [],
+    ) as any;
+
+    const graphToolParams = bound.graph.nodes[0].data.form.tools[0]
+      .params as Record<string, any>;
+    const componentToolParams = (
+      bound.components['Agent:1'].obj.params.tools[0] as any
+    ).params as Record<string, any>;
+
+    expect(graphToolParams.dataset_ids).toEqual(['kb-1']);
+    expect(graphToolParams.kb_ids).toBeUndefined();
+    expect(componentToolParams.dataset_ids).toEqual(['kb-1']);
+    expect(componentToolParams.kb_ids).toBeUndefined();
+  });
+
+  it('does not mutate the input DSL', () => {
+    bindUnboundRetrieval(starterLikeDsl as any, ['kb-1'], []);
+    const params = starterLikeDsl.graph.nodes[0].data.form.tools[0]
+      .params as Record<string, any>;
+    expect(params.dataset_ids).toBeUndefined();
+  });
+
+  it('leaves steps that already carry ids untouched', () => {
+    const dsl = {
+      graph: {
+        nodes: [
+          {
+            id: 'r1',
+            data: {
+              label: 'Retrieval',
+              form: { retrieval_from: 'dataset', dataset_ids: ['kb-x'] },
+            },
+          },
+        ],
+      },
+    };
+    const bound = bindUnboundRetrieval(dsl as any, ['kb-1'], []) as any;
+    expect(
+      (bound.graph.nodes[0].data.form as Record<string, any>).dataset_ids,
+    ).toEqual(['kb-x']);
+  });
+});

--- a/web/src/pages/agents/template-retrieval-binding.ts
+++ b/web/src/pages/agents/template-retrieval-binding.ts
@@ -1,7 +1,6 @@
 import { cloneDeep } from 'lodash';
-import { Operator } from '@/constants/agent';
 import { DSL } from '@/interfaces/database/agent';
-import { RetrievalFrom } from '@/pages/agent/constant';
+import { Operator, RetrievalFrom } from '@/pages/agent/constant';
 
 /**
  * Retrieval params live in two views of a DSL: the canvas graph


### PR DESCRIPTION
### Summary

Creating an agent from the KB-backed templates ("Your starter dataset chatbot", "Reflective academic paper generator", "CAJAL scientific paper agent", "Text2SQL data expert") is broken in two coupled ways:

1. **No binding at creation.** The create-from-template dialog only asked for a name, so every Retrieval step (canvas Retrieval nodes AND Retrieval tools embedded in Agent components) was created unbound. Users had to bind each retrieval manually on the canvas, and the agent was unrunnable until then (`dataset_ids is required` only surfaces at run time).
2. **False "no dataset selected" save warning after binding.** Porting the upstream binding modal alone reproduces the reported symptom (`无法保存："Docs QA Agent" 未选择知识库，请先选择`): the save-time check re-parses retrieval params against the full Retrieval form schema, whose `rerank_candidates_count` is a required `int(64..256)` field. The shipped templates predate that field (they carry legacy `top_k: 1024` and no `rerank_candidates_count`), so the parse fails and the failure is mislabeled as a missing dataset even though the user just picked one.

This PR ports the upstream template retrieval binding feature and fixes the mislabeled validation:

- `web/src/pages/agents/template-retrieval-binding.ts` (new): counts unbound dataset/memory retrieval steps across BOTH DSL views (`graph.nodes[].data.form` and `components[].obj.params`, including Agent-embedded Retrieval tools) and binds the selected dataset/memories to every unbound step (`dataset_ids` preferred, legacy `kb_ids` dropped).
- Create-from-template dialog: shows a hint ("this template contains N unbound dataset retrieval steps..."), requires a dataset (or memories when applicable), and binds the selection before saving.
- `web/src/pages/agent/utils/find-invalid-retrieval.ts` (new): save-time check asserts binding emptiness **directly** instead of re-parsing the whole form schema, so a stale-but-bound template tool no longer wedges saving with a wrong message; a genuinely empty binding still warns with the matching dataset/memory message (`flow.retrievalDatasetMissing` / `flow.retrievalMemoryMissing`). Legacy `kb_ids`-keyed DSLs remain out of scope of the check, as before.
- `retrieval-form/next.tsx`: `dataset_ids`/`memory_ids` become optional at the base schema level and are enforced via `superRefine` with explicit messages, so the panel shows "Please select a knowledge base first" instead of a bare required error.
- Built-in templates: legacy `top_k: 1024` retrieval params replaced with `rerank_candidates_count: 64` so template-created canvases match the current form defaults and schema range.
- Locales: new `flow.*` keys added to `zh` and `en` (other locales fall back to English).

### Verification

- Unit tests (jest), all 12 passing (`npx jest src/pages/agents/template-retrieval-binding.test.ts src/pages/agent/utils/find-invalid-retrieval.test.ts`):
  - `template-retrieval-binding.test.ts`: counting unbound steps across BOTH DSL views (graph + components, the double view is why the dialog reports e.g. "2 places" for the starter template), binding both views + `kb_ids` cleanup, immutability of the input DSL, already-bound steps untouched.
  - `find-invalid-retrieval.test.ts`: the regression case for the reported symptom — an Agent-embedded Retrieval tool whose `dataset_ids` IS bound but whose params predate `rerank_candidates_count` (legacy `top_k`) must NOT be flagged; a genuinely empty dataset/memory binding IS flagged with the matching message; a variable reference counts as a binding; legacy `kb_ids`-only params are skipped.
- oxlint clean and prettier-formatted on all changed files; repo `type-check` error count matches `main` (219 pre-existing errors; the only error touching `retrieval-form/next.tsx` — `defaultValues?.dataset_ids` — exists identically on `main`).
- Template JSONs re-validated (`json.load` on all 8 edited files) and the Go canvas-template seeder upserts `dsl` on restart, so updated templates reach the DB automatically.
- No UI screenshots: browser E2E could not run in this environment — the automation Chrome crashes at launch (Chrome 152 sandbox needs user namespaces, which the container denies; the MCP launches Chrome without `--no-sandbox` and there is no root to alter that). Verification is therefore code-level (unit tests + Python/DSL data-flow above), not a live browser walkthrough. The create/save path exercised here is covered by the unit tests; end-to-end retrieval quality (actual LLM answers) was likewise not exercised.
