### PR TITLE
fix(docs): document dataset language create and update behavior

### DIFF
--- a/api/apps/restful_apis/dataset_api.py
+++ b/api/apps/restful_apis/dataset_api.py
@@ -116,8 +116,9 @@ async def create(tenant_id: str = None):
               description: Optional dataset description.
             language:
               type: string
+              minLength: 1
               maxLength: 32
-              description: Optional document language (e.g. "English", "Chinese"); if omitted, the server default is used.
+              description: Optional document language (e.g. "English", "Chinese"); leading/trailing whitespace is stripped and the trimmed value must contain 1 to 32 characters. If omitted, the server/database default is used.
             embedding_model:
               type: string
               description: Optional embedding model name; if omitted, the tenant's default embedding model is used.
@@ -260,6 +261,11 @@ async def update(tenant_id, dataset_id):
             description:
               type: string
               description: Updated description of the dataset.
+            language:
+              type: string
+              minLength: 1
+              maxLength: 32
+              description: Optional document language (e.g. "English", "Chinese"); leading/trailing whitespace is stripped and the trimmed value must contain 1 to 32 characters. If omitted, the existing language is unchanged.
             embedding_model:
               type: string
               description: Updated embedding model Name.

--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -515,6 +515,7 @@ Creates a dataset.
   - `"name"`: `string`
   - `"avatar"`: `string`
   - `"description"`: `string`
+  - `"language"`: `string`
   - `"embedding_model"`: `string`
   - `"permission"`: `string`
   - `"chunk_method"`: `string`
@@ -547,6 +548,7 @@ curl --request POST \
   --header 'Authorization: Bearer <YOUR_API_KEY>' \
   --data '{
    "name": "test-sdk",
+   "language": "English",
    "parse_type": <NUMBER_OF_PARSERS_IN_YOUR_PARSER_COMPONENT>,
    "pipeline_id": "<PIPELINE_ID_32_HEX>"
   }'
@@ -567,6 +569,13 @@ curl --request POST \
 - `"description"`: (*Body parameter*), `string`
   A brief description of the dataset to create.
   - Maximum 65535 characters
+
+- `"language"`: (*Body parameter*), `string`
+  Optional document/dataset language, for example: `"English"` or `"Chinese"`.
+  Leading and trailing whitespace are stripped.
+  After trimming, it must contain at least 1 character and at most 32 characters. The limit counts characters, not UTF-8 bytes.
+  No restricted list of language values is enforced.
+  If omitted, the server/database default is used.
 
 - `"embedding_model"`: (*Body parameter*), `string`
   The name of the embedding model to use. For example: `"BAAI/bge-large-zh-v1.5@BAAI"`
@@ -784,6 +793,7 @@ Updates configurations for a specified dataset.
   - `"name"`: `string`
   - `"avatar"`: `string`
   - `"description"`: `string`
+  - `"language"`: `string`
   - `"embedding_model"`: `string`
   - `"permission"`: `string`
   - `"chunk_method"`: `string`
@@ -820,6 +830,12 @@ curl --request PUT \
   - Ensure that `"chunk_count"` is `0` before updating `"embedding_model"`.
   - Maximum 255 characters
   - Must follow `model_name@model_factory` format
+- `"language"`: (*Body parameter*), `string`
+  Optional document/dataset language, for example: `"English"` or `"Chinese"`.
+  Leading and trailing whitespace are stripped.
+  After trimming, it must contain at least 1 character and at most 32 characters. The limit counts characters, not UTF-8 bytes.
+  No restricted list of language values is enforced.
+  If omitted, the existing dataset language remains unchanged.
 - `"permission"`: (*Body parameter*), `string`
   The updated dataset permission. Available options:
   - `"me"`: (Default) Only you can manage the dataset.


### PR DESCRIPTION
### Summary

The API docs now describe the optional language field for dataset creation and updates. They document trimming, validation limits, defaults, and unchanged update behavior.