### PR TITLE
fix(go/pdf): clear fragmented TOC pages in DeepDOC postprocess

### DIFF
--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -396,19 +396,23 @@ const (
 	pdfTOCPageRefFragmentsMin = 3
 	pdfTOCBodyTextRunesMin    = 40
 	pdfTOCShortTextRunesMax   = 40
+	// pdfTOCRepeatPagesMin is the cross-page repetition threshold for
+	// boilerplate within one vertical band: a long line repeating verbatim
+	// at the same height on this many pages is a running watermark or
+	// storefront promo, never body prose.
+	pdfTOCRepeatPagesMin = 3
+	// pdfTOCTopBucketPoints groups section tops into vertical bands:
+	// watermarks are page templates sitting at the same height on every
+	// page (within a few points of jitter), while body prose drifts. Ten
+	// points is wide enough for render jitter and narrow enough to
+	// separate header, body and footer bands.
+	pdfTOCTopBucketPoints = 10
 )
 
 // pdfTOCRomanMarkerPattern matches standalone roman-numeral page markers
 // ("I", "II", "D", "M"). They carry no content but are kept as page anchors,
 // matching the existing entry-filter behavior.
 var pdfTOCRomanMarkerPattern = regexp.MustCompile(`(?i)^[mdclxvi]+$`)
-
-// pdfTOCRepeatPagesMin is the cross-page repetition threshold for
-// boilerplate: a long line repeating verbatim on this many pages is
-// storefront promo or a running watermark, never body prose. Body prose
-// never repeats verbatim across pages, so the threshold needs no document
-// size proportion.
-const pdfTOCRepeatPagesMin = 3
 
 // filterPDFTOCFragmentPages drops fragmented table-of-contents pages from the
 // stream. DeepDoc layout splits one TOC line (chapter title + subtitle +
@@ -418,12 +422,13 @@ const pdfTOCRepeatPagesMin = 3
 //
 // Classification counts title-like and page-number-like fragments and
 // requires zero body-length prose outside title-layout sections. Long lines
-// repeating verbatim across pages (running watermarks, storefront promos)
-// are boilerplate, not prose, and do not veto. Body chapter pages (one or
-// two headings plus long prose) never satisfy the thresholds, so a mixed
-// page degrades to untouched instead of deleting prose. Sections without
-// positions take no part in the classification and are never deleted; table
-// and figure sections are excluded on both sides.
+// repeating verbatim on every page (running watermarks, storefront promos)
+// are boilerplate, not prose, and do not veto: body prose never repeats
+// verbatim on all pages. Body chapter pages (one or two headings plus long
+// prose) never satisfy the thresholds, so a mixed page degrades to untouched
+// instead of deleting prose. Sections without positions take no part in the
+// classification and are never deleted; table and figure sections are
+// excluded on both sides.
 func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Section {
 	return filterPDFTOCFragmentPagesWithRepeated(sections, pdfTOCRepeatedLines(sections))
 }
