### PR TITLE
fix: specify RAGFlow image for macOS deployment

### DIFF
--- a/docker/docker-compose-macos.yml
+++ b/docker/docker-compose-macos.yml
@@ -4,6 +4,7 @@ include:
 services:
   ragflow:
     platform: linux/amd64
+    image: ${RAGFLOW_IMAGE}
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
### Summary

Add the missing `image: ${RAGFLOW_IMAGE}` field to the `ragflow` service in `docker/docker-compose-macos.yml`.

Previously, the macOS Compose configuration did not reference `RAGFLOW_IMAGE`, so deployment did not use the intended image configured in `.env`. In the affected deployment, the resulting container lacked the NLTK resources `punkt`, `punkt_tab`, and `omw-1.4`, causing failures when those resources were required.

Explicitly setting the image ensures that the macOS deployment references the configured RAGFlow image containing the required NLTK data.