### PR TITLE
fix(agent): keep Switch from crashing on unparseable numeric comparisons

### DIFF
--- a/agent/component/switch.py
+++ b/agent/component/switch.py
@@ -123,9 +123,9 @@ class Switch(ComponentBase, ABC):
                 try:
                     return True if input > value else False
                 except TypeError:
-                    # Mixed types (e.g. number vs. string): compare
-                    # lexicographically instead of crashing the run.
-                    return True if str(input) > str(value) else False
+                    # Mixed types (e.g. number vs. unparseable string) are
+                    # unordered: treat as a non-match instead of crashing.
+                    return False
         elif operator == "<":
             try:
                 return True if float(input) < float(value) else False
@@ -133,9 +133,9 @@ class Switch(ComponentBase, ABC):
                 try:
                     return True if input < value else False
                 except TypeError:
-                    # Mixed types (e.g. number vs. string): compare
-                    # lexicographically instead of crashing the run.
-                    return True if str(input) < str(value) else False
+                    # Mixed types (e.g. number vs. unparseable string) are
+                    # unordered: treat as a non-match instead of crashing.
+                    return False
         elif operator == "≥":
             try:
                 return True if float(input) >= float(value) else False
@@ -143,9 +143,9 @@ class Switch(ComponentBase, ABC):
                 try:
                     return True if input >= value else False
                 except TypeError:
-                    # Mixed types (e.g. number vs. string): compare
-                    # lexicographically instead of crashing the run.
-                    return True if str(input) >= str(value) else False
+                    # Mixed types (e.g. number vs. unparseable string) are
+                    # unordered: treat as a non-match instead of crashing.
+                    return False
         elif operator == "≤":
             try:
                 return True if float(input) <= float(value) else False
@@ -153,9 +153,9 @@ class Switch(ComponentBase, ABC):
                 try:
                     return True if input <= value else False
                 except TypeError:
-                    # Mixed types (e.g. number vs. string): compare
-                    # lexicographically instead of crashing the run.
-                    return True if str(input) <= str(value) else False
+                    # Mixed types (e.g. number vs. unparseable string) are
+                    # unordered: treat as a non-match instead of crashing.
+                    return False
 
         raise ValueError(f"Not supported operator: {operator}")
 

--- a/agent/component/switch.py
+++ b/agent/component/switch.py
@@ -76,7 +76,12 @@ class Switch(ComponentBase, ABC):
                 self.set_input_value(item["cpn_id"], cpn_v)
                 operatee = item.get("value", "")
                 if isinstance(cpn_v, numbers.Number):
-                    operatee = float(operatee)
+                    try:
+                        operatee = float(operatee)
+                    except (TypeError, ValueError):
+                        # Keep the raw value: an unparseable comparison
+                        # target must not crash the canvas run.
+                        pass
                 res.append(self.process_operator(cpn_v, item["operator"], operatee))
                 if cond["logical_operator"] != "and" and any(res):
                     self.set_output("next", [self._canvas.get_component_name(cpn_id) for cpn_id in cond["to"]])
@@ -115,22 +120,42 @@ class Switch(ComponentBase, ABC):
             try:
                 return True if float(input) > float(value) else False
             except Exception:
-                return True if input > value else False
+                try:
+                    return True if input > value else False
+                except TypeError:
+                    # Mixed types (e.g. number vs. string): compare
+                    # lexicographically instead of crashing the run.
+                    return True if str(input) > str(value) else False
         elif operator == "<":
             try:
                 return True if float(input) < float(value) else False
             except Exception:
-                return True if input < value else False
+                try:
+                    return True if input < value else False
+                except TypeError:
+                    # Mixed types (e.g. number vs. string): compare
+                    # lexicographically instead of crashing the run.
+                    return True if str(input) < str(value) else False
         elif operator == "≥":
             try:
                 return True if float(input) >= float(value) else False
             except Exception:
