### PR TITLE
fix(compiler): resolve global built-in template scope

### DIFF
--- a/internal/dao/compilation_template.go
+++ b/internal/dao/compilation_template.go
@@ -117,7 +117,8 @@ func (dao *CompilationTemplateDAO) ResolveGroupTemplateIDs(ctx context.Context, 
 func (dao *CompilationTemplateDAO) GetTemplate(ctx context.Context, db *gorm.DB, tenantID, templateID string) (*entity.CompilationTemplate, error) {
 	var t entity.CompilationTemplate
 	if err := db.WithContext(ctx).
-		Where("id = ? AND tenant_id = ? AND status = ?", templateID, tenantID, string(entity.StatusValid)).
+		Where("id = ? AND status = ? AND (tenant_id = ? OR (tenant_id IS NULL AND (is_builtin = ? OR group_id = ?)))",
+			templateID, string(entity.StatusValid), tenantID, true, BuiltinCompilationTemplateGroupID).
 		First(&t).Error; err != nil {
 		return nil, fmt.Errorf("load compilation template %q: %w", templateID, err)
 	}

--- a/internal/dao/compilation_template_seed_test.go
+++ b/internal/dao/compilation_template_seed_test.go
@@ -141,4 +141,33 @@ func TestSeedBuiltinCompilationTemplatesForTenant(t *testing.T) {
 	if len(resolved) != len(builtinCompilationTemplateKinds) {
 		t.Fatalf("resolved %d template ids, want %d", len(resolved), len(builtinCompilationTemplateKinds))
 	}
+
+	got, err := NewCompilationTemplateDAO().GetTemplate(ctx, db, "some-other-tenant", builtinTemplateID("tree"))
+	if err != nil {
+		t.Fatalf("resolve global built-in template: %v", err)
+	}
+	if got.Kind != "tree" {
+		t.Fatalf("resolved built-in kind = %q, want tree", got.Kind)
+	}
+}
+
+func TestGetTemplateKeepsTenantScopeForCustomTemplates(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err = db.AutoMigrate(&entity.CompilationTemplate{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	tenantID := "tenant-1"
+	status := string(entity.StatusValid)
+	if err = db.Create(&entity.CompilationTemplate{
+		ID: "custom-template", TenantID: &tenantID, Name: "Custom", Kind: "tree",
+		Config: entity.JSONMap{"kind": "tree"}, Status: &status,
+	}).Error; err != nil {
+		t.Fatalf("insert custom template: %v", err)
+	}
+	if _, err = NewCompilationTemplateDAO().GetTemplate(t.Context(), db, "tenant-2", "custom-template"); err == nil {
+		t.Fatal("custom template resolved for the wrong tenant")
+	}
 }


### PR DESCRIPTION
The compiler now resolves global built-in templates for every tenant. Custom templates still require the owning tenant.