### PR TITLE
docs: clarify user_default_llm deprecation

### DIFF
--- a/docs/administrator/configurations/configurations.md
+++ b/docs/administrator/configurations/configurations.md
@@ -250,21 +250,14 @@ oauth:
 
 ### `user_default_llm`
 
-The default LLM to use for a new RAGFlow user. It is disabled by default. To enable this feature, uncomment the corresponding lines in **service_conf.yaml.template**.
+Assigning default models to newly registered users through `user_default_llm` is deprecated and no longer supported in the open-source version. Uncommenting this section in **service_conf.yaml.template** does not configure models for new users.
 
-- `factory`: The LLM supplier. Available options:
-  - `"OpenAI"`
-  - `"DeepSeek"`
-  - `"Moonshot"`
-  - `"Tongyi-Qianwen"`
-  - `"VolcEngine"`
-  - `"ZHIPU-AI"`
-- `api_key`: The API key for the specified LLM. You will need to apply for your model API key online.
-- `allowed_factories`: If this is set, the users will be allowed to add only the factories in this list.
-  - `"OpenAI"`
-  - `"DeepSeek"`
-  - `"Moonshot"`
+Each tenant must configure its own model provider instances and credentials. New users do not automatically inherit an administrator's configured instances or default model selections.
 
-:::tip NOTE
-If you do not set the default LLM here, configure the default LLM on the **Settings** page in the RAGFlow UI.
+Go to **User settings** **>** **Model providers** to configure provider instances, add models, and select default models. See [Configure Model API Key](../../guides/models/llm_api_key_setup.md) for instructions.
+
+The Enterprise Edition provides role-level default model settings.
+
+:::note Builtin embedding
+If you deploy TEI, keep the shipped `user_default_llm.default_models.embedding_model` connection settings in **service_conf.yaml.template**. They are used by the TEI `Builtin` embedding service and do not assign administrator-owned model instances to new tenants.
 :::


### PR DESCRIPTION
### Summary

The configuration guide still tells administrators to uncomment `user_default_llm` to assign default models to new users, although this behavior is no longer supported. Update the section to explain that each OSS tenant configures its own provider instances and defaults, link to the model setup guide, and distinguish Enterprise role-level defaults.

Retain a note about the shipped TEI Builtin embedding connection settings, which are still consumed at runtime, so the deprecation explanation does not imply that TEI deployments should delete them.

Follows the [maintainer's clarification in #18185](https://github.com/infiniflow/ragflow/pull/18185#issuecomment-5539810173) and the registration behavior in #18875. Related to #5838.

Validation: checked the wording against current registration, provider lookup, and TEI resolution code; verified the relative documentation link and `git diff --check`. Documentation only; no runtime tests required.
