### PR TITLE
CI: Optimize api test cases failed

### DIFF
--- a/test/testcases/restful_api/conftest.py
+++ b/test/testcases/restful_api/conftest.py
@@ -153,7 +153,7 @@ def rest_client_noauth():
 @pytest.fixture
 def clear_datasets(rest_client):
     def _cleanup():
-        res = rest_client.delete("/datasets", json={"ids": None, "delete_all": True})
+        res = rest_client.delete("/datasets", json={"ids": None, "delete_all": True}, timeout=120)
         assert res.status_code == 200, res.text
         payload = res.json()
         assert payload["code"] in (0, 102), payload
@@ -190,7 +190,7 @@ def create_dataset(rest_client, clear_datasets):
     yield _create
 
     if created_ids:
-        res = rest_client.delete("/datasets", json={"ids": created_ids})
+        res = rest_client.delete("/datasets", json={"ids": created_ids}, timeout=120)
         assert res.status_code == 200
         payload = res.json()
         # Dataset may already be removed by test logic/cleanup.

--- a/test/testcases/restful_api/test_documents.py
+++ b/test/testcases/restful_api/test_documents.py
@@ -1148,12 +1148,12 @@ def test_documents_delete_invalid_dataset_partial_duplicate_repeat_and_cross_dat
     assert duplicate_payload["code"] == 101, duplicate_payload
     assert "Field: <ids> - Message: <Duplicate ids:" in duplicate_payload["message"], duplicate_payload
 
-    delete_once_res = rest_client.delete(f"/datasets/{dataset_id}/documents", json={"ids": document_ids})
+    delete_once_res = rest_client.delete(f"/datasets/{dataset_id}/documents", json={"ids": document_ids}, timeout=120)
     assert delete_once_res.status_code == 200
     delete_once_payload = delete_once_res.json()
     assert delete_once_payload["code"] == 0, delete_once_payload
 
-    delete_twice_res = rest_client.delete(f"/datasets/{dataset_id}/documents", json={"ids": document_ids})
+    delete_twice_res = rest_client.delete(f"/datasets/{dataset_id}/documents", json={"ids": document_ids}, timeout=120)
     assert delete_twice_res.status_code == 200
     delete_twice_payload = delete_twice_res.json()
     assert delete_twice_payload["code"] == 102, delete_twice_payload


### PR DESCRIPTION
optimize ci api tests cases failed:   test_documents_delete_invalid_dataset_partial_duplicate_repeat_and_cross_dataset - requests.exceptions.ReadTimeout: HTTPConnectionPool(host='host.docker.internal', port=15799): Read timed out. (read timeout=30)

