### PR TITLE
fix(data_source): support custom base URL and HTTP for Azure DevOps c…

### DIFF
--- a/common/data_source/azure_devops/connector.py
+++ b/common/data_source/azure_devops/connector.py
@@ -4,7 +4,8 @@ import copy
 import logging
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from typing_extensions import override
 
@@ -582,12 +583,20 @@ class AzureDevOpsConnector(
         An unknown selector would otherwise pass silently and the sync would
         complete without producing a single document.
         """
-        if not self.organization and not self.base_url:
-            raise UnexpectedValidationError("Azure DevOps organization or base URL must be provided.")
-        if self.base_url and not self.base_url.startswith(("http://", "https://")):
-            raise UnexpectedValidationError("Azure DevOps base URL must use HTTP or HTTPS.")
-        if self.organization and "://" in self.organization and not self.organization.startswith(("http://", "https://")):
-            raise UnexpectedValidationError("Azure DevOps organization URL must use HTTP or HTTPS.")
+        if not self.organization:
+            raise UnexpectedValidationError("Azure DevOps organization or collection must be provided.")
+        if self.base_url:
+            if not self.base_url.startswith(("http://", "https://")):
+                raise UnexpectedValidationError("Azure DevOps base URL must use HTTP or HTTPS.")
+            parsed_base = urlparse(self.base_url)
+            if parsed_base.username or parsed_base.password:
+                raise UnexpectedValidationError("Azure DevOps base URL must not contain credentials; provide a personal access token instead.")
+        if self.organization and "://" in self.organization:
+            if not self.organization.startswith(("http://", "https://")):
+                raise UnexpectedValidationError("Azure DevOps organization URL must use HTTP or HTTPS.")
+            parsed_org = urlparse(self.organization)
+            if parsed_org.username or parsed_org.password:
+                raise UnexpectedValidationError("Azure DevOps organization URL must not contain credentials; provide a personal access token instead.")
         if self.index_mode not in (INDEX_MODE_ORGANIZATION, INDEX_MODE_PROJECTS, INDEX_MODE_REPOSITORIES):
             raise UnexpectedValidationError(f"Unsupported index mode: {self.index_mode}")
         if self.content_types not in (CONTENT_CODE, CONTENT_PULL_REQUESTS, CONTENT_BOTH):

--- a/common/data_source/azure_devops/connector.py
+++ b/common/data_source/azure_devops/connector.py
@@ -100,10 +100,12 @@ class AzureDevOpsConnector(
 
     Works against both Azure DevOps Services and self-hosted Azure DevOps Server:
     pass a bare organization name for the former, or the full collection URL for
-    the latter.
+    the latter, or provide a custom base URL.
 
     Args:
         organization: Organization name, or base URL of a self-hosted collection.
+        base_url: Optional custom base URL (e.g. https://dev.azure.com or
+            http://tfs.corp.local:8080/tfs).
         index_mode: Scope selector — ``organization``, ``projects`` or ``repositories``.
         projects: Comma-separated team projects, used when ``index_mode`` is ``projects``.
         repositories: Comma-separated repositories, used when ``index_mode`` is
@@ -114,14 +116,20 @@ class AzureDevOpsConnector(
 
     def __init__(
         self,
-        organization: str,
+        organization: str | None = None,
+        base_url: str | None = None,
         index_mode: str = INDEX_MODE_ORGANIZATION,
         projects: str | None = None,
         repositories: str | None = None,
         content_types: str = CONTENT_BOTH,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:
-        self.organization = organization
+        self.base_url = (base_url or "").strip() or None
+        self.organization = (organization or "").strip()
+        if not self.organization and self.base_url:
+            path_segments = [seg for seg in self.base_url.split("://", 1)[-1].split("/")[1:] if seg]
+            if path_segments:
+                self.organization = path_segments[-1]
         self.index_mode = index_mode or INDEX_MODE_ORGANIZATION
         self._projects = self._split(projects)
         self._repositories = self._split(repositories)
@@ -139,6 +147,7 @@ class AzureDevOpsConnector(
         credentials = config.get("credentials") or {}
         connector = cls(
             organization=config.get("organization"),
+            base_url=config.get("base_url"),
             index_mode=config.get("index_mode") or INDEX_MODE_ORGANIZATION,
             projects=config.get("projects"),
             repositories=config.get("repositories"),
@@ -156,7 +165,7 @@ class AzureDevOpsConnector(
 
     @property
     def _org_url(self) -> str:
-        return organization_url(self.organization)
+        return organization_url(self.organization, self.base_url)
 
     def _client(self) -> "httpx.Client":
         if not self.personal_access_token:
@@ -573,6 +582,12 @@ class AzureDevOpsConnector(
         An unknown selector would otherwise pass silently and the sync would
         complete without producing a single document.
         """
+        if not self.organization and not self.base_url:
+            raise UnexpectedValidationError("Azure DevOps organization or base URL must be provided.")
+        if self.base_url and not self.base_url.startswith(("http://", "https://")):
+            raise UnexpectedValidationError("Azure DevOps base URL must use HTTP or HTTPS.")
+        if self.organization and "://" in self.organization and not self.organization.startswith(("http://", "https://")):
+            raise UnexpectedValidationError("Azure DevOps organization URL must use HTTP or HTTPS.")
         if self.index_mode not in (INDEX_MODE_ORGANIZATION, INDEX_MODE_PROJECTS, INDEX_MODE_REPOSITORIES):
             raise UnexpectedValidationError(f"Unsupported index mode: {self.index_mode}")
         if self.content_types not in (CONTENT_CODE, CONTENT_PULL_REQUESTS, CONTENT_BOTH):
@@ -603,7 +618,8 @@ class AzureDevOpsConnector(
                 )
                 raise_for_auth(response)
                 if response.status_code == 404:
-                    raise UnexpectedValidationError(f"Azure DevOps organization not found: {self.organization}")
+                    target = self.organization or self.base_url or "organization"
+                    raise UnexpectedValidationError(f"Azure DevOps organization not found: {target}")
                 if response.status_code < 200 or response.status_code >= 300:
                     raise UnexpectedValidationError(f"Unexpected Azure DevOps error (status={response.status_code}).")
 

--- a/common/data_source/azure_devops/utils.py
+++ b/common/data_source/azure_devops/utils.py
@@ -101,18 +101,38 @@ def build_auth_client(personal_access_token: str) -> httpx.Client:
     return httpx.Client(auth=("", personal_access_token), timeout=REQUEST_TIMEOUT_SECONDS)
 
 
-def organization_url(organization: str) -> str:
+def organization_url(organization: str | None = None, base_url: str | None = None) -> str:
     """Resolve the API root for a hosted organization or a self-hosted server.
 
-    ``organization`` may be a bare organization name (Azure DevOps Services) or a
-    full base URL such as ``https://tfs.contoso.com/DefaultCollection`` for
-    Azure DevOps Server.
+    ``organization`` may be a bare organization name (Azure DevOps Services),
+    a collection name, or a full base URL such as
+    ``https://tfs.contoso.com/DefaultCollection`` for Azure DevOps Server.
+
+    ``base_url`` is an optional custom base URL (e.g. ``https://dev.azure.com``,
+    ``https://tfs.contoso.com/tfs``, or ``http://tfs.corp.local:8080/tfs``).
     """
-    if organization.startswith("http://"):
-        raise UnexpectedValidationError("Azure DevOps collection URLs must use HTTPS; the personal access token is sent in the Authorization header.")
-    if organization.startswith("https://"):
-        return organization.rstrip("/")
-    return f"https://dev.azure.com/{quote(organization, safe='')}"
+    clean_base = (base_url or "").strip().rstrip("/")
+    clean_org = (organization or "").strip().rstrip("/")
+
+    if clean_base:
+        if not clean_base.startswith(("http://", "https://")):
+            raise UnexpectedValidationError("Azure DevOps base URL must use HTTP or HTTPS.")
+        if not clean_org:
+            return clean_base
+        if clean_org.startswith(("http://", "https://")):
+            return clean_org
+        if clean_base.endswith((f"/{clean_org}", f"/{quote(clean_org, safe='')}")):
+            return clean_base
+        return f"{clean_base}/{quote(clean_org, safe='')}"
+
+    if not clean_org:
+        raise UnexpectedValidationError("Azure DevOps organization or base URL must be provided.")
+
+    if clean_org.startswith(("http://", "https://")):
+        return clean_org
+    if "://" in clean_org:
+        raise UnexpectedValidationError("Azure DevOps collection URLs must use HTTP or HTTPS.")
+    return f"https://dev.azure.com/{quote(clean_org, safe='')}"
 
 
 def raise_for_auth(response: httpx.Response, expect_json: bool = True) -> None:

--- a/common/data_source/azure_devops/utils.py
+++ b/common/data_source/azure_devops/utils.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import httpx
 
@@ -117,9 +117,18 @@ def organization_url(organization: str | None = None, base_url: str | None = Non
     if clean_base:
         if not clean_base.startswith(("http://", "https://")):
             raise UnexpectedValidationError("Azure DevOps base URL must use HTTP or HTTPS.")
+        parsed_base = urlparse(clean_base)
+        if parsed_base.username or parsed_base.password:
+            raise UnexpectedValidationError("Azure DevOps base URL must not contain credentials; provide a personal access token instead.")
         if not clean_org:
+            path_segments = [seg for seg in parsed_base.path.strip("/").split("/") if seg]
+            if not path_segments:
+                raise UnexpectedValidationError("Azure DevOps organization or collection must be provided.")
             return clean_base
         if clean_org.startswith(("http://", "https://")):
+            parsed_org = urlparse(clean_org)
+            if parsed_org.username or parsed_org.password:
+                raise UnexpectedValidationError("Azure DevOps organization URL must not contain credentials; provide a personal access token instead.")
             return clean_org
         if clean_base.endswith((f"/{clean_org}", f"/{quote(clean_org, safe='')}")):
             return clean_base
@@ -129,6 +138,9 @@ def organization_url(organization: str | None = None, base_url: str | None = Non
         raise UnexpectedValidationError("Azure DevOps organization or base URL must be provided.")
 
     if clean_org.startswith(("http://", "https://")):
+        parsed_org = urlparse(clean_org)
+        if parsed_org.username or parsed_org.password:
+            raise UnexpectedValidationError("Azure DevOps organization URL must not contain credentials; provide a personal access token instead.")
         return clean_org
     if "://" in clean_org:
         raise UnexpectedValidationError("Azure DevOps collection URLs must use HTTP or HTTPS.")

--- a/internal/syncer/connector/azure_devops.go
+++ b/internal/syncer/connector/azure_devops.go
@@ -241,8 +241,8 @@ func (c *AzureDevOpsConnector) checkSettings() error {
 	if c == nil {
 		return fmt.Errorf("azure devops connector is nil")
 	}
-	if c.organization == "" && c.baseURL == "" {
-		return fmt.Errorf("Invalid connector settings: 'organization' or 'base_url' must be provided")
+	if c.organization == "" {
+		return fmt.Errorf("Invalid connector settings: Azure DevOps organization or collection must be provided")
 	}
 	if c.pat == "" {
 		return fmt.Errorf("Missing azure_devops_pat in credentials")
@@ -251,10 +251,16 @@ func (c *AzureDevOpsConnector) checkSettings() error {
 		if !strings.HasPrefix(c.customBaseURL, "http://") && !strings.HasPrefix(c.customBaseURL, "https://") {
 			return fmt.Errorf("Invalid connector settings: Azure DevOps base URL must use HTTP or HTTPS")
 		}
+		if u, err := url.Parse(c.customBaseURL); err == nil && u.User != nil {
+			return fmt.Errorf("Invalid connector settings: Azure DevOps base URL must not contain credentials")
+		}
 	}
 	if c.organization != "" && strings.Contains(c.organization, "://") {
 		if !strings.HasPrefix(c.organization, "http://") && !strings.HasPrefix(c.organization, "https://") {
 			return fmt.Errorf("Invalid connector settings: Azure DevOps collection URLs must use HTTP or HTTPS")
+		}
+		if u, err := url.Parse(c.organization); err == nil && u.User != nil {
+			return fmt.Errorf("Invalid connector settings: Azure DevOps collection URL must not contain credentials")
 		}
 	}
 	switch c.indexMode {

--- a/internal/syncer/connector/azure_devops.go
+++ b/internal/syncer/connector/azure_devops.go
@@ -95,15 +95,16 @@ func (e *azureDevOpsHTTPError) Error() string {
 
 // AzureDevOpsConnector reads Azure Repos source files and pull requests.
 type AzureDevOpsConnector struct {
-	organization string
-	indexMode    string
-	projects     []string
-	repositories []string
-	contentTypes string
-	pat          string
-	batchSize    int
-	baseURL      string
-	httpClient   *http.Client
+	organization  string
+	customBaseURL string
+	indexMode     string
+	projects      []string
+	repositories  []string
+	contentTypes  string
+	pat           string
+	batchSize     int
+	baseURL       string
+	httpClient    *http.Client
 }
 
 // azureDevOpsRepository is one repository selected for indexing.
@@ -158,36 +159,63 @@ type azureDevOpsPullRequest struct {
 func NewAzureDevOpsConnector(config map[string]any) (*AzureDevOpsConnector, error) {
 	credentials, _ := config["credentials"].(map[string]any)
 	organization := strings.TrimSpace(stringConfig(config["organization"]))
+	customBaseURL := strings.TrimRight(strings.TrimSpace(stringConfig(config["base_url"])), "/")
+
+	baseURL, effectiveOrg := azureDevOpsResolveURL(organization, customBaseURL)
 
 	connector := &AzureDevOpsConnector{
-		organization: organization,
-		indexMode:    firstNonEmpty(strings.TrimSpace(stringConfig(config["index_mode"])), azureDevOpsIndexModeOrganization),
-		projects:     splitAzureDevOpsList(stringConfig(config["projects"])),
-		repositories: splitAzureDevOpsList(stringConfig(config["repositories"])),
-		contentTypes: firstNonEmpty(strings.TrimSpace(stringConfig(config["content_types"])), azureDevOpsContentBoth),
-		pat:          strings.TrimSpace(stringConfig(credentials["azure_devops_pat"])),
-		batchSize:    configInt(config["batch_size"], defaultAzureDevOpsBatchSize),
-		baseURL:      azureDevOpsOrganizationURL(organization),
-		httpClient:   &http.Client{Timeout: 60 * time.Second},
+		organization:  effectiveOrg,
+		customBaseURL: customBaseURL,
+		indexMode:     firstNonEmpty(strings.TrimSpace(stringConfig(config["index_mode"])), azureDevOpsIndexModeOrganization),
+		projects:      splitAzureDevOpsList(stringConfig(config["projects"])),
+		repositories:  splitAzureDevOpsList(stringConfig(config["repositories"])),
+		contentTypes:  firstNonEmpty(strings.TrimSpace(stringConfig(config["content_types"])), azureDevOpsContentBoth),
+		pat:           strings.TrimSpace(stringConfig(credentials["azure_devops_pat"])),
+		batchSize:     configInt(config["batch_size"], defaultAzureDevOpsBatchSize),
+		baseURL:       baseURL,
+		httpClient:    &http.Client{Timeout: 60 * time.Second},
 	}
 	return connector, nil
+}
+
+func azureDevOpsResolveURL(organization, customBaseURL string) (string, string) {
+	cleanBase := strings.TrimRight(strings.TrimSpace(customBaseURL), "/")
+	cleanOrg := strings.TrimRight(strings.TrimSpace(organization), "/")
+
+	if cleanBase != "" {
+		if cleanOrg == "" {
+			if u, err := url.Parse(cleanBase); err == nil && u.Path != "" {
+				trimmedPath := strings.Trim(u.Path, "/")
+				if trimmedPath != "" {
+					parts := strings.Split(trimmedPath, "/")
+					cleanOrg = parts[len(parts)-1]
+				}
+			}
+			return cleanBase, cleanOrg
+		}
+		if strings.HasPrefix(cleanOrg, "http://") || strings.HasPrefix(cleanOrg, "https://") {
+			return cleanOrg, cleanOrg
+		}
+		if strings.HasSuffix(cleanBase, "/"+cleanOrg) || strings.HasSuffix(cleanBase, "/"+url.PathEscape(cleanOrg)) {
+			return cleanBase, cleanOrg
+		}
+		return cleanBase + "/" + url.PathEscape(cleanOrg), cleanOrg
+	}
+
+	if cleanOrg == "" {
+		return "", ""
+	}
+	if strings.HasPrefix(cleanOrg, "http://") || strings.HasPrefix(cleanOrg, "https://") {
+		return cleanOrg, cleanOrg
+	}
+	return azureDevOpsHostedBaseURL + "/" + url.PathEscape(cleanOrg), cleanOrg
 }
 
 // azureDevOpsOrganizationURL resolves the API root of a hosted organization or
 // a self-hosted Azure DevOps Server collection.
 func azureDevOpsOrganizationURL(organization string) string {
-	if organization == "" {
-		return ""
-	}
-	if strings.HasPrefix(organization, "http://") {
-		// Rejected in checkSettings; never build a client that would send the
-		// personal access token in cleartext.
-		return ""
-	}
-	if strings.HasPrefix(organization, "https://") {
-		return strings.TrimRight(organization, "/")
-	}
-	return azureDevOpsHostedBaseURL + "/" + url.PathEscape(organization)
+	baseURL, _ := azureDevOpsResolveURL(organization, "")
+	return baseURL
 }
 
 func splitAzureDevOpsList(value string) []string {
@@ -213,14 +241,21 @@ func (c *AzureDevOpsConnector) checkSettings() error {
 	if c == nil {
 		return fmt.Errorf("azure devops connector is nil")
 	}
-	if c.organization == "" {
-		return fmt.Errorf("Invalid connector settings: 'organization' must be provided")
+	if c.organization == "" && c.baseURL == "" {
+		return fmt.Errorf("Invalid connector settings: 'organization' or 'base_url' must be provided")
 	}
 	if c.pat == "" {
 		return fmt.Errorf("Missing azure_devops_pat in credentials")
 	}
-	if strings.HasPrefix(c.organization, "http://") {
-		return fmt.Errorf("Invalid connector settings: Azure DevOps collection URLs must use HTTPS, the personal access token is sent in the Authorization header")
+	if c.customBaseURL != "" {
+		if !strings.HasPrefix(c.customBaseURL, "http://") && !strings.HasPrefix(c.customBaseURL, "https://") {
+			return fmt.Errorf("Invalid connector settings: Azure DevOps base URL must use HTTP or HTTPS")
+		}
+	}
+	if c.organization != "" && strings.Contains(c.organization, "://") {
+		if !strings.HasPrefix(c.organization, "http://") && !strings.HasPrefix(c.organization, "https://") {
+			return fmt.Errorf("Invalid connector settings: Azure DevOps collection URLs must use HTTP or HTTPS")
+		}
 	}
 	switch c.indexMode {
 	case azureDevOpsIndexModeOrganization, azureDevOpsIndexModeProjects, azureDevOpsIndexModeRepositories:

--- a/internal/syncer/connector/azure_devops_test.go
+++ b/internal/syncer/connector/azure_devops_test.go
@@ -681,6 +681,54 @@ func TestAzureDevOpsRejectsInvalidScheme(t *testing.T) {
 	}
 }
 
+func TestAzureDevOpsRejectsRootBaseURLWithoutOrganization(t *testing.T) {
+	connector, err := NewAzureDevOpsConnector(map[string]any{
+		"base_url":    "https://dev.azure.com",
+		"credentials": map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := connector.Validate(context.Background()); err == nil || !strings.Contains(err.Error(), "organization or collection") {
+		t.Fatalf("root base URL without organization must be rejected, got %v", err)
+	}
+
+	connectorHTTP, err := NewAzureDevOpsConnector(map[string]any{
+		"base_url":    "http://tfs.corp.local:8080",
+		"credentials": map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := connectorHTTP.Validate(context.Background()); err == nil || !strings.Contains(err.Error(), "organization or collection") {
+		t.Fatalf("root base URL without organization must be rejected, got %v", err)
+	}
+}
+
+func TestAzureDevOpsRejectsURLWithCredentials(t *testing.T) {
+	connectorBase, err := NewAzureDevOpsConnector(map[string]any{
+		"base_url":    "http://user:pass@tfs.corp.local:8080/tfs/DefaultCollection",
+		"credentials": map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := connectorBase.Validate(context.Background()); err == nil || !strings.Contains(err.Error(), "credentials") {
+		t.Fatalf("base URL with credentials must be rejected, got %v", err)
+	}
+
+	connectorOrg, err := NewAzureDevOpsConnector(map[string]any{
+		"organization": "http://user:pass@tfs.corp.local:8080/tfs/DefaultCollection",
+		"credentials":  map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := connectorOrg.Validate(context.Background()); err == nil || !strings.Contains(err.Error(), "credentials") {
+		t.Fatalf("organization URL with credentials must be rejected, got %v", err)
+	}
+}
+
 func TestAzureDevOpsRejectsUnknownSelectorValues(t *testing.T) {
 	for field, value := range map[string]string{"index_mode": "everything", "content_types": "everything"} {
 		connector, _ := NewAzureDevOpsConnector(map[string]any{

--- a/internal/syncer/connector/azure_devops_test.go
+++ b/internal/syncer/connector/azure_devops_test.go
@@ -89,6 +89,56 @@ func TestAzureDevOpsOrganizationURLSupportsSelfHostedCollection(t *testing.T) {
 	if got := azureDevOpsOrganizationURL("https://tfs.contoso.com/DefaultCollection/"); got != "https://tfs.contoso.com/DefaultCollection" {
 		t.Fatalf("unexpected self-hosted URL: %s", got)
 	}
+	if got := azureDevOpsOrganizationURL("http://tfs.contoso.local:8080/DefaultCollection/"); got != "http://tfs.contoso.local:8080/DefaultCollection" {
+		t.Fatalf("unexpected HTTP self-hosted URL: %s", got)
+	}
+}
+
+func TestAzureDevOpsSupportsCustomBaseURL(t *testing.T) {
+	connector, err := NewAzureDevOpsConnector(map[string]any{
+		"base_url":     "http://tfs.corp.local:8080/tfs",
+		"organization": "DefaultCollection",
+		"credentials":  map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if connector.baseURL != "http://tfs.corp.local:8080/tfs/DefaultCollection" {
+		t.Fatalf("unexpected baseURL: %s", connector.baseURL)
+	}
+	if connector.organization != "DefaultCollection" {
+		t.Fatalf("unexpected organization: %s", connector.organization)
+	}
+}
+
+func TestAzureDevOpsCustomBaseURLWithCollectionIncluded(t *testing.T) {
+	connector, err := NewAzureDevOpsConnector(map[string]any{
+		"base_url":     "https://tfs.corp.local/tfs/DefaultCollection",
+		"organization": "DefaultCollection",
+		"credentials":  map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if connector.baseURL != "https://tfs.corp.local/tfs/DefaultCollection" {
+		t.Fatalf("unexpected baseURL: %s", connector.baseURL)
+	}
+}
+
+func TestAzureDevOpsCustomBaseURLWithEmptyOrganization(t *testing.T) {
+	connector, err := NewAzureDevOpsConnector(map[string]any{
+		"base_url":    "http://tfs.corp.local:8080/tfs/DefaultCollection",
+		"credentials": map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if connector.baseURL != "http://tfs.corp.local:8080/tfs/DefaultCollection" {
+		t.Fatalf("unexpected baseURL: %s", connector.baseURL)
+	}
+	if connector.organization != "DefaultCollection" {
+		t.Fatalf("unexpected organization: %s", connector.organization)
+	}
 }
 
 func TestAzureDevOpsDefaultsIndexModeAndContentTypes(t *testing.T) {
@@ -605,7 +655,7 @@ func TestAzureDevOpsLongPullRequestDescriptionIsRefetchedInFull(t *testing.T) {
 	}
 }
 
-func TestAzureDevOpsRejectsCleartextCollectionURL(t *testing.T) {
+func TestAzureDevOpsAcceptsHTTPCollectionURLInClosedNetwork(t *testing.T) {
 	connector, err := NewAzureDevOpsConnector(map[string]any{
 		"organization": "http://tfs.contoso.com/DefaultCollection",
 		"credentials":  map[string]any{"azure_devops_pat": "token"},
@@ -613,8 +663,21 @@ func TestAzureDevOpsRejectsCleartextCollectionURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := connector.Validate(context.Background()); err == nil || !strings.Contains(err.Error(), "HTTPS") {
-		t.Fatalf("cleartext collection URLs must be rejected, got %v", err)
+	if connector.baseURL != "http://tfs.contoso.com/DefaultCollection" {
+		t.Fatalf("expected HTTP collection URL, got %s", connector.baseURL)
+	}
+}
+
+func TestAzureDevOpsRejectsInvalidScheme(t *testing.T) {
+	connector, err := NewAzureDevOpsConnector(map[string]any{
+		"base_url":    "ftp://tfs.contoso.com/tfs",
+		"credentials": map[string]any{"azure_devops_pat": "token"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := connector.Validate(context.Background()); err == nil || !strings.Contains(err.Error(), "HTTP") {
+		t.Fatalf("invalid scheme must be rejected, got %v", err)
 	}
 }
 

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -1971,6 +1971,7 @@ class AzureDevOps(SyncBase):
     async def _generate(self, task: dict):
         self.connector = AzureDevOpsConnector(
             organization=self.conf.get("organization"),
+            base_url=self.conf.get("base_url"),
             index_mode=self.conf.get("index_mode") or "organization",
             projects=self.conf.get("projects"),
             repositories=self.conf.get("repositories"),
@@ -2025,7 +2026,8 @@ class AzureDevOps(SyncBase):
             for batch in document_batches():
                 yield batch
 
-        self.log_connection("AzureDevOps", f"organization({self.conf.get('organization')})", task)
+        target = self.conf.get("base_url") or f"organization({self.conf.get('organization')})"
+        self.log_connection("AzureDevOps", target, task)
         return wrapper()
 
 

--- a/rag/svr/sync_data_source.py
+++ b/rag/svr/sync_data_source.py
@@ -34,6 +34,7 @@ import threading
 import traceback
 from datetime import UTC, datetime, timezone
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 from flask import json
 
@@ -108,6 +109,20 @@ def _redact_mailbox(value: str) -> str:
         local_mask = local if len(local) <= 2 else local[:2] + "***"
         return f"{local_mask}@***"
     return f"{value[:4]}***" if len(value) > 4 else "***"
+
+
+def _redact_url(value: str | None) -> str:
+    """Sanitize URL before logging, stripping user credentials, query, and fragment."""
+    if not value or "://" not in value:
+        return value or ""
+    try:
+        parsed = urlparse(value)
+        netloc = parsed.hostname or ""
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+        return urlunparse((parsed.scheme, netloc, parsed.path, "", "", ""))
+    except (ValueError, TypeError):
+        return value
 
 
 async def _iterate_document_batches(generator):
@@ -2026,7 +2041,7 @@ class AzureDevOps(SyncBase):
             for batch in document_batches():
                 yield batch
 
-        target = self.conf.get("base_url") or f"organization({self.conf.get('organization')})"
+        target = _redact_url(self.conf.get("base_url")) or f"organization({self.conf.get('organization')})"
         self.log_connection("AzureDevOps", target, task)
         return wrapper()
 

--- a/test/unit_test/data_source/test_azure_devops_connector_unit.py
+++ b/test/unit_test/data_source/test_azure_devops_connector_unit.py
@@ -273,32 +273,20 @@ def test_organization_url_accepts_http_in_closed_network():
 @pytest.mark.p2
 def test_organization_url_supports_custom_base_url():
     """Custom base URL combined with organization name."""
-    assert (
-        azure_utils.organization_url(organization="DefaultCollection", base_url="http://tfs.corp.local:8080/tfs")
-        == "http://tfs.corp.local:8080/tfs/DefaultCollection"
-    )
-    assert (
-        azure_utils.organization_url(organization="DefaultCollection", base_url="https://tfs.contoso.com/tfs")
-        == "https://tfs.contoso.com/tfs/DefaultCollection"
-    )
+    assert azure_utils.organization_url(organization="DefaultCollection", base_url="http://tfs.corp.local:8080/tfs") == "http://tfs.corp.local:8080/tfs/DefaultCollection"
+    assert azure_utils.organization_url(organization="DefaultCollection", base_url="https://tfs.contoso.com/tfs") == "https://tfs.contoso.com/tfs/DefaultCollection"
 
 
 @pytest.mark.p2
 def test_organization_url_custom_base_url_already_includes_organization():
     """When base_url already contains the collection, it must not be appended twice."""
-    assert (
-        azure_utils.organization_url(organization="DefaultCollection", base_url="http://tfs.corp.local:8080/tfs/DefaultCollection")
-        == "http://tfs.corp.local:8080/tfs/DefaultCollection"
-    )
+    assert azure_utils.organization_url(organization="DefaultCollection", base_url="http://tfs.corp.local:8080/tfs/DefaultCollection") == "http://tfs.corp.local:8080/tfs/DefaultCollection"
 
 
 @pytest.mark.p2
 def test_organization_url_custom_base_url_empty_organization():
     """Custom base URL without organization returns the base URL."""
-    assert (
-        azure_utils.organization_url(base_url="http://tfs.corp.local:8080/tfs/DefaultCollection")
-        == "http://tfs.corp.local:8080/tfs/DefaultCollection"
-    )
+    assert azure_utils.organization_url(base_url="http://tfs.corp.local:8080/tfs/DefaultCollection") == "http://tfs.corp.local:8080/tfs/DefaultCollection"
 
 
 @pytest.mark.p2
@@ -466,6 +454,28 @@ def test_connector_custom_base_url_extracts_organization():
 
 
 @pytest.mark.p2
+def test_organization_url_rejects_root_only_base_url_without_organization():
+    with pytest.raises(UnexpectedValidationError) as excinfo:
+        azure_utils.organization_url(base_url="https://dev.azure.com")
+    assert "organization or collection" in str(excinfo.value)
+
+    with pytest.raises(UnexpectedValidationError) as excinfo:
+        azure_utils.organization_url("", base_url="http://tfs.corp.local:8080")
+    assert "organization or collection" in str(excinfo.value)
+
+
+@pytest.mark.p2
+def test_organization_url_rejects_credentials_in_urls():
+    with pytest.raises(UnexpectedValidationError) as excinfo:
+        azure_utils.organization_url(organization="DefaultCollection", base_url="http://user:pass@tfs.corp.local:8080/tfs")
+    assert "credentials" in str(excinfo.value)
+
+    with pytest.raises(UnexpectedValidationError) as excinfo:
+        azure_utils.organization_url("http://user:pass@tfs.corp.local:8080/tfs/DefaultCollection")
+    assert "credentials" in str(excinfo.value)
+
+
+@pytest.mark.p2
 def test_html_body_is_not_an_auth_failure_for_raw_content():
     """A repository may legitimately contain .html files."""
     response = _FakeResponse(status_code=200, content_type="text/html", text="<html>page</html>")
@@ -482,6 +492,10 @@ def test_html_body_is_not_an_auth_failure_for_raw_content():
         {"organization": "", "base_url": ""},
         {"organization": "", "base_url": "ftp://invalid"},
         {"organization": "ftp://invalid", "base_url": ""},
+        {"organization": "", "base_url": "https://dev.azure.com"},
+        {"organization": "", "base_url": "http://tfs.corp.local:8080"},
+        {"organization": "DefaultCollection", "base_url": "http://user:pass@tfs.corp.local:8080/tfs"},
+        {"organization": "http://user:pass@tfs.corp.local:8080/tfs/DefaultCollection", "base_url": ""},
     ],
 )
 def test_unusable_settings_are_rejected_before_any_request(overrides):

--- a/test/unit_test/data_source/test_azure_devops_connector_unit.py
+++ b/test/unit_test/data_source/test_azure_devops_connector_unit.py
@@ -265,6 +265,43 @@ def test_organization_url_accepts_self_hosted_collection():
 
 
 @pytest.mark.p2
+def test_organization_url_accepts_http_in_closed_network():
+    """On-premises Azure DevOps Server inside a closed network often runs over HTTP."""
+    assert azure_utils.organization_url("http://tfs.contoso.local:8080/DefaultCollection/") == "http://tfs.contoso.local:8080/DefaultCollection"
+
+
+@pytest.mark.p2
+def test_organization_url_supports_custom_base_url():
+    """Custom base URL combined with organization name."""
+    assert (
+        azure_utils.organization_url(organization="DefaultCollection", base_url="http://tfs.corp.local:8080/tfs")
+        == "http://tfs.corp.local:8080/tfs/DefaultCollection"
+    )
+    assert (
+        azure_utils.organization_url(organization="DefaultCollection", base_url="https://tfs.contoso.com/tfs")
+        == "https://tfs.contoso.com/tfs/DefaultCollection"
+    )
+
+
+@pytest.mark.p2
+def test_organization_url_custom_base_url_already_includes_organization():
+    """When base_url already contains the collection, it must not be appended twice."""
+    assert (
+        azure_utils.organization_url(organization="DefaultCollection", base_url="http://tfs.corp.local:8080/tfs/DefaultCollection")
+        == "http://tfs.corp.local:8080/tfs/DefaultCollection"
+    )
+
+
+@pytest.mark.p2
+def test_organization_url_custom_base_url_empty_organization():
+    """Custom base URL without organization returns the base URL."""
+    assert (
+        azure_utils.organization_url(base_url="http://tfs.corp.local:8080/tfs/DefaultCollection")
+        == "http://tfs.corp.local:8080/tfs/DefaultCollection"
+    )
+
+
+@pytest.mark.p2
 def test_invalid_token_returns_203_sign_in_page_not_401():
     """Azure DevOps answers a bad PAT with 203 and an HTML sign-in page.
 
@@ -385,11 +422,47 @@ def test_default_branch_strips_ref_prefix():
 
 
 @pytest.mark.p2
-def test_cleartext_collection_url_is_rejected():
-    """The PAT travels in the Authorization header, so HTTP is refused."""
+def test_invalid_scheme_url_is_rejected():
+    """Non-HTTP/HTTPS URLs are refused."""
     with pytest.raises(UnexpectedValidationError) as excinfo:
-        azure_utils.organization_url("http://tfs.contoso.com/DefaultCollection")
-    assert "HTTPS" in str(excinfo.value)
+        azure_utils.organization_url("ftp://tfs.contoso.com/DefaultCollection")
+    assert "HTTP" in str(excinfo.value)
+
+    with pytest.raises(UnexpectedValidationError) as excinfo:
+        azure_utils.organization_url(base_url="ftp://tfs.contoso.com/tfs")
+    assert "HTTP" in str(excinfo.value)
+
+
+@pytest.mark.p2
+def test_connector_supports_custom_base_url():
+    connector = AzureDevOpsConnector(
+        organization="DefaultCollection",
+        base_url="http://tfs.corp.local:8080/tfs",
+    )
+    assert connector._org_url == "http://tfs.corp.local:8080/tfs/DefaultCollection"
+    assert connector.base_url == "http://tfs.corp.local:8080/tfs"
+
+
+@pytest.mark.p2
+def test_connector_build_connector_with_base_url():
+    connector = AzureDevOpsConnector.build_connector(
+        {
+            "organization": "DefaultCollection",
+            "base_url": "http://tfs.corp.local:8080/tfs",
+            "credentials": {"azure_devops_pat": "token"},
+        }
+    )
+    assert connector._org_url == "http://tfs.corp.local:8080/tfs/DefaultCollection"
+    assert connector.personal_access_token == "token"
+
+
+@pytest.mark.p2
+def test_connector_custom_base_url_extracts_organization():
+    connector = AzureDevOpsConnector(
+        base_url="http://tfs.corp.local:8080/tfs/DefaultCollection",
+    )
+    assert connector.organization == "DefaultCollection"
+    assert connector._org_url == "http://tfs.corp.local:8080/tfs/DefaultCollection"
 
 
 @pytest.mark.p2
@@ -406,11 +479,14 @@ def test_html_body_is_not_an_auth_failure_for_raw_content():
         {"index_mode": "everything"},
         {"content_types": "everything"},
         {"index_mode": INDEX_MODE_REPOSITORIES},
+        {"organization": "", "base_url": ""},
+        {"organization": "", "base_url": "ftp://invalid"},
+        {"organization": "ftp://invalid", "base_url": ""},
     ],
 )
 def test_unusable_settings_are_rejected_before_any_request(overrides):
     connector = _build_connector(**overrides)
-    with pytest.raises(UnexpectedValidationError, match="(?i)unsupported|required"):
+    with pytest.raises(UnexpectedValidationError):
         connector._validate_settings()
 
 

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -1414,6 +1414,7 @@ This auto-tagging feature enhances retrieval by adding another layer of domain-s
       dataSourceFieldIsCloud: 'Is Cloud',
       dataSourceFieldIndexMode: 'Index Mode',
       dataSourceFieldAzureDevOpsPat: 'Azure DevOps personal access token',
+      dataSourceFieldAzureDevOpsBaseUrl: 'Base URL',
       dataSourceFieldAzureDevOpsOrganization: 'Azure DevOps organization',
       dataSourceFieldAzureDevOpsRepositories: 'Repositories',
       dataSourceFieldAzureDevOpsContentTypes: 'Content types',
@@ -1603,8 +1604,10 @@ Example: Virtual Hosted Style`,
       sharepointSiteUrlTip:
         'Full URL of the SharePoint site to index, e.g. https://contoso.sharepoint.com/sites/MySite. Requires an Azure AD app with Sites.Read.All and Files.Read.All application permissions (admin consent).',
       azureDevOpsPatTip: 'A personal access token with the Code (Read) scope.',
+      azureDevOpsBaseUrlTip:
+        'The Base URL of your Azure DevOps instance (e.g. https://dev.azure.com, or http://tfs.corp.local:8080/tfs for Azure DevOps Server / closed network). Defaults to https://dev.azure.com if omitted.',
       azureDevOpsOrganizationTip:
-        'Organization name (e.g. "contoso"), or the full collection URL of a self-hosted Azure DevOps Server (e.g. https://tfs.contoso.com/DefaultCollection).',
+        'Organization name (e.g. "contoso"), or project collection name (e.g. "DefaultCollection"), or the full collection URL of a self-hosted Azure DevOps Server.',
       azureDevOpsProjectsTip:
         'Comma separated team project names. E.g., Project1,Project2',
       azureDevOpsRepositoriesTip:

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1263,8 +1263,10 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
         '要索引的 SharePoint 站点完整 URL，例如 https://contoso.sharepoint.com/sites/MySite。需要具备 Sites.Read.All 与 Files.Read.All 应用权限（管理员同意）的 Azure AD 应用。',
       boxDescription: '连接你的 Box 云盘以同步文件和文件夹。',
       azureDevOpsPatTip: '需要具有 Code (Read) 权限的个人访问令牌。',
+      azureDevOpsBaseUrlTip:
+        'Azure DevOps 实例的基础 URL（例如 https://dev.azure.com，或私有网络/本地部署的 Azure DevOps Server 例如 http://tfs.corp.local:8080/tfs）。留空默认使用 https://dev.azure.com。',
       azureDevOpsOrganizationTip:
-        '组织名称（例如 contoso），或自托管 Azure DevOps Server 的集合地址（例如 https://tfs.contoso.com/DefaultCollection）。',
+        '组织名称（例如 contoso），或项目集合名称（例如 DefaultCollection），或自托管 Azure DevOps Server 的集合地址。',
       azureDevOpsProjectsTip:
         '以逗号分隔的团队项目名称。例如：Project1,Project2',
       azureDevOpsRepositoriesTip:
@@ -1418,6 +1420,7 @@ NER：使用 spaCy NER 和基于规则的关键词提取来抽取 Entities 和 R
       dataSourceFieldIsCloud: '是否为云版本',
       dataSourceFieldIndexMode: '索引模式',
       dataSourceFieldAzureDevOpsPat: 'Azure DevOps 个人访问令牌',
+      dataSourceFieldAzureDevOpsBaseUrl: '基础 URL',
       dataSourceFieldAzureDevOpsOrganization: 'Azure DevOps 组织',
       dataSourceFieldAzureDevOpsRepositories: '仓库',
       dataSourceFieldAzureDevOpsContentTypes: '内容类型',

--- a/web/src/pages/user-setting/data-source/constant/azure-devops-constant.tsx
+++ b/web/src/pages/user-setting/data-source/constant/azure-devops-constant.tsx
@@ -26,10 +26,27 @@ export const azureDevOpsConstant = (t: TFunction) => [
     tooltip: t('setting.azureDevOpsPatTip'),
   },
   {
+    label: t('setting.dataSourceFieldAzureDevOpsBaseUrl'),
+    name: 'config.base_url',
+    type: FormFieldType.Text,
+    required: false,
+    placeholder: 'https://dev.azure.com',
+    tooltip: t('setting.azureDevOpsBaseUrlTip'),
+  },
+  {
     label: t('setting.dataSourceFieldAzureDevOpsOrganization'),
     name: 'config.organization',
     type: FormFieldType.Text,
-    required: true,
+    required: false,
+    customValidate: (val: string, formValues: any) => {
+      const baseUrl = formValues?.config?.base_url;
+      if (!val?.trim() && !baseUrl?.trim()) {
+        return t('setting.dataSourceValidationFieldRequired', {
+          label: t('setting.dataSourceFieldAzureDevOpsOrganization'),
+        });
+      }
+      return true;
+    },
     tooltip: t('setting.azureDevOpsOrganizationTip'),
   },
   {

--- a/web/src/pages/user-setting/data-source/constant/azure-devops-constant.tsx
+++ b/web/src/pages/user-setting/data-source/constant/azure-devops-constant.tsx
@@ -32,6 +32,24 @@ export const azureDevOpsConstant = (t: TFunction) => [
     required: false,
     placeholder: 'https://dev.azure.com',
     tooltip: t('setting.azureDevOpsBaseUrlTip'),
+    customValidate: (val: string) => {
+      const trimmed = val?.trim();
+      if (!trimmed) {
+        return true;
+      }
+      if (!/^https?:\/\//i.test(trimmed)) {
+        return t('setting.azureDevOpsBaseUrlTip');
+      }
+      try {
+        const parsed = new URL(trimmed);
+        if (parsed.username || parsed.password) {
+          return t('setting.azureDevOpsPatTip');
+        }
+      } catch {
+        return t('setting.azureDevOpsBaseUrlTip');
+      }
+      return true;
+    },
   },
   {
     label: t('setting.dataSourceFieldAzureDevOpsOrganization'),
@@ -39,11 +57,32 @@ export const azureDevOpsConstant = (t: TFunction) => [
     type: FormFieldType.Text,
     required: false,
     customValidate: (val: string, formValues: any) => {
-      const baseUrl = formValues?.config?.base_url;
-      if (!val?.trim() && !baseUrl?.trim()) {
+      const org = val?.trim();
+      if (org) {
+        return true;
+      }
+      const baseUrl = formValues?.config?.base_url?.trim();
+      if (!baseUrl) {
         return t('setting.dataSourceValidationFieldRequired', {
           label: t('setting.dataSourceFieldAzureDevOpsOrganization'),
         });
+      }
+      try {
+        const parsed = new URL(baseUrl);
+        const pathSegments = parsed.pathname.split('/').filter(Boolean);
+        if (pathSegments.length === 0) {
+          return t('setting.dataSourceValidationFieldRequired', {
+            label: t('setting.dataSourceFieldAzureDevOpsOrganization'),
+          });
+        }
+      } catch {
+        const withoutScheme = baseUrl.replace(/^[a-zA-Z]+:\/\//, '');
+        const segments = withoutScheme.split('/').slice(1).filter(Boolean);
+        if (segments.length === 0) {
+          return t('setting.dataSourceValidationFieldRequired', {
+            label: t('setting.dataSourceFieldAzureDevOpsOrganization'),
+          });
+        }
       }
       return true;
     },

--- a/web/src/pages/user-setting/data-source/constant/index.test.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.test.tsx
@@ -119,3 +119,75 @@ describe('Sitemap data source', () => {
     expect(batchSize?.validation?.min).toBe(1);
   });
 });
+
+describe('Azure DevOps data source', () => {
+  it('registers its catalog entry and defaults', () => {
+    const info = generateDataSourceInfo(translate)[DataSourceKey.AZURE_DEVOPS];
+    const defaults = DataSourceFormDefaultValues[DataSourceKey.AZURE_DEVOPS];
+
+    expect(info.name).toBe('Azure DevOps');
+    expect(info.description).toBe('setting.azureDevOpsDescription');
+    expect(defaults).toMatchObject({
+      name: '',
+      source: DataSourceKey.AZURE_DEVOPS,
+      config: {
+        base_url: '',
+        organization: '',
+        index_mode: 'organization',
+        projects: '',
+        repositories: '',
+        content_types: 'both',
+        credentials: { azure_devops_pat: '' },
+      },
+    });
+  });
+
+  it('validates organization requires collection path when empty', () => {
+    const fields = getDataSourceFieldsWithExtras(
+      translate,
+      DataSourceKey.AZURE_DEVOPS,
+    ) as Array<{
+      name: string;
+      customValidate?: (val: string, formValues?: any) => boolean | string;
+    }>;
+    const orgField = fields.find((f) => f.name === 'config.organization');
+    expect(orgField).toBeDefined();
+    const validate = orgField!.customValidate!;
+
+    // Valid when organization is explicitly provided
+    expect(validate('contoso', { config: { base_url: '' } })).toBe(true);
+    expect(
+      validate('contoso', { config: { base_url: 'https://dev.azure.com' } }),
+    ).toBe(true);
+
+    // Valid when base_url includes collection path
+    expect(
+      validate('', {
+        config: {
+          base_url: 'http://tfs.corp.local:8080/tfs/DefaultCollection',
+        },
+      }),
+    ).toBe(true);
+    expect(
+      validate('', {
+        config: { base_url: 'https://dev.azure.com/myorg' },
+      }),
+    ).toBe(true);
+
+    // Invalid when both are empty
+    expect(validate('', { config: { base_url: '' } })).toBe(
+      'setting.dataSourceValidationFieldRequired',
+    );
+
+    // Invalid when base_url is root-only
+    expect(
+      validate('', { config: { base_url: 'https://dev.azure.com' } }),
+    ).toBe('setting.dataSourceValidationFieldRequired');
+    expect(
+      validate('', { config: { base_url: 'https://dev.azure.com/' } }),
+    ).toBe('setting.dataSourceValidationFieldRequired');
+    expect(
+      validate('', { config: { base_url: 'http://tfs.corp.local:8080' } }),
+    ).toBe('setting.dataSourceValidationFieldRequired');
+  });
+});

--- a/web/src/pages/user-setting/data-source/constant/index.tsx
+++ b/web/src/pages/user-setting/data-source/constant/index.tsx
@@ -2415,6 +2415,7 @@ export const DataSourceFormDefaultValues = {
     name: '',
     source: DataSourceKey.AZURE_DEVOPS,
     config: {
+      base_url: '',
       organization: '',
       index_mode: 'organization',
       projects: '',


### PR DESCRIPTION

Support custom base URL and HTTP connections for Azure DevOps connector:

- Allow specifying a custom base_url for self-hosted Azure DevOps Server / TFS instances in closed networks.
- Support HTTP scheme in addition to HTTPS for internal/closed networks.
- Update Go syncer connector and unit tests for custom base URL resolution and HTTP validation.
- Update Python connector and unit tests for custom base URL resolution and HTTP validation.
- Add frontend form field and English/Chinese localizations for Azure DevOps base URL.

### Summary

Support custom base URL and HTTP connections for Azure DevOps connector:
