### PR TITLE
fix(agent): schedule parameter reference dependencies

### DIFF
--- a/agent/component/iteration.py
+++ b/agent/component/iteration.py
@@ -46,6 +46,9 @@ class IterationParam(ComponentParamBase):
 class Iteration(ComponentBase, ABC):
     component_name = "Iteration"
 
+    def param_refs(self) -> list[str]:
+        return [self._param.items_ref]
+
     def get_start(self):
         for cid in self._canvas.components.keys():
             if self._canvas.get_component(cid)["obj"].component_name.lower() != "iterationitem":

--- a/agent/component/list_operations.py
+++ b/agent/component/list_operations.py
@@ -48,6 +48,9 @@ class ListOperationsParam(ComponentParamBase):
 class ListOperations(ComponentBase, ABC):
     component_name = "ListOperations"
 
+    def param_refs(self) -> list[str]:
+        return [self._param.query]
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60)))
     def _invoke(self, **kwargs):
         self.input_objects = []

--- a/agent/component/switch.py
+++ b/agent/component/switch.py
@@ -56,6 +56,9 @@ class SwitchParam(ComponentParamBase):
 class Switch(ComponentBase, ABC):
     component_name = "Switch"
 
+    def param_refs(self) -> list[str]:
+        return [item.get("cpn_id") for condition in self._param.conditions for item in condition.get("items", []) if isinstance(item, dict)]
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 3)))
     def _invoke(self, **kwargs):
         if self.check_if_canceled("Switch processing"):

--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -40,6 +40,9 @@ class VariableAssigner(ComponentBase, ABC):
     component_name = "VariableAssigner"
     _NO_PARAMETER_OPERATORS = {"clear", "remove_first", "remove_last"}
 
+    def param_refs(self) -> list[str]:
+        return [ref for item in self._param.variables if isinstance(item, dict) for ref in (item.get("variable"), item.get("parameter"))]
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60)))
     def _invoke(self, **kwargs):
         if not isinstance(self._param.variables, list):

--- a/test/unit_test/agent/component/test_param_dependency_ids.py
+++ b/test/unit_test/agent/component/test_param_dependency_ids.py
@@ -1,0 +1,36 @@
+import pytest
+
+from agent.component.iteration import Iteration, IterationParam
+from agent.component.list_operations import ListOperations, ListOperationsParam
+from agent.component.switch import Switch, SwitchParam
+from agent.component.variable_assigner import VariableAssigner, VariableAssignerParam
+
+
+@pytest.mark.parametrize(
+    ("component", "param", "values", "expected"),
+    [
+        (
+            Switch,
+            SwitchParam,
+            {"conditions": [{"items": [{"cpn_id": "producer@result"}]}]},
+            ["producer"],
+        ),
+        (
+            VariableAssigner,
+            VariableAssignerParam,
+            {"variables": [{"variable": "target@value", "parameter": "source@value"}]},
+            ["target", "source"],
+        ),
+        (Iteration, IterationParam, {"items_ref": "producer@items"}, ["producer"]),
+        (ListOperations, ListOperationsParam, {"query": "producer@items"}, ["producer"]),
+    ],
+)
+def test_parameter_references_are_scheduler_dependencies(component, param, values, expected):
+    params = param()
+    for key, value in values.items():
+        setattr(params, key, value)
+
+    cpn = component.__new__(component)
+    cpn._param = params
+
+    assert cpn.get_dependency_ids() == expected


### PR DESCRIPTION
## Summary

Fixes #19362.

- Include parameter-level variable references in scheduler dependency collection for Switch, VariableAssigner, Iteration, and ListOperations.
- Prevent components in the same batch from reading stale outputs when dependencies are referenced in component parameters instead of explicit graph edges.
- Add regression coverage for all four component types.

## Testing

- [1mpytest --confcutdir=test/unit_test/agent test/unit_test/agent/test_canvas_batch_readiness.py -q[0m (11 passed)
- [1mruff format --check[0m on changed files (passed)
- [1mruff check --select E9,F401,F821,ASYNC --ignore E402[0m on changed files (passed)
- [1mpython -m compileall[0m on changed Python files (passed)

The focused new component test could not be collected in this environment because the Python 3.11 environment lacks RAGFlow's full test dependencies (including quart and nltk).