### PR TITLE
fix(agent): tolerate mixed-type and None values in ListOperations sort

### DIFF
--- a/agent/component/list_operations.py
+++ b/agent/component/list_operations.py
@@ -1,4 +1,5 @@
 from abc import ABC
+import functools
 import os
 from agent.component.base import ComponentBase, ComponentParamBase
 from api.utils.api_utils import timeout
@@ -184,37 +185,63 @@ class ListOperations(ComponentBase, ABC):
             sort_by_raw = getattr(self._param, "sort_by", "") or ""
             sort_by = [k.strip() for k in sort_by_raw.split(",") if k.strip()]
             if sort_by:
-                outputs = sorted(
-                    items,
-                    key=lambda x: tuple(self._scalar_sort_key(x.get(k) if isinstance(x, dict) else x) for k in sort_by),
-                    reverse=reverse,
-                )
+                def _cmp_items(a, b):
+                    for k in sort_by:
+                        c = self._cmp_scalar(a.get(k) if isinstance(a, dict) else a,
+                                             b.get(k) if isinstance(b, dict) else b)
+                        if c:
+                            return c
+                    return 0
+
+                outputs = sorted(items, key=functools.cmp_to_key(_cmp_items), reverse=reverse)
             else:
                 outputs = sorted(
                     items,
-                    key=lambda x: self._comparable_sort_key(self._hashable(x)),
+                    key=functools.cmp_to_key(lambda a, b: self._cmp_key(self._hashable(a), self._hashable(b))),
                     reverse=reverse,
                 )
         else:
-            outputs = sorted(items, key=self._scalar_sort_key, reverse=reverse)
+            outputs = sorted(items, key=functools.cmp_to_key(self._cmp_scalar), reverse=reverse)
 
         self._set_outputs(outputs)
 
     @staticmethod
-    def _scalar_sort_key(v):
-        # A total order that never raises on mixed content: real numbers sort
-        # numerically ahead of everything else, and all other values (strings,
-        # None, booleans, containers) order by their string form. This mirrors
-        # the Go port's lessScalar, which compares numbers numerically and
-        # every other value textually (internal/agent/component/list_operations.go).
-        if isinstance(v, bool) or not isinstance(v, (int, float)):
-            return (1, str(v))
-        return (0, v)
+    def _cmp_scalar(a, b):
+        # Three-way comparison that never raises on mixed content and mirrors
+        # the Go port's lessScalar (internal/agent/component/list_operations.go):
+        # two real numbers compare numerically, every other pair compares by
+        # its Go %v text form.
+        a_num = isinstance(a, (int, float)) and not isinstance(a, bool)
+        b_num = isinstance(b, (int, float)) and not isinstance(b, bool)
+        if a_num and b_num:
+            return (a > b) - (a < b)
+        ta, tb = ListOperations._go_text(a), ListOperations._go_text(b)
+        return (ta > tb) - (ta < tb)
 
-    def _comparable_sort_key(self, v):
-        if isinstance(v, tuple):
-            return tuple(self._comparable_sort_key(i) for i in v)
-        return self._scalar_sort_key(v)
+    @staticmethod
+    def _go_text(v):
+        # Mirror Go's fmt.Sprintf("%v", v) for JSON-shaped scalars.
+        if v is None:
+            return "<nil>"
+        if isinstance(v, bool):
+            return "true" if v else "false"
+        if isinstance(v, float) and v.is_integer():
+            return str(int(v))
+        if isinstance(v, (list, tuple)):
+            # Go renders slices as "[a b c]" (no quotes on string members).
+            return "[" + " ".join(ListOperations._go_text(i) for i in v) + "]"
+        return str(v)
+
+    def _cmp_key(self, a, b):
+        # Mirror the Go port's lessKey: element-wise on canonical tuples,
+        # shorter tuple first on a shared prefix.
+        if isinstance(a, tuple) and isinstance(b, tuple):
+            for x, y in zip(a, b):
+                c = self._cmp_scalar(x, y)
+                if c:
+                    return c
+            return (len(a) > len(b)) - (len(a) < len(b))
+        return self._cmp_scalar(a, b)
 
     def _drop_duplicates(self):
         seen = set()
@@ -228,12 +255,15 @@ class ListOperations(ComponentBase, ABC):
         self._set_outputs(outs)
 
     def _hashable(self, x):
+        # Canonicalize with the comparison helpers instead of raw sorted() so
+        # mixed-type dict keys and set members never raise TypeError.
         if isinstance(x, dict):
