### PR TITLE
fix(pipeline): init Graph.globals and allow Compiler chaining

### DIFF
--- a/agent/canvas.py
+++ b/agent/canvas.py
@@ -91,6 +91,14 @@ class Graph:
         self.path = []
         self.components = {}
         self.error = ""
+        # Pipeline (Graph) and Canvas both resolve bare template vars via
+        # get_variable_value → self.globals. Canvas.load() may overwrite this.
+        self.globals = {
+            "sys.query": "",
+            "sys.user_id": tenant_id,
+            "sys.conversation_turns": 0,
+            "sys.files": [],
+        }
         # Accept legacy DSL on read, but keep the in-memory canvas in the latest schema.
         self.dsl = normalize_chunker_dsl(json.loads(dsl))
         self._tenant_id = tenant_id

--- a/rag/flow/compiler/compiler.py
+++ b/rag/flow/compiler/compiler.py
@@ -520,9 +520,8 @@ class Compiler(ProcessBase, LLM):
         self.callback(random.randint(1, 5) / 100.0, "Start knowledge compilation.")
 
         # Pipeline components receive the previous component's output as
-        # kwargs. Do not call LLM.get_input_elements() here: it resolves the
-        # inherited prompt variables through Canvas.globals, while Pipeline
-        # is a Graph and has no globals.
+        # kwargs. Do not call LLM.get_input_elements() here: Compiler does not
+        # use prompt template variables and should not depend on Graph.globals.
         output_format = kwargs.get("output_format")
         if output_format == "chunks":
             raw_chunks = kwargs.get("chunks") or []

--- a/web/src/pages/agent/canvas/node/dropdown/accordion-operators.tsx
+++ b/web/src/pages/agent/canvas/node/dropdown/accordion-operators.tsx
@@ -176,11 +176,9 @@ export function PipelineAccordionOperators({
       ...restrictSingleOperatorOnCanvas([Operator.Parser, Operator.Tokenizer]),
     ];
     list.push(Operator.Extractor);
-    if (getOperatorTypeFromId(nodeId) !== Operator.Compiler) {
-      list.push(Operator.Compiler);
-    }
+    list.push(Operator.Compiler);
     return list;
-  }, [getOperatorTypeFromId, nodeId, restrictSingleOperatorOnCanvas]);
+  }, [restrictSingleOperatorOnCanvas]);
 
   const chunkerOperators = useMemo(() => {
     return [


### PR DESCRIPTION
## Summary
- Initialize minimal `globals` on `Graph` so Pipeline/`Extractor.get_input_elements()` can resolve bare template vars (`sys.*`) without `AttributeError: Pipeline has no attribute globals`.
- Allow adding a Compiler after another Compiler in the pipeline operator dropdown (serial chaining). Parallel fan-out remains limited by the existing 1:1 handle rule.
- Update the outdated Compiler comment that claimed Pipeline/Graph had no globals.

## Test plan
- [ ] Run a dataflow with Extractor whose prompt references `{sys.query}` or other bare vars; confirm no `globals` AttributeError
- [ ] Run Extractor after TitleChunker with prompt component refs; confirm chunks still flow
- [ ] In pipeline canvas, from a Compiler node open the operator menu and add another Compiler downstream
- [ ] Confirm a single Tokenizer/Parser restriction on canvas is unchanged
