### PR TITLE
fix(web): align parse status badge colors with list dots and rename table header

### DIFF
--- a/web/src/components/file-status-badge.tsx
+++ b/web/src/components/file-status-badge.tsx
@@ -31,48 +31,55 @@ interface StatusBadgeProps {
 
 const FileStatusBadge: FC<StatusBadgeProps> = ({ status, name, className }) => {
   const getStatusColor = () => {
+    // Aligned with RunningStatusMap colors in src/pages/dataset/dataset/constant.ts
+    // so the badge matches the status dot in the document list.
     // #3ba05c  → rgb(59, 160, 92)   // state-success
     // #d8494b  → rgb(216, 73, 75)   // state-error
     // #00beb4  → rgb(0, 190, 180)   // accent-primary
     // #faad14  → rgb(250, 173, 20)  // state-warning
+    // #5c96c8  → rgb(92, 150, 200)  // team-member
     switch (status) {
       case RunningStatus.DONE:
       case RunningStatusOld.DONE:
-        return `bg-[rgba(59,160,92,0.1)] text-state-success`;
+        return `bg-state-success/10 text-state-success`;
       case RunningStatus.FAIL:
       case RunningStatusOld.FAIL:
-        return `bg-[rgba(216,73,75,0.1)] text-state-error`;
+        return `bg-state-error/10 text-state-error`;
       case RunningStatus.RUNNING:
       case RunningStatusOld.RUNNING:
-        return `bg-[rgba(0,190,180,0.1)] text-accent-primary`;
+        return `bg-[rgba(92,150,200,0.1)] text-team-member`;
       case RunningStatus.UNSTART:
       case RunningStatusOld.UNSTART:
+        return `bg-accent-primary/10 text-accent-primary`;
+      case RunningStatus.CANCEL:
+      case RunningStatusOld.CANCEL:
       case RunningStatus.QUEUED:
-        return `bg-[rgba(250,173,20,0.1)] text-state-warning`;
+        return `bg-state-warning/10 text-state-warning`;
       default:
         return 'bg-gray-500/10 text-text-secondary';
     }
   };
 
   const getBgStatusColor = () => {
-    // #3ba05c  → rgb(59, 160, 92)   // state-success
-    // #d8494b  → rgb(216, 73, 75)   // state-error
-    // #00beb4  → rgb(0, 190, 180)   // accent-primary
-    // #faad14  → rgb(250, 173, 20)  // state-warning
+    // Aligned with RunningStatusMap colors in src/pages/dataset/dataset/constant.ts
+    // so the badge matches the status dot in the document list.
     switch (status) {
       case RunningStatus.DONE:
       case RunningStatusOld.DONE:
-        return `bg-[rgba(59,160,92,1)] text-state-success`;
+        return `bg-state-success text-state-success`;
       case RunningStatus.FAIL:
       case RunningStatusOld.FAIL:
-        return `bg-[rgba(216,73,75,1)] text-state-error`;
+        return `bg-state-error text-state-error`;
       case RunningStatus.RUNNING:
       case RunningStatusOld.RUNNING:
-        return `bg-[rgba(0,190,180,1)] text-accent-primary`;
+        return `bg-team-member text-team-member`;
       case RunningStatus.UNSTART:
       case RunningStatusOld.UNSTART:
+        return `bg-accent-primary text-accent-primary`;
+      case RunningStatus.CANCEL:
+      case RunningStatusOld.CANCEL:
       case RunningStatus.QUEUED:
-        return `bg-[rgba(250,173,20,1)] text-state-warning`;
+        return `bg-state-warning text-state-warning`;
       default:
         return `bg-[rgba(117,120,122,1)] text-text-secondary`;
     }

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -468,7 +468,7 @@ export default {
       chunkMethod: '切片方法',
       enabled: '启用',
       disabled: '禁用',
-      action: '动作',
+      action: '操作',
       parsingStatus: '解析状态',
       parsingStatusTip:
         '文本解析的时间取决于诸多因素。如果开启了 Graph、RAPTOR、自动问题提取、自动关键词提取等功能，时间会更长。如果解析进度条长时间不更新，也可以参考这两条 FAQ：https://ragflow.io/docs/dev/faq#why-does-my-document-parsing-stall-at-under-one-percent。',


### PR DESCRIPTION
### Summary

- Change zh locale for dataset table header from 动作 to 操作
- Align FileStatusBadge color mapping with the RunningStatusMap used by the status dot in the document list (UNSTART accent-primary, RUNNING team-member, CANCEL state-warning) so the process log dialog status matches the dot colors
