### PR TITLE
fix(agent): defer Switch, VariableAssigner, Iteration, and ListOperations behind batch producers (#19361)

### DIFF
--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -618,7 +618,7 @@ class ComponentBase(ABC):
     @staticmethod
     def normalize_param_ref(ref: str) -> str:
         """Strip outer braces and surrounding whitespace from a parameter reference."""
-        return ref.strip("{").strip("}").strip()
+        return ref.strip().removeprefix("{").removesuffix("}").strip()
 
     def param_refs(self) -> list[str]:
         """Return variable references resolved from component parameters."""

--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -615,16 +615,21 @@ class ComponentBase(ABC):
     def get_input_elements(self) -> dict[str, Any]:
         return self._param.inputs
 
+    @staticmethod
+    def normalize_param_ref(ref: str) -> str:
+        """Strip outer braces and surrounding whitespace from a parameter reference."""
+        return ref.strip("{").strip("}").strip()
+
     def param_refs(self) -> list[str]:
-        # Variable references a component resolves from its own params instead
-        # of from `inputs`. Override where `_invoke` calls get_variable_value.
+        """Return variable references resolved from component parameters."""
         return []
 
     def get_dependency_ids(self) -> list[str]:
+        """Collect upstream component IDs from input elements and parameter references."""
         ids = [ele["_cpn_id"] for ele in self.get_input_elements().values() if isinstance(ele, dict) and ele.get("_cpn_id")]
         for ref in self.param_refs():
             if isinstance(ref, str):
-                cleaned = ref.strip("{").strip("}").strip()
+                cleaned = self.normalize_param_ref(ref)
                 if cleaned.find("@") > 0:
                     ids.append(cleaned.split("@", 1)[0])
         return ids

--- a/agent/component/base.py
+++ b/agent/component/base.py
@@ -623,8 +623,10 @@ class ComponentBase(ABC):
     def get_dependency_ids(self) -> list[str]:
         ids = [ele["_cpn_id"] for ele in self.get_input_elements().values() if isinstance(ele, dict) and ele.get("_cpn_id")]
         for ref in self.param_refs():
-            if isinstance(ref, str) and ref.find("@") > 0:
-                ids.append(ref.split("@", 1)[0])
+            if isinstance(ref, str):
+                cleaned = ref.strip("{").strip("}").strip()
+                if cleaned.find("@") > 0:
+                    ids.append(cleaned.split("@", 1)[0])
         return ids
 
     def get_input_form(self) -> dict[str, dict]:

--- a/agent/component/iteration.py
+++ b/agent/component/iteration.py
@@ -47,9 +47,10 @@ class Iteration(ComponentBase, ABC):
     component_name = "Iteration"
 
     def param_refs(self) -> list[str]:
+        """Return parameter references resolved by the Iteration component."""
         items_ref = getattr(self._param, "items_ref", None)
         if isinstance(items_ref, str) and items_ref:
-            return [items_ref.strip("{").strip("}").strip()]
+            return [self.normalize_param_ref(items_ref)]
         return []
 
     def get_start(self):

--- a/agent/component/iteration.py
+++ b/agent/component/iteration.py
@@ -46,6 +46,12 @@ class IterationParam(ComponentParamBase):
 class Iteration(ComponentBase, ABC):
     component_name = "Iteration"
 
+    def param_refs(self) -> list[str]:
+        items_ref = getattr(self._param, "items_ref", None)
+        if isinstance(items_ref, str) and items_ref:
+            return [items_ref.strip("{").strip("}").strip()]
+        return []
+
     def get_start(self):
         for cid in self._canvas.components.keys():
             if self._canvas.get_component(cid)["obj"].component_name.lower() != "iterationitem":

--- a/agent/component/list_operations.py
+++ b/agent/component/list_operations.py
@@ -48,6 +48,12 @@ class ListOperationsParam(ComponentParamBase):
 class ListOperations(ComponentBase, ABC):
     component_name = "ListOperations"
 
+    def param_refs(self) -> list[str]:
+        query = getattr(self._param, "query", None)
+        if isinstance(query, str) and query:
+            return [query.strip("{").strip("}").strip()]
+        return []
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60)))
     def _invoke(self, **kwargs):
         self.input_objects = []

--- a/agent/component/list_operations.py
+++ b/agent/component/list_operations.py
@@ -49,9 +49,10 @@ class ListOperations(ComponentBase, ABC):
     component_name = "ListOperations"
 
     def param_refs(self) -> list[str]:
+        """Return parameter references resolved by the ListOperations component."""
         query = getattr(self._param, "query", None)
         if isinstance(query, str) and query:
-            return [query.strip("{").strip("}").strip()]
+            return [self.normalize_param_ref(query)]
         return []
 
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60)))

--- a/agent/component/switch.py
+++ b/agent/component/switch.py
@@ -56,6 +56,20 @@ class SwitchParam(ComponentParamBase):
 class Switch(ComponentBase, ABC):
     component_name = "Switch"
 
+    def param_refs(self) -> list[str]:
+        refs = []
+        conditions = getattr(self._param, "conditions", []) or []
+        if isinstance(conditions, list):
+            for cond in conditions:
+                if not isinstance(cond, dict):
+                    continue
+                for item in cond.get("items", []) or []:
+                    if isinstance(item, dict):
+                        ref = item.get("cpn_id")
+                        if isinstance(ref, str) and ref:
+                            refs.append(ref.strip("{").strip("}").strip())
+        return refs
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 3)))
     def _invoke(self, **kwargs):
         if self.check_if_canceled("Switch processing"):

--- a/agent/component/switch.py
+++ b/agent/component/switch.py
@@ -57,6 +57,7 @@ class Switch(ComponentBase, ABC):
     component_name = "Switch"
 
     def param_refs(self) -> list[str]:
