### PR TITLE
fix(web): disable textarea resizing in agent note node

### DIFF
--- a/web/src/pages/agent/canvas/node/note-node/index.tsx
+++ b/web/src/pages/agent/canvas/node/note-node/index.tsx
@@ -106,6 +106,7 @@ function NoteNode({
                   <FormControl>
                     <Textarea
                       placeholder={t('flow.notePlaceholder')}
+                      resize="none"
                       className="resize-none rounded-none p-1 py-0 overflow-auto bg-transparent focus-visible:ring-0 border-none text-text-secondary focus-visible:ring-offset-0 !text-xs h-full"
                       {...field}
                     />


### PR DESCRIPTION
### Summary

The note node's textarea on the agent canvas could be manually resized, which broke its fixed-height layout. Pass `resize="none"` so the textarea always fills its container without showing a resize handle.
