### PR TITLE
fix(web): hide sign up until registration is enabled

### DIFF
--- a/web/src/pages/login-next/index.test.tsx
+++ b/web/src/pages/login-next/index.test.tsx
@@ -1,0 +1,114 @@
+import { useSystemConfig } from '@/hooks/use-system-request';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Login from './index';
+
+jest.mock('@/hooks/use-system-request', () => ({
+  useSystemConfig: jest.fn(),
+}));
+
+jest.mock('@/hooks/auth-hooks', () => ({
+  useAuth: () => ({ isLogin: false }),
+}));
+
+jest.mock('@/hooks/use-login-request', () => ({
+  useLogin: () => ({ login: jest.fn(), loading: false }),
+  useRegister: () => ({ register: jest.fn(), loading: false }),
+  useLoginChannels: () => ({ channels: [], loading: false }),
+  useLoginWithChannel: () => ({ login: jest.fn(), loading: false }),
+}));
+
+jest.mock('react-router', () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/utils', () => ({ rsaPsw: jest.fn() }));
+jest.mock('@/components/svg-icon', () => () => null);
+jest.mock('@/components/spotlight', () => () => null);
+jest.mock('./bg', () => ({ BgSvg: () => null }));
+jest.mock('./card', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+  FlipFaceContext: jest.requireActual('react').createContext('front'),
+}));
+
+const MockUseSystemConfig = jest.mocked(useSystemConfig);
+const OriginalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+});
+
+afterAll(() => {
+  globalThis.ResizeObserver = OriginalResizeObserver;
+});
+
+describe('login registration entry', () => {
+  beforeEach(() => {
+    MockUseSystemConfig.mockReturnValue({ config: undefined, loading: true });
+  });
+
+  it.each([0, false])(
+    'keeps sign up hidden while loading and when registerEnabled is %s',
+    (registerEnabled) => {
+      const { rerender } = render(<Login />);
+
+      expect(
+        screen.queryByTestId('auth-toggle-register'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('auth-submit')).toBeEnabled();
+
+      MockUseSystemConfig.mockReturnValue({
+        config: { registerEnabled },
+        loading: false,
+      });
+      rerender(<Login />);
+
+      expect(
+        screen.queryByTestId('auth-toggle-register'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('auth-submit')).toBeEnabled();
+    },
+  );
+
+  it.each([1, true])(
+    'allows switching to sign up when registerEnabled is %s',
+    async (registerEnabled) => {
+      const { rerender } = render(<Login />);
+
+      expect(
+        screen.queryByTestId('auth-toggle-register'),
+      ).not.toBeInTheDocument();
+
+      MockUseSystemConfig.mockReturnValue({
+        config: { registerEnabled },
+        loading: false,
+      });
+      rerender(<Login />);
+
+      fireEvent.click(screen.getByTestId('auth-toggle-register'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-nickname')).toBeInTheDocument();
+      });
+    },
+  );
+
+  it('keeps sign up hidden when loading ends without a configuration', () => {
+    MockUseSystemConfig.mockReturnValue({ config: undefined, loading: false });
+
+    render(<Login />);
+
+    expect(
+      screen.queryByTestId('auth-toggle-register'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('auth-submit')).toBeEnabled();
+  });
+});

--- a/web/src/pages/login-next/index.tsx
+++ b/web/src/pages/login-next/index.tsx
@@ -265,7 +265,8 @@ const Login = () => {
     channelsLoading ||
     loginWithChannelLoading;
   const { config } = useSystemConfig();
-  const registerEnabled = config?.registerEnabled !== 0;
+  const registerEnabled =
+    config?.registerEnabled === 1 || config?.registerEnabled === true;
 
   const { isLogin } = useAuth();
   useEffect(() => {


### PR DESCRIPTION
### Summary

Fixes #19342.

With `REGISTER_ENABLED=0`, the login page briefly shows Sign up before the system configuration request finishes. The current comparison treats an undefined setting as enabled.

Show the registration entry only when `registerEnabled` is `1` (Python) or `true` (Go). The login form stays usable while the configuration loads. Add login-page tests for both backends' enabled and disabled values, and a missing configuration after loading ends. The enabled cases also check that users can open the registration form.

### Validation

Run from `web/`:

- `npm run test -- --runInBand --coverage=false src/pages/login-next/index.test.tsx` — all 5 tests pass. All 5 fail on the original code because Sign up is rendered before a configuration is available.
- `./node_modules/.bin/oxlint src/pages/login-next/index.tsx src/pages/login-next/index.test.tsx` — no errors; one existing `no-console` warning in the login page.
- `./node_modules/.bin/oxfmt --check src/pages/login-next/index.tsx src/pages/login-next/index.test.tsx` — passes.
- `npm run type-check` — fails with the same 216 diagnostics on both this change and unmodified main at `fd9f9e7f6123d452ae56e2b38e30db7e2482ae5d`. No diagnostics were added or removed.
