### PR TITLE
fix(api): validate connector create payload

### DIFF
--- a/api/apps/restful_apis/connector_api.py
+++ b/api/apps/restful_apis/connector_api.py
@@ -88,10 +88,17 @@ async def update_connector(connector_id):
 
 @manager.route("/connectors", methods=["POST"])  # noqa: F821
 @login_required
+@validate_request("name", "source", "config")
 async def create_connector():
     """Create a connector owned by the current tenant."""
     req = await get_request_json()
     if req:
+        try:
+            refresh_freq = int(req.get("refresh_freq", 5))
+            prune_freq = int(req.get("prune_freq", 5))
+            timeout_secs = int(req.get("timeout_secs", 60 * 29))
+        except (TypeError, ValueError):
+            return get_data_error_result(message="refresh_freq, prune_freq and timeout_secs must be integers")
         req["id"] = get_uuid()
         conn = {
             "id": req["id"],
@@ -100,9 +107,9 @@ async def create_connector():
             "source": req["source"],
             "input_type": InputType.POLL,
             "config": req["config"],
-            "refresh_freq": int(req.get("refresh_freq", 5)),
-            "prune_freq": int(req.get("prune_freq", 5)),
-            "timeout_secs": int(req.get("timeout_secs", 60 * 29)),
+            "refresh_freq": refresh_freq,
+            "prune_freq": prune_freq,
+            "timeout_secs": timeout_secs,
             "status": TaskStatus.UNSTART,
         }
         ConnectorService.save(**conn)

--- a/api/apps/restful_apis/connector_api.py
+++ b/api/apps/restful_apis/connector_api.py
@@ -93,10 +93,15 @@ async def create_connector():
     """Create a connector owned by the current tenant."""
     req = await get_request_json()
     if req:
+        def _parse_frequency(value):
+            if isinstance(value, bool) or isinstance(value, float) and not value.is_integer():
+                raise ValueError(f"not an integer: {value!r}")
+            return int(value)
+
         try:
-            refresh_freq = int(req.get("refresh_freq", 5))
-            prune_freq = int(req.get("prune_freq", 5))
-            timeout_secs = int(req.get("timeout_secs", 60 * 29))
+            refresh_freq = _parse_frequency(req.get("refresh_freq", 5))
+            prune_freq = _parse_frequency(req.get("prune_freq", 5))
+            timeout_secs = _parse_frequency(req.get("timeout_secs", 60 * 29))
         except (TypeError, ValueError):
             return get_data_error_result(message="refresh_freq, prune_freq and timeout_secs must be integers")
         req["id"] = get_uuid()

--- a/test/unit_test/api/apps/restful_apis/test_connector_create_validation_unit.py
+++ b/test/unit_test/api/apps/restful_apis/test_connector_create_validation_unit.py
@@ -139,11 +139,12 @@ def test_missing_mandatory_fields_return_data_error_not_keyerror(monkeypatch):
 
 @pytest.mark.p2
 @pytest.mark.parametrize("field", ["refresh_freq", "prune_freq", "timeout_secs"])
-def test_non_integer_frequency_returns_data_error_not_500(monkeypatch, field):
+@pytest.mark.parametrize("value", ["abc", 1.5, True])
+def test_non_integer_frequency_returns_data_error_not_500(monkeypatch, field, value):
     module = _load_connector_api(monkeypatch)
     SAVED_CONNECTORS.clear()
     REQUEST_JSON.clear()
-    REQUEST_JSON.update({"name": "kb", "source": "local", "config": {}, field: "abc"})
+    REQUEST_JSON.update({"name": "kb", "source": "local", "config": {}, field: value})
     res = asyncio.run(module.create_connector())
     assert res["code"] == 102
     assert "must be integers" in res["message"]

