### PR TITLE
fix(embedding): use Replicate run API for query embeddings

### DIFF
--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -1130,8 +1130,8 @@ class ReplicateEmbed(Base):
         return np.array(ress), token_count
 
     def encode_queries(self, text):
-        res = self.client.embed(self.model_name, input={"texts": [text]})
-        return np.array(res), num_tokens_from_string(text)
+        vectors, token_count = self.encode([text])
+        return vectors[0], token_count
 
 
 class BaiduYiyanEmbed(Base):

--- a/test/unit_test/rag/llm/test_embedding_model.py
+++ b/test/unit_test/rag/llm/test_embedding_model.py
@@ -45,6 +45,7 @@ from rag.llm.embedding_model import (
     NvidiaEmbed,
     OllamaEmbed,
     OpenAIEmbed,
+    ReplicateEmbed,
     ZhipuEmbed,
 )
 from common.exceptions import ModelException
@@ -367,6 +368,22 @@ class TestNvidiaInputType:
         with patch("rag.llm.embedding_model.requests.post", return_value=self._mock_resp()) as post:
             embed.encode_queries("a query")
         assert post.call_args.kwargs["json"]["input_type"] == "query"
+
+
+@pytest.mark.p2
+class TestReplicateEmbedding:
+    def test_query_uses_run_and_returns_single_vector(self):
+        embed = ReplicateEmbed.__new__(ReplicateEmbed)
+        embed.model_name = "owner/model:version"
+        embed.client = MagicMock(spec=["run"])
+        embed.client.run.return_value = [[1.0, 2.0, 3.0]]
+
+        vector, tokens = embed.encode_queries("hello")
+
+        embed.client.run.assert_called_once_with("owner/model:version", input={"texts": ["hello"]})
+        assert vector.shape == (3,)
+        np.testing.assert_array_equal(vector, np.array([1.0, 2.0, 3.0]))
+        assert tokens == num_tokens_from_string("hello")
 
 
 @pytest.mark.p2


### PR DESCRIPTION
### Summary

Fix `ReplicateEmbed.encode_queries()` calling a method that is unavailable in the currently pinned Replicate SDK.

The pinned Replicate SDK does not provide `Client.embed()`. The document embedding path already uses the supported `Client.run()` API, so this change reuses that path for a single query and removes the batch dimension from the result.

### Problem

RAGFlow exposes two Replicate embedding models in `conf/models/replicate.json`.
Model validation and document embedding call `ReplicateEmbed.encode()`, which uses `Client.run()`. Retrieval operations that generate a query vector follow this path:

`Dealer.get_vector()` -> `LLMBundle.encode_queries()` -> `ReplicateEmbed.encode_queries()`.

The query implementation currently calls a different SDK method:

```python
res = self.client.embed(self.model_name, input={"texts": [text]})
return np.array(res), num_tokens_from_string(text)
```

RAGFlow pins `replicate==0.31.0`, where `Client.run()` exists but `Client.embed()` does not. A dataset may therefore be embedded successfully, while generating a query vector with the same model fails before an HTTP request is sent:

```text
AttributeError: 'Client' object has no attribute 'embed'
```

After using a supported SDK method, the result shape also needs to satisfy the query-vector contract. If the API returns a single-item batch, converting it directly to an array retains the batch dimension, while `rag/nlp/search.py` expects a one-dimensional query vector.

### Change

- Reuse `ReplicateEmbed.encode([text])`, which already calls the supported `Client.run()` API and handles token counting.
- Return the first batch item so that `encode_queries()` satisfies the one-dimensional query-vector contract.
- Add a regression test with a run-only mock client that verifies the request.