-            return tuple(sorted((k, self._hashable(v)) for k, v in x.items()))
+            entries = sorted(x.items(), key=functools.cmp_to_key(lambda a, b: self._cmp_scalar(a[0], b[0])))
+            return tuple((k, self._hashable(v)) for k, v in entries)
         if isinstance(x, (list, tuple)):
             return tuple(self._hashable(v) for v in x)
         if isinstance(x, set):
-            return tuple(sorted(self._hashable(v) for v in x))
+            return tuple(sorted((self._hashable(v) for v in x), key=functools.cmp_to_key(self._cmp_scalar)))
         return x
 
     def thoughts(self) -> str:

--- a/agent/component/list_operations.py
+++ b/agent/component/list_operations.py
@@ -186,19 +186,35 @@ class ListOperations(ComponentBase, ABC):
             if sort_by:
                 outputs = sorted(
                     items,
-                    key=lambda x: tuple(x.get(k) for k in sort_by),
+                    key=lambda x: tuple(self._scalar_sort_key(x.get(k) if isinstance(x, dict) else x) for k in sort_by),
                     reverse=reverse,
                 )
             else:
                 outputs = sorted(
                     items,
-                    key=lambda x: self._hashable(x),
+                    key=lambda x: self._comparable_sort_key(self._hashable(x)),
                     reverse=reverse,
                 )
         else:
-            outputs = sorted(items, reverse=reverse)
+            outputs = sorted(items, key=self._scalar_sort_key, reverse=reverse)
 
         self._set_outputs(outputs)
+
+    @staticmethod
+    def _scalar_sort_key(v):
+        # A total order that never raises on mixed content: real numbers sort
+        # numerically ahead of everything else, and all other values (strings,
+        # None, booleans, containers) order by their string form. This mirrors
+        # the Go port's lessScalar, which compares numbers numerically and
+        # every other value textually (internal/agent/component/list_operations.go).
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            return (1, str(v))
+        return (0, v)
+
+    def _comparable_sort_key(self, v):
+        if isinstance(v, tuple):
+            return tuple(self._comparable_sort_key(i) for i in v)
+        return self._scalar_sort_key(v)
 
     def _drop_duplicates(self):
         seen = set()

--- a/test/testcases/test_web_api/test_canvas_app/test_list_operations_unit.py
+++ b/test/testcases/test_web_api/test_canvas_app/test_list_operations_unit.py
@@ -219,3 +219,81 @@ def test_invoke_still_raises_for_non_list_input(monkeypatch):
     component = _make_invoke_component(module, resolved="not-a-list")
     with pytest.raises(TypeError, match="should be an array"):
         component._invoke()
