### PR TITLE
fix(ingestion): finalize STOPPING ingestion task on re-parse instead of erroring

### DIFF
--- a/internal/service/document/document_ingest.go
+++ b/internal/service/document/document_ingest.go
@@ -71,9 +71,13 @@ func (s *DocumentService) Ingest(ctx context.Context, userID string, req *Ingest
 		validatedIDs = append(validatedIDs, docID)
 	}
 
-	// Batch pre-check for reparse with delete: use the validated doc IDs
-	// so we don't silently skip non-existent or unauthorized documents.
-	if run == string(entity.TaskStatusRunning) && req.Delete {
+	// Batch pre-check for reparse: use the validated doc IDs so we don't
+	// silently skip non-existent or unauthorized documents. Runs for every
+	// start request (with or without chunk deletion) so an actively-parsing
+	// document yields the friendly stop-first message instead of the raw
+	// "already exists" enqueue error. A STOPPING task passes: its stop was
+	// already requested and the enqueue path finalizes it.
+	if run == string(entity.TaskStatusRunning) {
 		if err = s.AssertIngestionTasksTerminal(ctx, validatedIDs); err != nil {
 			return common.CodeDataError, err
 		}

--- a/internal/service/document/document_parse.go
+++ b/internal/service/document/document_parse.go
@@ -88,10 +88,12 @@ func (s *DocumentService) StartParseDocuments(ctx context.Context, doc *entity.D
 	return nil
 }
 
-// AssertIngestionTasksTerminal verifies none of the documents has an
-// in-flight (RUNNING/STOPPING) ingestion task. Used as a batch pre-check
-// before re-parsing so a single non-terminal doc rejects the whole request
-// up front instead of partially cleaning some docs then failing.
+// AssertIngestionTasksTerminal verifies none of the documents has a RUNNING
+// ingestion task. Used as a batch pre-check before re-parsing so a single
+// actively-parsing doc rejects the whole request up front instead of
+// partially cleaning some docs then failing. A STOPPING task does not block
+// re-parse: its stop was already requested, and CreateAndEnqueue finalizes it
+// (STOPPING → STOPPED) and recycles the row for the new run.
 func (s *DocumentService) AssertIngestionTasksTerminal(ctx context.Context, docIDs []string) error {
 	for _, docID := range docIDs {
 		task, err := s.ingestionTaskDAO.GetByDocumentID(ctx, dao.DB, docID)
@@ -101,7 +103,7 @@ func (s *DocumentService) AssertIngestionTasksTerminal(ctx context.Context, docI
 		if task == nil {
 			continue
 		}
-		if task.Status == common.RUNNING || task.Status == common.STOPPING {
+		if task.Status == common.RUNNING {
 			return fmt.Errorf("document %s ingestion task is %s; stop it and wait for a terminal state before re-parsing", docID, task.Status)
 		}
 	}
@@ -113,32 +115,35 @@ func (s *DocumentService) clearDocumentParseResults(ctx context.Context, doc *en
 		return fmt.Errorf("document is nil")
 	}
 
-	// Refuse to clear a non-terminal ingestion task. An in-flight worker
-	// (RUNNING) or one mid-stop (STOPPING) would keep writing chunks and
-	// corrupt the new run's results. The caller must stop the task first
-	// and wait for a terminal state (COMPLETED/STOPPED/FAILED), CREATED, or
-	// SCHEDULED.
+	// Refuse to clear a RUNNING ingestion task: an in-flight worker would
+	// keep writing chunks and corrupt the new run's results. The caller must
+	// stop the task first. A STOPPING task is allowed through: its stop was
+	// already requested (the Redis cancel flag is still set, so a live worker
+	// aborts on its next cancel poll) and CreateAndEnqueue finalizes the
+	// STOPPING row instead of leaving it to block re-parse forever.
 	task, err := s.ingestionTaskDAO.GetByDocumentID(ctx, dao.DB, doc.ID)
 	if err != nil {
 		return fmt.Errorf("get ingestion task for document %s: %w", doc.ID, err)
 	}
-	taskExisted := task != nil
-	if task != nil {
-		if task.Status == common.RUNNING || task.Status == common.STOPPING {
-			return fmt.Errorf("document %s ingestion task is %s; stop it and wait for a terminal state before re-parsing", doc.ID, task.Status)
-		}
-		taskExisted = true
+	if task != nil && task.Status == common.RUNNING {
+		return fmt.Errorf("document %s ingestion task is %s; stop it and wait for a terminal state before re-parsing", doc.ID, task.Status)
 	}
 
-	// Delete terminal, CREATED, and SCHEDULED ingestion tasks atomically, leaving
-	// RUNNING/STOPPING tasks untouched so the check-then-delete window
-	// between GetByDocumentID and the delete cannot delete a task that just
-	// transitioned to RUNNING. In that case, do not clear its parse results.
-	deleted, err := s.ingestionTaskDAO.DeleteIfTerminal(ctx, dao.DB, doc.ID)
+	// Delete terminal, CREATED, and SCHEDULED ingestion tasks atomically,
+	// leaving RUNNING/STOPPING tasks untouched so the check-then-delete
+	// window between GetByDocumentID and the delete cannot delete a task
+	// that just transitioned to RUNNING. A surviving STOPPING row is fine —
+	// CreateAndEnqueue finalizes and recycles it — but a surviving RUNNING
+	// row means a worker just claimed the task and its results must not be
+	// cleared underneath it.
+	if _, err = s.ingestionTaskDAO.DeleteIfTerminal(ctx, dao.DB, doc.ID); err != nil {
+		return err
+	}
+	survivor, err := s.ingestionTaskDAO.GetByDocumentID(ctx, dao.DB, doc.ID)
 	if err != nil {
 		return err
 	}
-	if taskExisted && deleted == 0 {
+	if survivor != nil && survivor.Status == common.RUNNING {
 		return fmt.Errorf("document %s ingestion task started running; stop it before re-parsing", doc.ID)
 	}
 

--- a/internal/service/document/document_test.go
+++ b/internal/service/document/document_test.go
@@ -2127,10 +2127,12 @@ func TestClearDocumentParseResultsIsIdempotentForStaleDocSnapshot(t *testing.T) 
 
 // TestClearDocumentParseResults_RejectsNonTerminalIngestionTask verifies
 // that reparsing is refused while a document's ingestion task is still
-// RUNNING or STOPPING. Deleting a non-terminal task would let the in-flight
-// worker keep writing chunks and corrupt the new run's results.
+// RUNNING. Deleting a running task would let the in-flight worker keep
+// writing chunks and corrupt the new run's results. A STOPPING task is
+// covered separately: its stop was already requested, so the row survives
+// for CreateAndEnqueue to finalize and recycle.
 func TestClearDocumentParseResults_RejectsNonTerminalIngestionTask(t *testing.T) {
-	for _, status := range []string{common.RUNNING, common.STOPPING} {
+	for _, status := range []string{common.RUNNING} {
 		t.Run(status, func(t *testing.T) {
 			db := setupServiceTestDB(t)
 			pushServiceDB(t, db)
@@ -2153,6 +2155,40 @@ func TestClearDocumentParseResults_RejectsNonTerminalIngestionTask(t *testing.T)
 				t.Fatalf("%s ingestion task must not be deleted", status)
 			}
 		})
+	}
+}
+
+// TestClearDocumentParseResults_AllowsStoppingTask verifies that a STOPPING
+// ingestion task no longer blocks re-parse cleanup: the stop was already
+// requested, so the counters are cleared while the row itself survives for
+// CreateAndEnqueue to finalize (STOPPING → STOPPED) and recycle.
+func TestClearDocumentParseResults_AllowsStoppingTask(t *testing.T) {
+	db := setupServiceTestDB(t)
+	pushServiceDB(t, db)
+	insertTestKB(t, "kb-1", "tenant-1", 1, 10, 5)
+	insertTestDocWithRun(t, "doc-1", "kb-1", string(entity.TaskStatusCancel), 10, 5)
+	insertTestIngestionTaskWithStatus(t, "task-1", "user-1", "doc-1", "kb-1", common.STOPPING)
+
+	ctx := t.Context()
+	doc, err := dao.NewDocumentDAO().GetByID(ctx, db, "doc-1")
+	if err != nil {
+		t.Fatalf("get doc: %v", err)
+	}
+	svc := testDocumentService(t)
+
+	if err = svc.clearDocumentParseResults(ctx, doc, "tenant-1"); err != nil {
+		t.Fatalf("clearDocumentParseResults with STOPPING task failed: %v", err)
+	}
+	task, _ := svc.ingestionTaskDAO.GetByDocumentID(ctx, db, "doc-1")
+	if task == nil {
+		t.Fatal("STOPPING ingestion task must survive the clear for CreateAndEnqueue to recycle")
+	}
+	if task.Status != common.STOPPING {
+		t.Fatalf("task status = %q, want unchanged %q", task.Status, common.STOPPING)
+	}
+	updatedDoc, _ := dao.NewDocumentDAO().GetByID(ctx, db, "doc-1")
+	if updatedDoc.TokenNum != 0 || updatedDoc.ChunkNum != 0 {
+		t.Fatalf("doc counters = token:%d chunk:%d, want zero", updatedDoc.TokenNum, updatedDoc.ChunkNum)
 	}
 }
 
@@ -2261,10 +2297,14 @@ func TestAssertIngestionTasksTerminal_AcceptsAllTerminal(t *testing.T) {
 	insertTestDoc(t, "doc-2", "kb-1", 0, 0)
 	insertTestIngestionTaskWithStatus(t, "task-1", "user-1", "doc-1", "kb-1", common.COMPLETED)
 	insertTestIngestionTaskWithStatus(t, "task-2", "user-1", "doc-2", "kb-1", common.STOPPED)
+	insertTestDoc(t, "doc-3", "kb-1", 0, 0)
+	insertTestIngestionTaskWithStatus(t, "task-3", "user-1", "doc-3", "kb-1", common.STOPPING)
 
 	ctx := t.Context()
 	svc := testDocumentService(t)
-	if err := svc.AssertIngestionTasksTerminal(ctx, []string{"doc-1", "doc-2"}); err != nil {
+	// STOPPING is accepted: the stop was already requested, and the enqueue
+	// path finalizes the task instead of rejecting the re-parse.
+	if err := svc.AssertIngestionTasksTerminal(ctx, []string{"doc-1", "doc-2", "doc-3"}); err != nil {
 		t.Fatalf("expected nil for all-terminal batch, got %v", err)
 	}
 }

--- a/internal/service/ingestion_task_service.go
+++ b/internal/service/ingestion_task_service.go
@@ -397,24 +397,20 @@ func (s *IngestionTaskService) CreateAndEnqueue(ctx context.Context, task *entit
 				return nil, err
 			}
 			return s.markScheduledAfterPublish(ctx, existing.ID)
+		case common.STOPPING:
+			// A stop was already requested for this run (the document's run
+			// field already reports CANCEL), so re-parsing must finalize the
+			// stop instead of failing. Without this, a task whose worker died
+			// between RequestStop and markStopped stays STOPPING forever and
+			// every later parse of the document errors with "already exists,
+			// status: STOPPING".
+			stopped, stopErr := s.finalizeRequestedStop(ctx, existing.ID)
+			if stopErr != nil {
+				return nil, stopErr
+			}
+			return s.recycleTerminalTask(ctx, stopped, common.STOPPED)
 		case common.FAILED, common.STOPPED:
-			originalStatus := existing.Status
-			existing, err = s.transition(ctx, existing.ID, common.CREATED)
-			if err != nil {
-				return nil, err
-			}
-			// The previous run is terminal, so any leftover Redis cancel flag
-			// is stale: a genuine cancel of the new run can only come through
-			// RequestStop once the task is RUNNING again. Clear it so the
-			// re-queued task is not cancelled at the worker's pre-start check.
-			clearCancelFlag(ctx, existing.ID)
-			if err = s.enqueueTask(existing.ID); err != nil {
-				if rollbackErr := s.rollbackRetriedTask(ctx, existing.ID, originalStatus); rollbackErr != nil {
-					return nil, fmt.Errorf("enqueue task %s: %w (rollback failed: %w)", existing.ID, err, rollbackErr)
-				}
-				return nil, err
-			}
-			return s.markScheduledAfterPublish(ctx, existing.ID)
+			return s.recycleTerminalTask(ctx, existing, existing.Status)
 		default:
 			return nil, fmt.Errorf("document id %s already exists, status: %s, task id: %s", task.DocumentID, existing.Status, existing.ID)
 		}
@@ -431,6 +427,50 @@ func (s *IngestionTaskService) CreateAndEnqueue(ctx context.Context, task *entit
 		return nil, err
 	}
 	return s.markScheduledAfterPublish(ctx, created.ID)
+}
+
+// finalizeRequestedStop completes a stop that RequestStop started but no
+// worker came back to finish: STOPPING → STOPPED. The transition is
+// CAS-guarded; when the owning worker wins the race and finalizes first, the
+// conflict resolves by re-reading the row, because STOPPING can only ever
+// move to STOPPED.
+func (s *IngestionTaskService) finalizeRequestedStop(ctx context.Context, taskID string) (*entity.IngestionTask, error) {
+	task, err := s.transition(ctx, taskID, common.STOPPED)
+	if err == nil {
+		return task, nil
+	}
+	var conflict *TaskStatusConflictError
+	if !errors.As(err, &conflict) {
+		return nil, err
+	}
+	current, getErr := s.GetTask(ctx, taskID)
+	if getErr != nil || current == nil || current.Status != common.STOPPED {
+		return nil, err
+	}
+	return current, nil
+}
+
+// recycleTerminalTask resets a finished task row (FAILED/STOPPED) for a new
+// run: transition back to CREATED, drop the stale Redis cancel flag, publish,
+// then mark SCHEDULED. On publish failure the row rolls back to
+// originalStatus.
+func (s *IngestionTaskService) recycleTerminalTask(ctx context.Context, task *entity.IngestionTask, originalStatus string) (*entity.IngestionTask, error) {
+	recycled, err := s.transition(ctx, task.ID, common.CREATED)
+	if err != nil {
+		return nil, err
+	}
+	// The previous run is over, so any leftover Redis cancel flag is stale: a
+	// genuine cancel of the new run can only come through RequestStop once
+	// the task is RUNNING again. Clear it so the re-queued task is not
+	// cancelled at the worker's pre-start check.
+	clearCancelFlag(ctx, recycled.ID)
+	if err = s.enqueueTask(recycled.ID); err != nil {
+		if rollbackErr := s.rollbackRetriedTask(ctx, recycled.ID, originalStatus); rollbackErr != nil {
+			return nil, fmt.Errorf("enqueue task %s: %w (rollback failed: %w)", recycled.ID, err, rollbackErr)
+		}
+		return nil, err
+	}
+	return s.markScheduledAfterPublish(ctx, recycled.ID)
 }
 
 func (s *IngestionTaskService) rollbackRetriedTask(ctx context.Context, taskID, status string) error {

--- a/internal/service/ingestion_task_service_test.go
+++ b/internal/service/ingestion_task_service_test.go
@@ -605,6 +605,7 @@ func TestIngestionTaskServiceCreateAndEnqueueRetriesTerminalTask(t *testing.T) {
 	}{
 		{name: "failed", status: common.FAILED},
 		{name: "stopped", status: common.STOPPED},
+		{name: "stopping", status: common.STOPPING},
 	}
 
 	ctx := t.Context()


### PR DESCRIPTION
### Summary

**Background.** In the dataset file list, stopping a document parse and immediately clicking parse again shows a red toast:

```
failed to enqueue document <doc_id>: document id <doc_id> already exists, status: STOPPING, task id: <task_id>
```

Stopping a parse flips the ingestion task to `STOPPING` and immediately reports `CANCEL` in the document's legacy `run` field, so the UI offers the reparse icon right away (for 0-chunk documents the reparse dialog even auto-submits without the `delete` flag). The enqueue path, however, treated the still-`STOPPING` task row as a hard conflict:

- `IngestionTaskService.CreateAndEnqueue` fell into the `default` case for `STOPPING` and returned the raw `document id ... already exists, status: STOPPING` error (the batch pre-check that produces the friendly stop-first message only ran when `delete=true`).
- Nothing but a live worker ever moves `STOPPING` to `STOPPED` (startup recovery only handles `CREATED`), so a task whose worker died between `RequestStop` and `markStopped` stays `STOPPING` forever and the document can never be parsed again.

This diverges from the Python implementation, where re-parse always re-queues: `queue_tasks` unconditionally deletes the document's previous task rows and creates fresh ones.

**Fix.** A stop that has already been requested must not block a new parse; only a genuinely `RUNNING` task does:

- `CreateAndEnqueue` now finalizes a `STOPPING` task (`STOPPING -> STOPPED`, CAS-guarded, race-safe against a worker doing the same finalization) and recycles the row for the new run exactly like the `FAILED`/`STOPPED` retry path (`STOPPED -> CREATED -> SCHEDULED`, stale Redis cancel flag cleared). The shared recycle logic is factored into `recycleTerminalTask`.
- `AssertIngestionTasksTerminal` and `clearDocumentParseResults` now refuse only `RUNNING`; a surviving `STOPPING` row is left for `CreateAndEnqueue` to finalize (the reparse-cleanup race check re-reads the task after the conditional delete instead of relying on the pre-delete snapshot).
- `DocumentService.Ingest` runs the batch pre-check for every start request, not only when chunk deletion is requested, so an actively-parsing document returns the friendly "stop it and wait" message on both paths.

This continues the direction of #17708 (which cleared the stale cancel flag so the *first* re-parse after a completed cancel runs); the difference is that #17708 only helped once the task had already reached `STOPPED`, while this PR resolves the task that is still (or permanently stuck) in `STOPPING`.

### Verification

- Unit tests (`bash build.sh --test ./internal/service/... ./internal/dao/...`): added the `stopping` case to `TestIngestionTaskServiceCreateAndEnqueueRetriesTerminalTask` (STOPPING → finalized → recycled → SCHEDULED, one published message), added `TestClearDocumentParseResults_AllowsStoppingTask`, and extended `TestAssertIngestionTasksTerminal_AcceptsAllTerminal` with a STOPPING document. All packages pass.
- End-to-end on the local Go stack (login through the web login form, upload a document, parse → stop → re-parse through `/api/v1/documents/ingest`):
  - before the fix: re-parse while `ingestion_status=STOPPING` returned `code:100 "failed to enqueue document ...: document id ... already exists, status: STOPPING, task id: ..."` — the exact reported error:
    ![repro: re-parse while STOPPING fails with the reported error](https://github.com/euvre/ragflow/releases/download/pr-assets/t255-01-repro.png)
  - after the fix: the same scenario returns `code:0, data:true` and the parse restarts:
    ![fixed: re-parse while STOPPING is accepted](https://github.com/euvre/ragflow/releases/download/pr-assets/t255-02-fixed.png)
  - Note: the document's pipeline itself ends `FAILED` in this environment both before and after the change because the test dataset has no embedding model configured; that is unrelated to the enqueue fix verified here.
