### PR TITLE
fix(web): block chunk save and show error when tag is not selected

### DIFF
--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -919,6 +919,7 @@ Paragraphs:
       pageRank: 'Page rank',
       pageRankTip: `You can assign a higher PageRank score to specific datasets during retrieval. The corresponding score is added to the hybrid similarity scores of retrieved chunks from these datasets, increasing their ranking. See https://ragflow.io/docs/dataset_configuration#basic-information for details.`,
       tagName: 'Tag',
+      tagMessage: 'Please select a tag',
       frequency: 'Frequency',
       searchTags: 'Search tags',
       tagCloud: 'Cloud',

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -831,6 +831,7 @@ export default {
       pageRank: '页面排名',
       pageRankTip: `知识库检索时，你可以为特定知识库设置较高的 PageRank 分数，该知识库中匹配文本块的混合相似度得分会自动叠加 PageRank 分数，从而提升排序权重。详见 https://ragflow.io/docs/dataset_configuration#basic-information。`,
       tagName: '标签',
+      tagMessage: '请选择标签',
       frequency: '频次',
       searchTags: '搜索标签',
       tagCloud: '云',

--- a/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-creating-modal/tag-feature-item.tsx
+++ b/web/src/pages/chunk/parsed-result/add-knowledge/components/knowledge-chunk/components/chunk-creating-modal/tag-feature-item.tsx
@@ -76,6 +76,10 @@ export const TagFeatureItem = () => {
                     <FormField
                       control={form.control}
                       name={`${FieldKey}.${name}.tag` as any}
+                      rules={{
+                        validate: (value: string) =>
+                          value ? true : t('knowledgeConfiguration.tagMessage'),
+                      }}
                       render={({ field }) => (
                         <FormItem className="w-2/3">
                           <FormControl className="w-full">


### PR DESCRIPTION
### Summary

Add a validate rule to the tag field in the chunk editing modal so an empty tag row shows an inline error message below the select instead of submitting a request with an empty tag key.