+        """Return parameter references resolved in Switch condition items."""
         refs = []
         conditions = getattr(self._param, "conditions", []) or []
         if isinstance(conditions, list):
@@ -67,7 +68,7 @@ class Switch(ComponentBase, ABC):
                     if isinstance(item, dict):
                         ref = item.get("cpn_id")
                         if isinstance(ref, str) and ref:
-                            refs.append(ref.strip("{").strip("}").strip())
+                            refs.append(self.normalize_param_ref(ref))
         return refs
 
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 3)))

--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -40,6 +40,34 @@ class VariableAssigner(ComponentBase, ABC):
     component_name = "VariableAssigner"
     _NO_PARAMETER_OPERATORS = {"clear", "remove_first", "remove_last"}
 
+    def param_refs(self) -> list[str]:
+        refs = []
+        variables = getattr(self._param, "variables", []) or []
+        if isinstance(variables, list):
+            for item in variables:
+                if not isinstance(item, dict):
+                    continue
+                variable = item.get("variable")
+                if isinstance(variable, str) and "@" in variable:
+                    refs.append(variable.strip("{").strip("}").strip())
+
+                operator = item.get("operator")
+                parameter = item.get("parameter")
+                if isinstance(parameter, str) and "@" in parameter:
+                    if operator == "set":
+                        refs.extend([m.group(1) for m in self.variable_ref_patt_re.finditer(parameter)])
+                    elif operator in ("overwrite", "append", "extend"):
+                        matches = [m.group(1) for m in self.variable_ref_patt_re.finditer(parameter)]
+                        if matches:
+                            refs.extend(matches)
+                        else:
+                            refs.append(parameter.strip("{").strip("}").strip())
+                    else:
+                        matches = [m.group(1) for m in self.variable_ref_patt_re.finditer(parameter)]
+                        if matches:
+                            refs.extend(matches)
+        return refs
+
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60)))
     def _invoke(self, **kwargs):
         if not isinstance(self._param.variables, list):

--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -41,6 +41,7 @@ class VariableAssigner(ComponentBase, ABC):
     _NO_PARAMETER_OPERATORS = {"clear", "remove_first", "remove_last"}
 
     def param_refs(self) -> list[str]:
+        """Return variable references resolved in VariableAssigner operations."""
         refs = []
         variables = getattr(self._param, "variables", []) or []
         if isinstance(variables, list):
@@ -49,23 +50,16 @@ class VariableAssigner(ComponentBase, ABC):
                     continue
                 variable = item.get("variable")
                 if isinstance(variable, str) and "@" in variable:
-                    refs.append(variable.strip("{").strip("}").strip())
+                    refs.append(self.normalize_param_ref(variable))
 
                 operator = item.get("operator")
                 parameter = item.get("parameter")
                 if isinstance(parameter, str) and "@" in parameter:
-                    if operator == "set":
-                        refs.extend([m.group(1) for m in self.variable_ref_patt_re.finditer(parameter)])
+                    matches = [m.group(1) for m in self.variable_ref_patt_re.finditer(parameter)]
+                    if matches:
+                        refs.extend(matches)
                     elif operator in ("overwrite", "append", "extend"):
-                        matches = [m.group(1) for m in self.variable_ref_patt_re.finditer(parameter)]
-                        if matches:
-                            refs.extend(matches)
-                        else:
-                            refs.append(parameter.strip("{").strip("}").strip())
-                    else:
-                        matches = [m.group(1) for m in self.variable_ref_patt_re.finditer(parameter)]
-                        if matches:
-                            refs.extend(matches)
+                        refs.append(self.normalize_param_ref(parameter))
         return refs
 
     @timeout(int(os.environ.get("COMPONENT_EXEC_TIMEOUT", 10 * 60)))

--- a/test/unit_test/agent/test_canvas_batch_readiness.py
+++ b/test/unit_test/agent/test_canvas_batch_readiness.py
@@ -44,13 +44,16 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _load_canvas_stack(monkeypatch):
+    """Load the agent canvas stack with lightweight stubs for isolated batch testing."""
     def _pkg(name, path):
+        """Register an isolated mock package module in sys.modules."""
         mod = ModuleType(name)
         mod.__path__ = [str(path)]
         monkeypatch.setitem(sys.modules, name, mod)
         return mod
 
     def _stub(name, **attrs):
+        """Register an isolated stub module with mocked attributes in sys.modules."""
         mod = ModuleType(name)
         for key, value in attrs.items():
             setattr(mod, key, value)
@@ -58,6 +61,7 @@ def _load_canvas_stack(monkeypatch):
         return mod
 
     def _real(name, relpath):
+        """Load a real module from disk into sys.modules."""
         spec = importlib.util.spec_from_file_location(name, REPO_ROOT / relpath)
         mod = importlib.util.module_from_spec(spec)
         monkeypatch.setitem(sys.modules, name, mod)
@@ -113,65 +117,90 @@ def _load_canvas_stack(monkeypatch):
 
 
 class _Trace:
+    """Thread-safe event logger tracking component start and completion times."""
+
     def __init__(self):
+        """Initialize trace event container and start time."""
         self.events: list[tuple[str, str, float]] = []
         self._lock = threading.Lock()
         self._t0 = time.perf_counter()
 
     def record(self, kind, cpn_id):
+        """Record execution timestamp for a component event."""
         with self._lock:
             self.events.append((kind, cpn_id, time.perf_counter() - self._t0))
 
     def at(self, kind, cpn_id):
+        """Return the recorded timestamp for a component event."""
         return next(t for k, c, t in self.events if k == kind and c == cpn_id)
 
     def runs(self, cpn_id):