+
+
+def _make_sort_component(module, *, inputs, sort_method="asc", sort_by=""):
+    component = module.ListOperations.__new__(module.ListOperations)
+    component.inputs = inputs
+    component._param = SimpleNamespace(
+        sort_method=sort_method,
+        sort_by=sort_by,
+        outputs={
+            "result": {"value": []},
+            "first": {"value": None},
+            "last": {"value": None},
+        },
+    )
+    return component
+
+
+@pytest.mark.p2
+def test_sort_by_tolerates_missing_field_values(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    items = [{"name": "b", "score": None}, {"name": "a", "score": 5}, {"name": "c", "score": 3}]
+    component = _make_sort_component(module, inputs=items, sort_by="score")
+    component._sort()
+    assert [i["name"] for i in component._param.outputs["result"]["value"]] == ["c", "a", "b"]
+
+
+@pytest.mark.p2
+def test_sort_by_tolerates_mixed_value_types(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    items = [{"k": 10}, {"k": "9"}, {"k": 2}]
+    component = _make_sort_component(module, inputs=items, sort_by="k")
+    component._sort()
+    assert [i["k"] for i in component._param.outputs["result"]["value"]] == [2, 10, "9"]
+
+
+@pytest.mark.p2
+def test_sort_by_tolerates_non_dict_items(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    items = [{"k": 1}, "plain", {"k": 0}]
+    component = _make_sort_component(module, inputs=items, sort_by="k")
+    component._sort()
+    result = component._param.outputs["result"]["value"]
+    assert result[0] == {"k": 0}
+    assert result[1] == {"k": 1}
+    assert result[2] == "plain"
+
+
+@pytest.mark.p2
+def test_sort_plain_list_tolerates_mixed_scalars(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[1, "a", None, 2])
+    component._sort()
+    assert component._param.outputs["result"]["value"] == [1, 2, None, "a"]
+
+
+@pytest.mark.p2
+def test_sort_legacy_hashable_path_tolerates_mixed_values(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[{"a": 1}, {"a": "x"}, {"a": 0}])
+    component._sort()
+    assert [i["a"] for i in component._param.outputs["result"]["value"]] == [0, 1, "x"]
+
+
+@pytest.mark.p2
+def test_sort_still_orders_numbers_numerically_desc(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[3, 10, 2], sort_method="desc")
+    component._sort()
+    assert component._param.outputs["result"]["value"] == [10, 3, 2]
+
+
+@pytest.mark.p2
+def test_sort_by_multi_key_still_applies_tiebreak(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    items = [{"a": 1, "b": 2}, {"a": 1, "b": 1}, {"a": 0, "b": 9}]
+    component = _make_sort_component(module, inputs=items, sort_by="a,b")
+    component._sort()
+    assert [(i["a"], i["b"]) for i in component._param.outputs["result"]["value"]] == [(0, 9), (1, 1), (1, 2)]

--- a/test/testcases/test_web_api/test_canvas_app/test_list_operations_unit.py
+++ b/test/testcases/test_web_api/test_canvas_app/test_list_operations_unit.py
@@ -297,3 +297,51 @@ def test_sort_by_multi_key_still_applies_tiebreak(monkeypatch):
     component = _make_sort_component(module, inputs=items, sort_by="a,b")
     component._sort()
     assert [(i["a"], i["b"]) for i in component._param.outputs["result"]["value"]] == [(0, 9), (1, 1), (1, 2)]
+
+
+@pytest.mark.p2
+def test_sort_matches_go_text_order_for_mixed_number_and_string(monkeypatch):
+    # Go lessScalar compares a number/string pair by text, so "10" sorts
+    # before 2 (internal/agent/component/list_operations.go).
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[2, "10"])
+    component._sort()
+    assert component._param.outputs["result"]["value"] == ["10", 2]
+
+
+@pytest.mark.p2
+def test_sort_orders_none_by_go_nil_text_form(monkeypatch):
+    # Go renders nil as "<nil>", which sorts after digit text and before
+    # letters.
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[None, "a", "10"])
+    component._sort()
+    assert component._param.outputs["result"]["value"] == ["10", None, "a"]
+
+
+@pytest.mark.p2
+def test_sort_treats_bool_as_text_not_number(monkeypatch):
+    # Mirrors Go's toFloat64OK, which excludes booleans from numeric ordering.
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[True, 1])
+    component._sort()
+    assert component._param.outputs["result"]["value"] == [1, True]
+
+
+@pytest.mark.p2
+def test_sort_legacy_path_tolerates_nested_mixed_set(monkeypatch):
+    # Raw sorted() inside the legacy canonicalization raised TypeError on
+    # mixed set members; the comparator-based canonical form never raises.
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[{"tags": {1, "x"}}, {"tags": {2}}])
+    component._sort()
+    assert component._param.outputs["result"]["value"] == [{"tags": {1, "x"}}, {"tags": {2}}]
+
+
+@pytest.mark.p2
+def test_sort_legacy_path_tolerates_mixed_dict_keys(monkeypatch):
+    module = _load_list_operations_module(monkeypatch)
+    component = _make_sort_component(module, inputs=[{1: "v", "k": "w"}, {"a": 1}])
+    component._sort()
+    # Deterministic, no TypeError: the nested canonical form compares first.
+    assert component._param.outputs["result"]["value"] == [{1: "v", "k": "w"}, {"a": 1}]


### PR DESCRIPTION
Fixes #19427

The Python `_sort` path compared values directly, so None vs number, int vs str, or mixed scalar lists raised TypeError. Sort with a pairwise comparator that mirrors the Go port's `lessScalar`: two real numbers compare numerically, and every other pair compares by its Go `%v` text form (`None` as `"<nil>"`, booleans as text). The legacy hashable path canonicalizes with the same comparator instead of raw `sorted()`, so nested mixed-type containers can't raise before the key is applied.

**Tests:** 12 new unit tests in `test/testcases/test_web_api/test_canvas_app/test_list_operations_unit.py` covering None values, int/str mixes, the Go text ordering (`"10"` before `2`), booleans, descending order, and the legacy path (nested mixed sets, mixed dict keys). The mixed/None cases raise TypeError on current main and pass with the fix. Full web API suite not run (needs a live stack).