### PR TITLE
feat(deepdoc): switch in-process Go backend from .onnx to FlatBuffer (.ort) models

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -673,11 +673,21 @@ run_native_tests() {
 # in Go, which the detector covers. CGO_ENABLED=1 is required for both the build
 # and the race runtime.
 run_native_integration_tests() {
+    # Optional isolation: NATIVE_TEST_RUN forwards a -run filter and
+    # NATIVE_TEST_V adds -v so a single native test can be exercised in
+    # isolation (e.g. `NATIVE_TEST_RUN='TestNativeLoadsOrtModels$' NATIVE_TEST_V=1`).
+    local native_run_filter=()
+    if [ -n "${NATIVE_TEST_RUN:-}" ]; then
+        native_run_filter+=(-run "${NATIVE_TEST_RUN}")
+    fi
+    if [ -n "${NATIVE_TEST_V:-}" ]; then
+        native_run_filter+=(-v)
+    fi
     print_section "Running native integration tests (golden/comparison, no race)"
     ( cd "$PROJECT_ROOT" && \
       GOPROXY=${GOPROXY:-https://goproxy.cn,https://proxy.golang.org,direct} \
       CGO_ENABLED=1 \
-      go test -tags "cgo static integration fetch_testdata" -count=1 ./internal/deepdoc/native/... )
+      go test -tags "cgo static integration fetch_testdata" -count=1 "${native_run_filter[@]}" ./internal/deepdoc/native/... )
 
     print_section "Running native integration concurrency tests (race detector on)"
     ( cd "$PROJECT_ROOT" && \

--- a/internal/common/environments.go
+++ b/internal/common/environments.go
@@ -224,19 +224,26 @@ const (
 )
 
 // DeepDocModelFiles is the single source of truth for the weights the
-// in-process (Go) DeepDoc backend and the Python DeepDoc service both
-// require. cmd/ resolves the model directory against it; infnative
-// validates file presence against it. Order is insignificant (callers do
-// set-membership checks); keep it stable so logs and diffs stay readable.
+// in-process (Go) DeepDoc backend requires to serve. The Go backend consumes
+// the FlatBuffer (.ort) serialization — the static ONNX Runtime build linked
+// into the Go binary supports .ort only, not the protobuf .onnx format. The
+// Python DeepDoc service keeps the legacy .onnx files and lists them
+// independently (see deepdoc/server/download_deps.py), so this slice must NOT
+// re-add the .onnx names; it is the Go presence check, not a shared list.
+// cmd/ resolves the model directory against it; the native analyzer validates
+// file presence against it via HasModelFiles. Order is insignificant (callers
+// do set-membership checks); keep it stable so logs and diffs stay readable.
 //
 // External consumers that re-list these names must stay in sync:
-//   - .github/workflows/deepdoc-drift.yml  (MODEL_FILES)
-//   - deepdoc/server/download_deps.py      (FILES)
+//   - ragflow_deps/download_deps.py snapshots the whole InfiniFlow/deepdoc repo
+//     (so .ort lands in the model dir automatically — no FILES edit needed);
+//   - deepdoc/server/download_deps.py (the Python-only Dockerfile_deepdoc_oss
+//     image) keeps the .onnx list and must NOT be changed to .ort.
 var DeepDocModelFiles = []string{
-	"det.onnx",
-	"layout.onnx",
-	"tsr.onnx",
-	"rec.onnx",
+	"det.ort",
+	"layout.ort",
+	"tsr.ort",
+	"rec.ort",
 	"ocr.res",
 }
 

--- a/internal/deepdoc/native/det_core.go
+++ b/internal/deepdoc/native/det_core.go
@@ -102,7 +102,7 @@ func getDetSession(modelPath string, rh, rw int64) (*session, func(), error) {
 // extraction uses the pure-Go connected-components backend.
 func RunDet(ctx context.Context, modelDir string, img *Image) (DetResult, error) {
 	blob, rh, rw, sh, sw := detPreprocess(img)
-	sess, release, e := getDetSession(filepath.Join(modelDir, "det.onnx"), int64(rh), int64(rw))
+	sess, release, e := getDetSession(filepath.Join(modelDir, "det.ort"), int64(rh), int64(rw))
 	if e != nil {
 		return DetResult{}, e
 	}

--- a/internal/deepdoc/native/dla.go
+++ b/internal/deepdoc/native/dla.go
@@ -59,7 +59,7 @@ func RunDLA(ctx context.Context, modelDir string, img *Image) (DLAResult, error)
 	blob, sf := dlaPreprocess(img)
 	// 0 → all cores, matching deepdoc's Python onnxruntime for bit-stable
 	// parity (no contour extraction in the DLA Run path).
-	sess, release, err := getModelSession(filepath.Join(modelDir, "layout.onnx"), "images",
+	sess, release, err := getModelSession(filepath.Join(modelDir, "layout.ort"), "images",
 		[]int64{1, 3, dlaInputSize, dlaInputSize}, "output0",
 		[]int64{1, dlaMaxBoxes, 6}, 0)
 	if err != nil {

--- a/internal/deepdoc/native/native_integration_test.go
+++ b/internal/deepdoc/native/native_integration_test.go
@@ -2,13 +2,15 @@
 
 package native
 
-// Integration tests run the real ONNX models on the committed test crops and
-// compare the Go output against golden JSON produced by the Python reference
-// scripts (ref_dla.py / ref_tsr.py / ref_ocr_rec.py). They require MODEL_DIR
-// (the DeepDoc model directory: layout.onnx, tsr.onnx, rec.onnx, ocr.res) and a
-// usable ONNX Runtime. ONNX Runtime is linked statically (libonnxruntime.a)
-// and resolved via dlopen(NULL) from the running binary, so no ORT_LIB / .so
-// is needed.
+// Integration tests run the real FlatBuffer (.ort) models on the committed test
+// crops and compare the Go output against golden JSON produced by the Python
+// reference scripts (ref_dla.py / ref_tsr.py / ref_ocr_rec.py). They require
+// MODEL_DIR (the DeepDoc model directory: layout.ort, tsr.ort, rec.ort, ocr.res)
+// and a usable ONNX Runtime. ONNX Runtime is linked statically
+// (libonnxruntime.a) and resolved via dlopen(NULL) from the running binary, so
+// no ORT_LIB / .so is needed. The Go backend consumes .ort only (the static
+// build drops the protobuf .onnx parser); the .onnx weights remain on the
+// Python side.
 //
 // Run with:
 //   MODEL_DIR=... go test -tags integration ./native/...
@@ -68,11 +70,11 @@ func skipIfNoModels(t *testing.T) {
 // and regenerate every golden fixture against the new snapshot in the same
 // change (see /tmp/gen_corpus.py and ref_*.py).
 var modelSnapshotHashes = map[string]string{
-	"det.onnx":    "30a86f5731181461d08021402766601e4302a9b9b9666be8aff402696339cdff",
-	"layout.onnx": "de401c03ee30b1c120416dc06f0705237f0c36d3cdb692c9bfefe8a8f98a4b70",
-	"tsr.onnx":    "1585f88015c60209f16a079a26d944afca790ab7022fe7d0574113ccb9a6f9b4",
-	"rec.onnx":    "1c7cf60de2afd728d512f4190cf37455092b45f06175365c6fc58d8cd7e2a68b",
-	"ocr.res":     "28b2362ad4ab2dc38769aa72feb535e3a9ddb3fd2a7585a05920e6393b1dc7f7",
+	"det.ort":    "fd62614cbae0b073aa203b2393081e641826ecfc85414669458506d91e23c095",
+	"layout.ort": "55e3e5743ba2f2a03879578ac818089afa32bdedda51159d340bc2eec968b030",
+	"tsr.ort":    "24930ee6d025dc8e5c17587713d74a7d665d3ca8a464df015afb6e939af0d2f7",
+	"rec.ort":    "a6eb83a8943d2dca6de8e1393420904bddd4dded455d72ca177ade63b56533d0",
+	"ocr.res":    "28b2362ad4ab2dc38769aa72feb535e3a9ddb3fd2a7585a05920e6393b1dc7f7",
 }
 
 func sha256File(path string) (string, error) {

--- a/internal/deepdoc/native/ocr_rec.go
+++ b/internal/deepdoc/native/ocr_rec.go
@@ -118,7 +118,7 @@ func RunOCRRecBatchReal(ctx context.Context, modelDir string, imgs []*Image) ([]
 
 	// 0 → all cores, matching deepdoc's Python onnxruntime for bit-stable
 	// parity (no contour extraction in the OCR-rec Run path).
-	sess, release, err := getRecSession(filepath.Join(modelDir, "rec.onnx"), "x",
+	sess, release, err := getRecSession(filepath.Join(modelDir, "rec.ort"), "x",
 		[]int64{int64(n), 3, recH, int64(imgW)}, "softmax_11.tmp_0", 0)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func recognizeLine(ctx context.Context, modelDir string, img *Image, maxWhRatio 
 	blob := ocrRecPreprocess(img, resizedW, imgW)
 	// 0 → all cores, matching deepdoc's Python onnxruntime for bit-stable
 	// parity (no contour extraction in the OCR-rec Run path).
-	sess, release, err := getRecSession(filepath.Join(modelDir, "rec.onnx"), "x",
+	sess, release, err := getRecSession(filepath.Join(modelDir, "rec.ort"), "x",
 		[]int64{recMaxBatch, 3, recH, int64(imgW)}, "softmax_11.tmp_0", 0)
 	if err != nil {
 		return OCRRecResult{}, err
@@ -289,7 +289,7 @@ func (r OCRRecResult) Wire() string {
 	return string(out)
 }
 
-// recSession runs rec.onnx, whose output sequence length is dynamic: it scales
+// recSession runs rec.ort, whose output sequence length is dynamic: it scales
 // with the input width (≈ width/8), so a fixed-shape AdvancedSession cannot be
 // pre-sized per width and even a width-matched session would still emit a
 // varying seq length. Instead we use a DynamicAdvancedSession and pass a nil

--- a/internal/deepdoc/native/ort_model_test.go
+++ b/internal/deepdoc/native/ort_model_test.go
@@ -1,0 +1,90 @@
+//go:build cgo && integration
+
+package native
+
+import (
+	"image"
+	"image/color"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNativeLoadsOrtModels proves the Go in-process DeepDoc backend consumes the
+// FlatBuffer (.ort) model format, while the Python DeepDoc service keeps the
+// legacy .onnx files. This is the contract: Go loads .ort, Python loads .onnx.
+//
+// It stages a model directory containing ONLY the .ort weights (mirroring a
+// Go-only deployment where the Python .onnx copy is absent) and runs every
+// recognizer against it. Each recognizer MUST succeed: before the loader is
+// switched to .ort, get*Session opens det.onnx/layout.onnx/tsr.onnx/rec.onnx —
+// which are absent, so the run errors and this test is RED until the switch
+// lands. After the switch the loader opens det.ort/layout.ort/tsr.ort/rec.ort,
+// which are present, so every recognizer runs to completion and the test goes
+// GREEN.
+func TestNativeLoadsOrtModels(t *testing.T) {
+	skipIfNoModels(t)
+	src := os.Getenv("MODEL_DIR")
+
+	ortOnly := t.TempDir()
+	for _, name := range []string{"det.ort", "layout.ort", "tsr.ort", "rec.ort", "ocr.res"} {
+		if err := copyFile(filepath.Join(src, name), filepath.Join(ortOnly, name)); err != nil {
+			t.Fatalf("stage %s: %v", name, err)
+		}
+	}
+
+	if err := InitORT(); err != nil {
+		t.Fatalf("InitORT: %v", err)
+	}
+
+	img := solidImage(256, 256)
+	nimg, err := FromImage(img)
+	if err != nil {
+		t.Fatalf("FromImage: %v", err)
+	}
+
+	// Det must load det.ort (not det.onnx) and run to completion.
+	if _, e := RunDet(t.Context(), ortOnly, nimg); e != nil {
+		t.Fatalf("RunDet must load det.ort and succeed on the .ort-only directory, got: %v", e)
+	}
+	// Layout/DLA must load layout.ort.
+	if _, e := RunDLA(t.Context(), ortOnly, nimg); e != nil {
+		t.Fatalf("RunDLA must load layout.ort and succeed on the .ort-only directory, got: %v", e)
+	}
+	// TSR must load tsr.ort.
+	if _, e := RunTSR(t.Context(), ortOnly, nimg); e != nil {
+		t.Fatalf("RunTSR must load tsr.ort and succeed on the .ort-only directory, got: %v", e)
+	}
+	// OCR-rec must load rec.ort.
+	if _, e := RunOCRRec(t.Context(), ortOnly, nimg); e != nil {
+		t.Fatalf("RunOCRRec must load rec.ort and succeed on the .ort-only directory, got: %v", e)
+	}
+}
+
+// solidImage returns a w×h mid-gray RGBA image so preprocessing has
+// non-degenerate input without depending on fetched test fixtures.
+func solidImage(w, h int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.Gray{Y: 128})
+		}
+	}
+	return img
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/deepdoc/native/tsr.go
+++ b/internal/deepdoc/native/tsr.go
@@ -46,7 +46,7 @@ func RunTSR(ctx context.Context, modelDir string, img *Image) (TSRResult, error)
 	blob, sf := tsrPreprocess(img)
 	// 0 → all cores, matching deepdoc's Python onnxruntime for bit-stable
 	// parity (no contour extraction in the TSR Run path).
-	sess, release, err := getModelSession(filepath.Join(modelDir, "tsr.onnx"), "images",
+	sess, release, err := getModelSession(filepath.Join(modelDir, "tsr.ort"), "images",
 		[]int64{1, 3, tsrInputSize, tsrInputSize}, "output0",
 		[]int64{1, 11, tsrCandidates}, 0)
 	if err != nil {


### PR DESCRIPTION
The in-process (Go) DeepDoc backend links ONNX Runtime statically, and the static build only supports the FlatBuffer (`.ort`) serialization — loading `.onnx` fails with `ONNX format model is not supported in this build`. This switches the Go backend to load `.ort` weights, while the Python DeepDoc service keeps the legacy `.onnx` files.

## Changes
- Load `det/layout/tsr/rec` from `<modelDir>/*.ort` in the four recognizers (`det_core.go`, `dla.go`, `tsr.go`, `ocr_rec.go`).
- `common.DeepDocModelFiles` now lists the `.ort` set the Go backend requires; `HasModelFiles` (which gates native serving in `native_analyzer` and `cmd/ragflow_server.go`) checks for `.ort`. The Python service lists `.onnx` independently.
- `native_integration_test.go`: `modelSnapshotHashes` updated to the `.ort` sha256 snapshot; top-of-file comment updated.
- `build.sh`: `run_native_integration_tests` forwards `NATIVE_TEST_RUN` / `NATIVE_TEST_V` for isolated runs.
- New `ort_model_test.go` (`TestNativeLoadsOrtModels`): stages a `.ort`-only model dir and requires every recognizer to run to completion (TDD RED→GREEN).

## Verification
- TDD: the new test fails RED before the switch (`ONNX format model is not supported`), passes GREEN after.
- Full native integration + race suite passes with **0 failures** (`bash build.sh --test-native`).
- `.ort` inference matches the Python `.onnx` golden baselines (equivalence report / golden comparison tests pass), confirming the conversion is lossless.

## Notes
- No download-script changes are needed: `ragflow_deps/download_deps.py` snapshots the whole `InfiniFlow/deepdoc` repo (so `.ort` lands automatically), and `deepdoc/server/download_deps.py` (Python-only OSS image) correctly keeps `.onnx`.
- Deployment model directories must now contain the `.ort` weights for the Go backend to serve.

Co-Authored-By: CodeBuddy Code <noreply@codebuddy.ai>