+        """Return the number of completed runs for a component."""
         return sum(1 for k, c, _ in self.events if k == "end" and c == cpn_id)
 
     def ran(self, cpn_id):
+        """Check if a component completed at least one run."""
         return self.runs(cpn_id) > 0
 
 
 def _make_components(base, aggregator, trace, switch=None, assigner=None, iteration=None, list_operations=None):
+    """Create instrumented test component classes wired to trace recording."""
     class BeginParam(base.ComponentParamBase):
+        """Parameter specification for test Begin component."""
+
         def __init__(self):
+            """Initialize Begin component parameters."""
             super().__init__()
             self.mode = "conversational"
             self.prologue = ""
 
         def check(self):
+            """Validate Begin parameters."""
             pass
 
     class Begin(base.ComponentBase):
+        """Test Begin component logging start and end events."""
+
         component_name = "Begin"
 
         def thoughts(self) -> str:
+            """Return thoughts trace for Begin."""
             return ""
 
         def _invoke(self, **kwargs):
+            """Record execution events for Begin component."""
             trace.record("start", self._id)
             trace.record("end", self._id)
 
     class EchoParam(base.ComponentParamBase):
+        """Parameter specification for test Echo component."""
+
         def __init__(self):
+            """Initialize Echo component parameters."""
             super().__init__()
             self.text = ""
             self.delay = 0.0
             self.outputs = {"result": {"value": "", "type": "string"}}
 
         def check(self):
+            """Validate Echo parameters."""
             pass
 
     class Echo(base.ComponentBase):
+        """Test Echo component outputting interpolated text with optional delay."""
+
         component_name = "Echo"
 
         def thoughts(self) -> str:
+            """Return thoughts trace for Echo."""
             return ""
 
         def get_input_elements(self):
+            """Extract input element dependencies from text template."""
             return self.get_input_elements_from_text(self._param.text)
 
         def _invoke(self, **kwargs):
+            """Execute Echo component with optional delay and record trace."""
             trace.record("start", self._id)
             value = self._canvas.get_value_with_variable(self._param.text)
             if self._param.delay:
@@ -180,9 +209,12 @@ def _make_components(base, aggregator, trace, switch=None, assigner=None, iterat
             trace.record("end", self._id)
 
     class TracedAggregator(aggregator.VariableAggregator):
+        """Traced subclass of VariableAggregator recording execution timestamps."""
+
         component_name = "VariableAggregator"
 
         def _invoke(self, **kwargs):
+            """Execute VariableAggregator and record trace."""
             trace.record("start", self._id)
             super()._invoke(**kwargs)
             trace.record("end", self._id)
@@ -198,9 +230,12 @@ def _make_components(base, aggregator, trace, switch=None, assigner=None, iterat
 
     if switch:
         class TracedSwitch(switch.Switch):
+            """Traced subclass of Switch recording execution timestamps."""
+
             component_name = "Switch"
 
             def _invoke(self, **kwargs):
+                """Execute Switch component and record trace."""
                 trace.record("start", self._id)
                 super()._invoke(**kwargs)
                 trace.record("end", self._id)
@@ -210,9 +245,12 @@ def _make_components(base, aggregator, trace, switch=None, assigner=None, iterat
 
     if assigner:
         class TracedVariableAssigner(assigner.VariableAssigner):
+            """Traced subclass of VariableAssigner recording execution timestamps."""
+
             component_name = "VariableAssigner"
 
             def _invoke(self, **kwargs):
+                """Execute VariableAssigner component and record trace."""
                 trace.record("start", self._id)
                 super()._invoke(**kwargs)
                 trace.record("end", self._id)
@@ -222,9 +260,12 @@ def _make_components(base, aggregator, trace, switch=None, assigner=None, iterat
 
     if iteration:
         class TracedIteration(iteration.Iteration):
+            """Traced subclass of Iteration recording execution timestamps."""
+
             component_name = "Iteration"
 
             def _invoke(self, **kwargs):
+                """Execute Iteration component and record trace."""
                 trace.record("start", self._id)
                 super()._invoke(**kwargs)
                 trace.record("end", self._id)
@@ -234,9 +275,12 @@ def _make_components(base, aggregator, trace, switch=None, assigner=None, iterat
 
     if list_operations:
         class TracedListOperations(list_operations.ListOperations):
+            """Traced subclass of ListOperations recording execution timestamps."""
+
             component_name = "ListOperations"
 
             def _invoke(self, **kwargs):
+                """Execute ListOperations component and record trace."""
                 trace.record("start", self._id)
                 super()._invoke(**kwargs)
                 trace.record("end", self._id)
@@ -248,10 +292,12 @@ def _make_components(base, aggregator, trace, switch=None, assigner=None, iterat
 
 
 def _node(name, params, downstream, upstream):
+    """Create a DSL component node dictionary."""
     return {"obj": {"component_name": name, "params": params}, "downstream": downstream, "upstream": upstream}
 
 
 def _dsl(components):
+    """Serialize component graph definitions to Canvas DSL JSON."""
     return json.dumps(
         {
             "components": components,
@@ -289,6 +335,7 @@ def _aggregator_graph(deep_branches):
 
 
 def _echo_join_graph():
+    """Create a graph where an Echo join node depends on two unbalanced branches."""
     return _dsl(
         {
             "begin": _node("Begin", {}, ["a", "b"], []),
@@ -301,6 +348,7 @@ def _echo_join_graph():
 
 
 def _unreachable_dependency_graph():
+    """Create a graph where a sink node depends on an unscheduled ghost node."""
     return _dsl(
         {
             "begin": _node("Begin", {}, ["a"], []),
@@ -338,6 +386,7 @@ def _two_join_graph():
 
 
 def _mutually_referencing_graph():
+    """Create a graph with mutually referencing sibling nodes."""
     return _dsl(
         {
             "begin": _node("Begin", {}, ["x", "y"], []),
@@ -348,6 +397,7 @@ def _mutually_referencing_graph():
 
 
 def _switch_sibling_graph():
+    """Create a graph where Switch condition references a slow sibling producer."""
     return _dsl(
         {
             "begin": _node("Begin", {}, ["producer", "sw"], []),
@@ -374,6 +424,7 @@ def _switch_sibling_graph():
 
 
 def _assigner_sibling_graph():
+    """Create a graph where VariableAssigner copies output from a slow sibling producer."""
     return json.dumps(
         {
             "components": {
@@ -404,6 +455,7 @@ def _assigner_sibling_graph():
 
 
 def _iteration_sibling_graph():
+    """Create a graph where Iteration items_ref references a slow sibling producer."""
     return _dsl(
         {
             "begin": _node("Begin", {}, ["producer", "iter_node"], []),
@@ -419,6 +471,7 @@ def _iteration_sibling_graph():
 
 
 def _list_operations_sibling_graph():
+    """Create a graph where ListOperations query references a slow sibling producer."""
     return _dsl(
         {
             "begin": _node("Begin", {}, ["producer", "list_ops"], []),
@@ -434,7 +487,10 @@ def _list_operations_sibling_graph():
 
 
 class _CanvasStack(tuple):
+    """Container tuple providing test access to canvas and components."""
+
     def __new__(cls, canvas, trace, code_exec, switch=None, assigner=None, iteration=None, list_operations=None):
+        """Construct a named tuple holding loaded canvas modules and helpers."""
         instance = super().__new__(cls, (canvas, trace, code_exec))
         instance.canvas = canvas
         instance.trace = trace
@@ -448,6 +504,7 @@ class _CanvasStack(tuple):
 
 @pytest.fixture
 def canvas_stack(monkeypatch):
+    """Fixture providing isolated Canvas test environment and traced components."""
     canvas, base, aggregator, code_exec, switch, assigner, iteration, list_operations, registry = _load_canvas_stack(monkeypatch)
     trace = _Trace()
     registry.update(_make_components(base, aggregator, trace, switch, assigner, iteration, list_operations))
@@ -455,7 +512,9 @@ def canvas_stack(monkeypatch):
 
 
 def _run(canvas_module, dsl):
+    """Execute Canvas workflow synchronously and return the graph."""
     async def _drain():
+        """Drain the asynchronous Canvas generator to completion."""
         graph = canvas_module.Canvas(dsl, tenant_id="t", task_id="task")
         async for _ in graph.run(query="Ragflow"):
             pass
@@ -466,6 +525,7 @@ def _run(canvas_module, dsl):
 
 @pytest.mark.p1
 def test_aggregator_waits_for_the_deeper_branch(canvas_stack):
+    """Verify VariableAggregator waits until slower upstream branch finishes."""
     canvas_module, trace, _ = canvas_stack
     graph = _run(canvas_module, _aggregator_graph(deep_branches=1))
     agg = graph.get_component_obj("agg")
@@ -477,6 +537,7 @@ def test_aggregator_waits_for_the_deeper_branch(canvas_stack):
 
 @pytest.mark.p1
 def test_join_node_waits_for_the_deeper_branch(canvas_stack):
+    """Verify an Echo join node waits until slower upstream branch finishes."""
     canvas_module, trace, _ = canvas_stack
     graph = _run(canvas_module, _echo_join_graph())
 
@@ -486,6 +547,7 @@ def test_join_node_waits_for_the_deeper_branch(canvas_stack):
 
 @pytest.mark.p1
 def test_balanced_branches_still_run_concurrently(canvas_stack):
+    """Verify balanced branches are dispatched concurrently in the same batch."""
     canvas_module, trace, _ = canvas_stack
     graph = _run(canvas_module, _aggregator_graph(deep_branches=2))
     agg = graph.get_component_obj("agg")
@@ -499,6 +561,7 @@ def test_balanced_branches_still_run_concurrently(canvas_stack):
 
 @pytest.mark.p1
 def test_node_whose_upstream_was_never_scheduled_is_dropped(canvas_stack):
+    """Verify nodes depending on unscheduled nodes are dropped instead of stalled."""
     canvas_module, trace, _ = canvas_stack
     _run(canvas_module, _unreachable_dependency_graph())
 
@@ -508,6 +571,7 @@ def test_node_whose_upstream_was_never_scheduled_is_dropped(canvas_stack):
 
 @pytest.mark.p1
 def test_a_drop_carries_to_the_node_reading_it(canvas_stack):
+    """Verify dropped status cascades to downstream dependent nodes."""
     canvas_module, trace, _ = canvas_stack
     _run(canvas_module, _dropped_upstream_graph())
 
@@ -519,6 +583,7 @@ def test_a_drop_carries_to_the_node_reading_it(canvas_stack):
 
 @pytest.mark.p1
 def test_two_joins_held_back_together_each_run_once(canvas_stack):
+    """Verify multiple join nodes held back in the same batch each execute once."""
     canvas_module, trace, _ = canvas_stack
     graph = _run(canvas_module, _two_join_graph())
 
@@ -530,6 +595,7 @@ def test_two_joins_held_back_together_each_run_once(canvas_stack):
 
 @pytest.mark.p1
 def test_nodes_that_reference_each_other_fail_instead_of_running(canvas_stack):
+    """Verify mutually referencing nodes abort with error instead of deadlock."""
     canvas_module, trace, _ = canvas_stack
     graph = _run(canvas_module, _mutually_referencing_graph())
 
@@ -542,6 +608,7 @@ def test_nodes_that_reference_each_other_fail_instead_of_running(canvas_stack):
 
 @pytest.mark.p1
 def test_a_cycle_still_terminates_the_run(canvas_stack):
+    """Verify cyclic node references terminate execution without hanging."""
     canvas_module, _, _ = canvas_stack
     graph = canvas_module.Canvas(_mutually_referencing_graph(), tenant_id="t", task_id="task")
     graph.path = ["begin", "x", "y"]
@@ -552,6 +619,7 @@ def test_a_cycle_still_terminates_the_run(canvas_stack):
 
 @pytest.mark.p1
 def test_being_unrunnable_once_does_not_disable_the_node(canvas_stack):
+    """Verify temporary unrunnable flag does not permanently disable node across loops."""
     canvas_module, trace, _ = canvas_stack
     graph = canvas_module.Canvas(_echo_join_graph(), tenant_id="t", task_id="task")
     cpn = graph.get_component_obj("b")
@@ -569,6 +637,7 @@ def test_being_unrunnable_once_does_not_disable_the_node(canvas_stack):
 
 @pytest.mark.p1
 def test_resumed_run_keeps_its_stored_order(canvas_stack):
+    """Verify resumed workflow run preserves its persisted execution order."""
     canvas_module, _, _ = canvas_stack
     graph = canvas_module.Canvas(_echo_join_graph(), tenant_id="t", task_id="task")
     graph.path = ["userfillup_0", "c", "b"]
@@ -579,6 +648,7 @@ def test_resumed_run_keeps_its_stored_order(canvas_stack):
 
 @pytest.mark.p1
 def test_code_node_dependencies_come_from_its_arguments(canvas_stack):
+    """Verify CodeExec derives upstream dependencies from its argument bindings."""
     _, _, code_exec = canvas_stack
     param = code_exec.CodeExecParam()
     param.arguments = {"arg1": "code_1@result", "arg2": "sys.query", "arg3": ""}
@@ -590,6 +660,7 @@ def test_code_node_dependencies_come_from_its_arguments(canvas_stack):
 
 @pytest.mark.p1
 def test_switch_param_refs_and_dependency_ids(canvas_stack):
+    """Verify Switch extracts condition cpn_id references as dependency IDs."""
     switch_mod = canvas_stack.switch
     param = switch_mod.SwitchParam()
     param.conditions = [
@@ -613,6 +684,7 @@ def test_switch_param_refs_and_dependency_ids(canvas_stack):
 
 @pytest.mark.p1
 def test_switch_waits_for_producer_in_same_batch(canvas_stack):
+    """Verify Switch sibling is deferred behind producer in the same batch window."""
     canvas_module, trace, _ = canvas_stack
     graph = _run(canvas_module, _switch_sibling_graph())
     sw = graph.get_component_obj("sw")
@@ -623,6 +695,7 @@ def test_switch_waits_for_producer_in_same_batch(canvas_stack):
 
 @pytest.mark.p1
 def test_variable_assigner_param_refs_and_dependency_ids(canvas_stack):
+    """Verify VariableAssigner extracts variable and parameter references correctly."""
     assigner_mod = canvas_stack.assigner
     param = assigner_mod.VariableAssignerParam()
     param.variables = [
@@ -651,6 +724,7 @@ def test_variable_assigner_param_refs_and_dependency_ids(canvas_stack):
 
 @pytest.mark.p1
 def test_variable_assigner_waits_for_producer_in_same_batch(canvas_stack):
+    """Verify VariableAssigner sibling waits for producer in the same batch window."""
     canvas_module, trace, _ = canvas_stack
     graph = _run(canvas_module, _assigner_sibling_graph())
 
@@ -660,6 +734,7 @@ def test_variable_assigner_waits_for_producer_in_same_batch(canvas_stack):
 
 @pytest.mark.p1
 def test_iteration_param_refs_and_dependency_ids(canvas_stack):
+    """Verify Iteration extracts items_ref as parameter reference and dependency ID."""
     iteration_mod = canvas_stack.iteration
     param = iteration_mod.IterationParam()
     param.items_ref = "generator@items"
@@ -672,6 +747,7 @@ def test_iteration_param_refs_and_dependency_ids(canvas_stack):
 
 @pytest.mark.p1
 def test_iteration_waits_for_producer_in_same_batch(canvas_stack):
+    """Verify Iteration sibling waits for producer in the same batch window."""
     canvas_module, trace, _ = canvas_stack
     _run(canvas_module, _iteration_sibling_graph())
 
@@ -680,6 +756,7 @@ def test_iteration_waits_for_producer_in_same_batch(canvas_stack):
 
 @pytest.mark.p1
 def test_list_operations_param_refs_and_dependency_ids(canvas_stack):
+    """Verify ListOperations extracts query as parameter reference and dependency ID."""
     list_ops_mod = canvas_stack.list_operations
     param = list_ops_mod.ListOperationsParam()
     param.query = "retrieval@chunks"
@@ -692,6 +769,7 @@ def test_list_operations_param_refs_and_dependency_ids(canvas_stack):
 
 @pytest.mark.p1
 def test_list_operations_waits_for_producer_in_same_batch(canvas_stack):
+    """Verify ListOperations sibling waits for producer in the same batch window."""
     canvas_module, trace, _ = canvas_stack
     _run(canvas_module, _list_operations_sibling_graph())
 
@@ -700,12 +778,16 @@ def test_list_operations_waits_for_producer_in_same_batch(canvas_stack):
 
 @pytest.mark.p1
 def test_dependency_ids_handles_braced_param_refs(canvas_stack):
+    """Verify ComponentBase.get_dependency_ids strips outer braces from references."""
     base = sys.modules["agent.component.base"]
 
     class DummyComponent(base.ComponentBase):
+        """Dummy component returning braced and whitespace-padded parameter references."""
+
         component_name = "Dummy"
 
         def param_refs(self):
+            """Return test parameter references with braces and whitespace."""
             return ["{producer_1@output}", "producer_2@output", "{ sys.query }", "invalid_no_at"]
 
     c = DummyComponent.__new__(DummyComponent)

--- a/test/unit_test/agent/test_canvas_batch_readiness.py
+++ b/test/unit_test/agent/test_canvas_batch_readiness.py
@@ -87,6 +87,7 @@ def _load_canvas_stack(monkeypatch):
     _real("agent.settings", "agent/settings.py")
     _real("agent.dsl_migration", "agent/dsl_migration.py")
 
+    _stub("api.utils.api_utils", timeout=lambda *a, **kw: lambda fn: fn)
     base = _real("agent.component.base", "agent/component/base.py")
     component_pkg.base = base
 
@@ -95,6 +96,10 @@ def _load_canvas_stack(monkeypatch):
 
     canvas = _real("agent.canvas", "agent/canvas.py")
     aggregator = _real("agent.component.variable_aggregator", "agent/component/variable_aggregator.py")
+    switch = _real("agent.component.switch", "agent/component/switch.py")
+    assigner = _real("agent.component.variable_assigner", "agent/component/variable_assigner.py")
+    iteration = _real("agent.component.iteration", "agent/component/iteration.py")
+    list_operations = _real("agent.component.list_operations", "agent/component/list_operations.py")
 
     _pkg("agent.tools", REPO_ROOT / "agent" / "tools")
     _stub("common.mcp_tool_call_conn", MCPToolBinding=MagicMock(), MCPToolCallSession=MagicMock(), ToolCallSession=MagicMock())
@@ -104,7 +109,7 @@ def _load_canvas_stack(monkeypatch):
     sys.modules["rag.prompts.generator"].kb_prompt = MagicMock()
     _real("agent.tools.base", "agent/tools/base.py")
     code_exec = _real("agent.tools.code_exec", "agent/tools/code_exec.py")
-    return canvas, base, aggregator, code_exec, registry
+    return canvas, base, aggregator, code_exec, switch, assigner, iteration, list_operations, registry
 
 
 class _Trace:
@@ -127,7 +132,7 @@ class _Trace:
         return self.runs(cpn_id) > 0
 
 
-def _make_components(base, aggregator, trace):
+def _make_components(base, aggregator, trace, switch=None, assigner=None, iteration=None, list_operations=None):
     class BeginParam(base.ComponentParamBase):
         def __init__(self):
             super().__init__()
@@ -182,7 +187,7 @@ def _make_components(base, aggregator, trace):
             super()._invoke(**kwargs)
             trace.record("end", self._id)
 
-    return {
+    components = {
         "Begin": Begin,
         "BeginParam": BeginParam,
         "Echo": Echo,
@@ -190,6 +195,56 @@ def _make_components(base, aggregator, trace):
         "VariableAggregator": TracedAggregator,
         "VariableAggregatorParam": aggregator.VariableAggregatorParam,
     }
+
+    if switch:
+        class TracedSwitch(switch.Switch):
+            component_name = "Switch"
+
+            def _invoke(self, **kwargs):
+                trace.record("start", self._id)
+                super()._invoke(**kwargs)
+                trace.record("end", self._id)
+
+        components["Switch"] = TracedSwitch
+        components["SwitchParam"] = switch.SwitchParam
+
+    if assigner:
+        class TracedVariableAssigner(assigner.VariableAssigner):
+            component_name = "VariableAssigner"
+
+            def _invoke(self, **kwargs):
+                trace.record("start", self._id)
+                super()._invoke(**kwargs)
+                trace.record("end", self._id)
+
+        components["VariableAssigner"] = TracedVariableAssigner
+        components["VariableAssignerParam"] = assigner.VariableAssignerParam
+
+    if iteration:
+        class TracedIteration(iteration.Iteration):
+            component_name = "Iteration"
+
+            def _invoke(self, **kwargs):
+                trace.record("start", self._id)
+                super()._invoke(**kwargs)
+                trace.record("end", self._id)
+
+        components["Iteration"] = TracedIteration
+        components["IterationParam"] = iteration.IterationParam
+
+    if list_operations:
+        class TracedListOperations(list_operations.ListOperations):
+            component_name = "ListOperations"
+
+            def _invoke(self, **kwargs):
+                trace.record("start", self._id)
+                super()._invoke(**kwargs)
+                trace.record("end", self._id)
+
+        components["ListOperations"] = TracedListOperations
+        components["ListOperationsParam"] = list_operations.ListOperationsParam
+
+    return components
 
 
 def _node(name, params, downstream, upstream):
@@ -292,12 +347,111 @@ def _mutually_referencing_graph():
     )
 
 
+def _switch_sibling_graph():
+    return _dsl(
+        {
+            "begin": _node("Begin", {}, ["producer", "sw"], []),
+            "producer": _node("Echo", {"text": "ready", "delay": 0.20}, [], ["begin"]),
+            "sw": _node(
+                "Switch",
+                {
+                    "conditions": [
+                        {
+                            "logical_operator": "and",
+                            "items": [{"cpn_id": "producer@result", "operator": "=", "value": "ready"}],
+                            "to": ["matched"],
+                        }
+                    ],
+                    "end_cpn_ids": ["else_sink"],
+                },
+                ["matched", "else_sink"],
+                ["begin"],
+            ),
+            "matched": _node("Echo", {"text": "matched_path"}, [], ["sw"]),
+            "else_sink": _node("Echo", {"text": "else_path"}, [], ["sw"]),
+        }
+    )
+
+
+def _assigner_sibling_graph():
+    return json.dumps(
+        {
+            "components": {
+                "begin": _node("Begin", {}, ["producer", "assigner"], []),
+                "producer": _node("Echo", {"text": "computed_val", "delay": 0.20}, [], ["begin"]),
+                "assigner": _node(
+                    "VariableAssigner",
+                    {
+                        "variables": [
+                            {
+                                "variable": "assigned_res",
+                                "operator": "set",
+                                "parameter": "{producer@result}",
+                            }
+                        ]
+                    },
+                    [],
+                    ["begin"],
+                ),
+            },
+            "history": [],
+            "retrieval": [],
+            "memory": [],
+            "path": [],
+            "globals": {"sys.query": "", "sys.user_id": "u", "sys.conversation_turns": 0, "sys.files": [], "sys.history": [], "assigned_res": ""},
+        }
+    )
+
+
+def _iteration_sibling_graph():
+    return _dsl(
+        {
+            "begin": _node("Begin", {}, ["producer", "iter_node"], []),
+            "producer": _node("Echo", {"text": "ready", "delay": 0.20}, [], ["begin"]),
+            "iter_node": _node(
+                "Iteration",
+                {"items_ref": "producer@result"},
+                [],
+                ["begin"],
+            ),
+        }
+    )
+
+
+def _list_operations_sibling_graph():
+    return _dsl(
+        {
+            "begin": _node("Begin", {}, ["producer", "list_ops"], []),
+            "producer": _node("Echo", {"text": "ready", "delay": 0.20}, [], ["begin"]),
+            "list_ops": _node(
+                "ListOperations",
+                {"query": "producer@result", "operations": "nth", "n": 1},
+                [],
+                ["begin"],
+            ),
+        }
+    )
+
+
+class _CanvasStack(tuple):
+    def __new__(cls, canvas, trace, code_exec, switch=None, assigner=None, iteration=None, list_operations=None):
+        instance = super().__new__(cls, (canvas, trace, code_exec))
+        instance.canvas = canvas
+        instance.trace = trace
+        instance.code_exec = code_exec
+        instance.switch = switch
+        instance.assigner = assigner
+        instance.iteration = iteration
+        instance.list_operations = list_operations
+        return instance
+
+
 @pytest.fixture
 def canvas_stack(monkeypatch):
-    canvas, base, aggregator, code_exec, registry = _load_canvas_stack(monkeypatch)
+    canvas, base, aggregator, code_exec, switch, assigner, iteration, list_operations, registry = _load_canvas_stack(monkeypatch)
     trace = _Trace()
-    registry.update(_make_components(base, aggregator, trace))
-    return canvas, trace, code_exec
+    registry.update(_make_components(base, aggregator, trace, switch, assigner, iteration, list_operations))
+    return _CanvasStack(canvas, trace, code_exec, switch, assigner, iteration, list_operations)
 
 
 def _run(canvas_module, dsl):
@@ -432,3 +586,130 @@ def test_code_node_dependencies_come_from_its_arguments(canvas_stack):
     cpn._param = param
 
     assert cpn.get_dependency_ids() == ["code_1"]
+
+
+@pytest.mark.p1
+def test_switch_param_refs_and_dependency_ids(canvas_stack):
+    switch_mod = canvas_stack.switch
+    param = switch_mod.SwitchParam()
+    param.conditions = [
+        {
+            "logical_operator": "and",
+            "items": [
+                {"cpn_id": "producer_1@output", "operator": "=", "value": "1"},
+                {"cpn_id": "producer_2@output", "operator": "contains", "value": "2"},
+                {"cpn_id": "", "operator": "=", "value": "3"},
+            ],
+            "to": ["dest"],
+        }
+    ]
+    param.end_cpn_ids = ["else_dest"]
+    cpn = switch_mod.Switch.__new__(switch_mod.Switch)
+    cpn._param = param
+
+    assert cpn.param_refs() == ["producer_1@output", "producer_2@output"]
+    assert cpn.get_dependency_ids() == ["producer_1", "producer_2"]
+
+
+@pytest.mark.p1
+def test_switch_waits_for_producer_in_same_batch(canvas_stack):
+    canvas_module, trace, _ = canvas_stack
+    graph = _run(canvas_module, _switch_sibling_graph())
+    sw = graph.get_component_obj("sw")
+
+    assert sw.output("_next") == ["matched"]
+    assert trace.at("start", "sw") >= trace.at("end", "producer")
+
+
+@pytest.mark.p1
+def test_variable_assigner_param_refs_and_dependency_ids(canvas_stack):
+    assigner_mod = canvas_stack.assigner
+    param = assigner_mod.VariableAssignerParam()
+    param.variables = [
+        {"variable": "sys.query", "operator": "set", "parameter": "{node_a@result}"},
+        {"variable": "node_b@var", "operator": "overwrite", "parameter": "node_c@result"},
+        {"variable": "global_val", "operator": "set", "parameter": "plain {node_d@out1} and {node_e@out2}"},
+        {"variable": "email_literal", "operator": "set", "parameter": "support@example.com"},
+        {"variable": "mixed_email", "operator": "set", "parameter": "email support@example.com or {node_f@email}"},
+        {"variable": "sys.count", "operator": "+=", "parameter": 1},
+        {"variable": "sys.list", "operator": "clear", "parameter": None},
+    ]
+    cpn = assigner_mod.VariableAssigner.__new__(assigner_mod.VariableAssigner)
+    cpn._param = param
+
+    refs = cpn.param_refs()
+    assert "node_a@result" in refs
+    assert "node_b@var" in refs
+    assert "node_c@result" in refs
+    assert "node_d@out1" in refs
+    assert "node_e@out2" in refs
+    assert "node_f@email" in refs
+    assert "support@example.com" not in refs
+    dep_ids = cpn.get_dependency_ids()
+    assert dep_ids == ["node_a", "node_b", "node_c", "node_d", "node_e", "node_f"]
+
+
+@pytest.mark.p1
+def test_variable_assigner_waits_for_producer_in_same_batch(canvas_stack):
+    canvas_module, trace, _ = canvas_stack
+    graph = _run(canvas_module, _assigner_sibling_graph())
+
+    assert graph.get_variable_value("assigned_res") == "computed_val"
+    assert trace.at("start", "assigner") >= trace.at("end", "producer")
+
+
+@pytest.mark.p1
+def test_iteration_param_refs_and_dependency_ids(canvas_stack):
+    iteration_mod = canvas_stack.iteration
+    param = iteration_mod.IterationParam()
+    param.items_ref = "generator@items"
+    cpn = iteration_mod.Iteration.__new__(iteration_mod.Iteration)
+    cpn._param = param
+
+    assert cpn.param_refs() == ["generator@items"]
+    assert cpn.get_dependency_ids() == ["generator"]
+
+
+@pytest.mark.p1
+def test_iteration_waits_for_producer_in_same_batch(canvas_stack):
+    canvas_module, trace, _ = canvas_stack
+    _run(canvas_module, _iteration_sibling_graph())
+
+    assert trace.at("start", "iter_node") >= trace.at("end", "producer")
+
+
+@pytest.mark.p1
+def test_list_operations_param_refs_and_dependency_ids(canvas_stack):
+    list_ops_mod = canvas_stack.list_operations
+    param = list_ops_mod.ListOperationsParam()
+    param.query = "retrieval@chunks"
+    cpn = list_ops_mod.ListOperations.__new__(list_ops_mod.ListOperations)
+    cpn._param = param
+
+    assert cpn.param_refs() == ["retrieval@chunks"]
+    assert cpn.get_dependency_ids() == ["retrieval"]
+
+
+@pytest.mark.p1
+def test_list_operations_waits_for_producer_in_same_batch(canvas_stack):
+    canvas_module, trace, _ = canvas_stack
+    _run(canvas_module, _list_operations_sibling_graph())
+
+    assert trace.at("start", "list_ops") >= trace.at("end", "producer")
+
+
+@pytest.mark.p1
+def test_dependency_ids_handles_braced_param_refs(canvas_stack):
+    base = sys.modules["agent.component.base"]
+
+    class DummyComponent(base.ComponentBase):
+        component_name = "Dummy"
+
+        def param_refs(self):
+            return ["{producer_1@output}", "producer_2@output", "{ sys.query }", "invalid_no_at"]
+
+    c = DummyComponent.__new__(DummyComponent)
+    param = base.ComponentParamBase.__new__(base.ComponentParamBase)
+    param.inputs = {}
+    c._param = param
+    assert c.get_dependency_ids() == ["producer_1", "producer_2"]

--- a/test/unit_test/agent/test_canvas_batch_readiness.py
+++ b/test/unit_test/agent/test_canvas_batch_readiness.py
@@ -788,10 +788,10 @@ def test_dependency_ids_handles_braced_param_refs(canvas_stack):
 
         def param_refs(self):
             """Return test parameter references with braces and whitespace."""
-            return ["{producer_1@output}", "producer_2@output", "{ sys.query }", "invalid_no_at"]
+            return ["{producer_1@output}", "producer_2@output", " {producer_3@output} ", " { producer_4@output } ", "{ sys.query }", "invalid_no_at"]
 
     c = DummyComponent.__new__(DummyComponent)
     param = base.ComponentParamBase.__new__(base.ComponentParamBase)
     param.inputs = {}
     c._param = param
-    assert c.get_dependency_ids() == ["producer_1", "producer_2"]
+    assert c.get_dependency_ids() == ["producer_1", "producer_2", "producer_3", "producer_4"]


### PR DESCRIPTION
### Summary

Fixes #19361

PR #19282 added `param_refs()` to `VariableAggregator` and `CodeExec` so that canvas batch scheduling (`Canvas._schedulable()`) can detect cross-component variable dependencies that are not connected via direct graph edges and defer dependents behind their producer.

However, four other components also resolve cross-component variables directly from component configuration rather than `inputs`:
- **`Switch`**: Condition items resolve `cpn_id` (e.g. `producer@output`) via `Canvas.get_variable_value()`.
- **`VariableAssigner`**: Variable operations resolve `parameter` (both bare references like `producer@output` in `overwrite`/`append`/`extend` and `{producer@output}` template strings in `set`) and component targets in `variable`.
- **`Iteration`**: Iteration input array resolves `items_ref` (e.g. `producer@output`) via `Canvas.get_variable_value()`.
- **`ListOperations`**: Input list resolves `query` (e.g. `producer@output`) via `Canvas.get_variable_value()`.

When any of these components shared a canvas batch window `path[idx:to]` with their producer (e.g. siblings branching from `Begin`), they were scheduled concurrently before the producer finished, causing them to read stale or `None` values.

### Changes
1. **Component `param_refs()`**:
   - `Switch`: Extracts `cpn_id` from all condition items.
   - `VariableAssigner`: Exposes component targets in `variable`, template refs via `variable_ref_patt_re` in `set`, and component refs in `overwrite`, `append`, and `extend`. Differentiates operator semantics so literal strings with `@` (e.g. email addresses) under `set` do not create false-positive dependencies.
   - `Iteration`: Exposes `items_ref`.
   - `ListOperations`: Exposes `query`.
2. **`ComponentBase.get_dependency_ids()`**:
   - Safely strips outer braces/whitespace from references before extracting the component ID prefix before `@`.
3. **Tests**:
   - Added unit tests for `param_refs()` and `get_dependency_ids()` across all 4 components.
   - Added integration tests for canvas batch scheduling verifying that `Switch`, `VariableAssigner`, `Iteration`, and `ListOperations` are deferred behind their producer when sharing a batch window.