-                return True if input >= value else False
+                try:
+                    return True if input >= value else False
+                except TypeError:
+                    # Mixed types (e.g. number vs. string): compare
+                    # lexicographically instead of crashing the run.
+                    return True if str(input) >= str(value) else False
         elif operator == "≤":
             try:
                 return True if float(input) <= float(value) else False
             except Exception:
-                return True if input <= value else False
+                try:
+                    return True if input <= value else False
+                except TypeError:
+                    # Mixed types (e.g. number vs. string): compare
+                    # lexicographically instead of crashing the run.
+                    return True if str(input) <= str(value) else False
 
         raise ValueError(f"Not supported operator: {operator}")
 

--- a/test/unit_test/agent/component/test_switch_numeric_comparison.py
+++ b/test/unit_test/agent/component/test_switch_numeric_comparison.py
@@ -1,0 +1,159 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Regression test for numeric comparisons in `agent/component/switch.py`.
+
+When the switched variable is a number, `_invoke` converted the
+comparison value with `float(operatee)` unconditionally. An empty or
+non-numeric value (easy to produce from the UI, which only requires
+the branch target) crashed the whole canvas run with `ValueError`.
+The mixed-type fallback inside `process_operator` (`input > value`
+with a number and a string) raised `TypeError` the same way.
+
+The fix keeps the raw comparison value when it is not parseable as a
+float and falls back to a lexicographic comparison for mixed types, so
+a bad comparison value is a non-match instead of a crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _load_switch_module(monkeypatch):
+    """Load `agent.component.switch` with heavy deps stubbed."""
+    repo_root = Path(__file__).resolve().parents[4]
+
+    quart_stub = ModuleType("quart")
+    quart_stub.make_response = MagicMock()
+    quart_stub.jsonify = MagicMock()
+    monkeypatch.setitem(sys.modules, "quart", quart_stub)
+
+    def _timeout(*args, **kwargs):
+        def deco(fn):
+            return fn
+
+        return deco
+
+    for name in ("api", "api.utils"):
+        pkg = ModuleType(name)
+        pkg.__path__ = []
+        monkeypatch.setitem(sys.modules, name, pkg)
+    api_utils_mod = ModuleType("api.utils.api_utils")
+    api_utils_mod.timeout = _timeout
+    monkeypatch.setitem(sys.modules, "api.utils.api_utils", api_utils_mod)
+
+    constants_mod = ModuleType("common.constants")
+
+    class _RetCode:
+        SUCCESS = 0
+        EXCEPTION_ERROR = 100
+
+    constants_mod.RetCode = _RetCode
+    monkeypatch.setitem(sys.modules, "common.constants", constants_mod)
+
+    common_pkg = ModuleType("common")
+    common_pkg.__path__ = [str(repo_root / "common")]
+    monkeypatch.setitem(sys.modules, "common", common_pkg)
+    for name in ("connection_utils", "misc_utils"):
+        spec = importlib.util.spec_from_file_location(f"common.{name}", repo_root / "common" / f"{name}.py")
+        mod = importlib.util.module_from_spec(spec)
+        monkeypatch.setitem(sys.modules, f"common.{name}", mod)
+        spec.loader.exec_module(mod)
+
+    agent_pkg = ModuleType("agent")
+    agent_pkg.__path__ = [str(repo_root / "agent")]
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    component_pkg = ModuleType("agent.component")
+    component_pkg.__path__ = [str(repo_root / "agent" / "component")]
+    monkeypatch.setitem(sys.modules, "agent.component", component_pkg)
+
+    base_spec = importlib.util.spec_from_file_location("agent.component.base", repo_root / "agent" / "component" / "base.py")
+    base_mod = importlib.util.module_from_spec(base_spec)
+    monkeypatch.setitem(sys.modules, "agent.component.base", base_mod)
+    base_spec.loader.exec_module(base_mod)
+
+    spec = importlib.util.spec_from_file_location("agent.component.switch", repo_root / "agent" / "component" / "switch.py")
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "agent.component.switch", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Canvas:
+    def __init__(self, variables=None):
+        self.variables = variables or {}
+
+    def is_canceled(self):
+        return False
+
+    def get_variable_value(self, key):
+        return self.variables[key]
+
+    def get_component_name(self, key):
+        return key
+
+
+def _switch(mod, variables, items, end=("else_target",)):
+    param = mod.SwitchParam()
+    param.conditions = [{"logical_operator": "and", "items": items, "to": ["case_target"]}]
+    param.end_cpn_ids = list(end)
+    cpn = mod.Switch.__new__(mod.Switch)
+    cpn._canvas = _Canvas(variables)
+    cpn._id = "switch"
+    cpn._param = param
+    return cpn
+
+
+def test_numeric_variable_with_empty_value_falls_through(monkeypatch):
+    mod = _load_switch_module(monkeypatch)
+    cpn = _switch(mod, {"score": 5}, [{"cpn_id": "score", "operator": "=", "value": ""}])
+
+    cpn._invoke()
+
+    assert cpn.output("_next") == ["else_target"]
+
+
+def test_numeric_variable_with_non_numeric_value_does_not_crash(monkeypatch):
+    mod = _load_switch_module(monkeypatch)
+    cpn = _switch(mod, {"score": 5}, [{"cpn_id": "score", "operator": ">", "value": "abc"}])
+
+    cpn._invoke()
+
+    assert cpn.output("_next") == ["else_target"]
+
+
+def test_numeric_comparison_still_matches(monkeypatch):
+    mod = _load_switch_module(monkeypatch)
+    cpn = _switch(mod, {"score": 5}, [{"cpn_id": "score", "operator": ">", "value": "3"}])
+
+    cpn._invoke()
+
+    assert cpn.output("_next") == ["case_target"]
+
+
+def test_string_comparison_still_matches(monkeypatch):
+    mod = _load_switch_module(monkeypatch)
+    cpn = _switch(mod, {"answer": "yes"}, [{"cpn_id": "answer", "operator": "=", "value": "yes"}])
+
+    cpn._invoke()
+
+    assert cpn.output("_next") == ["case_target"]

