### PR TITLE
fix(storage): accept tenant arguments in encrypted Azure calls

### DIFF
--- a/rag/utils/azure_sas_conn.py
+++ b/rag/utils/azure_sas_conn.py
@@ -61,13 +61,13 @@ class RAGFlowAzureSasBlob:
                 self.__open__()
                 time.sleep(1)
 
-    def rm(self, bucket, fnm):
+    def rm(self, bucket, fnm, tenant_id=None):
         try:
             self.conn.delete_blob(f"{bucket}/{fnm}")
         except Exception:
             logging.exception(f"Fail rm {bucket}/{fnm}")
 
-    def get(self, bucket, fnm):
+    def get(self, bucket, fnm, tenant_id=None):
         blob_name = f"{bucket}/{fnm}"
         for _ in range(1):
             try:
@@ -79,7 +79,7 @@ class RAGFlowAzureSasBlob:
                 time.sleep(1)
         return None
 
-    def obj_exist(self, bucket, fnm):
+    def obj_exist(self, bucket, fnm, tenant_id=None):
         blob_name = f"{bucket}/{fnm}"
         try:
             return self.conn.get_blob_client(f"{blob_name}").exists()

--- a/rag/utils/azure_sas_conn.py
+++ b/rag/utils/azure_sas_conn.py
@@ -84,7 +84,7 @@ class RAGFlowAzureSasBlob:
         try:
             return self.conn.get_blob_client(f"{blob_name}").exists()
         except Exception:
-            logging.exception(f"Fail put {blob_name}")
+            logging.exception(f"Fail obj_exist {blob_name}")
         return False
 
     def get_presigned_url(self, bucket, fnm, expires):

--- a/rag/utils/azure_spn_conn.py
+++ b/rag/utils/azure_spn_conn.py
@@ -80,14 +80,14 @@ class RAGFlowAzureSpnBlob:
                 return None
         return None
 
-    def rm(self, bucket, fnm):
+    def rm(self, bucket, fnm, tenant_id=None):
         blob = f"{bucket}/{fnm}"
         try:
             self.conn.delete_file(f"{blob}")
         except Exception:
             logging.exception(f"Fail rm {blob}")
 
-    def get(self, bucket, fnm):
+    def get(self, bucket, fnm, tenant_id=None):
         blob = f"{bucket}/{fnm}"
         for _ in range(1):
             try:
@@ -100,7 +100,7 @@ class RAGFlowAzureSpnBlob:
                 time.sleep(1)
         return None
 
-    def obj_exist(self, bucket, fnm):
+    def obj_exist(self, bucket, fnm, tenant_id=None):
         blob = f"{bucket}/{fnm}"
         try:
             client = self.conn.get_blob_client(f"{blob}")

--- a/rag/utils/azure_spn_conn.py
+++ b/rag/utils/azure_spn_conn.py
@@ -106,7 +106,7 @@ class RAGFlowAzureSpnBlob:
             client = self.conn.get_blob_client(f"{blob}")
             return client.exists()
         except Exception:
-            logging.exception(f"Fail put {blob}")
+            logging.exception(f"Fail obj_exist {blob}")
         return False
 
     def get_presigned_url(self, bucket, fnm, expires):

