### PR TITLE
fix(api): return argument errors instead of 500 when page_size exceeds the public maximum

### DIFF
--- a/api/apps/restful_apis/agent_api.py
+++ b/api/apps/restful_apis/agent_api.py
@@ -434,8 +434,11 @@ async def _run_workflow_session(
 def list_agent_sessions(agent_id, tenant_id):
     session_id = request.args.get("id")
     user_id = request.args.get("user_id")
-    page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
-    items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
+        items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        return get_result(code=RetCode.ARGUMENT_ERROR, message=str(e))
     keywords = request.args.get("keywords")
     from_date = request.args.get("from_date")
     to_date = request.args.get("to_date")
@@ -703,8 +706,11 @@ def list_agents(tenant_id):
     except ValueError as e:
         return get_result(code=RetCode.ARGUMENT_ERROR, message=str(e))
 
-    page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
-    items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
+        items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        return get_result(code=RetCode.ARGUMENT_ERROR, message=str(e))
     order_by = request.args.get("orderby", "create_time")
     desc = str(request.args.get("desc", "true")).lower() != "false"
     tenants = TenantService.get_joined_tenants_by_user_id(tenant_id)

--- a/api/apps/restful_apis/bot_api.py
+++ b/api/apps/restful_apis/bot_api.py
@@ -353,8 +353,11 @@ async def ask_about_embedded(tenant_id=None):
 @validate_request("kb_id", "question")
 async def retrieval_test_embedded(tenant_id=None):
     req = await get_request_json()
-    page = validate_rest_api_page(req.get("page", DEFAULT_PAGE))
-    size = validate_rest_api_page_size(req.get("page_size", req.get("size", DEFAULT_PAGE_SIZE)))
+    try:
+        page = validate_rest_api_page(req.get("page", DEFAULT_PAGE))
+        size = validate_rest_api_page_size(req.get("page_size", req.get("size", DEFAULT_PAGE_SIZE)))
+    except ValueError as e:
+        return get_json_result(code=RetCode.ARGUMENT_ERROR, message=str(e))
     question = req["question"]
     kb_ids = req["kb_id"]
     if isinstance(kb_ids, str):

--- a/api/apps/restful_apis/chunk_api.py
+++ b/api/apps/restful_apis/chunk_api.py
@@ -371,8 +371,11 @@ async def retrieval_test(tenant_id, dataset_id=None):
         return get_result(message=embd_err, code=RetCode.DATA_ERROR)
     if "question" not in req:
         return get_error_data_result("`question` is required.")
-    page = validate_rest_api_page(req.get("page", DEFAULT_PAGE))
-    size = validate_rest_api_page_size(req.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page = validate_rest_api_page(req.get("page", DEFAULT_PAGE))
+        size = validate_rest_api_page_size(req.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        return get_result(code=RetCode.ARGUMENT_ERROR, message=str(e))
     question = req["question"].strip() if isinstance(req["question"], str) else req["question"]
     if not question:
         return get_result(data={"total": 0, "chunks": [], "doc_aggs": {}})
@@ -558,8 +561,11 @@ async def list_chunks(tenant_id, dataset_id, document_id):
         return get_error_data_result(message=f"you don't own the document {document_id}")
     doc = doc[0]
     req = request.args
-    page = validate_rest_api_page(req.get("page", DEFAULT_PAGE))
-    size = validate_rest_api_page_size(req.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page = validate_rest_api_page(req.get("page", DEFAULT_PAGE))
+        size = validate_rest_api_page_size(req.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        return get_result(code=RetCode.ARGUMENT_ERROR, message=str(e))
     question = req.get("keywords", "")
     chunk_ids = _get_query_id_list(req, "chunk_ids")
     try:

--- a/api/apps/restful_apis/compilation_template_group_api.py
+++ b/api/apps/restful_apis/compilation_template_group_api.py
@@ -24,6 +24,7 @@ from api.db.services.compilation_template_group_service import (
 )
 from api.utils.api_utils import (
     get_data_error_result,
+    get_error_argument_result,
     get_json_result,
     get_request_json,
     server_error_response,
@@ -71,8 +72,11 @@ def _validate_group_payload(req: dict, require_all: bool = True) -> str:
 def list_groups() -> Response:
     keywords = request.args.get("keywords", "")
     scope = request.args.get("scope", "")
-    page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
-    items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
+        items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        return get_error_argument_result(str(e))
     orderby = request.args.get("orderby", "create_time")
     desc = request.args.get("desc", "true").lower() != "false"
 

--- a/api/apps/restful_apis/connector_api.py
+++ b/api/apps/restful_apis/connector_api.py
@@ -141,10 +141,15 @@ def list_logs(connector_id):
         return _connector_auth_error(connector_id, current_user.id)
 
     req = request.args.to_dict(flat=True)
+    try:
+        page = validate_rest_api_page(req.get("page", DEFAULT_PAGE))
+        page_size = validate_rest_api_page_size(req.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as exc:
+        return get_json_result(code=RetCode.ARGUMENT_ERROR, message=str(exc))
     arr, total = SyncLogsService.list_sync_tasks(
         connector_id,
-        validate_rest_api_page(req.get("page", DEFAULT_PAGE)),
-        validate_rest_api_page_size(req.get("page_size", DEFAULT_PAGE_SIZE)),
+        page,
+        page_size,
     )
     return get_json_result(data={"total": total, "logs": arr})
 

--- a/api/apps/restful_apis/mcp_api.py
+++ b/api/apps/restful_apis/mcp_api.py
@@ -71,8 +71,13 @@ def _assert_mcp_url_is_safe(url, invalid_message: str = "Invalid url.") -> tuple
 @login_required
 async def list_mcp() -> Response:
     keywords = request.args.get("keywords", "")
-    page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
-    items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
+        items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        from api.utils.api_utils import get_error_argument_result
+
+        return get_error_argument_result(str(e))
     orderby = request.args.get("orderby", "create_time")
     if request.args.get("desc", "true").lower() == "false":
         desc = False

--- a/api/apps/restful_apis/memory_api.py
+++ b/api/apps/restful_apis/memory_api.py
@@ -147,8 +147,11 @@ async def list_memory():
     if "storage_type" in request.args:
         filter_params["storage_type"] = request.args.get("storage_type")
     keywords = request.args.get("keywords")
-    page = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
-    page_size = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
+        page_size = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        return get_error_argument_result(str(e))
     try:
         for field_name in ("owner_ids", "ids"):
             validate_rest_api_ids(filter_params.get(field_name), field_name)
@@ -186,8 +189,11 @@ async def get_memory_messages(memory_id):
         agent_ids = agent_ids[0].split(",")
     keywords = args.get("keywords", "")
     keywords = keywords.strip()
-    page = validate_rest_api_page(args.get("page", 1))
-    page_size = validate_rest_api_page_size(args.get("page_size", 50))
+    try:
+        page = validate_rest_api_page(args.get("page", 1))
+        page_size = validate_rest_api_page_size(args.get("page_size", 50))
+    except ValueError as e:
+        return get_error_argument_result(str(e))
     try:
         validate_rest_api_ids(agent_ids, "agent_id")
     except ValueError as e:

--- a/api/apps/restful_apis/search_api.py
+++ b/api/apps/restful_apis/search_api.py
@@ -78,8 +78,11 @@ async def create():
 @login_required
 def list_searches():
     keywords = request.args.get("keywords", "")
-    page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
-    items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    try:
+        page_number = validate_rest_api_page(request.args.get("page", DEFAULT_PAGE))
+        items_per_page = validate_rest_api_page_size(request.args.get("page_size", DEFAULT_PAGE_SIZE))
+    except ValueError as e:
+        return get_json_result(code=RetCode.ARGUMENT_ERROR, message=str(e))
     orderby = request.args.get("orderby", "create_time")
     desc = request.args.get("desc", "true").lower() != "false"
     owner_ids = request.args.getlist("owner_ids")

--- a/test/testcases/restful_api/test_mcp_routes_unit.py
+++ b/test/testcases/restful_api/test_mcp_routes_unit.py
@@ -806,4 +806,4 @@ def test_list_mcp_page_size_above_max_returns_argument_error(monkeypatch):
     res = _run(module.list_mcp())
 
     assert res["code"] == 101
-    assert "page_size" in res["message"]
+    assert res["message"] == "page_size must be less than or equal to 100"

--- a/test/testcases/restful_api/test_mcp_routes_unit.py
+++ b/test/testcases/restful_api/test_mcp_routes_unit.py
@@ -792,3 +792,18 @@ def test_test_mcp_route_matrix_unit(monkeypatch):
     res = _run(module.test_mcp("mcp-1"))
     assert res["code"] == 100
     assert "session explode" in res["message"]
+
+
+@pytest.mark.p2
+def test_list_mcp_page_size_above_max_returns_argument_error(monkeypatch):
+    """Regression: page_size over the public maximum must surface an
+    argument error, not an unhandled ValueError from
+    validate_rest_api_page_size."""
+    module = _load_mcp_api(monkeypatch)
+    sys.modules["api.utils.api_utils"].get_error_argument_result = lambda message="": {"code": 101, "message": message}
+    monkeypatch.setattr(module, "request", SimpleNamespace(args=_Args({"page_size": "101"})))
+
+    res = _run(module.list_mcp())
+
+    assert res["code"] == 101
+    assert "page_size" in res["message"]


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #19414

`validate_rest_api_page_size` raises `ValueError` when `page_size` exceeds the public maximum (100), but a dozen REST endpoints call it outside any error handling, so `page_size=101` fails with an unhandled 500 instead of the argument-error response neighboring validation returns.

Fix: catch `ValueError` at each unguarded call site and return the file's established argument-error response. Affected routes: `GET /searches`, `GET /mcp/servers`, `GET /memories` (+ message list), `POST /retrieval`, `GET /datasets/<id>/documents/<id>/chunks`, `POST /searchbots/retrieval_test`, `GET /agents/<id>/sessions` + agent list, `GET /connectors/<id>/logs`, `GET /compilation-template-groups`.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Testing

Added `test_list_mcp_page_size_above_max_returns_argument_error` to `test/testcases/restful_api/test_mcp_routes_unit.py`:

- without the fix, `GET /mcp/servers?page_size=101` raises `ValueError` out of the handler (verified by stashing the change)
- with the fix, it returns code 101 with "page_size must be less than or equal to 100"

Full `test_mcp_routes_unit.py`: 12/12 pass. All touched modules byte-compile.