### PR TITLE
chore(deps): let download_go_deps.py fetch Go DeepDoc .ort weights

### DIFF
--- a/.github/workflows/sep-tests.yml
+++ b/.github/workflows/sep-tests.yml
@@ -1731,6 +1731,10 @@ jobs:
     # Skip unless DeepDoc native backend code/build/testdata actually changed.
     if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci') && (github.event.action != 'labeled' || github.event.label.name == 'ci'))) && needs.ragflow_preflight.outputs.has_native_deepdoc_changes == 'true' }}
     runs-on: [ "self-hosted", "ragflow-test" ]
+    # Shared by the assert step and the test step below so the mount path is
+    # declared once.
+    env:
+      RAGFLOW_TESTDATA_DIR: /opt/ragflow-testdata
     steps:
       - name: Ensure workspace ownership
         run: |
@@ -1781,13 +1785,13 @@ jobs:
         # package later does not invalidate the check.
         run: |
           set -euo pipefail
-          if [ ! -d /opt/ragflow-testdata/deepdoc ]; then
-            echo "ERROR: /opt/ragflow-testdata/deepdoc missing on this runner." >&2
+          if [ ! -d "${RAGFLOW_TESTDATA_DIR}/deepdoc" ]; then
+            echo "ERROR: ${RAGFLOW_TESTDATA_DIR}/deepdoc missing on this runner." >&2
             echo "       Native backend tests expect the asset repo pre-seeded there." >&2
             exit 1
           fi
-          echo "✓ pre-seeded testdata found at /opt/ragflow-testdata/deepdoc:"
-          ls -l /opt/ragflow-testdata/deepdoc
+          echo "✓ pre-seeded testdata found at ${RAGFLOW_TESTDATA_DIR}/deepdoc:"
+          ls -l "${RAGFLOW_TESTDATA_DIR}/deepdoc"
 
       - name: Run in-process DeepDoc backend integration tests (correctness + race)
         # Doc-engine-independent: the same native backend (det/layout/tsr/rec
@@ -1806,7 +1810,6 @@ jobs:
         # back to when it runs outside this job (local dev, no mount).
         env:
           MODEL_DIR: /opt/ragflow-deepdoc-models
-          RAGFLOW_TESTDATA_DIR: /opt/ragflow-testdata
           CGO_ENABLED: '1'
           DEEPDOC_NATIVE_REQUIRED: '1'
           XDG_CACHE_HOME: ${{ github.workspace }}/.cache

--- a/.github/workflows/sep-tests.yml
+++ b/.github/workflows/sep-tests.yml
@@ -1769,6 +1769,26 @@ jobs:
             infiniflow/infinity_builder:ubuntu22_clang20
           sudo docker exec "${BUILDER_CONTAINER}" bash -c 'git config --global safe.directory "*" && cd /ragflow && ./build.sh --cpp'
 
+      - name: Assert pre-seeded DeepDoc testdata
+        # Only the self-hosted ragflow-test runners bake infiniflow/ragflow-testdata
+        # into /opt/ragflow-testdata — the same image-level contract as
+        # MODEL_DIR=/opt/ragflow-deepdoc-models, which has no fallback either.
+        # Fail here rather than letting the fetch script silently fall back to
+        # cloning: a missing mount is an environment defect, and a silent
+        # fallback only makes the job slower while hiding it.
+        #
+        # Assert the `deepdoc` level, not a per-package subtree, so adding a
+        # package later does not invalidate the check.
+        run: |
+          set -euo pipefail
+          if [ ! -d /opt/ragflow-testdata/deepdoc ]; then
+            echo "ERROR: /opt/ragflow-testdata/deepdoc missing on this runner." >&2
+            echo "       Native backend tests expect the asset repo pre-seeded there." >&2
+            exit 1
+          fi
+          echo "✓ pre-seeded testdata found at /opt/ragflow-testdata/deepdoc:"
+          ls -l /opt/ragflow-testdata/deepdoc
+
       - name: Run in-process DeepDoc backend integration tests (correctness + race)
         # Doc-engine-independent: the same native backend (det/layout/tsr/rec
         # ONNX models + onnxruntime) is exercised regardless of DOC_ENGINE, so
@@ -1778,10 +1798,12 @@ jobs:
         # race-detection value, ~10x memory tax) and only the concurrency
         # correctness tests run WITH -race (see run_native_integration_tests).
         #
-        # Testdata is pre-seeded on the runner at /opt/ragflow-testdata;
-        # RAGFLOW_TESTDATA_DIR points the fetch script at it so the network
-        # clone is skipped (see scripts/fetch_deepdoc_testdata.sh). Runners
-        # without that mount fall back to cloning into XDG_CACHE_HOME.
+        # Testdata is pre-seeded on the runner at /opt/ragflow-testdata
+        # (asserted by the previous step). RAGFLOW_TESTDATA_DIR points the fetch
+        # script at it so the network clone is skipped (see
+        # scripts/fetch_deepdoc_testdata.sh) — which is why no actions/cache step
+        # is needed here. XDG_CACHE_HOME remains the location the script falls
+        # back to when it runs outside this job (local dev, no mount).
         env:
           MODEL_DIR: /opt/ragflow-deepdoc-models
           RAGFLOW_TESTDATA_DIR: /opt/ragflow-testdata

--- a/.github/workflows/sep-tests.yml
+++ b/.github/workflows/sep-tests.yml
@@ -1769,16 +1769,6 @@ jobs:
             infiniflow/infinity_builder:ubuntu22_clang20
           sudo docker exec "${BUILDER_CONTAINER}" bash -c 'git config --global safe.directory "*" && cd /ragflow && ./build.sh --cpp'
 
-      - name: Cache external DeepDoc testdata
-        # The native backend tests fetch pinned test assets from
-        # infiniflow/ragflow-testdata (see scripts/fetch_deepdoc_testdata.sh).
-        # Cache them across runs, keyed by the pinned ref recorded in
-        # internal/deepdoc/native/testdata.ref so a ref bump invalidates the cache.
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.cache/ragflow-testdata
-          key: deepdoc-testdata-${{ hashFiles('internal/deepdoc/native/testdata.ref') }}
-
       - name: Run in-process DeepDoc backend integration tests (correctness + race)
         # Doc-engine-independent: the same native backend (det/layout/tsr/rec
         # ONNX models + onnxruntime) is exercised regardless of DOC_ENGINE, so
