### PR TITLE
Fix: fall back to llm_factories is_tools when tenant_model.extra is empty

### DIFF
--- a/api/db/joint_services/tenant_model_service.py
+++ b/api/db/joint_services/tenant_model_service.py
@@ -62,6 +62,19 @@ def _lookup_factory_llm_info(provider_name: str, pure_model_name: str, extra_fie
     return llm_list[0] if llm_list else None
 
 
+def _resolve_is_tools(model_extra: dict | None, api_key_is_tools: bool | None, llm_info: dict | None) -> bool:
+    # Prefer the UI "Tool call" flag on the tenant model, then a JSON-wrapped
+    # instance api_key, then llm_factories.json. Custom models with a plain
+    # api_key and empty extra otherwise leave is_tools unset, so agentic chat
+    # skips bind_tools even when the factory catalog says the model supports it.
+    extra = model_extra or {}
+    if "is_tools" in extra:
+        return bool(extra["is_tools"])
+    if api_key_is_tools is not None:
+        return bool(api_key_is_tools)
+    return bool((llm_info or {}).get("is_tools", False))
+
+
 def _decode_api_key_config(raw_api_key: str) -> tuple[str, bool | None, str | None]:
     if not raw_api_key:
         return raw_api_key, None, None
@@ -305,7 +318,7 @@ def get_model_config_from_provider_instance(tenant_id, model_type: str | enum.En
             "llm_name": model_obj.model_name,
             "api_base": extra_fields.get("base_url", ""),
             "model_type": model_type_val,
-            "is_tools": model_extra.get("is_tools", is_tool),
+            "is_tools": _resolve_is_tools(model_extra, is_tool, llm_info),
             "max_tokens": max_tokens,
         }
         if provider_name.lower() == "somark":
@@ -353,6 +366,7 @@ def get_model_config_by_id(tenant_id: str, model_type: str | enum.Enum, model_id
     api_key, is_tool, api_key_payload = _decode_api_key_config(instance_obj.api_key)
     extra_fields = json.loads(instance_obj.extra) if instance_obj.extra else {}
     model_extra = json.loads(model_obj.extra) if model_obj.extra else {}
+    llm_info = _lookup_factory_llm_info(provider_obj.provider_name, model_obj.model_name, extra_fields)
 
     model_config = {
         "llm_factory": provider_obj.provider_name,
@@ -360,7 +374,7 @@ def get_model_config_by_id(tenant_id: str, model_type: str | enum.Enum, model_id
         "llm_name": model_obj.model_name,
         "api_base": extra_fields.get("base_url", ""),
         "model_type": model_type_val,
-        "is_tools": model_extra.get("is_tools", is_tool),
+        "is_tools": _resolve_is_tools(model_extra, is_tool, llm_info),
         "max_tokens": model_extra.get("max_tokens") or 8192,
     }
     if provider_obj.provider_name.lower() == "somark":

--- a/test/unit_test/api/db/joint_services/test_tenant_model_service_is_tools.py
+++ b/test/unit_test/api/db/joint_services/test_tenant_model_service_is_tools.py
@@ -1,0 +1,144 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from types import SimpleNamespace
+
+import pytest
+
+from common.constants import ActiveStatusEnum, LLMType
+from api.db.joint_services import tenant_model_service as tms
+
+
+def _factory_infos(is_tools=True):
+    return [
+        {
+            "name": "OpenAI-API-Compatible",
+            "llm": [
+                {
+                    "llm_name": "qwen-test",
+                    "model_type": "chat",
+                    "is_tools": is_tools,
+                    "max_tokens": 32768,
+                }
+            ],
+        }
+    ]
+
+
+def _patch_name_lookup(monkeypatch, provider, instance, model, factory_infos):
+    monkeypatch.setattr(
+        tms.TenantModelProviderService,
+        "get_by_tenant_id_and_provider_name",
+        lambda tenant_id, provider_name: provider,
+    )
+    monkeypatch.setattr(
+        tms.TenantModelInstanceService,
+        "get_by_provider_id_and_instance_name",
+        lambda provider_id, instance_name: instance,
+    )
+    monkeypatch.setattr(
+        tms.TenantModelService,
+        "get_by_provider_id_and_instance_id_and_model_type_and_model_name",
+        lambda provider_id, instance_id, model_type, model_name: model,
+    )
+    monkeypatch.setattr(tms.settings, "FACTORY_LLM_INFOS", factory_infos)
+
+
+@pytest.mark.p1
+def test_is_tools_falls_back_to_factory_when_extra_and_api_key_are_plain(monkeypatch):
+    provider = SimpleNamespace(id="provider-1", provider_name="OpenAI-API-Compatible")
+    instance = SimpleNamespace(id="instance-1", api_key="sk-test", extra='{"base_url": "http://llm"}')
+    model = SimpleNamespace(
+        model_name="qwen-test",
+        model_type="chat",
+        status=ActiveStatusEnum.ACTIVE.value,
+        extra="{}",
+    )
+    _patch_name_lookup(monkeypatch, provider, instance, model, _factory_infos(True))
+
+    config = tms.get_model_config_from_provider_instance(
+        "tenant-1", "chat", "qwen-test@litellm@OpenAI-API-Compatible"
+    )
+
+    assert config["is_tools"] is True
+
+
+@pytest.mark.p1
+def test_is_tools_prefers_model_extra_over_factory(monkeypatch):
+    provider = SimpleNamespace(id="provider-1", provider_name="OpenAI-API-Compatible")
+    instance = SimpleNamespace(id="instance-1", api_key="sk-test", extra="{}")
+    model = SimpleNamespace(
+        model_name="qwen-test",
+        model_type="chat",
+        status=ActiveStatusEnum.ACTIVE.value,
+        extra='{"is_tools": false}',
+    )
+    _patch_name_lookup(monkeypatch, provider, instance, model, _factory_infos(True))
+
+    config = tms.get_model_config_from_provider_instance(
+        "tenant-1", "chat", "qwen-test@litellm@OpenAI-API-Compatible"
+    )
+
+    assert config["is_tools"] is False
+
+
+@pytest.mark.p1
+def test_is_tools_prefers_api_key_json_over_factory_when_extra_empty(monkeypatch):
+    provider = SimpleNamespace(id="provider-1", provider_name="OpenAI-API-Compatible")
+    instance = SimpleNamespace(
+        id="instance-1",
+        api_key='{"api_key": "sk-test", "is_tools": false}',
+        extra="{}",
+    )
+    model = SimpleNamespace(
+        model_name="qwen-test",
+        model_type="chat",
+        status=ActiveStatusEnum.ACTIVE.value,
+        extra="{}",
+    )
+    _patch_name_lookup(monkeypatch, provider, instance, model, _factory_infos(True))
+
+    config = tms.get_model_config_from_provider_instance(
+        "tenant-1", "chat", "qwen-test@litellm@OpenAI-API-Compatible"
+    )
+
+    assert config["is_tools"] is False
+
+
+@pytest.mark.p1
+def test_get_model_config_by_id_falls_back_to_factory_is_tools(monkeypatch):
+    tenant_id = "tenant-1"
+    model_id = "model-1"
+    model = SimpleNamespace(
+        id=model_id,
+        provider_id="provider-1",
+        instance_id="instance-1",
+        model_name="qwen-test",
+        model_type=tms.calculate_model_type(LLMType.CHAT.value),
+        status=ActiveStatusEnum.ACTIVE.value,
+        extra="{}",
+    )
+    provider = SimpleNamespace(id="provider-1", tenant_id=tenant_id, provider_name="OpenAI-API-Compatible")
+    instance = SimpleNamespace(id="instance-1", api_key="sk-test", extra="{}")
+
+    monkeypatch.setattr(tms.TenantModelService, "get_by_id", lambda _id: (True, model))
+    monkeypatch.setattr(tms.TenantModelProviderService, "get_by_id", lambda _id: (True, provider))
+    monkeypatch.setattr(tms.TenantModelInstanceService, "get_by_id", lambda _id: (True, instance))
+    monkeypatch.setattr(tms.settings, "FACTORY_LLM_INFOS", _factory_infos(True))
+
+    config = tms.get_model_config_by_id(tenant_id, LLMType.CHAT, model_id)
+
+    assert config["is_tools"] is True


### PR DESCRIPTION
### Summary

Agentic chat modes (Ultra / High / Medium / Low) can return an empty answer
with only a Thought block when the chat LLM is an OpenAI-API-Compatible model
listed in `llm_factories.json` with `is_tools: true`. Naive mode and
`/api/v1/retrieval` still work.

`LLMBundle.bind_tools` skips tool binding when `is_tools` is falsy and logs
`Model does not support tool call, but you have assigned one or more tools to it!`.
The model then plans to call the `rag` tool but never executes it.

Chat resolves the model via `tenant.tenant_llm_id` → `get_model_config_by_id`.
That path sets `is_tools` from `tenant_model.extra` (or from a JSON-wrapped
instance `api_key`) and never consults `FACTORY_LLM_INFOS`.
`get_model_config_from_provider_instance` already looks up factory metadata
for `max_tokens`, but still does not use `llm_info["is_tools"]`.

When `extra` is `{}` and the API key is a plain string (the common custom-model
case), `is_tools` becomes `None` even if `llm_factories.json` has `is_tools: true`.
The UI "Tool call" checkbox still wins when it is stored in `extra`.

This PR resolves `is_tools` in order: model `extra` → api_key JSON → factory catalog.

Relates to #14227. Follows #15946 (read `is_tools` from the model record; still
empty when `extra` has no flag).

Made with [Cursor](https://cursor.com)