--- a/test/unit_test/rag/utils/test_azure_encrypted_storage.py
+++ b/test/unit_test/rag/utils/test_azure_encrypted_storage.py
@@ -1,0 +1,100 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Azure adapters must accept the tenant argument forwarded by encrypted storage."""
+
+import importlib.util
+import sys
+from io import BytesIO
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+from azure.storage.blob import ContainerClient
+from azure.storage.filedatalake import FileSystemClient
+
+import common
+from rag.utils.encrypted_storage import EncryptedStorageWrapper
+
+pytestmark = pytest.mark.p2
+
+
+@pytest.fixture(params=[("azure_sas_conn", "RAGFlowAzureSasBlob", ContainerClient), ("azure_spn_conn", "RAGFlowAzureSpnBlob", FileSystemClient)])
+def storage(request, monkeypatch):
+    """Load a fresh singleton without loading service settings or credentials."""
+    name, factory, client_type = request.param
+    settings = ModuleType("common.settings")
+    settings.AZURE = {}
+    monkeypatch.setitem(sys.modules, "common.settings", settings)
+    monkeypatch.setattr(common, "settings", settings, raising=False)
+    path = Path(__file__).resolve().parents[4] / "rag" / "utils" / (name + ".py")
+    spec = importlib.util.spec_from_file_location("test_" + name, path)
+    module = importlib.util.module_from_spec(spec)
+    # Bypass only singleton/connection setup; keep all adapter method bodies.
+    with monkeypatch.context() as load_patch:
+        load_patch.setattr("common.decorator.singleton", lambda cls: cls)
+        spec.loader.exec_module(module)
+    cls = getattr(module, factory)
+    adapter = cls.__new__(cls)
+    adapter.conn = Mock(spec=client_type)
+    return adapter, name
+
+
+@pytest.mark.parametrize("tenant_id", [None, "tenant-a"])
+def test_encrypted_get_decrypts_backend_bytes(storage, tenant_id):
+    adapter, name = storage
+    wrapper = EncryptedStorageWrapper(adapter, key="test-key")
+    encrypted = wrapper.crypto.encrypt(b"document contents")
+    if name == "azure_sas_conn":
+        adapter.conn.download_blob.return_value = BytesIO(encrypted)
+    else:
+        adapter.conn.get_file_client.return_value.download_file.return_value = BytesIO(encrypted)
+    assert wrapper.get("kb", "file.txt", tenant_id) == b"document contents"
+
+
+@pytest.mark.parametrize("tenant_id", [None, "tenant-a"])
+def test_encrypted_rm_deletes_same_object(storage, tenant_id):
+    adapter, name = storage
+    wrapper = EncryptedStorageWrapper(adapter, key="test-key")
+    wrapper.rm("kb", "file.txt", tenant_id)
+    delete = adapter.conn.delete_blob if name == "azure_sas_conn" else adapter.conn.delete_file
+    delete.assert_called_once_with("kb/file.txt")
+
+
+@pytest.mark.parametrize("tenant_id", [None, "tenant-a"])
+@pytest.mark.parametrize("exists", [False, True])
+def test_encrypted_obj_exist_preserves_backend_result(storage, tenant_id, exists):
+    adapter, name = storage
+    if name == "azure_sas_conn":
+        adapter.conn.get_blob_client.return_value.exists.return_value = exists
+    else:
+        adapter.conn.get_file_client.return_value.exists.return_value = exists
+    # The separate SPN get_blob_client defect remains out of scope: the real
+    # FileSystemClient spec rejects it, and the adapter currently returns False.
+    expected = adapter.obj_exist("kb", "file.txt")
+    wrapper = EncryptedStorageWrapper(adapter, key="test-key")
+    assert wrapper.obj_exist("kb", "file.txt", tenant_id) is expected
+
+
+def test_direct_get_and_rm_remain_callable_without_tenant(storage):
+    adapter, name = storage
+    if name == "azure_sas_conn":
+        adapter.conn.download_blob.return_value = BytesIO(b"plain")
+    else:
+        adapter.conn.get_file_client.return_value.download_file.return_value = BytesIO(b"plain")
+    assert adapter.get("kb", "file.txt") == b"plain"
+    adapter.rm("kb", "file.txt")


### PR DESCRIPTION
### Summary

Enabling storage encryption with `AZURE_SAS` or `AZURE_SPN` makes `get`, `rm`, and `obj_exist` raise `TypeError` before they can reach the Azure client. `EncryptedStorageWrapper` always forwards a third `tenant_id` argument, including when it is `None`, but those six adapter methods only accept `bucket` and `fnm`.

Accept optional `tenant_id=None` on both adapters, matching their existing `put` signatures and the other storage backends. Azure object paths and credentials continue to come from the existing adapter configuration.

### Validation

- Added 18 focused unit cases covering encrypted reads with real encryption/decryption, deletion routing, existence-result forwarding, omitted tenant support on direct calls, and `None`/explicit tenant values. On unchanged main `c0405a9dd`, 16 fail with the target `TypeError` and 2 direct-call controls pass; all 18 pass with the fix.
- Six additional local HTTP probes use the real Azure SDK: SAS get/existence/delete, SPN get/delete, and a SAS encrypt/write/read/delete round trip. All six fail on the baseline and pass with the fix. These are local protocol checks, not live Azure validation.
- Ruff passes for the added test file; formatting and `git diff --check` pass. Ruff 0.16.6 reports 20 existing findings in the two adapter files, identical on baseline and branch.
- Tests ran in a minimal Python 3.13 environment with repository-pinned Azure dependencies. The shared NLTK bootstrap was excluded for these storage-only tests. Live Azure, the full service suite, and database/connector end-to-end flows were not run.

### Scope

The separate SPN `get_blob_client`/`get_file_client` existence defect remains tracked by #14561. The existence tests preserve the current backend result using SDK-spec mocks; this PR does not claim to fix that defect or restore the entire SPN workflow. Checked #13458 and #17070 as well: their current Azure method signatures still lack these arguments. Optional presigned URL support is outside this core read/delete/existence fix.