--- a/test/unit_test/api/apps/restful_apis/test_connector_create_validation_unit.py
+++ b/test/unit_test/api/apps/restful_apis/test_connector_create_validation_unit.py
@@ -1,0 +1,165 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Unit tests for POST /connectors payload validation.
+
+Missing mandatory fields and non-integer frequency values must produce a
+data error (400-class envelope) instead of KeyError/ValueError 500s.
+"""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+class _DummyManager:
+    def route(self, *_args, **_kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+def _module_stub(name, **attrs):
+    mod = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+REQUEST_JSON: dict = {}
+SAVED_CONNECTORS: list = []
+
+
+def _validate_request(*required):
+    def decorator(func):
+        async def wrapper(*args, **kwargs):
+            req = REQUEST_JSON
+            missing = [k for k in required if k not in req]
+            if missing:
+                return {"code": 101, "message": f"missing required arguments: {', '.join(missing)}", "data": None}
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def _load_connector_api(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[5]
+
+    saved_connector = SimpleNamespace(to_dict=lambda: {"id": "conn-1", "name": "kb"})
+    connector_service = SimpleNamespace(
+        save=lambda **kw: SAVED_CONNECTORS.append(kw),
+        get_by_id=lambda _id: (True, saved_connector),
+    )
+
+    monkeypatch.setitem(sys.modules, "quart", _module_stub("quart", request=SimpleNamespace(args={}), make_response=None))
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib", ModuleType("google_auth_oauthlib"))
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", _module_stub("google_auth_oauthlib.flow", Flow=None))
+    monkeypatch.setitem(sys.modules, "box_sdk_gen", _module_stub("box_sdk_gen", BoxOAuth=None, OAuthConfig=None, GetAuthorizeUrlOptions=None))
+    monkeypatch.setitem(sys.modules, "api.db", _module_stub("api.db", InputType=SimpleNamespace(POLL="poll")))
+    monkeypatch.setitem(
+        sys.modules,
+        "api.db.services.connector_service",
+        _module_stub("api.db.services.connector_service", ConnectorAuthorizationError=Exception, ConnectorService=connector_service, SyncLogsService=SimpleNamespace()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "api.utils.api_utils",
+        _module_stub(
+            "api.utils.api_utils",
+            get_data_error_result=lambda *a, **kw: {"code": 102, "message": kw.get("message", a[0] if a else ""), "data": None},
+            get_json_result=lambda **kw: {"code": kw.get("code", 0), "message": kw.get("message", ""), "data": kw.get("data")},
+            get_request_json=lambda: asyncio.sleep(0, result=REQUEST_JSON),
+            validate_request=_validate_request,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "api.utils.pagination_utils",
+        _module_stub("api.utils.pagination_utils", DEFAULT_PAGE=1, DEFAULT_PAGE_SIZE=30, validate_rest_api_page=lambda p: int(p), validate_rest_api_page_size=lambda s: int(s)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "common.constants",
+        _module_stub("common.constants", FileSource=SimpleNamespace(), RetCode=SimpleNamespace(DATA_ERROR=102, ARGUMENT_ERROR=101), TaskStatus=SimpleNamespace(UNSTART="0")),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "common.data_source.config",
+        _module_stub("common.data_source.config", GOOGLE_DRIVE_WEB_OAUTH_REDIRECT_URI="", GMAIL_WEB_OAUTH_REDIRECT_URI="", BOX_WEB_OAUTH_REDIRECT_URI="", DocumentSource=SimpleNamespace()),
+    )
+    monkeypatch.setitem(sys.modules, "common.data_source.google_util.constant", _module_stub("common.data_source.google_util.constant", WEB_OAUTH_POPUP_TEMPLATE="", GOOGLE_SCOPES=[]))
+    monkeypatch.setitem(sys.modules, "common.misc_utils", _module_stub("common.misc_utils", get_uuid=lambda: "uuid-1"))
+    monkeypatch.setitem(sys.modules, "rag.utils.redis_conn", _module_stub("rag.utils.redis_conn", REDIS_CONN=SimpleNamespace()))
+    monkeypatch.setitem(
+        sys.modules,
+        "api.apps",
+        _module_stub("api.apps", login_required=lambda f: f, current_user=SimpleNamespace(id="tenant-1")),
+    )
+
+    module_name = "test_connector_api_unit_module"
+    module_path = repo_root / "api" / "apps" / "restful_apis" / "connector_api.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    module.manager = _DummyManager()
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "asyncio", SimpleNamespace(sleep=lambda *_a, **_k: asyncio.sleep(0)))
+    return module
+
+
+@pytest.mark.p2
+def test_missing_mandatory_fields_return_data_error_not_keyerror(monkeypatch):
+    module = _load_connector_api(monkeypatch)
+    REQUEST_JSON.clear()
+    REQUEST_JSON.update({"name": "kb"})  # missing source and config
+    res = asyncio.run(module.create_connector())
+    assert res["code"] == 101
+    assert "source" in res["message"] and "config" in res["message"]
+
+
+@pytest.mark.p2
+@pytest.mark.parametrize("field", ["refresh_freq", "prune_freq", "timeout_secs"])
+def test_non_integer_frequency_returns_data_error_not_500(monkeypatch, field):
+    module = _load_connector_api(monkeypatch)
+    SAVED_CONNECTORS.clear()
+    REQUEST_JSON.clear()
+    REQUEST_JSON.update({"name": "kb", "source": "local", "config": {}, field: "abc"})
+    res = asyncio.run(module.create_connector())
+    assert res["code"] == 102
+    assert "must be integers" in res["message"]
+    assert SAVED_CONNECTORS == []
+
+
+@pytest.mark.p2
+def test_valid_payload_creates_connector_with_defaults(monkeypatch):
+    module = _load_connector_api(monkeypatch)
+    SAVED_CONNECTORS.clear()
+    REQUEST_JSON.clear()
+    REQUEST_JSON.update({"name": "kb", "source": "local", "config": {}})
+    res = asyncio.run(module.create_connector())
+    assert res["code"] == 0
+    assert res["data"]["name"] == "kb"
+    assert len(SAVED_CONNECTORS) == 1
+    assert SAVED_CONNECTORS[0]["refresh_freq"] == 5
+    assert SAVED_CONNECTORS[0]["prune_freq"] == 5
+    assert SAVED_CONNECTORS[0]["timeout_secs"] == 60 * 29


### PR DESCRIPTION
## What problem does this PR solve?
Fixes #19470.

`POST /connectors` read `name`/`source`/`config` and parsed the frequency fields with no validation, so a missing key raised `KeyError` and a non-integer frequency raised `ValueError` - both surfacing as 500s. The route now requires the mandatory fields via `validate_request` and answers non-integer frequencies with a data error. The connector is not persisted on invalid input.

- New unit tests in test/unit_test/api/apps/restful_apis/test_connector_create_validation_unit.py cover the missing-field error, a data error for each of the three frequency fields, and the valid path with default frequencies.
- Not run: test/testcases/restful_api suites (need a live server and LLM keys).

## Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)