### PR TITLE
fix: support agent input mapping and converged edges

### DIFF
--- a/internal/agent/canvas/scheduler.go
+++ b/internal/agent/canvas/scheduler.go
@@ -639,8 +639,16 @@ func BuildWorkflow(ctx context.Context, c *Canvas) (*compose.Workflow[map[string
 		}
 		return nil
 	}
+	wired := make(map[pendingEdge]struct{}, len(pending))
 	first := make(map[string]bool, len(c.Components))
 	for _, e := range pending {
+		// Multiple output handles may converge on the same downstream
+		// node. The DSL keeps one upstream entry per handle, while eino
+		// permits only one control edge for a source/target pair.
+		if _, ok := wired[e]; ok {
+			continue
+		}
+		wired[e] = struct{}{}
 		if e.cpn == e.up {
 			return nil, fmt.Errorf("canvas: self-edge on %q", e.cpn)
 		}

--- a/internal/agent/canvas/scheduler_test.go
+++ b/internal/agent/canvas/scheduler_test.go
@@ -92,6 +92,38 @@ func TestBuildWorkflow_5NodeDiamond(t *testing.T) {
 	}
 }
 
+// TestBuildWorkflow_DuplicateUpstreamSucceeds verifies that multiple output
+// handles from one branching node may converge on the same downstream node.
+// The DSL records one upstream entry per handle, while eino requires only one
+// control edge between the two nodes.
+func TestBuildWorkflow_DuplicateUpstreamSucceeds(t *testing.T) {
+	c := &Canvas{
+		Components: map[string]CanvasComponent{
+			"begin_0": {
+				Obj:        CanvasComponentObj{ComponentName: "Begin", Params: map[string]any{}},
+				Downstream: []string{"categorize_0"},
+			},
+			"categorize_0": {
+				Obj:        CanvasComponentObj{ComponentName: "Categorize", Params: map[string]any{}},
+				Downstream: []string{"message_0", "message_0"},
+				Upstream:   []string{"begin_0"},
+			},
+			"message_0": {
+				Obj:      CanvasComponentObj{ComponentName: "Message", Params: map[string]any{}},
+				Upstream: []string{"categorize_0", "categorize_0"},
+			},
+		},
+	}
+
+	cc, err := Compile(t.Context(), c)
+	if err != nil {
+		t.Fatalf("Compile duplicate upstream: %v", err)
+	}
+	if cc == nil || cc.Workflow == nil {
+		t.Fatal("Compile produced nil workflow")
+	}
+}
+
 // TestBuildWorkflow_MultiTerminalSucceeds verifies that canvases with
 // more than one terminal component still compile cleanly. The scheduler
 // normalizes multiple terminal outputs through an internal merge node so

--- a/internal/agent/component/begin.go
+++ b/internal/agent/component/begin.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sort"
 
 	"ragflow/internal/agent/runtime"
 
@@ -47,13 +48,17 @@ const componentNameBegin = "Begin"
 // ParamBase surface is intentionally omitted for P0 — Begin is trivial
 // and needs no validation beyond what the State writes perform.
 type BeginComponent struct {
-	name string
+	name        string
+	inputFields []string
 }
 
 // NewBeginComponent constructs a Begin component. It accepts the DSL params
 // map but does not retain it (Begin has no per-instance configuration).
-func NewBeginComponent(_ map[string]any) (Component, error) {
-	return &BeginComponent{name: componentNameBegin}, nil
+func NewBeginComponent(params map[string]any) (Component, error) {
+	return &BeginComponent{
+		name:        componentNameBegin,
+		inputFields: beginInputFields(params),
+	}, nil
 }
 
 // Name returns the registered component name. Used by the registry and
@@ -97,7 +102,64 @@ func (b *BeginComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map[str
 	// Passthrough: a shallow copy keeps the caller's map un-aliased.
 	out := make(map[string]any, len(inputs))
 	mapsCopy(out, inputs)
+	for _, field := range b.inputFields {
+		if value, ok := beginInputValue(inputs, field); ok {
+			out[field] = value
+		}
+	}
 	return out, nil
+}
+
+// beginInputFields returns the custom input names declared by the Begin DSL
+// node. The frontend stores one entry per user-facing input under
+// params.inputs. Sorting keeps the single-field fallback deterministic.
+func beginInputFields(params map[string]any) []string {
+	if params == nil {
+		return nil
+	}
+	declared, ok := params["inputs"].(map[string]any)
+	if !ok || len(declared) == 0 {
+		return nil
+	}
+	fields := make([]string, 0, len(declared))
+	for field := range declared {
+		if field != "" {
+			fields = append(fields, field)
+		}
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+// beginInputValue maps the workflow's canonical query input to a Begin DSL
+// field. A scalar query is valid when the Begin node has one declared field;
+// a map query can populate several named fields. Directly supplied named
+// inputs are also accepted for webhook and programmatic callers.
+func beginInputValue(inputs map[string]any, field string) (any, bool) {
+	if value, ok := inputs[field]; ok {
+		return unwrapBeginInputValue(value), true
+	}
+	query, ok := inputs["query"]
+	if !ok {
+		return nil, false
+	}
+	if values, ok := query.(map[string]any); ok {
+		value, exists := values[field]
+		if !exists {
+			return nil, false
+		}
+		return unwrapBeginInputValue(value), true
+	}
+	return query, true
+}
+
+func unwrapBeginInputValue(value any) any {
+	if wrapper, ok := value.(map[string]any); ok {
+		if unwrapped, exists := wrapper["value"]; exists {
+			return unwrapped
+		}
+	}
+	return value
 }
 
 // Stream is a synchronous facade over Invoke for P0. SSE streaming of

--- a/internal/agent/component/begin_test.go
+++ b/internal/agent/component/begin_test.go
@@ -52,6 +52,50 @@ func TestBegin_InjectsSys(t *testing.T) {
 	}
 }
 
+func TestBegin_MapsQueryToDeclaredInput(t *testing.T) {
+	c, err := NewBeginComponent(map[string]any{
+		"inputs": map[string]any{
+			"customer_review": map[string]any{"key": "customer_review"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBeginComponent: %v", err)
+	}
+	state := canvas.NewCanvasState("run-custom-input", "task-custom-input")
+	ctx := canvas.WithState(t.Context(), state)
+
+	out, err := c.Invoke(ctx, nil, map[string]any{"query": "The product arrived damaged."})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := out["customer_review"]; got != "The product arrived damaged." {
+		t.Errorf("outputs[customer_review] = %v, want original review", got)
+	}
+}
+
+func TestBegin_MapsNamedQueryInputs(t *testing.T) {
+	c, _ := NewBeginComponent(map[string]any{
+		"inputs": map[string]any{
+			"customer_review": map[string]any{},
+			"language":        map[string]any{},
+		},
+	})
+	state := canvas.NewCanvasState("run-named-inputs", "task-named-inputs")
+	ctx := canvas.WithState(t.Context(), state)
+	query := map[string]any{
+		"customer_review": map[string]any{"value": "Damaged package"},
+		"language":        "English",
+	}
+
+	out, err := c.Invoke(ctx, nil, map[string]any{"query": query})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if out["customer_review"] != "Damaged package" || out["language"] != "English" {
+		t.Errorf("named inputs = %#v", out)
+	}
+}
+
 // TestBegin_PassesThroughInputs asserts the full inputs map — including
 // arbitrary keys beyond query / user_id — is returned unchanged as
 // outputs. This is the contract downstream components rely on to access


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes two Agent Canvas issues:

- Prevents duplicate control edges when multiple branching outputs converge on the same downstream node.
- Maps runtime input values to custom fields declared in the Begin node, allowing references such as `{begin@customer_review}` to resolve correctly.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)