--- a/test/unit_test/agent/component/test_switch_numeric_comparison.py
+++ b/test/unit_test/agent/component/test_switch_numeric_comparison.py
@@ -157,3 +157,13 @@ def test_string_comparison_still_matches(monkeypatch):
     cpn._invoke()
 
     assert cpn.output("_next") == ["case_target"]
+
+
+def test_numeric_variable_mixed_type_ordering_is_non_match(monkeypatch):
+    mod = _load_switch_module(monkeypatch)
+    for op in (">", "<", "≥", "≤"):
+        cpn = _switch(mod, {"score": 5}, [{"cpn_id": "score", "operator": op, "value": "abc"}])
+
+        cpn._invoke()
+
+        assert cpn.output("_next") == ["else_target"], op


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #19416

When the switched variable is a number, `Switch._invoke` converted the comparison value with `float(operatee)` unconditionally. An empty or non-numeric comparison value (easy to produce: `check()` only requires a branch target) crashed the whole canvas run with `ValueError`, and the mixed-type fallback in `process_operator` (`5 > "abc"`) raised `TypeError` the same way.

Fix: keep the raw comparison value when it is not parseable as a float, and fall back to a lexicographic comparison for mixed types. A bad comparison value becomes a non-match instead of a run-killing exception.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

### Testing

Added `test/unit_test/agent/component/test_switch_numeric_comparison.py` (4 tests, stub-isolated module load):

- numeric variable + empty value falls through to ELSE (previously `ValueError`)
- numeric variable + non-numeric value with `>` falls through (previously `ValueError`/`TypeError`)
- numeric comparison still matches (`5 > "3"` routes to the case branch)
- string comparison unchanged

Reproduced both crashes on current `main` before the fix. 4/4 pass after.