### PR TITLE
fix(sdk): preserve JSON document downloads

### DIFF
--- a/sdk/python/ragflow_sdk/modules/document.py
+++ b/sdk/python/ragflow_sdk/modules/document.py
@@ -71,10 +71,9 @@ class Document(Base):
             logger.debug("Document.download returning attachment content dataset_id=%s document_id=%s", self.dataset_id, self.id)
             return res.content
 
-        error_keys = {"code", "message"}
         try:
             response = res.json()
-            if isinstance(response, dict) and set(response) == error_keys and response.get("code") != 0:
+            if isinstance(response, dict) and "code" in response and response["code"] != 0:
                 raise Exception(response.get("message"))
         except ValueError:
             pass

--- a/sdk/python/ragflow_sdk/modules/document.py
+++ b/sdk/python/ragflow_sdk/modules/document.py
@@ -64,14 +64,16 @@ class Document(Base):
 
     def download(self):
         res = self.get(f"/datasets/{self.dataset_id}/documents/{self.id}")
-        error_keys = set(["code", "message"])
+        content_disposition = res.headers.get("Content-Disposition", "")
+        if content_disposition.lstrip().lower().startswith("attachment"):
+            return res.content
+
+        error_keys = {"code", "message"}
         try:
             response = res.json()
-            actual_keys = set(response.keys())
-            if actual_keys == error_keys:
+            if isinstance(response, dict) and set(response) == error_keys:
                 raise Exception(response.get("message"))
-            else:
-                return res.content
+            return res.content
         except json.JSONDecodeError:
             return res.content
 

--- a/sdk/python/ragflow_sdk/modules/document.py
+++ b/sdk/python/ragflow_sdk/modules/document.py
@@ -14,10 +14,12 @@
 #  limitations under the License.
 #
 
-import json
+import logging
 
 from .base import Base
 from .chunk import Chunk
+
+logger = logging.getLogger(__name__)
 
 
 class Document(Base):
@@ -66,16 +68,18 @@ class Document(Base):
         res = self.get(f"/datasets/{self.dataset_id}/documents/{self.id}")
         content_disposition = res.headers.get("Content-Disposition", "")
         if content_disposition.lstrip().lower().startswith("attachment"):
+            logger.debug("Document.download returning attachment content dataset_id=%s document_id=%s", self.dataset_id, self.id)
             return res.content
 
         error_keys = {"code", "message"}
         try:
             response = res.json()
-            if isinstance(response, dict) and set(response) == error_keys:
+            if isinstance(response, dict) and set(response) == error_keys and response.get("code") != 0:
                 raise Exception(response.get("message"))
-            return res.content
-        except json.JSONDecodeError:
-            return res.content
+        except ValueError:
+            pass
+        logger.debug("Document.download returning non-attachment content dataset_id=%s document_id=%s", self.dataset_id, self.id)
+        return res.content
 
     def list_chunks(self, page=1, page_size=30, keywords="", id=""):
         data = {"keywords": keywords, "page": page, "page_size": page_size, "id": id}

--- a/test/testcases/test_sdk_api/test_file_management_within_dataset/test_download_document.py
+++ b/test/testcases/test_sdk_api/test_file_management_within_dataset/test_download_document.py
@@ -28,6 +28,8 @@ class _DownloadResponse:
         self.headers = headers or {}
 
     def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
         return self._payload
 
 
@@ -70,6 +72,22 @@ def test_download_still_raises_api_error_without_attachment(monkeypatch):
 
     with pytest.raises(Exception, match="document not found"):
         document.download()
+
+
+@pytest.mark.p2
+@pytest.mark.parametrize(
+    "content,payload",
+    [
+        (b'{"code": 0, "message": "success"}', {"code": 0, "message": "success"}),
+        (b"plain text", ValueError("not JSON")),
+    ],
+)
+def test_download_preserves_non_error_content_without_attachment(monkeypatch, content, payload):
+    response = _DownloadResponse(content, payload, {"Content-Type": "application/json"})
+    document = Document(None, {"id": "doc", "dataset_id": "dataset"})
+    monkeypatch.setattr(document, "get", lambda *_args, **_kwargs: response)
+
+    assert document.download() == content
 
 
 @pytest.mark.p1

