### PR TITLE
fix: filter structure alteration by document products

### DIFF
--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -2472,6 +2472,26 @@ async def _current_chunk_doc_ids(index_nm, dataset_id: str, doc_ids: set[str]) -
     )
 
 
+async def _current_structure_product_doc_ids(index_nm, dataset_id: str, kind: str, doc_ids: set[str]) -> set[str]:
+    """Return documents that have produced a document-scoped structure graph."""
+    if not doc_ids:
+        return set()
+    return await _involved_doc_ids_paged(
+        index_nm,
+        dataset_id,
+        {
+            "doc_id": sorted(doc_ids),
+            "scope_kwd": ["doc"],
+            "knowledge_graph_kwd": ["entity", "relation"],
+            "compilation_template_kind_kwd": [kind],
+            "available_int": [1],
+        },
+        "doc_id",
+        from_list=False,
+        raise_on_error=True,
+    )
+
+
 async def _involved_doc_ids_for_kind(index_nm, dataset_id: str, kind: str, tenant_id: str, wiki_map_state: dict | None = None) -> set:
     """Gather the doc ids baked into the compiled product for ``kind``."""
     if kind == "wiki":
@@ -2568,11 +2588,14 @@ async def _get_alteration(dataset_id: str, tenant_id: str, kind: str):
             eligible_before_chunk_filter = len(eligible_doc_ids)
             chunk_doc_ids = await _current_chunk_doc_ids(index_nm, dataset_id, eligible_doc_ids)
             eligible_doc_ids &= chunk_doc_ids
+            product_doc_ids = await _current_structure_product_doc_ids(index_nm, dataset_id, kind, eligible_doc_ids)
+            eligible_doc_ids &= product_doc_ids
             logging.debug(
-                "alteration: structure chunk eligibility kind=%s kb=%s before=%d after=%d",
+                "alteration: structure eligibility kind=%s kb=%s before=%d after_chunks=%d after_products=%d",
                 kind,
                 dataset_id,
                 eligible_before_chunk_filter,
+                len(chunk_doc_ids),
                 len(eligible_doc_ids),
             )
         wiki_map_state = None

--- a/api/apps/services/dataset_api_service.py
+++ b/api/apps/services/dataset_api_service.py
@@ -2476,6 +2476,7 @@ async def _current_structure_product_doc_ids(index_nm, dataset_id: str, kind: st
     """Return documents that have produced a document-scoped structure graph."""
     if not doc_ids:
         return set()
+    stored_kinds = sorted(_ALTERATION_ELIGIBLE_TEMPLATE_KINDS.get(kind) or {kind})
     return await _involved_doc_ids_paged(
         index_nm,
         dataset_id,
@@ -2483,8 +2484,7 @@ async def _current_structure_product_doc_ids(index_nm, dataset_id: str, kind: st
             "doc_id": sorted(doc_ids),
             "scope_kwd": ["doc"],
             "knowledge_graph_kwd": ["entity", "relation"],
-            "compilation_template_kind_kwd": [kind],
-            "available_int": [1],
+            "compilation_template_kind_kwd": stored_kinds,
         },
         "doc_id",
         from_list=False,

--- a/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
+++ b/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
@@ -523,7 +523,7 @@ async def test_current_structure_product_doc_ids_only_returns_document_scoped_pr
     result = await module._current_structure_product_doc_ids(
         "tenant-index",
         "kb-1",
-        "knowledge_graph",
+        "graph",
         {"doc-with-product", "doc-without-product"},
     )
 
@@ -535,11 +535,18 @@ async def test_current_structure_product_doc_ids_only_returns_document_scoped_pr
             "scope_kwd": ["doc"],
             "knowledge_graph_kwd": ["entity", "relation"],
             "compilation_template_kind_kwd": ["knowledge_graph"],
-            "available_int": [1],
         },
         "field": "doc_id",
         "from_list": False,
     }
+
+    await module._current_structure_product_doc_ids(
+        "tenant-index",
+        "kb-1",
+        "tree",
+        {"doc-with-product"},
+    )
+    assert captured["condition"]["compilation_template_kind_kwd"] == ["page_index", "tree"]
 
 
 @pytest.mark.asyncio

--- a/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
+++ b/test/unit_test/api/apps/services/test_dataset_api_service_list_datasets.py
@@ -504,6 +504,45 @@ async def test_current_chunk_doc_ids_propagates_search_errors(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_current_structure_product_doc_ids_only_returns_document_scoped_products(monkeypatch):
+    module, _, _ = _load_list_datasets_module(
+        monkeypatch,
+        kbs=[],
+        parsing_status_by_kb={},
+    )
+
+    captured = {}
+
+    async def _paged(_index, dataset_id, condition, field, from_list, *, raise_on_error):
+        captured.update(dataset_id=dataset_id, condition=condition, field=field, from_list=from_list)
+        assert raise_on_error is True
+        return {"doc-with-product"}
+
+    monkeypatch.setattr(module, "_involved_doc_ids_paged", _paged)
+
+    result = await module._current_structure_product_doc_ids(
+        "tenant-index",
+        "kb-1",
+        "knowledge_graph",
+        {"doc-with-product", "doc-without-product"},
+    )
+
+    assert result == {"doc-with-product"}
+    assert captured == {
+        "dataset_id": "kb-1",
+        "condition": {
+            "doc_id": ["doc-with-product", "doc-without-product"],
+            "scope_kwd": ["doc"],
+            "knowledge_graph_kwd": ["entity", "relation"],
+            "compilation_template_kind_kwd": ["knowledge_graph"],
+            "available_int": [1],
+        },
+        "field": "doc_id",
+        "from_list": False,
+    }
+
+
+@pytest.mark.asyncio
 async def test_wiki_involved_ids_use_active_map_state_when_pages_are_missing(monkeypatch):
     """Use MAP provenance even when a participating document has no page row."""
     module, _, _ = _load_list_datasets_module(


### PR DESCRIPTION
### What problem does this PR solve?

Structure alteration statistics included documents that had chunks but did not have a corresponding document-level graph product.

This PR ensures that only documents with both parsed chunks and a document-level structure product are included in the dataset-level alteration calculation.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)