### PR TITLE
feat(llm): add OpenRouter embedding model support

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -2513,7 +2513,7 @@
         {
             "name": "OpenRouter",
             "logo": "",
-            "tags": "LLM,IMAGE2TEXT",
+            "tags": "LLM,TEXT EMBEDDING,IMAGE2TEXT",
             "status": "1",
             "llm": [],
             "rank": "989",

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -1216,6 +1216,15 @@ class JiekouAIEmbed(OpenAIEmbed):
         super().__init__(key, model_name, base_url)
 
 
+class OpenRouterEmbed(OpenAIEmbed):
+    _FACTORY_NAME = "OpenRouter"
+
+    def __init__(self, key, model_name, base_url="https://openrouter.ai/api/v1"):
+        if not base_url:
+            base_url = "https://openrouter.ai/api/v1"
+        super().__init__(key, model_name, base_url)
+
+
 class RAGconEmbed(OpenAIEmbed):
     """
     RAGcon Embedding Provider - routes through LiteLLM proxy

--- a/web/src/pages/user-setting/setting-model/modal/provider-modal/field-config/local-llm-configs.ts
+++ b/web/src/pages/user-setting/setting-model/modal/provider-modal/field-config/local-llm-configs.ts
@@ -92,7 +92,7 @@ export const LocalLlmConfigs: Record<string, ProviderConfig> = {
   [LLMFactory.OpenRouter]: buildLocalConfig(
     LLMFactory.OpenRouter,
     'OpenRouter',
-    ['chat', 'image2text'],
+    ['chat', 'embedding', 'image2text'],
     undefined,
     true,
     [


### PR DESCRIPTION
Adds OpenRouterEmbed to the embedding factory registry so OpenRouter can be used as an embedding provider, alongside its existing chat/vision support. Updates the model-provider UI to allow "embedding" as a selectable type for OpenRouter.