### PR TITLE
fix(parser): drop PDF TOC pages via geometric page-number column

### DIFF
--- a/internal/deepdoc/parser/pdf/layout/toc_geometry.go
+++ b/internal/deepdoc/parser/pdf/layout/toc_geometry.go
@@ -107,7 +107,7 @@ func FilterTOCBoxes(boxes []pdf.TextBox, medianHeights map[int]float64) []pdf.Te
 			continue
 		}
 
-		if dedicatedTOCPage(boxes, eligible, entries, mh) {
+		if dedicatedTOCPage(boxes, pageIdx, eligible, entries, mh) {
 			for _, i := range pageIdx {
 				drop[i] = true
 			}
@@ -241,9 +241,28 @@ func qualifyingTOCColumn(boxes []pdf.TextBox, cluster []tocCandidate) bool {
 // non-entry line of a pure TOC page is a short, isolated run — a cover
 // title, watermark, page marker or TOC heading. Any continuous body
 // paragraph fails the short-run check even when each of its lines is
-// shorter than tocShortRunMaxRunes.
-func dedicatedTOCPage(boxes []pdf.TextBox, eligible, entries []int, mh float64) bool {
+// shorter than tocShortRunMaxRunes. A page that carries structured content
+// (a table, figure or equation box) is never whole-page deleted: the
+// structured box is kept and only the TOC entries are removed.
+func dedicatedTOCPage(boxes []pdf.TextBox, pageIdx, eligible, entries []int, mh float64) bool {
+	if pageHasStructuredContent(boxes, pageIdx) {
+		return false
+	}
 	return allNonEntryRunsShort(boxes, eligible, entries, mh)
+}
+
+// pageHasStructuredContent reports whether any box on the page is a table,
+// figure or equation. Structured boxes are excluded from the TOC entry
+// analysis entirely, so their presence must also veto whole-page deletion —
+// otherwise a DLA-detected table on the page would be dropped with the TOC.
+func pageHasStructuredContent(boxes []pdf.TextBox, pageIdx []int) bool {
+	for _, i := range pageIdx {
+		switch boxes[i].LayoutType {
+		case pdf.LayoutTypeTable, pdf.LayoutTypeFigure, pdf.LayoutTypeEquation:
+			return true
+		}
+	}
+	return false
 }
 
 // allNonEntryRunsShort splits the non-entry lines into vertical runs (lines
@@ -273,24 +292,43 @@ func allNonEntryRunsShort(boxes []pdf.TextBox, eligible, entries []int, mh float
 		return boxes[a].Top < boxes[b].Top
 	})
 
-	var runRunes, runLines int
-	lastBottom := 0.0
-	lastCol := -1
-	for k, i := range nonEntry {
-		if k > 0 && boxes[i].ColID == lastCol && boxes[i].Top-lastBottom < tocGapFactor*mh {
-			runRunes += utf8.RuneCountInString(strings.TrimSpace(boxes[i].Text))
-			runLines++
-		} else {
-			runRunes = utf8.RuneCountInString(strings.TrimSpace(boxes[i].Text))
-			runLines = 1
+	// Run state is tracked per column: boxes are visited in global
+	// top-to-bottom order, so the lines of two interleaved columns are
+	// mixed in the iteration. A single global run would reset one column's
+	// accumulation every time the other column's line sorts between two of
+	// its lines, letting a real paragraph slip under the cap.
+	runs := make(map[int]*tocRunState, len(nonEntry))
+	for _, i := range nonEntry {
+		col := boxes[i].ColID
+		st := runs[col]
+		if st == nil {
+			st = &tocRunState{}
+			runs[col] = st
 		}
-		lastBottom = boxes[i].Bottom
-		lastCol = boxes[i].ColID
-		if runLines >= 2 && runRunes > tocShortRunMaxRunes {
+		runes := utf8.RuneCountInString(strings.TrimSpace(boxes[i].Text))
+		if st.seen && boxes[i].Top-st.bottom < tocGapFactor*mh {
+			st.runes += runes
+			st.lines++
+		} else {
+			st.runes = runes
+			st.lines = 1
+		}
+		st.bottom = boxes[i].Bottom
+		st.seen = true
+		if st.lines >= 2 && st.runes > tocShortRunMaxRunes {
 			return false
 		}
 	}
 	return true
+}
+
+// tocRunState tracks the vertical run of one column: consecutive lines
+// whose gap stays below tocGapFactor×median height.
+type tocRunState struct {
+	runes  int
+	lines  int
+	bottom float64
+	seen   bool
 }
 
 // tocWrappedTitlePartners returns the non-entry line sitting directly above

--- a/internal/deepdoc/parser/pdf/layout/toc_geometry.go
+++ b/internal/deepdoc/parser/pdf/layout/toc_geometry.go
@@ -1,0 +1,372 @@
+// TOC removal by page geometry.
+//
+// Table-of-contents pages are detected at line granularity (before
+// NaiveVerticalMerge collapses the lines into blocks): a page whose lines
+// form a right-aligned, monotonically increasing page-number column is a TOC
+// page. This keying on the page-number column is deliberately independent of
+// the leader character used by the typesetter — dots, ellipses, middots,
+// wide spaces, or none at all — and of whether DeepDoc extracted each entry
+// as one line or split the title and its page number into separate columns
+// (a layout this repo observed on real book PDFs).
+//
+// Deletion policy:
+//   - A page whose entries dominate the text AND whose every other line is a
+//     short, isolated run (cover title, watermark, page marker, TOC heading)
+//     is a dedicated TOC page: every box on the page is dropped.
+//   - Otherwise (mixed page) only the entry boxes are dropped, plus a
+//     wrapped-entry title line sitting directly above a bare page number and
+//     a standalone TOC heading above the column. Prose, tables and figures
+//     on the page are kept.
+package layout
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	pdf "ragflow/internal/deepdoc/parser/pdf/type"
+	"ragflow/internal/deepdoc/parser/type"
+)
+
+// tocEntryShapePattern matches the trailing "page number" of a candidate
+// entry line: 1-4 digits with an optional roman-numeral fragment, e.g.
+// ".20", "6", "..8", "……39 II", "第27章 ……37". The leading text may be a
+// title or nothing at all (a bare page reference on its own line).
+var tocEntryShapePattern = regexp.MustCompile(`(\d{1,4})([IVXLCivxlc]{0,5})$`)
+
+// tocLeaderChars are the characters that may make up a bare page reference's
+// leader: whitespace, dots, middots, ellipses and CJK separators. If a
+// candidate line is ONLY leaders followed by the page number it is a
+// number-only reference (the wrapped-entry shape); anything else is a
+// titled entry.
+var tocLeaderChars = " \t.·…⋯‥，。、"
+
+const (
+	// tocRightEdgeTolerance is the maximum spread (PDF points) allowed
+	// among the right edges of one page-number column.
+	tocRightEdgeTolerance = 3.0
+	// tocMinClusterSize is the minimum number of aligned page numbers that
+	// proves a column is a page-number column, not prose with one or two
+	// stray numbers.
+	tocMinClusterSize = 3
+	// tocShortRunMaxRunes bounds a continuous run of non-entry lines. Only
+	// runs of two or more chained lines are length-checked (a single
+	// isolated line, however long — a URL watermark — is not prose).
+	// Body paragraphs chain past the cap; TOC heading lines and titles stay
+	// under it.
+	tocShortRunMaxRunes = 50
+	// tocGapFactor scales the per-page median box height into the vertical
+	// gap below which two lines count as one continuous run.
+	tocGapFactor = 1.5
+	// tocPartnerX0Tolerance is how far a wrapped-entry title line may sit
+	// from the bare page-number line it completes (PDF points).
+	tocPartnerX0Tolerance = 10.0
+	// tocHeadingGapFactor scales the gap between a standalone TOC heading
+	// and the topmost entry of its column.
+	tocHeadingGapFactor = 2.0
+)
+
+// FilterTOCBoxes drops table-of-contents boxes from the stream. It must run
+// on line-shaped boxes (TextMerge output, before FinalReadingOrderMerge /
+// NaiveVerticalMerge) so the per-line right-edge alignment is still visible.
+// medianHeights is the per-page median box height used for vertical
+// contiguity decisions; a missing/zero value falls back to 10pt. The input
+// slice is not mutated; the returned slice preserves the input order.
+func FilterTOCBoxes(boxes []pdf.TextBox, medianHeights map[int]float64) []pdf.TextBox {
+	if len(boxes) == 0 {
+		return boxes
+	}
+	pageGroups, sortedPages := groupBoxesByPage(boxes)
+	drop := make([]bool, len(boxes))
+
+	for _, pg := range sortedPages {
+		pageIdx := pageGroups[pg]
+		mh := medianHeights[pg]
+		if mh <= 0 {
+			mh = 10
+		}
+
+		eligible := eligibleTOCBoxes(boxes, pageIdx)
+		if len(eligible) < tocMinClusterSize {
+			continue
+		}
+		candidates := tocCandidates(boxes, eligible)
+
+		// Cluster candidates by right edge: each cluster is one page-number
+		// column. Two-column TOCs produce two independent clusters.
+		var entries []int
+		for _, cluster := range clusterByRightEdge(boxes, candidates) {
+			if qualifyingTOCColumn(boxes, cluster) {
+				for _, c := range cluster {
+					entries = append(entries, c.idx)
+				}
+			}
+		}
+		if len(entries) == 0 {
+			continue
+		}
+
+		if dedicatedTOCPage(boxes, eligible, entries, mh) {
+			for _, i := range pageIdx {
+				drop[i] = true
+			}
+			continue
+		}
+
+		// Mixed page: drop the entries, wrapped-title partners and a TOC
+		// heading; keep everything else.
+		for _, i := range entries {
+			drop[i] = true
+		}
+		for _, i := range tocWrappedTitlePartners(boxes, eligible, entries, mh) {
+			drop[i] = true
+		}
+		if h := tocHeadingBox(boxes, eligible, entries, mh); h >= 0 {
+			drop[h] = true
+		}
+	}
+
+	out := make([]pdf.TextBox, 0, len(boxes))
+	for i, b := range boxes {
+		if drop[i] {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// eligibleTOCBoxes returns the indices of page boxes that are real text
+// candidates: tables, figures and equations are excluded because their rows
+// often end in right-aligned numbers but are not TOC entries.
+func eligibleTOCBoxes(boxes []pdf.TextBox, pageIdx []int) []int {
+	out := make([]int, 0, len(pageIdx))
+	for _, i := range pageIdx {
+		switch boxes[i].LayoutType {
+		case pdf.LayoutTypeTable, pdf.LayoutTypeFigure, pdf.LayoutTypeEquation:
+			continue
+		}
+		if strings.TrimSpace(boxes[i].Text) == "" {
+			continue
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
+// tocCandidate is an eligible line whose text ends in a page-number shape.
+type tocCandidate struct {
+	idx        int
+	right      float64
+	top        float64
+	num        int
+	numberOnly bool
+	runes      int
+}
+
+// tocCandidates extracts the entry-shaped lines (trailing 1-4 digit page
+// number, optional roman fragment). A line is numberOnly when everything
+// before the page number is just leader characters — the wrapped-entry
+// shape whose title lives on the line above.
+func tocCandidates(boxes []pdf.TextBox, eligible []int) []tocCandidate {
+	out := make([]tocCandidate, 0, len(eligible))
+	for _, i := range eligible {
+		text := strings.TrimSpace(boxes[i].Text)
+		m := tocEntryShapePattern.FindStringSubmatchIndex(text)
+		if m == nil {
+			continue
+		}
+		num := 0
+		for _, r := range text[m[2]:m[3]] {
+			num = num*10 + int(r-'0')
+		}
+		prefix := strings.Trim(text[:m[2]], tocLeaderChars)
+		out = append(out, tocCandidate{
+			idx:        i,
+			right:      boxes[i].X1,
+			top:        boxes[i].Top,
+			num:        num,
+			numberOnly: prefix == "",
+			runes:      utf8.RuneCountInString(text),
+		})
+	}
+	return out
+}
+
+// clusterByRightEdge greedily groups candidates whose right edges fall
+// within tocRightEdgeTolerance. The first member anchors the cluster.
+func clusterByRightEdge(boxes []pdf.TextBox, candidates []tocCandidate) [][]tocCandidate {
+	sorted := append([]tocCandidate(nil), candidates...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].right < sorted[j].right
+	})
+	var clusters [][]tocCandidate
+	for _, c := range sorted {
+		if len(clusters) == 0 || c.right-clusters[len(clusters)-1][0].right > tocRightEdgeTolerance {
+			clusters = append(clusters, []tocCandidate{c})
+			continue
+		}
+		clusters[len(clusters)-1] = append(clusters[len(clusters)-1], c)
+	}
+	return clusters
+}
+
+// qualifyingTOCColumn reports whether a right-edge cluster is a genuine
+// page-number column: at least tocMinClusterSize members whose page numbers
+// run in page order. Page numbers must be mostly non-decreasing — sub-entries
+// may repeat a page, and the occasional out-of-order entry (a misplaced
+// section, an appendix) is tolerated. A price list or statistics table, whose
+// numbers do not run in page order at all, still fails the allowance.
+func qualifyingTOCColumn(boxes []pdf.TextBox, cluster []tocCandidate) bool {
+	if len(cluster) < tocMinClusterSize {
+		return false
+	}
+	sorted := append([]tocCandidate(nil), cluster...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].top < sorted[j].top })
+	descents := 0
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i].num < sorted[i-1].num {
+			descents++
+		}
+	}
+	return descents <= 1+len(sorted)/4
+}
+
+// dedicatedTOCPage reports whether the page is a pure TOC page and
+// whole-page deletion is safe. The gate is content-nature, not a text-share
+// ratio: a real TOC page (especially a column-split one) can have most of its
+// text in title lines that carry no page number, so an entry-text ratio
+// rejects it. The only thing that must be protected is prose, and every
+// non-entry line of a pure TOC page is a short, isolated run — a cover
+// title, watermark, page marker or TOC heading. Any continuous body
+// paragraph fails the short-run check even when each of its lines is
+// shorter than tocShortRunMaxRunes.
+func dedicatedTOCPage(boxes []pdf.TextBox, eligible, entries []int, mh float64) bool {
+	return allNonEntryRunsShort(boxes, eligible, entries, mh)
+}
+
+// allNonEntryRunsShort splits the non-entry lines into vertical runs (lines
+// in the same column with a gap below tocGapFactor×median height chain) and
+// requires every CONTINUOUS run to stay under tocShortRunMaxRunes. A single
+// isolated line is exempt from the length cap: a long one-liner (a URL
+// watermark, a cover title) is not prose. Only a run of two or more chained
+// lines — a body paragraph, whose every single line is short — must pass the
+// cap, and any paragraph fails it even when each line is shorter than
+// tocShortRunMaxRunes.
+func allNonEntryRunsShort(boxes []pdf.TextBox, eligible, entries []int, mh float64) bool {
+	entrySet := make(map[int]bool, len(entries))
+	for _, i := range entries {
+		entrySet[i] = true
+	}
+	nonEntry := make([]int, 0, len(eligible))
+	for _, i := range eligible {
+		if !entrySet[i] {
+			nonEntry = append(nonEntry, i)
+		}
+	}
+	sort.Slice(nonEntry, func(i, j int) bool {
+		a, b := nonEntry[i], nonEntry[j]
+		if boxes[a].PageNumber != boxes[b].PageNumber {
+			return boxes[a].PageNumber < boxes[b].PageNumber
+		}
+		return boxes[a].Top < boxes[b].Top
+	})
+
+	var runRunes, runLines int
+	lastBottom := 0.0
+	lastCol := -1
+	for k, i := range nonEntry {
+		if k > 0 && boxes[i].ColID == lastCol && boxes[i].Top-lastBottom < tocGapFactor*mh {
+			runRunes += utf8.RuneCountInString(strings.TrimSpace(boxes[i].Text))
+			runLines++
+		} else {
+			runRunes = utf8.RuneCountInString(strings.TrimSpace(boxes[i].Text))
+			runLines = 1
+		}
+		lastBottom = boxes[i].Bottom
+		lastCol = boxes[i].ColID
+		if runLines >= 2 && runRunes > tocShortRunMaxRunes {
+			return false
+		}
+	}
+	return true
+}
+
+// tocWrappedTitlePartners returns the non-entry line sitting directly above
+// a number-only page reference, when it is close enough and left-aligned —
+// the wrapped-entry title line ("朴素贝叶斯分类" above "……39").
+func tocWrappedTitlePartners(boxes []pdf.TextBox, eligible, entries []int, mh float64) []int {
+	numberOnly := make(map[int]bool)
+	for _, i := range entries {
+		text := strings.TrimSpace(boxes[i].Text)
+		m := tocEntryShapePattern.FindStringSubmatchIndex(text)
+		if m == nil {
+			continue
+		}
+		if strings.Trim(text[:m[2]], tocLeaderChars) == "" {
+			numberOnly[i] = true
+		}
+	}
+	entrySet := make(map[int]bool, len(entries))
+	for _, i := range entries {
+		entrySet[i] = true
+	}
+	var partners []int
+	for ref := range numberOnly {
+		best, bestBottom := -1, -1.0
+		for _, i := range eligible {
+			if entrySet[i] {
+				continue
+			}
+			if boxes[i].Bottom > boxes[ref].Top {
+				continue // not above
+			}
+			gap := boxes[ref].Top - boxes[i].Bottom
+			if gap >= tocGapFactor*mh {
+				continue
+			}
+			if absF(boxes[i].X0-boxes[ref].X0) > tocPartnerX0Tolerance {
+				continue
+			}
+			if best < 0 || boxes[i].Bottom > bestBottom {
+				best, bestBottom = i, boxes[i].Bottom
+			}
+		}
+		if best >= 0 {
+			partners = append(partners, best)
+		}
+	}
+	return partners
+}
+
+// tocHeadingBox returns the standalone TOC heading line ("目录"/"contents"…)
+// sitting within tocHeadingGapFactor×median height above the column's
+// topmost entry, if any.
+func tocHeadingBox(boxes []pdf.TextBox, eligible, entries []int, mh float64) int {
+	topEntry := 0
+	for _, i := range entries {
+		if topEntry == 0 || boxes[i].Top < boxes[topEntry].Top {
+			topEntry = i
+		}
+	}
+	for _, i := range eligible {
+		if !doctype.IsTOCTitleHeading(boxes[i].Text) {
+			continue
+		}
+		if boxes[i].Bottom > boxes[topEntry].Top {
+			continue
+		}
+		if boxes[topEntry].Top-boxes[i].Bottom <= tocHeadingGapFactor*mh {
+			return i
+		}
+	}
+	return -1
+}
+
+func absF(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/internal/deepdoc/parser/pdf/layout/toc_geometry_test.go
+++ b/internal/deepdoc/parser/pdf/layout/toc_geometry_test.go
@@ -1,0 +1,341 @@
+package layout
+
+import (
+	"testing"
+
+	pdf "ragflow/internal/deepdoc/parser/pdf/type"
+)
+
+// medianH is the per-page median box height used by the contiguity rules in
+// FilterTOCBoxes; these tests use a single page with 12pt-tall lines.
+var medianH = map[int]float64{0: 12}
+
+func texts(boxes []pdf.TextBox) []string {
+	out := make([]string, 0, len(boxes))
+	for _, b := range boxes {
+		out = append(out, b.Text)
+	}
+	return out
+}
+
+func contains(out []pdf.TextBox, want string) bool {
+	for _, b := range out {
+		if b.Text == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFilterTOCBoxes_RealColumnSplitPage replicates the observed DeepDoc
+// layout of 道德经.pdf page 1: the TOC is extracted as THREE independent
+// columns — chapter markers (第N章), chapter titles, and a right-aligned
+// page-number column whose entries carry only 0-2 leader dots ("6", ".11",
+// "..8"). The current regex path survives all of this; the geometric filter
+// must drop the whole page because every non-entry line is a short isolated
+// run.
+func TestFilterTOCBoxes_RealColumnSplitPage(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 61, 199, 42, 54, "木瓜树  更多的书籍免费下载"),
+		makeBox(0, 199, 351, 80, 92, "《道德经》全文及翻译"),
+		makeBox(0, 109, 141, 121, 133, "前言："),
+	}
+	// left column: chapter markers
+	leftTop := []float64{160, 197, 234, 272, 308, 346, 384}
+	for i, top := range leftTop {
+		boxes = append(boxes, makeBox(0, 110, 149, top, top+12, "第"+string(rune('1'+i))+"章"))
+	}
+	// left column: entries whose title is embedded
+	embedded := []struct {
+		top  float64
+		text string
+	}{
+		{422, "第8章  夫唯不争，故无尤."},
+		{459, "第9章  功成身退，天之道也"},
+		{495, "第10章  长而不宰，是谓玄德."},
+		{534, "第11章  有之以为利，无之以为用"},
+		{571, "第12章"},
+		{609, "第13章  以身为天下，可寄/托天下."},
+	}
+	for _, e := range embedded {
+		boxes = append(boxes, makeBox(0, 111, 300, e.top, e.top+12, e.text))
+	}
+	// middle column: chapter titles
+	middle := []struct {
+		top  float64
+		text string
+	}{
+		{159, "“道”"},
+		{197, "圣人居无为之事，行不言之教."},
+		{234, "无为而治."},
+		{272, "道冲.."},
+		{308, "“守中”"},
+		{346, "“谷神”"},
+		{383, "后其身而身先，外其身而身存."},
+		{572, "为腹不为目,故去彼取此"},
+	}
+	for _, m := range middle {
+		boxes = append(boxes, makeBox(0, 155, 316, m.top, m.top+12, m.text))
+	}
+	// right column: bare page references, right-aligned
+	refs := []struct {
+		top  float64
+		text string
+	}{
+		{239, "6"}, {276, "6"}, {348, "..8"}, {386, "10"}, {424, ".11"},
+		{460, ".13"}, {499, ".14"}, {535, ".15"}, {573, ".17"}, {611, ".18"},
+	}
+	for _, r := range refs {
+		boxes = append(boxes, makeBox(0, 434, 447, r.top, r.top+12, r.text))
+	}
+
+	out := FilterTOCBoxes(boxes, medianH)
+	if len(out) != 0 {
+		t.Fatalf("column-split TOC page: expected whole-page removal, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_DedicatedInlineEntryPage covers the classic inline
+// shape (title+leader+page on one line). The page also carries a watermark,
+// cover title and a roman page marker — all short isolated lines — so the
+// whole page is dropped.
+func TestFilterTOCBoxes_DedicatedInlineEntryPage(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 61, 199, 40, 52, "木瓜树  更多的书籍免费下载"),
+		makeBox(0, 199, 351, 70, 82, "《道德经》全文及翻译"),
+		makeBox(0, 50, 550, 120, 140, "第1章 道可道…………3"),
+		makeBox(0, 50, 550, 160, 180, "Introduction ....... 12"),
+		makeBox(0, 50, 550, 200, 220, "Chapter Three ...... 45"),
+		makeBox(0, 440, 448, 240, 252, "II"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if len(out) != 0 {
+		t.Fatalf("dedicated inline-entry TOC page: expected whole-page removal, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_LeaderVariants pins that detection depends on the
+// page-number column, not on the leader character. Every line below is a
+// valid entry despite leaders that the regex path rejects (single dot, bare
+// number, spaced dots, single ellipsis, fullwidth dot, U+2025).
+func TestFilterTOCBoxes_LeaderVariants(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 61, 199, 40, 52, "木瓜树  更多的书籍免费下载"),
+		makeBox(0, 199, 351, 70, 82, "《道德经》全文及翻译"),
+		makeBox(0, 50, 550, 100, 120, "6"),
+		makeBox(0, 50, 550, 140, 160, "..8"),
+		makeBox(0, 50, 550, 180, 200, "前言：.11"),
+		makeBox(0, 50, 550, 220, 240, "第1章 “道”...14"),
+		makeBox(0, 50, 550, 260, 280, "第2章 圣人居无为之事，行不言之教..17"),
+		makeBox(0, 50, 550, 300, 320, "第3章 无为而治。.20"),
+		makeBox(0, 440, 448, 340, 352, "II"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if len(out) != 0 {
+		t.Fatalf("leader-variant TOC page: expected whole-page removal, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_MixedPageKeepsProse protects a page where a continuous
+// body paragraph shares the page with an aligned page-number column. The
+// entries are dropped; the paragraph (whose every single line is short but
+// whose continuous run exceeds 50 runes) and the watermark survive.
+func TestFilterTOCBoxes_MixedPageKeepsProse(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 61, 199, 40, 52, "木瓜树  更多的书籍免费下载"),
+		makeBox(0, 434, 447, 100, 112, ".20"),
+		makeBox(0, 434, 447, 140, 152, ".22"),
+		makeBox(0, 434, 447, 180, 192, ".25"),
+		makeBox(0, 60, 500, 300, 312, "这是前言的第一行文字内容，用来模拟正文段落。"),
+		makeBox(0, 60, 500, 320, 332, "第二行继续，依然是一段连续的正文文字内容。"),
+		makeBox(0, 60, 500, 340, 352, "第三行收尾，这一段累计字数一定超过五十字限制。"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	for _, keep := range []string{
+		"木瓜树  更多的书籍免费下载",
+		"这是前言的第一行文字内容，用来模拟正文段落。",
+		"第二行继续，依然是一段连续的正文文字内容。",
+		"第三行收尾，这一段累计字数一定超过五十字限制。",
+	} {
+		if !contains(out, keep) {
+			t.Errorf("mixed page: expected to keep %q, got %v", keep, texts(out))
+		}
+	}
+	for _, drop := range []string{".20", ".22", ".25"} {
+		if contains(out, drop) {
+			t.Errorf("mixed page: expected to drop %q, got %v", drop, texts(out))
+		}
+	}
+}
+
+// TestFilterTOCBoxes_WrappedEntryArbitraryTitle deletes a wrapped entry whose
+// title line ("朴素贝叶斯分类") sits directly above its bare page reference —
+// a pairing the character-regex path cannot make because the title is not a
+// 第N章/Chapter-style heading. Prose on the page is kept.
+func TestFilterTOCBoxes_WrappedEntryArbitraryTitle(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 434, 447, 100, 112, ".20"),
+		makeBox(0, 434, 447, 140, 152, ".22"),
+		makeBox(0, 440, 460, 160, 172, "朴素贝叶斯分类"),
+		makeBox(0, 440, 447, 180, 192, "……39"),
+		makeBox(0, 60, 500, 300, 312, "这是前言的第一行文字内容，用来模拟正文段落。"),
+		makeBox(0, 60, 500, 320, 332, "第二行继续，依然是一段连续的正文文字内容。"),
+		makeBox(0, 60, 500, 340, 352, "第三行收尾，这一段累计字数一定超过五十字限制。"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if contains(out, "朴素贝叶斯分类") {
+		t.Errorf("wrapped title must be dropped with its bare page ref, got %v", texts(out))
+	}
+	if contains(out, "……39") || contains(out, ".20") || contains(out, ".22") {
+		t.Errorf("bare page refs must be dropped, got %v", texts(out))
+	}
+	if !contains(out, "这是前言的第一行文字内容，用来模拟正文段落。") {
+		t.Errorf("prose must survive, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_TableExcluded: rows of a detected table end in
+// right-aligned numbers but must never be treated as TOC entries.
+func TestFilterTOCBoxes_TableExcluded(t *testing.T) {
+	var boxes []pdf.TextBox
+	for i, top := range []float64{100, 140, 180, 220, 260} {
+		boxes = append(boxes, pdf.TextBox{
+			X0: 100, X1: 447, Top: top, Bottom: top + 12,
+			Text:       "第" + string(rune('A'+i)) + "项 " + string(rune('1'+i)) + "2",
+			PageNumber: 0, LayoutType: pdf.LayoutTypeTable,
+		})
+	}
+	// only two non-table aligned lines: below the cluster minimum
+	boxes = append(boxes,
+		makeBox(0, 434, 447, 300, 312, ".30"),
+		makeBox(0, 434, 447, 340, 352, ".35"),
+	)
+	out := FilterTOCBoxes(boxes, medianH)
+	if len(out) != len(boxes) {
+		t.Fatalf("table rows and sub-threshold lines must survive, got %d of %d: %v", len(out), len(boxes), texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_BelowClusterMinimum: two aligned entries prove nothing.
+func TestFilterTOCBoxes_BelowClusterMinimum(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 434, 447, 100, 112, ".20"),
+		makeBox(0, 434, 447, 140, 152, ".22"),
+		makeBox(0, 60, 500, 300, 312, "正文段落文字内容。"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if len(out) != len(boxes) {
+		t.Fatalf("below-cluster-minimum page must be untouched, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_NonMonotonicRejected: right-aligned numbers that do not
+// run in page order are a price/statistics column, not a TOC.
+func TestFilterTOCBoxes_NonMonotonicRejected(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 434, 447, 100, 112, ".10"),
+		makeBox(0, 434, 447, 140, 152, ".05"),
+		makeBox(0, 434, 447, 180, 192, ".03"),
+		makeBox(0, 60, 500, 300, 312, "正文段落文字内容。"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if len(out) != len(boxes) {
+		t.Fatalf("non-monotonic column must be untouched, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_HeadingOnMixedPage drops the standalone "目录" heading
+// above a mixed page's entry column while keeping the prose.
+func TestFilterTOCBoxes_HeadingOnMixedPage(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 100, 130, 100, 112, "目录"),
+		makeBox(0, 434, 447, 130, 142, ".20"),
+		makeBox(0, 434, 447, 170, 182, ".22"),
+		makeBox(0, 434, 447, 210, 222, ".25"),
+		makeBox(0, 60, 500, 300, 312, "这是前言的第一行文字内容，用来模拟正文段落。"),
+		makeBox(0, 60, 500, 320, 332, "第二行继续，依然是一段连续的正文文字内容。"),
+		makeBox(0, 60, 500, 340, 352, "第三行收尾，这一段累计字数一定超过五十字限制。"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if contains(out, "目录") {
+		t.Errorf("TOC heading must be dropped on the mixed page, got %v", texts(out))
+	}
+	if contains(out, ".20") || contains(out, ".22") || contains(out, ".25") {
+		t.Errorf("entries must be dropped, got %v", texts(out))
+	}
+	if !contains(out, "这是前言的第一行文字内容，用来模拟正文段落。") {
+		t.Errorf("prose must survive, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_TwoColumnTOC: two right-aligned page-number columns are
+// detected independently and both are dropped on a mixed page.
+func TestFilterTOCBoxes_TwoColumnTOC(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 190, 200, 100, 112, ".10"),
+		makeBox(0, 190, 200, 140, 152, ".12"),
+		makeBox(0, 190, 200, 180, 192, ".14"),
+		makeBox(0, 430, 447, 100, 112, ".20"),
+		makeBox(0, 430, 447, 140, 152, ".22"),
+		makeBox(0, 430, 447, 180, 192, ".25"),
+		makeBox(0, 60, 500, 300, 312, "这是前言的第一行文字内容，用来模拟正文段落。"),
+		makeBox(0, 60, 500, 320, 332, "第二行继续，依然是一段连续的正文文字内容。"),
+		makeBox(0, 60, 500, 340, 352, "第三行收尾，这一段累计字数一定超过五十字限制。"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	for _, drop := range []string{".10", ".12", ".14", ".20", ".22", ".25"} {
+		if contains(out, drop) {
+			t.Errorf("two-column TOC: expected to drop %q, got %v", drop, texts(out))
+		}
+	}
+	if !contains(out, "这是前言的第一行文字内容，用来模拟正文段落。") {
+		t.Errorf("two-column TOC: prose must survive, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_URLWatermarkExempt pins that a single isolated line is
+// exempt from the short-run cap even when it is longer than
+// tocShortRunMaxRunes: the 道德经 TOC pages carry a ~54-rune URL watermark,
+// and the page must still be whole-page deleted because the watermark is not
+// prose. Only chained multi-line runs are length-checked.
+func TestFilterTOCBoxes_URLWatermarkExempt(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 61, 406, 43, 55, "木瓜树  更多的书籍免费下载 http://forum.law58.cn/?fromuid=381879"),
+		makeBox(0, 111, 287, 78, 90, "第14章  执古之道，以御今之有."),
+		makeBox(0, 111, 297, 114, 127, "第15章  夫唯不盈，故能蔽而新成"),
+		makeBox(0, 111, 262, 152, 165, "第16章  道乃久，没身不殆."),
+		makeBox(0, 434, 447, 80, 89, ".20"),
+		makeBox(0, 434, 447, 116, 126, ".22"),
+		makeBox(0, 434, 447, 154, 164, ".23"),
+		makeBox(0, 441, 449, 637, 644, "II"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if len(out) != 0 {
+		t.Fatalf("URL-watermark TOC page: expected whole-page removal, got %v", texts(out))
+	}
+}
+
+// TestFilterTOCBoxes_ToleratesOccasionalNonMonotonic pins the relaxed order
+// check: one or two out-of-order page numbers (a misplaced section, an
+// appendix) do not disqualify an otherwise page-ordered column.
+func TestFilterTOCBoxes_ToleratesOccasionalNonMonotonic(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 434, 447, 100, 112, ".10"),
+		makeBox(0, 434, 447, 140, 152, ".12"),
+		makeBox(0, 434, 447, 180, 192, ".20"),
+		makeBox(0, 434, 447, 220, 232, ".18"), // one dip: tolerated
+		makeBox(0, 434, 447, 260, 272, ".25"),
+		makeBox(0, 60, 500, 300, 312, "这是前言的第一行文字内容，用来模拟正文段落。"),
+		makeBox(0, 60, 500, 320, 332, "第二行继续，依然是一段连续的正文文字内容。"),
+		makeBox(0, 60, 500, 340, 352, "第三行收尾，这一段累计字数一定超过五十字限制。"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	for _, drop := range []string{".10", ".12", ".20", ".18", ".25"} {
+		if contains(out, drop) {
+			t.Errorf("one-dip column: expected to drop %q, got %v", drop, texts(out))
+		}
+	}
+	if !contains(out, "这是前言的第一行文字内容，用来模拟正文段落。") {
+		t.Errorf("one-dip column: prose must survive, got %v", texts(out))
+	}
+}

--- a/internal/deepdoc/parser/pdf/layout/toc_geometry_test.go
+++ b/internal/deepdoc/parser/pdf/layout/toc_geometry_test.go
@@ -339,3 +339,68 @@ func TestFilterTOCBoxes_ToleratesOccasionalNonMonotonic(t *testing.T) {
 		t.Errorf("one-dip column: prose must survive, got %v", texts(out))
 	}
 }
+
+// TestFilterTOCBoxes_InterleavedColumnsKeepProse regresses the per-column run
+// tracking: two columns interleave by Top, and a body paragraph in one column
+// is interleaved with a TOC number column in the other. A single global run
+// would reset the paragraph's accumulation every time the other column sorts
+// between its lines, under-counting it below tocShortRunMaxRunes and wrongly
+// whole-page deleting the prose.
+func TestFilterTOCBoxes_InterleavedColumnsKeepProse(t *testing.T) {
+	boxes := []pdf.TextBox{
+		// column 1: a three-line body paragraph (each line short, run > 50 runes)
+		{X0: 60, X1: 500, Top: 100, Bottom: 112, Text: "这是前言的第一行文字内容，用来模拟正文段落。", PageNumber: 0, ColID: 1},
+		{X0: 60, X1: 500, Top: 120, Bottom: 132, Text: "第二行继续，依然是一段连续的正文文字内容。", PageNumber: 0, ColID: 1},
+		{X0: 60, X1: 500, Top: 140, Bottom: 152, Text: "第三行收尾，这一段累计字数一定超过五十字限制。", PageNumber: 0, ColID: 1},
+		// column 2: an aligned TOC page-number column interleaved by Top
+		{X0: 434, X1: 447, Top: 105, Bottom: 117, Text: ".20", PageNumber: 0, ColID: 2},
+		{X0: 434, X1: 447, Top: 125, Bottom: 137, Text: ".22", PageNumber: 0, ColID: 2},
+		{X0: 434, X1: 447, Top: 145, Bottom: 157, Text: ".25", PageNumber: 0, ColID: 2},
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	for _, keep := range []string{
+		"这是前言的第一行文字内容，用来模拟正文段落。",
+		"第二行继续，依然是一段连续的正文文字内容。",
+		"第三行收尾，这一段累计字数一定超过五十字限制。",
+	} {
+		if !contains(out, keep) {
+			t.Errorf("interleaved columns: expected to keep %q, got %v", keep, texts(out))
+		}
+	}
+	for _, drop := range []string{".20", ".22", ".25"} {
+		if contains(out, drop) {
+			t.Errorf("interleaved columns: expected to drop %q, got %v", drop, texts(out))
+		}
+	}
+}
+
+// TestFilterTOCBoxes_StructuredContentRejectsWholePage regresses the
+// structured-content guard: a page that would otherwise qualify for
+// whole-page deletion carries a DLA-detected table box. Whole-page deletion
+// must be rejected — the table and the short lines survive, only the TOC
+// entries are removed.
+func TestFilterTOCBoxes_StructuredContentRejectsWholePage(t *testing.T) {
+	boxes := []pdf.TextBox{
+		makeBox(0, 61, 199, 40, 52, "木瓜树  更多的书籍免费下载"),
+		makeBox(0, 434, 447, 100, 112, ".20"),
+		makeBox(0, 434, 447, 140, 152, ".22"),
+		makeBox(0, 434, 447, 180, 192, ".25"),
+		{ // a table row that ends in a right-aligned number
+			X0: 100, X1: 447, Top: 220, Bottom: 232,
+			Text: "列A 列B 12", PageNumber: 0, LayoutType: pdf.LayoutTypeTable,
+		},
+		makeBox(0, 441, 449, 260, 272, "II"),
+	}
+	out := FilterTOCBoxes(boxes, medianH)
+	if !contains(out, "列A 列B 12") {
+		t.Errorf("table box must survive, got %v", texts(out))
+	}
+	if !contains(out, "木瓜树  更多的书籍免费下载") {
+		t.Errorf("watermark must survive, got %v", texts(out))
+	}
+	for _, drop := range []string{".20", ".22", ".25"} {
+		if contains(out, drop) {
+			t.Errorf("structured-content page: expected to drop %q, got %v", drop, texts(out))
+		}
+	}
+}

--- a/internal/deepdoc/parser/pdf/parser.go
+++ b/internal/deepdoc/parser/pdf/parser.go
@@ -534,6 +534,15 @@ func (p *Parser) buildLayout(ctx context.Context,
 	boxes = lyt.TextMerge(boxes, medianHeights)
 	result.Metrics.BoxesTextMerge = len(boxes)
 
+	// Geometric table-of-contents removal runs while the boxes are still
+	// line-shaped: the right-aligned page-number column a TOC page is built
+	// on is destroyed by the vertical merge below, so the filter must see
+	// the lines first. Gated on the filetype-level "remove original table
+	// of contents" toggle (ParserConfig.RemoveTOC).
+	if p.Config.RemoveTOC {
+		boxes = lyt.FilterTOCBoxes(boxes, medianHeights)
+	}
+
 	// Preserve column-major content order while NaiveVerticalMerge promotes a
 	// page-leading title isolated in its own column.
 	boxes = lyt.FinalReadingOrderMerge(boxes)

--- a/internal/deepdoc/parser/type/types.go
+++ b/internal/deepdoc/parser/type/types.go
@@ -7,6 +7,8 @@ package doctype
 import (
 	"context"
 	"image"
+	"regexp"
+	"strings"
 	"unicode"
 )
 
@@ -237,6 +239,11 @@ type ParserConfig struct {
 	// nil/empty means parse all pages. Ranges beyond the document are clamped
 	// at parse time; fully out-of-range ranges are skipped.
 	Pages [][]int
+	// RemoveTOC enables the box-level geometric table-of-contents removal
+	// (layout.FilterTOCBoxes): page-number columns are detected before
+	// vertical merge collapses the lines, and the TOC pages/entries are
+	// dropped while the layout is still line-shaped.
+	RemoveTOC bool
 }
 
 // DefaultParserConfig returns a ParserConfig with sensible defaults.
@@ -312,7 +319,7 @@ func SetNativeDocAnalyzerFactory(f func() (DocAnalyzer, bool)) {
 	NativeDocAnalyzerFactory = f
 }
 
-// ── Outline ────────────────────────────────────────────────────────────
+// ── Outline / TOC title matching ───────────────────────────────────────
 
 // Outline represents one entry in a PDF's document outline (table of contents).
 // Python: extract_pdf_outlines() in deepdoc/parser/utils.py
@@ -320,6 +327,17 @@ type Outline struct {
 	Title      string
 	Level      int
 	PageNumber int // 1-indexed, matching Python
+}
+
+// tocTitlePattern matches a standalone table-of-contents heading: the whole
+// line is exactly one of the conventional TOC titles. It is the single
+// source of truth shared by the box-level geometric TOC filter (layout
+// package) and the outline-based page-range removal (parser package).
+var tocTitlePattern = regexp.MustCompile(`(?i)^(contents|目录|目次|table of contents|致谢|acknowledge)$`)
+
+// IsTOCTitleHeading reports whether text is a standalone TOC heading line.
+func IsTOCTitleHeading(text string) bool {
+	return tocTitlePattern.MatchString(strings.TrimSpace(text))
 }
 
 // PDFEngine abstracts page extraction capabilities.

--- a/internal/parser/parser/pdf_parser_cgo.go
+++ b/internal/parser/parser/pdf_parser_cgo.go
@@ -35,6 +35,7 @@ func (p *PDFParser) ParseWithResult(ctx context.Context, filename string, data [
 	}
 	cfg := deepdoctype.DefaultParserConfig()
 	cfg.Pages = p.Pages
+	cfg.RemoveTOC = p.RemoveTOC
 	parser := deepdocpdf.NewParser(cfg)
 	res := parsePDFWithDeepDocOptions(ctx, filename, data, pdfPostProcessOptions{
 		outputFormat:       p.OutputFormat,


### PR DESCRIPTION
## Summary

- Detect PDF table-of-contents pages geometrically (a right-aligned, page-ordered page-number column) and drop them when `remove_toc` is enabled, running before DeepDoc merges lines into blocks.
- Fixes column-split TOCs (titles and page numbers in separate columns), bare or single-dot page numbers, wrapped entries, and keeps body prose on mixed pages intact. The existing regex-based removal is kept as a fallback.

## Testing

- `bash build.sh --test ./internal/parser/parser/ ./internal/deepdoc/parser/type/ ./internal/deepdoc/parser/pdf/layout/ ./internal/deepdoc/parser/pdf/`
- Manual DeepDoc parse of a real book PDF (道德经.pdf, pages 1-10, remove_toc on): TOC pages removed, 0 leftover TOC artifacts, body content intact.
