### PR TITLE
fix(ragcon): scope embedding drop_params to official endpoint

### DIFF
--- a/rag/llm/cv_model.py
+++ b/rag/llm/cv_model.py
@@ -1342,7 +1342,7 @@ class RAGconCV(GptV4):
     RAGcon CV Provider - routes through LiteLLM proxy
 
     Supports vision models through LiteLLM.
-    Default Base URL: https://connect.ragcon.ai/v1
+    Default Base URL: https://connect.ragcon.com/v1
     """
 
     _FACTORY_NAME = "RAGcon"

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -1393,19 +1393,20 @@ class RAGconEmbed(OpenAIEmbed):
     """
     RAGcon Embedding Provider - routes through LiteLLM proxy
 
-    Default Base URL: https://connect.ragcon.ai/v1
+    Default Base URL: https://connect.ragcon.com/v1
     """
 
     _FACTORY_NAME = "RAGcon"
 
     def __init__(self, key, model_name="text-embedding-3-small", base_url=None):
         if not base_url:
-            base_url = "https://connect.ragcon.ai/v1"
+            base_url = "https://connect.ragcon.com/v1"
 
         super().__init__(key, model_name, base_url)
 
     def _extra_body(self):
-        if (urlparse(self.base_url).hostname or "").lower() == "connect.ragcon.ai":
+        host = (urlparse(self.base_url).hostname or "").lower()
+        if host in {"connect.ragcon.com", "connect.ragcon.ai"} or host.endswith((".connect.ragcon.com", ".connect.ragcon.ai")):
             return {"drop_params": True}
         return None
 

--- a/rag/llm/embedding_model.py
+++ b/rag/llm/embedding_model.py
@@ -267,15 +267,18 @@ class OpenAIEmbed(Base):
         self.client = OpenAI(api_key=key, base_url=self.base_url)
         self.model_name = model_name
 
+    def _extra_body(self):
+        return None
+
     def _call(self, batch):
-        # extra_body is forwarded verbatim to the provider. `drop_params` is
-        # an OpenRouter-specific convention; Together AI (and any strict
-        # OpenAI-compatible provider) rejects it with HTTP 400
-        # "Unrecognized request arguments supplied: drop_params".
         # `user` is OpenAI-standard and is only sent when LLM request context
         # is active. Local servers that reject unknown fields (LocalAI,
         # LM Studio, Xinference) use their own embed classes and omit it.
-        res = self.client.embeddings.create(input=batch, model=self.model_name, encoding_format="float", **openai_user_kwargs())
+        kwargs = {"input": batch, "model": self.model_name, "encoding_format": "float", **openai_user_kwargs()}
+        extra_body = self._extra_body()
+        if extra_body is not None:
+            kwargs["extra_body"] = extra_body
+        res = self.client.embeddings.create(**kwargs)
         return [d.embedding for d in _sorted_by_index(res.data)], total_token_count_from_response(res)
 
     def encode(self, texts: list):
@@ -1397,9 +1400,14 @@ class RAGconEmbed(OpenAIEmbed):
 
     def __init__(self, key, model_name="text-embedding-3-small", base_url=None):
         if not base_url:
-            base_url = "https://connect.ragcon.com/v1"
+            base_url = "https://connect.ragcon.ai/v1"
 
         super().__init__(key, model_name, base_url)
+
+    def _extra_body(self):
+        if (urlparse(self.base_url).hostname or "").lower() == "connect.ragcon.ai":
+            return {"drop_params": True}
+        return None
 
 
 class PerplexityEmbed(Base):

--- a/rag/llm/tts_model.py
+++ b/rag/llm/tts_model.py
@@ -532,7 +532,7 @@ class RAGconTTS(Base):
     RAGcon TTS Provider - routes through LiteLLM proxy
 
     Text-to-speech models routed through LiteLLM.
-    Default Base URL: https://connect.ragcon.ai/v1
+    Default Base URL: https://connect.ragcon.com/v1
     """
 
     _FACTORY_NAME = "RAGcon"

--- a/test/unit_test/rag/llm/test_embedding_drop_params.py
+++ b/test/unit_test/rag/llm/test_embedding_drop_params.py
@@ -169,8 +169,18 @@ def test_openrouter_embed_call_appends_provider_when_provider_order_set():
     assert extra_body.get("provider") == {"order": ["Azure", "OpenAI"], "allow_fallbacks": False}
 
 
-def test_ragcon_embed_official_endpoint_sends_drop_params():
-    embed = _make_ragcon_embed()
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        None,
+        "https://connect.ragcon.com/v1",
+        "https://connect.ragcon.ai/v1",
+        "https://api.connect.ragcon.com/v1",
+        "https://api.connect.ragcon.ai/v1",
+    ],
+)
+def test_ragcon_embed_official_endpoint_sends_drop_params(endpoint):
+    embed = _make_ragcon_embed(endpoint)
     embed._call(["hello"])
 
     kwargs = embed.client.embeddings.create.call_args.kwargs

--- a/test/unit_test/rag/llm/test_embedding_drop_params.py
+++ b/test/unit_test/rag/llm/test_embedding_drop_params.py
@@ -42,7 +42,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from rag.llm.embedding_model import OpenAIEmbed, OpenRouterEmbed
+from rag.llm.embedding_model import OpenAIEmbed, OpenRouterEmbed, RAGconEmbed
 
 
 # ---------------------------------------------------------------------------
@@ -72,6 +72,13 @@ def _make_openrouter_embed():
     ``extra_body`` is exactly the base case.
     """
     embed = OpenRouterEmbed("key", "openai/text-embedding-3-small", base_url="https://openrouter.ai/api/v1")
+    embed.client = MagicMock()
+    embed.client.embeddings.create = MagicMock(side_effect=lambda input, model, **kwargs: _FakeResp([[float(i)] for i in range(len(input))]))
+    return embed
+
+
+def _make_ragcon_embed(base_url=None):
+    embed = RAGconEmbed("key", "text-embedding-3-small", base_url=base_url)
     embed.client = MagicMock()
     embed.client.embeddings.create = MagicMock(side_effect=lambda input, model, **kwargs: _FakeResp([[float(i)] for i in range(len(input))]))
     return embed
@@ -160,6 +167,22 @@ def test_openrouter_embed_call_appends_provider_when_provider_order_set():
     extra_body = kwargs.get("extra_body", {})
     assert extra_body.get("drop_params") is True
     assert extra_body.get("provider") == {"order": ["Azure", "OpenAI"], "allow_fallbacks": False}
+
+
+def test_ragcon_embed_official_endpoint_sends_drop_params():
+    embed = _make_ragcon_embed()
+    embed._call(["hello"])
+
+    kwargs = embed.client.embeddings.create.call_args.kwargs
+    assert kwargs["extra_body"] == {"drop_params": True}
+
+
+def test_ragcon_embed_custom_endpoint_omits_extra_body():
+    embed = _make_ragcon_embed("https://example.invalid/v1")
+    embed._call(["hello"])
+
+    kwargs = embed.client.embeddings.create.call_args.kwargs
+    assert "extra_body" not in kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
RAGcon sends drop_params only to its official endpoint. Custom endpoints use the standard embedding request.
based on #18587