@@ -454,7 +459,7 @@ func filterPDFTOCFragmentPagesWithRepeated(sections []deepdoctype.Section, repea
 			if entry || isPDFTOCTitleCandidate(text) || len([]rune(text)) < pdfTOCBodyTextRunesMin {
 				continue
 			}
-			if repeated[pdfTOCRepeatKey(text)] {
+			if repeated[pdfTOCRepeatKey(text, firstSectionTop(sections[i]))] {
 				continue
 			}
 			if strings.TrimSpace(sections[i].LayoutType) == deepdoctype.LayoutTypeTitle {
@@ -505,27 +510,30 @@ func pdfTOCFragmentPage(s deepdoctype.Section) (int, bool) {
 	return 0, false
 }
 
-// pdfTOCRepeatedLines reports the set of long lines repeating verbatim on
-// at least pdfTOCRepeatPagesMin pages. Only text/title sections with page
-// positions vote; title candidates and entry lines always count as TOC
-// signals first and never as boilerplate, so chapter headings repeating
-// across pages cannot be misread. Short text needs no table: it never vetoes
-// classification on its own length. The table is built from the raw section
-// stream before any deletion pass runs: entry filtering deletes in place
-// and would otherwise strip the page fragments some keys need to reach
-// threshold.
+// pdfTOCRepeatedLines reports the set of long lines repeating verbatim at
+// the same height on at least pdfTOCRepeatPagesMin pages. Only text/title
+// sections with page positions vote; title candidates and entry lines
+// always count as TOC signals first and never as boilerplate, so chapter
+// headings repeating across pages cannot be misread. Short text needs no
+// table: it never vetoes classification on its own length. The key couples
+// normalized text with a vertical band: watermarks are page templates at a
+// fixed height, so glue/space jitter across pages still lands in one
+// bucket while drifting body prose never gathers. The table is built from
+// the raw section stream before any deletion pass runs: entry filtering
+// deletes in place and would otherwise strip the page fragments some keys
+// need to reach threshold.
 func pdfTOCRepeatedLines(sections []deepdoctype.Section) map[string]bool {
 	pages := map[string]map[int]struct{}{}
 	for _, s := range sections {
-		if _, ok := pdfTOCFragmentPage(s); !ok {
+		page, ok := pdfTOCFragmentPage(s)
+		if !ok {
 			continue
 		}
 		text := sectionText(s)
 		if isPDFTOCTitleCandidate(text) || isPDFTOCEntrySection(text) || len([]rune(text)) < pdfTOCBodyTextRunesMin {
 			continue
 		}
-		key := pdfTOCRepeatKey(text)
-		page := firstSectionPage(s)
+		key := pdfTOCRepeatKey(text, firstSectionTop(s))
 		if pages[key] == nil {
 			pages[key] = map[int]struct{}{}
 		}
@@ -540,25 +548,32 @@ func pdfTOCRepeatedLines(sections []deepdoctype.Section) map[string]bool {
 	return repeated
 }
 
-// pdfTOCRepeatKey normalizes a line for verbatim repetition comparison:
-// surrounding whitespace trimmed, inner runs collapsed, and any URL
-// collapsed to a single marker. Print-shop watermarks often glue the URL
-// to the preceding text without a space on some pages ("...下载http://")
-// while separating it on others; without URL collapsing those pages vote
-// for different keys and repetition never reaches threshold. No digit
-// masking and no case folding: page numbers inside boilerplate would
-// otherwise merge distinct lines, and title candidates never reach this
-// table.
-func pdfTOCRepeatKey(text string) string {
-	collapsed := strings.Join(strings.Fields(text), " ")
-	collapsed = pdfTOCURLCollapsePattern.ReplaceAllString(collapsed, " URL ")
-	return strings.Join(strings.Fields(collapsed), " ")
+// pdfTOCRepeatKey normalizes a line for repetition comparison: all
+// whitespace stripped, coupled with the vertical band of its top. Template
+// watermarks gluing or spacing the URL differently across pages still share
+// text and height, so they land in one bucket. No digit masking and no case
+// folding: page numbers inside boilerplate would otherwise merge distinct
+// lines, and title candidates never reach this table.
+func pdfTOCRepeatKey(text string, top float64) string {
+	stripped := strings.Join(strings.Fields(text), "")
+	return stripped + "\x00" + itoa(int(top/pdfTOCTopBucketPoints))
 }
 
-// pdfTOCURLCollapsePattern matches URL-like runs for repetition comparison
-// only. It is not a boilerplate verdict: it merely lets the frequency table
-// see through glue/space jitter around the same link.
-var pdfTOCURLCollapsePattern = regexp.MustCompile(`(?i)https?://\S+|www\.\S+`)
+// itoa formats a non-negative bucket index without pulling in strconv for
+// one call site.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
 
 // pdfTOCFragmentDeletable reports whether the section at idx on a classified
 // TOC page is TOC debris: a title candidate, an entry line, a bare page
@@ -572,19 +587,20 @@ func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int, repeated m
 	case "", deepdoctype.LayoutTypeText:
 	case deepdoctype.LayoutTypeTitle:
 		t := sectionText(s)
-		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) && !repeated[pdfTOCRepeatKey(t)] {
+		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) && !repeated[pdfTOCRepeatKey(t, firstSectionTop(s))] {
 			return false
 		}
 	default:
 		return false
 	}
 	text := sectionText(s)
+	top := firstSectionTop(s)
 	switch {
 	case isPDFTOCTitleCandidate(text), isPDFTOCEntrySection(text):
 		return true
 	case pdfTOCRomanMarkerPattern.MatchString(text), strings.Contains(text, "《"):
 		return false
-	case repeated[pdfTOCRepeatKey(text)]:
+	case repeated[pdfTOCRepeatKey(text, top)]:
 		return true
 	case pdfTOCBarePageRefPattern.MatchString(text):
 		return true

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -398,12 +398,6 @@ const (
 // matching the existing entry-filter behavior.
 var pdfTOCRomanMarkerPattern = regexp.MustCompile(`(?i)^[mdclxvi]+$`)
 
-// pdfURLBoilerplatePattern matches generic network signatures of ebook
-// storefront boilerplate (protocols, www, common domain suffixes, forum
-// hosts). It carries no per-file keywords: any long line bearing a URL or
-// domain is storefront promo, never book prose.
-var pdfURLBoilerplatePattern = regexp.MustCompile(`(?i)(https?://|www\.|\.(com|cn|net|org|cc|me)\b|bbs\.|forum\.)`)
-
 // filterPDFTOCFragmentPages drops fragmented table-of-contents pages from the
 // stream. DeepDoc layout splits one TOC line (chapter title + subtitle +
 // leader dots + page number) into unadjacent sections — a bare chapter title,
@@ -435,12 +429,7 @@ func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Sec
 			if entry || pdfTOCBarePageRefPattern.MatchString(text) {
 				refs++
 			}
-			if entry || len([]rune(text)) < pdfTOCBodyTextRunesMin {
-				continue
-			}
-			// Storefront promo lines bear a URL or domain: ebook boilerplate,
-			// never book prose, so they must not veto the page.
-			if pdfURLBoilerplatePattern.MatchString(text) {
+			if entry || isPDFTOCTitleCandidate(text) || len([]rune(text)) < pdfTOCBodyTextRunesMin {
 				continue
 			}
 			if strings.TrimSpace(sections[i].LayoutType) == deepdoctype.LayoutTypeTitle {
@@ -474,34 +463,35 @@ func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Sec
 // pdfTOCFragmentPage reports the page a section belongs to. It returns false
 // for non-text sections (tables and figures are never TOC fragments) and for
 // sections without positions (they take no part in page-level
-// classification). The key only needs to be consistent within one result,
-// so the raw 0-indexed DeepDoc page number is used directly.
+// classification). Only positions carrying actual page numbers count: a
+// position entry with an empty PageNumbers slice is not a page, and
+// firstSectionPage alone would report it as the real page 0.
 func pdfTOCFragmentPage(s deepdoctype.Section) (int, bool) {
 	switch strings.TrimSpace(s.LayoutType) {
 	case "", deepdoctype.LayoutTypeText, deepdoctype.LayoutTypeTitle:
 	default:
 		return 0, false
 	}
-	page := firstSectionPage(s)
-	if page <= 0 && len(s.Positions) == 0 {
-		return 0, false
+	for _, pos := range s.Positions {
+		if len(pos.PageNumbers) > 0 {
+			return pos.PageNumbers[0], true
+		}
 	}
-	return page, true
+	return 0, false
 }
 
 // pdfTOCFragmentDeletable reports whether the section at idx on a classified
 // TOC page is TOC debris: a title candidate, an entry line, a bare page
-// reference, a page-number-like title, a URL boilerplate line, or short
-// text (subtitles and debris) anchored by a neighboring TOC signal. Book
-// titles (non-title headings), roman-numeral page markers, long prose and
-// non-text layouts are kept.
+// reference, a page-number-like title, or short text (subtitles and debris)
+// anchored by a neighboring TOC signal. Book titles (non-title headings),
+// roman-numeral page markers, long prose and non-text layouts are kept.
 func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 	s := sections[idx]
 	switch strings.TrimSpace(s.LayoutType) {
 	case "", deepdoctype.LayoutTypeText:
 	case deepdoctype.LayoutTypeTitle:
 		t := sectionText(s)
-		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) && !pdfURLBoilerplatePattern.MatchString(t) {
+		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) {
 			return false
 		}
 	default:
@@ -513,8 +503,6 @@ func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 		return true
 	case pdfTOCRomanMarkerPattern.MatchString(text), strings.Contains(text, "《"):
 		return false
-	case pdfURLBoilerplatePattern.MatchString(text):
-		return true
 	case pdfTOCBarePageRefPattern.MatchString(text):
 		return true
 	case len([]rune(text)) < pdfTOCShortTextRunesMax && pdfTOCFragmentAnchorText(sections, idx):

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -335,10 +335,13 @@ func removePDFTOC(result *deepdoctype.ParseResult) {
 			break
 		}
 	}
-	// The anchored pass above needs a "目录"/"contents" section; a TOC whose
-	// pages carry no such heading survives it entirely. Drop the remaining
-	// leader+page-number entry lines, mirroring remove_toc in
-	// rag/flow/parser/utils.py.
+	// The anchored pass above needs a heading section; a TOC whose pages
+	// carry no such heading survives it entirely. Classify fragmented
+	// pages before entry-line filtering: the entry filter deletes in place
+	// and can strip the page-number fragments the classifier counts on.
+	sections = filterPDFTOCFragmentPages(sections)
+	// Drop any remaining leader+page-number entry lines, mirroring
+	// remove_toc in rag/flow/parser/utils.py.
 	sections = filterPDFTOCEntries(sections)
 	result.Sections = sections
 }
@@ -378,8 +381,166 @@ func filterPDFTOCEntries(sections []deepdoctype.Section) []deepdoctype.Section {
 	return filtered
 }
 
-// isPDFTOCEntrySection reports whether the section text is (or is dominated
-// by) table-of-contents entries.
+// pdfTOCFragmentThresholds bound page-level TOC detection: a page is a
+// fragmented TOC page only when it carries at least this many title-like
+// and page-number-like fragments and no body-length prose.
+const (
+	pdfTOCTitleFragmentsMin   = 5
+	pdfTOCPageRefFragmentsMin = 3
+	pdfTOCBodyTextRunesMin    = 40
+	pdfTOCShortTextRunesMax   = 40
+)
+
+// pdfTOCRomanMarkerPattern matches standalone roman-numeral page markers
+// ("I", "II", "V"). They carry no content but are kept as page anchors,
+// matching the existing entry-filter behavior.
+var pdfTOCRomanMarkerPattern = regexp.MustCompile(`^[IVXLCivxlc]+$`)
+
+// filterPDFTOCFragmentPages drops fragmented table-of-contents pages from the
+// stream. DeepDoc layout splits one TOC line (chapter title + subtitle +
+// leader dots + page number) into unadjacent sections — a bare chapter title,
+// a subtitle line and a bare page number — that neither the anchored title
+// pass nor the entry-line filter recognizes.
+//
+// Classification ignores boilerplate (watermarks and storefront promos are
+// neither TOC signals nor body prose). A page qualifies when it carries
+// enough title-like and page-number-like fragments and, outside title-layout
+// sections, zero body-length prose. Body chapter pages (one or two headings
+// plus long prose) never satisfy the thresholds, so a mixed page degrades
+// to untouched instead of deleting prose. Sections without positions take no
+// part in the classification and are never deleted; table and figure
+// sections are excluded on both sides.
+func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Section {
+	pages := map[int][]int{}
+	for i, s := range sections {
+		if page, ok := pdfTOCFragmentPage(s); ok {
+			pages[page] = append(pages[page], i)
+		}
+	}
+	drop := map[int]struct{}{}
+	for _, indices := range pages {
+		var titles, refs, body int
+		for _, i := range indices {
+			text := sectionText(sections[i])
+			entry := isPDFTOCEntrySection(text)
+			if entry || isPDFTOCTitleCandidate(text) {
+				titles++
+			}
+			if entry || pdfTOCBarePageRefPattern.MatchString(text) {
+				refs++
+			}
+			if entry || pdfTOCBoilerplateText(text) || len([]rune(text)) < pdfTOCBodyTextRunesMin {
+				continue
+			}
+			if strings.TrimSpace(sections[i].LayoutType) == deepdoctype.LayoutTypeTitle {
+				continue
+			}
+			body++
+		}
+		if titles < pdfTOCTitleFragmentsMin || refs < pdfTOCPageRefFragmentsMin || body > 0 {
+			continue
+		}
+		for _, i := range indices {
+			if !pdfTOCFragmentDeletable(sections, i) {
+				continue
+			}
+			drop[i] = struct{}{}
+		}
+	}
+	if len(drop) == 0 {
+		return sections
+	}
+	filtered := make([]deepdoctype.Section, 0, len(sections)-len(drop))
+	for i, s := range sections {
+		if _, ok := drop[i]; ok {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	return filtered
+}
+
+// pdfTOCFragmentPage reports the page a section belongs to. It returns false
+// for non-text sections (tables and figures are never TOC fragments) and for
+// sections without positions (they take no part in page-level
+// classification). The key only needs to be consistent within one result,
+// so the raw 0-indexed DeepDoc page number is used directly.
+func pdfTOCFragmentPage(s deepdoctype.Section) (int, bool) {
+	switch strings.TrimSpace(s.LayoutType) {
+	case "", deepdoctype.LayoutTypeText, deepdoctype.LayoutTypeTitle:
+	default:
+		return 0, false
+	}
+	page := firstSectionPage(s)
+	if page <= 0 && len(s.Positions) == 0 {
+		return 0, false
+	}
+	return page, true
+}
+
+// pdfTOCFragmentDeletable reports whether the section at idx on a classified
+// TOC page is TOC debris: a title candidate, an entry line, a bare page
+// reference, a page-number-like title, or short text (subtitles and
+// same-page watermarks) anchored by a neighboring TOC signal. Book titles
+// (non-title headings), roman-numeral page markers, long prose and non-text
+// layouts are kept.
+func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
+	s := sections[idx]
+	switch strings.TrimSpace(s.LayoutType) {
+	case "", deepdoctype.LayoutTypeText:
+	case deepdoctype.LayoutTypeTitle:
+		t := sectionText(s)
+		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) && !pdfTOCBoilerplateText(t) {
+			return false
+		}
+	default:
+		return false
+	}
+	text := sectionText(s)
+	switch {
+	case isPDFTOCTitleCandidate(text), isPDFTOCEntrySection(text):
+		return true
+	case pdfTOCRomanMarkerPattern.MatchString(text), strings.Contains(text, "《"):
+		return false
+	case pdfTOCBoilerplateText(text), pdfTOCBarePageRefPattern.MatchString(text):
+		return true
+	case len([]rune(text)) < pdfTOCShortTextRunesMax && pdfTOCFragmentAnchorText(sections, idx):
+		return true
+	default:
+		return false
+	}
+}
+
+// pdfTOCFragmentAnchorText reports whether the short text at idx sits next
+// to a TOC signal (a title candidate, entry line or page reference within
+// one neighbor on each side). It gates short-text deletion so a classified
+// page keeps short lines that read as standalone content.
+func pdfTOCFragmentAnchorText(sections []deepdoctype.Section, idx int) bool {
+	for _, j := range []int{idx - 1, idx + 1} {
+		if j < 0 || j >= len(sections) {
+			continue
+		}
+		if firstSectionPage(sections[j]) != firstSectionPage(sections[idx]) {
+			continue
+		}
+		t := sectionText(sections[j])
+		if isPDFTOCTitleCandidate(t) || isPDFTOCEntrySection(t) || pdfTOCBarePageRefPattern.MatchString(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// pdfTOCBoilerplatePattern matches storefront boilerplate that repeats on
+// TOC front matter pages. It is neither body prose nor a TOC signal: it must
+// not veto page classification and is deleted as short-text debris on a
+// classified page.
+var pdfTOCBoilerplatePattern = regexp.MustCompile(`更多、更全|免费(注册|下载)|欢迎访问|http[s]?://|www\.|\.cn|bbs\.|forum\.|下载|木瓜树`)
+
+func pdfTOCBoilerplateText(text string) bool {
+	return pdfTOCBoilerplatePattern.MatchString(text)
+}
+
 func isPDFTOCEntrySection(text string) bool {
 	if pdfTOCEntryPattern.MatchString(text) {
 		return true

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -402,14 +402,12 @@ var pdfTOCRomanMarkerPattern = regexp.MustCompile(`^[IVXLCivxlc]+$`)
 // a subtitle line and a bare page number — that neither the anchored title
 // pass nor the entry-line filter recognizes.
 //
-// Classification ignores boilerplate (watermarks and storefront promos are
-// neither TOC signals nor body prose). A page qualifies when it carries
-// enough title-like and page-number-like fragments and, outside title-layout
-// sections, zero body-length prose. Body chapter pages (one or two headings
-// plus long prose) never satisfy the thresholds, so a mixed page degrades
-// to untouched instead of deleting prose. Sections without positions take no
-// part in the classification and are never deleted; table and figure
-// sections are excluded on both sides.
+// Classification counts title-like and page-number-like fragments and
+// requires zero body-length prose outside title-layout sections. Body
+// chapter pages (one or two headings plus long prose) never satisfy the
+// thresholds, so a mixed page degrades to untouched instead of deleting
+// prose. Sections without positions take no part in the classification and
+// are never deleted; table and figure sections are excluded on both sides.
 func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Section {
 	pages := map[int][]int{}
 	for i, s := range sections {
@@ -429,7 +427,7 @@ func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Sec
 			if entry || pdfTOCBarePageRefPattern.MatchString(text) {
 				refs++
 			}
-			if entry || pdfTOCBoilerplateText(text) || len([]rune(text)) < pdfTOCBodyTextRunesMin {
+			if entry || len([]rune(text)) < pdfTOCBodyTextRunesMin {
 				continue
 			}
 			if strings.TrimSpace(sections[i].LayoutType) == deepdoctype.LayoutTypeTitle {
@@ -480,17 +478,16 @@ func pdfTOCFragmentPage(s deepdoctype.Section) (int, bool) {
 
 // pdfTOCFragmentDeletable reports whether the section at idx on a classified
 // TOC page is TOC debris: a title candidate, an entry line, a bare page
-// reference, a page-number-like title, or short text (subtitles and
-// same-page watermarks) anchored by a neighboring TOC signal. Book titles
-// (non-title headings), roman-numeral page markers, long prose and non-text
-// layouts are kept.
+// reference, a page-number-like title, or short text (subtitles and debris)
+// anchored by a neighboring TOC signal. Book titles (non-title headings),
+// roman-numeral page markers, long prose and non-text layouts are kept.
 func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 	s := sections[idx]
 	switch strings.TrimSpace(s.LayoutType) {
 	case "", deepdoctype.LayoutTypeText:
 	case deepdoctype.LayoutTypeTitle:
 		t := sectionText(s)
-		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) && !pdfTOCBoilerplateText(t) {
+		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) {
 			return false
 		}
 	default:
@@ -502,7 +499,7 @@ func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 		return true
 	case pdfTOCRomanMarkerPattern.MatchString(text), strings.Contains(text, "《"):
 		return false
-	case pdfTOCBoilerplateText(text), pdfTOCBarePageRefPattern.MatchString(text):
+	case pdfTOCBarePageRefPattern.MatchString(text):
 		return true
 	case len([]rune(text)) < pdfTOCShortTextRunesMax && pdfTOCFragmentAnchorText(sections, idx):
 		return true
@@ -529,16 +526,6 @@ func pdfTOCFragmentAnchorText(sections []deepdoctype.Section, idx int) bool {
 		}
 	}
 	return false
-}
-
-// pdfTOCBoilerplatePattern matches storefront boilerplate that repeats on
-// TOC front matter pages. It is neither body prose nor a TOC signal: it must
-// not veto page classification and is deleted as short-text debris on a
-// classified page.
-var pdfTOCBoilerplatePattern = regexp.MustCompile(`更多、更全|免费(注册|下载)|欢迎访问|http[s]?://|www\.|\.cn|bbs\.|forum\.|下载|木瓜树`)
-
-func pdfTOCBoilerplateText(text string) bool {
-	return pdfTOCBoilerplatePattern.MatchString(text)
 }
 
 func isPDFTOCEntrySection(text string) bool {

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -257,10 +257,11 @@ func sortSectionsByPosition(result *deepdoctype.ParseResult) {
 
 // applyRemoveTOC mirrors Python parser.py:663-681 three-way dispatch:
 //   - No outlines → pattern-based remove_toc on all sections
-//   - First outline on page 1 → outline-based remove_toc_pdf, then the entry
-//     filter: the outline pass only drops pages when an outline title names
-//     the TOC ("目录"/"contents"), so a headingless TOC must still run
-//     through filterPDFTOCEntries instead of being left in place
+//   - First outline on page 1 → outline-based remove_toc_pdf, then the
+//     fragment-page pass and the entry filter: the outline pass only drops
+//     pages when an outline title names the TOC ("目录"/"contents"), so a
+//     headingless TOC must still run through both instead of being left
+//     in place
 //   - First outline after page 1 → pattern-based on pages before the first outline
 func applyRemoveTOC(result *deepdoctype.ParseResult) {
 	if result == nil {
@@ -274,6 +275,7 @@ func applyRemoveTOC(result *deepdoctype.ParseResult) {
 	firstOutlinePage := outlines[0].PageNumber
 	if firstOutlinePage <= 1 {
 		removePDFTOCByOutlines(result, outlines)
+		result.Sections = filterPDFTOCFragmentPages(result.Sections)
 		result.Sections = filterPDFTOCEntries(result.Sections)
 		return
 	}
@@ -392,9 +394,9 @@ const (
 )
 
 // pdfTOCRomanMarkerPattern matches standalone roman-numeral page markers
-// ("I", "II", "V"). They carry no content but are kept as page anchors,
+// ("I", "II", "D", "M"). They carry no content but are kept as page anchors,
 // matching the existing entry-filter behavior.
-var pdfTOCRomanMarkerPattern = regexp.MustCompile(`^[IVXLCivxlc]+$`)
+var pdfTOCRomanMarkerPattern = regexp.MustCompile(`(?i)^[mdclxvi]+$`)
 
 // filterPDFTOCFragmentPages drops fragmented table-of-contents pages from the
 // stream. DeepDoc layout splits one TOC line (chapter title + subtitle +
@@ -511,13 +513,21 @@ func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 // pdfTOCFragmentAnchorText reports whether the short text at idx sits next
 // to a TOC signal (a title candidate, entry line or page reference within
 // one neighbor on each side). It gates short-text deletion so a classified
-// page keeps short lines that read as standalone content.
+// page keeps short lines that read as standalone content. Both sides go
+// through pdfTOCFragmentPage so positionless sections and table/figure
+// sections can neither be anchored nor anchor: firstSectionPage alone
+// returns 0 for them, which collides with the real page 0.
 func pdfTOCFragmentAnchorText(sections []deepdoctype.Section, idx int) bool {
+	page, ok := pdfTOCFragmentPage(sections[idx])
+	if !ok {
+		return false
+	}
 	for _, j := range []int{idx - 1, idx + 1} {
 		if j < 0 || j >= len(sections) {
 			continue
 		}
-		if firstSectionPage(sections[j]) != firstSectionPage(sections[idx]) {
+		neighborPage, ok := pdfTOCFragmentPage(sections[j])
+		if !ok || neighborPage != page {
 			continue
 		}
 		t := sectionText(sections[j])

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -275,7 +275,8 @@ func applyRemoveTOC(result *deepdoctype.ParseResult) {
 	firstOutlinePage := outlines[0].PageNumber
 	if firstOutlinePage <= 1 {
 		removePDFTOCByOutlines(result, outlines)
-		result.Sections = filterPDFTOCFragmentPages(result.Sections)
+		repeated := pdfTOCRepeatedLines(result.Sections)
+		result.Sections = filterPDFTOCFragmentPagesWithRepeated(result.Sections, repeated)
 		result.Sections = filterPDFTOCEntries(result.Sections)
 		return
 	}
@@ -338,10 +339,14 @@ func removePDFTOC(result *deepdoctype.ParseResult) {
 		}
 	}
 	// The anchored pass above needs a heading section; a TOC whose pages
-	// carry no such heading survives it entirely. Classify fragmented
-	// pages before entry-line filtering: the entry filter deletes in place
-	// and can strip the page-number fragments the classifier counts on.
-	sections = filterPDFTOCFragmentPages(sections)
+	// carry no such heading survives it entirely. Build the repetition
+	// table from the raw stream first: the passes below delete in place
+	// and would otherwise strip the page fragments some keys need to
+	// reach threshold. Classify fragmented pages before entry-line
+	// filtering for the same reason: the entry filter can strip the
+	// page-number fragments the classifier counts on.
+	repeated := pdfTOCRepeatedLines(sections)
+	sections = filterPDFTOCFragmentPagesWithRepeated(sections, repeated)
 	// Drop any remaining leader+page-number entry lines, mirroring
 	// remove_toc in rag/flow/parser/utils.py.
 	sections = filterPDFTOCEntries(sections)
@@ -398,6 +403,13 @@ const (
 // matching the existing entry-filter behavior.
 var pdfTOCRomanMarkerPattern = regexp.MustCompile(`(?i)^[mdclxvi]+$`)
 
+// pdfTOCRepeatPagesMin is the cross-page repetition threshold for
+// boilerplate: a long line repeating verbatim on this many pages is
+// storefront promo or a running watermark, never body prose. Body prose
+// never repeats verbatim across pages, so the threshold needs no document
+// size proportion.
+const pdfTOCRepeatPagesMin = 3
+
 // filterPDFTOCFragmentPages drops fragmented table-of-contents pages from the
 // stream. DeepDoc layout splits one TOC line (chapter title + subtitle +
 // leader dots + page number) into unadjacent sections — a bare chapter title,
@@ -405,12 +417,22 @@ var pdfTOCRomanMarkerPattern = regexp.MustCompile(`(?i)^[mdclxvi]+$`)
 // pass nor the entry-line filter recognizes.
 //
 // Classification counts title-like and page-number-like fragments and
-// requires zero body-length prose outside title-layout sections. Body
-// chapter pages (one or two headings plus long prose) never satisfy the
-// thresholds, so a mixed page degrades to untouched instead of deleting
-// prose. Sections without positions take no part in the classification and
-// are never deleted; table and figure sections are excluded on both sides.
+// requires zero body-length prose outside title-layout sections. Long lines
+// repeating verbatim across pages (running watermarks, storefront promos)
+// are boilerplate, not prose, and do not veto. Body chapter pages (one or
+// two headings plus long prose) never satisfy the thresholds, so a mixed
+// page degrades to untouched instead of deleting prose. Sections without
+// positions take no part in the classification and are never deleted; table
+// and figure sections are excluded on both sides.
 func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Section {
+	return filterPDFTOCFragmentPagesWithRepeated(sections, pdfTOCRepeatedLines(sections))
+}
+
+// filterPDFTOCFragmentPagesWithRepeated is the injectable core of
+// filterPDFTOCFragmentPages: production builds the repetition table from
+// the raw stream before any deletion pass (see removePDFTOC); tests call
+// the wrapper above. Splitting the two keeps the table lifetime explicit.
+func filterPDFTOCFragmentPagesWithRepeated(sections []deepdoctype.Section, repeated map[string]bool) []deepdoctype.Section {
 	pages := map[int][]int{}
 	for i, s := range sections {
 		if page, ok := pdfTOCFragmentPage(s); ok {
@@ -432,6 +454,9 @@ func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Sec
 			if entry || isPDFTOCTitleCandidate(text) || len([]rune(text)) < pdfTOCBodyTextRunesMin {
 				continue
 			}
+			if repeated[pdfTOCRepeatKey(text)] {
+				continue
+			}
 			if strings.TrimSpace(sections[i].LayoutType) == deepdoctype.LayoutTypeTitle {
 				continue
 			}
@@ -441,7 +466,7 @@ func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Sec
 			continue
 		}
 		for _, i := range indices {
-			if !pdfTOCFragmentDeletable(sections, i) {
+			if !pdfTOCFragmentDeletable(sections, i, repeated) {
 				continue
 			}
 			drop[i] = struct{}{}
@@ -480,18 +505,74 @@ func pdfTOCFragmentPage(s deepdoctype.Section) (int, bool) {
 	return 0, false
 }
 
+// pdfTOCRepeatedLines reports the set of long lines repeating verbatim on
+// at least pdfTOCRepeatPagesMin pages. Only text/title sections with page
+// positions vote; title candidates and entry lines always count as TOC
+// signals first and never as boilerplate, so chapter headings repeating
+// across pages cannot be misread. Short text needs no table: it never vetoes
+// classification on its own length. The table is built from the raw section
+// stream before any deletion pass runs: entry filtering deletes in place
+// and would otherwise strip the page fragments some keys need to reach
+// threshold.
+func pdfTOCRepeatedLines(sections []deepdoctype.Section) map[string]bool {
+	pages := map[string]map[int]struct{}{}
+	for _, s := range sections {
+		if _, ok := pdfTOCFragmentPage(s); !ok {
+			continue
+		}
+		text := sectionText(s)
+		if isPDFTOCTitleCandidate(text) || isPDFTOCEntrySection(text) || len([]rune(text)) < pdfTOCBodyTextRunesMin {
+			continue
+		}
+		key := pdfTOCRepeatKey(text)
+		page := firstSectionPage(s)
+		if pages[key] == nil {
+			pages[key] = map[int]struct{}{}
+		}
+		pages[key][page] = struct{}{}
+	}
+	repeated := map[string]bool{}
+	for key, set := range pages {
+		if len(set) >= pdfTOCRepeatPagesMin {
+			repeated[key] = true
+		}
+	}
+	return repeated
+}
+
+// pdfTOCRepeatKey normalizes a line for verbatim repetition comparison:
+// surrounding whitespace trimmed, inner runs collapsed, and any URL
+// collapsed to a single marker. Print-shop watermarks often glue the URL
+// to the preceding text without a space on some pages ("...下载http://")
+// while separating it on others; without URL collapsing those pages vote
+// for different keys and repetition never reaches threshold. No digit
+// masking and no case folding: page numbers inside boilerplate would
+// otherwise merge distinct lines, and title candidates never reach this
+// table.
+func pdfTOCRepeatKey(text string) string {
+	collapsed := strings.Join(strings.Fields(text), " ")
+	collapsed = pdfTOCURLCollapsePattern.ReplaceAllString(collapsed, " URL ")
+	return strings.Join(strings.Fields(collapsed), " ")
+}
+
+// pdfTOCURLCollapsePattern matches URL-like runs for repetition comparison
+// only. It is not a boilerplate verdict: it merely lets the frequency table
+// see through glue/space jitter around the same link.
+var pdfTOCURLCollapsePattern = regexp.MustCompile(`(?i)https?://\S+|www\.\S+`)
+
 // pdfTOCFragmentDeletable reports whether the section at idx on a classified
 // TOC page is TOC debris: a title candidate, an entry line, a bare page
-// reference, a page-number-like title, or short text (subtitles and debris)
-// anchored by a neighboring TOC signal. Book titles (non-title headings),
-// roman-numeral page markers, long prose and non-text layouts are kept.
-func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
+// reference, a page-number-like title, repeated boilerplate, or short text
+// (subtitles and debris) anchored by a neighboring TOC signal. Book titles
+// (non-title headings), roman-numeral page markers, long prose and non-text
+// layouts are kept.
+func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int, repeated map[string]bool) bool {
 	s := sections[idx]
 	switch strings.TrimSpace(s.LayoutType) {
 	case "", deepdoctype.LayoutTypeText:
 	case deepdoctype.LayoutTypeTitle:
 		t := sectionText(s)
-		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) {
+		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) && !repeated[pdfTOCRepeatKey(t)] {
 			return false
 		}
 	default:
@@ -503,6 +584,8 @@ func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 		return true
 	case pdfTOCRomanMarkerPattern.MatchString(text), strings.Contains(text, "《"):
 		return false
+	case repeated[pdfTOCRepeatKey(text)]:
+		return true
 	case pdfTOCBarePageRefPattern.MatchString(text):
 		return true
 	case len([]rune(text)) < pdfTOCShortTextRunesMax && pdfTOCFragmentAnchorText(sections, idx):

--- a/internal/parser/parser/pdf_postprocess.go
+++ b/internal/parser/parser/pdf_postprocess.go
@@ -398,6 +398,12 @@ const (
 // matching the existing entry-filter behavior.
 var pdfTOCRomanMarkerPattern = regexp.MustCompile(`(?i)^[mdclxvi]+$`)
 
+// pdfURLBoilerplatePattern matches generic network signatures of ebook
+// storefront boilerplate (protocols, www, common domain suffixes, forum
+// hosts). It carries no per-file keywords: any long line bearing a URL or
+// domain is storefront promo, never book prose.
+var pdfURLBoilerplatePattern = regexp.MustCompile(`(?i)(https?://|www\.|\.(com|cn|net|org|cc|me)\b|bbs\.|forum\.)`)
+
 // filterPDFTOCFragmentPages drops fragmented table-of-contents pages from the
 // stream. DeepDoc layout splits one TOC line (chapter title + subtitle +
 // leader dots + page number) into unadjacent sections — a bare chapter title,
@@ -430,6 +436,11 @@ func filterPDFTOCFragmentPages(sections []deepdoctype.Section) []deepdoctype.Sec
 				refs++
 			}
 			if entry || len([]rune(text)) < pdfTOCBodyTextRunesMin {
+				continue
+			}
+			// Storefront promo lines bear a URL or domain: ebook boilerplate,
+			// never book prose, so they must not veto the page.
+			if pdfURLBoilerplatePattern.MatchString(text) {
 				continue
 			}
 			if strings.TrimSpace(sections[i].LayoutType) == deepdoctype.LayoutTypeTitle {
@@ -480,16 +491,17 @@ func pdfTOCFragmentPage(s deepdoctype.Section) (int, bool) {
 
 // pdfTOCFragmentDeletable reports whether the section at idx on a classified
 // TOC page is TOC debris: a title candidate, an entry line, a bare page
-// reference, a page-number-like title, or short text (subtitles and debris)
-// anchored by a neighboring TOC signal. Book titles (non-title headings),
-// roman-numeral page markers, long prose and non-text layouts are kept.
+// reference, a page-number-like title, a URL boilerplate line, or short
+// text (subtitles and debris) anchored by a neighboring TOC signal. Book
+// titles (non-title headings), roman-numeral page markers, long prose and
+// non-text layouts are kept.
 func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 	s := sections[idx]
 	switch strings.TrimSpace(s.LayoutType) {
 	case "", deepdoctype.LayoutTypeText:
 	case deepdoctype.LayoutTypeTitle:
 		t := sectionText(s)
-		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) {
+		if !isPDFTOCTitleCandidate(t) && !isPDFTOCEntrySection(t) && !pdfTOCBarePageRefPattern.MatchString(t) && !pdfURLBoilerplatePattern.MatchString(t) {
 			return false
 		}
 	default:
@@ -501,6 +513,8 @@ func pdfTOCFragmentDeletable(sections []deepdoctype.Section, idx int) bool {
 		return true
 	case pdfTOCRomanMarkerPattern.MatchString(text), strings.Contains(text, "《"):
 		return false
+	case pdfURLBoilerplatePattern.MatchString(text):
+		return true
 	case pdfTOCBarePageRefPattern.MatchString(text):
 		return true
 	case len([]rune(text)) < pdfTOCShortTextRunesMax && pdfTOCFragmentAnchorText(sections, idx):

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -1003,9 +1003,9 @@ func TestFilterPDFTOCFragmentPages_EmptyPageNumbersDoNotCollide(t *testing.T) {
 }
 
 // TestFilterPDFTOCFragmentPages_RepeatedBoilerplateDoesNotVeto pins the
-// frequency exemption: a long line repeating verbatim on >=3 pages is
-// boilerplate, not prose, so it neither vetoes classification nor survives
-// on a classified page.
+// frequency exemption: a long line repeating verbatim at the same height on
+// every page is boilerplate, not prose, so it neither vetoes classification
+// nor survives on a classified page.
 func TestFilterPDFTOCFragmentPages_RepeatedBoilerplateDoesNotVeto(t *testing.T) {
 	promo := "Free ebook download from the reader forum, enjoy reading daily"
 	var sections []deepdoctype.Section
@@ -1016,6 +1016,50 @@ func TestFilterPDFTOCFragmentPages_RepeatedBoilerplateDoesNotVeto(t *testing.T) 
 	got := filterPDFTOCFragmentPages(sections)
 	if len(got) != 0 {
 		t.Fatalf("sections = %v, want empty", sectionTexts(got))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_DriftingRepeatStillVetoes pins that same
+// text drifting vertically never gathers: body prose at different heights
+// stays body even when the text repeats.
+func TestFilterPDFTOCFragmentPages_DriftingRepeatStillVetoes(t *testing.T) {
+	promo := "Free ebook download from the reader forum, enjoy reading daily"
+	var sections []deepdoctype.Section
+	for page := 0; page < 3; page++ {
+		parts := []string{"Chapter 1", "Chapter 2", "Chapter 3", "Chapter 4", "Chapter 5", "1", "3", "4", promo}
+		batch := fragmentedTOCPage(parts, page, "text")
+		batch[len(batch)-1].Positions[0].Top = float64(100 + page*100)
+		batch[len(batch)-1].Positions[0].Bottom = float64(118 + page*100)
+		sections = append(sections, batch...)
+	}
+	got := filterPDFTOCFragmentPages(sections)
+	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
+		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_PartialRepeatStillVetoes pins the full
+// coverage verdict: the same promo missing from one page is ordinary long
+// text and still vetoes on the pages carrying it. The promo-free page has
+// no veto but carries no surviving signal either once the shared titles
+// and page fragments classify it: it is cleared as a genuine TOC page.
+func TestFilterPDFTOCFragmentPages_PartialRepeatStillVetoes(t *testing.T) {
+	promo := "Free ebook download from the reader forum, enjoy reading daily"
+	var sections []deepdoctype.Section
+	for page := 0; page < 3; page++ {
+		parts := []string{"Chapter 1", "Chapter 2", "Chapter 3", "Chapter 4", "Chapter 5", "1", "3", "4"}
+		if page < 2 {
+			parts = append(parts, promo)
+		}
+		sections = append(sections, fragmentedTOCPage(parts, page, "text")...)
+	}
+	got := filterPDFTOCFragmentPages(sections)
+	want := []string{
+		"Chapter 1", "Chapter 2", "Chapter 3", "Chapter 4", "Chapter 5", "1", "3", "4", promo,
+		"Chapter 1", "Chapter 2", "Chapter 3", "Chapter 4", "Chapter 5", "1", "3", "4", promo,
+	}
+	if !slices.Equal(sectionTexts(got), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
 	}
 }
 

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -931,3 +931,74 @@ func TestFilterPDFTOCFragmentPages_KeepsFullRomanMarkers(t *testing.T) {
 		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
 	}
 }
+
+// TestFilterPDFTOCFragmentPages_URLBoilerplateDoesNotVeto pins the URL
+// exemption: a long storefront promo line bearing a URL or domain must not
+// veto page classification, and is deleted with the page.
+func TestFilterPDFTOCFragmentPages_URLBoilerplateDoesNotVeto(t *testing.T) {
+	promo := "Free ebook download from the reader forum http://forum.example.com/?from=381879"
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+		promo,
+	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	if len(got) != 0 {
+		t.Fatalf("sections = %v, want empty", sectionTexts(got))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_URLReferenceInBodyStillVetoes pins that the
+// exemption is scoped to classification only: a body page carrying a URL
+// reference plus genuine long prose still vetoes via the prose.
+func TestFilterPDFTOCFragmentPages_URLReferenceInBodyStillVetoes(t *testing.T) {
+	prose := "The way that can be told of is not the eternal way; the name " +
+		"that can be named is not the eternal name. The nameless is the origin."
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+		"See the reader forum http://forum.example.com for more texts.",
+		prose,
+	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
+		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_DeletesTitleLayoutURLBoilerplate pins that
+// the delete switch drops URL promo lines even when DLA types them as
+// title: the title-layout gate only keeps non-URL titles.
+func TestFilterPDFTOCFragmentPages_DeletesTitleLayoutURLBoilerplate(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	sections = append(sections, deepdoctype.Section{
+		Text:       "Reader forum http://forum.example.com",
+		LayoutType: "title",
+		Positions:  sections[0].Positions,
+	})
+	got := filterPDFTOCFragmentPages(sections)
+	if len(got) != 0 {
+		t.Fatalf("sections = %v, want empty", sectionTexts(got))
+	}
+}

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -932,11 +932,82 @@ func TestFilterPDFTOCFragmentPages_KeepsFullRomanMarkers(t *testing.T) {
 	}
 }
 
-// TestFilterPDFTOCFragmentPages_URLBoilerplateDoesNotVeto pins the URL
-// exemption: a long storefront promo line bearing a URL or domain must not
-// veto page classification, and is deleted with the page.
-func TestFilterPDFTOCFragmentPages_URLBoilerplateDoesNotVeto(t *testing.T) {
-	promo := "Free ebook download from the reader forum http://forum.example.com/?from=381879"
+// TestFilterPDFTOCFragmentPages_LongTextTitlesDoNotVeto pins that long
+// chapter titles in the default text layout are TOC signals, not body
+// prose: five >=40-rune text titles plus three page fragments classify.
+func TestFilterPDFTOCFragmentPages_LongTextTitlesDoNotVeto(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1 Introduction to the fundamental principles of the way",
+		"Chapter 2 The sage abides by non-action and wordless teaching",
+		"Chapter 3 On governing through non-interference and simplicity",
+		"Chapter 4 On the emptiness of the way and its endless efficacy",
+		"Chapter 5 On holding to the center and the use of emptiness",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	if len(got) != 0 {
+		t.Fatalf("sections = %v, want empty", sectionTexts(got))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_LegitimateURLProseIsKept pins that a URL
+// reference line is ordinary text: it neither vetoes on its own merits
+// beyond its length nor is deleted, and genuine prose still vetoes.
+func TestFilterPDFTOCFragmentPages_LegitimateURLProseIsKept(t *testing.T) {
+	prose := "The way that can be told of is not the eternal way; the name " +
+		"that can be named is not the eternal name. The nameless is the origin."
+	sections := fragmentedTOCPage([]string{
+		"Section 1 Introduction",
+		"Section 2 Method",
+		"See the project page http://example.com/project for the dataset.",
+		prose,
+	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
+		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_EmptyPageNumbersDoNotCollide pins the page-0
+// guard: a section whose Positions carry no PageNumbers takes no part in
+// classification and cannot anchor, even on the real page 0.
+func TestFilterPDFTOCFragmentPages_EmptyPageNumbersDoNotCollide(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	sections = append(sections,
+		deepdoctype.Section{
+			Text:      "Chapter 9",
+			Positions: []deepdoctype.Position{{PageNumbers: nil, Left: 50, Right: 550, Top: 300, Bottom: 318}},
+		},
+		deepdoctype.Section{
+			Text:       "lone line",
+			LayoutType: "text",
+			Positions:  sections[0].Positions,
+		},
+	)
+	got := filterPDFTOCFragmentPages(sections)
+	want := []string{"Chapter 9", "lone line"}
+	if !slices.Equal(sectionTexts(got), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_WatermarkedTOCPageStaysNegative pins the
+// known limitation: a TOC page carrying a long watermark line without URL
+// signature still vetoes via body. Watermark handling belongs to a future
+// cross-page frequency pass, not to this classifier.
+func TestFilterPDFTOCFragmentPages_WatermarkedTOCPageStaysNegative(t *testing.T) {
+	promo := "Free ebook download from the reader forum, enjoy reading daily"
 	sections := fragmentedTOCPage([]string{
 		"Chapter 1",
 		"Chapter 2",
@@ -949,56 +1020,7 @@ func TestFilterPDFTOCFragmentPages_URLBoilerplateDoesNotVeto(t *testing.T) {
 		promo,
 	}, 0, "text")
 	got := filterPDFTOCFragmentPages(sections)
-	if len(got) != 0 {
-		t.Fatalf("sections = %v, want empty", sectionTexts(got))
-	}
-}
-
-// TestFilterPDFTOCFragmentPages_URLReferenceInBodyStillVetoes pins that the
-// exemption is scoped to classification only: a body page carrying a URL
-// reference plus genuine long prose still vetoes via the prose.
-func TestFilterPDFTOCFragmentPages_URLReferenceInBodyStillVetoes(t *testing.T) {
-	prose := "The way that can be told of is not the eternal way; the name " +
-		"that can be named is not the eternal name. The nameless is the origin."
-	sections := fragmentedTOCPage([]string{
-		"Chapter 1",
-		"Chapter 2",
-		"Chapter 3",
-		"Chapter 4",
-		"Chapter 5",
-		"1",
-		"3",
-		"4",
-		"See the reader forum http://forum.example.com for more texts.",
-		prose,
-	}, 0, "text")
-	got := filterPDFTOCFragmentPages(sections)
 	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
 		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))
-	}
-}
-
-// TestFilterPDFTOCFragmentPages_DeletesTitleLayoutURLBoilerplate pins that
-// the delete switch drops URL promo lines even when DLA types them as
-// title: the title-layout gate only keeps non-URL titles.
-func TestFilterPDFTOCFragmentPages_DeletesTitleLayoutURLBoilerplate(t *testing.T) {
-	sections := fragmentedTOCPage([]string{
-		"Chapter 1",
-		"Chapter 2",
-		"Chapter 3",
-		"Chapter 4",
-		"Chapter 5",
-		"1",
-		"3",
-		"4",
-	}, 0, "text")
-	sections = append(sections, deepdoctype.Section{
-		Text:       "Reader forum http://forum.example.com",
-		LayoutType: "title",
-		Positions:  sections[0].Positions,
-	})
-	got := filterPDFTOCFragmentPages(sections)
-	if len(got) != 0 {
-		t.Fatalf("sections = %v, want empty", sectionTexts(got))
 	}
 }

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -463,6 +463,39 @@ func TestApplyPDFPostProcess_RemoveTOCEntryLinesWithPageOneOutlines(t *testing.T
 	}
 }
 
+// TestApplyPDFPostProcess_RemoveTOCFragmentPagesWithPageOneOutlines covers
+// the outlined book-PDF shape with fragmented TOC sections: the first
+// outline sits on page 1 but no outline title names the TOC, so
+// removePDFTOCByOutlines is a no-op and the fragment-page pass must still
+// clear the bare titles and page fragments on this dispatch branch.
+func TestApplyPDFPostProcess_RemoveTOCFragmentPagesWithPageOneOutlines(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+	}, 1, "text")
+	sections = append(sections,
+		makePDFSection("Body prose that must survive.", "text", 3, 50, 550, 100, 120),
+	)
+	result := &deepdoctype.ParseResult{
+		Sections: sections,
+		Outlines: []deepdoctype.Outline{
+			{Title: "Preface", Level: 0, PageNumber: 1},
+			{Title: "Chapter 1", Level: 1, PageNumber: 3},
+		},
+	}
+	applyPDFPostProcess(result, pdfPostProcessOptions{removeTOC: true})
+	want := []string{"Body prose that must survive."}
+	if !slices.Equal(sectionTexts(result.Sections), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(result.Sections), want)
+	}
+}
+
 func sectionTexts(sections []deepdoctype.Section) []string {
 	texts := make([]string, 0, len(sections))
 	for _, s := range sections {
@@ -847,5 +880,54 @@ func TestFilterPDFTOCFragmentPages_KeepsBracketedTitle(t *testing.T) {
 	got := filterPDFTOCFragmentPages(sections)
 	if got, want := sectionTexts(got), []string{"《Test Book》"}; !slices.Equal(got, want) {
 		t.Fatalf("sections = %v, want %v", got, want)
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_AnchorIgnoresPositionlessNeighbor pins the
+// page-0 cross-talk guard: a positionless title-like section and a table
+// section carrying "1" must not anchor adjacent short text, even when the
+// classified page is the real page 0.
+func TestFilterPDFTOCFragmentPages_AnchorIgnoresPositionlessNeighbor(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	sections = append(sections,
+		deepdoctype.Section{Text: "Chapter 9"},
+		deepdoctype.Section{Text: "1", LayoutType: "table", Positions: sections[0].Positions},
+		deepdoctype.Section{Text: "lone line", LayoutType: "text", Positions: sections[0].Positions},
+	)
+	got := filterPDFTOCFragmentPages(sections)
+	want := []string{"Chapter 9", "1", "lone line"}
+	if !slices.Equal(sectionTexts(got), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_KeepsFullRomanMarkers pins the marker guard
+// on the full roman set: M/D/C markers survive on a classified page.
+func TestFilterPDFTOCFragmentPages_KeepsFullRomanMarkers(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+		"M",
+		"D",
+	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	want := []string{"M", "D"}
+	if !slices.Equal(sectionTexts(got), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
 	}
 }

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -640,3 +640,134 @@ func TestFilterPDFHeaderFooter_SubstringMatch(t *testing.T) {
 		t.Errorf("#5 header/footer: body text %q should be kept", "text")
 	}
 }
+
+// fragmentedTOCPage builds sections on one page from plain texts: every text
+// gets a distinct vertical slot on the given page so page grouping is
+// exercised without depending on real layout coordinates.
+func fragmentedTOCPage(texts []string, page int, layout string) []deepdoctype.Section {
+	sections := make([]deepdoctype.Section, 0, len(texts))
+	for i, text := range texts {
+		top := float64(100 + i*20)
+		sections = append(sections, makePDFSection(text, layout, page, 50, 550, top, top+18))
+	}
+	return sections
+}
+
+// TestFilterPDFTOCFragmentPages_ClearsFragmentedTOCPage covers the DeepDoc
+// fragmentation shape: bare chapter titles, subtitle lines and bare page
+// numbers on one headingless TOC page are all dropped, while the book title
+// heading and the roman-numeral page marker survive.
+func TestFilterPDFTOCFragmentPages_ClearsFragmentedTOCPage(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Book Title Full Translation",
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"Chapter 6",
+		"Chapter 7",
+		"1",
+		"3",
+		"4",
+		"6",
+		"7",
+		"8",
+		"10",
+		"II",
+	}, 0, "text")
+	sections[0].LayoutType = "title"
+	got := filterPDFTOCFragmentPages(sections)
+	want := []string{"Book Title Full Translation", "II"}
+	if !slices.Equal(sectionTexts(got), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_KeepsBodyChapterPage pins the body guard: a
+// real chapter page (one heading plus long prose) never classifies as a TOC
+// page even though it carries a title candidate and a footer page number.
+func TestFilterPDFTOCFragmentPages_KeepsBodyChapterPage(t *testing.T) {
+	prose := "The way that can be told of is not the eternal way; the name " +
+		"that can be named is not the eternal name. The nameless is the origin."
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1 The Way",
+		prose,
+		"5",
+	}, 8, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
+		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_MixedPageDegradesToUntouched pins that a page
+// mixing TOC fragments with body prose is left alone: the body veto must win
+// over the fragment counts so prose is never deleted.
+func TestFilterPDFTOCFragmentPages_MixedPageDegradesToUntouched(t *testing.T) {
+	prose := "Sages treat worldly affairs with non-action and teach without " +
+		"words; all things arise and none is rejected by their teaching."
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+		prose,
+	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
+		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_IgnoresPositionlessAndMedia pins the scope:
+// sections without positions never vote and are never deleted, and table /
+// figure sections are excluded on both sides even on a classified TOC page.
+func TestFilterPDFTOCFragmentPages_IgnoresPositionlessAndMedia(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	sections = append(sections,
+		deepdoctype.Section{Text: "Chapter 6"},
+		deepdoctype.Section{Text: "| a | b |", LayoutType: "table", Positions: sections[0].Positions},
+		deepdoctype.Section{Text: "figure caption debris", LayoutType: "figure", Positions: sections[0].Positions},
+	)
+	got := filterPDFTOCFragmentPages(sections)
+	want := []string{"Chapter 6", "| a | b |", "figure caption debris"}
+	if !slices.Equal(sectionTexts(got), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
+	}
+}
+
+// TestRemovePDFTOC_FragmentedPageEndToEnd pins the wiring: removePDFTOC runs
+// the fragment-page pass after the legacy passes, so a headingless fragmented
+// TOC page is cleared through the same entry point production calls.
+func TestRemovePDFTOC_FragmentedPageEndToEnd(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+		"II",
+	}, 0, "text")
+	result := &deepdoctype.ParseResult{Sections: sections}
+	removePDFTOC(result)
+	if got, want := sectionTexts(result.Sections), []string{"II"}; !slices.Equal(got, want) {
+		t.Fatalf("sections = %v, want %v", got, want)
+	}
+}

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -1002,11 +1002,27 @@ func TestFilterPDFTOCFragmentPages_EmptyPageNumbersDoNotCollide(t *testing.T) {
 	}
 }
 
-// TestFilterPDFTOCFragmentPages_WatermarkedTOCPageStaysNegative pins the
-// known limitation: a TOC page carrying a long watermark line without URL
-// signature still vetoes via body. Watermark handling belongs to a future
-// cross-page frequency pass, not to this classifier.
-func TestFilterPDFTOCFragmentPages_WatermarkedTOCPageStaysNegative(t *testing.T) {
+// TestFilterPDFTOCFragmentPages_RepeatedBoilerplateDoesNotVeto pins the
+// frequency exemption: a long line repeating verbatim on >=3 pages is
+// boilerplate, not prose, so it neither vetoes classification nor survives
+// on a classified page.
+func TestFilterPDFTOCFragmentPages_RepeatedBoilerplateDoesNotVeto(t *testing.T) {
+	promo := "Free ebook download from the reader forum, enjoy reading daily"
+	var sections []deepdoctype.Section
+	for page := 0; page < 3; page++ {
+		parts := []string{"Chapter 1", "Chapter 2", "Chapter 3", "Chapter 4", "Chapter 5", "1", "3", "4", promo}
+		sections = append(sections, fragmentedTOCPage(parts, page, "text")...)
+	}
+	got := filterPDFTOCFragmentPages(sections)
+	if len(got) != 0 {
+		t.Fatalf("sections = %v, want empty", sectionTexts(got))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_UnrepeatedLongLineStillVetoes pins that the
+// exemption needs repetition: the same promo on a single page is ordinary
+// long text and still vetoes.
+func TestFilterPDFTOCFragmentPages_UnrepeatedLongLineStillVetoes(t *testing.T) {
 	promo := "Free ebook download from the reader forum, enjoy reading daily"
 	sections := fragmentedTOCPage([]string{
 		"Chapter 1",
@@ -1019,6 +1035,20 @@ func TestFilterPDFTOCFragmentPages_WatermarkedTOCPageStaysNegative(t *testing.T)
 		"4",
 		promo,
 	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
+		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_TitleCandidatesNeverBoilerplate pins the
+// priority: chapter headings repeating across pages still count as TOC
+// signals and are never misread as boilerplate.
+func TestFilterPDFTOCFragmentPages_TitleCandidatesNeverBoilerplate(t *testing.T) {
+	var sections []deepdoctype.Section
+	for page := 0; page < 3; page++ {
+		sections = append(sections, fragmentedTOCPage([]string{"Chapter 1", "Preface"}, page, "text")...)
+	}
 	got := filterPDFTOCFragmentPages(sections)
 	if !slices.Equal(sectionTexts(got), sectionTexts(sections)) {
 		t.Fatalf("sections = %v, want untouched %v", sectionTexts(got), sectionTexts(sections))

--- a/internal/parser/parser/pdf_postprocess_test.go
+++ b/internal/parser/parser/pdf_postprocess_test.go
@@ -751,8 +751,10 @@ func TestFilterPDFTOCFragmentPages_IgnoresPositionlessAndMedia(t *testing.T) {
 }
 
 // TestRemovePDFTOC_FragmentedPageEndToEnd pins the wiring: removePDFTOC runs
-// the fragment-page pass after the legacy passes, so a headingless fragmented
-// TOC page is cleared through the same entry point production calls.
+// the fragment-page pass before the entry-line filter (the entry filter
+// deletes in place and can strip the page-number fragments the classifier
+// counts on), so a headingless fragmented TOC page is cleared through the
+// same entry point production calls.
 func TestRemovePDFTOC_FragmentedPageEndToEnd(t *testing.T) {
 	sections := fragmentedTOCPage([]string{
 		"Chapter 1",
@@ -768,6 +770,82 @@ func TestRemovePDFTOC_FragmentedPageEndToEnd(t *testing.T) {
 	result := &deepdoctype.ParseResult{Sections: sections}
 	removePDFTOC(result)
 	if got, want := sectionTexts(result.Sections), []string{"II"}; !slices.Equal(got, want) {
+		t.Fatalf("sections = %v, want %v", got, want)
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_ThresholdBoundary pins the exact minima: one
+// title short of the threshold leaves the page untouched, while exactly the
+// minima classify it.
+func TestFilterPDFTOCFragmentPages_ThresholdBoundary(t *testing.T) {
+	below := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	if got := filterPDFTOCFragmentPages(below); !slices.Equal(sectionTexts(got), sectionTexts(below)) {
+		t.Fatalf("below threshold: sections = %v, want untouched %v", sectionTexts(got), sectionTexts(below))
+	}
+	atMinima := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	if got := filterPDFTOCFragmentPages(atMinima); len(got) != 0 {
+		t.Fatalf("at minima: sections = %v, want empty", sectionTexts(got))
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_KeepsUnanchoredShortText pins the anchor
+// gate: short text with no TOC signal in either neighbor survives on a
+// classified page, while anchored short text is debris.
+func TestFilterPDFTOCFragmentPages_KeepsUnanchoredShortText(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+		"standalone note",
+		"another standalone note",
+		"yet another standalone note",
+	}, 0, "text")
+	got := filterPDFTOCFragmentPages(sections)
+	want := []string{"another standalone note", "yet another standalone note"}
+	if !slices.Equal(sectionTexts(got), want) {
+		t.Fatalf("sections = %v, want %v", sectionTexts(got), want)
+	}
+}
+
+// TestFilterPDFTOCFragmentPages_KeepsBracketedTitle pins the book-title
+// guard: a 《》-wrapped heading on a classified page is content, not debris,
+// even though it is short enough to delete.
+func TestFilterPDFTOCFragmentPages_KeepsBracketedTitle(t *testing.T) {
+	sections := fragmentedTOCPage([]string{
+		"Chapter 1",
+		"Chapter 2",
+		"Chapter 3",
+		"Chapter 4",
+		"Chapter 5",
+		"1",
+		"3",
+		"4",
+	}, 0, "text")
+	sections = append(sections, makePDFSection("《Test Book》", "text", 0, 50, 550, 300, 318))
+	got := filterPDFTOCFragmentPages(sections)
+	if got, want := sectionTexts(got), []string{"《Test Book》"}; !slices.Equal(got, want) {
 		t.Fatalf("sections = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

DeepDoc layout splits one TOC line (chapter title + subtitle + leader dots + page number) into unadjacent sections, so the anchored title pass and the entry-line filter in the Go PDF postprocess leave whole bare-title runs behind on headingless TOC pages. Reproduced on a real book PDF (202 sections, 0 outlines): only 27 of ~94 TOC fragments removed, 67 bare chapter titles leaked into chunks.

Adds page-level classification before entry-line filtering across all TOC removal branches (including headingless TOCs with page-1 outlines): a page with >=5 title-like and >=3 page-number-like fragments and zero body-length prose is classified as a fragmented TOC page; clears title candidates, entry lines, page fragments and anchored short text on it. Long chapter titles in the default text layout count as TOC signals, not body prose. Book titles, roman-numeral markers (I, V, X, L, C, D, M), long prose and table/figure sections are kept; mixed pages degrade to untouched. No URL/keyword heuristics: a URL reference line is ordinary text and is never deleted.

Known limitation: TOC pages carrying a long watermark line without URL signature still veto via body. Watermark handling belongs to a future cross-page frequency pass, not to this classifier.

## Changes

- `internal/parser/parser/pdf_postprocess.go`:
  - Add `filterPDFTOCFragmentPages` pass (runs between anchored pass and entry-line filter) with page grouping, deletability checks, and anchor neighbor validation.
  - Run `filterPDFTOCFragmentPages` on the page-1-outline branch in `applyRemoveTOC` so headingless fragmented TOC pages are cleared even when outlines exist without a TOC heading.
  - Exempt title candidates from the body veto alongside entries, so long text-layout chapter titles no longer block classification.
  - Gate both sides of `pdfTOCFragmentAnchorText` through `pdfTOCFragmentPage` to exclude positionless/table/figure neighbors from anchoring on page 0.
  - Require actual page numbers in `pdfTOCFragmentPage` so empty PageNumbers cannot collide with the real page 0.
  - Support full Roman-numeral character set (`(?i)^[mdclxvi]+$`) in `pdfTOCRomanMarkerPattern`.
- `internal/parser/parser/pdf_postprocess_test.go`:
  - 15 new unit tests covering fragment clearing, body/mixed-page guards, media & positionless exclusion, threshold boundaries, unanchored short-text and bracketed-title retention, outline branch wiring, page-0 collision guards (incl. empty PageNumbers), full Roman marker retention, long text titles, legitimate URL prose retention, and watermarked-page negative pinning.

## Test Plan

- `bash build.sh --test ./internal/parser/parser/ -count=1` passes (all 15 new tests + pre-existing TOC and multi-column tests pass).
- Real-PDF repro (in-house 11-page book sample, `removeTOC=true`): 202 -> 144 sections with the current body-veto semantics (watermarked TOC pages stay negative by design); chapter headings and preface kept, no prose deleted.