### PR TITLE
fix(invoke): tolerate invalid headers across runtimes

### DIFF
--- a/agent/component/invoke.py
+++ b/agent/component/invoke.py
@@ -185,12 +185,29 @@ class Invoke(ComponentBase, ABC):
         return url
 
     def _build_headers(self, kwargs: dict) -> dict:
-        if not self._param.headers:
+        raw_headers = self._param.headers
+        if raw_headers is None or (isinstance(raw_headers, str) and not raw_headers.strip()):
             return {}
 
-        headers = json.loads(self._param.headers)
+        if isinstance(raw_headers, dict):
+            headers = raw_headers
+        elif isinstance(raw_headers, str):
+            try:
+                headers = json.loads(raw_headers)
+            except json.JSONDecodeError as exc:
+                logging.warning(
+                    "Invoke headers ignored: invalid JSON (line=%s column=%s)",
+                    exc.lineno,
+                    exc.colno,
+                )
+                return {}
+        else:
+            logging.warning("Invoke headers ignored: unsupported type=%s", type(raw_headers).__name__)
+            return {}
+
         if not isinstance(headers, dict):
-            raise ValueError("Invoke headers must be a JSON object.")
+            logging.warning("Invoke headers ignored: decoded type=%s", type(headers).__name__)
+            return {}
 
         return {key: self._resolve_header_text(value, kwargs) if isinstance(value, str) else value for key, value in headers.items()}
 

--- a/internal/agent/component/invoke.go
+++ b/internal/agent/component/invoke.go
@@ -354,15 +354,22 @@ func invokeHeaders(raw any) (map[string]any, error) {
 		return headers, nil
 	}
 	text, ok := raw.(string)
-	if !ok || strings.TrimSpace(text) == "" {
+	if !ok {
+		zap.L().Warn("Invoke headers ignored: unsupported type", zap.String("type", fmt.Sprintf("%T", raw)))
 		return nil, nil
 	}
-	var headers map[string]any
-	if err := json.Unmarshal([]byte(text), &headers); err != nil {
-		return nil, fmt.Errorf("Invoke: headers must be a JSON object: %w", err)
+	if strings.TrimSpace(text) == "" {
+		return nil, nil
 	}
-	if headers == nil {
-		return nil, errors.New("Invoke: headers must be a JSON object")
+	var decoded any
+	if err := json.Unmarshal([]byte(text), &decoded); err != nil {
+		zap.L().Warn("Invoke headers ignored: invalid JSON", zap.Error(err))
+		return nil, nil
+	}
+	headers, ok := decoded.(map[string]any)
+	if !ok {
+		zap.L().Warn("Invoke headers ignored: decoded type", zap.String("type", fmt.Sprintf("%T", decoded)))
+		return nil, nil
 	}
 	return headers, nil
 }

--- a/internal/agent/component/invoke_test.go
+++ b/internal/agent/component/invoke_test.go
@@ -18,15 +18,19 @@ package component
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"ragflow/internal/utility"
 )
 
@@ -145,6 +149,52 @@ func TestInvoke_UsesNodeParams(t *testing.T) {
 	}
 	if got, _ := out["result"].(string); got != "configured" {
 		t.Errorf("result = %q, want configured", got)
+	}
+}
+
+func TestInvokeHeadersToleratesInvalidInput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want map[string]any
+	}{
+		{name: "malformed JSON", raw: `{"Authorization":"Bearer secret-token"`, want: nil},
+		{name: "empty", raw: "", want: nil},
+		{name: "array", raw: `["secret-token"]`, want: nil},
+		{name: "scalar", raw: `true`, want: nil},
+		{name: "null", raw: "null", want: nil},
+		{name: "unsupported", raw: 42, want: nil},
+		{name: "object", raw: `{"X-Test":"yes"}`, want: map[string]any{"X-Test": "yes"}},
+		{name: "direct map", raw: map[string]any{"X-Test": "yes"}, want: map[string]any{"X-Test": "yes"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := invokeHeaders(tt.raw)
+			if err != nil {
+				t.Fatalf("invokeHeaders() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("invokeHeaders() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInvokeHeadersDoesNotLogRawPayload(t *testing.T) {
+	previous := zap.L()
+	core, logs := observer.New(zap.WarnLevel)
+	zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(func() { zap.ReplaceGlobals(previous) })
+
+	const secret = "Bearer secret-token"
+	if _, err := invokeHeaders(`{"Authorization":"` + secret); err != nil {
+		t.Fatalf("invokeHeaders() error = %v", err)
+	}
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, secret) || strings.Contains(fmt.Sprint(entry.ContextMap()), secret) {
+			t.Fatalf("log contains raw header payload: %#v", entry)
+		}
 	}
 }
 

--- a/test/testcases/test_web_api/test_canvas_app/test_invoke_component_unit.py
+++ b/test/testcases/test_web_api/test_canvas_app/test_invoke_component_unit.py
@@ -201,6 +201,38 @@ def test_header_empty(monkeypatch):
     assert mock_get.call_args[1]["headers"] == {}
 
 
+@pytest.mark.parametrize("headers", ['{"Authorization":"Bearer secret-token"', '["secret-token"]', "null"])
+def test_header_invalid_input_is_ignored_without_logging_raw_value(monkeypatch, caplog, headers):
+    module = _load_invoke_module(monkeypatch)
+    invoke = _make_invoke(module, headers=headers)
+
+    with caplog.at_level("WARNING"):
+        assert invoke._build_headers({}) == {}
+
+    assert "secret-token" not in caplog.text
+
+
+def test_header_dict_is_accepted_and_interpolated(monkeypatch):
+    module = _load_invoke_module(monkeypatch)
+    invoke = _make_invoke(
+        module,
+        headers={"Authorization": "Bearer {token}"},
+        variable_values={"token": "secret-token"},
+    )
+
+    assert invoke._build_headers({}) == {"Authorization": "Bearer secret-token"}
+
+
+def test_header_unsupported_type_is_ignored(monkeypatch, caplog):
+    module = _load_invoke_module(monkeypatch)
+    invoke = _make_invoke(module, headers=object())
+
+    with caplog.at_level("WARNING"):
+        assert invoke._build_headers({}) == {}
+
+    assert "object" in caplog.text
+
+
 @pytest.mark.p2
 def test_header_component_ref_variable(monkeypatch):
     module = _load_invoke_module(monkeypatch)


### PR DESCRIPTION
### Summary

Invalid or malformed headers are now ignored safely. Valid headers and variable interpolation continue to work.
based on #19184