### PR TITLE
fix(retrieval): scope mother chunks by document

### DIFF
--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -47,6 +47,23 @@ def index_name(uid):
     return f"ragflow_{uid}"
 
 
+def _scope_values(value) -> frozenset:
+    if isinstance(value, (list, tuple, set)):
+        return frozenset(item for item in value if item is not None)
+    if value is None:
+        return frozenset()
+    return frozenset((value,))
+
+
+def _parent_matches_children(parent: dict, children: list[dict]) -> bool:
+    child_scopes = {(_scope_values(child.get("doc_id")), _scope_values(child.get("kb_id"))) for child in children}
+    if len(child_scopes) != 1:
+        return False
+
+    ((child_doc_ids, child_kb_ids),) = child_scopes
+    return bool(child_doc_ids and child_kb_ids) and (_scope_values(parent.get("doc_id")) == child_doc_ids and _scope_values(parent.get("kb_id")) == child_kb_ids)
+
+
 class Dealer:
     # Short-lived cache of "doc_id exists in MySQL" used by _prune_deleted_chunks.
     # Every retrieval would otherwise hit MySQL per query (fan-out searches and the
@@ -998,6 +1015,14 @@ class Dealer:
             if chunk is None:
                 logging.warning(
                     "Parent chunk '%s' not found in the index; falling back to %d child chunk(s).",
+                    id,
+                    len(cks),
+                )
+                chunks.extend(cks)
+                continue
+            if not _parent_matches_children(chunk, cks):
+                logging.warning(
+                    "Parent chunk '%s' metadata does not match its child scope; falling back to %d child chunk(s).",
                     id,
                     len(cks),
                 )