@@ -1788,11 +1778,13 @@ jobs:
         # race-detection value, ~10x memory tax) and only the concurrency
         # correctness tests run WITH -race (see run_native_integration_tests).
         #
-        # XDG_CACHE_HOME is pinned to a workspace path so the test fetch script
-        # and this job's actions/cache step agree on a single, deterministic
-        # location (the self-hosted runner's $HOME is not stable across steps).
+        # Testdata is pre-seeded on the runner at /opt/ragflow-testdata;
+        # RAGFLOW_TESTDATA_DIR points the fetch script at it so the network
+        # clone is skipped (see scripts/fetch_deepdoc_testdata.sh). Runners
+        # without that mount fall back to cloning into XDG_CACHE_HOME.
         env:
           MODEL_DIR: /opt/ragflow-deepdoc-models
+          RAGFLOW_TESTDATA_DIR: /opt/ragflow-testdata
           CGO_ENABLED: '1'
           DEEPDOC_NATIVE_REQUIRED: '1'
           XDG_CACHE_HOME: ${{ github.workspace }}/.cache

--- a/build.sh
+++ b/build.sh
@@ -914,6 +914,11 @@ main() {
             if [ "${#pkgs[@]}" -eq 0 ]; then
                 pkgs=(./internal/deepdoc/parser/pdf/inference/native_analyzer/...)
             fi
+            # The in-process (Go) DeepDoc backend needs the .ort weights. Default
+            # MODEL_DIR to the canonical repo model dir (rag/res/deepdoc) so a
+            # local run needs no MODEL_DIR export after `download_go_deps.py`.
+            REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+            export MODEL_DIR="${MODEL_DIR:-$REPO_ROOT/rag/res/deepdoc}"
             run_go_tests_tagged "cgo integration" "${pkgs[@]}"
             run_native_integration_tests
             ;;

--- a/internal/common/environments.go
+++ b/internal/common/environments.go
@@ -237,6 +237,9 @@ const (
 // do set-membership checks); keep it stable so logs and diffs stay readable.
 //
 // External consumers that re-list these names must stay in sync:
+//   - ragflow_deps/download_go_deps.py re-lists them as DEEPDOC_MODEL_FILES
+//     (it fetches the files one by one, so it MUST be edited by hand when this
+//     slice changes);
 //   - ragflow_deps/download_deps.py snapshots the whole InfiniFlow/deepdoc repo
 //     (so .ort lands in the model dir automatically — no FILES edit needed);
 //   - deepdoc/server/download_deps.py (the Python-only Dockerfile_deepdoc_oss

--- a/internal/deepdoc/native/run.sh
+++ b/internal/deepdoc/native/run.sh
@@ -8,11 +8,17 @@
 #   bash run.sh            # uses default MODEL_DIR below
 #   MODEL_DIR=... bash run.sh
 set -euo pipefail
-cd "$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
 
 # ONNX Runtime is statically linked (libonnxruntime.a) and resolved via
 # dlopen(NULL); no ORT_LIB is needed.
-MODEL_DIR="${MODEL_DIR:?Set MODEL_DIR to the deepdoc model directory (e.g. .../rag/res/deepdoc)}"
+#
+# Default MODEL_DIR to the canonical repo model dir (rag/res/deepdoc) so running
+# `download_go_deps.py` is enough — no MODEL_DIR export is required for local
+# Go DeepDoc runs. Override with `MODEL_DIR=... bash run.sh` if needed.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MODEL_DIR="${MODEL_DIR:-$REPO_ROOT/rag/res/deepdoc}"
 export MODEL_DIR
 
 run_task() {

--- a/internal/development.md
+++ b/internal/development.md
@@ -43,9 +43,12 @@ sudo apt install libpcre2-dev
 # download_go_deps.py is the Go-end script: it now fetches the ONNX Runtime
 # static lib too, so this single command covers every native dependency the
 # Go server binary needs (incl. the in-process DeepDoc backend).
+# It also fetches the .ort model weights into rag/res/deepdoc/ (see §1.6).
 python3 ragflow_deps/download_go_deps.py
 # Shared (Go + Python) deps. Retains ONNX Runtime for the ragflow_deps image /
 # backward-compat; also pulls Python-side artifacts (models, nltk, tika, ...).
+# Its InfiniFlow/deepdoc snapshot carries BOTH weight formats: .ort (Go) and
+# .onnx (Python).
 uv run python3 ragflow_deps/download_deps.py
 ```
 
@@ -99,7 +102,8 @@ uv run python3 ragflow_deps/download_deps.py
 > needs `-ldl` to *compile*, so a binary built **without** ORT links
 > successfully but dies at startup with:
 > `Error looking up OrtGetApiBase in statically-linked ONNX Runtime` → fatal
-> `no in-process DeepDoc backend serving`.
+> `no in-process DeepDoc backend serving`. The same fatal also fires when the
+> `.ort` weights are missing from the model directory — see §1.6.
 > Since `build.sh` (`build_go`) now **fails fast** when ORT is absent from
 > `CGO_LDFLAGS`, this breakage surfaces at build time instead of at runtime. If
 > you see `Error: ONNX Runtime static libraries are not linked`, run
@@ -131,12 +135,38 @@ The in-process DeepDoc backend is statically linked against ONNX Runtime
 (see §1.4). After a successful `./build.sh -s --go`, the `ragflow_server`
 binary carries it and registers the backend at startup.
 
+#### Model weights
+
+The Go backend loads **`.ort`** (FlatBuffer) weights; the Python side loads
+**`.onnx`**. Both formats live side by side in `rag/res/deepdoc/` — neither
+supersedes the other, so do not delete one to "clean up".
+
+| | Go (in-process) | Python |
+|---|---|---|
+| Format | `.ort` | `.onnx` |
+| Files | `det.ort`, `layout.ort`, `tsr.ort`, `rec.ort`, `ocr.res` | `det.onnx`, `layout.onnx`, `tsr.onnx`, `rec.onnx`, `ocr.res` |
+
+`rag/res/deepdoc/` is the directory the Go server auto-discovers, so no
+`MODEL_DIR` / `DEEPDOC_MODEL_DIR` export is needed. `download_go_deps.py`
+(§1.4) fetches the five `.ort` files into it; `download_deps.py` snapshots the
+whole `InfiniFlow/deepdoc` repo and therefore carries both formats.
+
+`common.DeepDocModelFiles` (`internal/common/environments.go`) is the
+authoritative list — `HasModelFiles()` refuses to serve when any file in it is
+missing from the model directory.
+
+> **Note**: A `rag/res/deepdoc/` populated before the `.ort` switch holds only
+> `.onnx` and will NOT serve the Go backend, even though the directory looks
+> fully populated. Re-run `download_go_deps.py` after updating.
+
 - **Confirm it is serving** — the server logs, at startup:
   `in-process DeepDoc backend registered (production backend)`
-  If you instead see a fatal `no in-process DeepDoc backend serving`, ORT was
-  not linked into the binary. Re-run `uv run python3 ragflow_deps/download_go_deps.py`
-  and rebuild (§1.4 explains why; `build.sh` fails fast with
-  `Error: ONNX Runtime static libraries are not linked` before this happens).
+  If you instead see a fatal `no in-process DeepDoc backend serving`, it has
+  two possible causes: ORT was not linked into the binary, or the `.ort`
+  weights are missing from the model directory. Check the weights above first,
+  then re-run `uv run python3 ragflow_deps/download_go_deps.py` and rebuild
+  (§1.4 explains the ORT link failure; `build.sh` fails fast with
+  `Error: ONNX Runtime static libraries are not linked` before that happens).
 
 - **Run the binary directly (local dev)** — `./bin/ragflow_server --api`
   (start `--admin` first, see §2) launches the Go server and registers the

--- a/internal/development.md
+++ b/internal/development.md
@@ -43,7 +43,7 @@ sudo apt install libpcre2-dev
 # download_go_deps.py is the Go-end script: it now fetches the ONNX Runtime
 # static lib too, so this single command covers every native dependency the
 # Go server binary needs (incl. the in-process DeepDoc backend).
-# It also fetches the .ort model weights into rag/res/deepdoc/ (see §1.6).
+# It also fetches the Go model weights (four .ort + ocr.res) into rag/res/deepdoc/ (see §1.6).
 python3 ragflow_deps/download_go_deps.py
 # Shared (Go + Python) deps. Retains ONNX Runtime for the ragflow_deps image /
 # backward-compat; also pulls Python-side artifacts (models, nltk, tika, ...).
@@ -146,10 +146,16 @@ supersedes the other, so do not delete one to "clean up".
 | Format | `.ort` | `.onnx` |
 | Files | `det.ort`, `layout.ort`, `tsr.ort`, `rec.ort`, `ocr.res` | `det.onnx`, `layout.onnx`, `tsr.onnx`, `rec.onnx`, `ocr.res` |
 
-`rag/res/deepdoc/` is the directory the Go server auto-discovers, so no
-`MODEL_DIR` / `DEEPDOC_MODEL_DIR` export is needed. `download_go_deps.py`
-(§1.4) fetches the five `.ort` files into it; `download_deps.py` snapshots the
-whole `InfiniFlow/deepdoc` repo and therefore carries both formats.
+`download_go_deps.py` (§1.4) fetches the five required files — four `.ort` plus
+`ocr.res` — into `rag/res/deepdoc/`; `download_deps.py` snapshots the whole
+`InfiniFlow/deepdoc` repo and therefore carries both formats.
+
+Auto-discovery is **relative to the server process's working directory**:
+`resolveDeepDocModelDir()` (`cmd/ragflow_server.go`) probes
+`<cwd>/rag/res/deepdoc`, then `<cwd>/huggingface.co/InfiniFlow/deepdoc`.
+Launching `./bin/ragflow_server` from the repo root therefore needs no
+`MODEL_DIR` / `DEEPDOC_MODEL_DIR` export; from any other CWD — or an image with
+a different WORKDIR — set `MODEL_DIR` explicitly.
 
 `common.DeepDocModelFiles` (`internal/common/environments.go`) is the
 authoritative list — `HasModelFiles()` refuses to serve when any file in it is
@@ -162,15 +168,16 @@ missing from the model directory.
 - **Confirm it is serving** — the server logs, at startup:
   `in-process DeepDoc backend registered (production backend)`
   If you instead see a fatal `no in-process DeepDoc backend serving`, it has
-  two possible causes: ORT was not linked into the binary, or the `.ort`
-  weights are missing from the model directory. Check the weights above first,
-  then re-run `uv run python3 ragflow_deps/download_go_deps.py` and rebuild
+  two possible causes: ORT was not linked into the binary, or the model
+  directory is missing one of the five required files listed above. Check the
+  weights first, then re-run `uv run python3 ragflow_deps/download_go_deps.py` and rebuild
   (§1.4 explains the ORT link failure; `build.sh` fails fast with
   `Error: ONNX Runtime static libraries are not linked` before that happens).
 
 - **Run the binary directly (local dev)** — `./bin/ragflow_server --api`
   (start `--admin` first, see §2) launches the Go server and registers the
-  backend. No extra environment variable is required.
+  backend. Run it from the repo root so the weights above are auto-discovered
+  (see the CWD caveat); no environment variable is required there.
 
 - **Run the Go Docker image** — the container entrypoint only starts the Go
   server (`bin/ragflow_server --api/--ingestor/--admin`) when

--- a/ragflow_deps/download_deps.py
+++ b/ragflow_deps/download_deps.py
@@ -273,3 +273,21 @@ if __name__ == "__main__":
     for repo_id in repos:
         print(f"Downloading huggingface repo {repo_id}...")
         download_model(repo_id)
+
+    # Guard: the Go in-process DeepDoc backend loads the .ort weights from the
+    # InfiniFlow/deepdoc snapshot pulled above. snapshot_download fetches the
+    # whole repo, so these must be present; fail loudly if a future repo layout
+    # drops them, so the Go backend can never silently ship without its models.
+    # (internal/common.DeepDocModelFiles is the authoritative list.)
+    deepdoc_local = os.path.abspath(os.path.join("huggingface.co", "InfiniFlow", "deepdoc"))
+    go_model_files = ["det.ort", "layout.ort", "tsr.ort", "rec.ort", "ocr.res"]
+    if os.path.isdir(deepdoc_local):
+        for f in go_model_files:
+            if not os.path.exists(os.path.join(deepdoc_local, f)):
+                print(
+                    f"  ERROR: expected Go model file {f} missing from {deepdoc_local}; "
+                    f"the InfiniFlow/deepdoc snapshot no longer ships .ort weights.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        print(f"  ✓ Go .ort model files present under {deepdoc_local}")

--- a/ragflow_deps/download_deps.py
+++ b/ragflow_deps/download_deps.py
@@ -33,6 +33,7 @@
 import argparse
 import os
 import shutil
+import sys
 import urllib.request
 
 # NLTK >=3.10 refuses proxied downloads (SSRF guard) unless opted in; the
@@ -285,8 +286,7 @@ if __name__ == "__main__":
         for f in go_model_files:
             if not os.path.exists(os.path.join(deepdoc_local, f)):
                 print(
-                    f"  ERROR: expected Go model file {f} missing from {deepdoc_local}; "
-                    f"the InfiniFlow/deepdoc snapshot no longer ships .ort weights.",
+                    f"  ERROR: expected Go model file {f} missing from {deepdoc_local}; the InfiniFlow/deepdoc snapshot no longer ships .ort weights.",
                     file=sys.stderr,
                 )
                 sys.exit(1)

--- a/ragflow_deps/download_deps.py
+++ b/ragflow_deps/download_deps.py
@@ -282,12 +282,18 @@ if __name__ == "__main__":
     # (internal/common.DeepDocModelFiles is the authoritative list.)
     deepdoc_local = os.path.abspath(os.path.join("huggingface.co", "InfiniFlow", "deepdoc"))
     go_model_files = ["det.ort", "layout.ort", "tsr.ort", "rec.ort", "ocr.res"]
-    if os.path.isdir(deepdoc_local):
-        for f in go_model_files:
-            if not os.path.exists(os.path.join(deepdoc_local, f)):
-                print(
-                    f"  ERROR: expected Go model file {f} missing from {deepdoc_local}; the InfiniFlow/deepdoc snapshot no longer ships .ort weights.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-        print(f"  ✓ Go .ort model files present under {deepdoc_local}")
+    if not os.path.isdir(deepdoc_local):
+        print(
+            f"  ERROR: {deepdoc_local} does not exist; the InfiniFlow/deepdoc snapshot did not materialize.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    missing_models = [f for f in go_model_files if not os.path.isfile(os.path.join(deepdoc_local, f))]
+    if missing_models:
+        for f in missing_models:
+            print(
+                f"  ERROR: expected Go model file {f} missing from {deepdoc_local}; the InfiniFlow/deepdoc snapshot no longer ships .ort weights.",
+                file=sys.stderr,
+            )
+        sys.exit(1)
+    print(f"  ✓ Go .ort model files present under {deepdoc_local}")

--- a/ragflow_deps/download_go_deps.py
+++ b/ragflow_deps/download_go_deps.py
@@ -254,7 +254,7 @@ def download_go_models(use_china_mirrors=False):
         sys.exit(1)
 
     print(f"  ✓ Go DeepDoc models ready under {target_dir}")
-    print(f"    No MODEL_DIR env needed: the Go backend auto-discovers this directory.")
+    print("    No MODEL_DIR env needed: the Go backend auto-discovers this directory.")
 
 
 if __name__ == "__main__":

--- a/ragflow_deps/download_go_deps.py
+++ b/ragflow_deps/download_go_deps.py
@@ -36,12 +36,16 @@
 #
 # Go DeepDoc weights: in addition to the native libs, this script downloads the
 # five Go model files (internal/common.DeepDocModelFiles) from InfiniFlow/deepdoc
-# into huggingface.co/InfiniFlow/deepdoc/ (the snapshot path download_deps.py
-# uses). After running, point the Go backend at them:
+# straight into the repo's canonical model directory `rag/res/deepdoc/` (one level
+# up from this script). The Go server auto-discovers that directory via
+# resolveDeepDocModelDir(), and build.sh --test-native / internal/deepdoc/native/run.sh
+# default MODEL_DIR there too — so after running this script NO MODEL_DIR env needs
+# to be set:
 #
-#   export DEEPDOC_MODEL_DIR="$PWD/huggingface.co/InfiniFlow/deepdoc"  # server
-#   export MODEL_DIR="$PWD/huggingface.co/InfiniFlow/deepdoc"          # native tests / run.sh
-#   cd ../.. && bash build.sh --test-native
+#   bash build.sh --test-native          # or: cd internal/deepdoc/native && bash run.sh
+#
+# (The same files are also mirrored into huggingface.co/InfiniFlow/deepdoc/ for the
+# ragflow_deps Docker image build context.)
 
 import argparse
 import os
@@ -197,10 +201,16 @@ def download_with_progress(url, filename):
 
 
 def download_go_models(use_china_mirrors=False):
-    """Download the Go DeepDoc `.ort` weights into the ragflow_deps build
-    context at `huggingface.co/InfiniFlow/deepdoc/`, so this single script
-    provisions both the native static libs (above) and the model files a Go dev
-    needs — no separate `download_deps.py` run required for Go work.
+    """Download the Go DeepDoc `.ort` weights so a Go dev can run the in-process
+    backend with no further setup.
+
+    The files are written into the repo's canonical model directory
+    `rag/res/deepdoc/` (relative to the repo root, one level up from this
+    script). The Go server auto-discovers that directory via
+    resolveDeepDocModelDir(), and build.sh --test-native / run.sh default
+    MODEL_DIR there too — so after this script runs, no MODEL_DIR env needs to
+    be set. The same files are also mirrored into the ragflow_deps build context
+    (huggingface.co/InfiniFlow/deepdoc/) used when building the Docker image.
 
     Uses hf_hub_download per-file (not snapshot_download) to fetch only the
     five Go model files; the `.onnx` siblings are Python-only and skipped.
@@ -212,18 +222,29 @@ def download_go_models(use_china_mirrors=False):
     # huggingface-free) without the huggingface_hub dependency installed.
     from huggingface_hub import hf_hub_download
 
-    model_dir = os.path.abspath(os.path.join("huggingface.co", DEEPDOC_REPO))
-    os.makedirs(model_dir, exist_ok=True)
+    # Canonical local-dev model dir the Go backend auto-discovers.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    target_dir = os.path.join(repo_root, "rag", "res", "deepdoc")
+    # Build-context mirror for the ragflow_deps Docker image.
+    ctx_dir = os.path.abspath(os.path.join("huggingface.co", DEEPDOC_REPO))
+    for d in (target_dir, ctx_dir):
+        os.makedirs(d, exist_ok=True)
 
     missing = []
     for fname in DEEPDOC_MODEL_FILES:
-        local_path = os.path.join(model_dir, fname)
-        if os.path.exists(local_path):
+        dest = os.path.join(target_dir, fname)
+        if os.path.exists(dest):
             print(f"  ✓ {fname} already present")
+            # Keep the build-context mirror in sync if it lags behind.
+            ctx_dest = os.path.join(ctx_dir, fname)
+            if not os.path.exists(ctx_dest):
+                shutil.copyfile(dest, ctx_dest)
             continue
         print(f"Downloading deepdoc model {fname}...")
         try:
-            hf_hub_download(repo_id=DEEPDOC_REPO, filename=fname, local_dir=model_dir)
+            hf_hub_download(repo_id=DEEPDOC_REPO, filename=fname, local_dir=target_dir)
+            # Mirror into the build context for the Docker image.
+            shutil.copyfile(dest, os.path.join(ctx_dir, fname))
         except Exception as e:  # noqa: BLE001 - collected and surfaced below
             missing.append((fname, e))
 
@@ -232,8 +253,8 @@ def download_go_models(use_china_mirrors=False):
             print(f"  ERROR: failed to download {fname}: {e}", file=sys.stderr)
         sys.exit(1)
 
-    print(f"  ✓ Go DeepDoc models ready under {model_dir}")
-    print(f"    Set DEEPDOC_MODEL_DIR / MODEL_DIR to this path for local Go DeepDoc runs.")
+    print(f"  ✓ Go DeepDoc models ready under {target_dir}")
+    print(f"    No MODEL_DIR env needed: the Go backend auto-discovers this directory.")
 
 
 if __name__ == "__main__":

--- a/ragflow_deps/download_go_deps.py
+++ b/ragflow_deps/download_go_deps.py
@@ -43,9 +43,6 @@
 # to be set:
 #
 #   bash build.sh --test-native          # or: cd internal/deepdoc/native && bash run.sh
-#
-# (The same files are also mirrored into huggingface.co/InfiniFlow/deepdoc/ for the
-# ragflow_deps Docker image build context.)
 
 import argparse
 import os
@@ -209,8 +206,7 @@ def download_go_models(use_china_mirrors=False):
     script). The Go server auto-discovers that directory via
     resolveDeepDocModelDir(), and build.sh --test-native / run.sh default
     MODEL_DIR there too — so after this script runs, no MODEL_DIR env needs to
-    be set. The same files are also mirrored into the ragflow_deps build context
-    (huggingface.co/InfiniFlow/deepdoc/) used when building the Docker image.
+    be set.
 
     Uses hf_hub_download per-file (not snapshot_download) to fetch only the
     five Go model files; the `.onnx` siblings are Python-only and skipped.
@@ -225,32 +221,38 @@ def download_go_models(use_china_mirrors=False):
     # Canonical local-dev model dir the Go backend auto-discovers.
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     target_dir = os.path.join(repo_root, "rag", "res", "deepdoc")
-    # Build-context mirror for the ragflow_deps Docker image.
-    ctx_dir = os.path.abspath(os.path.join("huggingface.co", DEEPDOC_REPO))
-    for d in (target_dir, ctx_dir):
-        os.makedirs(d, exist_ok=True)
+    os.makedirs(target_dir, exist_ok=True)
 
     missing = []
     for fname in DEEPDOC_MODEL_FILES:
         dest = os.path.join(target_dir, fname)
-        if os.path.exists(dest):
+        if os.path.isfile(dest):
             print(f"  ✓ {fname} already present")
-            # Keep the build-context mirror in sync if it lags behind.
-            ctx_dest = os.path.join(ctx_dir, fname)
-            if not os.path.exists(ctx_dest):
-                shutil.copyfile(dest, ctx_dest)
             continue
         print(f"Downloading deepdoc model {fname}...")
         try:
             hf_hub_download(repo_id=DEEPDOC_REPO, filename=fname, local_dir=target_dir)
-            # Mirror into the build context for the Docker image.
-            shutil.copyfile(dest, os.path.join(ctx_dir, fname))
         except Exception as e:  # noqa: BLE001 - collected and surfaced below
             missing.append((fname, e))
 
     if missing:
         for fname, e in missing:
             print(f"  ERROR: failed to download {fname}: {e}", file=sys.stderr)
+        print(
+            "\n"
+            "The Go in-process DeepDoc backend loads ONLY the .ort weights listed in\n"
+            "internal/common.DeepDocModelFiles. They are fetched from "
+            f"{DEEPDOC_REPO} into:\n"
+            f"  {target_dir}\n"
+            "Without them the backend cannot serve — the server exits with a fatal\n"
+            '"no in-process DeepDoc backend serving". To recover:\n'
+            "  - re-run this script (a transient HF/network error usually clears);\n"
+            "  - behind the GFW, re-run with --china-mirrors (routes via hf-mirror.com);\n"
+            "  - or run `uv run python3 ragflow_deps/download_deps.py`, which snapshots\n"
+            f"    all of {DEEPDOC_REPO} (it also provides the Python-side .onnx);\n"
+            "  - or copy the missing files into that directory by hand.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     print(f"  ✓ Go DeepDoc models ready under {target_dir}")

--- a/ragflow_deps/download_go_deps.py
+++ b/ragflow_deps/download_go_deps.py
@@ -10,10 +10,13 @@
 # ]
 # ///
 
-# This script downloads every artifact that the `infiniflow/ragflow_deps`
-# Docker image bakes in. Run it from anywhere — the `__main__` block
-# chdir's into this file's own directory, so all outputs land under
-# `ragflow_deps/` regardless of the caller's CWD.
+# This script downloads every artifact the Go build needs: the native static
+# libraries (pdfium / pdf_oxide / office_oxide / onnxruntime) for `build.sh`,
+# and the Go DeepDoc `.ort` weights (det/layout/tsr/rec.ort + ocr.res) so a Go
+# dev can run the in-process backend locally without separately running
+# `download_deps.py`. Run it from anywhere — the `__main__` block chdir's into
+# this file's own directory, so all outputs land under `ragflow_deps/`
+# regardless of the caller's CWD.
 #
 # Build-context relationship: `ragflow_deps/Dockerfile` is built with
 # `ragflow_deps/` as its build context, so the files written here MUST
@@ -30,6 +33,15 @@
 # The main `Dockerfile` (built from the project root) pulls this image
 # via `--mount=type=bind,from=infiniflow/ragflow_deps:latest,...` and
 # is unaffected by where these files live locally.
+#
+# Go DeepDoc weights: in addition to the native libs, this script downloads the
+# five Go model files (internal/common.DeepDocModelFiles) from InfiniFlow/deepdoc
+# into huggingface.co/InfiniFlow/deepdoc/ (the snapshot path download_deps.py
+# uses). After running, point the Go backend at them:
+#
+#   export DEEPDOC_MODEL_DIR="$PWD/huggingface.co/InfiniFlow/deepdoc"  # server
+#   export MODEL_DIR="$PWD/huggingface.co/InfiniFlow/deepdoc"          # native tests / run.sh
+#   cd ../.. && bash build.sh --test-native
 
 import argparse
 import os
@@ -47,6 +59,13 @@ import requests
 # (pyproject.toml) and the onnxruntime_go binding minor (go.mod) must stay on
 # the same minor line.
 ORT_VERSION = "1.23.2"
+
+# Mirrors internal/common.DeepDocModelFiles (Go in-process DeepDoc backend).
+# These are the ONLY weights the Go backend loads; the full InfiniFlow/deepdoc
+# repo also ships .onnx (Python-only), which this Go-only script deliberately
+# skips to keep the download lean.
+DEEPDOC_REPO = "InfiniFlow/deepdoc"
+DEEPDOC_MODEL_FILES = ["det.ort", "layout.ort", "tsr.ort", "rec.ort", "ocr.res"]
 
 
 def prune_stale_onnxruntime(static_lib_dir, version):
@@ -177,6 +196,46 @@ def download_with_progress(url, filename):
     print()
 
 
+def download_go_models(use_china_mirrors=False):
+    """Download the Go DeepDoc `.ort` weights into the ragflow_deps build
+    context at `huggingface.co/InfiniFlow/deepdoc/`, so this single script
+    provisions both the native static libs (above) and the model files a Go dev
+    needs — no separate `download_deps.py` run required for Go work.
+
+    Uses hf_hub_download per-file (not snapshot_download) to fetch only the
+    five Go model files; the `.onnx` siblings are Python-only and skipped.
+    On China mirrors, route through hf-mirror.com via HF_ENDPOINT.
+    """
+    if use_china_mirrors:
+        os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
+    # Imported lazily so the module stays importable (and its unit tests stay
+    # huggingface-free) without the huggingface_hub dependency installed.
+    from huggingface_hub import hf_hub_download
+
+    model_dir = os.path.abspath(os.path.join("huggingface.co", DEEPDOC_REPO))
+    os.makedirs(model_dir, exist_ok=True)
+
+    missing = []
+    for fname in DEEPDOC_MODEL_FILES:
+        local_path = os.path.join(model_dir, fname)
+        if os.path.exists(local_path):
+            print(f"  ✓ {fname} already present")
+            continue
+        print(f"Downloading deepdoc model {fname}...")
+        try:
+            hf_hub_download(repo_id=DEEPDOC_REPO, filename=fname, local_dir=model_dir)
+        except Exception as e:  # noqa: BLE001 - collected and surfaced below
+            missing.append((fname, e))
+
+    if missing:
+        for fname, e in missing:
+            print(f"  ERROR: failed to download {fname}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"  ✓ Go DeepDoc models ready under {model_dir}")
+    print(f"    Set DEEPDOC_MODEL_DIR / MODEL_DIR to this path for local Go DeepDoc runs.")
+
+
 if __name__ == "__main__":
     # Anchor CWD to this file's directory so all relative outputs
     # (huggingface.co/, nltk_data/, *.deb, *.jar, *.tar.gz, etc.) land
@@ -257,3 +316,7 @@ if __name__ == "__main__":
     else:
         print(f"  ERROR: ONNX Runtime .a files still missing under {ort_static_dir} after extraction; build.sh will refuse to link.", file=sys.stderr)
         sys.exit(1)
+
+    # Download the Go DeepDoc `.ort` weights so this script is a one-stop for Go
+    # dev: native libs (above) + model files (below) from a single invocation.
+    download_go_models(args.china_mirrors)

--- a/scripts/fetch_deepdoc_testdata.sh
+++ b/scripts/fetch_deepdoc_testdata.sh
@@ -16,9 +16,17 @@
 # Env:
 #   RAGFLOW_TESTDATA_REPO  repo "owner/name" (default infiniflow/ragflow-testdata)
 #   RAGFLOW_TESTDATA_REF   override the anchor tag/ref (else read testdata.ref)
+#   RAGFLOW_TESTDATA_DIR   pre-seeded asset repo root (first level: deepdoc/).
+#                          When it carries deepdoc/<pkg>/testdata, that copy is
+#                          used as-is: no ref pinning, no network fetch. This is
+#                          what a CI runner that mounts the asset repo should
+#                          set; a missing subtree falls back to cloning.
 #   XDG_CACHE_HOME         cache base (default ~/.cache)
 #
 # Behavior:
+#   - With RAGFLOW_TESTDATA_DIR set, the pre-seeded copy wins over everything
+#     below. The ref pin is bypassed — whoever seeds the directory owns its
+#     freshness.
 #   - If testdata is already present INLINE (a real dir, pre-migration), this
 #     script leaves it untouched and exits (nothing to fetch).
 #   - If a correct symlink already exists, it exits.
@@ -40,6 +48,44 @@ PKG="$1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+TARGET="$ROOT/internal/deepdoc/$PKG/testdata"
+
+# Determine whether we need a writable copy (regeneration) or a symlink.
+NEED_WRITE=0
+for v in "${!GEN_@}"; do
+  if [ -n "${!v:-}" ]; then NEED_WRITE=1; break; fi
+done
+
+# Pre-seeded testdata: CI runners mount the asset repo at a fixed path instead
+# of cloning it. Use that copy directly when it carries this package's subtree.
+# This runs before the ref is resolved: a pre-seeded copy carries no ref, so
+# packages without a testdata.ref can be served this way too.
+if [ -n "${RAGFLOW_TESTDATA_DIR:-}" ]; then
+  PRESET="$RAGFLOW_TESTDATA_DIR/deepdoc/$PKG/testdata"
+  if [ -d "$PRESET" ] && [ -n "$(ls -A "$PRESET" 2>/dev/null)" ]; then
+    if [ -L "$TARGET" ] && [ "$(readlink -f "$TARGET")" = "$(readlink -f "$PRESET")" ] && [ -n "$(ls -A "$PRESET" 2>/dev/null)" ]; then
+      echo "fetch_deepdoc_testdata: $PKG already linked to pre-seeded $PRESET"
+      exit 0
+    fi
+    if [ -d "$TARGET" ] && [ ! -L "$TARGET" ] && [ -n "$(ls -A "$TARGET" 2>/dev/null)" ]; then
+      echo "fetch_deepdoc_testdata: $PKG testdata already present inline at $TARGET"
+      exit 0
+    fi
+    rm -f "$TARGET" 2>/dev/null || true
+    if [ "$NEED_WRITE" -eq 1 ]; then
+      echo "fetch_deepdoc_testdata: copying writable pre-seeded testdata for regeneration ($PKG)"
+      rm -rf "$TARGET"
+      cp -r "$PRESET" "$TARGET"
+    else
+      echo "fetch_deepdoc_testdata: linking $TARGET -> $PRESET (pre-seeded)"
+      ln -s "$PRESET" "$TARGET"
+    fi
+    echo "fetch_deepdoc_testdata: done ($PKG, pre-seeded)"
+    exit 0
+  fi
+  echo "fetch_deepdoc_testdata: RAGFLOW_TESTDATA_DIR set but deepdoc/$PKG/testdata is missing; falling back to clone" >&2
+fi
+
 REF_FILE="$ROOT/internal/deepdoc/$PKG/testdata.ref"
 REF="${RAGFLOW_TESTDATA_REF:-}"
 if [ -z "$REF" ] && [ -f "$REF_FILE" ]; then
@@ -54,13 +100,6 @@ REPO="${RAGFLOW_TESTDATA_REPO:-infiniflow/ragflow-testdata}"
 CACHE_BASE="${XDG_CACHE_HOME:-$HOME/.cache}/ragflow-testdata"
 CACHE="$CACHE_BASE/$REF"
 SRC="$CACHE/deepdoc/$PKG/testdata"
-TARGET="$ROOT/internal/deepdoc/$PKG/testdata"
-
-# Determine whether we need a writable copy (regeneration) or a symlink.
-NEED_WRITE=0
-for v in "${!GEN_@}"; do
-  if [ -n "${!v:-}" ]; then NEED_WRITE=1; break; fi
-done
 
 # Already a correct symlink -> done.
 if [ -L "$TARGET" ] && [ "$(readlink -f "$TARGET")" = "$(readlink -f "$SRC")" ] && [ -n "$(ls -A "$SRC" 2>/dev/null)" ]; then

--- a/scripts/fetch_deepdoc_testdata.sh
+++ b/scripts/fetch_deepdoc_testdata.sh
@@ -71,7 +71,12 @@ if [ -n "${RAGFLOW_TESTDATA_DIR:-}" ]; then
       echo "fetch_deepdoc_testdata: $PKG testdata already present inline at $TARGET"
       exit 0
     fi
-    rm -f "$TARGET" 2>/dev/null || true
+    # rm -rf, not rm -f: TARGET may be a leftover EMPTY directory (a failed
+    # GEN_* copy, a half-restored cache). rm -f cannot remove it, and ln -s
+    # would then nest the link inside it (<TARGET>/testdata) while this script
+    # still reports success. Both guards above have already returned for a
+    # non-empty real dir, so nothing real is deleted here.
+    rm -rf -- "$TARGET"
     if [ "$NEED_WRITE" -eq 1 ]; then
       echo "fetch_deepdoc_testdata: copying writable pre-seeded testdata for regeneration ($PKG)"
       rm -rf "$TARGET"
@@ -114,7 +119,9 @@ if [ -d "$TARGET" ] && [ ! -L "$TARGET" ] && [ -n "$(ls -A "$TARGET" 2>/dev/null
 fi
 
 # Absent (or stale symlink) -> fetch.
-rm -f "$TARGET" 2>/dev/null || true
+# rm -rf for the same reason as the pre-seeded branch: a leftover empty
+# directory must be removed, not silently turned into a nested symlink.
+rm -rf -- "$TARGET"
 
 if [ ! -e "$SRC" ] || [ -z "$(ls -A "$SRC" 2>/dev/null)" ]; then
   echo "fetch_deepdoc_testdata: cloning $REPO @ $REF (subtree deepdoc/$PKG/testdata)"


### PR DESCRIPTION
## Summary

Make `ragflow_deps/download_go_deps.py` a true one-stop script for Go development: it now also downloads the Go DeepDoc model files (`det.ort`, `layout.ort`, `tsr.ort`, `rec.ort`, `ocr.res`) — and, crucially, writes them into the **canonical repo model directory `rag/res/deepdoc/`** that the Go backend auto-discovers — resolved **relative to the server process's CWD**. After running the script, launching `./bin/ragflow_server` from the repo root needs **no `MODEL_DIR` / `DEEPDOC_MODEL_DIR` env setting at all**; from any other CWD, set `MODEL_DIR` explicitly.

`ragflow_deps/download_deps.py` already snapshots the whole `InfiniFlow/deepdoc` repo (which includes `.ort`); this PR adds a guard that fails loudly if the `.ort` weights ever go missing from the snapshot, so the Go in-process backend can never silently ship without its models.

## Why

The Go in-process DeepDoc backend loads **only** `.ort` weights (see `internal/common.DeepDocModelFiles`); the Python side uses `.onnx`. Previously `download_go_deps.py` pulled the native static libraries (pdfium / pdf_oxide / office_oxide / onnxruntime) but **not** the model files, so a Go dev had to run the much heavier `download_deps.py` (full snapshot + nltk + chrome + tika) just to get `.ort`. Worse, even after fetching they had to manually export `MODEL_DIR`/`DEEPDOC_MODEL_DIR` — friction that `.onnx` users never faced (the server auto-discovers `rag/res/deepdoc`). This closes that gap so `.ort` is as convenient to use as `.onnx`.

## Changes

- `ragflow_deps/download_go_deps.py`
  - New `DEEPDOC_REPO` / `DEEPDOC_MODEL_FILES` constants mirroring `internal/common.DeepDocModelFiles`.
  - New `download_go_models(use_china_mirrors)` that `hf_hub_download`s the five Go model files **into `rag/res/deepdoc/`** (the directory `resolveDeepDocModelDir()` auto-discovers) **and mirrors them into `huggingface.co/InfiniFlow/deepdoc/`** (the `ragflow_deps` Docker build context). Uses per-file `hf_hub_download` (not `snapshot_download`) to skip the Python-only `.onnx` siblings; routes through `hf-mirror.com` under `--china-mirrors`. Import is lazy so the module's unit tests stay huggingface-free. Already-present files are skipped and mirrored across the two dirs.
  - Called from `__main__`; prints a hint that **no env setting is needed** after running.
- `ragflow_deps/download_deps.py`
  - Post-snapshot guard asserting the `.ort` weights are present. Exits non-zero
    when the snapshot directory is missing entirely, and when a required path is
    absent **or** is a directory rather than a regular file (the original
    `os.path.exists` check accepted a directory carrying a model filename).
- `build.sh` (`--test-native`)
  - Defaults `MODEL_DIR` to `$REPO_ROOT/rag/res/deepdoc` when unset, so native Go tests run with no export after `download_go_deps.py`.
- `internal/deepdoc/native/run.sh`
  - Replaced the required `MODEL_DIR:?` with a default of `$REPO_ROOT/rag/res/deepdoc`, so `bash run.sh` works out of the box. Override with `MODEL_DIR=... bash run.sh` if needed.

- `internal/development.md`
  - Document the `.ort` switch: the Go backend loads `.ort` while the Python side
    keeps `.onnx`; both live side by side in `rag/res/deepdoc/` and neither
    supersedes the other.
  - Qualify auto-discovery: `resolveDeepDocModelDir()` (`cmd/ragflow_server.go`)
    resolves the model dir relative to the server process's CWD, so the
    "no `MODEL_DIR` needed" promise holds when the binary is launched from the
    repo root.
  - Split the fatal `no in-process DeepDoc backend serving` into its two real
    causes (ORT not linked / model files missing). Only the former was documented
    before, which sent troubleshooting down the wrong path.
  - The required set is four `.ort` files **plus `ocr.res`** — `ocr.res` is not
    an `.ort` file, so the old "five `.ort` files" wording was misleading.
- `scripts/fetch_deepdoc_testdata.sh`
  - New `RAGFLOW_TESTDATA_DIR`: when a CI runner pre-seeds the asset repo (first
    level `deepdoc/`), use it directly instead of cloning. It is resolved before
    the ref, so packages without a `testdata.ref` are served too; a missing
    subtree still falls back to cloning, so an unmounted runner is not broken.
  - Fix a silent-failure path: `rm -f` cannot remove a leftover *empty* target
    directory, after which `ln -s` nested the link inside it (`<target>/testdata`)
    while the script still reported success and exited 0.
- `.github/workflows/sep-tests.yml`
  - Point the native job at the runner's pre-seeded `/opt/ragflow-testdata` and
    drop the now-redundant `actions/cache` step for testdata.
- `internal/common/environments.go`
  - Register `ragflow_deps/download_go_deps.py` (`DEEPDOC_MODEL_FILES`) as an
    external consumer of `common.DeepDocModelFiles`. Unlike the snapshot-based
    `download_deps.py`, it fetches the files one by one, so it needs a manual
    edit whenever that slice changes.

## Verification

- Empirically confirmed `InfiniFlow/deepdoc` currently ships `det.ort`, `layout.ort`, `tsr.ort`, `rec.ort`, `ocr.res` (plus `layout.*.ort` domain variants) and `ocr.res`.
- `python3 -m py_compile` on both scripts: OK.
- `bash -n` on `build.sh` / `run.sh`: OK.
- Existing unit tests `ragflow_deps/test_download_go_deps.py`: 4 passed (import surface unchanged).
- Logic smoke-tested with a stubbed `hf_hub_download`: correct 5-file set written to **both** `rag/res/deepdoc/` and the build context, China-mirror `HF_ENDPOINT` set, already-present files skipped.

- `scripts/fetch_deepdoc_testdata.sh` exercised against a scratch repo, 7 cases:
  pre-seeded hit, empty-directory leftover (the fixed bug), clone path,
  idempotent re-run, non-empty inline dir preserved (proves `rm -rf` deletes
  nothing real), `GEN_*` writable copy, `bash -n`.
- The `.ort` guard verified to exit 1 for a missing directory, an empty
  directory, and a directory masquerading under a model filename; it passes only
  when all five paths are regular files.

Note: `rag/res/deepdoc` and `huggingface.co/` are already gitignored, so writing the weights there produces no git noise.

No Python-side runtime or Dockerfile changes; the `.onnx` path and the OSS Python image are untouched.