--- a/test/testcases/test_sdk_api/test_file_management_within_dataset/test_download_document.py
+++ b/test/testcases/test_sdk_api/test_file_management_within_dataset/test_download_document.py
@@ -75,6 +75,20 @@ def test_download_still_raises_api_error_without_attachment(monkeypatch):
 
 
 @pytest.mark.p2
+def test_download_raises_api_error_with_extra_response_fields(monkeypatch):
+    response = _DownloadResponse(
+        b'{"code": 102, "message": "document not found", "data": null}',
+        {"code": 102, "message": "document not found", "data": None},
+        {"Content-Type": "application/json"},
+    )
+    document = Document(None, {"id": "doc", "dataset_id": "dataset"})
+    monkeypatch.setattr(document, "get", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(Exception, match="document not found"):
+        document.download()
+
+
+@pytest.mark.p2
 @pytest.mark.parametrize(
     "content,payload",
     [

--- a/test/testcases/test_sdk_api/test_file_management_within_dataset/test_download_document.py
+++ b/test/testcases/test_sdk_api/test_file_management_within_dataset/test_download_document.py
@@ -17,7 +17,59 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 from common import bulk_upload_documents
+from ragflow_sdk.modules.document import Document
 from utils import compare_by_hash
+
+
+class _DownloadResponse:
+    def __init__(self, content, payload, headers=None):
+        self.content = content
+        self._payload = payload
+        self.headers = headers or {}
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.p2
+@pytest.mark.parametrize(
+    "content,payload",
+    [
+        (b"[]", []),
+        (b"[1, 2]", [1, 2]),
+        (b"null", None),
+        (b'"hello"', "hello"),
+        (b"42", 42),
+        (
+            b'{"code": 0, "message": "file content"}',
+            {"code": 0, "message": "file content"},
+        ),
+    ],
+)
+def test_download_preserves_attached_json_bytes(monkeypatch, content, payload):
+    response = _DownloadResponse(
+        content,
+        payload,
+        {"Content-Disposition": 'attachment; filename="sample.json"'},
+    )
+    document = Document(None, {"id": "doc", "dataset_id": "dataset"})
+    monkeypatch.setattr(document, "get", lambda *_args, **_kwargs: response)
+
+    assert document.download() == content
+
+
+@pytest.mark.p2
+def test_download_still_raises_api_error_without_attachment(monkeypatch):
+    response = _DownloadResponse(
+        b'{"code": 102, "message": "document not found"}',
+        {"code": 102, "message": "document not found"},
+        {"Content-Type": "application/json"},
+    )
+    document = Document(None, {"id": "doc", "dataset_id": "dataset"})
+    monkeypatch.setattr(document, "get", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(Exception, match="document not found"):
+        document.download()
 
 
 @pytest.mark.p1


### PR DESCRIPTION
### Summary

- identify successful document downloads from their `Content-Disposition: attachment` response before inspecting the body as JSON
- return parseable JSON arrays, scalars, `null`, and object-shaped file contents byte for byte
- preserve API error handling for nonzero JSON error responses while returning successful and non-JSON fallback bodies
- add content-free debug logging for the selected download path

### Root cause

`Document.download()` attempted to classify every response by parsing its body as JSON. It then assumed the decoded value was an object, which raised `AttributeError` for valid JSON arrays and scalars. A valid JSON file containing exactly `code` and `message` was also mistaken for an API error.

The download endpoint already distinguishes files from JSON error envelopes with `Content-Disposition: attachment`, so the SDK can use that response contract before examining the body. Non-attachment responses now use the same `code != 0` error rule as the rest of the SDK and tolerate every `ValueError` raised by `Response.json()`.

### Testing

- focused SDK regression tests: 10 passed
- the same tests against `origin/main` (`0d83b5bec`) reproduce the issue: 6 failed, 1 passed
- the extra-field API error regression fails against the previous PR head (`4b595681c`) and passes after the follow-up
- `ruff check` passed for both changed files
- `ruff format --check` passed for both changed files
- `py_compile` passed for both changed files