--- a/rag/svr/task_executor.py
+++ b/rag/svr/task_executor.py
@@ -1331,7 +1331,7 @@ async def insert_chunks(task_id, task_tenant_id, task_dataset_id, chunks, progre
         chunks: List of chunk dictionaries to insert
         progress_callback: Callback function for progress updates
     """
-    from rag.svr.task_executor_refactor.chunk_service import apply_source_chunks_document_availability
+    from rag.svr.task_executor_refactor.chunk_service import apply_source_chunks_document_availability, make_mother_chunk_id
 
     apply_source_chunks_document_availability(chunks)
 
@@ -1341,13 +1341,13 @@ async def insert_chunks(task_id, task_tenant_id, task_dataset_id, chunks, progre
         mom = ck.get("mom") or ck.get("mom_with_weight") or ""
         if not mom:
             continue
-        id = xxhash.xxh64(mom.encode("utf-8")).hexdigest()
-        ck["mom_id"] = id
-        if id in mother_ids:
+        mom_id = make_mother_chunk_id(mom, ck.get("doc_id"))
+        ck["mom_id"] = mom_id
+        if mom_id in mother_ids:
             continue
-        mother_ids.add(id)
+        mother_ids.add(mom_id)
         mom_ck = copy.deepcopy(ck)
-        mom_ck["id"] = id
+        mom_ck["id"] = mom_id
         mom_ck["content_with_weight"] = mom
         mom_ck["available_int"] = 0
         flds = list(mom_ck.keys())

--- a/rag/svr/task_executor_refactor/chunk_service.py
+++ b/rag/svr/task_executor_refactor/chunk_service.py
@@ -60,6 +60,11 @@ from rag.svr.task_executor_refactor.chunk_post_processor import (
 )
 
 
+def make_mother_chunk_id(content: str, doc_id: Any) -> str:
+    """Build a deterministic parent-chunk ID scoped to its source document."""
+    return xxhash.xxh64((content + str(doc_id or "")).encode("utf-8", "surrogatepass")).hexdigest()
+
+
 def apply_document_availability(chunks: List[Dict[str, Any]], status) -> int:
     """Stamp ordinary source chunks available_int=0 when document status is disabled.
 
@@ -351,7 +356,7 @@ class ChunkService:
             if not mom:
                 continue
 
-            mom_id = xxhash.xxh64(mom.encode("utf-8")).hexdigest()
+            mom_id = make_mother_chunk_id(mom, ck.get("doc_id"))
             ck["mom_id"] = mom_id
 
             if mom_id in mother_ids:

--- a/test/unit_test/rag/svr/task_executor_refactor/test_mother_chunk_scope.py
+++ b/test/unit_test/rag/svr/task_executor_refactor/test_mother_chunk_scope.py
@@ -1,0 +1,85 @@
+#
+#  Copyright 2024 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from rag.nlp.search import Dealer
+from rag.svr.task_executor_refactor.chunk_service import ChunkService, make_mother_chunk_id
+
+
+def test_mother_chunk_ids_are_scoped_to_the_source_document():
+    assert make_mother_chunk_id("same summary", "doc-a") != make_mother_chunk_id("same summary", "doc-b")
+    assert make_mother_chunk_id("same summary", "doc-a") == make_mother_chunk_id("same summary", "doc-a")
+
+    chunks = [
+        {"mom": "same summary", "doc_id": "doc-a", "kb_id": "kb-a"},
+        {"mom": "same summary", "doc_id": "doc-b", "kb_id": "kb-b"},
+    ]
+    mothers = ChunkService._create_mother_chunks(chunks)
+
+    assert chunks[0]["mom_id"] != chunks[1]["mom_id"]
+    assert {mother["doc_id"] for mother in mothers} == {"doc-a", "doc-b"}
+
+
+class _DataStore:
+    def __init__(self, parent):
+        self.parent = parent
+
+    def get(self, _parent_id, _index_name, _dataset_ids):
+        return self.parent
+
+
+def _dealer(parent):
+    dealer = Dealer.__new__(Dealer)
+    dealer.dataStore = _DataStore(parent)
+    return dealer
+
+
+def _child(doc_id="doc-a", kb_id="kb-a"):
+    return {
+        "mom_id": "legacy-colliding-id",
+        "content_ltks": "child content",
+        "content_with_weight": "child content",
+        "doc_id": doc_id,
+        "kb_id": kb_id,
+        "similarity": 0.8,
+    }
+
+
+def test_retrieval_falls_back_when_parent_metadata_is_from_another_document():
+    child = _child()
+    parent = {
+        "content_with_weight": "parent from another document",
+        "doc_id": "doc-b",
+        "kb_id": "kb-b",
+    }
+
+    result = _dealer(parent).retrieval_by_children([child], ["tenant"])
+
+    assert result == [child]
+    assert result[0]["content_with_weight"] == "child content"
+
+
+def test_retrieval_uses_parent_when_parent_metadata_matches_children():
+    child = _child()
+    parent = {
+        "content_with_weight": "parent content",
+        "doc_id": "doc-a",
+        "kb_id": "kb-a",
+    }
+
+    result = _dealer(parent).retrieval_by_children([child], ["tenant"])
+
+    assert result[0]["chunk_id"] == "legacy-colliding-id"
+    assert result[0]["content_with_weight"] == "parent content"
+    assert result[0]["doc_id"] == "doc-a"


### PR DESCRIPTION
## Summary

Closes #19350.

- Scope generated parent (mother) chunk IDs by source document so identical parent text cannot overwrite provenance across documents in the same tenant index.
- Reuse the same ID helper in both the legacy and refactored chunk insertion paths.
- Validate a fetched parent against its child document and dataset before replacing children; fall back to the children for legacy collisions or mismatched metadata.
- Add regression coverage for document-scoped IDs, safe fallback, and the matching-parent path.

## Validation

- ruff format --check on the four changed files
- ruff check --select E9,F401,F821,ASYNC --ignore E402 on the four changed files
- python -m compileall on the four changed files
- git diff --check
- Focused pytest collection is blocked in the local environment because the Python 3.11 environment is missing RAGFlow dependencies (first missing nltk, then roman_numbers); the Python 3.13 environment does not have pytest installed.