### PR TITLE
fix: report incremental wiki map errors

### DIFF
--- a/rag/svr/task_executor_refactor/dataset_wiki_generator.py
+++ b/rag/svr/task_executor_refactor/dataset_wiki_generator.py
@@ -1844,6 +1844,7 @@ async def run_wiki_incremental(
                     tenant_id=ctx.tenant_id,
                     kb_id=ctx.kb_id,
                     language=ctx.language,
+                    callback=lambda p, msg: progress(p, msg),
                     parser_config=parser_cfg,
                     batch_size_cap=8,
                     window_fraction=0.5,


### PR DESCRIPTION
### What problem does this PR solve?

Wiki MAP timeout and LLM errors from the incremental compilation path were only written to backend logs and were not visible in the frontend task log.

This PR forwards the incremental Wiki MAP progress callback so these errors are reported to users.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)