### PR TITLE
fix(ingestion): enforce text-only pre-index wire contract

### DIFF
--- a/internal/ingestion/component/chunker/common.go
+++ b/internal/ingestion/component/chunker/common.go
@@ -130,14 +130,24 @@ func splitDroppingDelim(text string, pattern *regexp.Regexp) []string {
 // chunk-doc helpers
 // ---------------------------------------------------------------------------
 
-// itemText returns the text payload from a JSON-style chunk item,
-// preferring "text", then "content_with_weight".
+// requireChunkText enforces the pre-index wire contract before chunk-id
+// generation or image upload.
+func requireChunkText(ck map[string]any) (string, error) {
+	textRaw, exists := ck["text"]
+	if !exists {
+		return "", fmt.Errorf("chunk missing required string text field")
+	}
+	text, ok := textRaw.(string)
+	if !ok {
+		return "", fmt.Errorf("chunk text must be string, got %T", textRaw)
+	}
+	return text, nil
+}
+
+// itemText returns the canonical pre-index text payload from a chunk item.
 func itemText(it schema.ChunkDoc) (string, bool) {
 	if it.Text != "" {
 		return it.Text, true
-	}
-	if it.ContentWithWeight != "" {
-		return it.ContentWithWeight, true
 	}
 	return "", false
 }

--- a/internal/ingestion/component/chunker/group.go
+++ b/internal/ingestion/component/chunker/group.go
@@ -450,9 +450,6 @@ func recordsFromStructured(items []schema.ChunkDoc) []lineRecord {
 		if it.ContentSmLtks != "" {
 			meta["content_sm_ltks"] = it.ContentSmLtks
 		}
-		if it.ContentWithWeight != "" {
-			meta["content_with_weight"] = it.ContentWithWeight
-		}
 		if it.TitleTks != "" {
 			meta["title_tks"] = it.TitleTks
 		}

--- a/internal/ingestion/component/chunker/image_upload_test.go
+++ b/internal/ingestion/component/chunker/image_upload_test.go
@@ -229,7 +229,7 @@ func TestImageUploadDecorator_EndToEnd(t *testing.T) {
 		"kb_id":  testKBID,
 		"doc_id": testDocID,
 		"chunks": []map[string]any{
-			{"content_with_weight": "a cropped figure", "image": "data:image/png;base64," + pngBase64},
+			{"text": "a cropped figure", "image": "data:image/png;base64," + pngBase64},
 		},
 	}
 	out, err := decorated.Invoke(context.Background(), nil, inputs)
@@ -306,7 +306,7 @@ func TestImageUploadDecorator_DebugSkipsUpload(t *testing.T) {
 		"kb_id":  "", // debug mode: no KB -> no upload
 		"doc_id": testDocID,
 		"chunks": []map[string]any{
-			{"content_with_weight": "a cropped figure", "image": "data:image/png;base64," + pngBase64},
+			{"text": "a cropped figure", "image": "data:image/png;base64," + pngBase64},
 		},
 	}
 	out, err := decorated.Invoke(context.Background(), nil, inputs)
@@ -349,7 +349,7 @@ func TestImageUploadDecorator_DebugCapsChunks(t *testing.T) {
 	src := make([]map[string]any, 0, 6)
 	for i := 0; i < 6; i++ {
 		src = append(src, map[string]any{
-			"content_with_weight": fmt.Sprintf("chunk-%d", i),
+			"text": fmt.Sprintf("chunk-%d", i),
 		})
 	}
 	decorated := &imageUploadDecorator{inner: &stubChunker{chunks: src}}
@@ -376,8 +376,8 @@ func TestImageUploadDecorator_DebugCapsChunks(t *testing.T) {
 	}
 	for i, ck := range chunks {
 		want := fmt.Sprintf("chunk-%d", i)
-		if got, _ := ck["content_with_weight"].(string); got != want {
-			t.Errorf("chunks[%d].content_with_weight = %q, want %q (wrong chunk kept after truncation)", i, got, want)
+		if got, _ := ck["text"].(string); got != want {
+			t.Errorf("chunks[%d].text = %q, want %q (wrong chunk kept after truncation)", i, got, want)
 		}
 	}
 }
@@ -389,7 +389,7 @@ func TestImageUploadDecorator_NoCapKeepsAll(t *testing.T) {
 	src := make([]map[string]any, 0, 5)
 	for i := 0; i < 5; i++ {
 		src = append(src, map[string]any{
-			"content_with_weight": fmt.Sprintf("chunk-%d", i),
+			"text": fmt.Sprintf("chunk-%d", i),
 		})
 	}
 	decorated := &imageUploadDecorator{inner: &stubChunker{chunks: src}}

--- a/internal/ingestion/component/chunker/python_parity_test.go
+++ b/internal/ingestion/component/chunker/python_parity_test.go
@@ -134,21 +134,16 @@ func TestChunker_PassesPDFPositionsThrough(t *testing.T) {
 	}
 }
 
-// TestChunker_FallsBackToContentWithWeight pins the
-// content_with_weight fallback on the chunker read side. Python's
-// token_chunker.py:111 falls back to content_with_weight when
-// the text field is empty.
-func TestChunker_FallsBackToContentWithWeight(t *testing.T) {
+// TestChunker_DropsContentWithWeightOnlyItems enforces the pre-index wire
+// contract: chunkers consume canonical "text" only.
+func TestChunker_DropsContentWithWeightOnlyItems(t *testing.T) {
 	items := []map[string]any{
 		{"content_with_weight": "fallback text", "doc_type_kwd": "text"},
 	}
 	out := invokeAsTokenChunker(t, items)
 	chunks := chunksFromOutput(t, out)
-	if len(chunks) == 0 {
-		t.Fatal("no chunks emitted")
-	}
-	if got, want := chunks[0]["text"], "fallback text"; got != want {
-		t.Errorf("chunks[0].text = %v, want %v (content_with_weight fallback)", got, want)
+	if len(chunks) != 0 {
+		t.Fatalf("content_with_weight-only items must not produce chunks, got %d", len(chunks))
 	}
 }
 

--- a/internal/ingestion/component/chunker/register.go
+++ b/internal/ingestion/component/chunker/register.go
@@ -27,7 +27,6 @@ package chunker
 
 import (
 	"context"
-	"fmt"
 
 	"ragflow/internal/agent/runtime"
 	"ragflow/internal/common"

--- a/internal/ingestion/component/chunker/register.go
+++ b/internal/ingestion/component/chunker/register.go
@@ -27,6 +27,7 @@ package chunker
 
 import (
 	"context"
+	"fmt"
 
 	"ragflow/internal/agent/runtime"
 	"ragflow/internal/common"
@@ -93,7 +94,10 @@ func (d *imageUploadDecorator) Invoke(ctx context.Context, db *gorm.DB, inputs m
 	// can read ck["id"] without deriving it itself. Downstream, the persist
 	// stage reuses the same formula as a fallback when ck["id"] is absent.
 	for _, ck := range chunks {
-		text, _ := ck["text"].(string)
+		text, err := requireChunkText(ck)
+		if err != nil {
+			return nil, err
+		}
 		ck["id"] = common.ChunkID(docID, text)
 	}
 

--- a/internal/ingestion/component/chunker/table_test.go
+++ b/internal/ingestion/component/chunker/table_test.go
@@ -47,12 +47,12 @@ func TestTableChunker_OneChunkPerRow(t *testing.T) {
 		"output_format": "json",
 		"json": []map[string]any{
 			{
-				"content_with_weight": "- name: Alice\n- age: 30",
-				"doc_type_kwd":        "table",
+				"text":           "- name: Alice\n- age: 30",
+				"doc_type_kwd":   "table",
 			},
 			{
-				"content_with_weight": "- name: Bob\n- age: 25",
-				"doc_type_kwd":        "table",
+				"text":           "- name: Bob\n- age: 25",
+				"doc_type_kwd":   "table",
 			},
 		},
 	})
@@ -60,11 +60,11 @@ func TestTableChunker_OneChunkPerRow(t *testing.T) {
 	if len(chunks) != 2 {
 		t.Fatalf("got %d chunks, want 2", len(chunks))
 	}
-	if chunks[0]["content_with_weight"] != "- name: Alice\n- age: 30" {
-		t.Errorf("chunk0 content = %v", chunks[0]["content_with_weight"])
+	if chunks[0]["text"] != "- name: Alice\n- age: 30" {
+		t.Errorf("chunk0 text = %v", chunks[0]["text"])
 	}
-	if chunks[1]["content_with_weight"] != "- name: Bob\n- age: 25" {
-		t.Errorf("chunk1 content = %v", chunks[1]["content_with_weight"])
+	if chunks[1]["text"] != "- name: Bob\n- age: 25" {
+		t.Errorf("chunk1 text = %v", chunks[1]["text"])
 	}
 }
 

--- a/internal/ingestion/component/extractor.go
+++ b/internal/ingestion/component/extractor.go
@@ -293,7 +293,7 @@ func NewExtractorComponent(params map[string]any) (runtime.Component, error) {
 // self.chat_mdl; the Go port exposes it explicitly).
 func (c *ExtractorComponent) Inputs() map[string]string {
 	return map[string]string{
-		"chunks": "List of map[string]any from upstream Tokenizer. Each entry must carry a string 'text' (or 'content_with_weight') field. Optional — when absent the LLM is called once with the resolved args.",
+		"chunks": "List of map[string]any from upstream Tokenizer. Each entry must carry a string 'text' field. Optional — when absent the LLM is called once with the resolved args.",
 		"llm_id": "Optional per-call LLM id override. Falls back to Param.LLMID when absent.",
 	}
 }
@@ -1006,20 +1006,9 @@ func (c *ExtractorComponent) runEnableMetadata(ctx context.Context, db *gorm.DB,
 }
 
 // extractorChunkText resolves the body an extraction is run against.
-//
-// "text" wins over "content_with_weight": every chunker writes the
-// authoritative body to "text" (and derives the chunk id from it), while
-// "content_with_weight" may survive as pass-through metadata from an upstream
-// parser block. Preferring the latter would send the LLM a different body than
-// the one the chunk id — and therefore the cache entry — stands for. This is
-// the same priority the Tokenizer applies (normalizeChunkTextFallback) and the
-// chunkers apply (itemText). The fallback keeps a chunk that only carries the
-// structured field extractable rather than sending an empty body.
+// Pre-index components must carry canonical string "text" only.
 func extractorChunkText(ck map[string]any) string {
-	if v, _ := ck["text"].(string); strings.TrimSpace(v) != "" {
-		return v
-	}
-	v, _ := ck["content_with_weight"].(string)
+	v, _ := ck["text"].(string)
 	return v
 }
 

--- a/internal/ingestion/component/extractor_tag.go
+++ b/internal/ingestion/component/extractor_tag.go
@@ -974,13 +974,8 @@ func getChunkText(chunk map[string]any) string {
 
 	var parts []string
 
-	// 1. Main chunk content. "text" is preferred because every chunker writes
-	// the authoritative body there and derives the chunk id from it. Legacy
-	// chunks that only carry "content_with_weight" (parser-block output, many
-	// unit tests) are accepted as a fallback so detection/tagging still works.
+	// 1. Main chunk content — pre-index chunks must carry canonical "text".
 	if v, ok := chunk["text"].(string); ok && strings.TrimSpace(v) != "" {
-		parts = append(parts, strings.TrimSpace(v))
-	} else if v, ok := chunk["content_with_weight"].(string); ok && strings.TrimSpace(v) != "" {
 		parts = append(parts, strings.TrimSpace(v))
 	}
 

--- a/internal/ingestion/component/extractor_tag_integration_test.go
+++ b/internal/ingestion/component/extractor_tag_integration_test.go
@@ -74,7 +74,7 @@ func TestMatchAndTagChunk_AsymmetricLength(t *testing.T) {
 
 	// 800-word long technical chunk containing the reference example words
 	longBody := strings.Repeat("RAGFlow is an advanced system that integrates vector database and retrieval architecture engine into scalable workflows. ", 40)
-	chunk := map[string]any{"content_with_weight": longBody}
+	chunk := map[string]any{"text": longBody}
 
 	matched := matchAndTagChunk(chunk, idx, tok, 5)
 	if matched == nil {
@@ -107,7 +107,7 @@ func TestMatchAndTagChunk_TopKWeighted(t *testing.T) {
 
 	// Chunk has high overlap with AI example, slight overlap with Finance
 	chunk := map[string]any{
-		"content_with_weight": "machine learning artificial intelligence deep neural networks banking financial",
+		"text": "machine learning artificial intelligence deep neural networks banking financial",
 	}
 
 	matched := matchAndTagChunk(chunk, idx, tok, 5)
@@ -135,7 +135,7 @@ func TestMatchAndTagChunk_DuplicateTagsDedup(t *testing.T) {
 		t.Fatalf("expected 2 unique tags in example, got %v", idx.examples[0].Tags)
 	}
 
-	chunk := map[string]any{"content_with_weight": "natural language processing text analysis"}
+	chunk := map[string]any{"text": "natural language processing text analysis"}
 	matched := matchAndTagChunk(chunk, idx, tok, 5)
 	if matched == nil {
 		t.Fatal("expected non-nil match")
@@ -157,7 +157,7 @@ func TestMatchAndTagChunk_AllEmptyTags(t *testing.T) {
 		t.Fatalf("expected nil index when all tags are empty, got %v", idx)
 	}
 
-	chunk := map[string]any{"content_with_weight": "some text without tags"}
+	chunk := map[string]any{"text": "some text without tags"}
 	matched := matchAndTagChunk(chunk, idx, tok, 5)
 	if matched != nil {
 		t.Fatalf("expected nil match when index is nil, got %v", matched)
@@ -175,7 +175,7 @@ func TestMatchAndTagChunk_DeterministicTieBreak(t *testing.T) {
 		t.Fatal("expected non-nil index")
 	}
 
-	chunk := map[string]any{"content_with_weight": "shared keyword match document"}
+	chunk := map[string]any{"text": "shared keyword match document"}
 	// Ask for top 2 out of 3 equal-scoring tags
 	matched := matchAndTagChunk(chunk, idx, tok, 2)
 	if matched == nil {
@@ -235,7 +235,7 @@ func BenchmarkMatchAndTagChunk_5000Examples(b *testing.B) {
 	}
 
 	chunk := map[string]any{
-		"content_with_weight": "This is a detailed chunk talking about sample content document 42 with keywords topic42 and subtopic42 for domain categorization in practice.",
+		"text": "This is a detailed chunk talking about sample content document 42 with keywords topic42 and subtopic42 for domain categorization in practice.",
 	}
 
 	b.ReportAllocs()

--- a/internal/ingestion/component/extractor_tag_test.go
+++ b/internal/ingestion/component/extractor_tag_test.go
@@ -49,7 +49,7 @@ func TestExtractorTags_NoTagFileID(t *testing.T) {
 	comp, _ := NewExtractorComponent(map[string]any{"tags": map[string]any{"top_n": 3}})
 	out, err := comp.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "test"},
+			{"text": "test"},
 		},
 	})
 	if err != nil {
@@ -72,7 +72,7 @@ func TestExtractorTags_NoLLMID(t *testing.T) {
 	comp, _ := NewExtractorComponent(map[string]any{"tags": map[string]any{"top_n": 3}})
 	out, err := comp.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "some unrelated text"},
+			{"text": "some unrelated text"},
 		},
 	})
 	if err != nil {
@@ -102,7 +102,7 @@ func TestExtractorTags_WithKeywords(t *testing.T) {
 	})
 	out, err := comp.Invoke(t.Context(), nil, map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "some unrelated textxyz"},
+			{"text": "some unrelated textxyz"},
 		},
 	})
 	if err != nil {
@@ -275,7 +275,7 @@ func TestLlmtagChunk_MessageFit(t *testing.T) {
 	capt := pushCapturingTagChat(t)
 
 	longText := longChunkText()
-	chunk := map[string]any{"content_with_weight": longText}
+	chunk := map[string]any{"text": longText}
 	allTags := map[string]float64{"RAG": 1, "database": 1, "AI": 1}
 	examples := []schema.TaggedChunk{{Content: "example one", TagWeights: map[string]int{"AI": 5}}}
 
@@ -298,7 +298,7 @@ func TestLlmtagChunk_NoContextLength_SkipsFit(t *testing.T) {
 	capt := pushCapturingTagChat(t)
 
 	longText := longChunkText()
-	chunk := map[string]any{"content_with_weight": longText}
+	chunk := map[string]any{"text": longText}
 	allTags := map[string]float64{"RAG": 1}
 	examples := []schema.TaggedChunk{{Content: "example", TagWeights: map[string]int{"AI": 5}}}
 
@@ -323,7 +323,7 @@ func TestLlmtagChunk_ColdStartFallback(t *testing.T) {
 		allTags: map[string]float64{"NLP": 0.33, "AI": 0.33, "Search": 0.33},
 	}
 
-	chunk := map[string]any{"content_with_weight": "some content"}
+	chunk := map[string]any{"text": "some content"}
 	llmTagChunk(t.Context(), nil, capt, chunk, idx.allTags, nil, nil, "test@test", "test@test", "test_driver", "test_model", "test_key", "", 3, idx)
 
 	if len(capt.req.Messages) != 2 {
@@ -543,7 +543,7 @@ func TestGetChunkText_Enrichment(t *testing.T) {
 		},
 		{
 			name:  "content only",
-			chunk: map[string]any{"content_with_weight": "simple body text"},
+			chunk: map[string]any{"text": "simple body text"},
 			want:  "simple body text",
 		},
 		{
@@ -555,7 +555,7 @@ func TestGetChunkText_Enrichment(t *testing.T) {
 			name: "content present ignores docnm_kwd",
 			chunk: map[string]any{
 				"docnm_kwd":           "2026_Engineering_Bidding_Doc.pdf",
-				"content_with_weight": "contract guidelines",
+				"text": "contract guidelines",
 			},
 			want: "contract guidelines",
 		},
@@ -578,7 +578,7 @@ func TestGetChunkText_Enrichment(t *testing.T) {
 			name: "important_kwd string slice",
 			chunk: map[string]any{
 				"important_kwd":       []string{"Bidding", "Tender"},
-				"content_with_weight": "body",
+				"text": "body",
 			},
 			want: "body Bidding Tender",
 		},
@@ -586,7 +586,7 @@ func TestGetChunkText_Enrichment(t *testing.T) {
 			name: "important_kwd any slice",
 			chunk: map[string]any{
 				"important_kwd":       []any{"Alpha", "Beta"},
-				"content_with_weight": "body",
+				"text": "body",
 			},
 			want: "body Alpha Beta",
 		},
@@ -594,7 +594,7 @@ func TestGetChunkText_Enrichment(t *testing.T) {
 			name: "important_kwd string",
 			chunk: map[string]any{
 				"important_kwd":       "SingleKey",
-				"content_with_weight": "body",
+				"text": "body",
 			},
 			want: "body SingleKey",
 		},
@@ -603,7 +603,7 @@ func TestGetChunkText_Enrichment(t *testing.T) {
 			chunk: map[string]any{
 				"docnm_kwd":           "Project_Tender_Specification.pdf",
 				"important_kwd":       []string{"Procurement", "Compliance"},
-				"content_with_weight": "All bidders must follow instructions.",
+				"text": "All bidders must follow instructions.",
 			},
 			want: "All bidders must follow instructions. Procurement Compliance",
 		},
@@ -619,7 +619,7 @@ func TestGetChunkText_Enrichment(t *testing.T) {
 			chunk: map[string]any{
 				"docnm_kwd":           "   ",
 				"important_kwd":       []string{"  ", ""},
-				"content_with_weight": "   ",
+				"text": "   ",
 			},
 			want: "",
 		},
@@ -718,7 +718,7 @@ func TestContainsCJK_LanguageAutoDetection(t *testing.T) {
 
 func TestPopulateTagKwd_LLMTagChunk(t *testing.T) {
 	capt := pushCapturingTagChat(t)
-	chunk := map[string]any{"content_with_weight": "some content"}
+	chunk := map[string]any{"text": "some content"}
 	allTags := map[string]float64{"RAG": 0.5, "vector database": 0.5}
 
 	llmTagChunk(t.Context(), nil, capt, chunk, allTags, nil, nil, "test@test", "test@test", "test_driver", "test_model", "test_key", "", 3, nil)
@@ -789,7 +789,7 @@ func TestMatchAndTagChunk_TagKwdPopulated(t *testing.T) {
 	}
 
 	chunk := map[string]any{
-		"content_with_weight": "retrieval augmented generation system with vector search database",
+		"text": "retrieval augmented generation system with vector search database",
 	}
 
 	res := matchAndTagChunk(chunk, idx, tok, 5)
@@ -875,7 +875,7 @@ func TestMatchAndTagChunk_ChunkTFSaliencyGradient(t *testing.T) {
 	}, " ")
 
 	chunk := map[string]any{
-		"content_with_weight": chunkText,
+		"text": chunkText,
 	}
 
 	res := matchAndTagChunk(chunk, idx, tok, 5)
@@ -955,7 +955,7 @@ func TestMatchAndTagChunk_RankDecayScoreDistribution(t *testing.T) {
 
 	// Chunk containing repeated terms that match specific/rare tag (dominant topic) and 1 mention of medium tag
 	chunk := map[string]any{
-		"content_with_weight": strings.Join([]string{
+		"text": strings.Join([]string{
 			"retrieval augmented generation vector search algorithm indexing",
 			"retrieval augmented generation embedding chunk retrieval ranker",
 			"retrieval augmented generation vector search algorithm indexing",
@@ -1003,15 +1003,15 @@ func TestMatchAndTagChunk_RankDecayScoreDistribution(t *testing.T) {
 }
 
 func TestGetChunkText_NoTitlePollution(t *testing.T) {
-	// Case 1: When content_with_weight is present, docnm_kwd should NOT be prepended
+	// Case 1: When canonical text is present, docnm_kwd should NOT be prepended
 	chunkWithContent := map[string]any{
 		"docnm_kwd":           "Financial_Report_2026.pdf",
-		"content_with_weight": "Quarterly revenue increased by 15 percent.",
+		"text": "Quarterly revenue increased by 15 percent.",
 	}
 	got := getChunkText(chunkWithContent)
 	want := "Quarterly revenue increased by 15 percent."
 	if got != want {
-		t.Errorf("getChunkText with content_with_weight = %q, want %q", got, want)
+		t.Errorf("getChunkText with text = %q, want %q", got, want)
 	}
 
 	// Case 2: When text is present (fallback), docnm_kwd should NOT be prepended
@@ -1029,7 +1029,7 @@ func TestGetChunkText_NoTitlePollution(t *testing.T) {
 	chunkWithKwds := map[string]any{
 		"docnm_kwd":           "Internal_Guidelines.pdf",
 		"important_kwd":       []string{"Security", "Compliance"},
-		"content_with_weight": "All employees must follow access protocols.",
+		"text": "All employees must follow access protocols.",
 	}
 	gotKwds := getChunkText(chunkWithKwds)
 	wantKwds := "All employees must follow access protocols. Security Compliance"
@@ -1076,7 +1076,7 @@ func TestProbabilityMassConservation_MultiTag(t *testing.T) {
 
 	// Match a chunk that matches Example 1 with 100% coverage
 	chunk := map[string]any{
-		"content_with_weight": "quantum computing quantum algorithms superposition",
+		"text": "quantum computing quantum algorithms superposition",
 	}
 
 	res := matchAndTagChunk(chunk, idx, tok, 10)
@@ -1209,7 +1209,7 @@ func TestMatchAndTagChunk_ShortExampleMultiTokenRequirement(t *testing.T) {
 	// Chunk 1: Matches only 1 token ("machine") of the 2-token example "machine learning"
 	// Should NOT match on only 1 token
 	chunkSingleMatch := map[string]any{
-		"content_with_weight": "the coffee machine is broken today",
+		"text": "the coffee machine is broken today",
 	}
 	res1 := matchAndTagChunk(chunkSingleMatch, idx, tok, 5)
 	if res1 != nil {
@@ -1221,7 +1221,7 @@ func TestMatchAndTagChunk_ShortExampleMultiTokenRequirement(t *testing.T) {
 	// Chunk 2: Matches both tokens ("machine learning")
 	// Should match
 	chunkFullMatch := map[string]any{
-		"content_with_weight": "practical machine learning models and training",
+		"text": "practical machine learning models and training",
 	}
 	res2 := matchAndTagChunk(chunkFullMatch, idx, tok, 5)
 	if res2 == nil {
@@ -1341,7 +1341,7 @@ func TestDetectTextLanguage_CJK_Kana_Hangul(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			chunks := []map[string]any{
-				{"content_with_weight": tt.text},
+				{"text": tt.text},
 			}
 			got := detectTextLanguage(chunks)
 			if got != tt.want {
@@ -1367,7 +1367,7 @@ func TestMatchAndTagChunk_RankDecaySalienceBoost(t *testing.T) {
 
 	// Chunk has "indexing" repeated 5 times
 	chunk := map[string]any{
-		"content_with_weight": "vector database indexing indexing indexing indexing indexing",
+		"text": "vector database indexing indexing indexing indexing indexing",
 	}
 
 	res := matchAndTagChunk(chunk, idx, tok, 5)
@@ -1439,7 +1439,7 @@ func TestMatchAndTagChunk_RankDecayGradientScores(t *testing.T) {
 
 	// Chunk has high prominence with repeated terms for DeepLearning, secondary support for Database, minor mention of CloudInfra
 	chunk := map[string]any{
-		"content_with_weight": "neural network deep learning transformer model training deep learning transformer attention mechanism architecture deep learning transformer neural network deep learning transformer deep learning transformer database storage query index optimization postgresql cloud deployment devops kubernetes",
+		"text": "neural network deep learning transformer model training deep learning transformer attention mechanism architecture deep learning transformer neural network deep learning transformer deep learning transformer database storage query index optimization postgresql cloud deployment devops kubernetes",
 	}
 
 	res := matchAndTagChunk(chunk, idx, tok, 10)

--- a/internal/ingestion/component/extractor_test.go
+++ b/internal/ingestion/component/extractor_test.go
@@ -1415,7 +1415,7 @@ func TestExtractorModularPromptsExecution(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "Hello world content"},
+			{"text": "Hello world content"},
 		},
 	}
 
@@ -1528,7 +1528,7 @@ func TestExtractorModularMetadataExecution(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "Written by Alice in 2026."},
+			{"text": "Written by Alice in 2026."},
 		},
 	}
 
@@ -1572,7 +1572,7 @@ func TestExtractorDefaultSummaryPromptInjection(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "This is a detailed paragraph about artificial intelligence."},
+			{"text": "This is a detailed paragraph about artificial intelligence."},
 		},
 	}
 
@@ -1627,7 +1627,7 @@ func TestExtractorCustomSummarySystemPrompt(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "Text to summarize."},
+			{"text": "Text to summarize."},
 		},
 	}
 
@@ -1685,7 +1685,7 @@ func TestExtractorCustomKeywordsAndQuestionsSystemPrompt(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "Content text."},
+			{"text": "Content text."},
 		},
 	}
 
@@ -1741,7 +1741,7 @@ func TestExtractorTopNPlaceholderSubstitution(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "Content text."},
+			{"text": "Content text."},
 		},
 	}
 
@@ -1783,7 +1783,7 @@ func TestExtractorDefaultPromptsRenderTopN(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "Content text."},
+			{"text": "Content text."},
 		},
 	}
 
@@ -1826,7 +1826,7 @@ func TestExtractorDisabledSummarySkipsCall(t *testing.T) {
 
 	in := map[string]any{
 		"chunks": []map[string]any{
-			{"content_with_weight": "Some text."},
+			{"text": "Some text."},
 		},
 	}
 
@@ -2047,7 +2047,7 @@ func TestExtractor_KeywordsThenTagsSynergy(t *testing.T) {
 		"chunks": []map[string]any{
 			{
 				"docnm_kwd":           "Tender_Notice.pdf",
-				"content_with_weight": "General bidding notice content.",
+				"text": "General bidding notice content.",
 			},
 		},
 	}

--- a/internal/ingestion/component/knowledge_compiler/component.go
+++ b/internal/ingestion/component/knowledge_compiler/component.go
@@ -66,7 +66,7 @@ func NewKnowledgeCompilerComponent(name string, params map[string]any) (runtime.
 // Inputs documents the component's input surface for the catalog.
 func (c *KnowledgeCompilerComponent) Inputs() map[string]string {
 	return map[string]string{
-		"chunks":                "List of map[string]any from upstream chunker/parser; each must carry id + text/content_with_weight.",
+		"chunks":                "List of map[string]any from upstream chunker/parser; each must carry id + text.",
 		"historical_candidates": "Optional []common.Candidate override for historical dedup (test/offline).",
 	}
 }
@@ -403,8 +403,7 @@ func productsToChunkDocs(products []common.Product) ([]schema.ChunkDoc, error) {
 	docs := make([]schema.ChunkDoc, 0, len(products))
 	for _, p := range products {
 		doc := schema.ChunkDoc{
-			Text:              p.Content,
-			ContentWithWeight: p.Content,
+			Text: p.Content,
 		}
 		// Populate content_ltks / content_sm_ltks the same way the chunker
 		// components do (see chunker/tag.go, chunker/qa.go): coarse tokenize
@@ -844,9 +843,7 @@ func buildInputs(inputs map[string]any, param common.Param) (common.Inputs, erro
 		}
 		if t, ok := m["text"].(string); ok {
 			ch.Text = t
-		}
-		if cw, ok := m["content_with_weight"].(string); ok {
-			ch.Content = cw
+			ch.Content = t
 		}
 		// Reuse the embedding the upstream pipeline already computed on the
 		// chunk (stored under q_<dim>_vec); variants fall back to embedding
@@ -878,7 +875,7 @@ func init() {
 	meta := runtime.Metadata{
 		Version: "0.1.0",
 		Inputs: map[string]string{
-			"chunks":                "Upstream chunker/parser output chunks (id + text/content_with_weight).",
+			"chunks":                "Upstream chunker/parser output chunks (id + text).",
 			"historical_candidates": "Optional historical dedup candidates for offline/test runs.",
 		},
 		Outputs: chunkerOutputs,

--- a/internal/ingestion/component/knowledge_compiler/component_test.go
+++ b/internal/ingestion/component/knowledge_compiler/component_test.go
@@ -1355,7 +1355,7 @@ func TestKnowledgeCompiler_TenantFromGlobals(t *testing.T) {
 	// all this test needs to assert.
 	_, _ = c.Invoke(ctx, nil, map[string]any{
 		"llm_id":          "llm1",
-		"chunks":          []any{map[string]any{"id": "c1", "content_with_weight": "alpha beta", "text": "alpha beta"}},
+		"chunks":          []any{map[string]any{"id": "c1", "text": "alpha beta"}},
 		"embedding_model": "emb1",
 	})
 	if gotTenant != "tenant-from-globals" {

--- a/internal/ingestion/component/schema/chunk_types.go
+++ b/internal/ingestion/component/schema/chunk_types.go
@@ -99,9 +99,8 @@ func (m ChunkerFileMeta) MarshalJSON() ([]byte, error) {
 // boundaries. Common fields are explicit; dynamic enrichments are
 // preserved in Extra for forward compatibility.
 type ChunkDoc struct {
-	Text              string                     `json:"text,omitempty"`
-	ContentWithWeight string                     `json:"content_with_weight,omitempty"`
-	DocType           string                     `json:"doc_type_kwd,omitempty"`
+	Text          string                     `json:"text,omitempty"`
+	DocType       string                     `json:"doc_type_kwd,omitempty"`
 	CKType            string                     `json:"ck_type,omitempty"`
 	TKNums            *int                       `json:"tk_nums,omitempty"`
 	Mom               string                     `json:"mom,omitempty"`
@@ -139,7 +138,7 @@ func (d *ChunkDoc) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	for _, key := range []string{
-		"text", "content_with_weight", "doc_type_kwd", "mom", "img_id",
+		"text", "doc_type_kwd", "mom", "img_id",
 		"ck_type", "tk_nums", "layout", "layout_type", "layoutno", "image",
 		"context_above", "context_below", "questions", "keywords", "summary",
 		"chunk_order_int", "title_tks", "title_sm_tks", "content_ltks",
@@ -237,6 +236,7 @@ func (d ChunkDoc) ToMap() map[string]any {
 	for k, raw := range d.Extra {
 		out[k] = decodeExtraValue(raw)
 	}
+	delete(out, "content_with_weight")
 	if len(d.PDFPositions) > 0 {
 		out["_pdf_positions"] = decodeStructuredValue(d.PDFPositions)
 	}

--- a/internal/ingestion/component/slice3_integration_test.go
+++ b/internal/ingestion/component/slice3_integration_test.go
@@ -25,10 +25,9 @@ import (
 	"testing"
 )
 
-// TestTokenizer_FallsBackToContentWithWeight pins the python
-// rag/flow/tokenizer.py:111 fallback. A chunk with only
-// content_with_weight (no text) must tokenize the fallback text.
-func TestTokenizer_FallsBackToContentWithWeight(t *testing.T) {
+// TestTokenizer_DropsContentWithWeightOnlyChunks enforces the pre-index wire
+// contract: chunks without canonical "text" are dropped before tokenization.
+func TestTokenizer_DropsContentWithWeightOnlyChunks(t *testing.T) {
 	requireTokenizerPool(t)
 	c := &TokenizerComponent{}
 	c.param.SearchMethod = []string{"full_text"}
@@ -46,13 +45,8 @@ func TestTokenizer_FallsBackToContentWithWeight(t *testing.T) {
 		t.Fatalf("Tokenizer.Invoke: %v", err)
 	}
 	chunks, _ := out["chunks"].([]map[string]any)
-	if len(chunks) == 0 {
-		t.Fatal("no chunks emitted")
-	}
-	if got := chunks[0]["content_ltks"]; got == nil {
-		t.Errorf("content_ltks missing; content_with_weight fallback did not run")
-	} else if s, ok := got.(string); !ok || s == "" {
-		t.Errorf("content_ltks = %v (type %T), want non-empty string", got, got)
+	if len(chunks) != 0 {
+		t.Fatalf("content_with_weight-only chunks must be dropped, got %d chunk(s)", len(chunks))
 	}
 }
 

--- a/internal/ingestion/component/tokenizer.go
+++ b/internal/ingestion/component/tokenizer.go
@@ -333,8 +333,6 @@ func (c *TokenizerComponent) Invoke(ctx context.Context, db *gorm.DB, inputs map
 	)
 	titleStem := titleExtRE.ReplaceAllString(name, "")
 
-	normalizeChunkTextFallback(chunks)
-
 	// chunk_order_int is the position of the chunk in the (post-filter) reading
 	// sequence. It is set unconditionally on every surviving chunk so that all
 	// retrievable chunks carry a stable reading-order index on every path, not
@@ -648,15 +646,10 @@ func chunksFromTokenizerUpstream(in schema.TokenizerFromUpstream) []schema.Chunk
 	default:
 		raw = cloneChunkDocs(in.JSONResult)
 	}
-	// Keep only chunks that have retrievable content: a chunk is dropped only
-	// when both text and content_with_weight are empty. The ContentWithWeight
-	// guard preserves the Parser path, whose blocks carry content_with_weight
-	// without text; normalizeChunkTextFallback backfills text afterwards, so
-	// this guard is required to avoid dropping legitimate Parser blocks before
-	// the backfill runs.
+	// Keep only chunks that carry canonical pre-index text.
 	filtered := raw[:0]
 	for _, ck := range raw {
-		if ck.Text == "" && ck.ContentWithWeight == "" {
+		if strings.TrimSpace(ck.Text) == "" {
 			continue
 		}
 		filtered = append(filtered, ck)
@@ -709,27 +702,6 @@ func cloneTokenizerChunkDoc(in schema.ChunkDoc) schema.ChunkDoc {
 		out.Positions = append(json.RawMessage(nil), in.Positions...)
 	}
 	return out
-}
-
-// normalizeChunkTextFallback populates each chunk's "text" key
-// from "content_with_weight" when "text" is absent or empty. Mirrors
-// the python rag/flow/tokenizer.py:111 fallback so a chunk that
-// arrives from the parser path with only the structured
-// content_with_weight field still tokenizes.
-//
-// The function mutates the input slice in place; callers should
-// not retain separate copies of the chunks map. If both fields
-// are present, the existing "text" wins — preserves the python
-// contract where the chunker's emitted text is authoritative.
-func normalizeChunkTextFallback(chunks []schema.ChunkDoc) {
-	for i := range chunks {
-		if chunks[i].Text != "" {
-			continue
-		}
-		if chunks[i].ContentWithWeight != "" {
-			chunks[i].Text = chunks[i].ContentWithWeight
-		}
-	}
 }
 
 // tokenizeChunks annotates each chunk with title_tks, content_ltks,
@@ -845,8 +817,6 @@ func concatFields(ck schema.ChunkDoc, fields []string) string {
 		switch f {
 		case "text":
 			b.WriteString(ck.Text)
-		case "content_with_weight":
-			b.WriteString(ck.ContentWithWeight)
 		case "questions":
 			b.WriteString(ck.Questions)
 		case "keywords":

--- a/internal/ingestion/component/tokenizer_unit_test.go
+++ b/internal/ingestion/component/tokenizer_unit_test.go
@@ -507,21 +507,14 @@ func TestChunkOrderInt_EmbeddingOnly(t *testing.T) {
 }
 
 // TestChunksFromTokenizerUpstream_FiltersPhantomChunks covers A5 at the
-// pipeline level: a chunk is dropped only when BOTH text and
-// content_with_weight are empty. Blocks that carry only image / summary /
-// questions / nothing are dropped (they produce no retrievable content),
-// while a content_with_weight-only block is kept (Parser path; normalize
-// backfills text). Deliberate deviation from Python's "filter None only"
-// rule — user value (retrievable content) wins.
+// pipeline level: a chunk is dropped when canonical "text" is empty.
 func TestChunksFromTokenizerUpstream_FiltersPhantomChunks(t *testing.T) {
-	// JSON path: 6 items. Only the text block and the content_with_weight
-	// block survive; the other four are dropped by the A5 gate.
 	items := []map[string]any{
 		{"text": "valid chunk", "doc_type_kwd": "text"}, // keep
-		{"image": "data:image/png;base64,abc"},          // drop: no text, no content_with_weight
+		{"image": "data:image/png;base64,abc"},          // drop
 		{"summary": "a summary"},                        // drop
 		{"questions": "q1"},                             // drop
-		{"content_with_weight": "weighted"},             // keep (text backfilled by normalize)
+		{"content_with_weight": "weighted"},             // drop: storage field, not canonical text
 		{},                                              // drop: empty
 	}
 	// Use embedding-only mode to avoid CGo tokenizer dependency.
@@ -542,16 +535,11 @@ func TestChunksFromTokenizerUpstream_FiltersPhantomChunks(t *testing.T) {
 		t.Fatalf("Invoke: %v", err)
 	}
 	chunks := out["chunks"].([]map[string]any)
-	// A5 keeps only the text block and the content_with_weight block.
-	if len(chunks) != 2 {
-		t.Fatalf("want 2 chunks (4 phantoms filtered), got %d: %#v", len(chunks), chunks)
+	if len(chunks) != 1 {
+		t.Fatalf("want 1 chunk (5 phantoms filtered), got %d: %#v", len(chunks), chunks)
 	}
-	// Surviving chunks, in upstream order.
 	if chunks[0]["text"] != "valid chunk" {
 		t.Errorf("chunk 0 text = %q, want %q", chunks[0]["text"], "valid chunk")
-	}
-	if chunks[1]["text"] != "weighted" {
-		t.Errorf("chunk 1 text = %q, want %q (content_with_weight backfilled to text)", chunks[1]["text"], "weighted")
 	}
 }
 

--- a/internal/ingestion/task/indexdoc/process.go
+++ b/internal/ingestion/task/indexdoc/process.go
@@ -25,14 +25,13 @@ import (
 	"ragflow/internal/utility"
 )
 
-// RenameTextToContentWithWeight renames the "text" key to "content_with_weight".
-// If "content_with_weight" already exists, the "text" key is simply removed.
-// Mirrors Python: ck["content_with_weight"] = ck["text"]; del ck["text"]
+// RenameTextToContentWithWeight maps the canonical pre-index "text" field to the
+// storage field "content_with_weight" and removes "text". The text value is
+// always authoritative at this boundary — any pre-existing content_with_weight
+// is overwritten so identity/embedding and persisted content cannot diverge.
 func RenameTextToContentWithWeight(chunk map[string]any) {
-	if _, exists := chunk["content_with_weight"]; !exists {
-		if text, ok := chunk["text"]; ok {
-			chunk["content_with_weight"] = text
-		}
+	if text, ok := chunk["text"].(string); ok {
+		chunk["content_with_weight"] = text
 	}
 	delete(chunk, "text")
 }
@@ -85,8 +84,12 @@ func ProcessChunksForPipeline(
 		ck["create_time"] = timeStr
 		ck["create_timestamp_flt"] = timestamp
 
+		text, err := requireStringText(ck)
+		if err != nil {
+			return nil, err
+		}
+
 		if _, exists := ck["id"]; !exists {
-			text, _ := ck["text"].(string)
 			ck["id"] = common.ChunkID(docID, text)
 		}
 
@@ -96,6 +99,20 @@ func ProcessChunksForPipeline(
 		processChunkPositions(ck)
 	}
 	return metadata, nil
+}
+
+// requireStringText enforces the pre-index wire contract: every chunk must
+// carry a string "text" field before chunk-id generation or persistence mapping.
+func requireStringText(ck map[string]any) (string, error) {
+	textRaw, exists := ck["text"]
+	if !exists {
+		return "", fmt.Errorf("chunk missing required string text field")
+	}
+	text, ok := textRaw.(string)
+	if !ok {
+		return "", fmt.Errorf("chunk text must be string, got %T", textRaw)
+	}
+	return text, nil
 }
 
 // cleanupConsumedChunkFields materializes the stored array form of the

--- a/internal/ingestion/task/indexdoc/process_test.go
+++ b/internal/ingestion/task/indexdoc/process_test.go
@@ -23,8 +23,8 @@ func TestRenameTextToContentWithWeight_Basic(t *testing.T) {
 func TestRenameTextToContentWithWeight_PreservesExisting(t *testing.T) {
 	chunk := map[string]any{"content_with_weight": "already set", "text": "hello"}
 	RenameTextToContentWithWeight(chunk)
-	if chunk["content_with_weight"] != "already set" {
-		t.Errorf("preserved value should not be overwritten")
+	if chunk["content_with_weight"] != "hello" {
+		t.Errorf("text must be authoritative at the storage boundary, got %q", chunk["content_with_weight"])
 	}
 	if _, exists := chunk["text"]; exists {
 		t.Error("text should still be removed")
@@ -108,19 +108,13 @@ func TestProcessChunksForPipeline_GeneratesID(t *testing.T) {
 	}
 }
 
-// TestProcessChunksForPipeline_GeneratesIDOnNonStringText pins the id fallback:
-// when ck["id"] is absent and ck["text"] is a non-string (e.g. from a
-// malformed input), the type assertion silently yields "" and
-// component.ChunkID computes a valid id from empty text, rather than erroring.
-func TestProcessChunksForPipeline_GeneratesIDOnNonStringText(t *testing.T) {
+// TestProcessChunksForPipeline_RejectsNonStringText pins the strict contract:
+// non-string text must fail before chunk-id generation.
+func TestProcessChunksForPipeline_RejectsNonStringText(t *testing.T) {
 	chunks := []map[string]any{{"text": []any{"bad-shape"}}}
 	_, err := ProcessChunksForPipeline(chunks, "doc-1", "test-doc.pdf", time.Now())
-	if err != nil {
-		t.Fatalf("ProcessChunksForPipeline: %v", err)
-	}
-	id, ok := chunks[0]["id"].(string)
-	if !ok || id == "" {
-		t.Errorf("id should be generated even for non-string text, got %v", chunks[0]["id"])
+	if err == nil {
+		t.Fatal("ProcessChunksForPipeline should reject non-string text")
 	}
 }
 
@@ -333,14 +327,22 @@ func TestProcessChunksForPipeline_TextRenamed(t *testing.T) {
 	}
 }
 
-func TestProcessChunksForPipeline_PreservesContentWithWeight(t *testing.T) {
+func TestProcessChunksForPipeline_TextAuthoritativeAtRename(t *testing.T) {
 	chunks := []map[string]any{{"content_with_weight": "already set", "text": "hello"}}
 	_, err := ProcessChunksForPipeline(chunks, "doc-1", "test-doc.pdf", time.Now())
 	if err != nil {
 		t.Fatalf("ProcessChunksForPipeline: %v", err)
 	}
-	if chunks[0]["content_with_weight"] != "already set" {
-		t.Errorf("content_with_weight = %q, want \"already set\"", chunks[0]["content_with_weight"])
+	if chunks[0]["content_with_weight"] != "hello" {
+		t.Errorf("content_with_weight = %q, want %q", chunks[0]["content_with_weight"], "hello")
+	}
+}
+
+func TestProcessChunksForPipeline_RejectsMissingText(t *testing.T) {
+	chunks := []map[string]any{{"content_with_weight": "already set"}}
+	_, err := ProcessChunksForPipeline(chunks, "doc-1", "test-doc.pdf", time.Now())
+	if err == nil {
+		t.Fatal("ProcessChunksForPipeline should reject chunks without text")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #19345 — Go ingestion DSL still leaks `content_with_weight` before persistence.

This enforces the pre-index wire contract so `text` is the sole canonical chunk content field until the final persistence rename:

- **Chunkers** (`itemText`, GroupTitle metadata): read `text` only; validate `text` before `ChunkID` in `imageUploadDecorator`
- **Tokenizer**: drop CWW fallback/normalization; filter on non-empty `text` only; remove `content_with_weight` from `concatFields`
- **Extractor / tagger**: resolve chunk body from `text` only
- **Knowledge compiler**: emit/consume `text` only in compiled products and buildInputs
- **Schema** (`ChunkDoc`): remove typed `ContentWithWeight`; strip stray `content_with_weight` from `ToMap()`
- **Persistence boundary** (`ProcessChunksForPipeline`): require string `text` before ID generation; `RenameTextToContentWithWeight` always maps `text` → `content_with_weight` authoritatively

Post-index readers/writers (`knowledge_compile/*`, retrieval services) continue using `content_with_weight` unchanged.

## Test plan

- [x] Updated regression tests for chunker/tokenizer/extractor/indexdoc contract
- [x] `go test ./internal/ingestion/task/indexdoc/...`
- [x] `go test ./internal/ingestion/component/schema/...`
- [x] `go test ./internal/ingestion/component/knowledge_compiler/...`
- [x] Full `./internal/ingestion/component/chunker/...` suite (requires `office_oxide` CGO headers in CI/dev env)